### PR TITLE
feat(ui): comprehensive UI/UX improvements (theme, focus, status, modal UX, polish)

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -549,6 +549,121 @@ project exists at index 0 and `.mcp.json` is up-to-date.
 
 ---
 
+## Theme System
+
+All UI colors are centralized in `src/ui/theme.rs` via semantic
+constants on a `Theme` struct. Widget files reference `Theme::ACCENT`,
+`Theme::TEXT_PRIMARY`, etc. instead of hard-coded `Color::*` values.
+
+### Why centralized?
+
+- ~50 color references were scattered across 13+ widget files.
+  Changing the accent color required editing every file.
+- Semantic names (`ACCENT`, `STATUS_BUSY`, `BORDER_FOCUSED`)
+  make the intent clear at each call site.
+- A single file enables future theming support (dark/light/custom)
+  without touching widget code.
+
+### Color categories
+
+| Category | Constants | Purpose |
+|----------|-----------|---------|
+| Accent | `ACCENT` | Focused borders, selected items, highlights |
+| Status | `STATUS_BUSY/WAITING/IDLE/ERROR` | Session status indicators |
+| Text | `TEXT_PRIMARY/SECONDARY/MUTED` | Three-level text hierarchy |
+| Borders | `BORDER_FOCUSED/UNFOCUSED` | Panel border states |
+| Domain | `ROLE_NAME/ADMIN_BADGE/BRANCH_NAME` | Semantic domain colors |
+| Hints | `KEYBIND_HINT/TOOL_ALLOWED/TOOL_DISALLOWED` | Interactive hints |
+
+Composite style methods (`focused_title()`, `keybind()`, `cursor()`,
+etc.) combine colors with modifiers for common patterns.
+
+---
+
+## Focus Levels
+
+Panels use a tri-state focus system (`Focused`, `Active`, `Inactive`)
+for clear navigation feedback.
+
+| Level | Border | Title | Meaning |
+|-------|--------|-------|---------|
+| `Focused` | Thick cyan | Bold cyan | Receiving input |
+| `Active` | Plain cyan | Cyan text | Contextually relevant |
+| `Inactive` | Plain gray | Gray text | Background |
+
+### Focus mapping
+
+| `InputFocus` | Projects | Sessions | Terminal |
+|---|---|---|---|
+| `ProjectList` | Focused | Inactive | Inactive |
+| `SessionList` | Active | Focused | Inactive |
+| `Terminal` | Inactive | Active | Focused |
+
+---
+
+## Status Messages
+
+Status messages replace the previous `error_message: Option<String>`.
+Messages have a severity level and auto-dismiss after 5 seconds.
+
+| Level | Badge | Text color | Use case |
+|-------|-------|------------|----------|
+| `Error` | Red `ERROR` | Red | Validation failures, operation errors |
+| `Warning` | Yellow `WARN` | Yellow | Non-blocking issues |
+| `Info` | Cyan `INFO` | Gray | Success feedback ("Project saved") |
+
+Positive feedback is shown for: project create/edit/delete, role save,
+session start/restart.
+
+---
+
+## Modal Breadcrumbs
+
+Nested modals (up to 3 deep) show a breadcrumb trail at the top:
+
+```text
+ Edit "myproject" > Roles > "coder"
+ Edit "myproject" > MCP Servers > "thurbox-mcp"
+```
+
+This provides navigation context without consuming extra screen space.
+
+---
+
+## Unsaved Changes Guard
+
+When pressing `Esc` in the role or MCP editor with modified fields,
+a confirmation overlay asks "Discard changes? y/n". This prevents
+accidental loss of edits.
+
+Dirty detection uses snapshot comparison: field values are captured
+when the editor opens and compared on `Esc`. If unchanged, the editor
+closes immediately without prompting.
+
+---
+
+## Empty Terminal State
+
+When no sessions exist, the terminal panel shows a centered hint box:
+
+```text
+┌───────────────────────────────┐
+│ No active sessions            │
+│                               │
+│   Ctrl+N  New session         │
+│   F1      Help                │
+└───────────────────────────────┘
+```
+
+---
+
+## Info Panel Separators
+
+Section boundaries in the info panel use styled `──────` separator
+lines instead of blank lines, improving visual structure.
+
+---
+
 ## Planned Features
 
 Directional intent, not commitments.

