### PR TITLE
docs(mcp): add MCP_ROLES.md and enhance role documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,12 +164,19 @@ cargo run --bin thurbox-mcp         # Run (stdin/stdout JSON-RPC)
 |------|-------------|
 | `list_projects` | List all active projects |
 | `get_project` | Get a project by name or UUID |
-| `create_project` | Create a new project |
-| `update_project` | Update project name/repos |
-| `delete_project` | Soft-delete a project |
-| `list_roles` | List roles for a project |
-| `set_roles` | Replace all roles for a project |
-| `list_sessions` | List sessions (optional project filter) |
+| `create_project` | Create a new project with name and repo paths |
+| `update_project` | Update project name and/or repos (partial update) |
+| `delete_project` | Soft-delete a project (preserves for undo) |
+| `list_roles` | List all roles for a project (by name or UUID) |
+| `set_roles` | Atomically replace all roles for a project |
+| `list_sessions` | List sessions, optionally filtered by project |
+
+**Role Management**: `set_roles` performs an atomic replacement —
+all existing roles are deleted and replaced in a single transaction.
+To add a role, include all existing roles plus the new one.
+See [`docs/MCP_ROLES.md`](docs/MCP_ROLES.md) for the complete
+role configuration guide including permission modes, tool name
+format, and example role patterns.
 
 ### Admin Session (built-in MCP client)
 
@@ -294,6 +301,7 @@ For rationale behind decisions, see `docs/`:
 - `docs/CONSTITUTION.md` — Core principles and non-negotiable rules
 - `docs/ARCHITECTURE.md` — Architectural decisions with rationale
 - `docs/FEATURES.md` — Feature-level design choices
+- `docs/MCP_ROLES.md` — MCP role configuration guide (permissions, tool patterns, examples)
 
 **Rule**: If a code change invalidates or extends a documented
 decision, update the relevant doc in the same PR.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -439,3 +439,6 @@ server can operate without a terminal or tmux.
   tool integration with AI agents.
 - *Shared library with thin binary wrapper* — over-engineering;
   the `thurbox` crate already exposes the needed types as `pub mod`.
+
+**See also**: [MCP_ROLES.md](MCP_ROLES.md) for role configuration
+via the MCP server (permission modes, tool patterns, examples).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -437,6 +437,9 @@ Roles can be managed from the TUI via the edit project modal
 (`Ctrl+E`). The Roles field provides an inline list with
 add/edit/delete capabilities; editing a role opens a detail form.
 
+For programmatic role management via the MCP server, see
+[MCP_ROLES.md](MCP_ROLES.md).
+
 Projects start with no roles. Users add roles explicitly.
 When no roles are defined, sessions spawn with default
 (empty) permissions and no role selector is shown.

