### PR TITLE
feat(core): remove default project

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -209,26 +209,25 @@ sessions) and works at all supported widths.
 
 ---
 
-## ADR-10: Default project — projects list is never empty
+## ADR-10: No default project — Admin guarantees non-empty list
 
-**Choice**: When no projects are configured, an ephemeral
-"Default" project is created using the current working directory.
-It is never persisted to disk. This guarantees
-`projects.len() > 0` at all times.
+**Choice**: There is no auto-created "Default" project. The
+built-in Admin project (always present) guarantees
+`projects.len() > 0`. On first launch with an empty DB, users
+see only the Admin project and create their first project via
+`Ctrl+N` or the Admin MCP session.
 
-**Why**: An always-non-empty project list eliminates
-orphaned-session edge cases, removes empty-state UI branches,
-and simplifies `active_project_sessions()` — no `Option` handling
-needed. The default project coexists with user-added projects
-and disappears on restart once user projects exist.
+**Why**: The original default project (created from CWD) was
+confusing — it couldn't be edited or deleted, and its CWD-based
+repo was often wrong. The Admin project already satisfies the
+non-empty invariant, so the default project added no value.
+Removing it simplifies the codebase (no `is_default` checks)
+and gives users full control over their project list.
 
-**Rejected**:
-
-- *Replace default on first user project* — would reassign
-  sessions created under the default, causing confusing
-  ownership changes mid-session.
-- *Persist default to disk* — pollutes the config file with
-  auto-generated entries the user didn't create.
+**Previous design**: An ephemeral "Default" project was
+auto-created from CWD when no projects existed. It was
+non-editable, non-deletable, and persisted to the DB for FK
+constraints. Superseded when the Admin project was introduced.
 
 ---
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3453,7 +3453,6 @@ mod tests {
                     id: None,
                 },
                 session_ids: vec![],
-                is_default: false,
                 is_admin: false,
             });
         }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -141,7 +141,7 @@ impl ThurboxMcp {
         let id = config.deterministic_id();
 
         let db = self.db.lock().unwrap();
-        if let Err(e) = db.insert_project(id, &params.name, &repos, false) {
+        if let Err(e) = db.insert_project(id, &params.name, &repos) {
             return error_json(&e.to_string());
         }
 

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -82,7 +82,6 @@ pub struct ProjectInfo {
     pub id: ProjectId,
     pub config: ProjectConfig,
     pub session_ids: Vec<SessionId>,
-    pub is_default: bool,
     pub is_admin: bool,
 }
 
@@ -93,18 +92,6 @@ impl ProjectInfo {
             id,
             config,
             session_ids: Vec::new(),
-            is_default: false,
-            is_admin: false,
-        }
-    }
-
-    pub fn new_default(config: ProjectConfig) -> Self {
-        let id = config.effective_id();
-        Self {
-            id,
-            config,
-            session_ids: Vec::new(),
-            is_default: true,
             is_admin: false,
         }
     }
@@ -115,21 +102,8 @@ impl ProjectInfo {
             id,
             config,
             session_ids: Vec::new(),
-            is_default: false,
             is_admin: true,
         }
-    }
-}
-
-/// Create a default project config using the current working directory.
-pub fn create_default_project() -> ProjectConfig {
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    ProjectConfig {
-        name: "Default".to_string(),
-        repos: vec![cwd],
-        roles: Vec::new(),
-        mcp_servers: Vec::new(),
-        id: None,
     }
 }
 
@@ -164,18 +138,7 @@ mod tests {
         let info = ProjectInfo::new(config);
         assert!(info.session_ids.is_empty());
         assert_eq!(info.config.name, "test");
-        assert!(!info.is_default);
         assert!(!info.is_admin);
-    }
-
-    #[test]
-    fn project_info_new_default_sets_flag() {
-        let config = create_default_project();
-        let info = ProjectInfo::new_default(config);
-        assert!(info.is_default);
-        assert!(!info.is_admin);
-        assert_eq!(info.config.name, "Default");
-        assert!(!info.config.repos.is_empty());
     }
 
     #[test]
@@ -189,7 +152,6 @@ mod tests {
         };
         let info = ProjectInfo::new_admin(config);
         assert!(info.is_admin);
-        assert!(!info.is_default);
         assert!(info.session_ids.is_empty());
         assert_eq!(info.config.name, "Admin");
     }

