### PR TITLE
feat(ui): enrich project list with status dots, admin separation, and wrap navigation

### DIFF
--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -36,13 +36,13 @@ pub fn compute_layout(area: Rect, show_info_panel: bool) -> PanelAreas {
     }
 
     if show_info_panel && area.width >= 120 {
-        // 3-panel mode: 15% left panel | 15% info | 70% terminal
+        // 3-panel mode: 18% left panel | 15% info | 67% terminal
         let horizontal = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([
+                Constraint::Percentage(18),
                 Constraint::Percentage(15),
-                Constraint::Percentage(15),
-                Constraint::Percentage(70),
+                Constraint::Percentage(67),
             ])
             .split(content);
 
@@ -54,10 +54,10 @@ pub fn compute_layout(area: Rect, show_info_panel: bool) -> PanelAreas {
             footer,
         }
     } else {
-        // 2-panel mode: 20% left panel | 80% terminal
+        // 2-panel mode: 25% left panel | 75% terminal
         let horizontal = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(20), Constraint::Percentage(80)])
+            .constraints([Constraint::Percentage(25), Constraint::Percentage(75)])
             .split(content);
 
         PanelAreas {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -74,6 +74,34 @@ pub fn focus_block(title_text: &str, level: FocusLevel) -> Block<'_> {
     }
 }
 
+/// Build a [`Block`] with yellow admin styling (tri-state focus).
+///
+/// Focused/Active use `ADMIN_BORDER` (yellow); Inactive falls back to
+/// the standard unfocused gray, keeping the admin chrome unobtrusive
+/// when the panel is in the background.
+pub fn admin_block(title_text: &str, level: FocusLevel) -> Block<'_> {
+    match level {
+        FocusLevel::Focused => Block::default()
+            .title(Line::from(Span::styled(title_text, Theme::admin_title())))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Thick)
+            .border_style(Style::default().fg(Theme::ADMIN_BORDER)),
+        FocusLevel::Active => Block::default()
+            .title(Line::from(Span::styled(title_text, Theme::admin_title())))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Plain)
+            .border_style(Style::default().fg(Theme::ADMIN_BORDER)),
+        FocusLevel::Inactive => Block::default()
+            .title(Line::from(Span::styled(
+                title_text,
+                Theme::unfocused_title(),
+            )))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Plain)
+            .border_style(Style::default().fg(Theme::BORDER_UNFOCUSED)),
+    }
+}
+
 /// Build a [`Block`] with focused or unfocused styling (backward compat).
 ///
 /// Focused: thick borders in accent color with a highlighted title badge.
@@ -328,5 +356,20 @@ mod tests {
         assert!(inner_focused.height < test_area.height);
         assert!(inner_unfocused.width < test_area.width);
         assert!(inner_unfocused.height < test_area.height);
+    }
+
+    #[test]
+    fn admin_block_returns_block_for_all_focus_levels() {
+        let test_area = area(40, 10);
+        for level in [
+            FocusLevel::Focused,
+            FocusLevel::Active,
+            FocusLevel::Inactive,
+        ] {
+            let block = admin_block(" Admin ", level);
+            let inner = block.inner(test_area);
+            assert!(inner.width < test_area.width);
+            assert!(inner.height < test_area.height);
+        }
     }
 }

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -6,15 +6,20 @@ use ratatui::{
     Frame,
 };
 
-use super::focus_block;
 use super::theme::Theme;
 use super::FocusLevel;
+use super::{admin_block, focus_block};
 use crate::session::SessionInfo;
 
 pub struct ProjectEntry<'a> {
     pub name: &'a str,
-    pub session_count: usize,
     pub is_admin: bool,
