### PR TITLE
feat(ui): multi-repo add-project modal with path autocompletion

### DIFF
--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -97,6 +97,7 @@ impl TextInput {
 pub enum AddProjectField {
     Name,
     Path,
+    RepoList,
 }
 
 // ── Modal State Structs ────────────────────────────────────────────────────
@@ -106,6 +107,9 @@ pub struct AddProjectModal {
     pub name: TextInput,
     pub path: TextInput,
     pub field: AddProjectField,
+    pub repos: Vec<PathBuf>,
+    pub repo_index: usize,
+    pub path_suggestion: Option<String>,
 }
 
 impl Default for AddProjectModal {
@@ -114,6 +118,9 @@ impl Default for AddProjectModal {
             name: TextInput::default(),
             path: TextInput::default(),
             field: AddProjectField::Name,
+            repos: Vec::new(),
+            repo_index: 0,
+            path_suggestion: None,
         }
     }
 }
@@ -606,6 +613,29 @@ mod tests {
         assert_eq!(modal.name.value(), "");
         assert_eq!(modal.path.value(), "");
         assert_eq!(modal.field, AddProjectField::Name);
+        assert!(modal.repos.is_empty());
+        assert_eq!(modal.repo_index, 0);
+        assert!(modal.path_suggestion.is_none());
+    }
+
+    #[test]
+    fn test_add_project_field_has_repo_list_variant() {
+        let field = AddProjectField::RepoList;
+        assert_ne!(field, AddProjectField::Name);
+        assert_ne!(field, AddProjectField::Path);
+    }
+
+    #[test]
+    fn test_add_project_modal_with_repos() {
+        let mut modal = AddProjectModal::default();
+        modal.repos.push(PathBuf::from("/path/to/repo1"));
+        modal.repos.push(PathBuf::from("/path/to/repo2"));
+        modal.repo_index = 1;
+        modal.path_suggestion = Some("er/".to_string());
+
+        assert_eq!(modal.repos.len(), 2);
+        assert_eq!(modal.repo_index, 1);
+        assert_eq!(modal.path_suggestion.as_deref(), Some("er/"));
     }
 
     #[test]

--- a/src/ui/add_project_modal.rs
+++ b/src/ui/add_project_modal.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::{Color, Style},
@@ -6,7 +8,7 @@ use ratatui::{
     Frame,
 };
 
-use super::{centered_fixed_height_rect, render_text_field};
+use super::{centered_fixed_height_rect, render_text_field, render_text_field_with_suggestion};
 use crate::app::AddProjectField;
 
 pub struct AddProjectModalState<'a> {
@@ -14,11 +16,23 @@ pub struct AddProjectModalState<'a> {
     pub name_cursor: usize,
     pub path: &'a str,
     pub path_cursor: usize,
+    pub path_suggestion: Option<&'a str>,
+    pub repos: &'a [PathBuf],
+    pub repo_index: usize,
     pub focused_field: AddProjectField,
 }
 
 pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<'_>) {
-    let area = centered_fixed_height_rect(50, 11, frame.area());
+    // Dynamic height: name(3) + path(3) + repo_list(max 6 items + 2 border) + footer(1) + outer border(2)
+    let repo_list_inner = if state.repos.is_empty() {
+        1
+    } else {
+        state.repos.len().min(6)
+    };
+    let repo_list_height = repo_list_inner as u16 + 2; // +2 for borders
+    let total_height = 3 + 3 + repo_list_height + 1 + 2; // name + path + repos + footer + outer
+
+    let area = centered_fixed_height_rect(50, total_height, frame.area());
 
     frame.render_widget(Clear, area);
 
@@ -30,13 +44,13 @@ pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    // Layout: name field, gap, path field, gap, footer
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3), // Name field
-            Constraint::Length(3), // Path field
-            Constraint::Min(1),    // Footer
+            Constraint::Length(3),                // Name field
+            Constraint::Length(3),                // Path field
+            Constraint::Length(repo_list_height), // Repo list
+            Constraint::Min(1),                   // Footer
         ])
         .split(inner);
 
@@ -49,23 +63,107 @@ pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<
         state.focused_field == AddProjectField::Name,
     );
 
