### PR TITLE
feat(git): add git worktree support for branch-isolated sessions

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,0 +1,149 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+/// List local branch names for a repo.
+pub fn list_branches(repo_path: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["branch", "--format=%(refname:short)"])
+        .current_dir(repo_path)
+        .output()
+        .context("failed to run git branch")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git branch failed: {stderr}");
+    }
+
+    let branches = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    Ok(branches)
+}
+
+/// Create a git worktree on a new branch and return the worktree directory path.
+///
+/// Creates `new_branch` starting from `base_branch`.
+/// Path format: `<repo>/.git/thurbox-worktrees/<sanitized-new-branch>`
+pub fn create_worktree(repo_path: &Path, new_branch: &str, base_branch: &str) -> Result<PathBuf> {
+    let wt_path = worktree_path(repo_path, new_branch);
+
+    let output = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            new_branch,
+            &wt_path.display().to_string(),
+            base_branch,
+        ])
+        .current_dir(repo_path)
+        .output()
+        .context("failed to run git worktree add")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git worktree add failed: {stderr}");
+    }
+
+    Ok(wt_path)
+}
+
+/// Remove a git worktree (force removal).
+pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
+    let output = Command::new("git")
+        .args([
+            "worktree",
+            "remove",
+            "--force",
+            &worktree_path.display().to_string(),
+        ])
+        .current_dir(repo_path)
+        .output()
+        .context("failed to run git worktree remove")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git worktree remove failed: {stderr}");
+    }
+
+    Ok(())
+}
+
+/// Deterministic worktree directory path for a repo + branch.
+fn worktree_path(repo_path: &Path, branch: &str) -> PathBuf {
+    let sanitized = branch.replace('/', "-");
+    repo_path
+        .join(".git")
+        .join("thurbox-worktrees")
+        .join(sanitized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worktree_path_simple_branch() {
+        let repo = Path::new("/home/user/repo");
+        let result = worktree_path(repo, "main");
+        assert_eq!(
+            result,
+            PathBuf::from("/home/user/repo/.git/thurbox-worktrees/main")
+        );
+    }
+
+    #[test]
+    fn worktree_path_slash_branch() {
+        let repo = Path::new("/home/user/repo");
+        let result = worktree_path(repo, "feature/foo");
+        assert_eq!(
+            result,
+            PathBuf::from("/home/user/repo/.git/thurbox-worktrees/feature-foo")
+        );
+    }
+
+    #[test]
+    fn worktree_path_nested_slashes() {
+        let repo = Path::new("/home/user/repo");
+        let result = worktree_path(repo, "feature/team/task");
+        assert_eq!(
+            result,
+            PathBuf::from("/home/user/repo/.git/thurbox-worktrees/feature-team-task")
+        );
+    }
+
+    #[test]
+    fn worktree_path_no_slashes_unchanged() {
+        let repo = Path::new("/repo");
+        let result = worktree_path(repo, "my-branch");
+        assert_eq!(
+            result,
+            PathBuf::from("/repo/.git/thurbox-worktrees/my-branch")
+        );
+    }
+
+    #[test]
+    fn worktree_path_trailing_slash() {
+        let repo = Path::new("/repo");
+        let result = worktree_path(repo, "branch/");
+        assert_eq!(
+            result,
+            PathBuf::from("/repo/.git/thurbox-worktrees/branch-")
+        );
+    }
+
+    #[test]
+    fn worktree_path_leading_slash() {
+        let repo = Path::new("/repo");
+        let result = worktree_path(repo, "/branch");
+        assert_eq!(
+            result,
+            PathBuf::from("/repo/.git/thurbox-worktrees/-branch")
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod app;
 pub mod claude;
+pub mod git;
 pub mod project;
 pub mod session;
 pub mod ui;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -3,6 +3,13 @@ use std::path::PathBuf;
 
 use uuid::Uuid;
 
+#[derive(Debug, Clone)]
+pub struct WorktreeInfo {
+    pub repo_path: PathBuf,
+    pub worktree_path: PathBuf,
+    pub branch: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SessionId(Uuid);
 
@@ -49,6 +56,7 @@ pub struct SessionInfo {
     pub id: SessionId,
     pub name: String,
     pub status: SessionStatus,
+    pub worktree: Option<WorktreeInfo>,
 }
 
 impl SessionInfo {
@@ -57,6 +65,7 @@ impl SessionInfo {
             id: SessionId::default(),
             name,
             status: SessionStatus::Running,
+            worktree: None,
         }
     }
 }
@@ -106,5 +115,26 @@ mod tests {
         let info = SessionInfo::new("Test".to_string());
         assert_eq!(info.name, "Test");
         assert_eq!(info.status, SessionStatus::Running);
+    }
+
+    #[test]
+    fn session_info_new_has_no_worktree() {
+        let info = SessionInfo::new("Test".to_string());
+        assert!(info.worktree.is_none());
+    }
+
+    #[test]
+    fn worktree_info_stores_fields() {
+        let wt = WorktreeInfo {
+            repo_path: PathBuf::from("/repo"),
+            worktree_path: PathBuf::from("/repo/.git/thurbox-worktrees/feat"),
+            branch: "feat".to_string(),
+        };
+        assert_eq!(wt.repo_path, PathBuf::from("/repo"));
+        assert_eq!(
+            wt.worktree_path,
+            PathBuf::from("/repo/.git/thurbox-worktrees/feat")
+        );
+        assert_eq!(wt.branch, "feat");
     }
 }

--- a/src/ui/add_project_modal.rs
+++ b/src/ui/add_project_modal.rs
@@ -1,12 +1,12 @@
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout},
     style::{Color, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
-use super::centered_fixed_height_rect;
+use super::{centered_fixed_height_rect, render_text_field};
 use crate::app::AddProjectField;
 
 pub struct AddProjectModalState<'a> {
@@ -68,60 +68,4 @@ pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<
     ]);
     let footer_paragraph = Paragraph::new(footer);
     frame.render_widget(footer_paragraph, chunks[2]);
-}
-
-fn render_text_field(
-    frame: &mut Frame,
-    area: Rect,
-    label: &str,
-    value: &str,
-    cursor: usize,
-    focused: bool,
-) {
-    let border_color = if focused { Color::Cyan } else { Color::Gray };
-
-    let block = Block::default()
-        .title(format!(" {label} "))
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(border_color));
-
-    let inner = block.inner(area);
-
-    // Build display text with cursor
-    let display = if focused {
-        let chars: Vec<char> = value.chars().collect();
-        let (before, after) = if cursor <= chars.len() {
-            let before: String = chars[..cursor].iter().collect();
-            let after: String = chars[cursor..].iter().collect();
-            (before, after)
-        } else {
-            (value.to_string(), String::new())
-        };
-
-        let cursor_char = if after.is_empty() {
-            " ".to_string()
-        } else {
-            after.chars().next().unwrap().to_string()
-        };
-
-        let rest = if after.len() > cursor_char.len() {
-            &after[cursor_char.len()..]
-        } else {
-            ""
-        };
-
-        Line::from(vec![
-            Span::styled(before, Style::default().fg(Color::White)),
-            Span::styled(
-                cursor_char,
-                Style::default().fg(Color::Black).bg(Color::White),
-            ),
-            Span::styled(rest.to_string(), Style::default().fg(Color::White)),
-        ])
-    } else {
-        Line::from(Span::styled(value, Style::default().fg(Color::White)))
-    };
-
-    frame.render_widget(block, area);
-    frame.render_widget(Paragraph::new(display), inner);
 }

