### PR TITLE
docs: remove outdated tree view from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,22 +201,7 @@ cog commit feat -B "redesign API interface" api
 
 ## Architecture
 
-Thurbox follows a modular architecture with clear separation of concerns:
-
-```text
-thurbox/
-├── src/
-│   ├── main.rs          # Application entry point
-│   ├── lib.rs           # Library root and error types
-│   ├── claude.rs        # Claude API integration
-│   ├── git.rs           # Git operations and worktree management
-│   └── ui.rs            # TUI components and state
-├── tests/
-│   ├── integration_test.rs      # Integration tests
-│   └── architecture_rules.rs    # Architecture validation
-└── benches/
-    └── benchmarks.rs    # Performance benchmarks
-```
+Thurbox follows a modular architecture with clear separation of concerns.
 
 ### Architectural Rules
 


### PR DESCRIPTION
## Summary
- Remove outdated ASCII tree view from README.md that showed incorrect flat file structure
- The actual codebase uses module directories (app/, claude/, git/, project/, session/, ui/)
- Architecture section now flows cleanly from intro to architectural rules

## Test plan
- [x] `rumdl check README.md` passes
- [x] Visual review confirms Architecture section reads coherently