### PR TITLE
feat(ui): add text selection and copy-paste support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +87,26 @@ name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
 
 [[package]]
 name = "arrayvec"
@@ -227,6 +253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +403,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +452,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -505,6 +561,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "euclid"
 version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +662,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +718,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -744,6 +855,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +889,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1051,6 +1183,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1431,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1450,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1373,12 +1539,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1551,6 +1781,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1831,21 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -2220,6 +2478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,6 +2754,7 @@ name = "thurbox"
 version = "0.0.0-dev"
 dependencies = [
  "anyhow",
+ "arboard",
  "axum",
  "bytes",
  "clap",
@@ -2512,6 +2777,20 @@ dependencies = [
  "tui-term",
  "uuid",
  "vt100",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3057,6 +3336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3440,6 +3725,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,3 +3849,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ sysinfo = "0.34"
 # Error handling
 anyhow = "1.0"
 
+# Clipboard
+arboard = "3"
+
 # MCP server
 rmcp = { version = "0.15", features = ["server", "transport-io", "transport-streamable-http-server", "schemars"] }
 serde_json = "1"

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,7 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "BSL-1.0",
     "ISC",
     "Unicode-3.0",
     "Unicode-DFS-2016",

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -116,6 +116,25 @@ impl App {
             return;
         }
 
+        // Ctrl+C: copy selection if active, otherwise forward to terminal as SIGINT
+        if code == KeyCode::Char('c')
+            && mods.contains(KeyModifiers::CONTROL)
+            && self.text_selection.is_some()
+        {
+            self.copy_selection_to_clipboard();
+            return;
+        }
+
+        // Ctrl+V: paste from clipboard
+        if code == KeyCode::Char('v') && mods.contains(KeyModifiers::CONTROL) {
+            self.text_selection = None;
+            self.paste_from_clipboard();
+            return;
+        }
+
+        // Any key press clears text selection (but the key still performs its action)
+        self.text_selection = None;
+
         // Global keybindings (always active)
         if mods.contains(KeyModifiers::CONTROL) {
             match code {
@@ -130,10 +149,6 @@ impl App {
                     } else {
                         self.spawn_session();
                     }
-                    return;
-                }
-                KeyCode::Char('c') => {
-                    self.close_active_session();
                     return;
                 }
                 KeyCode::Char('d') => match self.focus {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -29,6 +29,7 @@ use crate::session::{
 use crate::storage::Database;
 use crate::storage::DeletedSessionInfo;
 use crate::sync::{self, SharedWorktree, StateDelta, SyncState};
+use crate::ui::selection::{self, PaneBounds, Selection, TermPos};
 use crate::ui::{
     add_project_modal, branch_selector_modal, delete_project_modal, edit_project_modal, info_panel,
     layout, project_list, repo_selector_modal, restore_sessions_modal, role_editor_modal,
@@ -296,6 +297,14 @@ pub enum AppMessage {
         y: u16,
         modifiers: KeyModifiers,
     },
+    MouseDrag {
+        x: u16,
+        y: u16,
+    },
+    MouseUp {
+        x: u16,
+        y: u16,
+    },
     Resize(u16, u16),
     ExternalStateChange(StateDelta),
     /// A VM has finished provisioning and is ready for a session.
@@ -468,6 +477,12 @@ pub struct App {
     pending_vm_id: Option<String>,
     /// MCP servers to write into the VM working directory before spawning.
     pending_vm_mcp_servers: Option<Vec<crate::session::McpServerConfig>>,
+    /// Active text selection (click+drag), uses screen-absolute coordinates.
+    pub(crate) text_selection: Option<Selection>,
+    /// Cached text extracted from the frame buffer for the current selection.
+    selected_text_cache: Option<String>,
+    /// Persistent clipboard handle to avoid "dropped too quickly" warnings on Linux.
+    clipboard: Option<arboard::Clipboard>,
 }
 
 /// Snapshot of editor field values for dirty detection.
@@ -758,6 +773,9 @@ impl App {
             pending_vm_config: None,
             pending_vm_id: None,
             pending_vm_mcp_servers: None,
+            text_selection: None,
+            selected_text_cache: None,
+            clipboard: arboard::Clipboard::new().ok(),
         }
     }
 
@@ -1253,6 +1271,8 @@ impl App {
             AppMessage::MouseScrollUp => self.scroll_terminal_up(MOUSE_SCROLL_LINES),
             AppMessage::MouseScrollDown => self.scroll_terminal_down(MOUSE_SCROLL_LINES),
             AppMessage::MouseClick { x, y, modifiers } => self.handle_mouse_click(x, y, modifiers),
+            AppMessage::MouseDrag { x, y } => self.handle_mouse_drag(x, y),
+            AppMessage::MouseUp { x, y } => self.handle_mouse_up(x, y),
             AppMessage::Resize(cols, rows) => self.handle_resize(cols, rows),
             AppMessage::ExternalStateChange(delta) => self.handle_external_state_change(delta),
             AppMessage::VmReady { vm_id } => self.handle_vm_ready(&vm_id),
@@ -1321,14 +1341,16 @@ impl App {
         }
     }
 
-    pub(crate) fn scroll_terminal_up(&self, lines: usize) {
+    pub(crate) fn scroll_terminal_up(&mut self, lines: usize) {
+        self.text_selection = None;
         self.with_active_parser(|parser| {
             let current = parser.screen().scrollback();
             parser.screen_mut().set_scrollback(current + lines);
         });
     }
 
-    pub(crate) fn scroll_terminal_down(&self, lines: usize) {
+    pub(crate) fn scroll_terminal_down(&mut self, lines: usize) {
+        self.text_selection = None;
         self.with_active_parser(|parser| {
             let current = parser.screen().scrollback();
             parser
@@ -1342,31 +1364,129 @@ impl App {
         (rows as usize) / 2
     }
 
-    fn handle_mouse_click(&self, x: u16, y: u16, modifiers: KeyModifiers) {
+    fn handle_mouse_click(&mut self, x: u16, y: u16, modifiers: KeyModifiers) {
         use crate::ui::links;
 
-        if !modifiers.contains(KeyModifiers::CONTROL) {
-            return;
-        }
-
         let area = Rect::new(0, 0, self.terminal_cols, self.terminal_rows);
-        let term_area = layout::compute_layout(area, self.show_info_panel).terminal;
-        let inner = Block::default().borders(Borders::ALL).inner(term_area);
+        let areas = layout::compute_layout(area, self.show_info_panel);
+        let border_block = Block::default().borders(Borders::ALL);
 
-        if !inner.contains(Position::new(x, y)) {
+        // Ctrl+Click: URL opening (terminal-relative, existing behavior)
+        if modifiers.contains(KeyModifiers::CONTROL) {
+            self.text_selection = None;
+            let inner = border_block.inner(areas.terminal);
+
+            if inner.contains(Position::new(x, y)) {
+                let screen_col = (x - inner.x) as usize;
+                let screen_row = (y - inner.y) as usize;
+                self.with_active_parser(|parser| {
+                    let rows = links::extract_screen_rows(parser.screen());
+                    let detected = links::detect_urls(&rows);
+                    if let Some(url) = links::url_at_position(&detected, screen_row, screen_col) {
+                        open_url(url);
+                    }
+                });
+            }
             return;
         }
 
-        let screen_col = (x - inner.x) as usize;
-        let screen_row = (y - inner.y) as usize;
+        // Find which pane was clicked; use inner area (excluding borders).
+        let pos = Position::new(x, y);
+        let pane_rects = [Some(areas.terminal), areas.left_panel, areas.info_panel];
+        let pane_inner = pane_rects
+            .into_iter()
+            .flatten()
+            .find(|r| r.contains(pos))
+            .map(|r| border_block.inner(r));
 
-        self.with_active_parser(|parser| {
-            let rows = links::extract_screen_rows(parser.screen());
-            let detected = links::detect_urls(&rows);
-            if let Some(url) = links::url_at_position(&detected, screen_row, screen_col) {
-                open_url(url);
+        let Some(inner) = pane_inner else {
+            self.text_selection = None;
+            return;
+        };
+
+        let pane = PaneBounds::from_rect(inner);
+        let anchor = TermPos {
+            row: y as usize,
+            col: x as usize,
+        };
+        self.text_selection = Some(Selection::new(anchor, pane));
+    }
+
+    fn handle_mouse_drag(&mut self, x: u16, y: u16) {
+        if let Some(ref mut sel) = self.text_selection {
+            let (cx, cy) = sel.pane.clamp(x, y);
+            sel.cursor = TermPos {
+                row: cy as usize,
+                col: cx as usize,
+            };
+        }
+    }
+
+    fn handle_mouse_up(&mut self, x: u16, y: u16) {
+        self.handle_mouse_drag(x, y);
+
+        if let Some(ref mut sel) = self.text_selection {
+            sel.dragging = false;
+
+            // If anchor == cursor, it was just a click (no drag) — clear selection
+            if sel.anchor == sel.cursor {
+                self.text_selection = None;
             }
-        });
+        }
+    }
+
+    fn copy_selection_to_clipboard(&mut self) {
+        let text = match &self.selected_text_cache {
+            Some(t) if !t.is_empty() => t.clone(),
+            _ => return,
+        };
+
+        let Some(clipboard) = &mut self.clipboard else {
+            self.set_error("Clipboard not available");
+            return;
+        };
+
+        if let Err(e) = clipboard.set_text(&text) {
+            self.set_error(format!("Clipboard write failed: {e}"));
+            return;
+        }
+
+        self.text_selection = None;
+        self.selected_text_cache = None;
+        self.set_status(StatusLevel::Info, "Copied to clipboard");
+    }
+
+    fn paste_from_clipboard(&mut self) {
+        let Some(clipboard) = &mut self.clipboard else {
+            self.set_error("Clipboard not available");
+            return;
+        };
+
+        let text = match clipboard.get_text() {
+            Ok(t) => t,
+            Err(e) => {
+                self.set_error(format!("Clipboard read failed: {e}"));
+                return;
+            }
+        };
+
+        if text.is_empty() {
+            return;
+        }
+
+        if let Some(session) = self.sessions.get(self.active_index) {
+            let bytes = text.into_bytes();
+            let result = if let (TerminalView::Shell, Some(shell)) =
+                (self.active_terminal_view(), &session.shell_pane)
+            {
+                shell.send_input(bytes)
+            } else {
+                session.send_input(bytes)
+            };
+            if let Err(e) = result {
+                error!("Failed to send pasted input: {e}");
+            }
+        }
     }
 
     pub(crate) fn submit_role_editor(&mut self) {
@@ -2574,7 +2694,7 @@ impl App {
         }
     }
 
-    pub fn view(&self, frame: &mut Frame) {
+    pub fn view(&mut self, frame: &mut Frame) {
         let areas = layout::compute_layout(frame.area(), self.show_info_panel);
 
         status_bar::render_header(frame, areas.header);
@@ -2988,6 +3108,21 @@ impl App {
                     ..inner
                 },
             );
+        }
+
+        // Selection highlight and text cache — runs after all rendering.
+        if let Some(ref sel) = self.text_selection {
+            let sel_style = Style::default()
+                .bg(Theme::SELECTION_BG)
+                .fg(Theme::SELECTION_FG);
+            let sel_clone = sel.clone();
+
+            selection::highlight_buffer(frame.buffer_mut(), &sel_clone, sel_style);
+
+            let text = selection::extract_text_from_buffer(frame.buffer_mut(), &sel_clone);
+            self.selected_text_cache = if text.is_empty() { None } else { Some(text) };
+        } else {
+            self.selected_text_cache = None;
         }
     }
 
@@ -3626,7 +3761,7 @@ fn render_help_overlay(frame: &mut Frame) {
         Line::from(""),
         help_section("Session Management"),
         help_line("Ctrl+N", "New project (project focus) / session"),
-        help_line("Ctrl+C", "Close active session"),
+        help_line("Ctrl+C", "Copy selection / SIGINT (terminal)"),
         help_line("Ctrl+R", "Restart active session"),
         help_line("Ctrl+S", "Sync all worktrees with main"),
         help_line("Ctrl+T", "Toggle shell pane"),
@@ -3659,6 +3794,8 @@ fn render_help_overlay(frame: &mut Frame) {
         help_line("Shift+\u{2191}/\u{2193}", "Scroll up/down 1 line"),
         help_line("Shift+PgUp/PgDn", "Scroll up/down half page"),
         help_line("Mouse wheel", "Scroll up/down 3 lines"),
+        help_line("Click+drag", "Select text (any pane)"),
+        help_line("Ctrl+V", "Paste from clipboard"),
         help_line("*", "All other keys forwarded to session"),
         Line::from(""),
         Line::from(Span::styled(
@@ -5216,12 +5353,52 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_c_closes_active_session() {
-        let mut app = app_with_sessions(2);
-        app.active_index = 0;
+    fn ctrl_c_copies_selection_or_falls_through() {
+        let mut app = app_with_sessions(1);
         let initial_count = app.sessions.len();
+        // With no selection, Ctrl+C should NOT close session (it falls through to terminal)
         app.handle_key(KeyCode::Char('c'), KeyModifiers::CONTROL);
-        assert!(app.sessions.len() < initial_count);
+        assert_eq!(app.sessions.len(), initial_count);
+    }
+
+    #[test]
+    fn any_key_clears_text_selection() {
+        let mut app = app_with_sessions(1);
+        // Set up a fake selection
+        app.text_selection = Some(Selection::new(
+            TermPos { row: 0, col: 0 },
+            PaneBounds::from_rect(ratatui::layout::Rect::new(0, 0, 80, 24)),
+        ));
+        assert!(app.text_selection.is_some());
+
+        // Any non-copy key should clear the selection
+        app.handle_key(KeyCode::Char('a'), KeyModifiers::empty());
+        assert!(app.text_selection.is_none());
+    }
+
+    #[test]
+    fn ctrl_v_clears_selection() {
+        let mut app = app_with_sessions(1);
+        app.text_selection = Some(Selection::new(
+            TermPos { row: 0, col: 0 },
+            PaneBounds::from_rect(ratatui::layout::Rect::new(0, 0, 80, 24)),
+        ));
+
+        // Ctrl+V should clear selection (paste)
+        app.handle_key(KeyCode::Char('v'), KeyModifiers::CONTROL);
+        assert!(app.text_selection.is_none());
+    }
+
+    #[test]
+    fn scroll_clears_selection() {
+        let mut app = app_with_sessions(1);
+        app.text_selection = Some(Selection::new(
+            TermPos { row: 0, col: 0 },
+            PaneBounds::from_rect(ratatui::layout::Rect::new(0, 0, 80, 24)),
+        ));
+
+        app.scroll_terminal_up(1);
+        assert!(app.text_selection.is_none());
     }
 
     #[test]
@@ -6333,7 +6510,9 @@ mod tests {
         app.active_project_index = app.projects.len() - 1;
         app.active_index = 0;
 
-        app.handle_key(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        // Ctrl+D from session list attempts to close sessions
+        app.focus = InputFocus::SessionList;
+        app.handle_key(KeyCode::Char('d'), KeyModifiers::CONTROL);
         assert_eq!(app.sessions.len(), 1); // Session not closed
         assert_eq!(
             app.status_message.as_ref().map(|m| m.text.as_str()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,14 @@ async fn run_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Res
                         y: m.row,
                         modifiers: m.modifiers,
                     }),
+                    MouseEventKind::Drag(MouseButton::Left) => Some(AppMessage::MouseDrag {
+                        x: m.column,
+                        y: m.row,
+                    }),
+                    MouseEventKind::Up(MouseButton::Left) => Some(AppMessage::MouseUp {
+                        x: m.column,
+                        y: m.row,
+                    }),
                     _ => None,
                 },
                 Event::Resize(cols, rows) => Some(AppMessage::Resize(cols, rows)),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,6 +11,7 @@ pub mod repo_selector_modal;
 pub mod restore_sessions_modal;
 pub mod role_editor_modal;
 pub mod role_selector_modal;
+pub mod selection;
 pub mod session_mode_modal;
 pub mod status_bar;
 pub mod terminal_view;

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -1,0 +1,378 @@
+use ratatui::layout::{Position, Rect};
+
+/// A position on screen (absolute coordinates, 0-indexed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TermPos {
+    pub row: usize,
+    pub col: usize,
+}
+
+/// Rectangular bounds of the pane a selection is confined to.
+///
+/// Wraps a `Rect` and adds selection-specific helpers (clamping, hit-testing).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneBounds(Rect);
+
+impl PaneBounds {
+    pub fn from_rect(r: Rect) -> Self {
+        Self(r)
+    }
+
+    pub fn rect(&self) -> Rect {
+        self.0
+    }
+
+    /// Clamp a screen-absolute position to within this pane.
+    pub fn clamp(&self, x: u16, y: u16) -> (u16, u16) {
+        let r = self.0;
+        let cx = x.max(r.x).min(r.x + r.width.saturating_sub(1));
+        let cy = y.max(r.y).min(r.y + r.height.saturating_sub(1));
+        (cx, cy)
+    }
+
+    pub fn contains(&self, x: u16, y: u16) -> bool {
+        self.0.contains(Position::new(x, y))
+    }
+}
+
+/// Active text selection state.
+#[derive(Debug, Clone)]
+pub struct Selection {
+    /// Where the mouse button was first pressed.
+    pub anchor: TermPos,
+    /// Current drag position (updated on MouseDrag, finalized on MouseUp).
+    pub cursor: TermPos,
+    /// Whether the selection is still being dragged (vs finalized).
+    pub dragging: bool,
+    /// The pane this selection is confined to.
+    pub pane: PaneBounds,
+}
+
+impl Selection {
+    pub fn new(pos: TermPos, pane: PaneBounds) -> Self {
+        Self {
+            anchor: pos,
+            cursor: pos,
+            dragging: true,
+            pane,
+        }
+    }
+
+    /// Returns (start, end) in reading order (top-left to bottom-right).
+    pub fn ordered(&self) -> (TermPos, TermPos) {
+        if self.anchor.row < self.cursor.row
+            || (self.anchor.row == self.cursor.row && self.anchor.col <= self.cursor.col)
+        {
+            (self.anchor, self.cursor)
+        } else {
+            (self.cursor, self.anchor)
+        }
+    }
+
+    /// Check whether a given (row, col) falls within the selection.
+    pub fn contains(&self, row: usize, col: usize) -> bool {
+        let (start, end) = self.ordered();
+        if row < start.row || row > end.row {
+            return false;
+        }
+        if start.row == end.row {
+            col >= start.col && col <= end.col
+        } else if row == start.row {
+            col >= start.col
+        } else if row == end.row {
+            col <= end.col
+        } else {
+            true
+        }
+    }
+
+    /// Iterate over (row, col_start, col_end_exclusive) spans in the selection,
+    /// clamped to pane bounds.
+    fn row_spans(&self) -> impl Iterator<Item = (usize, usize, usize)> + '_ {
+        let (start, end) = self.ordered();
+        let pane = self.pane.rect();
+        (start.row..=end.row)
+            .take_while(move |&row| (row as u16) < pane.y + pane.height)
+            .map(move |row| {
+                let col_start = if row == start.row {
+                    start.col
+                } else {
+                    pane.x as usize
+                };
+                let col_end = if row == end.row {
+                    end.col + 1
+                } else {
+                    (pane.x + pane.width) as usize
+                };
+                (row, col_start, col_end)
+            })
+    }
+}
+
+/// Apply a style to all buffer cells within the selection.
+pub fn highlight_buffer(
+    buf: &mut ratatui::buffer::Buffer,
+    selection: &Selection,
+    style: ratatui::style::Style,
+) {
+    let buf_right = buf.area.x + buf.area.width;
+    for (row, col_start, col_end) in selection.row_spans() {
+        for col in col_start..col_end {
+            if col as u16 >= buf_right {
+                break;
+            }
+            if let Some(cell) = buf.cell_mut(Position::new(col as u16, row as u16)) {
+                cell.set_style(style);
+            }
+        }
+    }
+}
+
+/// Extract selected text from a ratatui frame buffer.
+///
+/// Reads cell symbols within the selection, clamped to pane bounds.
+/// Trailing whitespace is trimmed per line, lines joined with `\n`.
+pub fn extract_text_from_buffer(buf: &ratatui::buffer::Buffer, selection: &Selection) -> String {
+    let buf_right = buf.area.x + buf.area.width;
+    let mut lines = Vec::new();
+
+    for (row, col_start, col_end) in selection.row_spans() {
+        let mut line = String::new();
+        for col in col_start..col_end {
+            if col as u16 >= buf_right {
+                break;
+            }
+            if let Some(cell) = buf.cell(Position::new(col as u16, row as u16)) {
+                line.push_str(cell.symbol());
+            }
+        }
+        lines.push(line.trim_end().to_string());
+    }
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_pane() -> PaneBounds {
+        PaneBounds::from_rect(Rect::new(0, 0, 200, 50))
+    }
+
+    #[test]
+    fn selection_ordered_forward() {
+        let sel = Selection {
+            anchor: TermPos { row: 0, col: 5 },
+            cursor: TermPos { row: 2, col: 10 },
+            dragging: false,
+            pane: test_pane(),
+        };
+        let (start, end) = sel.ordered();
+        assert_eq!(start, TermPos { row: 0, col: 5 });
+        assert_eq!(end, TermPos { row: 2, col: 10 });
+    }
+
+    #[test]
+    fn selection_ordered_backward() {
+        let sel = Selection {
+            anchor: TermPos { row: 2, col: 10 },
+            cursor: TermPos { row: 0, col: 5 },
+            dragging: false,
+            pane: test_pane(),
+        };
+        let (start, end) = sel.ordered();
+        assert_eq!(start, TermPos { row: 0, col: 5 });
+        assert_eq!(end, TermPos { row: 2, col: 10 });
+    }
+
+    #[test]
+    fn selection_contains_single_line() {
+        let sel = Selection {
+            anchor: TermPos { row: 1, col: 3 },
+            cursor: TermPos { row: 1, col: 8 },
+            dragging: false,
+            pane: test_pane(),
+        };
+        assert!(sel.contains(1, 5));
+        assert!(sel.contains(1, 3));
+        assert!(sel.contains(1, 8));
+        assert!(!sel.contains(1, 2));
+        assert!(!sel.contains(1, 9));
+        assert!(!sel.contains(0, 5));
+        assert!(!sel.contains(2, 5));
+    }
+
+    #[test]
+    fn selection_contains_multi_line() {
+        let sel = Selection {
+            anchor: TermPos { row: 1, col: 5 },
+            cursor: TermPos { row: 3, col: 10 },
+            dragging: false,
+            pane: test_pane(),
+        };
+        // First row: col >= 5
+        assert!(sel.contains(1, 5));
+        assert!(sel.contains(1, 80));
+        assert!(!sel.contains(1, 4));
+        // Middle row: all cols
+        assert!(sel.contains(2, 0));
+        assert!(sel.contains(2, 999));
+        // Last row: col <= 10
+        assert!(sel.contains(3, 0));
+        assert!(sel.contains(3, 10));
+        assert!(!sel.contains(3, 11));
+        // Outside rows
+        assert!(!sel.contains(0, 5));
+        assert!(!sel.contains(4, 5));
+    }
+
+    fn make_sel(anchor: (usize, usize), cursor: (usize, usize), pane: PaneBounds) -> Selection {
+        Selection {
+            anchor: TermPos {
+                row: anchor.0,
+                col: anchor.1,
+            },
+            cursor: TermPos {
+                row: cursor.0,
+                col: cursor.1,
+            },
+            dragging: false,
+            pane,
+        }
+    }
+
+    /// Fill a buffer region with known text for extraction tests.
+    fn fill_buffer(buf: &mut ratatui::buffer::Buffer, rows: &[&str]) {
+        for (row_idx, text) in rows.iter().enumerate() {
+            for (col_idx, ch) in text.chars().enumerate() {
+                let pos = Position::new(col_idx as u16, row_idx as u16);
+                if let Some(cell) = buf.cell_mut(pos) {
+                    cell.set_symbol(&ch.to_string());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn row_spans_single_row() {
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 80, 24));
+        let sel = make_sel((2, 5), (2, 10), pane);
+        let spans: Vec<_> = sel.row_spans().collect();
+        assert_eq!(spans, vec![(2, 5, 11)]);
+    }
+
+    #[test]
+    fn row_spans_multi_row() {
+        let pane = PaneBounds::from_rect(Rect::new(10, 0, 50, 10));
+        let sel = make_sel((1, 15), (3, 20), pane);
+        let spans: Vec<_> = sel.row_spans().collect();
+        // Row 1: starts at sel start col (15), ends at pane right (60)
+        // Row 2: full pane width (10..60)
+        // Row 3: pane left (10) to sel end col+1 (21)
+        assert_eq!(spans, vec![(1, 15, 60), (2, 10, 60), (3, 10, 21)]);
+    }
+
+    #[test]
+    fn row_spans_clamped_by_pane_height() {
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 80, 3));
+        let sel = make_sel((1, 0), (5, 10), pane);
+        let spans: Vec<_> = sel.row_spans().collect();
+        // Pane height 3 means rows 0..3, so rows 1 and 2 are included
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].0, 1);
+        assert_eq!(spans[1].0, 2);
+    }
+
+    #[test]
+    fn extract_from_buffer_single_line() {
+        let mut buf = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 20, 5));
+        fill_buffer(&mut buf, &["hello world"]);
+
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 20, 5));
+        let sel = make_sel((0, 0), (0, 4), pane);
+        assert_eq!(extract_text_from_buffer(&buf, &sel), "hello");
+    }
+
+    #[test]
+    fn extract_from_buffer_multi_line() {
+        let mut buf = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 20, 5));
+        fill_buffer(&mut buf, &["first line", "second line", "third line"]);
+
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 20, 5));
+        let sel = make_sel((0, 6), (2, 4), pane);
+        let text = extract_text_from_buffer(&buf, &sel);
+        assert_eq!(text, "line\nsecond line\nthird");
+    }
+
+    #[test]
+    fn extract_trims_trailing_whitespace() {
+        let mut buf = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 20, 5));
+        fill_buffer(&mut buf, &["  hello   "]);
+
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 20, 5));
+        let sel = make_sel((0, 0), (0, 9), pane);
+        assert_eq!(extract_text_from_buffer(&buf, &sel), "  hello");
+    }
+
+    #[test]
+    fn highlight_buffer_applies_style() {
+        use ratatui::style::{Color, Style};
+
+        let mut buf = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 10, 3));
+        fill_buffer(&mut buf, &["0123456789", "abcdefghij"]);
+
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 10, 3));
+        let sel = make_sel((0, 2), (0, 4), pane);
+        let style = Style::default().fg(Color::Red);
+
+        highlight_buffer(&mut buf, &sel, style);
+
+        // Cells 2..5 should have the style, others should not
+        assert_eq!(buf.cell(Position::new(1, 0)).unwrap().fg, Color::Reset);
+        assert_eq!(buf.cell(Position::new(2, 0)).unwrap().fg, Color::Red);
+        assert_eq!(buf.cell(Position::new(4, 0)).unwrap().fg, Color::Red);
+        assert_eq!(buf.cell(Position::new(5, 0)).unwrap().fg, Color::Reset);
+    }
+
+    #[test]
+    fn extract_respects_pane_offset() {
+        let mut buf = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 30, 5));
+        fill_buffer(
+            &mut buf,
+            &[
+                "......header area.........",
+                "|borders||content here....",
+                "|borders||more content!...",
+            ],
+        );
+
+        // Pane starts at col 10, width 15 (cols 10..25), simulating inner area
+        let pane = PaneBounds::from_rect(Rect::new(10, 1, 15, 3));
+        // Select from (1,10) to (2,22) — within pane bounds
+        let sel = make_sel((1, 10), (2, 22), pane);
+        let text = extract_text_from_buffer(&buf, &sel);
+        // Row 1: cols 10..25 (full pane width) = "content here..."
+        // Row 2: cols 10..23 = "more content!"
+        assert_eq!(text, "content here...\nmore content!");
+    }
+
+    #[test]
+    fn pane_bounds_clamp() {
+        let pane = PaneBounds::from_rect(Rect::new(10, 5, 20, 10));
+        assert_eq!(pane.clamp(15, 8), (15, 8)); // inside
+        assert_eq!(pane.clamp(5, 3), (10, 5)); // top-left
+        assert_eq!(pane.clamp(50, 20), (29, 14)); // bottom-right
+    }
+
+    #[test]
+    fn pane_bounds_contains() {
+        let pane = PaneBounds::from_rect(Rect::new(10, 5, 20, 10));
+        assert!(pane.contains(10, 5));
+        assert!(pane.contains(29, 14));
+        assert!(!pane.contains(9, 5));
+        assert!(!pane.contains(30, 5));
+        assert!(!pane.contains(10, 4));
+        assert!(!pane.contains(10, 15));
+    }
+}

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -50,6 +50,11 @@ impl Theme {
 
     pub const DANGER: Color = Color::Red;
 
+    // ── Selection ──────────────────────────────────────────────────────────
+
+    pub const SELECTION_BG: Color = Color::Indexed(24);
+    pub const SELECTION_FG: Color = Color::White;
+
     // ── Background colors ───────────────────────────────────────────────────
 
     pub const INVERTED_FG: Color = Color::Black;


### PR DESCRIPTION
## Summary

- Add click-drag text selection across all panes (terminal, sessions, projects, info panel)
- Selection is per-pane, confined to the clicked pane with border exclusion
- Ctrl+C copies selection to clipboard (or sends SIGINT if no selection)
- Ctrl+V pastes from clipboard into active session/shell
- Visual highlight via post-render ratatui buffer manipulation
- Remove Ctrl+C as "close session" — only Ctrl+D closes/deletes

## Test plan

- [ ] Click and drag in terminal pane — verify blue highlight appears, Ctrl+C copies text
- [ ] Click and drag in sessions/projects/info panes — verify selection is confined to that pane
- [ ] Verify borders are excluded from selection (border chars not copied)
- [ ] Ctrl+V pastes into active terminal session
- [ ] Ctrl+C without selection sends SIGINT to terminal (e.g. cancels running command)
- [ ] Scroll clears selection
- [ ] All 756+ unit tests pass: `cargo nextest run --all`