### PR TITLE
feat(ui): display version in TUI header

### DIFF
--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -19,6 +19,10 @@ pub fn render_header(frame: &mut Frame, area: Rect) {
             " Multi-Session Claude Code Orchestrator",
             Style::default().fg(Color::Gray),
         ),
+        Span::styled(
+            concat!("  v", env!("THURBOX_VERSION")),
+            Style::default().fg(Color::DarkGray),
+        ),
     ]));
     frame.render_widget(header, area);
 }


### PR DESCRIPTION
## Summary

- Adds a compile-time version `Span` to the header bar in `src/ui/status_bar.rs`
- Uses `concat!` + `env!("THURBOX_VERSION")` — zero runtime cost
- Dev builds show `v0.0.0-dev`; release builds show the real version (e.g. `v0.1.0`) injected by `build.rs` via `THURBOX_RELEASE_VERSION`
- Styled `DarkGray` to match the footer's tertiary info hints

## Test plan

- [x] `cargo check --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no warnings)
- [x] `cargo nextest run --all` — all 408 tests pass
- [ ] Visual: run `cargo run` and confirm version appears in the header bar