### PR TITLE
feat(mcp): add containerfile, container config, and VM image tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,15 @@ thurbox-mcp --transport streamable-http --port 9090  # Custom port
 | `restore_session` | Restore a soft-deleted session |
 | `list_vms` | List active VMs, optionally filtered by project |
 | `get_vm` | Get a VM by UUID |
+| `list_containerfile_templates` | List template names + files in each |
+| `get_containerfile_template` | Read a template's Containerfile content and list support files |
+| `set_containerfile_template` | Create/update a template (Containerfile + optional support files) |
+| `delete_containerfile_template` | Delete a template (refuses to delete "default") |
+| `configure_project_container` | Set project container defaults (image, cpus, memory, firewall, template) |
+| `get_project_container_config` | Read current project container config |
+| `list_vm_images` | List downloaded VM images with file sizes |
+| `download_vm_image` | Download a VM image from an HTTPS URL |
+| `delete_vm_image` | Delete a cached VM image |
 
 **Role Management**: `set_roles` performs an atomic replacement —
 all existing roles are deleted and replaced in a single transaction.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -71,6 +71,15 @@ const ADMIN_MCP_TOOLS: &[&str] = &[
     "mcp__thurbox__get_session",
     "mcp__thurbox__delete_session",
     "mcp__thurbox__restart_session",
+    "mcp__thurbox__list_containerfile_templates",
+    "mcp__thurbox__get_containerfile_template",
+    "mcp__thurbox__set_containerfile_template",
+    "mcp__thurbox__delete_containerfile_template",
+    "mcp__thurbox__configure_project_container",
+    "mcp__thurbox__get_project_container_config",
+    "mcp__thurbox__list_vm_images",
+    "mcp__thurbox__download_vm_image",
+    "mcp__thurbox__delete_vm_image",
 ];
 
 /// System prompt appended to the admin session to give Claude context about its
@@ -86,14 +95,17 @@ You can:
 - Configure MCP servers for projects
 - List, inspect, delete, and restart sessions
 - Create and manage Containerfile templates for container-based sessions
+- Configure per-project container defaults (image, cpus, memory, firewall, template)
+- List, download, and delete VM images for sandbox sessions
 
 Containerfile templates live in ~/.local/share/thurbox/containerfiles/. Each \
 template is a folder containing a Containerfile and any support files (e.g. \
 init-firewall.sh). The default/ template includes Node.js LTS, tmux, git, \
-iptables, and claude-code. To create a new template, create a new folder \
-(e.g. python/) with a Containerfile inside it. The entire folder is used as \
-the build context. Users select a template when spawning a container session. \
-The containerfiles directory is available in your working directory.
+iptables, and claude-code. Use the containerfile template tools to list, read, \
+create, update, and delete templates — no need to edit files directly.
+
+VM images live in ~/.local/share/thurbox/images/. Use the VM image tools to \
+list cached images, download new ones from HTTPS URLs, or delete old ones.
 
 When the user asks you to manage projects, roles, sessions, or MCP servers, use \
 the appropriate thurbox MCP tool. Always list existing resources before making \
