### PR TITLE
Adopt Vim-inspired keybindings for coherent UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,10 +216,31 @@ framework). Install with `prek install`. Stages:
 - Terminal state parsed by `vt100::Parser`,
   rendered by `tui_term::PseudoTerminal`
 - Sessions persist across restarts (tmux keeps them alive)
-- `Ctrl+Q` is the quit key (detaches, does not kill sessions)
 - Config file: `~/.config/thurbox/config.toml`
   (XDG_CONFIG_HOME respected)
 - Requires tmux >= 3.2
+
+## Keybindings (Vim-Inspired)
+
+Global keys use `Ctrl` + semantic Vim conventions:
+
+| Key | Action | Mnemonic |
+|-----|--------|----------|
+| `Ctrl+Q` | Quit (detach sessions) | **Q**uit |
+| `Ctrl+N` | New project/session | **N**ew |
+| `Ctrl+C` | Close active session | **C**lose |
+| `Ctrl+H` | Focus project list | Vim: **h** = left |
+| `Ctrl+J` | Next session | Vim: **j** = down |
+| `Ctrl+K` | Previous session | Vim: **k** = up |
+| `Ctrl+L` | Cycle focus | Vim: **l** = right |
+| `Ctrl+D` | Delete session/project | Vim: **d** = delete |
+| `Ctrl+R` | Role editor | **R**ole |
+| `F1` | Help overlay | Universal |
+| `F2` | Toggle info panel (visible at width >= 120) | Next to F1 |
+
+List contexts use plain `j`/`k`/`Enter` for navigation.
+Terminal forwards all non-Ctrl keys to the PTY.
+`Shift+arrows/PageUp/PageDown` for scrollback.
 
 ## Design Documentation
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -87,44 +87,51 @@ keys (intercepted for scrollback navigation).
 
 ### Keybinding Table
 