-    render_text_field(
+    render_text_field_with_suggestion(
         frame,
         chunks[1],
-        "Repo",
+        "Repo Path",
         state.path,
         state.path_cursor,
         state.focused_field == AddProjectField::Path,
+        state.path_suggestion,
     );
 
-    let footer = Line::from(vec![
-        Span::styled("Tab", Style::default().fg(Color::Yellow)),
-        Span::styled(" switch  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Enter", Style::default().fg(Color::Yellow)),
-        Span::styled(" submit  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Esc", Style::default().fg(Color::Yellow)),
-        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
-    ]);
-    let footer_paragraph = Paragraph::new(footer);
-    frame.render_widget(footer_paragraph, chunks[2]);
+    // Repo list
+    let list_focused = state.focused_field == AddProjectField::RepoList;
+    let list_border_color = if list_focused {
+        Color::Cyan
+    } else {
+        Color::Gray
+    };
+
+    let list_block = Block::default()
+        .title(format!(" Repos ({}) ", state.repos.len()))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(list_border_color));
+
+    let list_inner = list_block.inner(chunks[2]);
+    frame.render_widget(list_block, chunks[2]);
+
+    if state.repos.is_empty() {
+        let placeholder = Paragraph::new(Line::from(Span::styled(
+            "(none — add via Path field above)",
+            Style::default().fg(Color::DarkGray),
+        )));
+        frame.render_widget(placeholder, list_inner);
+    } else {
+        let visible_count = list_inner.height as usize;
+        // Scroll so that selected item is always visible
+        let scroll_offset = if state.repo_index >= visible_count {
+            state.repo_index - visible_count + 1
+        } else {
+            0
+        };
+
+        let lines: Vec<Line> = state
+            .repos
+            .iter()
+            .enumerate()
+            .skip(scroll_offset)
+            .take(visible_count)
+            .map(|(i, path)| {
+                let selected = i == state.repo_index && list_focused;
+                let marker = if selected { "▸ " } else { "  " };
+                let path_str = path.display().to_string();
+                let (marker_color, path_color) = if selected {
+                    (Color::Cyan, Color::White)
+                } else {
+                    (Color::DarkGray, Color::Gray)
+                };
+                Line::from(vec![
+                    Span::styled(marker, Style::default().fg(marker_color)),
+                    Span::styled(path_str, Style::default().fg(path_color)),
+                ])
+            })
+            .collect();
+
+        frame.render_widget(Paragraph::new(lines), list_inner);
+    }
+
+    // Context-sensitive footer
+    let footer = match state.focused_field {
+        AddProjectField::Name => Line::from(vec![
+            Span::styled("Tab", Style::default().fg(Color::Yellow)),
+            Span::styled(" next  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::styled(" submit  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        ]),
+        AddProjectField::Path => {
+            let tab_hint = if state.path_suggestion.is_some() {
+                " complete  "
+            } else {
+                " next  "
+            };
+            Line::from(vec![
+                Span::styled("Tab", Style::default().fg(Color::Yellow)),
+                Span::styled(tab_hint, Style::default().fg(Color::DarkGray)),
+                Span::styled("Enter", Style::default().fg(Color::Yellow)),
+                Span::styled(" add repo  ", Style::default().fg(Color::DarkGray)),
+                Span::styled("Esc", Style::default().fg(Color::Yellow)),
+                Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+            ])
+        }
+        AddProjectField::RepoList => Line::from(vec![
+            Span::styled("j/k", Style::default().fg(Color::Yellow)),
+            Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("d", Style::default().fg(Color::Yellow)),
+            Span::styled(" delete  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::styled(" submit  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        ]),
+    };
+    frame.render_widget(Paragraph::new(footer), chunks[3]);
 }


### PR DESCRIPTION
## Summary

- Add fish-style directory path autocompletion (grayed-out suffix, Tab to accept)
- Support adding multiple repos per project via Enter key
- Display repo list with j/k navigation and d to delete
- Three-field modal: Name, Path (with completion), Repo list
- Context-sensitive footer hints
- Add 11 tests (path completion + modal state)
- Refactor: DRY cleanup in text field rendering

## Test plan

- [x] All 383 tests pass
- [x] 0 clippy warnings
- [x] 0 rustdoc warnings
- [x] Manual testing: Add Project modal with multi-repo workflow