### PR TITLE
feat(ui): add htop-style system metrics to info panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1320,6 +1320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2330,6 +2348,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,6 +2501,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sysinfo",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -3119,16 +3151,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -3136,6 +3201,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3158,6 +3234,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ toml = "0.8"
 # Storage
 rusqlite = { version = "0.33", features = ["bundled"] }
 
+# System metrics
+sysinfo = "0.34"
+
 # Error handling
 anyhow = "1.0"
 

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -115,6 +115,9 @@ pub trait SessionBackend: Send + Sync {
     fn default_shell(&self) -> String {
         std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
     }
+
+    /// Return the PID of the process running in a backend pane.
+    fn pane_pid(&self, backend_id: &str) -> Result<Option<u32>>;
 }
 
 /// Internal bundle of I/O handles before wiring.
@@ -418,6 +421,11 @@ impl Session {
     /// Return the backend name.
     pub fn backend_name(&self) -> &str {
         self.backend.name()
+    }
+
+    /// Return the PID of the process running in this session's backend pane.
+    pub fn pane_pid(&self) -> Result<Option<u32>> {
+        self.backend.pane_pid(&self.backend_id)
     }
 
     /// Restart the session: kill the old pane, spawn a fresh one with new config.

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -120,6 +120,15 @@ mod tests {
         fn detach(&self, _: &str) -> Result<()> {
             Ok(())
         }
+        fn prepare_vm(&self, _vm_id: &str) -> Result<()> {
+            Ok(())
+        }
+        fn default_shell(&self) -> String {
+            "/bin/sh".to_string()
+        }
+        fn pane_pid(&self, _: &str) -> Result<Option<u32>> {
+            Ok(None)
+        }
     }
 
     #[test]

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -120,12 +120,6 @@ mod tests {
         fn detach(&self, _: &str) -> Result<()> {
             Ok(())
         }
-        fn prepare_vm(&self, _vm_id: &str) -> Result<()> {
-            Ok(())
-        }
-        fn default_shell(&self) -> String {
-            "/bin/sh".to_string()
-        }
         fn pane_pid(&self, _: &str) -> Result<Option<u32>> {
             Ok(None)
         }

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -735,6 +735,20 @@ impl SessionBackend for LocalTmuxBackend {
         let _ = self.unregister_pane(backend_id);
         Ok(())
     }
+
+    fn pane_pid(&self, backend_id: &str) -> Result<Option<u32>> {
+        let result = self.ctrl_command(&format!(
+            "display-message -t {backend_id} -p '#{{pane_pid}}'"
+        ))?;
+        let trimmed = result.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        match trimmed.parse::<u32>() {
+            Ok(pid) => Ok(Some(pid)),
+            Err(_) => Ok(None),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -740,14 +740,7 @@ impl SessionBackend for LocalTmuxBackend {
         let result = self.ctrl_command(&format!(
             "display-message -t {backend_id} -p '#{{pane_pid}}'"
         ))?;
-        let trimmed = result.trim();
-        if trimmed.is_empty() {
-            return Ok(None);
-        }
-        match trimmed.parse::<u32>() {
-            Ok(pid) => Ok(Some(pid)),
-            Err(_) => Ok(None),
-        }
+        Ok(result.trim().parse().ok())
     }
 }
 

--- a/src/agent/vm.rs
+++ b/src/agent/vm.rs
@@ -1687,6 +1687,22 @@ impl SessionBackend for QemuVmBackend {
     fn default_shell(&self) -> String {
         "/bin/bash".to_string()
     }
+
+    fn pane_pid(&self, backend_id: &str) -> Result<Option<u32>> {
+        let (vm_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        let result = self.ctrl_command(
+            vm_id,
+            &format!("display-message -t {pane_id} -p '#{{pane_pid}}'"),
+        )?;
+        let trimmed = result.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        match trimmed.parse::<u32>() {
+            Ok(pid) => Ok(Some(pid)),
+            Err(_) => Ok(None),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/agent/vm.rs
+++ b/src/agent/vm.rs
@@ -1694,14 +1694,7 @@ impl SessionBackend for QemuVmBackend {
             vm_id,
             &format!("display-message -t {pane_id} -p '#{{pane_pid}}'"),
         )?;
-        let trimmed = result.trim();
-        if trimmed.is_empty() {
-            return Ok(None);
-        }
-        match trimmed.parse::<u32>() {
-            Ok(pid) => Ok(Some(pid)),
-            Err(_) => Ok(None),
-        }
+        Ok(result.trim().parse().ok())
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -417,6 +417,10 @@ pub struct App {
     worktree_sync_pending: usize,
     worktree_sync_completed: Vec<(SessionId, git::SyncResult)>,
     tick_count: u64,
+    /// System info collector for CPU/RAM metrics.
+    sys: sysinfo::System,
+    /// Cached system metrics for the info panel.
+    system_metrics: crate::ui::info_panel::SystemMetrics,
     /// Deferred inputs: `(session_id, data, tick_at_which_to_send)`.
     /// Used to introduce a small delay between pasting text and pressing Enter.
     deferred_inputs: Vec<(SessionId, Vec<u8>, u64)>,
@@ -715,6 +719,13 @@ impl App {
             worktree_sync_pending: 0,
             worktree_sync_completed: Vec::new(),
             tick_count: 0,
+            sys: sysinfo::System::new(),
+            system_metrics: crate::ui::info_panel::SystemMetrics {
+                cpu_percent: 0.0,
+                memory_used: 0,
+                memory_total: 0,
+                per_session: Vec::new(),
+            },
             deferred_inputs: Vec::new(),
             session_terminal_views: HashMap::new(),
             pending_delete: None,
@@ -2109,6 +2120,71 @@ impl App {
 
         // Process queued session commands from MCP
         self.process_session_commands();
+
+        // Refresh system metrics ~every second (100 ticks at 10ms polling)
+        if self.tick_count % 100 == 0 {
+            self.refresh_system_metrics();
+        }
+    }
+
+    /// Collect CPU/RAM metrics from sysinfo and per-session process trees.
+    fn refresh_system_metrics(&mut self) {
+        use sysinfo::{Pid, ProcessesToUpdate};
+
+        self.sys.refresh_cpu_all();
+        self.sys.refresh_memory();
+        self.sys.refresh_processes(ProcessesToUpdate::All, true);
+
+        let cpu_percent = self.sys.global_cpu_usage();
+        let memory_used = self.sys.used_memory();
+        let memory_total = self.sys.total_memory();
+
+        let mut per_session = Vec::new();
+
+        // Collect PIDs for each active session in the current project
+        if let Some(project) = self.projects.get(self.active_project_index) {
+            for session in &self.sessions {
+                if !project.session_ids.contains(&session.info.id) {
+                    continue;
+                }
+                if let Ok(Some(root_pid)) = session.pane_pid() {
+                    let (cpu, mem) = Self::sum_process_tree(&self.sys, Pid::from_u32(root_pid));
+                    per_session.push(crate::ui::info_panel::SessionMetrics {
+                        name: session.info.name.clone(),
+                        cpu_percent: cpu,
+                        memory_bytes: mem,
+                    });
+                }
+            }
+        }
+
+        self.system_metrics = crate::ui::info_panel::SystemMetrics {
+            cpu_percent,
+            memory_used,
+            memory_total,
+            per_session,
+        };
+    }
+
+    /// Sum CPU% and memory for a process and all its descendants.
+    fn sum_process_tree(sys: &sysinfo::System, root: sysinfo::Pid) -> (f32, u64) {
+        let mut cpu = 0.0f32;
+        let mut mem = 0u64;
+        // Collect all PIDs in the tree via BFS
+        let mut queue = vec![root];
+        while let Some(pid) = queue.pop() {
+            if let Some(proc_) = sys.process(pid) {
+                cpu += proc_.cpu_usage();
+                mem += proc_.memory();
+                // Find children of this process
+                for (child_pid, child_proc) in sys.processes() {
+                    if child_proc.parent() == Some(pid) {
+                        queue.push(*child_pid);
+                    }
+                }
+            }
+        }
+        (cpu, mem)
     }
 
     /// Send deferred inputs whose scheduled tick has arrived.
@@ -2551,6 +2627,7 @@ impl App {
                     info,
                     active_project,
                     vm_details.as_ref(),
+                    Some(&self.system_metrics),
                 );
             }
         }
@@ -3862,6 +3939,9 @@ mod tests {
         }
         fn detach(&self, _: &str) -> anyhow::Result<()> {
             Ok(())
+        }
+        fn pane_pid(&self, _: &str) -> anyhow::Result<Option<u32>> {
+            Ok(None)
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -50,6 +50,9 @@ const SYNC_CONFLICT_PROMPT: &str = "Please sync this worktree with main. Run: gi
 /// At ~10ms per tick, 10 ticks ≈ 100ms — enough for the app to process the pasted text.
 const DEFERRED_INPUT_DELAY_TICKS: u64 = 10;
 
+/// How often to refresh system metrics (in ticks). At ~10ms per tick, 100 ≈ 1 second.
+const METRICS_REFRESH_TICKS: u64 = 100;
+
 /// MCP tool names auto-allowed in the admin session so Claude can manage
 /// Thurbox without repeated permission prompts.
 const ADMIN_MCP_TOOLS: &[&str] = &[
@@ -720,7 +723,7 @@ impl App {
             worktree_sync_completed: Vec::new(),
             tick_count: 0,
             sys: sysinfo::System::new(),
-            system_metrics: crate::ui::info_panel::SystemMetrics {
+            system_metrics: info_panel::SystemMetrics {
                 cpu_percent: 0.0,
                 memory_used: 0,
                 memory_total: 0,
@@ -2121,15 +2124,15 @@ impl App {
         // Process queued session commands from MCP
         self.process_session_commands();
 
-        // Refresh system metrics ~every second (100 ticks at 10ms polling)
-        if self.tick_count % 100 == 0 {
+        // Refresh system metrics periodically
+        if self.tick_count % METRICS_REFRESH_TICKS == 0 {
             self.refresh_system_metrics();
         }
     }
 
     /// Collect CPU/RAM metrics from sysinfo and per-session process trees.
     fn refresh_system_metrics(&mut self) {
-        use sysinfo::{Pid, ProcessesToUpdate};
+        use sysinfo::ProcessesToUpdate;
 
         self.sys.refresh_cpu_all();
         self.sys.refresh_memory();
@@ -2141,15 +2144,18 @@ impl App {
 
         let mut per_session = Vec::new();
 
-        // Collect PIDs for each active session in the current project
         if let Some(project) = self.projects.get(self.active_project_index) {
+            // Build parent→children map once for all session tree walks
+            let children_map = Self::build_children_map(&self.sys);
+
             for session in &self.sessions {
                 if !project.session_ids.contains(&session.info.id) {
                     continue;
                 }
                 if let Ok(Some(root_pid)) = session.pane_pid() {
-                    let (cpu, mem) = Self::sum_process_tree(&self.sys, Pid::from_u32(root_pid));
-                    per_session.push(crate::ui::info_panel::SessionMetrics {
+                    let root = sysinfo::Pid::from_u32(root_pid);
+                    let (cpu, mem) = Self::sum_process_tree(&self.sys, root, &children_map);
+                    per_session.push(info_panel::SessionMetrics {
                         name: session.info.name.clone(),
                         cpu_percent: cpu,
                         memory_bytes: mem,
@@ -2158,7 +2164,7 @@ impl App {
             }
         }
 
-        self.system_metrics = crate::ui::info_panel::SystemMetrics {
+        self.system_metrics = info_panel::SystemMetrics {
             cpu_percent,
             memory_used,
             memory_total,
@@ -2166,22 +2172,33 @@ impl App {
         };
     }
 
+    /// Build a parent→children index from the process table.
+    fn build_children_map(sys: &sysinfo::System) -> HashMap<sysinfo::Pid, Vec<sysinfo::Pid>> {
+        let mut map: HashMap<sysinfo::Pid, Vec<sysinfo::Pid>> = HashMap::new();
+        for (pid, proc_) in sys.processes() {
+            if let Some(parent) = proc_.parent() {
+                map.entry(parent).or_default().push(*pid);
+            }
+        }
+        map
+    }
+
     /// Sum CPU% and memory for a process and all its descendants.
-    fn sum_process_tree(sys: &sysinfo::System, root: sysinfo::Pid) -> (f32, u64) {
+    fn sum_process_tree(
+        sys: &sysinfo::System,
+        root: sysinfo::Pid,
+        children_map: &HashMap<sysinfo::Pid, Vec<sysinfo::Pid>>,
+    ) -> (f32, u64) {
         let mut cpu = 0.0f32;
         let mut mem = 0u64;
-        // Collect all PIDs in the tree via BFS
-        let mut queue = vec![root];
-        while let Some(pid) = queue.pop() {
+        let mut stack = vec![root];
+        while let Some(pid) = stack.pop() {
             if let Some(proc_) = sys.process(pid) {
                 cpu += proc_.cpu_usage();
                 mem += proc_.memory();
-                // Find children of this process
-                for (child_pid, child_proc) in sys.processes() {
-                    if child_proc.parent() == Some(pid) {
-                        queue.push(*child_pid);
-                    }
-                }
+            }
+            if let Some(kids) = children_map.get(&pid) {
+                stack.extend(kids);
             }
         }
         (cpu, mem)

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -19,6 +19,12 @@ pub struct VmDetails {
     pub base_image: String,
 }
 
+/// Width of the gauge bar in characters.
+const GAUGE_BAR_WIDTH: usize = 20;
+
+/// Max display width for session names in the per-session metrics table.
+const SESSION_NAME_WIDTH: usize = 14;
+
 /// Per-session CPU/memory metrics.
 pub struct SessionMetrics {
     pub name: String,
@@ -79,7 +85,11 @@ pub fn render_info_panel(
             for sm in &m.per_session {
                 lines.push(Line::from(vec![
                     Span::styled(
-                        format!("  {:<14}", truncate_name(&sm.name, 14)),
+                        format!(
+                            "  {:<width$}",
+                            truncate_name(&sm.name, SESSION_NAME_WIDTH),
+                            width = SESSION_NAME_WIDTH
+                        ),
                         Style::default().fg(Theme::TEXT_PRIMARY),
                     ),
                     Span::styled(
@@ -368,23 +378,16 @@ fn find_role<'a>(roles: &'a [RoleConfig], name: &str) -> Option<&'a RoleConfig> 
 
 /// Render a gauge bar like: `CPU [████████░░░░░░░░░░░░] 42%`
 fn render_gauge<'a>(label: &'a str, percent: f32, suffix: Option<String>) -> Line<'a> {
-    let bar_width = 20;
     let clamped = percent.clamp(0.0, 100.0);
-    let filled = ((clamped / 100.0) * bar_width as f32).round() as usize;
-    let empty = bar_width - filled;
+    let filled = ((clamped / 100.0) * GAUGE_BAR_WIDTH as f32).round() as usize;
+    let empty = GAUGE_BAR_WIDTH - filled;
 
-    let filled_str: String = "█".repeat(filled);
-    let empty_str: String = "░".repeat(empty);
-
-    let right_text = match suffix {
-        Some(s) => s,
-        None => format!("{clamped:.0}%"),
-    };
+    let right_text = suffix.unwrap_or_else(|| format!("{clamped:.0}%"));
 
     Line::from(vec![
         Span::styled(format!("{label} ["), Style::default().fg(Theme::TEXT_MUTED)),
-        Span::styled(filled_str, Style::default().fg(Theme::ACCENT)),
-        Span::styled(empty_str, Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled("█".repeat(filled), Style::default().fg(Theme::ACCENT)),
+        Span::styled("░".repeat(empty), Style::default().fg(Theme::TEXT_MUTED)),
         Span::styled("] ", Style::default().fg(Theme::TEXT_MUTED)),
         Span::styled(right_text, Style::default().fg(Theme::TEXT_PRIMARY)),
     ])
@@ -392,46 +395,193 @@ fn render_gauge<'a>(label: &'a str, percent: f32, suffix: Option<String>) -> Lin
 
 /// Format a used/total byte pair like "8.2/16.0 GB".
 fn format_bytes_pair(used: u64, total: u64) -> String {
-    let (total_val, unit) = human_bytes(total);
-    let used_val = used as f64 / unit_divisor(unit);
+    let (total_val, divisor, unit) = human_bytes(total);
+    let used_val = used as f64 / divisor;
     format!("{used_val:.1}/{total_val:.1} {unit}")
 }
 
 /// Format bytes as a human-readable string like "1.2 GB".
 fn format_bytes(bytes: u64) -> String {
-    let (val, unit) = human_bytes(bytes);
+    let (val, _, unit) = human_bytes(bytes);
     format!("{val:.1} {unit}")
 }
 
-fn human_bytes(bytes: u64) -> (f64, &'static str) {
-    const GB: u64 = 1_073_741_824;
-    const MB: u64 = 1_048_576;
-    const KB: u64 = 1_024;
+/// Convert bytes to a human-readable (value, divisor, unit) tuple.
+fn human_bytes(bytes: u64) -> (f64, f64, &'static str) {
+    const GB: f64 = 1_073_741_824.0;
+    const MB: f64 = 1_048_576.0;
+    const KB: f64 = 1_024.0;
 
-    if bytes >= GB {
-        (bytes as f64 / GB as f64, "GB")
-    } else if bytes >= MB {
-        (bytes as f64 / MB as f64, "MB")
+    let b = bytes as f64;
+    if b >= GB {
+        (b / GB, GB, "GB")
+    } else if b >= MB {
+        (b / MB, MB, "MB")
     } else {
-        (bytes as f64 / KB as f64, "KB")
-    }
-}
-
-fn unit_divisor(unit: &str) -> f64 {
-    match unit {
-        "GB" => 1_073_741_824.0,
-        "MB" => 1_048_576.0,
-        _ => 1_024.0,
+        (b / KB, KB, "KB")
     }
 }
 
 /// Truncate a name to fit within `max_len` characters, appending "…" if truncated.
 fn truncate_name(name: &str, max_len: usize) -> String {
-    if name.len() <= max_len {
+    let char_count = name.chars().count();
+    if char_count <= max_len {
         name.to_string()
     } else {
         let mut s: String = name.chars().take(max_len - 1).collect();
         s.push('…');
         s
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── human_bytes tests ──
+
+    #[test]
+    fn human_bytes_gigabytes() {
+        let (val, _, unit) = human_bytes(2_147_483_648); // 2 GB
+        assert!((val - 2.0).abs() < 0.01);
+        assert_eq!(unit, "GB");
+    }
+
+    #[test]
+    fn human_bytes_megabytes() {
+        let (val, _, unit) = human_bytes(104_857_600); // 100 MB
+        assert!((val - 100.0).abs() < 0.01);
+        assert_eq!(unit, "MB");
+    }
+
+    #[test]
+    fn human_bytes_kilobytes() {
+        let (val, _, unit) = human_bytes(512_000); // ~500 KB
+        assert_eq!(unit, "KB");
+        assert!(val > 400.0 && val < 600.0);
+    }
+
+    #[test]
+    fn human_bytes_zero() {
+        let (val, _, unit) = human_bytes(0);
+        assert!((val - 0.0).abs() < 0.01);
+        assert_eq!(unit, "KB");
+    }
+
+    #[test]
+    fn human_bytes_divisor_matches_unit() {
+        let bytes = 3_221_225_472u64; // 3 GB
+        let (val, divisor, unit) = human_bytes(bytes);
+        assert_eq!(unit, "GB");
+        assert!((bytes as f64 / divisor - val).abs() < 0.001);
+    }
+
+    // ── format_bytes tests ──
+
+    #[test]
+    fn format_bytes_gb() {
+        let s = format_bytes(1_073_741_824);
+        assert_eq!(s, "1.0 GB");
+    }
+
+    #[test]
+    fn format_bytes_mb() {
+        let s = format_bytes(524_288_000);
+        assert_eq!(s, "500.0 MB");
+    }
+
+    // ── format_bytes_pair tests ──
+
+    #[test]
+    fn format_bytes_pair_same_unit() {
+        let s = format_bytes_pair(8_589_934_592, 17_179_869_184); // 8/16 GB
+        assert_eq!(s, "8.0/16.0 GB");
+    }
+
+    #[test]
+    fn format_bytes_pair_zero_used() {
+        let s = format_bytes_pair(0, 17_179_869_184);
+        assert_eq!(s, "0.0/16.0 GB");
+    }
+
+    // ── truncate_name tests ──
+
+    #[test]
+    fn truncate_name_short() {
+        assert_eq!(truncate_name("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_name_exact() {
+        assert_eq!(truncate_name("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_name_long() {
+        let result = truncate_name("very-long-session-name", 10);
+        assert_eq!(result, "very-long…");
+        assert_eq!(result.chars().count(), 10);
+    }
+
+    #[test]
+    fn truncate_name_multibyte() {
+        let result = truncate_name("café-session", 5);
+        assert_eq!(result.chars().count(), 5);
+        assert!(result.ends_with('…'));
+    }
+
+    // ── render_gauge tests ──
+
+    #[test]
+    fn render_gauge_zero_percent() {
+        let line = render_gauge("CPU", 0.0, None);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("CPU ["));
+        assert!(text.contains("0%"));
+        // All empty chars
+        assert!(text.contains(&"░".repeat(GAUGE_BAR_WIDTH)));
+    }
+
+    #[test]
+    fn render_gauge_hundred_percent() {
+        let line = render_gauge("CPU", 100.0, None);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("100%"));
+        assert!(text.contains(&"█".repeat(GAUGE_BAR_WIDTH)));
+    }
+
+    #[test]
+    fn render_gauge_fifty_percent() {
+        let line = render_gauge("RAM", 50.0, None);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("50%"));
+    }
+
+    #[test]
+    fn render_gauge_with_suffix() {
+        let line = render_gauge("RAM", 50.0, Some("8.0/16.0 GB".to_string()));
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("8.0/16.0 GB"));
+        assert!(!text.contains("50%"));
+    }
+
+    #[test]
+    fn render_gauge_clamps_above_100() {
+        let line = render_gauge("CPU", 150.0, None);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("100%"));
+    }
+
+    #[test]
+    fn render_gauge_clamps_below_zero() {
+        let line = render_gauge("CPU", -10.0, None);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("0%"));
+    }
+
+    // ── constants compile-time checks ──
+    const _: () = assert!(GAUGE_BAR_WIDTH >= 10);
+    const _: () = assert!(GAUGE_BAR_WIDTH <= 50);
+    const _: () = assert!(SESSION_NAME_WIDTH >= 8);
+    const _: () = assert!(SESSION_NAME_WIDTH <= 30);
 }

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -19,12 +19,32 @@ pub struct VmDetails {
     pub base_image: String,
 }
 
+/// Per-session CPU/memory metrics.
+pub struct SessionMetrics {
+    pub name: String,
+    pub cpu_percent: f32,
+    pub memory_bytes: u64,
+}
+
+/// System-wide and per-session resource metrics.
+pub struct SystemMetrics {
+    /// Overall CPU usage 0-100.
+    pub cpu_percent: f32,
+    /// Total RAM used in bytes.
+    pub memory_used: u64,
+    /// Total RAM in bytes.
+    pub memory_total: u64,
+    /// Per-session resource usage.
+    pub per_session: Vec<SessionMetrics>,
+}
+
 pub fn render_info_panel(
     frame: &mut Frame,
     area: Rect,
     info: &SessionInfo,
     project: Option<&ProjectInfo>,
     vm_details: Option<&VmDetails>,
+    metrics: Option<&SystemMetrics>,
 ) {
     let block = Block::default()
         .title(" Info ")
@@ -32,6 +52,51 @@ pub fn render_info_panel(
         .border_style(Style::default().fg(Theme::BORDER_UNFOCUSED));
 
     let mut lines = Vec::new();
+
+    // ── System metrics section ──
+    if let Some(m) = metrics {
+        lines.push(Line::from(Span::styled(
+            "System Resources",
+            Theme::section_header(),
+        )));
+        lines.push(render_gauge("CPU", m.cpu_percent, None));
+        lines.push(render_gauge(
+            "RAM",
+            if m.memory_total > 0 {
+                (m.memory_used as f64 / m.memory_total as f64 * 100.0) as f32
+            } else {
+                0.0
+            },
+            Some(format_bytes_pair(m.memory_used, m.memory_total)),
+        ));
+
+        if !m.per_session.is_empty() {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Session Resources",
+                Theme::section_header(),
+            )));
+            for sm in &m.per_session {
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("  {:<14}", truncate_name(&sm.name, 14)),
+                        Style::default().fg(Theme::TEXT_PRIMARY),
+                    ),
+                    Span::styled(
+                        format!("{:>3}%", sm.cpu_percent as u32),
+                        Style::default().fg(Theme::ACCENT),
+                    ),
+                    Span::styled(" CPU  ", Style::default().fg(Theme::TEXT_MUTED)),
+                    Span::styled(
+                        format_bytes(sm.memory_bytes),
+                        Style::default().fg(Theme::ACCENT),
+                    ),
+                ]));
+            }
+        }
+
+        lines.push(separator());
+    }
 
     // ── Project section ──
     if let Some(proj) = project {
@@ -299,4 +364,74 @@ fn separator<'a>() -> Line<'a> {
 
 fn find_role<'a>(roles: &'a [RoleConfig], name: &str) -> Option<&'a RoleConfig> {
     roles.iter().find(|r| r.name == name)
+}
+
+/// Render a gauge bar like: `CPU [████████░░░░░░░░░░░░] 42%`
+fn render_gauge<'a>(label: &'a str, percent: f32, suffix: Option<String>) -> Line<'a> {
+    let bar_width = 20;
+    let clamped = percent.clamp(0.0, 100.0);
+    let filled = ((clamped / 100.0) * bar_width as f32).round() as usize;
+    let empty = bar_width - filled;
+
+    let filled_str: String = "█".repeat(filled);
+    let empty_str: String = "░".repeat(empty);
+
+    let right_text = match suffix {
+        Some(s) => s,
+        None => format!("{clamped:.0}%"),
+    };
+
+    Line::from(vec![
+        Span::styled(format!("{label} ["), Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled(filled_str, Style::default().fg(Theme::ACCENT)),
+        Span::styled(empty_str, Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled("] ", Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled(right_text, Style::default().fg(Theme::TEXT_PRIMARY)),
+    ])
+}
+
+/// Format a used/total byte pair like "8.2/16.0 GB".
+fn format_bytes_pair(used: u64, total: u64) -> String {
+    let (total_val, unit) = human_bytes(total);
+    let used_val = used as f64 / unit_divisor(unit);
+    format!("{used_val:.1}/{total_val:.1} {unit}")
+}
+
+/// Format bytes as a human-readable string like "1.2 GB".
+fn format_bytes(bytes: u64) -> String {
+    let (val, unit) = human_bytes(bytes);
+    format!("{val:.1} {unit}")
+}
+
+fn human_bytes(bytes: u64) -> (f64, &'static str) {
+    const GB: u64 = 1_073_741_824;
+    const MB: u64 = 1_048_576;
+    const KB: u64 = 1_024;
+
+    if bytes >= GB {
+        (bytes as f64 / GB as f64, "GB")
+    } else if bytes >= MB {
+        (bytes as f64 / MB as f64, "MB")
+    } else {
+        (bytes as f64 / KB as f64, "KB")
+    }
+}
+
+fn unit_divisor(unit: &str) -> f64 {
+    match unit {
+        "GB" => 1_073_741_824.0,
+        "MB" => 1_048_576.0,
+        _ => 1_024.0,
+    }
+}
+
+/// Truncate a name to fit within `max_len` characters, appending "…" if truncated.
+fn truncate_name(name: &str, max_len: usize) -> String {
+    if name.len() <= max_len {
+        name.to_string()
+    } else {
+        let mut s: String = name.chars().take(max_len - 1).collect();
+        s.push('…');
+        s
+    }
 }


### PR DESCRIPTION
## Summary

- Adds real-time CPU/RAM monitoring at the top of the info panel (F2 toggle, width >= 120)
- Shows overall system CPU gauge, RAM gauge with used/total, and per-session CPU% + memory for the active project's sessions
- Metrics refresh every ~1 second via sysinfo crate, with process tree walking to capture each session's full resource footprint
- Adds `pane_pid()` to `SessionBackend` trait to get process PIDs from tmux panes

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Add `sysinfo = "0.34"` dependency |
| `src/agent/backend.rs` | Add `pane_pid()` to trait + `Session` wrapper |
| `src/agent/tmux.rs` | Implement `pane_pid()` for `LocalTmuxBackend` |
| `src/agent/vm.rs` | Implement `pane_pid()` for `QemuVmBackend` |
| `src/agent/registry.rs` | Add `pane_pid()` to test stub |
| `src/ui/info_panel.rs` | `SystemMetrics`/`SessionMetrics` structs, gauge rendering, 20 unit tests |
| `src/app/mod.rs` | `sysinfo::System` field, `refresh_system_metrics()`, O(n) process tree walk |

## Test plan

- [x] `cargo check --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run --all` — 723 tests pass (including 20 new)
- [x] Architecture rules pass
- [ ] Manual: launch TUI, press F2 at width >= 120, verify CPU/RAM bars update ~every second
- [ ] Manual: verify per-session metrics show for active project's sessions
- [ ] Manual: verify existing session/project/role info still renders below metrics