### PR TITLE
fix(core): use non-login shell in tmux to preserve user PATH

### DIFF
--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -350,6 +350,11 @@ impl LocalTmuxBackend {
 
     /// Apply initial config to the tmux server.
     fn apply_config(&self) -> Result<()> {
+        // Use a non-login shell so that macOS path_helper (/etc/zprofile)
+        // doesn't clobber PATH additions from ~/.zshenv (e.g. cargo, asdf).
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        self.tmux_run(&["set-option", "-s", "default-command", &shell])?;
+
         // Server-wide options
         let server_opts = [
             ("default-terminal", "xterm-256color"),


### PR DESCRIPTION
## Summary
- On macOS, tmux starts login shells by default, triggering `path_helper` in `/etc/zprofile` which clobbers PATH additions from `~/.zshenv` (e.g. cargo, asdf, nvm)
- Sets `default-command` to `$SHELL` on the thurbox tmux server so panes spawn non-login shells that respect `~/.zshenv`

## Test plan
- [ ] Verify `which cargo` works inside Thurbox sessions on macOS
- [ ] Verify tools added via `.zshenv` (asdf shims, cargo, etc.) are available in spawned Claude sessions
- [ ] Confirm existing session functionality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)