### PR TITLE
fix(ui): use compute_layout() for tmux pane sizing

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2573,29 +2573,10 @@ impl App {
     }
 
     pub(crate) fn content_area_size(&self) -> (u16, u16) {
-        // Header: 1 line, Footer: 1 line, Borders: 2 lines top+bottom
-        let rows = self.terminal_rows.saturating_sub(4);
-
-        let three_panel = self.show_info_panel && self.terminal_cols >= 120;
-
-        let list_width = if self.terminal_cols >= 80 {
-            if three_panel {
-                self.terminal_cols * 15 / 100 // matches layout.rs 3-panel: 15%
-            } else {
-                self.terminal_cols * 20 / 100 // matches layout.rs 2-panel: 20%
-            }
-        } else {
-            0
-        };
-        let info_width = if three_panel {
-            self.terminal_cols * 15 / 100 // matches layout.rs 3-panel: 15%
-        } else {
-            0
-        };
-        let cols = self
-            .terminal_cols
-            .saturating_sub(list_width + info_width + 2);
-        (rows, cols)
+        let area = Rect::new(0, 0, self.terminal_cols, self.terminal_rows);
+        let terminal = layout::compute_layout(area, self.show_info_panel).terminal;
+        let inner = Block::default().borders(Borders::ALL).inner(terminal);
+        (inner.height, inner.width)
     }
 }
 


### PR DESCRIPTION
## Summary

- **Fixed** `content_area_size()` using wrong percentages (20%/15%) vs `compute_layout()` (25%/18%), causing tmux panes to be wider than the visible ratatui area and Claude Code output to overflow horizontally
- **Replaced** duplicated manual percentage math with a single call to `compute_layout()` + `Block::inner()`, making layout the single source of truth
- **Added** 4 dimension-pinning tests to `layout.rs` covering 2-panel, 3-panel, narrow, and wide terminal widths

## Test plan

- [x] `cargo check --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run --all` — 575/575 tests pass (4 new)
- [x] All 11 pre-commit hooks pass
- [ ] Manual: run thurbox at 80, 120, 160+ col widths and verify no horizontal overflow