### PR TITLE
chore(docs): add rumdl markdown linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,13 @@ repos:
         pass_filenames: false
         always_run: true
 
+      - id: rumdl-check
+        name: Markdown lint check
+        entry: rumdl check .
+        language: system
+        types: [markdown]
+        pass_filenames: false
+
       - id: cocogitto-check
         name: Check commit history
         entry: cog check

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,5 @@
+[MD013]
+line_length = 100
+# Allow longer lines in tables and code blocks
+tables = false
+code_blocks = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Initial project setup with Rust TUI framework (Ratatui)
 - Basic application structure with modules for Claude, Git, and UI
 - Pre-commit hooks using prek

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,13 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code)
+when working with code in this repository.
 
 ## Project
 
-Thurbox is a multi-session Claude Code TUI orchestrator built with Rust. It runs multiple `claude` CLI instances inside PTYs, rendered as terminal panels via ratatui + tui-term.
+Thurbox is a multi-session Claude Code TUI orchestrator built
+with Rust. It runs multiple `claude` CLI instances inside PTYs,
+rendered as terminal panels via ratatui + tui-term.
 
 ## Build & Development Commands
 
@@ -20,43 +23,50 @@ cargo run                            # Run in dev mode
 ```bash
 cargo nextest run --all              # Run all tests (preferred runner)
 cargo nextest run -E 'test(name)'    # Run a single test by name
-cargo nextest run --all --profile ci # Run with CI profile (retries, stricter timeouts)
+cargo nextest run --all --profile ci # Run with CI profile
 cargo test test_name                 # Run single test via cargo test
 ```
 
 ## Linting & Formatting
 
 ```bash
-cargo fmt --all                      # Format (rustfmt config in rustfmt.toml: 100 char max width)
-cargo clippy --all-targets --all-features -- -D warnings  # Lint (warnings = errors)
-RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features  # Doc warnings = errors
+cargo fmt --all                      # Format (rustfmt: 100 char max)
+cargo clippy --all-targets --all-features -- -D warnings  # Lint
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features  # Docs
+rumdl check .                        # Markdown lint (.rumdl.toml)
+rumdl fmt .                          # Markdown auto-fix
 ```
 
 ## Architecture Enforcement
 
 ```bash
-cargo modules structure --lib                                        # Module structure visualization
-cargo +nightly-2026-01-22 pup check --pup-config pup.ron             # Architecture rules (nightly required)
-cargo deny check advisories                                          # Security advisories
-cargo deny check bans licenses sources                               # Dependency policy
-cargo audit                                                          # Security audit
+cargo modules structure --lib                             # Module viz
+cargo +nightly-2026-01-22 pup check --pup-config pup.ron  # Arch rules
+cargo deny check advisories                               # Advisories
+cargo deny check bans licenses sources                    # Dep policy
+cargo audit                                               # Audit
 ```
 
 ## Conventional Commits
 
