### PR TITLE
feat(git): add worktree auto-sync with origin/main

### DIFF
--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -129,6 +129,10 @@ impl App {
                     self.restart_active_session();
                     return;
                 }
+                KeyCode::Char('s') => {
+                    self.start_sync();
+                    return;
+                }
                 // Vim navigation: h=left, j=down, k=up, l=cycle-right
                 KeyCode::Char('h') => {
                     self.focus = InputFocus::ProjectList;
@@ -702,7 +706,7 @@ impl App {
             KeyCode::Enter => {
                 let new_branch = self.worktree_name_input.value().trim().to_string();
                 if new_branch.is_empty() {
-                    self.error_message = Some("Branch name cannot be empty".to_string());
+                    self.set_error("Branch name cannot be empty");
                     return;
                 }
                 self.show_worktree_name_modal = false;
@@ -1132,7 +1136,7 @@ impl App {
         };
         match crate::git::list_branches(repo_path) {
             Ok(branches) if branches.is_empty() => {
-                self.error_message = Some("No branches found in repository".to_string());
+                self.set_error("No branches found in repository");
                 self.pending_repo_path = None;
             }
             Ok(mut branches) => {
@@ -1149,7 +1153,7 @@ impl App {
             }
             Err(e) => {
                 error!("Failed to list branches: {e}");
-                self.error_message = Some(format!("Failed to list branches: {e:#}"));
+                self.set_error(format!("Failed to list branches: {e:#}"));
                 self.pending_repo_path = None;
             }
         }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -6,6 +6,10 @@ use ratatui::{
     Frame,
 };
 
+use crate::app::{StatusLevel, StatusMessage};
+
+const SPINNER_CHARS: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
 pub fn render_header(frame: &mut Frame, area: Rect) {
     let header = Paragraph::new(Line::from(vec![
         Span::styled(
@@ -27,43 +31,71 @@ pub fn render_header(frame: &mut Frame, area: Rect) {
     frame.render_widget(header, area);
 }
 
-pub fn render_footer(
-    frame: &mut Frame,
-    area: Rect,
-    session_count: usize,
-    project_count: usize,
-    error: Option<&str>,
-    focus_label: &str,
-) {
+/// State needed to render the footer bar.
+pub struct FooterState<'a> {
+    pub session_count: usize,
+    pub project_count: usize,
+    pub status: Option<&'a StatusMessage>,
+    pub focus_label: &'a str,
+    pub sync_in_progress: bool,
+    pub tick_count: u64,
+}
+
+pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
     let focus_badge = Span::styled(
-        format!(" {focus_label} "),
+        format!(" {} ", state.focus_label),
         Style::default()
             .fg(Color::Black)
             .bg(Color::Cyan)
             .add_modifier(Modifier::BOLD),
     );
 
-    let status = if let Some(err) = error {
+    let line = if state.sync_in_progress {
+        let idx = (state.tick_count as usize / 10) % SPINNER_CHARS.len();
+        let spinner = SPINNER_CHARS[idx];
+        let text = state
+            .status
+            .map_or("Syncing...".to_string(), |s| s.text.clone());
         Line::from(vec![
             focus_badge,
-            Span::styled(" ERROR ", Style::default().fg(Color::White).bg(Color::Red)),
-            Span::styled(format!(" {err}"), Style::default().fg(Color::Red)),
+            Span::styled(
+                format!(" {spinner} SYNC "),
+                Style::default()
+                    .fg(Color::White)
+                    .bg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(format!(" {text}"), Style::default().fg(Color::Blue)),
+        ])
+    } else if let Some(msg) = state.status {
+        let (badge_text, badge_bg, text_color) = match msg.level {
+            StatusLevel::Info => (" INFO ", Color::Blue, Color::Blue),
+            StatusLevel::Success => (" ✓ SYNC ", Color::Green, Color::Green),
+            StatusLevel::Error => (" ERROR ", Color::Red, Color::Red),
+        };
+        Line::from(vec![
+            focus_badge,
+            Span::styled(badge_text, Style::default().fg(Color::White).bg(badge_bg)),
+            Span::styled(format!(" {}", msg.text), Style::default().fg(text_color)),
         ])
     } else {
-        let counts = if project_count > 0 {
-            format!(" {project_count} project(s) | {session_count} session(s) ")
+        let counts = if state.project_count > 0 {
+            format!(
+                " {} project(s) | {} session(s) ",
+                state.project_count, state.session_count
+            )
         } else {
-            format!(" {session_count} session(s) ")
+            format!(" {} session(s) ", state.session_count)
         };
         Line::from(vec![
             focus_badge,
             Span::styled(counts, Style::default().fg(Color::Gray)),
             Span::styled(
-                " ^N New  ^C Close  ^D Delete  ^E Edit  ^R Restart  ^H/J/K/L Nav  F1 Help  F2 Info  ^Q Quit ",
+                " ^N New  ^C Close  ^D Delete  ^E Edit  ^R Restart  ^S Sync  ^H/J/K/L Nav  F1 Help  F2 Info  ^Q Quit ",
                 Style::default().fg(Color::DarkGray),
             ),
         ])
     };
 
-    frame.render_widget(Paragraph::new(status), area);
+    frame.render_widget(Paragraph::new(line), area);
 }


### PR DESCRIPTION
## Summary

- Adds `Ctrl+S` keybinding to sync all worktree sessions with `origin/main` (stash → fetch → rebase → stash pop)
- Conflict resolution is delegated to the session's Claude: text is sent via bracketed paste, Enter is deferred ~100ms via a tick-based queue so the app processes the paste before submitting
- Footer shows a Braille spinner during sync and typed status badges (✓ SYNC / INFO / ERROR) on completion

## Test plan

- [ ] Press `Ctrl+S` with no worktree sessions → "No worktrees to sync" info message appears in footer
- [ ] Press `Ctrl+S` while sync is in progress → no duplicate sync starts
- [ ] Press `Ctrl+S` with a worktree session → footer spinner appears, then success message after rebase
- [ ] Introduce a rebase conflict → Claude session receives the conflict resolution prompt and submits it
- [ ] All 494 unit tests pass (`cargo nextest run --all`)