### PR TITLE
fix(mcp): expose env field in set_roles tool description

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -251,7 +251,7 @@ impl ThurboxMcp {
     }
 
     #[tool(
-        description = "Atomically replace all roles for a project. Deletes existing roles and inserts the provided list in a single transaction. To add a role, include all existing roles plus the new one. To clear all roles, pass an empty array. Each role has: name (1-64 chars, unique), description, permission_mode (default/plan/acceptEdits/dontAsk/bypassPermissions), allowed_tools, disallowed_tools, tools, append_system_prompt. See docs/MCP_ROLES.md for the complete guide."
+        description = "Atomically replace all roles for a project. Deletes existing roles and inserts the provided list in a single transaction. To add a role, include all existing roles plus the new one. To clear all roles, pass an empty array. Each role has: name (1-64 chars, unique), description, permission_mode (default/plan/acceptEdits/dontAsk/bypassPermissions), allowed_tools, disallowed_tools, tools, append_system_prompt, env (object of key-value environment variables injected into sessions). See docs/MCP_ROLES.md for the complete guide."
     )]
     fn set_roles(&self, Parameters(params): Parameters<SetRolesParams>) -> String {
         let db = self.db.lock().unwrap();


### PR DESCRIPTION
## Summary

- Add `env` to the `set_roles` tool description text so MCP clients discover environment variable support on roles
- The `env` field was already wired through the JSON Schema (`RoleInput`) but was absent from the human-readable description, making it invisible to LLM-based clients

## Test plan

- [x] `cargo check --all` — clean
- [ ] Manual: confirm Admin session Claude can set env vars on roles via natural language