### PR TITLE
feat(core): add env vars to roles with TUI editor and tmux injection

### DIFF
--- a/docs/MCP_ROLES.md
+++ b/docs/MCP_ROLES.md
@@ -23,6 +23,11 @@ claude --permission-mode <mode> \
        --append-system-prompt "<text>"
 ```
 
+Roles can also carry environment variables (`env`) that are
+injected into the session's tmux pane at spawn time via
+`tmux new-window -e KEY=VALUE`. This is useful for API keys,
+custom paths, or feature flags.
+
 Each project can have zero or more roles. Sessions select a role
 at creation time. If no roles are defined, sessions spawn with
 default (empty) permissions.
@@ -135,6 +140,7 @@ Tool lists are JSON arrays of strings:
 | `disallowed_tools` | string[] | no | `[]` | Tools that are blocked entirely. See [Tool Name Format](#tool-name-format). |
 | `tools` | string \| null | no | `null` | Restrict available tool set. `"default"` = all tools, `""` = none, or comma-separated list. |
 | `append_system_prompt` | string \| null | no | `null` | Text appended to Claude's system prompt for this role. |
+| `env` | object | no | `{}` | Environment variables passed to sessions using this role (key-value string pairs). |
 
 ### Validation rules
 
@@ -315,6 +321,23 @@ Atomically replace all roles for a project.
   "allowed_tools": ["Read", "Grep", "Glob", "WebFetch"],
   "disallowed_tools": ["Edit", "Write", "Bash", "NotebookEdit"],
   "append_system_prompt": "You are performing a security audit. Report findings but do not modify any files."
+}
+```
+
+### API Worker — with environment variables
+
+```json
+{
+  "name": "api-worker",
+  "description": "API development with custom environment",
+  "permission_mode": "acceptEdits",
+  "allowed_tools": ["Read", "Edit", "Bash(cargo:*)"],
+  "disallowed_tools": [],
+  "env": {
+    "API_KEY": "sk-test-123",
+    "DATABASE_URL": "postgres://localhost/dev",
+    "RUST_LOG": "debug"
+  }
 }
 ```
 

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -77,6 +77,11 @@ pub struct RoleInput {
     pub tools: Option<String>,
     #[schemars(description = "Text appended to Claude's system prompt for this role")]
     pub append_system_prompt: Option<String>,
+    #[serde(default)]
+    #[schemars(
+        description = "Environment variables passed to sessions using this role (e.g. {\"API_KEY\": \"sk-...\", \"PATH_EXTRA\": \"/opt/bin\"})"
+    )]
+    pub env: HashMap<String, String>,
 }
 
 /// Parameters for the `set_roles` tool.
@@ -179,6 +184,8 @@ pub struct RoleResponse {
     pub tools: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub append_system_prompt: Option<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -112,6 +112,9 @@ pub struct RolePermissions {
     /// Text appended to Claude's system prompt for sessions using this role.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub append_system_prompt: Option<String>,
+    /// Environment variables injected into the spawned session process.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
 }
 
 /// A named role definition.
@@ -414,6 +417,7 @@ mod tests {
         assert!(perms.disallowed_tools.is_empty());
         assert!(perms.tools.is_none());
         assert!(perms.append_system_prompt.is_none());
+        assert!(perms.env.is_empty());
     }
 
     #[test]
@@ -424,6 +428,7 @@ mod tests {
             disallowed_tools: vec![],
             tools: None,
             append_system_prompt: Some("Be careful".to_string()),
+            env: HashMap::new(),
         };
         let serialized = toml::to_string_pretty(&perms).unwrap();
         let deserialized: RolePermissions = toml::from_str(&serialized).unwrap();
@@ -438,6 +443,21 @@ mod tests {
             disallowed_tools: vec!["Edit".to_string()],
             tools: Some("default".to_string()),
             append_system_prompt: Some("Be careful".to_string()),
+            env: HashMap::new(),
+        };
+        let serialized = toml::to_string_pretty(&perms).unwrap();
+        let deserialized: RolePermissions = toml::from_str(&serialized).unwrap();
+        assert_eq!(perms, deserialized);
+    }
+
+    #[test]
+    fn role_permissions_env_serde_roundtrip() {
+        let perms = RolePermissions {
+            env: HashMap::from([
+                ("API_KEY".to_string(), "sk-secret".to_string()),
+                ("DEBUG".to_string(), "1".to_string()),
+            ]),
+            ..RolePermissions::default()
         };
         let serialized = toml::to_string_pretty(&perms).unwrap();
         let deserialized: RolePermissions = toml::from_str(&serialized).unwrap();

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1,7 +1,7 @@
 use rusqlite::Connection;
 
 /// Current schema version. Incremented when schema changes.
-pub const SCHEMA_VERSION: u32 = 7;
+pub const SCHEMA_VERSION: u32 = 8;
 
 /// Create all tables and indexes if they don't exist.
 pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
@@ -88,6 +88,7 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             disallowed_tools    TEXT NOT NULL DEFAULT '',
             tools               TEXT,
             append_system_prompt TEXT,
+            env                 TEXT NOT NULL DEFAULT '',
             created_at          INTEGER NOT NULL,
             updated_at          INTEGER NOT NULL,
             PRIMARY KEY (project_id, role_name)
@@ -207,6 +208,14 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
     if version < 7 {
         // v6 → v7: add shell_backend_id column to sessions
         let _ = conn.execute("ALTER TABLE sessions ADD COLUMN shell_backend_id TEXT", []);
+    }
+
+    if version < 8 {
+        // v7 → v8: add env column to project_roles (JSON-encoded environment variables)
+        let _ = conn.execute(
+            "ALTER TABLE project_roles ADD COLUMN env TEXT NOT NULL DEFAULT ''",
+            [],
+        );
     }
 
     if version < SCHEMA_VERSION {


### PR DESCRIPTION
## Summary

- Add `env: HashMap<String, String>` to `RolePermissions` and store it as JSON in `project_roles` (schema v8 migration)
- Inject env vars into tmux sessions via `new-window -e KEY=VALUE`; shell panes (Ctrl+T) inherit the same role env
- Fix quoting bug: values with spaces are now quoted as a single `KEY=VALUE` unit so tmux parses them correctly
- TUI role editor gains an **Env** list field (same add/delete/navigate UX as allowed/disallowed tools)
- MCP `set_roles` / `list_roles` / `get_project` expose `env` on `RoleInput` and `RoleResponse`
- Redundant `SessionConfig.env` field removed (DRY — `permissions.env` is the single source of truth)
- 6 new tests: serde roundtrip, tmux flag construction, JSON helpers, MCP integration

## Test plan

- [x] `cargo nextest run --all` — 601 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] Manual: create role with env via MCP `set_roles`, spawn session, verify `env | grep KEY`
- [ ] Manual: edit role env in TUI editor, restart session, verify updated env
- [ ] Manual: Ctrl+T shell pane inherits role env vars