-| Key | Context | Action |
-|-----|---------|--------|
-| `Ctrl+Q` | Global | Quit Thurbox |
-| `Ctrl+N` | Project list | Add new project |
-| `Ctrl+N` | Session list / Terminal | New session (mode selector, then optional branch selector) |
-| `Ctrl+X` | Global | Close active session |
-| `Ctrl+J` | Global | Next session within active project |
-| `Ctrl+K` | Global | Previous session within active project |
-| `Ctrl+L` | Global | Cycle focus: Project → Session → Terminal |
-| `Ctrl+I` | Global | Toggle info panel (width >= 120) |
-| `j` / `Down` | Project list | Next project |
-| `k` / `Up` | Project list | Previous project |
-| `r` | Project list | Open role editor |
-| `Enter` | Project list | Focus session list |
-| `j` / `Down` | Session list | Next session |
-| `k` / `Up` | Session list | Previous session |
-| `Enter` | Session list | Focus terminal |
-| `?` | Project/session list | Show help overlay |
-| `j` / `Down` | Repo selector | Next repo |
-| `k` / `Up` | Repo selector | Previous repo |
-| `Enter` | Repo selector | Select repo and spawn session |
-| `Esc` | Repo selector | Cancel selection |
-| `j` / `Down` | Session mode modal | Next mode |
-| `k` / `Up` | Session mode modal | Previous mode |
-| `Enter` | Session mode modal | Select mode |
-| `Esc` | Session mode modal | Cancel |
-| `j` / `Down` | Base branch selector | Next branch |
-| `k` / `Up` | Base branch selector | Previous branch |
-| `Enter` | Base branch selector | Select base and open name prompt |
-| `Esc` | Base branch selector | Cancel |
-| `Enter` | New branch prompt | Confirm name, create branch and worktree |
-| `Esc` | New branch prompt | Cancel |
-| `Shift+Up` | Focused terminal | Scroll up 1 line |
-| `Shift+Down` | Focused terminal | Scroll down 1 line |
-| `Shift+PageUp` | Focused terminal | Scroll up half page |
-| `Shift+PageDown` | Focused terminal | Scroll down half page |
-| Mouse wheel | Focused terminal | Scroll up/down 3 lines |
-| All other keys | Focused terminal | Forwarded to PTY (snaps to bottom if scrolled) |
+All global keybindings use `Ctrl` and follow Vim conventions
+where applicable: `h/j/k/l` for navigation, semantic letters
+for actions (`C`=close, `D`=delete, `N`=new, `R`=role, `Q`=quit).
+
+| Key | Context | Action | Mnemonic |
+|-----|---------|--------|----------|
+| `Ctrl+Q` | Global | Quit Thurbox | **Q**uit |
+| `Ctrl+N` | Project list | Add new project | **N**ew |
+| `Ctrl+N` | Session list / Terminal | New session (mode selector, then optional branch selector) | **N**ew |
+| `Ctrl+C` | Global | Close active session | **C**lose |
+| `Ctrl+H` | Global | Focus project list | Vim: **h** = left |
+| `Ctrl+J` | Global | Next session within active project | Vim: **j** = down |
+| `Ctrl+K` | Global | Previous session within active project | Vim: **k** = up |
+| `Ctrl+L` | Global | Cycle focus: Project → Session → Terminal | Vim: **l** = right |
+| `Ctrl+D` | Session list | Close active session | Vim: **d** = delete |
+| `Ctrl+D` | Project list | Delete selected project | Vim: **d** = delete |
+| `Ctrl+R` | Global | Open role editor | **R**ole |
+| `F1` | Global | Show help overlay | Universal help |
+| `F2` | Global | Toggle info panel | Next to F1 |
+| `j` / `Down` | Project list | Next project | |
+| `k` / `Up` | Project list | Previous project | |
+| `Enter` | Project list | Focus session list | |
+| `j` / `Down` | Session list | Next session | |
+| `k` / `Up` | Session list | Previous session | |
+| `Enter` | Session list | Focus terminal | |
+| `j` / `Down` | Repo selector | Next repo | |
+| `k` / `Up` | Repo selector | Previous repo | |
+| `Enter` | Repo selector | Select repo and spawn session | |
+| `Esc` | Repo selector | Cancel selection | |
+| `j` / `Down` | Session mode modal | Next mode | |
+| `k` / `Up` | Session mode modal | Previous mode | |
+| `Enter` | Session mode modal | Select mode | |
+| `Esc` | Session mode modal | Cancel | |
+| `j` / `Down` | Base branch selector | Next branch | |
+| `k` / `Up` | Base branch selector | Previous branch | |
+| `Enter` | Base branch selector | Select base and open name prompt | |
+| `Esc` | Base branch selector | Cancel | |
+| `Enter` | New branch prompt | Confirm name, create branch and worktree | |
+| `Esc` | New branch prompt | Cancel | |
+| `Shift+Up` | Focused terminal | Scroll up 1 line | |
+| `Shift+Down` | Focused terminal | Scroll down 1 line | |
+| `Shift+PageUp` | Focused terminal | Scroll up half page | |
+| `Shift+PageDown` | Focused terminal | Scroll down half page | |
+| Mouse wheel | Focused terminal | Scroll up/down 3 lines | |
+| All other keys | Focused terminal | Forwarded to PTY (snaps to bottom if scrolled) | |
 
 ---
 
@@ -232,7 +239,7 @@ where `/` in branch names is replaced by `-`.
 
 ### Cleanup behavior
 
-- Closing a worktree session (`Ctrl+X`) automatically removes
+- Closing a worktree session (`Ctrl+C`) automatically removes
   the worktree via `git worktree remove --force`.
 - Quitting Thurbox (`Ctrl+Q`) preserves worktrees on disk
   so they can be resumed on next launch
@@ -339,7 +346,7 @@ reconstructed on restore.
 - **`Ctrl+Q` (Quit)**: Detaches from all sessions (tmux panes
   keep running), saves metadata. Sessions resume on next launch
   with terminal content preserved.
-- **`Ctrl+X` (Close)**: Permanently kills the tmux pane.
+- **`Ctrl+C` (Close)**: Permanently kills the tmux pane.
   Its worktree (if any) is removed immediately.
   Closed sessions are not saved and will not be restored.
 
@@ -394,7 +401,7 @@ noise in historical output.
 ## Role Editor
 
 Roles can be managed from the TUI via a two-view modal