--- a/src/app/mcp_editor_modal.rs
+++ b/src/app/mcp_editor_modal.rs
@@ -24,6 +24,7 @@ impl App {
         self.mcp_editor_args.reset();
         self.mcp_editor_env.reset();
         self.mcp_editor_field = McpEditorField::Name;
+        self.mcp_editor_snapshot = Some(self.capture_mcp_editor_snapshot());
     }
 
     /// Populate the MCP editor from an existing server config.
@@ -41,6 +42,7 @@ impl App {
         self.mcp_editor_env.load(&env_strings);
 
         self.mcp_editor_field = McpEditorField::Name;
+        self.mcp_editor_snapshot = Some(self.capture_mcp_editor_snapshot());
     }
 
     /// Validate and save the MCP editor state to the working copy.
@@ -89,6 +91,7 @@ impl App {
         }
 
         self.show_mcp_editor = false;
+        self.mcp_editor_snapshot = None;
         self.mcp_editor_field = McpEditorField::Name;
     }
 }

--- a/src/ui/add_project_modal.rs
+++ b/src/ui/add_project_modal.rs
@@ -2,12 +2,13 @@ use std::path::PathBuf;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::{Color, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
+use super::theme::Theme;
 use super::{centered_fixed_height_rect, render_text_field, render_text_field_with_suggestion};
 use crate::app::AddProjectField;
 
@@ -39,7 +40,7 @@ pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<
     let block = Block::default()
         .title(" Add Project ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Theme::ACCENT));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -76,9 +77,9 @@ pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<
     // Repo list
     let list_focused = state.focused_field == AddProjectField::RepoList;
     let list_border_color = if list_focused {
-        Color::Cyan
+        Theme::BORDER_FOCUSED
     } else {
-        Color::Gray
+        Theme::BORDER_UNFOCUSED
     };
 
     let list_block = Block::default()
@@ -92,7 +93,7 @@ pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<
     if state.repos.is_empty() {
         let placeholder = Paragraph::new(Line::from(Span::styled(
             "(none — add via Path field above)",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(Theme::TEXT_MUTED),
         )));
         frame.render_widget(placeholder, list_inner);
     } else {
@@ -115,9 +116,9 @@ pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<
                 let marker = if selected { "▸ " } else { "  " };
                 let path_str = path.display().to_string();
                 let (marker_color, path_color) = if selected {
-                    (Color::Cyan, Color::White)
+                    (Theme::ACCENT, Theme::TEXT_PRIMARY)
                 } else {
-                    (Color::DarkGray, Color::Gray)
+                    (Theme::TEXT_MUTED, Theme::TEXT_SECONDARY)
                 };
                 Line::from(vec![
                     Span::styled(marker, Style::default().fg(marker_color)),
@@ -132,12 +133,12 @@ pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<
     // Context-sensitive footer
     let footer = match state.focused_field {
         AddProjectField::Name => Line::from(vec![
-            Span::styled("Tab", Style::default().fg(Color::Yellow)),
-            Span::styled(" next  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Enter", Style::default().fg(Color::Yellow)),
-            Span::styled(" submit  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Esc", Style::default().fg(Color::Yellow)),
-            Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+            Span::styled("Tab", Theme::keybind()),
+            Span::styled(" next  ", Theme::keybind_desc()),
+            Span::styled("Enter", Theme::keybind()),
+            Span::styled(" submit  ", Theme::keybind_desc()),
+            Span::styled("Esc", Theme::keybind()),
+            Span::styled(" cancel", Theme::keybind_desc()),
         ]),
         AddProjectField::Path => {
             let tab_hint = if state.path_suggestion.is_some() {
@@ -146,23 +147,23 @@ pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<
                 " next  "
             };
             Line::from(vec![
-                Span::styled("Tab", Style::default().fg(Color::Yellow)),
-                Span::styled(tab_hint, Style::default().fg(Color::DarkGray)),
-                Span::styled("Enter", Style::default().fg(Color::Yellow)),
-                Span::styled(" add repo  ", Style::default().fg(Color::DarkGray)),
-                Span::styled("Esc", Style::default().fg(Color::Yellow)),
-                Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+                Span::styled("Tab", Theme::keybind()),
+                Span::styled(tab_hint, Theme::keybind_desc()),
+                Span::styled("Enter", Theme::keybind()),
+                Span::styled(" add repo  ", Theme::keybind_desc()),
+                Span::styled("Esc", Theme::keybind()),
+                Span::styled(" cancel", Theme::keybind_desc()),
             ])
         }
         AddProjectField::RepoList => Line::from(vec![
-            Span::styled("j/k", Style::default().fg(Color::Yellow)),
-            Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("d", Style::default().fg(Color::Yellow)),
-            Span::styled(" delete  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Enter", Style::default().fg(Color::Yellow)),
-            Span::styled(" submit  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Esc", Style::default().fg(Color::Yellow)),
-            Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+            Span::styled("j/k", Theme::keybind()),
+            Span::styled(" navigate  ", Theme::keybind_desc()),
+            Span::styled("d", Theme::keybind()),
+            Span::styled(" delete  ", Theme::keybind_desc()),
+            Span::styled("Enter", Theme::keybind()),
+            Span::styled(" submit  ", Theme::keybind_desc()),
+            Span::styled("Esc", Theme::keybind()),
+            Span::styled(" cancel", Theme::keybind_desc()),
         ]),
     };
     frame.render_widget(Paragraph::new(footer), chunks[3]);

--- a/src/ui/branch_selector_modal.rs
+++ b/src/ui/branch_selector_modal.rs
@@ -1,12 +1,13 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::{Color, Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::theme::Theme;
 
 pub struct BranchSelectorState<'a> {
     pub branches: &'a [String],
@@ -22,7 +23,7 @@ pub fn render_branch_selector_modal(frame: &mut Frame, state: &BranchSelectorSta
     let block = Block::default()
         .title(" Base Branch ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Theme::ACCENT));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -41,11 +42,9 @@ pub fn render_branch_selector_modal(frame: &mut Frame, state: &BranchSelectorSta
         .enumerate()
         .map(|(i, branch)| {
             let style = if i == state.selected_index {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                Theme::selected_item()
             } else {
-                Style::default().fg(Color::White)
+                Theme::normal_item()
             };
             let prefix = if i == state.selected_index {
                 "▸ "
@@ -60,12 +59,12 @@ pub fn render_branch_selector_modal(frame: &mut Frame, state: &BranchSelectorSta
     frame.render_widget(list, chunks[0]);
 
     let footer = Line::from(vec![
-        Span::styled("j/k", Style::default().fg(Color::Yellow)),
-        Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Enter", Style::default().fg(Color::Yellow)),
-        Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Esc", Style::default().fg(Color::Yellow)),
-        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        Span::styled("j/k", Theme::keybind()),
+        Span::styled(" navigate  ", Theme::keybind_desc()),
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" select  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
     ]);
     frame.render_widget(Paragraph::new(footer), chunks[1]);
 }

--- a/src/ui/delete_project_modal.rs
+++ b/src/ui/delete_project_modal.rs
@@ -1,12 +1,13 @@
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::theme::Theme;
 
 pub struct DeleteProjectModalState<'a> {
     pub project_name: &'a str,
@@ -23,7 +24,7 @@ pub fn render_delete_project_modal(frame: &mut Frame, state: &DeleteProjectModal
     let block = Block::default()
         .title(" Delete Project ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Red));
+        .border_style(Style::default().fg(Theme::DANGER));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -44,7 +45,9 @@ pub fn render_delete_project_modal(frame: &mut Frame, state: &DeleteProjectModal
     let warning = Paragraph::new(vec![
         Line::from(Span::styled(
             "⚠ Delete Project",
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Theme::DANGER)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(vec![
@@ -52,7 +55,7 @@ pub fn render_delete_project_modal(frame: &mut Frame, state: &DeleteProjectModal
             Span::styled(
                 state.project_name,
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(Theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw(" to confirm"),
@@ -67,16 +70,16 @@ pub fn render_delete_project_modal(frame: &mut Frame, state: &DeleteProjectModal
     // Error message
     if let Some(error) = state.error {
         let error_msg = Paragraph::new(error)
-            .style(Style::default().fg(Color::Red))
+            .style(Style::default().fg(Theme::DANGER))
             .alignment(Alignment::Left);
         frame.render_widget(error_msg, chunks[3]);
     }
 
     // Help text
     let help = Line::from(vec![
-        Span::styled("Enter", Style::default().fg(Color::Yellow)),
+        Span::styled("Enter", Theme::keybind()),
         Span::raw(" confirm  "),
-        Span::styled("Esc", Style::default().fg(Color::Yellow)),
+        Span::styled("Esc", Theme::keybind()),
         Span::raw(" cancel"),
     ]);
     let help_paragraph = Paragraph::new(help).alignment(Alignment::Left);
@@ -87,7 +90,7 @@ fn render_confirmation_input(frame: &mut Frame, area: Rect, state: &DeleteProjec
     let block = Block::default()
         .title(" Confirmation ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::White));
+        .border_style(Style::default().fg(Theme::TEXT_PRIMARY));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -102,7 +105,10 @@ fn render_confirmation_input(frame: &mut Frame, area: Rect, state: &DeleteProjec
         // Text before cursor
         if cursor > 0 {
             let before: String = chars[..cursor].iter().collect();
-            spans.push(Span::styled(before, Style::default().fg(Color::White)));
+            spans.push(Span::styled(
+                before,
+                Style::default().fg(Theme::TEXT_PRIMARY),
+            ));
         }
 
         // Cursor character or space
@@ -111,15 +117,15 @@ fn render_confirmation_input(frame: &mut Frame, area: Rect, state: &DeleteProjec
         } else {
             " ".to_string()
         };
-        spans.push(Span::styled(
-            cursor_char,
-            Style::default().fg(Color::Black).bg(Color::White),
-        ));
+        spans.push(Span::styled(cursor_char, Theme::cursor()));
 
         // Text after cursor
         if cursor + 1 < chars.len() {
             let after: String = chars[cursor + 1..].iter().collect();
-            spans.push(Span::styled(after, Style::default().fg(Color::White)));
+            spans.push(Span::styled(
+                after,
+                Style::default().fg(Theme::TEXT_PRIMARY),
+            ));
         }
     }
 

--- a/src/ui/repo_selector_modal.rs
+++ b/src/ui/repo_selector_modal.rs
@@ -2,13 +2,14 @@ use std::path::PathBuf;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::{Color, Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::theme::Theme;
 
 pub struct RepoSelectorState<'a> {
     pub repos: &'a [PathBuf],
@@ -24,7 +25,7 @@ pub fn render_repo_selector_modal(frame: &mut Frame, state: &RepoSelectorState<'
     let block = Block::default()
         .title(" Select Repo ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Theme::ACCENT));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -44,11 +45,9 @@ pub fn render_repo_selector_modal(frame: &mut Frame, state: &RepoSelectorState<'
         .map(|(i, path)| {
             let display = path.display().to_string();
             let style = if i == state.selected_index {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                Theme::selected_item()
             } else {
-                Style::default().fg(Color::White)
+                Theme::normal_item()
             };
             let prefix = if i == state.selected_index {
                 "▸ "
@@ -66,12 +65,12 @@ pub fn render_repo_selector_modal(frame: &mut Frame, state: &RepoSelectorState<'
     frame.render_widget(list, chunks[0]);
 
     let footer = Line::from(vec![
-        Span::styled("j/k", Style::default().fg(Color::Yellow)),
-        Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Enter", Style::default().fg(Color::Yellow)),
-        Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Esc", Style::default().fg(Color::Yellow)),
-        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        Span::styled("j/k", Theme::keybind()),
+        Span::styled(" navigate  ", Theme::keybind_desc()),
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" select  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
     ]);
     frame.render_widget(Paragraph::new(footer), chunks[1]);
 }

--- a/src/ui/role_selector_modal.rs
+++ b/src/ui/role_selector_modal.rs
@@ -1,12 +1,13 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::{Color, Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::theme::Theme;
 use crate::session::RoleConfig;
 
 pub struct RoleSelectorState<'a> {
@@ -24,7 +25,7 @@ pub fn render_role_selector_modal(frame: &mut Frame, state: &RoleSelectorState<'
     let block = Block::default()
         .title(" Session Role ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Theme::ACCENT));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -44,11 +45,9 @@ pub fn render_role_selector_modal(frame: &mut Frame, state: &RoleSelectorState<'
         .enumerate()
         .map(|(i, role)| {
             let style = if i == state.selected_index {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                Theme::selected_item()
             } else {
-                Style::default().fg(Color::White)
+                Theme::normal_item()
             };
             let prefix = if i == state.selected_index {
                 "▸ "
@@ -69,18 +68,18 @@ pub fn render_role_selector_modal(frame: &mut Frame, state: &RoleSelectorState<'
     if let Some(role) = state.roles.get(state.selected_index) {
         let desc = Line::from(Span::styled(
             &role.description,
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(Theme::TEXT_MUTED),
         ));
         frame.render_widget(Paragraph::new(desc), chunks[1]);
     }
 
     let footer = Line::from(vec![
-        Span::styled("j/k", Style::default().fg(Color::Yellow)),
-        Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Enter", Style::default().fg(Color::Yellow)),
-        Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Esc", Style::default().fg(Color::Yellow)),
-        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        Span::styled("j/k", Theme::keybind()),
+        Span::styled(" navigate  ", Theme::keybind_desc()),
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" select  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
     ]);
     frame.render_widget(Paragraph::new(footer), chunks[2]);
 }

--- a/src/ui/session_mode_modal.rs
+++ b/src/ui/session_mode_modal.rs
@@ -1,12 +1,13 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::{Color, Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::theme::Theme;
 
 const MODES: [&str; 2] = ["Normal", "Worktree"];
 
@@ -22,7 +23,7 @@ pub fn render_session_mode_modal(frame: &mut Frame, state: &SessionModeState) {
     let block = Block::default()
         .title(" Session Mode ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Theme::ACCENT));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -40,11 +41,9 @@ pub fn render_session_mode_modal(frame: &mut Frame, state: &SessionModeState) {
         .enumerate()
         .map(|(i, mode)| {
             let style = if i == state.selected_index {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
+                Theme::selected_item()
             } else {
-                Style::default().fg(Color::White)
+                Theme::normal_item()
             };
             let prefix = if i == state.selected_index {
                 "▸ "
@@ -59,12 +58,12 @@ pub fn render_session_mode_modal(frame: &mut Frame, state: &SessionModeState) {
     frame.render_widget(list, chunks[0]);
 
     let footer = Line::from(vec![
-        Span::styled("j/k", Style::default().fg(Color::Yellow)),
-        Span::styled(" navigate  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Enter", Style::default().fg(Color::Yellow)),
-        Span::styled(" select  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Esc", Style::default().fg(Color::Yellow)),
-        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        Span::styled("j/k", Theme::keybind()),
+        Span::styled(" navigate  ", Theme::keybind_desc()),
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" select  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
     ]);
     frame.render_widget(Paragraph::new(footer), chunks[1]);
 }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -1,31 +1,26 @@
 use ratatui::{
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::Paragraph,
     Frame,
 };
 
+use super::theme::Theme;
 use crate::app::{StatusLevel, StatusMessage};
 
 const SPINNER_CHARS: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
 pub fn render_header(frame: &mut Frame, area: Rect) {
     let header = Paragraph::new(Line::from(vec![
-        Span::styled(
-            " thurbox ",
-            Style::default()
-                .fg(Color::Black)
-                .bg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(" thurbox ", Theme::focused_title()),
         Span::styled(
             " Multi-Session Claude Code Orchestrator",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(Theme::TEXT_SECONDARY),
         ),
         Span::styled(
             concat!("  v", env!("THURBOX_VERSION")),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(Theme::TEXT_MUTED),
         ),
     ]));
     frame.render_widget(header, area);
@@ -42,13 +37,7 @@ pub struct FooterState<'a> {
 }
 
 pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
-    let focus_badge = Span::styled(
-        format!(" {} ", state.focus_label),
-        Style::default()
-            .fg(Color::Black)
-            .bg(Color::Cyan)
-            .add_modifier(Modifier::BOLD),
-    );
+    let focus_badge = Span::styled(format!(" {} ", state.focus_label), Theme::focused_title());
 
     let line = if state.sync_in_progress {
         let idx = (state.tick_count as usize / 10) % SPINNER_CHARS.len();
@@ -60,22 +49,22 @@ pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
             focus_badge,
             Span::styled(
                 format!(" {spinner} SYNC "),
-                Style::default()
-                    .fg(Color::White)
-                    .bg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(Theme::TEXT_PRIMARY).bg(Theme::ACCENT),
             ),
-            Span::styled(format!(" {text}"), Style::default().fg(Color::Blue)),
+            Span::styled(format!(" {text}"), Style::default().fg(Theme::ACCENT)),
         ])
     } else if let Some(msg) = state.status {
         let (badge_text, badge_bg, text_color) = match msg.level {
-            StatusLevel::Info => (" INFO ", Color::Blue, Color::Blue),
-            StatusLevel::Success => (" ✓ SYNC ", Color::Green, Color::Green),
-            StatusLevel::Error => (" ERROR ", Color::Red, Color::Red),
+            StatusLevel::Info => (" INFO ", Theme::ACCENT, Theme::TEXT_SECONDARY),
+            StatusLevel::Success => (" ✓ SYNC ", Theme::STATUS_BUSY, Theme::STATUS_BUSY),
+            StatusLevel::Error => (" ERROR ", Theme::STATUS_ERROR, Theme::STATUS_ERROR),
         };
         Line::from(vec![
             focus_badge,
-            Span::styled(badge_text, Style::default().fg(Color::White).bg(badge_bg)),
+            Span::styled(
+                badge_text,
+                Style::default().fg(Theme::TEXT_PRIMARY).bg(badge_bg),
+            ),
             Span::styled(format!(" {}", msg.text), Style::default().fg(text_color)),
         ])
     } else {
@@ -89,10 +78,10 @@ pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
         };
         Line::from(vec![
             focus_badge,
-            Span::styled(counts, Style::default().fg(Color::Gray)),
+            Span::styled(counts, Style::default().fg(Theme::TEXT_SECONDARY)),
             Span::styled(
                 " ^N New  ^C Close  ^D Delete  ^E Edit  ^R Restart  ^S Sync  ^H/J/K/L Nav  F1 Help  F2 Info  ^Q Quit ",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(Theme::TEXT_MUTED),
             ),
         ])
     };

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,0 +1,108 @@
+use ratatui::style::{Color, Modifier, Style};
+
+/// Centralized color and style constants for the Thurbox UI.
+///
+/// All widget files reference these constants instead of hard-coding colors,
+/// enabling consistent theming and single-line visual changes.
+pub struct Theme;
+
+impl Theme {
+    // ── Accent ──────────────────────────────────────────────────────────────
+
+    /// Primary accent color used for focused borders, selected items, branding.
+    pub const ACCENT: Color = Color::Cyan;
+
+    // ── Status colors ───────────────────────────────────────────────────────
+
+    pub const STATUS_BUSY: Color = Color::Green;
+    pub const STATUS_WAITING: Color = Color::Yellow;
+    pub const STATUS_IDLE: Color = Color::DarkGray;
+    pub const STATUS_ERROR: Color = Color::Red;
+
+    // ── Text hierarchy ──────────────────────────────────────────────────────
+
+    pub const TEXT_PRIMARY: Color = Color::White;
+    pub const TEXT_SECONDARY: Color = Color::Gray;
+    pub const TEXT_MUTED: Color = Color::DarkGray;
+
+    // ── Borders ─────────────────────────────────────────────────────────────
+
+    pub const BORDER_FOCUSED: Color = Color::Cyan;
+    pub const BORDER_UNFOCUSED: Color = Color::Gray;
+
+    // ── Domain-specific colors ──────────────────────────────────────────────
+
+    pub const ROLE_NAME: Color = Color::Magenta;
+    pub const ADMIN_BADGE: Color = Color::Yellow;
+    pub const BRANCH_NAME: Color = Color::Green;
+
+    // ── Keybind hints / tool permissions ─────────────────────────────────────
+
+    pub const KEYBIND_HINT: Color = Color::Yellow;
+    pub const TOOL_ALLOWED: Color = Color::Green;
+    pub const TOOL_DISALLOWED: Color = Color::Red;
+
+    // ── Danger / destructive ────────────────────────────────────────────────
+
+    pub const DANGER: Color = Color::Red;
+
+    // ── Background colors ───────────────────────────────────────────────────
+
+    pub const INVERTED_FG: Color = Color::Black;
+
+    // ── Composite styles ────────────────────────────────────────────────────
+
+    /// Style for a focused panel/modal title: bold black on accent background.
+    pub fn focused_title() -> Style {
+        Style::default()
+            .fg(Self::INVERTED_FG)
+            .bg(Self::ACCENT)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Style for an unfocused panel title: dimmed secondary text.
+    pub fn unfocused_title() -> Style {
+        Style::default().fg(Self::BORDER_UNFOCUSED)
+    }
+
+    /// Style for section headers (e.g. info panel sections, help overlay).
+    pub fn section_header() -> Style {
+        Style::default()
+            .fg(Self::ACCENT)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Style for labels in info panels and status displays.
+    pub fn label() -> Style {
+        Style::default().fg(Self::TEXT_MUTED)
+    }
+
+    /// Style for keybind hint keys in modal footers.
+    pub fn keybind() -> Style {
+        Style::default().fg(Self::KEYBIND_HINT)
+    }
+
+    /// Style for keybind descriptions in modal footers.
+    pub fn keybind_desc() -> Style {
+        Style::default().fg(Self::TEXT_MUTED)
+    }
+
+    /// Style for selected/active list items.
+    pub fn selected_item() -> Style {
+        Style::default()
+            .fg(Self::ACCENT)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Style for normal (unselected) list items.
+    pub fn normal_item() -> Style {
+        Style::default().fg(Self::TEXT_PRIMARY)
+    }
+
+    /// Style for the block cursor in text fields.
+    pub fn cursor() -> Style {
+        Style::default()
+            .fg(Self::INVERTED_FG)
+            .bg(Self::TEXT_PRIMARY)
+    }
+}

--- a/src/ui/worktree_name_modal.rs
+++ b/src/ui/worktree_name_modal.rs
@@ -1,12 +1,13 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::{Color, Style},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::theme::Theme;
 
 pub struct WorktreeNameState<'a> {
     pub name: &'a str,
@@ -22,7 +23,7 @@ pub fn render_worktree_name_modal(frame: &mut Frame, state: &WorktreeNameState<'
     let block = Block::default()
         .title(format!(" New Branch (from {}) ", state.base_branch))
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(Theme::ACCENT));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -45,10 +46,10 @@ pub fn render_worktree_name_modal(frame: &mut Frame, state: &WorktreeNameState<'
     );
 
     let footer = Line::from(vec![
-        Span::styled("Enter", Style::default().fg(Color::Yellow)),
-        Span::styled(" confirm  ", Style::default().fg(Color::DarkGray)),
-        Span::styled("Esc", Style::default().fg(Color::Yellow)),
-        Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" confirm  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
     ]);
     frame.render_widget(Paragraph::new(footer), chunks[1]);
 }


### PR DESCRIPTION
## Summary

- **Theme module** (`src/ui/theme.rs`): centralize ~50 hard-coded `Color::*` values across 13+ files into semantic constants (`ACCENT`, `TEXT_*`, `STATUS_*`, `BORDER_*`) and composite style methods
- **Tri-state focus** (`Focused`/`Active`/`Inactive`): panels now have distinct visual styles per focus level; sessions show multi-line items with status icons, elapsed time, role, and branch
- **Auto-dismissing status messages**: `StatusMessage` with `Error`/`Success`/`Info` severity, 5-second TTL auto-dismiss, positive feedback for project/role/session operations
- **Modal breadcrumbs**: role and MCP editor modals show `Edit "project" > Roles > "name"` trail
- **Unsaved-changes guard**: Esc in role/MCP editor checks dirty state (snapshot comparison) and shows `Discard changes? y/n` confirmation overlay
- **Empty terminal hint box**: centered box with `Ctrl+N` / `F1` hints when no sessions exist
- **Info panel separators**: styled `──────` lines between sections instead of blank lines
- **ADR-14** + FEATURES.md documentation for all new UI features

## Test plan

- [ ] `cargo check --all` — clean
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings  
- [ ] `cargo nextest run --all` — 480 tests pass
- [ ] `cargo doc --no-deps --all-features` — no doc warnings
- [ ] Architecture rules test — 8/8 pass
- [ ] Visual: panels show tri-state focus (focused=thick cyan, active=plain cyan, inactive=gray)
- [ ] Visual: session items show 2-line format with role + branch
- [ ] Visual: status messages auto-dismiss after 5s
- [ ] Visual: breadcrumb in role/MCP editor modals
- [ ] Visual: unsaved-changes confirmation when Esc with dirty fields
- [ ] Visual: empty terminal state shows hint box
- [ ] Visual: info panel section separators