@@ -7832,7 +7844,7 @@ mod tests {
     #[test]
     fn admin_mcp_permissions_contains_all_tools() {
         let perms = super::admin_mcp_permissions();
-        assert_eq!(perms.allowed_tools.len(), 13);
+        assert_eq!(perms.allowed_tools.len(), 22);
         assert!(perms
             .allowed_tools
             .iter()

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -6,7 +6,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::{tool, tool_router};
 
 use crate::project::{ProjectConfig, ProjectId};
-use crate::session::{McpServerConfig, RoleConfig, RolePermissions, SessionId};
+use crate::session::{ContainerConfig, McpServerConfig, RoleConfig, RolePermissions, SessionId};
 use crate::storage::Database;
 use crate::sync::{SharedProject, SharedSession};
 
@@ -14,11 +14,15 @@ use crate::session::VmConfig;
 use crate::storage::vms::VmRecord;
 
 use super::types::{
-    ConfigureProjectVmParams, CreateProjectParams, DeleteProjectParams, DeleteSessionParams,
-    GetProjectParams, GetSessionParams, GetVmParams, ListMcpServersParams, ListRolesParams,
-    ListSessionsParams, ListVmsParams, McpServerResponse, ProjectResponse, ProjectVmConfigResponse,
-    RestartSessionParams, RestoreSessionParams, RoleResponse, SessionResponse, SetMcpServersParams,
-    SetRolesParams, UpdateProjectParams, VmResponse, WorktreeResponse,
+    ConfigureProjectContainerParams, ConfigureProjectVmParams, ContainerfileTemplateResponse,
+    ContainerfileTemplateSummary, CreateProjectParams, DeleteContainerfileTemplateParams,
+    DeleteProjectParams, DeleteSessionParams, DeleteVmImageParams, DownloadVmImageParams,
+    GetContainerfileTemplateParams, GetProjectContainerConfigParams, GetProjectParams,
+    GetSessionParams, GetVmParams, ListMcpServersParams, ListRolesParams, ListSessionsParams,
+    ListVmsParams, McpServerResponse, ProjectContainerConfigResponse, ProjectResponse,
+    ProjectVmConfigResponse, RestartSessionParams, RestoreSessionParams, RoleResponse,
+    SessionResponse, SetContainerfileTemplateParams, SetMcpServersParams, SetRolesParams,
+    UpdateProjectParams, VmImageResponse, VmResponse, WorktreeResponse,
 };
 use super::ThurboxMcp;
 
@@ -136,6 +140,24 @@ fn json_text<T: serde::Serialize>(v: &T) -> String {
 
 fn error_json(msg: &str) -> String {
     serde_json::json!({ "error": msg }).to_string()
+}
+
+/// Validate a name for use as a filesystem directory/file name.
+/// Rejects path traversal, hidden files, and overly long names.
+fn validate_safe_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err(error_json("Name cannot be empty"));
+    }
+    if name.len() > 64 {
+        return Err(error_json("Name too long (max 64 characters)"));
+    }
+    if name.starts_with('.') {
+        return Err(error_json("Name cannot start with '.'"));
+    }
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        return Err(error_json("Name contains invalid characters"));
+    }
+    Ok(())
 }
 
 // ── Tool implementations ────────────────────────────────────────
@@ -534,6 +556,388 @@ impl ThurboxMcp {
             .to_string(),
             Err(e) => error_json(&e.to_string()),
         }
+    }
+
+    // ── Containerfile Template Tools ────────────────────────────
+
+    #[tool(description = "List all Containerfile templates with their files")]
+    fn list_containerfile_templates(&self) -> String {
+        let dir = match crate::paths::containerfiles_directory() {
+            Some(d) => d,
+            None => return error_json("Could not resolve containerfiles directory"),
+        };
+
+        if !dir.exists() {
+            return json_text(&Vec::<ContainerfileTemplateSummary>::new());
+        }
+
+        let mut templates = Vec::new();
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(e) => return error_json(&format!("Failed to read directory: {e}")),
+        };
+
+        for entry in entries.flatten() {
+            if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            let mut files = Vec::new();
+            if let Ok(children) = std::fs::read_dir(entry.path()) {
+                for child in children.flatten() {
+                    if child.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+                        files.push(child.file_name().to_string_lossy().to_string());
+                    }
+                }
+            }
+            files.sort();
+            templates.push(ContainerfileTemplateSummary { name, files });
+        }
+        templates.sort_by(|a, b| a.name.cmp(&b.name));
+        json_text(&templates)
+    }
+
+    #[tool(description = "Get a Containerfile template's content and list its support files")]
+    fn get_containerfile_template(
+        &self,
+        Parameters(params): Parameters<GetContainerfileTemplateParams>,
+    ) -> String {
+        if let Err(e) = validate_safe_name(&params.name) {
+            return e;
+        }
+
+        let dir = match crate::paths::containerfiles_directory() {
+            Some(d) => d,
+            None => return error_json("Could not resolve containerfiles directory"),
+        };
+
+        let template_dir = dir.join(&params.name);
+        if !template_dir.is_dir() {
+            return error_json(&format!("Template not found: {}", params.name));
+        }
+
+        let containerfile_path = template_dir.join("Containerfile");
+        let containerfile_content = match std::fs::read_to_string(&containerfile_path) {
+            Ok(c) => c,
+            Err(_) => {
+                return error_json(&format!("Template '{}' has no Containerfile", params.name))
+            }
+        };
+
+        let mut support_files = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&template_dir) {
+            for entry in entries.flatten() {
+                if entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+                    let fname = entry.file_name().to_string_lossy().to_string();
+                    if fname != "Containerfile" {
+                        support_files.push(fname);
+                    }
+                }
+            }
+        }
+        support_files.sort();
+
+        json_text(&ContainerfileTemplateResponse {
+            name: params.name,
+            containerfile_content,
+            support_files,
+        })
+    }
+
+    #[tool(
+        description = "Create or update a Containerfile template. Writes the Containerfile and optional support files to the template directory."
+    )]
+    fn set_containerfile_template(
+        &self,
+        Parameters(params): Parameters<SetContainerfileTemplateParams>,
+    ) -> String {
+        if let Err(e) = validate_safe_name(&params.name) {
+            return e;
+        }
+
+        let dir = match crate::paths::containerfiles_directory() {
+            Some(d) => d,
+            None => return error_json("Could not resolve containerfiles directory"),
+        };
+
+        let template_dir = dir.join(&params.name);
+        if let Err(e) = std::fs::create_dir_all(&template_dir) {
+            return error_json(&format!("Failed to create template directory: {e}"));
+        }
+
+        if let Err(e) = std::fs::write(
+            template_dir.join("Containerfile"),
+            &params.containerfile_content,
+        ) {
+            return error_json(&format!("Failed to write Containerfile: {e}"));
+        }
+
+        let mut all_files = vec!["Containerfile".to_string()];
+        if let Some(ref files) = params.support_files {
+            for f in files {
+                if let Err(e) = validate_safe_name(&f.filename) {
+                    return e;
+                }
+                if let Err(e) = std::fs::write(template_dir.join(&f.filename), &f.content) {
+                    return error_json(&format!("Failed to write {}: {e}", f.filename));
+                }
+                all_files.push(f.filename.clone());
+            }
+        }
+        all_files.sort();
+
+        json_text(&ContainerfileTemplateSummary {
+            name: params.name,
+            files: all_files,
+        })
+    }
+
+    #[tool(description = "Delete a Containerfile template directory. Refuses to delete 'default'.")]
+    fn delete_containerfile_template(
+        &self,
+        Parameters(params): Parameters<DeleteContainerfileTemplateParams>,
+    ) -> String {
+        if let Err(e) = validate_safe_name(&params.name) {
+            return e;
+        }
+
+        if params.name == "default" {
+            return error_json("Cannot delete the 'default' template");
+        }
+
+        let dir = match crate::paths::containerfiles_directory() {
+            Some(d) => d,
+            None => return error_json("Could not resolve containerfiles directory"),
+        };
+
+        let template_dir = dir.join(&params.name);
+        if !template_dir.is_dir() {
+            return error_json(&format!("Template not found: {}", params.name));
+        }
+
+        if let Err(e) = std::fs::remove_dir_all(&template_dir) {
+            return error_json(&format!("Failed to delete template: {e}"));
+        }
+
+        serde_json::json!({
+            "deleted": true,
+            "name": params.name,
+        })
+        .to_string()
+    }
+
+    // ── Project Container Config Tools ──────────────────────────
+
+    #[tool(
+        description = "Configure default container settings for a project. These settings apply to new container sessions created for the project."
+    )]
+    fn configure_project_container(
+        &self,
+        Parameters(params): Parameters<ConfigureProjectContainerParams>,
+    ) -> String {
+        let db = self.db.lock().unwrap();
+        let (projects, idx) = match require_project(&db, &params.project) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let project = &projects[idx];
+
+        let defaults = ContainerConfig::default();
+        let config = ContainerConfig {
+            image: params.image.or(defaults.image),
+            cpus: params.cpus.unwrap_or(defaults.cpus),
+            memory_mb: params.memory_mb.unwrap_or(defaults.memory_mb),
+            firewall_enabled: params.firewall_enabled.unwrap_or(defaults.firewall_enabled),
+            containerfile: params.containerfile.or(defaults.containerfile),
+        };
+
+        if let Err(e) = db.set_project_container_config(&project.id.to_string(), &config) {
+            return error_json(&e.to_string());
+        }
+
+        match db.get_project_container_config(&project.id.to_string()) {
+            Ok(Some(cfg)) => json_text(&ProjectContainerConfigResponse {
+                project_id: cfg.project_id,
+                image: cfg.image,
+                cpus: cfg.cpus,
+                memory_mb: cfg.memory_mb,
+                firewall_enabled: cfg.firewall_enabled,
+                containerfile: cfg.containerfile,
+            }),
+            Ok(None) => error_json("Config not found after save"),
+            Err(e) => error_json(&e.to_string()),
+        }
+    }
+
+    #[tool(description = "Get the current container configuration for a project")]
+    fn get_project_container_config(
+        &self,
+        Parameters(params): Parameters<GetProjectContainerConfigParams>,
+    ) -> String {
+        let db = self.db.lock().unwrap();
+        let (projects, idx) = match require_project(&db, &params.project) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let project = &projects[idx];
+
+        match db.get_project_container_config(&project.id.to_string()) {
+            Ok(Some(cfg)) => json_text(&ProjectContainerConfigResponse {
+                project_id: cfg.project_id,
+                image: cfg.image,
+                cpus: cfg.cpus,
+                memory_mb: cfg.memory_mb,
+                firewall_enabled: cfg.firewall_enabled,
+                containerfile: cfg.containerfile,
+            }),
+            Ok(None) => json_text(&serde_json::json!({
+                "project_id": project.id.to_string(),
+                "message": "No container config set (using defaults)"
+            })),
+            Err(e) => error_json(&e.to_string()),
+        }
+    }
+
+    // ── VM Image Tools ──────────────────────────────────────────
+
+    #[tool(description = "List downloaded VM images with file sizes")]
+    fn list_vm_images(&self) -> String {
+        let dir = match crate::paths::images_directory() {
+            Some(d) => d,
+            None => return error_json("Could not resolve images directory"),
+        };
+
+        if !dir.exists() {
+            return json_text(&Vec::<VmImageResponse>::new());
+        }
+
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(e) => return error_json(&format!("Failed to read images directory: {e}")),
+        };
+
+        let mut images = Vec::new();
+        for entry in entries.flatten() {
+            if entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+                let filename = entry.file_name().to_string_lossy().to_string();
+                if filename.ends_with(".partial") {
+                    continue;
+                }
+                let size_bytes = entry.metadata().map(|m| m.len()).unwrap_or(0);
+                images.push(VmImageResponse {
+                    filename,
+                    size_bytes,
+                });
+            }
+        }
+        images.sort_by(|a, b| a.filename.cmp(&b.filename));
+        json_text(&images)
+    }
+
+    #[tool(
+        description = "Download a VM image from an HTTPS URL to the images directory. Uses atomic download (writes to .partial file, then renames)."
+    )]
+    fn download_vm_image(&self, Parameters(params): Parameters<DownloadVmImageParams>) -> String {
+        if !params.url.starts_with("https://") {
+            return error_json("Only HTTPS URLs are allowed");
+        }
+
+        let filename = match &params.filename {
+            Some(f) => {
+                if let Err(e) = validate_safe_name(f) {
+                    return e;
+                }
+                f.clone()
+            }
+            None => {
+                // Derive filename from URL path
+                match params.url.rsplit('/').next() {
+                    Some(f) if !f.is_empty() => {
+                        let name = f.split('?').next().unwrap_or(f).to_string();
+                        if let Err(e) = validate_safe_name(&name) {
+                            return e;
+                        }
+                        name
+                    }
+                    _ => {
+                        return error_json(
+                            "Cannot derive filename from URL; provide one explicitly",
+                        )
+                    }
+                }
+            }
+        };
+
+        let dir = match crate::paths::images_directory() {
+            Some(d) => d,
+            None => return error_json("Could not resolve images directory"),
+        };
+
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            return error_json(&format!("Failed to create images directory: {e}"));
+        }
+
+        let partial_path = dir.join(format!("{filename}.partial"));
+        let final_path = dir.join(&filename);
+
+        let result = std::process::Command::new("curl")
+            .args([
+                "-fSL",
+                "--output",
+                &partial_path.to_string_lossy(),
+                &params.url,
+            ])
+            .output();
+
+        match result {
+            Ok(output) if output.status.success() => {
+                if let Err(e) = std::fs::rename(&partial_path, &final_path) {
+                    let _ = std::fs::remove_file(&partial_path);
+                    return error_json(&format!("Failed to finalize download: {e}"));
+                }
+                let size = std::fs::metadata(&final_path).map(|m| m.len()).unwrap_or(0);
+                json_text(&VmImageResponse {
+                    filename,
+                    size_bytes: size,
+                })
+            }
+            Ok(output) => {
+                let _ = std::fs::remove_file(&partial_path);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                error_json(&format!("Download failed: {stderr}"))
+            }
+            Err(e) => {
+                let _ = std::fs::remove_file(&partial_path);
+                error_json(&format!("Failed to run curl: {e}"))
+            }
+        }
+    }
+
+    #[tool(description = "Delete a cached VM image")]
+    fn delete_vm_image(&self, Parameters(params): Parameters<DeleteVmImageParams>) -> String {
+        if let Err(e) = validate_safe_name(&params.filename) {
+            return e;
+        }
+
+        let dir = match crate::paths::images_directory() {
+            Some(d) => d,
+            None => return error_json("Could not resolve images directory"),
+        };
+
+        let path = dir.join(&params.filename);
+        if !path.is_file() {
+            return error_json(&format!("Image not found: {}", params.filename));
+        }
+
+        if let Err(e) = std::fs::remove_file(&path) {
+            return error_json(&format!("Failed to delete image: {e}"));
+        }
+
+        serde_json::json!({
+            "deleted": true,
+            "filename": params.filename,
+        })
+        .to_string()
     }
 }
 