--- a/src/ui/branch_selector_modal.rs
+++ b/src/ui/branch_selector_modal.rs
@@ -1,0 +1,71 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    Frame,
+};
+
+use super::centered_fixed_height_rect;
+
+pub struct BranchSelectorState<'a> {
+    pub branches: &'a [String],
+    pub selected_index: usize,
+}
+
+pub fn render_branch_selector_modal(frame: &mut Frame, state: &BranchSelectorState<'_>) {
+    let height = (state.branches.len().min(15) + 4) as u16;
+    let area = centered_fixed_height_rect(50, height, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Base Branch ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),    // Branch list
+            Constraint::Length(1), // Footer
+        ])
+        .split(inner);
+
+    let items: Vec<ListItem<'_>> = state
+        .branches
+        .iter()
+        .enumerate()
+        .map(|(i, branch)| {
+            let style = if i == state.selected_index {
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            let prefix = if i == state.selected_index {
+                "▸ "
+            } else {
+                "  "
+            };
+            ListItem::new(Line::from(Span::styled(format!("{prefix}{branch}"), style)))
+        })
+        .collect();
+
+    let list = List::new(items);
+    frame.render_widget(list, chunks[0]);
+
+    let footer = Line::from(vec![
+        Span::styled("j/k", Style::default().fg(Color::Yellow)),
+        Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[1]);
+}

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -77,6 +77,27 @@ pub fn render_info_panel(
         Span::styled(info.id.to_string(), Style::default().fg(Color::DarkGray)),
     ]));
 
+    if let Some(wt) = &info.worktree {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Worktree",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(vec![
+            Span::styled("Branch: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&wt.branch, Style::default().fg(Color::Green)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("Path: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                wt.worktree_path.display().to_string(),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+    }
+
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
 }

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -128,12 +128,19 @@ fn render_session_section(
                 Style::default().fg(Color::White)
             };
 
