### PR TITLE
feat(mcp): add get_session, delete_session, and restart_session tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,9 @@ cargo run --bin thurbox-mcp         # Run (stdin/stdout JSON-RPC)
 | `list_roles` | List all roles for a project (by name or UUID) |
 | `set_roles` | Atomically replace all roles for a project |
 | `list_sessions` | List sessions, optionally filtered by project |
+| `get_session` | Get a session by UUID |
+| `delete_session` | Soft-delete a session (TUI cleans up tmux/worktree) |
+| `restart_session` | Queue a session restart (TUI processes the command) |
 
 **Role Management**: `set_roles` performs an atomic replacement —
 all existing roles are deleted and replaced in a single transaction.

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -102,6 +102,24 @@ pub struct ListSessionsParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetSessionParams {
+    #[schemars(description = "Session UUID")]
+    pub session: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DeleteSessionParams {
+    #[schemars(description = "Session UUID")]
+    pub session: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct RestartSessionParams {
+    #[schemars(description = "Session UUID")]
+    pub session: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListMcpServersParams {
     #[schemars(description = "Project name or UUID")]
     pub project: String,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -223,6 +223,15 @@ impl SessionInfo {
     }
 }
 
+/// A queued command for a session, inserted by MCP and processed by the TUI.
+#[derive(Debug, Clone)]
+pub struct SessionCommand {
+    pub id: i64,
+    pub session_id: SessionId,
+    pub command: String,
+    pub created_at: u64,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct SessionConfig {
     pub resume_session_id: Option<String>,


### PR DESCRIPTION
## Summary

- Adds `get_session`, `delete_session`, and `restart_session` MCP tools so the admin session (or any MCP client) can manage individual sessions by UUID
- Introduces a `session_commands` table (schema v5) as a command queue: MCP writes commands, the TUI polls and executes them on each `tick()`
- `delete_session` soft-deletes in the DB; the TUI's existing 250ms sync polling detects the removal and cleans up the tmux pane and worktree
- `restart_session` enqueues a `"restart"` command; the TUI's new `process_session_commands()` method processes it and calls `session.restart()` with the existing Claude session ID
- New storage methods: `get_session_by_id`, `enqueue_session_command`, `pending_session_commands`, `mark_command_processed`
- Adapts to upstream's `resolve_role_permissions_for_project(role_name, project_index)` instance method for finding role permissions from any project

## Test plan

- [ ] All 495 unit tests pass (`cargo nextest run --all`)
- [ ] Clippy clean with no warnings
- [ ] Architecture rules pass
- [ ] Schema migration: fresh DB initialises with `session_commands` table; existing DB at v4 migrates cleanly to v5
- [ ] Manual: run thurbox, use admin session to `list_sessions`, copy a UUID, call `restart_session` and observe TUI restart; call `delete_session` and observe pane close