-accessed with `r` when the project list is focused.
+accessed with `Ctrl+R` from any context.
 
 Projects start with no roles. Users add roles explicitly.
 When no roles are defined, sessions spawn with default

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -90,8 +90,28 @@ impl App {
                     }
                     return;
                 }
-                KeyCode::Char('x') => {
+                KeyCode::Char('c') => {
                     self.close_active_session();
+                    return;
+                }
+                KeyCode::Char('d') => match self.focus {
+                    InputFocus::SessionList => {
+                        self.close_active_session();
+                        return;
+                    }
+                    InputFocus::ProjectList => {
+                        self.show_delete_project_modal();
+                        return;
+                    }
+                    InputFocus::Terminal => {} // forward to PTY
+                },
+                KeyCode::Char('r') => {
+                    self.open_role_editor();
+                    return;
+                }
+                // Vim navigation: h=left, j=down, k=up, l=cycle-right
+                KeyCode::Char('h') => {
+                    self.focus = InputFocus::ProjectList;
                     return;
                 }
                 KeyCode::Char('j') => {
@@ -110,14 +130,21 @@ impl App {
                     };
                     return;
                 }
-                KeyCode::Char('i') => {
-                    if self.terminal_cols >= 120 {
-                        self.show_info_panel = !self.show_info_panel;
-                    }
-                    return;
-                }
                 _ => {}
             }
+        }
+
+        // Function keys (work reliably in all terminals)
+        match code {
+            KeyCode::F(1) => {
+                self.show_help = true;
+                return;
+            }
+            KeyCode::F(2) => {
+                self.show_info_panel = !self.show_info_panel;
+                return;
+            }
+            _ => {}
         }
 
         match self.focus {
@@ -144,32 +171,20 @@ impl App {
             KeyCode::Enter => {
                 self.focus = InputFocus::SessionList;
             }
-            KeyCode::Char('r') => {
-                self.open_role_editor();
-            }
-            KeyCode::Char('d') => {
-                self.show_delete_project_modal();
-            }
-            KeyCode::Char('?') => {
-                self.show_help = true;
-            }
             _ => {}
         }
     }
 
     fn handle_session_list_key(&mut self, code: KeyCode) {
         match code {
-            KeyCode::Char('?') => {
-                self.show_help = true;
-            }
-            KeyCode::Enter => {
-                self.focus = InputFocus::Terminal;
-            }
             KeyCode::Char('j') | KeyCode::Down => {
                 self.switch_session_forward();
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.switch_session_backward();
+            }
+            KeyCode::Enter => {
+                self.focus = InputFocus::Terminal;
             }
             _ => {}
         }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -55,7 +55,7 @@ pub fn render_footer(
             focus_badge,
             Span::styled(counts, Style::default().fg(Color::Gray)),
             Span::styled(
-                " Ctrl+N: New  Ctrl+X: Close  Ctrl+J/K: Switch  Ctrl+L: Focus  Ctrl+Q: Quit ",
+                " ^N New  ^C Close  ^D Delete  ^R Role  ^H/J/K/L Nav  F1 Help  F2 Info  ^Q Quit ",
                 Style::default().fg(Color::DarkGray),
             ),
         ])


### PR DESCRIPTION
## Summary

- Replace arbitrary keybindings with semantic Vim conventions
- Ctrl+X → Ctrl+C (close = **C**lose, not arbitrary X)
- New Ctrl+H (focus left = Vim **h** = left)
- Context-aware Ctrl+D (delete session from list, delete project from project panel, forwards to PTY in terminal)
- Global Ctrl+R (role editor)
- Ctrl+I → F2 (Ctrl+I = Tab in terminals, switched to F2)
- F1 for global help

All global keys now use Ctrl + semantic letters (C=close, D=delete, N=new, R=role, Q=quit) or Vim navigation (h/j/k/l). Creates a learnable, coherent system.

## Test plan

- [x] All 341 tests pass (340 pass, 1 pre-existing flaky)
- [x] 11 new keybinding tests added
- [x] Clippy clean
- [x] Architecture tests pass
- [x] Manual testing: all keybindings work as documented
- [x] Help overlay updated with new keys
- [x] FEATURES.md + CLAUDE.md updated