### PR TITLE
feat(core): add multi-repo worktree support

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -98,11 +98,15 @@ fn session_to_response(s: &SharedSession) -> SessionResponse {
         backend_type: s.backend_type.clone(),
         claude_session_id: s.claude_session_id.clone(),
         cwd: s.cwd.clone(),
-        worktree: s.worktree.as_ref().map(|w| WorktreeResponse {
-            repo_path: w.repo_path.clone(),
-            worktree_path: w.worktree_path.clone(),
-            branch: w.branch.clone(),
-        }),
+        worktrees: s
+            .worktrees
+            .iter()
+            .map(|w| WorktreeResponse {
+                repo_path: w.repo_path.clone(),
+                worktree_path: w.worktree_path.clone(),
+                branch: w.branch.clone(),
+            })
+            .collect(),
     }
 }
 
@@ -1018,7 +1022,7 @@ mod tests {
             claude_session_id: Some("claude-abc".to_string()),
             cwd: None,
             additional_dirs: Vec::new(),
-            worktree: None,
+            worktrees: Vec::new(),
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -196,8 +196,8 @@ pub struct SessionResponse {
     pub claude_session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<PathBuf>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub worktree: Option<WorktreeResponse>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub worktrees: Vec<WorktreeResponse>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -200,7 +200,7 @@ pub struct SessionInfo {
     pub name: String,
     pub status: SessionStatus,
     pub role: String,
-    pub worktree: Option<WorktreeInfo>,
+    pub worktrees: Vec<WorktreeInfo>,
     pub claude_session_id: Option<String>,
     pub cwd: Option<PathBuf>,
     pub additional_dirs: Vec<PathBuf>,
@@ -214,7 +214,7 @@ impl SessionInfo {
             name,
             status: SessionStatus::Busy,
             role: DEFAULT_ROLE_NAME.to_string(),
-            worktree: None,
+            worktrees: Vec::new(),
             claude_session_id: None,
             cwd: None,
             additional_dirs: Vec::new(),
@@ -355,7 +355,7 @@ mod tests {
     #[test]
     fn session_info_new_has_no_worktree() {
         let info = SessionInfo::new("Test".to_string());
-        assert!(info.worktree.is_none());
+        assert!(info.worktrees.is_empty());
     }
 
     #[test]

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -76,7 +76,7 @@ mod tests {
             claude_session_id: None,
             cwd: None,
             additional_dirs: Vec::new(),
-            worktree: None,
+            worktrees: Vec::new(),
             tombstone: false,
             tombstone_at: None,
         }

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -147,26 +147,33 @@ pub fn render_info_panel(
         }
     }
 
-    // ── Worktree section ──
-    if let Some(wt) = &info.worktree {
+    // ── Worktrees section ──
+    if !info.worktrees.is_empty() {
         lines.push(Line::from(""));
+        let header = if info.worktrees.len() == 1 {
+            "Worktree"
+        } else {
+            "Worktrees"
+        };
         lines.push(Line::from(Span::styled(
-            "Worktree",
+            header,
             Style::default()
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         )));
-        lines.push(Line::from(vec![
-            Span::styled("Branch: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(&wt.branch, Style::default().fg(Color::Green)),
-        ]));
-        lines.push(Line::from(vec![
-            Span::styled("Path: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                wt.worktree_path.display().to_string(),
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]));
+        for wt in &info.worktrees {
+            lines.push(Line::from(vec![
+                Span::styled("Branch: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(&wt.branch, Style::default().fg(Color::Green)),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("Path: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    wt.worktree_path.display().to_string(),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]));
+        }
     }
 
     // ── Role Details section ──

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -148,7 +148,7 @@ fn render_session_section(
                 Style::default().fg(Color::Magenta),
             ));
 
-            if let Some(wt) = &info.worktree {
+            if let Some(wt) = info.worktrees.first() {
                 spans.push(Span::styled(
                     format!(" [{}]", wt.branch),
                     Style::default().fg(Color::Green),

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -27,7 +27,7 @@ pub fn render_terminal(
     };
 
     let title = {
-        let base = if let Some(wt) = &info.worktree {
+        let base = if let Some(wt) = info.worktrees.first() {
             format!(
                 " {} ({}) [{}] [{}] ",
                 info.name, info.role, wt.branch, info.status


### PR DESCRIPTION
## Summary

- Enable worktree mode for projects with 2+ repositories: Ctrl+N now shows the session mode modal for all repo counts, letting users pick Normal or Worktree
- Worktree sessions create a git worktree in every repo simultaneously with the same branch name; CWD is the first repo's worktree, remaining worktree paths become `--add-dir`
- Rollback on failure: if any repo's `git worktree add` fails, already-created worktrees are removed before returning an error
- SQLite schema bumped to v5 with composite PK `(session_id, repo_path)` on the `worktrees` table; v4→v5 migration recreates the table
- `From` trait impls between `WorktreeInfo` and `SharedWorktree` added to `sync/state.rs` (architecture-safe location)
- Multi-worktree session sync propagates across instances via LEFT JOIN row merging in `query_sessions`

## Test plan

- [x] `cargo nextest run --all` — 488 tests pass (7 new tests added)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo test --test architecture_rules` — 8/8 rules pass
- [ ] Manual: create a 2-repo project, press Ctrl+N, select Worktree, pick branch, verify worktrees exist in both repos
- [ ] Manual: close the session (Ctrl+C), verify both worktrees are removed
- [ ] Manual: restart thurbox, verify multi-worktree session is restored correctly