### PR TITLE
fix(core): preserve worktrees, containers, and VMs on soft delete

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1131,14 +1131,12 @@ impl App {
         infos
     }
 
-    /// Finalize a pending delete — kill backend and remove worktrees.
+    /// Finalize a pending delete — kill the backend session.
+    ///
+    /// Worktrees, containers, and VMs are intentionally preserved on disk
+    /// so that restored sessions (Ctrl+U) can reuse them without re-cloning.
     fn finalize_pending_delete(&mut self) {
         if let Some(pending) = self.pending_delete.take() {
-            for wt in &pending.session.info.worktrees {
-                if let Err(e) = git::remove_worktree(&wt.repo_path, &wt.worktree_path) {
-                    error!("Failed to remove worktree: {e}");
-                }
-            }
             pending.session.kill();
         }
     }


### PR DESCRIPTION
## Summary

- Remove the worktree removal loop from `finalize_pending_delete()` so that git worktrees, containers, and VMs are preserved on disk when a session is deleted
- Restored sessions (Ctrl+U) can now reuse existing worktrees directly via `add_existing_worktree()`, which already returns early if the directory exists
- Containers and VMs were already preserved (kill() only kills the tmux pane); worktrees are now consistent with that behaviour

## Test plan

- [ ] Delete a session with a git worktree — verify worktree directory remains on disk after the 10-second undo window expires
- [ ] Restore the deleted session (Ctrl+U) — verify it reattaches to the existing worktree without re-cloning
- [ ] Ctrl+Z undo within the window still works as before
- [ ] `cargo nextest run --all` passes (835 tests)