### PR TITLE
refactor(ui): rename "Sandbox VM" → "VM" and "Devcontainer" → "Container"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ prompt to Claude. Closing the session automatically removes
 the worktree. Worktree sessions show the branch name in the
 terminal title and session list.
 
-### Devcontainer Sessions
+### Container Sessions
 
 Run sessions inside Docker or Podman containers for lightweight
-isolation. Choose "Devcontainer" in the session mode selector —
+isolation. Choose "Container" in the session mode selector —
 Thurbox builds a container image from a Containerfile template,
 runs the container with optional firewall-restricted network
 egress (nftables/iptables allowlist), and spawns the Claude
@@ -64,10 +64,10 @@ templates by creating folders with a `Containerfile` and any
 support files. Containers are auto-detected (Podman preferred,
 Docker fallback) and survive Thurbox restarts.
 
-### Sandbox VM Sessions
+### VM Sessions
 
 Run sessions inside QEMU/KVM virtual machines for full OS-level
-isolation. Choose "Sandbox VM" in the session mode selector —
+isolation. Choose "VM" in the session mode selector —
 Thurbox provisions a Debian 13 (Trixie) VM with 2 CPUs, 2 GB
 RAM, and a 10 GB qcow2 overlay disk, bootstrapped via
 cloud-init with tmux, git, rsync, and the Claude CLI
@@ -166,7 +166,7 @@ The binary will be available at `target/release/thurbox`.
    focused. Enter a name and one or more repository paths.
 3. **Create a session** — select your project, then press
    `Ctrl+N` again. Choose a session mode (Normal, Worktree,
-   Devcontainer, or Sandbox VM) and optionally select a role.
+   Container, or VM) and optionally select a role.
 4. **Work with Claude** — the terminal panel shows the live
    Claude Code session. All keys are forwarded to the PTY.
 5. **Navigate** — `Ctrl+L` cycles focus (project list → session

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -673,12 +673,12 @@ lines instead of blank lines, improving visual structure.
 
 ---
 
-## Devcontainer Sessions
+## Container Sessions
 
 Sessions can run inside Docker or Podman containers for
 lightweight OS-level isolation. This is opt-in: the session
-mode selector modal offers "Devcontainer" alongside "Normal",
-"Worktree", and "Sandbox VM".
+mode selector modal offers "Container" alongside "Normal",
+"Worktree", and "VM".
 
 ### Container runtime
 
@@ -752,11 +752,11 @@ with a foreign key to `sessions(id)`.
 
 ---
 
-## Sandbox VM Sessions
+## VM Sessions
 
 Sessions can run inside QEMU/KVM virtual machines for full OS-level
 isolation. This is opt-in: the session mode selector modal offers
-"Sandbox VM" alongside "Normal", "Worktree", and "Devcontainer".
+"VM" alongside "Normal", "Worktree", and "Container".
 
 ### VM specifications
 
@@ -785,8 +785,8 @@ lives under `~/.local/share/thurbox/vms/<vm-uuid>/`.
 
 1. `Ctrl+N` triggers session creation.
 2. The session mode modal offers "Normal", "Worktree", or
-   "Sandbox VM".
-3. Choosing "Sandbox VM" starts asynchronous VM provisioning:
+   "VM".
+3. Choosing "VM" starts asynchronous VM provisioning:
    - Downloads the Debian 13 base image (once, cached)
    - Creates a qcow2 CoW overlay disk
    - Generates cloud-init ISO (SSH key, user setup, packages)
@@ -833,7 +833,7 @@ and associated session ID.
 
 ### UI indicators
 
-- **Session mode modal**: "Sandbox VM" option with description.
+- **Session mode modal**: "VM" option with description.
 - **Info panel**: Shows VM ID, SSH port, and provisioning status
   for VM-backed sessions.
 - **Status bar**: Provisioning steps displayed during VM creation.

--- a/src/agent/vm.rs
+++ b/src/agent/vm.rs
@@ -149,7 +149,7 @@ impl VmManager {
         }
     }
 
