### PR TITLE
feat(core): add devcontainer session backend

### DIFF
--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -20,6 +20,12 @@ use crate::session::{SessionConfig, SessionInfo};
 /// consumed by `QemuVmBackend::spawn()` to route the session to the correct VM.
 pub(crate) const VM_ID_ENV_KEY: &str = "__THURBOX_VM_ID";
 
+/// Internal env key used to pass the target container ID through `SessionBackend::spawn()`.
+///
+/// Injected by `Session::spawn/restart/ensure_shell_pane` when `SessionConfig.container_id` is
+/// set; consumed by `DevcontainerBackend::spawn()` to route the session to the correct container.
+pub(crate) const CONTAINER_ID_ENV_KEY: &str = "__THURBOX_CONTAINER_ID";
+
 pub(crate) fn now_millis() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -195,10 +201,13 @@ impl Session {
         let args = provider.build_args(config);
         let window_name = format!("tb-{name}");
 
-        // Build env map, injecting VM_ID_ENV_KEY if a VM target is specified.
+        // Build env map, injecting VM/container ID if a target is specified.
         let mut env = config.permissions.env.clone();
         if let Some(ref vm_id) = config.vm_id {
             env.insert(VM_ID_ENV_KEY.to_string(), vm_id.clone());
+        }
+        if let Some(ref container_id) = config.container_id {
+            env.insert(CONTAINER_ID_ENV_KEY.to_string(), container_id.clone());
         }
 
         let spawned = backend.spawn(
@@ -438,10 +447,13 @@ impl Session {
         let args = self.provider.build_args(config);
         let window_name = format!("tb-{}", self.info.name);
 
-        // Inject __THURBOX_VM_ID for VM-backed sessions (same as Session::spawn).
+        // Inject __THURBOX_VM_ID / __THURBOX_CONTAINER_ID for backend-routed sessions.
         let mut env = config.permissions.env.clone();
         if let Some(ref vm_id) = config.vm_id {
             env.insert(VM_ID_ENV_KEY.to_string(), vm_id.clone());
+        }
+        if let Some(ref container_id) = config.container_id {
+            env.insert(CONTAINER_ID_ENV_KEY.to_string(), container_id.clone());
         }
 
         let spawned = self.backend.spawn(
@@ -514,11 +526,14 @@ impl Session {
         let shell_cmd = self.backend.default_shell();
         let window_name = format!("tbs-{}", self.info.name);
 
-        // Inject __THURBOX_VM_ID for VM-backed sessions so the backend
-        // knows which VM to create the shell pane in.
+        // Inject __THURBOX_VM_ID / __THURBOX_CONTAINER_ID for backend-routed sessions
+        // so the backend knows which VM/container to create the shell pane in.
         let mut env = self.env.clone();
         if let Some(ref vm_id) = self.info.vm_id {
             env.insert(VM_ID_ENV_KEY.to_string(), vm_id.clone());
+        }
+        if let Some(ref container_id) = self.info.container_id {
+            env.insert(CONTAINER_ID_ENV_KEY.to_string(), container_id.clone());
         }
 
         let spawned = self.backend.spawn(
@@ -618,5 +633,10 @@ mod tests {
     fn vm_id_env_key_is_internal() {
         // The key should start with __ to signal it's an internal implementation detail.
         assert!(VM_ID_ENV_KEY.starts_with("__"));
+    }
+
+    #[test]
+    fn container_id_env_key_is_internal() {
+        assert!(CONTAINER_ID_ENV_KEY.starts_with("__"));
     }
 }

--- a/src/agent/devcontainer.rs
+++ b/src/agent/devcontainer.rs
@@ -1,0 +1,1707 @@
+//! Container-based session backend using native Docker/Podman.
+//!
+//! Provides isolated session environments using Docker or Podman (auto-detected,
+//! preferring Podman). Each session gets its own container with optional
+//! firewall-restricted network egress.
+//!
+//! ## Container storage layout
+//!
+//! ```text
+//! ~/.local/share/thurbox/containers/<container-uuid>/
+//!   ...  (runtime state)
+//! ```
+//!
+//! ## Containerfile templates
+//!
+//! User-editable templates live in `~/.local/share/thurbox/containerfiles/`.
+//! Each template is a **folder** containing a `Containerfile` and any support
+//! files (e.g. `init-firewall.sh`). The entire folder is used as the build
+//! context.
+//!
+//! ```text
+//! ~/.local/share/thurbox/containerfiles/
+//!   default/
+//!     Containerfile
+//!     init-firewall.sh
+//!   python/
+//!     Containerfile
+//!     requirements.txt
+//! ```
+//!
+//! A `default/` template is seeded on first run. Users can add more folders
+//! for different environments and select them via a picker in the TUI.
+//!
+//! ## Architecture
+//!
+//! - `ContainerManager` handles the container lifecycle (build, run, stop, destroy).
+//! - `DockerExecControlMode` tunnels tmux control mode over `docker/podman exec`.
+//! - `DevcontainerBackend` implements `SessionBackend` and wires everything together.
+
+use std::collections::{HashMap, VecDeque};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{sync_channel, Sender, SyncSender};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use tracing::{debug, info, warn};
+
+use crate::agent::backend::{AdoptedSession, DiscoveredSession, SessionBackend, SpawnedSession};
+use crate::agent::control_mode::{
+    self, CommandResponse, ControlModeReader, ControlModeWriter, Notification,
+    PaneSendersMapShared, PANE_CHANNEL_CAPACITY,
+};
+use crate::session::{ContainerConfig, ContainerState};
+
+// ---------------------------------------------------------------------------
+// Container runtime detection
+// ---------------------------------------------------------------------------
+
+/// Supported container runtimes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerRuntime {
+    Podman,
+    Docker,
+}
+
+impl ContainerRuntime {
+    /// Return the CLI command name for this runtime.
+    pub fn cmd(&self) -> &'static str {
+        match self {
+            Self::Podman => "podman",
+            Self::Docker => "docker",
+        }
+    }
+}
+
+impl std::fmt::Display for ContainerRuntime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.cmd())
+    }
+}
+
+/// Auto-detect the available container runtime, preferring Podman over Docker.
+pub fn detect_runtime() -> Result<ContainerRuntime> {
+    // Try podman first
+    let podman = Command::new("podman")
+        .arg("info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    if let Ok(s) = podman {
+        if s.success() {
+            return Ok(ContainerRuntime::Podman);
+        }
+    }
+
+    // Fall back to docker
+    let docker = Command::new("docker")
+        .arg("info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    match docker {
+        Ok(s) if s.success() => Ok(ContainerRuntime::Docker),
+        _ => bail!("No container runtime found. Install Podman or Docker."),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Directory inside the container where host repos are mounted.
+const CONTAINER_REPOS_DIR: &str = "/workspaces";
+
+/// Tmux socket name inside the container.
+const DC_TMUX_SOCKET: &str = "thurbox";
+
+/// Tmux session name inside the container.
+const DC_TMUX_SESSION: &str = "thurbox";
+
+/// Timeout for waiting for a control mode command response.
+const DC_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Max attempts to wait for a stopped container to become running after `start`.
+const CONTAINER_START_MAX_ATTEMPTS: u32 = 10;
+
+/// Delay between readiness checks when starting a stopped container.
+const CONTAINER_START_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+// ---------------------------------------------------------------------------
+// Embedded default devcontainer assets
+// ---------------------------------------------------------------------------
+
+/// Default Containerfile for thurbox container sessions.
+///
+/// Based on the claude-code devcontainer but stripped to essentials:
+/// Node.js LTS base, tmux, git, iptables/ipset, claude-code, non-root user.
+/// This content is used to seed the `default` template in the containerfiles dir.
+pub const DEFAULT_CONTAINERFILE: &str = r#"FROM debian:bookworm-slim
+
+# Install development tools and firewall tooling
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  curl \
+  ca-certificates \
+  less \
+  git \
+  procps \
+  sudo \
+  tmux \
+  iptables \
+  ipset \
+  iproute2 \
+  dnsutils \
+  aggregate \
+  jq \
+  rsync \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Dedicated sandbox user with fixed UID/GID (no host UID mapping)
+RUN groupadd -g 5000 thurbox && \
+  useradd -m -s /bin/bash -u 5000 -g 5000 thurbox && \
+  echo 'thurbox ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+ENV DEVCONTAINER=true
+
+# Create workspace directory
+RUN mkdir -p /workspaces && chown thurbox:thurbox /workspaces
+
+WORKDIR /workspaces
+
+USER thurbox
+
+# Install Claude Code via native installer
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/home/thurbox/.local/bin:${PATH}"
+
+# Copy firewall script and allowlist
+COPY init-firewall.sh allowlist.conf /usr/local/bin/
+USER root
+RUN chmod +x /usr/local/bin/init-firewall.sh && \
+  echo "thurbox ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/thurbox-firewall && \
+  chmod 0440 /etc/sudoers.d/thurbox-firewall
+USER thurbox
+"#;
+
+/// Firewall init script adapted from claude-code.
+///
+/// Whitelists Anthropic API, GitHub IPs, npm, sentry, statsig, localhost, DNS.
+/// Drops all other egress.
+///
+/// This script is always injected into the build context alongside the
+/// Containerfile so the `COPY init-firewall.sh /usr/local/bin/` instruction
+/// works. It is also seeded into the containerfiles directory for visibility.
+pub const INIT_FIREWALL_SH: &str = r#"#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# ---------------------------------------------------------------------------
+# Firewall allowlist — loaded from allowlist.conf alongside this script.
+#
+# Edit allowlist.conf to add/remove allowed domains, CIDRs, or special
+# directives. Changes take effect the next time a container is built.
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ALLOWLIST="${SCRIPT_DIR}/allowlist.conf"
+
+if [ ! -f "$ALLOWLIST" ]; then
+    echo "ERROR: allowlist.conf not found at $ALLOWLIST"
+    exit 1
+fi
+
+# Parse allowlist.conf into arrays
+DOMAINS=()
+CIDRS=()
+FETCH_GITHUB=false
+
+while IFS= read -r line || [ -n "$line" ]; do
+    # Strip comments and whitespace
+    line="${line%%#*}"
+    line="$(echo "$line" | xargs)" 2>/dev/null || true
+    [ -z "$line" ] && continue
+
+    if [ "$line" = "@github" ]; then
+        FETCH_GITHUB=true
+    elif [[ "$line" =~ / ]]; then
+        # CIDR notation
+        CIDRS+=("$line")
+    else
+        # Domain name
+        DOMAINS+=("$line")
+    fi
+done < "$ALLOWLIST"
+
+# 1. Extract Docker DNS info BEFORE any flushing
+DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
+
+# Flush existing rules and delete existing ipsets
+iptables -F
+iptables -X
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+ipset destroy allowed-domains 2>/dev/null || true
+
+# 2. Selectively restore ONLY internal Docker DNS resolution
+if [ -n "$DOCKER_DNS_RULES" ]; then
+    echo "Restoring Docker DNS rules..."
+    iptables -t nat -N DOCKER_OUTPUT 2>/dev/null || true
+    iptables -t nat -N DOCKER_POSTROUTING 2>/dev/null || true
+    echo "$DOCKER_DNS_RULES" | xargs -L 1 iptables -t nat
+else
+    echo "No Docker DNS rules to restore"
+fi
+
+# First allow DNS and localhost before any restrictions
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A INPUT -p udp --sport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
+iptables -A INPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# Create ipset with CIDR support
+ipset create allowed-domains hash:net
+
+# Fetch GitHub meta information and aggregate + add their IP ranges
+if [ "$FETCH_GITHUB" = true ]; then
+    echo "Fetching GitHub IP ranges..."
+    gh_ranges=$(curl -s https://api.github.com/meta)
+    if [ -z "$gh_ranges" ]; then
+        echo "WARNING: Failed to fetch GitHub IP ranges, skipping"
+    else
+        if echo "$gh_ranges" | jq -e '.web and .api and .git' >/dev/null 2>&1; then
+            echo "Processing GitHub IPs..."
+            while read -r cidr; do
+                if [[ "$cidr" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$ ]]; then
+                    ipset add allowed-domains "$cidr" 2>/dev/null || true
+                fi
+            done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q 2>/dev/null || echo "$gh_ranges" | jq -r '(.web + .api + .git)[]')
+        fi
+    fi
+fi
+
+# Add explicit CIDRs from allowlist
+for cidr in "${CIDRS[@]+"${CIDRS[@]}"}"; do
+    echo "Adding CIDR $cidr..."
+    ipset add allowed-domains "$cidr" 2>/dev/null || true
+done
+
+# Resolve and add allowed domains
+for domain in "${DOMAINS[@]+"${DOMAINS[@]}"}"; do
+    echo "Resolving $domain..."
+    ips=$(dig +noall +answer A "$domain" 2>/dev/null | awk '$4 == "A" {print $5}') || true
+    if [ -n "$ips" ]; then
+        while read -r ip; do
+            if [[ "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+                ipset add allowed-domains "$ip" 2>/dev/null || true
+            fi
+        done < <(echo "$ips")
+    else
+        echo "WARNING: Failed to resolve $domain"
+    fi
+done
+
+# Get host IP from default route
+HOST_IP=$(ip route | grep default | cut -d" " -f3 || true)
+if [ -n "$HOST_IP" ]; then
+    HOST_NETWORK=$(echo "$HOST_IP" | sed "s/\.[0-9]*$/.0\/24/")
+    echo "Host network detected as: $HOST_NETWORK"
+    iptables -A INPUT -s "$HOST_NETWORK" -j ACCEPT
+    iptables -A OUTPUT -d "$HOST_NETWORK" -j ACCEPT
+fi
+
+# Set default policies to DROP
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP
+
+# Allow established connections
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+# Allow only specific outbound traffic to allowed domains
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+
+# Reject all other outbound traffic
+iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+
+echo "Firewall configuration complete"
+"#;
+
+/// Default allowlist for the firewall script.
+///
+/// Seeded into each template's `allowlist.conf`. Users edit this file to
+/// control which domains/CIDRs the container can reach. One entry per line:
+/// - Domain names are resolved at firewall init time (e.g. `api.anthropic.com`)
+/// - CIDR ranges are added directly (e.g. `10.0.0.0/8`)
+/// - `@github` fetches GitHub's published IP ranges from their API
+/// - Lines starting with `#` are comments
+pub const DEFAULT_ALLOWLIST: &str = "\
+# Firewall allowlist — one entry per line.
+# Domains are resolved at container start. CIDRs are added directly.
+# @github fetches GitHub's published IP ranges from their API.
+
+# Anthropic API
+api.anthropic.com
+statsig.anthropic.com
+sentry.io
+statsig.com
+
+# GitHub (fetches IP ranges from https://api.github.com/meta)
+@github
+
+# Package registries
+registry.npmjs.org
+";
+
+// ---------------------------------------------------------------------------
+// Section 1: ContainerManager
+// ---------------------------------------------------------------------------
+
+/// A running or stopped container instance.
+pub struct ContainerInstance {
+    /// Unique container identifier (thurbox-side UUID).
+    pub id: String,
+    /// Current state.
+    pub state: ContainerState,
+    /// Docker/Podman container name (e.g. `thurbox-<uuid>`).
+    pub docker_container_id: Option<String>,
+    /// Configuration used to create this container.
+    pub config: ContainerConfig,
+    /// Host-side workspace directory.
+    pub workspace_dir: PathBuf,
+}
+
+/// Manages container lifecycle: build, run, stop, destroy.
+pub struct ContainerManager {
+    containers_dir: PathBuf,
+    containerfiles_dir: PathBuf,
+    runtime: ContainerRuntime,
+    instances: Mutex<HashMap<String, ContainerInstance>>,
+}
+
+impl ContainerManager {
+    /// Create a new container manager.
+    pub fn new(data_dir: &Path, containerfiles_dir: PathBuf, runtime: ContainerRuntime) -> Self {
+        Self {
+            containers_dir: data_dir.join("containers"),
+            containerfiles_dir,
+            runtime,
+            instances: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Return the container runtime in use.
+    pub fn runtime(&self) -> ContainerRuntime {
+        self.runtime
+    }
+
+    /// Check if the container runtime is available.
+    pub fn check_available(runtime: ContainerRuntime) -> Result<()> {
+        let status = Command::new(runtime.cmd())
+            .arg("info")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+
+        match status {
+            Ok(s) if s.success() => Ok(()),
+            _ => bail!("{} not available or not running", runtime.cmd()),
+        }
+    }
+
+    /// Ensure storage directories exist.
+    pub fn ensure_dirs(&self) -> Result<()> {
+        std::fs::create_dir_all(&self.containers_dir)
+            .context("Failed to create containers directory")?;
+        Ok(())
+    }
+
+    /// Get the host PID of a container's init process (PID 1 inside the container).
+    ///
+    /// Uses `<runtime> inspect` to query the container's State.Pid. Returns `None`
+    /// if the container is not running or the PID cannot be determined.
+    pub fn container_host_pid(&self, container_id: &str) -> Option<u32> {
+        let docker_id = {
+            let instances = self.instances.lock().ok()?;
+            instances
+                .get(container_id)
+                .and_then(|i| i.docker_container_id.clone())?
+        };
+        let output = Command::new(self.runtime.cmd())
+            .args(["inspect", "-f", "{{.State.Pid}}", &docker_id])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let pid_str = String::from_utf8_lossy(&output.stdout);
+        let pid: u32 = pid_str.trim().parse().ok()?;
+        if pid == 0 {
+            None
+        } else {
+            Some(pid)
+        }
+    }
+
+    /// Get a reference to a container instance.
+    pub fn get_instance(&self, container_id: &str) -> Option<ContainerInstance> {
+        let instances = self.instances.lock().ok()?;
+        instances.get(container_id).map(|inst| ContainerInstance {
+            id: inst.id.clone(),
+            state: inst.state.clone(),
+            docker_container_id: inst.docker_container_id.clone(),
+            config: inst.config.clone(),
+            workspace_dir: inst.workspace_dir.clone(),
+        })
+    }
+
+    /// Create and start a container using native docker/podman commands.
+    ///
+    /// Pipeline:
+    /// 1. Locate the template folder (`containerfiles/<name>/`)
+    /// 2. Build using the folder as the build context (contains Containerfile + support files)
+    /// 3. `<runtime> run -d --name thurbox-<uuid> ... sleep infinity`
+    /// 4. Copy repo into container (if provided)
+    /// 5. Run firewall init (if enabled)
+    /// 6. Verify tmux is available inside container
+    pub fn create_container(
+        &self,
+        container_id: &str,
+        config: &ContainerConfig,
+        containerfile_name: &str,
+        repo_path: Option<&Path>,
+        progress: &Sender<String>,
+    ) -> Result<()> {
+        let rt = self.runtime.cmd();
+        let container_name = format!("thurbox-{container_id}");
+        let image_tag = container_name.clone();
+
+        // 1. Locate the template folder (the folder IS the build context)
+        let _ = progress.send("Preparing build context...".to_string());
+        let template_dir = self.containerfiles_dir.join(containerfile_name);
+        let containerfile = template_dir.join("Containerfile");
+        if !containerfile.exists() {
+            bail!(
+                "Containerfile not found in template '{}': expected {}",
+                containerfile_name,
+                containerfile.display()
+            );
+        }
+
+        // 2. Build the image using the template folder as the build context
+        let _ = progress.send("Building container image...".to_string());
+        let build_output = Command::new(rt)
+            .args(["build", "-t", &image_tag, "-f", "Containerfile", "."])
+            .current_dir(&template_dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("Failed to run container build")?;
+
+        if !build_output.status.success() {
+            let stderr = String::from_utf8_lossy(&build_output.stderr);
+            bail!("Container image build failed: {stderr}");
+        }
+
+        // 3. Run the container
+        let _ = progress.send("Starting container...".to_string());
+        let mut run_args = vec![
+            "run".to_string(),
+            "-d".to_string(),
+            "--name".to_string(),
+            container_name.clone(),
+            "--cap-add".to_string(),
+            "NET_ADMIN".to_string(),
+            "--cap-add".to_string(),
+            "NET_RAW".to_string(),
+        ];
+
+        // Resource limits
+        run_args.push("--cpus".to_string());
+        run_args.push(config.cpus.to_string());
+        run_args.push("-m".to_string());
+        run_args.push(format!("{}m", config.memory_mb));
+
+        // Image and command
+        run_args.push(image_tag);
+        run_args.push("sleep".to_string());
+        run_args.push("infinity".to_string());
+
+        let run_output = Command::new(rt)
+            .args(&run_args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("Failed to run container")?;
+
+        if !run_output.status.success() {
+            let stderr = String::from_utf8_lossy(&run_output.stderr);
+            bail!("Container run failed: {stderr}");
+        }
+
+        // Container name is predictable — use it as docker_container_id
+        let docker_container_id = container_name;
+
+        info!(
+            container_id = %container_id,
+            docker_id = %docker_container_id,
+            "Container started"
+        );
+
+        // 4. Copy repo into container (isolated copy, not a bind mount)
+        if let Some(repo) = repo_path {
+            self.copy_repo_into_container(rt, &docker_container_id, container_id, repo, progress)?;
+        }
+
+        // 5. Run firewall init if enabled
+        if config.firewall_enabled {
+            let _ = progress.send("Configuring firewall...".to_string());
+            let fw_status = Command::new(rt)
+                .args([
+                    "exec",
+                    &docker_container_id,
+                    "sudo",
+                    "/usr/local/bin/init-firewall.sh",
+                ])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .status();
+
+            match fw_status {
+                Ok(s) if s.success() => {
+                    info!(container_id = %container_id, "Firewall configured");
+                }
+                Ok(s) => {
+                    warn!(
+                        container_id = %container_id,
+                        exit_code = ?s.code(),
+                        "Firewall init failed (container will run without firewall)"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        container_id = %container_id,
+                        "Failed to run firewall init: {e}"
+                    );
+                }
+            }
+        }
+
+        // 6. Verify tmux is available inside the container
+        let _ = progress.send("Verifying tmux...".to_string());
+        let tmux_check = Command::new(rt)
+            .args(["exec", &docker_container_id, "tmux", "-V"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .status()
+            .context("Failed to check tmux in container")?;
+
+        if !tmux_check.success() {
+            bail!("tmux not available inside container");
+        }
+
+        // Determine workspace directory
+        let workspace_dir = if let Some(repo) = repo_path {
+            repo.to_path_buf()
+        } else {
+            self.containers_dir.join(container_id)
+        };
+
+        // Store instance
+        let instance = ContainerInstance {
+            id: container_id.to_string(),
+            state: ContainerState::Ready,
+            docker_container_id: Some(docker_container_id),
+            config: config.clone(),
+            workspace_dir,
+        };
+
+        let mut instances = self
+            .instances
+            .lock()
+            .map_err(|e| anyhow::anyhow!("instances lock: {e}"))?;
+        instances.insert(container_id.to_string(), instance);
+
+        let _ = progress.send("Container ready".to_string());
+        Ok(())
+    }
+
+    /// Copy a host repository into the container using `docker/podman cp`.
+    fn copy_repo_into_container(
+        &self,
+        rt: &str,
+        docker_container_id: &str,
+        container_id: &str,
+        repo: &Path,
+        progress: &Sender<String>,
+    ) -> Result<()> {
+        let _ = progress.send("Copying repository into container...".to_string());
+        let basename = repo
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("workspace"));
+        let dest = PathBuf::from(CONTAINER_REPOS_DIR).join(basename);
+        let dest_str = dest.display().to_string();
+
+        // Create the destination directory
+        let mkdir_status = Command::new(rt)
+            .args(["exec", docker_container_id, "mkdir", "-p", &dest_str])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        if let Ok(s) = mkdir_status {
+            if !s.success() {
+                warn!(container_id = %container_id, "Failed to create workspace dir in container");
+            }
+        }
+
+        // Trailing /. copies contents of the directory into dest
+        let mut src_dot = repo.to_path_buf();
+        src_dot.push(".");
+        let cp_output = Command::new(rt)
+            .args([
+                "cp",
+                &src_dot.display().to_string(),
+                &format!("{docker_container_id}:{dest_str}"),
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("Failed to copy repo into container")?;
+
+        if !cp_output.status.success() {
+            let stderr = String::from_utf8_lossy(&cp_output.stderr);
+            bail!("Failed to copy repo into container: {stderr}");
+        }
+
+        // Ensure thurbox user owns the copied files
+        let chown_status = Command::new(rt)
+            .args([
+                "exec",
+                "--user",
+                "root",
+                docker_container_id,
+                "chown",
+                "-R",
+                "thurbox:thurbox",
+                &dest_str,
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        if let Ok(s) = chown_status {
+            if !s.success() {
+                warn!(container_id = %container_id, "Failed to chown workspace");
+            }
+        }
+
+        info!(
+            container_id = %container_id,
+            repo = %repo.display(),
+            "Repository copied into container"
+        );
+        Ok(())
+    }
+
+    /// Stop a running container.
+    pub fn stop_container(&self, container_id: &str) -> Result<()> {
+        let mut instances = self
+            .instances
+            .lock()
+            .map_err(|e| anyhow::anyhow!("instances lock: {e}"))?;
+
+        let instance = instances
+            .get_mut(container_id)
+            .context(format!("Container {container_id} not found"))?;
+
+        if matches!(
+            instance.state,
+            ContainerState::Stopped | ContainerState::Stopping
+        ) {
+            return Ok(());
+        }
+
+        instance.state = ContainerState::Stopping;
+
+        if let Some(ref docker_id) = instance.docker_container_id {
+            let _ = Command::new(self.runtime.cmd())
+                .args(["stop", docker_id])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+
+        instance.state = ContainerState::Stopped;
+        info!(container_id = %container_id, "Container stopped");
+        Ok(())
+    }
+
+    /// Destroy a container (stop + remove).
+    pub fn destroy_container(&self, container_id: &str) -> Result<()> {
+        let docker_id = {
+            let instances = self
+                .instances
+                .lock()
+                .map_err(|e| anyhow::anyhow!("instances lock: {e}"))?;
+            instances
+                .get(container_id)
+                .and_then(|i| i.docker_container_id.clone())
+        };
+
+        // Stop first
+        let _ = self.stop_container(container_id);
+
+        // Remove the container
+        if let Some(ref docker_id) = docker_id {
+            let _ = Command::new(self.runtime.cmd())
+                .args(["rm", "-f", docker_id])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+
+        // Remove from instances
+        let mut instances = self
+            .instances
+            .lock()
+            .map_err(|e| anyhow::anyhow!("instances lock: {e}"))?;
+        instances.remove(container_id);
+
+        info!(container_id = %container_id, "Container destroyed");
+        Ok(())
+    }
+
+    /// Restore a container from a database record (on restart).
+    ///
+    /// If the container is stopped, starts it first. Re-registers it in the
+    /// instance map once running.
+    pub fn restore_container(
+        &self,
+        container_id: &str,
+        docker_container_id: &str,
+        config: &ContainerConfig,
+        workspace_dir: &Path,
+    ) -> Result<()> {
+        // Check if the container exists and its state
+        let output = Command::new(self.runtime.cmd())
+            .args(["inspect", "-f", "{{.State.Status}}", docker_container_id])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .context("Failed to inspect container")?;
+
+        if !output.status.success() {
+            bail!("Container {docker_container_id} not found");
+        }
+
+        let status = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        match status.as_str() {
+            "running" => {}
+            "exited" | "stopped" | "created" => {
+                info!(
+                    docker_id = %docker_container_id,
+                    status = %status,
+                    "Container is stopped, starting it"
+                );
+                let start = Command::new(self.runtime.cmd())
+                    .args(["start", docker_container_id])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::piped())
+                    .output()
+                    .context("Failed to start stopped container")?;
+                if !start.status.success() {
+                    let stderr = String::from_utf8_lossy(&start.stderr);
+                    bail!("Failed to start container {docker_container_id}: {stderr}");
+                }
+
+                // Wait for the container to become running
+                for attempt in 0..CONTAINER_START_MAX_ATTEMPTS {
+                    let check = Command::new(self.runtime.cmd())
+                        .args(["inspect", "-f", "{{.State.Running}}", docker_container_id])
+                        .stdout(Stdio::piped())
+                        .stderr(Stdio::null())
+                        .output();
+                    if let Ok(out) = check {
+                        if String::from_utf8_lossy(&out.stdout).trim() == "true" {
+                            break;
+                        }
+                    }
+                    if attempt == CONTAINER_START_MAX_ATTEMPTS - 1 {
+                        bail!("Container {docker_container_id} did not become running after start");
+                    }
+                    std::thread::sleep(CONTAINER_START_POLL_INTERVAL);
+                }
+
+                info!(docker_id = %docker_container_id, "Container restarted successfully");
+            }
+            _ => {
+                bail!("Container {docker_container_id} is in unexpected state: {status}");
+            }
+        }
+
+        let instance = ContainerInstance {
+            id: container_id.to_string(),
+            state: ContainerState::Ready,
+            docker_container_id: Some(docker_container_id.to_string()),
+            config: config.clone(),
+            workspace_dir: workspace_dir.to_path_buf(),
+        };
+
+        let mut instances = self
+            .instances
+            .lock()
+            .map_err(|e| anyhow::anyhow!("instances lock: {e}"))?;
+        instances.insert(container_id.to_string(), instance);
+
+        info!(
+            container_id = %container_id,
+            docker_id = %docker_container_id,
+            "Container restored"
+        );
+        Ok(())
+    }
+}
+
+/// Map a host path to the container workspace path.
+///
+/// Mirrors `host_to_vm_path` but uses the devcontainer workspace directory.
+pub fn host_to_container_path(host_path: &Path) -> PathBuf {
+    let basename = host_path
+        .file_name()
+        .unwrap_or_else(|| std::ffi::OsStr::new("workspace"));
+    PathBuf::from(CONTAINER_REPOS_DIR).join(basename)
+}
+
+// ---------------------------------------------------------------------------
+// Section 2: DockerExecControlMode
+// ---------------------------------------------------------------------------
+
+/// Tmux control mode connection tunneled through `docker exec` into a container.
+///
+/// Mirrors `SshControlMode` in `vm.rs` but spawns:
+/// ```text
+/// docker exec -i <container_id> tmux -L thurbox -C new-session -A -s thurbox
+/// ```
+/// instead of SSH.
+struct DockerExecControlMode {
+    stdin: Arc<Mutex<ChildStdin>>,
+    pane_senders: PaneSendersMapShared,
+    response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
+    reader_handle: Mutex<Option<JoinHandle<()>>>,
+    child: Mutex<Child>,
+}
+
+impl DockerExecControlMode {
+    /// Start a control mode connection to a container via docker/podman exec.
+    fn start(runtime: &str, docker_container_id: &str) -> Result<Self> {
+        let mut cmd = Command::new(runtime);
+        cmd.args([
+            "exec",
+            "-i",
+            docker_container_id,
+            "tmux",
+            "-L",
+            DC_TMUX_SOCKET,
+            "-C",
+            "new-session",
+            "-A",
+            "-s",
+            DC_TMUX_SESSION,
+        ]);
+
+        let mut child = cmd
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("Failed to start docker exec control mode")?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .context("Failed to get docker exec stdin")?;
+        let stdout = child
+            .stdout
+            .take()
+            .context("Failed to get docker exec stdout")?;
+
+        let stdin = Arc::new(Mutex::new(stdin));
+        let pane_senders: PaneSendersMapShared = Arc::new(Mutex::new(HashMap::new()));
+        let response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>> =
+            Arc::new(Mutex::new(VecDeque::new()));
+
+        let reader_stdin = Arc::clone(&stdin);
+        let reader_pane_senders = Arc::clone(&pane_senders);
+        let reader_queue = Arc::clone(&response_queue);
+
+        let reader_handle = std::thread::Builder::new()
+            .name("dc-control-reader".into())
+            .spawn(move || {
+                Self::reader_thread(stdout, reader_stdin, reader_pane_senders, reader_queue);
+            })
+            .context("Failed to spawn docker exec control reader thread")?;
+
+        let control = Self {
+            stdin,
+            pane_senders,
+            response_queue,
+            reader_handle: Mutex::new(Some(reader_handle)),
+            child: Mutex::new(child),
+        };
+
+        // Wait for initial session creation output.
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Drain initial output.
+        if control.send_command("refresh-client").is_err() {
+            debug!("Initial refresh-client timed out, retrying");
+            control.send_command("refresh-client")?;
+        }
+
+        // Enable flow control.
+        control.send_command("refresh-client -f pause-after=5")?;
+
+        // Apply container-side tmux config.
+        control.send_command("set-option -g remain-on-exit on")?;
+        control.send_command("set-option -g status off")?;
+        control.send_command("set-option -g history-limit 5000")?;
+        control.send_command("set-option -sg default-terminal xterm-256color")?;
+        control.send_command("set-option -sg extended-keys on")?;
+
+        Ok(control)
+    }
+
+    /// Background reader thread — identical logic to `SshControlMode::reader_thread`.
+    fn reader_thread(
+        stdout: std::process::ChildStdout,
+        stdin: Arc<Mutex<ChildStdin>>,
+        pane_senders: PaneSendersMapShared,
+        response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
+    ) {
+        let mut reader = BufReader::new(stdout);
+        let mut collecting: Option<Vec<String>> = None;
+        let mut line_buf = Vec::new();
+
+        loop {
+            line_buf.clear();
+            match reader.read_until(b'\n', &mut line_buf) {
+                Ok(0) => {
+                    debug!("Docker exec control reader: EOF on stdout");
+                    break;
+                }
+                Ok(n) => {
+                    let preview = String::from_utf8_lossy(&line_buf);
+                    debug!(bytes = n, line = %preview.trim(), "Docker exec control reader: line received");
+                }
+                Err(e) => {
+                    debug!("Docker exec control reader I/O error: {e}");
+                    break;
+                }
+            }
+            if line_buf.last() == Some(&b'\n') {
+                line_buf.pop();
+            }
+            // docker exec without -t doesn't add \r, but handle it defensively
+            if line_buf.last() == Some(&b'\r') {
+                line_buf.pop();
+            }
+            let line = String::from_utf8_lossy(&line_buf);
+
+            match control_mode::parse_notification(&line) {
+                Notification::Output { pane_id, data } => {
+                    if let Ok(senders) = pane_senders.lock() {
+                        if let Some(tx_vec) = senders.get(&pane_id) {
+                            for tx in tx_vec {
+                                match tx.try_send(data.clone()) {
+                                    Ok(()) => {}
+                                    Err(std::sync::mpsc::TrySendError::Full(_)) => {
+                                        debug!(
+                                            pane_id = %pane_id,
+                                            "Container pane output channel full, dropping chunk"
+                                        );
+                                    }
+                                    Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {}
+                                }
+                            }
+                        }
+                    }
+                }
+                Notification::Begin => {
+                    collecting = Some(Vec::new());
+                }
+                end_or_error @ (Notification::End | Notification::Error) => {
+                    let lines = collecting.take().unwrap_or_default();
+                    if let Ok(mut queue) = response_queue.lock() {
+                        if let Some(tx) = queue.pop_front() {
+                            let _ = tx.send(CommandResponse {
+                                lines,
+                                is_error: matches!(end_or_error, Notification::Error),
+                            });
+                        }
+                    }
+                }
+                Notification::Pause { pane_id } => {
+                    let cmd = format!(
+                        "refresh-client -A '{}:continue'\n",
+                        pane_id.replace('\'', "'\\''")
+                    );
+                    if let Ok(mut s) = stdin.lock() {
+                        let _ = s.write_all(cmd.as_bytes());
+                        let _ = s.flush();
+                    }
+                }
+                Notification::Other(text) => {
+                    if let Some(ref mut lines) = collecting {
+                        lines.push(text);
+                    }
+                }
+            }
+        }
+
+        debug!("Docker exec control reader thread exiting");
+        if let Ok(mut senders) = pane_senders.lock() {
+            senders.clear();
+        }
+    }
+
+    /// Send a command and wait for its response.
+    fn send_command(&self, cmd: &str) -> Result<String> {
+        let (tx, rx) = sync_channel(1);
+
+        {
+            let mut queue = self
+                .response_queue
+                .lock()
+                .map_err(|e| anyhow::anyhow!("response_queue lock: {e}"))?;
+            queue.push_back(tx);
+        }
+
+        {
+            let mut stdin = self
+                .stdin
+                .lock()
+                .map_err(|e| anyhow::anyhow!("stdin lock: {e}"))?;
+            writeln!(stdin, "{cmd}")?;
+            stdin.flush()?;
+        }
+
+        let response = rx.recv_timeout(DC_COMMAND_TIMEOUT).context(format!(
+            "Timeout waiting for container tmux response to: {cmd}"
+        ))?;
+
+        if response.is_error {
+            bail!(
+                "Container tmux command failed: {cmd}: {}",
+                response.lines.join("\n")
+            );
+        }
+
+        Ok(response.lines.join("\n"))
+    }
+
+    /// Send a command without waiting for a response.
+    fn send_command_nowait(&self, cmd: &str) -> Result<()> {
+        let mut stdin = self
+            .stdin
+            .lock()
+            .map_err(|e| anyhow::anyhow!("stdin lock: {e}"))?;
+        writeln!(stdin, "{cmd}")?;
+        stdin.flush()?;
+        Ok(())
+    }
+}
+
+impl Drop for DockerExecControlMode {
+    fn drop(&mut self) {
+        if let Ok(mut stdin) = self.stdin.lock() {
+            let _ = writeln!(stdin, "detach-client");
+            let _ = stdin.flush();
+        }
+        if let Ok(mut handle) = self.reader_handle.lock() {
+            if let Some(h) = handle.take() {
+                let _ = h.join();
+            }
+        }
+        if let Ok(mut child) = self.child.lock() {
+            let _ = child.wait();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Section 3: DevcontainerBackend
+// ---------------------------------------------------------------------------
+
+/// Session backend that runs sessions inside containers (Docker or Podman).
+///
+/// Each container gets its own tmux server (accessed via `exec` control mode).
+/// The backend manages the mapping from container IDs to control mode connections.
+pub struct DevcontainerBackend {
+    /// Container lifecycle manager (shared with app layer for provisioning).
+    manager: Arc<Mutex<ContainerManager>>,
+    /// Container runtime (podman or docker).
+    runtime: ContainerRuntime,
+    /// Active exec control mode connections, keyed by container ID.
+    controls: Mutex<HashMap<String, DockerExecControlMode>>,
+}
+
+impl DevcontainerBackend {
+    /// Create a new devcontainer backend.
+    pub fn new(manager: Arc<Mutex<ContainerManager>>, runtime: ContainerRuntime) -> Self {
+        Self {
+            manager,
+            runtime,
+            controls: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Ensure a docker exec control mode connection exists for the given container.
+    fn ensure_control(&self, container_id: &str) -> Result<()> {
+        let mut controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+
+        if controls.contains_key(container_id) {
+            return Ok(());
+        }
+
+        let manager = self
+            .manager
+            .lock()
+            .map_err(|e| anyhow::anyhow!("manager lock: {e}"))?;
+
+        let instance = manager
+            .get_instance(container_id)
+            .context(format!("Container {container_id} not found"))?;
+
+        if instance.state != ContainerState::Ready {
+            bail!(
+                "Container {container_id} is not ready (state: {})",
+                instance.state
+            );
+        }
+
+        let docker_id = instance
+            .docker_container_id
+            .as_ref()
+            .context("Container has no docker container ID")?
+            .clone();
+        drop(manager); // Release lock before starting exec (may take time)
+
+        let control = DockerExecControlMode::start(self.runtime.cmd(), &docker_id)?;
+        controls.insert(container_id.to_string(), control);
+
+        debug!(container_id = %container_id, "Docker exec control mode established");
+        Ok(())
+    }
+
+    /// Get the container ID from a backend_id (format: "dc:<container_id>:<pane_id>").
+    fn parse_backend_id(backend_id: &str) -> Result<(&str, &str)> {
+        let parts: Vec<&str> = backend_id.splitn(3, ':').collect();
+        if parts.len() != 3 || parts[0] != "dc" {
+            bail!(
+                "Invalid devcontainer backend_id format: {backend_id} (expected dc:<container_id>:<pane_id>)"
+            );
+        }
+        Ok((parts[1], parts[2]))
+    }
+
+    /// Build a composite backend_id: "dc:<container_id>:<pane_id>".
+    fn make_backend_id(container_id: &str, pane_id: &str) -> String {
+        format!("dc:{container_id}:{pane_id}")
+    }
+
+    /// Run a tmux command on a specific container's control mode.
+    fn ctrl_command(&self, container_id: &str, cmd: &str) -> Result<String> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+        let ctrl = controls
+            .get(container_id)
+            .context(format!("No control mode for container {container_id}"))?;
+        ctrl.send_command(cmd)
+    }
+
+    /// Run a tmux command without waiting for response.
+    fn ctrl_command_nowait(&self, container_id: &str, cmd: &str) -> Result<()> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+        let ctrl = controls
+            .get(container_id)
+            .context(format!("No control mode for container {container_id}"))?;
+        ctrl.send_command_nowait(cmd)
+    }
+
+    /// Register a pane sender for output monitoring.
+    fn register_pane(&self, container_id: &str, pane_id: &str) -> Result<ControlModeReader> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+        let ctrl = controls
+            .get(container_id)
+            .context(format!("No control mode for container {container_id}"))?;
+        let (tx, rx) = sync_channel(PANE_CHANNEL_CAPACITY);
+        {
+            let mut senders = ctrl
+                .pane_senders
+                .lock()
+                .map_err(|e| anyhow::anyhow!("pane_senders lock: {e}"))?;
+            senders.entry(pane_id.to_string()).or_default().push(tx);
+        }
+        Ok(ControlModeReader::new(rx))
+    }
+
+    /// Unregister a pane sender.
+    fn unregister_pane(&self, container_id: &str, pane_id: &str) -> Result<()> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+        if let Some(ctrl) = controls.get(container_id) {
+            let mut senders = ctrl
+                .pane_senders
+                .lock()
+                .map_err(|e| anyhow::anyhow!("pane_senders lock: {e}"))?;
+            senders.remove(pane_id);
+        }
+        Ok(())
+    }
+
+    /// Create a writer for a pane on a specific container.
+    fn pane_writer(&self, container_id: &str, pane_id: &str) -> Result<ControlModeWriter> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+        let ctrl = controls
+            .get(container_id)
+            .context(format!("No control mode for container {container_id}"))?;
+        Ok(ControlModeWriter {
+            stdin: Arc::clone(&ctrl.stdin),
+            pane_id: pane_id.to_string(),
+        })
+    }
+
+    /// Capture screen content from a pane.
+    fn capture_pane(&self, container_id: &str, pane_id: &str) -> Vec<u8> {
+        let cmd = format!("capture-pane -t {pane_id} -p -e -S -");
+        let content = self.ctrl_command(container_id, &cmd).unwrap_or_default();
+        debug!(
+            container_id = %container_id,
+            pane_id = %pane_id,
+            bytes = content.len(),
+            "capture-pane result"
+        );
+        content.into_bytes()
+    }
+
+    /// Connect I/O to an existing pane in a container.
+    fn connect_pane(
+        &self,
+        container_id: &str,
+        pane_id: &str,
+        rows: u16,
+        cols: u16,
+    ) -> Result<AdoptedSession> {
+        let reader = self.register_pane(container_id, pane_id)?;
+        self.ctrl_command(
+            container_id,
+            &format!("refresh-client -A '{}:on'", pane_id.replace('\'', "'\\''")),
+        )?;
+        let initial_screen = self.capture_pane(container_id, pane_id);
+        let writer = self.pane_writer(container_id, pane_id)?;
+
+        // Force resize to trigger repaint.
+        self.force_resize(container_id, pane_id, rows, cols)?;
+
+        Ok(AdoptedSession {
+            output: Box::new(reader),
+            input: Box::new(writer),
+            initial_screen,
+        })
+    }
+
+    /// Force a resize to trigger SIGWINCH in the container's pane.
+    fn force_resize(&self, container_id: &str, pane_id: &str, rows: u16, cols: u16) -> Result<()> {
+        if rows > 1 {
+            self.do_resize(container_id, pane_id, rows - 1, cols)?;
+        } else {
+            self.do_resize(container_id, pane_id, rows + 1, cols)?;
+        }
+        self.do_resize(container_id, pane_id, rows, cols)?;
+        Ok(())
+    }
+
+    /// Resize a pane inside a container's tmux.
+    fn do_resize(&self, container_id: &str, pane_id: &str, rows: u16, cols: u16) -> Result<()> {
+        self.ctrl_command(
+            container_id,
+            &format!("resize-window -t {pane_id} -x {cols} -y {rows}"),
+        )?;
+        self.ctrl_command(
+            container_id,
+            &format!("resize-pane -t {pane_id} -x {cols} -y {rows}"),
+        )?;
+        Ok(())
+    }
+
+    /// Build a shell command string (same logic as other backends).
+    fn build_shell_command(command: &str, args: &[String]) -> String {
+        let mut parts = vec![command.to_string()];
+        for arg in args {
+            parts.push(control_mode::shell_escape(arg));
+        }
+        parts.join(" ")
+    }
+
+    /// Disconnect from a container's control mode.
+    pub fn disconnect_container(&self, container_id: &str) {
+        if let Ok(mut controls) = self.controls.lock() {
+            controls.remove(container_id);
+        }
+    }
+}
+
+impl SessionBackend for DevcontainerBackend {
+    fn name(&self) -> &str {
+        "devcontainer"
+    }
+
+    fn check_available(&self) -> Result<()> {
+        ContainerManager::check_available(self.runtime)
+    }
+
+    fn ensure_ready(&self) -> Result<()> {
+        let manager = self
+            .manager
+            .lock()
+            .map_err(|e| anyhow::anyhow!("manager lock: {e}"))?;
+        manager.ensure_dirs()
+    }
+
+    fn spawn(
+        &self,
+        window_name: &str,
+        command: &str,
+        args: &[String],
+        cwd: Option<&Path>,
+        env: &HashMap<String, String>,
+        rows: u16,
+        cols: u16,
+    ) -> Result<SpawnedSession> {
+        // The target container ID is passed via the env map (injected by Session::spawn).
+        let container_id = env
+            .get(crate::agent::backend::CONTAINER_ID_ENV_KEY)
+            .cloned()
+            .context("No container ID in env — caller must set SessionConfig.container_id")?;
+
+        let shell_cmd = Self::build_shell_command(command, args);
+
+        let cwd_part = match cwd {
+            Some(dir) => {
+                format!(" -c {}", control_mode::shell_escape(&dir.to_string_lossy()))
+            }
+            None => String::new(),
+        };
+        let cmd = format!(
+            "new-window -t {DC_TMUX_SESSION} -n {window_name} -P -F '#{{pane_id}}'{cwd_part} {shell_cmd}"
+        );
+        let result = self.ctrl_command(&container_id, &cmd)?;
+        let pane_id = result.trim().to_string();
+
+        debug!(container_id = %container_id, pane_id = %pane_id, "Container tmux window created");
+
+        let connected = self.connect_pane(&container_id, &pane_id, rows, cols)?;
+        let composite_id = Self::make_backend_id(&container_id, &pane_id);
+
+        Ok(SpawnedSession {
+            backend_id: composite_id,
+            output: connected.output,
+            input: connected.input,
+            initial_screen: connected.initial_screen,
+        })
+    }
+
+    fn adopt(&self, backend_id: &str, rows: u16, cols: u16) -> Result<AdoptedSession> {
+        let (container_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        self.ensure_control(container_id)?;
+        self.connect_pane(container_id, pane_id, rows, cols)
+    }
+
+    fn discover(&self) -> Result<Vec<DiscoveredSession>> {
+        let controls = self
+            .controls
+            .lock()
+            .map_err(|e| anyhow::anyhow!("controls lock: {e}"))?;
+
+        let mut sessions = Vec::new();
+        for (container_id, ctrl) in controls.iter() {
+            let result = match ctrl.send_command(&format!(
+                "list-windows -t {DC_TMUX_SESSION} -F '#{{pane_id}}|#{{window_name}}|#{{pane_dead}}'"
+            )) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+
+            for line in result.lines() {
+                let parts: Vec<&str> = line.splitn(3, '|').collect();
+                if parts.len() < 3 {
+                    continue;
+                }
+
+                let window_name = parts[1];
+                if !window_name.starts_with("tb-") {
+                    continue;
+                }
+
+                sessions.push(DiscoveredSession {
+                    backend_id: Self::make_backend_id(container_id, parts[0]),
+                    name: window_name.to_string(),
+                    is_alive: parts[2] != "1",
+                });
+            }
+        }
+
+        Ok(sessions)
+    }
+
+    fn resize(&self, backend_id: &str, rows: u16, cols: u16) -> Result<()> {
+        let (container_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        self.do_resize(container_id, pane_id, rows, cols)
+    }
+
+    fn is_dead(&self, backend_id: &str) -> Result<bool> {
+        let (container_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        let result = self.ctrl_command(
+            container_id,
+            &format!("display-message -t {pane_id} -p '#{{pane_dead}}'"),
+        )?;
+        Ok(result.trim() == "1")
+    }
+
+    fn kill(&self, backend_id: &str) -> Result<()> {
+        let (container_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        let _ = self.unregister_pane(container_id, pane_id);
+        self.ctrl_command(container_id, &format!("kill-pane -t {pane_id}"))?;
+        Ok(())
+    }
+
+    fn detach(&self, backend_id: &str) -> Result<()> {
+        let (container_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        if let Err(e) = self.ctrl_command_nowait(
+            container_id,
+            &format!("refresh-client -A '{}:off'", pane_id.replace('\'', "'\\''")),
+        ) {
+            warn!("Failed to disable container output monitoring during detach: {e}");
+        }
+        let _ = self.unregister_pane(container_id, pane_id);
+        Ok(())
+    }
+
+    fn prepare_vm(&self, container_id: &str) -> Result<()> {
+        self.ensure_control(container_id)
+    }
+
+    fn default_shell(&self) -> String {
+        "/bin/bash".to_string()
+    }
+
+    fn pane_pid(&self, backend_id: &str) -> Result<Option<u32>> {
+        let (container_id, pane_id) = Self::parse_backend_id(backend_id)?;
+        let result = self.ctrl_command(
+            container_id,
+            &format!("display-message -t {pane_id} -p '#{{pane_pid}}'"),
+        )?;
+        Ok(result.trim().parse().ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_to_container_path_basic() {
+        let result = host_to_container_path(Path::new("/home/user/projects/my-app"));
+        assert_eq!(result, PathBuf::from("/workspaces/my-app"));
+    }
+
+    #[test]
+    fn host_to_container_path_trailing_slash() {
+        let result = host_to_container_path(Path::new("/home/user/projects/my-app/"));
+        assert_eq!(result, PathBuf::from("/workspaces/my-app"));
+    }
+
+    #[test]
+    fn host_to_container_path_root_fallback() {
+        let result = host_to_container_path(Path::new("/"));
+        assert_eq!(result, PathBuf::from("/workspaces/workspace"));
+    }
+
+    #[test]
+    fn parse_backend_id_valid() {
+        let (cid, pid) = DevcontainerBackend::parse_backend_id("dc:abc-123:%42").unwrap();
+        assert_eq!(cid, "abc-123");
+        assert_eq!(pid, "%42");
+    }
+
+    #[test]
+    fn parse_backend_id_invalid_prefix() {
+        assert!(DevcontainerBackend::parse_backend_id("vm:abc:%42").is_err());
+    }
+
+    #[test]
+    fn parse_backend_id_too_few_parts() {
+        assert!(DevcontainerBackend::parse_backend_id("dc:abc").is_err());
+    }
+
+    #[test]
+    fn make_backend_id_format() {
+        assert_eq!(
+            DevcontainerBackend::make_backend_id("abc-123", "%42"),
+            "dc:abc-123:%42"
+        );
+    }
+
+    #[test]
+    fn container_runtime_cmd() {
+        assert_eq!(ContainerRuntime::Podman.cmd(), "podman");
+        assert_eq!(ContainerRuntime::Docker.cmd(), "docker");
+    }
+
+    #[test]
+    fn container_runtime_display() {
+        assert_eq!(ContainerRuntime::Podman.to_string(), "podman");
+        assert_eq!(ContainerRuntime::Docker.to_string(), "docker");
+    }
+
+    #[test]
+    fn container_state_db_roundtrip() {
+        let states = vec![
+            ContainerState::Building,
+            ContainerState::Starting,
+            ContainerState::Ready,
+            ContainerState::Stopping,
+            ContainerState::Stopped,
+            ContainerState::Failed("build error".to_string()),
+        ];
+        for state in states {
+            let db_str = state.to_db_str();
+            let restored = ContainerState::from_db_str(&db_str);
+            assert_eq!(state, restored);
+        }
+    }
+
+    #[test]
+    fn container_state_unknown_defaults_to_stopped() {
+        assert_eq!(
+            ContainerState::from_db_str("unknown"),
+            ContainerState::Stopped
+        );
+    }
+
+    #[test]
+    fn container_config_default() {
+        let config = ContainerConfig::default();
+        assert!(config.image.is_none());
+        assert_eq!(config.cpus, 2);
+        assert_eq!(config.memory_mb, 2048);
+        assert!(config.firewall_enabled);
+        assert_eq!(config.containerfile, Some("default".to_string()));
+    }
+
+    #[test]
+    fn make_then_parse_backend_id_roundtrip() {
+        let id = DevcontainerBackend::make_backend_id("my-container-uuid", "%99");
+        let (cid, pid) = DevcontainerBackend::parse_backend_id(&id).unwrap();
+        assert_eq!(cid, "my-container-uuid");
+        assert_eq!(pid, "%99");
+    }
+
+    #[test]
+    fn parse_backend_id_preserves_colons_in_pane_id() {
+        // splitn(3, ':') means the third part captures everything after the second ':'
+        let (cid, pid) = DevcontainerBackend::parse_backend_id("dc:abc:%42:extra").unwrap();
+        assert_eq!(cid, "abc");
+        assert_eq!(pid, "%42:extra");
+    }
+
+    #[test]
+    fn build_shell_command_no_args() {
+        let cmd = DevcontainerBackend::build_shell_command("claude", &[]);
+        assert_eq!(cmd, "claude");
+    }
+
+    #[test]
+    fn build_shell_command_with_args() {
+        let cmd = DevcontainerBackend::build_shell_command(
+            "claude",
+            &["--resume".to_string(), "session-id".to_string()],
+        );
+        assert!(cmd.starts_with("claude "));
+        assert!(cmd.contains("--resume"));
+        assert!(cmd.contains("session-id"));
+    }
+
+    #[test]
+    fn container_state_display() {
+        assert_eq!(ContainerState::Building.to_string(), "Building");
+        assert_eq!(ContainerState::Ready.to_string(), "Ready");
+        assert_eq!(
+            ContainerState::Failed("oops".to_string()).to_string(),
+            "Failed: oops"
+        );
+    }
+
+    #[test]
+    fn default_containerfile_has_thurbox_user() {
+        assert!(DEFAULT_CONTAINERFILE.contains("useradd"));
+        assert!(DEFAULT_CONTAINERFILE.contains("thurbox"));
+        assert!(DEFAULT_CONTAINERFILE.contains("-u 5000"));
+        assert!(DEFAULT_CONTAINERFILE.contains("-g 5000"));
+    }
+
+    #[test]
+    fn default_containerfile_has_rsync() {
+        assert!(DEFAULT_CONTAINERFILE.contains("rsync"));
+    }
+
+    #[test]
+    fn default_containerfile_has_path_env() {
+        assert!(DEFAULT_CONTAINERFILE.contains("ENV PATH=\"/home/thurbox/.local/bin:${PATH}\""));
+    }
+
+    #[test]
+    fn default_containerfile_uses_native_installer() {
+        assert!(DEFAULT_CONTAINERFILE.contains("claude.ai/install.sh"));
+        assert!(!DEFAULT_CONTAINERFILE.contains("npm install"));
+    }
+
+    #[test]
+    fn default_allowlist_is_nonempty() {
+        assert!(!DEFAULT_ALLOWLIST.trim().is_empty());
+        assert!(DEFAULT_ALLOWLIST.contains("api.anthropic.com"));
+    }
+
+    #[test]
+    fn start_poll_constants_are_sensible() {
+        let max_attempts = CONTAINER_START_MAX_ATTEMPTS;
+        let poll_ms = CONTAINER_START_POLL_INTERVAL.as_millis();
+        assert!(max_attempts >= 5, "Too few attempts: {max_attempts}");
+        assert!(poll_ms >= 100, "Poll interval too short: {poll_ms}ms");
+        assert!(poll_ms <= 2000, "Poll interval too long: {poll_ms}ms");
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,6 +1,7 @@
 pub mod backend;
 pub mod claude;
 pub mod control_mode;
+pub mod devcontainer;
 pub mod input;
 pub mod provider;
 pub mod registry;
@@ -8,6 +9,10 @@ pub mod tmux;
 pub mod vm;
 
 pub use backend::{Session, SessionBackend};
+pub use devcontainer::{
+    detect_runtime, host_to_container_path, ContainerManager, ContainerRuntime,
+    DevcontainerBackend, DEFAULT_ALLOWLIST, DEFAULT_CONTAINERFILE, INIT_FIREWALL_SH,
+};
 pub use provider::AgentProvider;
 pub use registry::BackendRegistry;
 pub use vm::{host_to_vm_path, QemuVmBackend, VmManager};

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -44,6 +44,12 @@ impl App {
             return;
         }
 
+        // Containerfile picker modal captures all input
+        if self.show_containerfile_picker {
+            self.handle_containerfile_picker_key(code);
+            return;
+        }
+
         // Session mode modal captures all input
         if self.show_session_mode_modal {
             self.handle_session_mode_key(code);
@@ -737,7 +743,15 @@ impl App {
     }
 
     fn handle_session_mode_key(&mut self, code: KeyCode) {
-        let max_index = if self.backends.has("qemu-vm") { 2 } else { 1 };
+        // Build the dynamic mode list matching the UI modal.
+        let mode_state = crate::ui::session_mode_modal::SessionModeState {
+            selected_index: self.session_mode_index,
+            devcontainer_available: self.backends.has("devcontainer"),
+            vm_available: self.backends.has("qemu-vm"),
+        };
+        let modes = mode_state.mode_names();
+        let max_index = modes.len().saturating_sub(1);
+
         match code {
             KeyCode::Esc => {
                 self.show_session_mode_modal = false;
@@ -754,11 +768,10 @@ impl App {
             }
             KeyCode::Enter => {
                 self.show_session_mode_modal = false;
-                match self.session_mode_index {
-                    0 => {
-                        // Normal mode
+                let selected_mode = modes.get(self.session_mode_index).copied().unwrap_or("");
+                match selected_mode {
+                    "Normal" => {
                         if let Some(all_repos) = self.pending_all_repos.take() {
-                            // Multi-repo project: use first repo as CWD, rest as add-dir
                             self.pending_repo_path = None;
                             let config = SessionConfig {
                                 cwd: Some(all_repos[0].clone()),
@@ -767,15 +780,50 @@ impl App {
                             };
                             self.spawn_session_with_config(&config);
                         } else if let Some(path) = self.pending_repo_path.take() {
-                            // Single-repo project
                             self.spawn_session_in_repo(path);
                         }
                     }
-                    1 => {
-                        // Worktree mode
+                    "Worktree" => {
                         self.start_branch_selection();
                     }
-                    2 => {
+                    "Devcontainer" => {
+                        // Devcontainer mode — build config for role selection after
+                        // container is ready, store MCP servers for writing into container.
+                        let config = if let Some(all_repos) = self.pending_all_repos.clone() {
+                            SessionConfig {
+                                cwd: Some(all_repos[0].clone()),
+                                additional_dirs: all_repos[1..].to_vec(),
+                                ..SessionConfig::default()
+                            }
+                        } else if let Some(ref path) = self.pending_repo_path {
+                            SessionConfig {
+                                cwd: Some(path.clone()),
+                                ..SessionConfig::default()
+                            }
+                        } else {
+                            SessionConfig::default()
+                        };
+                        self.pending_container_config = Some(config);
+                        self.pending_container_mcp_servers = self
+                            .active_project()
+                            .map(|p| p.config.mcp_servers.clone())
+                            .filter(|s| !s.is_empty());
+
+                        // Show containerfile picker (skip if only one file)
+                        let containerfiles = self.load_containerfiles();
+                        if containerfiles.len() <= 1 {
+                            self.pending_containerfile_name = containerfiles
+                                .first()
+                                .cloned()
+                                .or_else(|| Some("default".to_string()));
+                            self.start_container_provisioning();
+                        } else {
+                            self.containerfile_list = containerfiles;
+                            self.containerfile_picker_index = 0;
+                            self.show_containerfile_picker = true;
+                        }
+                    }
+                    "Sandbox VM" => {
                         // Sandbox VM mode — build config for role selection after
                         // VM is ready, store MCP servers for writing into the VM.
                         let config = if let Some(all_repos) = self.pending_all_repos.clone() {
@@ -801,6 +849,40 @@ impl App {
                     }
                     _ => {}
                 }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_containerfile_picker_key(&mut self, code: KeyCode) {
+        let max_index = self.containerfile_list.len().saturating_sub(1);
+        match code {
+            KeyCode::Esc => {
+                self.show_containerfile_picker = false;
+                self.containerfile_list.clear();
+                self.pending_container_config = None;
+                self.pending_container_mcp_servers = None;
+                self.pending_repo_path = None;
+                self.pending_all_repos = None;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.containerfile_picker_index < max_index {
+                    self.containerfile_picker_index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.containerfile_picker_index = self.containerfile_picker_index.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                let name = self
+                    .containerfile_list
+                    .get(self.containerfile_picker_index)
+                    .cloned()
+                    .unwrap_or_else(|| "default".to_string());
+                self.show_containerfile_picker = false;
+                self.containerfile_list.clear();
+                self.pending_containerfile_name = Some(name);
+                self.start_container_provisioning();
             }
             _ => {}
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -31,9 +31,10 @@ use crate::storage::DeletedSessionInfo;
 use crate::sync::{self, SharedWorktree, StateDelta, SyncState};
 use crate::ui::selection::{self, PaneBounds, Selection, TermPos};
 use crate::ui::{
-    add_project_modal, branch_selector_modal, delete_project_modal, edit_project_modal, info_panel,
-    layout, project_list, repo_selector_modal, restore_sessions_modal, role_editor_modal,
-    role_selector_modal, session_mode_modal, status_bar, terminal_view, worktree_name_modal,
+    add_project_modal, branch_selector_modal, containerfile_picker, delete_project_modal,
+    edit_project_modal, info_panel, layout, project_list, repo_selector_modal,
+    restore_sessions_modal, role_editor_modal, role_selector_modal, session_mode_modal, status_bar,
+    terminal_view, worktree_name_modal,
 };
 
 const MOUSE_SCROLL_LINES: usize = 3;
@@ -84,6 +85,15 @@ You can:
 - Configure roles for projects (named permission presets applied to sessions)
 - Configure MCP servers for projects
 - List, inspect, delete, and restart sessions
+- Create and manage Containerfile templates for container-based sessions
+
+Containerfile templates live in ~/.local/share/thurbox/containerfiles/. Each \
+template is a folder containing a Containerfile and any support files (e.g. \
+init-firewall.sh). The default/ template includes Node.js LTS, tmux, git, \
+iptables, and claude-code. To create a new template, create a new folder \
+(e.g. python/) with a Containerfile inside it. The entire folder is used as \
+the build context. Users select a template when spawning a container session. \
+The containerfiles directory is available in your working directory.
 
 When the user asks you to manage projects, roles, sessions, or MCP servers, use \
 the appropriate thurbox MCP tool. Always list existing resources before making \
@@ -483,6 +493,34 @@ pub struct App {
     selected_text_cache: Option<String>,
     /// Persistent clipboard handle to avoid "dropped too quickly" warnings on Linux.
     clipboard: Option<arboard::Clipboard>,
+    /// Containerfile picker modal visible.
+    pub(crate) show_containerfile_picker: bool,
+    /// Selected index in the containerfile picker.
+    pub(crate) containerfile_picker_index: usize,
+    /// Available containerfile template names.
+    pub(crate) containerfile_list: Vec<String>,
+    /// Containerfile name selected by the user (consumed during provisioning).
+    pub(crate) pending_containerfile_name: Option<String>,
+    /// Container provisioning in progress.
+    container_provisioning: bool,
+    /// Container ID currently being provisioned.
+    container_provisioning_id: Option<String>,
+    /// Container lifecycle manager (shared with background provisioning thread).
+    container_manager: Option<Arc<std::sync::Mutex<crate::agent::ContainerManager>>>,
+    /// Receiver for container provisioning results from background thread.
+    container_provision_rx: Option<mpsc::Receiver<Result<String, String>>>,
+    /// Receiver for container provisioning step updates (progress messages).
+    container_provision_step_rx: Option<mpsc::Receiver<String>>,
+    /// Current container provisioning step description.
+    container_provisioning_step: String,
+    /// Placeholder session shown during container provisioning.
+    container_placeholder: Option<SessionInfo>,
+    /// Session config preserved during container provisioning for role selection after ready.
+    pending_container_config: Option<SessionConfig>,
+    /// Container ID stored after provisioning completes, consumed by `do_spawn_session`.
+    pending_container_id: Option<String>,
+    /// MCP servers to write into the container working directory before spawning.
+    pending_container_mcp_servers: Option<Vec<crate::session::McpServerConfig>>,
 }
 
 /// Snapshot of editor field values for dirty detection.
@@ -650,6 +688,7 @@ impl App {
         provider: Arc<dyn crate::agent::AgentProvider>,
         db: Database,
         vm_manager: Option<Arc<std::sync::Mutex<crate::agent::VmManager>>>,
+        container_manager: Option<Arc<std::sync::Mutex<crate::agent::ContainerManager>>>,
     ) -> Self {
         // Migrate roles from config.toml on first run after upgrade
         migrate_config_toml_roles(&db);
@@ -776,7 +815,96 @@ impl App {
             text_selection: None,
             selected_text_cache: None,
             clipboard: arboard::Clipboard::new().ok(),
+            show_containerfile_picker: false,
+            containerfile_picker_index: 0,
+            containerfile_list: Vec::new(),
+            pending_containerfile_name: None,
+            container_provisioning: false,
+            container_provisioning_id: None,
+            container_manager,
+            container_provision_rx: None,
+            container_provision_step_rx: None,
+            container_provisioning_step: String::new(),
+            container_placeholder: None,
+            pending_container_config: None,
+            pending_container_id: None,
+            pending_container_mcp_servers: None,
         }
+    }
+
+    /// Ensure the containerfiles template directory exists and is seeded with defaults.
+    ///
+    /// Creates `~/.local/share/thurbox/containerfiles/default/` containing:
+    /// - `Containerfile` — the default container image definition
+    /// - `init-firewall.sh` — the firewall script referenced by the Containerfile
+    ///
+    /// Each template is a folder used as the build context.
+    pub fn ensure_containerfiles_dir(&self) {
+        let Some(dir) = crate::paths::containerfiles_directory() else {
+            return;
+        };
+        let default_dir = dir.join("default");
+        if let Err(e) = std::fs::create_dir_all(&default_dir) {
+            tracing::warn!("Failed to create default containerfile directory: {e}");
+            return;
+        }
+        // Always overwrite the "default" template to keep it in sync with the
+        // built-in version. Users who want a custom template should create a
+        // new named template instead of modifying "default".
+        if let Err(e) = std::fs::write(
+            default_dir.join("Containerfile"),
+            crate::agent::DEFAULT_CONTAINERFILE,
+        ) {
+            tracing::warn!("Failed to write default Containerfile: {e}");
+        }
+        if let Err(e) = std::fs::write(
+            default_dir.join("init-firewall.sh"),
+            crate::agent::INIT_FIREWALL_SH,
+        ) {
+            tracing::warn!("Failed to write init-firewall.sh: {e}");
+        }
+        if let Err(e) = std::fs::write(
+            default_dir.join("allowlist.conf"),
+            crate::agent::DEFAULT_ALLOWLIST,
+        ) {
+            tracing::warn!("Failed to write allowlist.conf: {e}");
+        }
+    }
+
+    /// Load available containerfile template names from the templates directory.
+    ///
+    /// Each template is a subdirectory containing a `Containerfile`. Returns
+    /// sorted directory names, excluding hidden directories and directories
+    /// without a `Containerfile`.
+    pub fn load_containerfiles(&self) -> Vec<String> {
+        let Some(dir) = crate::paths::containerfiles_directory() else {
+            return vec!["default".to_string()];
+        };
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => return vec!["default".to_string()],
+        };
+        let mut names: Vec<String> = entries
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+            .filter_map(|e| {
+                let name = e.file_name().to_string_lossy().to_string();
+                if name.starts_with('.') {
+                    return None;
+                }
+                // Only include if the directory contains a Containerfile
+                if e.path().join("Containerfile").exists() {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        names.sort();
+        if names.is_empty() {
+            names.push("default".to_string());
+        }
+        names
     }
 
     /// Ensure the global admin project and `.mcp.json` exist.
@@ -960,6 +1088,7 @@ impl App {
             role,
             permissions,
             vm_id: session.info.vm_id.clone(),
+            container_id: session.info.container_id.clone(),
         };
 
         let (rows, cols) = self.content_area_size();
@@ -1137,6 +1266,7 @@ impl App {
             role: deleted.role,
             permissions,
             vm_id: None,
+            container_id: None,
         };
 
         let session_name = deleted.name.clone();
@@ -1587,15 +1717,21 @@ impl App {
         // When a VM was just provisioned, use the VM backend and take the
         // placeholder's name instead of generating a new one.
         let vm_id = self.pending_vm_id.take();
+        let container_id = self.pending_container_id.take();
         let placeholder = if vm_id.is_some() {
             self.vm_placeholder.take()
+        } else if container_id.is_some() {
+            self.container_placeholder.take()
         } else {
             None
         };
         let placeholder_id = placeholder.as_ref().map(|ph| ph.id);
-        // Tie the session to its specific VM.
+        // Tie the session to its specific VM or container.
         if vm_id.is_some() {
             config.vm_id = vm_id.clone();
+        }
+        if container_id.is_some() {
+            config.container_id = container_id.clone();
         }
         let (backend, spawn_name): (Arc<dyn SessionBackend>, String) = if vm_id.is_some() {
             let vm_name = placeholder
@@ -1606,6 +1742,18 @@ impl App {
                 Some(b) => (Arc::clone(b), vm_name),
                 None => {
                     self.set_error("QEMU VM backend disappeared".to_string());
+                    return;
+                }
+            }
+        } else if container_id.is_some() {
+            let dc_name = placeholder
+                .as_ref()
+                .map(|ph| ph.name.clone())
+                .unwrap_or_else(|| name.clone());
+            match self.backends.get("devcontainer") {
+                Some(b) => (Arc::clone(b), dc_name),
+                None => {
+                    self.set_error("Devcontainer backend disappeared".to_string());
                     return;
                 }
             }
@@ -1654,6 +1802,38 @@ impl App {
                     }
                 }
 
+                if let Some(ref cid) = container_id {
+                    session.info.container_id = Some(cid.clone());
+
+                    // Replace the placeholder ID with the real session ID.
+                    if let Some(ph_id) = placeholder_id {
+                        if let Some(project) = self.projects.get_mut(self.active_project_index) {
+                            project.session_ids.retain(|id| *id != ph_id);
+                        }
+                    }
+
+                    // Update container state to Ready with docker ID.
+                    let docker_id = if let Some(ref mgr) = self.container_manager {
+                        if let Ok(mgr) = mgr.lock() {
+                            mgr.get_instance(cid)
+                                .and_then(|i| i.docker_container_id.clone())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+
+                    if let Err(e) = self.db.update_container_state(
+                        cid,
+                        &crate::session::ContainerState::Ready,
+                        docker_id.as_deref(),
+                        None,
+                    ) {
+                        error!(container_id = %cid, "Failed to update container state to Ready: {e}");
+                    }
+                }
+
                 self.sessions.push(session);
                 self.active_index = self.sessions.len() - 1;
                 self.focus = InputFocus::Terminal;
@@ -1681,6 +1861,18 @@ impl App {
                             vm_id = %vid,
                             session_id = %sid_str,
                             "Failed to link VM record to session: {e}"
+                        );
+                    }
+                }
+
+                // Link the container record to this session (same FK constraint).
+                if let Some(ref cid) = container_id {
+                    let sid_str = session_id.to_string();
+                    if let Err(e) = self.db.update_container_session(cid, &sid_str) {
+                        error!(
+                            container_id = %cid,
+                            session_id = %sid_str,
+                            "Failed to link container record to session: {e}"
                         );
                     }
                 }
@@ -1914,6 +2106,242 @@ impl App {
             let _ = self.db.update_vm_state(
                 id,
                 &crate::session::VmState::Failed(error.to_string()),
+                None,
+                Some(error),
+            );
+        }
+    }
+
+    /// Start container provisioning in a background thread.
+    pub(crate) fn start_container_provisioning(&mut self) {
+        if self.container_provisioning {
+            self.set_info("Container is already being provisioned...".to_string());
+            return;
+        }
+
+        if self.backends.get("devcontainer").is_none() {
+            self.set_error("Devcontainer backend not available".to_string());
+            return;
+        }
+
+        let manager = match self.container_manager {
+            Some(ref m) => Arc::clone(m),
+            None => {
+                self.set_error("Container manager not initialized".to_string());
+                return;
+            }
+        };
+
+        let container_id = uuid::Uuid::new_v4().to_string();
+        self.container_provisioning = true;
+        self.container_provisioning_id = Some(container_id.clone());
+
+        // Create a placeholder session visible in the session list during provisioning.
+        let name = self.next_session_name();
+        let mut placeholder = SessionInfo::new(name);
+        placeholder.status = SessionStatus::Provisioning;
+        placeholder.container_id = Some(container_id.clone());
+        placeholder.provisioning_step = Some("Preparing workspace...".to_string());
+
+        // Add placeholder to the active project's session list so it renders.
+        if let Some(project) = self.projects.get_mut(self.active_project_index) {
+            project.session_ids.push(placeholder.id);
+        }
+        self.container_placeholder = Some(placeholder);
+
+        self.set_info("Provisioning container...".to_string());
+
+        // Determine repo path for the container workspace.
+        let repo_path: Option<PathBuf> = if let Some(ref all_repos) = self.pending_all_repos {
+            Some(all_repos[0].clone())
+        } else {
+            self.pending_repo_path.clone()
+        };
+
+        let containerfile_name = self
+            .pending_containerfile_name
+            .take()
+            .unwrap_or_else(|| "default".to_string());
+        let config = crate::session::ContainerConfig {
+            containerfile: Some(containerfile_name.clone()),
+            ..crate::session::ContainerConfig::default()
+        };
+        let project_id = self.active_project().map(|p| p.id.to_string());
+
+        // Record in DB
+        if let Err(e) = self.db.insert_container(
+            &container_id,
+            None,
+            project_id.as_deref(),
+            &crate::session::ContainerState::Building,
+            &config,
+        ) {
+            error!("Failed to insert container record: {e}");
+            self.set_error(format!("Failed to create container: {e}"));
+            self.container_provisioning = false;
+            self.container_provisioning_id = None;
+            return;
+        }
+
+        // Spawn background thread for container provisioning.
+        let (tx, rx) = mpsc::channel();
+        let (step_tx, step_rx) = mpsc::channel();
+        self.container_provision_rx = Some(rx);
+        self.container_provision_step_rx = Some(step_rx);
+        self.container_provisioning_step = "Preparing workspace...".to_string();
+        let container_id_thread = container_id.clone();
+        let config_thread = config;
+        let containerfile_thread = containerfile_name;
+        tracing::info!(container_id = %container_id, "Container provisioning started");
+
+        let spawn_result = std::thread::Builder::new()
+            .name(format!("dc-provision-{}", &container_id[..8]))
+            .spawn(move || {
+                let mgr = manager.lock().unwrap();
+                let result = mgr.create_container(
+                    &container_id_thread,
+                    &config_thread,
+                    &containerfile_thread,
+                    repo_path.as_deref(),
+                    &step_tx,
+                );
+                drop(mgr);
+                match result {
+                    Ok(()) => {
+                        let _ = tx.send(Ok(container_id_thread));
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(format!("{e:#}")));
+                    }
+                }
+            });
+
+        if let Err(e) = spawn_result {
+            error!("Failed to spawn container provisioning thread: {e}");
+            self.set_error(format!("Failed to start container provisioning: {e}"));
+            self.container_provisioning = false;
+            self.container_provisioning_id = None;
+            self.container_provision_rx = None;
+        }
+    }
+
+    /// Poll for container provisioning results from the background thread.
+    fn poll_container_provision(&mut self) {
+        // Drain step updates (keep the latest).
+        if let Some(ref rx) = self.container_provision_step_rx {
+            while let Ok(step) = rx.try_recv() {
+                self.container_provisioning_step = step.clone();
+                if let Some(ref mut ph) = self.container_placeholder {
+                    ph.provisioning_step = Some(step);
+                }
+            }
+        }
+
+        let result = match self.container_provision_rx {
+            Some(ref rx) => match rx.try_recv() {
+                Ok(r) => Some(r),
+                Err(mpsc::TryRecvError::Empty) => None,
+                Err(mpsc::TryRecvError::Disconnected) => Some(Err(
+                    "Container provisioning thread terminated unexpectedly".to_string(),
+                )),
+            },
+            None => None,
+        };
+
+        if let Some(result) = result {
+            self.container_provision_rx = None;
+            self.container_provision_step_rx = None;
+            self.container_provisioning_step.clear();
+            match result {
+                Ok(container_id) => self.handle_container_ready(&container_id),
+                Err(error) => self.handle_container_failed(&error),
+            }
+        }
+    }
+
+    /// Handle successful container provisioning.
+    fn handle_container_ready(&mut self, container_id: &str) {
+        self.container_provisioning = false;
+        self.container_provisioning_id = None;
+        self.set_info("Container ready — starting session...".to_string());
+
+        let backend = match self.backends.get("devcontainer") {
+            Some(b) => Arc::clone(b),
+            None => {
+                self.set_error("Devcontainer backend disappeared".to_string());
+                return;
+            }
+        };
+
+        // Establish docker exec control mode connection.
+        if let Err(e) = backend.prepare_vm(container_id) {
+            error!("Failed to establish container control mode: {e}");
+            self.set_error(format!("Container ready but control mode failed: {e:#}"));
+            return;
+        }
+
+        // Take the pending config, remap host paths to container paths.
+        let mut config = self.pending_container_config.take().unwrap_or_default();
+        if let Some(ref cwd) = config.cwd {
+            config.cwd = Some(crate::agent::host_to_container_path(cwd));
+        }
+        config.additional_dirs = config
+            .additional_dirs
+            .iter()
+            .map(|p| crate::agent::host_to_container_path(p))
+            .collect();
+        self.pending_repo_path = None;
+        self.pending_all_repos = None;
+
+        // Write project MCP servers as .mcp.json into the container working directory.
+        if let Some(mcp_servers) = self.pending_container_mcp_servers.take() {
+            if let Some(ref cwd) = config.cwd {
+                if let Some(ref mgr) = self.container_manager {
+                    if let Ok(mgr) = mgr.lock() {
+                        let rt = mgr.runtime().cmd();
+                        if let Some(instance) = mgr.get_instance(container_id) {
+                            if let Some(ref docker_id) = instance.docker_container_id {
+                                if let Err(e) =
+                                    write_container_mcp_json(rt, docker_id, cwd, &mcp_servers)
+                                {
+                                    warn!("Failed to write .mcp.json into container: {e:#}");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Store container ID so `do_spawn_session` uses the devcontainer backend.
+        self.pending_container_id = Some(container_id.to_string());
+
+        // Route through role selection.
+        self.prepare_spawn(config, Vec::new());
+    }
+
+    /// Handle a failed container provisioning attempt.
+    fn handle_container_failed(&mut self, error: &str) {
+        self.container_provisioning = false;
+        let container_id = self.container_provisioning_id.take();
+        self.set_error(format!("Container provisioning failed: {error}"));
+        self.pending_repo_path = None;
+        self.pending_all_repos = None;
+        self.pending_container_config = None;
+        self.pending_container_id = None;
+        self.pending_container_mcp_servers = None;
+
+        // Update placeholder to show error state.
+        if let Some(ref mut ph) = self.container_placeholder {
+            ph.status = SessionStatus::Error;
+            ph.provisioning_step = Some(error.to_string());
+        }
+
+        // Update DB record
+        if let Some(id) = &container_id {
+            let _ = self.db.update_container_state(
+                id,
+                &crate::session::ContainerState::Failed(error.to_string()),
                 None,
                 Some(error),
             );
@@ -2221,6 +2649,9 @@ impl App {
         // Poll for VM provisioning results from background thread
         self.poll_vm_provision();
 
+        // Poll for container provisioning results from background thread
+        self.poll_container_provision();
+
         // Process queued session commands from MCP
         self.process_session_commands();
 
@@ -2257,13 +2688,26 @@ impl App {
         let mut per_session = Vec::new();
 
         for session in &self.sessions {
-            // VM sessions: use the QEMU host PID; local sessions: tmux pane PID.
+            // VM sessions: use the QEMU host PID.
+            // Container sessions: use the container init PID on the host.
+            // Local sessions: use the tmux pane PID.
             let root_pid = self
                 .db
                 .get_vm_by_session(&session.info.id.to_string())
                 .ok()
                 .flatten()
                 .and_then(|vm| vm.qemu_pid)
+                .or_else(|| {
+                    // For container sessions, look up the container's host init PID.
+                    if let Some(ref cid) = session.info.container_id {
+                        if let Some(ref mgr) = self.container_manager {
+                            if let Ok(mgr) = mgr.lock() {
+                                return mgr.container_host_pid(cid);
+                            }
+                        }
+                    }
+                    None
+                })
                 .or_else(|| session.pane_pid().ok().flatten());
 
             if let Some(pid) = root_pid {
@@ -2275,11 +2719,13 @@ impl App {
                     .unwrap_or_default();
                 let worktree_branch = session.info.worktrees.first().map(|wt| wt.branch.clone());
                 let is_vm = session.info.vm_id.is_some();
+                let is_container = session.info.container_id.is_some();
                 per_session.push(info_panel::SessionMetrics {
                     name: session.info.name.clone(),
                     project_name,
                     worktree_branch,
                     is_vm,
+                    is_container,
                     cpu_percent: cpu,
                     memory_bytes: mem,
                 });
@@ -2623,6 +3069,7 @@ impl App {
                             role: shared_session.role.clone(),
                             permissions,
                             vm_id: None,
+                            container_id: None,
                         };
 
                         let (rows, cols) = self.content_area_size();
@@ -2721,6 +3168,16 @@ impl App {
                 }
             }
 
+            // Include container placeholder in the session list if it belongs to this project.
+            if let Some(ref ph) = self.container_placeholder {
+                if let Some(project) = self.projects.get(self.active_project_index) {
+                    if project.session_ids.contains(&ph.id) {
+                        project_sessions.push(ph);
+                        session_elapsed_ms.push(0);
+                    }
+                }
+            }
+
             let panel_focus = match self.focus {
                 InputFocus::ProjectList => project_list::LeftPanelFocus::Projects,
                 InputFocus::SessionList | InputFocus::Terminal => {
@@ -2762,7 +3219,8 @@ impl App {
                 .sessions
                 .get(self.active_index)
                 .map(|s| &s.info)
-                .or(self.vm_placeholder.as_ref());
+                .or(self.vm_placeholder.as_ref())
+                .or(self.container_placeholder.as_ref());
 
             if let Some(info) = info_session {
                 let vm_details = info.vm_id.as_deref().and_then(|vm_id| {
@@ -2840,6 +3298,8 @@ impl App {
                 sync_in_progress: self.worktree_sync_in_progress,
                 vm_provisioning: self.vm_provisioning,
                 vm_provisioning_step: &self.vm_provisioning_step,
+                container_provisioning: self.container_provisioning,
+                container_provisioning_step: &self.container_provisioning_step,
                 tick_count: self.tick_count,
             },
         );
@@ -2919,7 +3379,19 @@ impl App {
                 frame,
                 &session_mode_modal::SessionModeState {
                     selected_index: self.session_mode_index,
+                    devcontainer_available: self.backends.has("devcontainer"),
                     vm_available: self.backends.has("qemu-vm"),
+                },
+            );
+        }
+
+        // Containerfile picker modal
+        if self.show_containerfile_picker {
+            containerfile_picker::render_containerfile_picker(
+                frame,
+                &containerfile_picker::ContainerfilePickerState {
+                    containerfiles: self.containerfile_list.clone(),
+                    selected_index: self.containerfile_picker_index,
                 },
             );
         }
@@ -3293,11 +3765,13 @@ impl App {
     pub fn restore_sessions(&mut self, sessions: Vec<sync::SharedSession>, session_counter: usize) {
         self.session_counter = session_counter;
 
-        // Pre-flight: restore any VMs that sessions depend on, so that
-        // discover() on the VM backend can find their tmux panes.
+        // Pre-flight: restore any VMs/containers that sessions depend on, so that
+        // discover() on the VM/devcontainer backend can find their tmux panes.
         for shared in &sessions {
             if shared.backend_type == "qemu-vm" {
                 self.restore_vm_for_session(shared);
+            } else if shared.backend_type == "devcontainer" {
+                self.restore_container_for_session(shared);
             }
         }
 
@@ -3411,6 +3885,15 @@ impl App {
                     }
                 }
 
+                // Restore container_id on adopted devcontainer sessions.
+                if shared.backend_type == "devcontainer" {
+                    if let Ok(Some(container_record)) =
+                        self.db.get_container_by_session(&session_id.to_string())
+                    {
+                        session.info.container_id = Some(container_record.id);
+                    }
+                }
+
                 // Re-adopt shell pane if one was persisted
                 if let Some(shell_bid) = &shared.shell_backend_id {
                     if discovered
@@ -3457,12 +3940,11 @@ impl App {
                 let permissions =
                     self.resolve_role_permissions_for_project(&role, target_project_index);
 
-                // For VM sessions where the VM died, trigger re-provisioning so
-                // do_spawn_session uses the VM backend instead of local-tmux.
+                // For VM sessions where the VM died, fall back to local-tmux.
+                let mut resolved_vm_id = None;
                 if shared.backend_type == "qemu-vm" {
                     if let Ok(Some(vm_record)) = self.db.get_vm_by_session(&session_id.to_string())
                     {
-                        // Check if the VM was restored (it's in VmManager).
                         let vm_alive = self.vm_manager.as_ref().is_some_and(|mgr| {
                             mgr.lock()
                                 .ok()
@@ -3475,12 +3957,52 @@ impl App {
                                 vm_id = %vm_record.id,
                                 "VM died — session will be re-spawned with --resume on local-tmux"
                             );
-                            // Mark VM as stopped in DB.
                             let _ = self.db.update_vm_state(
                                 &vm_record.id,
                                 &crate::session::VmState::Stopped,
                                 None,
                                 Some("VM not reachable after restart"),
+                            );
+                        } else {
+                            resolved_vm_id = Some(vm_record.id);
+                        }
+                    }
+                }
+
+                // For container sessions, re-use the container if it's alive.
+                let mut resolved_container_id = None;
+                if shared.backend_type == "devcontainer" {
+                    if let Ok(Some(container_record)) =
+                        self.db.get_container_by_session(&session_id.to_string())
+                    {
+                        let container_alive = self.container_manager.as_ref().is_some_and(|mgr| {
+                            mgr.lock()
+                                .ok()
+                                .and_then(|m| m.get_instance(&container_record.id))
+                                .is_some_and(|inst| {
+                                    inst.state == crate::session::ContainerState::Ready
+                                })
+                        });
+                        if container_alive {
+                            info!(
+                                session = %session_id,
+                                container_id = %container_record.id,
+                                "Container alive — re-spawning session inside container"
+                            );
+                            resolved_container_id = Some(container_record.id.clone());
+                            // Set pending so do_spawn_session picks the devcontainer backend.
+                            self.pending_container_id = Some(container_record.id);
+                        } else {
+                            warn!(
+                                session = %session_id,
+                                container_id = %container_record.id,
+                                "Container not alive — session will be re-spawned on local-tmux"
+                            );
+                            let _ = self.db.update_container_state(
+                                &container_record.id,
+                                &crate::session::ContainerState::Stopped,
+                                None,
+                                Some("Container not reachable after restart"),
                             );
                         }
                     }
@@ -3503,7 +4025,8 @@ impl App {
                     additional_dirs: shared.additional_dirs,
                     role,
                     permissions,
-                    vm_id: None,
+                    vm_id: resolved_vm_id,
+                    container_id: resolved_container_id,
                 };
                 self.do_spawn_session(name, &config, worktrees, Some(target_project_index));
             }
@@ -3576,6 +4099,94 @@ impl App {
                     vm_id = %vm_record.id,
                     session = %shared.id,
                     "VM restored and control mode established"
+                );
+            }
+        }
+    }
+
+    /// Restore a container instance for a devcontainer-backed session before discovery/adoption.
+    ///
+    /// Looks up the container record from the DB, re-registers it in `ContainerManager`
+    /// (starting the container if stopped), then establishes the docker exec
+    /// control mode connection so `discover()` can find its tmux panes.
+    fn restore_container_for_session(&mut self, shared: &sync::SharedSession) {
+        let session_id_str = shared.id.to_string();
+        let container_record = match self.db.get_container_by_session(&session_id_str) {
+            Ok(Some(rec)) => rec,
+            Ok(None) => {
+                warn!(session = %shared.id, "No container record found for devcontainer session");
+                return;
+            }
+            Err(e) => {
+                warn!(session = %shared.id, "Failed to look up container record: {e}");
+                return;
+            }
+        };
+
+        let docker_id = match container_record.docker_container_id {
+            Some(ref id) => id.clone(),
+            None => {
+                warn!(
+                    container_id = %container_record.id,
+                    "Container record has no docker container ID"
+                );
+                return;
+            }
+        };
+
+        // Re-register the running container in ContainerManager.
+        if let Some(ref mgr) = self.container_manager {
+            match mgr.lock() {
+                Ok(mgr) => {
+                    let config = crate::session::ContainerConfig {
+                        image: container_record.image.clone(),
+                        cpus: container_record.cpus,
+                        memory_mb: container_record.memory_mb,
+                        firewall_enabled: container_record.firewall_enabled,
+                        containerfile: container_record.containerfile.clone(),
+                    };
+
+                    // Determine workspace dir from the session's cwd or use containers dir
+                    let workspace_dir = shared
+                        .cwd
+                        .clone()
+                        .unwrap_or_else(|| std::path::PathBuf::from("/workspaces"));
+
+                    if let Err(e) = mgr.restore_container(
+                        &container_record.id,
+                        &docker_id,
+                        &config,
+                        &workspace_dir,
+                    ) {
+                        warn!(
+                            container_id = %container_record.id,
+                            "Container not reachable, will fall through to re-spawn: {e}"
+                        );
+                        return;
+                    }
+                }
+                Err(e) => {
+                    warn!("ContainerManager lock poisoned: {e}");
+                    return;
+                }
+            }
+        } else {
+            warn!("No ContainerManager available for container session restore");
+            return;
+        }
+
+        // Establish docker exec control mode connection so discover() works.
+        if let Some(dc_backend) = self.backends.get("devcontainer") {
+            if let Err(e) = dc_backend.prepare_vm(&container_record.id) {
+                warn!(
+                    container_id = %container_record.id,
+                    "Failed to establish docker exec control mode: {e}"
+                );
+            } else {
+                info!(
+                    container_id = %container_record.id,
+                    session = %shared.id,
+                    "Container restored and control mode established"
                 );
             }
         }
@@ -3698,6 +4309,7 @@ impl App {
             role,
             permissions,
             vm_id: session.info.vm_id.clone(),
+            container_id: session.info.container_id.clone(),
         };
 
         let (rows, cols) = self.content_area_size();
@@ -3922,6 +4534,64 @@ fn write_vm_mcp_json(
     }
 
     info!("Wrote .mcp.json into VM at {}", dest.display());
+    Ok(())
+}
+
+/// Write a `.mcp.json` file into a container directory via `docker exec` so Claude Code
+/// discovers the project's MCP servers when running inside the devcontainer.
+fn write_container_mcp_json(
+    runtime: &str,
+    docker_container_id: &str,
+    container_cwd: &std::path::Path,
+    mcp_servers: &[crate::session::McpServerConfig],
+) -> anyhow::Result<()> {
+    if mcp_servers.is_empty() {
+        return Ok(());
+    }
+
+    let docker_id = docker_container_id;
+
+    // Build the .mcp.json structure Claude Code expects.
+    let mut servers = serde_json::Map::new();
+    for srv in mcp_servers {
+        let mut entry = serde_json::Map::new();
+        entry.insert(
+            "command".to_string(),
+            serde_json::Value::String(srv.command.clone()),
+        );
+        if !srv.args.is_empty() {
+            entry.insert("args".to_string(), serde_json::json!(srv.args));
+        }
+        if !srv.env.is_empty() {
+            entry.insert("env".to_string(), serde_json::json!(srv.env));
+        }
+        servers.insert(srv.name.clone(), serde_json::Value::Object(entry));
+    }
+    let doc = serde_json::json!({ "mcpServers": servers });
+    let json_str = serde_json::to_string_pretty(&doc)?;
+
+    let dest = container_cwd.join(".mcp.json");
+    let shell_cmd = format!("cat > '{}'", dest.to_string_lossy().replace('\'', "'\\''"));
+    let output = std::process::Command::new(runtime)
+        .args(["exec", "-i", docker_id, "sh", "-c", &shell_cmd])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(json_str.as_bytes())?;
+            }
+            child.wait_with_output()
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("{runtime} exec write .mcp.json failed: {stderr}");
+    }
+
+    info!("Wrote .mcp.json into container at {}", dest.display());
     Ok(())
 }
 
@@ -4199,6 +4869,7 @@ mod tests {
             provider.clone(),
             test_db_with_project(&test_project_config()),
             None,
+            None,
         );
         for _i in 0..count {
             let session = Session::stub("test-session", &backend_arc, &provider);
@@ -4323,14 +4994,30 @@ mod tests {
 
     #[test]
     fn page_scroll_amount_is_half_content_height() {
-        let app = App::new(50, 100, stub_backend(), stub_provider(), test_db(), None);
+        let app = App::new(
+            50,
+            100,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         // rows = 50 - 4 = 46, half = 23
         assert_eq!(app.page_scroll_amount(), 23);
     }
 
     #[test]
     fn page_scroll_amount_small_terminal() {
-        let app = App::new(6, 80, stub_backend(), stub_provider(), test_db(), None);
+        let app = App::new(
+            6,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         // rows = 6 - 4 = 2, half = 1
         assert_eq!(app.page_scroll_amount(), 1);
     }
@@ -4344,13 +5031,29 @@ mod tests {
 
     #[test]
     fn next_session_name_starts_at_one() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         assert_eq!(app.next_session_name(), "1");
     }
 
     #[test]
     fn next_session_name_increments() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         assert_eq!(app.next_session_name(), "1");
         assert_eq!(app.next_session_name(), "2");
         assert_eq!(app.next_session_name(), "3");
@@ -4358,7 +5061,15 @@ mod tests {
 
     #[test]
     fn next_session_name_continues_from_restored_counter() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.session_counter = 5;
         assert_eq!(app.next_session_name(), "6");
     }
@@ -4373,6 +5084,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&test_project_config()),
+            None,
             None,
         );
         app.open_role_editor();
@@ -4404,6 +5116,7 @@ mod tests {
             stub_provider(),
             test_db_with_project(&config),
             None,
+            None,
         );
         app.open_role_editor();
         assert_eq!(app.role_editor_roles.len(), 1);
@@ -4412,7 +5125,15 @@ mod tests {
 
     #[test]
     fn role_editor_submit_uses_allowed_tools_list() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         for c in "reviewer".chars() {
@@ -4432,7 +5153,15 @@ mod tests {
 
     #[test]
     fn role_editor_submit_uses_disallowed_tools_list() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         for c in "restricted".chars() {
@@ -4484,6 +5213,7 @@ mod tests {
             stub_provider(),
             test_db_with_project(&config),
             None,
+            None,
         );
         let session_config = SessionConfig::default();
         app.prepare_spawn(session_config, Vec::new());
@@ -4506,6 +5236,7 @@ mod tests {
             stub_provider(),
             test_db_with_project(&config),
             None,
+            None,
         );
         // With no roles, the selector should never be set
         assert!(!app.show_role_selector);
@@ -4513,7 +5244,15 @@ mod tests {
 
     #[test]
     fn role_editor_name_validation_rejects_empty() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         // Try to submit with empty name
@@ -4544,7 +5283,15 @@ mod tests {
 
     #[test]
     fn role_editor_name_validation_rejects_duplicate() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         // Add first role
         app.handle_role_editor_list_key(KeyCode::Char('a'));
@@ -4597,6 +5344,7 @@ mod tests {
             stub_provider(),
             test_db_with_project(&config),
             None,
+            None,
         );
         app.open_role_editor();
         app.open_role_for_editing(0);
@@ -4619,7 +5367,15 @@ mod tests {
 
     #[test]
     fn role_editor_new_role_has_no_extra_fields() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_name.set("new-role");
@@ -4658,6 +5414,7 @@ mod tests {
             stub_provider(),
             test_db_with_project(&config),
             None,
+            None,
         );
         app.open_role_editor();
         app.open_role_for_editing(0);
@@ -4678,7 +5435,15 @@ mod tests {
     #[test]
     fn role_editor_tab_cycles_fields_forward() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -4700,7 +5465,15 @@ mod tests {
     #[test]
     fn role_editor_backtab_cycles_fields_backward() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -4721,7 +5494,15 @@ mod tests {
 
     #[test]
     fn role_editor_esc_returns_to_edit_project() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         assert_eq!(app.role_editor_view, RoleEditorView::Editor);
@@ -4761,6 +5542,7 @@ mod tests {
             stub_provider(),
             test_db_with_project(&config),
             None,
+            None,
         );
         app.open_role_editor();
         // Select the last role
@@ -4773,7 +5555,15 @@ mod tests {
 
     #[test]
     fn role_editor_submit_clears_error_on_success() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -4896,7 +5686,15 @@ mod tests {
     #[test]
     fn tool_browse_add_via_key_handler() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
 
@@ -4929,7 +5727,15 @@ mod tests {
     #[test]
     fn tool_browse_delete_via_key_handler() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_field = RoleEditorField::AllowedTools;
@@ -4946,7 +5752,15 @@ mod tests {
     #[test]
     fn tool_adding_esc_cancels() {
         use role_editor_modal::RoleEditorField;
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_field = RoleEditorField::DisallowedTools;
@@ -4988,6 +5802,7 @@ mod tests {
             stub_provider(),
             test_db_with_project(&config),
             None,
+            None,
         );
         app.open_role_editor();
         app.open_role_for_editing(0);
@@ -5007,7 +5822,15 @@ mod tests {
 
     #[test]
     fn system_prompt_empty_saves_as_none() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.open_role_editor();
         app.handle_role_editor_list_key(KeyCode::Char('a'));
         app.role_editor_name.set("test");
@@ -5043,6 +5866,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
             None,
         );
         // With exactly 1 role, prepare_spawn should not show selector
@@ -5146,7 +5970,15 @@ mod tests {
 
     #[test]
     fn empty_db_app_has_valid_active_project_index() {
-        let app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         // With an empty DB, the project list is empty, but the index should be valid
         assert!(
             app.projects.is_empty() || app.active_project_index < app.projects.len(),
@@ -5301,7 +6133,7 @@ mod tests {
         db.soft_delete_project(id).unwrap();
         assert!(!db.project_exists(id).unwrap());
 
-        let app = App::new(24, 120, backend, provider, db, None);
+        let app = App::new(24, 120, backend, provider, db, None, None);
 
         // Create a project with the same deterministic ID
         let project = ProjectInfo::new(config);
@@ -5557,7 +6389,15 @@ mod tests {
 
     #[test]
     fn load_persisted_state_empty_db_returns_none() {
-        let app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         assert!(app.load_persisted_state_from_db().is_none());
     }
 
@@ -5592,7 +6432,7 @@ mod tests {
         };
         db.upsert_session(&session).unwrap();
 
-        let app = App::new(24, 80, stub_backend(), stub_provider(), db, None);
+        let app = App::new(24, 80, stub_backend(), stub_provider(), db, None, None);
         assert!(app.load_persisted_state_from_db().is_none());
     }
 
@@ -5646,7 +6486,7 @@ mod tests {
         db.upsert_session(&s2).unwrap();
         db.set_session_counter(7).unwrap();
 
-        let app = App::new(24, 80, stub_backend(), stub_provider(), db, None);
+        let app = App::new(24, 80, stub_backend(), stub_provider(), db, None, None);
         let (sessions, counter) = app.load_persisted_state_from_db().unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].name, "2");
@@ -5663,6 +6503,7 @@ mod tests {
             BackendRegistry::new(backend_arc.clone()),
             provider.clone(),
             test_db_with_project(&test_project_config()),
+            None,
             None,
         );
 
@@ -5683,7 +6524,15 @@ mod tests {
 
     #[test]
     fn save_state_persists_session_counter() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.session_counter = 42;
 
         app.save_state();
@@ -5702,6 +6551,7 @@ mod tests {
             BackendRegistry::new(backend_arc.clone()),
             provider.clone(),
             test_db_with_project(&test_project_config()),
+            None,
             None,
         );
 
@@ -5741,6 +6591,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
             None,
         )
     }
@@ -5975,6 +6826,7 @@ mod tests {
             provider.clone(),
             db,
             None,
+            None,
         );
 
         // Verify initial state: 1 project named "TestA"
@@ -6029,6 +6881,7 @@ mod tests {
             BackendRegistry::new(backend_arc.clone()),
             provider.clone(),
             app.db,
+            None,
             None,
         );
 
@@ -6150,6 +7003,7 @@ mod tests {
             provider.clone(),
             test_db_with_project(&test_project_config()),
             None,
+            None,
         );
 
         let mut session = Session::stub("test-session", &backend_arc, &provider);
@@ -6186,6 +7040,7 @@ mod tests {
             stub_backend(),
             stub_provider(),
             test_db_with_project(&config),
+            None,
             None,
         )
     }
@@ -6352,6 +7207,7 @@ mod tests {
             provider.clone(),
             test_db_with_project(&test_project_config()),
             None,
+            None,
         );
 
         let mut session = Session::stub("test-session", &backend_arc, &provider);
@@ -6396,6 +7252,7 @@ mod tests {
             provider,
             test_db_with_project(&admin_config),
             None,
+            None,
         );
         app.projects[0].is_admin = true;
 
@@ -6411,7 +7268,15 @@ mod tests {
 
     #[test]
     fn cannot_edit_admin_project() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
 
         // Add an admin project and select it
         let admin_project = ProjectInfo::new_admin(ProjectConfig {
@@ -6434,7 +7299,15 @@ mod tests {
 
     #[test]
     fn cannot_delete_admin_project() {
-        let mut app = App::new(24, 120, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
 
         // Add an admin project and select it
         let admin_project = ProjectInfo::new_admin(ProjectConfig {
@@ -6465,6 +7338,7 @@ mod tests {
             BackendRegistry::new(backend_arc.clone()),
             provider.clone(),
             test_db(),
+            None,
             None,
         );
 
@@ -6499,7 +7373,15 @@ mod tests {
 
     #[test]
     fn set_error_creates_error_status() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.set_error("something failed");
         let msg = app.status_message.as_ref().unwrap();
         assert_eq!(msg.level, StatusLevel::Error);
@@ -6508,7 +7390,15 @@ mod tests {
 
     #[test]
     fn set_status_creates_typed_status() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.set_status(StatusLevel::Success, "all good");
         let msg = app.status_message.as_ref().unwrap();
         assert_eq!(msg.level, StatusLevel::Success);
@@ -6517,7 +7407,15 @@ mod tests {
 
     #[test]
     fn set_status_replaces_previous() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.set_error("old error");
         app.set_status(StatusLevel::Info, "new info");
         let msg = app.status_message.as_ref().unwrap();
@@ -6529,7 +7427,15 @@ mod tests {
 
     #[test]
     fn start_sync_with_no_worktrees_shows_info() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.start_sync();
         assert!(!app.worktree_sync_in_progress);
         let msg = app.status_message.as_ref().unwrap();
@@ -6539,7 +7445,15 @@ mod tests {
 
     #[test]
     fn start_sync_ignores_if_already_in_progress() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.worktree_sync_in_progress = true;
         app.status_message = None;
         app.start_sync();
@@ -6549,7 +7463,15 @@ mod tests {
 
     #[test]
     fn ctrl_s_triggers_start_sync() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.handle_key(KeyCode::Char('s'), KeyModifiers::CONTROL);
         // No worktrees → info message
         let msg = app.status_message.as_ref().unwrap();
@@ -6575,7 +7497,15 @@ mod tests {
 
     #[test]
     fn tick_increments_tick_count() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         assert_eq!(app.tick_count, 0);
         app.tick();
         assert_eq!(app.tick_count, 1);
@@ -6585,7 +7515,15 @@ mod tests {
 
     #[test]
     fn finish_sync_all_synced_shows_success() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         let id = SessionId::default();
         app.worktree_sync_completed = vec![
             (id, git::SyncResult::Synced),
@@ -6599,7 +7537,15 @@ mod tests {
 
     #[test]
     fn finish_sync_with_errors_shows_error() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.worktree_sync_completed = vec![(
             SessionId::default(),
             git::SyncResult::Error("fetch failed".into()),
@@ -6613,7 +7559,15 @@ mod tests {
 
     #[test]
     fn finish_sync_with_conflicts_shows_info() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.worktree_sync_completed = vec![
             (SessionId::default(), git::SyncResult::Synced),
             (
@@ -6630,7 +7584,15 @@ mod tests {
 
     #[test]
     fn finish_sync_errors_take_priority_over_conflicts() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.worktree_sync_completed = vec![
             (
                 SessionId::default(),
@@ -6649,7 +7611,15 @@ mod tests {
 
     #[test]
     fn drain_deferred_inputs_sends_at_correct_tick() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         let id = SessionId::default();
         app.deferred_inputs.push((id, b"hello".to_vec(), 5));
 
@@ -6666,7 +7636,15 @@ mod tests {
 
     #[test]
     fn drain_deferred_inputs_retains_future_items() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         let id = SessionId::default();
         app.deferred_inputs.push((id, b"early".to_vec(), 5));
         app.deferred_inputs.push((id, b"late".to_vec(), 20));
@@ -6679,7 +7657,15 @@ mod tests {
 
     #[test]
     fn send_conflict_prompt_noop_for_unknown_session() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         app.send_conflict_prompt(SessionId::default());
         assert!(app.deferred_inputs.is_empty());
     }
@@ -6697,7 +7683,15 @@ mod tests {
 
     #[test]
     fn poll_sync_results_triggers_finish_when_all_received() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         let (tx, rx) = mpsc::channel();
         let id = SessionId::default();
 
@@ -6718,7 +7712,15 @@ mod tests {
 
     #[test]
     fn poll_sync_results_waits_for_all_pending() {
-        let mut app = App::new(24, 80, stub_backend(), stub_provider(), test_db(), None);
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
         let (tx, rx) = mpsc::channel();
 
         tx.send((SessionId::default(), git::SyncResult::Synced))
@@ -6748,7 +7750,7 @@ mod tests {
             repos: vec![PathBuf::from("/other")],
             ..test_project_config()
         };
-        let mut app = App::new(24, 120, backend, provider, test_db(), None);
+        let mut app = App::new(24, 120, backend, provider, test_db(), None, None);
         app.projects.push(ProjectInfo::new(test_project_config()));
         let project_b = ProjectInfo::new(config_b);
         let id_b = project_b.id;
@@ -6763,7 +7765,7 @@ mod tests {
     fn find_project_index_falls_back_to_active_project() {
         let backend = stub_backend();
         let provider = stub_provider();
-        let mut app = App::new(24, 120, backend, provider, test_db(), None);
+        let mut app = App::new(24, 120, backend, provider, test_db(), None, None);
         app.projects.push(ProjectInfo::new(test_project_config()));
         app.active_project_index = 0;
 
@@ -6789,7 +7791,7 @@ mod tests {
             }],
             ..test_project_config()
         };
-        let mut app = App::new(24, 120, backend, provider, test_db(), None);
+        let mut app = App::new(24, 120, backend, provider, test_db(), None, None);
         app.projects.push(ProjectInfo::new(test_project_config()));
         app.projects.push(ProjectInfo::new(config_with_roles));
         app.active_project_index = 0;
@@ -6808,7 +7810,7 @@ mod tests {
         use crate::session::RolePermissions;
         let backend = stub_backend();
         let provider = stub_provider();
-        let mut app = App::new(24, 120, backend, provider, test_db(), None);
+        let mut app = App::new(24, 120, backend, provider, test_db(), None, None);
         app.projects.push(ProjectInfo::new(test_project_config()));
         app.active_project_index = 0;
 
@@ -6821,7 +7823,7 @@ mod tests {
         use crate::session::RolePermissions;
         let backend = stub_backend();
         let provider = stub_provider();
-        let app = App::new(24, 120, backend, provider, test_db(), None);
+        let app = App::new(24, 120, backend, provider, test_db(), None, None);
 
         let perms = app.resolve_role_permissions_for_project("any-role", 999);
         assert_eq!(perms, RolePermissions::default());
@@ -6843,7 +7845,7 @@ mod tests {
     #[test]
     fn resolve_role_permissions_returns_admin_tools_for_admin_project() {
         let backend = stub_backend();
-        let mut app = App::new(24, 120, backend, stub_provider(), test_db(), None);
+        let mut app = App::new(24, 120, backend, stub_provider(), test_db(), None, None);
         let admin_project = ProjectInfo::new_admin(ProjectConfig {
             name: "Admin".to_string(),
             repos: vec![],

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,10 @@ use crossterm::execute;
 
 use thurbox::agent::claude::ClaudeProvider;
 use thurbox::agent::tmux::LocalTmuxBackend;
-use thurbox::agent::{AgentProvider, BackendRegistry, QemuVmBackend, SessionBackend, VmManager};
+use thurbox::agent::{
+    detect_runtime, AgentProvider, BackendRegistry, ContainerManager, DevcontainerBackend,
+    QemuVmBackend, SessionBackend, VmManager,
+};
 use thurbox::app::{App, AppMessage};
 use thurbox::storage::Database;
 
@@ -59,6 +62,36 @@ async fn main() -> Result<()> {
         tracing::debug!("QEMU VM backend not available (qemu-system-x86_64 not found or /dev/kvm not accessible)");
     }
 
+    // Register container backend if available (optional — requires Docker or Podman).
+    let mut container_manager_for_app = None;
+    match detect_runtime() {
+        Ok(runtime) => {
+            let containerfiles_dir = thurbox::paths::containerfiles_directory()
+                .unwrap_or_else(|| data_dir.join("containerfiles"));
+            let container_manager = Arc::new(std::sync::Mutex::new(ContainerManager::new(
+                &data_dir,
+                containerfiles_dir,
+                runtime,
+            )));
+            let dc_backend: Arc<dyn SessionBackend> = Arc::new(DevcontainerBackend::new(
+                Arc::clone(&container_manager),
+                runtime,
+            ));
+            if dc_backend.check_available().is_ok() {
+                if let Err(e) = dc_backend.ensure_ready() {
+                    tracing::warn!("Container backend available but setup failed: {e}");
+                } else {
+                    tracing::info!("Container backend registered (runtime: {runtime})");
+                    backends.register(dc_backend);
+                    container_manager_for_app = Some(container_manager);
+                }
+            }
+        }
+        Err(_) => {
+            tracing::debug!("Container backend not available (no Docker or Podman found)");
+        }
+    }
+
     // Open SQLite database for persistent state
     let db_path = thurbox::paths::database_file().unwrap_or_else(|| {
         let mut p = std::path::PathBuf::from(std::env::var_os("HOME").unwrap_or_default());
@@ -82,7 +115,11 @@ async fn main() -> Result<()> {
         provider,
         db,
         vm_manager_for_app,
+        container_manager_for_app,
     );
+
+    // Ensure containerfile templates directory exists and is seeded
+    app.ensure_containerfiles_dir();
 
     // Load session state from DB and restore
     if let Some((sessions, counter)) = app.load_persisted_state_from_db() {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -52,6 +52,8 @@ pub enum PathKind {
     Database,
     /// Admin session directory: `~/.local/share/thurbox/admin/`
     AdminDir,
+    /// Containerfile templates: `~/.local/share/thurbox/containerfiles/`
+    ContainerfilesDir,
 }
 
 /// Path resolution strategy (thread-local).
@@ -155,6 +157,24 @@ fn resolve_xdg(kind: PathKind) -> Option<PathBuf> {
                 p
             })
         }
+        PathKind::ContainerfilesDir => {
+            // Prefer $XDG_DATA_HOME, fall back to $HOME/.local/share
+            if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+                let mut p = PathBuf::from(xdg);
+                p.push(app_dir_name());
+                p.push("containerfiles");
+                return Some(p);
+            }
+
+            std::env::var_os("HOME").map(|h| {
+                let mut p = PathBuf::from(h);
+                p.push(".local");
+                p.push("share");
+                p.push(app_dir_name());
+                p.push("containerfiles");
+                p
+            })
+        }
     }
 }
 
@@ -165,6 +185,7 @@ fn resolve_override(base: &Path, kind: PathKind) -> PathBuf {
         PathKind::LogDir => base.to_path_buf(),
         PathKind::Database => base.join("thurbox.db"),
         PathKind::AdminDir => base.join("admin"),
+        PathKind::ContainerfilesDir => base.join("containerfiles"),
     }
 }
 
@@ -194,6 +215,14 @@ pub fn database_file() -> Option<PathBuf> {
 /// Returns: `$XDG_DATA_HOME/thurbox/admin/` or `$HOME/.local/share/thurbox/admin/`
 pub fn admin_directory() -> Option<PathBuf> {
     resolve(PathKind::AdminDir)
+}
+
+/// Resolve the containerfiles template directory path.
+///
+/// Returns: `$XDG_DATA_HOME/thurbox/containerfiles/` or
+/// `$HOME/.local/share/thurbox/containerfiles/`
+pub fn containerfiles_directory() -> Option<PathBuf> {
+    resolve(PathKind::ContainerfilesDir)
 }
 
 /// Resolve the path to the `thurbox-mcp` binary.
@@ -429,6 +458,10 @@ mod tests {
         assert_eq!(resolve(PathKind::LogDir), Some(base.clone()));
         assert_eq!(resolve(PathKind::Database), Some(base.join("thurbox.db")));
         assert_eq!(resolve(PathKind::AdminDir), Some(base.join("admin")));
+        assert_eq!(
+            resolve(PathKind::ContainerfilesDir),
+            Some(base.join("containerfiles"))
+        );
 
         reset_to_xdg();
     }
@@ -473,6 +506,17 @@ mod tests {
 
         let path = admin_directory().unwrap();
         assert!(path.ends_with("admin"));
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn containerfiles_directory_convenience() {
+        let base = PathBuf::from("/custom");
+        set_test_dir(&base);
+
+        let path = containerfiles_directory().unwrap();
+        assert!(path.ends_with("containerfiles"));
 
         reset_to_xdg();
     }
@@ -558,6 +602,10 @@ mod tests {
         assert_eq!(
             resolve_override(base, PathKind::AdminDir),
             PathBuf::from("/data/admin")
+        );
+        assert_eq!(
+            resolve_override(base, PathKind::ContainerfilesDir),
+            PathBuf::from("/data/containerfiles")
         );
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -232,6 +232,8 @@ pub struct SessionInfo {
     pub shell_backend_id: Option<String>,
     /// VM identifier when this session runs inside a sandboxed VM.
     pub vm_id: Option<String>,
+    /// Container identifier when this session runs inside a devcontainer.
+    pub container_id: Option<String>,
     /// Current provisioning step description (shown while status is `Provisioning`).
     pub provisioning_step: Option<String>,
 }
@@ -250,6 +252,7 @@ impl SessionInfo {
             backend_id: None,
             shell_backend_id: None,
             vm_id: None,
+            container_id: None,
             provisioning_step: None,
         }
     }
@@ -277,6 +280,11 @@ pub struct SessionConfig {
     /// When set, the VM backend uses this to spawn the session on the specific VM
     /// rather than picking arbitrarily. Ensures each session is tied to its own VM.
     pub vm_id: Option<String>,
+    /// Target container ID for devcontainer-backed sessions.
+    ///
+    /// When set, the devcontainer backend uses this to spawn the session on the
+    /// specific container. Ensures each session is tied to its own container.
+    pub container_id: Option<String>,
 }
 
 /// VM state machine for sandboxed sessions.
@@ -364,6 +372,95 @@ impl Default for VmConfig {
             memory_mb: 2048,
             disk_gb: 10,
             setup_script: None,
+        }
+    }
+}
+
+/// Container state machine for devcontainer-backed sessions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContainerState {
+    /// Devcontainer image is being built.
+    Building,
+    /// Container is starting up.
+    Starting,
+    /// Container is running and ready for sessions.
+    Ready,
+    /// Container stop has been requested.
+    Stopping,
+    /// Container has been stopped.
+    Stopped,
+    /// Something went wrong.
+    Failed(String),
+}
+
+impl fmt::Display for ContainerState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Building => write!(f, "Building"),
+            Self::Starting => write!(f, "Starting"),
+            Self::Ready => write!(f, "Ready"),
+            Self::Stopping => write!(f, "Stopping"),
+            Self::Stopped => write!(f, "Stopped"),
+            Self::Failed(msg) => write!(f, "Failed: {msg}"),
+        }
+    }
+}
+
+impl ContainerState {
+    /// Parse from database string representation.
+    pub fn from_db_str(s: &str) -> Self {
+        match s {
+            "building" => Self::Building,
+            "starting" => Self::Starting,
+            "ready" => Self::Ready,
+            "stopping" => Self::Stopping,
+            "stopped" => Self::Stopped,
+            other => {
+                if let Some(msg) = other.strip_prefix("failed:") {
+                    Self::Failed(msg.trim().to_string())
+                } else {
+                    Self::Stopped
+                }
+            }
+        }
+    }
+
+    /// Convert to database string representation.
+    pub fn to_db_str(&self) -> String {
+        match self {
+            Self::Building => "building".to_string(),
+            Self::Starting => "starting".to_string(),
+            Self::Ready => "ready".to_string(),
+            Self::Stopping => "stopping".to_string(),
+            Self::Stopped => "stopped".to_string(),
+            Self::Failed(msg) => format!("failed:{msg}"),
+        }
+    }
+}
+
+/// Configuration for a container instance.
+#[derive(Debug, Clone)]
+pub struct ContainerConfig {
+    /// Docker image to use (None = build from Containerfile template).
+    pub image: Option<String>,
+    /// Number of CPUs to allocate.
+    pub cpus: u32,
+    /// RAM in megabytes.
+    pub memory_mb: u32,
+    /// Whether to enable egress firewall rules.
+    pub firewall_enabled: bool,
+    /// Containerfile template name (filename in containerfiles dir).
+    pub containerfile: Option<String>,
+}
+
+impl Default for ContainerConfig {
+    fn default() -> Self {
+        Self {
+            image: None,
+            cpus: 2,
+            memory_mb: 2048,
+            firewall_enabled: true,
+            containerfile: Some("default".to_string()),
         }
     }
 }
@@ -560,6 +657,7 @@ mod tests {
         assert_eq!(config.role, "");
         assert_eq!(config.permissions, RolePermissions::default());
         assert!(config.vm_id.is_none());
+        assert!(config.container_id.is_none());
     }
 
     #[test]

--- a/src/storage/containers.rs
+++ b/src/storage/containers.rs
@@ -1,0 +1,529 @@
+//! Container CRUD operations for the SQLite database.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::params;
+
+use crate::session::{ContainerConfig, ContainerState};
+
+use super::Database;
+
+fn now_epoch() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+/// A container record from the database.
+#[derive(Debug, Clone)]
+pub struct ContainerRecord {
+    pub id: String,
+    pub session_id: Option<String>,
+    pub project_id: Option<String>,
+    pub state: ContainerState,
+    pub docker_container_id: Option<String>,
+    pub image: Option<String>,
+    pub cpus: u32,
+    pub memory_mb: u32,
+    pub firewall_enabled: bool,
+    pub containerfile: Option<String>,
+    pub error_msg: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Per-project container configuration from the database.
+#[derive(Debug, Clone)]
+pub struct ProjectContainerConfigRecord {
+    pub project_id: String,
+    pub image: Option<String>,
+    pub cpus: Option<u32>,
+    pub memory_mb: Option<u32>,
+    pub firewall_enabled: Option<bool>,
+    pub containerfile: Option<String>,
+}
+
+impl Database {
+    /// Insert a new container record.
+    pub fn insert_container(
+        &self,
+        container_id: &str,
+        session_id: Option<&str>,
+        project_id: Option<&str>,
+        state: &ContainerState,
+        config: &ContainerConfig,
+    ) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "INSERT INTO containers (id, session_id, project_id, state, image, cpus, memory_mb, firewall_enabled, containerfile, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            params![
+                container_id,
+                session_id,
+                project_id,
+                state.to_db_str(),
+                config.image,
+                config.cpus,
+                config.memory_mb,
+                config.firewall_enabled as i64,
+                config.containerfile,
+                now,
+                now,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Update container state.
+    pub fn update_container_state(
+        &self,
+        container_id: &str,
+        state: &ContainerState,
+        docker_container_id: Option<&str>,
+        error_msg: Option<&str>,
+    ) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "UPDATE containers SET state = ?1, docker_container_id = ?2, error_msg = ?3, updated_at = ?4 WHERE id = ?5",
+            params![
+                state.to_db_str(),
+                docker_container_id,
+                error_msg,
+                now,
+                container_id,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Get a container record by ID.
+    pub fn get_container(&self, container_id: &str) -> rusqlite::Result<Option<ContainerRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, session_id, project_id, state, docker_container_id, image, cpus, memory_mb, firewall_enabled, containerfile, error_msg, created_at, updated_at
+             FROM containers WHERE id = ?1 AND deleted_at IS NULL",
+        )?;
+
+        let mut rows = stmt.query(params![container_id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row_to_container_record(row)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Get container record by session ID.
+    pub fn get_container_by_session(
+        &self,
+        session_id: &str,
+    ) -> rusqlite::Result<Option<ContainerRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, session_id, project_id, state, docker_container_id, image, cpus, memory_mb, firewall_enabled, containerfile, error_msg, created_at, updated_at
+             FROM containers WHERE session_id = ?1 AND deleted_at IS NULL",
+        )?;
+
+        let mut rows = stmt.query(params![session_id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row_to_container_record(row)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// List all active containers, optionally filtered by project.
+    pub fn list_containers(
+        &self,
+        project_id: Option<&str>,
+    ) -> rusqlite::Result<Vec<ContainerRecord>> {
+        let mut records = Vec::new();
+
+        if let Some(pid) = project_id {
+            let mut stmt = self.conn.prepare(
+                "SELECT id, session_id, project_id, state, docker_container_id, image, cpus, memory_mb, firewall_enabled, containerfile, error_msg, created_at, updated_at
+                 FROM containers WHERE project_id = ?1 AND deleted_at IS NULL
+                 ORDER BY created_at",
+            )?;
+            let mut rows = stmt.query(params![pid])?;
+            while let Some(row) = rows.next()? {
+                records.push(row_to_container_record(row)?);
+            }
+        } else {
+            let mut stmt = self.conn.prepare(
+                "SELECT id, session_id, project_id, state, docker_container_id, image, cpus, memory_mb, firewall_enabled, containerfile, error_msg, created_at, updated_at
+                 FROM containers WHERE deleted_at IS NULL
+                 ORDER BY created_at",
+            )?;
+            let mut rows = stmt.query([])?;
+            while let Some(row) = rows.next()? {
+                records.push(row_to_container_record(row)?);
+            }
+        }
+
+        Ok(records)
+    }
+
+    /// Update the session ID on a container record.
+    pub fn update_container_session(
+        &self,
+        container_id: &str,
+        session_id: &str,
+    ) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "UPDATE containers SET session_id = ?1, updated_at = ?2 WHERE id = ?3",
+            params![session_id, now, container_id],
+        )?;
+        Ok(())
+    }
+
+    /// Soft-delete a container record.
+    pub fn soft_delete_container(&self, container_id: &str) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "UPDATE containers SET deleted_at = ?1, updated_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+            params![now, container_id],
+        )?;
+        Ok(())
+    }
+
+    /// Get project container configuration.
+    pub fn get_project_container_config(
+        &self,
+        project_id: &str,
+    ) -> rusqlite::Result<Option<ProjectContainerConfigRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT project_id, image, cpus, memory_mb, firewall_enabled, containerfile
+             FROM project_container_config WHERE project_id = ?1",
+        )?;
+
+        let mut rows = stmt.query(params![project_id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(ProjectContainerConfigRecord {
+                project_id: row.get(0)?,
+                image: row.get(1)?,
+                cpus: row.get::<_, Option<i64>>(2)?.map(|v| v as u32),
+                memory_mb: row.get::<_, Option<i64>>(3)?.map(|v| v as u32),
+                firewall_enabled: row.get::<_, Option<i64>>(4)?.map(|v| v != 0),
+                containerfile: row.get(5)?,
+            })),
+            None => Ok(None),
+        }
+    }
+
+    /// Set project container configuration (upsert).
+    pub fn set_project_container_config(
+        &self,
+        project_id: &str,
+        config: &ContainerConfig,
+    ) -> rusqlite::Result<()> {
+        let now = now_epoch();
+        self.conn.execute(
+            "INSERT INTO project_container_config (project_id, image, cpus, memory_mb, firewall_enabled, containerfile, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(project_id) DO UPDATE SET
+                image = ?2, cpus = ?3, memory_mb = ?4, firewall_enabled = ?5, containerfile = ?6, updated_at = ?7",
+            params![
+                project_id,
+                config.image,
+                config.cpus,
+                config.memory_mb,
+                config.firewall_enabled as i64,
+                config.containerfile,
+                now,
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+fn row_to_container_record(row: &rusqlite::Row) -> rusqlite::Result<ContainerRecord> {
+    let state_str: String = row.get(3)?;
+    Ok(ContainerRecord {
+        id: row.get(0)?,
+        session_id: row.get(1)?,
+        project_id: row.get(2)?,
+        state: ContainerState::from_db_str(&state_str),
+        docker_container_id: row.get(4)?,
+        image: row.get(5)?,
+        cpus: row.get::<_, i64>(6)? as u32,
+        memory_mb: row.get::<_, i64>(7)? as u32,
+        firewall_enabled: row.get::<_, i64>(8)? != 0,
+        containerfile: row.get(9)?,
+        error_msg: row.get(10)?,
+        created_at: row.get(11)?,
+        updated_at: row.get(12)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    fn test_project(db: &Database) -> String {
+        let id = crate::project::ProjectId::default();
+        db.insert_project(id, "test-project", &[]).unwrap();
+        id.to_string()
+    }
+
+    #[test]
+    fn insert_and_get_container() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = ContainerConfig::default();
+
+        db.insert_container(
+            "c-1",
+            None,
+            Some(&project_id),
+            &ContainerState::Building,
+            &config,
+        )
+        .unwrap();
+
+        let c = db.get_container("c-1").unwrap().unwrap();
+        assert_eq!(c.id, "c-1");
+        assert_eq!(c.state, ContainerState::Building);
+        assert_eq!(c.cpus, 2);
+        assert_eq!(c.memory_mb, 2048);
+        assert!(c.firewall_enabled);
+    }
+
+    #[test]
+    fn get_nonexistent_container() {
+        let db = test_db();
+        let c = db.get_container("nonexistent").unwrap();
+        assert!(c.is_none());
+    }
+
+    #[test]
+    fn update_container_state() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = ContainerConfig::default();
+
+        db.insert_container(
+            "c-1",
+            None,
+            Some(&project_id),
+            &ContainerState::Building,
+            &config,
+        )
+        .unwrap();
+        db.update_container_state("c-1", &ContainerState::Ready, Some("abc123"), None)
+            .unwrap();
+
+        let c = db.get_container("c-1").unwrap().unwrap();
+        assert_eq!(c.state, ContainerState::Ready);
+        assert_eq!(c.docker_container_id, Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn list_containers_all() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = ContainerConfig::default();
+
+        db.insert_container(
+            "c-1",
+            None,
+            Some(&project_id),
+            &ContainerState::Ready,
+            &config,
+        )
+        .unwrap();
+        db.insert_container(
+            "c-2",
+            None,
+            Some(&project_id),
+            &ContainerState::Stopped,
+            &config,
+        )
+        .unwrap();
+
+        let containers = db.list_containers(None).unwrap();
+        assert_eq!(containers.len(), 2);
+    }
+
+    #[test]
+    fn list_containers_by_project() {
+        let db = test_db();
+        let project_a = test_project(&db);
+        let config = ContainerConfig::default();
+
+        // Create a second project
+        let project_b = crate::project::ProjectId::default();
+        db.insert_project(project_b, "other-project", &[]).unwrap();
+        let project_b = project_b.to_string();
+
+        db.insert_container(
+            "c-1",
+            None,
+            Some(&project_a),
+            &ContainerState::Ready,
+            &config,
+        )
+        .unwrap();
+        db.insert_container(
+            "c-2",
+            None,
+            Some(&project_b),
+            &ContainerState::Ready,
+            &config,
+        )
+        .unwrap();
+
+        let a_containers = db.list_containers(Some(&project_a)).unwrap();
+        assert_eq!(a_containers.len(), 1);
+        assert_eq!(a_containers[0].id, "c-1");
+
+        let b_containers = db.list_containers(Some(&project_b)).unwrap();
+        assert_eq!(b_containers.len(), 1);
+        assert_eq!(b_containers[0].id, "c-2");
+    }
+
+    #[test]
+    fn soft_delete_container() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = ContainerConfig::default();
+
+        db.insert_container(
+            "c-1",
+            None,
+            Some(&project_id),
+            &ContainerState::Stopped,
+            &config,
+        )
+        .unwrap();
+        db.soft_delete_container("c-1").unwrap();
+
+        let c = db.get_container("c-1").unwrap();
+        assert!(c.is_none());
+    }
+
+    #[test]
+    fn get_container_by_session() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = ContainerConfig::default();
+
+        let session_id = uuid::Uuid::new_v4().to_string();
+        db.conn
+            .execute(
+                "INSERT INTO sessions (id, name, project_id, created_at, updated_at) VALUES (?1, 'test', ?2, 0, 0)",
+                rusqlite::params![session_id, project_id],
+            )
+            .unwrap();
+
+        db.insert_container(
+            "c-1",
+            Some(&session_id),
+            Some(&project_id),
+            &ContainerState::Ready,
+            &config,
+        )
+        .unwrap();
+
+        let c = db.get_container_by_session(&session_id).unwrap().unwrap();
+        assert_eq!(c.id, "c-1");
+        assert_eq!(c.session_id, Some(session_id));
+    }
+
+    #[test]
+    fn update_container_state_with_error() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = ContainerConfig::default();
+
+        db.insert_container(
+            "c-1",
+            None,
+            Some(&project_id),
+            &ContainerState::Starting,
+            &config,
+        )
+        .unwrap();
+        db.update_container_state(
+            "c-1",
+            &ContainerState::Failed("build error".to_string()),
+            None,
+            Some("build error"),
+        )
+        .unwrap();
+
+        let c = db.get_container("c-1").unwrap().unwrap();
+        assert_eq!(c.state, ContainerState::Failed("build error".to_string()));
+        assert_eq!(c.error_msg, Some("build error".to_string()));
+    }
+
+    #[test]
+    fn project_container_config_crud() {
+        let db = test_db();
+        let project_id = test_project(&db);
+
+        let cfg = db.get_project_container_config(&project_id).unwrap();
+        assert!(cfg.is_none());
+
+        let config = ContainerConfig {
+            image: Some("node:20".to_string()),
+            cpus: 4,
+            memory_mb: 8192,
+            firewall_enabled: false,
+            containerfile: Some("default".to_string()),
+        };
+        db.set_project_container_config(&project_id, &config)
+            .unwrap();
+
+        let cfg = db
+            .get_project_container_config(&project_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cfg.image, Some("node:20".to_string()));
+        assert_eq!(cfg.cpus, Some(4));
+        assert_eq!(cfg.memory_mb, Some(8192));
+        assert_eq!(cfg.firewall_enabled, Some(false));
+
+        // Update (upsert)
+        let config2 = ContainerConfig { cpus: 8, ..config };
+        db.set_project_container_config(&project_id, &config2)
+            .unwrap();
+        let cfg = db
+            .get_project_container_config(&project_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(cfg.cpus, Some(8));
+    }
+
+    #[test]
+    fn update_container_session_links() {
+        let db = test_db();
+        let project_id = test_project(&db);
+        let config = ContainerConfig::default();
+
+        let session_id = uuid::Uuid::new_v4().to_string();
+        db.conn
+            .execute(
+                "INSERT INTO sessions (id, name, project_id, created_at, updated_at) VALUES (?1, 'test', ?2, 0, 0)",
+                rusqlite::params![session_id, project_id],
+            )
+            .unwrap();
+
+        db.insert_container(
+            "c-1",
+            None,
+            Some(&project_id),
+            &ContainerState::Ready,
+            &config,
+        )
+        .unwrap();
+        db.update_container_session("c-1", &session_id).unwrap();
+
+        let c = db.get_container("c-1").unwrap().unwrap();
+        assert_eq!(c.session_id, Some(session_id.clone()));
+
+        let c = db.get_container_by_session(&session_id).unwrap().unwrap();
+        assert_eq!(c.id, "c-1");
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,6 +12,7 @@
 //! ```
 
 pub mod audit;
+pub mod containers;
 mod mcp_servers;
 mod projects;
 mod roles;

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1,7 +1,7 @@
 use rusqlite::Connection;
 
 /// Current schema version. Incremented when schema changes.
-pub const SCHEMA_VERSION: u32 = 9;
+pub const SCHEMA_VERSION: u32 = 11;
 
 /// Create all tables and indexes if they don't exist.
 pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
@@ -146,6 +146,38 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             ON vms(session_id) WHERE deleted_at IS NULL;
         CREATE INDEX IF NOT EXISTS idx_vms_project
             ON vms(project_id) WHERE deleted_at IS NULL;
+
+        CREATE TABLE IF NOT EXISTS containers (
+            id                  TEXT PRIMARY KEY,
+            session_id          TEXT REFERENCES sessions(id),
+            project_id          TEXT REFERENCES projects(id),
+            state               TEXT NOT NULL DEFAULT 'stopped',
+            docker_container_id TEXT,
+            image               TEXT,
+            cpus                INTEGER NOT NULL DEFAULT 2,
+            memory_mb           INTEGER NOT NULL DEFAULT 2048,
+            firewall_enabled    INTEGER NOT NULL DEFAULT 1,
+            containerfile       TEXT,
+            error_msg           TEXT,
+            created_at          INTEGER NOT NULL,
+            updated_at          INTEGER NOT NULL,
+            deleted_at          INTEGER
+        );
+
+        CREATE TABLE IF NOT EXISTS project_container_config (
+            project_id       TEXT PRIMARY KEY REFERENCES projects(id),
+            image            TEXT,
+            cpus             INTEGER,
+            memory_mb        INTEGER,
+            firewall_enabled INTEGER,
+            containerfile    TEXT,
+            updated_at       INTEGER NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_containers_session
+            ON containers(session_id) WHERE deleted_at IS NULL;
+        CREATE INDEX IF NOT EXISTS idx_containers_project
+            ON containers(project_id) WHERE deleted_at IS NULL;
         ",
     )?;
 
@@ -292,6 +324,50 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         );
     }
 
+    if version < 10 {
+        // v9 → v10: add containers and project_container_config tables
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS containers (
+                id                  TEXT PRIMARY KEY,
+                session_id          TEXT REFERENCES sessions(id),
+                project_id          TEXT REFERENCES projects(id),
+                state               TEXT NOT NULL DEFAULT 'stopped',
+                docker_container_id TEXT,
+                image               TEXT,
+                cpus                INTEGER NOT NULL DEFAULT 2,
+                memory_mb           INTEGER NOT NULL DEFAULT 2048,
+                firewall_enabled    INTEGER NOT NULL DEFAULT 1,
+                error_msg           TEXT,
+                created_at          INTEGER NOT NULL,
+                updated_at          INTEGER NOT NULL,
+                deleted_at          INTEGER
+            );
+
+            CREATE TABLE IF NOT EXISTS project_container_config (
+                project_id       TEXT PRIMARY KEY REFERENCES projects(id),
+                image            TEXT,
+                cpus             INTEGER,
+                memory_mb        INTEGER,
+                firewall_enabled INTEGER,
+                updated_at       INTEGER NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_containers_session
+                ON containers(session_id) WHERE deleted_at IS NULL;
+            CREATE INDEX IF NOT EXISTS idx_containers_project
+                ON containers(project_id) WHERE deleted_at IS NULL;",
+        )?;
+    }
+
+    if version < 11 {
+        // v10 → v11: add containerfile column to containers and project_container_config
+        let _ = conn.execute("ALTER TABLE containers ADD COLUMN containerfile TEXT", []);
+        let _ = conn.execute(
+            "ALTER TABLE project_container_config ADD COLUMN containerfile TEXT",
+            [],
+        );
+    }
+
     if version < SCHEMA_VERSION {
         conn.execute(
             "UPDATE metadata SET value = ?1 WHERE key = 'schema_version'",
@@ -328,6 +404,8 @@ mod tests {
         assert!(tables.contains(&"worktrees".to_string()));
         assert!(tables.contains(&"audit_log".to_string()));
         assert!(tables.contains(&"session_commands".to_string()));
+        assert!(tables.contains(&"containers".to_string()));
+        assert!(tables.contains(&"project_container_config".to_string()));
     }
 
     #[test]

--- a/src/ui/containerfile_picker.rs
+++ b/src/ui/containerfile_picker.rs
@@ -9,47 +9,21 @@ use ratatui::{
 use super::centered_fixed_height_rect;
 use super::theme::Theme;
 
-const MODES_BASE: [&str; 2] = ["Normal", "Worktree"];
-const MODE_DEVCONTAINER: &str = "Devcontainer";
-const MODE_SANDBOX_VM: &str = "Sandbox VM";
-
-pub struct SessionModeState {
+pub struct ContainerfilePickerState {
+    pub containerfiles: Vec<String>,
     pub selected_index: usize,
-    /// Whether the "Devcontainer" option should be shown.
-    pub devcontainer_available: bool,
-    /// Whether the "Sandbox VM" option should be shown.
-    pub vm_available: bool,
 }
 
-impl SessionModeState {
-    /// Build the list of visible mode names.
-    pub fn mode_names(&self) -> Vec<&'static str> {
-        let mut modes: Vec<&str> = MODES_BASE.to_vec();
-        if self.devcontainer_available {
-            modes.push(MODE_DEVCONTAINER);
-        }
-        if self.vm_available {
-            modes.push(MODE_SANDBOX_VM);
-        }
-        modes
-    }
-
-    /// Number of visible modes.
-    pub fn mode_count(&self) -> usize {
-        self.mode_names().len()
-    }
-}
-
-pub fn render_session_mode_modal(frame: &mut Frame, state: &SessionModeState) {
-    let mode_count = state.mode_count();
-    // Height = modes + 2 (border) + 1 (footer)
-    let height = mode_count as u16 + 3;
+pub fn render_containerfile_picker(frame: &mut Frame, state: &ContainerfilePickerState) {
+    let item_count = state.containerfiles.len();
+    // Height = items + 2 (border) + 1 (footer)
+    let height = (item_count as u16 + 3).min(frame.area().height.saturating_sub(4));
     let area = centered_fixed_height_rect(50, height, frame.area());
 
     frame.render_widget(Clear, area);
 
     let block = Block::default()
-        .title(" Session Mode ")
+        .title(" Select Containerfile ")
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Theme::ACCENT));
 
@@ -59,17 +33,16 @@ pub fn render_session_mode_modal(frame: &mut Frame, state: &SessionModeState) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(1),    // Mode list
+            Constraint::Min(1),    // Item list
             Constraint::Length(1), // Footer
         ])
         .split(inner);
 
-    let modes = state.mode_names();
-
-    let items: Vec<ListItem<'_>> = modes
+    let items: Vec<ListItem<'_>> = state
+        .containerfiles
         .iter()
         .enumerate()
-        .map(|(i, mode)| {
+        .map(|(i, name)| {
             let style = if i == state.selected_index {
                 Theme::selected_item()
             } else {
@@ -80,7 +53,7 @@ pub fn render_session_mode_modal(frame: &mut Frame, state: &SessionModeState) {
             } else {
                 "  "
             };
-            ListItem::new(Line::from(Span::styled(format!("{prefix}{mode}"), style)))
+            ListItem::new(Line::from(Span::styled(format!("{prefix}{name}"), style)))
         })
         .collect();
 

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -27,6 +27,7 @@ pub struct SessionMetrics {
     pub project_name: String,
     pub worktree_branch: Option<String>,
     pub is_vm: bool,
+    pub is_container: bool,
     pub cpu_percent: f32,
     pub memory_bytes: u64,
 }
@@ -219,6 +220,8 @@ fn render_session_name_line<'a>(sm: &'a SessionMetrics, name_width: usize) -> Li
     }
     if sm.is_vm {
         context.push_str(" VM");
+    } else if sm.is_container {
+        context.push_str(" Container");
     }
     if !context.is_empty() {
         spans.push(Span::styled(
@@ -488,6 +491,7 @@ mod tests {
             project_name: "myproj".into(),
             worktree_branch: None,
             is_vm: false,
+            is_container: false,
             cpu_percent: 42.0,
             memory_bytes: 1_073_741_824, // 1 GB
         }
@@ -512,6 +516,17 @@ mod tests {
         let line = render_session_name_line(&sm, 50);
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("[myproj feat-x VM]"));
+    }
+
+    #[test]
+    fn session_name_line_with_container() {
+        let sm = SessionMetrics {
+            is_container: true,
+            ..sample_metrics()
+        };
+        let line = render_session_name_line(&sm, 50);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("[myproj Container]"));
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 pub mod add_project_modal;
 pub mod branch_selector_modal;
+pub mod containerfile_picker;
 pub mod delete_project_modal;
 pub mod edit_project_modal;
 pub mod info_panel;

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -336,6 +336,12 @@ fn render_session_section(
                 if info.vm_id.is_some() {
                     line2_spans.push(Span::styled(" · ", Style::default().fg(Theme::TEXT_MUTED)));
                     line2_spans.push(Span::styled("VM", Style::default().fg(Theme::ACCENT)));
+                } else if info.container_id.is_some() {
+                    line2_spans.push(Span::styled(" · ", Style::default().fg(Theme::TEXT_MUTED)));
+                    line2_spans.push(Span::styled(
+                        "Container",
+                        Style::default().fg(Theme::ACCENT),
+                    ));
                 }
                 Line::from(line2_spans)
             };

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -35,6 +35,8 @@ pub struct FooterState<'a> {
     pub sync_in_progress: bool,
     pub vm_provisioning: bool,
     pub vm_provisioning_step: &'a str,
+    pub container_provisioning: bool,
+    pub container_provisioning_step: &'a str,
     pub tick_count: u64,
 }
 
@@ -57,6 +59,27 @@ pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
                         "Starting VM..."
                     } else {
                         state.vm_provisioning_step
+                    }
+                ),
+                Style::default().fg(Theme::ACCENT),
+            ),
+        ])
+    } else if state.container_provisioning {
+        let idx = (state.tick_count as usize / 10) % SPINNER_CHARS.len();
+        let spinner = SPINNER_CHARS[idx];
+        Line::from(vec![
+            focus_badge,
+            Span::styled(
+                format!(" {spinner} CONTAINER "),
+                Style::default().fg(Theme::TEXT_PRIMARY).bg(Theme::ACCENT),
+            ),
+            Span::styled(
+                format!(
+                    " {}",
+                    if state.container_provisioning_step.is_empty() {
+                        "Starting container..."
+                    } else {
+                        state.container_provisioning_step
                     }
                 ),
                 Style::default().fg(Theme::ACCENT),


### PR DESCRIPTION
## Summary

- Adds a new `DevcontainerBackend` that runs Claude Code sessions inside isolated Docker/Podman containers (auto-detected, prefers Podman)
- Container lifecycle managed by `ContainerManager`: build from user-editable Containerfile templates, copy repo via `docker cp`, firewall init, tmux control mode over `docker exec`
- Dedicated `thurbox` sandbox user (UID/GID 5000) with full workspace ownership; PATH includes claude install dir
- Containerfile templates stored in `~/.local/share/thurbox/containerfiles/` (default template always kept in sync with built-in)
- Containerfile picker modal in TUI when multiple templates exist
- Stopped containers are automatically restarted on thurbox restart; sessions re-attach to the same container
- SQLite schema v11: `containers` and `project_container_config` tables
- 792 tests passing

## Test plan

- [ ] Create a new session → select "Devcontainer" → container builds and Claude starts inside it
- [ ] Verify `whoami` returns `thurbox` and `claude --version` works inside the container
- [ ] Verify workspace files are owned by `thurbox` and writable
- [ ] Stop the container externally (`podman stop <name>`), restart thurbox → session re-attaches to the same container
- [ ] Quit and restart thurbox → devcontainer session restores
- [ ] Ctrl+D destroys the container
- [ ] Add a second Containerfile template → picker shows both options