### PR TITLE
feat(ui): add Ctrl+J/K shortcuts for session navigation

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -93,6 +93,8 @@ keys (intercepted for scrollback navigation).
 | `Ctrl+N` | Project list | Add new project |
 | `Ctrl+N` | Session list / Terminal | New session (mode selector, then optional branch selector) |
 | `Ctrl+X` | Global | Close active session |
+| `Ctrl+J` | Global | Next session within active project |
+| `Ctrl+K` | Global | Previous session within active project |
 | `Ctrl+L` | Global | Cycle focus: Project → Session → Terminal |
 | `Ctrl+I` | Global | Toggle info panel (width >= 120) |
 | `j` / `Down` | Project list | Next project |

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -55,7 +55,7 @@ pub fn render_footer(
             focus_badge,
             Span::styled(counts, Style::default().fg(Color::Gray)),
             Span::styled(
-                " Ctrl+N: New  Ctrl+X: Close  Ctrl+L: Cycle Focus  Ctrl+Q: Quit ",
+                " Ctrl+N: New  Ctrl+X: Close  Ctrl+J/K: Switch  Ctrl+L: Focus  Ctrl+Q: Quit ",
                 Style::default().fg(Color::DarkGray),
             ),
         ])


### PR DESCRIPTION
## Summary

- Add global `Ctrl+J` and `Ctrl+K` keybindings to switch between sessions within the active project
- Works from any focus state (Terminal, SessionList, ProjectList)
- Eliminates need to cycle focus just to change sessions
- Extract `switch_session_by_offset` helper to eliminate DRY violation
- Add 6 unit tests covering navigation edge cases
- Add `PtySession::stub()` test-only constructor
- Update status bar footer, help overlay, and FEATURES.md

## Test plan

- [x] All 89 unit tests pass (6 new session switching tests)
- [x] Clippy clean
- [x] cargo check passes
- [x] Pre-commit hooks passed