+    pub repo_count: usize,
+    pub repo_short: Option<&'a str>,
+    pub role_count: usize,
+    pub busy_count: usize,
+    pub waiting_count: usize,
+    pub error_count: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,22 +44,69 @@ pub struct LeftPanelState<'a> {
 }
 
 pub fn render_left_panel(frame: &mut Frame, area: Rect, state: &LeftPanelState<'_>) {
+    // Partition projects into regular and admin groups, keeping original indices
+    let regular: Vec<(usize, &ProjectEntry<'_>)> = state
+        .projects
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| !p.is_admin)
+        .collect();
+    let admin: Vec<(usize, &ProjectEntry<'_>)> = state
+        .projects
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.is_admin)
+        .collect();
+
+    // 2 lines per regular project, 1 line per admin entry, +2 for borders per section
+    let regular_content = regular.len() as u16 * 2;
+    let regular_height = regular_content + 2; // borders
+
+    let has_admin = !admin.is_empty();
+    let admin_content = admin.len() as u16; // admin entries are single-line
+    let admin_height = if has_admin {
+        admin_content + 2 // borders
+    } else {
+        0
+    };
+
+    let mut constraints = vec![Constraint::Length(regular_height)];
+    if has_admin {
+        constraints.push(Constraint::Length(admin_height));
+    }
+    constraints.push(Constraint::Min(4)); // sessions
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .constraints(constraints)
         .split(area);
 
+    // Render regular projects section
     render_project_section(
         frame,
         chunks[0],
-        state.projects,
+        &regular,
         state.active_project,
         state.project_focus,
     );
 
+    let session_chunk_idx = if has_admin {
+        // Render admin section
+        render_admin_section(
+            frame,
+            chunks[1],
+            &admin,
+            state.active_project,
+            state.project_focus,
+        );
+        2
+    } else {
+        1
+    };
+
     render_session_section(
         frame,
-        chunks[1],
+        chunks[session_chunk_idx],
         state.sessions,
         state.active_session,
         state.session_elapsed_ms,
@@ -62,10 +114,50 @@ pub fn render_left_panel(frame: &mut Frame, area: Rect, state: &LeftPanelState<'
     );
 }
 
+/// Build status dot spans for a project's aggregate session statuses.
+fn status_dots<'a>(project: &ProjectEntry<'a>) -> Vec<Span<'a>> {
+    let mut dots = Vec::new();
+    for _ in 0..project.busy_count {
+        dots.push(Span::styled("●", Style::default().fg(Theme::STATUS_BUSY)));
+    }
+    for _ in 0..project.waiting_count {
+        dots.push(Span::styled(
+            "◉",
+            Style::default().fg(Theme::STATUS_WAITING),
+        ));
+    }
+    for _ in 0..project.error_count {
+        dots.push(Span::styled("✗", Style::default().fg(Theme::STATUS_ERROR)));
+    }
+    dots
+}
+
+/// Build the metadata line (line 2) for a regular project entry.
+fn project_meta_line<'a>(project: &ProjectEntry<'a>) -> Line<'a> {
+    let repo_text = if project.repo_count == 1 {
+        project.repo_short.unwrap_or("1 repo").to_string()
+    } else if project.repo_count > 1 {
+        format!("{} repos", project.repo_count)
+    } else {
+        "no repos".to_string()
+    };
+
+    let role_text = if project.role_count == 1 {
+        "1 role".to_string()
+    } else {
+        format!("{} roles", project.role_count)
+    };
+
+    Line::from(vec![Span::styled(
+        format!("    {repo_text} · {role_text}"),
+        Theme::project_meta(),
+    )])
+}
+
 fn render_project_section(
     frame: &mut Frame,
     area: Rect,
-    projects: &[ProjectEntry<'_>],
+    projects: &[(usize, &ProjectEntry<'_>)],
     active_index: usize,
     level: FocusLevel,
 ) {
@@ -73,36 +165,37 @@ fn render_project_section(
 
     let items: Vec<ListItem> = projects
         .iter()
-        .enumerate()
-        .map(|(i, project)| {
-            let base_color = if project.is_admin {
-                Theme::ADMIN_BADGE
-            } else if i == active_index {
-                Theme::ACCENT
+        .map(|&(orig_idx, project)| {
+            let is_active = orig_idx == active_index;
+            let name_style = if is_active {
+                Style::default()
+                    .fg(Theme::ACCENT)
+                    .add_modifier(Modifier::BOLD)
             } else {
-                Theme::TEXT_PRIMARY
-            };
-            let style = if i == active_index {
-                Style::default().fg(base_color).add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(base_color)
+                Style::default().fg(Theme::TEXT_PRIMARY)
             };
 
-            let indicator = if i == active_index { "▸" } else { " " };
-            let prefix = if project.is_admin { "⚙ " } else { "" };
+            let indicator = if is_active { "▸" } else { " " };
 
-            let line = Line::from(vec![
-                Span::styled(format!("{indicator} "), style),
-                Span::styled(format!("{prefix}{}", project.name), style),
-                Span::styled(
-                    format!(" ({})", project.session_count),
-                    Style::default().fg(Theme::TEXT_MUTED),
-                ),
-            ]);
+            // Line 1: indicator + name + status dots
+            let mut line1_spans = vec![
+                Span::styled(format!("{indicator} "), name_style),
+                Span::styled(project.name, name_style),
+                Span::raw("  "),
+            ];
+            line1_spans.extend(status_dots(project));
 
-            ListItem::new(line)
+            let line1 = Line::from(line1_spans);
+            let line2 = project_meta_line(project);
+
+            ListItem::new(vec![line1, line2])
         })
         .collect();
+
+    // Find which index within the regular list is active
+    let list_active = projects
+        .iter()
+        .position(|&(orig_idx, _)| orig_idx == active_index);
 
     let list = List::new(items).block(block).highlight_style(
         Style::default()
@@ -110,9 +203,58 @@ fn render_project_section(
             .add_modifier(Modifier::BOLD),
     );
 
-    let mut state = ListState::default();
-    state.select(Some(active_index));
-    frame.render_stateful_widget(list, area, &mut state);
+    let mut list_state = ListState::default();
+    list_state.select(list_active);
+    frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn render_admin_section(
+    frame: &mut Frame,
+    area: Rect,
+    projects: &[(usize, &ProjectEntry<'_>)],
+    active_index: usize,
+    level: FocusLevel,
+) {
+    let block = admin_block(" Admin ", level);
+
+    let items: Vec<ListItem> = projects
+        .iter()
+        .map(|&(orig_idx, project)| {
+            let is_active = orig_idx == active_index;
+            let name_style = if is_active {
+                Style::default()
+                    .fg(Theme::ADMIN_BADGE)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Theme::ADMIN_BADGE)
+            };
+
+            let indicator = if is_active { "▸" } else { " " };
+
+            let mut line_spans = vec![
+                Span::styled(format!("{indicator} ⚙ "), name_style),
+                Span::styled(project.name, name_style),
+                Span::raw("  "),
+            ];
+            line_spans.extend(status_dots(project));
+
+            ListItem::new(Line::from(line_spans))
+        })
+        .collect();
+
+    let list_active = projects
+        .iter()
+        .position(|&(orig_idx, _)| orig_idx == active_index);
+
+    let list = List::new(items).block(block).highlight_style(
+        Style::default()
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let mut list_state = ListState::default();
+    list_state.select(list_active);
+    frame.render_stateful_widget(list, area, &mut list_state);
 }
 
 fn render_session_section(
@@ -133,6 +275,9 @@ fn render_session_section(
         return;
     }
 
+    // Available width inside the block (subtract 2 for borders)
+    let inner_width = area.width.saturating_sub(2) as usize;
+
     let items: Vec<ListItem> = sessions
         .iter()
         .enumerate()
@@ -140,7 +285,6 @@ fn render_session_section(
             let is_active = i == active_index;
             let prefix = if is_active { "▸" } else { " " };
 
-            // Line 1: status icon + #N + right-aligned status text
             let status_text = format_status_with_elapsed(info.status, elapsed_ms.get(i).copied());
             let name_style = if is_active {
                 Theme::selected_item()
@@ -148,16 +292,23 @@ fn render_session_section(
                 Theme::normal_item()
             };
 
+            // "▸ ● " prefix is 4 chars wide (indicator + space + icon + space)
+            let prefix_width = 4;
+            let name_len = info.name.chars().count();
+            let status_len = status_text.chars().count();
+            let used = prefix_width + name_len + status_len;
+            let gap = if used < inner_width {
+                inner_width - used
+            } else {
+                1
+            };
+
+            let status_style = Style::default().fg(super::status_color(info.status));
             let line1 = Line::from(vec![
-                Span::styled(
-                    format!("{prefix} {} ", info.status.icon()),
-                    Style::default().fg(super::status_color(info.status)),
-                ),
+                Span::styled(format!("{prefix} {} ", info.status.icon()), status_style),
                 Span::styled(&info.name, name_style),
-                Span::styled(
-                    format!("  {status_text}"),
-                    Style::default().fg(super::status_color(info.status)),
-                ),
+                Span::raw(" ".repeat(gap)),
+                Span::styled(status_text, status_style),
             ]);
 
             // Line 2: indented role name + optional · branch
@@ -205,5 +356,130 @@ fn format_status_with_elapsed(
             format!("{status} {secs}s")
         }
         _ => format!("{status}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::SessionStatus;
+
+    fn test_entry<'a>(
+        name: &'a str,
+        busy: usize,
+        waiting: usize,
+        error: usize,
+        repo_count: usize,
+        repo_short: Option<&'a str>,
+        role_count: usize,
+    ) -> ProjectEntry<'a> {
+        ProjectEntry {
+            name,
+            is_admin: false,
+            repo_count,
+            repo_short,
+            role_count,
+            busy_count: busy,
+            waiting_count: waiting,
+            error_count: error,
+        }
+    }
+
+    // --- status_dots ---
+
+    #[test]
+    fn status_dots_empty_for_no_sessions() {
+        let entry = test_entry("P", 0, 0, 0, 0, None, 0);
+        assert!(status_dots(&entry).is_empty());
+    }
+
+    #[test]
+    fn status_dots_counts_match_input() {
+        let entry = test_entry("P", 2, 1, 3, 0, None, 0);
+        let dots = status_dots(&entry);
+        assert_eq!(dots.len(), 6); // 2 busy + 1 waiting + 3 error
+    }
+
+    #[test]
+    fn status_dots_ordering_is_busy_waiting_error() {
+        let entry = test_entry("P", 1, 1, 1, 0, None, 0);
+        let dots = status_dots(&entry);
+        assert_eq!(dots.len(), 3);
+        // Busy dot uses ●
+        assert_eq!(dots[0].content, "●");
+        // Waiting dot uses ◉
+        assert_eq!(dots[1].content, "◉");
+        // Error dot uses ✗
+        assert_eq!(dots[2].content, "✗");
+    }
+
+    // --- project_meta_line ---
+
+    #[test]
+    fn meta_line_single_repo_shows_name() {
+        let entry = test_entry("P", 0, 0, 0, 1, Some("myrepo"), 2);
+        let line = project_meta_line(&entry);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("myrepo"));
+        assert!(text.contains("2 roles"));
+    }
+
+    #[test]
+    fn meta_line_multiple_repos_shows_count() {
+        let entry = test_entry("P", 0, 0, 0, 3, None, 1);
+        let line = project_meta_line(&entry);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("3 repos"));
+        assert!(text.contains("1 role"));
+    }
+
+    #[test]
+    fn meta_line_no_repos() {
+        let entry = test_entry("P", 0, 0, 0, 0, None, 0);
+        let line = project_meta_line(&entry);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("no repos"));
+        assert!(text.contains("0 roles"));
+    }
+
+    #[test]
+    fn meta_line_single_repo_without_short_name() {
+        let entry = test_entry("P", 0, 0, 0, 1, None, 1);
+        let line = project_meta_line(&entry);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("1 repo"));
+        assert!(text.contains("1 role"));
+    }
+
+    // --- format_status_with_elapsed ---
+
+    #[test]
+    fn elapsed_minutes_shown_above_60s() {
+        let text = format_status_with_elapsed(SessionStatus::Waiting, Some(120_000));
+        assert_eq!(text, "Waiting 2m");
+    }
+
+    #[test]
+    fn elapsed_seconds_shown_between_10s_and_60s() {
+        let text = format_status_with_elapsed(SessionStatus::Idle, Some(30_000));
+        assert_eq!(text, "Idle 30s");
+    }
+
+    #[test]
+    fn elapsed_not_shown_below_10s() {
+        let text = format_status_with_elapsed(SessionStatus::Waiting, Some(5_000));
+        assert_eq!(text, "Waiting");
+    }
+
+    #[test]
+    fn elapsed_not_shown_for_busy() {
+        let text = format_status_with_elapsed(SessionStatus::Busy, Some(120_000));
+        assert_eq!(text, "Busy");
+    }
+
+    #[test]
+    fn elapsed_none_shows_plain_status() {
+        let text = format_status_with_elapsed(SessionStatus::Error, None);
+        assert_eq!(text, "Error");
     }
 }

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -6,9 +6,9 @@ use ratatui::{
 };
 use tui_term::widget::{Cursor, PseudoTerminal};
 
-use super::focus_block;
 use super::theme::Theme;
 use super::FocusLevel;
+use super::{admin_block, focus_block};
 use crate::session::SessionInfo;
 
 pub fn render_terminal(
@@ -17,6 +17,7 @@ pub fn render_terminal(
     parser: &mut vt100::Parser,
     info: &SessionInfo,
     level: FocusLevel,
+    is_admin: bool,
 ) {
     let scroll_offset = parser.screen().scrollback();
 
@@ -46,7 +47,11 @@ pub fn render_terminal(
         }
     };
 
-    let block = focus_block(&title, level);
+    let block = if is_admin {
+        admin_block(&title, level)
+    } else {
+        focus_block(&title, level)
+    };
 
     let mut pseudo_term = PseudoTerminal::new(parser.screen())
         .block(block)

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -42,6 +42,10 @@ impl Theme {
     pub const TOOL_ALLOWED: Color = Color::Green;
     pub const TOOL_DISALLOWED: Color = Color::Red;
 
+    // ── Admin ─────────────────────────────────────────────────────────────
+
+    pub const ADMIN_BORDER: Color = Color::Yellow;
+
     // ── Danger / destructive ────────────────────────────────────────────────
 
     pub const DANGER: Color = Color::Red;
@@ -97,6 +101,18 @@ impl Theme {
     /// Style for normal (unselected) list items.
     pub fn normal_item() -> Style {
         Style::default().fg(Self::TEXT_PRIMARY)
+    }
+
+    /// Style for admin section title: yellow bold.
+    pub fn admin_title() -> Style {
+        Style::default()
+            .fg(Self::ADMIN_BORDER)
+            .add_modifier(Modifier::BOLD)
+    }
+
+    /// Style for project metadata lines (repo info, role count).
+    pub fn project_meta() -> Style {
+        Style::default().fg(Self::TEXT_MUTED)
     }
 
     /// Style for the block cursor in text fields.


### PR DESCRIPTION
## Summary

- Two-line project entries showing aggregate session status dots (●◉✗) and repo/role metadata
- Admin projects visually separated in a yellow-bordered section; yellow border also applied to terminal when admin session is active
- Shared `admin_block()` extracted to `ui/mod.rs`, eliminating duplication between project list and terminal view
- `j`/`k` / `Ctrl+J`/`Ctrl+K` now wrap around the project list (reaching admin with one keypress from bottom)
- Layout proportions widened: 25/75 (2-panel) and 18/15/67 (3-panel)

## Test plan

- [x] All 558 tests pass (`cargo nextest run --all`)
- [x] Zero clippy warnings (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] 13 new unit tests added for `status_dots`, `project_meta_line`, `format_status_with_elapsed`, `admin_block`
- [x] Wrap-around tests updated to assert new behavior
- [ ] Visual check: project list shows 2-line entries with status dots
- [ ] Visual check: admin session has yellow terminal border
- [ ] Visual check: j/k wraps from last project to first and back