### PR TITLE
feat(core): add session restore with undo and deleted sessions modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,8 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+D` | Delete session/project | Vim: **d** = delete |
 | `Ctrl+E` | Edit active project (name, repos, roles) | **E**dit |
 | `Ctrl+R` | Restart active session | **R**estart |
+| `Ctrl+Z` | Undo session delete | **Z** = undo |
+| `Ctrl+U` | Restore deleted session | **U**ndelete |
 | `F1` | Help overlay | Universal |
 | `F2` | Toggle info panel (visible at width >= 120) | Next to F1 |
 

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -120,6 +120,12 @@ pub struct RestartSessionParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct RestoreSessionParams {
+    #[schemars(description = "Session UUID of a soft-deleted session")]
+    pub session: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListMcpServersParams {
     #[schemars(description = "Project name or UUID")]
     pub project: String,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -17,6 +17,7 @@ mod projects;
 mod roles;
 mod schema;
 mod sessions;
+pub use sessions::DeletedSessionInfo;
 pub mod sync;
 mod worktrees;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub mod links;
 pub mod mcp_editor_modal;
 pub mod project_list;
 pub mod repo_selector_modal;
+pub mod restore_sessions_modal;
 pub mod role_editor_modal;
 pub mod role_selector_modal;
 pub mod session_mode_modal;

--- a/src/ui/restore_sessions_modal.rs
+++ b/src/ui/restore_sessions_modal.rs
@@ -1,0 +1,100 @@
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::Style,
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use super::centered_fixed_height_rect;
+use super::theme::Theme;
+
+/// View-only entry for the restore sessions modal.
+pub struct DeletedSessionEntry {
+    pub name: String,
+    pub role: String,
+    pub deleted_ago: String,
+    pub has_worktrees: bool,
+}
+
+pub struct RestoreSessionsModalState<'a> {
+    pub entries: &'a [DeletedSessionEntry],
+    pub selected_index: usize,
+}
+
+pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsModalState<'_>) {
+    let list_height = state.entries.len().max(1) as u16;
+    // 2 (borders) + list_height + 1 (footer) + 2 (padding)
+    let total_height = (list_height + 5).min(20);
+    let area = centered_fixed_height_rect(60, total_height, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Restore Deleted Sessions ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Theme::ACCENT));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if state.entries.is_empty() {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(inner);
+
+        let empty = Paragraph::new(Line::from(Span::styled(
+            "No deleted sessions",
+            Style::default().fg(Theme::TEXT_MUTED),
+        )))
+        .alignment(Alignment::Center);
+        frame.render_widget(empty, chunks[0]);
+
+        let help = Line::from(vec![
+            Span::styled("Esc", Theme::keybind()),
+            Span::raw(" close"),
+        ]);
+        frame.render_widget(Paragraph::new(help), chunks[1]);
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    // Session list
+    let lines: Vec<Line<'_>> = state
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            let selected = i == state.selected_index;
+            let wt_indicator = if entry.has_worktrees { " [wt]" } else { "" };
+            let text = format!(
+                " {} ({}) {}{} ",
+                entry.name, entry.role, entry.deleted_ago, wt_indicator
+            );
+            if selected {
+                Line::from(Span::styled(text, Theme::selected_item()))
+            } else {
+                Line::from(Span::styled(
+                    text,
+                    Style::default().fg(Theme::TEXT_SECONDARY),
+                ))
+            }
+        })
+        .collect();
+
+    frame.render_widget(Paragraph::new(lines), chunks[0]);
+
+    // Footer
+    let help = Line::from(vec![
+        Span::styled("Enter", Theme::keybind()),
+        Span::raw(" restore  "),
+        Span::styled("Esc", Theme::keybind()),
+        Span::raw(" close"),
+    ]);
+    frame.render_widget(Paragraph::new(help), chunks[1]);
+}

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -80,7 +80,7 @@ pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
             focus_badge,
             Span::styled(counts, Style::default().fg(Theme::TEXT_SECONDARY)),
             Span::styled(
-                " ^N New  ^C Close  ^D Delete  ^E Edit  ^R Restart  ^S Sync  ^T Shell  ^H/J/K/L Nav  F1 Help  F2 Info  ^Q Quit ",
+                " ^N New  ^C Close  ^D Delete  ^E Edit  ^R Restart  ^S Sync  ^T Shell  ^Z Undo  ^U Restore  ^H/J/K/L Nav  F1 Help  F2 Info  ^Q Quit ",
                 Style::default().fg(Theme::TEXT_MUTED),
             ),
         ])


### PR DESCRIPTION
## Summary

- **Ctrl+Z** — Deferred cleanup with 10s undo window after session delete; pressing Ctrl+Z within the window restores the session in-place without re-spawning
- **Ctrl+U** — Modal listing all soft-deleted sessions for the active project; Enter restores a selected session by re-spawning with `--resume` and recreating git worktrees
- **MCP `restore_session` tool** — Restores a soft-deleted session via the MCP server; the TUI picks it up via sync polling and spawns with `--resume`
- Git helpers `add_existing_worktree` / `branch_exists` for safe worktree recreation during restore
- Storage: `DeletedSessionInfo` struct, `list_deleted_sessions_for_project`, `get_deleted_session_by_id`
- Status bar footer and help overlay updated with all new keybindings
- 18 new tests (563 total); all passing, clippy clean, 8/8 architecture rules pass

## Test plan

- [ ] Delete a session → see "Deleted. Ctrl+Z to undo" status → press Ctrl+Z → session reappears with working terminal
- [ ] Delete a session → wait 10s → verify tmux pane killed and worktree removed
- [ ] Delete a session → Ctrl+U → session appears in list → Enter → session restored with worktree and `--resume`
- [ ] MCP `restore_session` → TUI picks up and spawns with `--resume`
- [ ] `cargo nextest run --all` passes