@@ -1508,5 +1912,425 @@ mod tests {
         }));
         let v = parse_json(&result);
         assert!(v["error"].as_str().unwrap().contains("Project not found"));
+    }
+
+    // ── validate_safe_name tests ───────────────────────────────
+
+    #[test]
+    fn validate_safe_name_rejects_empty() {
+        assert!(validate_safe_name("").is_err());
+    }
+
+    #[test]
+    fn validate_safe_name_rejects_long_name() {
+        let long = "a".repeat(65);
+        assert!(validate_safe_name(&long).is_err());
+    }
+
+    #[test]
+    fn validate_safe_name_accepts_max_length() {
+        let max = "a".repeat(64);
+        assert!(validate_safe_name(&max).is_ok());
+    }
+
+    #[test]
+    fn validate_safe_name_rejects_dot_prefix() {
+        assert!(validate_safe_name(".hidden").is_err());
+    }
+
+    #[test]
+    fn validate_safe_name_rejects_path_traversal() {
+        assert!(validate_safe_name("../etc").is_err());
+        assert!(validate_safe_name("foo/bar").is_err());
+        assert!(validate_safe_name("foo\\bar").is_err());
+        assert!(validate_safe_name("foo..bar").is_err());
+    }
+
+    #[test]
+    fn validate_safe_name_accepts_valid_names() {
+        assert!(validate_safe_name("default").is_ok());
+        assert!(validate_safe_name("my-template").is_ok());
+        assert!(validate_safe_name("python_3.12").is_ok());
+    }
+
+    // ── Containerfile template tool tests ──────────────────────
+
+    #[test]
+    fn list_containerfile_templates_empty() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let result = server.list_containerfile_templates();
+        let v = parse_json(&result);
+        assert_eq!(v, serde_json::json!([]));
+    }
+
+    #[test]
+    fn list_containerfile_templates_with_templates() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let cf_dir = temp.path().join("containerfiles");
+        std::fs::create_dir_all(cf_dir.join("default")).unwrap();
+        std::fs::write(cf_dir.join("default/Containerfile"), "FROM ubuntu").unwrap();
+        std::fs::write(cf_dir.join("default/init.sh"), "#!/bin/sh").unwrap();
+
+        let result = server.list_containerfile_templates();
+        let v = parse_json(&result);
+        assert_eq!(v[0]["name"], "default");
+        assert!(v[0]["files"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("Containerfile")));
+        assert!(v[0]["files"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("init.sh")));
+    }
+
+    #[test]
+    fn get_containerfile_template_existing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let cf_dir = temp.path().join("containerfiles").join("python");
+        std::fs::create_dir_all(&cf_dir).unwrap();
+        std::fs::write(cf_dir.join("Containerfile"), "FROM python:3.12").unwrap();
+        std::fs::write(cf_dir.join("setup.sh"), "pip install stuff").unwrap();
+
+        let result = server.get_containerfile_template(Parameters(
+            super::super::types::GetContainerfileTemplateParams {
+                name: "python".to_string(),
+            },
+        ));
+        let v = parse_json(&result);
+        assert_eq!(v["name"], "python");
+        assert_eq!(v["containerfile_content"], "FROM python:3.12");
+        assert!(v["support_files"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("setup.sh")));
+    }
+
+    #[test]
+    fn get_containerfile_template_not_found() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let result = server.get_containerfile_template(Parameters(
+            super::super::types::GetContainerfileTemplateParams {
+                name: "nonexistent".to_string(),
+            },
+        ));
+        let v = parse_json(&result);
+        assert!(v["error"].as_str().unwrap().contains("Template not found"));
+    }
+
+    #[test]
+    fn get_containerfile_template_invalid_name() {
+        let server = test_server();
+        let result = server.get_containerfile_template(Parameters(
+            super::super::types::GetContainerfileTemplateParams {
+                name: "../escape".to_string(),
+            },
+        ));
+        let v = parse_json(&result);
+        assert!(v["error"].is_string());
+    }
+
+    #[test]
+    fn set_containerfile_template_creates_new() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let result = server.set_containerfile_template(Parameters(
+            super::super::types::SetContainerfileTemplateParams {
+                name: "rust".to_string(),
+                containerfile_content: "FROM rust:latest".to_string(),
+                support_files: Some(vec![super::super::types::SupportFileInput {
+                    filename: "build.sh".to_string(),
+                    content: "cargo build".to_string(),
+                }]),
+            },
+        ));
+        let v = parse_json(&result);
+        assert_eq!(v["name"], "rust");
+        assert!(v["files"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("Containerfile")));
+        assert!(v["files"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("build.sh")));
+
+        // Verify files on disk
+        let cf_dir = temp.path().join("containerfiles").join("rust");
+        assert!(cf_dir.join("Containerfile").exists());
+        assert_eq!(
+            std::fs::read_to_string(cf_dir.join("Containerfile")).unwrap(),
+            "FROM rust:latest"
+        );
+        assert_eq!(
+            std::fs::read_to_string(cf_dir.join("build.sh")).unwrap(),
+            "cargo build"
+        );
+    }
+
+    #[test]
+    fn delete_containerfile_template_refuses_default() {
+        let server = test_server();
+        let result = server.delete_containerfile_template(Parameters(
+            super::super::types::DeleteContainerfileTemplateParams {
+                name: "default".to_string(),
+            },
+        ));
+        let v = parse_json(&result);
+        assert!(v["error"]
+            .as_str()
+            .unwrap()
+            .contains("Cannot delete the 'default' template"));
+    }
+
+    #[test]
+    fn delete_containerfile_template_not_found() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let result = server.delete_containerfile_template(Parameters(
+            super::super::types::DeleteContainerfileTemplateParams {
+                name: "ghost".to_string(),
+            },
+        ));
+        let v = parse_json(&result);
+        assert!(v["error"].as_str().unwrap().contains("Template not found"));
+    }
+
+    #[test]
+    fn delete_containerfile_template_success() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let cf_dir = temp.path().join("containerfiles").join("custom");
+        std::fs::create_dir_all(&cf_dir).unwrap();
+        std::fs::write(cf_dir.join("Containerfile"), "FROM ubuntu").unwrap();
+
+        let result = server.delete_containerfile_template(Parameters(
+            super::super::types::DeleteContainerfileTemplateParams {
+                name: "custom".to_string(),
+            },
+        ));
+        let v = parse_json(&result);
+        assert_eq!(v["deleted"], true);
+        assert_eq!(v["name"], "custom");
+        assert!(!cf_dir.exists());
+    }
+
+    // ── Project container config tool tests ────────────────────
+
+    #[test]
+    fn configure_project_container_happy_path() {
+        let server = test_server();
+        server.create_project(Parameters(CreateProjectParams {
+            name: "myapp".to_string(),
+            repos: vec![],
+        }));
+
+        let result = server.configure_project_container(Parameters(
+            super::super::types::ConfigureProjectContainerParams {
+                project: "myapp".to_string(),
+                image: Some("ubuntu:24.04".to_string()),
+                cpus: Some(4),
+                memory_mb: None,
+                firewall_enabled: Some(false),
+                containerfile: None,
+            },
+        ));
+        let v = parse_json(&result);
+        assert!(v["project_id"].is_string());
+        assert_eq!(v["image"], "ubuntu:24.04");
+        assert_eq!(v["cpus"], 4);
+        assert_eq!(v["firewall_enabled"], false);
+    }
+
+    #[test]
+    fn configure_project_container_nonexistent_project() {
+        let server = test_server();
+        let result = server.configure_project_container(Parameters(
+            super::super::types::ConfigureProjectContainerParams {
+                project: "ghost".to_string(),
+                image: None,
+                cpus: None,
+                memory_mb: None,
+                firewall_enabled: None,
+                containerfile: None,
+            },
+        ));
+        let v = parse_json(&result);
+        assert!(v["error"].as_str().unwrap().contains("Project not found"));
+    }
+
+    #[test]
+    fn get_project_container_config_no_config() {
+        let server = test_server();
+        server.create_project(Parameters(CreateProjectParams {
+            name: "myapp".to_string(),
+            repos: vec![],
+        }));
+
+        let result = server.get_project_container_config(Parameters(
+            super::super::types::GetProjectContainerConfigParams {
+                project: "myapp".to_string(),
+            },
+        ));
+        let v = parse_json(&result);
+        assert!(v["message"].as_str().unwrap().contains("using defaults"));
+    }
+
+    #[test]
+    fn get_project_container_config_with_config() {
+        let server = test_server();
+        server.create_project(Parameters(CreateProjectParams {
+            name: "myapp".to_string(),
+            repos: vec![],
+        }));
+        server.configure_project_container(Parameters(
+            super::super::types::ConfigureProjectContainerParams {
+                project: "myapp".to_string(),
+                image: Some("node:20".to_string()),
+                cpus: Some(2),
+                memory_mb: Some(4096),
+                firewall_enabled: Some(true),
+                containerfile: Some("default".to_string()),
+            },
+        ));
+
+        let result = server.get_project_container_config(Parameters(
+            super::super::types::GetProjectContainerConfigParams {
+                project: "myapp".to_string(),
+            },
+        ));
+        let v = parse_json(&result);
+        assert_eq!(v["image"], "node:20");
+        assert_eq!(v["cpus"], 2);
+        assert_eq!(v["memory_mb"], 4096);
+        assert_eq!(v["firewall_enabled"], true);
+        assert_eq!(v["containerfile"], "default");
+    }
+
+    // ── VM image tool tests ────────────────────────────────────
+
+    #[test]
+    fn list_vm_images_empty() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let result = server.list_vm_images();
+        let v = parse_json(&result);
+        assert_eq!(v, serde_json::json!([]));
+    }
+
+    #[test]
+    fn list_vm_images_skips_partial() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let img_dir = temp.path().join("images");
+        std::fs::create_dir_all(&img_dir).unwrap();
+        std::fs::write(img_dir.join("debian.qcow2"), "image data").unwrap();
+        std::fs::write(img_dir.join("ubuntu.qcow2.partial"), "downloading").unwrap();
+
+        let result = server.list_vm_images();
+        let v = parse_json(&result);
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["filename"], "debian.qcow2");
+        assert!(arr[0]["size_bytes"].as_u64().unwrap() > 0);
+    }
+
+    #[test]
+    fn delete_vm_image_not_found() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let result = server.delete_vm_image(Parameters(super::super::types::DeleteVmImageParams {
+            filename: "ghost.qcow2".to_string(),
+        }));
+        let v = parse_json(&result);
+        assert!(v["error"].as_str().unwrap().contains("Image not found"));
+    }
+
+    #[test]
+    fn delete_vm_image_invalid_name() {
+        let server = test_server();
+        let result = server.delete_vm_image(Parameters(super::super::types::DeleteVmImageParams {
+            filename: "../etc/passwd".to_string(),
+        }));
+        let v = parse_json(&result);
+        assert!(v["error"].is_string());
+    }
+
+    #[test]
+    fn delete_vm_image_success() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let server = test_server();
+
+        let img_dir = temp.path().join("images");
+        std::fs::create_dir_all(&img_dir).unwrap();
+        std::fs::write(img_dir.join("old.qcow2"), "data").unwrap();
+
+        let result = server.delete_vm_image(Parameters(super::super::types::DeleteVmImageParams {
+            filename: "old.qcow2".to_string(),
+        }));
+        let v = parse_json(&result);
+        assert_eq!(v["deleted"], true);
+        assert!(!img_dir.join("old.qcow2").exists());
+    }
+
+    #[test]
+    fn download_vm_image_rejects_non_https() {
+        let server = test_server();
+        let result =
+            server.download_vm_image(Parameters(super::super::types::DownloadVmImageParams {
+                url: "http://example.com/image.qcow2".to_string(),
+                filename: None,
+            }));
+        let v = parse_json(&result);
+        assert!(v["error"].as_str().unwrap().contains("HTTPS"));
+    }
+
+    #[test]
+    fn download_vm_image_rejects_file_url() {
+        let server = test_server();
+        let result =
+            server.download_vm_image(Parameters(super::super::types::DownloadVmImageParams {
+                url: "file:///etc/passwd".to_string(),
+                filename: None,
+            }));
+        let v = parse_json(&result);
+        assert!(v["error"].as_str().unwrap().contains("HTTPS"));
+    }
+
+    #[test]
+    fn download_vm_image_rejects_unsafe_filename() {
+        let server = test_server();
+        let result =
+            server.download_vm_image(Parameters(super::super::types::DownloadVmImageParams {
+                url: "https://example.com/image.qcow2".to_string(),
+                filename: Some("../escape.qcow2".to_string()),
+            }));
+        let v = parse_json(&result);
+        assert!(v["error"].is_string());
     }
 }

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -186,6 +186,79 @@ pub struct ConfigureProjectVmParams {
     pub setup_script: Option<String>,
 }
 
