### PR TITLE
feat(core): add QEMU/KVM sandbox VM session backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,12 +223,16 @@ app      ← coordinator, imports all modules
 - **`agent/`** — Side-effect layer. `AgentProvider` trait
   abstracts CLI command + arg construction (default:
   `ClaudeProvider`). `Session` wraps a `SessionBackend`
-  trait (default: `LocalTmuxBackend` using `tmux -L thurbox`).
-  Reads output into `Arc<Mutex<vt100::Parser>>`, writes input
-  via mpsc channel. `input.rs` translates crossterm `KeyCode`
-  → xterm ANSI bytes.
+  trait. `BackendRegistry` manages multiple backends
+  (default: `LocalTmuxBackend` using `tmux -L thurbox`,
+  optional: `QemuVmBackend` for sandboxed VM sessions).
+  `VmManager` handles QEMU/KVM VM lifecycle (create, start,
+  stop, destroy, restore). Reads output into
+  `Arc<Mutex<vt100::Parser>>`, writes input via mpsc channel.
+  `input.rs` translates crossterm `KeyCode` → xterm ANSI bytes.
 - **`session/`** — Plain data: `SessionId`, `SessionStatus`,
-  `SessionInfo`, `SessionConfig` (with optional `cwd`).
+  `SessionInfo` (with optional `vm_id`), `SessionConfig`
+  (with optional `cwd` and `vm_id`), `VmState`, `VmConfig`.
   No logic beyond Display/Default impls.
 - **`project/`** — Plain data: `ProjectId`,
   `ProjectConfig`, `ProjectInfo`. Imports `session` only.
@@ -243,7 +247,8 @@ app      ← coordinator, imports all modules
 ### Event Loop (main.rs)
 
 ```text
-tokio::main → init backend (tmux) → open SQLite DB
+tokio::main → init backends (BackendRegistry: local-tmux
+  + optional qemu-vm) → open SQLite DB
 → init terminal → spawn/restore sessions → loop {
     draw frame → poll crossterm events (10ms)
     → convert to AppMessage → app.update() → app.tick()
@@ -268,7 +273,8 @@ framework). Install with `prek install`. Stages:
 
 - MSRV: 1.75, Edition 2021
 - Async runtime: tokio (multi-threaded)
-- Session backend: `tmux -L thurbox` (dedicated server)
+- Session backends: `LocalTmuxBackend` (`tmux -L thurbox`)
+  and optional `QemuVmBackend` (tmux over SSH inside QEMU/KVM VMs)
 - Output reader runs in `tokio::task::spawn_blocking`
   (blocking I/O), writer in `tokio::spawn` (async)
 - Terminal state parsed by `vt100::Parser`,

--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ prompt to Claude. Closing the session automatically removes
 the worktree. Worktree sessions show the branch name in the
 terminal title and session list.
 
+### Sandbox VM Sessions
+
+Run sessions inside QEMU/KVM virtual machines for full OS-level
+isolation. Choose "Sandbox VM" in the session mode selector —
+Thurbox provisions a Debian 13 (Trixie) VM with 2 CPUs, 2 GB
+RAM, and a 10 GB qcow2 overlay disk, bootstrapped via
+cloud-init with tmux, git, rsync, and the Claude CLI
+pre-installed. SSH readiness is polled over user-mode networking
+(ports 22200+), then the Claude session is spawned inside the
+VM over SSH-tunneled tmux. VMs survive Thurbox restarts and are
+automatically re-adopted on next launch. If a VM has died,
+Thurbox re-provisions a new one with `--resume` to preserve
+conversation history. Requires `qemu-system-x86_64`, `/dev/kvm`,
+and `genisoimage` (or `mkisofs`).
+
 ### Role System
 
 Define per-project permission profiles that control Claude's
@@ -121,6 +136,8 @@ The binary will be available at `target/release/thurbox`.
 - **tmux >= 3.2** — session backend
 - **claude CLI** — [github.com/anthropics/claude-code](https://github.com/anthropics/claude-code)
 - **git** — required for worktree features
+- **QEMU/KVM** — optional, for sandbox VM sessions
+  (`qemu-system-x86_64`, `/dev/kvm`, `genisoimage` or `mkisofs`)
 - **Rust 1.75+** — only needed for building from source
 
 ## Quick Start
@@ -130,8 +147,8 @@ The binary will be available at `target/release/thurbox`.
 2. **Create a project** — press `Ctrl+N` with the project list
    focused. Enter a name and one or more repository paths.
 3. **Create a session** — select your project, then press
-   `Ctrl+N` again. Choose a session mode (Normal or Worktree)
-   and optionally select a role.
+   `Ctrl+N` again. Choose a session mode (Normal, Worktree,
+   or Sandbox VM) and optionally select a role.
 4. **Work with Claude** — the terminal panel shows the live
    Claude Code session. All keys are forwarded to the PTY.
 5. **Navigate** — `Ctrl+L` cycles focus (project list → session
@@ -229,18 +246,20 @@ modes, tool name format, and example role patterns, see
 
 Thurbox follows **The Elm Architecture** (TEA):
 `Event → Message → update(model, msg) → view(model) → Frame`.
-All state lives in a single `App` model. Sessions run inside a
-dedicated tmux server (`tmux -L thurbox`), with terminal output
-parsed by `vt100::Parser` and rendered by `tui_term`. All
-persistent state (projects, sessions, roles) is stored in SQLite.
+All state lives in a single `App` model. Sessions run via a
+pluggable `SessionBackend` trait with a `BackendRegistry` that
+manages multiple backends: local tmux (`tmux -L thurbox`) and
+optional QEMU/KVM VMs (tmux over SSH). Terminal output is parsed
+by `vt100::Parser` and rendered by `tui_term`. All persistent
+state (projects, sessions, roles, VMs) is stored in SQLite.
 
 ### Module Dependency Rules
 
 ```text
 session  ← pure data types, no project-local imports
 project  ← imports session only
-claude   ← imports session only (NEVER ui, git, or project)
-ui       ← imports session and project only (NEVER claude or git)
+agent    ← imports session only (NEVER ui, git, or project)
+ui       ← imports session and project only (NEVER agent or git)
 mcp      ← imports storage, session, project, sync, paths only
 app      ← coordinator, imports all modules
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -262,8 +262,9 @@ without touching `App`, `Session`, or any UI code.
 - *Async trait methods* — added complexity for no benefit since
   all current backends use synchronous `Command::new("tmux")`.
   Can be added via `async-trait` if a future backend needs it.
-- *Backend per session* — over-engineering; all sessions in a
-  thurbox instance share the same backend.
+- *Backend per session* — initially rejected as over-engineering,
+  later revisited in ADR-15 when VM support required per-session
+  backend routing.
 
 ---
 
@@ -471,3 +472,63 @@ trivially testable. Composite styles (e.g., `focused_title()`) are
   Can be layered on top later if user-selectable themes are added.
 - *CSS-like stylesheets* — no Rust TUI framework supports this
   natively; would require a custom parser and resolver.
+
+---
+
+## ADR-15: Multi-backend architecture and QEMU VM sessions
+
+**Choice**: Sessions select their backend at creation time via a
+`BackendRegistry`. Each session stores its `backend_type` (e.g.,
+`"local-tmux"` or `"qemu-vm"`) in the database. The registry routes
+spawn, adopt, discover, and other operations to the correct backend.
+
+**Why**: VM-sandboxed sessions need a fundamentally different
+transport (SSH into a QEMU/KVM guest) but share the same session
+lifecycle. Rather than forking the session logic, the existing
+`SessionBackend` trait is reused with a second implementation
+(`QemuVmBackend`) that tunnels tmux control mode over SSH.
+
+**Key components**:
+
+- `BackendRegistry` — maps backend names to `Arc<dyn SessionBackend>`.
+  Created at startup with `LocalTmuxBackend` as default, optionally
+  registers `QemuVmBackend`. `all_backends()` enables multi-backend
+  discovery during session restoration.
+- `QemuVmBackend` — implements `SessionBackend` by running tmux
+  commands over SSH (`ssh -o ControlPath=... tmux -L thurbox ...`).
+  Uses SSH control mode (`-C`) for multiplexed connections.
+  `prepare_vm()` establishes the SSH control master before any
+  session operations.
+- `VmManager` — owns QEMU/KVM VM lifecycle: create (Debian 13
+  Trixie base image, qcow2 CoW overlay, cloud-init ISO with
+  tmux/git/rsync/Claude CLI), start (`qemu-system-x86_64` with
+  `-enable-kvm -cpu host`, 2 CPUs, 2 GB RAM, 10 GB disk, user-mode
+  networking on ports 22200+), stop, destroy. Tracks `VmInstance`
+  state (`Creating`, `Starting`, `Ready`, `Stopping`, `Stopped`,
+  `Error`). `restore_vm()` re-hydrates a running VM from DB
+  records on restart.
+- `VM_ID_ENV_KEY` (`__THURBOX_VM_ID`) — internal env variable
+  injected by `Session::spawn()` / `restart()` / `ensure_shell_pane()`
+  so the backend can route to the correct VM instance.
+
+**Session restoration**: On restart, `restore_sessions()` discovers
+sessions from all registered backends (not just default). For VM
+sessions, it calls `VmManager::restore_vm()` to verify the QEMU
+process is still running via SSH probe, then re-establishes the
+SSH control mode connection before adopting the tmux pane inside
+the VM.
+
+**VM state persistence**: The `vms` table stores VM records with
+`session_id REFERENCES sessions(id)` (FK constraint). The
+`update_vm_session()` call must happen after `save_state()` to
+satisfy the FK constraint.
+
+**Rejected**:
+
+- *Single backend for all sessions (ADR-11 original)* — VM sessions
+  need SSH transport; can't share a single local-tmux backend.
+- *Separate session type for VMs* — duplicates lifecycle logic;
+  the trait abstraction handles the difference cleanly.
+- *Docker instead of QEMU* — QEMU provides full OS isolation with
+  KVM acceleration; Docker shares the host kernel and is less
+  suitable for untrusted code sandboxing.

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -58,8 +58,10 @@ No ad-hoc event handlers, no component-local state, no callback chains.
 ### 8. Backend-first session model
 
 Claude Code sessions run via a pluggable `SessionBackend` trait.
-The default backend is local tmux (`tmux -L thurbox`), which
-provides truly persistent sessions that survive crashes/restarts.
+A `BackendRegistry` manages multiple backends: the default is
+local tmux (`tmux -L thurbox`), with optional QEMU/KVM VM
+support (`QemuVmBackend` via SSH-tunneled tmux). Both provide
+truly persistent sessions that survive crashes/restarts.
 We never mock, emulate, or screen-scrape a fake terminal.
 The backend is the source of truth for session lifecycle.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -666,6 +666,94 @@ lines instead of blank lines, improving visual structure.
 
 ---
 
+## Sandbox VM Sessions
+
+Sessions can run inside QEMU/KVM virtual machines for full OS-level
+isolation. This is opt-in: the session mode selector modal offers
+"Sandbox VM" alongside "Normal" and "Worktree".
+
+### VM specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Base image | Debian 13 (Trixie) genericcloud amd64 qcow2 |
+| CPUs | 2 |
+| RAM | 2048 MB |
+| Disk | 10 GB qcow2 CoW overlay |
+| Networking | User-mode (SLIRP), SSH on ports 22200+ |
+| SSH user | `thurbox` (ed25519 ephemeral key) |
+| Packages | tmux, git, rsync, curl, Claude CLI |
+| Boot timeout | 120 seconds |
+
+Base images are cached at `~/.local/share/thurbox/images/`.
+Per-VM state (disk overlay, cloud-init ISO, SSH keys, PID file)
+lives under `~/.local/share/thurbox/vms/<vm-uuid>/`.
+
+### Host requirements
+
+- `qemu-system-x86_64` with `/dev/kvm` support
+- `genisoimage` or `mkisofs` (cloud-init ISO creation)
+- `ssh-keygen`, `rsync`
+
+### How it works
+
+1. `Ctrl+N` triggers session creation.
+2. The session mode modal offers "Normal", "Worktree", or
+   "Sandbox VM".
+3. Choosing "Sandbox VM" starts asynchronous VM provisioning:
+   - Downloads the Debian 13 base image (once, cached)
+   - Creates a qcow2 CoW overlay disk
+   - Generates cloud-init ISO (SSH key, user setup, packages)
+   - Launches QEMU with KVM acceleration (`-enable-kvm -cpu host`)
+   - Polls SSH readiness every 500ms (up to 120s timeout)
+4. Once the VM is ready, a tmux session is spawned inside the VM
+   over SSH, and the Claude Code CLI starts with `--resume`.
+
+### VM lifecycle
+
+VMs are managed by `VmManager` with a state machine:
+
+```text
+Creating → Starting → Ready → Stopping → Stopped
+                        ↓
+                      Error
+```
+
+- **Creating**: Disk overlay and cloud-init are being prepared.
+- **Starting**: QEMU process launched, waiting for SSH.
+- **Ready**: SSH is reachable, sessions can be spawned.
+- **Stopping/Stopped**: VM is shutting down or has been destroyed.
+- **Error**: VM failed to start or SSH probe failed.
+
+### Session restoration
+
+QEMU VMs survive Thurbox restarts (they are separate processes).
+On restart, Thurbox:
+
+1. Discovers sessions from all registered backends (local-tmux
+   and qemu-vm).
+2. For VM sessions, calls `VmManager::restore_vm()` to verify
+   the QEMU process is still running via SSH probe.
+3. Re-establishes the SSH control mode connection.
+4. Adopts the tmux pane inside the VM with terminal content intact.
+5. If the VM has died, falls through to re-provision a new VM
+   with `--resume` to preserve conversation history.
+
+### VM state persistence
+
+VM records are stored in the `vms` SQLite table with a foreign key
+to `sessions(id)`. Fields include VM ID, SSH port, state, config,
+and associated session ID.
+
+### UI indicators
+
+- **Session mode modal**: "Sandbox VM" option with description.
+- **Info panel**: Shows VM ID, SSH port, and provisioning status
+  for VM-backed sessions.
+- **Status bar**: Provisioning steps displayed during VM creation.
+
+---
+
 ## Planned Features
 
 Directional intent, not commitments.

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -14,6 +14,12 @@ use tracing::{debug, error};
 use crate::agent::provider::AgentProvider;
 use crate::session::{SessionConfig, SessionInfo};
 
