### PR TITLE
refactor(ui): improve info panel readability

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2151,6 +2151,7 @@ impl App {
     }
 
     /// Collect CPU/RAM metrics from sysinfo and per-session process trees.
+    /// Includes ALL sessions across ALL projects.
     fn refresh_system_metrics(&mut self) {
         use sysinfo::ProcessesToUpdate;
 
@@ -2162,35 +2163,46 @@ impl App {
         let memory_used = self.sys.used_memory();
         let memory_total = self.sys.total_memory();
 
+        // Build parent→children map once for all session tree walks
+        let children_map = Self::build_children_map(&self.sys);
+
+        // Build session_id → project_name lookup
+        let mut session_project: HashMap<SessionId, String> = HashMap::new();
+        for project in &self.projects {
+            for sid in &project.session_ids {
+                session_project.insert(*sid, project.config.name.clone());
+            }
+        }
+
         let mut per_session = Vec::new();
 
-        if let Some(project) = self.projects.get(self.active_project_index) {
-            // Build parent→children map once for all session tree walks
-            let children_map = Self::build_children_map(&self.sys);
+        for session in &self.sessions {
+            // VM sessions: use the QEMU host PID; local sessions: tmux pane PID.
+            let root_pid = self
+                .db
+                .get_vm_by_session(&session.info.id.to_string())
+                .ok()
+                .flatten()
+                .and_then(|vm| vm.qemu_pid)
+                .or_else(|| session.pane_pid().ok().flatten());
 
-            for session in &self.sessions {
-                if !project.session_ids.contains(&session.info.id) {
-                    continue;
-                }
-
-                // VM sessions: use the QEMU host PID; local sessions: tmux pane PID.
-                let root_pid = self
-                    .db
-                    .get_vm_by_session(&session.info.id.to_string())
-                    .ok()
-                    .flatten()
-                    .and_then(|vm| vm.qemu_pid)
-                    .or_else(|| session.pane_pid().ok().flatten());
-
-                if let Some(pid) = root_pid {
-                    let root = sysinfo::Pid::from_u32(pid);
-                    let (cpu, mem) = Self::sum_process_tree(&self.sys, root, &children_map);
-                    per_session.push(info_panel::SessionMetrics {
-                        name: session.info.name.clone(),
-                        cpu_percent: cpu,
-                        memory_bytes: mem,
-                    });
-                }
+            if let Some(pid) = root_pid {
+                let root = sysinfo::Pid::from_u32(pid);
+                let (cpu, mem) = Self::sum_process_tree(&self.sys, root, &children_map);
+                let project_name = session_project
+                    .get(&session.info.id)
+                    .cloned()
+                    .unwrap_or_default();
+                let worktree_branch = session.info.worktrees.first().map(|wt| wt.branch.clone());
+                let is_vm = session.info.vm_id.is_some();
+                per_session.push(info_panel::SessionMetrics {
+                    name: session.info.name.clone(),
+                    project_name,
+                    worktree_branch,
+                    is_vm,
+                    cpu_percent: cpu,
+                    memory_bytes: mem,
+                });
             }
         }
 

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -6,6 +6,8 @@ use ratatui::{
     Frame,
 };
 
+use std::path::Path;
+
 use super::theme::Theme;
 use crate::project::ProjectInfo;
 use crate::session::{RoleConfig, SessionInfo, SessionStatus};
@@ -19,15 +21,12 @@ pub struct VmDetails {
     pub base_image: String,
 }
 
-/// Width of the gauge bar in characters.
-const GAUGE_BAR_WIDTH: usize = 20;
-
-/// Max display width for session names in the per-session metrics table.
-const SESSION_NAME_WIDTH: usize = 14;
-
-/// Per-session CPU/memory metrics.
+/// Per-session CPU/memory metrics with context.
 pub struct SessionMetrics {
     pub name: String,
+    pub project_name: String,
+    pub worktree_branch: Option<String>,
+    pub is_vm: bool,
     pub cpu_percent: f32,
     pub memory_bytes: u64,
 }
@@ -40,7 +39,7 @@ pub struct SystemMetrics {
     pub memory_used: u64,
     /// Total RAM in bytes.
     pub memory_total: u64,
-    /// Per-session resource usage.
+    /// Per-session resource usage (all projects).
     pub per_session: Vec<SessionMetrics>,
 }
 
@@ -57,115 +56,12 @@ pub fn render_info_panel(
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Theme::BORDER_UNFOCUSED));
 
+    let inner_width = area.width.saturating_sub(2) as usize;
+    let inner_height = area.height.saturating_sub(2) as usize;
+
     let mut lines = Vec::new();
 
-    // ── System metrics section ──
-    if let Some(m) = metrics {
-        lines.push(Line::from(Span::styled(
-            "System Resources",
-            Theme::section_header(),
-        )));
-        lines.push(render_gauge("CPU", m.cpu_percent, None));
-        lines.push(render_gauge(
-            "RAM",
-            if m.memory_total > 0 {
-                (m.memory_used as f64 / m.memory_total as f64 * 100.0) as f32
-            } else {
-                0.0
-            },
-            Some(format_bytes_pair(m.memory_used, m.memory_total)),
-        ));
-
-        if !m.per_session.is_empty() {
-            lines.push(Line::from(""));
-            lines.push(Line::from(Span::styled(
-                "Session Resources",
-                Theme::section_header(),
-            )));
-            for sm in &m.per_session {
-                lines.push(Line::from(vec![
-                    Span::styled(
-                        format!(
-                            "  {:<width$}",
-                            truncate_name(&sm.name, SESSION_NAME_WIDTH),
-                            width = SESSION_NAME_WIDTH
-                        ),
-                        Style::default().fg(Theme::TEXT_PRIMARY),
-                    ),
-                    Span::styled(
-                        format!("{:>3}%", sm.cpu_percent as u32),
-                        Style::default().fg(Theme::ACCENT),
-                    ),
-                    Span::styled(" CPU  ", Style::default().fg(Theme::TEXT_MUTED)),
-                    Span::styled(
-                        format_bytes(sm.memory_bytes),
-                        Style::default().fg(Theme::ACCENT),
-                    ),
-                ]));
-            }
-        }
-
-        lines.push(separator());
-    }
-
-    // ── Project section ──
-    if let Some(proj) = project {
-        let project_line = vec![
-            Span::styled("Project: ", Theme::label()),
-            Span::styled(
-                &proj.config.name,
-                Style::default()
-                    .fg(Theme::ACCENT)
-                    .add_modifier(Modifier::BOLD),
-            ),
-        ];
-        lines.push(Line::from(project_line));
-
-        if proj.config.repos.len() == 1 {
-            lines.push(Line::from(vec![
-                Span::styled("Repo: ", Theme::label()),
-                Span::styled(
-                    proj.config.repos[0].display().to_string(),
-                    Style::default().fg(Theme::TEXT_MUTED),
-                ),
-            ]));
-        } else {
-            lines.push(Line::from(Span::styled("Repos:", Theme::label())));
-            for repo in &proj.config.repos {
-                lines.push(Line::from(Span::styled(
-                    format!("  {}", repo.display()),
-                    Style::default().fg(Theme::TEXT_MUTED),
-                )));
-            }
-        }
-
-        lines.push(Line::from(vec![
-            Span::styled("Sessions: ", Theme::label()),
-            Span::styled(
-                proj.session_ids.len().to_string(),
-                Style::default().fg(Theme::TEXT_PRIMARY),
-            ),
-        ]));
-
-        let roles_text = if proj.config.roles.is_empty() {
-            "(none)".to_string()
-        } else {
-            proj.config
-                .roles
-                .iter()
-                .map(|r| r.name.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
-        };
-        lines.push(Line::from(vec![
-            Span::styled("Roles: ", Theme::label()),
-            Span::styled(roles_text, Style::default().fg(Theme::TEXT_PRIMARY)),
-        ]));
-
-        lines.push(separator());
-    }
-
-    // ── Session section ──
+    // ── Session section (most relevant: "what am I looking at") ──
     lines.push(Line::from(vec![
         Span::styled("Name: ", Theme::label()),
         Span::styled(&info.name, Style::default().fg(Theme::TEXT_PRIMARY)),
@@ -188,28 +84,181 @@ pub fn render_info_panel(
                 .add_modifier(Modifier::BOLD),
         ),
     ]));
-    lines.push(Line::from(vec![
-        Span::styled("ID: ", Theme::label()),
-        Span::styled(info.id.to_string(), Style::default().fg(Theme::TEXT_MUTED)),
-    ]));
-    lines.push(Line::from(vec![
-        Span::styled("Claude: ", Theme::label()),
-        Span::styled(
-            info.agent_session_id.as_deref().unwrap_or("(none)"),
-            Style::default().fg(Theme::TEXT_MUTED),
-        ),
-    ]));
-    lines.push(Line::from(vec![
-        Span::styled("Backend: ", Theme::label()),
-        Span::styled(
-            info.backend_id.as_deref().unwrap_or("(none)"),
-            Style::default().fg(Theme::TEXT_MUTED),
-        ),
-    ]));
 
+    // ── Project section ──
+    if let Some(proj) = project {
+        lines.push(separator(inner_width));
+
+        lines.push(Line::from(vec![
+            Span::styled("Project: ", Theme::label()),
+            Span::styled(
+                &proj.config.name,
+                Style::default()
+                    .fg(Theme::ACCENT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+
+        if proj.config.repos.len() == 1 {
+            lines.push(Line::from(vec![
+                Span::styled("Repo: ", Theme::label()),
+                Span::styled(
+                    short_path(&proj.config.repos[0]),
+                    Style::default().fg(Theme::TEXT_MUTED),
+                ),
+            ]));
+        } else {
+            lines.push(Line::from(Span::styled("Repos:", Theme::label())));
+            for repo in &proj.config.repos {
+                lines.push(Line::from(Span::styled(
+                    format!("  {}", short_path(repo)),
+                    Style::default().fg(Theme::TEXT_MUTED),
+                )));
+            }
+        }
+
+        let roles_text = if proj.config.roles.is_empty() {
+            "(none)".to_string()
+        } else {
+            proj.config
+                .roles
+                .iter()
+                .map(|r| r.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        lines.push(Line::from(vec![
+            Span::styled("Roles: ", Theme::label()),
+            Span::styled(roles_text, Style::default().fg(Theme::TEXT_PRIMARY)),
+        ]));
+    }
+
+    // ── System Resources section (global CPU/RAM) ──
+    if let Some(m) = metrics {
+        lines.push(separator(inner_width));
+        lines.push(Line::from(Span::styled("System", Theme::section_header())));
+
+        let gauge_lines = render_gauge_lines("CPU", m.cpu_percent, None, inner_width);
+        lines.extend(gauge_lines);
+
+        let ram_lines = render_gauge_lines(
+            "RAM",
+            if m.memory_total > 0 {
+                (m.memory_used as f64 / m.memory_total as f64 * 100.0) as f32
+            } else {
+                0.0
+            },
+            Some(format_bytes_pair(m.memory_used, m.memory_total)),
+            inner_width,
+        );
+        lines.extend(ram_lines);
+    }
+
+    // ── Middle sections (VM, Directories, Worktrees, Role Details) ──
+    append_detail_sections(&mut lines, info, project, vm_details, inner_width);
+
+    // ── Per-session CPU/RAM (all projects, height-capped, always last) ──
+    if let Some(m) = metrics {
+        if !m.per_session.is_empty() {
+            let total = m.per_session.len();
+            let section_header_cost = 2; // separator + "Sessions"
+            let used = lines.len() + section_header_cost;
+            let remaining = inner_height.saturating_sub(used);
+            let fits = remaining / 2; // 2 lines per session
+            let show_count = if fits >= total {
+                total
+            } else {
+                // Reserve 1 line for "+N more"
+                inner_height
+                    .saturating_sub(used + 1)
+                    .checked_div(2)
+                    .unwrap_or(0)
+                    .max(1)
+                    .min(total)
+            };
+
+            lines.push(separator(inner_width));
+            lines.push(Line::from(Span::styled(
+                "Sessions",
+                Theme::section_header(),
+            )));
+
+            let name_width = inner_width.saturating_sub(2);
+            for sm in m.per_session.iter().take(show_count) {
+                lines.push(render_session_name_line(sm, name_width));
+                lines.push(render_session_stats_line(sm));
+            }
+
+            if show_count < total {
+                lines.push(Line::from(Span::styled(
+                    format!("  +{} more", total - show_count),
+                    Style::default().fg(Theme::TEXT_MUTED),
+                )));
+            }
+        }
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+/// Render a session's name line with context tags (project, branch, VM).
+fn render_session_name_line<'a>(sm: &'a SessionMetrics, name_width: usize) -> Line<'a> {
+    let mut spans: Vec<Span<'a>> = vec![Span::styled(
+        format!("  {}", truncate_name(&sm.name, name_width)),
+        Style::default().fg(Theme::TEXT_PRIMARY),
+    )];
+
+    let mut context = String::new();
+    context.push_str(&sm.project_name);
+    if let Some(ref branch) = sm.worktree_branch {
+        context.push(' ');
+        context.push_str(branch);
+    }
+    if sm.is_vm {
+        context.push_str(" VM");
+    }
+    if !context.is_empty() {
+        spans.push(Span::styled(
+            format!(
+                " [{}]",
+                truncate_name(&context, name_width.saturating_sub(4))
+            ),
+            Style::default().fg(Theme::TEXT_MUTED),
+        ));
+    }
+
+    Line::from(spans)
+}
+
+/// Render a session's CPU% and RAM stats line.
+fn render_session_stats_line(sm: &SessionMetrics) -> Line<'static> {
+    let ram = format_bytes(sm.memory_bytes);
+    Line::from(vec![
+        Span::styled("    ", Style::default()),
+        Span::styled(
+            format!("{:>3}%", sm.cpu_percent as u32),
+            Style::default().fg(Theme::ACCENT),
+        ),
+        Span::styled(" CPU  ", Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled(ram, Style::default().fg(Theme::ACCENT)),
+        Span::styled(" RAM", Style::default().fg(Theme::TEXT_MUTED)),
+    ])
+}
+
+/// Append detail sections (VM, Directories, Worktrees, Role Details) to `lines`.
+fn append_detail_sections<'a>(
+    lines: &mut Vec<Line<'a>>,
+    info: &'a SessionInfo,
+    project: Option<&'a ProjectInfo>,
+    vm_details: Option<&'a VmDetails>,
+    inner_width: usize,
+) {
     // ── VM section (for sandboxed sessions) ──
-    if let Some(vm_id) = &info.vm_id {
-        lines.push(separator());
+    if info.vm_id.is_some() {
+        lines.push(separator(inner_width));
         lines.push(Line::from(Span::styled(
             "Sandbox VM",
             Theme::section_header(),
@@ -220,16 +269,6 @@ pub fn render_info_panel(
                 Span::styled("State: ", Theme::label()),
                 Span::styled(&vm.state, Style::default().fg(Theme::TEXT_PRIMARY)),
             ]));
-        }
-
-        // Show short VM ID (first 8 chars)
-        let short_id = if vm_id.len() > 8 { &vm_id[..8] } else { vm_id };
-        lines.push(Line::from(vec![
-            Span::styled("VM ID: ", Theme::label()),
-            Span::styled(short_id, Style::default().fg(Theme::TEXT_MUTED)),
-        ]));
-
-        if let Some(vm) = vm_details {
             lines.push(Line::from(vec![
                 Span::styled("CPUs: ", Theme::label()),
                 Span::styled(
@@ -257,7 +296,6 @@ pub fn render_info_panel(
             ]));
         }
 
-        // Show provisioning step when provisioning.
         if info.status == SessionStatus::Provisioning {
             if let Some(ref step) = info.provisioning_step {
                 lines.push(Line::from(vec![
@@ -270,66 +308,41 @@ pub fn render_info_panel(
 
     // ── Directories section ──
     if info.cwd.is_some() || !info.additional_dirs.is_empty() {
-        lines.push(separator());
+        lines.push(separator(inner_width));
         lines.push(Line::from(Span::styled(
             "Directories",
             Theme::section_header(),
         )));
         if let Some(cwd) = &info.cwd {
             lines.push(Line::from(Span::styled(
-                format!("  {} (cwd)", cwd.display()),
+                format!("  {} (cwd)", short_path(cwd)),
                 Style::default().fg(Theme::TEXT_MUTED),
             )));
         }
         for dir in &info.additional_dirs {
             lines.push(Line::from(Span::styled(
-                format!("  {}", dir.display()),
+                format!("  {}", short_path(dir)),
                 Style::default().fg(Theme::TEXT_MUTED),
             )));
         }
     }
 
-    // ── Worktrees section ──
-    if !info.worktrees.is_empty() {
-        lines.push(separator());
-        let header = if info.worktrees.len() == 1 {
-            "Worktree"
-        } else {
-            "Worktrees"
-        };
-        lines.push(Line::from(Span::styled(header, Theme::section_header())));
-        for wt in &info.worktrees {
-            lines.push(Line::from(vec![
-                Span::styled("Branch: ", Theme::label()),
-                Span::styled(&wt.branch, Style::default().fg(Theme::BRANCH_NAME)),
-            ]));
-            lines.push(Line::from(vec![
-                Span::styled("Path: ", Theme::label()),
-                Span::styled(
-                    wt.worktree_path.display().to_string(),
-                    Style::default().fg(Theme::TEXT_MUTED),
-                ),
-            ]));
-        }
+    // ── Worktree section ──
+    if let Some(wt) = info.worktrees.first() {
+        lines.push(separator(inner_width));
+        lines.push(Line::from(vec![
+            Span::styled("Worktree: ", Theme::label()),
+            Span::styled(&wt.branch, Style::default().fg(Theme::BRANCH_NAME)),
+        ]));
     }
 
     // ── Role Details section ──
     if let Some(role_config) = project.and_then(|p| find_role(&p.config.roles, &info.role)) {
-        lines.push(separator());
+        lines.push(separator(inner_width));
         lines.push(Line::from(Span::styled(
             "Role Details",
             Theme::section_header(),
         )));
-
-        if !role_config.description.is_empty() {
-            lines.push(Line::from(vec![
-                Span::styled("Desc: ", Theme::label()),
-                Span::styled(
-                    &role_config.description,
-                    Style::default().fg(Theme::TEXT_PRIMARY),
-                ),
-            ]));
-        }
 
         if let Some(mode) = &role_config.permissions.permission_mode {
             lines.push(Line::from(vec![
@@ -339,35 +352,34 @@ pub fn render_info_panel(
         }
 
         if !role_config.permissions.allowed_tools.is_empty() {
+            let label = "Allowed: ";
+            let max = inner_width.saturating_sub(label.len());
             lines.push(Line::from(vec![
-                Span::styled("Allowed: ", Theme::label()),
+                Span::styled(label, Theme::label()),
                 Span::styled(
-                    role_config.permissions.allowed_tools.join(", "),
+                    truncate_name(&role_config.permissions.allowed_tools.join(", "), max),
                     Style::default().fg(Theme::TOOL_ALLOWED),
                 ),
             ]));
         }
 
         if !role_config.permissions.disallowed_tools.is_empty() {
+            let label = "Disallowed: ";
+            let max = inner_width.saturating_sub(label.len());
             lines.push(Line::from(vec![
-                Span::styled("Disallowed: ", Theme::label()),
+                Span::styled(label, Theme::label()),
                 Span::styled(
-                    role_config.permissions.disallowed_tools.join(", "),
+                    truncate_name(&role_config.permissions.disallowed_tools.join(", "), max),
                     Style::default().fg(Theme::TOOL_DISALLOWED),
                 ),
             ]));
         }
     }
-
-    let paragraph = Paragraph::new(lines)
-        .block(block)
-        .wrap(Wrap { trim: false });
-    frame.render_widget(paragraph, area);
 }
 
-fn separator<'a>() -> Line<'a> {
+fn separator(width: usize) -> Line<'static> {
     Line::from(Span::styled(
-        "──────────────────────",
+        "─".repeat(width),
         Style::default().fg(Theme::BORDER_UNFOCUSED),
     ))
 }
@@ -376,21 +388,46 @@ fn find_role<'a>(roles: &'a [RoleConfig], name: &str) -> Option<&'a RoleConfig> 
     roles.iter().find(|r| r.name == name)
 }
 
-/// Render a gauge bar like: `CPU [████████░░░░░░░░░░░░] 42%`
-fn render_gauge<'a>(label: &'a str, percent: f32, suffix: Option<String>) -> Line<'a> {
+/// Render a gauge as two lines:
+/// Line 1: label left-aligned, suffix/percent right-aligned
+/// Line 2: full-width bar `[███░░░░]` scaled to `width - 2`
+fn render_gauge_lines(
+    label: &str,
+    percent: f32,
+    suffix: Option<String>,
+    width: usize,
+) -> Vec<Line<'static>> {
     let clamped = percent.clamp(0.0, 100.0);
-    let filled = ((clamped / 100.0) * GAUGE_BAR_WIDTH as f32).round() as usize;
-    let empty = GAUGE_BAR_WIDTH - filled;
-
     let right_text = suffix.unwrap_or_else(|| format!("{clamped:.0}%"));
 
-    Line::from(vec![
-        Span::styled(format!("{label} ["), Style::default().fg(Theme::TEXT_MUTED)),
+    // Line 1: label + right-aligned suffix
+    let label_len = label.chars().count();
+    let right_len = right_text.chars().count();
+    let padding = width.saturating_sub(label_len + right_len);
+    let header_line = Line::from(vec![
+        Span::styled(label.to_string(), Style::default().fg(Theme::TEXT_MUTED)),
+        Span::raw(" ".repeat(padding)),
+        Span::styled(right_text, Style::default().fg(Theme::TEXT_PRIMARY)),
+    ]);
+
+    // Line 2: bar scaled to width - 2 (for [ and ])
+    let bar_width = width.saturating_sub(2);
+    let filled = ((clamped / 100.0) * bar_width as f32).round() as usize;
+    let empty = bar_width.saturating_sub(filled);
+    let bar_line = Line::from(vec![
+        Span::styled("[", Style::default().fg(Theme::TEXT_MUTED)),
         Span::styled("█".repeat(filled), Style::default().fg(Theme::ACCENT)),
         Span::styled("░".repeat(empty), Style::default().fg(Theme::TEXT_MUTED)),
-        Span::styled("] ", Style::default().fg(Theme::TEXT_MUTED)),
-        Span::styled(right_text, Style::default().fg(Theme::TEXT_PRIMARY)),
-    ])
+        Span::styled("]", Style::default().fg(Theme::TEXT_MUTED)),
+    ]);
+
+    vec![header_line, bar_line]
+}
+
+/// Format bytes as a human-readable string like "1.2 GB".
+fn format_bytes(bytes: u64) -> String {
+    let (val, _, unit) = human_bytes(bytes);
+    format!("{val:.1} {unit}")
 }
 
 /// Format a used/total byte pair like "8.2/16.0 GB".
@@ -398,12 +435,6 @@ fn format_bytes_pair(used: u64, total: u64) -> String {
     let (total_val, divisor, unit) = human_bytes(total);
     let used_val = used as f64 / divisor;
     format!("{used_val:.1}/{total_val:.1} {unit}")
-}
-
-/// Format bytes as a human-readable string like "1.2 GB".
-fn format_bytes(bytes: u64) -> String {
-    let (val, _, unit) = human_bytes(bytes);
-    format!("{val:.1} {unit}")
 }
 
 /// Convert bytes to a human-readable (value, divisor, unit) tuple.
@@ -422,6 +453,17 @@ fn human_bytes(bytes: u64) -> (f64, f64, &'static str) {
     }
 }
 
+/// Display a path with `$HOME` replaced by `~`.
+fn short_path(path: &Path) -> String {
+    let s = path.display().to_string();
+    if let Ok(home) = std::env::var("HOME") {
+        if let Some(rest) = s.strip_prefix(&home) {
+            return format!("~{rest}");
+        }
+    }
+    s
+}
+
 /// Truncate a name to fit within `max_len` characters, appending "…" if truncated.
 fn truncate_name(name: &str, max_len: usize) -> String {
     let char_count = name.chars().count();
@@ -429,7 +471,7 @@ fn truncate_name(name: &str, max_len: usize) -> String {
         name.to_string()
     } else {
         let mut s: String = name.chars().take(max_len - 1).collect();
-        s.push('…');
+        s.push('\u{2026}');
         s
     }
 }
@@ -437,6 +479,62 @@ fn truncate_name(name: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── render_session_name_line / render_session_stats_line tests ──
+
+    fn sample_metrics() -> SessionMetrics {
+        SessionMetrics {
+            name: "worker-1".into(),
+            project_name: "myproj".into(),
+            worktree_branch: None,
+            is_vm: false,
+            cpu_percent: 42.0,
+            memory_bytes: 1_073_741_824, // 1 GB
+        }
+    }
+
+    #[test]
+    fn session_name_line_shows_name_and_context() {
+        let sm = sample_metrics();
+        let line = render_session_name_line(&sm, 40);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("worker-1"));
+        assert!(text.contains("[myproj]"));
+    }
+
+    #[test]
+    fn session_name_line_with_branch_and_vm() {
+        let sm = SessionMetrics {
+            worktree_branch: Some("feat-x".into()),
+            is_vm: true,
+            ..sample_metrics()
+        };
+        let line = render_session_name_line(&sm, 50);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("[myproj feat-x VM]"));
+    }
+
+    #[test]
+    fn session_name_line_no_context() {
+        let sm = SessionMetrics {
+            project_name: String::new(),
+            ..sample_metrics()
+        };
+        let line = render_session_name_line(&sm, 30);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(!text.contains('['));
+    }
+
+    #[test]
+    fn session_stats_line_shows_cpu_and_ram() {
+        let sm = sample_metrics();
+        let line = render_session_stats_line(&sm);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("42%"));
+        assert!(text.contains("CPU"));
+        assert!(text.contains("1.0 GB"));
+        assert!(text.contains("RAM"));
+    }
 
     // ── human_bytes tests ──
 
@@ -476,20 +574,6 @@ mod tests {
         assert!((bytes as f64 / divisor - val).abs() < 0.001);
     }
 
-    // ── format_bytes tests ──
-
-    #[test]
-    fn format_bytes_gb() {
-        let s = format_bytes(1_073_741_824);
-        assert_eq!(s, "1.0 GB");
-    }
-
-    #[test]
-    fn format_bytes_mb() {
-        let s = format_bytes(524_288_000);
-        assert_eq!(s, "500.0 MB");
-    }
-
     // ── format_bytes_pair tests ──
 
     #[test]
@@ -519,69 +603,116 @@ mod tests {
     #[test]
     fn truncate_name_long() {
         let result = truncate_name("very-long-session-name", 10);
-        assert_eq!(result, "very-long…");
+        assert_eq!(result, "very-long\u{2026}");
         assert_eq!(result.chars().count(), 10);
     }
 
     #[test]
     fn truncate_name_multibyte() {
-        let result = truncate_name("café-session", 5);
+        let result = truncate_name("caf\u{00e9}-session", 5);
         assert_eq!(result.chars().count(), 5);
-        assert!(result.ends_with('…'));
+        assert!(result.ends_with('\u{2026}'));
     }
 
-    // ── render_gauge tests ──
+    // ── render_gauge_lines tests ──
 
     #[test]
-    fn render_gauge_zero_percent() {
-        let line = render_gauge("CPU", 0.0, None);
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(text.contains("CPU ["));
-        assert!(text.contains("0%"));
-        // All empty chars
-        assert!(text.contains(&"░".repeat(GAUGE_BAR_WIDTH)));
-    }
-
-    #[test]
-    fn render_gauge_hundred_percent() {
-        let line = render_gauge("CPU", 100.0, None);
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(text.contains("100%"));
-        assert!(text.contains(&"█".repeat(GAUGE_BAR_WIDTH)));
+    fn render_gauge_lines_zero_percent() {
+        let lines = render_gauge_lines("CPU", 0.0, None, 20);
+        assert_eq!(lines.len(), 2);
+        let header: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(header.contains("CPU"));
+        assert!(header.contains("0%"));
+        let bar: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
+        // bar_width = 20 - 2 = 18, all empty
+        assert!(bar.contains(&"░".repeat(18)));
+        assert!(!bar.contains('█'));
     }
 
     #[test]
-    fn render_gauge_fifty_percent() {
-        let line = render_gauge("RAM", 50.0, None);
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(text.contains("50%"));
+    fn render_gauge_lines_hundred_percent() {
+        let lines = render_gauge_lines("CPU", 100.0, None, 20);
+        let header: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(header.contains("100%"));
+        let bar: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
+        // bar_width = 18, all filled
+        assert!(bar.contains(&"█".repeat(18)));
+        assert!(!bar.contains('░'));
     }
 
     #[test]
-    fn render_gauge_with_suffix() {
-        let line = render_gauge("RAM", 50.0, Some("8.0/16.0 GB".to_string()));
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(text.contains("8.0/16.0 GB"));
-        assert!(!text.contains("50%"));
+    fn render_gauge_lines_fifty_percent() {
+        let lines = render_gauge_lines("RAM", 50.0, None, 20);
+        let header: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(header.contains("50%"));
     }
 
     #[test]
-    fn render_gauge_clamps_above_100() {
-        let line = render_gauge("CPU", 150.0, None);
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(text.contains("100%"));
+    fn render_gauge_lines_with_suffix() {
+        let lines = render_gauge_lines("RAM", 50.0, Some("8.0/16.0 GB".to_string()), 20);
+        let header: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(header.contains("8.0/16.0 GB"));
+        assert!(!header.contains("50%"));
     }
 
     #[test]
-    fn render_gauge_clamps_below_zero() {
-        let line = render_gauge("CPU", -10.0, None);
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(text.contains("0%"));
+    fn render_gauge_lines_clamps_above_100() {
+        let lines = render_gauge_lines("CPU", 150.0, None, 20);
+        let header: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(header.contains("100%"));
     }
 
-    // ── constants compile-time checks ──
-    const _: () = assert!(GAUGE_BAR_WIDTH >= 10);
-    const _: () = assert!(GAUGE_BAR_WIDTH <= 50);
-    const _: () = assert!(SESSION_NAME_WIDTH >= 8);
-    const _: () = assert!(SESSION_NAME_WIDTH <= 30);
+    #[test]
+    fn render_gauge_lines_clamps_below_zero() {
+        let lines = render_gauge_lines("CPU", -10.0, None, 20);
+        let header: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(header.contains("0%"));
+    }
+
+    #[test]
+    fn render_gauge_lines_bar_width_matches_inner_width() {
+        let inner_width = 16;
+        let lines = render_gauge_lines("CPU", 42.0, None, inner_width);
+        let bar: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
+        // bar should be [<filled><empty>] with total bar_width = inner_width - 2
+        let bar_content_len = bar.chars().count();
+        assert_eq!(bar_content_len, inner_width); // [ + bar_width + ]
+    }
+
+    // ── short_path tests ──
+
+    #[test]
+    fn short_path_replaces_home() {
+        let home = std::env::var("HOME").unwrap();
+        let p = std::path::PathBuf::from(format!("{home}/projects/foo"));
+        assert_eq!(short_path(&p), "~/projects/foo");
+    }
+
+    #[test]
+    fn short_path_leaves_non_home_unchanged() {
+        let p = std::path::PathBuf::from("/tmp/something");
+        assert_eq!(short_path(&p), "/tmp/something");
+    }
+
+    // ── format_bytes tests ──
+
+    #[test]
+    fn format_bytes_gb() {
+        assert_eq!(format_bytes(1_073_741_824), "1.0 GB");
+    }
+
+    #[test]
+    fn format_bytes_mb() {
+        assert_eq!(format_bytes(524_288_000), "500.0 MB");
+    }
+
+    // ── separator tests ──
+
+    #[test]
+    fn separator_width_matches() {
+        let line = separator(16);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text.chars().count(), 16);
+        assert!(text.chars().all(|c| c == '─'));
+    }
 }


### PR DESCRIPTION
## Summary

- Reorder info panel sections: session context first (name, status, role), then project, then system metrics
- Remove debug noise: session UUID, Claude agent session ID, backend ID, VM ID
- Add adaptive-width gauge bars and separators that scale to panel width
- Cap per-session metrics list to available height with "+N more" overflow indicator
- Collect metrics across all projects (not just active)
- Add `short_path()` helper to replace `$HOME` with `~` in displayed paths
- Add enriched session context tags (project name, branch, VM) to per-session rows
- Add 5 new unit tests for `short_path`, `format_bytes`, and `separator`

## Test plan

- [x] All 739 tests pass (`cargo nextest run --all`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] Architecture rules pass
- [ ] Visual verification at different terminal widths (120, 160, 200 cols)