### PR TITLE
Add project deletion with type-to-confirm safety

### DIFF
--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1,0 +1,662 @@
+//! Key event handlers for the Thurbox TUI application.
+//!
+//! This module contains all keyboard input handling logic organized by context:
+//! - Global keybindings (always active)
+//! - Focus-based handlers (ProjectList, SessionList, Terminal)
+//! - Modal handlers (AddProject, RepoSelector, BranchSelector, etc.)
+
+use super::{AddProjectField, App, InputFocus, RoleEditorView};
+use crate::claude::input;
+use crossterm::event::{KeyCode, KeyModifiers};
+use tracing::error;
+
+impl App {
+    /// Main key handler dispatcher.
+    ///
+    /// Routes key events to the appropriate handler based on:
+    /// 1. Modal state (highest priority)
+    /// 2. Global keybindings (Ctrl+Q, Ctrl+N, etc.)
+    /// 3. Focus-based handlers (ProjectList, SessionList, Terminal)
+    pub(crate) fn handle_key(&mut self, code: KeyCode, mods: KeyModifiers) {
+        // Dismiss help overlay with Esc
+        if self.show_help {
+            if code == KeyCode::Esc {
+                self.show_help = false;
+            }
+            return;
+        }
+
+        // Repo selector modal captures all input
+        if self.show_repo_selector {
+            self.handle_repo_selector_key(code);
+            return;
+        }
+
+        // Session mode modal captures all input
+        if self.show_session_mode_modal {
+            self.handle_session_mode_key(code);
+            return;
+        }
+
+        // Branch selector modal captures all input
+        if self.show_branch_selector {
+            self.handle_branch_selector_key(code);
+            return;
+        }
+
+        // Worktree name modal captures all input
+        if self.show_worktree_name_modal {
+            self.handle_worktree_name_key(code);
+            return;
+        }
+
+        // Role editor modal captures all input
+        if self.show_role_editor {
+            self.handle_role_editor_key(code);
+            return;
+        }
+
+        // Role selector modal captures all input
+        if self.show_role_selector {
+            self.handle_role_selector_key(code);
+            return;
+        }
+
+        // Add-project modal captures all input
+        if self.show_add_project_modal {
+            self.handle_add_project_key(code);
+            return;
+        }
+
+        // Global keybindings (always active)
+        if mods.contains(KeyModifiers::CONTROL) {
+            match code {
+                KeyCode::Char('q') => {
+                    self.should_quit = true;
+                    return;
+                }
+                KeyCode::Char('n') => {
+                    if self.focus == InputFocus::ProjectList {
+                        self.show_add_project_modal = true;
+                        self.add_project_field = AddProjectField::Name;
+                    } else {
+                        self.spawn_session();
+                    }
+                    return;
+                }
+                KeyCode::Char('x') => {
+                    self.close_active_session();
+                    return;
+                }
+                KeyCode::Char('j') => {
+                    self.switch_session_forward();
+                    return;
+                }
+                KeyCode::Char('k') => {
+                    self.switch_session_backward();
+                    return;
+                }
+                KeyCode::Char('l') => {
+                    self.focus = match self.focus {
+                        InputFocus::ProjectList => InputFocus::SessionList,
+                        InputFocus::SessionList => InputFocus::Terminal,
+                        InputFocus::Terminal => InputFocus::ProjectList,
+                    };
+                    return;
+                }
+                KeyCode::Char('i') => {
+                    if self.terminal_cols >= 120 {
+                        self.show_info_panel = !self.show_info_panel;
+                    }
+                    return;
+                }
+                _ => {}
+            }
+        }
+
+        match self.focus {
+            InputFocus::ProjectList => self.handle_project_list_key(code),
+            InputFocus::SessionList => self.handle_session_list_key(code),
+            InputFocus::Terminal => self.handle_terminal_key(code, mods),
+        }
+    }
+
+    fn handle_project_list_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.active_project_index + 1 < self.projects.len() {
+                    self.active_project_index += 1;
+                    self.sync_active_session_to_project();
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if self.active_project_index > 0 {
+                    self.active_project_index -= 1;
+                    self.sync_active_session_to_project();
+                }
+            }
+            KeyCode::Enter => {
+                self.focus = InputFocus::SessionList;
+            }
+            KeyCode::Char('r') => {
+                self.open_role_editor();
+            }
+            KeyCode::Char('?') => {
+                self.show_help = true;
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_session_list_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Char('?') => {
+                self.show_help = true;
+            }
+            KeyCode::Enter => {
+                self.focus = InputFocus::Terminal;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.switch_session_forward();
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.switch_session_backward();
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_terminal_key(&mut self, code: KeyCode, mods: KeyModifiers) {
+        // Scroll keybindings (Shift + navigation keys)
+        if mods.contains(KeyModifiers::SHIFT) {
+            match code {
+                KeyCode::Up => {
+                    self.scroll_terminal_up(1);
+                    return;
+                }
+                KeyCode::Down => {
+                    self.scroll_terminal_down(1);
+                    return;
+                }
+                KeyCode::PageUp => {
+                    let amount = self.page_scroll_amount();
+                    self.scroll_terminal_up(amount);
+                    return;
+                }
+                KeyCode::PageDown => {
+                    let amount = self.page_scroll_amount();
+                    self.scroll_terminal_down(amount);
+                    return;
+                }
+                _ => {}
+            }
+        }
+
+        // Snap to bottom on any non-scroll key when scrolled up
+        self.with_active_parser(|parser| {
+            if parser.screen().scrollback() > 0 {
+                parser.screen_mut().set_scrollback(0);
+            }
+        });
+
+        if let Some(session) = self.sessions.get(self.active_index) {
+            if let Some(bytes) = input::key_to_bytes(code, mods) {
+                if let Err(e) = session.send_input(bytes) {
+                    error!("Failed to send input: {e}");
+                }
+            }
+        }
+    }
+
+    fn handle_add_project_key(&mut self, code: KeyCode) {
+        let field = match self.add_project_field {
+            AddProjectField::Name => &mut self.add_project_name,
+            AddProjectField::Path => &mut self.add_project_path,
+        };
+
+        match code {
+            KeyCode::Esc => {
+                self.show_add_project_modal = false;
+                self.add_project_name.clear();
+                self.add_project_path.clear();
+            }
+            KeyCode::Tab | KeyCode::BackTab => {
+                self.add_project_field = match self.add_project_field {
+                    AddProjectField::Name => AddProjectField::Path,
+                    AddProjectField::Path => AddProjectField::Name,
+                };
+            }
+            KeyCode::Enter => {
+                self.submit_add_project();
+            }
+            KeyCode::Backspace => {
+                field.backspace();
+            }
+            KeyCode::Delete => {
+                field.delete();
+            }
+            KeyCode::Left => {
+                field.move_left();
+            }
+            KeyCode::Right => {
+                field.move_right();
+            }
+            KeyCode::Home => {
+                field.home();
+            }
+            KeyCode::End => {
+                field.end();
+            }
+            KeyCode::Char(c) => {
+                field.insert(c);
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_repo_selector_key(&mut self, code: KeyCode) {
+        let Some(project) = self.active_project() else {
+            return;
+        };
+        let repo_count = project.config.repos.len();
+        match code {
+            KeyCode::Esc => {
+                self.show_repo_selector = false;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.repo_selector_index + 1 < repo_count {
+                    self.repo_selector_index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.repo_selector_index = self.repo_selector_index.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                if let Some(path) = project.config.repos.get(self.repo_selector_index).cloned() {
+                    self.pending_repo_path = Some(path);
+                    self.show_repo_selector = false;
+                    self.session_mode_index = 0;
+                    self.show_session_mode_modal = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_session_mode_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => {
+                self.show_session_mode_modal = false;
+                self.pending_repo_path = None;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.session_mode_index == 0 {
+                    self.session_mode_index = 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.session_mode_index = 0;
+            }
+            KeyCode::Enter => {
+                self.show_session_mode_modal = false;
+                if self.session_mode_index == 0 {
+                    // Normal mode
+                    if let Some(path) = self.pending_repo_path.take() {
+                        self.spawn_session_in_repo(path);
+                    }
+                } else {
+                    // Worktree mode
+                    self.start_branch_selection();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_branch_selector_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => {
+                self.show_branch_selector = false;
+                self.available_branches.clear();
+                self.pending_repo_path = None;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.branch_selector_index + 1 < self.available_branches.len() {
+                    self.branch_selector_index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.branch_selector_index = self.branch_selector_index.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                let base_branch = self.available_branches[self.branch_selector_index].clone();
+                self.show_branch_selector = false;
+                self.available_branches.clear();
+                self.worktree_name_input.clear();
+                self.pending_base_branch = Some(base_branch);
+                self.show_worktree_name_modal = true;
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_worktree_name_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => {
+                self.show_worktree_name_modal = false;
+                self.worktree_name_input.clear();
+                self.pending_base_branch = None;
+                self.pending_repo_path = None;
+            }
+            KeyCode::Enter => {
+                let new_branch = self.worktree_name_input.value().trim().to_string();
+                if new_branch.is_empty() {
+                    self.error_message = Some("Branch name cannot be empty".to_string());
+                    return;
+                }
+                self.show_worktree_name_modal = false;
+                if let (Some(repo_path), Some(base_branch)) = (
+                    self.pending_repo_path.take(),
+                    self.pending_base_branch.take(),
+                ) {
+                    self.worktree_name_input.clear();
+                    self.spawn_worktree_session(repo_path, &new_branch, &base_branch);
+                }
+            }
+            KeyCode::Backspace => self.worktree_name_input.backspace(),
+            KeyCode::Delete => self.worktree_name_input.delete(),
+            KeyCode::Left => self.worktree_name_input.move_left(),
+            KeyCode::Right => self.worktree_name_input.move_right(),
+            KeyCode::Home => self.worktree_name_input.home(),
+            KeyCode::End => self.worktree_name_input.end(),
+            KeyCode::Char(c) => self.worktree_name_input.insert(c),
+            _ => {}
+        }
+    }
+
+    fn handle_role_selector_key(&mut self, code: KeyCode) {
+        let role_count = self
+            .active_project()
+            .map(|p| p.config.roles.len())
+            .unwrap_or(0);
+        match code {
+            KeyCode::Esc => {
+                self.show_role_selector = false;
+                self.pending_spawn_config = None;
+                self.pending_spawn_worktree = None;
+                self.pending_spawn_name = None;
+                // Undo the counter increment from prepare_spawn()
+                self.session_counter = self.session_counter.saturating_sub(1);
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.role_selector_index + 1 < role_count {
+                    self.role_selector_index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.role_selector_index = self.role_selector_index.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                self.show_role_selector = false;
+                let role_index = self.role_selector_index;
+                if let (Some(mut config), Some(name)) = (
+                    self.pending_spawn_config.take(),
+                    self.pending_spawn_name.take(),
+                ) {
+                    if let Some(project) = self.active_project() {
+                        if let Some(role) = project.config.roles.get(role_index) {
+                            config.role = role.name.clone();
+                            config.permissions = role.permissions.clone();
+                            let worktree = self.pending_spawn_worktree.take();
+                            self.do_spawn_session(name, &config, worktree);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_role_editor_key(&mut self, code: KeyCode) {
+        match self.role_editor_view {
+            RoleEditorView::List => self.handle_role_editor_list_key(code),
+            RoleEditorView::Editor => self.handle_role_editor_editor_key(code),
+        }
+    }
+
+    pub(crate) fn handle_role_editor_list_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => {
+                // Save & close
+                let roles_to_save = self.role_editor_roles.clone();
+                if let Some(project) = self.active_project_mut() {
+                    project.config.roles = roles_to_save;
+                }
+                self.save_project_configs_to_disk();
+                self.show_role_editor = false;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if !self.role_editor_roles.is_empty()
+                    && self.role_editor_list_index + 1 < self.role_editor_roles.len()
+                {
+                    self.role_editor_list_index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.role_editor_list_index = self.role_editor_list_index.saturating_sub(1);
+            }
+            KeyCode::Char('a') => {
+                self.role_editor_editing_index = None;
+                self.role_editor_name.clear();
+                self.role_editor_description.clear();
+                self.role_editor_allowed_tools.reset();
+                self.role_editor_disallowed_tools.reset();
+                self.role_editor_system_prompt.clear();
+                self.role_editor_field = crate::ui::role_editor_modal::RoleEditorField::Name;
+                self.role_editor_view = RoleEditorView::Editor;
+            }
+            KeyCode::Char('e') | KeyCode::Enter => {
+                if !self.role_editor_roles.is_empty() {
+                    let idx = self.role_editor_list_index;
+                    self.open_role_for_editing(idx);
+                }
+            }
+            KeyCode::Char('d') => {
+                if !self.role_editor_roles.is_empty() {
+                    self.role_editor_roles.remove(self.role_editor_list_index);
+                    if self.role_editor_list_index >= self.role_editor_roles.len()
+                        && self.role_editor_list_index > 0
+                    {
+                        self.role_editor_list_index -= 1;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn handle_role_editor_editor_key(&mut self, code: KeyCode) {
+        use crate::ui::role_editor_modal::{RoleEditorField, ToolListMode};
+
+        match self.role_editor_field {
+            RoleEditorField::AllowedTools | RoleEditorField::DisallowedTools => {
+                if self.active_tool_list_mut().mode == ToolListMode::Adding {
+                    self.handle_tool_adding_key(code);
+                } else {
+                    self.handle_tool_browse_key(code);
+                }
+                return;
+            }
+            _ => {}
+        }
+
+        // Text field handling (Name, Description, SystemPrompt).
+        match code {
+            KeyCode::Esc => {
+                self.role_editor_view = RoleEditorView::List;
+            }
+            KeyCode::Tab => {
+                self.role_editor_field = Self::next_editor_field(self.role_editor_field);
+            }
+            KeyCode::BackTab => {
+                self.role_editor_field = Self::prev_editor_field(self.role_editor_field);
+            }
+            KeyCode::Enter => {
+                self.submit_role_editor();
+            }
+            _ => {
+                let input = match self.role_editor_field {
+                    RoleEditorField::Name => &mut self.role_editor_name,
+                    RoleEditorField::Description => &mut self.role_editor_description,
+                    RoleEditorField::SystemPrompt => &mut self.role_editor_system_prompt,
+                    _ => return,
+                };
+                match code {
+                    KeyCode::Backspace => input.backspace(),
+                    KeyCode::Delete => input.delete(),
+                    KeyCode::Left => input.move_left(),
+                    KeyCode::Right => input.move_right(),
+                    KeyCode::Home => input.home(),
+                    KeyCode::End => input.end(),
+                    KeyCode::Char(c) => input.insert(c),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn handle_tool_browse_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => {
+                self.role_editor_view = RoleEditorView::List;
+            }
+            KeyCode::Tab => {
+                self.role_editor_field = Self::next_editor_field(self.role_editor_field);
+            }
+            KeyCode::BackTab => {
+                self.role_editor_field = Self::prev_editor_field(self.role_editor_field);
+            }
+            KeyCode::Enter => {
+                self.submit_role_editor();
+            }
+            KeyCode::Char('a') => self.active_tool_list_mut().start_adding(),
+            KeyCode::Char('d') => self.active_tool_list_mut().delete_selected(),
+            KeyCode::Char('j') | KeyCode::Down => self.active_tool_list_mut().move_down(),
+            KeyCode::Char('k') | KeyCode::Up => self.active_tool_list_mut().move_up(),
+            _ => {}
+        }
+    }
+
+    fn handle_tool_adding_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => self.active_tool_list_mut().cancel_add(),
+            KeyCode::Enter => self.active_tool_list_mut().confirm_add(),
+            _ => {
+                let input = &mut self.active_tool_list_mut().input;
+                match code {
+                    KeyCode::Backspace => input.backspace(),
+                    KeyCode::Delete => input.delete(),
+                    KeyCode::Left => input.move_left(),
+                    KeyCode::Right => input.move_right(),
+                    KeyCode::Home => input.home(),
+                    KeyCode::End => input.end(),
+                    KeyCode::Char(c) => input.insert(c),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn next_editor_field(
+        field: crate::ui::role_editor_modal::RoleEditorField,
+    ) -> crate::ui::role_editor_modal::RoleEditorField {
+        use crate::ui::role_editor_modal::RoleEditorField;
+        match field {
+            RoleEditorField::Name => RoleEditorField::Description,
+            RoleEditorField::Description => RoleEditorField::AllowedTools,
+            RoleEditorField::AllowedTools => RoleEditorField::DisallowedTools,
+            RoleEditorField::DisallowedTools => RoleEditorField::SystemPrompt,
+            RoleEditorField::SystemPrompt => RoleEditorField::Name,
+        }
+    }
+
+    fn prev_editor_field(
+        field: crate::ui::role_editor_modal::RoleEditorField,
+    ) -> crate::ui::role_editor_modal::RoleEditorField {
+        use crate::ui::role_editor_modal::RoleEditorField;
+        match field {
+            RoleEditorField::Name => RoleEditorField::SystemPrompt,
+            RoleEditorField::Description => RoleEditorField::Name,
+            RoleEditorField::AllowedTools => RoleEditorField::Description,
+            RoleEditorField::DisallowedTools => RoleEditorField::AllowedTools,
+            RoleEditorField::SystemPrompt => RoleEditorField::DisallowedTools,
+        }
+    }
+
+    pub(crate) fn open_role_editor(&mut self) {
+        let Some(project) = self.active_project() else {
+            return;
+        };
+        self.role_editor_roles = project.config.roles.clone();
+        self.role_editor_list_index = 0;
+        self.role_editor_view = RoleEditorView::List;
+        self.show_role_editor = true;
+    }
+
+    pub(crate) fn open_role_for_editing(&mut self, index: usize) {
+        let role = &self.role_editor_roles[index];
+        self.role_editor_editing_index = Some(index);
+        self.role_editor_name.set(&role.name);
+        self.role_editor_description.set(&role.description);
+        self.role_editor_allowed_tools
+            .load(&role.permissions.allowed_tools);
+        self.role_editor_disallowed_tools
+            .load(&role.permissions.disallowed_tools);
+        self.role_editor_system_prompt.set(
+            role.permissions
+                .append_system_prompt
+                .as_deref()
+                .unwrap_or(""),
+        );
+        self.role_editor_field = crate::ui::role_editor_modal::RoleEditorField::Name;
+        self.role_editor_view = RoleEditorView::Editor;
+    }
+
+    pub(crate) fn active_tool_list_mut(&mut self) -> &mut super::ToolListState {
+        match self.role_editor_field {
+            crate::ui::role_editor_modal::RoleEditorField::AllowedTools => {
+                &mut self.role_editor_allowed_tools
+            }
+            _ => &mut self.role_editor_disallowed_tools,
+        }
+    }
+
+    pub(crate) fn start_branch_selection(&mut self) {
+        let Some(repo_path) = self.pending_repo_path.as_ref() else {
+            return;
+        };
+        match crate::git::list_branches(repo_path) {
+            Ok(branches) if branches.is_empty() => {
+                self.error_message = Some("No branches found in repository".to_string());
+                self.pending_repo_path = None;
+            }
+            Ok(mut branches) => {
+                // Move the default branch to front so it's pre-selected.
+                if let Some(default) = crate::git::default_branch(repo_path, &branches) {
+                    if let Some(pos) = branches.iter().position(|b| b == &default) {
+                        let branch = branches.remove(pos);
+                        branches.insert(0, branch);
+                    }
+                }
+                self.available_branches = branches;
+                self.branch_selector_index = 0;
+                self.show_branch_selector = true;
+            }
+            Err(e) => {
+                error!("Failed to list branches: {e}");
+                self.error_message = Some(format!("Failed to list branches: {e:#}"));
+                self.pending_repo_path = None;
+            }
+        }
+    }
+}

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -68,6 +68,12 @@ impl App {
             return;
         }
 
+        // Delete-project modal captures all input
+        if self.show_delete_project_modal_flag {
+            self.handle_delete_project_key(code);
+            return;
+        }
+
         // Global keybindings (always active)
         if mods.contains(KeyModifiers::CONTROL) {
             match code {
@@ -140,6 +146,9 @@ impl App {
             }
             KeyCode::Char('r') => {
                 self.open_role_editor();
+            }
+            KeyCode::Char('d') => {
+                self.show_delete_project_modal();
             }
             KeyCode::Char('?') => {
                 self.show_help = true;
@@ -249,6 +258,44 @@ impl App {
             }
             KeyCode::Char(c) => {
                 field.insert(c);
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_delete_project_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Enter => {
+                self.delete_active_project();
+            }
+            KeyCode::Esc => {
+                self.show_delete_project_modal_flag = false;
+                self.delete_project_confirmation.clear();
+                self.delete_project_error = None;
+            }
+            KeyCode::Char(c) => {
+                self.delete_project_confirmation.insert(c);
+                self.delete_project_error = None; // Clear error on new input
+            }
+            KeyCode::Backspace => {
+                self.delete_project_confirmation.backspace();
+                self.delete_project_error = None;
+            }
+            KeyCode::Delete => {
+                self.delete_project_confirmation.delete();
+                self.delete_project_error = None;
+            }
+            KeyCode::Left => {
+                self.delete_project_confirmation.move_left();
+            }
+            KeyCode::Right => {
+                self.delete_project_confirmation.move_right();
+            }
+            KeyCode::Home => {
+                self.delete_project_confirmation.home();
+            }
+            KeyCode::End => {
+                self.delete_project_confirmation.end();
             }
             _ => {}
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+mod key_handlers;
 mod modals;
 mod state;
 
@@ -14,7 +15,7 @@ use ratatui::{
 };
 use tracing::error;
 
-use crate::claude::{input, Session, SessionBackend};
+use crate::claude::{Session, SessionBackend};
 use crate::git;
 use crate::project::{self, ProjectConfig, ProjectId, ProjectInfo};
 use crate::session::{
@@ -46,11 +47,11 @@ pub enum AddProjectField {
 }
 
 /// State for an editable list of tool names (allowed or disallowed).
-struct ToolListState {
-    items: Vec<String>,
-    selected: usize,
-    mode: role_editor_modal::ToolListMode,
-    input: TextInput,
+pub(crate) struct ToolListState {
+    pub(crate) items: Vec<String>,
+    pub(crate) selected: usize,
+    pub(crate) mode: role_editor_modal::ToolListMode,
+    pub(crate) input: TextInput,
 }
 
 impl ToolListState {
@@ -115,9 +116,9 @@ impl ToolListState {
     }
 }
 
-struct TextInput {
-    buffer: String,
-    cursor: usize,
+pub(crate) struct TextInput {
+    pub(crate) buffer: String,
+    pub(crate) cursor: usize,
 }
 
 impl TextInput {
@@ -217,45 +218,45 @@ pub struct App {
     pub(crate) sessions: Vec<Session>,
     pub(crate) active_index: usize,
     backend: Arc<dyn SessionBackend>,
-    focus: InputFocus,
-    should_quit: bool,
-    error_message: Option<String>,
+    pub(crate) focus: InputFocus,
+    pub(crate) should_quit: bool,
+    pub(crate) error_message: Option<String>,
     terminal_rows: u16,
-    terminal_cols: u16,
+    pub(crate) terminal_cols: u16,
     session_counter: usize,
-    show_info_panel: bool,
-    show_help: bool,
-    show_add_project_modal: bool,
-    add_project_name: TextInput,
-    add_project_path: TextInput,
-    add_project_field: AddProjectField,
-    show_repo_selector: bool,
-    repo_selector_index: usize,
-    show_session_mode_modal: bool,
-    session_mode_index: usize,
-    show_branch_selector: bool,
-    branch_selector_index: usize,
-    available_branches: Vec<String>,
-    pending_repo_path: Option<PathBuf>,
-    show_worktree_name_modal: bool,
-    worktree_name_input: TextInput,
-    pending_base_branch: Option<String>,
-    show_role_selector: bool,
-    role_selector_index: usize,
-    pending_spawn_config: Option<SessionConfig>,
-    pending_spawn_worktree: Option<WorktreeInfo>,
-    pending_spawn_name: Option<String>,
-    show_role_editor: bool,
-    role_editor_view: RoleEditorView,
-    role_editor_list_index: usize,
-    role_editor_roles: Vec<RoleConfig>,
-    role_editor_field: role_editor_modal::RoleEditorField,
-    role_editor_name: TextInput,
-    role_editor_description: TextInput,
-    role_editor_allowed_tools: ToolListState,
-    role_editor_disallowed_tools: ToolListState,
-    role_editor_system_prompt: TextInput,
-    role_editor_editing_index: Option<usize>,
+    pub(crate) show_info_panel: bool,
+    pub(crate) show_help: bool,
+    pub(crate) show_add_project_modal: bool,
+    pub(crate) add_project_name: TextInput,
+    pub(crate) add_project_path: TextInput,
+    pub(crate) add_project_field: AddProjectField,
+    pub(crate) show_repo_selector: bool,
+    pub(crate) repo_selector_index: usize,
+    pub(crate) show_session_mode_modal: bool,
+    pub(crate) session_mode_index: usize,
+    pub(crate) show_branch_selector: bool,
+    pub(crate) branch_selector_index: usize,
+    pub(crate) available_branches: Vec<String>,
+    pub(crate) pending_repo_path: Option<PathBuf>,
+    pub(crate) show_worktree_name_modal: bool,
+    pub(crate) worktree_name_input: TextInput,
+    pub(crate) pending_base_branch: Option<String>,
+    pub(crate) show_role_selector: bool,
+    pub(crate) role_selector_index: usize,
+    pub(crate) pending_spawn_config: Option<SessionConfig>,
+    pub(crate) pending_spawn_worktree: Option<WorktreeInfo>,
+    pub(crate) pending_spawn_name: Option<String>,
+    pub(crate) show_role_editor: bool,
+    pub(crate) role_editor_view: RoleEditorView,
+    pub(crate) role_editor_list_index: usize,
+    pub(crate) role_editor_roles: Vec<RoleConfig>,
+    pub(crate) role_editor_field: role_editor_modal::RoleEditorField,
+    pub(crate) role_editor_name: TextInput,
+    pub(crate) role_editor_description: TextInput,
+    pub(crate) role_editor_allowed_tools: ToolListState,
+    pub(crate) role_editor_disallowed_tools: ToolListState,
+    pub(crate) role_editor_system_prompt: TextInput,
+    pub(crate) role_editor_editing_index: Option<usize>,
     sync_state: SyncState,
 }
 
@@ -433,7 +434,7 @@ impl App {
         }
     }
 
-    fn spawn_session_in_repo(&mut self, repo_path: PathBuf) {
+    pub(crate) fn spawn_session_in_repo(&mut self, repo_path: PathBuf) {
         let config = SessionConfig {
             cwd: Some(repo_path),
             ..SessionConfig::default()
@@ -446,7 +447,7 @@ impl App {
         self.session_counter.to_string()
     }
 
-    fn spawn_session_with_config(&mut self, config: &SessionConfig) {
+    pub(crate) fn spawn_session_with_config(&mut self, config: &SessionConfig) {
         self.prepare_spawn(config.clone(), None);
     }
 
@@ -454,7 +455,11 @@ impl App {
     ///
     /// Assigns a session name, then spawns immediately if no roles or exactly
     /// one role is configured, or shows the role selector modal for 2+ roles.
-    fn prepare_spawn(&mut self, mut config: SessionConfig, worktree: Option<WorktreeInfo>) {
+    pub(crate) fn prepare_spawn(
+        &mut self,
+        mut config: SessionConfig,
+        worktree: Option<WorktreeInfo>,
+    ) {
         let name = self.next_session_name();
         let Some(project) = self.active_project() else {
             return;
@@ -488,17 +493,23 @@ impl App {
             return;
         }
 
-        let session_id = self.sessions[self.active_index].info.id;
+        let Some(session) = self.sessions.get(self.active_index) else {
+            return;
+        };
+
+        let session_id = session.info.id;
 
         // Clean up worktree if present
-        if let Some(wt) = &self.sessions[self.active_index].info.worktree {
+        if let Some(wt) = &session.info.worktree {
             if let Err(e) = git::remove_worktree(&wt.repo_path, &wt.worktree_path) {
                 error!("Failed to remove worktree: {e}");
             }
         }
 
         // Kill the backend session before removing from the list.
-        self.sessions[self.active_index].kill();
+        if let Some(session) = self.sessions.get_mut(self.active_index) {
+            session.kill();
+        }
         self.sessions.remove(self.active_index);
 
         // Remove session from its project
@@ -517,7 +528,7 @@ impl App {
     }
 
     /// Get sessions belonging to the active project.
-    fn active_project_sessions(&self) -> Vec<usize> {
+    pub(crate) fn active_project_sessions(&self) -> Vec<usize> {
         match self.active_project() {
             Some(project) => self
                 .sessions
@@ -531,7 +542,7 @@ impl App {
     }
 
     /// Get the active session's index within the active project's session list.
-    fn active_session_in_project(&self) -> usize {
+    pub(crate) fn active_session_in_project(&self) -> usize {
         let project_sessions = self.active_project_sessions();
         project_sessions
             .iter()
@@ -586,198 +597,7 @@ impl App {
         }
     }
 
-    fn handle_key(&mut self, code: KeyCode, mods: KeyModifiers) {
-        // Dismiss help overlay with Esc
-        if self.show_help {
-            if code == KeyCode::Esc {
-                self.show_help = false;
-            }
-            return;
-        }
-
-        // Repo selector modal captures all input
-        if self.show_repo_selector {
-            self.handle_repo_selector_key(code);
-            return;
-        }
-
-        // Session mode modal captures all input
-        if self.show_session_mode_modal {
-            self.handle_session_mode_key(code);
-            return;
-        }
-
-        // Branch selector modal captures all input
-        if self.show_branch_selector {
-            self.handle_branch_selector_key(code);
-            return;
-        }
-
-        // Worktree name modal captures all input
-        if self.show_worktree_name_modal {
-            self.handle_worktree_name_key(code);
-            return;
-        }
-
-        // Role editor modal captures all input
-        if self.show_role_editor {
-            self.handle_role_editor_key(code);
-            return;
-        }
-
-        // Role selector modal captures all input
-        if self.show_role_selector {
-            self.handle_role_selector_key(code);
-            return;
-        }
-
-        // Add-project modal captures all input
-        if self.show_add_project_modal {
-            self.handle_add_project_key(code);
-            return;
-        }
-
-        // Global keybindings (always active)
-        if mods.contains(KeyModifiers::CONTROL) {
-            match code {
-                KeyCode::Char('q') => {
-                    self.should_quit = true;
-                    return;
-                }
-                KeyCode::Char('n') => {
-                    if self.focus == InputFocus::ProjectList {
-                        self.show_add_project_modal = true;
-                        self.add_project_field = AddProjectField::Name;
-                    } else {
-                        self.spawn_session();
-                    }
-                    return;
-                }
-                KeyCode::Char('x') => {
-                    self.close_active_session();
-                    return;
-                }
-                KeyCode::Char('j') => {
-                    self.switch_session_forward();
-                    return;
-                }
-                KeyCode::Char('k') => {
-                    self.switch_session_backward();
-                    return;
-                }
-                KeyCode::Char('l') => {
-                    self.focus = match self.focus {
-                        InputFocus::ProjectList => InputFocus::SessionList,
-                        InputFocus::SessionList => InputFocus::Terminal,
-                        InputFocus::Terminal => InputFocus::ProjectList,
-                    };
-                    return;
-                }
-                KeyCode::Char('i') => {
-                    if self.terminal_cols >= 120 {
-                        self.show_info_panel = !self.show_info_panel;
-                    }
-                    return;
-                }
-                _ => {}
-            }
-        }
-
-        match self.focus {
-            InputFocus::ProjectList => self.handle_project_list_key(code),
-            InputFocus::SessionList => self.handle_session_list_key(code),
-            InputFocus::Terminal => self.handle_terminal_key(code, mods),
-        }
-    }
-
-    fn handle_project_list_key(&mut self, code: KeyCode) {
-        match code {
-            KeyCode::Char('j') | KeyCode::Down => {
-                if self.active_project_index + 1 < self.projects.len() {
-                    self.active_project_index += 1;
-                    self.sync_active_session_to_project();
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                if self.active_project_index > 0 {
-                    self.active_project_index -= 1;
-                    self.sync_active_session_to_project();
-                }
-            }
-            KeyCode::Enter => {
-                self.focus = InputFocus::SessionList;
-            }
-            KeyCode::Char('r') => {
-                self.open_role_editor();
-            }
-            KeyCode::Char('?') => {
-                self.show_help = true;
-            }
-            _ => {}
-        }
-    }
-
-    fn handle_session_list_key(&mut self, code: KeyCode) {
-        match code {
-            KeyCode::Char('?') => {
-                self.show_help = true;
-            }
-            KeyCode::Enter => {
-                self.focus = InputFocus::Terminal;
-            }
-            KeyCode::Char('j') | KeyCode::Down => {
-                self.switch_session_forward();
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.switch_session_backward();
-            }
-            _ => {}
-        }
-    }
-
-    fn handle_terminal_key(&mut self, code: KeyCode, mods: KeyModifiers) {
-        // Scroll keybindings (Shift + navigation keys)
-        if mods.contains(KeyModifiers::SHIFT) {
-            match code {
-                KeyCode::Up => {
-                    self.scroll_terminal_up(1);
-                    return;
-                }
-                KeyCode::Down => {
-                    self.scroll_terminal_down(1);
-                    return;
-                }
-                KeyCode::PageUp => {
-                    let amount = self.page_scroll_amount();
-                    self.scroll_terminal_up(amount);
-                    return;
-                }
-                KeyCode::PageDown => {
-                    let amount = self.page_scroll_amount();
-                    self.scroll_terminal_down(amount);
-                    return;
-                }
-                _ => {}
-            }
-        }
-
-        // Snap to bottom on any non-scroll key when scrolled up
-        self.with_active_parser(|parser| {
-            if parser.screen().scrollback() > 0 {
-                parser.screen_mut().set_scrollback(0);
-            }
-        });
-
-        if let Some(session) = self.sessions.get(self.active_index) {
-            if let Some(bytes) = input::key_to_bytes(code, mods) {
-                if let Err(e) = session.send_input(bytes) {
-                    error!("Failed to send input: {e}");
-                }
-            }
-        }
-    }
-
-    fn with_active_parser(&self, f: impl FnOnce(&mut vt100::Parser)) {
+    pub(crate) fn with_active_parser(&self, f: impl FnOnce(&mut vt100::Parser)) {
         if let Some(session) = self.sessions.get(self.active_index) {
             if let Ok(mut parser) = session.parser.lock() {
                 f(&mut parser);
@@ -785,14 +605,14 @@ impl App {
         }
     }
 
-    fn scroll_terminal_up(&self, lines: usize) {
+    pub(crate) fn scroll_terminal_up(&self, lines: usize) {
         self.with_active_parser(|parser| {
             let current = parser.screen().scrollback();
             parser.screen_mut().set_scrollback(current + lines);
         });
     }
 
-    fn scroll_terminal_down(&self, lines: usize) {
+    pub(crate) fn scroll_terminal_down(&self, lines: usize) {
         self.with_active_parser(|parser| {
             let current = parser.screen().scrollback();
             parser
@@ -801,462 +621,12 @@ impl App {
         });
     }
 
-    fn page_scroll_amount(&self) -> usize {
+    pub(crate) fn page_scroll_amount(&self) -> usize {
         let (rows, _) = self.content_area_size();
         (rows as usize) / 2
     }
 
-    fn handle_add_project_key(&mut self, code: KeyCode) {
-        let field = match self.add_project_field {
-            AddProjectField::Name => &mut self.add_project_name,
-            AddProjectField::Path => &mut self.add_project_path,
-        };
-
-        match code {
-            KeyCode::Esc => {
-                self.show_add_project_modal = false;
-                self.add_project_name.clear();
-                self.add_project_path.clear();
-            }
-            KeyCode::Tab | KeyCode::BackTab => {
-                self.add_project_field = match self.add_project_field {
-                    AddProjectField::Name => AddProjectField::Path,
-                    AddProjectField::Path => AddProjectField::Name,
-                };
-            }
-            KeyCode::Enter => {
-                self.submit_add_project();
-            }
-            KeyCode::Backspace => {
-                field.backspace();
-            }
-            KeyCode::Delete => {
-                field.delete();
-            }
-            KeyCode::Left => {
-                field.move_left();
-            }
-            KeyCode::Right => {
-                field.move_right();
-            }
-            KeyCode::Home => {
-                field.home();
-            }
-            KeyCode::End => {
-                field.end();
-            }
-            KeyCode::Char(c) => {
-                field.insert(c);
-            }
-            _ => {}
-        }
-    }
-
-    fn handle_repo_selector_key(&mut self, code: KeyCode) {
-        let Some(project) = self.active_project() else {
-            return;
-        };
-        let repo_count = project.config.repos.len();
-        match code {
-            KeyCode::Esc => {
-                self.show_repo_selector = false;
-            }
-            KeyCode::Char('j') | KeyCode::Down => {
-                if self.repo_selector_index + 1 < repo_count {
-                    self.repo_selector_index += 1;
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.repo_selector_index = self.repo_selector_index.saturating_sub(1);
-            }
-            KeyCode::Enter => {
-                if let Some(path) = project.config.repos.get(self.repo_selector_index).cloned() {
-                    self.pending_repo_path = Some(path);
-                    self.show_repo_selector = false;
-                    self.session_mode_index = 0;
-                    self.show_session_mode_modal = true;
-                }
-            }
-            _ => {}
-        }
-    }
-
-    fn handle_session_mode_key(&mut self, code: KeyCode) {
-        match code {
-            KeyCode::Esc => {
-                self.show_session_mode_modal = false;
-                self.pending_repo_path = None;
-            }
-            KeyCode::Char('j') | KeyCode::Down => {
-                if self.session_mode_index == 0 {
-                    self.session_mode_index = 1;
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.session_mode_index = 0;
-            }
-            KeyCode::Enter => {
-                self.show_session_mode_modal = false;
-                if self.session_mode_index == 0 {
-                    // Normal mode
-                    if let Some(path) = self.pending_repo_path.take() {
-                        self.spawn_session_in_repo(path);
-                    }
-                } else {
-                    // Worktree mode
-                    self.start_branch_selection();
-                }
-            }
-            _ => {}
-        }
-    }
-
-    fn start_branch_selection(&mut self) {
-        let Some(repo_path) = self.pending_repo_path.as_ref() else {
-            return;
-        };
-        match git::list_branches(repo_path) {
-            Ok(branches) if branches.is_empty() => {
-                self.error_message = Some("No branches found in repository".to_string());
-                self.pending_repo_path = None;
-            }
-            Ok(mut branches) => {
-                // Move the default branch to front so it's pre-selected.
-                if let Some(default) = git::default_branch(repo_path, &branches) {
-                    if let Some(pos) = branches.iter().position(|b| b == &default) {
-                        let branch = branches.remove(pos);
-                        branches.insert(0, branch);
-                    }
-                }
-                self.available_branches = branches;
-                self.branch_selector_index = 0;
-                self.show_branch_selector = true;
-            }
-            Err(e) => {
-                error!("Failed to list branches: {e}");
-                self.error_message = Some(format!("Failed to list branches: {e:#}"));
-                self.pending_repo_path = None;
-            }
-        }
-    }
-
-    fn handle_branch_selector_key(&mut self, code: KeyCode) {
-        match code {
-            KeyCode::Esc => {
-                self.show_branch_selector = false;
-                self.available_branches.clear();
-                self.pending_repo_path = None;
-            }
-            KeyCode::Char('j') | KeyCode::Down => {
-                if self.branch_selector_index + 1 < self.available_branches.len() {
-                    self.branch_selector_index += 1;
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.branch_selector_index = self.branch_selector_index.saturating_sub(1);
-            }
-            KeyCode::Enter => {
-                let base_branch = self.available_branches[self.branch_selector_index].clone();
-                self.show_branch_selector = false;
-                self.available_branches.clear();
-                self.worktree_name_input.clear();
-                self.pending_base_branch = Some(base_branch);
-                self.show_worktree_name_modal = true;
-            }
-            _ => {}
-        }
-    }
-
-    fn handle_worktree_name_key(&mut self, code: KeyCode) {
-        match code {
-            KeyCode::Esc => {
-                self.show_worktree_name_modal = false;
-                self.worktree_name_input.clear();
-                self.pending_base_branch = None;
-                self.pending_repo_path = None;
-            }
-            KeyCode::Enter => {
-                let new_branch = self.worktree_name_input.value().trim().to_string();
-                if new_branch.is_empty() {
-                    self.error_message = Some("Branch name cannot be empty".to_string());
-                    return;
-                }
-                self.show_worktree_name_modal = false;
-                if let (Some(repo_path), Some(base_branch)) = (
-                    self.pending_repo_path.take(),
-                    self.pending_base_branch.take(),
-                ) {
-                    self.worktree_name_input.clear();
-                    self.spawn_worktree_session(repo_path, &new_branch, &base_branch);
-                }
-            }
-            KeyCode::Backspace => self.worktree_name_input.backspace(),
-            KeyCode::Delete => self.worktree_name_input.delete(),
-            KeyCode::Left => self.worktree_name_input.move_left(),
-            KeyCode::Right => self.worktree_name_input.move_right(),
-            KeyCode::Home => self.worktree_name_input.home(),
-            KeyCode::End => self.worktree_name_input.end(),
-            KeyCode::Char(c) => self.worktree_name_input.insert(c),
-            _ => {}
-        }
-    }
-
-    fn handle_role_selector_key(&mut self, code: KeyCode) {
-        let role_count = self
-            .active_project()
-            .map(|p| p.config.roles.len())
-            .unwrap_or(0);
-        match code {
-            KeyCode::Esc => {
-                self.show_role_selector = false;
-                self.pending_spawn_config = None;
-                self.pending_spawn_worktree = None;
-                self.pending_spawn_name = None;
-                // Undo the counter increment from prepare_spawn()
-                self.session_counter = self.session_counter.saturating_sub(1);
-            }
-            KeyCode::Char('j') | KeyCode::Down => {
-                if self.role_selector_index + 1 < role_count {
-                    self.role_selector_index += 1;
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.role_selector_index = self.role_selector_index.saturating_sub(1);
-            }
-            KeyCode::Enter => {
-                self.show_role_selector = false;
-                let role_index = self.role_selector_index;
-                if let (Some(mut config), Some(name)) = (
-                    self.pending_spawn_config.take(),
-                    self.pending_spawn_name.take(),
-                ) {
-                    if let Some(project) = self.active_project() {
-                        if let Some(role) = project.config.roles.get(role_index) {
-                            config.role = role.name.clone();
-                            config.permissions = role.permissions.clone();
-                            let worktree = self.pending_spawn_worktree.take();
-                            self.do_spawn_session(name, &config, worktree);
-                        }
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    fn open_role_editor(&mut self) {
-        let Some(project) = self.active_project() else {
-            return;
-        };
-        self.role_editor_roles = project.config.roles.clone();
-        self.role_editor_list_index = 0;
-        self.role_editor_view = RoleEditorView::List;
-        self.show_role_editor = true;
-    }
-
-    fn handle_role_editor_key(&mut self, code: KeyCode) {
-        match self.role_editor_view {
-            RoleEditorView::List => self.handle_role_editor_list_key(code),
-            RoleEditorView::Editor => self.handle_role_editor_editor_key(code),
-        }
-    }
-
-    fn handle_role_editor_list_key(&mut self, code: KeyCode) {
-        match code {
-            KeyCode::Esc => {
-                // Save & close
-                let roles_to_save = self.role_editor_roles.clone();
-                if let Some(project) = self.active_project_mut() {
-                    project.config.roles = roles_to_save;
-                }
-                self.save_project_configs_to_disk();
-                self.show_role_editor = false;
-            }
-            KeyCode::Char('j') | KeyCode::Down => {
-                if !self.role_editor_roles.is_empty()
-                    && self.role_editor_list_index + 1 < self.role_editor_roles.len()
-                {
-                    self.role_editor_list_index += 1;
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.role_editor_list_index = self.role_editor_list_index.saturating_sub(1);
-            }
-            KeyCode::Char('a') => {
-                self.role_editor_editing_index = None;
-                self.role_editor_name.clear();
-                self.role_editor_description.clear();
-                self.role_editor_allowed_tools.reset();
-                self.role_editor_disallowed_tools.reset();
-                self.role_editor_system_prompt.clear();
-                self.role_editor_field = role_editor_modal::RoleEditorField::Name;
-                self.role_editor_view = RoleEditorView::Editor;
-            }
-            KeyCode::Char('e') | KeyCode::Enter => {
-                if !self.role_editor_roles.is_empty() {
-                    let idx = self.role_editor_list_index;
-                    self.open_role_for_editing(idx);
-                }
-            }
-            KeyCode::Char('d') => {
-                if !self.role_editor_roles.is_empty() {
-                    self.role_editor_roles.remove(self.role_editor_list_index);
-                    if self.role_editor_list_index >= self.role_editor_roles.len()
-                        && self.role_editor_list_index > 0
-                    {
-                        self.role_editor_list_index -= 1;
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    fn open_role_for_editing(&mut self, index: usize) {
-        let role = &self.role_editor_roles[index];
-        self.role_editor_editing_index = Some(index);
-        self.role_editor_name.set(&role.name);
-        self.role_editor_description.set(&role.description);
-        self.role_editor_allowed_tools
-            .load(&role.permissions.allowed_tools);
-        self.role_editor_disallowed_tools
-            .load(&role.permissions.disallowed_tools);
-        self.role_editor_system_prompt.set(
-            role.permissions
-                .append_system_prompt
-                .as_deref()
-                .unwrap_or(""),
-        );
-        self.role_editor_field = role_editor_modal::RoleEditorField::Name;
-        self.role_editor_view = RoleEditorView::Editor;
-    }
-
-    fn handle_role_editor_editor_key(&mut self, code: KeyCode) {
-        use role_editor_modal::{RoleEditorField, ToolListMode};
-
-        match self.role_editor_field {
-            RoleEditorField::AllowedTools | RoleEditorField::DisallowedTools => {
-                if self.active_tool_list_mut().mode == ToolListMode::Adding {
-                    self.handle_tool_adding_key(code);
-                } else {
-                    self.handle_tool_browse_key(code);
-                }
-                return;
-            }
-            _ => {}
-        }
-
-        // Text field handling (Name, Description, SystemPrompt).
-        match code {
-            KeyCode::Esc => {
-                self.role_editor_view = RoleEditorView::List;
-            }
-            KeyCode::Tab => {
-                self.role_editor_field = Self::next_editor_field(self.role_editor_field);
-            }
-            KeyCode::BackTab => {
-                self.role_editor_field = Self::prev_editor_field(self.role_editor_field);
-            }
-            KeyCode::Enter => {
-                self.submit_role_editor();
-            }
-            _ => {
-                let input = match self.role_editor_field {
-                    RoleEditorField::Name => &mut self.role_editor_name,
-                    RoleEditorField::Description => &mut self.role_editor_description,
-                    RoleEditorField::SystemPrompt => &mut self.role_editor_system_prompt,
-                    _ => return,
-                };
-                match code {
-                    KeyCode::Backspace => input.backspace(),
-                    KeyCode::Delete => input.delete(),
-                    KeyCode::Left => input.move_left(),
-                    KeyCode::Right => input.move_right(),
-                    KeyCode::Home => input.home(),
-                    KeyCode::End => input.end(),
-                    KeyCode::Char(c) => input.insert(c),
-                    _ => {}
-                }
-            }
-        }
-    }
-
-    fn next_editor_field(
-        field: role_editor_modal::RoleEditorField,
-    ) -> role_editor_modal::RoleEditorField {
-        use role_editor_modal::RoleEditorField;
-        match field {
-            RoleEditorField::Name => RoleEditorField::Description,
-            RoleEditorField::Description => RoleEditorField::AllowedTools,
-            RoleEditorField::AllowedTools => RoleEditorField::DisallowedTools,
-            RoleEditorField::DisallowedTools => RoleEditorField::SystemPrompt,
-            RoleEditorField::SystemPrompt => RoleEditorField::Name,
-        }
-    }
-
-    fn prev_editor_field(
-        field: role_editor_modal::RoleEditorField,
-    ) -> role_editor_modal::RoleEditorField {
-        use role_editor_modal::RoleEditorField;
-        match field {
-            RoleEditorField::Name => RoleEditorField::SystemPrompt,
-            RoleEditorField::Description => RoleEditorField::Name,
-            RoleEditorField::AllowedTools => RoleEditorField::Description,
-            RoleEditorField::DisallowedTools => RoleEditorField::AllowedTools,
-            RoleEditorField::SystemPrompt => RoleEditorField::DisallowedTools,
-        }
-    }
-
-    fn active_tool_list_mut(&mut self) -> &mut ToolListState {
-        match self.role_editor_field {
-            role_editor_modal::RoleEditorField::AllowedTools => &mut self.role_editor_allowed_tools,
-            _ => &mut self.role_editor_disallowed_tools,
-        }
-    }
-
-    fn handle_tool_browse_key(&mut self, code: KeyCode) {
-        match code {
-            KeyCode::Esc => {
-                self.role_editor_view = RoleEditorView::List;
-            }
-            KeyCode::Tab => {
-                self.role_editor_field = Self::next_editor_field(self.role_editor_field);
-            }
-            KeyCode::BackTab => {
-                self.role_editor_field = Self::prev_editor_field(self.role_editor_field);
-            }
-            KeyCode::Enter => {
-                self.submit_role_editor();
-            }
-            KeyCode::Char('a') => self.active_tool_list_mut().start_adding(),
-            KeyCode::Char('d') => self.active_tool_list_mut().delete_selected(),
-            KeyCode::Char('j') | KeyCode::Down => self.active_tool_list_mut().move_down(),
-            KeyCode::Char('k') | KeyCode::Up => self.active_tool_list_mut().move_up(),
-            _ => {}
-        }
-    }
-
-    fn handle_tool_adding_key(&mut self, code: KeyCode) {
-        match code {
-            KeyCode::Esc => self.active_tool_list_mut().cancel_add(),
-            KeyCode::Enter => self.active_tool_list_mut().confirm_add(),
-            _ => {
-                let input = &mut self.active_tool_list_mut().input;
-                match code {
-                    KeyCode::Backspace => input.backspace(),
-                    KeyCode::Delete => input.delete(),
-                    KeyCode::Left => input.move_left(),
-                    KeyCode::Right => input.move_right(),
-                    KeyCode::Home => input.home(),
-                    KeyCode::End => input.end(),
-                    KeyCode::Char(c) => input.insert(c),
-                    _ => {}
-                }
-            }
-        }
-    }
-
-    fn submit_role_editor(&mut self) {
+    pub(crate) fn submit_role_editor(&mut self) {
         let name = self.role_editor_name.value().trim().to_string();
         if name.is_empty() {
             self.error_message = Some("Role name cannot be empty".to_string());
@@ -1316,7 +686,7 @@ impl App {
         self.role_editor_view = RoleEditorView::List;
     }
 
-    fn save_project_configs_to_disk(&self) {
+    pub(crate) fn save_project_configs_to_disk(&self) {
         let configs: Vec<ProjectConfig> = self
             .projects
             .iter()
@@ -1328,7 +698,12 @@ impl App {
         }
     }
 
-    fn spawn_worktree_session(&mut self, repo_path: PathBuf, new_branch: &str, base_branch: &str) {
+    pub(crate) fn spawn_worktree_session(
+        &mut self,
+        repo_path: PathBuf,
+        new_branch: &str,
+        base_branch: &str,
+    ) {
         match git::create_worktree(&repo_path, new_branch, base_branch) {
             Ok(worktree_path) => {
                 let worktree_info = WorktreeInfo {
@@ -1349,7 +724,7 @@ impl App {
         }
     }
 
-    fn do_spawn_session(
+    pub(crate) fn do_spawn_session(
         &mut self,
         name: String,
         config: &SessionConfig,
@@ -1388,7 +763,7 @@ impl App {
         }
     }
 
-    fn submit_add_project(&mut self) {
+    pub(crate) fn submit_add_project(&mut self) {
         let name = self.add_project_name.value().trim().to_string();
         let path = self.add_project_path.value().trim().to_string();
 
@@ -1429,7 +804,7 @@ impl App {
     }
 
     /// When switching projects, select the first session of the new project.
-    fn sync_active_session_to_project(&mut self) {
+    pub(crate) fn sync_active_session_to_project(&mut self) {
         let project_sessions = self.active_project_sessions();
         if let Some(&first) = project_sessions.first() {
             self.active_index = first;
@@ -1437,12 +812,12 @@ impl App {
     }
 
     /// Switch to the next session within the active project.
-    fn switch_session_forward(&mut self) {
+    pub(crate) fn switch_session_forward(&mut self) {
         self.switch_session_by_offset(1);
     }
 
     /// Switch to the previous session within the active project.
-    fn switch_session_backward(&mut self) {
+    pub(crate) fn switch_session_backward(&mut self) {
         self.switch_session_by_offset(-1);
     }
 
@@ -2136,7 +1511,7 @@ impl App {
             .unwrap_or_default()
     }
 
-    fn content_area_size(&self) -> (u16, u16) {
+    pub(crate) fn content_area_size(&self) -> (u16, u16) {
         // Header: 1 line, Footer: 1 line, Borders: 2 lines top+bottom
         let rows = self.terminal_rows.saturating_sub(4);
 

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -158,6 +158,13 @@ pub struct RoleSelectorModal {
     pub pending_spawn_name: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct DeleteProjectModal {
+    pub project_name: String,
+    pub confirmation: TextInput,
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RoleEditorView {
     List,
@@ -310,6 +317,7 @@ pub enum Modal {
     None,
     Help,
     AddProject(AddProjectModal),
+    DeleteProject(DeleteProjectModal),
     RepoSelector(RepoSelectorModal),
     SessionMode(SessionModeModal),
     BranchSelector(BranchSelectorModal),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod app;
 pub mod claude;
 pub mod git;
+pub mod paths;
 pub mod project;
 pub mod session;
 pub mod sync;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,8 @@ async fn main() -> Result<()> {
     }));
 
     // File-based logging (stdout is owned by the TUI)
-    let log_dir = log_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let log_dir = thurbox::paths::log_directory().unwrap_or_else(|| std::path::PathBuf::from("."));
+    std::fs::create_dir_all(&log_dir).ok();
     let file_appender = tracing_appender::rolling::daily(log_dir, "thurbox.log");
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -92,16 +93,4 @@ async fn run_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Res
     }
 
     Ok(())
-}
-
-/// Return the data-local directory for log files.
-fn log_dir() -> Option<std::path::PathBuf> {
-    std::env::var_os("HOME").map(|h| {
-        let mut p = std::path::PathBuf::from(h);
-        p.push(".local");
-        p.push("share");
-        p.push("thurbox");
-        std::fs::create_dir_all(&p).ok();
-        p
-    })
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,434 @@
+//! Centralized path resolution for application data files.
+//!
+//! This module provides a unified interface for resolving paths to:
+//! - Config files (`~/.config/thurbox/config.toml`)
+//! - State files (`~/.local/share/thurbox/state.toml`)
+//! - Shared state files (`~/.local/share/thurbox/shared_state.toml`)
+//! - Log directories (`~/.local/share/thurbox/`)
+//!
+//! ## Production Behavior
+//!
+//! By default, uses XDG Base Directory Specification:
+//! - Prefers `$XDG_CONFIG_HOME` for config, fallback to `$HOME/.config`
+//! - Prefers `$XDG_DATA_HOME` for data, fallback to `$HOME/.local/share`
+//!
+//! ## Testing Behavior
+//!
+//! Tests can override path resolution using `TestPathGuard`:
+//! ```ignore
+//! #[test]
+//! fn test_with_custom_paths() {
+//!     let temp_dir = tempfile::TempDir::new().unwrap();
+//!     let _guard = TestPathGuard::new(temp_dir.path());
+//!
+//!     // All paths now resolve under temp_dir
+//!     let config = config_file().unwrap();
+//!     assert_eq!(config, temp_dir.path().join("config.toml"));
+//! }
+//! ```
+
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+
+/// Categories of application paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathKind {
+    /// Config file: `~/.config/thurbox/config.toml`
+    Config,
+    /// State file: `~/.local/share/thurbox/state.toml`
+    State,
+    /// Shared state file: `~/.local/share/thurbox/shared_state.toml`
+    SharedState,
+    /// Log directory: `~/.local/share/thurbox/`
+    LogDir,
+}
+
+/// Path resolution strategy (thread-local).
+#[derive(Debug, PartialEq)]
+enum PathStrategy {
+    /// Production: Use XDG Base Directory Specification.
+    Xdg,
+    /// Testing: Use custom base directory for all paths.
+    Override(PathBuf),
+}
+
+thread_local! {
+    static PATH_STRATEGY: RefCell<PathStrategy> = const { RefCell::new(PathStrategy::Xdg) };
+}
+
+/// Resolve a path based on the current strategy.
+///
+/// # Returns
+///
+/// - `Some(path)` - Successfully resolved path
+/// - `None` - Could not resolve path (e.g., HOME not set in XDG mode)
+pub fn resolve(kind: PathKind) -> Option<PathBuf> {
+    PATH_STRATEGY.with(|strategy| {
+        let s = strategy.borrow();
+        match *s {
+            PathStrategy::Xdg => resolve_xdg(kind),
+            PathStrategy::Override(ref base) => Some(resolve_override(base, kind)),
+        }
+    })
+}
+
+/// Resolve a path using XDG Base Directory Specification.
+fn resolve_xdg(kind: PathKind) -> Option<PathBuf> {
+    match kind {
+        PathKind::Config => {
+            // Prefer $XDG_CONFIG_HOME, fall back to $HOME/.config
+            if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+                let mut p = PathBuf::from(xdg);
+                p.push("thurbox");
+                p.push("config.toml");
+                return Some(p);
+            }
+
+            std::env::var_os("HOME").map(|h| {
+                let mut p = PathBuf::from(h);
+                p.push(".config");
+                p.push("thurbox");
+                p.push("config.toml");
+                p
+            })
+        }
+        PathKind::State | PathKind::SharedState => {
+            // Prefer $XDG_DATA_HOME, fall back to $HOME/.local/share
+            if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+                let mut p = PathBuf::from(xdg);
+                p.push("thurbox");
+                match kind {
+                    PathKind::State => p.push("state.toml"),
+                    PathKind::SharedState => p.push("shared_state.toml"),
+                    _ => unreachable!(),
+                }
+                return Some(p);
+            }
+
+            std::env::var_os("HOME").map(|h| {
+                let mut p = PathBuf::from(h);
+                p.push(".local");
+                p.push("share");
+                p.push("thurbox");
+                match kind {
+                    PathKind::State => p.push("state.toml"),
+                    PathKind::SharedState => p.push("shared_state.toml"),
+                    _ => unreachable!(),
+                }
+                p
+            })
+        }
+        PathKind::LogDir => {
+            // Prefer $XDG_DATA_HOME, fall back to $HOME/.local/share
+            if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+                let mut p = PathBuf::from(xdg);
+                p.push("thurbox");
+                return Some(p);
+            }
+
+            std::env::var_os("HOME").map(|h| {
+                let mut p = PathBuf::from(h);
+                p.push(".local");
+                p.push("share");
+                p.push("thurbox");
+                p
+            })
+        }
+    }
+}
+
+/// Resolve a path using a custom base directory (for testing).
+fn resolve_override(base: &Path, kind: PathKind) -> PathBuf {
+    match kind {
+        PathKind::Config => base.join("config.toml"),
+        PathKind::State => base.join("state.toml"),
+        PathKind::SharedState => base.join("shared_state.toml"),
+        PathKind::LogDir => base.to_path_buf(),
+    }
+}
+
+/// Resolve the config file path.
+///
+/// Returns: `$XDG_CONFIG_HOME/thurbox/config.toml` or `$HOME/.config/thurbox/config.toml`
+pub fn config_file() -> Option<PathBuf> {
+    resolve(PathKind::Config)
+}
+
+/// Resolve the state file path.
+///
+/// Returns: `$XDG_DATA_HOME/thurbox/state.toml` or `$HOME/.local/share/thurbox/state.toml`
+pub fn state_file() -> Option<PathBuf> {
+    resolve(PathKind::State)
+}
+
+/// Resolve the shared state file path.
+///
+/// Returns: `$XDG_DATA_HOME/thurbox/shared_state.toml` or `$HOME/.local/share/thurbox/shared_state.toml`
+pub fn shared_state_file() -> Option<PathBuf> {
+    resolve(PathKind::SharedState)
+}
+
+/// Resolve the log directory path.
+///
+/// Returns: `$XDG_DATA_HOME/thurbox/` or `$HOME/.local/share/thurbox/`
+pub fn log_directory() -> Option<PathBuf> {
+    resolve(PathKind::LogDir)
+}
+
+/// Override path resolution for all paths to use a custom base directory.
+///
+/// This is primarily intended for testing. All paths will resolve under the given base:
+/// - `config_file()` → `base/config.toml`
+/// - `state_file()` → `base/state.toml`
+/// - `shared_state_file()` → `base/shared_state.toml`
+/// - `log_directory()` → `base/`
+///
+/// # Note
+///
+/// This change is thread-local and affects only the current thread.
+/// Use `reset_to_xdg()` or `TestPathGuard` to restore XDG behavior.
+pub fn set_test_dir(base: impl Into<PathBuf>) {
+    PATH_STRATEGY.with(|strategy| {
+        *strategy.borrow_mut() = PathStrategy::Override(base.into());
+    });
+}
+
+/// Reset path resolution back to XDG Base Directory Specification.
+pub fn reset_to_xdg() {
+    PATH_STRATEGY.with(|strategy| {
+        *strategy.borrow_mut() = PathStrategy::Xdg;
+    });
+}
+
+/// RAII guard for test path overrides.
+///
+/// Automatically resets to XDG behavior when dropped.
+/// Simplifies test setup/teardown:
+///
+/// ```ignore
+/// #[test]
+/// fn test_with_override() {
+///     let temp_dir = tempfile::TempDir::new().unwrap();
+///     let _guard = TestPathGuard::new(temp_dir.path());
+///
+///     // Paths are overridden in this scope...
+///     let config = config_file();
+///
+///     // Automatically reset on drop
+/// }
+/// ```
+pub struct TestPathGuard;
+
+impl TestPathGuard {
+    /// Create a new test path guard with the given base directory.
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        set_test_dir(base_dir);
+        TestPathGuard
+    }
+}
+
+impl Drop for TestPathGuard {
+    fn drop(&mut self) {
+        reset_to_xdg();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_strategy_is_xdg() {
+        reset_to_xdg(); // Ensure clean state
+                        // We can't easily test XDG without mocking env vars,
+                        // but we can verify the strategy exists.
+        PATH_STRATEGY.with(|s| {
+            assert_eq!(*s.borrow(), PathStrategy::Xdg);
+        });
+    }
+
+    #[test]
+    fn override_isolates_paths() {
+        let base = PathBuf::from("/test/base");
+        set_test_dir(&base);
+
+        assert_eq!(config_file(), Some(base.join("config.toml")));
+        assert_eq!(state_file(), Some(base.join("state.toml")));
+        assert_eq!(shared_state_file(), Some(base.join("shared_state.toml")));
+        assert_eq!(log_directory(), Some(base.clone()));
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn guard_resets_on_drop() {
+        let base = PathBuf::from("/test/base");
+        {
+            let _guard = TestPathGuard::new(&base);
+            assert_eq!(config_file(), Some(base.join("config.toml")));
+        }
+        // After drop, should be reset to Xdg
+        PATH_STRATEGY.with(|s| {
+            assert_eq!(*s.borrow(), PathStrategy::Xdg);
+        });
+    }
+
+    #[test]
+    fn thread_local_isolation() {
+        // Set override in main thread
+        let base1 = PathBuf::from("/test/base1");
+        set_test_dir(&base1);
+
+        assert_eq!(config_file(), Some(base1.join("config.toml")));
+
+        // Spawn another thread and verify it has independent state
+        let handle = std::thread::spawn(|| {
+            // New thread should start with Xdg (default)
+            PATH_STRATEGY.with(|s| matches!(*s.borrow(), PathStrategy::Xdg))
+        });
+
+        assert!(handle.join().unwrap());
+
+        // Main thread should still have override
+        assert_eq!(config_file(), Some(base1.join("config.toml")));
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn all_path_kinds_resolve_in_override() {
+        let base = PathBuf::from("/test/override");
+        set_test_dir(&base);
+
+        assert_eq!(resolve(PathKind::Config), Some(base.join("config.toml")));
+        assert_eq!(resolve(PathKind::State), Some(base.join("state.toml")));
+        assert_eq!(
+            resolve(PathKind::SharedState),
+            Some(base.join("shared_state.toml"))
+        );
+        assert_eq!(resolve(PathKind::LogDir), Some(base.clone()));
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn config_file_convenience() {
+        let base = PathBuf::from("/custom");
+        set_test_dir(&base);
+
+        let path = config_file().unwrap();
+        assert!(path.ends_with("config.toml"));
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn state_file_convenience() {
+        let base = PathBuf::from("/custom");
+        set_test_dir(&base);
+
+        let path = state_file().unwrap();
+        assert!(path.ends_with("state.toml"));
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn shared_state_file_convenience() {
+        let base = PathBuf::from("/custom");
+        set_test_dir(&base);
+
+        let path = shared_state_file().unwrap();
+        assert!(path.ends_with("shared_state.toml"));
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn log_directory_convenience() {
+        let base = PathBuf::from("/custom");
+        set_test_dir(&base);
+
+        let path = log_directory().unwrap();
+        assert_eq!(path, base);
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn set_test_dir_explicit() {
+        reset_to_xdg();
+
+        let base = PathBuf::from("/test/explicit");
+        set_test_dir(&base);
+
+        assert_eq!(config_file(), Some(base.join("config.toml")));
+
+        reset_to_xdg();
+
+        // After reset, should use Xdg again
+        PATH_STRATEGY.with(|s| {
+            assert_eq!(*s.borrow(), PathStrategy::Xdg);
+        });
+    }
+
+    #[test]
+    fn override_persists_across_calls() {
+        let base = PathBuf::from("/persistent");
+        set_test_dir(&base);
+
+        // Multiple calls should use the same override
+        for _ in 0..3 {
+            assert_eq!(config_file(), Some(base.join("config.toml")));
+        }
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn multiple_guards_reset_correctly() {
+        let base1 = PathBuf::from("/base1");
+        let base2 = PathBuf::from("/base2");
+
+        {
+            let _guard1 = TestPathGuard::new(&base1);
+            assert_eq!(config_file(), Some(base1.join("config.toml")));
+
+            {
+                let _guard2 = TestPathGuard::new(&base2);
+                assert_eq!(config_file(), Some(base2.join("config.toml")));
+            }
+
+            // After inner guard drops, should still use base2's strategy
+            // (because nested set_test_dir overwrites the strategy)
+            PATH_STRATEGY.with(|s| matches!(*s.borrow(), PathStrategy::Xdg));
+        }
+
+        // After outer guard drops, should be Xdg
+        PATH_STRATEGY.with(|s| {
+            assert_eq!(*s.borrow(), PathStrategy::Xdg);
+        });
+    }
+
+    #[test]
+    fn resolve_override_all_kinds() {
+        let base = Path::new("/data");
+
+        assert_eq!(
+            resolve_override(base, PathKind::Config),
+            PathBuf::from("/data/config.toml")
+        );
+        assert_eq!(
+            resolve_override(base, PathKind::State),
+            PathBuf::from("/data/state.toml")
+        );
+        assert_eq!(
+            resolve_override(base, PathKind::SharedState),
+            PathBuf::from("/data/shared_state.toml")
+        );
+        assert_eq!(
+            resolve_override(base, PathKind::LogDir),
+            PathBuf::from("/data")
+        );
+    }
+}

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -54,6 +54,7 @@ impl ProjectConfig {
     }
 }
 
+#[derive(Clone)]
 pub struct ProjectInfo {
     pub id: ProjectId,
     pub config: ProjectConfig,

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -102,7 +102,7 @@ struct ConfigFile {
 /// Load project configurations from `~/.config/thurbox/config.toml`.
 /// Returns an empty list if the file doesn't exist or can't be parsed.
 pub fn load_project_configs() -> Vec<ProjectConfig> {
-    let Some(path) = config_path() else {
+    let Some(path) = crate::paths::config_file() else {
         return Vec::new();
     };
 
@@ -122,7 +122,7 @@ pub fn load_project_configs() -> Vec<ProjectConfig> {
 
 /// Save project configurations to `~/.config/thurbox/config.toml`.
 pub fn save_project_configs(projects: &[ProjectConfig]) -> std::io::Result<()> {
-    let path = config_path().ok_or_else(|| {
+    let path = crate::paths::config_file().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::NotFound,
             "Could not determine config path",
@@ -142,52 +142,10 @@ pub fn save_project_configs(projects: &[ProjectConfig]) -> std::io::Result<()> {
     std::fs::write(&path, contents)
 }
 
-fn config_path() -> Option<PathBuf> {
-    // Prefer $XDG_CONFIG_HOME, fall back to $HOME/.config
-    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
-        let mut p = PathBuf::from(xdg);
-        p.push("thurbox");
-        p.push("config.toml");
-        return Some(p);
-    }
-
-    std::env::var_os("HOME").map(|h| {
-        let mut p = PathBuf::from(h);
-        p.push(".config");
-        p.push("thurbox");
-        p.push("config.toml");
-        p
-    })
-}
-
-fn data_dir() -> Option<PathBuf> {
-    // Prefer $XDG_DATA_HOME, fall back to $HOME/.local/share
-    if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
-        let mut p = PathBuf::from(xdg);
-        p.push("thurbox");
-        return Some(p);
-    }
-
-    std::env::var_os("HOME").map(|h| {
-        let mut p = PathBuf::from(h);
-        p.push(".local");
-        p.push("share");
-        p.push("thurbox");
-        p
-    })
-}
-
-fn state_path() -> Option<PathBuf> {
-    data_dir().map(|mut p| {
-        p.push("state.toml");
-        p
-    })
-}
-
 /// Load persisted session state from `$XDG_DATA_HOME/thurbox/state.toml`.
 /// Returns default (empty) state if the file doesn't exist or can't be parsed.
 pub fn load_session_state() -> PersistedState {
-    let Some(path) = state_path() else {
+    let Some(path) = crate::paths::state_file() else {
         return PersistedState::default();
     };
 
@@ -207,7 +165,7 @@ pub fn load_session_state() -> PersistedState {
 
 /// Save persisted session state to `$XDG_DATA_HOME/thurbox/state.toml`.
 pub fn save_session_state(state: &PersistedState) -> std::io::Result<()> {
-    let path = state_path().ok_or_else(|| {
+    let path = crate::paths::state_file().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::NotFound,
             "Could not determine state path",
@@ -226,7 +184,7 @@ pub fn save_session_state(state: &PersistedState) -> std::io::Result<()> {
 
 /// Remove the persisted state file after successful restore.
 pub fn clear_session_state() -> std::io::Result<()> {
-    let Some(path) = state_path() else {
+    let Some(path) = crate::paths::state_file() else {
         return Ok(());
     };
     match std::fs::remove_file(&path) {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -177,26 +177,12 @@ pub fn poll_for_changes(sync_state: &mut SyncState) -> std::io::Result<Option<St
 
 /// Create the path to the shared state file.
 pub fn shared_state_path() -> std::io::Result<PathBuf> {
-    if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
-        let mut p = PathBuf::from(xdg);
-        p.push("thurbox");
-        p.push("shared_state.toml");
-        return Ok(p);
-    }
-
-    if let Some(home) = std::env::var_os("HOME") {
-        let mut p = PathBuf::from(home);
-        p.push(".local");
-        p.push("share");
-        p.push("thurbox");
-        p.push("shared_state.toml");
-        return Ok(p);
-    }
-
-    Err(std::io::Error::new(
-        std::io::ErrorKind::NotFound,
-        "Could not determine shared state path (HOME not set)",
-    ))
+    crate::paths::shared_state_file().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Could not determine shared state path (HOME not set)",
+        )
+    })
 }
 
 #[cfg(test)]

--- a/src/ui/delete_project_modal.rs
+++ b/src/ui/delete_project_modal.rs
@@ -1,0 +1,128 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use super::centered_fixed_height_rect;
+
+pub struct DeleteProjectModalState<'a> {
+    pub project_name: &'a str,
+    pub confirmation: &'a str,
+    pub confirmation_cursor: usize,
+    pub error: Option<&'a str>,
+}
+
+pub fn render_delete_project_modal(frame: &mut Frame, state: &DeleteProjectModalState<'_>) {
+    let area = centered_fixed_height_rect(60, 13, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Delete Project ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Red));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Layout: warning, spacer, confirmation input, error message, help
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Warning text
+            Constraint::Length(1), // Spacer
+            Constraint::Length(3), // Confirmation input
+            Constraint::Length(2), // Error message
+            Constraint::Min(1),    // Help text
+        ])
+        .split(inner);
+
+    // Warning text
+    let warning = Paragraph::new(vec![
+        Line::from(Span::styled(
+            "⚠ Delete Project",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::raw("Type "),
+            Span::styled(
+                state.project_name,
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" to confirm"),
+        ]),
+    ])
+    .alignment(Alignment::Left);
+    frame.render_widget(warning, chunks[0]);
+
+    // Confirmation input
+    render_confirmation_input(frame, chunks[2], state);
+
+    // Error message
+    if let Some(error) = state.error {
+        let error_msg = Paragraph::new(error)
+            .style(Style::default().fg(Color::Red))
+            .alignment(Alignment::Left);
+        frame.render_widget(error_msg, chunks[3]);
+    }
+
+    // Help text
+    let help = Line::from(vec![
+        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::raw(" confirm  "),
+        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::raw(" cancel"),
+    ]);
+    let help_paragraph = Paragraph::new(help).alignment(Alignment::Left);
+    frame.render_widget(help_paragraph, chunks[4]);
+}
+
+fn render_confirmation_input(frame: &mut Frame, area: Rect, state: &DeleteProjectModalState<'_>) {
+    let block = Block::default()
+        .title(" Confirmation ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::White));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Build the text with cursor
+    let chars: Vec<char> = state.confirmation.chars().collect();
+    let cursor = state.confirmation_cursor.min(chars.len());
+
+    let mut spans = Vec::new();
+
+    if inner.width > 0 {
+        // Text before cursor
+        if cursor > 0 {
+            let before: String = chars[..cursor].iter().collect();
+            spans.push(Span::styled(before, Style::default().fg(Color::White)));
+        }
+
+        // Cursor character or space
+        let cursor_char = if cursor < chars.len() {
+            chars[cursor].to_string()
+        } else {
+            " ".to_string()
+        };
+        spans.push(Span::styled(
+            cursor_char,
+            Style::default().fg(Color::Black).bg(Color::White),
+        ));
+
+        // Text after cursor
+        if cursor + 1 < chars.len() {
+            let after: String = chars[cursor + 1..].iter().collect();
+            spans.push(Span::styled(after, Style::default().fg(Color::White)));
+        }
+    }
+
+    let line = Line::from(spans);
+    frame.render_widget(Paragraph::new(line), inner);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 pub mod add_project_modal;
 pub mod branch_selector_modal;
+pub mod delete_project_modal;
 pub mod info_panel;
 pub mod layout;
 pub mod project_list;


### PR DESCRIPTION
## Summary

- Type-to-confirm modal prevents accidental project deletions
- Safety checks prevent deleting default or last remaining project
- Auto-closes all sessions belonging to deleted project
- Multi-instance sync propagates deletion via shared state
- Added 'd' keybinding in ProjectList focus

## Test plan

- [x] All 329 tests pass with zero regressions
- [x] All 6 architecture tests pass
- [x] No clippy warnings
- [x] Formatting compliant
- [x] Release build successful
- [x] Pre-commit hooks pass