--- a/docs/MCP_ROLES.md
+++ b/docs/MCP_ROLES.md
@@ -1,0 +1,364 @@
+# MCP Role Configuration Guide
+
+Complete reference for configuring roles via the `thurbox-mcp`
+MCP server. Roles define Claude Code permission profiles that
+control which tools are available, how they behave, and what
+system prompt text is appended.
+
+For TUI-based role editing, see the
+[Role Editor](FEATURES.md#role-editor) section in FEATURES.md.
+
+---
+
+## Overview
+
+Roles are per-project permission profiles stored in Thurbox's
+SQLite database. When a session starts, its assigned role
+determines the Claude CLI flags passed at spawn time:
+
+```text
+claude --permission-mode <mode> \
+       --allowed-tools "<tool1> <tool2>" \
+       --disallowed-tools "<tool3>" \
+       --append-system-prompt "<text>"
+```
+
+Each project can have zero or more roles. Sessions select a role
+at creation time. If no roles are defined, sessions spawn with
+default (empty) permissions.
+
+---
+
+## Permission Modes
+
+The `permission_mode` field controls Claude Code's base
+permission behavior. Valid values:
+
+| Mode | Description |
+|------|-------------|
+| `default` | Claude asks the user before running tools (standard behavior) |
+| `plan` | Claude can only plan; no tool execution until user approves |
+| `acceptEdits` | Auto-approve file edits; ask for everything else |
+| `dontAsk` | Auto-approve all tool calls without prompting |
+| `bypassPermissions` | Skip all permission checks (use with caution) |
+
+When `permission_mode` is omitted or `null`, Claude Code uses
+its own default behavior (equivalent to `"default"`).
+
+---
+
+## Allow / Ask / Deny Semantics
+
+Roles use three permission tiers:
+
+| Tier | Behavior | Configured via |
+|------|----------|----------------|
+| **Allow** | Tool runs without asking the user | `allowed_tools` |
+| **Ask** | User is prompted before tool runs | *(default for unlisted tools)* |
+| **Deny** | Tool is completely blocked | `disallowed_tools` |
+
+**Interaction rules**:
+
+- Tools in `allowed_tools` auto-approve without user prompt.
+- Tools in `disallowed_tools` are removed from Claude's
+  available tools entirely — Claude cannot invoke them.
+- Tools not in either list follow the `permission_mode` behavior
+  (usually "ask the user").
+- If a tool appears in both `allowed_tools` and
+  `disallowed_tools`, the deny takes precedence.
+
+---
+
+## Tool Name Format
+
+Tool names in `allowed_tools` and `disallowed_tools` follow
+Claude Code's tool naming conventions.
+
+### Simple tool names
+
+Use the tool's base name:
+
+| Tool | Description |
+|------|-------------|
+| `Read` | Read files |
+| `Edit` | Edit files |
+| `Write` | Write/create files |
+| `Bash` | Execute shell commands |
+| `Glob` | Find files by pattern |
+| `Grep` | Search file contents |
+| `WebFetch` | Fetch web content |
+| `WebSearch` | Search the web |
+| `Task` | Launch sub-agents |
+| `NotebookEdit` | Edit Jupyter notebooks |
+
+### Scope patterns
+
+Bash commands can be scoped using `Bash(specifier)` syntax:
+
+```text
+Bash(git:*)         # All git subcommands
+Bash(npm run *)     # npm run with any script name
+Bash(cargo:*)       # All cargo subcommands
+Bash(docker:*)      # All docker subcommands
+```
+
+File tools can be scoped to paths:
+
+```text
+Read(.env*)         # Read .env files
+Edit(src/**)        # Edit files in src/
+```
+
+### Format in JSON
+
+Tool lists are JSON arrays of strings:
+
+```json
+{
+  "allowed_tools": ["Read", "Grep", "Bash(git:*)"],
+  "disallowed_tools": ["Write", "Bash(rm:*)"]
+}
+```
+
+---
+
+## Field Reference
+
+### RoleInput fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | yes | — | Role identifier, unique per project. 1-64 chars, trimmed. |
+| `description` | string | yes | — | Human-readable summary of the role's purpose. |
+| `permission_mode` | string \| null | no | `null` | One of: `default`, `plan`, `acceptEdits`, `dontAsk`, `bypassPermissions`. |
+| `allowed_tools` | string[] | no | `[]` | Tools that auto-approve. See [Tool Name Format](#tool-name-format). |
+| `disallowed_tools` | string[] | no | `[]` | Tools that are blocked entirely. See [Tool Name Format](#tool-name-format). |
+| `tools` | string \| null | no | `null` | Restrict available tool set. `"default"` = all tools, `""` = none, or comma-separated list. |
+| `append_system_prompt` | string \| null | no | `null` | Text appended to Claude's system prompt for this role. |
+
+### Validation rules
+
+- `name` must be non-empty after trimming and at most
+  64 characters.
+- `name` must be unique within the project. Duplicate names
+  in a `set_roles` call will cause a database constraint error.
+- `description` can be empty but must be present.
+- `permission_mode` is passed verbatim to the Claude CLI
+  `--permission-mode` flag. Invalid values will cause Claude
+  to reject the flag at session startup.
+
+---
+
+## MCP Tool Reference
+
+### list_roles
+
+List all roles for a project.
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project` | string | yes | Project name (case-insensitive) or UUID |
+
+**Response**: JSON array of role objects.
+
+**Example request**:
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "list_roles",
+    "arguments": {
+      "project": "my-app"
+    }
+  }
+}
+```
+
+**Example response**:
+
+```json
+[
+  {
+    "name": "developer",
+    "description": "Full development access",
+    "permission_mode": "acceptEdits",
+    "allowed_tools": ["Bash(git:*)", "Bash(cargo:*)"]
+  },
+  {
+    "name": "reviewer",
+    "description": "Read-only code review",
+    "permission_mode": "plan",
+    "allowed_tools": ["Read", "Grep", "Glob"]
+  }
+]
+```
+
+**Error cases**:
+
+- Project not found: `{"error": "Project not found: <name>"}`
+
+### set_roles
+
+Atomically replace all roles for a project.
+
+**Parameters**:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project` | string | yes | Project name (case-insensitive) or UUID |
+| `roles` | RoleInput[] | yes | Complete list of roles (replaces all existing) |
+
+**Behavior**:
+
+- All existing roles are deleted and replaced in a single
+  database transaction.
+- To add a role, include all existing roles plus the new one.
+- To remove a role, include all roles except the one to remove.
+- To clear all roles, pass an empty array.
+- The operation is atomic: if any role fails validation,
+  no changes are applied.
+
+**Example request**:
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "set_roles",
+    "arguments": {
+      "project": "my-app",
+      "roles": [
+        {
+          "name": "developer",
+          "description": "Full development access",
+          "permission_mode": "acceptEdits",
+          "allowed_tools": ["Bash(git:*)", "Bash(cargo:*)"],
+          "disallowed_tools": []
+        },
+        {
+          "name": "reviewer",
+          "description": "Read-only code review",
+          "permission_mode": "plan",
+          "allowed_tools": ["Read", "Grep", "Glob"],
+          "disallowed_tools": ["Edit", "Write", "Bash"]
+        }
+      ]
+    }
+  }
+}
+```
+
+**Example response**: JSON array of the newly set roles
+(same format as `list_roles`).
+
+**Error cases**:
+
+- Project not found: `{"error": "Project not found: <name>"}`
+- Database error: `{"error": "<sqlite error message>"}`
+
+---
+
+## Common Role Patterns
+
+### Developer — full access with git auto-approve
+
+```json
+{
+  "name": "developer",
+  "description": "Full development access with git auto-approved",
+  "permission_mode": "acceptEdits",
+  "allowed_tools": ["Bash(git:*)", "Bash(cargo:*)"],
+  "disallowed_tools": []
+}
+```
+
+### Reviewer — read-only code review
+
+```json
+{
+  "name": "reviewer",
+  "description": "Read-only access for code review",
+  "permission_mode": "plan",
+  "allowed_tools": ["Read", "Grep", "Glob"],
+  "disallowed_tools": ["Edit", "Write", "Bash"]
+}
+```
+
+### CI Runner — build and test only
+
+```json
+{
+  "name": "ci-runner",
+  "description": "Run builds and tests, no file modifications",
+  "permission_mode": "default",
+  "allowed_tools": [
+    "Read",
+    "Grep",
+    "Glob",
+    "Bash(cargo:*)",
+    "Bash(npm:*)"
+  ],
+  "disallowed_tools": ["Edit", "Write"]
+}
+```
+
+### Auditor — read everything, change nothing
+
+```json
+{
+  "name": "auditor",
+  "description": "Full read access for security audits",
+  "permission_mode": "plan",
+  "allowed_tools": ["Read", "Grep", "Glob", "WebFetch"],
+  "disallowed_tools": ["Edit", "Write", "Bash", "NotebookEdit"],
+  "append_system_prompt": "You are performing a security audit. Report findings but do not modify any files."
+}
+```
+
+### Guided — ask before everything
+
+```json
+{
+  "name": "guided",
+  "description": "Human-in-the-loop for all actions",
+  "permission_mode": "default",
+  "allowed_tools": [],
+  "disallowed_tools": []
+}
+```
+
+---
+
+## Integration
+
+### From the Admin Session
+
+The Thurbox admin session has `thurbox-mcp` auto-configured.
+Use natural language:
+
+> "Set up developer and reviewer roles for the my-app project.
+> Developer should have acceptEdits mode with git auto-approved.
+> Reviewer should be plan-only with read access."
+
+### From Claude Code CLI
+
+Configure `thurbox-mcp` in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "thurbox": {
+      "command": "thurbox-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+Then use the `set_roles` and `list_roles` tools directly.
+After setting roles, new sessions can select any configured role.
+The role selector appears when creating a session (`Ctrl+N`)
+in a project with multiple roles defined.

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -43,31 +43,54 @@ pub struct ListRolesParams {
     pub project: String,
 }
 
+/// A role definition for configuring Claude Code session permissions.
+///
+/// Roles map to Claude Code CLI flags (`--permission-mode`, `--allowed-tools`,
+/// `--disallowed-tools`, `--append-system-prompt`), controlling which tools
+/// are available and how they behave within a session.
+///
+/// See `docs/MCP_ROLES.md` for the complete configuration guide.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct RoleInput {
-    #[schemars(description = "Role name")]
+    #[schemars(description = "Role name (1-64 chars, unique per project)")]
     pub name: String,
-    #[schemars(description = "Role description")]
+    #[schemars(description = "Human-readable summary of the role's purpose")]
     pub description: String,
-    #[schemars(description = "Permission mode for Claude CLI")]
+    #[schemars(
+        description = "Permission mode: default, plan, acceptEdits, dontAsk, or bypassPermissions"
+    )]
     pub permission_mode: Option<String>,
     #[serde(default)]
-    #[schemars(description = "List of allowed tool names")]
+    #[schemars(
+        description = "Tools that auto-approve without prompting (e.g. [\"Read\", \"Bash(git:*)\"])"
+    )]
     pub allowed_tools: Vec<String>,
     #[serde(default)]
