### PR TITLE
docs: update all docs for new features (devcontainer, copy-paste, shell pane, URL links)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,13 +149,16 @@ Enforced by cocogitto via pre-commit hooks.
 ## MCP Server
 
 A separate binary (`thurbox-mcp`) exposes Thurbox configuration
-over the Model Context Protocol via stdio transport. It shares
-the same SQLite database as the TUI — changes appear in the TUI
+over the Model Context Protocol. It supports stdio (default) and
+Streamable HTTP (`--transport streamable-http`) transports, and
+shares the same SQLite database as the TUI — changes appear
 automatically via `PRAGMA data_version` polling.
 
 ```bash
 cargo build --bin thurbox-mcp       # Build MCP server
-cargo run --bin thurbox-mcp         # Run (stdin/stdout JSON-RPC)
+cargo run --bin thurbox-mcp         # Run stdio (default)
+thurbox-mcp --transport streamable-http        # HTTP on 127.0.0.1:8080
+thurbox-mcp --transport streamable-http --port 9090  # Custom port
 ```
 
 ### Available Tools
@@ -175,6 +178,9 @@ cargo run --bin thurbox-mcp         # Run (stdin/stdout JSON-RPC)
 | `get_session` | Get a session by UUID |
 | `delete_session` | Soft-delete a session (TUI cleans up tmux/worktree) |
 | `restart_session` | Queue a session restart (TUI processes the command) |
+| `restore_session` | Restore a soft-deleted session |
+| `list_vms` | List active VMs, optionally filtered by project |
+| `get_vm` | Get a VM by UUID |
 
 **Role Management**: `set_roles` performs an atomic replacement —
 all existing roles are deleted and replaced in a single transaction.
@@ -225,14 +231,20 @@ app      ← coordinator, imports all modules
   `ClaudeProvider`). `Session` wraps a `SessionBackend`
   trait. `BackendRegistry` manages multiple backends
   (default: `LocalTmuxBackend` using `tmux -L thurbox`,
+  `DevcontainerBackend` for Docker/Podman containers,
   optional: `QemuVmBackend` for sandboxed VM sessions).
-  `VmManager` handles QEMU/KVM VM lifecycle (create, start,
-  stop, destroy, restore). Reads output into
-  `Arc<Mutex<vt100::Parser>>`, writes input via mpsc channel.
-  `input.rs` translates crossterm `KeyCode` → xterm ANSI bytes.
+  `ContainerManager` handles container lifecycle (build,
+  run, stop, destroy) with auto-detected runtime (Podman
+  preferred, Docker fallback). `VmManager` handles QEMU/KVM
+  VM lifecycle (create, start, stop, destroy, restore).
+  Reads output into `Arc<Mutex<vt100::Parser>>`, writes input
+  via mpsc channel. `input.rs` translates crossterm `KeyCode`
+  → xterm ANSI bytes.
 - **`session/`** — Plain data: `SessionId`, `SessionStatus`,
-  `SessionInfo` (with optional `vm_id`), `SessionConfig`
-  (with optional `cwd` and `vm_id`), `VmState`, `VmConfig`.
+  `SessionInfo` (with optional `vm_id` and `container_id`),
+  `SessionConfig` (with optional `cwd`, `vm_id`, `container_id`),
+  `VmState`, `VmConfig`, `ContainerState`, `ContainerConfig`.
+  `default_developer_role()` provides the seeded developer role.
   No logic beyond Display/Default impls.
 - **`project/`** — Plain data: `ProjectId`,
   `ProjectConfig`, `ProjectInfo`. Imports `session` only.
@@ -240,15 +252,17 @@ app      ← coordinator, imports all modules
   panel areas (responsive: <80 = terminal only, >=80 = 2-panel,
   >=120 = optional 3-panel). Widgets: `project_list` (two-section
   left panel), `terminal_view`, `info_panel`, `status_bar`.
+  `selection.rs` handles mouse-drag text selection,
+  `links.rs` detects and highlights clickable URLs.
 - **`mcp/`** — MCP server (`thurbox-mcp` binary). Exposes
