### PR TITLE
feat(core): add session role-based access control (RBAC)

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -99,6 +99,7 @@ keys (intercepted for scrollback navigation).
 | `Ctrl+I` | Global | Toggle info panel (width >= 120) |
 | `j` / `Down` | Project list | Next project |
 | `k` / `Up` | Project list | Previous project |
+| `r` | Project list | Open role editor |
 | `Enter` | Project list | Focus session list |
 | `j` / `Down` | Session list | Next session |
 | `k` / `Up` | Session list | Previous session |
@@ -369,6 +370,75 @@ content. The thumb position is inverted from the offset
 visual expectations. When scrolled up, the block title shows a
 `[N↑]` indicator and the PTY cursor is hidden to avoid visual
 noise in historical output.
+
+---
+
+## Role Editor
+
+Roles can be managed from the TUI via a two-view modal
+accessed with `r` when the project list is focused.
+
+Projects start with no roles. Users add roles explicitly.
+When no roles are defined, sessions spawn with default
+(empty) permissions and no role selector is shown.
+
+### Allow / Ask / Deny Semantics
+
+Each role maps to Claude CLI flags:
+
+| Concept | CLI Flag | In TOML |
+|---------|----------|---------|
+| Allow (auto-approve) | `--allowed-tools "Read Bash(git:*)"` | `allowed_tools = ["Read", "Bash(git:*)"]` |
+| Deny (blocked) | `--disallowed-tools "Edit"` | `disallowed_tools = ["Edit"]` |
+| Ask (prompt user) | *(default for unlisted tools)* | *(omitted from both lists)* |
+| Permission mode | `--permission-mode plan` | `permission_mode = "plan"` |
+
+Bash scope patterns like `Bash(git:*)` and `Bash(cargo:*)`
+are supported in both allowed and disallowed tool lists.
+
+### Role List View
+
+Shows all roles for the active project. Supports
+add (`a`), edit (`e` / `Enter`), and delete (`d`).
+Pressing `Esc` saves changes to the config file and
+closes the modal.
+
+### Role Editor View
+
+Edits a single role with four text fields:
+
+- **Name** — role identifier (required, unique)
+- **Description** — human-readable summary
+- **Allowed Tools** — space-separated tool names
+  (auto-approved)
+- **Disallowed Tools** — space-separated tool names
+  (blocked)
+
+Permission mode defaults to `dontAsk` and can be
+overridden per-role via the config file
+(`permission_mode = "plan"` in the role's TOML block).
+
+`Tab` / `Shift+Tab` cycles between fields.
+`Enter` saves the role, `Esc` discards changes.
+
+### Keybindings (role list)
+
+| Key | Action |
+|-----|--------|
+| `j` / `Down` | Next role |
+| `k` / `Up` | Previous role |
+| `a` | Add new role |
+| `e` / `Enter` | Edit selected role |
+| `d` | Delete selected role |
+| `Esc` | Save and close |
+
+### Keybindings (role editor)
+
+| Key | Action |
+|-----|--------|
+| `Tab` / `Shift+Tab` | Cycle fields |
+| `Enter` | Save role |
+| `Esc` | Discard changes |
 
 ---
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -4,6 +4,34 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Default role name assigned when no explicit role is configured.
+pub const DEFAULT_ROLE_NAME: &str = "developer";
+
+/// Permission flags passed to the Claude CLI when spawning a session.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RolePermissions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permission_mode: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_tools: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub disallowed_tools: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub append_system_prompt: Option<String>,
+}
+
+/// A named role definition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoleConfig {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(flatten)]
+    pub permissions: RolePermissions,
+}
+
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
     pub repo_path: PathBuf,
