### PR TITLE
build(config): remove --check from cargo-fmt pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         language: system
         types: [rust]
         pass_filenames: false
-        args: ["--all", "--", "--check"]
+        args: ["--all"]
 
       - id: cargo-clippy
         name: Cargo clippy


### PR DESCRIPTION
## Summary

- Switch `cargo-fmt` pre-commit hook from check-only mode (`--check`) to auto-format
- Files will now be formatted in-place before commit instead of failing the hook

## Test plan

- [ ] Make a formatting change and verify `git commit` auto-formats rather than errors