### PR TITLE
fix(core): fix version display in release builds

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = ["THURBOX_RELEASE_VERSION"]

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,6 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=THURBOX_RELEASE_VERSION");
+
     let version = get_version();
     println!("cargo:rustc-env=THURBOX_VERSION={}", version);
 
@@ -11,9 +13,9 @@ fn main() {
 }
 
 fn get_version() -> String {
-    // Use THURBOX_RELEASE_VERSION if set (from CI release workflow)
-    if let Ok(release_version) = std::env::var("THURBOX_RELEASE_VERSION") {
-        return release_version;
+    // CI sets THURBOX_RELEASE_VERSION (e.g. "v0.7.0"); strip the "v" prefix
+    if let Ok(v) = std::env::var("THURBOX_RELEASE_VERSION") {
+        return v.strip_prefix('v').unwrap_or(&v).to_string();
     }
 
     // Fallback to Cargo.toml version for local development

--- a/tests/version_format.rs
+++ b/tests/version_format.rs
@@ -1,0 +1,37 @@
+//! Verify that `build.rs` sets `THURBOX_VERSION` correctly.
+//!
+//! The version embedded at compile time must:
+//! - Never start with `v` (the UI prepends it: `concat!("v", env!("THURBOX_VERSION"))`)
+//! - Be a valid semver-ish string (digits and dots, optionally with a pre-release suffix)
+//!
+//! In dev builds (no `THURBOX_RELEASE_VERSION` env var), this equals the
+//! Cargo.toml version (`0.0.0-dev`).  In CI release builds the env var is
+//! stripped of its `v` prefix (e.g. `v0.7.0` → `0.7.0`).
+
+const VERSION: &str = env!("THURBOX_VERSION");
+
+#[test]
+fn version_has_no_v_prefix() {
+    assert!(
+        !VERSION.starts_with('v'),
+        "THURBOX_VERSION must not start with 'v' (got {VERSION:?}); \
+         the UI already prepends the prefix"
+    );
+}
+
+#[test]
+fn version_starts_with_digit() {
+    assert!(
+        VERSION.starts_with(|c: char| c.is_ascii_digit()),
+        "THURBOX_VERSION must start with a digit (got {VERSION:?})"
+    );
+}
+
+#[test]
+fn dev_build_version_matches_cargo_toml() {
+    // When THURBOX_RELEASE_VERSION is not set, build.rs falls back to CARGO_PKG_VERSION.
+    // This test validates that contract for the default (dev) build.
+    if VERSION.contains("-dev") {
+        assert_eq!(VERSION, env!("CARGO_PKG_VERSION"));
+    }
+}


### PR DESCRIPTION
## Summary

- **musl builds showed `v0.0.0-dev`**: `cross` builds musl inside Docker and doesn't forward host env vars by default. Added `Cross.toml` with `passthrough = ["THURBOX_RELEASE_VERSION"]` so the CI env var reaches `build.rs` inside the container.
- **GNU/macOS builds showed `vv0.7.0`**: `build.rs` stored the raw CI value (`v0.7.0`) but `status_bar.rs` prepends another `v`. Fixed by stripping the leading `v` prefix in `build.rs` so `THURBOX_VERSION` is `0.7.0`.
- **Stale cached versions**: Added `cargo:rerun-if-env-changed=THURBOX_RELEASE_VERSION` so Cargo reruns `build.rs` when the env var changes.
- Moved the rerun directive to `main()` alongside other `cargo:` directives for clarity.
- Added `tests/version_format.rs` with 3 tests to guard the no-`v`-prefix contract going forward.

## Test plan

- [x] `cargo build` — compiles successfully
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run --all` — 411/411 tests pass (3 new)
- [x] `THURBOX_RELEASE_VERSION=v0.7.0 cargo build && strings target/debug/thurbox | grep '0.7.0'` — confirms prefix stripping
- [ ] CI musl build should now show `v0.7.0` in the TUI header instead of `v0.0.0-dev`