@@ -60,6 +88,7 @@ pub struct SessionInfo {
     pub id: SessionId,
     pub name: String,
     pub status: SessionStatus,
+    pub role: String,
     pub worktree: Option<WorktreeInfo>,
     pub claude_session_id: Option<String>,
     pub cwd: Option<PathBuf>,
@@ -71,6 +100,7 @@ impl SessionInfo {
             id: SessionId::default(),
             name,
             status: SessionStatus::Busy,
+            role: DEFAULT_ROLE_NAME.to_string(),
             worktree: None,
             claude_session_id: None,
             cwd: None,
@@ -83,6 +113,8 @@ pub struct SessionConfig {
     pub resume_session_id: Option<String>,
     pub claude_session_id: Option<String>,
     pub cwd: Option<PathBuf>,
+    pub role: String,
+    pub permissions: RolePermissions,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,6 +123,8 @@ pub struct PersistedSession {
     pub claude_session_id: String,
     pub cwd: Option<PathBuf>,
     pub worktree: Option<PersistedWorktree>,
+    #[serde(default)]
+    pub role: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -170,11 +204,115 @@ mod tests {
     }
 
     #[test]
+    fn session_info_new_has_developer_role() {
+        let info = SessionInfo::new("Test".to_string());
+        assert_eq!(info.role, DEFAULT_ROLE_NAME);
+    }
+
+    #[test]
+    fn default_role_name_is_developer() {
+        assert_eq!(DEFAULT_ROLE_NAME, "developer");
+    }
+
+    #[test]
     fn session_config_default_has_all_none() {
         let config = SessionConfig::default();
         assert!(config.resume_session_id.is_none());
         assert!(config.claude_session_id.is_none());
         assert!(config.cwd.is_none());
+        assert_eq!(config.role, "");
+        assert_eq!(config.permissions, RolePermissions::default());
+    }
+
+    #[test]
+    fn role_permissions_default_is_empty() {
+        let perms = RolePermissions::default();
+        assert!(perms.permission_mode.is_none());
+        assert!(perms.allowed_tools.is_empty());
+        assert!(perms.disallowed_tools.is_empty());
+        assert!(perms.tools.is_none());
+        assert!(perms.append_system_prompt.is_none());
+    }
+
+    #[test]
+    fn role_permissions_serde_roundtrip() {
+        let perms = RolePermissions {
+            permission_mode: Some("plan".to_string()),
+            allowed_tools: vec!["Read".to_string(), "Bash(git:*)".to_string()],
+            disallowed_tools: vec![],
+            tools: None,
+            append_system_prompt: Some("Be careful".to_string()),
+        };
+        let serialized = toml::to_string_pretty(&perms).unwrap();
+        let deserialized: RolePermissions = toml::from_str(&serialized).unwrap();
+        assert_eq!(perms, deserialized);
+    }
+
+    #[test]
+    fn role_permissions_all_fields_serde_roundtrip() {
+        let perms = RolePermissions {
+            permission_mode: Some("plan".to_string()),
+            allowed_tools: vec!["Read".to_string(), "Bash(git:*)".to_string()],
+            disallowed_tools: vec!["Edit".to_string()],
+            tools: Some("default".to_string()),
+            append_system_prompt: Some("Be careful".to_string()),
+        };
+        let serialized = toml::to_string_pretty(&perms).unwrap();
+        let deserialized: RolePermissions = toml::from_str(&serialized).unwrap();
+        assert_eq!(perms, deserialized);
+    }
+
+    #[test]
+    fn role_config_serde_roundtrip() {
+        let role = RoleConfig {
+            name: "reviewer".to_string(),
+            description: "Read-only code review".to_string(),
+            permissions: RolePermissions {
+                permission_mode: Some("plan".to_string()),
+                allowed_tools: vec!["Read".to_string()],
+                ..RolePermissions::default()
+            },
+        };
+        let serialized = toml::to_string_pretty(&role).unwrap();
+        let deserialized: RoleConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(role, deserialized);
+    }
+
+    #[test]
+    fn role_config_flatten_includes_permission_fields() {
+        let role = RoleConfig {
+            name: "test".to_string(),
+            description: String::new(),
+            permissions: RolePermissions {
+                permission_mode: Some("plan".to_string()),
+                ..RolePermissions::default()
+            },
+        };
+        let serialized = toml::to_string_pretty(&role).unwrap();
+        assert!(serialized.contains("permission_mode"));
+        assert!(serialized.contains("plan"));
+    }
+
+    #[test]
+    fn persisted_session_with_role() {
+        let toml_str = r#"
+name = "Session 1"
+claude_session_id = "abc-123"
+role = "reviewer"
+"#;
+        let session: PersistedSession = toml::from_str(toml_str).unwrap();
+        assert_eq!(session.role, "reviewer");
+    }
+
+    #[test]
+    fn persisted_session_backward_compat_no_role() {
+        let toml_str = r#"
+name = "Session 1"
+claude_session_id = "abc-123"
+"#;
+        let session: PersistedSession = toml::from_str(toml_str).unwrap();
+        assert_eq!(session.name, "Session 1");
+        assert_eq!(session.role, "");
     }
 
     #[test]

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -73,6 +73,16 @@ pub fn render_info_panel(
     ]));
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
+        Span::styled("Role: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            &info.role,
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
         Span::styled("ID: ", Style::default().fg(Color::DarkGray)),
         Span::styled(info.id.to_string(), Style::default().fg(Color::DarkGray)),
     ]));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,8 @@ pub mod info_panel;
 pub mod layout;
 pub mod project_list;
 pub mod repo_selector_modal;
