### PR TITLE
feat(mcp): add per-project MCP server configuration

### DIFF
--- a/src/app/mcp_editor_modal.rs
+++ b/src/app/mcp_editor_modal.rs
@@ -1,0 +1,94 @@
+//! MCP server editor logic for the App.
+
+use std::collections::HashMap;
+
+use crate::session::McpServerConfig;
+
+use super::App;
+
+/// Which field is focused in the MCP editor modal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpEditorField {
+    Name,
+    Command,
+    Args,
+    Env,
+}
+
+impl App {
+    /// Reset MCP editor fields to prepare for adding a new server.
+    pub(crate) fn prepare_new_mcp_editor(&mut self) {
+        self.mcp_editor_editing_index = None;
+        self.mcp_editor_name.clear();
+        self.mcp_editor_command.clear();
+        self.mcp_editor_args.reset();
+        self.mcp_editor_env.reset();
+        self.mcp_editor_field = McpEditorField::Name;
+    }
+
+    /// Populate the MCP editor from an existing server config.
+    pub(crate) fn open_mcp_server_for_editing(&mut self, idx: usize) {
+        let server = &self.edit_project_mcp_servers[idx];
+        self.mcp_editor_editing_index = Some(idx);
+        self.mcp_editor_name.set(&server.name);
+        self.mcp_editor_command.set(&server.command);
+        self.mcp_editor_args.load(&server.args);
+
+        // Convert env HashMap to "KEY=VALUE" strings for the tool list
+        let mut env_strings: Vec<String> =
+            server.env.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        env_strings.sort();
+        self.mcp_editor_env.load(&env_strings);
+
+        self.mcp_editor_field = McpEditorField::Name;
+    }
+
+    /// Validate and save the MCP editor state to the working copy.
+    pub(crate) fn submit_mcp_editor(&mut self) {
+        let name = self.mcp_editor_name.value().trim().to_string();
+        let command = self.mcp_editor_command.value().trim().to_string();
+
+        if name.is_empty() || command.is_empty() {
+            return;
+        }
+
+        // Check duplicate names (excluding the server being edited)
+        let is_duplicate = self
+            .edit_project_mcp_servers
+            .iter()
+            .enumerate()
+            .any(|(i, s)| s.name == name && Some(i) != self.mcp_editor_editing_index);
+        if is_duplicate {
+            return;
+        }
+
+        // Parse env entries from "KEY=VALUE" strings
+        let env: HashMap<String, String> = self
+            .mcp_editor_env
+            .items
+            .iter()
+            .filter_map(|entry| {
+                let (k, v) = entry.split_once('=')?;
+                Some((k.to_string(), v.to_string()))
+            })
+            .collect();
+
+        let server = McpServerConfig {
+            name,
+            command,
+            args: self.mcp_editor_args.items.clone(),
+            env,
+        };
+
+        if let Some(idx) = self.mcp_editor_editing_index {
+            self.edit_project_mcp_servers[idx] = server;
+        } else {
+            self.edit_project_mcp_servers.push(server);
+            self.edit_project_mcp_server_index =
+                self.edit_project_mcp_servers.len().saturating_sub(1);
+        }
+
+        self.show_mcp_editor = false;
+        self.mcp_editor_field = McpEditorField::Name;
+    }
+}

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -1,5 +1,6 @@
 //! Request parameter and response types for MCP tool handlers.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use rmcp::schemars;
