### PR TITLE
docs: add Ctrl+S/Z/U keybindings and fix stale documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,8 @@ cargo run --bin thurbox-mcp         # Run (stdin/stdout JSON-RPC)
 | `delete_project` | Soft-delete a project (preserves for undo) |
 | `list_roles` | List all roles for a project (by name or UUID) |
 | `set_roles` | Atomically replace all roles for a project |
+| `list_mcp_servers` | List MCP servers for a project |
+| `set_mcp_servers` | Set MCP servers for a project |
 | `list_sessions` | List sessions, optionally filtered by project |
 | `get_session` | Get a session by UUID |
 | `delete_session` | Soft-delete a session (TUI cleans up tmux/worktree) |
@@ -288,10 +290,11 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+K` | Previous project (project focus) / session | Vim: **k** = up |
 | `Ctrl+L` | Cycle focus | Vim: **l** = right |
 | `Ctrl+D` | Delete session/project | Vim: **d** = delete |
-| `Ctrl+E` | Edit active project (name, repos, roles) | **E**dit |
+| `Ctrl+E` | Edit active project (name, repos, roles, MCP servers) | **E**dit |
 | `Ctrl+R` | Restart active session | **R**estart |
-| `Ctrl+Z` | Undo session delete | **Z** = undo |
-| `Ctrl+U` | Restore deleted session | **U**ndelete |
+| `Ctrl+S` | Sync worktrees with origin/main | **S**ync |
+| `Ctrl+Z` | Undo session/project delete | **Z** = undo |
+| `Ctrl+U` | Restore deleted sessions | **U**ndelete |
 | `F1` | Help overlay | Universal |
 | `F2` | Toggle info panel (visible at width >= 120) | Next to F1 |
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ own tmux pane. Sessions persist across crashes, restarts, and
 even multiple concurrent Thurbox instances — tmux keeps them
 alive in the background. Restart a session with `Ctrl+R` to
 pick up new role permissions while preserving conversation
-history via `--resume`. Recover sessions externally at any time
-with `tmux -L thurbox attach`.
+history via `--resume`. Each session displays elapsed time
+("Waiting 45s", "Idle 2m") and highlights clickable URLs in
+terminal output. Recover sessions externally at any time with
+`tmux -L thurbox attach`.
 
 ### Project Management
 
@@ -27,19 +29,24 @@ Organize work into projects, each with its own sessions and
 settings. The two-section left sidebar shows all projects on top
 and the active project's sessions below. Projects support
 multiple repositories — the first repo becomes the working
-directory and the rest are passed via `--add-dir`. Edit projects
-on the fly with `Ctrl+E` without losing running sessions.
-A built-in Admin project (pinned at index 0) provides
-conversational access to Thurbox management via MCP.
+directory and the rest are passed via `--add-dir`. Edit
+projects on the fly with `Ctrl+E` (name, repos, roles, MCP
+servers) without losing running sessions. Soft-deleted
+projects and sessions can be restored via the Admin session
+or MCP API. A built-in Admin project (pinned at index 0)
+provides conversational access to Thurbox management via MCP.
 
 ### Git Worktree Support
 
 Optionally spawn sessions inside git worktrees for branch
 isolation. When creating a session (`Ctrl+N`), choose "Worktree"
 mode to select a base branch and name a new branch — Thurbox
-creates the worktree and launches Claude inside it. Closing the
-session automatically removes the worktree. Worktree sessions
-show the branch name in the terminal title and session list.
+creates the worktree and launches Claude inside it. Press
+`Ctrl+S` to sync all worktree sessions with `origin/main` —
+on rebase conflicts, Thurbox automatically sends a resolution
+prompt to Claude. Closing the session automatically removes
+the worktree. Worktree sessions show the branch name in the
+terminal title and session list.
 
 ### Role System
 
@@ -129,9 +136,10 @@ The binary will be available at `target/release/thurbox`.
    Claude Code session. All keys are forwarded to the PTY.
 5. **Navigate** — `Ctrl+L` cycles focus (project list → session
    list → terminal). `Ctrl+H` jumps to the project list.
-   `Ctrl+J` / `Ctrl+K` switch sessions.
+   `Ctrl+J` / `Ctrl+K` switch projects or sessions.
 6. **Manage projects** — `Ctrl+E` edits the active project
-   (name, repos, roles). `Ctrl+D` deletes a session or project.
+   (name, repos, roles, MCP servers). `Ctrl+D` deletes a
+   session or project.
 7. **Restart a session** — `Ctrl+R` restarts with `--resume` to
    preserve conversation history while picking up new
    role permissions.
@@ -148,12 +156,15 @@ The binary will be available at `target/release/thurbox`.
 | `Ctrl+N` | New project or session | **N**ew |
 | `Ctrl+C` | Close active session | **C**lose |
 | `Ctrl+H` | Focus project list | Vim: **h** = left |
-| `Ctrl+J` | Next session | Vim: **j** = down |
-| `Ctrl+K` | Previous session | Vim: **k** = up |
+| `Ctrl+J` | Next project (project list) / session | Vim: **j** = down |
+| `Ctrl+K` | Previous project (project list) / session | Vim: **k** = up |
 | `Ctrl+L` | Cycle focus | Vim: **l** = right |
 | `Ctrl+D` | Delete session or project | Vim: **d** = delete |
 | `Ctrl+E` | Edit active project | **E**dit |
 | `Ctrl+R` | Restart active session | **R**estart |
+| `Ctrl+S` | Sync worktrees with origin/main | **S**ync |
+| `Ctrl+Z` | Undo session/project delete | **Z** = undo |
+| `Ctrl+U` | Restore deleted sessions | **U**ndelete |
 | `F1` | Help overlay | Universal |
 | `F2` | Toggle info panel | Next to F1 |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -338,7 +338,7 @@ delivers pixel-perfect rendering with all original formatting.
 
 ---
 
-## ADR-7: Multi-Instance Sync — SQLite with PRAGMA data_version
+## ADR-7b: Multi-Instance Sync — SQLite with PRAGMA data_version
 
 **Choice**: Multiple thurbox instances synchronize all state
 (projects, sessions, roles, worktrees) via a shared SQLite database

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -51,13 +51,9 @@ at `~/.local/share/thurbox/thurbox.db` (`$XDG_DATA_HOME` respected).
 Projects are created and edited via the TUI (add-project modal
 with `Ctrl+N`, edit with `Ctrl+E`).
 
-If the database is empty on first launch, Thurbox creates an
-ephemeral Default project using the current working directory.
-The Default project is not persisted to the database.
-
-On upgrade from a version that used `config.toml`, roles are
-automatically migrated to the database on first launch. The
-old `config.toml` is renamed to `config.toml.bak`.
+If the database is empty on first launch, only the built-in
+Admin project is present. Users create their first project via
+`Ctrl+N` or through the Admin session.
 
 ### Edit project modal
 
@@ -128,13 +124,16 @@ for actions (`C`=close, `D`=delete, `N`=new, `R`=restart, `Q`=quit).
 | `Ctrl+N` | Session list / Terminal | New session (mode selector, then optional branch selector) | **N**ew |
 | `Ctrl+C` | Global | Close active session | **C**lose |
 | `Ctrl+H` | Global | Focus project list | Vim: **h** = left |
-| `Ctrl+J` | Global | Next session within active project | Vim: **j** = down |
-| `Ctrl+K` | Global | Previous session within active project | Vim: **k** = up |
+| `Ctrl+J` | Global | Next project (project list focused) or session | Vim: **j** = down |
+| `Ctrl+K` | Global | Previous project (project list focused) or session | Vim: **k** = up |
 | `Ctrl+L` | Global | Cycle focus: Project → Session → Terminal | Vim: **l** = right |
 | `Ctrl+D` | Session list | Close active session | Vim: **d** = delete |
 | `Ctrl+D` | Project list | Delete selected project | Vim: **d** = delete |
-| `Ctrl+E` | Global | Edit active project (name, repos, roles) | **E**dit |
+| `Ctrl+E` | Global | Edit active project (name, repos, roles, MCP servers) | **E**dit |
 | `Ctrl+R` | Global | Restart active session | **R**estart |
+| `Ctrl+S` | Global | Sync all worktree sessions with origin/main | **S**ync |
+| `Ctrl+Z` | Global | Undo session/project delete | **Z** = undo |
+| `Ctrl+U` | Global | Restore deleted sessions | **U**ndelete |
 | `F1` | Global | Show help overlay | Universal help |
 | `F2` | Global | Toggle info panel | Next to F1 |
 | `j` / `Down` | Project list | Next project | |
@@ -386,9 +385,9 @@ reconstructed on restore.
 ### Multi-instance support
 
 Multiple thurbox instances can view the same tmux sessions.
-The primary instance (first to connect) uses `pipe-pane` for
-real-time output streaming. Input can be sent from any instance
-via the pane TTY.
+Each instance independently connects to tmux in control mode
+(`-C`). Tmux broadcasts `%output` notifications to all connected
+clients — there is no primary/secondary distinction.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ event loop), see [`CLAUDE.md`](../CLAUDE.md).
 | [CONSTITUTION.md](CONSTITUTION.md) | Core principles | Adding/removing an enforced invariant |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Architecture decisions | Changing a technology or structural pattern |
 | [FEATURES.md](FEATURES.md) | Feature-level design | Altering keybindings, lifecycle, layout, or UX |
+| [MCP_ROLES.md](MCP_ROLES.md) | MCP role configuration | Adding/changing role config, permission modes, tool patterns |
 
 ## Keeping Docs Current
 


### PR DESCRIPTION
## Summary

- Add `Ctrl+S` (sync), `Ctrl+Z` (undo delete), and `Ctrl+U` (restore sessions) to keybinding tables in README.md, CLAUDE.md, and docs/FEATURES.md
- Fix `Ctrl+J`/`Ctrl+K` descriptions to reflect context-sensitivity (project list vs session)
- Update `Ctrl+E` description to include MCP servers across all docs
- Add elapsed time display and URL highlighting to README session section
- Add soft-delete/restore and worktree sync (`Ctrl+S`) details to README features
- Replace stale Default project text with Admin-only first-launch description; remove obsolete TOML migration note
- Replace pipe-pane multi-instance description with accurate control mode description
- Rename duplicate `ADR-7` heading to `ADR-7b` in ARCHITECTURE.md
- Add `MCP_ROLES.md` row to docs/README.md documents table
- Add `list_mcp_servers` and `set_mcp_servers` to CLAUDE.md MCP tools table

## Test plan

- [x] `rumdl check .` passes with no issues
- [x] All three keybinding tables (README.md, CLAUDE.md, FEATURES.md) are consistent
- [x] No merge conflict markers remain in any file