+pub mod role_editor_modal;
+pub mod role_selector_modal;
 pub mod session_mode_modal;
 pub mod status_bar;
 pub mod terminal_view;

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -136,6 +136,11 @@ fn render_session_section(
                 Span::styled(&info.name, style),
             ];
 
+            spans.push(Span::styled(
+                format!(" [{}]", info.role),
+                Style::default().fg(Color::Magenta),
+            ));
+
             if let Some(wt) = &info.worktree {
                 spans.push(Span::styled(
                     format!(" [{}]", wt.branch),

--- a/src/ui/role_editor_modal.rs
+++ b/src/ui/role_editor_modal.rs
@@ -1,0 +1,201 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    Frame,
+};
+
+use super::{centered_fixed_height_rect, render_text_field};
+use crate::session::RoleConfig;
+
+// ── Role List View ──────────────────────────────────────────────────────────
+
+pub struct RoleListState<'a> {
+    pub roles: &'a [RoleConfig],
+    pub selected_index: usize,
+}
+
+pub fn render_role_list_modal(frame: &mut Frame, state: &RoleListState<'_>) {
+    // 2 (border) + max(roles, 1) + 1 (description) + 1 (footer)
+    let list_rows = if state.roles.is_empty() {
+        1
+    } else {
+        state.roles.len() as u16
+    };
+    let height = list_rows + 4;
+    let area = centered_fixed_height_rect(50, height, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Project Roles ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),    // Role list
+            Constraint::Length(1), // Description
+            Constraint::Length(1), // Footer
+        ])
+        .split(inner);
+
+    if state.roles.is_empty() {
+        let empty = Paragraph::new(Line::from(Span::styled(
+            "  No roles defined",
+            Style::default().fg(Color::DarkGray),
+        )));
+        frame.render_widget(empty, chunks[0]);
+    } else {
+        let items: Vec<ListItem<'_>> = state
+            .roles
+            .iter()
+            .enumerate()
+            .map(|(i, role)| {
+                let style = if i == state.selected_index {
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                let prefix = if i == state.selected_index {
+                    "▸ "
+                } else {
+                    "  "
+                };
+                ListItem::new(Line::from(Span::styled(
+                    format!("{prefix}{}", role.name),
+                    style,
+                )))
+            })
+            .collect();
+
+        let list = List::new(items);
+        frame.render_widget(list, chunks[0]);
+
+        // Description of selected role
+        if let Some(role) = state.roles.get(state.selected_index) {
+            let desc = Line::from(Span::styled(
+                &role.description,
+                Style::default().fg(Color::DarkGray),
+            ));
+            frame.render_widget(Paragraph::new(desc), chunks[1]);
+        }
+    }
+
+    let footer = Line::from(vec![
+        Span::styled("a", Style::default().fg(Color::Yellow)),
+        Span::styled(" add  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("e", Style::default().fg(Color::Yellow)),
+        Span::styled("/", Style::default().fg(Color::DarkGray)),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::styled(" edit  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("d", Style::default().fg(Color::Yellow)),
+        Span::styled(" delete  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::styled(" save & close", Style::default().fg(Color::DarkGray)),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[2]);
+}
+
+// ── Role Editor View ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoleEditorField {
+    Name,
+    Description,
+    AllowedTools,
+    DisallowedTools,
+}
+
+pub struct RoleEditorState<'a> {
+    pub name: &'a str,
+    pub name_cursor: usize,
+    pub description: &'a str,
+    pub description_cursor: usize,
+    pub allowed_tools: &'a str,
+    pub allowed_tools_cursor: usize,
+    pub disallowed_tools: &'a str,
+    pub disallowed_tools_cursor: usize,
+    pub focused_field: RoleEditorField,
+}
+
+pub fn render_role_editor_modal(frame: &mut Frame, state: &RoleEditorState<'_>) {
+    // 2 (border) + 4*3 (text fields) + 1 (footer) = 15
+    let height = 15;
+    let area = centered_fixed_height_rect(60, height, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Edit Role ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Name
+            Constraint::Length(3), // Description
+            Constraint::Length(3), // Allowed Tools
+            Constraint::Length(3), // Disallowed Tools
+            Constraint::Length(1), // Footer
+        ])
+        .split(inner);
+
+    render_text_field(
+        frame,
+        chunks[0],
+        "Name",
+        state.name,
+        state.name_cursor,
+        state.focused_field == RoleEditorField::Name,
+    );
+
+    render_text_field(
+        frame,
+        chunks[1],
+        "Description",
+        state.description,
+        state.description_cursor,
+        state.focused_field == RoleEditorField::Description,
+    );
+
+    render_text_field(
+        frame,
+        chunks[2],
+        "Allowed Tools (space-separated)",
+        state.allowed_tools,
+        state.allowed_tools_cursor,
+        state.focused_field == RoleEditorField::AllowedTools,
+    );
+
+    render_text_field(
+        frame,
+        chunks[3],
+        "Disallowed Tools (space-separated)",
+        state.disallowed_tools,
+        state.disallowed_tools_cursor,
+        state.focused_field == RoleEditorField::DisallowedTools,
+    );
+
+    // Footer
+    let footer = Line::from(vec![
+        Span::styled("Tab", Style::default().fg(Color::Yellow)),
+        Span::styled(" switch  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::styled(" save  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::styled(" discard", Style::default().fg(Color::DarkGray)),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[4]);
+}

--- a/src/ui/role_selector_modal.rs
+++ b/src/ui/role_selector_modal.rs
@@ -1,0 +1,86 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    Frame,
+};
+
+use super::centered_fixed_height_rect;
+use crate::session::RoleConfig;
+
+pub struct RoleSelectorState<'a> {
+    pub roles: &'a [RoleConfig],
+    pub selected_index: usize,
+}
+
+pub fn render_role_selector_modal(frame: &mut Frame, state: &RoleSelectorState<'_>) {
+    // 2 (border) + roles count + 1 (description) + 1 (footer)
+    let height = (state.roles.len() as u16) + 4;
+    let area = centered_fixed_height_rect(50, height, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Session Role ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),    // Role list
+            Constraint::Length(1), // Description
+            Constraint::Length(1), // Footer
+        ])
+        .split(inner);
+
+    let items: Vec<ListItem<'_>> = state
+        .roles
+        .iter()
+        .enumerate()
+        .map(|(i, role)| {
+            let style = if i == state.selected_index {
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            let prefix = if i == state.selected_index {
+                "▸ "
+            } else {
+                "  "
+            };
+            ListItem::new(Line::from(Span::styled(
+                format!("{prefix}{}", role.name),
+                style,
+            )))
+        })
+        .collect();
+
+    let list = List::new(items);
+    frame.render_widget(list, chunks[0]);
+
+    // Description of selected role
+    if let Some(role) = state.roles.get(state.selected_index) {
+        let desc = Line::from(Span::styled(
+            &role.description,
+            Style::default().fg(Color::DarkGray),
+        ));
+        frame.render_widget(Paragraph::new(desc), chunks[1]);
+    }
+
+    let footer = Line::from(vec![
+        Span::styled("j/k", Style::default().fg(Color::Yellow)),
+        Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[2]);
+}

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -28,9 +28,12 @@ pub fn render_terminal(
 
     let title = {
         let base = if let Some(wt) = &info.worktree {
-            format!(" {} [{}] [{}] ", info.name, wt.branch, info.status)
+            format!(
+                " {} ({}) [{}] [{}] ",
+                info.name, info.role, wt.branch, info.status
+            )
         } else {
-            format!(" {} [{}] ", info.name, info.status)
+            format!(" {} ({}) [{}] ", info.name, info.role, info.status)
         };
         if scroll_offset > 0 {
             // Insert scroll indicator before the trailing space


### PR DESCRIPTION
## Summary

- Add per-project role definitions (RBAC) for Claude CLI sessions with configurable permission flags (`--permission-mode`, `--allowed-tools`, `--disallowed-tools`, `--tools`, `--append-system-prompt`)
- New data types: `RolePermissions`, `RoleConfig` in `session/mod.rs`; `roles` field + `resolve_roles()`/`default_roles()` in `project/mod.rs`
- Role selector modal appears when a project has 2+ roles; auto-assigns when only 1 role
- Role persisted across restarts and displayed in info panel, terminal title, and session list

## Test plan

- [x] 150 tests pass (`cargo nextest run --all`)
- [x] `cargo clippy` clean
- [x] Serde roundtrip tests for `RolePermissions`, `RoleConfig`, `PersistedSession` with/without role
- [x] `build_claude_args` unit tests for all permission flag combinations
- [x] `resolve_roles` tests: empty → defaults, custom → passthrough
- [ ] Manual: config with no roles → sessions auto-assign "developer", no modal
- [ ] Manual: config with 2+ roles → role selector appears
- [ ] Manual: quit + restart → role persists