### PR TITLE
fix(mcp): make thurbox-mcp chmod conditional and fix set -e edge cases

### DIFF
--- a/scripts/install.bats
+++ b/scripts/install.bats
@@ -89,3 +89,30 @@
 @test "script supports INSTALL_DIR env var" {
   grep -q "INSTALL_DIR" "${BATS_TEST_DIRNAME}/install.sh"
 }
+
+@test "do_install succeeds without thurbox-mcp in tarball" {
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/src" "$tmpdir/dest"
+  printf '#!/bin/sh\n' > "$tmpdir/src/thurbox"
+  tar -czf "$tmpdir/archive.tar.gz" -C "$tmpdir/src" thurbox
+  TEST_TMPDIR=1 sh -c ". '${BATS_TEST_DIRNAME}/install.sh'; do_install '$tmpdir/archive.tar.gz' '$tmpdir/dest'"
+  [ -x "$tmpdir/dest/thurbox" ]
+  [ ! -f "$tmpdir/dest/thurbox-mcp" ]
+  rm -rf "$tmpdir"
+}
+
+@test "do_install chmods both binaries when thurbox-mcp is present" {
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/src" "$tmpdir/dest"
+  printf '#!/bin/sh\n' > "$tmpdir/src/thurbox"
+  printf '#!/bin/sh\n' > "$tmpdir/src/thurbox-mcp"
+  tar -czf "$tmpdir/archive.tar.gz" -C "$tmpdir/src" thurbox thurbox-mcp
+  TEST_TMPDIR=1 sh -c ". '${BATS_TEST_DIRNAME}/install.sh'; do_install '$tmpdir/archive.tar.gz' '$tmpdir/dest'"
+  [ -x "$tmpdir/dest/thurbox" ]
+  [ -x "$tmpdir/dest/thurbox-mcp" ]
+  rm -rf "$tmpdir"
+}
+
+@test "script conditionally chmods thurbox-mcp" {
+  grep -q 'thurbox-mcp.*chmod' "${BATS_TEST_DIRNAME}/install.sh"
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ TEMP_DIR=""
 
 # Cleanup
 cleanup() {
-  [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ] && rm -rf "$TEMP_DIR"
+  [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ] && rm -rf "$TEMP_DIR" || true
 }
 trap cleanup EXIT INT TERM
 
@@ -153,7 +153,7 @@ do_install() {
   mkdir -p "$dir"
   tar -xzf "$tarball" -C "$dir"
   chmod +x "$dir/thurbox"
-  chmod +x "$dir/thurbox-mcp"
+  if [ -f "$dir/thurbox-mcp" ]; then chmod +x "$dir/thurbox-mcp"; fi
 }
 
 # Show success message
@@ -196,4 +196,4 @@ main() {
   success "Installation complete!"
 }
 
-[ -z "$TEST_TMPDIR" ] && main "$@"
+if [ -z "$TEST_TMPDIR" ]; then main "$@"; fi


### PR DESCRIPTION
## Summary

- Replace `chmod +x "$dir/thurbox-mcp"` with an `if`-guarded conditional so installations against older releases (without the MCP binary) succeed without error
- Fix two pre-existing `set -e` edge cases: `cleanup()` now ends with `|| true` to avoid non-zero exit when `TEMP_DIR` is empty, and the `TEST_TMPDIR` guard is now an `if/fi` block so sourcing the script in tests doesn't abort
- Add 3 functional bats tests: install without `thurbox-mcp`, install with both binaries, and a pattern check for the conditional chmod

## Test plan

- [x] `bats scripts/install.bats` — all 25 tests pass (3 new)
- [x] `sh -n scripts/install.sh` — syntax valid
- [x] Pre-commit hooks pass (bats, deny, doc, conventional commit)