### PR TITLE
docs: add CLAUDE.md and design documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,3 +96,12 @@ tokio::main → init terminal → spawn initial session → loop {
 - Terminal state parsed by `vt100::Parser`, rendered by `tui_term::PseudoTerminal`
 - `Ctrl+Q` is the quit key (only key not forwarded to PTY when terminal is focused)
 - Architecture tests in `tests/architecture_rules.rs` are `#[ignore]` due to upstream cargo-pup bug with workspace detection
+
+## Design Documentation
+
+For rationale behind decisions, see `docs/`:
+- `docs/CONSTITUTION.md` — Core principles and non-negotiable rules
+- `docs/ARCHITECTURE.md` — Architectural decisions with rationale
+- `docs/FEATURES.md` — Feature-level design choices
+
+**Rule**: If a code change invalidates or extends a documented decision, update the relevant doc in the same PR.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,91 @@
+# Architecture Decisions
+
+Each decision follows a mini-ADR format: **Choice**, **Why**, **Rejected alternatives**.
+
+---
+
+## ADR-1: The Elm Architecture (TEA)
+
+**Choice**: All state lives in a single `App` model. Events become messages, `update()` applies them, `view()` renders the result.
+
+**Why**: TEA makes state transitions explicit and testable. Every input has a traceable path from event to screen change. There's no hidden state scattered across components, which matters a lot when multiple PTY sessions are producing concurrent output.
+
+**Rejected**:
+- *Component-based (each panel owns state)* — leads to synchronization bugs when sessions interact.
+- *Ad-hoc event handlers* — untraceable control flow; hard to reason about as the app grows.
+
+---
+
+## ADR-2: PTY pipeline — portable-pty + vt100 + tui-term
+
+**Choice**: `portable-pty` spawns the `claude` CLI, `vt100::Parser` interprets escape sequences, `tui_term::PseudoTerminal` renders the parsed screen into ratatui.
+
+**Why**: Each crate handles exactly one concern. `portable-pty` abstracts platform differences (Linux, macOS). `vt100` gives us a full in-memory terminal state we can query without scraping. `tui_term` bridges that state to ratatui widgets with zero custom rendering code.
+
+**Rejected**:
+- *`nix::pty` directly* — Linux-only; would require a separate Windows/macOS backend.
+- *`alacritty_terminal`* — full terminal emulator, far heavier than needed. We don't need font rendering or GPU acceleration.
+- *Parsing raw ANSI ourselves* — error-prone, massive surface area, already solved by `vt100`.
+
+---
+
+## ADR-3: Async design — tokio multi-threaded + spawn_blocking for PTY reads
+
+**Choice**: The app runs on tokio's multi-threaded runtime. PTY read loops run inside `spawn_blocking` (blocking I/O in a threadpool), while PTY write and event handling run in `tokio::spawn` (async).
+
+**Why**: PTY reads are blocking by nature (`read()` on a file descriptor). Putting them in `spawn_blocking` prevents stalling the async executor. The writer side is naturally async — it awaits messages from an mpsc channel and writes when they arrive.
+
+**Rejected**:
+- *Single-threaded tokio* — PTY reads would block the entire runtime, freezing the UI.
+- *`std::thread` for everything* — works but loses tokio's structured concurrency, select!, and channel ergonomics.
+
+---
+
+## ADR-4: Input translation — crossterm KeyCode to xterm ANSI
+
+**Choice**: `input.rs` maps crossterm `KeyCode`/`KeyModifiers` to raw xterm ANSI byte sequences before writing to the PTY.
+
+**Why**: crossterm gives us structured key events. PTYs expect raw bytes. The translation layer is explicit and testable — each key has a known byte sequence, and edge cases (arrow keys, function keys, modifier combos) are handled in one place.
+
+**Rejected**:
+- *Raw passthrough (forward crossterm's raw bytes)* — crossterm's internal byte representation doesn't match xterm sequences. Modifier keys, in particular, would break.
+
+---
+
+## ADR-5: Responsive layout breakpoints
+
+**Choice**: Three layout tiers based on terminal width:
+- `<80 cols` — terminal panel only (full screen)
+- `>=80 cols` — two panels (session list + terminal)
+- `>=120 cols` — three panels (session list + terminal + info)
+
+**Why**: 80 columns is the smallest usable terminal width. Below that, showing a sidebar wastes too much space. At 120+, there's room for supplementary info without shrinking the terminal panel below readable width. Fixed breakpoints are predictable — the layout never "jitters" near a threshold.
+
+**Rejected**:
+- *Fixed layout (always 3 panels)* — unusable on small terminals.
+- *User-configurable breakpoints* — premature complexity. Can be added later if needed.
+
+---
+
+## ADR-6: File-based logging only
+
+**Choice**: All tracing output goes to `~/.local/share/thurbox/thurbox.log`. Nothing writes to stdout or stderr.
+
+**Why**: The TUI owns stdout entirely. Any stray `println!` or log line to stdout would corrupt the terminal display. File-based logging also makes it easy to `tail -f` the log in a second terminal while developing.
+
+**Rejected**:
+- *Stderr logging* — crossterm's alternate screen captures stderr on some platforms, still risks display corruption.
+- *In-app log panel* — useful eventually, but adds complexity before the core features are stable.
+
+---
+
+## ADR-7: Build profiles
+
+| Profile | `opt-level` | LTO | `codegen-units` | `strip` | `debug` | Use case |
+|---------|-------------|-----|------------------|---------|---------|----------|
+| `dev` | 0 | off | default | no | yes | Fast iteration |
+| `test` | 1 | off | default | no | yes | Faster test execution without sacrificing debuggability |
+| `release` | 3 | thin → full | 1 | yes | no | Distribution binary (smallest, fastest) |
+| `release-with-debug` | 3 | full | 1 | no | yes | Profiling and performance investigation |
+
+**Why**: `test` at opt-level 1 catches optimization-dependent bugs earlier while keeping compile times reasonable. The release profile strips everything for a minimal binary. `release-with-debug` exists specifically for `perf` / `flamegraph` workflows.

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -1,0 +1,80 @@
+# Constitution
+
+Non-negotiable rules that define what Thurbox **must** always be. Each principle has an automated enforcement mechanism — if it can't be enforced, it doesn't belong here.
+
+## Principles
+
+### 1. Crash-free operation
+
+Errors are displayed in the UI (status bar / footer), never via panics. The only panic path is the emergency terminal-restore hook in `main.rs`, which exists to leave the user's terminal in a usable state if something truly unexpected happens.
+
+### 2. Module isolation
+
+Dependency flow is strictly one-directional:
+
+```
+session  (no project-local imports)
+claude   → session
+ui       → session
+app      → session, claude, ui
+```
+
+`claude` and `ui` never import each other. This keeps the side-effect layer (PTY management) completely decoupled from the rendering layer.
+
+### 3. Zero-warning policy
+
+Both `clippy` and `rustdoc` run with warnings promoted to errors. If it compiles with warnings, CI fails.
+
+### 4. Permissive licenses only
+
+All dependencies must carry licenses from the allowlist in `deny.toml`. Copyleft crates are rejected at PR time.
+
+### 5. Zero known vulnerabilities
+
+`cargo-deny` advisories and `cargo-audit` block merges when known CVEs affect the dependency tree.
+
+### 6. Conventional commits
+
+Every commit message is validated against the Conventional Commits spec by `cocogitto`. Non-conforming commits are rejected by the `commit-msg` hook.
+
+### 7. TEA as the single architectural pattern
+
+The Elm Architecture (`Event -> Message -> update -> view -> Frame`) is the only sanctioned control-flow pattern. No ad-hoc event handlers, no component-local state, no callback chains.
+
+### 8. PTY-first session model
+
+Claude Code sessions run inside real PTYs (`portable-pty`). We never mock, emulate, or screen-scrape a fake terminal. The PTY is the source of truth.
+
+### 9. Logging never touches stdout
+
+Stdout belongs to the TUI. All diagnostic output goes to the log file at `~/.local/share/thurbox/thurbox.log`.
+
+### 10. Test-driven development (Red, Green, Refactor)
+
+All features and bug fixes follow the TDD/BDD cycle:
+
+1. **Red** — Write a failing test that defines the expected behavior.
+2. **Green** — Write the minimum code to make the test pass.
+3. **Refactor** — Clean up while keeping tests green.
+
+Tests are written *before* or *alongside* the implementation, never as an afterthought. If a bug is reported, the fix starts with a test that reproduces it.
+
+### 11. Deterministic CI — scripts over LLMs
+
+CI pipelines must be reproducible and deterministic. Every check is a script or tool that produces the same result given the same input. LLM-generated judgments (code review bots, AI-powered linters) are never gating — they may advise, but deterministic tools (`clippy`, `nextest`, `cargo-deny`, `cog`) make the pass/fail decision. Changes to CI configuration require careful review because a broken pipeline affects every contributor.
+
+## Enforcement Map
+
+| Principle | Enforced by | Config file |
+|-----------|-------------|-------------|
+| Crash-free operation | Code review + `#[deny(clippy::unwrap_used)]` (planned) | `clippy.toml` |
+| Module isolation | `cargo-pup` | `pup.ron` |
+| Zero warnings | `clippy -D warnings` + `RUSTDOCFLAGS="-D warnings"` | CI + pre-commit |
+| Permissive licenses | `cargo-deny check bans licenses` | `deny.toml` |
+| Zero vulnerabilities | `cargo-deny check advisories` + `cargo-audit` | `deny.toml` |
+| Conventional commits | `cocogitto` (`cog verify`) | `cog.toml` |
+| TEA pattern | `cargo-pup` rules + code review | `pup.ron` |
+| PTY-first model | Code review | — |
+| Logging off stdout | Code review | — |
+| TDD (Red/Green/Refactor) | `cargo-nextest` + code review | `.config/nextest.toml` |
+| Deterministic CI | Scripts and tools only; no LLM-gated checks | CI config + pre-commit |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,89 @@
+# Feature Decisions
+
+Design rationale for user-facing behavior. For architectural choices, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+---
+
+## Keybinding Design
+
+### Philosophy: Ctrl = global, everything else = PTY
+
+When the terminal panel is focused, **all keys are forwarded to the PTY** except those with a `Ctrl` modifier. Ctrl-prefixed keys are intercepted by Thurbox as global commands.
+
+**Why Ctrl, not Alt?**
+- Claude Code and shell programs heavily use Alt-key combinations. Intercepting Alt would break readline, vim, and Claude's own keybindings.
+- Ctrl has well-established precedent for "meta" actions in terminal multiplexers (tmux uses `Ctrl+B`, screen uses `Ctrl+A`).
+- Ctrl combos are easier to type one-handed, which matters for a tool you use alongside other terminals.
+
+### Keybinding Table
+
+| Key | Context | Action |
+|-----|---------|--------|
+| `Ctrl+Q` | Global | Quit Thurbox |
+| `Ctrl+N` | Global | New session (planned) |
+| `Ctrl+W` | Global | Close current session (planned) |
+| `Ctrl+Tab` | Global | Next session (planned) |
+| `Ctrl+Shift+Tab` | Global | Previous session (planned) |
+| `q` / `Esc` | Unfocused | Quit (scaffold-only, will be removed) |
+| All other keys | Focused terminal | Forwarded to PTY |
+
+---
+
+## Session Lifecycle
+
+```
+Create (UUID v4) → Running → Idle / Error
+                      ↓
+                  Shutdown (SIGHUP)
+```
+
+### States
+
+- **Running**: PTY is alive, read loop is active, output is streaming to the terminal widget.
+- **Idle**: Claude CLI has exited cleanly (exit code 0). Session is still displayed but no longer accepts input.
+- **Error**: PTY or Claude CLI exited with a non-zero code. Error details shown in status bar.
+- **Shutdown**: Triggered by the user closing a session or quitting the app. Sends `SIGHUP` to the PTY child process, then waits for clean exit before dropping resources.
+
+### Why UUID v4?
+
+Sessions need unique identifiers for the lifetime of the process. UUIDs are collision-free without coordination, simple to generate, and usable as map keys. Sequential IDs would work too, but UUIDs prevent bugs where an old session ID accidentally refers to a new session after recycling.
+
+---
+
+## Error Handling UX
+
+### Rule: never crash, never modal
+
+Errors are shown in the status bar footer as transient messages. They do not block interaction, do not require dismissal, and auto-clear after a timeout or on the next successful action.
+
+**Why non-modal?**
+- Modal error dialogs in a TUI are jarring — they steal focus from the terminal where the user is working.
+- Most errors are recoverable (session failed to start, PTY read error). Showing them passively lets the user decide when to act.
+- Fatal errors (can't initialize terminal) are the only case where the app exits, and those happen before the TUI is even rendered.
+
+---
+
+## Responsive Layout
+
+### Breakpoint Rationale
+
+| Width | Layout | Why |
+|-------|--------|-----|
+| `<80 cols` | Terminal only | Below 80 columns, a sidebar would leave <60 cols for the terminal — too narrow for most CLI tools. Full-screen maximizes readability. |
+| `>=80 cols` | Session list + terminal | 20-col sidebar + 60-col terminal is the minimum comfortable split. The session list provides at-a-glance multi-session awareness. |
+| `>=120 cols` | Session list + terminal + info panel | At 120 cols, the terminal still gets ~70+ columns after both sidebars. The info panel shows session metadata without switching views. |
+
+### Why not user-configurable?
+
+Configurable breakpoints add UI, storage, and edge-case complexity for minimal gain. The fixed values cover standard terminal sizes (80, 120, 160+). If a user resizes their terminal, the layout adapts instantly. Custom breakpoints can be added later if real demand emerges.
+
+---
+
+## Planned Features
+
+Directional intent, not commitments. These may change as the project evolves.
+
+- **Multi-session orchestration**: Run N Claude Code instances side-by-side, switch between them, broadcast input to all.
+- **Git worktree integration**: Automatically create worktrees for parallel tasks, one session per worktree.
+- **Session persistence**: Save/restore session layouts and PTY history across restarts.
+- **Task delegation**: Split a task across multiple sessions with dependency tracking.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Design Documentation
+
+This directory contains the **rationale** behind Thurbox's design decisions. For operational guidance (build commands, module layout, event loop), see [`CLAUDE.md`](../CLAUDE.md).
+
+## Documents
+
+| Document | Purpose | Update when... |
+|----------|---------|----------------|
+| [CONSTITUTION.md](CONSTITUTION.md) | Core principles and non-negotiable rules | Adding/removing an enforced invariant |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Architectural decisions with rationale | Changing a technology choice or structural pattern |
+| [FEATURES.md](FEATURES.md) | Feature-level design choices | Altering keybindings, lifecycle, layout, or UX behavior |
+
+## Keeping Docs Current
+
+**Rule**: If a code change invalidates or extends a documented decision, update the relevant doc in the same PR.
+
+- Operational changes (new commands, module moves) go in `CLAUDE.md`
+- Decisional changes (why we chose X over Y) go in `docs/`
+- Don't duplicate content between the two


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with operational guidance for Claude Code (build commands, module layout, event loop, pre-commit hooks)
- Adds `docs/` directory with rationale-focused design documentation:
  - **CONSTITUTION.md** — 11 non-negotiable principles (crash-free operation, module isolation, zero warnings, TDD/BDD, deterministic CI, etc.) with enforcement map
  - **ARCHITECTURE.md** — 7 ADRs in choice/why/rejected format (TEA, PTY pipeline, async design, input translation, layout breakpoints, logging, build profiles)
  - **FEATURES.md** — Feature-level decisions (keybinding philosophy, session lifecycle, error handling UX, responsive layout)
  - **README.md** — Index with update triggers per document
- Separation principle: `CLAUDE.md` = "what and how" (operational), `docs/` = "why and why not" (decisional)
- Establishes rule: code changes that invalidate a documented decision must update the relevant doc in the same PR

## Test plan

- [x] `cargo check --all` passes (docs-only change, no code impact)
- [x] All pre-commit hooks pass
- [ ] Review documents for accuracy against current codebase
- [ ] Verify no duplication between CLAUDE.md and docs/ content