### PR TITLE
fix(core): restart admin session fresh on tmux kill

### DIFF
--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -763,7 +763,7 @@ impl App {
                             config.role = role.name.clone();
                             config.permissions = role.permissions.clone();
                             let worktree = self.pending_spawn_worktree.take();
-                            self.do_spawn_session(name, &config, worktree);
+                            self.do_spawn_session(name, &config, worktree, None);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- When tmux is killed and thurbox restarts, admin sessions were respawned with `--resume <stale_id>`, causing Claude to report "no conversation found"
- Fixed by detecting the Admin project during `restore_sessions()` and spawning it without `--resume` so it starts a fresh conversation
- Root cause: `is_admin` flag isn't set until `ensure_admin_session()` runs (after `restore_sessions()`), so checking `p.is_admin` during restore was always false; now checks `p.config.name == "Admin"` instead

## Refactoring included

- `do_spawn_session()` now accepts an explicit `target_project_index: Option<usize>` instead of always using `active_project_index` (fixes `spawn_admin_session` hack of saving/restoring the index)
- Extracted `find_project_index_for_session()` helper (deduplicates lookup logic in `restore_sessions`)
- Extracted `resolve_role_permissions_for_project()` helper with `resolve_role_permissions()` delegating to it
- Added unit tests for both new helpers

## Test plan

- [x] `cargo nextest run --all` — 485/485 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] Manual: kill tmux (`tmux -L thurbox kill-server`), restart thurbox, verify admin session starts fresh without "no conversation found"