### PR TITLE
fix(core): change default permission mode from dontAsk to default

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -445,7 +445,7 @@ Edits a single role with four text fields:
 - **Disallowed Tools** — space-separated tool names
   (blocked)
 
-Permission mode defaults to `dontAsk` and can be
+Permission mode defaults to `default` and can be
 overridden per-role via the role editor.
 
 `Tab` / `Shift+Tab` cycles between fields.

--- a/src/claude/backend.rs
+++ b/src/claude/backend.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error};
 use crate::session::{SessionConfig, SessionInfo};
 
 /// Default permission mode passed to the Claude CLI when no explicit mode is configured.
-const DEFAULT_PERMISSION_MODE: &str = "dontAsk";
+const DEFAULT_PERMISSION_MODE: &str = "default";
 
 pub(crate) fn now_millis() -> u64 {
     SystemTime::now()
@@ -36,7 +36,7 @@ pub fn build_claude_args(config: &SessionConfig) -> Vec<String> {
         args.push(session_id.clone());
     }
 
-    // Role permission flags — default to "dontAsk" when no mode is configured.
+    // Role permission flags — default to "default" when no mode is configured.
     let mode = config
         .permissions
         .permission_mode
@@ -397,7 +397,7 @@ mod tests {
     fn build_args_empty_config() {
         let config = SessionConfig::default();
         let args = build_claude_args(&config);
-        assert_eq!(args, vec!["--permission-mode", "dontAsk"]);
+        assert_eq!(args, vec!["--permission-mode", "default"]);
     }
 
     #[test]
@@ -409,7 +409,7 @@ mod tests {
         let args = build_claude_args(&config);
         assert_eq!(
             args,
-            vec!["--session-id", "abc-123", "--permission-mode", "dontAsk"]
+            vec!["--session-id", "abc-123", "--permission-mode", "default"]
         );
     }
 
@@ -423,7 +423,7 @@ mod tests {
         let args = build_claude_args(&config);
         assert_eq!(
             args,
-            vec!["--resume", "resume-id", "--permission-mode", "dontAsk"]
+            vec!["--resume", "resume-id", "--permission-mode", "default"]
         );
     }
 
@@ -454,7 +454,7 @@ mod tests {
             args,
             vec![
                 "--permission-mode",
-                "dontAsk",
+                "default",
                 "--allowed-tools",
                 "Read Bash(git:*)"
             ]
@@ -473,7 +473,7 @@ mod tests {
         let args = build_claude_args(&config);
         assert_eq!(
             args,
-            vec!["--permission-mode", "dontAsk", "--disallowed-tools", "Edit"]
+            vec!["--permission-mode", "default", "--disallowed-tools", "Edit"]
         );
     }
 
@@ -487,7 +487,7 @@ mod tests {
             ..SessionConfig::default()
         };
         let args = build_claude_args(&config);
-        assert_eq!(args, vec!["--permission-mode", "dontAsk", "--tools", ""]);
+        assert_eq!(args, vec!["--permission-mode", "default", "--tools", ""]);
     }
 
     #[test]
@@ -504,7 +504,7 @@ mod tests {
             args,
             vec![
                 "--permission-mode",
-                "dontAsk",
+                "default",
                 "--append-system-prompt",
                 "Be careful"
             ]

--- a/src/claude/tmux.rs
+++ b/src/claude/tmux.rs
@@ -992,10 +992,10 @@ mod tests {
             "--resume".to_string(),
             "abc-123".to_string(),
             "--permission-mode".to_string(),
-            "dontAsk".to_string(),
+            "default".to_string(),
         ];
         let cmd = LocalTmuxBackend::build_shell_command("claude", &args);
-        assert_eq!(cmd, "claude --resume abc-123 --permission-mode dontAsk");
+        assert_eq!(cmd, "claude --resume abc-123 --permission-mode default");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Changes the default `--permission-mode` flag passed to `claude` CLI from `dontAsk` (auto-deny) to `default` (standard interactive mode)
- Updates all test assertions in `backend.rs` and `tmux.rs` to reflect the new default
- Updates `docs/FEATURES.md` documentation

## Test plan
- [x] All 408 existing tests pass
- [x] All pre-commit hooks pass (fmt, clippy, nextest, arch rules, etc.)