-    #[schemars(description = "List of disallowed tool names")]
+    #[schemars(
+        description = "Tools that are blocked entirely (e.g. [\"Edit\", \"Write\", \"Bash\"])"
+    )]
     pub disallowed_tools: Vec<String>,
-    #[schemars(description = "Tool configuration")]
+    #[schemars(
+        description = "Restrict available tool set: \"default\" = all, \"\" = none, or comma-separated"
+    )]
     pub tools: Option<String>,
-    #[schemars(description = "Text to append to the system prompt")]
+    #[schemars(description = "Text appended to Claude's system prompt for this role")]
     pub append_system_prompt: Option<String>,
 }
 
+/// Parameters for the `set_roles` tool.
+///
+/// Atomically replaces all roles for a project. All existing roles are deleted
+/// and the provided list is inserted in a single database transaction. To add
+/// a role, include all existing roles plus the new one. To clear all roles,
+/// pass an empty array.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SetRolesParams {
     #[schemars(description = "Project name or UUID")]
     pub project: String,
-    #[schemars(description = "List of role definitions (replaces all existing)")]
+    #[schemars(
+        description = "Complete list of roles — atomically replaces all existing roles for the project"
+    )]
     pub roles: Vec<RoleInput>,
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -81,16 +81,34 @@ impl fmt::Display for RoleNameError {
 impl std::error::Error for RoleNameError {}
 
 /// Permission flags passed to the Claude CLI when spawning a session.
+///
+/// Maps directly to Claude Code CLI flags:
+/// - `permission_mode` → `--permission-mode` (default, plan, acceptEdits, dontAsk, bypassPermissions)
+/// - `allowed_tools` → `--allowed-tools` (tools that auto-approve without prompting)
+/// - `disallowed_tools` → `--disallowed-tools` (tools blocked entirely)
+/// - `tools` → `--tools` (restrict available tool set)
+/// - `append_system_prompt` → `--append-system-prompt` (extra instructions)
+///
+/// Tools not in either allowed or disallowed lists follow the `permission_mode` behavior.
+/// If a tool appears in both lists, deny takes precedence.
+///
+/// See `docs/MCP_ROLES.md` for the complete configuration guide.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RolePermissions {
+    /// Base permission behavior. Valid values: `default`, `plan`, `acceptEdits`,
+    /// `dontAsk`, `bypassPermissions`. When `None`, Claude uses its default mode.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permission_mode: Option<String>,
+    /// Tools that auto-approve without user prompt (e.g. `["Read", "Bash(git:*)"]`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allowed_tools: Vec<String>,
+    /// Tools that are blocked entirely — Claude cannot invoke them.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub disallowed_tools: Vec<String>,
+    /// Restrict available tool set. `"default"` = all, `""` = none, or comma-separated.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<String>,
+    /// Text appended to Claude's system prompt for sessions using this role.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub append_system_prompt: Option<String>,
 }