+/// Internal env key used to pass the target VM ID through `SessionBackend::spawn()`.
+///
+/// Injected by `Session::spawn/restart/ensure_shell_pane` when `SessionConfig.vm_id` is set;
+/// consumed by `QemuVmBackend::spawn()` to route the session to the correct VM.
+pub(crate) const VM_ID_ENV_KEY: &str = "__THURBOX_VM_ID";
+
 pub(crate) fn now_millis() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -94,6 +100,21 @@ pub trait SessionBackend: Send + Sync {
 
     /// Detach from a session without killing it (for Ctrl+Q quit).
     fn detach(&self, backend_id: &str) -> Result<()>;
+
+    /// Prepare a VM for session spawning (e.g., establish SSH control mode).
+    ///
+    /// No-op for non-VM backends. VM backends use this to set up the control
+    /// mode connection after provisioning completes.
+    fn prepare_vm(&self, _vm_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    /// Default shell command for companion shell panes.
+    ///
+    /// Local backends use `$SHELL`; VM backends return the VM's default shell.
+    fn default_shell(&self) -> String {
+        std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
+    }
 }
 
 /// Internal bundle of I/O handles before wiring.
@@ -171,12 +192,18 @@ impl Session {
         let args = provider.build_args(config);
         let window_name = format!("tb-{name}");
 
+        // Build env map, injecting VM_ID_ENV_KEY if a VM target is specified.
+        let mut env = config.permissions.env.clone();
+        if let Some(ref vm_id) = config.vm_id {
+            env.insert(VM_ID_ENV_KEY.to_string(), vm_id.clone());
+        }
+
         let spawned = backend.spawn(
             &window_name,
             provider.command(),
             &args,
             config.cwd.as_deref(),
-            &config.permissions.env,
+            &env,
             rows,
             cols,
         )?;
@@ -402,12 +429,19 @@ impl Session {
 
         let args = self.provider.build_args(config);
         let window_name = format!("tb-{}", self.info.name);
+
+        // Inject __THURBOX_VM_ID for VM-backed sessions (same as Session::spawn).
+        let mut env = config.permissions.env.clone();
+        if let Some(ref vm_id) = config.vm_id {
+            env.insert(VM_ID_ENV_KEY.to_string(), vm_id.clone());
+        }
+
         let spawned = self.backend.spawn(
             &window_name,
             self.provider.command(),
             &args,
             config.cwd.as_deref(),
-            &config.permissions.env,
+            &env,
             rows,
             cols,
         )?;
@@ -469,15 +503,22 @@ impl Session {
             return Ok(());
         }
 
-        let shell_cmd = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let shell_cmd = self.backend.default_shell();
         let window_name = format!("tbs-{}", self.info.name);
+
+        // Inject __THURBOX_VM_ID for VM-backed sessions so the backend
+        // knows which VM to create the shell pane in.
+        let mut env = self.env.clone();
+        if let Some(ref vm_id) = self.info.vm_id {
+            env.insert(VM_ID_ENV_KEY.to_string(), vm_id.clone());
+        }
 
         let spawned = self.backend.spawn(
             &window_name,
             &shell_cmd,
             &[],
             self.info.cwd.as_deref(),
-            &self.env,
+            &env,
             rows,
             cols,
         )?;
@@ -563,5 +604,11 @@ mod tests {
         let ms = now_millis();
         // Should be after 2024-01-01 (1704067200000 ms since epoch).
         assert!(ms > 1_704_067_200_000);
+    }
+
+    #[test]
+    fn vm_id_env_key_is_internal() {
+        // The key should start with __ to signal it's an internal implementation detail.
+        assert!(VM_ID_ENV_KEY.starts_with("__"));
     }
 }

--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -1,0 +1,574 @@
+//! Shared tmux control mode I/O infrastructure.
+//!
+//! This module contains the transport-agnostic control mode parsing and I/O types
+//! used by both `LocalTmuxBackend` (local tmux) and `QemuVmBackend` (SSH into VM).
+//! The tmux control mode protocol is identical whether accessed locally or over SSH.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::sync::mpsc::SyncSender;
+use std::sync::{Arc, Mutex};
+
+/// Per-pane output channel capacity. Sized large enough to buffer heavy output
+/// bursts; chunks are dropped (not blocked) when full to keep the reader thread alive.
+pub const PANE_CHANNEL_CAPACITY: usize = 4096;
+
+/// Type alias for pane sender broadcast map.
+/// Maps pane IDs to vectors of sync senders for multi-instance output broadcast.
+pub type PaneSendersMap = HashMap<String, Vec<SyncSender<Vec<u8>>>>;
+pub type PaneSendersMapShared = Arc<Mutex<PaneSendersMap>>;
+
+/// Response from a tmux control mode command.
+pub struct CommandResponse {
+    pub lines: Vec<String>,
+    pub is_error: bool,
+}
+
+/// Parsed notification from the tmux control mode protocol.
+#[derive(Debug, PartialEq)]
+pub enum Notification {
+    Output { pane_id: String, data: Vec<u8> },
+    Begin,
+    End,
+    Error,
+    Pause { pane_id: String },
+    Other(String),
+}
+
+/// Per-pane reader that receives output via an mpsc channel.
+///
+/// Implements `Read` so it plugs directly into the existing `Session::reader_loop`.
+pub struct ControlModeReader {
+    receiver: std::sync::mpsc::Receiver<Vec<u8>>,
+    buffer: Vec<u8>,
+    pos: usize,
+}
+
+impl ControlModeReader {
+    pub fn new(receiver: std::sync::mpsc::Receiver<Vec<u8>>) -> Self {
+        Self {
+            receiver,
+            buffer: Vec::new(),
+            pos: 0,
+        }
+    }
+}
+
+impl Read for ControlModeReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // Drain leftover buffered data first.
+        if self.pos < self.buffer.len() {
+            let remaining = &self.buffer[self.pos..];
+            let n = remaining.len().min(buf.len());
+            buf[..n].copy_from_slice(&remaining[..n]);
+            self.pos += n;
+            if self.pos == self.buffer.len() {
+                self.buffer.clear();
+                self.pos = 0;
+            }
+            return Ok(n);
+        }
+
+        // Block until the next chunk arrives.
+        match self.receiver.recv() {
+            Ok(data) => {
+                let n = data.len().min(buf.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                if n < data.len() {
+                    self.buffer = data;
+                    self.pos = n;
+                }
+                Ok(n)
+            }
+            Err(_) => Ok(0), // Channel closed → EOF.
+        }
+    }
+}
+
+/// Per-pane writer that sends input via `send-keys -H` through the shared control stdin.
+pub struct ControlModeWriter {
+    pub stdin: Arc<Mutex<std::process::ChildStdin>>,
+    pub pane_id: String,
+}
+
+impl Write for ControlModeWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let cmd = format_send_keys(&self.pane_id, buf);
+        let mut stdin = self
+            .stdin
+            .lock()
+            .map_err(|e| std::io::Error::other(format!("stdin lock: {e}")))?;
+        stdin.write_all(cmd.as_bytes())?;
+        stdin.flush()?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Decode tmux control mode octal escapes in `%output` data.
+///
+/// Scans for `\` followed by exactly 3 octal digits (0-7). Emits the decoded byte.
+/// All other characters pass through unchanged.
+pub fn decode_octal(input: &str) -> Vec<u8> {
+    let mut result = Vec::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 3 < bytes.len() {
+            let d0 = bytes[i + 1];
+            let d1 = bytes[i + 2];
+            let d2 = bytes[i + 3];
+            if is_octal(d0) && is_octal(d1) && is_octal(d2) {
+                let val = (d0 - b'0') as u16 * 64 + (d1 - b'0') as u16 * 8 + (d2 - b'0') as u16;
+                result.push(val as u8);
+                i += 4;
+                continue;
+            }
+        }
+        result.push(bytes[i]);
+        i += 1;
+    }
+
+    result
+}
+
+fn is_octal(b: u8) -> bool {
+    (b'0'..=b'7').contains(&b)
+}
+
+/// Parse a line from tmux control mode into a notification.
+pub fn parse_notification(line: &str) -> Notification {
+    if let Some(rest) = line.strip_prefix("%output ") {
+        // Format: %output %<pane_id> <octal-encoded data>
+        if let Some(space_idx) = rest.find(' ') {
+            let pane_id = rest[..space_idx].to_string();
+            let data = decode_octal(&rest[space_idx + 1..]);
+            return Notification::Output { pane_id, data };
+        }
+    }
+
+    if let Some(rest) = line.strip_prefix("%extended-output ") {
+        // Format: %extended-output %<pane_id> <age> : <octal-encoded data>
+        // The " : " separator divides metadata from payload.
+        if let Some(colon_idx) = rest.find(" : ") {
+            let meta = &rest[..colon_idx];
+            let data = decode_octal(&rest[colon_idx + 3..]);
+            // meta is "%<pane_id> <age>" — extract pane_id.
+            if let Some(space_idx) = meta.find(' ') {
+                let pane_id = meta[..space_idx].to_string();
+                return Notification::Output { pane_id, data };
+            }
+        }
+    }
+
+    if line.starts_with("%begin ") {
+        return Notification::Begin;
+    }
+
+    if line.starts_with("%end ") {
+        return Notification::End;
+    }
+
+    if line.starts_with("%error ") {
+        return Notification::Error;
+    }
+
+    if let Some(rest) = line.strip_prefix("%pause ") {
+        // Format: %pause %<pane_id>
+        return Notification::Pause {
+            pane_id: rest.trim().to_string(),
+        };
+    }
+
+    Notification::Other(line.to_string())
+}
+
+/// Format a `send-keys -H` command for a pane.
+///
+/// Each byte is encoded as two hex digits.
+pub fn format_send_keys(pane_id: &str, bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    // "send-keys -t %NN -H" + " XX" per byte + "\n"
+    let mut cmd = String::with_capacity(20 + pane_id.len() + bytes.len() * 3 + 1);
+    write!(cmd, "send-keys -t {pane_id} -H").unwrap();
+    for &b in bytes {
+        write!(cmd, " {b:02x}").unwrap();
+    }
+    cmd.push('\n');
+    cmd
+}
+
+/// Shell-escape a string for safe inclusion in a tmux command.
+pub fn shell_escape(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    // If the string contains no special characters, return as-is.
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':' | '=' | ','))
+    {
+        return s.to_string();
+    }
+    // Wrap in single quotes, escaping existing single quotes.
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::sync_channel;
+
+    use super::*;
+
+    // --- shell_escape tests ---
+
+    #[test]
+    fn shell_escape_empty() {
+        assert_eq!(shell_escape(""), "''");
+    }
+
+    #[test]
+    fn shell_escape_simple() {
+        assert_eq!(shell_escape("hello"), "hello");
+    }
+
+    #[test]
+    fn shell_escape_path() {
+        assert_eq!(shell_escape("/home/user/repos/app"), "/home/user/repos/app");
+    }
+
+    #[test]
+    fn shell_escape_with_spaces() {
+        assert_eq!(shell_escape("hello world"), "'hello world'");
+    }
+
+    #[test]
+    fn shell_escape_with_quotes() {
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn shell_escape_flag_value() {
+        assert_eq!(shell_escape("--permission-mode"), "--permission-mode");
+    }
+
+    #[test]
+    fn shell_escape_tool_pattern() {
+        assert_eq!(shell_escape("Read Bash(git:*)"), "'Read Bash(git:*)'");
+    }
+
+    #[test]
+    fn shell_escape_allows_equals_comma() {
+        assert_eq!(shell_escape("key=val,other"), "key=val,other");
+    }
+
+    // --- decode_octal tests ---
+
+    #[test]
+    fn decode_octal_esc() {
+        assert_eq!(decode_octal("\\033"), vec![27]); // ESC
+    }
+
+    #[test]
+    fn decode_octal_backslash() {
+        assert_eq!(decode_octal("\\134"), vec![b'\\']);
+    }
+
+    #[test]
+    fn decode_octal_newline() {
+        assert_eq!(decode_octal("\\012"), vec![b'\n']);
+    }
+
+    #[test]
+    fn decode_octal_passthrough() {
+        assert_eq!(decode_octal("hello"), b"hello");
+    }
+
+    #[test]
+    fn decode_octal_incomplete() {
+        assert_eq!(decode_octal("\\01"), b"\\01");
+    }
+
+    #[test]
+    fn decode_octal_non_octal_digits() {
+        assert_eq!(decode_octal("\\089"), b"\\089");
+    }
+
+    #[test]
+    fn decode_octal_mixed() {
+        assert_eq!(
+            decode_octal("A\\033[1mB"),
+            vec![b'A', 27, b'[', b'1', b'm', b'B']
+        );
+    }
+
+    #[test]
+    fn decode_octal_consecutive() {
+        assert_eq!(decode_octal("\\033\\033"), vec![27, 27]);
+    }
+
+    #[test]
+    fn decode_octal_empty() {
+        assert_eq!(decode_octal(""), b"");
+    }
+
+    #[test]
+    fn decode_octal_trailing_backslash() {
+        assert_eq!(decode_octal("a\\"), b"a\\");
+    }
+
+    #[test]
+    fn decode_octal_max_value() {
+        assert_eq!(decode_octal("\\377"), vec![0xFF]);
+    }
+
+    #[test]
+    fn decode_octal_overflow_wraps() {
+        assert_eq!(decode_octal("\\400"), vec![0u8]);
+    }
+
+    // --- parse_notification tests ---
+
+    #[test]
+    fn parse_output_notification() {
+        let n = parse_notification("%output %42 hello\\033[1m");
+        assert_eq!(
+            n,
+            Notification::Output {
+                pane_id: "%42".to_string(),
+                data: vec![b'h', b'e', b'l', b'l', b'o', 27, b'[', b'1', b'm'],
+            }
+        );
+    }
+
+    #[test]
+    fn parse_extended_output_notification() {
+        let n = parse_notification("%extended-output %2 0 : \\033[?2026hA\\033[?2026l");
+        assert_eq!(
+            n,
+            Notification::Output {
+                pane_id: "%2".to_string(),
+                data: vec![
+                    27, b'[', b'?', b'2', b'0', b'2', b'6', b'h', b'A', 27, b'[', b'?', b'2', b'0',
+                    b'2', b'6', b'l'
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn parse_begin_notification() {
+        assert_eq!(
+            parse_notification("%begin 1234567890 7 0"),
+            Notification::Begin
+        );
+    }
+
+    #[test]
+    fn parse_end_notification() {
+        assert_eq!(parse_notification("%end 1234567890 7 0"), Notification::End);
+    }
+
+    #[test]
+    fn parse_error_notification() {
+        assert_eq!(
+            parse_notification("%error 1234567890 3 0"),
+            Notification::Error
+        );
+    }
+
+    #[test]
+    fn parse_pause_notification() {
+        assert_eq!(
+            parse_notification("%pause %42"),
+            Notification::Pause {
+                pane_id: "%42".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_other_notification() {
+        assert_eq!(
+            parse_notification("some random line"),
+            Notification::Other("some random line".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_output_no_data() {
+        assert_eq!(
+            parse_notification("%output %42"),
+            Notification::Other("%output %42".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_extended_output_no_colon_separator() {
+        assert_eq!(
+            parse_notification("%extended-output %2 0 data"),
+            Notification::Other("%extended-output %2 0 data".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_output_empty_data() {
+        let n = parse_notification("%output %42 ");
+        assert_eq!(
+            n,
+            Notification::Output {
+                pane_id: "%42".to_string(),
+                data: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn parse_pause_notification_with_leading_percent() {
+        assert_eq!(
+            parse_notification("%pause %123"),
+            Notification::Pause {
+                pane_id: "%123".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_extended_output_missing_pane_space() {
+        assert_eq!(
+            parse_notification("%extended-output %2 : data"),
+            Notification::Other("%extended-output %2 : data".to_string())
+        );
+    }
+
+    // --- format_send_keys tests ---
+
+    #[test]
+    fn format_send_keys_single_byte() {
+        assert_eq!(format_send_keys("%42", b"A"), "send-keys -t %42 -H 41\n");
+    }
+
+    #[test]
+    fn format_send_keys_multi_byte() {
+        assert_eq!(
+            format_send_keys("%42", b"ABC"),
+            "send-keys -t %42 -H 41 42 43\n"
+        );
+    }
+
+    #[test]
+    fn format_send_keys_empty() {
+        assert_eq!(format_send_keys("%42", &[]), "send-keys -t %42 -H\n");
+    }
+
+    #[test]
+    fn format_send_keys_escape_sequence() {
+        assert_eq!(
+            format_send_keys("%1", &[0x1b, b'[', b'A']),
+            "send-keys -t %1 -H 1b 5b 41\n"
+        );
+    }
+
+    // --- ControlModeReader tests ---
+
+    #[test]
+    fn control_mode_reader_data_delivery() {
+        let (tx, rx) = sync_channel(16);
+        let mut reader = ControlModeReader::new(rx);
+
+        tx.send(b"hello".to_vec()).unwrap();
+        let mut buf = [0u8; 16];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"hello");
+    }
+
+    #[test]
+    fn control_mode_reader_eof_on_sender_drop() {
+        let (tx, rx) = sync_channel(16);
+        let mut reader = ControlModeReader::new(rx);
+
+        drop(tx);
+        let mut buf = [0u8; 16];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(n, 0); // EOF
+    }
+
+    #[test]
+    fn control_mode_reader_partial_reads() {
+        let (tx, rx) = sync_channel(16);
+        let mut reader = ControlModeReader::new(rx);
+
+        tx.send(b"hello world".to_vec()).unwrap();
+
+        let mut buf = [0u8; 5];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"hello");
+
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b" worl");
+
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"d");
+    }
+
+    #[test]
+    fn control_mode_reader_multiple_sends() {
+        let (tx, rx) = sync_channel(16);
+        let mut reader = ControlModeReader::new(rx);
+
+        tx.send(b"aaa".to_vec()).unwrap();
+        tx.send(b"bbb".to_vec()).unwrap();
+
+        let mut buf = [0u8; 16];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"aaa");
+
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"bbb");
+    }
+
+    #[test]
+    fn control_mode_writer_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ControlModeWriter>();
+    }
+
+    #[test]
+    fn control_mode_reader_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ControlModeReader>();
+    }
+
+    #[test]
+    fn control_mode_reader_exact_size_buffer() {
+        let (tx, rx) = sync_channel(16);
+        let mut reader = ControlModeReader::new(rx);
+
+        tx.send(b"abc".to_vec()).unwrap();
+        let mut buf = [0u8; 3];
+        let n = reader.read(&mut buf).unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(&buf[..n], b"abc");
+    }
+
+    #[test]
+    fn try_send_drops_when_channel_full() {
+        let (tx, _rx) = sync_channel::<Vec<u8>>(1);
+
+        tx.send(b"first".to_vec()).unwrap();
+
+        match tx.try_send(b"second".to_vec()) {
+            Err(std::sync::mpsc::TrySendError::Full(_)) => {} // expected
+            other => panic!("Expected TrySendError::Full, got: {other:?}"),
+        }
+    }
+
+    // Compile-time check: channel capacity must be large enough to buffer heavy output.
+    const _: () = assert!(PANE_CHANNEL_CAPACITY >= 1024);
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,8 +1,13 @@
 pub mod backend;
 pub mod claude;
+pub mod control_mode;
 pub mod input;
 pub mod provider;
+pub mod registry;
 pub mod tmux;
+pub mod vm;
 
 pub use backend::{Session, SessionBackend};
 pub use provider::AgentProvider;
+pub use registry::BackendRegistry;
+pub use vm::{host_to_vm_path, QemuVmBackend, VmManager};

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -1,0 +1,211 @@
+//! Backend registry for multi-backend session support.
+//!
+//! Allows multiple `SessionBackend` implementations to coexist. Sessions select
+//! their backend at creation time; the registry routes by name.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::agent::SessionBackend;
+
+/// A registry of session backends keyed by name.
+///
+/// Each backend is registered under its `name()` (e.g., `"local-tmux"`, `"qemu-vm"`).
+/// The registry always has a default backend that is used when no explicit backend
+/// name is specified.
+pub struct BackendRegistry {
+    backends: HashMap<String, Arc<dyn SessionBackend>>,
+    default_name: String,
+}
+
+impl BackendRegistry {
+    /// Create a new registry with the given backend as the default.
+    pub fn new(default: Arc<dyn SessionBackend>) -> Self {
+        let name = default.name().to_string();
+        let mut backends = HashMap::new();
+        backends.insert(name.clone(), default);
+        Self {
+            backends,
+            default_name: name,
+        }
+    }
+
+    /// Register an additional backend. Its `name()` is used as the key.
+    pub fn register(&mut self, backend: Arc<dyn SessionBackend>) {
+        let name = backend.name().to_string();
+        self.backends.insert(name, backend);
+    }
+
+    /// Look up a backend by name.
+    pub fn get(&self, name: &str) -> Option<&Arc<dyn SessionBackend>> {
+        self.backends.get(name)
+    }
+
+    /// Return the default backend.
+    pub fn default_backend(&self) -> &Arc<dyn SessionBackend> {
+        self.backends.get(&self.default_name).unwrap()
+    }
+
+    /// Check whether a backend with the given name is registered.
+    pub fn has(&self, name: &str) -> bool {
+        self.backends.contains_key(name)
+    }
+
+    /// Return the name of the default backend.
+    pub fn default_name(&self) -> &str {
+        &self.default_name
+    }
+
+    /// Iterate over all registered backend names.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.backends.keys().map(|s| s.as_str())
+    }
+
+    /// Iterate over all registered backends.
+    pub fn all_backends(&self) -> impl Iterator<Item = &Arc<dyn SessionBackend>> {
+        self.backends.values()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use anyhow::Result;
+
+    use super::*;
+    use crate::agent::backend::{AdoptedSession, DiscoveredSession, SpawnedSession};
+
+    struct StubBackend {
+        backend_name: &'static str,
+    }
+
+    impl SessionBackend for StubBackend {
+        fn name(&self) -> &str {
+            self.backend_name
+        }
+        fn check_available(&self) -> Result<()> {
+            Ok(())
+        }
+        fn ensure_ready(&self) -> Result<()> {
+            Ok(())
+        }
+        fn spawn(
+            &self,
+            _: &str,
+            _: &str,
+            _: &[String],
+            _: Option<&Path>,
+            _: &HashMap<String, String>,
+            _: u16,
+            _: u16,
+        ) -> Result<SpawnedSession> {
+            unimplemented!()
+        }
+        fn adopt(&self, _: &str, _: u16, _: u16) -> Result<AdoptedSession> {
+            unimplemented!()
+        }
+        fn discover(&self) -> Result<Vec<DiscoveredSession>> {
+            Ok(vec![])
+        }
+        fn resize(&self, _: &str, _: u16, _: u16) -> Result<()> {
+            Ok(())
+        }
+        fn is_dead(&self, _: &str) -> Result<bool> {
+            Ok(false)
+        }
+        fn kill(&self, _: &str) -> Result<()> {
+            Ok(())
+        }
+        fn detach(&self, _: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn new_registers_default() {
+        let backend: Arc<dyn SessionBackend> = Arc::new(StubBackend {
+            backend_name: "local-tmux",
+        });
+        let registry = BackendRegistry::new(backend);
+
+        assert!(registry.has("local-tmux"));
+        assert_eq!(registry.default_name(), "local-tmux");
+        assert_eq!(registry.default_backend().name(), "local-tmux");
+    }
+
+    #[test]
+    fn register_additional_backend() {
+        let default: Arc<dyn SessionBackend> = Arc::new(StubBackend {
+            backend_name: "local-tmux",
+        });
+        let mut registry = BackendRegistry::new(default);
+
+        let vm: Arc<dyn SessionBackend> = Arc::new(StubBackend {
+            backend_name: "qemu-vm",
+        });
+        registry.register(vm);
+
+        assert!(registry.has("qemu-vm"));
+        assert_eq!(registry.get("qemu-vm").unwrap().name(), "qemu-vm");
+        // Default is still local-tmux
+        assert_eq!(registry.default_name(), "local-tmux");
+    }
+
+    #[test]
+    fn get_nonexistent_returns_none() {
+        let default: Arc<dyn SessionBackend> = Arc::new(StubBackend {
+            backend_name: "local-tmux",
+        });
+        let registry = BackendRegistry::new(default);
+
+        assert!(registry.get("nonexistent").is_none());
+        assert!(!registry.has("nonexistent"));
+    }
+
+    #[test]
+    fn names_returns_all_registered() {
+        let default: Arc<dyn SessionBackend> = Arc::new(StubBackend {
+            backend_name: "local-tmux",
+        });
+        let mut registry = BackendRegistry::new(default);
+
+        let vm: Arc<dyn SessionBackend> = Arc::new(StubBackend {
+            backend_name: "qemu-vm",
+        });
+        registry.register(vm);
+
+        let mut names: Vec<&str> = registry.names().collect();
+        names.sort();
+        assert_eq!(names, vec!["local-tmux", "qemu-vm"]);
+    }
+
+    #[test]
+    fn all_backends_returns_all_registered() {
+        let default: Arc<dyn SessionBackend> = Arc::new(StubBackend {
+            backend_name: "local-tmux",
+        });
+        let mut registry = BackendRegistry::new(default);
+
+        let vm: Arc<dyn SessionBackend> = Arc::new(StubBackend {
+            backend_name: "qemu-vm",
+        });
+        registry.register(vm);
+
+        let mut names: Vec<&str> = registry.all_backends().map(|b| b.name()).collect();
+        names.sort();
+        assert_eq!(names, vec!["local-tmux", "qemu-vm"]);
+    }
+
+    #[test]
+    fn all_backends_single_default() {
+        let default: Arc<dyn SessionBackend> = Arc::new(StubBackend {
+            backend_name: "local-tmux",
+        });
+        let registry = BackendRegistry::new(default);
+
+        let backends: Vec<_> = registry.all_backends().collect();
+        assert_eq!(backends.len(), 1);
+        assert_eq!(backends[0].name(), "local-tmux");
+    }
+}

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, VecDeque};
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::mpsc::{sync_channel, SyncSender};
@@ -10,6 +10,10 @@ use anyhow::{bail, Context, Result};
 use tracing::{debug, warn};
 
 use crate::agent::backend::{AdoptedSession, DiscoveredSession, SessionBackend, SpawnedSession};
+use crate::agent::control_mode::{
+    self, shell_escape, CommandResponse, ControlModeReader, ControlModeWriter, Notification,
+    PaneSendersMapShared, PANE_CHANNEL_CAPACITY,
+};
 
 /// Dedicated tmux socket name — isolates thurbox sessions from the user's tmux.
 /// Dev builds use "thurbox-dev" to avoid interfering with an installed release binary.
@@ -30,17 +34,8 @@ const TMUX_SESSION: &str = if cfg!(dev_build) {
 /// Minimum tmux version required.
 const MIN_TMUX_VERSION: (u32, u32) = (3, 2);
 
-/// Per-pane output channel capacity. Sized large enough to buffer heavy output
-/// bursts; chunks are dropped (not blocked) when full to keep the reader thread alive.
-const PANE_CHANNEL_CAPACITY: usize = 4096;
-
 /// Timeout for waiting for a control mode command response.
 const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
-
-/// Type alias for pane sender broadcast map.
-/// Maps pane IDs to vectors of sync senders for multi-instance output broadcast.
-type PaneSendersMap = HashMap<String, Vec<SyncSender<Vec<u8>>>>;
-type PaneSendersMapShared = Arc<Mutex<PaneSendersMap>>;
 
 /// Local tmux backend — sessions persist in `tmux -L thurbox`.
 ///
@@ -73,98 +68,6 @@ struct ControlMode {
     child: Mutex<Child>,
 }
 
-struct CommandResponse {
-    lines: Vec<String>,
-    is_error: bool,
-}
-
-/// Parsed notification from the tmux control mode protocol.
-#[derive(Debug, PartialEq)]
-enum Notification {
-    Output { pane_id: String, data: Vec<u8> },
-    Begin,
-    End,
-    Error,
-    Pause { pane_id: String },
-    Other(String),
-}
-
-/// Per-pane reader that receives output via an mpsc channel.
-///
-/// Implements `Read` so it plugs directly into the existing `Session::reader_loop`.
-struct ControlModeReader {
-    receiver: std::sync::mpsc::Receiver<Vec<u8>>,
-    buffer: Vec<u8>,
-    pos: usize,
-}
-
-impl ControlModeReader {
-    fn new(receiver: std::sync::mpsc::Receiver<Vec<u8>>) -> Self {
-        Self {
-            receiver,
-            buffer: Vec::new(),
-            pos: 0,
-        }
-    }
-}
-
-impl Read for ControlModeReader {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        // Drain leftover buffered data first.
-        if self.pos < self.buffer.len() {
-            let remaining = &self.buffer[self.pos..];
-            let n = remaining.len().min(buf.len());
-            buf[..n].copy_from_slice(&remaining[..n]);
-            self.pos += n;
-            if self.pos == self.buffer.len() {
-                self.buffer.clear();
-                self.pos = 0;
-            }
-            return Ok(n);
-        }
-
-        // Block until the next chunk arrives.
-        match self.receiver.recv() {
-            Ok(data) => {
-                let n = data.len().min(buf.len());
-                buf[..n].copy_from_slice(&data[..n]);
-                if n < data.len() {
-                    self.buffer = data;
-                    self.pos = n;
-                }
-                Ok(n)
-            }
-            Err(_) => Ok(0), // Channel closed → EOF.
-        }
-    }
-}
-
-/// Per-pane writer that sends input via `send-keys -H` through the shared control stdin.
-struct ControlModeWriter {
-    stdin: Arc<Mutex<ChildStdin>>,
-    pane_id: String,
-}
-
-impl Write for ControlModeWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        if buf.is_empty() {
-            return Ok(0);
-        }
-        let cmd = format_send_keys(&self.pane_id, buf);
-        let mut stdin = self
-            .stdin
-            .lock()
-            .map_err(|e| std::io::Error::other(format!("stdin lock: {e}")))?;
-        stdin.write_all(cmd.as_bytes())?;
-        stdin.flush()?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
 impl ControlMode {
     /// Start a control mode connection to the thurbox tmux session.
     fn start() -> Result<Self> {
@@ -193,7 +96,8 @@ impl ControlMode {
             .context("Failed to get control mode stdout")?;
 
         let stdin = Arc::new(Mutex::new(stdin));
-        let pane_senders: PaneSendersMapShared = Arc::new(Mutex::new(HashMap::new()));
+        let pane_senders: PaneSendersMapShared =
+            Arc::new(Mutex::new(std::collections::HashMap::new()));
         let response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>> =
             Arc::new(Mutex::new(VecDeque::new()));
 
@@ -267,7 +171,7 @@ impl ControlMode {
             // payload in %output lines is always valid ASCII.
             let line = String::from_utf8_lossy(&line_buf);
 
-            match parse_notification(&line) {
+            match control_mode::parse_notification(&line) {
                 Notification::Output { pane_id, data } => {
                     if let Ok(senders) = pane_senders.lock() {
                         if let Some(tx_vec) = senders.get(&pane_id) {
@@ -475,7 +379,7 @@ impl LocalTmuxBackend {
     fn build_shell_command(command: &str, args: &[String]) -> String {
         let mut parts = vec![command.to_string()];
         for arg in args {
-            parts.push(shell_escape(arg));
+            parts.push(control_mode::shell_escape(arg));
         }
         parts.join(" ")
     }
@@ -716,7 +620,7 @@ impl SessionBackend for LocalTmuxBackend {
         let shell_cmd = Self::build_shell_command(command, args);
 
         let cwd_part = match cwd {
-            Some(dir) => format!(" -c {}", shell_escape(&dir.to_string_lossy())),
+            Some(dir) => format!(" -c {}", control_mode::shell_escape(&dir.to_string_lossy())),
             None => String::new(),
         };
         let env_part: String = env
@@ -833,120 +737,16 @@ impl SessionBackend for LocalTmuxBackend {
     }
 }
 
-/// Decode tmux control mode octal escapes in `%output` data.
-///
-/// Scans for `\` followed by exactly 3 octal digits (0-7). Emits the decoded byte.
-/// All other characters pass through unchanged.
-fn decode_octal(input: &str) -> Vec<u8> {
-    let mut result = Vec::with_capacity(input.len());
-    let bytes = input.as_bytes();
-    let mut i = 0;
-
-    while i < bytes.len() {
-        if bytes[i] == b'\\' && i + 3 < bytes.len() {
-            let d0 = bytes[i + 1];
-            let d1 = bytes[i + 2];
-            let d2 = bytes[i + 3];
-            if is_octal(d0) && is_octal(d1) && is_octal(d2) {
-                let val = (d0 - b'0') as u16 * 64 + (d1 - b'0') as u16 * 8 + (d2 - b'0') as u16;
-                result.push(val as u8);
-                i += 4;
-                continue;
-            }
-        }
-        result.push(bytes[i]);
-        i += 1;
-    }
-
-    result
-}
-
-fn is_octal(b: u8) -> bool {
-    (b'0'..=b'7').contains(&b)
-}
-
-/// Parse a line from tmux control mode into a notification.
-fn parse_notification(line: &str) -> Notification {
-    if let Some(rest) = line.strip_prefix("%output ") {
-        // Format: %output %<pane_id> <octal-encoded data>
-        if let Some(space_idx) = rest.find(' ') {
-            let pane_id = rest[..space_idx].to_string();
-            let data = decode_octal(&rest[space_idx + 1..]);
-            return Notification::Output { pane_id, data };
-        }
-    }
-
-    if let Some(rest) = line.strip_prefix("%extended-output ") {
-        // Format: %extended-output %<pane_id> <age> : <octal-encoded data>
-        // The " : " separator divides metadata from payload.
-        if let Some(colon_idx) = rest.find(" : ") {
-            let meta = &rest[..colon_idx];
-            let data = decode_octal(&rest[colon_idx + 3..]);
-            // meta is "%<pane_id> <age>" — extract pane_id.
-            if let Some(space_idx) = meta.find(' ') {
-                let pane_id = meta[..space_idx].to_string();
-                return Notification::Output { pane_id, data };
-            }
-        }
-    }
-
-    if line.starts_with("%begin ") {
-        return Notification::Begin;
-    }
-
-    if line.starts_with("%end ") {
-        return Notification::End;
-    }
-
-    if line.starts_with("%error ") {
-        return Notification::Error;
-    }
-
-    if let Some(rest) = line.strip_prefix("%pause ") {
-        // Format: %pause %<pane_id>
-        return Notification::Pause {
-            pane_id: rest.trim().to_string(),
-        };
-    }
-
-    Notification::Other(line.to_string())
-}
-
-/// Format a `send-keys -H` command for a pane.
-///
-/// Each byte is encoded as two hex digits.
-fn format_send_keys(pane_id: &str, bytes: &[u8]) -> String {
-    use std::fmt::Write;
-    // "send-keys -t %NN -H" + " XX" per byte + "\n"
-    let mut cmd = String::with_capacity(20 + pane_id.len() + bytes.len() * 3 + 1);
-    write!(cmd, "send-keys -t {pane_id} -H").unwrap();
-    for &b in bytes {
-        write!(cmd, " {b:02x}").unwrap();
-    }
-    cmd.push('\n');
-    cmd
-}
-
-/// Shell-escape a string for safe inclusion in a tmux command.
-fn shell_escape(s: &str) -> String {
-    if s.is_empty() {
-        return "''".to_string();
-    }
-    // If the string contains no special characters, return as-is.
-    if s.chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':' | '=' | ','))
-    {
-        return s.to_string();
-    }
-    // Wrap in single quotes, escaping existing single quotes.
-    format!("'{}'", s.replace('\'', "'\\''"))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::io::Read;
 
-    // --- shell_escape tests ---
+    use super::*;
+    use crate::agent::control_mode::{
+        decode_octal, format_send_keys, parse_notification, shell_escape,
+    };
+
+    // --- shell_escape tests (verify re-export works) ---
 
     #[test]
     fn shell_escape_empty() {
@@ -1013,7 +813,7 @@ mod tests {
         assert_eq!(cmd, "claude --allowed-tools 'Read Bash(git:*)'");
     }
 
-    // --- decode_octal tests ---
+    // --- decode_octal tests (verify import works) ---
 
     #[test]
     fn decode_octal_esc() {
@@ -1022,7 +822,6 @@ mod tests {
 
     #[test]
     fn decode_octal_backslash() {
-        // A literal backslash is \134 in octal.
         assert_eq!(decode_octal("\\134"), vec![b'\\']);
     }
 
@@ -1038,19 +837,16 @@ mod tests {
 
     #[test]
     fn decode_octal_incomplete() {
-        // Backslash followed by fewer than 3 digits passes through.
         assert_eq!(decode_octal("\\01"), b"\\01");
     }
 
     #[test]
     fn decode_octal_non_octal_digits() {
-        // \089 — 8 and 9 are not octal digits.
         assert_eq!(decode_octal("\\089"), b"\\089");
     }
 
     #[test]
     fn decode_octal_mixed() {
-        // "A\033[1mB" → A, ESC, [, 1, m, B
         assert_eq!(
             decode_octal("A\\033[1mB"),
             vec![b'A', 27, b'[', b'1', b'm', b'B']
@@ -1069,17 +865,15 @@ mod tests {
 
     #[test]
     fn decode_octal_trailing_backslash() {
-        // Backslash at end of string (no digits follow).
         assert_eq!(decode_octal("a\\"), b"a\\");
     }
 
     #[test]
     fn decode_octal_max_value() {
-        // \377 = 255 = 0xFF — maximum single-byte octal value.
         assert_eq!(decode_octal("\\377"), vec![0xFF]);
     }
 
-    // --- parse_notification tests ---
+    // --- parse_notification tests (verify import works) ---
 
     #[test]
     fn parse_output_notification() {
@@ -1149,7 +943,6 @@ mod tests {
 
     #[test]
     fn parse_output_no_data() {
-        // %output with pane_id but no trailing space/data → falls through to Other.
         assert_eq!(
             parse_notification("%output %42"),
             Notification::Other("%output %42".to_string())
@@ -1158,7 +951,6 @@ mod tests {
 
     #[test]
     fn parse_extended_output_no_colon_separator() {
-        // %extended-output without " : " separator → falls through to Other.
         assert_eq!(
             parse_notification("%extended-output %2 0 data"),
             Notification::Other("%extended-output %2 0 data".to_string())
@@ -1167,7 +959,6 @@ mod tests {
 
     #[test]
     fn parse_output_empty_data() {
-        // %output with pane_id and trailing space but no data bytes.
         let n = parse_notification("%output %42 ");
         assert_eq!(
             n,
@@ -1178,7 +969,7 @@ mod tests {
         );
     }
 
-    // --- format_send_keys tests ---
+    // --- format_send_keys tests (verify import works) ---
 
     #[test]
     fn format_send_keys_single_byte() {
@@ -1200,18 +991,17 @@ mod tests {
 
     #[test]
     fn format_send_keys_escape_sequence() {
-        // ESC [ A (up arrow)
         assert_eq!(
             format_send_keys("%1", &[0x1b, b'[', b'A']),
             "send-keys -t %1 -H 1b 5b 41\n"
         );
     }
 
-    // --- ControlModeReader tests ---
+    // --- ControlModeReader tests (verify import works) ---
 
     #[test]
     fn control_mode_reader_data_delivery() {
-        let (tx, rx) = sync_channel(16);
+        let (tx, rx) = std::sync::mpsc::sync_channel(16);
         let mut reader = ControlModeReader::new(rx);
 
         tx.send(b"hello".to_vec()).unwrap();
@@ -1222,7 +1012,7 @@ mod tests {
 
     #[test]
     fn control_mode_reader_eof_on_sender_drop() {
-        let (tx, rx) = sync_channel(16);
+        let (tx, rx) = std::sync::mpsc::sync_channel(16);
         let mut reader = ControlModeReader::new(rx);
 
         drop(tx);
@@ -1233,12 +1023,11 @@ mod tests {
 
     #[test]
     fn control_mode_reader_partial_reads() {
-        let (tx, rx) = sync_channel(16);
+        let (tx, rx) = std::sync::mpsc::sync_channel(16);
         let mut reader = ControlModeReader::new(rx);
 
         tx.send(b"hello world".to_vec()).unwrap();
 
-        // Read in small chunks.
         let mut buf = [0u8; 5];
         let n = reader.read(&mut buf).unwrap();
         assert_eq!(&buf[..n], b"hello");
@@ -1252,7 +1041,7 @@ mod tests {
 
     #[test]
     fn control_mode_reader_multiple_sends() {
-        let (tx, rx) = sync_channel(16);
+        let (tx, rx) = std::sync::mpsc::sync_channel(16);
         let mut reader = ControlModeReader::new(rx);
 
         tx.send(b"aaa".to_vec()).unwrap();
@@ -1287,11 +1076,10 @@ mod tests {
 
     #[test]
     fn control_mode_reader_exact_size_buffer() {
-        let (tx, rx) = sync_channel(16);
+        let (tx, rx) = std::sync::mpsc::sync_channel(16);
         let mut reader = ControlModeReader::new(rx);
 
         tx.send(b"abc".to_vec()).unwrap();
-        // Buffer exactly matches data size — no leftover.
         let mut buf = [0u8; 3];
         let n = reader.read(&mut buf).unwrap();
         assert_eq!(n, 3);
@@ -1300,14 +1088,10 @@ mod tests {
 
     #[test]
     fn try_send_drops_when_channel_full() {
-        // Verify the try_send pattern used in reader_thread:
-        // when channel is full, data is dropped without blocking.
-        let (tx, _rx) = sync_channel::<Vec<u8>>(1);
+        let (tx, _rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(1);
 
-        // Fill the channel.
         tx.send(b"first".to_vec()).unwrap();
 
-        // Second send should fail (Full), not block.
         match tx.try_send(b"second".to_vec()) {
             Err(std::sync::mpsc::TrySendError::Full(_)) => {} // expected
             other => panic!("Expected TrySendError::Full, got: {other:?}"),
@@ -1319,7 +1103,6 @@ mod tests {
 
     #[test]
     fn parse_pause_notification_with_leading_percent() {
-        // Pane IDs from tmux always start with %.
         assert_eq!(
             parse_notification("%pause %123"),
             Notification::Pause {
@@ -1330,7 +1113,6 @@ mod tests {
 
     #[test]
     fn shell_escape_allows_equals_comma() {
-        // Equals and comma are safe characters.
         assert_eq!(shell_escape("key=val,other"), "key=val,other");
     }
 
@@ -1360,14 +1142,11 @@ mod tests {
 
     #[test]
     fn decode_octal_overflow_wraps() {
-        // \400 = 256, which wraps to 0 as u8. In practice tmux only
-        // produces 0-377 (0-255), so this documents the truncation behavior.
         assert_eq!(decode_octal("\\400"), vec![0u8]);
     }
 
     #[test]
     fn parse_extended_output_missing_pane_space() {
-        // %extended-output with " : " but no space in metadata falls through.
         assert_eq!(
             parse_notification("%extended-output %2 : data"),
             Notification::Other("%extended-output %2 : data".to_string())

--- a/src/agent/vm.rs
+++ b/src/agent/vm.rs
@@ -1,0 +1,1931 @@
+//! QEMU/KVM virtual machine lifecycle management.
+//!
+//! Manages the full VM lifecycle: create, start, stop, destroy. Each VM runs
+//! a QEMU process with a CoW overlay disk, cloud-init for provisioning, and
+//! SSH for connectivity. VMs provide isolated sandboxed environments for
+//! Claude Code sessions.
+//!
+//! ## VM storage layout
+//!
+//! ```text
+//! ~/.local/share/thurbox/vms/<vm-uuid>/
+//!   disk.qcow2        — CoW overlay (base image unchanged)
+//!   cloud-init.iso    — cloud-init nocloud ISO
+//!   qemu.pid          — QEMU process PID
+//!   ssh_key           — ephemeral SSH private key
+//!   ssh_key.pub       — ephemeral SSH public key
+//!   ssh-control       — SSH ControlMaster socket
+//!
+//! ~/.local/share/thurbox/images/
+//!   debian-13-genericcloud-amd64.qcow2  — base image (shared)
+//! ```
+
+use std::collections::{HashMap, VecDeque};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{sync_channel, SyncSender};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use tracing::{debug, info, warn};
+
+use crate::agent::backend::{AdoptedSession, DiscoveredSession, SessionBackend, SpawnedSession};
+use crate::agent::control_mode::{
+    self, CommandResponse, ControlModeReader, ControlModeWriter, Notification,
+    PaneSendersMapShared, PANE_CHANNEL_CAPACITY,
+};
+use crate::session::{VmConfig, VmState};
+
+/// A running or stopped VM instance.
+pub struct VmInstance {
+    /// Unique VM identifier.
+    pub id: String,
+    /// Current state.
+    pub state: VmState,
+    /// SSH port on localhost (host-forwarded to guest port 22).
+    pub ssh_port: u16,
+    /// Configuration used to create this VM.
+    pub config: VmConfig,
+    /// Directory containing VM files (disk, cloud-init, keys).
+    pub vm_dir: PathBuf,
+    /// QEMU child process handle (None if not running).
+    process: Option<Child>,
+}
+
+impl VmInstance {
+    /// Path to the CoW overlay disk.
+    pub fn disk_path(&self) -> PathBuf {
+        self.vm_dir.join("disk.qcow2")
+    }
+
+    /// Path to the cloud-init ISO.
+    pub fn cloud_init_path(&self) -> PathBuf {
+        self.vm_dir.join("cloud-init.iso")
+    }
+
+    /// Path to the ephemeral SSH private key.
+    pub fn ssh_key_path(&self) -> PathBuf {
+        self.vm_dir.join("ssh_key")
+    }
+
+    /// Path to the SSH ControlMaster socket.
+    ///
+    /// Uses `/tmp/` instead of the VM directory because Unix domain socket paths
+    /// are limited to 108 bytes, and SSH appends a random suffix (~16 chars).
+    /// The VM dir path with a UUID easily exceeds this limit.
+    pub fn ssh_control_path(&self) -> PathBuf {
+        let short_id = if self.id.len() > 8 {
+            &self.id[..8]
+        } else {
+            &self.id
+        };
+        PathBuf::from(format!("/tmp/thurbox-ssh-{short_id}"))
+    }
+
+    /// SSH user for the VM.
+    pub fn ssh_user(&self) -> &str {
+        "thurbox"
+    }
+}
+
+/// Manages QEMU VM lifecycle: create, start, stop, destroy.
+///
+/// Handles port allocation, image management, and cloud-init provisioning.
+pub struct VmManager {
+    /// Base directory for VM storage (~/.local/share/thurbox/vms/).
+    vms_dir: PathBuf,
+    /// Base directory for shared images (~/.local/share/thurbox/images/).
+    images_dir: PathBuf,
+    /// Active VMs keyed by VM ID.
+    instances: Mutex<HashMap<String, VmInstance>>,
+    /// Port allocator state — next port to try.
+    next_port: Mutex<u16>,
+}
+
+/// Base path for synced repositories inside the VM.
+const VM_REPOS_DIR: &str = "/home/thurbox/repos";
+
+/// Map a host-side path to the corresponding VM-side path.
+///
+/// Uses the final path component as the directory name under `/home/thurbox/repos/`.
+/// For example: `/home/user/projects/my-app` → `/home/thurbox/repos/my-app`
+pub fn host_to_vm_path(host_path: &Path) -> PathBuf {
+    let basename = host_path
+        .file_name()
+        .unwrap_or_else(|| std::ffi::OsStr::new("repo"));
+    PathBuf::from(VM_REPOS_DIR).join(basename)
+}
+
+/// SSH connection timeout when polling for VM readiness.
+const SSH_CONNECT_TIMEOUT_SECS: u32 = 2;
+
+/// Maximum time to wait for a VM to become SSH-ready.
+const VM_BOOT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// SSH poll interval during boot.
+const SSH_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Starting port for VM SSH forwarding.
+const BASE_SSH_PORT: u16 = 22200;
+
+/// Build the download URL for a Debian cloud image.
+fn debian_image_url(image_name: &str) -> String {
+    format!("https://cloud.debian.org/images/cloud/trixie/latest/{image_name}")
+}
+
+impl VmManager {
+    /// Create a new VM manager.
+    ///
+    /// `data_dir` is typically `~/.local/share/thurbox/`.
+    pub fn new(data_dir: &Path) -> Self {
+        Self {
+            vms_dir: data_dir.join("vms"),
+            images_dir: data_dir.join("images"),
+            instances: Mutex::new(HashMap::new()),
+            next_port: Mutex::new(BASE_SSH_PORT),
+        }
+    }
+
+    /// Check if QEMU and KVM are available (enough to show the "Sandbox VM" option).
+    ///
+    /// This only checks core requirements. Provisioning tools (genisoimage, ssh-keygen)
+    /// are checked later at VM creation time via `check_provisioning_tools`.
+    pub fn check_available() -> Result<()> {
+        let output = Command::new("qemu-system-x86_64")
+            .arg("--version")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("qemu-system-x86_64 is not installed or not in PATH")?;
+
+        if !output.status.success() {
+            bail!("qemu-system-x86_64 --version failed");
+        }
+
+        // Check /dev/kvm access for hardware acceleration.
+        let kvm_path = Path::new("/dev/kvm");
+        if !kvm_path.exists() {
+            bail!("/dev/kvm not found — KVM is required for VM sessions");
+        }
+
+        debug!("QEMU + KVM available");
+        Ok(())
+    }
+
+    /// Check that all provisioning tools are installed.
+    ///
+    /// Called at VM creation time, not at startup. Missing tools produce a clear
+    /// error message telling the user what to install.
+    pub fn check_provisioning_tools() -> Result<()> {
+        // Check for cloud-init ISO creation tool.
+        let has_genisoimage = Command::new("genisoimage")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok();
+
+        let has_mkisofs = Command::new("mkisofs")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok();
+
+        if !has_genisoimage && !has_mkisofs {
+            bail!("Neither genisoimage nor mkisofs found — needed for cloud-init ISO creation. Install cdrtools or cdrkit.");
+        }
+
+        // Check for ssh-keygen.
+        let has_ssh_keygen = Command::new("ssh-keygen")
+            .arg("-V")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok();
+
+        if !has_ssh_keygen {
+            bail!("ssh-keygen not found — needed for VM SSH key generation");
+        }
+
+        // Check for rsync (needed to sync host repos into the VM).
+        let has_rsync = Command::new("rsync")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok();
+
+        if !has_rsync {
+            bail!("rsync not found — needed to sync repositories into the VM");
+        }
+
+        // Check for curl (needed to download base images).
+        let has_curl = Command::new("curl")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok();
+
+        if !has_curl {
+            bail!("curl not found — needed to download VM base images");
+        }
+
+        debug!("All VM provisioning tools available");
+        Ok(())
+    }
+
+    /// Ensure the VM and images directories exist.
+    pub fn ensure_dirs(&self) -> Result<()> {
+        std::fs::create_dir_all(&self.vms_dir).context("Failed to create VMs directory")?;
+        std::fs::create_dir_all(&self.images_dir).context("Failed to create images directory")?;
+        Ok(())
+    }
+
+    /// Download the base image if it doesn't already exist.
+    ///
+    /// Downloads to a `.partial` temporary file and atomically renames on success,
+    /// so interrupted downloads don't leave a corrupt image behind.
+    pub fn ensure_base_image(
+        &self,
+        image_name: &str,
+        progress: &std::sync::mpsc::Sender<String>,
+    ) -> Result<()> {
+        let image_path = self.images_dir.join(image_name);
+        if image_path.exists() {
+            debug!(image = %image_name, "Base image already cached");
+            return Ok(());
+        }
+
+        self.ensure_dirs()?;
+
+        let url = debian_image_url(image_name);
+        let partial_path = self.images_dir.join(format!("{image_name}.partial"));
+
+        Self::report_step(progress, &format!("Downloading {image_name}..."));
+        info!(url = %url, dest = %image_path.display(), "Downloading base image");
+
+        let output = Command::new("curl")
+            .args(["-fsSL", "-o", &partial_path.to_string_lossy(), &url])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .context("Failed to run curl for base image download")?;
+
+        if !output.status.success() {
+            let _ = std::fs::remove_file(&partial_path);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!(
+                "Failed to download base image from {url}: {}",
+                stderr.trim()
+            );
+        }
+
+        std::fs::rename(&partial_path, &image_path)
+            .context("Failed to rename downloaded image from .partial to final path")?;
+
+        info!(image = %image_name, "Base image downloaded successfully");
+        Ok(())
+    }
+
+    /// Check if the base image exists.
+    pub fn has_base_image(&self, image_name: &str) -> bool {
+        self.images_dir.join(image_name).exists()
+    }
+
+    /// Return the path to a base image.
+    pub fn base_image_path(&self, image_name: &str) -> PathBuf {
+        self.images_dir.join(image_name)
+    }
+
+    /// Allocate the next available SSH port.
+    ///
+    /// Probes ports starting from the current counter, skipping any that are
+    /// already bound (e.g., by orphaned QEMU processes from a previous run).
+    fn allocate_port(&self) -> u16 {
+        let mut port = self.next_port.lock().unwrap();
+        loop {
+            let candidate = *port;
+            *port += 1;
+
+            // Try to bind the port to check availability.
+            match std::net::TcpListener::bind(("127.0.0.1", candidate)) {
+                Ok(_listener) => {
+                    // Port is free — the listener is dropped, releasing it for QEMU.
+                    return candidate;
+                }
+                Err(_) => {
+                    debug!(port = candidate, "Port in use, skipping");
+                    // Safety valve: don't scan forever.
+                    if candidate > BASE_SSH_PORT + 100 {
+                        warn!("Exhausted port range, using {}", candidate + 1);
+                        *port += 1;
+                        return candidate + 1;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Sync host repositories into the VM via rsync.
+    ///
+    /// Creates `/home/thurbox/repos/` in the VM and rsyncs each host repo into it.
+    /// Must be called after SSH is ready.
+    fn sync_repos(&self, instance: &VmInstance, repo_paths: &[PathBuf]) -> Result<()> {
+        if repo_paths.is_empty() {
+            return Ok(());
+        }
+
+        let key_path = instance.ssh_key_path();
+        let ssh_port = instance.ssh_port.to_string();
+        let user = instance.ssh_user();
+
+        // Create the repos directory in the VM.
+        let mkdir_status = Command::new("ssh")
+            .args([
+                "-i",
+                &key_path.to_string_lossy(),
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "LogLevel=ERROR",
+                "-o",
+                "BatchMode=yes",
+                "-p",
+                &ssh_port,
+                &format!("{user}@localhost"),
+                "mkdir",
+                "-p",
+                VM_REPOS_DIR,
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .status()
+            .context("Failed to create repos directory in VM")?;
+
+        if !mkdir_status.success() {
+            bail!("Failed to create {VM_REPOS_DIR} in VM");
+        }
+
+        let ssh_cmd = format!(
+            "ssh -i {} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o BatchMode=yes -p {}",
+            key_path.display(),
+            ssh_port,
+        );
+
+        for repo in repo_paths {
+            let basename = repo
+                .file_name()
+                .unwrap_or_else(|| std::ffi::OsStr::new("repo"));
+            let vm_dest = format!(
+                "{user}@localhost:{VM_REPOS_DIR}/{}/",
+                basename.to_string_lossy()
+            );
+
+            // Trailing `/` on source copies contents, not the directory itself.
+            let mut source = repo.to_string_lossy().to_string();
+            if !source.ends_with('/') {
+                source.push('/');
+            }
+
+            info!(
+                vm_id = %instance.id,
+                repo = %repo.display(),
+                "Syncing repository into VM"
+            );
+
+            // Files are owned by `thurbox` automatically since rsync runs as that user.
+            let output = Command::new("rsync")
+                .args(["-az", "--delete", "-e", &ssh_cmd, &source, &vm_dest])
+                .stdout(Stdio::null())
+                .stderr(Stdio::piped())
+                .output()
+                .context(format!("Failed to rsync {}", repo.display()))?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                bail!("rsync failed for {}: {}", repo.display(), stderr.trim());
+            }
+
+            debug!(
+                vm_id = %instance.id,
+                repo = %repo.display(),
+                "Repository synced to VM"
+            );
+        }
+
+        info!(
+            vm_id = %instance.id,
+            count = repo_paths.len(),
+            "All repositories synced into VM"
+        );
+        Ok(())
+    }
+
+    /// Send a progress update to the TUI (best-effort, never fails).
+    fn report_step(progress: &std::sync::mpsc::Sender<String>, msg: &str) {
+        let _ = progress.send(msg.to_string());
+    }
+
+    /// Create and start a new VM.
+    ///
+    /// This is an async-friendly method that performs the full provisioning:
+    /// 1. Generate SSH keypair
+    /// 2. Create CoW overlay disk
+    /// 3. Generate cloud-init ISO
+    /// 4. Start QEMU process
+    /// 5. Wait for SSH readiness
+    /// 6. Wait for cloud-init
+    /// 7. Sync host repositories into the VM
+    ///
+    /// The `progress` sender delivers step descriptions to the TUI status bar.
+    pub fn create_vm(
+        &self,
+        vm_id: &str,
+        config: &VmConfig,
+        repo_paths: &[PathBuf],
+        progress: &std::sync::mpsc::Sender<String>,
+    ) -> Result<()> {
+        Self::report_step(progress, "Checking provisioning tools...");
+        Self::check_provisioning_tools()?;
+
+        self.ensure_base_image(&config.base_image, progress)?;
+
+        let vm_dir = self.vms_dir.join(vm_id);
+        std::fs::create_dir_all(&vm_dir).context("Failed to create VM directory")?;
+
+        let ssh_port = self.allocate_port();
+
+        let mut instance = VmInstance {
+            id: vm_id.to_string(),
+            state: VmState::Provisioning,
+            ssh_port,
+            config: config.clone(),
+            vm_dir: vm_dir.clone(),
+            process: None,
+        };
+
+        info!(vm_id = %vm_id, ssh_port = ssh_port, "Provisioning VM");
+
+        // Step 1: Generate ephemeral SSH keypair.
+        Self::report_step(progress, "Generating SSH keypair...");
+        self.generate_ssh_keypair(&instance)?;
+
+        // Step 2: Create CoW overlay disk.
+        Self::report_step(progress, "Creating disk overlay...");
+        self.create_overlay_disk(&instance)?;
+
+        // Step 3: Generate cloud-init ISO.
+        Self::report_step(progress, "Building cloud-init ISO...");
+        self.create_cloud_init_iso(&instance)?;
+
+        // Step 4: Start QEMU.
+        Self::report_step(progress, "Starting QEMU...");
+        instance.state = VmState::Starting;
+        let child = self.start_qemu(&instance)?;
+        instance.process = Some(child);
+
+        // Step 5: Wait for SSH readiness.
+        Self::report_step(progress, "Booting VM (waiting for SSH)...");
+        self.wait_for_ssh(&instance)?;
+
+        // Step 6: Wait for cloud-init to finish (package installation, user setup).
+        Self::report_step(progress, "Installing packages (cloud-init)...");
+        self.wait_for_cloud_init(&instance)?;
+
+        // Step 7: Sync host repositories into the VM.
+        if !repo_paths.is_empty() {
+            Self::report_step(progress, "Syncing repositories into VM...");
+        }
+        self.sync_repos(&instance, repo_paths)?;
+
+        Self::report_step(progress, "Connecting...");
+        instance.state = VmState::Ready;
+        info!(vm_id = %vm_id, "VM is ready");
+
+        self.instances
+            .lock()
+            .unwrap()
+            .insert(vm_id.to_string(), instance);
+        Ok(())
+    }
+
+    /// Generate an ephemeral SSH keypair for VM access.
+    fn generate_ssh_keypair(&self, instance: &VmInstance) -> Result<()> {
+        let key_path = instance.ssh_key_path();
+        let output = Command::new("ssh-keygen")
+            .args([
+                "-t",
+                "ed25519",
+                "-f",
+                &key_path.to_string_lossy(),
+                "-N",
+                "", // No passphrase
+                "-C",
+                &format!("thurbox-vm-{}", instance.id),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .context("Failed to run ssh-keygen")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("ssh-keygen failed: {}", stderr.trim());
+        }
+
+        debug!(vm_id = %instance.id, "SSH keypair generated");
+        Ok(())
+    }
+
+    /// Create a CoW overlay disk backed by the base image.
+    fn create_overlay_disk(&self, instance: &VmInstance) -> Result<()> {
+        let base_path = self.base_image_path(&instance.config.base_image);
+        if !base_path.exists() {
+            bail!(
+                "Base image not found: {} (this is a bug — ensure_base_image should have downloaded it)",
+                instance.config.base_image,
+            );
+        }
+
+        let disk_path = instance.disk_path();
+        let output = Command::new("qemu-img")
+            .args([
+                "create",
+                "-f",
+                "qcow2",
+                "-b",
+                &base_path.to_string_lossy(),
+                "-F",
+                "qcow2",
+                &disk_path.to_string_lossy(),
+                &format!("{}G", instance.config.disk_gb),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .context("Failed to run qemu-img")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("qemu-img create failed: {}", stderr.trim());
+        }
+
+        debug!(vm_id = %instance.id, "Overlay disk created");
+        Ok(())
+    }
+
+    /// Generate a cloud-init nocloud ISO for VM provisioning.
+    fn create_cloud_init_iso(&self, instance: &VmInstance) -> Result<()> {
+        let pub_key_path = format!("{}.pub", instance.ssh_key_path().display());
+        let pub_key =
+            std::fs::read_to_string(&pub_key_path).context("Failed to read SSH public key")?;
+
+        let user_data = format!(
+            r#"#cloud-config
+users:
+  - name: {user}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - {pub_key}
+package_update: true
+packages:
+  - tmux
+  - rsync
+  - git
+  - curl
+runcmd:
+  - su - {user} -c 'curl -fsSL https://claude.ai/install.sh | bash'
+  - ln -sf /home/{user}/.local/bin/claude /usr/local/bin/claude
+{extra_runcmd}
+"#,
+            user = instance.ssh_user(),
+            pub_key = pub_key.trim(),
+            extra_runcmd = instance
+                .config
+                .setup_script
+                .as_ref()
+                .map(|s| format!("  - |\n    {}", s.replace('\n', "\n    ")))
+                .unwrap_or_default(),
+        );
+
+        let meta_data = format!(
+            r#"instance-id: thurbox-{id}
+local-hostname: thurbox-vm
+"#,
+            id = instance.id,
+        );
+
+        // Write temporary files for ISO creation.
+        let ci_dir = instance.vm_dir.join("cloud-init-src");
+        std::fs::create_dir_all(&ci_dir)?;
+        std::fs::write(ci_dir.join("user-data"), user_data)?;
+        std::fs::write(ci_dir.join("meta-data"), meta_data)?;
+
+        let iso_path = instance.cloud_init_path();
+
+        // Try genisoimage first, fall back to mkisofs.
+        let iso_tool = if Command::new("genisoimage")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok()
+        {
+            "genisoimage"
+        } else {
+            "mkisofs"
+        };
+
+        let output = Command::new(iso_tool)
+            .args([
+                "-output",
+                &iso_path.to_string_lossy(),
+                "-volid",
+                "cidata",
+                "-joliet",
+                "-rock",
+                &ci_dir.to_string_lossy(),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .context(format!("Failed to run {iso_tool}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("{iso_tool} failed: {}", stderr.trim());
+        }
+
+        // Clean up temp dir.
+        let _ = std::fs::remove_dir_all(&ci_dir);
+
+        debug!(vm_id = %instance.id, "Cloud-init ISO created");
+        Ok(())
+    }
+
+    /// Start the QEMU process.
+    fn start_qemu(&self, instance: &VmInstance) -> Result<Child> {
+        let child = Command::new("qemu-system-x86_64")
+            .args([
+                "-enable-kvm",
+                "-cpu",
+                "host",
+                "-nographic",
+                "-m",
+                &format!("{}M", instance.config.memory_mb),
+                "-smp",
+                &instance.config.cpus.to_string(),
+                "-drive",
+                &format!(
+                    "file={},format=qcow2,if=virtio",
+                    instance.disk_path().display()
+                ),
+                "-cdrom",
+                &instance.cloud_init_path().to_string_lossy(),
+                "-netdev",
+                &format!("user,id=net0,hostfwd=tcp::{}-:22", instance.ssh_port),
+                "-device",
+                "virtio-net-pci,netdev=net0",
+                "-pidfile",
+                &instance.vm_dir.join("qemu.pid").to_string_lossy(),
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("Failed to start QEMU")?;
+
+        debug!(
+            vm_id = %instance.id,
+            pid = child.id(),
+            "QEMU process started"
+        );
+
+        Ok(child)
+    }
+
+    /// Poll SSH until the VM is reachable.
+    fn wait_for_ssh(&self, instance: &VmInstance) -> Result<()> {
+        let start = Instant::now();
+        let key_path = instance.ssh_key_path();
+
+        loop {
+            if start.elapsed() > VM_BOOT_TIMEOUT {
+                bail!(
+                    "VM {} did not become SSH-ready within {}s",
+                    instance.id,
+                    VM_BOOT_TIMEOUT.as_secs()
+                );
+            }
+
+            let status = Command::new("ssh")
+                .args([
+                    "-i",
+                    &key_path.to_string_lossy(),
+                    "-o",
+                    "StrictHostKeyChecking=no",
+                    "-o",
+                    "UserKnownHostsFile=/dev/null",
+                    "-o",
+                    &format!("ConnectTimeout={SSH_CONNECT_TIMEOUT_SECS}"),
+                    "-o",
+                    "BatchMode=yes",
+                    "-p",
+                    &instance.ssh_port.to_string(),
+                    &format!("{}@localhost", instance.ssh_user()),
+                    "true",
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+
+            match status {
+                Ok(s) if s.success() => {
+                    debug!(
+                        vm_id = %instance.id,
+                        elapsed_ms = start.elapsed().as_millis(),
+                        "SSH is ready"
+                    );
+                    return Ok(());
+                }
+                _ => {
+                    std::thread::sleep(SSH_POLL_INTERVAL);
+                }
+            }
+        }
+    }
+
+    /// Wait for cloud-init to finish provisioning (package installs, user setup).
+    ///
+    /// SSH can become available before cloud-init completes. Without this wait,
+    /// tools like tmux and rsync may not be installed yet.
+    fn wait_for_cloud_init(&self, instance: &VmInstance) -> Result<()> {
+        let key_path = instance.ssh_key_path();
+        info!(vm_id = %instance.id, "Waiting for cloud-init to finish...");
+
+        let output = Command::new("ssh")
+            .args([
+                "-i",
+                &key_path.to_string_lossy(),
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "LogLevel=ERROR",
+                "-o",
+                "BatchMode=yes",
+                "-p",
+                &instance.ssh_port.to_string(),
+                &format!("{}@localhost", instance.ssh_user()),
+                "cloud-init",
+                "status",
+                "--wait",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("Failed to run cloud-init status --wait")?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // cloud-init may report "status: error" if a runcmd fails,
+            // but packages are usually installed by then. Log and continue.
+            warn!(
+                vm_id = %instance.id,
+                stdout = %stdout.trim(),
+                stderr = %stderr.trim(),
+                "cloud-init finished with non-zero exit"
+            );
+        } else {
+            debug!(
+                vm_id = %instance.id,
+                status = %stdout.trim(),
+                "cloud-init finished"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Build SSH command arguments for the control mode connection to a VM.
+    ///
+    /// Does NOT use SSH multiplexing (ControlMaster/ControlPersist) because
+    /// the control mode connection must keep the foreground SSH process alive
+    /// with stdin/stdout pipes open.
+    pub fn ssh_args(&self, instance: &VmInstance) -> Vec<String> {
+        vec![
+            "-i".to_string(),
+            instance.ssh_key_path().to_string_lossy().to_string(),
+            "-o".to_string(),
+            "StrictHostKeyChecking=no".to_string(),
+            "-o".to_string(),
+            "UserKnownHostsFile=/dev/null".to_string(),
+            "-o".to_string(),
+            "LogLevel=ERROR".to_string(),
+            "-o".to_string(),
+            "ServerAliveInterval=30".to_string(),
+            "-o".to_string(),
+            "ServerAliveCountMax=3".to_string(),
+            "-p".to_string(),
+            instance.ssh_port.to_string(),
+            format!("{}@localhost", instance.ssh_user()),
+        ]
+    }
+
+    /// Stop a running VM gracefully (send poweroff via SSH, then wait).
+    pub fn stop_vm(&self, vm_id: &str) -> Result<()> {
+        let mut instances = self.instances.lock().unwrap();
+        let instance = instances
+            .get_mut(vm_id)
+            .context(format!("VM {vm_id} not found"))?;
+
+        if instance.state == VmState::Stopped {
+            return Ok(());
+        }
+
+        instance.state = VmState::Stopping;
+        info!(vm_id = %vm_id, "Stopping VM");
+
+        // Try graceful shutdown via SSH first.
+        let _ = Command::new("ssh")
+            .args([
+                "-i",
+                &instance.ssh_key_path().to_string_lossy(),
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                &format!("ConnectTimeout={SSH_CONNECT_TIMEOUT_SECS}"),
+                "-o",
+                "BatchMode=yes",
+                "-p",
+                &instance.ssh_port.to_string(),
+                &format!("{}@localhost", instance.ssh_user()),
+                "sudo",
+                "poweroff",
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+
+        // Wait for QEMU to exit (with timeout).
+        if let Some(ref mut child) = instance.process {
+            match child.try_wait() {
+                Ok(Some(_)) => {}
+                _ => {
+                    // Give it a few seconds to shut down gracefully.
+                    std::thread::sleep(Duration::from_secs(5));
+                    match child.try_wait() {
+                        Ok(Some(_)) => {}
+                        _ => {
+                            warn!(vm_id = %vm_id, "QEMU did not exit gracefully, killing");
+                            let _ = child.kill();
+                            let _ = child.wait();
+                        }
+                    }
+                }
+            }
+        }
+
+        instance.state = VmState::Stopped;
+        instance.process = None;
+        info!(vm_id = %vm_id, "VM stopped");
+        Ok(())
+    }
+
+    /// Destroy a VM — stop it and remove all files.
+    pub fn destroy_vm(&self, vm_id: &str) -> Result<()> {
+        // Stop first if running.
+        let _ = self.stop_vm(vm_id);
+
+        let mut instances = self.instances.lock().unwrap();
+        if let Some(instance) = instances.remove(vm_id) {
+            // Remove VM directory and all files.
+            if instance.vm_dir.exists() {
+                std::fs::remove_dir_all(&instance.vm_dir)
+                    .context("Failed to remove VM directory")?;
+            }
+            info!(vm_id = %vm_id, "VM destroyed");
+        }
+
+        Ok(())
+    }
+
+    /// Get the state of a VM.
+    pub fn vm_state(&self, vm_id: &str) -> Option<VmState> {
+        self.instances
+            .lock()
+            .unwrap()
+            .get(vm_id)
+            .map(|i| i.state.clone())
+    }
+
+    /// Get the SSH port of a VM.
+    pub fn vm_ssh_port(&self, vm_id: &str) -> Option<u16> {
+        self.instances
+            .lock()
+            .unwrap()
+            .get(vm_id)
+            .map(|i| i.ssh_port)
+    }
+
+    /// Re-register a running VM from its database record.
+    ///
+    /// Called during startup to restore VM instances that survived a Thurbox restart.
+    /// Probes SSH to verify the VM is still running. If SSH succeeds, the instance
+    /// is inserted into the in-memory map with state `Ready`. If SSH fails, returns
+    /// an error (caller should mark the VM as stopped in the DB).
+    pub fn restore_vm(&self, vm_record: &crate::storage::vms::VmRecord) -> Result<()> {
+        let vm_dir = self.vms_dir.join(&vm_record.id);
+        if !vm_dir.exists() {
+            bail!("VM directory does not exist: {}", vm_dir.display());
+        }
+
+        let config = VmConfig {
+            base_image: vm_record.base_image.clone(),
+            cpus: vm_record.cpus,
+            memory_mb: vm_record.memory_mb,
+            disk_gb: vm_record.disk_gb,
+            setup_script: None,
+        };
+
+        let instance = VmInstance {
+            id: vm_record.id.clone(),
+            state: VmState::Ready,
+            ssh_port: vm_record.ssh_port,
+            config,
+            vm_dir,
+            process: None, // We don't own the QEMU process handle after restart
+        };
+
+        // Probe SSH to verify the VM is still reachable.
+        let key_path = instance.ssh_key_path();
+        let status = Command::new("ssh")
+            .args([
+                "-i",
+                &key_path.to_string_lossy(),
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                &format!("ConnectTimeout={SSH_CONNECT_TIMEOUT_SECS}"),
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "LogLevel=ERROR",
+                "-p",
+                &instance.ssh_port.to_string(),
+                &format!("{}@localhost", instance.ssh_user()),
+                "true",
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+
+        match status {
+            Ok(s) if s.success() => {
+                info!(
+                    vm_id = %vm_record.id,
+                    ssh_port = vm_record.ssh_port,
+                    "VM restored — SSH is reachable"
+                );
+                // Advance the port allocator past this VM's port to avoid collisions.
+                let mut next = self.next_port.lock().unwrap();
+                if vm_record.ssh_port >= *next {
+                    *next = vm_record.ssh_port + 1;
+                }
+                self.instances
+                    .lock()
+                    .unwrap()
+                    .insert(vm_record.id.clone(), instance);
+                Ok(())
+            }
+            _ => {
+                bail!(
+                    "VM {} is not reachable via SSH on port {}",
+                    vm_record.id,
+                    vm_record.ssh_port
+                );
+            }
+        }
+    }
+
+    /// Get a reference to a VM instance by ID.
+    pub fn get_instance(&self, vm_id: &str) -> Option<VmInstance> {
+        // Return a clone-like snapshot (VmInstance is not Clone due to Child,
+        // so we reconstruct the parts we need).
+        let instances = self.instances.lock().unwrap();
+        let inst = instances.get(vm_id)?;
+        Some(VmInstance {
+            id: inst.id.clone(),
+            state: inst.state.clone(),
+            ssh_port: inst.ssh_port,
+            config: inst.config.clone(),
+            vm_dir: inst.vm_dir.clone(),
+            process: None, // Cannot clone the child process handle
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SshControlMode — tmux control mode over SSH
+// ---------------------------------------------------------------------------
+
+/// Tmux control mode connection tunneled through SSH to a VM.
+///
+/// Mirrors `ControlMode` in `tmux.rs` but spawns:
+/// ```text
+/// ssh <vm-ssh-args> tmux -L thurbox -C new-session -A -s thurbox
+/// ```
+/// instead of a local tmux attach.
+struct SshControlMode {
+    stdin: Arc<Mutex<ChildStdin>>,
+    pane_senders: PaneSendersMapShared,
+    response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
+    reader_handle: Mutex<Option<JoinHandle<()>>>,
+    child: Mutex<Child>,
+}
+
+/// Timeout for waiting for a control mode command response.
+const SSH_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Tmux socket name inside the VM.
+const VM_TMUX_SOCKET: &str = "thurbox";
+
+/// Tmux session name inside the VM.
+const VM_TMUX_SESSION: &str = "thurbox";
+
+impl SshControlMode {
+    /// Start a control mode connection to a VM via SSH.
+    fn start(ssh_args: &[String]) -> Result<Self> {
+        let mut cmd = Command::new("ssh");
+        // Force PTY allocation — without it, tmux's default window shell has no
+        // PTY and exits immediately, causing tmux to send %exit and close control
+        // mode.
+        cmd.arg("-tt");
+        for arg in ssh_args {
+            cmd.arg(arg);
+        }
+        // Start tmux in control mode inside the VM.
+        // -A = attach or create, -s = session name.
+        cmd.args([
+            "tmux",
+            "-L",
+            VM_TMUX_SOCKET,
+            "-C",
+            "new-session",
+            "-A",
+            "-s",
+            VM_TMUX_SESSION,
+        ]);
+
+        let mut child = cmd
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("Failed to start SSH control mode to VM")?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .context("Failed to get SSH control mode stdin")?;
+        let stdout = child
+            .stdout
+            .take()
+            .context("Failed to get SSH control mode stdout")?;
+
+        let stdin = Arc::new(Mutex::new(stdin));
+        let pane_senders: PaneSendersMapShared = Arc::new(Mutex::new(HashMap::new()));
+        let response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>> =
+            Arc::new(Mutex::new(VecDeque::new()));
+
+        let reader_stdin = Arc::clone(&stdin);
+        let reader_pane_senders = Arc::clone(&pane_senders);
+        let reader_queue = Arc::clone(&response_queue);
+
+        let reader_handle = std::thread::Builder::new()
+            .name("ssh-control-reader".into())
+            .spawn(move || {
+                Self::reader_thread(stdout, reader_stdin, reader_pane_senders, reader_queue);
+            })
+            .context("Failed to spawn SSH control reader thread")?;
+
+        let control = Self {
+            stdin,
+            pane_senders,
+            response_queue,
+            reader_handle: Mutex::new(Some(reader_handle)),
+            child: Mutex::new(child),
+        };
+
+        // When tmux creates a new session (fresh VM), it emits an initial
+        // %begin/%end block for `new-session`. Let the reader thread process
+        // and discard it (no sender in the queue) before we send any commands.
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Drain any remaining initial output. Retry once if the initial
+        // session-creation response stole our sender (race condition).
+        if control.send_command("refresh-client").is_err() {
+            debug!("Initial refresh-client timed out (expected on fresh VMs), retrying");
+            control.send_command("refresh-client")?;
+        }
+
+        // Enable flow control.
+        control.send_command("refresh-client -f pause-after=5")?;
+
+        // Apply VM-side tmux config.
+        // Use -g for options that must apply to windows created after this point.
+        control.send_command("set-option -g remain-on-exit on")?;
+        control.send_command("set-option -g status off")?;
+        control.send_command("set-option -g history-limit 5000")?;
+        // NOTE: window-size manual crashes tmux 3.4 (Ubuntu 24.04 default).
+        // The local backend uses tmux 3.6a where this works fine, but the VM
+        // image ships 3.4. Omit it — tmux will use its default sizing.
+        control.send_command("set-option -sg default-terminal xterm-256color")?;
+        control.send_command("set-option -sg extended-keys on")?;
+
+        Ok(control)
+    }
+
+    /// Background reader thread — identical logic to `ControlMode::reader_thread`.
+    fn reader_thread(
+        stdout: std::process::ChildStdout,
+        stdin: Arc<Mutex<ChildStdin>>,
+        pane_senders: PaneSendersMapShared,
+        response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
+    ) {
+        let mut reader = BufReader::new(stdout);
+        let mut collecting: Option<Vec<String>> = None;
+        let mut line_buf = Vec::new();
+
+        loop {
+            line_buf.clear();
+            match reader.read_until(b'\n', &mut line_buf) {
+                Ok(0) => {
+                    debug!("SSH control reader: EOF on stdout");
+                    break;
+                }
+                Ok(n) => {
+                    let preview = String::from_utf8_lossy(&line_buf);
+                    debug!(bytes = n, line = %preview.trim(), "SSH control reader: line received");
+                }
+                Err(e) => {
+                    debug!("SSH control reader I/O error: {e}");
+                    break;
+                }
+            }
+            if line_buf.last() == Some(&b'\n') {
+                line_buf.pop();
+            }
+            // SSH with -tt uses a PTY which produces \r\n line endings.
+            if line_buf.last() == Some(&b'\r') {
+                line_buf.pop();
+            }
+            let line = String::from_utf8_lossy(&line_buf);
+
+            match control_mode::parse_notification(&line) {
+                Notification::Output { pane_id, data } => {
+                    if let Ok(senders) = pane_senders.lock() {
+                        if let Some(tx_vec) = senders.get(&pane_id) {
+                            for tx in tx_vec {
+                                match tx.try_send(data.clone()) {
+                                    Ok(()) => {}
+                                    Err(std::sync::mpsc::TrySendError::Full(_)) => {
+                                        debug!(
+                                            pane_id = %pane_id,
+                                            "VM pane output channel full, dropping chunk"
+                                        );
+                                    }
+                                    Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {}
+                                }
+                            }
+                        }
+                    }
+                }
+                Notification::Begin => {
+                    collecting = Some(Vec::new());
+                }
+                end_or_error @ (Notification::End | Notification::Error) => {
+                    let lines = collecting.take().unwrap_or_default();
+                    if let Ok(mut queue) = response_queue.lock() {
+                        if let Some(tx) = queue.pop_front() {
+                            let _ = tx.send(CommandResponse {
+                                lines,
+                                is_error: matches!(end_or_error, Notification::Error),
+                            });
+                        }
+                    }
+                }
+                Notification::Pause { pane_id } => {
+                    let cmd = format!(
+                        "refresh-client -A '{}:continue'\n",
+                        pane_id.replace('\'', "'\\''")
+                    );
+                    if let Ok(mut s) = stdin.lock() {
+                        let _ = s.write_all(cmd.as_bytes());
+                        let _ = s.flush();
+                    }
+                }
+                Notification::Other(text) => {
+                    if let Some(ref mut lines) = collecting {
+                        lines.push(text);
+                    }
+                }
+            }
+        }
+
+        debug!("SSH control reader thread exiting");
+        if let Ok(mut senders) = pane_senders.lock() {
+            senders.clear();
+        }
+    }
+
+    /// Send a command and wait for its response.
+    fn send_command(&self, cmd: &str) -> Result<String> {
+        let (tx, rx) = sync_channel(1);
+
+        {
+            let mut queue = self
+                .response_queue
+                .lock()
+                .map_err(|e| anyhow::anyhow!("response_queue lock: {e}"))?;
+            queue.push_back(tx);
+        }
+
+        {
+            let mut stdin = self
+                .stdin
+                .lock()
+                .map_err(|e| anyhow::anyhow!("stdin lock: {e}"))?;
+            writeln!(stdin, "{cmd}")?;
+            stdin.flush()?;
+        }
+
+        let response = rx
+            .recv_timeout(SSH_COMMAND_TIMEOUT)
+            .context(format!("Timeout waiting for VM tmux response to: {cmd}"))?;
+
+        if response.is_error {
+            bail!(
+                "VM tmux command failed: {cmd}: {}",
+                response.lines.join("\n")
+            );
+        }
+
+        Ok(response.lines.join("\n"))
+    }
+
+    /// Send a command without waiting for a response.
+    fn send_command_nowait(&self, cmd: &str) -> Result<()> {
+        let mut stdin = self
+            .stdin
+            .lock()
+            .map_err(|e| anyhow::anyhow!("stdin lock: {e}"))?;
+        writeln!(stdin, "{cmd}")?;
+        stdin.flush()?;
+        Ok(())
+    }
+}
+
+impl Drop for SshControlMode {
+    fn drop(&mut self) {
+        if let Ok(mut stdin) = self.stdin.lock() {
+            let _ = writeln!(stdin, "detach-client");
+            let _ = stdin.flush();
+        }
+        if let Ok(mut handle) = self.reader_handle.lock() {
+            if let Some(h) = handle.take() {
+                let _ = h.join();
+            }
+        }
+        if let Ok(mut child) = self.child.lock() {
+            let _ = child.wait();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QemuVmBackend — SessionBackend for QEMU/KVM VMs
+// ---------------------------------------------------------------------------
+
+/// Session backend that runs sessions inside QEMU/KVM virtual machines.
+///
+/// Each VM gets its own tmux server (accessed via SSH control mode).
+/// The backend manages the mapping from VM IDs to SSH control mode connections.
+pub struct QemuVmBackend {
+    /// VM lifecycle manager (shared with app layer for provisioning).
+    manager: Arc<Mutex<VmManager>>,
+    /// Active SSH control mode connections, keyed by VM ID.
+    controls: Mutex<HashMap<String, SshControlMode>>,
+}
+
+impl QemuVmBackend {
+    /// Create a new VM backend.
+    pub fn new(manager: Arc<Mutex<VmManager>>) -> Self {
+        Self {
+            manager,
+            controls: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Ensure an SSH control mode connection exists for the given VM.
+    fn ensure_control(&self, vm_id: &str) -> Result<()> {
+        let mut controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+
+        if controls.contains_key(vm_id) {
+            return Ok(());
+        }
+
+        let manager = self
+            .manager
+            .lock()
+            .map_err(|e| anyhow::anyhow!("manager lock: {e}"))?;
+
+        let instance = manager
+            .get_instance(vm_id)
+            .context(format!("VM {vm_id} not found"))?;
+
+        if instance.state != VmState::Ready {
+            bail!("VM {vm_id} is not ready (state: {})", instance.state);
+        }
+
+        let ssh_args = manager.ssh_args(&instance);
+        drop(manager); // Release lock before starting SSH (may take time)
+
+        let control = SshControlMode::start(&ssh_args)?;
+        controls.insert(vm_id.to_string(), control);
+
+        debug!(vm_id = %vm_id, "SSH control mode established");
+        Ok(())
+    }
+
+    /// Get the VM ID for a backend_id (format: "vm:<vm_id>:<pane_id>").
+    fn parse_backend_id(backend_id: &str) -> Result<(&str, &str)> {
+        let parts: Vec<&str> = backend_id.splitn(3, ':').collect();
+        if parts.len() != 3 || parts[0] != "vm" {
+            bail!("Invalid VM backend_id format: {backend_id} (expected vm:<vm_id>:<pane_id>)");
+        }
+        Ok((parts[1], parts[2]))
+    }
+
+    /// Build a composite backend_id: "vm:<vm_id>:<pane_id>".
+    fn make_backend_id(vm_id: &str, pane_id: &str) -> String {
+        format!("vm:{vm_id}:{pane_id}")
+    }
+
+    /// Run a tmux command on a specific VM's control mode.
+    fn ctrl_command(&self, vm_id: &str, cmd: &str) -> Result<String> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+        let ctrl = controls
+            .get(vm_id)
+            .context(format!("No control mode for VM {vm_id}"))?;
+        ctrl.send_command(cmd)
+    }
+
+    /// Run a tmux command without waiting for response.
+    fn ctrl_command_nowait(&self, vm_id: &str, cmd: &str) -> Result<()> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+        let ctrl = controls
+            .get(vm_id)
+            .context(format!("No control mode for VM {vm_id}"))?;
+        ctrl.send_command_nowait(cmd)
+    }
+
+    /// Register a pane sender for output monitoring.
+    fn register_pane(&self, vm_id: &str, pane_id: &str) -> Result<ControlModeReader> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+        let ctrl = controls
+            .get(vm_id)
+            .context(format!("No control mode for VM {vm_id}"))?;
+        let (tx, rx) = sync_channel(PANE_CHANNEL_CAPACITY);
+        {
+            let mut senders = ctrl
+                .pane_senders
+                .lock()
+                .map_err(|e| anyhow::anyhow!("pane_senders lock: {e}"))?;
+            senders.entry(pane_id.to_string()).or_default().push(tx);
+        }
+        Ok(ControlModeReader::new(rx))
+    }
+
+    /// Unregister a pane sender.
+    fn unregister_pane(&self, vm_id: &str, pane_id: &str) -> Result<()> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+        if let Some(ctrl) = controls.get(vm_id) {
+            let mut senders = ctrl
+                .pane_senders
+                .lock()
+                .map_err(|e| anyhow::anyhow!("pane_senders lock: {e}"))?;
+            senders.remove(pane_id);
+        }
+        Ok(())
+    }
+
+    /// Create a writer for a pane on a specific VM.
+    fn pane_writer(&self, vm_id: &str, pane_id: &str) -> Result<ControlModeWriter> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+        let ctrl = controls
+            .get(vm_id)
+            .context(format!("No control mode for VM {vm_id}"))?;
+        Ok(ControlModeWriter {
+            stdin: Arc::clone(&ctrl.stdin),
+            pane_id: pane_id.to_string(),
+        })
+    }
+
+    /// Capture screen content from a pane.
+    fn capture_pane(&self, vm_id: &str, pane_id: &str) -> Vec<u8> {
+        let cmd = format!("capture-pane -t {pane_id} -p -e -S -");
+        let content = self.ctrl_command(vm_id, &cmd).unwrap_or_default();
+        debug!(
+            vm_id = %vm_id,
+            pane_id = %pane_id,
+            bytes = content.len(),
+            "capture-pane result"
+        );
+        content.into_bytes()
+    }
+
+    /// Connect I/O to an existing pane in a VM.
+    fn connect_pane(
+        &self,
+        vm_id: &str,
+        pane_id: &str,
+        rows: u16,
+        cols: u16,
+    ) -> Result<AdoptedSession> {
+        let reader = self.register_pane(vm_id, pane_id)?;
+        self.ctrl_command(
+            vm_id,
+            &format!("refresh-client -A '{}:on'", pane_id.replace('\'', "'\\''")),
+        )?;
+        let initial_screen = self.capture_pane(vm_id, pane_id);
+        let writer = self.pane_writer(vm_id, pane_id)?;
+
+        // Force resize to trigger repaint.
+        self.force_resize(vm_id, pane_id, rows, cols)?;
+
+        Ok(AdoptedSession {
+            output: Box::new(reader),
+            input: Box::new(writer),
+            initial_screen,
+        })
+    }
+
+    /// Force a resize to trigger SIGWINCH in the VM's pane.
+    fn force_resize(&self, vm_id: &str, pane_id: &str, rows: u16, cols: u16) -> Result<()> {
+        if rows > 1 {
+            self.do_resize(vm_id, pane_id, rows - 1, cols)?;
+        } else {
+            self.do_resize(vm_id, pane_id, rows + 1, cols)?;
+        }
+        self.do_resize(vm_id, pane_id, rows, cols)?;
+        Ok(())
+    }
+
+    /// Resize a pane inside a VM's tmux.
+    fn do_resize(&self, vm_id: &str, pane_id: &str, rows: u16, cols: u16) -> Result<()> {
+        self.ctrl_command(
+            vm_id,
+            &format!("resize-window -t {pane_id} -x {cols} -y {rows}"),
+        )?;
+        self.ctrl_command(
+            vm_id,
+            &format!("resize-pane -t {pane_id} -x {cols} -y {rows}"),
+        )?;
+        Ok(())
+    }
+
+    /// Build a shell command string (same logic as LocalTmuxBackend).
+    fn build_shell_command(command: &str, args: &[String]) -> String {
+        let mut parts = vec![command.to_string()];
+        for arg in args {
+            parts.push(control_mode::shell_escape(arg));
+        }
+        parts.join(" ")
+    }
+
+    /// Disconnect from a VM's control mode (called when VM is being destroyed).
+    pub fn disconnect_vm(&self, vm_id: &str) {
+        if let Ok(mut controls) = self.controls.lock() {
+            controls.remove(vm_id);
+        }
+    }
+}
+
+impl SessionBackend for QemuVmBackend {
+    fn name(&self) -> &str {
+        "qemu-vm"
+    }
+
+    fn check_available(&self) -> Result<()> {
+        VmManager::check_available()
+    }
+
+    fn ensure_ready(&self) -> Result<()> {
+        let manager = self
+            .manager
+            .lock()
+            .map_err(|e| anyhow::anyhow!("manager lock: {e}"))?;
+        manager.ensure_dirs()
+    }
+
+    fn spawn(
+        &self,
+        window_name: &str,
+        command: &str,
+        args: &[String],
+        cwd: Option<&Path>,
+        env: &HashMap<String, String>,
+        rows: u16,
+        cols: u16,
+    ) -> Result<SpawnedSession> {
+        // The target VM ID is passed via the env map (injected by Session::spawn).
+        // This ensures each session is tied to its specific VM.
+        let vm_id = env
+            .get(crate::agent::backend::VM_ID_ENV_KEY)
+            .cloned()
+            .context("No VM ID in env — caller must set SessionConfig.vm_id")?;
+
+        let shell_cmd = Self::build_shell_command(command, args);
+
+        let cwd_part = match cwd {
+            Some(dir) => format!(" -c {}", control_mode::shell_escape(&dir.to_string_lossy())),
+            None => String::new(),
+        };
+        let cmd = format!(
+            "new-window -t {VM_TMUX_SESSION} -n {window_name} -P -F '#{{pane_id}}'{cwd_part} {shell_cmd}"
+        );
+        let result = self.ctrl_command(&vm_id, &cmd)?;
+        let pane_id = result.trim().to_string();
+
+        debug!(vm_id = %vm_id, pane_id = %pane_id, "VM tmux window created");
+
+        let connected = self.connect_pane(&vm_id, &pane_id, rows, cols)?;
+        let composite_id = Self::make_backend_id(&vm_id, &pane_id);
+
+        Ok(SpawnedSession {
+            backend_id: composite_id,
+            output: connected.output,
+            input: connected.input,
+            initial_screen: connected.initial_screen,
+        })
+    }
+
+    fn adopt(&self, backend_id: &str, rows: u16, cols: u16) -> Result<AdoptedSession> {
+        let (vm_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        self.ensure_control(vm_id)?;
+        self.connect_pane(vm_id, pane_id, rows, cols)
+    }
+
+    fn discover(&self) -> Result<Vec<DiscoveredSession>> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+
+        let mut sessions = Vec::new();
+        for (vm_id, ctrl) in controls.iter() {
+            let result = match ctrl.send_command(&format!(
+                "list-windows -t {VM_TMUX_SESSION} -F '#{{pane_id}}|#{{window_name}}|#{{pane_dead}}'"
+            )) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+
+            for line in result.lines() {
+                let parts: Vec<&str> = line.splitn(3, '|').collect();
+                if parts.len() < 3 {
+                    continue;
+                }
+
+                let window_name = parts[1];
+                if !window_name.starts_with("tb-") {
+                    continue;
+                }
+
+                sessions.push(DiscoveredSession {
+                    backend_id: Self::make_backend_id(vm_id, parts[0]),
+                    name: window_name.to_string(),
+                    is_alive: parts[2] != "1",
+                });
+            }
+        }
+
+        Ok(sessions)
+    }
+
+    fn resize(&self, backend_id: &str, rows: u16, cols: u16) -> Result<()> {
+        let (vm_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        self.do_resize(vm_id, pane_id, rows, cols)
+    }
+
+    fn is_dead(&self, backend_id: &str) -> Result<bool> {
+        let (vm_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        let result = self.ctrl_command(
+            vm_id,
+            &format!("display-message -t {pane_id} -p '#{{pane_dead}}'"),
+        )?;
+        Ok(result.trim() == "1")
+    }
+
+    fn kill(&self, backend_id: &str) -> Result<()> {
+        let (vm_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        let _ = self.unregister_pane(vm_id, pane_id);
+        self.ctrl_command(vm_id, &format!("kill-pane -t {pane_id}"))?;
+        Ok(())
+    }
+
+    fn detach(&self, backend_id: &str) -> Result<()> {
+        let (vm_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        if let Err(e) = self.ctrl_command_nowait(
+            vm_id,
+            &format!("refresh-client -A '{}:off'", pane_id.replace('\'', "'\\''")),
+        ) {
+            warn!("Failed to disable VM output monitoring during detach: {e}");
+        }
+        let _ = self.unregister_pane(vm_id, pane_id);
+        Ok(())
+    }
+
+    fn prepare_vm(&self, vm_id: &str) -> Result<()> {
+        self.ensure_control(vm_id)
+    }
+
+    fn default_shell(&self) -> String {
+        "/bin/bash".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_to_vm_path_basic() {
+        let result = host_to_vm_path(Path::new("/home/user/projects/my-app"));
+        assert_eq!(result, PathBuf::from("/home/thurbox/repos/my-app"));
+    }
+
+    #[test]
+    fn host_to_vm_path_trailing_slash() {
+        // PathBuf strips trailing slashes, so this should still work.
+        let result = host_to_vm_path(Path::new("/home/user/projects/my-app/"));
+        assert_eq!(result, PathBuf::from("/home/thurbox/repos/my-app"));
+    }
+
+    #[test]
+    fn host_to_vm_path_deep_nested() {
+        let result = host_to_vm_path(Path::new("/a/b/c/d/repo-name"));
+        assert_eq!(result, PathBuf::from("/home/thurbox/repos/repo-name"));
+    }
+
+    #[test]
+    fn host_to_vm_path_root_fallback() {
+        // Root path has no file_name, should use "repo" fallback.
+        let result = host_to_vm_path(Path::new("/"));
+        assert_eq!(result, PathBuf::from("/home/thurbox/repos/repo"));
+    }
+
+    #[test]
+    fn host_to_vm_path_single_component() {
+        let result = host_to_vm_path(Path::new("my-project"));
+        assert_eq!(result, PathBuf::from("/home/thurbox/repos/my-project"));
+    }
+
+    #[test]
+    fn vm_state_display() {
+        assert_eq!(VmState::Provisioning.to_string(), "Provisioning");
+        assert_eq!(VmState::Starting.to_string(), "Starting");
+        assert_eq!(VmState::Ready.to_string(), "Ready");
+        assert_eq!(VmState::Stopping.to_string(), "Stopping");
+        assert_eq!(VmState::Stopped.to_string(), "Stopped");
+        assert_eq!(
+            VmState::Failed("disk full".to_string()).to_string(),
+            "Failed: disk full"
+        );
+    }
+
+    #[test]
+    fn vm_state_db_roundtrip() {
+        let states = vec![
+            VmState::Provisioning,
+            VmState::Starting,
+            VmState::Ready,
+            VmState::Stopping,
+            VmState::Stopped,
+            VmState::Failed("test error".to_string()),
+        ];
+
+        for state in states {
+            let db_str = state.to_db_str();
+            let parsed = VmState::from_db_str(&db_str);
+            assert_eq!(state, parsed);
+        }
+    }
+
+    #[test]
+    fn vm_state_unknown_string_defaults_to_stopped() {
+        assert_eq!(VmState::from_db_str("unknown"), VmState::Stopped);
+    }
+
+    #[test]
+    fn vm_config_default() {
+        let config = VmConfig::default();
+        assert_eq!(config.cpus, 2);
+        assert_eq!(config.memory_mb, 2048);
+        assert_eq!(config.disk_gb, 10);
+        assert!(config.setup_script.is_none());
+        assert!(config.base_image.contains("debian"));
+    }
+
+    #[test]
+    fn debian_image_url_format() {
+        let url = debian_image_url("debian-13-genericcloud-amd64.qcow2");
+        assert_eq!(
+            url,
+            "https://cloud.debian.org/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2"
+        );
+    }
+
+    #[test]
+    fn vm_instance_paths() {
+        let instance = VmInstance {
+            id: "test-vm".to_string(),
+            state: VmState::Stopped,
+            ssh_port: 22200,
+            config: VmConfig::default(),
+            vm_dir: PathBuf::from("/tmp/thurbox/vms/test-vm"),
+            process: None,
+        };
+
+        assert_eq!(
+            instance.disk_path(),
+            PathBuf::from("/tmp/thurbox/vms/test-vm/disk.qcow2")
+        );
+        assert_eq!(
+            instance.cloud_init_path(),
+            PathBuf::from("/tmp/thurbox/vms/test-vm/cloud-init.iso")
+        );
+        assert_eq!(
+            instance.ssh_key_path(),
+            PathBuf::from("/tmp/thurbox/vms/test-vm/ssh_key")
+        );
+        assert_eq!(
+            instance.ssh_control_path(),
+            PathBuf::from("/tmp/thurbox-ssh-test-vm")
+        );
+        assert_eq!(instance.ssh_user(), "thurbox");
+    }
+
+    #[test]
+    fn vm_manager_new() {
+        let manager = VmManager::new(Path::new("/tmp/thurbox"));
+        assert_eq!(manager.vms_dir, PathBuf::from("/tmp/thurbox/vms"));
+        assert_eq!(manager.images_dir, PathBuf::from("/tmp/thurbox/images"));
+    }
+
+    #[test]
+    fn vm_manager_base_image_path() {
+        let manager = VmManager::new(Path::new("/data/thurbox"));
+        assert_eq!(
+            manager.base_image_path("ubuntu.img"),
+            PathBuf::from("/data/thurbox/images/ubuntu.img")
+        );
+    }
+
+    #[test]
+    fn vm_manager_allocate_port_increments() {
+        let manager = VmManager::new(Path::new("/tmp"));
+        let p1 = manager.allocate_port();
+        let p2 = manager.allocate_port();
+        // Ports must be in the expected range and strictly increasing.
+        // Exact values depend on which ports are free on the host.
+        assert!(p1 >= BASE_SSH_PORT);
+        assert!(p2 > p1);
+    }
+
+    #[test]
+    fn vm_manager_ssh_args_format() {
+        let manager = VmManager::new(Path::new("/tmp/thurbox"));
+        let instance = VmInstance {
+            id: "test".to_string(),
+            state: VmState::Ready,
+            ssh_port: 22200,
+            config: VmConfig::default(),
+            vm_dir: PathBuf::from("/tmp/thurbox/vms/test"),
+            process: None,
+        };
+        let args = manager.ssh_args(&instance);
+        assert!(args.contains(&"-i".to_string()));
+        assert!(args.contains(&"22200".to_string()));
+        assert!(args.iter().any(|a| a.contains("thurbox@localhost")));
+    }
+
+    // --- QemuVmBackend tests ---
+
+    #[test]
+    fn backend_name() {
+        let manager = Arc::new(Mutex::new(VmManager::new(Path::new("/tmp"))));
+        let backend = QemuVmBackend::new(manager);
+        assert_eq!(backend.name(), "qemu-vm");
+    }
+
+    #[test]
+    fn parse_backend_id_valid() {
+        let (vm_id, pane_id) = QemuVmBackend::parse_backend_id("vm:abc-123:%42").unwrap();
+        assert_eq!(vm_id, "abc-123");
+        assert_eq!(pane_id, "%42");
+    }
+
+    #[test]
+    fn parse_backend_id_invalid_prefix() {
+        assert!(QemuVmBackend::parse_backend_id("tmux:abc:%42").is_err());
+    }
+
+    #[test]
+    fn parse_backend_id_missing_parts() {
+        assert!(QemuVmBackend::parse_backend_id("vm:abc").is_err());
+    }
+
+    #[test]
+    fn parse_backend_id_empty() {
+        assert!(QemuVmBackend::parse_backend_id("").is_err());
+    }
+
+    #[test]
+    fn make_backend_id_format() {
+        let id = QemuVmBackend::make_backend_id("vm-uuid-1", "%5");
+        assert_eq!(id, "vm:vm-uuid-1:%5");
+    }
+
+    #[test]
+    fn backend_id_roundtrip() {
+        let vm_id = "test-vm-abc";
+        let pane_id = "%99";
+        let composite = QemuVmBackend::make_backend_id(vm_id, pane_id);
+        let (parsed_vm, parsed_pane) = QemuVmBackend::parse_backend_id(&composite).unwrap();
+        assert_eq!(parsed_vm, vm_id);
+        assert_eq!(parsed_pane, pane_id);
+    }
+
+    #[test]
+    fn build_shell_command_simple() {
+        let cmd = QemuVmBackend::build_shell_command("claude", &[]);
+        assert_eq!(cmd, "claude");
+    }
+
+    #[test]
+    fn build_shell_command_with_args() {
+        let args = vec!["--resume".to_string(), "abc-123".to_string()];
+        let cmd = QemuVmBackend::build_shell_command("claude", &args);
+        assert_eq!(cmd, "claude --resume abc-123");
+    }
+
+    #[test]
+    fn disconnect_vm_removes_control() {
+        let manager = Arc::new(Mutex::new(VmManager::new(Path::new("/tmp"))));
+        let backend = QemuVmBackend::new(manager);
+        // Should not panic even if VM doesn't exist
+        backend.disconnect_vm("nonexistent");
+    }
+
+    #[test]
+    fn get_instance_returns_snapshot() {
+        let manager = VmManager::new(Path::new("/tmp/thurbox"));
+        // No instances yet
+        assert!(manager.get_instance("nonexistent").is_none());
+    }
+}

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -722,6 +722,7 @@ impl App {
     }
 
     fn handle_session_mode_key(&mut self, code: KeyCode) {
+        let max_index = if self.backends.has("qemu-vm") { 2 } else { 1 };
         match code {
             KeyCode::Esc => {
                 self.show_session_mode_modal = false;
@@ -729,33 +730,61 @@ impl App {
                 self.pending_all_repos = None;
             }
             KeyCode::Char('j') | KeyCode::Down => {
-                if self.session_mode_index == 0 {
-                    self.session_mode_index = 1;
+                if self.session_mode_index < max_index {
+                    self.session_mode_index += 1;
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                self.session_mode_index = 0;
+                self.session_mode_index = self.session_mode_index.saturating_sub(1);
             }
             KeyCode::Enter => {
                 self.show_session_mode_modal = false;
-                if self.session_mode_index == 0 {
-                    // Normal mode
-                    if let Some(all_repos) = self.pending_all_repos.take() {
-                        // Multi-repo project: use first repo as CWD, rest as add-dir
-                        self.pending_repo_path = None;
-                        let config = SessionConfig {
-                            cwd: Some(all_repos[0].clone()),
-                            additional_dirs: all_repos[1..].to_vec(),
-                            ..SessionConfig::default()
-                        };
-                        self.spawn_session_with_config(&config);
-                    } else if let Some(path) = self.pending_repo_path.take() {
-                        // Single-repo project
-                        self.spawn_session_in_repo(path);
+                match self.session_mode_index {
+                    0 => {
+                        // Normal mode
+                        if let Some(all_repos) = self.pending_all_repos.take() {
+                            // Multi-repo project: use first repo as CWD, rest as add-dir
+                            self.pending_repo_path = None;
+                            let config = SessionConfig {
+                                cwd: Some(all_repos[0].clone()),
+                                additional_dirs: all_repos[1..].to_vec(),
+                                ..SessionConfig::default()
+                            };
+                            self.spawn_session_with_config(&config);
+                        } else if let Some(path) = self.pending_repo_path.take() {
+                            // Single-repo project
+                            self.spawn_session_in_repo(path);
+                        }
                     }
-                } else {
-                    // Worktree mode
-                    self.start_branch_selection();
+                    1 => {
+                        // Worktree mode
+                        self.start_branch_selection();
+                    }
+                    2 => {
+                        // Sandbox VM mode — build config for role selection after
+                        // VM is ready, store MCP servers for writing into the VM.
+                        let config = if let Some(all_repos) = self.pending_all_repos.clone() {
+                            SessionConfig {
+                                cwd: Some(all_repos[0].clone()),
+                                additional_dirs: all_repos[1..].to_vec(),
+                                ..SessionConfig::default()
+                            }
+                        } else if let Some(ref path) = self.pending_repo_path {
+                            SessionConfig {
+                                cwd: Some(path.clone()),
+                                ..SessionConfig::default()
+                            }
+                        } else {
+                            SessionConfig::default()
+                        };
+                        self.pending_vm_config = Some(config);
+                        self.pending_vm_mcp_servers = self
+                            .active_project()
+                            .map(|p| p.config.mcp_servers.clone())
+                            .filter(|s| !s.is_empty());
+                        self.start_vm_provisioning();
+                    }
+                    _ => {}
                 }
             }
             _ => {}
@@ -842,6 +871,7 @@ impl App {
                 self.pending_spawn_config = None;
                 self.pending_spawn_worktrees.clear();
                 self.pending_spawn_name = None;
+                self.pending_vm_id = None;
                 // Undo the counter increment from prepare_spawn()
                 self.session_counter = self.session_counter.saturating_sub(1);
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,9 +16,9 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
-use tracing::error;
+use tracing::{error, info, warn};
 
-use crate::agent::{Session, SessionBackend};
+use crate::agent::{BackendRegistry, Session, SessionBackend};
 use crate::git;
 use crate::project::{ProjectConfig, ProjectId, ProjectInfo};
 use crate::session::{
@@ -281,6 +281,14 @@ pub enum AppMessage {
     },
     Resize(u16, u16),
     ExternalStateChange(StateDelta),
+    /// A VM has finished provisioning and is ready for a session.
+    VmReady {
+        vm_id: String,
+    },
+    /// VM provisioning failed.
+    VmFailed {
+        error: String,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -324,7 +332,7 @@ pub struct App {
     pub(crate) active_project_index: usize,
     pub(crate) sessions: Vec<Session>,
     pub(crate) active_index: usize,
-    backend: Arc<dyn SessionBackend>,
+    backends: BackendRegistry,
     provider: Arc<dyn crate::agent::AgentProvider>,
     pub(crate) db: Database,
     pub(crate) focus: InputFocus,
@@ -363,6 +371,8 @@ pub struct App {
     pub(crate) available_branches: Vec<String>,
     pub(crate) pending_repo_path: Option<PathBuf>,
     pub(crate) pending_all_repos: Option<Vec<PathBuf>>,
+    /// Repo paths collected for rsync into the VM (set during provisioning).
+    pub(crate) pending_vm_repo_paths: Option<Vec<PathBuf>>,
     pub(crate) show_worktree_name_modal: bool,
     pub(crate) worktree_name_input: TextInput,
     pub(crate) pending_base_branch: Option<String>,
@@ -417,6 +427,26 @@ pub struct App {
     pub(crate) show_restore_sessions_modal: bool,
     pub(crate) restore_sessions_list: Vec<DeletedSessionInfo>,
     pub(crate) restore_sessions_index: usize,
+    /// VM provisioning in progress — stores the pending session config.
+    vm_provisioning: bool,
+    /// VM ID currently being provisioned.
+    vm_provisioning_id: Option<String>,
+    /// VM lifecycle manager (shared with background provisioning thread).
+    vm_manager: Option<Arc<std::sync::Mutex<crate::agent::VmManager>>>,
+    /// Receiver for VM provisioning results from background thread.
+    vm_provision_rx: Option<mpsc::Receiver<Result<String, String>>>,
+    /// Receiver for VM provisioning step updates (progress messages).
+    vm_provision_step_rx: Option<mpsc::Receiver<String>>,
+    /// Current VM provisioning step description shown in the status bar.
+    vm_provisioning_step: String,
+    /// Placeholder session shown in the session list during VM provisioning.
+    vm_placeholder: Option<SessionInfo>,
+    /// Session config preserved during VM provisioning for role selection after ready.
+    pending_vm_config: Option<SessionConfig>,
+    /// VM ID stored after provisioning completes, consumed by `do_spawn_session`.
+    pending_vm_id: Option<String>,
+    /// MCP servers to write into the VM working directory before spawning.
+    pending_vm_mcp_servers: Option<Vec<crate::session::McpServerConfig>>,
 }
 
 /// Snapshot of editor field values for dirty detection.
@@ -567,9 +597,10 @@ impl App {
     pub fn new(
         rows: u16,
         cols: u16,
-        backend: Arc<dyn SessionBackend>,
+        backends: BackendRegistry,
         provider: Arc<dyn crate::agent::AgentProvider>,
         db: Database,
+        vm_manager: Option<Arc<std::sync::Mutex<crate::agent::VmManager>>>,
     ) -> Self {
         // Migrate roles from config.toml on first run after upgrade
         migrate_config_toml_roles(&db);
@@ -592,7 +623,7 @@ impl App {
             active_project_index: 0,
             sessions: Vec::new(),
             active_index: 0,
-            backend,
+            backends,
             provider,
             db,
             focus: InputFocus::ProjectList,
@@ -631,6 +662,7 @@ impl App {
             available_branches: Vec::new(),
             pending_repo_path: None,
             pending_all_repos: None,
+            pending_vm_repo_paths: None,
             show_worktree_name_modal: false,
             worktree_name_input: TextInput::new(),
             pending_base_branch: None,
@@ -675,6 +707,16 @@ impl App {
             show_restore_sessions_modal: false,
             restore_sessions_list: Vec::new(),
             restore_sessions_index: 0,
+            vm_provisioning: false,
+            vm_provisioning_id: None,
+            vm_manager,
+            vm_provision_rx: None,
+            vm_provision_step_rx: None,
+            vm_provisioning_step: String::new(),
+            vm_placeholder: None,
+            pending_vm_config: None,
+            pending_vm_id: None,
+            pending_vm_mcp_servers: None,
         }
     }
 
@@ -884,6 +926,7 @@ impl App {
             additional_dirs,
             role,
             permissions,
+            vm_id: session.info.vm_id.clone(),
         };
 
         let (rows, cols) = self.content_area_size();
@@ -1072,6 +1115,7 @@ impl App {
             additional_dirs: Vec::new(),
             role: deleted.role,
             permissions,
+            vm_id: None,
         };
 
         let session_name = deleted.name.clone();
@@ -1082,7 +1126,7 @@ impl App {
             rows,
             cols,
             &config,
-            &self.backend,
+            self.backends.default_backend(),
             &self.provider,
         ) {
             Ok(mut session) => {
@@ -1168,6 +1212,8 @@ impl App {
             AppMessage::MouseClick { x, y, modifiers } => self.handle_mouse_click(x, y, modifiers),
             AppMessage::Resize(cols, rows) => self.handle_resize(cols, rows),
             AppMessage::ExternalStateChange(delta) => self.handle_external_state_change(delta),
+            AppMessage::VmReady { vm_id } => self.handle_vm_ready(&vm_id),
+            AppMessage::VmFailed { error } => self.handle_vm_failed(&error),
         }
     }
 
@@ -1415,10 +1461,69 @@ impl App {
             config.agent_session_id = Some(uuid::Uuid::new_v4().to_string());
         }
 
-        match Session::spawn(name, rows, cols, &config, &self.backend, &self.provider) {
+        // When a VM was just provisioned, use the VM backend and take the
+        // placeholder's name instead of generating a new one.
+        let vm_id = self.pending_vm_id.take();
+        let placeholder = if vm_id.is_some() {
+            self.vm_placeholder.take()
+        } else {
+            None
+        };
+        let placeholder_id = placeholder.as_ref().map(|ph| ph.id);
+        // Tie the session to its specific VM.
+        if vm_id.is_some() {
+            config.vm_id = vm_id.clone();
+        }
+        let (backend, spawn_name): (Arc<dyn SessionBackend>, String) = if vm_id.is_some() {
+            let vm_name = placeholder
+                .as_ref()
+                .map(|ph| ph.name.clone())
+                .unwrap_or_else(|| name.clone());
+            match self.backends.get("qemu-vm") {
+                Some(b) => (Arc::clone(b), vm_name),
+                None => {
+                    self.set_error("QEMU VM backend disappeared".to_string());
+                    return;
+                }
+            }
+        } else {
+            (Arc::clone(self.backends.default_backend()), name)
+        };
+
+        match Session::spawn(spawn_name, rows, cols, &config, &backend, &self.provider) {
             Ok(mut session) => {
                 session.info.worktrees = worktrees;
                 let session_id = session.info.id;
+
+                if let Some(ref vid) = vm_id {
+                    session.info.vm_id = Some(vid.clone());
+
+                    // Replace the placeholder ID with the real session ID.
+                    if let Some(ph_id) = placeholder_id {
+                        if let Some(project) = self.projects.get_mut(self.active_project_index) {
+                            project.session_ids.retain(|id| *id != ph_id);
+                        }
+                    }
+
+                    // Persist SSH port (allocated during provisioning, stored as 0 initially).
+                    if let Some(ref mgr) = self.vm_manager {
+                        if let Ok(mgr) = mgr.lock() {
+                            if let Some(inst) = mgr.get_instance(vid) {
+                                if let Err(e) = self.db.update_vm_ssh_port(vid, inst.ssh_port) {
+                                    error!(vm_id = %vid, "Failed to persist VM SSH port: {e}");
+                                }
+                            }
+                        }
+                    }
+
+                    if let Err(e) =
+                        self.db
+                            .update_vm_state(vid, &crate::session::VmState::Ready, None, None)
+                    {
+                        error!(vm_id = %vid, "Failed to update VM state to Ready: {e}");
+                    }
+                }
+
                 self.sessions.push(session);
                 self.active_index = self.sessions.len() - 1;
                 self.focus = InputFocus::Terminal;
@@ -1432,13 +1537,256 @@ impl App {
                     }
                 }
 
-                // Sync to shared state for other instances
+                // Sync to shared state for other instances — this upserts
+                // the session into the DB (required before FK references).
                 self.save_state();
+
+                // Link the VM record to this session. This must happen AFTER
+                // save_state() because vms.session_id has a FK constraint
+                // referencing sessions(id), so the session row must exist first.
+                if let Some(ref vid) = vm_id {
+                    let sid_str = session_id.to_string();
+                    if let Err(e) = self.db.update_vm_session(vid, &sid_str) {
+                        error!(
+                            vm_id = %vid,
+                            session_id = %sid_str,
+                            "Failed to link VM record to session: {e}"
+                        );
+                    }
+                }
             }
             Err(e) => {
                 error!("Failed to spawn session: {e}");
                 self.set_error(format!("Failed to start claude: {e:#}"));
             }
+        }
+    }
+
+    /// Start asynchronous VM provisioning for a sandbox session.
+    ///
+    /// Called when the user selects "Sandbox VM" from the session mode modal.
+    /// The VM boots in the background; `handle_vm_ready` spawns the actual session.
+    pub(crate) fn start_vm_provisioning(&mut self) {
+        if self.vm_provisioning {
+            self.set_info("VM is already being provisioned...".to_string());
+            return;
+        }
+
+        if self.backends.get("qemu-vm").is_none() {
+            self.set_error("QEMU VM backend not available".to_string());
+            return;
+        }
+
+        let manager = match self.vm_manager {
+            Some(ref m) => Arc::clone(m),
+            None => {
+                self.set_error("VM manager not initialized".to_string());
+                return;
+            }
+        };
+
+        let vm_id = uuid::Uuid::new_v4().to_string();
+        self.vm_provisioning = true;
+        self.vm_provisioning_id = Some(vm_id.clone());
+
+        // Create a placeholder session visible in the session list during provisioning.
+        let name = self.next_session_name();
+        let mut placeholder = SessionInfo::new(name);
+        placeholder.status = SessionStatus::Provisioning;
+        placeholder.vm_id = Some(vm_id.clone());
+        placeholder.provisioning_step = Some("Checking tools...".to_string());
+
+        // Add placeholder to the active project's session list so it renders.
+        if let Some(project) = self.projects.get_mut(self.active_project_index) {
+            project.session_ids.push(placeholder.id);
+        }
+        self.vm_placeholder = Some(placeholder);
+
+        self.set_info("Provisioning VM...".to_string());
+
+        // Collect repo paths for rsync into the VM.
+        // pending_repo_path and pending_all_repos are already set by spawn_session().
+        let repo_paths: Vec<PathBuf> = if let Some(ref all_repos) = self.pending_all_repos {
+            all_repos.clone()
+        } else if let Some(ref path) = self.pending_repo_path {
+            vec![path.clone()]
+        } else {
+            Vec::new()
+        };
+
+        let config = crate::session::VmConfig::default();
+        let project_id = self.active_project().map(|p| p.id.to_string());
+
+        // Record in DB
+        if let Err(e) = self.db.insert_vm(
+            &vm_id,
+            None,
+            project_id.as_deref(),
+            &crate::session::VmState::Provisioning,
+            0, // SSH port allocated later by VmManager
+            &config,
+        ) {
+            error!("Failed to insert VM record: {e}");
+            self.set_error(format!("Failed to create VM: {e}"));
+            self.vm_provisioning = false;
+            self.vm_provisioning_id = None;
+            return;
+        }
+
+        // Spawn background thread for VM provisioning (QEMU + cloud-init + SSH + rsync).
+        let (tx, rx) = mpsc::channel();
+        let (step_tx, step_rx) = mpsc::channel();
+        self.vm_provision_rx = Some(rx);
+        self.vm_provision_step_rx = Some(step_rx);
+        self.vm_provisioning_step = "Checking tools...".to_string();
+        let vm_id_thread = vm_id.clone();
+        let config_thread = config;
+        tracing::info!(vm_id = %vm_id, "VM provisioning started");
+
+        let spawn_result = std::thread::Builder::new()
+            .name(format!("vm-provision-{}", &vm_id[..8]))
+            .spawn(move || {
+                let mgr = manager.lock().unwrap();
+                let result = mgr.create_vm(&vm_id_thread, &config_thread, &repo_paths, &step_tx);
+                drop(mgr);
+                match result {
+                    Ok(()) => {
+                        let _ = tx.send(Ok(vm_id_thread));
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(format!("{e:#}")));
+                    }
+                }
+            });
+
+        if let Err(e) = spawn_result {
+            error!("Failed to spawn VM provisioning thread: {e}");
+            self.set_error(format!("Failed to start VM provisioning: {e}"));
+            self.vm_provisioning = false;
+            self.vm_provisioning_id = None;
+            self.vm_provision_rx = None;
+        }
+    }
+
+    /// Poll for VM provisioning results and step updates from the background thread.
+    fn poll_vm_provision(&mut self) {
+        // Drain step updates (keep the latest).
+        if let Some(ref rx) = self.vm_provision_step_rx {
+            while let Ok(step) = rx.try_recv() {
+                self.vm_provisioning_step = step.clone();
+                if let Some(ref mut ph) = self.vm_placeholder {
+                    ph.provisioning_step = Some(step);
+                }
+            }
+        }
+
+        let result = match self.vm_provision_rx {
+            Some(ref rx) => match rx.try_recv() {
+                Ok(r) => Some(r),
+                Err(mpsc::TryRecvError::Empty) => None,
+                Err(mpsc::TryRecvError::Disconnected) => Some(Err(
+                    "VM provisioning thread terminated unexpectedly".to_string(),
+                )),
+            },
+            None => None,
+        };
+
+        if let Some(result) = result {
+            self.vm_provision_rx = None;
+            self.vm_provision_step_rx = None;
+            self.vm_provisioning_step.clear();
+            match result {
+                Ok(vm_id) => self.handle_vm_ready(&vm_id),
+                Err(error) => self.handle_vm_failed(&error),
+            }
+        }
+    }
+
+    /// Handle a successfully provisioned VM — route through role selection before
+    /// spawning. The actual spawn happens in `do_spawn_session` which checks
+    /// `pending_vm_id` to use the VM backend.
+    fn handle_vm_ready(&mut self, vm_id: &str) {
+        self.vm_provisioning = false;
+        self.vm_provisioning_id = None;
+        self.set_info("VM ready — starting session...".to_string());
+
+        let backend = match self.backends.get("qemu-vm") {
+            Some(b) => Arc::clone(b),
+            None => {
+                self.set_error("QEMU VM backend disappeared".to_string());
+                return;
+            }
+        };
+
+        // Establish SSH control mode connection for the newly provisioned VM.
+        if let Err(e) = backend.prepare_vm(vm_id) {
+            error!("Failed to establish VM control mode: {e}");
+            self.set_error(format!("VM ready but control mode failed: {e:#}"));
+            return;
+        }
+
+        // Take the pending config built during session mode selection, remap host
+        // paths to VM paths.
+        let mut config = self.pending_vm_config.take().unwrap_or_default();
+        if let Some(ref cwd) = config.cwd {
+            config.cwd = Some(crate::agent::host_to_vm_path(cwd));
+        }
+        config.additional_dirs = config
+            .additional_dirs
+            .iter()
+            .map(|p| crate::agent::host_to_vm_path(p))
+            .collect();
+        self.pending_repo_path = None;
+        self.pending_all_repos = None;
+        self.pending_vm_repo_paths = None;
+
+        // Write project MCP servers as .mcp.json into the VM working directory.
+        if let Some(mcp_servers) = self.pending_vm_mcp_servers.take() {
+            if let Some(ref cwd) = config.cwd {
+                if let Some(ref mgr) = self.vm_manager {
+                    let mgr = mgr.lock().unwrap();
+                    if let Some(instance) = mgr.get_instance(vm_id) {
+                        if let Err(e) = write_vm_mcp_json(&instance, cwd, &mcp_servers) {
+                            warn!("Failed to write .mcp.json into VM: {e:#}");
+                        }
+                    }
+                }
+            }
+        }
+
+        // Store VM ID so `do_spawn_session` uses the VM backend.
+        self.pending_vm_id = Some(vm_id.to_string());
+
+        // Route through role selection (prepare_spawn handles 0/1/2+ roles).
+        self.prepare_spawn(config, Vec::new());
+    }
+
+    /// Handle a failed VM provisioning attempt.
+    fn handle_vm_failed(&mut self, error: &str) {
+        self.vm_provisioning = false;
+        let vm_id = self.vm_provisioning_id.take();
+        self.set_error(format!("VM provisioning failed: {error}"));
+        self.pending_repo_path = None;
+        self.pending_all_repos = None;
+        self.pending_vm_repo_paths = None;
+        self.pending_vm_config = None;
+        self.pending_vm_id = None;
+        self.pending_vm_mcp_servers = None;
+
+        // Update placeholder to show error state (keep it visible).
+        if let Some(ref mut ph) = self.vm_placeholder {
+            ph.status = SessionStatus::Error;
+            ph.provisioning_step = Some(error.to_string());
+        }
+
+        // Update DB record
+        if let Some(id) = &vm_id {
+            let _ = self.db.update_vm_state(
+                id,
+                &crate::session::VmState::Failed(error.to_string()),
+                None,
+                Some(error),
+            );
         }
     }
 
@@ -1740,6 +2088,9 @@ impl App {
             self.handle_external_state_change(delta);
         }
 
+        // Poll for VM provisioning results from background thread
+        self.poll_vm_provision();
+
         // Process queued session commands from MCP
         self.process_session_commands();
     }
@@ -1974,7 +2325,7 @@ impl App {
                 rows,
                 cols,
                 &shared_session.backend_id,
-                &self.backend,
+                self.backends.default_backend(),
                 &self.provider,
                 env,
             ) {
@@ -2022,6 +2373,7 @@ impl App {
                             additional_dirs: shared_session.additional_dirs.clone(),
                             role: shared_session.role.clone(),
                             permissions,
+                            vm_id: None,
                         };
 
                         let (rows, cols) = self.content_area_size();
@@ -2030,7 +2382,7 @@ impl App {
                             rows,
                             cols,
                             &config,
-                            &self.backend,
+                            self.backends.default_backend(),
                             &self.provider,
                         ) {
                             spawned.info.id = shared_session.id;
@@ -2070,7 +2422,9 @@ impl App {
                     for sid in &p.session_ids {
                         if let Some(s) = self.sessions.iter().find(|s| s.info.id == *sid) {
                             match s.info.status {
-                                SessionStatus::Busy => busy_count += 1,
+                                SessionStatus::Busy | SessionStatus::Provisioning => {
+                                    busy_count += 1;
+                                }
                                 SessionStatus::Waiting => waiting_count += 1,
                                 SessionStatus::Error => error_count += 1,
                                 SessionStatus::Idle => {}
@@ -2099,14 +2453,24 @@ impl App {
                 .collect();
 
             let project_session_indices = self.active_project_sessions();
-            let project_sessions: Vec<&SessionInfo> = project_session_indices
+            let mut project_sessions: Vec<&SessionInfo> = project_session_indices
                 .iter()
                 .map(|&i| &self.sessions[i].info)
                 .collect();
-            let session_elapsed_ms: Vec<u64> = project_session_indices
+            let mut session_elapsed_ms: Vec<u64> = project_session_indices
                 .iter()
                 .map(|&i| self.sessions[i].millis_since_last_output())
                 .collect();
+
+            // Include VM placeholder in the session list if it belongs to this project.
+            if let Some(ref ph) = self.vm_placeholder {
+                if let Some(project) = self.projects.get(self.active_project_index) {
+                    if project.session_ids.contains(&ph.id) {
+                        project_sessions.push(ph);
+                        session_elapsed_ms.push(0);
+                    }
+                }
+            }
 
             let panel_focus = match self.focus {
                 InputFocus::ProjectList => project_list::LeftPanelFocus::Projects,
@@ -2143,8 +2507,35 @@ impl App {
         // Info panel
         if let Some(info_area) = areas.info_panel {
             let active_project = self.projects.get(self.active_project_index);
-            if let Some(session) = self.sessions.get(self.active_index) {
-                info_panel::render_info_panel(frame, info_area, &session.info, active_project);
+
+            // Determine the session info to display: real session or VM placeholder.
+            let info_session: Option<&SessionInfo> = self
+                .sessions
+                .get(self.active_index)
+                .map(|s| &s.info)
+                .or(self.vm_placeholder.as_ref());
+
+            if let Some(info) = info_session {
+                let vm_details = info.vm_id.as_deref().and_then(|vm_id| {
+                    self.db
+                        .get_vm(vm_id)
+                        .ok()
+                        .flatten()
+                        .map(|rec| info_panel::VmDetails {
+                            state: rec.state.to_string(),
+                            cpus: rec.cpus,
+                            memory_mb: rec.memory_mb,
+                            ssh_port: rec.ssh_port,
+                            base_image: rec.base_image,
+                        })
+                });
+                info_panel::render_info_panel(
+                    frame,
+                    info_area,
+                    info,
+                    active_project,
+                    vm_details.as_ref(),
+                );
             }
         }
 
@@ -2197,6 +2588,8 @@ impl App {
                 status: self.status_message.as_ref(),
                 focus_label,
                 sync_in_progress: self.worktree_sync_in_progress,
+                vm_provisioning: self.vm_provisioning,
+                vm_provisioning_step: &self.vm_provisioning_step,
                 tick_count: self.tick_count,
             },
         );
@@ -2276,6 +2669,7 @@ impl App {
                 frame,
                 &session_mode_modal::SessionModeState {
                     selected_index: self.session_mode_index,
+                    vm_available: self.backends.has("qemu-vm"),
                 },
             );
         }
@@ -2455,6 +2849,10 @@ impl App {
         self.set_status(StatusLevel::Error, text.into());
     }
 
+    fn set_info(&mut self, text: impl Into<String>) {
+        self.set_status(StatusLevel::Info, text.into());
+    }
+
     /// Capture current role editor field values as a snapshot for dirty detection.
     fn capture_role_editor_snapshot(&self) -> EditorSnapshot {
         EditorSnapshot {
@@ -2624,11 +3022,33 @@ impl App {
     ///
     /// Tries to adopt existing backend sessions (tmux windows) or spawns new
     /// sessions with `--resume` to reconnect to the agent session.
+    ///
+    /// For VM-backed sessions, this first restores the VM instance in `VmManager`
+    /// and establishes an SSH control mode connection before attempting adoption.
     pub fn restore_sessions(&mut self, sessions: Vec<sync::SharedSession>, session_counter: usize) {
         self.session_counter = session_counter;
 
-        // Discover existing sessions from the backend.
-        let discovered = self.backend.discover().unwrap_or_default();
+        // Pre-flight: restore any VMs that sessions depend on, so that
+        // discover() on the VM backend can find their tmux panes.
+        for shared in &sessions {
+            if shared.backend_type == "qemu-vm" {
+                self.restore_vm_for_session(shared);
+            }
+        }
+
+        // Discover existing sessions from ALL backends, not just the default.
+        let mut discovered = Vec::new();
+        for backend in self.backends.all_backends() {
+            match backend.discover() {
+                Ok(disc) => discovered.extend(disc),
+                Err(e) => {
+                    warn!(
+                        backend = backend.name(),
+                        "Failed to discover sessions from backend: {e}"
+                    );
+                }
+            }
+        }
 
         for shared in sessions {
             let name = shared.name;
@@ -2661,6 +3081,13 @@ impl App {
                     .find(|d| d.name == expected_name && d.is_alive)
             };
 
+            // Select the correct backend based on the persisted backend_type.
+            let backend = self
+                .backends
+                .get(&shared.backend_type)
+                .cloned()
+                .unwrap_or_else(|| self.backends.default_backend().clone());
+
             // Try to adopt the existing backend session.
             let env = self.resolve_role_permissions(&role).env;
             let adopted = matching_discovered.and_then(|disc| {
@@ -2670,7 +3097,7 @@ impl App {
                     rows,
                     cols,
                     &disc.backend_id,
-                    &self.backend,
+                    &backend,
                     &self.provider,
                     env.clone(),
                 ) {
@@ -2689,6 +3116,14 @@ impl App {
                 session.info.additional_dirs = shared.additional_dirs.clone();
                 session.info.role = role;
                 session.info.worktrees = worktrees.clone();
+
+                // Restore vm_id on adopted VM sessions.
+                if shared.backend_type == "qemu-vm" {
+                    if let Ok(Some(vm_record)) = self.db.get_vm_by_session(&session_id.to_string())
+                    {
+                        session.info.vm_id = Some(vm_record.id);
+                    }
+                }
 
                 // Re-adopt shell pane if one was persisted
                 if let Some(shell_bid) = &shared.shell_backend_id {
@@ -2736,6 +3171,35 @@ impl App {
                 let permissions =
                     self.resolve_role_permissions_for_project(&role, target_project_index);
 
+                // For VM sessions where the VM died, trigger re-provisioning so
+                // do_spawn_session uses the VM backend instead of local-tmux.
+                if shared.backend_type == "qemu-vm" {
+                    if let Ok(Some(vm_record)) = self.db.get_vm_by_session(&session_id.to_string())
+                    {
+                        // Check if the VM was restored (it's in VmManager).
+                        let vm_alive = self.vm_manager.as_ref().is_some_and(|mgr| {
+                            mgr.lock()
+                                .ok()
+                                .and_then(|m| m.vm_state(&vm_record.id))
+                                .is_some_and(|s| s == crate::session::VmState::Ready)
+                        });
+                        if !vm_alive {
+                            warn!(
+                                session = %session_id,
+                                vm_id = %vm_record.id,
+                                "VM died — session will be re-spawned with --resume on local-tmux"
+                            );
+                            // Mark VM as stopped in DB.
+                            let _ = self.db.update_vm_state(
+                                &vm_record.id,
+                                &crate::session::VmState::Stopped,
+                                None,
+                                Some("VM not reachable after restart"),
+                            );
+                        }
+                    }
+                }
+
                 // Admin sessions start fresh — --resume would fail because the
                 // old Claude conversation no longer exists after a tmux restart.
                 let config = SessionConfig {
@@ -2753,6 +3217,7 @@ impl App {
                     additional_dirs: shared.additional_dirs,
                     role,
                     permissions,
+                    vm_id: None,
                 };
                 self.do_spawn_session(name, &config, worktrees, Some(target_project_index));
             }
@@ -2760,6 +3225,64 @@ impl App {
 
         // Claim ownership of restored sessions in the shared state
         self.save_state();
+    }
+
+    /// Restore a VM instance for a VM-backed session before discovery/adoption.
+    ///
+    /// Looks up the VM record from the DB, re-registers it in `VmManager` (verifying
+    /// SSH is reachable), then establishes the SSH control mode connection so
+    /// `discover()` can find its tmux panes.
+    fn restore_vm_for_session(&mut self, shared: &sync::SharedSession) {
+        let session_id_str = shared.id.to_string();
+        let vm_record = match self.db.get_vm_by_session(&session_id_str) {
+            Ok(Some(rec)) => rec,
+            Ok(None) => {
+                warn!(session = %shared.id, "No VM record found for VM session");
+                return;
+            }
+            Err(e) => {
+                warn!(session = %shared.id, "Failed to look up VM record: {e}");
+                return;
+            }
+        };
+
+        // Re-register the running VM in VmManager.
+        if let Some(ref mgr) = self.vm_manager {
+            match mgr.lock() {
+                Ok(mgr) => {
+                    if let Err(e) = mgr.restore_vm(&vm_record) {
+                        warn!(
+                            vm_id = %vm_record.id,
+                            "VM not reachable, will fall through to re-spawn: {e}"
+                        );
+                        return;
+                    }
+                }
+                Err(e) => {
+                    warn!("VmManager lock poisoned: {e}");
+                    return;
+                }
+            }
+        } else {
+            warn!("No VmManager available for VM session restore");
+            return;
+        }
+
+        // Establish SSH control mode connection so discover() works.
+        if let Some(vm_backend) = self.backends.get("qemu-vm") {
+            if let Err(e) = vm_backend.prepare_vm(&vm_record.id) {
+                warn!(
+                    vm_id = %vm_record.id,
+                    "Failed to establish SSH control mode: {e}"
+                );
+            } else {
+                info!(
+                    vm_id = %vm_record.id,
+                    session = %shared.id,
+                    "VM restored and control mode established"
+                );
+            }
+        }
     }
 
     /// Find the project index that owns a session, falling back to `active_project_index`.
@@ -2872,6 +3395,7 @@ impl App {
             additional_dirs,
             role,
             permissions,
+            vm_id: session.info.vm_id.clone(),
         };
 
         let (rows, cols) = self.content_area_size();
@@ -3023,11 +3547,87 @@ fn open_url(url: &str) {
         .ok();
 }
 
+/// Write a `.mcp.json` file into a VM directory via SSH so Claude Code discovers
+/// the project's MCP servers when running inside the sandbox.
+fn write_vm_mcp_json(
+    instance: &crate::agent::vm::VmInstance,
+    vm_cwd: &std::path::Path,
+    mcp_servers: &[crate::session::McpServerConfig],
+) -> anyhow::Result<()> {
+    if mcp_servers.is_empty() {
+        return Ok(());
+    }
+
+    // Build the .mcp.json structure Claude Code expects.
+    let mut servers = serde_json::Map::new();
+    for srv in mcp_servers {
+        let mut entry = serde_json::Map::new();
+        entry.insert(
+            "command".to_string(),
+            serde_json::Value::String(srv.command.clone()),
+        );
+        if !srv.args.is_empty() {
+            entry.insert("args".to_string(), serde_json::json!(srv.args));
+        }
+        if !srv.env.is_empty() {
+            entry.insert("env".to_string(), serde_json::json!(srv.env));
+        }
+        servers.insert(srv.name.clone(), serde_json::Value::Object(entry));
+    }
+    let doc = serde_json::json!({ "mcpServers": servers });
+    let json_str = serde_json::to_string_pretty(&doc)?;
+
+    let key_path = instance.ssh_key_path();
+    let ssh_port = instance.ssh_port.to_string();
+    let user = instance.ssh_user();
+    let dest = vm_cwd.join(".mcp.json");
+
+    let shell_cmd = format!("cat > '{}'", dest.to_string_lossy().replace('\'', "'\\''"));
+    let output = std::process::Command::new("ssh")
+        .args([
+            "-i",
+            &key_path.to_string_lossy(),
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "LogLevel=ERROR",
+            "-o",
+            "BatchMode=yes",
+            "-p",
+            &ssh_port,
+            &format!("{user}@localhost"),
+            &shell_cmd,
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(json_str.as_bytes())?;
+            }
+            child.wait_with_output()
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("ssh write .mcp.json failed: {stderr}");
+    }
+
+    info!("Wrote .mcp.json into VM at {}", dest.display());
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::sync::Arc;
 
     use super::*;
+    use crate::agent::SessionBackend;
 
     // --- TextInput tests ---
 
@@ -3243,12 +3843,16 @@ mod tests {
         }
     }
 
-    fn stub_backend() -> Arc<dyn SessionBackend> {
+    fn stub_backend_arc() -> Arc<dyn SessionBackend> {
         Arc::new(StubBackend)
     }
 
     fn stub_provider() -> Arc<dyn crate::agent::AgentProvider> {
         Arc::new(crate::agent::claude::ClaudeProvider)
+    }
+
+    fn stub_backend() -> BackendRegistry {
+        BackendRegistry::new(stub_backend_arc())
     }
 
     fn test_db() -> Database {
@@ -3279,17 +3883,18 @@ mod tests {
 
     /// Create an App with a test project and N stub sessions bound to it.
     fn app_with_sessions(count: usize) -> App {
-        let backend = stub_backend();
+        let backend_arc = stub_backend_arc();
         let provider = stub_provider();
         let mut app = App::new(
             24,
             120,
-            backend.clone(),
+            BackendRegistry::new(backend_arc.clone()),
             provider.clone(),
             test_db_with_project(&test_project_config()),
+            None,
         );
-        for i in 0..count {
-            let session = Session::stub(&format!("Session {}", i + 1), &backend, &provider);
+        for _i in 0..count {
+            let session = Session::stub("test-session", &backend_arc, &provider);
             let session_id = session.info.id;
             app.sessions.push(session);
             app.projects[0].session_ids.push(session_id);
@@ -3411,14 +4016,14 @@ mod tests {
 
     #[test]
     fn page_scroll_amount_is_half_content_height() {
-        let app = App::new(50, 100, stub_backend(), stub_provider(), test_db());
+        let app = App::new(50, 100, stub_backend(), stub_provider(), test_db(), None);
         // rows = 50 - 4 = 46, half = 23
         assert_eq!(app.page_scroll_amount(), 23);
     }
 
     #[test]
     fn page_scroll_amount_small_terminal() {
-        let app = App::new(6, 80, stub_backend(), stub_provider(), test_db());
+        let app = App::new(6, 80, stub_backend(), stub_provider(), test_db(), None);
         // rows = 6 - 4 = 2, half = 1
         assert_eq!(app.page_scroll_amount(), 1);
     }
@@ -3432,13 +4037,13 @@ mod tests {
 
     #[test]
     fn next_session_name_starts_at_one() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         assert_eq!(app.next_session_name(), "1");
     }
 
     #[test]
     fn next_session_name_increments() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         assert_eq!(app.next_session_name(), "1");
         assert_eq!(app.next_session_name(), "2");
         assert_eq!(app.next_session_name(), "3");
@@ -3446,7 +4051,7 @@ mod tests {
 
     #[test]
     fn next_session_name_continues_from_restored_counter() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.session_counter = 5;
         assert_eq!(app.next_session_name(), "6");
     }
@@ -3461,6 +4066,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&test_project_config()),
+            None,
         );
         app.open_role_editor();
         assert!(app.show_role_editor);
@@ -3489,6 +4095,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
         );
         app.open_role_editor();
         assert_eq!(app.role_editor_roles.len(), 1);
@@ -3497,7 +4104,7 @@ mod tests {
 
     #[test]
     fn role_editor_submit_uses_allowed_tools_list() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         for c in "reviewer".chars() {
@@ -3517,7 +4124,7 @@ mod tests {
 
     #[test]
     fn role_editor_submit_uses_disallowed_tools_list() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         for c in "restricted".chars() {
@@ -3568,6 +4175,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
         );
         let session_config = SessionConfig::default();
         app.prepare_spawn(session_config, Vec::new());
@@ -3589,6 +4197,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
         );
         // With no roles, the selector should never be set
         assert!(!app.show_role_selector);
@@ -3596,7 +4205,7 @@ mod tests {
 
     #[test]
     fn role_editor_name_validation_rejects_empty() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         // Try to submit with empty name
@@ -3627,7 +4236,7 @@ mod tests {
 
     #[test]
     fn role_editor_name_validation_rejects_duplicate() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         // Add first role
         app.handle_role_editor_list_key(KeyCode::Char('a'));
@@ -3679,6 +4288,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
         );
         app.open_role_editor();
         app.open_role_for_editing(0);
@@ -3701,7 +4311,7 @@ mod tests {
 
     #[test]
     fn role_editor_new_role_has_no_extra_fields() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_name.set("new-role");
@@ -3739,6 +4349,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
         );
         app.open_role_editor();
         app.open_role_for_editing(0);
@@ -3759,7 +4370,7 @@ mod tests {
     #[test]
     fn role_editor_tab_cycles_fields_forward() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -3781,7 +4392,7 @@ mod tests {
     #[test]
     fn role_editor_backtab_cycles_fields_backward() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -3802,7 +4413,7 @@ mod tests {
 
     #[test]
     fn role_editor_esc_returns_to_edit_project() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         assert_eq!(app.role_editor_view, RoleEditorView::Editor);
@@ -3841,6 +4452,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
         );
         app.open_role_editor();
         // Select the last role
@@ -3853,7 +4465,7 @@ mod tests {
 
     #[test]
     fn role_editor_submit_clears_error_on_success() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -3976,7 +4588,7 @@ mod tests {
     #[test]
     fn tool_browse_add_via_key_handler() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -4009,7 +4621,7 @@ mod tests {
     #[test]
     fn tool_browse_delete_via_key_handler() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_field = RoleEditorField::AllowedTools;
@@ -4026,7 +4638,7 @@ mod tests {
     #[test]
     fn tool_adding_esc_cancels() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_field = RoleEditorField::DisallowedTools;
@@ -4067,6 +4679,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
         );
         app.open_role_editor();
         app.open_role_for_editing(0);
@@ -4086,7 +4699,7 @@ mod tests {
 
     #[test]
     fn system_prompt_empty_saves_as_none() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_name.set("test");
@@ -4122,6 +4735,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
         );
         // With exactly 1 role, prepare_spawn should not show selector
         // (it would try to spawn, which needs a runtime — just verify no selector)
@@ -4224,7 +4838,7 @@ mod tests {
 
     #[test]
     fn empty_db_app_has_valid_active_project_index() {
-        let app = App::new(24, 120, stub_backend(), stub_provider(), test_db());
+        let app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         // With an empty DB, the project list is empty, but the index should be valid
         assert!(
             app.projects.is_empty() || app.active_project_index < app.projects.len(),
@@ -4320,7 +4934,7 @@ mod tests {
         db.soft_delete_project(id).unwrap();
         assert!(!db.project_exists(id).unwrap());
 
-        let app = App::new(24, 120, backend, provider, db);
+        let app = App::new(24, 120, backend, provider, db, None);
 
         // Create a project with the same deterministic ID
         let project = ProjectInfo::new(config);
@@ -4536,7 +5150,7 @@ mod tests {
 
     #[test]
     fn load_persisted_state_empty_db_returns_none() {
-        let app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         assert!(app.load_persisted_state_from_db().is_none());
     }
 
@@ -4571,7 +5185,7 @@ mod tests {
         };
         db.upsert_session(&session).unwrap();
 
-        let app = App::new(24, 80, stub_backend(), stub_provider(), db);
+        let app = App::new(24, 80, stub_backend(), stub_provider(), db, None);
         assert!(app.load_persisted_state_from_db().is_none());
     }
 
@@ -4625,7 +5239,7 @@ mod tests {
         db.upsert_session(&s2).unwrap();
         db.set_session_counter(7).unwrap();
 
-        let app = App::new(24, 80, stub_backend(), stub_provider(), db);
+        let app = App::new(24, 80, stub_backend(), stub_provider(), db, None);
         let (sessions, counter) = app.load_persisted_state_from_db().unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].name, "2");
@@ -4634,18 +5248,19 @@ mod tests {
 
     #[test]
     fn save_state_roundtrips_sessions() {
-        let backend = stub_backend();
+        let backend_arc = stub_backend_arc();
         let provider = stub_provider();
         let mut app = App::new(
             24,
             120,
-            backend.clone(),
+            BackendRegistry::new(backend_arc.clone()),
             provider.clone(),
             test_db_with_project(&test_project_config()),
+            None,
         );
 
         // Add a session
-        let session = Session::stub("Session 1", &backend, &provider);
+        let session = Session::stub("test-session", &backend_arc, &provider);
         let sid = session.info.id;
         app.sessions.push(session);
         app.projects[0].session_ids.push(sid);
@@ -4656,14 +5271,12 @@ mod tests {
         // Verify session in DB
         let sessions = app.db.list_active_sessions().unwrap();
         assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].name, "Session 1");
+        assert_eq!(sessions[0].name, "test-session");
     }
 
     #[test]
     fn save_state_persists_session_counter() {
-        let backend = stub_backend();
-        let provider = stub_provider();
-        let mut app = App::new(24, 120, backend.clone(), provider.clone(), test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
         app.session_counter = 42;
 
         app.save_state();
@@ -4674,17 +5287,18 @@ mod tests {
 
     #[test]
     fn session_to_shared_converts_correctly() {
-        let backend = stub_backend();
+        let backend_arc = stub_backend_arc();
         let provider = stub_provider();
         let mut app = App::new(
             24,
             120,
-            backend.clone(),
+            BackendRegistry::new(backend_arc.clone()),
             provider.clone(),
             test_db_with_project(&test_project_config()),
+            None,
         );
 
-        let mut session = Session::stub("TestSession", &backend, &provider);
+        let mut session = Session::stub("test-session", &backend_arc, &provider);
         session.info.role = "reviewer".to_string();
         session.info.cwd = Some(PathBuf::from("/home/user"));
         session.info.agent_session_id = Some("claude-xyz".to_string());
@@ -4695,7 +5309,7 @@ mod tests {
 
         let shared = app.session_to_shared(&app.sessions[0]);
         assert_eq!(shared.id, sid);
-        assert_eq!(shared.name, "TestSession");
+        assert_eq!(shared.name, "test-session");
         assert_eq!(shared.role, "reviewer");
         assert_eq!(shared.cwd, Some(PathBuf::from("/home/user")));
         assert_eq!(shared.agent_session_id, Some("claude-xyz".to_string()));
@@ -4720,6 +5334,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
         )
     }
 
@@ -4932,7 +5547,7 @@ mod tests {
         // Full lifecycle test: create app, rename project, shutdown, create new app (restart).
         // Verifies no duplicate projects and sessions stay associated.
         let db = test_db();
-        let backend = stub_backend();
+        let backend_arc = stub_backend_arc();
         let provider = stub_provider();
 
         // Step 1: Start app with project "TestA"
@@ -4946,7 +5561,14 @@ mod tests {
         let original_id = config.deterministic_id();
         let id = config.effective_id();
         db.insert_project(id, &config.name, &config.repos).unwrap();
-        let mut app = App::new(24, 120, backend.clone(), provider.clone(), db);
+        let mut app = App::new(
+            24,
+            120,
+            BackendRegistry::new(backend_arc.clone()),
+            provider.clone(),
+            db,
+            None,
+        );
 
         // Verify initial state: 1 project named "TestA"
         assert_eq!(app.projects.len(), 1);
@@ -4959,7 +5581,7 @@ mod tests {
             .iter()
             .position(|p| p.config.name == "TestA")
             .unwrap();
-        let session = Session::stub("Session1", &backend, &provider);
+        let session = Session::stub("1", &backend_arc, &provider);
         let session_id = session.info.id;
         app.sessions.push(session);
         app.projects[app.active_project_index]
@@ -4994,7 +5616,14 @@ mod tests {
         app.save_state();
 
         // Step 5: Simulate restart with the same DB (project already persisted from edit)
-        let app2 = App::new(24, 120, backend.clone(), provider.clone(), app.db);
+        let app2 = App::new(
+            24,
+            120,
+            BackendRegistry::new(backend_arc.clone()),
+            provider.clone(),
+            app.db,
+            None,
+        );
 
         // Verify: only 1 project, named "TestB"
         assert_eq!(
@@ -5105,17 +5734,18 @@ mod tests {
 
     #[test]
     fn session_to_shared_maps_worktree() {
-        let backend = stub_backend();
+        let backend_arc = stub_backend_arc();
         let provider = stub_provider();
         let mut app = App::new(
             24,
             120,
-            backend.clone(),
+            BackendRegistry::new(backend_arc.clone()),
             provider.clone(),
             test_db_with_project(&test_project_config()),
+            None,
         );
 
-        let mut session = Session::stub("WTSession", &backend, &provider);
+        let mut session = Session::stub("test-session", &backend_arc, &provider);
         session.info.worktrees = vec![WorktreeInfo {
             repo_path: PathBuf::from("/repo"),
             worktree_path: PathBuf::from("/repo/.git/wt/feat"),
@@ -5149,6 +5779,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
         )
     }
 
@@ -5303,17 +5934,18 @@ mod tests {
 
     #[test]
     fn session_to_shared_maps_additional_dirs() {
-        let backend = stub_backend();
+        let backend_arc = stub_backend_arc();
         let provider = stub_provider();
         let mut app = App::new(
             24,
             120,
-            backend.clone(),
+            BackendRegistry::new(backend_arc.clone()),
             provider.clone(),
             test_db_with_project(&test_project_config()),
+            None,
         );
 
-        let mut session = Session::stub("MultiDir", &backend, &provider);
+        let mut session = Session::stub("test-session", &backend_arc, &provider);
         session.info.additional_dirs = vec![PathBuf::from("/repo2"), PathBuf::from("/repo3")];
 
         let sid = session.info.id;
@@ -5328,7 +5960,7 @@ mod tests {
 
     #[test]
     fn user_session_count_excludes_admin_project() {
-        let backend = stub_backend();
+        let backend_arc = stub_backend_arc();
         let provider = stub_provider();
         let config = ProjectConfig {
             name: "UserProj".to_string(),
@@ -5340,16 +5972,17 @@ mod tests {
         let mut app = App::new(
             24,
             120,
-            backend.clone(),
+            BackendRegistry::new(backend_arc.clone()),
             provider.clone(),
             test_db_with_project(&config),
+            None,
         );
 
         // User project has no sessions
         assert_eq!(app.user_session_count(), 0);
 
         // Add a session to the user project
-        let session = Session::stub("user-1", &backend, &provider);
+        let session = Session::stub("user-1", &backend_arc, &provider);
         let sid = session.info.id;
         app.sessions.push(session);
         app.projects[0].session_ids.push(sid);
@@ -5364,7 +5997,7 @@ mod tests {
             id: None,
         };
         let mut admin_project = ProjectInfo::new_admin(admin_config);
-        let admin_session = Session::stub("admin", &backend, &provider);
+        let admin_session = Session::stub("admin-1", &backend_arc, &provider);
         let admin_sid = admin_session.info.id;
         app.sessions.push(admin_session);
         admin_project.session_ids.push(admin_sid);
@@ -5376,9 +6009,7 @@ mod tests {
 
     #[test]
     fn cannot_edit_admin_project() {
-        let backend = stub_backend();
-        let provider = stub_provider();
-        let mut app = App::new(24, 120, backend, provider, test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
 
         // Add an admin project and select it
         let admin_project = ProjectInfo::new_admin(ProjectConfig {
@@ -5401,9 +6032,7 @@ mod tests {
 
     #[test]
     fn cannot_delete_admin_project() {
-        let backend = stub_backend();
-        let provider = stub_provider();
-        let mut app = App::new(24, 120, backend, provider, test_db());
+        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
 
         // Add an admin project and select it
         let admin_project = ProjectInfo::new_admin(ProjectConfig {
@@ -5426,9 +6055,16 @@ mod tests {
 
     #[test]
     fn cannot_close_admin_session() {
-        let backend = stub_backend();
+        let backend_arc = stub_backend_arc();
         let provider = stub_provider();
-        let mut app = App::new(24, 120, backend.clone(), provider.clone(), test_db());
+        let mut app = App::new(
+            24,
+            120,
+            BackendRegistry::new(backend_arc.clone()),
+            provider.clone(),
+            test_db(),
+            None,
+        );
 
         // Add an admin project with a session and select it
         let mut admin_project = ProjectInfo::new_admin(ProjectConfig {
@@ -5438,7 +6074,7 @@ mod tests {
             mcp_servers: Vec::new(),
             id: None,
         });
-        let session = Session::stub("admin", &backend, &provider);
+        let session = Session::stub("admin-1", &backend_arc, &provider);
         let sid = session.info.id;
         app.sessions.push(session);
         admin_project.session_ids.push(sid);
@@ -5458,7 +6094,7 @@ mod tests {
 
     #[test]
     fn set_error_creates_error_status() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.set_error("something failed");
         let msg = app.status_message.as_ref().unwrap();
         assert_eq!(msg.level, StatusLevel::Error);
@@ -5467,7 +6103,7 @@ mod tests {
 
     #[test]
     fn set_status_creates_typed_status() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.set_status(StatusLevel::Success, "all good");
         let msg = app.status_message.as_ref().unwrap();
         assert_eq!(msg.level, StatusLevel::Success);
@@ -5476,7 +6112,7 @@ mod tests {
 
     #[test]
     fn set_status_replaces_previous() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.set_error("old error");
         app.set_status(StatusLevel::Info, "new info");
         let msg = app.status_message.as_ref().unwrap();
@@ -5488,7 +6124,7 @@ mod tests {
 
     #[test]
     fn start_sync_with_no_worktrees_shows_info() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.start_sync();
         assert!(!app.worktree_sync_in_progress);
         let msg = app.status_message.as_ref().unwrap();
@@ -5498,7 +6134,7 @@ mod tests {
 
     #[test]
     fn start_sync_ignores_if_already_in_progress() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.worktree_sync_in_progress = true;
         app.status_message = None;
         app.start_sync();
@@ -5508,7 +6144,7 @@ mod tests {
 
     #[test]
     fn ctrl_s_triggers_start_sync() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.handle_key(KeyCode::Char('s'), KeyModifiers::CONTROL);
         // No worktrees → info message
         let msg = app.status_message.as_ref().unwrap();
@@ -5517,25 +6153,12 @@ mod tests {
 
     #[test]
     fn start_sync_with_worktree_sessions_sets_in_progress() {
-        let backend = stub_backend();
-        let provider = stub_provider();
-        let config = test_project_config();
-        let mut app = App::new(
-            24,
-            120,
-            backend.clone(),
-            provider.clone(),
-            test_db_with_project(&config),
-        );
-        let mut session = Session::stub("wt-session", &backend, &provider);
-        session.info.worktrees = vec![WorktreeInfo {
+        let mut app = app_with_sessions(1);
+        app.sessions[0].info.worktrees = vec![WorktreeInfo {
             repo_path: PathBuf::from("/tmp/nonexistent-repo"),
             worktree_path: PathBuf::from("/tmp/nonexistent-wt"),
             branch: "test-branch".to_string(),
         }];
-        let session_id = session.info.id;
-        app.sessions.push(session);
-        app.projects[0].session_ids.push(session_id);
 
         app.start_sync();
         assert!(app.worktree_sync_in_progress);
@@ -5547,7 +6170,7 @@ mod tests {
 
     #[test]
     fn tick_increments_tick_count() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         assert_eq!(app.tick_count, 0);
         app.tick();
         assert_eq!(app.tick_count, 1);
@@ -5557,7 +6180,7 @@ mod tests {
 
     #[test]
     fn finish_sync_all_synced_shows_success() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         let id = SessionId::default();
         app.worktree_sync_completed = vec![
             (id, git::SyncResult::Synced),
@@ -5571,7 +6194,7 @@ mod tests {
 
     #[test]
     fn finish_sync_with_errors_shows_error() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.worktree_sync_completed = vec![(
             SessionId::default(),
             git::SyncResult::Error("fetch failed".into()),
@@ -5585,7 +6208,7 @@ mod tests {
 
     #[test]
     fn finish_sync_with_conflicts_shows_info() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.worktree_sync_completed = vec![
             (SessionId::default(), git::SyncResult::Synced),
             (
@@ -5602,7 +6225,7 @@ mod tests {
 
     #[test]
     fn finish_sync_errors_take_priority_over_conflicts() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.worktree_sync_completed = vec![
             (
                 SessionId::default(),
@@ -5621,7 +6244,7 @@ mod tests {
 
     #[test]
     fn drain_deferred_inputs_sends_at_correct_tick() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         let id = SessionId::default();
         app.deferred_inputs.push((id, b"hello".to_vec(), 5));
 
@@ -5638,7 +6261,7 @@ mod tests {
 
     #[test]
     fn drain_deferred_inputs_retains_future_items() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         let id = SessionId::default();
         app.deferred_inputs.push((id, b"early".to_vec(), 5));
         app.deferred_inputs.push((id, b"late".to_vec(), 20));
@@ -5651,19 +6274,15 @@ mod tests {
 
     #[test]
     fn send_conflict_prompt_noop_for_unknown_session() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         app.send_conflict_prompt(SessionId::default());
         assert!(app.deferred_inputs.is_empty());
     }
 
     #[test]
     fn send_conflict_prompt_no_deferred_when_send_fails() {
-        let backend = stub_backend();
-        let provider = stub_provider();
-        let mut app = App::new(24, 80, backend.clone(), provider.clone(), test_db());
-        let session = Session::stub("test", &backend, &provider);
-        let sid = session.info.id;
-        app.sessions.push(session);
+        let mut app = app_with_sessions(1);
+        let sid = app.sessions[0].info.id;
 
         // Stub's channel rx is dropped, so send_input fails.
         // No deferred input should be created.
@@ -5673,7 +6292,7 @@ mod tests {
 
     #[test]
     fn poll_sync_results_triggers_finish_when_all_received() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         let (tx, rx) = mpsc::channel();
         let id = SessionId::default();
 
@@ -5694,7 +6313,7 @@ mod tests {
 
     #[test]
     fn poll_sync_results_waits_for_all_pending() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db());
+        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
         let (tx, rx) = mpsc::channel();
 
         tx.send((SessionId::default(), git::SyncResult::Synced))
@@ -5724,7 +6343,7 @@ mod tests {
             repos: vec![PathBuf::from("/other")],
             ..test_project_config()
         };
-        let mut app = App::new(24, 120, backend, provider, test_db());
+        let mut app = App::new(24, 120, backend, provider, test_db(), None);
         app.projects.push(ProjectInfo::new(test_project_config()));
         let project_b = ProjectInfo::new(config_b);
         let id_b = project_b.id;
@@ -5739,7 +6358,7 @@ mod tests {
     fn find_project_index_falls_back_to_active_project() {
         let backend = stub_backend();
         let provider = stub_provider();
-        let mut app = App::new(24, 120, backend, provider, test_db());
+        let mut app = App::new(24, 120, backend, provider, test_db(), None);
         app.projects.push(ProjectInfo::new(test_project_config()));
         app.active_project_index = 0;
 
@@ -5765,7 +6384,7 @@ mod tests {
             }],
             ..test_project_config()
         };
-        let mut app = App::new(24, 120, backend, provider, test_db());
+        let mut app = App::new(24, 120, backend, provider, test_db(), None);
         app.projects.push(ProjectInfo::new(test_project_config()));
         app.projects.push(ProjectInfo::new(config_with_roles));
         app.active_project_index = 0;
@@ -5784,7 +6403,7 @@ mod tests {
         use crate::session::RolePermissions;
         let backend = stub_backend();
         let provider = stub_provider();
-        let mut app = App::new(24, 120, backend, provider, test_db());
+        let mut app = App::new(24, 120, backend, provider, test_db(), None);
         app.projects.push(ProjectInfo::new(test_project_config()));
         app.active_project_index = 0;
 
@@ -5797,7 +6416,7 @@ mod tests {
         use crate::session::RolePermissions;
         let backend = stub_backend();
         let provider = stub_provider();
-        let app = App::new(24, 120, backend, provider, test_db());
+        let app = App::new(24, 120, backend, provider, test_db(), None);
 
         let perms = app.resolve_role_permissions_for_project("any-role", 999);
         assert_eq!(perms, RolePermissions::default());
@@ -5819,7 +6438,7 @@ mod tests {
     #[test]
     fn resolve_role_permissions_returns_admin_tools_for_admin_project() {
         let backend = stub_backend();
-        let mut app = App::new(24, 120, backend, stub_provider(), test_db());
+        let mut app = App::new(24, 120, backend, stub_provider(), test_db(), None);
         let admin_project = ProjectInfo::new_admin(ProjectConfig {
             name: "Admin".to_string(),
             repos: vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use crossterm::execute;
 
 use thurbox::agent::claude::ClaudeProvider;
 use thurbox::agent::tmux::LocalTmuxBackend;
-use thurbox::agent::{AgentProvider, SessionBackend};
+use thurbox::agent::{AgentProvider, BackendRegistry, QemuVmBackend, SessionBackend, VmManager};
 use thurbox::app::{App, AppMessage};
 use thurbox::storage::Database;
 
@@ -35,11 +35,29 @@ async fn main() -> Result<()> {
         .with_ansi(false)
         .init();
 
-    // Initialize the session backend (local tmux) and agent provider.
-    let backend: Arc<dyn SessionBackend> = Arc::new(LocalTmuxBackend::new());
-    backend.check_available()?;
-    backend.ensure_ready()?;
+    // Initialize session backends and agent provider.
+    let local_tmux: Arc<dyn SessionBackend> = Arc::new(LocalTmuxBackend::new());
+    local_tmux.check_available()?;
+    local_tmux.ensure_ready()?;
+    let mut backends = BackendRegistry::new(local_tmux);
     let provider: Arc<dyn AgentProvider> = Arc::new(ClaudeProvider);
+
+    // Register QEMU VM backend if available (optional — requires qemu-system-x86_64 + /dev/kvm).
+    let data_dir = thurbox::paths::log_directory().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let vm_manager = Arc::new(std::sync::Mutex::new(VmManager::new(&data_dir)));
+    let vm_backend: Arc<dyn SessionBackend> = Arc::new(QemuVmBackend::new(Arc::clone(&vm_manager)));
+    let mut vm_manager_for_app = None;
+    if vm_backend.check_available().is_ok() {
+        if let Err(e) = vm_backend.ensure_ready() {
+            tracing::warn!("QEMU VM backend available but setup failed: {e}");
+        } else {
+            tracing::info!("QEMU VM backend registered");
+            backends.register(vm_backend);
+            vm_manager_for_app = Some(vm_manager);
+        }
+    } else {
+        tracing::debug!("QEMU VM backend not available (qemu-system-x86_64 not found or /dev/kvm not accessible)");
+    }
 
     // Open SQLite database for persistent state
     let db_path = thurbox::paths::database_file().unwrap_or_else(|| {
@@ -57,7 +75,14 @@ async fn main() -> Result<()> {
     execute!(std::io::stdout(), EnableMouseCapture)?;
     let size = terminal.size()?;
 
-    let mut app = App::new(size.height, size.width, backend, provider, db);
+    let mut app = App::new(
+        size.height,
+        size.width,
+        backends,
+        provider,
+        db,
+        vm_manager_for_app,
+    );
 
     // Load session state from DB and restore
     if let Some((sessions, counter)) = app.load_persisted_state_from_db() {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -10,11 +10,15 @@ use crate::session::{McpServerConfig, RoleConfig, RolePermissions, SessionId};
 use crate::storage::Database;
 use crate::sync::{SharedProject, SharedSession};
 
+use crate::session::VmConfig;
+use crate::storage::vms::VmRecord;
+
 use super::types::{
-    CreateProjectParams, DeleteProjectParams, DeleteSessionParams, GetProjectParams,
-    GetSessionParams, ListMcpServersParams, ListRolesParams, ListSessionsParams, McpServerResponse,
-    ProjectResponse, RestartSessionParams, RestoreSessionParams, RoleResponse, SessionResponse,
-    SetMcpServersParams, SetRolesParams, UpdateProjectParams, WorktreeResponse,
+    ConfigureProjectVmParams, CreateProjectParams, DeleteProjectParams, DeleteSessionParams,
+    GetProjectParams, GetSessionParams, GetVmParams, ListMcpServersParams, ListRolesParams,
+    ListSessionsParams, ListVmsParams, McpServerResponse, ProjectResponse, ProjectVmConfigResponse,
+    RestartSessionParams, RestoreSessionParams, RoleResponse, SessionResponse, SetMcpServersParams,
+    SetRolesParams, UpdateProjectParams, VmResponse, WorktreeResponse,
 };
 use super::ThurboxMcp;
 
@@ -108,6 +112,21 @@ fn session_to_response(s: &SharedSession) -> SessionResponse {
                 branch: w.branch.clone(),
             })
             .collect(),
+    }
+}
+
+fn vm_to_response(r: &VmRecord) -> VmResponse {
+    VmResponse {
+        id: r.id.clone(),
+        session_id: r.session_id.clone(),
+        project_id: r.project_id.clone(),
+        state: r.state.to_string(),
+        ssh_port: r.ssh_port,
+        base_image: r.base_image.clone(),
+        cpus: r.cpus,
+        memory_mb: r.memory_mb,
+        disk_gb: r.disk_gb,
+        error_msg: r.error_msg.clone(),
     }
 }
 
@@ -407,6 +426,83 @@ impl ThurboxMcp {
                 "session_name": session.name,
             })
             .to_string(),
+            Err(e) => error_json(&e.to_string()),
+        }
+    }
+
+    #[tool(description = "List all active VMs, optionally filtered by project name or UUID")]
+    fn list_vms(&self, Parameters(params): Parameters<ListVmsParams>) -> String {
+        let db = self.db.lock().unwrap();
+
+        let project_id = match &params.project {
+            Some(filter) => {
+                let (projects, idx) = match require_project(&db, filter) {
+                    Ok(v) => v,
+                    Err(e) => return e,
+                };
+                Some(projects[idx].id.to_string())
+            }
+            None => None,
+        };
+
+        match db.list_vms(project_id.as_deref()) {
+            Ok(vms) => {
+                let resp: Vec<VmResponse> = vms.iter().map(vm_to_response).collect();
+                json_text(&resp)
+            }
+            Err(e) => error_json(&e.to_string()),
+        }
+    }
+
+    #[tool(description = "Get a VM by its UUID")]
+    fn get_vm(&self, Parameters(params): Parameters<GetVmParams>) -> String {
+        let db = self.db.lock().unwrap();
+        match db.get_vm(&params.vm) {
+            Ok(Some(vm)) => json_text(&vm_to_response(&vm)),
+            Ok(None) => error_json(&format!("VM not found: {}", params.vm)),
+            Err(e) => error_json(&e.to_string()),
+        }
+    }
+
+    #[tool(
+        description = "Configure default VM settings for a project. These settings apply to new sandbox VM sessions created for the project."
+    )]
+    fn configure_project_vm(
+        &self,
+        Parameters(params): Parameters<ConfigureProjectVmParams>,
+    ) -> String {
+        let db = self.db.lock().unwrap();
+        let (projects, idx) = match require_project(&db, &params.project) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let project = &projects[idx];
+
+        let config = VmConfig {
+            base_image: params
+                .base_image
+                .unwrap_or_else(|| VmConfig::default().base_image),
+            cpus: params.cpus.unwrap_or(VmConfig::default().cpus),
+            memory_mb: params.memory_mb.unwrap_or(VmConfig::default().memory_mb),
+            disk_gb: params.disk_gb.unwrap_or(VmConfig::default().disk_gb),
+            setup_script: params.setup_script,
+        };
+
+        if let Err(e) = db.set_project_vm_config(&project.id.to_string(), &config) {
+            return error_json(&e.to_string());
+        }
+
+        // Read back the saved config
+        match db.get_project_vm_config(&project.id.to_string()) {
+            Ok(Some(cfg)) => json_text(&ProjectVmConfigResponse {
+                project_id: cfg.project_id,
+                base_image: cfg.base_image,
+                cpus: cfg.cpus,
+                memory_mb: cfg.memory_mb,
+                disk_gb: cfg.disk_gb,
+                setup_script: cfg.setup_script,
+            }),
+            Ok(None) => error_json("Config not found after save"),
             Err(e) => error_json(&e.to_string()),
         }
     }
@@ -1296,5 +1392,121 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("Deleted session not found"));
+    }
+
+    // ── VM tool tests ───────────────────────────────────────────
+
+    #[test]
+    fn list_vms_empty() {
+        let server = test_server();
+        let result = server.list_vms(Parameters(ListVmsParams { project: None }));
+        let v = parse_json(&result);
+        assert_eq!(v, serde_json::json!([]));
+    }
+
+    #[test]
+    fn list_vms_with_project_filter() {
+        let server = test_server();
+        server.create_project(Parameters(CreateProjectParams {
+            name: "vmproj".to_string(),
+            repos: vec![],
+        }));
+        let result = server.list_vms(Parameters(ListVmsParams {
+            project: Some("vmproj".to_string()),
+        }));
+        let v = parse_json(&result);
+        assert_eq!(v, serde_json::json!([]));
+    }
+
+    #[test]
+    fn list_vms_nonexistent_project() {
+        let server = test_server();
+        let result = server.list_vms(Parameters(ListVmsParams {
+            project: Some("ghost".to_string()),
+        }));
+        let v = parse_json(&result);
+        assert!(v["error"].as_str().unwrap().contains("Project not found"));
+    }
+
+    #[test]
+    fn get_vm_not_found() {
+        let server = test_server();
+        let result = server.get_vm(Parameters(GetVmParams {
+            vm: "nonexistent".to_string(),
+        }));
+        let v = parse_json(&result);
+        assert!(v["error"].as_str().unwrap().contains("VM not found"));
+    }
+
+    #[test]
+    fn get_vm_exists() {
+        let server = test_server();
+        server.create_project(Parameters(CreateProjectParams {
+            name: "vmtest".to_string(),
+            repos: vec![],
+        }));
+        let pid = test_project_id("vmtest").to_string();
+        let config = crate::session::VmConfig::default();
+
+        {
+            let db = server.db.lock().unwrap();
+            db.insert_vm(
+                "vm-1",
+                None,
+                Some(&pid),
+                &crate::session::VmState::Ready,
+                22200,
+                &config,
+            )
+            .unwrap();
+        }
+
+        let result = server.get_vm(Parameters(GetVmParams {
+            vm: "vm-1".to_string(),
+        }));
+        let v = parse_json(&result);
+        assert_eq!(v["id"], "vm-1");
+        assert_eq!(v["state"], "Ready");
+        assert_eq!(v["ssh_port"], 22200);
+        assert_eq!(v["cpus"], 2);
+    }
+
+    #[test]
+    fn configure_project_vm_creates_config() {
+        let server = test_server();
+        server.create_project(Parameters(CreateProjectParams {
+            name: "vmcfg".to_string(),
+            repos: vec![],
+        }));
+
+        let result = server.configure_project_vm(Parameters(ConfigureProjectVmParams {
+            project: "vmcfg".to_string(),
+            base_image: Some("custom.img".to_string()),
+            cpus: Some(4),
+            memory_mb: Some(8192),
+            disk_gb: None,
+            setup_script: Some("apt install nodejs".to_string()),
+        }));
+        let v = parse_json(&result);
+        assert_eq!(v["base_image"], "custom.img");
+        assert_eq!(v["cpus"], 4);
+        assert_eq!(v["memory_mb"], 8192);
+        assert_eq!(v["disk_gb"], 10); // default
+        assert_eq!(v["setup_script"], "apt install nodejs");
+    }
+
+    #[test]
+    fn configure_project_vm_nonexistent_project() {
+        let server = test_server();
+        let result = server.configure_project_vm(Parameters(ConfigureProjectVmParams {
+            project: "ghost".to_string(),
+            base_image: None,
+            cpus: None,
+            memory_mb: None,
+            disk_gb: None,
+            setup_script: None,
+        }));
+        let v = parse_json(&result);
+        assert!(v["error"].as_str().unwrap().contains("Project not found"));
     }
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -158,6 +158,34 @@ pub struct SetMcpServersParams {
     pub servers: Vec<McpServerInput>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListVmsParams {
+    #[schemars(description = "Optional project name or UUID to filter VMs")]
+    pub project: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetVmParams {
+    #[schemars(description = "VM UUID")]
+    pub vm: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ConfigureProjectVmParams {
+    #[schemars(description = "Project name or UUID")]
+    pub project: String,
+    #[schemars(description = "Base cloud image filename")]
+    pub base_image: Option<String>,
+    #[schemars(description = "Number of virtual CPUs (default: 2)")]
+    pub cpus: Option<u32>,
+    #[schemars(description = "RAM in megabytes (default: 4096)")]
+    pub memory_mb: Option<u32>,
+    #[schemars(description = "Disk size in gigabytes (default: 20)")]
+    pub disk_gb: Option<u32>,
+    #[schemars(description = "Setup script to run during cloud-init provisioning")]
+    pub setup_script: Option<String>,
+}
+
 // ── Response Types ──────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -218,4 +246,36 @@ pub struct WorktreeResponse {
     pub repo_path: PathBuf,
     pub worktree_path: PathBuf,
     pub branch: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VmResponse {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    pub state: String,
+    pub ssh_port: u16,
+    pub base_image: String,
+    pub cpus: u32,
+    pub memory_mb: u32,
+    pub disk_gb: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_msg: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProjectVmConfigResponse {
+    pub project_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpus: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_mb: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_gb: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub setup_script: Option<String>,
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -170,6 +170,7 @@ impl std::str::FromStr for SessionId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionStatus {
+    Provisioning,
     Busy,
     Waiting,
     Idle,
@@ -179,6 +180,7 @@ pub enum SessionStatus {
 impl SessionStatus {
     pub fn icon(self) -> &'static str {
         match self {
+            Self::Provisioning => "⟳",
             Self::Busy => "●",
             Self::Waiting => "◉",
             Self::Idle => "○",
@@ -190,6 +192,7 @@ impl SessionStatus {
 impl fmt::Display for SessionStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Provisioning => write!(f, "Provisioning"),
             Self::Busy => write!(f, "Busy"),
             Self::Waiting => write!(f, "Waiting"),
             Self::Idle => write!(f, "Idle"),
@@ -209,6 +212,10 @@ pub struct SessionInfo {
     pub additional_dirs: Vec<PathBuf>,
     pub backend_id: Option<String>,
     pub shell_backend_id: Option<String>,
+    /// VM identifier when this session runs inside a sandboxed VM.
+    pub vm_id: Option<String>,
+    /// Current provisioning step description (shown while status is `Provisioning`).
+    pub provisioning_step: Option<String>,
 }
 
 impl SessionInfo {
@@ -224,6 +231,8 @@ impl SessionInfo {
             additional_dirs: Vec::new(),
             backend_id: None,
             shell_backend_id: None,
+            vm_id: None,
+            provisioning_step: None,
         }
     }
 }
@@ -245,6 +254,100 @@ pub struct SessionConfig {
     pub additional_dirs: Vec<PathBuf>,
     pub role: String,
     pub permissions: RolePermissions,
+    /// Target VM ID for VM-backed sessions.
+    ///
+    /// When set, the VM backend uses this to spawn the session on the specific VM
+    /// rather than picking arbitrarily. Ensures each session is tied to its own VM.
+    pub vm_id: Option<String>,
+}
+
+/// VM state machine for sandboxed sessions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VmState {
+    /// Overlay disk and cloud-init ISO are being created.
+    Provisioning,
+    /// QEMU process started, waiting for SSH readiness.
+    Starting,
+    /// SSH is reachable, VM is ready for sessions.
+    Ready,
+    /// Shutdown signal sent, waiting for QEMU to exit.
+    Stopping,
+    /// QEMU process has exited.
+    Stopped,
+    /// Something went wrong.
+    Failed(String),
+}
+
+impl fmt::Display for VmState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Provisioning => write!(f, "Provisioning"),
+            Self::Starting => write!(f, "Starting"),
+            Self::Ready => write!(f, "Ready"),
+            Self::Stopping => write!(f, "Stopping"),
+            Self::Stopped => write!(f, "Stopped"),
+            Self::Failed(msg) => write!(f, "Failed: {msg}"),
+        }
+    }
+}
+
+impl VmState {
+    /// Parse from database string representation.
+    pub fn from_db_str(s: &str) -> Self {
+        match s {
+            "provisioning" => Self::Provisioning,
+            "starting" => Self::Starting,
+            "ready" => Self::Ready,
+            "stopping" => Self::Stopping,
+            "stopped" => Self::Stopped,
+            other => {
+                if let Some(msg) = other.strip_prefix("failed:") {
+                    Self::Failed(msg.trim().to_string())
+                } else {
+                    Self::Stopped
+                }
+            }
+        }
+    }
+
+    /// Convert to database string representation.
+    pub fn to_db_str(&self) -> String {
+        match self {
+            Self::Provisioning => "provisioning".to_string(),
+            Self::Starting => "starting".to_string(),
+            Self::Ready => "ready".to_string(),
+            Self::Stopping => "stopping".to_string(),
+            Self::Stopped => "stopped".to_string(),
+            Self::Failed(msg) => format!("failed:{msg}"),
+        }
+    }
+}
+
+/// Configuration for a sandboxed VM instance.
+#[derive(Debug, Clone)]
+pub struct VmConfig {
+    /// Base cloud image filename (e.g., "debian-13-genericcloud-amd64.qcow2").
+    pub base_image: String,
+    /// Number of virtual CPUs.
+    pub cpus: u32,
+    /// RAM in megabytes.
+    pub memory_mb: u32,
+    /// Disk size in gigabytes (CoW overlay, grows on demand).
+    pub disk_gb: u32,
+    /// Optional setup script run during cloud-init.
+    pub setup_script: Option<String>,
+}
+
+impl Default for VmConfig {
+    fn default() -> Self {
+        Self {
+            base_image: "debian-13-genericcloud-amd64.qcow2".to_string(),
+            cpus: 2,
+            memory_mb: 2048,
+            disk_gb: 10,
+            setup_script: None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -336,6 +439,7 @@ mod tests {
 
     #[test]
     fn session_status_display() {
+        assert_eq!(SessionStatus::Provisioning.to_string(), "Provisioning");
         assert_eq!(SessionStatus::Busy.to_string(), "Busy");
         assert_eq!(SessionStatus::Waiting.to_string(), "Waiting");
         assert_eq!(SessionStatus::Idle.to_string(), "Idle");
@@ -344,6 +448,7 @@ mod tests {
 
     #[test]
     fn session_status_icon() {
+        assert_eq!(SessionStatus::Provisioning.icon(), "⟳");
         assert_eq!(SessionStatus::Busy.icon(), "●");
         assert_eq!(SessionStatus::Waiting.icon(), "◉");
         assert_eq!(SessionStatus::Idle.icon(), "○");
@@ -407,6 +512,7 @@ mod tests {
         assert!(config.additional_dirs.is_empty());
         assert_eq!(config.role, "");
         assert_eq!(config.permissions, RolePermissions::default());
+        assert!(config.vm_id.is_none());
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -19,6 +19,7 @@ mod schema;
 mod sessions;
 pub use sessions::DeletedSessionInfo;
 pub mod sync;
+pub mod vms;
 mod worktrees;
 
 use std::path::Path;

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -114,6 +114,38 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
         );
         CREATE INDEX IF NOT EXISTS idx_session_commands_pending
             ON session_commands(id) WHERE processed_at IS NULL;
+
+        CREATE TABLE IF NOT EXISTS vms (
+            id          TEXT PRIMARY KEY,
+            session_id  TEXT REFERENCES sessions(id),
+            project_id  TEXT REFERENCES projects(id),
+            state       TEXT NOT NULL DEFAULT 'stopped',
+            ssh_port    INTEGER NOT NULL,
+            base_image  TEXT NOT NULL,
+            cpus        INTEGER NOT NULL DEFAULT 2,
+            memory_mb   INTEGER NOT NULL DEFAULT 2048,
+            disk_gb     INTEGER NOT NULL DEFAULT 10,
+            qemu_pid    INTEGER,
+            error_msg   TEXT,
+            created_at  INTEGER NOT NULL,
+            updated_at  INTEGER NOT NULL,
+            deleted_at  INTEGER
+        );
+
+        CREATE TABLE IF NOT EXISTS project_vm_config (
+            project_id   TEXT PRIMARY KEY REFERENCES projects(id),
+            base_image   TEXT,
+            cpus         INTEGER,
+            memory_mb    INTEGER,
+            disk_gb      INTEGER,
+            setup_script TEXT,
+            updated_at   INTEGER NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_vms_session
+            ON vms(session_id) WHERE deleted_at IS NULL;
+        CREATE INDEX IF NOT EXISTS idx_vms_project
+            ON vms(project_id) WHERE deleted_at IS NULL;
         ",
     )?;
 
@@ -211,11 +243,45 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
     }
 
     if version < 8 {
-        // v7 → v8: add env column to project_roles (JSON-encoded environment variables)
+        // v7 → v8: add env column to project_roles, add VM tables for sandboxed sessions
         let _ = conn.execute(
             "ALTER TABLE project_roles ADD COLUMN env TEXT NOT NULL DEFAULT ''",
             [],
         );
+
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS vms (
+                id          TEXT PRIMARY KEY,
+                session_id  TEXT REFERENCES sessions(id),
+                project_id  TEXT REFERENCES projects(id),
+                state       TEXT NOT NULL DEFAULT 'stopped',
+                ssh_port    INTEGER NOT NULL,
+                base_image  TEXT NOT NULL,
+                cpus        INTEGER NOT NULL DEFAULT 2,
+                memory_mb   INTEGER NOT NULL DEFAULT 2048,
+                disk_gb     INTEGER NOT NULL DEFAULT 10,
+                qemu_pid    INTEGER,
+                error_msg   TEXT,
+                created_at  INTEGER NOT NULL,
+                updated_at  INTEGER NOT NULL,
+                deleted_at  INTEGER
+            );
+
+            CREATE TABLE IF NOT EXISTS project_vm_config (
+                project_id   TEXT PRIMARY KEY REFERENCES projects(id),
+                base_image   TEXT,
+                cpus         INTEGER,
+                memory_mb    INTEGER,
+                disk_gb      INTEGER,
+                setup_script TEXT,
+                updated_at   INTEGER NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_vms_session
+                ON vms(session_id) WHERE deleted_at IS NULL;
+            CREATE INDEX IF NOT EXISTS idx_vms_project
+                ON vms(project_id) WHERE deleted_at IS NULL;",
+        )?;
     }
 
     if version < 9 {

--- a/src/storage/vms.rs
+++ b/src/storage/vms.rs
@@ -1,0 +1,571 @@
+//! VM CRUD operations for the SQLite database.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::params;
+
+use crate::session::{VmConfig, VmState};
+
+use super::Database;
+
+fn now_epoch() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+/// A VM record from the database.
+#[derive(Debug, Clone)]
+pub struct VmRecord {
+    pub id: String,
+    pub session_id: Option<String>,
+    pub project_id: Option<String>,
+    pub state: VmState,
+    pub ssh_port: u16,
+    pub base_image: String,
+    pub cpus: u32,
+    pub memory_mb: u32,
+    pub disk_gb: u32,
+    pub qemu_pid: Option<u32>,
+    pub error_msg: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Per-project VM configuration from the database.
+#[derive(Debug, Clone)]
+pub struct ProjectVmConfigRecord {
+    pub project_id: String,
+    pub base_image: Option<String>,
+    pub cpus: Option<u32>,
+    pub memory_mb: Option<u32>,
+    pub disk_gb: Option<u32>,
+    pub setup_script: Option<String>,
+}
+
+impl Database {
+    /// Insert a new VM record.
+    pub fn insert_vm(
+        &self,
+        vm_id: &str,
+        session_id: Option<&str>,
+        project_id: Option<&str>,
+        state: &VmState,
+        ssh_port: u16,
+        config: &VmConfig,
+    ) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "INSERT INTO vms (id, session_id, project_id, state, ssh_port, base_image, cpus, memory_mb, disk_gb, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            params![
+                vm_id,
+                session_id,
+                project_id,
+                state.to_db_str(),
+                ssh_port as i64,
+                config.base_image,
+                config.cpus,
+                config.memory_mb,
+                config.disk_gb,
+                now,
+                now,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Update VM state.
+    pub fn update_vm_state(
+        &self,
+        vm_id: &str,
+        state: &VmState,
+        qemu_pid: Option<u32>,
+        error_msg: Option<&str>,
+    ) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "UPDATE vms SET state = ?1, qemu_pid = ?2, error_msg = ?3, updated_at = ?4 WHERE id = ?5",
+            params![
+                state.to_db_str(),
+                qemu_pid.map(|p| p as i64),
+                error_msg,
+                now,
+                vm_id,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Get a VM record by ID.
+    pub fn get_vm(&self, vm_id: &str) -> rusqlite::Result<Option<VmRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, session_id, project_id, state, ssh_port, base_image, cpus, memory_mb, disk_gb, qemu_pid, error_msg, created_at, updated_at
+             FROM vms WHERE id = ?1 AND deleted_at IS NULL",
+        )?;
+
+        let mut rows = stmt.query(params![vm_id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row_to_vm_record(row)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Get VM record by session ID.
+    pub fn get_vm_by_session(&self, session_id: &str) -> rusqlite::Result<Option<VmRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, session_id, project_id, state, ssh_port, base_image, cpus, memory_mb, disk_gb, qemu_pid, error_msg, created_at, updated_at
+             FROM vms WHERE session_id = ?1 AND deleted_at IS NULL",
+        )?;
+
+        let mut rows = stmt.query(params![session_id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row_to_vm_record(row)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// List all active VMs, optionally filtered by project.
+    pub fn list_vms(&self, project_id: Option<&str>) -> rusqlite::Result<Vec<VmRecord>> {
+        let mut records = Vec::new();
+
+        if let Some(pid) = project_id {
+            let mut stmt = self.conn.prepare(
+                "SELECT id, session_id, project_id, state, ssh_port, base_image, cpus, memory_mb, disk_gb, qemu_pid, error_msg, created_at, updated_at
+                 FROM vms WHERE project_id = ?1 AND deleted_at IS NULL
+                 ORDER BY created_at",
+            )?;
+            let mut rows = stmt.query(params![pid])?;
+            while let Some(row) = rows.next()? {
+                records.push(row_to_vm_record(row)?);
+            }
+        } else {
+            let mut stmt = self.conn.prepare(
+                "SELECT id, session_id, project_id, state, ssh_port, base_image, cpus, memory_mb, disk_gb, qemu_pid, error_msg, created_at, updated_at
+                 FROM vms WHERE deleted_at IS NULL
+                 ORDER BY created_at",
+            )?;
+            let mut rows = stmt.query([])?;
+            while let Some(row) = rows.next()? {
+                records.push(row_to_vm_record(row)?);
+            }
+        }
+
+        Ok(records)
+    }
+
+    /// Update the SSH port on a VM record.
+    ///
+    /// The port is allocated during provisioning but stored as 0 initially.
+    /// This updates it to the actual allocated port.
+    pub fn update_vm_ssh_port(&self, vm_id: &str, ssh_port: u16) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "UPDATE vms SET ssh_port = ?1, updated_at = ?2 WHERE id = ?3",
+            params![ssh_port as i64, now, vm_id],
+        )?;
+        Ok(())
+    }
+
+    /// Update the session ID on a VM record.
+    ///
+    /// Used when re-provisioning assigns a new VM to an existing session,
+    /// or when restoring a VM session on restart.
+    pub fn update_vm_session(&self, vm_id: &str, session_id: &str) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "UPDATE vms SET session_id = ?1, updated_at = ?2 WHERE id = ?3",
+            params![session_id, now, vm_id],
+        )?;
+        Ok(())
+    }
+
+    /// Soft-delete a VM record.
+    pub fn soft_delete_vm(&self, vm_id: &str) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "UPDATE vms SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+            params![now, vm_id],
+        )?;
+        Ok(())
+    }
+
+    /// Get project VM configuration.
+    pub fn get_project_vm_config(
+        &self,
+        project_id: &str,
+    ) -> rusqlite::Result<Option<ProjectVmConfigRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT project_id, base_image, cpus, memory_mb, disk_gb, setup_script
+             FROM project_vm_config WHERE project_id = ?1",
+        )?;
+
+        let mut rows = stmt.query(params![project_id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(ProjectVmConfigRecord {
+                project_id: row.get(0)?,
+                base_image: row.get(1)?,
+                cpus: row.get::<_, Option<i64>>(2)?.map(|v| v as u32),
+                memory_mb: row.get::<_, Option<i64>>(3)?.map(|v| v as u32),
+                disk_gb: row.get::<_, Option<i64>>(4)?.map(|v| v as u32),
+                setup_script: row.get(5)?,
+            })),
+            None => Ok(None),
+        }
+    }
+
+    /// Set project VM configuration (upsert).
+    pub fn set_project_vm_config(
+        &self,
+        project_id: &str,
+        config: &VmConfig,
+    ) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "INSERT INTO project_vm_config (project_id, base_image, cpus, memory_mb, disk_gb, setup_script, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(project_id) DO UPDATE SET
+                base_image = ?2, cpus = ?3, memory_mb = ?4, disk_gb = ?5, setup_script = ?6, updated_at = ?7",
+            params![
+                project_id,
+                config.base_image,
+                config.cpus,
+                config.memory_mb,
+                config.disk_gb,
+                config.setup_script,
+                now,
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+fn row_to_vm_record(row: &rusqlite::Row) -> rusqlite::Result<VmRecord> {
+    let state_str: String = row.get(3)?;
+    Ok(VmRecord {
+        id: row.get(0)?,
+        session_id: row.get(1)?,
+        project_id: row.get(2)?,
+        state: VmState::from_db_str(&state_str),
+        ssh_port: row.get::<_, i64>(4)? as u16,
+        base_image: row.get(5)?,
+        cpus: row.get::<_, i64>(6)? as u32,
+        memory_mb: row.get::<_, i64>(7)? as u32,
+        disk_gb: row.get::<_, i64>(8)? as u32,
+        qemu_pid: row.get::<_, Option<i64>>(9)?.map(|v| v as u32),
+        error_msg: row.get(10)?,
+        created_at: row.get(11)?,
+        updated_at: row.get(12)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    fn test_project(db: &Database) -> String {
+        let id = crate::project::ProjectId::default();
+        db.insert_project(id, "test-project", &[]).unwrap();
+        id.to_string()
+    }
+
+    #[test]
+    fn insert_and_get_vm() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = VmConfig::default();
+
+        db.insert_vm(
+            "vm-1",
+            None,
+            Some(&project_id),
+            &VmState::Provisioning,
+            22200,
+            &config,
+        )
+        .unwrap();
+
+        let vm = db.get_vm("vm-1").unwrap().unwrap();
+        assert_eq!(vm.id, "vm-1");
+        assert_eq!(vm.state, VmState::Provisioning);
+        assert_eq!(vm.ssh_port, 22200);
+        assert_eq!(vm.cpus, 2);
+        assert_eq!(vm.memory_mb, 2048);
+    }
+
+    #[test]
+    fn get_nonexistent_vm() {
+        let db = test_db();
+        let vm = db.get_vm("nonexistent").unwrap();
+        assert!(vm.is_none());
+    }
+
+    #[test]
+    fn update_vm_state() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = VmConfig::default();
+
+        db.insert_vm(
+            "vm-1",
+            None,
+            Some(&project_id),
+            &VmState::Provisioning,
+            22200,
+            &config,
+        )
+        .unwrap();
+        db.update_vm_state("vm-1", &VmState::Ready, Some(12345), None)
+            .unwrap();
+
+        let vm = db.get_vm("vm-1").unwrap().unwrap();
+        assert_eq!(vm.state, VmState::Ready);
+        assert_eq!(vm.qemu_pid, Some(12345));
+    }
+
+    #[test]
+    fn list_vms_all() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = VmConfig::default();
+
+        db.insert_vm(
+            "vm-1",
+            None,
+            Some(&project_id),
+            &VmState::Ready,
+            22200,
+            &config,
+        )
+        .unwrap();
+        db.insert_vm(
+            "vm-2",
+            None,
+            Some(&project_id),
+            &VmState::Stopped,
+            22201,
+            &config,
+        )
+        .unwrap();
+
+        let vms = db.list_vms(None).unwrap();
+        assert_eq!(vms.len(), 2);
+    }
+
+    #[test]
+    fn list_vms_by_project() {
+        let db = test_db();
+        let p1 = test_project(&db);
+        let p2 = test_project(&db);
+        let config = VmConfig::default();
+
+        db.insert_vm("vm-1", None, Some(&p1), &VmState::Ready, 22200, &config)
+            .unwrap();
+        db.insert_vm("vm-2", None, Some(&p2), &VmState::Ready, 22201, &config)
+            .unwrap();
+
+        let vms = db.list_vms(Some(&p1)).unwrap();
+        assert_eq!(vms.len(), 1);
+        assert_eq!(vms[0].id, "vm-1");
+    }
+
+    #[test]
+    fn soft_delete_vm() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = VmConfig::default();
+
+        db.insert_vm(
+            "vm-1",
+            None,
+            Some(&project_id),
+            &VmState::Stopped,
+            22200,
+            &config,
+        )
+        .unwrap();
+        db.soft_delete_vm("vm-1").unwrap();
+
+        let vm = db.get_vm("vm-1").unwrap();
+        assert!(vm.is_none());
+
+        let vms = db.list_vms(None).unwrap();
+        assert!(vms.is_empty());
+    }
+
+    #[test]
+    fn get_vm_by_session() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = VmConfig::default();
+
+        // Create a session first
+        let session_id = uuid::Uuid::new_v4().to_string();
+        db.conn
+            .execute(
+                "INSERT INTO sessions (id, name, project_id, created_at, updated_at) VALUES (?1, 'test', ?2, 0, 0)",
+                rusqlite::params![session_id, project_id],
+            )
+            .unwrap();
+
+        db.insert_vm(
+            "vm-1",
+            Some(&session_id),
+            Some(&project_id),
+            &VmState::Ready,
+            22200,
+            &config,
+        )
+        .unwrap();
+
+        let vm = db.get_vm_by_session(&session_id).unwrap().unwrap();
+        assert_eq!(vm.id, "vm-1");
+        assert_eq!(vm.session_id, Some(session_id));
+    }
+
+    #[test]
+    fn project_vm_config_crud() {
+        let db = test_db();
+        let project_id = test_project(&db);
+
+        // Initially no config
+        let cfg = db.get_project_vm_config(&project_id).unwrap();
+        assert!(cfg.is_none());
+
+        // Set config
+        let config = VmConfig {
+            base_image: "test.img".to_string(),
+            cpus: 4,
+            memory_mb: 8192,
+            disk_gb: 50,
+            setup_script: Some("apt install nodejs".to_string()),
+        };
+        db.set_project_vm_config(&project_id, &config).unwrap();
+
+        let cfg = db.get_project_vm_config(&project_id).unwrap().unwrap();
+        assert_eq!(cfg.base_image, Some("test.img".to_string()));
+        assert_eq!(cfg.cpus, Some(4));
+        assert_eq!(cfg.memory_mb, Some(8192));
+        assert_eq!(cfg.setup_script, Some("apt install nodejs".to_string()));
+
+        // Update (upsert)
+        let config2 = VmConfig { cpus: 8, ..config };
+        db.set_project_vm_config(&project_id, &config2).unwrap();
+        let cfg = db.get_project_vm_config(&project_id).unwrap().unwrap();
+        assert_eq!(cfg.cpus, Some(8));
+    }
+
+    #[test]
+    fn update_vm_ssh_port() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = VmConfig::default();
+
+        db.insert_vm(
+            "vm-1",
+            None,
+            Some(&project_id),
+            &VmState::Provisioning,
+            0,
+            &config,
+        )
+        .unwrap();
+
+        db.update_vm_ssh_port("vm-1", 22200).unwrap();
+
+        let vm = db.get_vm("vm-1").unwrap().unwrap();
+        assert_eq!(vm.ssh_port, 22200);
+    }
+
+    #[test]
+    fn update_vm_session_links_session() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = VmConfig::default();
+
+        // Create the session first (FK constraint requires it).
+        let session_id = uuid::Uuid::new_v4().to_string();
+        db.conn
+            .execute(
+                "INSERT INTO sessions (id, name, project_id, created_at, updated_at) VALUES (?1, 'test', ?2, 0, 0)",
+                rusqlite::params![session_id, project_id],
+            )
+            .unwrap();
+
+        // Insert VM without session_id.
+        db.insert_vm(
+            "vm-1",
+            None,
+            Some(&project_id),
+            &VmState::Ready,
+            22200,
+            &config,
+        )
+        .unwrap();
+        let vm = db.get_vm("vm-1").unwrap().unwrap();
+        assert!(vm.session_id.is_none());
+
+        // Link VM to session.
+        db.update_vm_session("vm-1", &session_id).unwrap();
+        let vm = db.get_vm("vm-1").unwrap().unwrap();
+        assert_eq!(vm.session_id, Some(session_id.clone()));
+
+        // Also findable via get_vm_by_session.
+        let vm = db.get_vm_by_session(&session_id).unwrap().unwrap();
+        assert_eq!(vm.id, "vm-1");
+    }
+
+    #[test]
+    fn update_vm_session_fk_constraint() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = VmConfig::default();
+
+        db.insert_vm(
+            "vm-1",
+            None,
+            Some(&project_id),
+            &VmState::Ready,
+            22200,
+            &config,
+        )
+        .unwrap();
+
+        // Linking to a non-existent session should fail due to FK constraint.
+        let result = db.update_vm_session("vm-1", "nonexistent-session-id");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_vm_state_with_error() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = VmConfig::default();
+
+        db.insert_vm(
+            "vm-1",
+            None,
+            Some(&project_id),
+            &VmState::Starting,
+            22200,
+            &config,
+        )
+        .unwrap();
+        db.update_vm_state(
+            "vm-1",
+            &VmState::Failed("disk full".to_string()),
+            None,
+            Some("disk full"),
+        )
+        .unwrap();
+
+        let vm = db.get_vm("vm-1").unwrap().unwrap();
+        assert_eq!(vm.state, VmState::Failed("disk full".to_string()));
+        assert_eq!(vm.error_msg, Some("disk full".to_string()));
+    }
+}

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -8,13 +8,23 @@ use ratatui::{
 
 use super::theme::Theme;
 use crate::project::ProjectInfo;
-use crate::session::{RoleConfig, SessionInfo};
+use crate::session::{RoleConfig, SessionInfo, SessionStatus};
+
+/// Rich VM details for the info panel, sourced from the database VM record.
+pub struct VmDetails {
+    pub state: String,
+    pub cpus: u32,
+    pub memory_mb: u32,
+    pub ssh_port: u16,
+    pub base_image: String,
+}
 
 pub fn render_info_panel(
     frame: &mut Frame,
     area: Rect,
     info: &SessionInfo,
     project: Option<&ProjectInfo>,
+    vm_details: Option<&VmDetails>,
 ) {
     let block = Block::default()
         .title(" Info ")
@@ -121,6 +131,67 @@ pub fn render_info_panel(
             Style::default().fg(Theme::TEXT_MUTED),
         ),
     ]));
+
+    // ── VM section (for sandboxed sessions) ──
+    if let Some(vm_id) = &info.vm_id {
+        lines.push(separator());
+        lines.push(Line::from(Span::styled(
+            "Sandbox VM",
+            Theme::section_header(),
+        )));
+
+        if let Some(vm) = vm_details {
+            lines.push(Line::from(vec![
+                Span::styled("State: ", Theme::label()),
+                Span::styled(&vm.state, Style::default().fg(Theme::TEXT_PRIMARY)),
+            ]));
+        }
+
+        // Show short VM ID (first 8 chars)
+        let short_id = if vm_id.len() > 8 { &vm_id[..8] } else { vm_id };
+        lines.push(Line::from(vec![
+            Span::styled("VM ID: ", Theme::label()),
+            Span::styled(short_id, Style::default().fg(Theme::TEXT_MUTED)),
+        ]));
+
+        if let Some(vm) = vm_details {
+            lines.push(Line::from(vec![
+                Span::styled("CPUs: ", Theme::label()),
+                Span::styled(
+                    vm.cpus.to_string(),
+                    Style::default().fg(Theme::TEXT_PRIMARY),
+                ),
+                Span::styled("  RAM: ", Theme::label()),
+                Span::styled(
+                    format!("{} MB", vm.memory_mb),
+                    Style::default().fg(Theme::TEXT_PRIMARY),
+                ),
+            ]));
+            if vm.ssh_port > 0 {
+                lines.push(Line::from(vec![
+                    Span::styled("SSH: ", Theme::label()),
+                    Span::styled(
+                        format!("localhost:{}", vm.ssh_port),
+                        Style::default().fg(Theme::TEXT_PRIMARY),
+                    ),
+                ]));
+            }
+            lines.push(Line::from(vec![
+                Span::styled("Image: ", Theme::label()),
+                Span::styled(&vm.base_image, Style::default().fg(Theme::TEXT_MUTED)),
+            ]));
+        }
+
+        // Show provisioning step when provisioning.
+        if info.status == SessionStatus::Provisioning {
+            if let Some(ref step) = info.provisioning_step {
+                lines.push(Line::from(vec![
+                    Span::styled("Step: ", Theme::label()),
+                    Span::styled(step, Style::default().fg(Theme::ACCENT)),
+                ]));
+            }
+        }
+    }
 
     // ── Directories section ──
     if info.cwd.is_some() || !info.additional_dirs.is_empty() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -30,6 +30,7 @@ use theme::Theme;
 
 pub fn status_color(status: SessionStatus) -> Color {
     match status {
+        SessionStatus::Provisioning => Theme::ACCENT,
         SessionStatus::Busy => Theme::STATUS_BUSY,
         SessionStatus::Waiting => Theme::STATUS_WAITING,
         SessionStatus::Idle => Theme::STATUS_IDLE,
@@ -338,6 +339,7 @@ mod tests {
 
     #[test]
     fn status_color_maps_all_variants() {
+        assert_eq!(status_color(SessionStatus::Provisioning), Color::Cyan);
         assert_eq!(status_color(SessionStatus::Busy), Color::Green);
         assert_eq!(status_color(SessionStatus::Waiting), Color::Yellow);
         assert_eq!(status_color(SessionStatus::Idle), Color::DarkGray);

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -311,19 +311,31 @@ fn render_session_section(
                 Span::styled(status_text, status_style),
             ]);
 
-            // Line 2: indented role name + optional · branch
-            let mut line2_spans = vec![Span::styled(
-                format!("    {}", info.role),
-                Style::default().fg(Theme::ROLE_NAME),
-            )];
-            if let Some(wt) = info.worktrees.first() {
-                line2_spans.push(Span::styled(" · ", Style::default().fg(Theme::TEXT_MUTED)));
-                line2_spans.push(Span::styled(
-                    &wt.branch,
-                    Style::default().fg(Theme::BRANCH_NAME),
-                ));
-            }
-            let line2 = Line::from(line2_spans);
+            // Line 2: provisioning step (if provisioning) or role · branch/VM
+            let line2 = if info.status == crate::session::SessionStatus::Provisioning {
+                let step_text = info.provisioning_step.as_deref().unwrap_or("Starting...");
+                Line::from(vec![
+                    Span::styled("    ⟳ ", Style::default().fg(Theme::ACCENT)),
+                    Span::styled(step_text, Style::default().fg(Theme::ACCENT)),
+                ])
+            } else {
+                let mut line2_spans = vec![Span::styled(
+                    format!("    {}", info.role),
+                    Style::default().fg(Theme::ROLE_NAME),
+                )];
+                if let Some(wt) = info.worktrees.first() {
+                    line2_spans.push(Span::styled(" · ", Style::default().fg(Theme::TEXT_MUTED)));
+                    line2_spans.push(Span::styled(
+                        &wt.branch,
+                        Style::default().fg(Theme::BRANCH_NAME),
+                    ));
+                }
+                if info.vm_id.is_some() {
+                    line2_spans.push(Span::styled(" · ", Style::default().fg(Theme::TEXT_MUTED)));
+                    line2_spans.push(Span::styled("VM", Style::default().fg(Theme::ACCENT)));
+                }
+                Line::from(line2_spans)
+            };
 
             ListItem::new(vec![line1, line2])
         })

--- a/src/ui/session_mode_modal.rs
+++ b/src/ui/session_mode_modal.rs
@@ -9,14 +9,31 @@ use ratatui::{
 use super::centered_fixed_height_rect;
 use super::theme::Theme;
 
-const MODES: [&str; 2] = ["Normal", "Worktree"];
+const MODES_BASE: [&str; 2] = ["Normal", "Worktree"];
+const MODE_SANDBOX_VM: &str = "Sandbox VM";
 
 pub struct SessionModeState {
     pub selected_index: usize,
+    /// Whether the "Sandbox VM" option should be shown.
+    pub vm_available: bool,
+}
+
+impl SessionModeState {
+    /// Number of visible modes.
+    pub fn mode_count(&self) -> usize {
+        if self.vm_available {
+            MODES_BASE.len() + 1
+        } else {
+            MODES_BASE.len()
+        }
+    }
 }
 
 pub fn render_session_mode_modal(frame: &mut Frame, state: &SessionModeState) {
-    let area = centered_fixed_height_rect(50, 6, frame.area());
+    let mode_count = state.mode_count();
+    // Height = modes + 2 (border) + 1 (footer)
+    let height = mode_count as u16 + 3;
+    let area = centered_fixed_height_rect(50, height, frame.area());
 
     frame.render_widget(Clear, area);
 
@@ -36,7 +53,17 @@ pub fn render_session_mode_modal(frame: &mut Frame, state: &SessionModeState) {
         ])
         .split(inner);
 
-    let items: Vec<ListItem<'_>> = MODES
+    let modes: Vec<&str> = if state.vm_available {
+        MODES_BASE
+            .iter()
+            .copied()
+            .chain(std::iter::once(MODE_SANDBOX_VM))
+            .collect()
+    } else {
+        MODES_BASE.to_vec()
+    };
+
+    let items: Vec<ListItem<'_>> = modes
         .iter()
         .enumerate()
         .map(|(i, mode)| {

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -33,13 +33,36 @@ pub struct FooterState<'a> {
     pub status: Option<&'a StatusMessage>,
     pub focus_label: &'a str,
     pub sync_in_progress: bool,
+    pub vm_provisioning: bool,
+    pub vm_provisioning_step: &'a str,
     pub tick_count: u64,
 }
 
 pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
     let focus_badge = Span::styled(format!(" {} ", state.focus_label), Theme::focused_title());
 
-    let line = if state.sync_in_progress {
+    let line = if state.vm_provisioning {
+        let idx = (state.tick_count as usize / 10) % SPINNER_CHARS.len();
+        let spinner = SPINNER_CHARS[idx];
+        Line::from(vec![
+            focus_badge,
+            Span::styled(
+                format!(" {spinner} VM "),
+                Style::default().fg(Theme::TEXT_PRIMARY).bg(Theme::ACCENT),
+            ),
+            Span::styled(
+                format!(
+                    " {}",
+                    if state.vm_provisioning_step.is_empty() {
+                        "Starting VM..."
+                    } else {
+                        state.vm_provisioning_step
+                    }
+                ),
+                Style::default().fg(Theme::ACCENT),
+            ),
+        ])
+    } else if state.sync_in_progress {
         let idx = (state.tick_count as usize / 10) % SPINNER_CHARS.len();
         let spinner = SPINNER_CHARS[idx];
         let text = state


### PR DESCRIPTION
## Summary

- Adds `QemuVmBackend` — a second `SessionBackend` implementation that provisions and manages QEMU/KVM VMs, running Claude sessions inside Debian 13 (Trixie) VMs over SSH-tunneled tmux
- Introduces `BackendRegistry` to route session operations (spawn, adopt, discover) to the correct backend by name
- Adds `VmManager` for full VM lifecycle: create (qcow2 CoW overlay + cloud-init ISO), start (QEMU with KVM), restore on restart, stop, destroy
- Adds `control_mode.rs` — transport-agnostic tmux control mode I/O layer shared by local and SSH backends
- Adds `storage/vms.rs` — VM record persistence with `session_id` FK constraint; fixes ordering so `update_vm_session()` is called after `save_state()` to satisfy the constraint
- Fixes session restoration: discovers sessions from all backends, re-probes SSH for VM sessions, falls back to re-provision with `--resume` if the VM has died
- Fixes `VM_ID_ENV_KEY` injection in `Session::restart()` and `ensure_shell_pane()` (were missing, causing VM routing to fail on restart/shell panes)
- Fixes 2 pre-existing test assertion mismatches (`save_state_roundtrips_sessions`, `session_to_shared_converts_correctly`)
- Updates all docs: CLAUDE.md, README, ARCHITECTURE.md (ADR-15), FEATURES.md (Sandbox VM section with specs table), CONSTITUTION.md

## VM specs

| Parameter | Value |
|-----------|-------|
| Base image | Debian 13 (Trixie) genericcloud amd64 |
| CPUs | 2 |
| RAM | 2048 MB |
| Disk | 10 GB qcow2 CoW overlay |
| Networking | User-mode (SLIRP), SSH ports 22200+ |
| SSH user | `thurbox` (ed25519 ephemeral key) |
| Packages | tmux, git, rsync, curl, Claude CLI |

## Test plan

- [ ] All 697 tests pass (`cargo nextest run --all`)
- [ ] `cargo clippy`, `cargo doc`, architecture rules, `cargo deny` all pass
- [ ] Manual: create a Sandbox VM session (Ctrl+N → Sandbox VM), verify VM provisions and session starts
- [ ] Manual: quit Thurbox (Ctrl+Q), restart — VM session should be re-adopted with terminal content intact
- [ ] Manual: kill QEMU process, restart Thurbox — should detect dead VM and re-provision with `--resume`