### PR TITLE
feat(core): restart session with Ctrl+R, embed role editor in edit-project modal

### DIFF
--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -59,7 +59,7 @@ pub fn render_footer(
             focus_badge,
             Span::styled(counts, Style::default().fg(Color::Gray)),
             Span::styled(
-                " ^N New  ^C Close  ^D Delete  ^R Role  ^H/J/K/L Nav  F1 Help  F2 Info  ^Q Quit ",
+                " ^N New  ^C Close  ^D Delete  ^E Edit  ^R Restart  ^H/J/K/L Nav  F1 Help  F2 Info  ^Q Quit ",
                 Style::default().fg(Color::DarkGray),
             ),
         ])


### PR DESCRIPTION
## Summary

- Add `Ctrl+R` to restart the active session (kills and re-spawns the claude process, resuming the same claude session ID with updated role permissions)
- Embed the role editor inline within the `Ctrl+E` edit-project modal (Roles field) — removes the standalone role editor modal triggered by the old `Ctrl+R`
- Update status bar hint from `^R Role` to `^E Edit  ^R Restart`
- Update help overlay and CLAUDE.md keybinding table accordingly

## Test plan

- [ ] Press `Ctrl+R` with an active session — verify it restarts (kills + re-spawns) the claude process
- [ ] Press `Ctrl+R` with no sessions — verify no crash/error
- [ ] Press `Ctrl+E` → Tab to Roles field — verify inline role editor works (a=add, e=edit, d=delete)
- [ ] Status bar shows `^E Edit  ^R Restart`
- [ ] F1 help overlay shows updated keybindings