-All commits must follow [Conventional Commits](https://www.conventionalcommits.org/). Enforced by cocogitto via pre-commit hooks.
+All commits must follow
+[Conventional Commits](https://www.conventionalcommits.org/).
+Enforced by cocogitto via pre-commit hooks.
 
-- **Types**: feat, fix, perf, refactor, docs, style, test, chore, ci, build, revert
+- **Types**: feat, fix, perf, refactor, docs, style, test,
+  chore, ci, build, revert
 - **Scopes**: api, cli, ui, git, core, docs, deps, config
-- Use `cog commit feat "message"` or `cog commit fix "message" scope`
+- Use `cog commit feat "message"`
+  or `cog commit fix "message" scope`
 
 ## Architecture (TEA Pattern)
 
-The app follows **The Elm Architecture**: `Event → Message → update(model, msg) → view(model) → Frame`
+The app follows **The Elm Architecture**:
+`Event → Message → update(model, msg) → view(model) → Frame`
 
 ### Module Dependency Rules (enforced by pup.ron)
 
-```
+```text
 session  ← pure data types, no project-local imports
 claude   ← imports session only (NEVER ui or git)
 ui       ← imports session only (NEVER claude or git)
@@ -65,43 +75,64 @@ app      ← coordinator, imports all modules
 
 ### Module Responsibilities
 
-- **`app/`** — Model (`App` struct) + Update (`AppMessage` enum + `handle_key/resize`) + View. Owns all state, coordinates side effects.
-- **`claude/`** — Side-effect layer. `PtySession` spawns `claude` CLI in PTY via `portable-pty`, reads output into `Arc<Mutex<vt100::Parser>>`, writes input via mpsc channel. `input.rs` translates crossterm `KeyCode` → xterm ANSI byte sequences.
-- **`session/`** — Plain data: `SessionId`, `SessionStatus`, `SessionInfo`, `SessionConfig`. No logic beyond Display/Default impls.
-- **`ui/`** — Pure rendering functions. `layout.rs` computes panel areas (responsive: <80 cols = terminal only, >=80 = 2-panel, >=120 = optional 3-panel). Individual widgets: `session_list`, `terminal_view`, `info_panel`, `status_bar`.
+- **`app/`** — Model (`App` struct) + Update
+  (`AppMessage` enum + `handle_key/resize`) + View.
+  Owns all state, coordinates side effects.
+- **`claude/`** — Side-effect layer. `PtySession` spawns `claude`
+  CLI in PTY via `portable-pty`, reads output into
+  `Arc<Mutex<vt100::Parser>>`, writes input via mpsc channel.
+  `input.rs` translates crossterm `KeyCode` → xterm ANSI bytes.
+- **`session/`** — Plain data: `SessionId`, `SessionStatus`,
+  `SessionInfo`, `SessionConfig`.
+  No logic beyond Display/Default impls.
+- **`ui/`** — Pure rendering functions. `layout.rs` computes
+  panel areas (responsive: <80 = terminal only, >=80 = 2-panel,
+  >=120 = optional 3-panel). Widgets: `session_list`,
+  `terminal_view`, `info_panel`, `status_bar`.
 
 ### Event Loop (main.rs)
 
-```
+```text
 tokio::main → init terminal → spawn initial session → loop {
-    draw frame → poll crossterm events (10ms) → convert to AppMessage → app.update() → app.tick()
+    draw frame → poll crossterm events (10ms)
+    → convert to AppMessage → app.update() → app.tick()
 } → app.shutdown() → restore terminal
 ```
 
-- Logging goes to `~/.local/share/thurbox/thurbox.log` (file-based, since stdout is owned by the TUI)
+- Logging goes to `~/.local/share/thurbox/thurbox.log`
+  (file-based, since stdout is owned by the TUI)
 - Panic hook restores terminal before printing
 
 ## Pre-commit Hooks
 
-11 hooks run automatically via `prek` (Rust-based pre-commit framework). Install with `prek install`. Stages:
+12 hooks run automatically via `prek` (Rust-based pre-commit
+framework). Install with `prek install`. Stages:
+
 - **commit-msg**: conventional commit validation (`cog verify`)
-- **pre-commit**: fmt, clippy, check, nextest, modules, pup, deny, audit, doc
+- **pre-commit**: fmt, clippy, check, nextest, modules, pup,
+  deny, audit, doc, rumdl
 - **pre-push**: commit history check (`cog check`)
 
 ## Key Technical Details
 
 - MSRV: 1.75, Edition 2021
 - Async runtime: tokio (multi-threaded)
-- PTY reader runs in `tokio::task::spawn_blocking` (blocking I/O), writer in `tokio::spawn` (async)
-- Terminal state parsed by `vt100::Parser`, rendered by `tui_term::PseudoTerminal`
-- `Ctrl+Q` is the quit key (only key not forwarded to PTY when terminal is focused)
-- Architecture tests in `tests/architecture_rules.rs` are `#[ignore]` due to upstream cargo-pup bug with workspace detection
+- PTY reader runs in `tokio::task::spawn_blocking` (blocking I/O),
+  writer in `tokio::spawn` (async)
+- Terminal state parsed by `vt100::Parser`,
+  rendered by `tui_term::PseudoTerminal`
+- `Ctrl+Q` is the quit key
+  (only key not forwarded to PTY when terminal is focused)
+- Architecture tests in `tests/architecture_rules.rs` are
+  `#[ignore]` due to upstream cargo-pup bug with workspace detection
 
 ## Design Documentation
 
 For rationale behind decisions, see `docs/`:
+
 - `docs/CONSTITUTION.md` — Core principles and non-negotiable rules
 - `docs/ARCHITECTURE.md` — Architectural decisions with rationale
 - `docs/FEATURES.md` — Feature-level design choices
 
-**Rule**: If a code change invalidates or extends a documented decision, update the relevant doc in the same PR.
+**Rule**: If a code change invalidates or extends a documented
+decision, update the relevant doc in the same PR.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ cargo-modules = "0.19.0"
 cargo-deny = "0.16.0"
 cargo-audit = "0.21.0"
 cargo-pup = "0.1.5"  # requires nightly-2026-01-22
+rumdl = "0.1.19"
 
 [dev-dependencies]
 cargo_pup_lint_config = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Thurbox
 
-A TUI (Terminal User Interface) for orchestrating multiple Claude Code instances with advanced repository and git worktree management.
+A TUI (Terminal User Interface) for orchestrating multiple
+Claude Code instances with advanced repository
+and git worktree management.
 
 [![CI](https://github.com/Thurbeen/thurbox/workflows/CI/badge.svg)](https://github.com/Thurbeen/thurbox/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -66,6 +68,9 @@ cargo install cargo-deny
 # Security auditing
 cargo install cargo-audit
 
+# Markdown linting
+cargo install rumdl
+
 # Architecture validation (requires specific nightly)
 rustup toolchain install nightly-2026-01-22
 rustup component add --toolchain nightly-2026-01-22 rust-src rustc-dev llvm-tools-preview
@@ -73,6 +78,7 @@ cargo +nightly-2026-01-22 install cargo_pup
 ```
 
 **Tip**: Install `cargo-binstall` for faster tool installation:
+
 ```bash
 cargo install cargo-binstall
 ```
@@ -80,17 +86,20 @@ cargo install cargo-binstall
 ### Initial Setup
 
 1. Clone the repository:
+
 ```bash
 git clone https://github.com/Thurbeen/thurbox.git
 cd thurbox
 ```
 
 2. Install pre-commit hooks:
+
 ```bash
 prek install
 ```
 
 3. Verify setup:
+
 ```bash
 cargo check
 cargo test
@@ -194,7 +203,7 @@ cog commit feat -B "redesign API interface" api
 
 Thurbox follows a modular architecture with clear separation of concerns:
 
-```
+```text
 thurbox/
 ├── src/
 │   ├── main.rs          # Application entry point

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,91 +1,147 @@
 # Architecture Decisions
 
-Each decision follows a mini-ADR format: **Choice**, **Why**, **Rejected alternatives**.
+Each decision follows a mini-ADR format:
+**Choice**, **Why**, **Rejected alternatives**.
 
 ---
 
 ## ADR-1: The Elm Architecture (TEA)
 
-**Choice**: All state lives in a single `App` model. Events become messages, `update()` applies them, `view()` renders the result.
+**Choice**: All state lives in a single `App` model.
+Events become messages, `update()` applies them,
+`view()` renders the result.
 
-**Why**: TEA makes state transitions explicit and testable. Every input has a traceable path from event to screen change. There's no hidden state scattered across components, which matters a lot when multiple PTY sessions are producing concurrent output.
+**Why**: TEA makes state transitions explicit and testable.
+Every input has a traceable path from event to screen change.
+There's no hidden state scattered across components, which matters
+when multiple PTY sessions are producing concurrent output.
 
 **Rejected**:
-- *Component-based (each panel owns state)* — leads to synchronization bugs when sessions interact.
-- *Ad-hoc event handlers* — untraceable control flow; hard to reason about as the app grows.
+
+- *Component-based (each panel owns state)* — leads to
+  synchronization bugs when sessions interact.
+- *Ad-hoc event handlers* — untraceable control flow;
+  hard to reason about as the app grows.
 
 ---
 
 ## ADR-2: PTY pipeline — portable-pty + vt100 + tui-term
 
-**Choice**: `portable-pty` spawns the `claude` CLI, `vt100::Parser` interprets escape sequences, `tui_term::PseudoTerminal` renders the parsed screen into ratatui.
+**Choice**: `portable-pty` spawns the `claude` CLI,
+`vt100::Parser` interprets escape sequences,
+`tui_term::PseudoTerminal` renders the parsed screen into ratatui.
 
-**Why**: Each crate handles exactly one concern. `portable-pty` abstracts platform differences (Linux, macOS). `vt100` gives us a full in-memory terminal state we can query without scraping. `tui_term` bridges that state to ratatui widgets with zero custom rendering code.
+**Why**: Each crate handles exactly one concern. `portable-pty`
+abstracts platform differences (Linux, macOS). `vt100` gives us a
+full in-memory terminal state we can query without scraping.
+`tui_term` bridges that state to ratatui widgets
+with zero custom rendering code.
 
 **Rejected**:
-- *`nix::pty` directly* — Linux-only; would require a separate Windows/macOS backend.
-- *`alacritty_terminal`* — full terminal emulator, far heavier than needed. We don't need font rendering or GPU acceleration.
-- *Parsing raw ANSI ourselves* — error-prone, massive surface area, already solved by `vt100`.
+
+- *`nix::pty` directly* — Linux-only;
+  would require a separate Windows/macOS backend.
+- *`alacritty_terminal`* — full terminal emulator,
+  far heavier than needed.
+  We don't need font rendering or GPU acceleration.
+- *Parsing raw ANSI ourselves* — error-prone,
+  massive surface area, already solved by `vt100`.
 
 ---
 
-## ADR-3: Async design — tokio multi-threaded + spawn_blocking for PTY reads
+## ADR-3: Async — tokio multi-threaded + spawn_blocking
 
-**Choice**: The app runs on tokio's multi-threaded runtime. PTY read loops run inside `spawn_blocking` (blocking I/O in a threadpool), while PTY write and event handling run in `tokio::spawn` (async).
+**Choice**: The app runs on tokio's multi-threaded runtime.
+PTY read loops run inside `spawn_blocking`
+(blocking I/O in a threadpool), while PTY write and event handling
+run in `tokio::spawn` (async).
 
-**Why**: PTY reads are blocking by nature (`read()` on a file descriptor). Putting them in `spawn_blocking` prevents stalling the async executor. The writer side is naturally async — it awaits messages from an mpsc channel and writes when they arrive.
+**Why**: PTY reads are blocking by nature
+(`read()` on a file descriptor). Putting them in `spawn_blocking`
+prevents stalling the async executor. The writer side is naturally
+async — it awaits messages from an mpsc channel
+and writes when they arrive.
 
 **Rejected**:
-- *Single-threaded tokio* — PTY reads would block the entire runtime, freezing the UI.
-- *`std::thread` for everything* — works but loses tokio's structured concurrency, select!, and channel ergonomics.
+
+- *Single-threaded tokio* — PTY reads would block the entire
+  runtime, freezing the UI.
+- *`std::thread` for everything* — works but loses tokio's
+  structured concurrency, select!, and channel ergonomics.
 
 ---
 
 ## ADR-4: Input translation — crossterm KeyCode to xterm ANSI
 
-**Choice**: `input.rs` maps crossterm `KeyCode`/`KeyModifiers` to raw xterm ANSI byte sequences before writing to the PTY.
+**Choice**: `input.rs` maps crossterm `KeyCode`/`KeyModifiers`
+to raw xterm ANSI byte sequences before writing to the PTY.
 
-**Why**: crossterm gives us structured key events. PTYs expect raw bytes. The translation layer is explicit and testable — each key has a known byte sequence, and edge cases (arrow keys, function keys, modifier combos) are handled in one place.
+**Why**: crossterm gives us structured key events.
+PTYs expect raw bytes. The translation layer is explicit and
+testable — each key has a known byte sequence, and edge cases
+(arrow keys, function keys, modifier combos)
+are handled in one place.
 
 **Rejected**:
-- *Raw passthrough (forward crossterm's raw bytes)* — crossterm's internal byte representation doesn't match xterm sequences. Modifier keys, in particular, would break.
+
+- *Raw passthrough (forward crossterm's raw bytes)* —
+  crossterm's internal byte representation doesn't match xterm
+  sequences. Modifier keys, in particular, would break.
 
 ---
 
 ## ADR-5: Responsive layout breakpoints
 
 **Choice**: Three layout tiers based on terminal width:
+
 - `<80 cols` — terminal panel only (full screen)
 - `>=80 cols` — two panels (session list + terminal)
 - `>=120 cols` — three panels (session list + terminal + info)
 
-**Why**: 80 columns is the smallest usable terminal width. Below that, showing a sidebar wastes too much space. At 120+, there's room for supplementary info without shrinking the terminal panel below readable width. Fixed breakpoints are predictable — the layout never "jitters" near a threshold.
+**Why**: 80 columns is the smallest usable terminal width. Below
+that, showing a sidebar wastes too much space. At 120+, there's
+room for supplementary info without shrinking the terminal panel
+below readable width. Fixed breakpoints are predictable — the
+layout never "jitters" near a threshold.
 
 **Rejected**:
+
 - *Fixed layout (always 3 panels)* — unusable on small terminals.
-- *User-configurable breakpoints* — premature complexity. Can be added later if needed.
+- *User-configurable breakpoints* — premature complexity.
+  Can be added later if needed.
 
 ---
 
 ## ADR-6: File-based logging only
 
-**Choice**: All tracing output goes to `~/.local/share/thurbox/thurbox.log`. Nothing writes to stdout or stderr.
+**Choice**: All tracing output goes to
+`~/.local/share/thurbox/thurbox.log`.
+Nothing writes to stdout or stderr.
 
-**Why**: The TUI owns stdout entirely. Any stray `println!` or log line to stdout would corrupt the terminal display. File-based logging also makes it easy to `tail -f` the log in a second terminal while developing.
+**Why**: The TUI owns stdout entirely. Any stray `println!` or
+log line to stdout would corrupt the terminal display. File-based
+logging also makes it easy to `tail -f` the log in a second
+terminal while developing.
 
 **Rejected**:
-- *Stderr logging* — crossterm's alternate screen captures stderr on some platforms, still risks display corruption.
-- *In-app log panel* — useful eventually, but adds complexity before the core features are stable.
+
+- *Stderr logging* — crossterm's alternate screen captures stderr
+  on some platforms, still risks display corruption.
+- *In-app log panel* — useful eventually, but adds complexity
+  before the core features are stable.
 
 ---
 
 ## ADR-7: Build profiles
 
-| Profile | `opt-level` | LTO | `codegen-units` | `strip` | `debug` | Use case |
-|---------|-------------|-----|------------------|---------|---------|----------|
-| `dev` | 0 | off | default | no | yes | Fast iteration |
-| `test` | 1 | off | default | no | yes | Faster test execution without sacrificing debuggability |
-| `release` | 3 | thin → full | 1 | yes | no | Distribution binary (smallest, fastest) |
-| `release-with-debug` | 3 | full | 1 | no | yes | Profiling and performance investigation |
+| Profile | `opt-level` | LTO | Strip | Debug | Use case |
+|---|---|---|---|---|---|
+| `dev` | 0 | off | no | yes | Fast iteration |
+| `test` | 1 | off | no | yes | Faster tests, still debuggable |
+| `release` | 3 | full | yes | no | Distribution binary |
+| `release-with-debug` | 3 | full | no | yes | Profiling / flamegraph |
 
-**Why**: `test` at opt-level 1 catches optimization-dependent bugs earlier while keeping compile times reasonable. The release profile strips everything for a minimal binary. `release-with-debug` exists specifically for `perf` / `flamegraph` workflows.
+**Why**: `test` at opt-level 1 catches optimization-dependent bugs
+earlier while keeping compile times reasonable. The release profile
+strips everything for a minimal binary. `release-with-debug` exists
+specifically for `perf` / `flamegraph` workflows.

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -1,53 +1,70 @@
 # Constitution
 
-Non-negotiable rules that define what Thurbox **must** always be. Each principle has an automated enforcement mechanism — if it can't be enforced, it doesn't belong here.
+Non-negotiable rules that define what Thurbox **must** always be.
+Each principle has an automated enforcement mechanism
+— if it can't be enforced, it doesn't belong here.
 
 ## Principles
 
 ### 1. Crash-free operation
 
-Errors are displayed in the UI (status bar / footer), never via panics. The only panic path is the emergency terminal-restore hook in `main.rs`, which exists to leave the user's terminal in a usable state if something truly unexpected happens.
+Errors are displayed in the UI (status bar / footer), never via panics.
+The only panic path is the emergency terminal-restore hook in `main.rs`,
+which exists to leave the user's terminal in a usable state
+if something truly unexpected happens.
 
 ### 2. Module isolation
 
 Dependency flow is strictly one-directional:
 
-```
+```text
 session  (no project-local imports)
 claude   → session
 ui       → session
 app      → session, claude, ui
 ```
 
-`claude` and `ui` never import each other. This keeps the side-effect layer (PTY management) completely decoupled from the rendering layer.
+`claude` and `ui` never import each other. This keeps the side-effect
+layer (PTY management) completely decoupled from the rendering layer.
 
 ### 3. Zero-warning policy
 
-Both `clippy` and `rustdoc` run with warnings promoted to errors. If it compiles with warnings, CI fails.
+Both `clippy` and `rustdoc` run with warnings promoted to errors.
+`rumdl` enforces markdown style (100-char line width, consistent
+formatting). If any linter reports warnings, CI fails.
 
 ### 4. Permissive licenses only
 
-All dependencies must carry licenses from the allowlist in `deny.toml`. Copyleft crates are rejected at PR time.
+All dependencies must carry licenses from the allowlist in `deny.toml`.
+Copyleft crates are rejected at PR time.
 
 ### 5. Zero known vulnerabilities
 
-`cargo-deny` advisories and `cargo-audit` block merges when known CVEs affect the dependency tree.
+`cargo-deny` advisories and `cargo-audit` block merges
+when known CVEs affect the dependency tree.
 
 ### 6. Conventional commits
 
-Every commit message is validated against the Conventional Commits spec by `cocogitto`. Non-conforming commits are rejected by the `commit-msg` hook.
+Every commit message is validated against the Conventional Commits spec
+by `cocogitto`. Non-conforming commits are rejected
+by the `commit-msg` hook.
 
 ### 7. TEA as the single architectural pattern
 
-The Elm Architecture (`Event -> Message -> update -> view -> Frame`) is the only sanctioned control-flow pattern. No ad-hoc event handlers, no component-local state, no callback chains.
+The Elm Architecture (`Event -> Message -> update -> view -> Frame`)
+is the only sanctioned control-flow pattern.
+No ad-hoc event handlers, no component-local state, no callback chains.
 
 ### 8. PTY-first session model
 
-Claude Code sessions run inside real PTYs (`portable-pty`). We never mock, emulate, or screen-scrape a fake terminal. The PTY is the source of truth.
+Claude Code sessions run inside real PTYs (`portable-pty`).
+We never mock, emulate, or screen-scrape a fake terminal.
+The PTY is the source of truth.
 
 ### 9. Logging never touches stdout
 
-Stdout belongs to the TUI. All diagnostic output goes to the log file at `~/.local/share/thurbox/thurbox.log`.
+Stdout belongs to the TUI. All diagnostic output goes to the log file
+at `~/.local/share/thurbox/thurbox.log`.
 
 ### 10. Test-driven development (Red, Green, Refactor)
 
@@ -57,19 +74,28 @@ All features and bug fixes follow the TDD/BDD cycle:
 2. **Green** — Write the minimum code to make the test pass.
 3. **Refactor** — Clean up while keeping tests green.
 
-Tests are written *before* or *alongside* the implementation, never as an afterthought. If a bug is reported, the fix starts with a test that reproduces it.
+Tests are written *before* or *alongside* the implementation,
+never as an afterthought. If a bug is reported,
+the fix starts with a test that reproduces it.
 
 ### 11. Deterministic CI — scripts over LLMs
 
-CI pipelines must be reproducible and deterministic. Every check is a script or tool that produces the same result given the same input. LLM-generated judgments (code review bots, AI-powered linters) are never gating — they may advise, but deterministic tools (`clippy`, `nextest`, `cargo-deny`, `cog`) make the pass/fail decision. Changes to CI configuration require careful review because a broken pipeline affects every contributor.
+CI pipelines must be reproducible and deterministic. Every check is a
+script or tool that produces the same result given the same input.
+LLM-generated judgments (code review bots, AI-powered linters)
+are never gating — they may advise, but deterministic tools
+(`clippy`, `nextest`, `cargo-deny`, `cog`, `rumdl`)
+make the pass/fail decision.
+Changes to CI configuration require careful review
+because a broken pipeline affects every contributor.
 
 ## Enforcement Map
 
 | Principle | Enforced by | Config file |
-|-----------|-------------|-------------|
+|---|---|---|
 | Crash-free operation | Code review + `#[deny(clippy::unwrap_used)]` (planned) | `clippy.toml` |
 | Module isolation | `cargo-pup` | `pup.ron` |
-| Zero warnings | `clippy -D warnings` + `RUSTDOCFLAGS="-D warnings"` | CI + pre-commit |
+| Zero warnings | `clippy -D warnings` + `RUSTDOCFLAGS="-D warnings"` + `rumdl` | CI + pre-commit |
 | Permissive licenses | `cargo-deny check bans licenses` | `deny.toml` |
 | Zero vulnerabilities | `cargo-deny check advisories` + `cargo-audit` | `deny.toml` |
 | Conventional commits | `cocogitto` (`cog verify`) | `cog.toml` |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,7 @@
 # Feature Decisions
 
-Design rationale for user-facing behavior. For architectural choices, see [ARCHITECTURE.md](ARCHITECTURE.md).
+Design rationale for user-facing behavior.
+For architectural choices, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---
 
@@ -8,12 +9,21 @@ Design rationale for user-facing behavior. For architectural choices, see [ARCHI
 
 ### Philosophy: Ctrl = global, everything else = PTY
 
-When the terminal panel is focused, **all keys are forwarded to the PTY** except those with a `Ctrl` modifier. Ctrl-prefixed keys are intercepted by Thurbox as global commands.
+When the terminal panel is focused,
+**all keys are forwarded to the PTY** except those with a `Ctrl`
+modifier. Ctrl-prefixed keys are intercepted by Thurbox
+as global commands.
 
 **Why Ctrl, not Alt?**
-- Claude Code and shell programs heavily use Alt-key combinations. Intercepting Alt would break readline, vim, and Claude's own keybindings.
-- Ctrl has well-established precedent for "meta" actions in terminal multiplexers (tmux uses `Ctrl+B`, screen uses `Ctrl+A`).
-- Ctrl combos are easier to type one-handed, which matters for a tool you use alongside other terminals.
+
+- Claude Code and shell programs heavily use Alt-key combinations.
+  Intercepting Alt would break readline, vim,
+  and Claude's own keybindings.
+- Ctrl has well-established precedent for "meta" actions
+  in terminal multiplexers
+  (tmux uses `Ctrl+B`, screen uses `Ctrl+A`).
+- Ctrl combos are easier to type one-handed, which matters
+  for a tool you use alongside other terminals.
 
 ### Keybinding Table
 
@@ -31,7 +41,7 @@ When the terminal panel is focused, **all keys are forwarded to the PTY** except
 
 ## Session Lifecycle
 
-```
+```text
 Create (UUID v4) → Running → Idle / Error
                       ↓
                   Shutdown (SIGHUP)
@@ -39,14 +49,23 @@ Create (UUID v4) → Running → Idle / Error
 
 ### States
 
-- **Running**: PTY is alive, read loop is active, output is streaming to the terminal widget.
-- **Idle**: Claude CLI has exited cleanly (exit code 0). Session is still displayed but no longer accepts input.
-- **Error**: PTY or Claude CLI exited with a non-zero code. Error details shown in status bar.
-- **Shutdown**: Triggered by the user closing a session or quitting the app. Sends `SIGHUP` to the PTY child process, then waits for clean exit before dropping resources.
+- **Running**: PTY is alive, read loop is active,
+  output is streaming to the terminal widget.
+- **Idle**: Claude CLI has exited cleanly (exit code 0).
+  Session is still displayed but no longer accepts input.
+- **Error**: PTY or Claude CLI exited with a non-zero code.
+  Error details shown in status bar.
+- **Shutdown**: Triggered by the user closing a session or
+  quitting the app. Sends `SIGHUP` to the PTY child process,
+  then waits for clean exit before dropping resources.
 
 ### Why UUID v4?
 
-Sessions need unique identifiers for the lifetime of the process. UUIDs are collision-free without coordination, simple to generate, and usable as map keys. Sequential IDs would work too, but UUIDs prevent bugs where an old session ID accidentally refers to a new session after recycling.
+Sessions need unique identifiers for the lifetime of the process.
+UUIDs are collision-free without coordination, simple to generate,
+and usable as map keys. Sequential IDs would work too, but UUIDs
+prevent bugs where an old session ID accidentally refers to
+a new session after recycling.
 
 ---
 
@@ -54,12 +73,20 @@ Sessions need unique identifiers for the lifetime of the process. UUIDs are coll
 
 ### Rule: never crash, never modal
 
-Errors are shown in the status bar footer as transient messages. They do not block interaction, do not require dismissal, and auto-clear after a timeout or on the next successful action.
+Errors are shown in the status bar footer as transient messages.
+They do not block interaction, do not require dismissal,
+and auto-clear after a timeout or on the next successful action.
 
 **Why non-modal?**
-- Modal error dialogs in a TUI are jarring — they steal focus from the terminal where the user is working.
-- Most errors are recoverable (session failed to start, PTY read error). Showing them passively lets the user decide when to act.
-- Fatal errors (can't initialize terminal) are the only case where the app exits, and those happen before the TUI is even rendered.
+
+- Modal error dialogs in a TUI are jarring — they steal focus
+  from the terminal where the user is working.
+- Most errors are recoverable (session failed to start,
+  PTY read error). Showing them passively lets the user
+  decide when to act.
+- Fatal errors (can't initialize terminal) are the only case
+  where the app exits, and those happen before the TUI
+  is even rendered.
 
 ---
 
@@ -69,21 +96,30 @@ Errors are shown in the status bar footer as transient messages. They do not blo
 
 | Width | Layout | Why |
 |-------|--------|-----|
-| `<80 cols` | Terminal only | Below 80 columns, a sidebar would leave <60 cols for the terminal — too narrow for most CLI tools. Full-screen maximizes readability. |
-| `>=80 cols` | Session list + terminal | 20-col sidebar + 60-col terminal is the minimum comfortable split. The session list provides at-a-glance multi-session awareness. |
-| `>=120 cols` | Session list + terminal + info panel | At 120 cols, the terminal still gets ~70+ columns after both sidebars. The info panel shows session metadata without switching views. |
+| `<80` | Terminal only | Sidebar would leave <60 cols — too narrow |
+| `>=80` | List + terminal | 20-col sidebar + 60-col terminal minimum |
+| `>=120` | List + terminal + info | Terminal still gets ~70+ cols |
 
 ### Why not user-configurable?
 
-Configurable breakpoints add UI, storage, and edge-case complexity for minimal gain. The fixed values cover standard terminal sizes (80, 120, 160+). If a user resizes their terminal, the layout adapts instantly. Custom breakpoints can be added later if real demand emerges.
+Configurable breakpoints add UI, storage, and edge-case complexity
+for minimal gain. The fixed values cover standard terminal sizes
+(80, 120, 160+). If a user resizes their terminal, the layout
+adapts instantly. Custom breakpoints can be added later
+if real demand emerges.
 
 ---
 
 ## Planned Features
 
-Directional intent, not commitments. These may change as the project evolves.
+Directional intent, not commitments.
+These may change as the project evolves.
 
-- **Multi-session orchestration**: Run N Claude Code instances side-by-side, switch between them, broadcast input to all.
-- **Git worktree integration**: Automatically create worktrees for parallel tasks, one session per worktree.
-- **Session persistence**: Save/restore session layouts and PTY history across restarts.
-- **Task delegation**: Split a task across multiple sessions with dependency tracking.
+- **Multi-session orchestration**: Run N Claude Code instances
+  side-by-side, switch between them, broadcast input to all.
+- **Git worktree integration**: Automatically create worktrees
+  for parallel tasks, one session per worktree.
+- **Session persistence**: Save/restore session layouts
+  and PTY history across restarts.
+- **Task delegation**: Split a task across multiple sessions
+  with dependency tracking.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,21 @@
 # Design Documentation
 
-This directory contains the **rationale** behind Thurbox's design decisions. For operational guidance (build commands, module layout, event loop), see [`CLAUDE.md`](../CLAUDE.md).
+This directory contains the **rationale** behind Thurbox's design
+decisions. For operational guidance (build commands, module layout,
+event loop), see [`CLAUDE.md`](../CLAUDE.md).
 
 ## Documents
 
 | Document | Purpose | Update when... |
-|----------|---------|----------------|
-| [CONSTITUTION.md](CONSTITUTION.md) | Core principles and non-negotiable rules | Adding/removing an enforced invariant |
-| [ARCHITECTURE.md](ARCHITECTURE.md) | Architectural decisions with rationale | Changing a technology choice or structural pattern |
-| [FEATURES.md](FEATURES.md) | Feature-level design choices | Altering keybindings, lifecycle, layout, or UX behavior |
+|---|---|---|
+| [CONSTITUTION.md](CONSTITUTION.md) | Core principles | Adding/removing an enforced invariant |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Architecture decisions | Changing a technology or structural pattern |
+| [FEATURES.md](FEATURES.md) | Feature-level design | Altering keybindings, lifecycle, layout, or UX |
 
 ## Keeping Docs Current
 
-**Rule**: If a code change invalidates or extends a documented decision, update the relevant doc in the same PR.
+**Rule**: If a code change invalidates or extends a documented decision,
+update the relevant doc in the same PR.
 
 - Operational changes (new commands, module moves) go in `CLAUDE.md`
 - Decisional changes (why we chose X over Y) go in `docs/`

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -23,6 +23,7 @@ $INSTALL_CMD cargo-nextest
 $INSTALL_CMD cargo-modules
 $INSTALL_CMD cargo-deny
 $INSTALL_CMD cargo-audit
+$INSTALL_CMD rumdl
 
 # Install nightly tools
 echo ""


### PR DESCRIPTION
## Summary

- Adds **rumdl** (Rust-native markdown linter) to the dev toolchain
- `.rumdl.toml` config: 100-char line width matching rustfmt, tables/code blocks exempt
- Pre-commit hook added to `.pre-commit-config.yaml`
- `Cargo.toml` dev-tools, `scripts/install-dev-tools.sh`, and `README.md` manual install updated
- `CLAUDE.md` updated with `rumdl check .` / `rumdl fmt .` commands, hook count bumped to 12
- All 98 existing markdown lint issues fixed across 7 files (line wrapping, blank lines, code block languages)
- `docs/CONSTITUTION.md` updated: rumdl added to zero-warning policy (principle 3), deterministic CI tools list (principle 11), and enforcement map

## Test plan

- [x] `rumdl check .` passes clean (0 issues, 31ms)
- [x] `cargo check --all` passes
- [x] All 12 pre-commit hooks pass (including new rumdl-check)
- [x] Pre-push hook passes