+// ── Containerfile Template Parameters ───────────────────────────
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetContainerfileTemplateParams {
+    #[schemars(description = "Template name (directory name under containerfiles/)")]
+    pub name: String,
+}
+
+/// A support file to include alongside the Containerfile in a template.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SupportFileInput {
+    #[schemars(description = "Filename (e.g. \"init-firewall.sh\")")]
+    pub filename: String,
+    #[schemars(description = "File content (text)")]
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SetContainerfileTemplateParams {
+    #[schemars(description = "Template name (creates or updates the directory)")]
+    pub name: String,
+    #[schemars(description = "Content of the Containerfile")]
+    pub containerfile_content: String,
+    #[schemars(description = "Optional support files to include in the template directory")]
+    pub support_files: Option<Vec<SupportFileInput>>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DeleteContainerfileTemplateParams {
+    #[schemars(description = "Template name to delete")]
+    pub name: String,
+}
+
+// ── Project Container Config Parameters ────────────────────────
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ConfigureProjectContainerParams {
+    #[schemars(description = "Project name or UUID")]
+    pub project: String,
+    #[schemars(description = "Docker image to use (None = build from Containerfile)")]
+    pub image: Option<String>,
+    #[schemars(description = "Number of CPUs (default: 2)")]
+    pub cpus: Option<u32>,
+    #[schemars(description = "RAM in megabytes (default: 2048)")]
+    pub memory_mb: Option<u32>,
+    #[schemars(description = "Enable egress firewall (default: true)")]
+    pub firewall_enabled: Option<bool>,
+    #[schemars(description = "Containerfile template name")]
+    pub containerfile: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetProjectContainerConfigParams {
+    #[schemars(description = "Project name or UUID")]
+    pub project: String,
+}
+
+// ── VM Image Parameters ────────────────────────────────────────
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DownloadVmImageParams {
+    #[schemars(description = "HTTPS URL to download the VM image from")]
+    pub url: String,
+    #[schemars(description = "Filename to save as (default: derived from URL)")]
+    pub filename: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DeleteVmImageParams {
+    #[schemars(description = "Filename of the image to delete")]
+    pub filename: String,
+}
+
 // ── Response Types ──────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -278,4 +351,39 @@ pub struct ProjectVmConfigResponse {
     pub disk_gb: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_script: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ContainerfileTemplateResponse {
+    pub name: String,
+    pub containerfile_content: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub support_files: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ContainerfileTemplateSummary {
+    pub name: String,
+    pub files: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProjectContainerConfigResponse {
+    pub project_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpus: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_mb: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub firewall_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub containerfile: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VmImageResponse {
+    pub filename: String,
+    pub size_bytes: u64,
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -54,6 +54,8 @@ pub enum PathKind {
     AdminDir,
     /// Containerfile templates: `~/.local/share/thurbox/containerfiles/`
     ContainerfilesDir,
+    /// VM images: `~/.local/share/thurbox/images/`
+    ImagesDir,
 }
 
 /// Path resolution strategy (thread-local).
@@ -175,6 +177,24 @@ fn resolve_xdg(kind: PathKind) -> Option<PathBuf> {
                 p
             })
         }
+        PathKind::ImagesDir => {
+            // Prefer $XDG_DATA_HOME, fall back to $HOME/.local/share
+            if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+                let mut p = PathBuf::from(xdg);
+                p.push(app_dir_name());
+                p.push("images");
+                return Some(p);
+            }
+
+            std::env::var_os("HOME").map(|h| {
+                let mut p = PathBuf::from(h);
+                p.push(".local");
+                p.push("share");
+                p.push(app_dir_name());
+                p.push("images");
+                p
+            })
+        }
     }
 }
 
@@ -186,6 +206,7 @@ fn resolve_override(base: &Path, kind: PathKind) -> PathBuf {
         PathKind::Database => base.join("thurbox.db"),
         PathKind::AdminDir => base.join("admin"),
         PathKind::ContainerfilesDir => base.join("containerfiles"),
+        PathKind::ImagesDir => base.join("images"),
     }
 }
 
@@ -223,6 +244,13 @@ pub fn admin_directory() -> Option<PathBuf> {
 /// `$HOME/.local/share/thurbox/containerfiles/`
 pub fn containerfiles_directory() -> Option<PathBuf> {
     resolve(PathKind::ContainerfilesDir)
+}
+
+/// Resolve the VM images directory path.
+///
+/// Returns: `$XDG_DATA_HOME/thurbox/images/` or `$HOME/.local/share/thurbox/images/`
+pub fn images_directory() -> Option<PathBuf> {
+    resolve(PathKind::ImagesDir)
 }
 
 /// Resolve the path to the `thurbox-mcp` binary.
@@ -462,6 +490,7 @@ mod tests {
             resolve(PathKind::ContainerfilesDir),
             Some(base.join("containerfiles"))
         );
+        assert_eq!(resolve(PathKind::ImagesDir), Some(base.join("images")));
 
         reset_to_xdg();
     }
@@ -517,6 +546,17 @@ mod tests {
 
         let path = containerfiles_directory().unwrap();
         assert!(path.ends_with("containerfiles"));
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn images_directory_convenience() {
+        let base = PathBuf::from("/custom");
+        set_test_dir(&base);
+
+        let path = images_directory().unwrap();
+        assert!(path.ends_with("images"));
 
         reset_to_xdg();
     }
@@ -606,6 +646,10 @@ mod tests {
         assert_eq!(
             resolve_override(base, PathKind::ContainerfilesDir),
             PathBuf::from("/data/containerfiles")
+        );
+        assert_eq!(
+            resolve_override(base, PathKind::ImagesDir),
+            PathBuf::from("/data/images")
         );
     }
 


### PR DESCRIPTION
## Summary

- Add 4 Containerfile template tools (`list/get/set/delete_containerfile_template`) — filesystem-based, manage `~/.local/share/thurbox/containerfiles/` without manual editing
- Add 2 project container config tools (`configure_project_container`, `get_project_container_config`) — database-backed, mirrors the existing `configure_project_vm` pattern
- Add 3 VM image tools (`list_vm_images`, `download_vm_image`, `delete_vm_image`) — filesystem-based with HTTPS-only atomic download and `PathKind::ImagesDir` added to `paths.rs`
- All 9 tools pre-allowed in `ADMIN_MCP_TOOLS`; admin system prompt updated to describe new capabilities
- `validate_safe_name()` helper rejects path traversal, hidden files, and names > 64 chars

## Test plan

- [x] 27 new unit tests covering all tools and `validate_safe_name` (820 tests total, all passing)
- [x] `cargo clippy` clean
- [x] Architecture rules pass (mcp only imports allowed modules)
- [x] All pre-commit hooks pass (fmt, clippy, check, nextest, arch, deny, doc, rumdl)