### PR TITLE
feat(core): eliminate config.toml, add edit-project modal, fix persis…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,9 +174,8 @@ app      ← coordinator, imports all modules
 - **`session/`** — Plain data: `SessionId`, `SessionStatus`,
   `SessionInfo`, `SessionConfig` (with optional `cwd`).
   No logic beyond Display/Default impls.
-- **`project/`** — Plain data + config loading: `ProjectId`,
-  `ProjectConfig`, `ProjectInfo`. Loads project list from
-  `~/.config/thurbox/config.toml`. Imports `session` only.
+- **`project/`** — Plain data: `ProjectId`,
+  `ProjectConfig`, `ProjectInfo`. Imports `session` only.
 - **`ui/`** — Pure rendering functions. `layout.rs` computes
   panel areas (responsive: <80 = terminal only, >=80 = 2-panel,
   >=120 = optional 3-panel). Widgets: `project_list` (two-section
@@ -185,7 +184,7 @@ app      ← coordinator, imports all modules
 ### Event Loop (main.rs)
 
 ```text
-tokio::main → init backend (tmux) → load project config
+tokio::main → init backend (tmux) → open SQLite DB
 → init terminal → spawn/restore sessions → loop {
     draw frame → poll crossterm events (10ms)
     → convert to AppMessage → app.update() → app.tick()
@@ -216,8 +215,8 @@ framework). Install with `prek install`. Stages:
 - Terminal state parsed by `vt100::Parser`,
   rendered by `tui_term::PseudoTerminal`
 - Sessions persist across restarts (tmux keeps them alive)
-- Config file: `~/.config/thurbox/config.toml`
-  (XDG_CONFIG_HOME respected)
+- All state (projects, sessions, roles) in SQLite:
+  `~/.local/share/thurbox/thurbox.db` (XDG_DATA_HOME respected)
 - Requires tmux >= 3.2
 
 ## Keybindings (Vim-Inspired)
@@ -234,6 +233,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+K` | Previous session | Vim: **k** = up |
 | `Ctrl+L` | Cycle focus | Vim: **l** = right |
 | `Ctrl+D` | Delete session/project | Vim: **d** = delete |
+| `Ctrl+E` | Edit active project | **E**dit |
 | `Ctrl+R` | Role editor | **R**ole |
 | `F1` | Help overlay | Universal |
 | `F2` | Toggle info panel (visible at width >= 120) | Next to F1 |

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use crossterm::execute;
 use thurbox::app::{App, AppMessage};
 use thurbox::claude::tmux::LocalTmuxBackend;
 use thurbox::claude::SessionBackend;
-use thurbox::project;
 use thurbox::storage::Database;
 
 #[tokio::main]
@@ -40,8 +39,6 @@ async fn main() -> Result<()> {
     backend.check_available()?;
     backend.ensure_ready()?;
 
-    let project_configs = project::load_project_configs();
-
     // Open SQLite database for persistent state
     let db_path = thurbox::paths::database_file().unwrap_or_else(|| {
         let mut p = std::path::PathBuf::from(std::env::var_os("HOME").unwrap_or_default());
@@ -54,7 +51,7 @@ async fn main() -> Result<()> {
     execute!(std::io::stdout(), EnableMouseCapture)?;
     let size = terminal.size()?;
 
-    let mut app = App::new(size.height, size.width, project_configs, backend, db);
+    let mut app = App::new(size.height, size.width, backend, db);
 
     // Load session state from DB and restore, or spawn a fresh session
     if let Some((sessions, counter)) = app.load_persisted_state_from_db() {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -32,7 +32,7 @@ use std::path::{Path, PathBuf};
 /// Categories of application paths.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathKind {
-    /// Config file: `~/.config/thurbox/config.toml`
+    /// Config file: `~/.config/thurbox/config.toml` (legacy, used for migration only)
     Config,
     /// Log directory: `~/.local/share/thurbox/`
     LogDir,

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -6,6 +6,8 @@ use uuid::Uuid;
 
 use crate::session::{RoleConfig, SessionId};
 
+// Keep serde on ProjectId for backward compat (used in session/mod.rs serialization)
+
 /// Namespace UUID for deriving deterministic project IDs.
 /// This is the namespace used for v5 UUID generation from project configs.
 /// Value is SHA1(UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), "thurbox:projects")
@@ -40,12 +42,14 @@ impl fmt::Display for ProjectId {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone)]
 pub struct ProjectConfig {
     pub name: String,
     pub repos: Vec<PathBuf>,
-    #[serde(default)]
     pub roles: Vec<RoleConfig>,
+    /// Stable project ID preserved across renames. When present, this takes
+    /// precedence over the name-derived deterministic ID.
+    pub id: Option<String>,
 }
 
 impl ProjectConfig {
@@ -56,6 +60,19 @@ impl ProjectConfig {
     /// This is critical for multi-instance session synchronization.
     pub fn deterministic_id(&self) -> ProjectId {
         ProjectId(Uuid::new_v5(&PROJECT_ID_NAMESPACE, self.name.as_bytes()))
+    }
+
+    /// Return the effective project ID: the persisted `id` if present,
+    /// otherwise the name-derived deterministic ID.
+    ///
+    /// After a project rename, `id` holds the original UUID so that
+    /// sessions and DB entries stay correctly associated.
+    pub fn effective_id(&self) -> ProjectId {
+        self.id
+            .as_ref()
+            .and_then(|s| s.parse::<Uuid>().ok())
+            .map(ProjectId::from_uuid)
+            .unwrap_or_else(|| self.deterministic_id())
     }
 }
 
@@ -69,7 +86,7 @@ pub struct ProjectInfo {
 
 impl ProjectInfo {
     pub fn new(config: ProjectConfig) -> Self {
-        let id = config.deterministic_id();
+        let id = config.effective_id();
         Self {
             id,
             config,
@@ -79,7 +96,7 @@ impl ProjectInfo {
     }
 
     pub fn new_default(config: ProjectConfig) -> Self {
-        let id = config.deterministic_id();
+        let id = config.effective_id();
         Self {
             id,
             config,
@@ -96,62 +113,13 @@ pub fn create_default_project() -> ProjectConfig {
         name: "Default".to_string(),
         repos: vec![cwd],
         roles: Vec::new(),
+        id: None,
     }
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct ConfigFile {
-    #[serde(default)]
-    projects: Vec<ProjectConfig>,
-}
-
-/// Load project configurations from `~/.config/thurbox/config.toml`.
-/// Returns an empty list if the file doesn't exist or can't be parsed.
-pub fn load_project_configs() -> Vec<ProjectConfig> {
-    let Some(path) = crate::paths::config_file() else {
-        return Vec::new();
-    };
-
-    let contents = match std::fs::read_to_string(&path) {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
-    };
-
-    match toml::from_str::<ConfigFile>(&contents) {
-        Ok(config) => config.projects,
-        Err(e) => {
-            tracing::warn!("Failed to parse config at {}: {e}", path.display());
-            Vec::new()
-        }
-    }
-}
-
-/// Save project configurations to `~/.config/thurbox/config.toml`.
-pub fn save_project_configs(projects: &[ProjectConfig]) -> std::io::Result<()> {
-    let path = crate::paths::config_file().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "Could not determine config path",
-        )
-    })?;
-
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    let config = ConfigFile {
-        projects: projects.to_vec(),
-    };
-    let contents = toml::to_string_pretty(&config)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-
-    std::fs::write(&path, contents)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::RolePermissions;
 
     #[test]
     fn project_id_display_is_uuid_format() {
@@ -169,82 +137,12 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_config_file() {
-        let toml_str = r#"
-[[projects]]
-name = "thurbox"
-repos = ["/home/user/repos/thurbox"]
-
-[[projects]]
-name = "other"
-repos = ["/home/user/repos/other"]
-"#;
-        let config: ConfigFile = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.projects.len(), 2);
-        assert_eq!(config.projects[0].name, "thurbox");
-        assert_eq!(
-            config.projects[0].repos,
-            vec![PathBuf::from("/home/user/repos/thurbox")]
-        );
-        assert_eq!(config.projects[1].name, "other");
-    }
-
-    #[test]
-    fn deserialize_empty_config() {
-        let toml_str = "";
-        let config: ConfigFile = toml::from_str(toml_str).unwrap();
-        assert!(config.projects.is_empty());
-    }
-
-    #[test]
-    fn serialize_roundtrip() {
-        let configs = vec![
-            ProjectConfig {
-                name: "alpha".to_string(),
-                repos: vec![PathBuf::from("/tmp/alpha")],
-                roles: Vec::new(),
-            },
-            ProjectConfig {
-                name: "beta".to_string(),
-                repos: vec![PathBuf::from("/tmp/beta")],
-                roles: Vec::new(),
-            },
-        ];
-
-        let file = ConfigFile { projects: configs };
-        let serialized = toml::to_string_pretty(&file).unwrap();
-        let deserialized: ConfigFile = toml::from_str(&serialized).unwrap();
-
-        assert_eq!(deserialized.projects.len(), 2);
-        assert_eq!(deserialized.projects[0].name, "alpha");
-        assert_eq!(
-            deserialized.projects[0].repos,
-            vec![PathBuf::from("/tmp/alpha")]
-        );
-        assert_eq!(deserialized.projects[1].name, "beta");
-    }
-
-    #[test]
-    fn serialize_format_is_toml_array() {
-        let configs = vec![ProjectConfig {
-            name: "test".to_string(),
-            repos: vec![PathBuf::from("/tmp/test")],
-            roles: Vec::new(),
-        }];
-
-        let file = ConfigFile { projects: configs };
-        let serialized = toml::to_string_pretty(&file).unwrap();
-        assert!(serialized.contains("[[projects]]"));
-        assert!(serialized.contains("name = \"test\""));
-        assert!(serialized.contains("/tmp/test"));
-    }
-
-    #[test]
     fn project_info_new_has_empty_sessions() {
         let config = ProjectConfig {
             name: "test".to_string(),
             repos: vec![PathBuf::from("/tmp/test")],
             roles: Vec::new(),
+            id: None,
         };
         let info = ProjectInfo::new(config);
         assert!(info.session_ids.is_empty());
@@ -262,96 +160,17 @@ repos = ["/home/user/repos/other"]
     }
 
     #[test]
-    fn deserialize_config_with_roles() {
-        let toml_str = r#"
-[[projects]]
-name = "myapp"
-repos = ["/tmp/myapp"]
-
-[[projects.roles]]
-name = "developer"
-description = "Full access"
-
-[[projects.roles]]
-name = "reviewer"
-description = "Read-only"
-permission_mode = "plan"
-allowed_tools = ["Read", "Bash(git:*)"]
-"#;
-        let config: ConfigFile = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.projects.len(), 1);
-        assert_eq!(config.projects[0].roles.len(), 2);
-        assert_eq!(config.projects[0].roles[0].name, "developer");
-        assert_eq!(config.projects[0].roles[1].name, "reviewer");
-        assert_eq!(
-            config.projects[0].roles[1].permissions.permission_mode,
-            Some("plan".to_string())
-        );
-    }
-
-    #[test]
-    fn serialize_roundtrip_with_roles() {
-        let configs = vec![ProjectConfig {
-            name: "myapp".to_string(),
-            repos: vec![PathBuf::from("/tmp/myapp")],
-            roles: vec![
-                RoleConfig {
-                    name: "developer".to_string(),
-                    description: "Full access".to_string(),
-                    permissions: RolePermissions::default(),
-                },
-                RoleConfig {
-                    name: "reviewer".to_string(),
-                    description: "Read-only".to_string(),
-                    permissions: RolePermissions {
-                        permission_mode: Some("plan".to_string()),
-                        allowed_tools: vec!["Read".to_string()],
-                        ..RolePermissions::default()
-                    },
-                },
-            ],
-        }];
-
-        let file = ConfigFile { projects: configs };
-        let serialized = toml::to_string_pretty(&file).unwrap();
-        let deserialized: ConfigFile = toml::from_str(&serialized).unwrap();
-
-        assert_eq!(deserialized.projects.len(), 1);
-        assert_eq!(deserialized.projects[0].roles.len(), 2);
-        assert_eq!(deserialized.projects[0].roles[0].name, "developer");
-        assert_eq!(deserialized.projects[0].roles[1].name, "reviewer");
-        assert_eq!(
-            deserialized.projects[0].roles[1]
-                .permissions
-                .permission_mode,
-            Some("plan".to_string())
-        );
-    }
-
-    #[test]
-    fn deserialize_config_without_roles_backward_compat() {
-        let toml_str = r#"
-[[projects]]
-name = "old-project"
-repos = ["/tmp/old"]
-"#;
-        let config: ConfigFile = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.projects.len(), 1);
-        assert!(config.projects[0].roles.is_empty());
-    }
-
-    #[test]
     fn project_id_is_deterministic() {
         let config = ProjectConfig {
             name: "Test Project".to_string(),
             repos: vec![PathBuf::from("/repo1"), PathBuf::from("/repo2")],
             roles: Vec::new(),
+            id: None,
         };
 
         let id1 = config.deterministic_id();
         let id2 = config.deterministic_id();
 
-        // Same config should always produce the same ID
         assert_eq!(id1, id2);
     }
 
@@ -361,18 +180,16 @@ repos = ["/tmp/old"]
             name: "Project A".to_string(),
             repos: vec![PathBuf::from("/repo")],
             roles: Vec::new(),
+            id: None,
         };
         let config2 = ProjectConfig {
             name: "Project B".to_string(),
             repos: vec![PathBuf::from("/repo")],
             roles: Vec::new(),
+            id: None,
         };
 
-        let id1 = config1.deterministic_id();
-        let id2 = config2.deterministic_id();
-
-        // Different names should produce different IDs
-        assert_ne!(id1, id2);
+        assert_ne!(config1.deterministic_id(), config2.deterministic_id());
     }
 
     #[test]
@@ -381,12 +198,11 @@ repos = ["/tmp/old"]
             name: "Test Project".to_string(),
             repos: vec![PathBuf::from("/repo")],
             roles: Vec::new(),
+            id: None,
         };
 
         let info = ProjectInfo::new(config.clone());
-        let expected_id = config.deterministic_id();
-
-        assert_eq!(info.id, expected_id);
+        assert_eq!(info.id, config.deterministic_id());
     }
 
     #[test]
@@ -395,15 +211,44 @@ repos = ["/tmp/old"]
             name: "Shared Project".to_string(),
             repos: vec![PathBuf::from("/shared/repo")],
             roles: Vec::new(),
+            id: None,
         };
 
-        // Simulate Instance A loading the config
         let info_a = ProjectInfo::new(config.clone());
-
-        // Simulate Instance B loading the same config
         let info_b = ProjectInfo::new(config.clone());
 
-        // Both instances should derive the same project ID
         assert_eq!(info_a.id, info_b.id);
+    }
+
+    #[test]
+    fn effective_id_falls_back_to_deterministic() {
+        let config = ProjectConfig {
+            name: "Test".to_string(),
+            repos: vec![PathBuf::from("/repo")],
+            roles: Vec::new(),
+            id: None,
+        };
+        assert_eq!(config.effective_id(), config.deterministic_id());
+    }
+
+    #[test]
+    fn effective_id_uses_persisted_id() {
+        let original_config = ProjectConfig {
+            name: "OldName".to_string(),
+            repos: vec![],
+            roles: Vec::new(),
+            id: None,
+        };
+        let original_id = original_config.deterministic_id();
+
+        let renamed_config = ProjectConfig {
+            name: "NewName".to_string(),
+            repos: vec![],
+            roles: Vec::new(),
+            id: Some(original_id.to_string()),
+        };
+
+        assert_eq!(renamed_config.effective_id(), original_id);
+        assert_ne!(renamed_config.deterministic_id(), original_id);
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod audit;
 mod projects;
+mod roles;
 mod schema;
 mod sessions;
 pub mod sync;
@@ -48,6 +49,11 @@ impl Database {
             instance_id: Uuid::new_v4().to_string(),
             last_data_version,
         })
+    }
+
+    /// Get a reference to the underlying connection (for metadata queries).
+    pub fn conn_ref(&self) -> &Connection {
+        &self.conn
     }
 
     /// Open an in-memory database (for testing).

--- a/src/storage/projects.rs
+++ b/src/storage/projects.rs
@@ -175,7 +175,14 @@ impl Database {
                 })?
                 .collect::<Result<_, _>>()?;
 