-    /// Check if QEMU and KVM are available (enough to show the "Sandbox VM" option).
+    /// Check if QEMU and KVM are available (enough to show the "VM" option).
     ///
     /// This only checks core requirements. Provisioning tools (genisoimage, ssh-keygen)
     /// are checked later at VM creation time via `check_provisioning_tools`.

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -786,8 +786,8 @@ impl App {
                     "Worktree" => {
                         self.start_branch_selection();
                     }
-                    "Devcontainer" => {
-                        // Devcontainer mode — build config for role selection after
+                    "Container" => {
+                        // Container mode — build config for role selection after
                         // container is ready, store MCP servers for writing into container.
                         let config = if let Some(all_repos) = self.pending_all_repos.clone() {
                             SessionConfig {
@@ -823,8 +823,8 @@ impl App {
                             self.show_containerfile_picker = true;
                         }
                     }
-                    "Sandbox VM" => {
-                        // Sandbox VM mode — build config for role selection after
+                    "VM" => {
+                        // VM mode — build config for role selection after
                         // VM is ready, store MCP servers for writing into the VM.
                         let config = if let Some(all_repos) = self.pending_all_repos.clone() {
                             SessionConfig {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1753,7 +1753,7 @@ impl App {
             match self.backends.get("devcontainer") {
                 Some(b) => (Arc::clone(b), dc_name),
                 None => {
-                    self.set_error("Devcontainer backend disappeared".to_string());
+                    self.set_error("Container backend disappeared".to_string());
                     return;
                 }
             }
@@ -1886,7 +1886,7 @@ impl App {
 
     /// Start asynchronous VM provisioning for a sandbox session.
     ///
-    /// Called when the user selects "Sandbox VM" from the session mode modal.
+    /// Called when the user selects "VM" from the session mode modal.
     /// The VM boots in the background; `handle_vm_ready` spawns the actual session.
     pub(crate) fn start_vm_provisioning(&mut self) {
         if self.vm_provisioning {
@@ -2120,7 +2120,7 @@ impl App {
         }
 
         if self.backends.get("devcontainer").is_none() {
-            self.set_error("Devcontainer backend not available".to_string());
+            self.set_error("Container backend not available".to_string());
             return;
         }
 
@@ -2268,7 +2268,7 @@ impl App {
         let backend = match self.backends.get("devcontainer") {
             Some(b) => Arc::clone(b),
             None => {
-                self.set_error("Devcontainer backend disappeared".to_string());
+                self.set_error("Container backend disappeared".to_string());
                 return;
             }
         };

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -465,7 +465,7 @@ impl ThurboxMcp {
     }
 
     #[tool(
-        description = "Configure default VM settings for a project. These settings apply to new sandbox VM sessions created for the project."
+        description = "Configure default VM settings for a project. These settings apply to new VM sessions created for the project."
     )]
     fn configure_project_vm(
         &self,

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -262,10 +262,7 @@ fn append_detail_sections<'a>(
     // ── VM section (for sandboxed sessions) ──
     if info.vm_id.is_some() {
         lines.push(separator(inner_width));
-        lines.push(Line::from(Span::styled(
-            "Sandbox VM",
-            Theme::section_header(),
-        )));
+        lines.push(Line::from(Span::styled("VM", Theme::section_header())));
 
         if let Some(vm) = vm_details {
             lines.push(Line::from(vec![

--- a/src/ui/session_mode_modal.rs
+++ b/src/ui/session_mode_modal.rs
@@ -10,14 +10,14 @@ use super::centered_fixed_height_rect;
 use super::theme::Theme;
 
 const MODES_BASE: [&str; 2] = ["Normal", "Worktree"];
-const MODE_DEVCONTAINER: &str = "Devcontainer";
-const MODE_SANDBOX_VM: &str = "Sandbox VM";
+const MODE_DEVCONTAINER: &str = "Container";
+const MODE_SANDBOX_VM: &str = "VM";
 
 pub struct SessionModeState {
     pub selected_index: usize,
-    /// Whether the "Devcontainer" option should be shown.
+    /// Whether the "Container" option should be shown.
     pub devcontainer_available: bool,
-    /// Whether the "Sandbox VM" option should be shown.
+    /// Whether the "VM" option should be shown.
     pub vm_available: bool,
 }
 


### PR DESCRIPTION
## Summary

- Shortens session mode modal labels: `"Devcontainer"` → `"Container"`, `"Sandbox VM"` → `"VM"`
- Updates match arms in `key_handlers.rs` to use new label strings
- Updates info panel section header and error messages in `app/mod.rs`
- Updates MCP tool description and doc comments
- Updates `docs/FEATURES.md` and `README.md` user-facing references
- Internal identifiers (`DevcontainerBackend`, backend key `"devcontainer"`) are unchanged

## Test plan

- [x] `cargo check --all` passes
- [x] `cargo nextest run --all` passes (792/792)
- [x] `session_name_line_with_container` test continues to pass