### PR TITLE
Optimize security audit CI stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
-      - name: Install nextest
-        run: cargo install cargo-nextest --locked
+      - uses: taiki-e/install-action@541dbe11e2898b05bb65bedbd1d0c4e3092b5bdd # v2.67.29
+        with:
+          tool: cargo-nextest
       - run: cargo nextest run --all --profile ci
 
   architecture:
@@ -75,15 +76,6 @@ jobs:
         with:
           command: check ${{ matrix.checks }}
           log-level: warn
-
-  audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
   docs:
     name: Documentation
@@ -119,7 +111,6 @@ jobs:
       - nextest
       - architecture
       - deny
-      - audit
       - docs
       - conventional-commits
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,13 +68,6 @@ repos:
         pass_filenames: false
         always_run: true
 
-      - id: cargo-audit
-        name: Cargo audit
-        entry: cargo audit
-        language: system
-        pass_filenames: false
-        always_run: true
-
       - id: cargo-doc
         name: Cargo doc
         entry: env RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,6 @@ rumdl fmt .                          # Markdown auto-fix
 cargo test --test architecture_rules                      # Arch rules
 cargo deny check advisories                               # Advisories
 cargo deny check bans licenses sources                    # Dep policy
-cargo audit                                               # Audit
 ```
 
 ## Conventional Commits

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -40,7 +40,7 @@ Copyleft crates are rejected at PR time.
 
 ### 5. Zero known vulnerabilities
 
-`cargo-deny` advisories and `cargo-audit` block merges
+`cargo-deny` advisories blocks merges
 when known CVEs affect the dependency tree.
 
 ### 6. Conventional commits
@@ -97,7 +97,7 @@ because a broken pipeline affects every contributor.
 | Module isolation | `tests/architecture_rules.rs` | — |
 | Zero warnings | `clippy -D warnings` + `RUSTDOCFLAGS="-D warnings"` + `rumdl` | CI + pre-commit |
 | Permissive licenses | `cargo-deny check bans licenses` | `deny.toml` |
-| Zero vulnerabilities | `cargo-deny check advisories` + `cargo-audit` | `deny.toml` |
+| Zero vulnerabilities | `cargo-deny check advisories` | `deny.toml` |
 | Conventional commits | `cocogitto` (`cog verify`) | `cog.toml` |
 | TEA pattern | `tests/architecture_rules.rs` + code review | — |
 | PTY-first model | Code review | — |

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -22,7 +22,6 @@ $INSTALL_CMD cocogitto
 $INSTALL_CMD cargo-nextest
 $INSTALL_CMD cargo-modules
 $INSTALL_CMD cargo-deny
-$INSTALL_CMD cargo-audit
 $INSTALL_CMD rumdl
 
 # Install nightly tools


### PR DESCRIPTION
## Summary

- Remove redundant `rustsec/audit-check` job (cargo-deny advisories already covers the same RustSec Advisory Database)
- Replace `cargo install` with `taiki-e/install-action` for nextest (pre-compiled binary vs compilation)
- Update docs and configs to remove cargo-audit references

## Test plan

- [x] All pre-commit hooks pass
- [ ] CI passes with optimized jobs
- [ ] Verify security checks still enforce zero vulnerabilities

**Estimated time savings:** ~5-8 minutes per CI run