### PR TITLE
feat(ui): context-sensitive Ctrl+J/K for project navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,8 +281,8 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+N` | New project/session | **N**ew |
 | `Ctrl+C` | Close active session | **C**lose |
 | `Ctrl+H` | Focus project list | Vim: **h** = left |
-| `Ctrl+J` | Next session | Vim: **j** = down |
-| `Ctrl+K` | Previous session | Vim: **k** = up |
+| `Ctrl+J` | Next project (project focus) / session | Vim: **j** = down |
+| `Ctrl+K` | Previous project (project focus) / session | Vim: **k** = up |
 | `Ctrl+L` | Cycle focus | Vim: **l** = right |
 | `Ctrl+D` | Delete session/project | Vim: **d** = delete |
 | `Ctrl+E` | Edit active project (name, repos, roles) | **E**dit |

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -135,11 +135,19 @@ impl App {
                     return;
                 }
                 KeyCode::Char('j') => {
-                    self.switch_session_forward();
+                    if self.focus == InputFocus::ProjectList {
+                        self.switch_project_forward();
+                    } else {
+                        self.switch_session_forward();
+                    }
                     return;
                 }
                 KeyCode::Char('k') => {
-                    self.switch_session_backward();
+                    if self.focus == InputFocus::ProjectList {
+                        self.switch_project_backward();
+                    } else {
+                        self.switch_session_backward();
+                    }
                     return;
                 }
                 KeyCode::Char('l') => {
@@ -177,16 +185,10 @@ impl App {
     fn handle_project_list_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
-                if self.active_project_index + 1 < self.projects.len() {
-                    self.active_project_index += 1;
-                    self.sync_active_session_to_project();
-                }
+                self.switch_project_forward();
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                if self.active_project_index > 0 {
-                    self.active_project_index -= 1;
-                    self.sync_active_session_to_project();
-                }
+                self.switch_project_backward();
             }
             KeyCode::Enter => {
                 self.focus = InputFocus::SessionList;


### PR DESCRIPTION
## Summary

- `Ctrl+J`/`Ctrl+K` now navigate projects when ProjectList is focused, sessions otherwise
- Extracted `switch_project_forward()`/`switch_project_backward()` to eliminate duplicated logic
- Updated help overlay and docs
- Added 6 tests covering navigation, session switching, and boundary cases

## Test plan

- [x] All tests pass (`cargo test --all`)
- [x] `cargo clippy` clean, all 11 pre-commit hooks pass
- [ ] Manual: `Ctrl+H` → focus project list → `Ctrl+J`/`Ctrl+K` navigates projects
- [ ] Manual: session/terminal focus → `Ctrl+J`/`Ctrl+K` switches sessions (unchanged)