-  project/role/session CRUD over stdio JSON-RPC. Shares the
-  same SQLite database as the TUI.
+  project/role/session/VM CRUD over stdio or Streamable HTTP
+  JSON-RPC. Shares the same SQLite database as the TUI.
 
 ### Event Loop (main.rs)
 
 ```text
 tokio::main → init backends (BackendRegistry: local-tmux
-  + optional qemu-vm) → open SQLite DB
+  + devcontainer + optional qemu-vm) → open SQLite DB
 → init terminal → spawn/restore sessions → loop {
     draw frame → poll crossterm events (10ms)
     → convert to AppMessage → app.update() → app.tick()
@@ -273,7 +287,8 @@ framework). Install with `prek install`. Stages:
 
 - MSRV: 1.75, Edition 2021
 - Async runtime: tokio (multi-threaded)
-- Session backends: `LocalTmuxBackend` (`tmux -L thurbox`)
+- Session backends: `LocalTmuxBackend` (`tmux -L thurbox`),
+  `DevcontainerBackend` (tmux over Docker/Podman exec),
   and optional `QemuVmBackend` (tmux over SSH inside QEMU/KVM VMs)
 - Output reader runs in `tokio::task::spawn_blocking`
   (blocking I/O), writer in `tokio::spawn` (async)
@@ -292,7 +307,9 @@ Global keys use `Ctrl` + semantic Vim conventions:
 |-----|--------|----------|
 | `Ctrl+Q` | Quit (detach sessions) | **Q**uit |
 | `Ctrl+N` | New project/session | **N**ew |
-| `Ctrl+C` | Close active session | **C**lose |
+| `Ctrl+C` | Close session / copy selection | **C**lose / **C**opy |
+| `Ctrl+V` | Paste from clipboard | Paste |
+| `Ctrl+T` | Toggle shell pane | **T**erminal |
 | `Ctrl+H` | Focus project list | Vim: **h** = left |
 | `Ctrl+J` | Next project (project focus) / session | Vim: **j** = down |
 | `Ctrl+K` | Previous project (project focus) / session | Vim: **k** = up |

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ alive in the background. Restart a session with `Ctrl+R` to
 pick up new role permissions while preserving conversation
 history via `--resume`. Each session displays elapsed time
 ("Waiting 45s", "Idle 2m") and highlights clickable URLs in
-terminal output. Recover sessions externally at any time with
-`tmux -L thurbox attach`.
+terminal output. Select text with mouse drag and copy with
+`Ctrl+C`, paste with `Ctrl+V`. Toggle a shell pane alongside
+the Claude session with `Ctrl+T`. Recover sessions externally
+at any time with `tmux -L thurbox attach`.
 
 ### Project Management
 
@@ -47,6 +49,20 @@ on rebase conflicts, Thurbox automatically sends a resolution
 prompt to Claude. Closing the session automatically removes
 the worktree. Worktree sessions show the branch name in the
 terminal title and session list.
+
+### Devcontainer Sessions
+
+Run sessions inside Docker or Podman containers for lightweight
+isolation. Choose "Devcontainer" in the session mode selector —
+Thurbox builds a container image from a Containerfile template,
+runs the container with optional firewall-restricted network
+egress (nftables/iptables allowlist), and spawns the Claude
+session inside it. Templates are stored at
+`~/.local/share/thurbox/containerfiles/` — a `default/` template
+(Debian Bookworm-based) is seeded on first run. Add custom
+templates by creating folders with a `Containerfile` and any
+support files. Containers are auto-detected (Podman preferred,
+Docker fallback) and survive Thurbox restarts.
 
 ### Sandbox VM Sessions
 
@@ -76,9 +92,9 @@ session creation.
 
 ### MCP Server
 
-The `thurbox-mcp` binary exposes 13 tools over the Model Context
-Protocol for managing projects, roles, sessions, and MCP server
-configurations. The Admin session auto-configures `thurbox-mcp`,
+The `thurbox-mcp` binary exposes 16 tools over the Model Context
+Protocol for managing projects, roles, sessions, VMs, and MCP
+server configurations. The Admin session auto-configures `thurbox-mcp`,
 so you can manage everything conversationally — "create a
 reviewer role for my-app with read-only access." See
 [MCP Server](#mcp-server-1) below for the full tool reference.
@@ -136,6 +152,8 @@ The binary will be available at `target/release/thurbox`.
 - **tmux >= 3.2** — session backend
 - **claude CLI** — [github.com/anthropics/claude-code](https://github.com/anthropics/claude-code)
 - **git** — required for worktree features
+- **Docker or Podman** — optional, for devcontainer sessions
+  (Podman preferred, Docker fallback)
 - **QEMU/KVM** — optional, for sandbox VM sessions
   (`qemu-system-x86_64`, `/dev/kvm`, `genisoimage` or `mkisofs`)
 - **Rust 1.75+** — only needed for building from source
@@ -148,7 +166,7 @@ The binary will be available at `target/release/thurbox`.
    focused. Enter a name and one or more repository paths.
 3. **Create a session** — select your project, then press
    `Ctrl+N` again. Choose a session mode (Normal, Worktree,
-   or Sandbox VM) and optionally select a role.
+   Devcontainer, or Sandbox VM) and optionally select a role.
 4. **Work with Claude** — the terminal panel shows the live
    Claude Code session. All keys are forwarded to the PTY.
 5. **Navigate** — `Ctrl+L` cycles focus (project list → session
@@ -171,7 +189,9 @@ The binary will be available at `target/release/thurbox`.
 |-----|--------|----------|
 | `Ctrl+Q` | Quit (detach sessions) | **Q**uit |
 | `Ctrl+N` | New project or session | **N**ew |
-| `Ctrl+C` | Close active session | **C**lose |
+| `Ctrl+C` | Close session / copy selection | **C**lose / **C**opy |
+| `Ctrl+V` | Paste from clipboard | Paste |
+| `Ctrl+T` | Toggle shell pane | **T**erminal |
 | `Ctrl+H` | Focus project list | Vim: **h** = left |
 | `Ctrl+J` | Next project (project list) / session | Vim: **j** = down |
 | `Ctrl+K` | Previous project (project list) / session | Vim: **k** = up |
@@ -193,23 +213,28 @@ The binary will be available at `target/release/thurbox`.
 | `k` / `Up` | Previous item |
 | `Enter` | Select / focus |
 
-### Terminal Scrollback
+### Terminal Scrollback and Selection
 
 | Key | Action |
 |-----|--------|
 | `Shift+Up` / `Shift+Down` | Scroll 1 line |
 | `Shift+PageUp` / `Shift+PageDown` | Scroll half page |
 | Mouse wheel | Scroll 3 lines |
+| Mouse drag | Select text |
 | Any other key | Snap to bottom + forward to PTY |
 
 ## MCP Server
 
 The `thurbox-mcp` binary exposes Thurbox configuration over the
-Model Context Protocol via stdio transport. It shares the same
-SQLite database as the TUI — changes appear immediately.
+Model Context Protocol. It supports stdio (default) and
+Streamable HTTP transports, and shares the same SQLite database
+as the TUI — changes appear immediately.
 
 ```bash
 cargo build --bin thurbox-mcp
