### PR TITLE
Replace portable-pty with tmux control mode backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,6 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -314,12 +308,6 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -585,7 +573,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix 0.29.0",
+ "nix",
  "winapi",
 ]
 
@@ -639,25 +627,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
@@ -860,27 +836,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-pty"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
-dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "downcast-rs",
- "filedescriptor",
- "lazy_static",
- "libc",
- "log",
- "nix 0.28.0",
- "serial2",
- "shared_library",
- "shell-words",
- "winapi",
- "winreg",
-]
 
 [[package]]
 name = "powerfmt"
@@ -1136,17 +1091,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial2"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc76fa68e25e771492ca1e3c53d447ef0be3093e05cd3b47f4b712ba10c6f3c"
-dependencies = [
- "cfg-if",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,22 +1109,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shared_library"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
-dependencies = [
- "lazy_static",
- "libc",
-]
-
-[[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "signal-hook"
@@ -1319,7 +1247,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix 0.29.0",
+ "nix",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -1399,7 +1327,6 @@ dependencies = [
  "anyhow",
  "bytes",
  "crossterm",
- "portable-pty",
  "ratatui",
  "serde",
  "tokio",
@@ -1451,8 +1378,13 @@ version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1868,15 +1800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,12 @@ ratatui = "0.30"
 crossterm = "0.29"
 tui-term = "0.3"
 
-# PTY & terminal emulation
-portable-pty = "0.9"
+# Terminal emulation
 vt100 = "0.16"
 bytes = "1"
 
 # Async runtime
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "process", "io-util"] }
 
 # Session management
 uuid = { version = "1", features = ["v4"] }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,25 +25,31 @@ when multiple PTY sessions are producing concurrent output.
 
 ---
 
-## ADR-2: PTY pipeline — portable-pty + vt100 + tui-term
+## ADR-2: Session pipeline — SessionBackend + vt100 + tui-term
 
-**Choice**: `portable-pty` spawns the `claude` CLI,
+**Choice**: A `SessionBackend` trait abstracts session lifecycle
+(spawn, adopt, resize, kill, detach, discover). The default
+backend is `LocalTmuxBackend` (`tmux -L thurbox`).
 `vt100::Parser` interprets escape sequences,
 `tui_term::PseudoTerminal` renders the parsed screen into ratatui.
 
-**Why**: Each crate handles exactly one concern. `portable-pty`
-abstracts platform differences (Linux, macOS). `vt100` gives us a
-full in-memory terminal state we can query without scraping.
-`tui_term` bridges that state to ratatui widgets
-with zero custom rendering code.
+**Why**: The trait-based design allows plugging in different
+transports (local tmux, SSH+tmux, Docker, cloud VM) without
+changing the app layer. tmux provides truly persistent sessions
+that survive thurbox crashes/restarts, multiple thurbox instances
+share the same running sessions, and external recovery is
+possible via `tmux -L thurbox attach`.
+
+**Previous design**: `portable-pty` spawned the `claude` CLI
+directly. Sessions died when thurbox exited, terminal content was
+lost on restart, and multiple instances had no coordination.
 
 **Rejected**:
 
-- *`nix::pty` directly* — Linux-only;
-  would require a separate Windows/macOS backend.
+- *`portable-pty` (previous)* — no session persistence,
+  no multi-instance sharing, terminal content lost on restart.
 - *`alacritty_terminal`* — full terminal emulator,
   far heavier than needed.
-  We don't need font rendering or GPU acceleration.
 - *Parsing raw ANSI ourselves* — error-prone,
   massive surface area, already solved by `vt100`.
 
@@ -223,3 +229,105 @@ and disappears on restart once user projects exist.
   ownership changes mid-session.
 - *Persist default to disk* — pollutes the config file with
   auto-generated entries the user didn't create.
+
+---
+
+## ADR-11: Trait-based session backends
+
+**Choice**: Session lifecycle is abstracted behind a
+`SessionBackend` trait (`src/claude/backend.rs`). The `Session`
+struct wraps the trait and manages reader/writer loops once,
+regardless of which backend is active.
+
+**Why**: Thurbox needs to support multiple deployment targets:
+local tmux today, SSH+tmux, Docker, and cloud VMs in the future.
+A trait boundary keeps the app layer completely backend-agnostic.
+Adding a new backend is a matter of implementing `SessionBackend`
+without touching `App`, `Session`, or any UI code.
+
+**Trait methods**: `check_available`, `ensure_ready`, `spawn`,
+`adopt`, `discover`, `resize`, `is_dead`, `kill`, `detach`.
+
+**Key design decisions**:
+
+- `spawn()` returns `(backend_id, output_reader, input_writer)`.
+  The `Session` struct owns the reader/writer loops.
+- `adopt()` reconnects to an existing session and returns initial
+  screen content for parser seeding.
+- `discover()` lists existing sessions for restore-on-startup.
+- `detach()` stops streaming without killing the session.
+- `kill()` permanently destroys the session.
+
+**Rejected**:
+
+- *Async trait methods* — added complexity for no benefit since
+  all current backends use synchronous `Command::new("tmux")`.
+  Can be added via `async-trait` if a future backend needs it.
+- *Backend per session* — over-engineering; all sessions in a
+  thurbox instance share the same backend.
+
+---
+
+## ADR-12: Local tmux as default backend
+
+**Choice**: The first `SessionBackend` implementation is
+`LocalTmuxBackend`, using a dedicated tmux server
+(`tmux -L thurbox`) with session name `thurbox`. All I/O goes
+through tmux control mode (`-C`).
+
+**Why**: tmux provides session persistence (survives crashes),
+multi-instance sharing (multiple thurbox processes see the same
+sessions), and external recovery (`tmux -L thurbox attach`).
+It handles terminal capability queries (DA1/DA2) natively via
+`extended-keys on`, eliminating the need for thurbox to intercept
+and respond to these sequences.
+
+Control mode (`-C`) provides a single multiplexed stdio
+connection with built-in flow control. Output arrives as
+`%output` notifications (octal-encoded), input is sent via
+`send-keys -H` (hex-encoded). This eliminates the previous
+`pipe-pane` + FIFO approach which suffered from tmux data-loss
+bugs (#641, #2989), required 3 external deps in the data path
+(`mkfifo`, `stdbuf`, `cat`), and had no flow control.
+
+**Configuration on init**:
+
+- `remain-on-exit on` — keeps panes alive after process exit
+- `status off` — no tmux status bar (thurbox renders its own)
+- `default-terminal xterm-256color` — standard terminal type
+- `history-limit 5000` — reasonable scrollback
+- `extended-keys on` — enhanced key reporting
+- `window-size manual` — windows size independently
+- `pause-after 5` — flow control (auto-resumed by reader)
+
+**Window naming**: `tb-<session-name>` prefix for discovery.
+
+**Output streaming**: `%output` notifications from control mode,
+demultiplexed by pane ID into per-pane mpsc channels. Each
+channel feeds a `ControlModeReader` (implements `Read`) consumed
+by the existing `Session::reader_loop`.
+
+**Input**: `send-keys -H <hex>` through the shared control mode
+stdin, wrapped in a `ControlModeWriter` (implements `Write`).
+
+**Command synchronization**: All commands that precede a
+`send_command` (waited) call must themselves be waited. A
+fire-and-forget (`send_command_nowait`) leaves an unclaimed
+`%begin`/`%end` response in the stream that can steal the next
+waiter. `send_command_nowait` is only safe when nothing follows
+(e.g., `detach`) or when issued from the reader thread itself
+(e.g., pause resume).
+
+**Session restore**: On reconnect, `capture-pane -p -e -S -`
+provides a quick initial approximation of the screen content
+(text + colors, but not full escape sequences). A forced resize
+then triggers SIGWINCH, causing the TUI application to repaint
+its full screen through the normal `%output` stream — this
+delivers pixel-perfect rendering with all original formatting.
+
+**Rejected**:
+
+- *`pipe-pane` + FIFO (previous)* — intermittent data loss from
+  tmux bugs #641/#2989, required `mkfifo`/`stdbuf`/`cat` in the
+  data path, no flow control, timing race on initial capture.
+- *Screen/dtach* — less widely available, fewer features.

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -55,11 +55,13 @@ The Elm Architecture (`Event -> Message -> update -> view -> Frame`)
 is the only sanctioned control-flow pattern.
 No ad-hoc event handlers, no component-local state, no callback chains.
 
-### 8. PTY-first session model
+### 8. Backend-first session model
 
-Claude Code sessions run inside real PTYs (`portable-pty`).
+Claude Code sessions run via a pluggable `SessionBackend` trait.
+The default backend is local tmux (`tmux -L thurbox`), which
+provides truly persistent sessions that survive crashes/restarts.
 We never mock, emulate, or screen-scrape a fake terminal.
-The PTY is the source of truth.
+The backend is the source of truth for session lifecycle.
 
 ### 9. Logging never touches stdout
 
@@ -100,7 +102,7 @@ because a broken pipeline affects every contributor.
 | Zero vulnerabilities | `cargo-deny check advisories` | `deny.toml` |
 | Conventional commits | `cocogitto` (`cog verify`) | `cog.toml` |
 | TEA pattern | `tests/architecture_rules.rs` + code review | — |
-| PTY-first model | Code review | — |
+| Backend-first model | Code review | — |
 | Logging off stdout | Code review | — |
 | TDD (Red/Green/Refactor) | `cargo-nextest` + code review | `.config/nextest.toml` |
 | Deterministic CI | Scripts and tools only; no LLM-gated checks | CI config + pre-commit |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
@@ -10,7 +11,7 @@ use ratatui::{
 };
 use tracing::error;
 
-use crate::claude::{input, PtySession};
+use crate::claude::{input, Session, SessionBackend};
 use crate::git;
 use crate::project::{self, ProjectConfig, ProjectInfo};
 use crate::session::{
@@ -208,8 +209,9 @@ pub enum InputFocus {
 pub struct App {
     projects: Vec<ProjectInfo>,
     active_project_index: usize,
-    sessions: Vec<PtySession>,
+    sessions: Vec<Session>,
     active_index: usize,
+    backend: Arc<dyn SessionBackend>,
     focus: InputFocus,
     should_quit: bool,
     error_message: Option<String>,
@@ -252,7 +254,12 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(rows: u16, cols: u16, project_configs: Vec<ProjectConfig>) -> Self {
+    pub fn new(
+        rows: u16,
+        cols: u16,
+        project_configs: Vec<ProjectConfig>,
+        backend: Arc<dyn SessionBackend>,
+    ) -> Self {
         let projects: Vec<ProjectInfo> = if project_configs.is_empty() {
             vec![ProjectInfo::new_default(project::create_default_project())]
         } else {
@@ -264,6 +271,7 @@ impl App {
             active_project_index: 0,
             sessions: Vec::new(),
             active_index: 0,
+            backend,
             focus: InputFocus::ProjectList,
             should_quit: false,
             error_message: None,
@@ -390,6 +398,8 @@ impl App {
             }
         }
 
+        // Kill the backend session before removing from the list.
+        self.sessions[self.active_index].kill();
         self.sessions.remove(self.active_index);
 
         // Remove session from its project
@@ -1197,7 +1207,7 @@ impl App {
             config.claude_session_id = Some(uuid::Uuid::new_v4().to_string());
         }
 
-        match PtySession::spawn_with_config(name, rows, cols, &config) {
+        match Session::spawn(name, rows, cols, &config, &self.backend) {
             Ok(mut session) => {
                 session.info.worktree = worktree;
                 let session_id = session.info.id;
@@ -1528,9 +1538,10 @@ impl App {
 
     pub fn shutdown(self) {
         self.save_state();
-        // Do NOT remove worktrees — they persist for resume
+        // Do NOT remove worktrees — they persist for resume.
+        // Detach from backend sessions without killing them — they persist in tmux.
         for session in self.sessions {
-            session.shutdown();
+            session.detach();
         }
     }
 
@@ -1550,6 +1561,8 @@ impl App {
                         branch: wt.branch.clone(),
                     }),
                     role: s.info.role.clone(),
+                    backend_id: s.backend_id().to_string(),
+                    backend_type: s.backend_name().to_string(),
                 })
             })
             .collect();
@@ -1567,6 +1580,9 @@ impl App {
     pub fn restore_sessions(&mut self, state: PersistedState) {
         self.session_counter = state.session_counter;
 
+        // Discover existing sessions from the backend.
+        let discovered = self.backend.discover().unwrap_or_default();
+
         for persisted in state.sessions {
             let name = persisted.name;
 
@@ -1575,14 +1591,6 @@ impl App {
             } else {
                 persisted.role
             };
-            let permissions = self.resolve_role_permissions(&role);
-            let config = SessionConfig {
-                resume_session_id: Some(persisted.claude_session_id.clone()),
-                claude_session_id: Some(persisted.claude_session_id),
-                cwd: persisted.cwd,
-                role,
-                permissions,
-            };
 
             let worktree = persisted.worktree.map(|wt| WorktreeInfo {
                 repo_path: wt.repo_path,
@@ -1590,7 +1598,63 @@ impl App {
                 branch: wt.branch,
             });
 
-            self.do_spawn_session(name, &config, worktree);
+            // Try to match a discovered backend session by backend_id.
+            let matching_discovered = if !persisted.backend_id.is_empty() {
+                discovered
+                    .iter()
+                    .find(|d| d.backend_id == persisted.backend_id && d.is_alive)
+            } else {
+                // Fall back to matching by window name (tb-<name>).
+                let expected_name = format!("tb-{name}");
+                discovered
+                    .iter()
+                    .find(|d| d.name == expected_name && d.is_alive)
+            };
+
+            if let Some(disc) = matching_discovered {
+                // Adopt the existing backend session — reconnect without re-spawning.
+                let (rows, cols) = self.content_area_size();
+                match Session::adopt(name.clone(), rows, cols, &disc.backend_id, &self.backend) {
+                    Ok(mut session) => {
+                        session.info.claude_session_id = Some(persisted.claude_session_id.clone());
+                        session.info.cwd = persisted.cwd;
+                        session.info.role = role;
+                        session.info.worktree = worktree;
+                        let session_id = session.info.id;
+                        self.sessions.push(session);
+                        self.active_index = self.sessions.len() - 1;
+                        self.focus = InputFocus::Terminal;
+
+                        if let Some(project) = self.projects.get_mut(self.active_project_index) {
+                            project.session_ids.push(session_id);
+                        }
+                    }
+                    Err(e) => {
+                        error!("Failed to adopt session '{name}': {e}");
+                        // Fall back to spawning a new session with --resume.
+                        let permissions = self.resolve_role_permissions(&role);
+                        let config = SessionConfig {
+                            resume_session_id: Some(persisted.claude_session_id.clone()),
+                            claude_session_id: Some(persisted.claude_session_id),
+                            cwd: persisted.cwd,
+                            role,
+                            permissions,
+                        };
+                        self.do_spawn_session(name, &config, worktree);
+                    }
+                }
+            } else {
+                // No matching backend session — spawn new with --resume.
+                let permissions = self.resolve_role_permissions(&role);
+                let config = SessionConfig {
+                    resume_session_id: Some(persisted.claude_session_id.clone()),
+                    claude_session_id: Some(persisted.claude_session_id),
+                    cwd: persisted.cwd,
+                    role,
+                    permissions,
+                };
+                self.do_spawn_session(name, &config, worktree);
+            }
         }
 
         if let Err(e) = project::clear_session_state() {
@@ -1742,6 +1806,8 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
 
     // --- TextInput tests ---
@@ -1909,11 +1975,64 @@ mod tests {
 
     // --- Session switching tests ---
 
+    /// Stub backend that does nothing — for unit tests only.
+    struct StubBackend;
+    impl SessionBackend for StubBackend {
+        fn name(&self) -> &str {
+            "stub"
+        }
+        fn check_available(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn ensure_ready(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn spawn(
+            &self,
+            _: &str,
+            _: &str,
+            _: &[String],
+            _: Option<&Path>,
+            _: u16,
+            _: u16,
+        ) -> anyhow::Result<crate::claude::backend::SpawnedSession> {
+            anyhow::bail!("stub backend does not spawn")
+        }
+        fn adopt(
+            &self,
+            _: &str,
+            _: u16,
+            _: u16,
+        ) -> anyhow::Result<crate::claude::backend::AdoptedSession> {
+            anyhow::bail!("stub backend does not adopt")
+        }
+        fn discover(&self) -> anyhow::Result<Vec<crate::claude::backend::DiscoveredSession>> {
+            Ok(vec![])
+        }
+        fn resize(&self, _: &str, _: u16, _: u16) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn is_dead(&self, _: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        fn kill(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn detach(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn stub_backend() -> Arc<dyn SessionBackend> {
+        Arc::new(StubBackend)
+    }
+
     /// Create an App with N stub sessions bound to the default project.
     fn app_with_sessions(count: usize) -> App {
-        let mut app = App::new(24, 120, vec![]);
+        let backend = stub_backend();
+        let mut app = App::new(24, 120, vec![], backend.clone());
         for i in 0..count {
-            let session = PtySession::stub(&format!("Session {}", i + 1));
+            let session = Session::stub(&format!("Session {}", i + 1), &backend);
             let session_id = session.info.id;
             app.sessions.push(session);
             app.projects[0].session_ids.push(session_id);
@@ -2035,14 +2154,14 @@ mod tests {
 
     #[test]
     fn page_scroll_amount_is_half_content_height() {
-        let app = App::new(50, 100, vec![]);
+        let app = App::new(50, 100, vec![], stub_backend());
         // rows = 50 - 4 = 46, half = 23
         assert_eq!(app.page_scroll_amount(), 23);
     }
 
     #[test]
     fn page_scroll_amount_small_terminal() {
-        let app = App::new(6, 80, vec![]);
+        let app = App::new(6, 80, vec![], stub_backend());
         // rows = 6 - 4 = 2, half = 1
         assert_eq!(app.page_scroll_amount(), 1);
     }
@@ -2056,13 +2175,13 @@ mod tests {
 
     #[test]
     fn next_session_name_starts_at_one() {
-        let mut app = App::new(24, 80, vec![]);
+        let mut app = App::new(24, 80, vec![], stub_backend());
         assert_eq!(app.next_session_name(), "1");
     }
 
     #[test]
     fn next_session_name_increments() {
-        let mut app = App::new(24, 80, vec![]);
+        let mut app = App::new(24, 80, vec![], stub_backend());
         assert_eq!(app.next_session_name(), "1");
         assert_eq!(app.next_session_name(), "2");
         assert_eq!(app.next_session_name(), "3");
@@ -2070,7 +2189,7 @@ mod tests {
 
     #[test]
     fn next_session_name_continues_from_restored_counter() {
-        let mut app = App::new(24, 80, vec![]);
+        let mut app = App::new(24, 80, vec![], stub_backend());
         app.session_counter = 5;
         assert_eq!(app.next_session_name(), "6");
     }
@@ -2079,7 +2198,7 @@ mod tests {
 
     #[test]
     fn open_role_editor_starts_empty_for_no_custom_roles() {
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         assert!(app.show_role_editor);
         assert!(app.role_editor_roles.is_empty());
@@ -2098,7 +2217,7 @@ mod tests {
                 permissions: RolePermissions::default(),
             }],
         };
-        let mut app = App::new(24, 120, vec![config]);
+        let mut app = App::new(24, 120, vec![config], stub_backend());
         app.open_role_editor();
         assert_eq!(app.role_editor_roles.len(), 1);
         assert_eq!(app.role_editor_roles[0].name, "ops");
@@ -2106,7 +2225,7 @@ mod tests {
 
     #[test]
     fn role_editor_submit_uses_allowed_tools_list() {
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         for c in "reviewer".chars() {
@@ -2126,7 +2245,7 @@ mod tests {
 
     #[test]
     fn role_editor_submit_uses_disallowed_tools_list() {
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         for c in "restricted".chars() {
@@ -2168,7 +2287,7 @@ mod tests {
                 },
             ],
         };
-        let mut app = App::new(24, 120, vec![config]);
+        let mut app = App::new(24, 120, vec![config], stub_backend());
         let session_config = SessionConfig::default();
         app.prepare_spawn(session_config, None);
         assert!(app.show_role_selector);
@@ -2181,14 +2300,14 @@ mod tests {
             repos: vec![],
             roles: vec![],
         };
-        let app = App::new(24, 120, vec![config]);
+        let app = App::new(24, 120, vec![config], stub_backend());
         // With no roles, the selector should never be set
         assert!(!app.show_role_selector);
     }
 
     #[test]
     fn role_editor_name_validation_rejects_empty() {
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         // Try to submit with empty name
@@ -2219,7 +2338,7 @@ mod tests {
 
     #[test]
     fn role_editor_name_validation_rejects_duplicate() {
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         // Add first role
         app.handle_role_editor_list_key(KeyCode::Char('a'));
@@ -2260,7 +2379,7 @@ mod tests {
                 },
             }],
         };
-        let mut app = App::new(24, 120, vec![config]);
+        let mut app = App::new(24, 120, vec![config], stub_backend());
         app.open_role_editor();
         app.open_role_for_editing(0);
 
@@ -2282,7 +2401,7 @@ mod tests {
 
     #[test]
     fn role_editor_new_role_has_no_extra_fields() {
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_name.set("new-role");
@@ -2311,7 +2430,7 @@ mod tests {
                 },
             }],
         };
-        let mut app = App::new(24, 120, vec![config]);
+        let mut app = App::new(24, 120, vec![config], stub_backend());
         app.open_role_editor();
         app.open_role_for_editing(0);
 
@@ -2331,7 +2450,7 @@ mod tests {
     #[test]
     fn role_editor_tab_cycles_fields_forward() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -2351,7 +2470,7 @@ mod tests {
     #[test]
     fn role_editor_backtab_cycles_fields_backward() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -2370,7 +2489,7 @@ mod tests {
 
     #[test]
     fn role_editor_esc_discards_and_returns_to_list() {
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         assert_eq!(app.role_editor_view, RoleEditorView::Editor);
@@ -2398,7 +2517,7 @@ mod tests {
                 },
             ],
         };
-        let mut app = App::new(24, 120, vec![config]);
+        let mut app = App::new(24, 120, vec![config], stub_backend());
         app.open_role_editor();
         // Select the last role
         app.role_editor_list_index = 1;
@@ -2410,7 +2529,7 @@ mod tests {
 
     #[test]
     fn role_editor_submit_clears_error_on_success() {
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -2530,7 +2649,7 @@ mod tests {
     #[test]
     fn tool_browse_add_via_key_handler() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -2563,7 +2682,7 @@ mod tests {
     #[test]
     fn tool_browse_delete_via_key_handler() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_field = RoleEditorField::AllowedTools;
@@ -2580,7 +2699,7 @@ mod tests {
     #[test]
     fn tool_adding_esc_cancels() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_field = RoleEditorField::DisallowedTools;
@@ -2612,7 +2731,7 @@ mod tests {
                 },
             }],
         };
-        let mut app = App::new(24, 120, vec![config]);
+        let mut app = App::new(24, 120, vec![config], stub_backend());
         app.open_role_editor();
         app.open_role_for_editing(0);
 
@@ -2631,7 +2750,7 @@ mod tests {
 
     #[test]
     fn system_prompt_empty_saves_as_none() {
-        let mut app = App::new(24, 120, vec![]);
+        let mut app = App::new(24, 120, vec![], stub_backend());
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_name.set("test");
@@ -2659,7 +2778,7 @@ mod tests {
                 },
             }],
         };
-        let app = App::new(24, 120, vec![config]);
+        let app = App::new(24, 120, vec![config], stub_backend());
         // With exactly 1 role, prepare_spawn should not show selector
         // (it would try to spawn, which needs a runtime — just verify no selector)
         assert!(!app.show_role_selector);

--- a/src/claude/mod.rs
+++ b/src/claude/mod.rs
@@ -1,4 +1,5 @@
+pub mod backend;
 pub mod input;
-pub mod pty_session;
+pub mod tmux;
 
-pub use pty_session::PtySession;
+pub use backend::{Session, SessionBackend};

--- a/src/claude/tmux.rs
+++ b/src/claude/tmux.rs
@@ -1,0 +1,1233 @@
+use std::collections::{HashMap, VecDeque};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{sync_channel, SyncSender};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
+use anyhow::{bail, Context, Result};
+use tracing::{debug, warn};
+
+use crate::claude::backend::{AdoptedSession, DiscoveredSession, SessionBackend, SpawnedSession};
+
+/// Dedicated tmux socket name — isolates thurbox sessions from the user's tmux.
+const TMUX_SOCKET: &str = "thurbox";
+
+/// tmux session name used to group all thurbox windows.
+const TMUX_SESSION: &str = "thurbox";
+
+/// Minimum tmux version required.
+const MIN_TMUX_VERSION: (u32, u32) = (3, 2);
+
+/// Per-pane output channel capacity (bounded to provide backpressure).
+const PANE_CHANNEL_CAPACITY: usize = 256;
+
+/// Timeout for waiting for a control mode command response.
+const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Local tmux backend — sessions persist in `tmux -L thurbox`.
+///
+/// Uses tmux control mode (`-C`) for all I/O after `ensure_ready()`.
+pub struct LocalTmuxBackend {
+    control: Mutex<Option<ControlMode>>,
+}
+
+impl Default for LocalTmuxBackend {
+    fn default() -> Self {
+        Self {
+            control: Mutex::new(None),
+        }
+    }
+}
+
+/// A live tmux control mode connection.
+///
+/// Commands are sent serially (stdin lock ensures ordering) and responses arrive
+/// in the same order. We use a FIFO queue instead of matching command numbers,
+/// which avoids numbering mismatches between our counter and tmux's internal
+/// counter (e.g., from `send_command_nowait` calls that still consume a tmux
+/// command number).
+struct ControlMode {
+    stdin: Arc<Mutex<ChildStdin>>,
+    pane_senders: Arc<Mutex<HashMap<String, SyncSender<Vec<u8>>>>>,
+    /// FIFO queue of response channels — one per `send_command()` call, in order.
+    response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
+    reader_handle: Mutex<Option<JoinHandle<()>>>,
+    child: Mutex<Child>,
+}
+
+struct CommandResponse {
+    lines: Vec<String>,
+    is_error: bool,
+}
+
+/// Parsed notification from the tmux control mode protocol.
+#[derive(Debug, PartialEq)]
+enum Notification {
+    Output { pane_id: String, data: Vec<u8> },
+    Begin,
+    End,
+    Error,
+    Pause { pane_id: String },
+    Other(String),
+}
+
+/// Per-pane reader that receives output via an mpsc channel.
+///
+/// Implements `Read` so it plugs directly into the existing `Session::reader_loop`.
+struct ControlModeReader {
+    receiver: std::sync::mpsc::Receiver<Vec<u8>>,
+    buffer: Vec<u8>,
+    pos: usize,
+}
+
+impl ControlModeReader {
+    fn new(receiver: std::sync::mpsc::Receiver<Vec<u8>>) -> Self {
+        Self {
+            receiver,
+            buffer: Vec::new(),
+            pos: 0,
+        }
+    }
+}
+
+impl Read for ControlModeReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // Drain leftover buffered data first.
+        if self.pos < self.buffer.len() {
+            let remaining = &self.buffer[self.pos..];
+            let n = remaining.len().min(buf.len());
+            buf[..n].copy_from_slice(&remaining[..n]);
+            self.pos += n;
+            if self.pos == self.buffer.len() {
+                self.buffer.clear();
+                self.pos = 0;
+            }
+            return Ok(n);
+        }
+
+        // Block until the next chunk arrives.
+        match self.receiver.recv() {
+            Ok(data) => {
+                let n = data.len().min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                if n < data.len() {
+                    self.buffer = data;
+                    self.pos = n;
+                }
+                Ok(n)
+            }
+            Err(_) => Ok(0), // Channel closed → EOF.
+        }
+    }
+}
+
+/// Per-pane writer that sends input via `send-keys -H` through the shared control stdin.
+struct ControlModeWriter {
+    stdin: Arc<Mutex<ChildStdin>>,
+    pane_id: String,
+}
+
+impl Write for ControlModeWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let cmd = format_send_keys(&self.pane_id, buf);
+        let mut stdin = self
+            .stdin
+            .lock()
+            .map_err(|e| std::io::Error::other(format!("stdin lock: {e}")))?;
+        stdin.write_all(cmd.as_bytes())?;
+        stdin.flush()?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl ControlMode {
+    /// Start a control mode connection to the thurbox tmux session.
+    fn start() -> Result<Self> {
+        // -C (single C): control mode with echo — works with piped stdin.
+        // -CC (double C) requires a TTY and fails with "tcgetattr: Inappropriate ioctl".
+        let mut child = Command::new("tmux")
+            .arg("-L")
+            .arg(TMUX_SOCKET)
+            .arg("-C")
+            .arg("attach-session")
+            .arg("-t")
+            .arg(TMUX_SESSION)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("Failed to start tmux control mode")?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .context("Failed to get control mode stdin")?;
+        let stdout = child
+            .stdout
+            .take()
+            .context("Failed to get control mode stdout")?;
+
+        let stdin = Arc::new(Mutex::new(stdin));
+        let pane_senders: Arc<Mutex<HashMap<String, SyncSender<Vec<u8>>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>> =
+            Arc::new(Mutex::new(VecDeque::new()));
+
+        let reader_stdin = Arc::clone(&stdin);
+        let reader_pane_senders = Arc::clone(&pane_senders);
+        let reader_queue = Arc::clone(&response_queue);
+
+        let reader_handle = std::thread::Builder::new()
+            .name("tmux-control-reader".into())
+            .spawn(move || {
+                Self::reader_thread(stdout, reader_stdin, reader_pane_senders, reader_queue);
+            })
+            .context("Failed to spawn control reader thread")?;
+
+        let control = Self {
+            stdin,
+            pane_senders,
+            response_queue,
+            reader_handle: Mutex::new(Some(reader_handle)),
+            child: Mutex::new(child),
+        };
+
+        // Drain the implicit attach response (%begin/%end) that tmux sends
+        // when a control mode client connects. We send a no-op command and
+        // wait for its response — this synchronizes with the reader thread
+        // and guarantees all prior unsolicited responses have been consumed.
+        control.send_command("refresh-client")?;
+
+        // Enable flow control (pause-after=5 seconds of buffered output).
+        control.send_command("refresh-client -f pause-after=5")?;
+
+        Ok(control)
+    }
+
+    /// Background thread that reads and dispatches control mode output.
+    ///
+    /// Responses arrive in FIFO order matching `send_command()` calls.
+    /// We track a single in-flight response at a time (`%begin` → collect
+    /// lines → `%end`/`%error`), then pop the next waiter from the queue.
+    /// Commands sent via `send_command_nowait()` also produce `%begin`/`%end`
+    /// blocks, but no waiter is in the queue for them — those responses are
+    /// simply discarded.
+    fn reader_thread(
+        stdout: std::process::ChildStdout,
+        stdin: Arc<Mutex<ChildStdin>>,
+        pane_senders: Arc<Mutex<HashMap<String, SyncSender<Vec<u8>>>>>,
+        response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
+    ) {
+        let reader = BufReader::new(stdout);
+        // Accumulates response lines for the current in-flight command.
+        let mut collecting: Option<Vec<String>> = None;
+
+        for line in reader.lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(e) => {
+                    debug!("Control reader I/O error: {e}");
+                    break;
+                }
+            };
+
+            match parse_notification(&line) {
+                Notification::Output { pane_id, data } => {
+                    if let Ok(senders) = pane_senders.lock() {
+                        if let Some(tx) = senders.get(&pane_id) {
+                            let _ = tx.send(data);
+                        }
+                    }
+                }
+                Notification::Begin => {
+                    collecting = Some(Vec::new());
+                }
+                end_or_error @ (Notification::End | Notification::Error) => {
+                    let lines = collecting.take().unwrap_or_default();
+                    if let Ok(mut queue) = response_queue.lock() {
+                        if let Some(tx) = queue.pop_front() {
+                            let _ = tx.send(CommandResponse {
+                                lines,
+                                is_error: matches!(end_or_error, Notification::Error),
+                            });
+                        }
+                    }
+                }
+                Notification::Pause { pane_id } => {
+                    let cmd = format!(
+                        "refresh-client -A '{}:continue'\n",
+                        pane_id.replace('\'', "'\\''")
+                    );
+                    if let Ok(mut s) = stdin.lock() {
+                        let _ = s.write_all(cmd.as_bytes());
+                        let _ = s.flush();
+                    }
+                }
+                Notification::Other(text) => {
+                    if let Some(ref mut lines) = collecting {
+                        lines.push(text);
+                    }
+                }
+            }
+        }
+
+        // EOF — control mode connection ended. Close all pane senders so readers get EOF.
+        debug!("Control reader thread exiting");
+        if let Ok(mut senders) = pane_senders.lock() {
+            senders.clear();
+        }
+    }
+
+    /// Send a command and wait for its response.
+    fn send_command(&self, cmd: &str) -> Result<String> {
+        let (tx, rx) = sync_channel(1);
+
+        // Enqueue our response channel before sending, so the reader thread
+        // can deliver the response even if it arrives before we start waiting.
+        {
+            let mut queue = self
+                .response_queue
+                .lock()
+                .map_err(|e| anyhow::anyhow!("response_queue lock: {e}"))?;
+            queue.push_back(tx);
+        }
+
+        {
+            let mut stdin = self
+                .stdin
+                .lock()
+                .map_err(|e| anyhow::anyhow!("stdin lock: {e}"))?;
+            writeln!(stdin, "{cmd}")?;
+            stdin.flush()?;
+        }
+
+        let response = rx
+            .recv_timeout(COMMAND_TIMEOUT)
+            .context(format!("Timeout waiting for response to: {cmd}"))?;
+
+        if response.is_error {
+            bail!("tmux command failed: {cmd}: {}", response.lines.join("\n"));
+        }
+
+        Ok(response.lines.join("\n"))
+    }
+
+    /// Send a command without waiting for a response.
+    ///
+    /// **Caution**: The response (`%begin`/`%end`) will still arrive on the
+    /// control mode stream. If a `send_command` call follows before the
+    /// response is consumed, the nowait response may steal the waiter.
+    /// Only use this when no `send_command` follows, or when the caller
+    /// is the reader thread itself (e.g., pause resume).
+    fn send_command_nowait(&self, cmd: &str) -> Result<()> {
+        let mut stdin = self
+            .stdin
+            .lock()
+            .map_err(|e| anyhow::anyhow!("stdin lock: {e}"))?;
+        writeln!(stdin, "{cmd}")?;
+        stdin.flush()?;
+        Ok(())
+    }
+}
+
+impl Drop for ControlMode {
+    fn drop(&mut self) {
+        // Try to gracefully detach.
+        if let Ok(mut stdin) = self.stdin.lock() {
+            let _ = writeln!(stdin, "detach-client");
+            let _ = stdin.flush();
+        }
+
+        // Join the reader thread.
+        if let Ok(mut handle) = self.reader_handle.lock() {
+            if let Some(h) = handle.take() {
+                let _ = h.join();
+            }
+        }
+
+        // Ensure the child process is cleaned up.
+        if let Ok(mut child) = self.child.lock() {
+            let _ = child.wait();
+        }
+    }
+}
+
+impl LocalTmuxBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Run a tmux command and return its stdout (used before control mode is available).
+    fn tmux_output(&self, args: &[&str]) -> Result<String> {
+        let output = Self::run_tmux(args)?;
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    /// Run a tmux command, returning Ok(()) on success (used before control mode is available).
+    fn tmux_run(&self, args: &[&str]) -> Result<()> {
+        Self::run_tmux(args)?;
+        Ok(())
+    }
+
+    /// Execute a tmux command on the thurbox socket and check for errors.
+    fn run_tmux(args: &[&str]) -> Result<std::process::Output> {
+        let output = Command::new("tmux")
+            .arg("-L")
+            .arg(TMUX_SOCKET)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("Failed to run tmux command")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("tmux {} failed: {}", args.join(" "), stderr.trim());
+        }
+
+        Ok(output)
+    }
+
+    /// Check if the thurbox tmux session exists.
+    fn session_exists(&self) -> bool {
+        self.tmux_run(&["has-session", "-t", TMUX_SESSION]).is_ok()
+    }
+
+    /// Apply initial config to the tmux server.
+    fn apply_config(&self) -> Result<()> {
+        // Server-wide options
+        let server_opts = [
+            ("default-terminal", "xterm-256color"),
+            ("extended-keys", "on"),
+        ];
+        for (key, val) in &server_opts {
+            self.tmux_run(&["set-option", "-s", key, val])?;
+        }
+
+        // Session-level options
+        let session_opts = [
+            ("remain-on-exit", "on"),
+            ("status", "off"),
+            ("history-limit", "5000"),
+            // Allow each window to have its own size, not constrained
+            // by the smallest attached client.
+            ("window-size", "manual"),
+        ];
+        for (key, val) in &session_opts {
+            self.tmux_run(&["set-option", "-t", TMUX_SESSION, key, val])?;
+        }
+
+        Ok(())
+    }
+
+    /// Build the shell command string to pass to tmux new-window.
+    fn build_shell_command(command: &str, args: &[String]) -> String {
+        let mut parts = vec![command.to_string()];
+        for arg in args {
+            parts.push(shell_escape(arg));
+        }
+        parts.join(" ")
+    }
+
+    /// Get a reference to the active control mode, or bail.
+    fn control(&self) -> Result<std::sync::MutexGuard<'_, Option<ControlMode>>> {
+        let guard = self
+            .control
+            .lock()
+            .map_err(|e| anyhow::anyhow!("control lock: {e}"))?;
+        if guard.is_none() {
+            bail!("Control mode not started — call ensure_ready() first");
+        }
+        Ok(guard)
+    }
+
+    /// Send a command via control mode and return the response.
+    fn ctrl_command(&self, cmd: &str) -> Result<String> {
+        let guard = self.control()?;
+        guard.as_ref().unwrap().send_command(cmd)
+    }
+
+    /// Send a command via control mode without waiting for a response.
+    fn ctrl_command_nowait(&self, cmd: &str) -> Result<()> {
+        let guard = self.control()?;
+        guard.as_ref().unwrap().send_command_nowait(cmd)
+    }
+
+    /// Register a pane sender and return the corresponding reader.
+    fn register_pane(&self, pane_id: &str) -> Result<ControlModeReader> {
+        let guard = self.control()?;
+        let ctrl = guard.as_ref().unwrap();
+        let (tx, rx) = sync_channel(PANE_CHANNEL_CAPACITY);
+        {
+            let mut senders = ctrl
+                .pane_senders
+                .lock()
+                .map_err(|e| anyhow::anyhow!("pane_senders lock: {e}"))?;
+            senders.insert(pane_id.to_string(), tx);
+        }
+        Ok(ControlModeReader::new(rx))
+    }
+
+    /// Unregister a pane sender (causes the reader to get EOF).
+    fn unregister_pane(&self, pane_id: &str) -> Result<()> {
+        let guard = self.control()?;
+        let ctrl = guard.as_ref().unwrap();
+        let mut senders = ctrl
+            .pane_senders
+            .lock()
+            .map_err(|e| anyhow::anyhow!("pane_senders lock: {e}"))?;
+        senders.remove(pane_id);
+        Ok(())
+    }
+
+    /// Create a writer for a specific pane.
+    fn pane_writer(&self, pane_id: &str) -> Result<ControlModeWriter> {
+        let guard = self.control()?;
+        let ctrl = guard.as_ref().unwrap();
+        Ok(ControlModeWriter {
+            stdin: Arc::clone(&ctrl.stdin),
+            pane_id: pane_id.to_string(),
+        })
+    }
+
+    /// Capture the full screen content (including scrollback) from a pane.
+    ///
+    /// `-S -` starts from the beginning of scrollback history,
+    /// `-e` includes ANSI escape sequences (colors, bold, etc.),
+    /// `-p` prints to stdout (captured via control mode response).
+    fn capture_pane(&self, pane_id: &str) -> Vec<u8> {
+        let cmd = format!("capture-pane -t {pane_id} -p -e -S -");
+        let content = self.ctrl_command(&cmd).unwrap_or_default();
+        debug!(
+            pane_id = %pane_id,
+            bytes = content.len(),
+            lines = content.lines().count(),
+            "capture-pane result"
+        );
+        content.into_bytes()
+    }
+
+    /// Connect I/O to an existing pane: start monitoring, capture screen,
+    /// resize (triggers app redraw), and create writer.
+    fn connect_pane(&self, pane_id: &str, rows: u16, cols: u16) -> Result<AdoptedSession> {
+        let reader = self.register_pane(pane_id)?;
+        // Must use send_command (waited) here — a nowait call would leave an
+        // unclaimed %begin/%end response in the stream that steals the next
+        // send_command waiter (e.g., capture-pane below).
+        self.ctrl_command(&format!(
+            "refresh-client -A '{}:on'",
+            pane_id.replace('\'', "'\\''")
+        ))?;
+        // Capture the current screen as a quick initial approximation (colors
+        // and backgrounds may be approximate since capture-pane -p renders text
+        // rather than replaying the original escape sequences).
+        let initial_screen = self.capture_pane(pane_id);
+        let writer = self.pane_writer(pane_id)?;
+
+        // Resize to the target dimensions. If the pane was already at this
+        // size, force a SIGWINCH by briefly shrinking by one row and resizing
+        // back. This makes TUI applications (like claude) repaint their full
+        // screen through the normal output stream, which the reader_loop
+        // processes with all escape sequences intact.
+        self.force_resize(pane_id, rows, cols)?;
+
+        Ok(AdoptedSession {
+            output: Box::new(reader),
+            input: Box::new(writer),
+            initial_screen,
+        })
+    }
+
+    /// Resize a pane, forcing a SIGWINCH even if dimensions haven't changed.
+    fn force_resize(&self, pane_id: &str, rows: u16, cols: u16) -> Result<()> {
+        // Briefly resize to different dimensions to guarantee a SIGWINCH,
+        // then resize to the actual target. This causes TUI apps to repaint.
+        if rows > 1 {
+            self.resize(pane_id, rows - 1, cols)?;
+        } else {
+            self.resize(pane_id, rows + 1, cols)?;
+        }
+        self.resize(pane_id, rows, cols)?;
+        Ok(())
+    }
+}
+
+impl SessionBackend for LocalTmuxBackend {
+    fn name(&self) -> &str {
+        "local-tmux"
+    }
+
+    fn check_available(&self) -> Result<()> {
+        let output = Command::new("tmux")
+            .arg("-V")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("tmux is not installed or not in PATH")?;
+
+        if !output.status.success() {
+            bail!("tmux -V failed");
+        }
+
+        let version_str = String::from_utf8_lossy(&output.stdout);
+        let version_str = version_str.trim();
+        // Parse "tmux X.Y" or "tmux X.Ya" (e.g., "tmux 3.4" or "tmux 3.3a")
+        let version_part = version_str.strip_prefix("tmux ").unwrap_or(version_str);
+
+        let parts: Vec<&str> = version_part.split('.').collect();
+        if parts.len() < 2 {
+            bail!("Cannot parse tmux version from: {version_str}");
+        }
+
+        let major: u32 = parts[0].parse().context(format!(
+            "Cannot parse tmux major version from: {version_str}"
+        ))?;
+        // Minor might have a trailing letter (e.g., "3a"), strip non-digits.
+        let minor_str: String = parts[1]
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
+        let minor: u32 = minor_str.parse().context(format!(
+            "Cannot parse tmux minor version from: {version_str}"
+        ))?;
+
+        if (major, minor) < MIN_TMUX_VERSION {
+            bail!(
+                "tmux {major}.{minor} is too old; thurbox requires >= {}.{}",
+                MIN_TMUX_VERSION.0,
+                MIN_TMUX_VERSION.1
+            );
+        }
+
+        debug!("tmux version: {version_str}");
+        Ok(())
+    }
+
+    fn ensure_ready(&self) -> Result<()> {
+        if !self.session_exists() {
+            debug!("Creating tmux session '{TMUX_SESSION}' on socket '{TMUX_SOCKET}'");
+            let output = Command::new("tmux")
+                .arg("-L")
+                .arg(TMUX_SOCKET)
+                .args([
+                    "new-session",
+                    "-d",
+                    "-s",
+                    TMUX_SESSION,
+                    "-x",
+                    "80",
+                    "-y",
+                    "24",
+                ])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .output()
+                .context("Failed to create tmux session")?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                bail!("Failed to create tmux session: {}", stderr.trim());
+            }
+
+            self.apply_config()?;
+        }
+
+        // Start control mode if not already running.
+        let mut guard = self
+            .control
+            .lock()
+            .map_err(|e| anyhow::anyhow!("control lock: {e}"))?;
+        if guard.is_none() {
+            debug!("Starting tmux control mode");
+            *guard = Some(ControlMode::start()?);
+        }
+
+        Ok(())
+    }
+
+    fn spawn(
+        &self,
+        window_name: &str,
+        command: &str,
+        args: &[String],
+        cwd: Option<&Path>,
+        rows: u16,
+        cols: u16,
+    ) -> Result<SpawnedSession> {
+        let shell_cmd = Self::build_shell_command(command, args);
+
+        let cwd_part = match cwd {
+            Some(dir) => format!(" -c {}", shell_escape(&dir.to_string_lossy())),
+            None => String::new(),
+        };
+        let cmd = format!(
+            "new-window -t {TMUX_SESSION} -n {window_name} -P -F '#{{pane_id}}'{cwd_part} {shell_cmd}"
+        );
+        let result = self.ctrl_command(&cmd)?;
+        let pane_id = result.trim().to_string();
+
+        debug!(pane_id = %pane_id, "tmux window created via control mode");
+
+        let connected = self.connect_pane(&pane_id, rows, cols)?;
+
+        Ok(SpawnedSession {
+            backend_id: pane_id,
+            output: connected.output,
+            input: connected.input,
+            initial_screen: connected.initial_screen,
+        })
+    }
+
+    fn adopt(&self, backend_id: &str, rows: u16, cols: u16) -> Result<AdoptedSession> {
+        self.connect_pane(backend_id, rows, cols)
+    }
+
+    fn discover(&self) -> Result<Vec<DiscoveredSession>> {
+        if !self.session_exists() {
+            return Ok(Vec::new());
+        }
+
+        // Use control mode if available, otherwise fall back to direct tmux command.
+        let result = {
+            let guard = self
+                .control
+                .lock()
+                .map_err(|e| anyhow::anyhow!("control lock: {e}"))?;
+            if let Some(ref ctrl) = *guard {
+                ctrl.send_command(&format!(
+                    "list-windows -t {TMUX_SESSION} -F '#{{pane_id}}|#{{window_name}}|#{{pane_dead}}'"
+                ))?
+            } else {
+                self.tmux_output(&[
+                    "list-windows",
+                    "-t",
+                    TMUX_SESSION,
+                    "-F",
+                    "#{pane_id}|#{window_name}|#{pane_dead}",
+                ])?
+            }
+        };
+
+        let mut sessions = Vec::new();
+        for line in result.lines() {
+            let parts: Vec<&str> = line.splitn(3, '|').collect();
+            if parts.len() < 3 {
+                continue;
+            }
+
+            let window_name = parts[1];
+            // Only discover windows with our prefix.
+            if !window_name.starts_with("tb-") {
+                continue;
+            }
+
+            sessions.push(DiscoveredSession {
+                backend_id: parts[0].to_string(),
+                name: window_name.to_string(),
+                is_alive: parts[2] != "1",
+            });
+        }
+
+        Ok(sessions)
+    }
+
+    fn resize(&self, backend_id: &str, rows: u16, cols: u16) -> Result<()> {
+        // Resize the window first — panes cannot exceed their window's dimensions.
+        self.ctrl_command(&format!(
+            "resize-window -t {backend_id} -x {cols} -y {rows}"
+        ))?;
+
+        // Then resize the pane within the window.
+        self.ctrl_command(&format!("resize-pane -t {backend_id} -x {cols} -y {rows}"))?;
+
+        Ok(())
+    }
+
+    fn is_dead(&self, backend_id: &str) -> Result<bool> {
+        let result = self.ctrl_command(&format!(
+            "display-message -t {backend_id} -p '#{{pane_dead}}'"
+        ))?;
+        Ok(result.trim() == "1")
+    }
+
+    fn kill(&self, backend_id: &str) -> Result<()> {
+        let _ = self.unregister_pane(backend_id);
+        self.ctrl_command(&format!("kill-pane -t {backend_id}"))?;
+        Ok(())
+    }
+
+    fn detach(&self, backend_id: &str) -> Result<()> {
+        // Disable output monitoring for this pane.
+        if let Err(e) = self.ctrl_command_nowait(&format!(
+            "refresh-client -A '{}:off'",
+            backend_id.replace('\'', "'\\''")
+        )) {
+            warn!("Failed to disable output monitoring during detach: {e}");
+        }
+        // Remove the pane sender — the ControlModeReader gets EOF.
+        let _ = self.unregister_pane(backend_id);
+        Ok(())
+    }
+}
+
+/// Decode tmux control mode octal escapes in `%output` data.
+///
+/// Scans for `\` followed by exactly 3 octal digits (0-7). Emits the decoded byte.
+/// All other characters pass through unchanged.
+fn decode_octal(input: &str) -> Vec<u8> {
+    let mut result = Vec::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 3 < bytes.len() {
+            let d0 = bytes[i + 1];
+            let d1 = bytes[i + 2];
+            let d2 = bytes[i + 3];
+            if is_octal(d0) && is_octal(d1) && is_octal(d2) {
+                let val = (d0 - b'0') as u16 * 64 + (d1 - b'0') as u16 * 8 + (d2 - b'0') as u16;
+                result.push(val as u8);
+                i += 4;
+                continue;
+            }
+        }
+        result.push(bytes[i]);
+        i += 1;
+    }
+
+    result
+}
+
+fn is_octal(b: u8) -> bool {
+    (b'0'..=b'7').contains(&b)
+}
+
+/// Parse a line from tmux control mode into a notification.
+fn parse_notification(line: &str) -> Notification {
+    if let Some(rest) = line.strip_prefix("%output ") {
+        // Format: %output %<pane_id> <octal-encoded data>
+        if let Some(space_idx) = rest.find(' ') {
+            let pane_id = rest[..space_idx].to_string();
+            let data = decode_octal(&rest[space_idx + 1..]);
+            return Notification::Output { pane_id, data };
+        }
+    }
+
+    if let Some(rest) = line.strip_prefix("%extended-output ") {
+        // Format: %extended-output %<pane_id> <age> : <octal-encoded data>
+        // The " : " separator divides metadata from payload.
+        if let Some(colon_idx) = rest.find(" : ") {
+            let meta = &rest[..colon_idx];
+            let data = decode_octal(&rest[colon_idx + 3..]);
+            // meta is "%<pane_id> <age>" — extract pane_id.
+            if let Some(space_idx) = meta.find(' ') {
+                let pane_id = meta[..space_idx].to_string();
+                return Notification::Output { pane_id, data };
+            }
+        }
+    }
+
+    if line.starts_with("%begin ") {
+        return Notification::Begin;
+    }
+
+    if line.starts_with("%end ") {
+        return Notification::End;
+    }
+
+    if line.starts_with("%error ") {
+        return Notification::Error;
+    }
+
+    if let Some(rest) = line.strip_prefix("%pause ") {
+        // Format: %pause %<pane_id>
+        return Notification::Pause {
+            pane_id: rest.trim().to_string(),
+        };
+    }
+
+    Notification::Other(line.to_string())
+}
+
+/// Format a `send-keys -H` command for a pane.
+///
+/// Each byte is encoded as two hex digits.
+fn format_send_keys(pane_id: &str, bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    // "send-keys -t %NN -H" + " XX" per byte + "\n"
+    let mut cmd = String::with_capacity(20 + pane_id.len() + bytes.len() * 3 + 1);
+    write!(cmd, "send-keys -t {pane_id} -H").unwrap();
+    for &b in bytes {
+        write!(cmd, " {b:02x}").unwrap();
+    }
+    cmd.push('\n');
+    cmd
+}
+
+/// Shell-escape a string for safe inclusion in a tmux command.
+fn shell_escape(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    // If the string contains no special characters, return as-is.
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':' | '=' | ','))
+    {
+        return s.to_string();
+    }
+    // Wrap in single quotes, escaping existing single quotes.
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- shell_escape tests ---
+
+    #[test]
+    fn shell_escape_empty() {
+        assert_eq!(shell_escape(""), "''");
+    }
+
+    #[test]
+    fn shell_escape_simple() {
+        assert_eq!(shell_escape("hello"), "hello");
+    }
+
+    #[test]
+    fn shell_escape_path() {
+        assert_eq!(shell_escape("/home/user/repos/app"), "/home/user/repos/app");
+    }
+
+    #[test]
+    fn shell_escape_with_spaces() {
+        assert_eq!(shell_escape("hello world"), "'hello world'");
+    }
+
+    #[test]
+    fn shell_escape_with_quotes() {
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn shell_escape_flag_value() {
+        assert_eq!(shell_escape("--permission-mode"), "--permission-mode");
+    }
+
+    #[test]
+    fn shell_escape_tool_pattern() {
+        assert_eq!(shell_escape("Read Bash(git:*)"), "'Read Bash(git:*)'");
+    }
+
+    // --- build_shell_command tests ---
+
+    #[test]
+    fn build_shell_command_simple() {
+        let cmd = LocalTmuxBackend::build_shell_command("claude", &[]);
+        assert_eq!(cmd, "claude");
+    }
+
+    #[test]
+    fn build_shell_command_with_args() {
+        let args = vec![
+            "--resume".to_string(),
+            "abc-123".to_string(),
+            "--permission-mode".to_string(),
+            "dontAsk".to_string(),
+        ];
+        let cmd = LocalTmuxBackend::build_shell_command("claude", &args);
+        assert_eq!(cmd, "claude --resume abc-123 --permission-mode dontAsk");
+    }
+
+    #[test]
+    fn build_shell_command_with_spaces_in_args() {
+        let args = vec![
+            "--allowed-tools".to_string(),
+            "Read Bash(git:*)".to_string(),
+        ];
+        let cmd = LocalTmuxBackend::build_shell_command("claude", &args);
+        assert_eq!(cmd, "claude --allowed-tools 'Read Bash(git:*)'");
+    }
+
+    // --- decode_octal tests ---
+
+    #[test]
+    fn decode_octal_esc() {
+        assert_eq!(decode_octal("\\033"), vec![27]); // ESC
+    }
+
+    #[test]
+    fn decode_octal_backslash() {
+        // A literal backslash is \134 in octal.
+        assert_eq!(decode_octal("\\134"), vec![b'\\']);
+    }
+
+    #[test]
+    fn decode_octal_newline() {
+        assert_eq!(decode_octal("\\012"), vec![b'\n']);
+    }
+
+    #[test]
+    fn decode_octal_passthrough() {
+        assert_eq!(decode_octal("hello"), b"hello");
+    }
+
+    #[test]
+    fn decode_octal_incomplete() {
+        // Backslash followed by fewer than 3 digits passes through.
+        assert_eq!(decode_octal("\\01"), b"\\01");
+    }
+
+    #[test]
+    fn decode_octal_non_octal_digits() {
+        // \089 — 8 and 9 are not octal digits.
+        assert_eq!(decode_octal("\\089"), b"\\089");
+    }
+
+    #[test]
+    fn decode_octal_mixed() {
+        // "A\033[1mB" → A, ESC, [, 1, m, B
+        assert_eq!(
+            decode_octal("A\\033[1mB"),
+            vec![b'A', 27, b'[', b'1', b'm', b'B']
+        );
+    }
+
+    #[test]
+    fn decode_octal_consecutive() {
+        assert_eq!(decode_octal("\\033\\033"), vec![27, 27]);
+    }
+
+    #[test]
+    fn decode_octal_empty() {
+        assert_eq!(decode_octal(""), b"");
+    }
+
+    #[test]
+    fn decode_octal_trailing_backslash() {
+        // Backslash at end of string (no digits follow).
+        assert_eq!(decode_octal("a\\"), b"a\\");
+    }
+
+    #[test]
+    fn decode_octal_max_value() {
+        // \377 = 255 = 0xFF — maximum single-byte octal value.
+        assert_eq!(decode_octal("\\377"), vec![0xFF]);
+    }
+
+    // --- parse_notification tests ---
+
+    #[test]
+    fn parse_output_notification() {
+        let n = parse_notification("%output %42 hello\\033[1m");
+        assert_eq!(
+            n,
+            Notification::Output {
+                pane_id: "%42".to_string(),
+                data: vec![b'h', b'e', b'l', b'l', b'o', 27, b'[', b'1', b'm'],
+            }
+        );
+    }
+
+    #[test]
+    fn parse_extended_output_notification() {
+        let n = parse_notification("%extended-output %2 0 : \\033[?2026hA\\033[?2026l");
+        assert_eq!(
+            n,
+            Notification::Output {
+                pane_id: "%2".to_string(),
+                data: vec![
+                    27, b'[', b'?', b'2', b'0', b'2', b'6', b'h', b'A', 27, b'[', b'?', b'2', b'0',
+                    b'2', b'6', b'l'
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn parse_begin_notification() {
+        assert_eq!(
+            parse_notification("%begin 1234567890 7 0"),
+            Notification::Begin
+        );
+    }
+
+    #[test]
+    fn parse_end_notification() {
+        assert_eq!(parse_notification("%end 1234567890 7 0"), Notification::End);
+    }
+
+    #[test]
+    fn parse_error_notification() {
+        assert_eq!(
+            parse_notification("%error 1234567890 3 0"),
+            Notification::Error
+        );
+    }
+
+    #[test]
+    fn parse_pause_notification() {
+        assert_eq!(
+            parse_notification("%pause %42"),
+            Notification::Pause {
+                pane_id: "%42".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_other_notification() {
+        assert_eq!(
+            parse_notification("some random line"),
+            Notification::Other("some random line".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_output_no_data() {
+        // %output with pane_id but no trailing space/data → falls through to Other.
+        assert_eq!(
+            parse_notification("%output %42"),
+            Notification::Other("%output %42".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_extended_output_no_colon_separator() {
+        // %extended-output without " : " separator → falls through to Other.
+        assert_eq!(
+            parse_notification("%extended-output %2 0 data"),
+            Notification::Other("%extended-output %2 0 data".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_output_empty_data() {
+        // %output with pane_id and trailing space but no data bytes.
+        let n = parse_notification("%output %42 ");
+        assert_eq!(
+            n,
+            Notification::Output {
+                pane_id: "%42".to_string(),
+                data: vec![],
+            }
+        );
+    }
+
+    // --- format_send_keys tests ---
+
+    #[test]
+    fn format_send_keys_single_byte() {
+        assert_eq!(format_send_keys("%42", b"A"), "send-keys -t %42 -H 41\n");
+    }
+
+    #[test]
+    fn format_send_keys_multi_byte() {
+        assert_eq!(
+            format_send_keys("%42", b"ABC"),
+            "send-keys -t %42 -H 41 42 43\n"
+        );
+    }
+
+    #[test]
+    fn format_send_keys_empty() {
+        assert_eq!(format_send_keys("%42", &[]), "send-keys -t %42 -H\n");
+    }
+
+    #[test]
+    fn format_send_keys_escape_sequence() {
+        // ESC [ A (up arrow)
+        assert_eq!(
+            format_send_keys("%1", &[0x1b, b'[', b'A']),
+            "send-keys -t %1 -H 1b 5b 41\n"
+        );
+    }
+
+    // --- ControlModeReader tests ---
+
+    #[test]
+    fn control_mode_reader_data_delivery() {
+        let (tx, rx) = sync_channel(16);
+        let mut reader = ControlModeReader::new(rx);
+
+        tx.send(b"hello".to_vec()).unwrap();
+        let mut buf = [0u8; 16];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"hello");
+    }
+
+    #[test]
+    fn control_mode_reader_eof_on_sender_drop() {
+        let (tx, rx) = sync_channel(16);
+        let mut reader = ControlModeReader::new(rx);
+
+        drop(tx);
+        let mut buf = [0u8; 16];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(n, 0); // EOF
+    }
+
+    #[test]
+    fn control_mode_reader_partial_reads() {
+        let (tx, rx) = sync_channel(16);
+        let mut reader = ControlModeReader::new(rx);
+
+        tx.send(b"hello world".to_vec()).unwrap();
+
+        // Read in small chunks.
+        let mut buf = [0u8; 5];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"hello");
+
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b" worl");
+
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"d");
+    }
+
+    #[test]
+    fn control_mode_reader_multiple_sends() {
+        let (tx, rx) = sync_channel(16);
+        let mut reader = ControlModeReader::new(rx);
+
+        tx.send(b"aaa".to_vec()).unwrap();
+        tx.send(b"bbb".to_vec()).unwrap();
+
+        let mut buf = [0u8; 16];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"aaa");
+
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"bbb");
+    }
+
+    #[test]
+    fn control_mode_writer_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ControlModeWriter>();
+    }
+
+    #[test]
+    fn control_mode_reader_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ControlModeReader>();
+    }
+
+    #[test]
+    fn backend_default_has_no_control_mode() {
+        let backend = LocalTmuxBackend::new();
+        let guard = backend.control.lock().unwrap();
+        assert!(guard.is_none());
+    }
+}

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -334,6 +334,8 @@ repos = ["/home/user/repos/other"]
                     cwd: Some(PathBuf::from("/tmp/repo")),
                     worktree: None,
                     role: "developer".to_string(),
+                    backend_id: String::new(),
+                    backend_type: String::new(),
                 },
                 PersistedSession {
                     name: "Session 2".to_string(),
@@ -345,6 +347,8 @@ repos = ["/home/user/repos/other"]
                         branch: "feat".to_string(),
                     }),
                     role: "reviewer".to_string(),
+                    backend_id: String::new(),
+                    backend_type: String::new(),
                 },
             ],
             session_counter: 2,
@@ -382,6 +386,8 @@ repos = ["/home/user/repos/other"]
                 cwd: None,
                 worktree: None,
                 role: "developer".to_string(),
+                backend_id: String::new(),
+                backend_type: String::new(),
             }],
             session_counter: 1,
         };

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -92,6 +92,7 @@ pub struct SessionInfo {
     pub worktree: Option<WorktreeInfo>,
     pub claude_session_id: Option<String>,
     pub cwd: Option<PathBuf>,
+    pub backend_id: Option<String>,
 }
 
 impl SessionInfo {
@@ -104,6 +105,7 @@ impl SessionInfo {
             worktree: None,
             claude_session_id: None,
             cwd: None,
+            backend_id: None,
         }
     }
 }
@@ -125,6 +127,10 @@ pub struct PersistedSession {
     pub worktree: Option<PersistedWorktree>,
     #[serde(default)]
     pub role: String,
+    #[serde(default)]
+    pub backend_id: String,
+    #[serde(default)]
+    pub backend_type: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -201,6 +207,12 @@ mod tests {
     fn session_info_new_has_no_cwd() {
         let info = SessionInfo::new("Test".to_string());
         assert!(info.cwd.is_none());
+    }
+
+    #[test]
+    fn session_info_new_has_no_backend_id() {
+        let info = SessionInfo::new("Test".to_string());
+        assert!(info.backend_id.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace portable-pty with trait-based SessionBackend architecture
- Implement LocalTmuxBackend using tmux control mode (-C) for persistent sessions
- Sessions survive thurbox crashes/restarts and work across multiple instances
- Remove libc dependency and eliminate pipe-pane + FIFO approach
- Add session restore via capture-pane + forced resize (SIGWINCH trigger)

## Test plan

- [x] All 205 tests pass (4 new tests added during refactoring)
- [x] Clippy clean with -D warnings
- [x] Docs compile with -D warnings
- [x] Pre-commit hooks pass (fmt, clippy, check, nextest, architecture, deny, audit, doc, rumdl)
- [x] Session reconnect shows full history with correct formatting