### PR TITLE
Sort default branch first in worktree selector

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -603,7 +603,14 @@ impl App {
                 self.error_message = Some("No branches found in repository".to_string());
                 self.pending_repo_path = None;
             }
-            Ok(branches) => {
+            Ok(mut branches) => {
+                // Move the default branch to front so it's pre-selected.
+                if let Some(default) = git::default_branch(repo_path, &branches) {
+                    if let Some(pos) = branches.iter().position(|b| b == &default) {
+                        let branch = branches.remove(pos);
+                        branches.insert(0, branch);
+                    }
+                }
                 self.available_branches = branches;
                 self.branch_selector_index = 0;
                 self.show_branch_selector = true;


### PR DESCRIPTION
## Summary
- Detect repo default branch via `git symbolic-ref refs/remotes/origin/HEAD` or fallback to main/master
- Pre-select default branch at index 0 in branch selector modal when creating worktree
- Add unit tests for branch detection logic (main vs master preference, fallbacks, edge cases)

## Test plan
- [x] Run `cargo nextest run --all` — all 87 tests pass
- [x] Run `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] Manual: Press Ctrl+N, select Worktree mode → default branch is first/pre-selected