+thurbox-mcp                                    # stdio (default)
+thurbox-mcp --transport streamable-http        # HTTP on 127.0.0.1:8080
+thurbox-mcp --transport streamable-http --port 9090  # custom port
 ```
 
 ### Available Tools
@@ -229,6 +254,9 @@ cargo build --bin thurbox-mcp
 | `get_session` | Get a session by UUID |
 | `delete_session` | Soft-delete a session |
 | `restart_session` | Queue a session restart |
+| `restore_session` | Restore a soft-deleted session |
+| `list_vms` | List active VMs, optionally by project |
+| `get_vm` | Get a VM by UUID |
 
 ### Admin Session
 
@@ -248,8 +276,9 @@ Thurbox follows **The Elm Architecture** (TEA):
 `Event → Message → update(model, msg) → view(model) → Frame`.
 All state lives in a single `App` model. Sessions run via a
 pluggable `SessionBackend` trait with a `BackendRegistry` that
-manages multiple backends: local tmux (`tmux -L thurbox`) and
-optional QEMU/KVM VMs (tmux over SSH). Terminal output is parsed
+manages multiple backends: local tmux (`tmux -L thurbox`),
+Docker/Podman containers (tmux over `exec`), and optional
+QEMU/KVM VMs (tmux over SSH). Terminal output is parsed
 by `vt100::Parser` and rendered by `tui_term`. All persistent
 state (projects, sessions, roles, VMs) is stored in SQLite.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -532,3 +532,79 @@ satisfy the FK constraint.
 - *Docker instead of QEMU* — QEMU provides full OS isolation with
   KVM acceleration; Docker shares the host kernel and is less
   suitable for untrusted code sandboxing.
+
+---
+
+## ADR-16: Devcontainer backend (Docker/Podman)
+
+**Choice**: A `DevcontainerBackend` implementation of
+`SessionBackend` runs sessions inside Docker or Podman
+containers. The runtime is auto-detected at startup (Podman
+preferred, Docker fallback). `ContainerManager` handles the
+container lifecycle (build, run, stop, destroy).
+`DockerExecControlMode` tunnels tmux control mode over
+`docker/podman exec`.
+
+**Why**: Containers provide lightweight isolation without
+the overhead of full VMs. Many developers already have Docker
+or Podman installed, lowering the barrier to sandboxed sessions.
+The Containerfile template system lets users customize
+environments per use case (Python, Node, Rust, etc.) while
+the firewall allowlist restricts network egress by default.
+
+**Key components**:
+
+- `detect_runtime()` — probes `podman info` then `docker info`
+  to find an available runtime. Prefers Podman for rootless
+  operation.
+- `ContainerManager` — builds images from Containerfile
+  templates, runs containers with volume-mounted repos, and
+  manages lifecycle. Supports optional nftables/iptables
+  firewall via `init-firewall.sh`.
+- `DockerExecControlMode` — tunnels tmux control mode over
+  `docker/podman exec -i`, providing the same
+  `ControlModeReader`/`ControlModeWriter` abstraction as the
+  SSH-based VM backend.
+- Containerfile templates at
+  `~/.local/share/thurbox/containerfiles/<name>/`. A `default/`
+  template (Debian Bookworm-based) is seeded on first run.
+
+**Container state persistence**: The `containers` table stores
+container records with `session_id REFERENCES sessions(id)` (FK
+constraint), mirroring the VM state persistence pattern.
+
+**Rejected**:
+
+- *Reusing QemuVmBackend for Docker* — Docker and QEMU have
+  fundamentally different interfaces (`exec` vs SSH). A shared
+  backend would require too many conditionals.
+- *Docker-only (no Podman)* — Podman is increasingly popular,
+  especially on Linux where rootless operation avoids privilege
+  escalation. Auto-detection supports both with zero config.
+- *Kubernetes pods* — over-engineering for local development;
+  requires a cluster and adds latency/complexity.
+
+---
+
+## ADR-17: Streamable HTTP transport for MCP server
+
+**Choice**: The `thurbox-mcp` binary supports a second transport
+(`--transport streamable-http`) that serves MCP over HTTP POST
+with optional SSE streaming, powered by axum and the `rmcp`
+crate's `StreamableHttpService`.
+
+**Why**: Stdio transport works for local CLI tool integration
+(e.g., the Admin session's `.mcp.json`), but HTTP enables
+remote MCP clients, web dashboards, and multi-user setups.
+Streamable HTTP is the MCP standard for networked transports.
+
+**Defaults**: `127.0.0.1:8080`, path `/mcp`. Configurable via
+`--host` and `--port` flags.
+
+**Rejected**:
+
+- *WebSocket transport* — not part of the MCP specification.
+  Streamable HTTP with SSE covers the same use cases.
+- *Always-on HTTP (no stdio)* — stdio is simpler for the
+  common case (local Admin session). HTTP is opt-in for
+  advanced deployments.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -122,7 +122,9 @@ for actions (`C`=close, `D`=delete, `N`=new, `R`=restart, `Q`=quit).
 | `Ctrl+Q` | Global | Quit Thurbox | **Q**uit |
 | `Ctrl+N` | Project list | Add new project | **N**ew |
 | `Ctrl+N` | Session list / Terminal | New session (mode selector, then optional branch selector) | **N**ew |
-| `Ctrl+C` | Global | Close active session | **C**lose |
+| `Ctrl+C` | Global | Close active session (or copy selection if text selected) | **C**lose / **C**opy |
+| `Ctrl+V` | Terminal | Paste from clipboard into PTY | Paste |
+| `Ctrl+T` | Global | Toggle shell pane alongside Claude session | **T**erminal |
 | `Ctrl+H` | Global | Focus project list | Vim: **h** = left |
 | `Ctrl+J` | Global | Next project (project list focused) or session | Vim: **j** = down |
 | `Ctrl+K` | Global | Previous project (project list focused) or session | Vim: **k** = up |
@@ -261,7 +263,8 @@ if real demand emerges.
 
 Sessions can optionally run inside git worktrees for branch
 isolation. This is opt-in: after pressing `Ctrl+N`, a session
-mode selector modal asks "Normal" or "Worktree".
+mode selector modal asks "Normal", "Worktree", "Devcontainer",
+or "Sandbox VM".
 
 ### Flow
 
@@ -270,8 +273,9 @@ mode selector modal asks "Normal" or "Worktree".
    using all repos (first as cwd, rest via `--add-dir`).
    No repo selector or session mode modal is shown.
 3. If the project has 1 repo, a session mode modal offers
-   "Normal" (spawn in repo root) or "Worktree" (spawn in
-   an isolated worktree).
+   "Normal" (spawn in repo root), "Worktree" (spawn in
+   an isolated worktree), "Devcontainer" (spawn in a
+   container), or "Sandbox VM" (spawn in a QEMU/KVM VM).
 4. Choosing "Worktree" opens a base branch selector listing
    local branches from the selected repo.
 5. Selecting a base branch opens a prompt for the new branch
@@ -439,9 +443,10 @@ add/edit/delete capabilities; editing a role opens a detail form.
 For programmatic role management via the MCP server, see
 [MCP_ROLES.md](MCP_ROLES.md).
 
-Projects start with no roles. Users add roles explicitly.
-When no roles are defined, sessions spawn with default
-(empty) permissions and no role selector is shown.
+New projects are seeded with a built-in "developer" role
+(`permission_mode: acceptEdits`, no tool restrictions). Users
+can edit, remove, or add roles as needed. When creating a
+session, a role selector appears if the project has roles.
 
 ### Allow / Ask / Deny Semantics
 
@@ -466,7 +471,7 @@ closes the modal.
 
 ### Role Editor View
 
-Edits a single role with four text fields:
+Edits a single role with five text fields:
 
 - **Name** — role identifier (required, unique)
 - **Description** — human-readable summary
@@ -474,6 +479,8 @@ Edits a single role with four text fields:
   (auto-approved)
 - **Disallowed Tools** — space-separated tool names
   (blocked)
+- **Environment Variables** — key=value pairs injected
+  into sessions using this role
 
 Permission mode defaults to `default` and can be
 overridden per-role via the role editor.
@@ -666,11 +673,90 @@ lines instead of blank lines, improving visual structure.
 
 ---
 
+## Devcontainer Sessions
+
+Sessions can run inside Docker or Podman containers for
+lightweight OS-level isolation. This is opt-in: the session
+mode selector modal offers "Devcontainer" alongside "Normal",
+"Worktree", and "Sandbox VM".
+
+### Container runtime
+
+Thurbox auto-detects Docker or Podman, preferring Podman.
+The runtime is detected once at startup via `detect_runtime()`.
+
+### Containerfile templates
+
+User-editable templates live in
+`~/.local/share/thurbox/containerfiles/`. Each template is
+a folder containing a `Containerfile` and any support files
+(e.g., `init-firewall.sh`). The entire folder is used as the
+build context.
+
+```text
+~/.local/share/thurbox/containerfiles/
+  default/
+    Containerfile
+    init-firewall.sh
+  python/
+    Containerfile
+    requirements.txt
+```
+
+A `default/` template (based on `debian:bookworm-slim`) is
+seeded on first run. Users can add more folders for different
+environments and select them via a picker in the TUI.
+
+### Container defaults
+
+| Parameter | Value |
+|-----------|-------|
+| CPUs | 2 |
+| Memory | 2048 MB |
+| Firewall | Enabled (nftables/iptables allowlist) |
+| Containerfile | `default/` template |
+
+### Firewall allowlist
+
+When `firewall_enabled` is true, the container runs
+`init-firewall.sh` which restricts egress to a configurable
+allowlist of domains and CIDRs. The default allowlist includes
+`api.anthropic.com`, `github.com`, `crates.io`, and other
+common development endpoints.
+
+### Container lifecycle
+
+```text
+Building → Starting → Ready → Stopping → Stopped
+                        ↓
+                      Failed
+```
+
+- **Building**: Container image is being built from the
+  Containerfile template.
+- **Starting**: Container launched, waiting for readiness.
+- **Ready**: Container is running, sessions can be spawned.
+- **Stopping/Stopped**: Container is shutting down or destroyed.
+- **Failed**: Container build or start failed.
+
+### Session restoration
+
+Containers survive Thurbox restarts. On restart, Thurbox
+discovers containers from the database, verifies they are
+still running, and re-adopts their tmux sessions.
+
+### Container state persistence
+
+Container records are stored in the `containers` SQLite table
+with a foreign key to `sessions(id)`.
+
+---
+
 ## Sandbox VM Sessions
 
 Sessions can run inside QEMU/KVM virtual machines for full OS-level
 isolation. This is opt-in: the session mode selector modal offers
-"Sandbox VM" alongside "Normal" and "Worktree".
+"Sandbox VM" alongside "Normal", "Worktree", and "Devcontainer".
 
 ### VM specifications
 
@@ -751,6 +837,53 @@ and associated session ID.
 - **Info panel**: Shows VM ID, SSH port, and provisioning status
   for VM-backed sessions.
 - **Status bar**: Provisioning steps displayed during VM creation.
+
+---
+
+## Text Selection and Copy-Paste
+
+Mouse drag selects text in the terminal panel. The selection
+is confined to the active pane bounds.
+
+- **Mouse drag**: Select text (anchor at press, cursor
+  follows drag).
+- **`Ctrl+C`** (with active selection): Copies selected text
+  to the system clipboard via `arboard`. Trailing whitespace
+  is trimmed per line.
+- **`Ctrl+C`** (no selection): Closes the active session
+  (original behavior).
+- **`Ctrl+V`**: Pastes from system clipboard into the active
+  PTY.
+- Any other keypress clears the selection.
+
+Selection is highlighted in the terminal render buffer using
+inverted colors. The clipboard handle is kept alive for the
+app lifetime to avoid Linux-specific "dropped too quickly"
+issues.
+
+---
+
+## Shell Pane Toggle
+
+`Ctrl+T` toggles between the Claude Code session and a shell
+pane (plain bash/zsh) for the active session. The shell runs
+in a separate tmux pane alongside the Claude pane.
+
+- **Status bar**: Shows "Shell" label when viewing the shell
+  pane.
+- **Per-session state**: Each session tracks its own
+  `TerminalView` (Claude or Shell) independently.
+- Input is forwarded to whichever pane is currently active.
+
+---
+
+## Clickable URL Highlighting
+
+URLs (`https://`, `http://`, `file://`) in terminal output
+are detected via regex and highlighted in the terminal render.
+Trailing punctuation (`.`, `,`, `;`, `:`, `)`, `]`) is stripped
+from detected URLs. Character-based column offsets ensure
+correct positioning with multibyte characters.
 
 ---
 


