### PR TITLE
feat(mcp): auto-allow thurbox-mcp tools in admin session

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -519,7 +519,9 @@ On startup, Thurbox creates:
    `thurbox-mcp` binary. Claude Code auto-discovers this file.
 3. An "Admin" pseudo-project pinned at index 0 in the project
    list, visually distinguished with a yellow `⚙` prefix.
-4. A single admin session with `cwd` set to the admin directory.
+4. A single admin session with `cwd` set to the admin directory
+   and all 11 `thurbox-mcp` tools pre-allowed (auto-approved
+   without user prompts).
 
 The `.mcp.json` is rewritten on every startup to pick up binary
 path changes after upgrades.


### PR DESCRIPTION
## Summary

- Auto-allow all 11 `thurbox-mcp` tools in the admin session so Claude can manage Thurbox without repeated permission prompts
- Permissions apply consistently across spawn, restore, and restart code paths via `resolve_role_permissions_for_project`
- Extracted `ADMIN_MCP_TOOLS` constant and `admin_mcp_permissions()` helper for single source of truth

## Test plan

- [x] `cargo check --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo nextest run --all` — 547 tests pass (2 new tests added)
- [x] All 11 pre-commit hooks pass
- [ ] Manual verification: start Thurbox, confirm admin session auto-allows MCP tool calls without prompting