@@ -100,6 +101,34 @@ pub struct ListSessionsParams {
     pub project: Option<String>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListMcpServersParams {
+    #[schemars(description = "Project name or UUID")]
+    pub project: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct McpServerInput {
+    #[schemars(description = "Server name (unique within project)")]
+    pub name: String,
+    #[schemars(description = "Command to run the MCP server")]
+    pub command: String,
+    #[serde(default)]
+    #[schemars(description = "Command-line arguments")]
+    pub args: Vec<String>,
+    #[serde(default)]
+    #[schemars(description = "Environment variables (key-value pairs)")]
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SetMcpServersParams {
+    #[schemars(description = "Project name or UUID")]
+    pub project: String,
+    #[schemars(description = "List of MCP server definitions (replaces all existing)")]
+    pub servers: Vec<McpServerInput>,
+}
+
 // ── Response Types ──────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -108,6 +137,8 @@ pub struct ProjectResponse {
     pub name: String,
     pub repos: Vec<PathBuf>,
     pub roles: Vec<RoleResponse>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub mcp_servers: Vec<McpServerResponse>,
 }
 
 #[derive(Debug, Serialize)]
@@ -124,6 +155,16 @@ pub struct RoleResponse {
     pub tools: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub append_system_prompt: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct McpServerResponse {
+    pub name: String,
+    pub command: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::session::{RoleConfig, SessionId};
+use crate::session::{McpServerConfig, RoleConfig, SessionId};
 
 // Keep serde on ProjectId for backward compat (used in session/mod.rs serialization)
 
@@ -47,6 +47,7 @@ pub struct ProjectConfig {
     pub name: String,
     pub repos: Vec<PathBuf>,
     pub roles: Vec<RoleConfig>,
+    pub mcp_servers: Vec<McpServerConfig>,
     /// Stable project ID preserved across renames. When present, this takes
     /// precedence over the name-derived deterministic ID.
     pub id: Option<String>,
@@ -127,6 +128,7 @@ pub fn create_default_project() -> ProjectConfig {
         name: "Default".to_string(),
         repos: vec![cwd],
         roles: Vec::new(),
+        mcp_servers: Vec::new(),
         id: None,
     }
 }
@@ -156,6 +158,7 @@ mod tests {
             name: "test".to_string(),
             repos: vec![PathBuf::from("/tmp/test")],
             roles: Vec::new(),
+            mcp_servers: Vec::new(),
             id: None,
         };
         let info = ProjectInfo::new(config);
@@ -181,6 +184,7 @@ mod tests {
             name: "Admin".to_string(),
             repos: vec![PathBuf::from("/admin")],
             roles: Vec::new(),
+            mcp_servers: Vec::new(),
             id: None,
         };
         let info = ProjectInfo::new_admin(config);
@@ -196,6 +200,7 @@ mod tests {
             name: "Test Project".to_string(),
             repos: vec![PathBuf::from("/repo1"), PathBuf::from("/repo2")],
             roles: Vec::new(),
+            mcp_servers: Vec::new(),
             id: None,
         };
 
@@ -211,12 +216,14 @@ mod tests {
             name: "Project A".to_string(),
             repos: vec![PathBuf::from("/repo")],
             roles: Vec::new(),
+            mcp_servers: Vec::new(),
             id: None,
         };
         let config2 = ProjectConfig {
             name: "Project B".to_string(),
             repos: vec![PathBuf::from("/repo")],
             roles: Vec::new(),
+            mcp_servers: Vec::new(),
             id: None,
         };
 
@@ -229,6 +236,7 @@ mod tests {
             name: "Test Project".to_string(),
             repos: vec![PathBuf::from("/repo")],
             roles: Vec::new(),
+            mcp_servers: Vec::new(),
             id: None,
         };
 
@@ -242,6 +250,7 @@ mod tests {
             name: "Shared Project".to_string(),
             repos: vec![PathBuf::from("/shared/repo")],
             roles: Vec::new(),
+            mcp_servers: Vec::new(),
             id: None,
         };
 
@@ -257,6 +266,7 @@ mod tests {
             name: "Test".to_string(),
             repos: vec![PathBuf::from("/repo")],
             roles: Vec::new(),
+            mcp_servers: Vec::new(),
             id: None,
         };
         assert_eq!(config.effective_id(), config.deterministic_id());
@@ -268,6 +278,7 @@ mod tests {
             name: "OldName".to_string(),
             repos: vec![],
             roles: Vec::new(),
+            mcp_servers: Vec::new(),
             id: None,
         };
         let original_id = original_config.deterministic_id();
@@ -276,6 +287,7 @@ mod tests {
             name: "NewName".to_string(),
             repos: vec![],
             roles: Vec::new(),
+            mcp_servers: Vec::new(),
             id: Some(original_id.to_string()),
         };
 

--- a/src/storage/mcp_servers.rs
+++ b/src/storage/mcp_servers.rs
@@ -1,0 +1,396 @@
+use std::collections::HashMap;
+
+use rusqlite::params;
+
+use crate::project::ProjectId;
+use crate::session::McpServerConfig;
+use crate::sync::current_time_millis;
+
+use super::Database;
+
+impl Database {
+    /// List all MCP servers for a specific project.
+    pub fn list_mcp_servers(
+        &self,
+        project_id: ProjectId,
+    ) -> rusqlite::Result<Vec<McpServerConfig>> {
+        let id_str = project_id.to_string();
+        let mut stmt = self.conn.prepare(
+            "SELECT server_name, command, args, env \
+             FROM project_mcp_servers WHERE project_id = ?1 ORDER BY server_name",
+        )?;
+
+        let servers = stmt
+            .query_map(params![id_str], |row| {
+                let name: String = row.get(0)?;
+                let command: String = row.get(1)?;
+                let args_str: String = row.get(2)?;
+                let env_str: String = row.get(3)?;
+
+                Ok(McpServerConfig {
+                    name,
+                    command,
+                    args: str_to_args(&args_str),
+                    env: str_to_env(&env_str),
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(servers)
+    }
+
+    /// List MCP servers for all active projects, keyed by project ID.
+    pub fn list_all_mcp_servers(
+        &self,
+    ) -> rusqlite::Result<HashMap<ProjectId, Vec<McpServerConfig>>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT ms.project_id, ms.server_name, ms.command, ms.args, ms.env \
+             FROM project_mcp_servers ms \
+             INNER JOIN projects p ON p.id = ms.project_id AND p.deleted_at IS NULL \
+             ORDER BY ms.project_id, ms.server_name",
+        )?;
+
+        let mut map: HashMap<ProjectId, Vec<McpServerConfig>> = HashMap::new();
+
+        let rows = stmt.query_map([], |row| {
+            let pid_str: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            let command: String = row.get(2)?;
+            let args_str: String = row.get(3)?;
+            let env_str: String = row.get(4)?;
+
+            Ok((
+                pid_str,
+                McpServerConfig {
+                    name,
+                    command,
+                    args: str_to_args(&args_str),
+                    env: str_to_env(&env_str),
+                },
+            ))
+        })?;
+
+        for row in rows {
+            let (pid_str, server) = row?;
+            let pid = pid_str
+                .parse::<uuid::Uuid>()
+                .map(ProjectId::from_uuid)
+                .unwrap_or_default();
+            map.entry(pid).or_default().push(server);
+        }
+
+        Ok(map)
+    }
+
+    /// Replace all MCP servers for a project (delete existing + insert new).
+    pub fn replace_mcp_servers(
+        &self,
+        project_id: ProjectId,
+        servers: &[McpServerConfig],
+    ) -> rusqlite::Result<()> {
+        let id_str = project_id.to_string();
+        let now = current_time_millis() as i64;
+
+        self.conn.execute(
+            "DELETE FROM project_mcp_servers WHERE project_id = ?1",
+            params![id_str],
+        )?;
+
+        for server in servers {
+            self.conn.execute(
+                "INSERT INTO project_mcp_servers \
+                 (project_id, server_name, command, args, env, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    id_str,
+                    server.name,
+                    server.command,
+                    args_to_str(&server.args),
+                    env_to_str(&server.env),
+                    now,
+                    now,
+                ],
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Serialize args as newline-separated (args may contain commas).
+fn args_to_str(args: &[String]) -> String {
+    args.join("\n")
+}
+
+/// Deserialize newline-separated args.
+fn str_to_args(s: &str) -> Vec<String> {
+    if s.is_empty() {
+        Vec::new()
+    } else {
+        s.split('\n').map(|s| s.to_string()).collect()
+    }
+}
+
+/// Serialize env as newline-separated `KEY=VALUE` pairs.
+fn env_to_str(env: &HashMap<String, String>) -> String {
+    let mut pairs: Vec<String> = env.iter().map(|(k, v)| format!("{k}={v}")).collect();
+    pairs.sort(); // deterministic ordering
+    pairs.join("\n")
+}
+
+/// Deserialize newline-separated `KEY=VALUE` pairs.
+fn str_to_env(s: &str) -> HashMap<String, String> {
+    if s.is_empty() {
+        HashMap::new()
+    } else {
+        s.split('\n')
+            .filter_map(|line| {
+                let (k, v) = line.split_once('=')?;
+                Some((k.to_string(), v.to_string()))
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use crate::project::ProjectConfig;
+
+    use super::*;
+
+    fn test_project_id(name: &str) -> ProjectId {
+        let config = ProjectConfig {
+            name: name.to_string(),
+            repos: vec![],
+            roles: vec![],
+            mcp_servers: vec![],
+            id: None,
+        };
+        config.deterministic_id()
+    }
+
+    fn setup_db_with_project(name: &str) -> (Database, ProjectId) {
+        let db = Database::open_in_memory().unwrap();
+        let pid = test_project_id(name);
+        db.insert_project(pid, name, &[PathBuf::from("/repo")], false)
+            .unwrap();
+        (db, pid)
+    }
+
+    #[test]
+    fn list_mcp_servers_empty_project() {
+        let (db, pid) = setup_db_with_project("test");
+        let servers = db.list_mcp_servers(pid).unwrap();
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn replace_and_list_mcp_servers() {
+        let (db, pid) = setup_db_with_project("test");
+
+        let servers = vec![
+            McpServerConfig {
+                name: "filesystem".to_string(),
+                command: "npx".to_string(),
+                args: vec![
+                    "-y".to_string(),
+                    "@modelcontextprotocol/server-filesystem".to_string(),
+                ],
+                env: HashMap::new(),
+            },
+            McpServerConfig {
+                name: "github".to_string(),
+                command: "npx".to_string(),
+                args: vec![
+                    "-y".to_string(),
+                    "@modelcontextprotocol/server-github".to_string(),
+                ],
+                env: HashMap::from([("GITHUB_TOKEN".to_string(), "ghp_xxx".to_string())]),
+            },
+        ];
+
+        db.replace_mcp_servers(pid, &servers).unwrap();
+        let loaded = db.list_mcp_servers(pid).unwrap();
+
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].name, "filesystem");
+        assert_eq!(loaded[0].command, "npx");
+        assert_eq!(loaded[0].args.len(), 2);
+        assert!(loaded[0].env.is_empty());
+
+        assert_eq!(loaded[1].name, "github");
+        assert_eq!(
+            loaded[1].env.get("GITHUB_TOKEN"),
+            Some(&"ghp_xxx".to_string())
+        );
+    }
+
+    #[test]
+    fn replace_mcp_servers_overwrites_existing() {
+        let (db, pid) = setup_db_with_project("test");
+
+        let initial = vec![McpServerConfig {
+            name: "old-server".to_string(),
+            command: "old-cmd".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+        }];
+        db.replace_mcp_servers(pid, &initial).unwrap();
+
+        let updated = vec![McpServerConfig {
+            name: "new-server".to_string(),
+            command: "new-cmd".to_string(),
+            args: vec!["--flag".to_string()],
+            env: HashMap::new(),
+        }];
+        db.replace_mcp_servers(pid, &updated).unwrap();
+
+        let loaded = db.list_mcp_servers(pid).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "new-server");
+    }
+
+    #[test]
+    fn replace_mcp_servers_empty_clears_all() {
+        let (db, pid) = setup_db_with_project("test");
+
+        let servers = vec![McpServerConfig {
+            name: "server".to_string(),
+            command: "cmd".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+        }];
+        db.replace_mcp_servers(pid, &servers).unwrap();
+        db.replace_mcp_servers(pid, &[]).unwrap();
+
+        let loaded = db.list_mcp_servers(pid).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn list_all_mcp_servers_multiple_projects() {
+        let db = Database::open_in_memory().unwrap();
+
+        let pid1 = test_project_id("proj1");
+        let pid2 = test_project_id("proj2");
+        db.insert_project(pid1, "proj1", &[], false).unwrap();
+        db.insert_project(pid2, "proj2", &[], false).unwrap();
+
+        db.replace_mcp_servers(
+            pid1,
+            &[McpServerConfig {
+                name: "s1".to_string(),
+                command: "cmd1".to_string(),
+                args: vec![],
+                env: HashMap::new(),
+            }],
+        )
+        .unwrap();
+        db.replace_mcp_servers(
+            pid2,
+            &[
+                McpServerConfig {
+                    name: "s2a".to_string(),
+                    command: "cmd2a".to_string(),
+                    args: vec![],
+                    env: HashMap::new(),
+                },
+                McpServerConfig {
+                    name: "s2b".to_string(),
+                    command: "cmd2b".to_string(),
+                    args: vec![],
+                    env: HashMap::new(),
+                },
+            ],
+        )
+        .unwrap();
+
+        let all = db.list_all_mcp_servers().unwrap();
+        assert_eq!(all.get(&pid1).unwrap().len(), 1);
+        assert_eq!(all.get(&pid2).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn list_all_mcp_servers_excludes_deleted_projects() {
+        let db = Database::open_in_memory().unwrap();
+        let pid = test_project_id("deleted");
+        db.insert_project(pid, "deleted", &[], false).unwrap();
+        db.replace_mcp_servers(
+            pid,
+            &[McpServerConfig {
+                name: "s".to_string(),
+                command: "c".to_string(),
+                args: vec![],
+                env: HashMap::new(),
+            }],
+        )
+        .unwrap();
+
+        db.soft_delete_project(pid).unwrap();
+
+        let all = db.list_all_mcp_servers().unwrap();
+        assert!(all.is_empty());
+    }
+
+    #[test]
+    fn args_env_roundtrip() {
+        assert_eq!(str_to_args(""), Vec::<String>::new());
+        assert_eq!(str_to_args("one"), vec!["one".to_string()]);
+        assert_eq!(
+            str_to_args("one\ntwo\nthree"),
+            vec!["one".to_string(), "two".to_string(), "three".to_string()]
+        );
+        assert_eq!(args_to_str(&[]), "");
+        assert_eq!(args_to_str(&["a".to_string()]), "a");
+        assert_eq!(args_to_str(&["a".to_string(), "b,c".to_string()]), "a\nb,c");
+
+        assert_eq!(str_to_env(""), HashMap::new());
+        assert_eq!(
+            str_to_env("KEY=VALUE"),
+            HashMap::from([("KEY".to_string(), "VALUE".to_string())])
+        );
+        assert_eq!(
+            str_to_env("A=1\nB=2"),
+            HashMap::from([
+                ("A".to_string(), "1".to_string()),
+                ("B".to_string(), "2".to_string()),
+            ])
+        );
+        assert_eq!(env_to_str(&HashMap::new()), "");
+    }
+
+    #[test]
+    fn env_value_with_equals_sign() {
+        let env = HashMap::from([("PATH".to_string(), "/usr/bin:/usr/local/bin".to_string())]);
+        let serialized = env_to_str(&env);
+        let deserialized = str_to_env(&serialized);
+        assert_eq!(deserialized, env);
+    }
+
+    #[test]
+    fn env_roundtrip_multiple_entries() {
+        let env = HashMap::from([
+            ("API_KEY".to_string(), "sk-abc123".to_string()),
+            ("DEBUG".to_string(), "1".to_string()),
+            ("URL".to_string(), "https://example.com?a=1&b=2".to_string()),
+        ]);
+        let serialized = env_to_str(&env);
+        let deserialized = str_to_env(&serialized);
+        assert_eq!(deserialized, env);
+    }
+
+    #[test]
+    fn args_roundtrip_preserves_commas() {
+        let args = vec![
+            "-y".to_string(),
+            "--config=a,b,c".to_string(),
+            "path with spaces".to_string(),
+        ];
+        let serialized = args_to_str(&args);
+        let deserialized = str_to_args(&serialized);
+        assert_eq!(deserialized, args);
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,6 +12,7 @@
 //! ```
 
 pub mod audit;
+mod mcp_servers;
 mod projects;
 mod roles;
 mod schema;

--- a/src/storage/projects.rs
+++ b/src/storage/projects.rs
@@ -176,12 +176,14 @@ impl Database {
                 .collect::<Result<_, _>>()?;
 
             let roles = self.list_roles(id)?;
+            let mcp_servers = self.list_mcp_servers(id)?;
 
             projects.push(SharedProject {
                 id,
                 name,
                 repos,
                 roles,
+                mcp_servers,
             });
         }
 
@@ -210,6 +212,7 @@ mod tests {
             name: name.to_string(),
             repos: vec![],
             roles: vec![],
+            mcp_servers: vec![],
             id: None,
         };
         config.deterministic_id()

--- a/src/storage/roles.rs
+++ b/src/storage/roles.rs
@@ -162,6 +162,7 @@ mod tests {
             name: name.to_string(),
             repos: vec![],
             roles: vec![],
+            mcp_servers: vec![],
             id: None,
         };
         config.deterministic_id()

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -254,6 +254,7 @@ mod tests {
             name: name.to_string(),
             repos: vec![],
             roles: vec![],
+            mcp_servers: vec![],
             id: None,
         };
         config.deterministic_id()

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -59,6 +59,7 @@ mod tests {
             name: name.to_string(),
             repos: vec![],
             roles: vec![],
+            mcp_servers: vec![],
             id: None,
         };
         config.deterministic_id()

--- a/src/storage/worktrees.rs
+++ b/src/storage/worktrees.rs
@@ -115,6 +115,7 @@ mod tests {
             name: "test".to_string(),
             repos: vec![],
             roles: vec![],
+            mcp_servers: vec![],
             id: None,
         };
         config.deterministic_id()

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -189,6 +189,7 @@ mod tests {
                 name: "Test".to_string(),
                 repos: vec![],
                 roles: vec![],
+                mcp_servers: vec![],
             }],
             ..Default::default()
         };

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::project::ProjectId;
-use crate::session::{RoleConfig, SessionId};
+use crate::session::{McpServerConfig, RoleConfig, SessionId};
 
 /// Current shared state format version.
 const SHARED_STATE_VERSION: u32 = 1;
@@ -104,6 +104,9 @@ pub struct SharedProject {
 
     /// Role definitions for this project.
     pub roles: Vec<RoleConfig>,
+
+    /// MCP server configurations for this project.
+    pub mcp_servers: Vec<McpServerConfig>,
 }
 
 /// Worktree information embedded in shared session.

--- a/src/ui/mcp_editor_modal.rs
+++ b/src/ui/mcp_editor_modal.rs
@@ -1,0 +1,153 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use super::{centered_fixed_height_rect, render_text_field};
+use crate::app::mcp_editor_modal::McpEditorField;
+use crate::ui::role_editor_modal::ToolListMode;
+
+pub struct McpEditorState<'a> {
+    pub name: &'a str,
+    pub name_cursor: usize,
+    pub command: &'a str,
+    pub command_cursor: usize,
+    pub args: &'a [String],
+    pub args_index: usize,
+    pub args_mode: ToolListMode,
+    pub args_input: &'a str,
+    pub args_input_cursor: usize,
+    pub env: &'a [String],
+    pub env_index: usize,
+    pub env_mode: ToolListMode,
+    pub env_input: &'a str,
+    pub env_input_cursor: usize,
+    pub focused_field: McpEditorField,
+}
+
+pub fn render_mcp_editor_modal(frame: &mut Frame, state: &McpEditorState<'_>) {
+    let args_rows = super::role_editor_modal::tool_list_height(
+        state.args,
+        state.args_mode,
+        state.focused_field == McpEditorField::Args,
+    );
+    let env_rows = super::role_editor_modal::tool_list_height(
+        state.env,
+        state.env_mode,
+        state.focused_field == McpEditorField::Env,
+    );
+
+    let content_height = 3 + 3 + args_rows + env_rows + 1;
+    let max_height = frame.area().height.saturating_sub(4);
+    let height = (content_height + 2).min(max_height);
+    let area = centered_fixed_height_rect(60, height, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Edit MCP Server ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),         // Name
+            Constraint::Length(3),         // Command
+            Constraint::Length(args_rows), // Args
+            Constraint::Length(env_rows),  // Env
+            Constraint::Length(1),         // Footer
+        ])
+        .split(inner);
+
+    render_text_field(
+        frame,
+        chunks[0],
+        "Name",
+        state.name,
+        state.name_cursor,
+        state.focused_field == McpEditorField::Name,
+    );
+
+    render_text_field(
+        frame,
+        chunks[1],
+        "Command",
+        state.command,
+        state.command_cursor,
+        state.focused_field == McpEditorField::Command,
+    );
+
+    super::role_editor_modal::render_tool_list(
+        frame,
+        chunks[2],
+        "Args",
+        state.args,
+        state.args_index,
+        state.args_mode,
+        state.args_input,
+        state.args_input_cursor,
+        state.focused_field == McpEditorField::Args,
+    );
+
+    super::role_editor_modal::render_tool_list(
+        frame,
+        chunks[3],
+        "Env (KEY=VALUE)",
+        state.env,
+        state.env_index,
+        state.env_mode,
+        state.env_input,
+        state.env_input_cursor,
+        state.focused_field == McpEditorField::Env,
+    );
+
+    // Footer — context-sensitive
+    let is_list_field = matches!(
+        state.focused_field,
+        McpEditorField::Args | McpEditorField::Env
+    );
+    let list_mode = match state.focused_field {
+        McpEditorField::Args => state.args_mode,
+        McpEditorField::Env => state.env_mode,
+        _ => ToolListMode::Browse,
+    };
+
+    let footer = if is_list_field && list_mode == ToolListMode::Adding {
+        Line::from(vec![
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::styled(" confirm  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        ])
+    } else if is_list_field {
+        Line::from(vec![
+            Span::styled("a", Style::default().fg(Color::Yellow)),
+            Span::styled(" add  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("d", Style::default().fg(Color::Yellow)),
+            Span::styled(" delete  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Tab", Style::default().fg(Color::Yellow)),
+            Span::styled(" next  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::styled(" save  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled(" discard", Style::default().fg(Color::DarkGray)),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled("Tab", Style::default().fg(Color::Yellow)),
+            Span::styled(" next  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::styled(" save  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::styled(" discard", Style::default().fg(Color::DarkGray)),
+        ])
+    };
+    frame.render_widget(Paragraph::new(footer), chunks[4]);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub mod delete_project_modal;
 pub mod edit_project_modal;
 pub mod info_panel;
 pub mod layout;
+pub mod mcp_editor_modal;
 pub mod project_list;
 pub mod repo_selector_modal;
 pub mod role_editor_modal;

--- a/src/ui/role_editor_modal.rs
+++ b/src/ui/role_editor_modal.rs
@@ -187,7 +187,7 @@ pub fn render_role_editor_modal(frame: &mut Frame, state: &RoleEditorState<'_>) 
 
 /// Compute the height needed for a tool list section.
 /// 2 (border) + max(items, 1 empty) + optional 1 for input row.
-fn tool_list_height(tools: &[String], mode: ToolListMode, focused: bool) -> u16 {
+pub fn tool_list_height(tools: &[String], mode: ToolListMode, focused: bool) -> u16 {
     let item_rows = if tools.is_empty() {
         1
     } else {
@@ -203,7 +203,7 @@ fn tool_list_height(tools: &[String], mode: ToolListMode, focused: bool) -> u16 
 
 /// Render a bordered tool list with optional inline add-input.
 #[allow(clippy::too_many_arguments)]
-fn render_tool_list(
+pub fn render_tool_list(
     frame: &mut Frame,
     area: ratatui::layout::Rect,
     label: &str,

--- a/tests/sync_integration.rs
+++ b/tests/sync_integration.rs
@@ -32,6 +32,7 @@ fn test_project_id(name: &str) -> ProjectId {
         name: name.to_string(),
         repos: vec![],
         roles: vec![],
+        mcp_servers: vec![],
         id: None,
     };
     config.deterministic_id()


### PR DESCRIPTION
## Summary

- Add `McpServerConfig` struct (name, command, args, env) to `session` module
- Migrate DB schema to v4 with new `project_mcp_servers` table (args as newline-separated, env as `KEY=VALUE` newline pairs)
- Add storage CRUD: `list_mcp_servers`, `replace_mcp_servers`, `list_all_mcp_servers`
- Wire `mcp_servers` through `SharedProject` → `ProjectConfig` → DB save/load
- Add MCP editor overlay modal in TUI (Ctrl+E → Tab to MCP Servers section); add/edit/delete servers with name, command, args, env fields
- Add `list_mcp_servers` and `set_mcp_servers` MCP tools to `thurbox-mcp` binary; `get_project` now includes `mcp_servers` in response
- Refactor: extract shared `handle_tool_list_adding_key` function (DRY between role editor and MCP editor)
- 464 tests pass, clippy clean, architecture rules pass

## Test plan

- [x] `cargo nextest run --all` — 464 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --test architecture_rules` — all 8 rules pass
- [ ] TUI: `Ctrl+E` on a project → Tab to MCP Servers → add/edit/delete a server
- [ ] MCP API: send `list_mcp_servers` and `set_mcp_servers` JSON-RPC calls to `thurbox-mcp`
- [ ] DB: verify servers persist across restart and appear in `get_project` response