### PR DESCRIPTION
## Summary

- Document **Devcontainer Sessions** (Docker/Podman backend, Containerfile templates, firewall allowlist, container lifecycle)
- Document **text selection and copy-paste** (mouse drag, `Ctrl+C` copy / `Ctrl+V` paste)
- Document **shell pane toggle** (`Ctrl+T`) alongside Claude session
- Document **clickable URL highlighting** in terminal output
- Add `Ctrl+C`/`Ctrl+V`/`Ctrl+T` to all keybinding tables
- Fix role editor: "projects start with no roles" → seeded `developer` role (`acceptEdits`)
- Add `env` field to role editor section in FEATURES.md
- Update MCP tools table: 13 → 16 tools (`restore_session`, `list_vms`, `get_vm`)
- Document `thurbox-mcp` Streamable HTTP transport (`--transport streamable-http`)
- Add **ADR-16** (devcontainer backend) and **ADR-17** (streamable HTTP) to ARCHITECTURE.md
- Update module descriptions in CLAUDE.md (`DevcontainerBackend`, `ContainerState/Config`, `selection.rs`, `links.rs`)

## Test plan

- [ ] Verify all keybinding tables are consistent across README, CLAUDE.md, and FEATURES.md
- [ ] Verify `rumdl check` passes (no markdown lint errors)
- [ ] Review devcontainer section matches actual `src/agent/devcontainer.rs` behavior
- [ ] Review ADR-16/17 rationale accuracy