--- a/src/storage/mcp_servers.rs
+++ b/src/storage/mcp_servers.rs
@@ -175,7 +175,7 @@ mod tests {
     fn setup_db_with_project(name: &str) -> (Database, ProjectId) {
         let db = Database::open_in_memory().unwrap();
         let pid = test_project_id(name);
-        db.insert_project(pid, name, &[PathBuf::from("/repo")], false)
+        db.insert_project(pid, name, &[PathBuf::from("/repo")])
             .unwrap();
         (db, pid)
     }
@@ -276,8 +276,8 @@ mod tests {
 
         let pid1 = test_project_id("proj1");
         let pid2 = test_project_id("proj2");
-        db.insert_project(pid1, "proj1", &[], false).unwrap();
-        db.insert_project(pid2, "proj2", &[], false).unwrap();
+        db.insert_project(pid1, "proj1", &[]).unwrap();
+        db.insert_project(pid2, "proj2", &[]).unwrap();
 
         db.replace_mcp_servers(
             pid1,
@@ -317,7 +317,7 @@ mod tests {
     fn list_all_mcp_servers_excludes_deleted_projects() {
         let db = Database::open_in_memory().unwrap();
         let pid = test_project_id("deleted");
-        db.insert_project(pid, "deleted", &[], false).unwrap();
+        db.insert_project(pid, "deleted", &[]).unwrap();
         db.replace_mcp_servers(
             pid,
             &[McpServerConfig {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! ```ignore
 //! let db = Database::open(path)?;
-//! db.insert_project(id, "name", &repos, false)?;
+//! db.insert_project(id, "name", &repos)?;
 //! db.upsert_session(&session)?;
 //! ```
 

--- a/src/storage/roles.rs
+++ b/src/storage/roles.rs
@@ -171,7 +171,7 @@ mod tests {
     fn setup_db_with_project(name: &str) -> (Database, ProjectId) {
         let db = Database::open_in_memory().unwrap();
         let pid = test_project_id(name);
-        db.insert_project(pid, name, &[PathBuf::from("/repo")], false)
+        db.insert_project(pid, name, &[PathBuf::from("/repo")])
             .unwrap();
         (db, pid)
     }
@@ -278,8 +278,8 @@ mod tests {
 
         let pid1 = test_project_id("proj1");
         let pid2 = test_project_id("proj2");
-        db.insert_project(pid1, "proj1", &[], false).unwrap();
-        db.insert_project(pid2, "proj2", &[], false).unwrap();
+        db.insert_project(pid1, "proj1", &[]).unwrap();
+        db.insert_project(pid2, "proj2", &[]).unwrap();
 
         db.replace_roles(
             pid1,
@@ -316,7 +316,7 @@ mod tests {
     fn list_all_roles_excludes_deleted_projects() {
         let db = Database::open_in_memory().unwrap();
         let pid = test_project_id("deleted");
-        db.insert_project(pid, "deleted", &[], false).unwrap();
+        db.insert_project(pid, "deleted", &[]).unwrap();
         db.replace_roles(
             pid,
             &[RoleConfig {

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -280,7 +280,7 @@ mod tests {
     fn setup_db_with_project() -> (Database, ProjectId) {
         let db = Database::open_in_memory().unwrap();
         let pid = test_project_id("test");
-        db.insert_project(pid, "test", &[], false).unwrap();
+        db.insert_project(pid, "test", &[]).unwrap();
         (db, pid)
     }
 
@@ -346,8 +346,8 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
         let pid1 = test_project_id("proj1");
         let pid2 = test_project_id("proj2");
-        db.insert_project(pid1, "proj1", &[], false).unwrap();
-        db.insert_project(pid2, "proj2", &[], false).unwrap();
+        db.insert_project(pid1, "proj1", &[]).unwrap();
+        db.insert_project(pid2, "proj2", &[]).unwrap();
 
         let s1 = make_session("S1", pid1);
         let s2 = make_session("S2", pid2);

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -86,7 +86,7 @@ mod tests {
     fn load_shared_state_from_db() {
         let db = Database::open_in_memory().unwrap();
         let pid = test_project_id("test");
-        db.insert_project(pid, "test", &[PathBuf::from("/repo")], false)
+        db.insert_project(pid, "test", &[PathBuf::from("/repo")])
             .unwrap();
 
         let session = make_session("S1", pid);
@@ -103,7 +103,7 @@ mod tests {
     fn compute_delta_detects_added_session() {
         let db = Database::open_in_memory().unwrap();
         let pid = test_project_id("test");
-        db.insert_project(pid, "test", &[], false).unwrap();
+        db.insert_project(pid, "test", &[]).unwrap();
 
         // Local state is empty
         let local = SharedState::new();
@@ -121,7 +121,7 @@ mod tests {
     fn compute_delta_detects_removed_session() {
         let db = Database::open_in_memory().unwrap();
         let pid = test_project_id("test");
-        db.insert_project(pid, "test", &[], false).unwrap();
+        db.insert_project(pid, "test", &[]).unwrap();
 
         // Local state has a session
         let session = make_session("S1", pid);
@@ -162,7 +162,7 @@ mod tests {
 
         // db2 makes a change
         let pid = test_project_id("test");
-        db2.insert_project(pid, "test", &[], false).unwrap();
+        db2.insert_project(pid, "test", &[]).unwrap();
 
         // db1 should detect the external change
         let changed = db1.has_external_changes().unwrap();

--- a/src/storage/worktrees.rs
+++ b/src/storage/worktrees.rs
@@ -124,7 +124,7 @@ mod tests {
     fn setup_db_with_session() -> (Database, SessionId) {
         let db = Database::open_in_memory().unwrap();
         let pid = test_project_id();
-        db.insert_project(pid, "test", &[], false).unwrap();
+        db.insert_project(pid, "test", &[]).unwrap();
 
         let session = SharedSession {
             id: SessionId::default(),

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -24,7 +24,7 @@ pub fn render_info_panel(
 
     // ── Project section ──
     if let Some(proj) = project {
-        let mut project_line = vec![
+        let project_line = vec![
             Span::styled("Project: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
                 &proj.config.name,
@@ -33,15 +33,6 @@ pub fn render_info_panel(
                     .add_modifier(Modifier::BOLD),
             ),
         ];
-        if proj.is_default {
-            project_line.push(Span::raw(" "));
-            project_line.push(Span::styled(
-                "[Default]",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ));
-        }
         lines.push(Line::from(project_line));
 
         if proj.config.repos.len() == 1 {

--- a/tests/sync_integration.rs
+++ b/tests/sync_integration.rs
@@ -123,7 +123,7 @@ fn db_instance_a_creates_session_visible_to_instance_b() {
     let db_b = Database::open(path).unwrap();
 
     let pid = test_project_id("test");
-    db_a.insert_project(pid, "test", &[], false).unwrap();
+    db_a.insert_project(pid, "test", &[]).unwrap();
 
     let session = make_session(SessionId::default(), "Session from A", pid);
     let sid = session.id;
@@ -145,7 +145,7 @@ fn db_instance_b_creates_session_without_erasing_instance_a() {
     let db_b = Database::open(path).unwrap();
 
     let pid = test_project_id("test");
-    db_a.insert_project(pid, "test", &[], false).unwrap();
+    db_a.insert_project(pid, "test", &[]).unwrap();
 
     // Instance A creates session
     let session_a = make_session(SessionId::default(), "Session A", pid);
@@ -178,7 +178,7 @@ fn db_soft_delete_propagates_across_instances() {
     let db_b = Database::open(path).unwrap();
 
     let pid = test_project_id("test");
-    db_a.insert_project(pid, "test", &[], false).unwrap();
+    db_a.insert_project(pid, "test", &[]).unwrap();
 
     let session = make_session(SessionId::default(), "Session to Delete", pid);
     let sid = session.id;
@@ -206,7 +206,7 @@ fn db_change_detection_across_instances() {
     let _ = db_a.has_external_changes().unwrap();
 
     let pid = test_project_id("test");
-    db_b.insert_project(pid, "test", &[], false).unwrap();
+    db_b.insert_project(pid, "test", &[]).unwrap();
 
     // Instance A should detect external change
     assert!(db_a.has_external_changes().unwrap());
@@ -223,7 +223,7 @@ fn db_compute_delta_detects_added_session() {
     let db = Database::open(path).unwrap();
 
     let pid = test_project_id("test");
-    db.insert_project(pid, "test", &[], false).unwrap();
+    db.insert_project(pid, "test", &[]).unwrap();
 
     // Local snapshot is empty
     let local = SharedState::new();
@@ -245,7 +245,7 @@ fn db_compute_delta_detects_removed_session() {
     let db = Database::open(path).unwrap();
 
     let pid = test_project_id("test");
-    db.insert_project(pid, "test", &[], false).unwrap();
+    db.insert_project(pid, "test", &[]).unwrap();
 
     let session = make_session(SessionId::default(), "Session to Remove", pid);
     let sid = session.id;
@@ -271,7 +271,7 @@ fn db_project_soft_delete_propagates() {
     let db_b = Database::open(path).unwrap();
 
     let pid = test_project_id("Shared Project");
-    db_a.insert_project(pid, "Shared Project", &[PathBuf::from("/repo")], false)
+    db_a.insert_project(pid, "Shared Project", &[PathBuf::from("/repo")])
         .unwrap();
 
     // Both see the project
@@ -289,7 +289,7 @@ fn db_audit_trail_records_operations() {
     let db = Database::open_in_memory().unwrap();
 
     let pid = test_project_id("test");
-    db.insert_project(pid, "test", &[], false).unwrap();
+    db.insert_project(pid, "test", &[]).unwrap();
 
     let session = make_session(SessionId::default(), "Audited Session", pid);
     db.upsert_session(&session).unwrap();
@@ -329,7 +329,7 @@ fn db_worktree_persisted_with_session() {
     let db = Database::open_in_memory().unwrap();
 
     let pid = test_project_id("test");
-    db.insert_project(pid, "test", &[], false).unwrap();
+    db.insert_project(pid, "test", &[]).unwrap();
 
     let mut session = make_session(SessionId::default(), "WT Session", pid);
     session.worktree = Some(SharedWorktree {
@@ -355,7 +355,7 @@ fn db_session_metadata_preserved_across_instances() {
     let db_b = Database::open(path).unwrap();
 
     let pid = test_project_id("test");
-    db_a.insert_project(pid, "test", &[], false).unwrap();
+    db_a.insert_project(pid, "test", &[]).unwrap();
 
     let session_id = SessionId::default();
     let session = SharedSession {
@@ -395,7 +395,7 @@ fn db_multiple_sessions_per_project() {
     let db_b = Database::open(path).unwrap();
 
     let pid = test_project_id("test");
-    db_a.insert_project(pid, "test", &[], false).unwrap();
+    db_a.insert_project(pid, "test", &[]).unwrap();
 
     // Instance A creates 2 sessions
     let s1 = make_session(SessionId::default(), "Session 1", pid);
@@ -467,7 +467,7 @@ fn poll_for_changes_detects_external_session_add() {
 
     // External writer adds a session
     let pid = test_project_id("test");
-    db_writer.insert_project(pid, "test", &[], false).unwrap();
+    db_writer.insert_project(pid, "test", &[]).unwrap();
     let session = make_session(SessionId::default(), "External Session", pid);
     db_writer.upsert_session(&session).unwrap();
 
@@ -506,7 +506,7 @@ fn db_project_rename_propagates_across_instances() {
     let db_b = Database::open(path).unwrap();
 
     let pid = test_project_id("OriginalName");
-    db_a.insert_project(pid, "OriginalName", &[PathBuf::from("/repo")], false)
+    db_a.insert_project(pid, "OriginalName", &[PathBuf::from("/repo")])
         .unwrap();
 
     // Instance A renames the project
@@ -529,7 +529,7 @@ fn db_project_rename_does_not_affect_sessions() {
     let db_b = Database::open(path).unwrap();
 
     let pid = test_project_id("TestProject");
-    db_a.insert_project(pid, "TestProject", &[PathBuf::from("/repo")], false)
+    db_a.insert_project(pid, "TestProject", &[PathBuf::from("/repo")])
         .unwrap();
 
     // Create a session tied to the project
@@ -557,7 +557,7 @@ fn db_role_sync_across_instances() {
     let db_b = Database::open(path).unwrap();
 
     let pid = test_project_id("RoleProject");
-    db_a.insert_project(pid, "RoleProject", &[], false).unwrap();
+    db_a.insert_project(pid, "RoleProject", &[]).unwrap();
 
     // Instance A adds roles
     let roles = vec![
@@ -590,8 +590,7 @@ fn db_delta_detects_role_change() {
     let db = Database::open(path).unwrap();
 
     let pid = test_project_id("DeltaRoleProject");
-    db.insert_project(pid, "DeltaRoleProject", &[], false)
-        .unwrap();
+    db.insert_project(pid, "DeltaRoleProject", &[]).unwrap();
 
     // Take initial snapshot (no roles)
     let initial = db.load_shared_state().unwrap();
@@ -628,7 +627,7 @@ fn db_delta_detects_project_rename() {
     let db = Database::open(path).unwrap();
 
     let pid = test_project_id("BeforeRename");
-    db.insert_project(pid, "BeforeRename", &[PathBuf::from("/repo")], false)
+    db.insert_project(pid, "BeforeRename", &[PathBuf::from("/repo")])
         .unwrap();
 
     // Take snapshot


### PR DESCRIPTION
## Summary

- Remove the auto-created "Default" project that was seeded when the DB was empty
- The built-in Admin project already guarantees `projects.len() > 0`, making the default redundant
- Users on first launch now see only the Admin project and create their first project via `Ctrl+N` or the Admin MCP session
- Drop `is_default` from `ProjectInfo`, `insert_project` signature, and all guards/UI badges
- Fix `ensure_admin_project` to keep `active_project_index` in-bounds when the project list is empty (exposed edge case)
- Keep `is_default` column in DB schema (hardcoded to 0) for backwards compatibility with existing databases
- Update ADR-10 in `docs/ARCHITECTURE.md`

## Test plan

- [x] `load_projects_from_db_empty_returns_empty` — empty DB returns empty vec (not a default project)
- [x] `empty_db_app_has_valid_active_project_index` — new test verifying index stays in-bounds on first launch
- [x] All 474 tests pass (`cargo nextest run --all`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Pre-commit hooks pass (fmt, clippy, check, nextest, architecture, deny, doc, rumdl)