-            projects.push(SharedProject { id, name, repos });
+            let roles = self.list_roles(id)?;
+
+            projects.push(SharedProject {
+                id,
+                name,
+                repos,
+                roles,
+            });
         }
 
         Ok(projects)
@@ -203,6 +210,7 @@ mod tests {
             name: name.to_string(),
             repos: vec![],
             roles: vec![],
+            id: None,
         };
         config.deterministic_id()
     }

--- a/src/storage/roles.rs
+++ b/src/storage/roles.rs
@@ -1,0 +1,350 @@
+use std::collections::HashMap;
+
+use rusqlite::params;
+
+use crate::project::ProjectId;
+use crate::session::{RoleConfig, RolePermissions};
+use crate::sync::current_time_millis;
+
+use super::Database;
+
+impl Database {
+    /// List all roles for a specific project.
+    pub fn list_roles(&self, project_id: ProjectId) -> rusqlite::Result<Vec<RoleConfig>> {
+        let id_str = project_id.to_string();
+        let mut stmt = self.conn.prepare(
+            "SELECT role_name, description, permission_mode, allowed_tools, \
+             disallowed_tools, tools, append_system_prompt \
+             FROM project_roles WHERE project_id = ?1 ORDER BY role_name",
+        )?;
+
+        let roles = stmt
+            .query_map(params![id_str], |row| {
+                let name: String = row.get(0)?;
+                let description: String = row.get(1)?;
+                let permission_mode: Option<String> = row.get(2)?;
+                let allowed_csv: String = row.get(3)?;
+                let disallowed_csv: String = row.get(4)?;
+                let tools: Option<String> = row.get(5)?;
+                let append_system_prompt: Option<String> = row.get(6)?;
+
+                Ok(RoleConfig {
+                    name,
+                    description,
+                    permissions: RolePermissions {
+                        permission_mode,
+                        allowed_tools: csv_to_vec(&allowed_csv),
+                        disallowed_tools: csv_to_vec(&disallowed_csv),
+                        tools,
+                        append_system_prompt,
+                    },
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(roles)
+    }
+
+    /// List roles for all active projects, keyed by project ID.
+    pub fn list_all_roles(&self) -> rusqlite::Result<HashMap<ProjectId, Vec<RoleConfig>>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT pr.project_id, pr.role_name, pr.description, pr.permission_mode, \
+             pr.allowed_tools, pr.disallowed_tools, pr.tools, pr.append_system_prompt \
+             FROM project_roles pr \
+             INNER JOIN projects p ON p.id = pr.project_id AND p.deleted_at IS NULL \
+             ORDER BY pr.project_id, pr.role_name",
+        )?;
+
+        let mut map: HashMap<ProjectId, Vec<RoleConfig>> = HashMap::new();
+
+        let rows = stmt.query_map([], |row| {
+            let pid_str: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            let description: String = row.get(2)?;
+            let permission_mode: Option<String> = row.get(3)?;
+            let allowed_csv: String = row.get(4)?;
+            let disallowed_csv: String = row.get(5)?;
+            let tools: Option<String> = row.get(6)?;
+            let append_system_prompt: Option<String> = row.get(7)?;
+
+            Ok((
+                pid_str,
+                RoleConfig {
+                    name,
+                    description,
+                    permissions: RolePermissions {
+                        permission_mode,
+                        allowed_tools: csv_to_vec(&allowed_csv),
+                        disallowed_tools: csv_to_vec(&disallowed_csv),
+                        tools,
+                        append_system_prompt,
+                    },
+                },
+            ))
+        })?;
+
+        for row in rows {
+            let (pid_str, role) = row?;
+            let pid = pid_str
+                .parse::<uuid::Uuid>()
+                .map(ProjectId::from_uuid)
+                .unwrap_or_default();
+            map.entry(pid).or_default().push(role);
+        }
+
+        Ok(map)
+    }
+
+    /// Replace all roles for a project (delete existing + insert new).
+    pub fn replace_roles(
+        &self,
+        project_id: ProjectId,
+        roles: &[RoleConfig],
+    ) -> rusqlite::Result<()> {
+        let id_str = project_id.to_string();
+        let now = current_time_millis() as i64;
+
+        self.conn.execute(
+            "DELETE FROM project_roles WHERE project_id = ?1",
+            params![id_str],
+        )?;
+
+        for role in roles {
+            self.conn.execute(
+                "INSERT INTO project_roles \
+                 (project_id, role_name, description, permission_mode, \
+                  allowed_tools, disallowed_tools, tools, append_system_prompt, \
+                  created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                params![
+                    id_str,
+                    role.name,
+                    role.description,
+                    role.permissions.permission_mode,
+                    vec_to_csv(&role.permissions.allowed_tools),
+                    vec_to_csv(&role.permissions.disallowed_tools),
+                    role.permissions.tools,
+                    role.permissions.append_system_prompt,
+                    now,
+                    now,
+                ],
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Convert a comma-separated string to a Vec<String>, filtering empty entries.
+fn csv_to_vec(csv: &str) -> Vec<String> {
+    if csv.is_empty() {
+        Vec::new()
+    } else {
+        csv.split(',').map(|s| s.to_string()).collect()
+    }
+}
+
+/// Convert a Vec<String> to a comma-separated string.
+fn vec_to_csv(v: &[String]) -> String {
+    v.join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::project::ProjectConfig;
+
+    use super::*;
+
+    fn test_project_id(name: &str) -> ProjectId {
+        let config = ProjectConfig {
+            name: name.to_string(),
+            repos: vec![],
+            roles: vec![],
+            id: None,
+        };
+        config.deterministic_id()
+    }
+
+    fn setup_db_with_project(name: &str) -> (Database, ProjectId) {
+        let db = Database::open_in_memory().unwrap();
+        let pid = test_project_id(name);
+        db.insert_project(pid, name, &[PathBuf::from("/repo")], false)
+            .unwrap();
+        (db, pid)
+    }
+
+    #[test]
+    fn list_roles_empty_project() {
+        let (db, pid) = setup_db_with_project("test");
+        let roles = db.list_roles(pid).unwrap();
+        assert!(roles.is_empty());
+    }
+
+    #[test]
+    fn replace_and_list_roles() {
+        let (db, pid) = setup_db_with_project("test");
+
+        let roles = vec![
+            RoleConfig {
+                name: "developer".to_string(),
+                description: "Full access".to_string(),
+                permissions: RolePermissions::default(),
+            },
+            RoleConfig {
+                name: "reviewer".to_string(),
+                description: "Read-only review".to_string(),
+                permissions: RolePermissions {
+                    permission_mode: Some("plan".to_string()),
+                    allowed_tools: vec!["Read".to_string(), "Bash(git:*)".to_string()],
+                    disallowed_tools: vec!["Edit".to_string()],
+                    tools: Some("default".to_string()),
+                    append_system_prompt: Some("Be careful".to_string()),
+                },
+            },
+        ];
+
+        db.replace_roles(pid, &roles).unwrap();
+        let loaded = db.list_roles(pid).unwrap();
+
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].name, "developer");
+        assert_eq!(loaded[0].description, "Full access");
+
+        assert_eq!(loaded[1].name, "reviewer");
+        assert_eq!(
+            loaded[1].permissions.permission_mode,
+            Some("plan".to_string())
+        );
+        assert_eq!(
+            loaded[1].permissions.allowed_tools,
+            vec!["Read".to_string(), "Bash(git:*)".to_string()]
+        );
+        assert_eq!(
+            loaded[1].permissions.disallowed_tools,
+            vec!["Edit".to_string()]
+        );
+        assert_eq!(loaded[1].permissions.tools, Some("default".to_string()));
+        assert_eq!(
+            loaded[1].permissions.append_system_prompt,
+            Some("Be careful".to_string())
+        );
+    }
+
+    #[test]
+    fn replace_roles_overwrites_existing() {
+        let (db, pid) = setup_db_with_project("test");
+
+        let initial = vec![RoleConfig {
+            name: "old-role".to_string(),
+            description: "old".to_string(),
+            permissions: RolePermissions::default(),
+        }];
+        db.replace_roles(pid, &initial).unwrap();
+
+        let updated = vec![RoleConfig {
+            name: "new-role".to_string(),
+            description: "new".to_string(),
+            permissions: RolePermissions::default(),
+        }];
+        db.replace_roles(pid, &updated).unwrap();
+
+        let loaded = db.list_roles(pid).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "new-role");
+    }
+
+    #[test]
+    fn replace_roles_empty_clears_all() {
+        let (db, pid) = setup_db_with_project("test");
+
+        let roles = vec![RoleConfig {
+            name: "dev".to_string(),
+            description: String::new(),
+            permissions: RolePermissions::default(),
+        }];
+        db.replace_roles(pid, &roles).unwrap();
+        db.replace_roles(pid, &[]).unwrap();
+
+        let loaded = db.list_roles(pid).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn list_all_roles_multiple_projects() {
+        let db = Database::open_in_memory().unwrap();
+
+        let pid1 = test_project_id("proj1");
+        let pid2 = test_project_id("proj2");
+        db.insert_project(pid1, "proj1", &[], false).unwrap();
+        db.insert_project(pid2, "proj2", &[], false).unwrap();
+
+        db.replace_roles(
+            pid1,
+            &[RoleConfig {
+                name: "dev".to_string(),
+                description: String::new(),
+                permissions: RolePermissions::default(),
+            }],
+        )
+        .unwrap();
+        db.replace_roles(
+            pid2,
+            &[
+                RoleConfig {
+                    name: "reviewer".to_string(),
+                    description: String::new(),
+                    permissions: RolePermissions::default(),
+                },
+                RoleConfig {
+                    name: "admin".to_string(),
+                    description: String::new(),
+                    permissions: RolePermissions::default(),
+                },
+            ],
+        )
+        .unwrap();
+
+        let all = db.list_all_roles().unwrap();
+        assert_eq!(all.get(&pid1).unwrap().len(), 1);
+        assert_eq!(all.get(&pid2).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn list_all_roles_excludes_deleted_projects() {
+        let db = Database::open_in_memory().unwrap();
+        let pid = test_project_id("deleted");
+        db.insert_project(pid, "deleted", &[], false).unwrap();
+        db.replace_roles(
+            pid,
+            &[RoleConfig {
+                name: "dev".to_string(),
+                description: String::new(),
+                permissions: RolePermissions::default(),
+            }],
+        )
+        .unwrap();
+
+        db.soft_delete_project(pid).unwrap();
+
+        let all = db.list_all_roles().unwrap();
+        assert!(all.is_empty());
+    }
+
+    #[test]
+    fn csv_roundtrip() {
+        assert_eq!(csv_to_vec(""), Vec::<String>::new());
+        assert_eq!(csv_to_vec("Read"), vec!["Read".to_string()]);
+        assert_eq!(
+            csv_to_vec("Read,Bash(git:*)"),
+            vec!["Read".to_string(), "Bash(git:*)".to_string()]
+        );
+        assert_eq!(vec_to_csv(&[]), "");
+        assert_eq!(vec_to_csv(&["Read".to_string()]), "Read");
+        assert_eq!(
+            vec_to_csv(&["Read".to_string(), "Edit".to_string()]),
+            "Read,Edit"
+        );
+    }
+}

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1,7 +1,7 @@
 use rusqlite::Connection;
 
 /// Current schema version. Incremented when schema changes.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Create all tables and indexes if they don't exist.
 pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
@@ -75,6 +75,20 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             ON sessions(id) WHERE deleted_at IS NULL;
         CREATE INDEX IF NOT EXISTS idx_projects_active
             ON projects(id) WHERE deleted_at IS NULL;
+
+        CREATE TABLE IF NOT EXISTS project_roles (
+            project_id          TEXT NOT NULL REFERENCES projects(id),
+            role_name           TEXT NOT NULL,
+            description         TEXT NOT NULL DEFAULT '',
+            permission_mode     TEXT,
+            allowed_tools       TEXT NOT NULL DEFAULT '',
+            disallowed_tools    TEXT NOT NULL DEFAULT '',
+            tools               TEXT,
+            append_system_prompt TEXT,
+            created_at          INTEGER NOT NULL,
+            updated_at          INTEGER NOT NULL,
+            PRIMARY KEY (project_id, role_name)
+        );
         ",
     )?;
 
@@ -111,6 +125,7 @@ mod tests {
         assert!(tables.contains(&"metadata".to_string()));
         assert!(tables.contains(&"projects".to_string()));
         assert!(tables.contains(&"project_repos".to_string()));
+        assert!(tables.contains(&"project_roles".to_string()));
         assert!(tables.contains(&"sessions".to_string()));
         assert!(tables.contains(&"worktrees".to_string()));
         assert!(tables.contains(&"audit_log".to_string()));

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -237,6 +237,7 @@ mod tests {
             name: name.to_string(),
             repos: vec![],
             roles: vec![],
+            id: None,
         };
         config.deterministic_id()
     }

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -59,6 +59,7 @@ mod tests {
             name: name.to_string(),
             repos: vec![],
             roles: vec![],
+            id: None,
         };
         config.deterministic_id()
     }

--- a/src/storage/worktrees.rs
+++ b/src/storage/worktrees.rs
@@ -115,6 +115,7 @@ mod tests {
             name: "test".to_string(),
             repos: vec![],
             roles: vec![],
+            id: None,
         };
         config.deterministic_id()
     }

--- a/src/sync/delta.rs
+++ b/src/sync/delta.rs
@@ -142,7 +142,7 @@ fn session_changed(old: &SharedSession, new: &SharedSession) -> bool {
 
 /// Check if a project's key metadata changed.
 fn project_changed(old: &SharedProject, new: &SharedProject) -> bool {
-    old.name != new.name || old.repos != new.repos
+    old.name != new.name || old.repos != new.repos || old.roles != new.roles
 }
 
 #[cfg(test)]

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::project::ProjectId;
-use crate::session::SessionId;
+use crate::session::{RoleConfig, SessionId};
 
 /// Current shared state format version.
 const SHARED_STATE_VERSION: u32 = 1;
@@ -98,6 +98,9 @@ pub struct SharedProject {
 
     /// Repository paths associated with this project.
     pub repos: Vec<PathBuf>,
+
+    /// Role definitions for this project.
+    pub roles: Vec<RoleConfig>,
 }
 
 /// Worktree information embedded in shared session.

--- a/src/ui/edit_project_modal.rs
+++ b/src/ui/edit_project_modal.rs
@@ -1,0 +1,208 @@
+use std::path::PathBuf;
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use super::{centered_fixed_height_rect, render_text_field, render_text_field_with_suggestion};
+use crate::app::EditProjectField;
+
+pub struct EditProjectModalState<'a> {
+    pub name: &'a str,
+    pub name_cursor: usize,
+    pub path: &'a str,
+    pub path_cursor: usize,
+    pub path_suggestion: Option<&'a str>,
+    pub repos: &'a [PathBuf],
+    pub repo_index: usize,
+    pub role_count: usize,
+    pub focused_field: EditProjectField,
+}
+
+pub fn render_edit_project_modal(frame: &mut Frame, state: &EditProjectModalState<'_>) {
+    // Dynamic height: name(3) + path(3) + repo_list(max 6 items + 2 border) + roles(3) + footer(1) + outer border(2)
+    let repo_list_inner = if state.repos.is_empty() {
+        1
+    } else {
+        state.repos.len().min(6)
+    };
+    let repo_list_height = repo_list_inner as u16 + 2; // +2 for borders
+    let total_height = 3 + 3 + repo_list_height + 3 + 1 + 2; // name + path + repos + roles + footer + outer
+
+    let area = centered_fixed_height_rect(50, total_height, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Edit Project ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),                // Name field
+            Constraint::Length(3),                // Path field
+            Constraint::Length(repo_list_height), // Repo list
+            Constraint::Length(3),                // Roles field
+            Constraint::Min(1),                   // Footer
+        ])
+        .split(inner);
+
+    render_text_field(
+        frame,
+        chunks[0],
+        "Name",
+        state.name,
+        state.name_cursor,
+        state.focused_field == EditProjectField::Name,
+    );
+
+    render_text_field_with_suggestion(
+        frame,
+        chunks[1],
+        "Add Repo Path",
+        state.path,
+        state.path_cursor,
+        state.focused_field == EditProjectField::Path,
+        state.path_suggestion,
+    );
+
+    // Repo list
+    let list_focused = state.focused_field == EditProjectField::RepoList;
+    let list_border_color = if list_focused {
+        Color::Cyan
+    } else {
+        Color::Gray
+    };
+
+    let list_block = Block::default()
+        .title(format!(" Repos ({}) ", state.repos.len()))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(list_border_color));
+
+    let list_inner = list_block.inner(chunks[2]);
+    frame.render_widget(list_block, chunks[2]);
+
+    if state.repos.is_empty() {
+        let placeholder = Paragraph::new(Line::from(Span::styled(
+            "(none — add via Path field above)",
+            Style::default().fg(Color::DarkGray),
+        )));
+        frame.render_widget(placeholder, list_inner);
+    } else {
+        let visible_count = list_inner.height as usize;
+        // Scroll so that selected item is always visible
+        let scroll_offset = if state.repo_index >= visible_count {
+            state.repo_index - visible_count + 1
+        } else {
+            0
+        };
+
+        let lines: Vec<Line> = state
+            .repos
+            .iter()
+            .enumerate()
+            .skip(scroll_offset)
+            .take(visible_count)
+            .map(|(i, path)| {
+                let selected = i == state.repo_index && list_focused;
+                let marker = if selected { "▸ " } else { "  " };
+                let path_str = path.display().to_string();
+                let (marker_color, path_color) = if selected {
+                    (Color::Cyan, Color::White)
+                } else {
+                    (Color::DarkGray, Color::Gray)
+                };
+                Line::from(vec![
+                    Span::styled(marker, Style::default().fg(marker_color)),
+                    Span::styled(path_str, Style::default().fg(path_color)),
+                ])
+            })
+            .collect();
+
+        frame.render_widget(Paragraph::new(lines), list_inner);
+    }
+
+    // Roles field
+    let roles_focused = state.focused_field == EditProjectField::Roles;
+    let roles_border_color = if roles_focused {
+        Color::Cyan
+    } else {
+        Color::Gray
+    };
+
+    let roles_block = Block::default()
+        .title(" Roles ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(roles_border_color));
+
+    let roles_inner = roles_block.inner(chunks[3]);
+    frame.render_widget(roles_block, chunks[3]);
+
+    let roles_text = match state.role_count {
+        0 => "No roles configured  Enter to add...".to_string(),
+        1 => "1 role configured  Enter to edit...".to_string(),
+        n => format!("{n} roles configured  Enter to edit..."),
+    };
+    let roles_color = if roles_focused {
+        Color::White
+    } else {
+        Color::Gray
+    };
+    let roles_line = Line::from(Span::styled(roles_text, Style::default().fg(roles_color)));
+    frame.render_widget(Paragraph::new(roles_line), roles_inner);
+
+    // Context-sensitive footer
+    let footer = match state.focused_field {
+        EditProjectField::Name => Line::from(vec![
+            Span::styled("Tab", Style::default().fg(Color::Yellow)),
+            Span::styled(" next  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::styled(" save  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        ]),
+        EditProjectField::Path => {
+            let tab_hint = if state.path_suggestion.is_some() {
+                " complete  "
+            } else {
+                " next  "
+            };
+            Line::from(vec![
+                Span::styled("Tab", Style::default().fg(Color::Yellow)),
+                Span::styled(tab_hint, Style::default().fg(Color::DarkGray)),
+                Span::styled("Enter", Style::default().fg(Color::Yellow)),
+                Span::styled(" add repo  ", Style::default().fg(Color::DarkGray)),
+                Span::styled("Esc", Style::default().fg(Color::Yellow)),
+                Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+            ])
+        }
+        EditProjectField::RepoList => Line::from(vec![
+            Span::styled("j/k", Style::default().fg(Color::Yellow)),
+            Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("d", Style::default().fg(Color::Yellow)),
+            Span::styled(" delete  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::styled(" save  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        ]),
+        EditProjectField::Roles => Line::from(vec![
+            Span::styled("Tab", Style::default().fg(Color::Yellow)),
+            Span::styled(" next  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::styled(" edit roles  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        ]),
+    };
+    frame.render_widget(Paragraph::new(footer), chunks[4]);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod add_project_modal;
 pub mod branch_selector_modal;
 pub mod delete_project_modal;
+pub mod edit_project_modal;
 pub mod info_panel;
 pub mod layout;
 pub mod project_list;


### PR DESCRIPTION
…tence bugs

- Migrate roles from config.toml to SQLite with one-time import
- Remove ConfigFile, load_and_merge_projects, save_project_configs_to_disk
- Add edit-project modal (Ctrl+E) with name, path, repos, and role editing
- Add project_roles table and storage/roles.rs for DB-backed role management
- Fix session duplication on restart by soft-deleting stale sessions
- Fix project persistence by persisting default project for FK constraints
- Fix save_project_to_db to handle soft-deleted PK conflicts via restore
- Initialize sync snapshot at startup to prevent false deltas
- Remove dead merge_projects_from_db method
- Add 3 new tests for default project persistence, sync snapshot, and restore