### PR TITLE
feat(core): add session persistence across restarts

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,3 +1,6 @@
+[global]
+exclude = [".git"]
+
 [MD013]
 line_length = 100
 # Allow longer lines in tables and code blocks

--- a/src/claude/pty_session.rs
+++ b/src/claude/pty_session.rs
@@ -40,6 +40,9 @@ impl PtySession {
         if let Some(ref session_id) = config.resume_session_id {
             cmd.arg("--resume");
             cmd.arg(session_id);
+        } else if let Some(ref session_id) = config.claude_session_id {
+            cmd.arg("--session-id");
+            cmd.arg(session_id);
         }
         if let Some(ref cwd) = config.cwd {
             cmd.cwd(cwd);
@@ -75,7 +78,9 @@ impl PtySession {
         let (input_tx, input_rx) = mpsc::unbounded_channel();
         tokio::spawn(Self::writer_loop(writer, input_rx));
 
-        let info = SessionInfo::new(name);
+        let mut info = SessionInfo::new(name);
+        info.claude_session_id = config.claude_session_id.clone();
+        info.cwd = config.cwd.clone();
         debug!(session_id = %info.id, "Spawned claude PTY session");
 
         Ok(Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,13 @@ async fn main() -> Result<()> {
     let size = terminal.size()?;
 
     let mut app = App::new(size.height, size.width, project_configs);
-    app.spawn_session();
+
+    let state = project::load_session_state();
+    if state.sessions.is_empty() {
+        app.spawn_session();
+    } else {
+        app.restore_sessions(state);
+    }
 
     let res = run_loop(&mut terminal, &mut app).await;
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[derive(Debug, Clone)]
@@ -57,6 +58,8 @@ pub struct SessionInfo {
     pub name: String,
     pub status: SessionStatus,
     pub worktree: Option<WorktreeInfo>,
+    pub claude_session_id: Option<String>,
+    pub cwd: Option<PathBuf>,
 }
 
 impl SessionInfo {
@@ -66,6 +69,8 @@ impl SessionInfo {
             name,
             status: SessionStatus::Running,
             worktree: None,
+            claude_session_id: None,
+            cwd: None,
         }
     }
 }
@@ -73,7 +78,31 @@ impl SessionInfo {
 #[derive(Debug, Clone, Default)]
 pub struct SessionConfig {
     pub resume_session_id: Option<String>,
+    pub claude_session_id: Option<String>,
     pub cwd: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedSession {
+    pub name: String,
+    pub claude_session_id: String,
+    pub cwd: Option<PathBuf>,
+    pub worktree: Option<PersistedWorktree>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedWorktree {
+    pub repo_path: PathBuf,
+    pub worktree_path: PathBuf,
+    pub branch: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PersistedState {
+    #[serde(default)]
+    pub sessions: Vec<PersistedSession>,
+    #[serde(default)]
+    pub session_counter: usize,
 }
 
 #[cfg(test)]
@@ -121,6 +150,26 @@ mod tests {
     fn session_info_new_has_no_worktree() {
         let info = SessionInfo::new("Test".to_string());
         assert!(info.worktree.is_none());
+    }
+
+    #[test]
+    fn session_info_new_has_no_claude_session_id() {
+        let info = SessionInfo::new("Test".to_string());
+        assert!(info.claude_session_id.is_none());
+    }
+
+    #[test]
+    fn session_info_new_has_no_cwd() {
+        let info = SessionInfo::new("Test".to_string());
+        assert!(info.cwd.is_none());
+    }
+
+    #[test]
+    fn session_config_default_has_all_none() {
+        let config = SessionConfig::default();
+        assert!(config.resume_session_id.is_none());
+        assert!(config.claude_session_id.is_none());
+        assert!(config.cwd.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Save all session metadata to `$XDG_DATA_HOME/thurbox/state.toml` on `Ctrl+Q` shutdown
- Restore sessions on next startup using Claude CLI's `--resume` flag with stable `claude_session_id` (UUID v4)
- Preserve worktrees on quit so resumed sessions keep their branch checkout; explicit `Ctrl+X` close still removes worktrees
- Exclude `.git` directory from rumdl markdown linting to avoid false positives from worktree checkouts

## Changes

| File | What |
|------|------|
| `src/session/mod.rs` | Add `claude_session_id`, `cwd` fields to `SessionInfo`/`SessionConfig`; add `PersistedSession`, `PersistedWorktree`, `PersistedState` serde types |
| `src/claude/pty_session.rs` | Pass `--session-id` on fresh spawn, propagate fields to `SessionInfo` |
| `src/project/mod.rs` | Add `data_dir()`, `state_path()`, `load_session_state()`, `save_session_state()`, `clear_session_state()` |
| `src/app/mod.rs` | Add `save_state()`, `restore_sessions()`; centralize UUID generation in `do_spawn_session()`; wire lifecycle in `shutdown()` |
| `src/main.rs` | Conditional restore vs fresh spawn on startup |
| `docs/FEATURES.md` | Document session persistence, cleanup behavior, and state file format |
| `.rumdl.toml` | Exclude `.git` from markdown linting |

## Test plan

- [x] `cargo check --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --all` (83 tests pass including 11 new persistence tests)
- [x] `cargo +nightly-2026-01-22 pup check --pup-config pup.ron`
- [x] `rumdl check .`
- [ ] Manual: Fresh start (no state file) spawns default session
- [ ] Manual: Spawn 2 sessions → `Ctrl+Q` → `state.toml` exists with 2 entries
- [ ] Manual: Relaunch → 2 sessions restored with same Claude conversations
- [ ] Manual: Worktree session persists across restart
- [ ] Manual: `Ctrl+X` close removes session permanently (not restored)