-            let line = Line::from(vec![
+            let mut spans = vec![
                 Span::styled(format!("{} ", info.status.icon()), style),
                 Span::styled(&info.name, style),
-            ]);
+            ];
 
-            ListItem::new(line)
+            if let Some(wt) = &info.worktree {
+                spans.push(Span::styled(
+                    format!(" [{}]", wt.branch),
+                    Style::default().fg(Color::Green),
+                ));
+            }
+
+            ListItem::new(Line::from(spans))
         })
         .collect();
 

--- a/src/ui/session_mode_modal.rs
+++ b/src/ui/session_mode_modal.rs
@@ -1,0 +1,70 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    Frame,
+};
+
+use super::centered_fixed_height_rect;
+
+const MODES: [&str; 2] = ["Normal", "Worktree"];
+
+pub struct SessionModeState {
+    pub selected_index: usize,
+}
+
+pub fn render_session_mode_modal(frame: &mut Frame, state: &SessionModeState) {
+    let area = centered_fixed_height_rect(50, 6, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Session Mode ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),    // Mode list
+            Constraint::Length(1), // Footer
+        ])
+        .split(inner);
+
+    let items: Vec<ListItem<'_>> = MODES
+        .iter()
+        .enumerate()
+        .map(|(i, mode)| {
+            let style = if i == state.selected_index {
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            let prefix = if i == state.selected_index {
+                "▸ "
+            } else {
+                "  "
+            };
+            ListItem::new(Line::from(Span::styled(format!("{prefix}{mode}"), style)))
+        })
+        .collect();
+
+    let list = List::new(items);
+    frame.render_widget(list, chunks[0]);
+
+    let footer = Line::from(vec![
+        Span::styled("j/k", Style::default().fg(Color::Yellow)),
+        Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[1]);
+}

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -16,7 +16,11 @@ pub fn render_terminal(
     info: &SessionInfo,
     focused: bool,
 ) {
-    let title = format!(" {} [{}] ", info.name, info.status);
+    let title = if let Some(wt) = &info.worktree {
+        format!(" {} [{}] [{}] ", info.name, wt.branch, info.status)
+    } else {
+        format!(" {} [{}] ", info.name, info.status)
+    };
     let block = focused_block(&title, focused);
 
     let pseudo_term = PseudoTerminal::new(parser.screen())

--- a/src/ui/worktree_name_modal.rs
+++ b/src/ui/worktree_name_modal.rs
@@ -1,0 +1,54 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use super::centered_fixed_height_rect;
+
+pub struct WorktreeNameState<'a> {
+    pub name: &'a str,
+    pub cursor: usize,
+    pub base_branch: &'a str,
+}
+
+pub fn render_worktree_name_modal(frame: &mut Frame, state: &WorktreeNameState<'_>) {
+    let area = centered_fixed_height_rect(50, 8, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(format!(" New Branch (from {}) ", state.base_branch))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Name field
+            Constraint::Min(1),    // Footer
+        ])
+        .split(inner);
+
+    super::render_text_field(
+        frame,
+        chunks[0],
+        "Branch Name",
+        state.name,
+        state.cursor,
+        true,
+    );
+
+    let footer = Line::from(vec![
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::styled(" confirm  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[1]);
+}


### PR DESCRIPTION
## Summary

- Adds opt-in git worktree mode to session creation: `Ctrl+N` → session mode modal ("Normal" / "Worktree") → base branch selector → new branch name prompt → worktree creation → session spawns inside worktree
- Auto-cleans worktrees on session close (`Ctrl+X`) and app shutdown (`Ctrl+Q`)
- New `git` module wrapping `git branch`, `git worktree add -b`, and `git worktree remove` via CLI
- New UI modals: session mode selector, base branch selector, worktree name prompt
- UI indicators: branch badge in session list, branch in terminal title, worktree section in info panel
- Extracted shared `render_text_field` to `ui/mod.rs` (DRY refactor of cursor rendering)

## Test plan

- [ ] Verify `cargo nextest run --all` passes (75 tests, all green)
- [ ] Verify `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [ ] Verify `cargo +nightly-2026-01-22 pup check --pup-config pup.ron` passes (git module rules)
- [ ] Manual: 0 repos project → `Ctrl+N` → spawns in `$HOME` (no mode modal)
- [ ] Manual: 1 repo project → `Ctrl+N` → mode modal → Normal → spawns in repo
- [ ] Manual: 1 repo project → `Ctrl+N` → mode modal → Worktree → branch list → name prompt → spawns in worktree
- [ ] Manual: 2+ repos project → `Ctrl+N` → repo selector → mode modal → continues flow
- [ ] Manual: Close worktree session (`Ctrl+X`) → worktree directory removed
- [ ] Manual: Quit app (`Ctrl+Q`) → all worktrees cleaned up