### PR DESCRIPTION
## Summary

- Create `docs/MCP_ROLES.md`: comprehensive reference guide for MCP role configuration covering permission modes, allow/ask/deny semantics, tool name format and scope patterns, field reference, 5 common role patterns (developer, reviewer, ci-runner, auditor, guided), and `list_roles`/`set_roles` JSON examples
- Enhance `src/mcp/types.rs`: add doc comments to `RoleInput` and `SetRolesParams` with full field semantics and `schemars` descriptions updated with valid values/examples
- Enhance `src/session/mod.rs`: add comprehensive doc comment to `RolePermissions` mapping each field to its Claude CLI flag
- Enhance `src/mcp/tools.rs`: improve `list_roles` and `set_roles` tool descriptions with atomicity details and guide reference; add 5 new tests (nonexistent project, empty clears all, atomic replacement, tools field, empty project listing)
- Update `CLAUDE.md`: better tool table descriptions + link to `docs/MCP_ROLES.md`
- Update `docs/FEATURES.md` and `docs/ARCHITECTURE.md`: add cross-references to `MCP_ROLES.md`

## Test plan

- [x] All 460 tests pass (`cargo nextest run --all`)
- [x] All pre-commit hooks pass (fmt, clippy, check, nextest, arch, deny, doc, rumdl)
- [x] `docs/MCP_ROLES.md` renders correctly with all code examples
- [x] New role tests cover: empty clear, atomic replace, tools field, nonexistent project, empty project