### PR TITLE
feat(ui): enhance info panel with project & session details

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1461,12 +1461,7 @@ impl App {
         if let Some(info_area) = areas.info_panel {
             let active_project = self.projects.get(self.active_project_index);
             if let Some(session) = self.sessions.get(self.active_index) {
-                info_panel::render_info_panel(
-                    frame,
-                    info_area,
-                    &session.info,
-                    active_project.map(|p| &p.config),
-                );
+                info_panel::render_info_panel(frame, info_area, &session.info, active_project);
             }
         }
 

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -2,18 +2,18 @@ use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph},
+    widgets::{Block, Borders, Paragraph, Wrap},
     Frame,
 };
 
-use crate::project::ProjectConfig;
-use crate::session::SessionInfo;
+use crate::project::ProjectInfo;
+use crate::session::{RoleConfig, SessionInfo};
 
 pub fn render_info_panel(
     frame: &mut Frame,
     area: Rect,
     info: &SessionInfo,
-    project: Option<&ProjectConfig>,
+    project: Option<&ProjectInfo>,
 ) {
     let block = Block::default()
         .title(" Info ")
@@ -22,22 +22,33 @@ pub fn render_info_panel(
 
     let mut lines = Vec::new();
 
-    // Project info (if available)
+    // ── Project section ──
     if let Some(proj) = project {
-        lines.push(Line::from(vec![
+        let mut project_line = vec![
             Span::styled("Project: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
-                &proj.name,
+                &proj.config.name,
                 Style::default()
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),
             ),
-        ]));
-        if proj.repos.len() == 1 {
+        ];
+        if proj.is_default {
+            project_line.push(Span::raw(" "));
+            project_line.push(Span::styled(
+                "[Default]",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
+        lines.push(Line::from(project_line));
+
+        if proj.config.repos.len() == 1 {
             lines.push(Line::from(vec![
                 Span::styled("Repo: ", Style::default().fg(Color::DarkGray)),
                 Span::styled(
-                    proj.repos[0].display().to_string(),
+                    proj.config.repos[0].display().to_string(),
                     Style::default().fg(Color::DarkGray),
                 ),
             ]));
@@ -46,22 +57,45 @@ pub fn render_info_panel(
                 "Repos:",
                 Style::default().fg(Color::DarkGray),
             )));
-            for repo in &proj.repos {
+            for repo in &proj.config.repos {
                 lines.push(Line::from(Span::styled(
                     format!("  {}", repo.display()),
                     Style::default().fg(Color::DarkGray),
                 )));
             }
         }
+
+        lines.push(Line::from(vec![
+            Span::styled("Sessions: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                proj.session_ids.len().to_string(),
+                Style::default().fg(Color::White),
+            ),
+        ]));
+
+        let roles_text = if proj.config.roles.is_empty() {
+            "(none)".to_string()
+        } else {
+            proj.config
+                .roles
+                .iter()
+                .map(|r| r.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        lines.push(Line::from(vec![
+            Span::styled("Roles: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(roles_text, Style::default().fg(Color::White)),
+        ]));
+
         lines.push(Line::from(""));
     }
 
-    // Session info
+    // ── Session section ──
     lines.push(Line::from(vec![
         Span::styled("Name: ", Style::default().fg(Color::DarkGray)),
         Span::styled(&info.name, Style::default().fg(Color::White)),
     ]));
-    lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::styled("Status: ", Style::default().fg(Color::DarkGray)),
         Span::styled(
@@ -71,7 +105,6 @@ pub fn render_info_panel(
                 .add_modifier(Modifier::BOLD),
         ),
     ]));
-    lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::styled("Role: ", Style::default().fg(Color::DarkGray)),
         Span::styled(
@@ -81,13 +114,27 @@ pub fn render_info_panel(
                 .add_modifier(Modifier::BOLD),
         ),
     ]));
-    lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::styled("ID: ", Style::default().fg(Color::DarkGray)),
         Span::styled(info.id.to_string(), Style::default().fg(Color::DarkGray)),
     ]));
+    lines.push(Line::from(vec![
+        Span::styled("Claude: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            info.claude_session_id.as_deref().unwrap_or("(none)"),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("Backend: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            info.backend_id.as_deref().unwrap_or("(none)"),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
 
-    if !info.additional_dirs.is_empty() {
+    // ── Directories section ──
+    if info.cwd.is_some() || !info.additional_dirs.is_empty() {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "Directories",
@@ -109,6 +156,7 @@ pub fn render_info_panel(
         }
     }
 
+    // ── Worktree section ──
     if let Some(wt) = &info.worktree {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
@@ -130,6 +178,57 @@ pub fn render_info_panel(
         ]));
     }
 
-    let paragraph = Paragraph::new(lines).block(block);
+    // ── Role Details section ──
+    if let Some(role_config) = project.and_then(|p| find_role(&p.config.roles, &info.role)) {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Role Details",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )));
+
+        if !role_config.description.is_empty() {
+            lines.push(Line::from(vec![
+                Span::styled("Desc: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(&role_config.description, Style::default().fg(Color::White)),
+            ]));
+        }
+
+        if let Some(mode) = &role_config.permissions.permission_mode {
+            lines.push(Line::from(vec![
+                Span::styled("Mode: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(mode, Style::default().fg(Color::Yellow)),
+            ]));
+        }
+
+        if !role_config.permissions.allowed_tools.is_empty() {
+            lines.push(Line::from(vec![
+                Span::styled("Allowed: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    role_config.permissions.allowed_tools.join(", "),
+                    Style::default().fg(Color::Green),
+                ),
+            ]));
+        }
+
+        if !role_config.permissions.disallowed_tools.is_empty() {
+            lines.push(Line::from(vec![
+                Span::styled("Disallowed: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    role_config.permissions.disallowed_tools.join(", "),
+                    Style::default().fg(Color::Red),
+                ),
+            ]));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, area);
+}
+
+fn find_role<'a>(roles: &'a [RoleConfig], name: &str) -> Option<&'a RoleConfig> {
+    roles.iter().find(|r| r.name == name)
 }


### PR DESCRIPTION
## Summary

- Surface all available metadata in the F2 info panel
- **Project section**: add `[Default]` badge, session count, and comma-joined roles list
- **Session section**: add Claude session ID and backend ID fields
- **Directories section**: now shows whenever `cwd` or `additional_dirs` exist (previously required non-empty `additional_dirs`)
- **Role Details section** (new): shows role description, permission mode, allowed tools (green), and disallowed tools (red)
- Add `.wrap(Wrap { trim: false })` so long paths wrap instead of being hard-clipped
- Signature change: `render_info_panel` now accepts `&ProjectInfo` instead of `&ProjectConfig` to access `is_default` and `session_ids`

## Test plan

- [ ] `cargo check --all` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (no warnings)
- [ ] `cargo test --test architecture_rules` passes (8/8)
- [ ] `cargo nextest run --all` passes (448/448)
- [ ] Manual: run `cargo run`, create a project with roles, open sessions, press F2 at ≥120 cols — verify all new fields render correctly