### PR TITLE
feat(mcp): add admin session with auto-configured thurbox-mcp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,15 @@ cargo run --bin thurbox-mcp         # Run (stdin/stdout JSON-RPC)
 | `set_roles` | Replace all roles for a project |
 | `list_sessions` | List sessions (optional project filter) |
 
+### Admin Session (built-in MCP client)
+
+The TUI includes a global "Admin" session that auto-configures
+`thurbox-mcp` as an MCP server. On startup, Thurbox creates
+`~/.local/share/thurbox/admin/.mcp.json` and spawns an admin
+session there. Claude Code discovers the MCP config automatically,
+enabling conversational project/role/session management inside
+the TUI. See `docs/FEATURES.md` for details.
+
 ### Module Isolation
 
 ```text

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -500,6 +500,52 @@ overridden per-role via the role editor.
 
 ---
 
+## Admin Session
+
+A global admin session provides conversational access to Thurbox
+management via Claude Code with the `thurbox-mcp` MCP server
+auto-configured.
+
+### How it works
+
+On startup, Thurbox creates:
+
+1. An admin directory at `~/.local/share/thurbox/admin/`
+   (or `thurbox-dev/admin/` for dev builds).
+2. A `.mcp.json` file in that directory pointing to the
+   `thurbox-mcp` binary. Claude Code auto-discovers this file.
+3. An "Admin" pseudo-project pinned at index 0 in the project
+   list, visually distinguished with a yellow `⚙` prefix.
+4. A single admin session with `cwd` set to the admin directory.
+
+The `.mcp.json` is rewritten on every startup to pick up binary
+path changes after upgrades.
+
+### Admin project restrictions
+
+- Cannot be edited (`Ctrl+E` shows an error message).
+- Cannot be deleted (`Ctrl+D` shows an error message).
+- Cannot have additional sessions created (`Ctrl+N` is a no-op
+  when sessions exist, or respawns if the session was closed).
+- The admin session cannot be closed (`Ctrl+C` shows an error).
+
+### Binary resolution
+
+The `thurbox-mcp` binary path is resolved by:
+
+1. Checking for a sibling of `current_exe()` (works for both
+   installed `~/.local/bin/` and dev `target/debug/` builds).
+2. Falling back to bare `"thurbox-mcp"` for `$PATH` lookup.
+
+### Persistence
+
+The admin project and session persist to the SQLite database
+like all other projects and sessions. On restart, the tmux
+pane is re-adopted; `ensure_admin_session` only ensures the
+project exists at index 0 and `.mcp.json` is up-to-date.
+
+---
+
 ## Planned Features
 
 Directional intent, not commitments.

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,10 +57,16 @@ async fn main() -> Result<()> {
 
     let mut app = App::new(size.height, size.width, backend, db);
 
-    // Load session state from DB and restore, or spawn a fresh session
+    // Load session state from DB and restore
     if let Some((sessions, counter)) = app.load_persisted_state_from_db() {
         app.restore_sessions(sessions, counter);
-    } else {
+    }
+
+    // Ensure admin project + session exist (idempotent; rewrites .mcp.json on every startup)
+    app.ensure_admin_session();
+
+    // If no user sessions exist, spawn a fresh one
+    if app.user_session_count() == 0 {
         app.spawn_session();
     }
 

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -82,6 +82,7 @@ pub struct ProjectInfo {
     pub config: ProjectConfig,
     pub session_ids: Vec<SessionId>,
     pub is_default: bool,
+    pub is_admin: bool,
 }
 
 impl ProjectInfo {
@@ -92,6 +93,7 @@ impl ProjectInfo {
             config,
             session_ids: Vec::new(),
             is_default: false,
+            is_admin: false,
         }
     }
 
@@ -102,6 +104,18 @@ impl ProjectInfo {
             config,
             session_ids: Vec::new(),
             is_default: true,
+            is_admin: false,
+        }
+    }
+
+    pub fn new_admin(config: ProjectConfig) -> Self {
+        let id = config.effective_id();
+        Self {
+            id,
+            config,
+            session_ids: Vec::new(),
+            is_default: false,
+            is_admin: true,
         }
     }
 }
@@ -148,6 +162,7 @@ mod tests {
         assert!(info.session_ids.is_empty());
         assert_eq!(info.config.name, "test");
         assert!(!info.is_default);
+        assert!(!info.is_admin);
     }
 
     #[test]
@@ -155,8 +170,24 @@ mod tests {
         let config = create_default_project();
         let info = ProjectInfo::new_default(config);
         assert!(info.is_default);
+        assert!(!info.is_admin);
         assert_eq!(info.config.name, "Default");
         assert!(!info.config.repos.is_empty());
+    }
+
+    #[test]
+    fn project_info_new_admin_sets_flag() {
+        let config = ProjectConfig {
+            name: "Admin".to_string(),
+            repos: vec![PathBuf::from("/admin")],
+            roles: Vec::new(),
+            id: None,
+        };
+        let info = ProjectInfo::new_admin(config);
+        assert!(info.is_admin);
+        assert!(!info.is_default);
+        assert!(info.session_ids.is_empty());
+        assert_eq!(info.config.name, "Admin");
     }
 
     #[test]

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -12,6 +12,7 @@ use crate::session::SessionInfo;
 pub struct ProjectEntry<'a> {
     pub name: &'a str,
     pub session_count: usize,
+    pub is_admin: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,19 +66,25 @@ fn render_project_section(
         .iter()
         .enumerate()
         .map(|(i, project)| {
-            let style = if i == active_index {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+            let base_color = if project.is_admin {
+                Color::Yellow
+            } else if i == active_index {
+                Color::Cyan
             } else {
-                Style::default().fg(Color::White)
+                Color::White
+            };
+            let style = if i == active_index {
+                Style::default().fg(base_color).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(base_color)
             };
 
             let indicator = if i == active_index { "▸" } else { " " };
+            let prefix = if project.is_admin { "⚙ " } else { "" };
 
             let line = Line::from(vec![
                 Span::styled(format!("{indicator} "), style),
-                Span::styled(project.name, style),
+                Span::styled(format!("{prefix}{}", project.name), style),
                 Span::styled(
                     format!(" ({})", project.session_count),
                     Style::default().fg(Color::DarkGray),


### PR DESCRIPTION
## Summary

- On startup, Thurbox creates `~/.local/share/thurbox/admin/.mcp.json` pointing to the `thurbox-mcp` binary so Claude Code auto-discovers the MCP server
- An "Admin" pseudo-project is pinned at index 0 with a yellow `⚙` prefix; its session's `cwd` is the admin directory
- Admin project and session are protected: cannot edit, delete, or close via the TUI
- `thurbox-mcp` binary resolved via sibling-of-`current_exe()` with `$PATH` fallback
- 7 new tests added; `docs/FEATURES.md` and `CLAUDE.md` updated

## Test plan

- [ ] `cargo nextest run --all` passes (455 tests)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] Run `cargo run`: "Admin" project appears first with `⚙` prefix in yellow
- [ ] Admin session spawns automatically in the admin directory
- [ ] Claude Code picks up `thurbox-mcp` tools (e.g. `list_projects`) in the admin session
- [ ] `Ctrl+E` / `Ctrl+D` on Admin project shows error message
- [ ] `Ctrl+C` on admin session shows error message
- [ ] Admin session survives restart (tmux re-adoption)