### PR TITLE
feat(ui): add agent monitoring to info panel

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -117,14 +117,61 @@ not just new ones.";
 /// Parse the PSS value (in bytes) from the contents of `smaps_rollup`.
 ///
 /// Looks for a line like `Pss:             12345 kB` and returns the value in bytes.
-fn parse_pss_from_smaps(content: &str) -> Option<u64> {
-    for line in content.lines() {
-        if let Some(rest) = line.strip_prefix("Pss:") {
-            let kib: u64 = rest.trim().strip_suffix("kB")?.trim().parse().ok()?;
-            return Some(kib * 1024);
-        }
+/// Parse agent metrics from a Claude CLI statusline JSON value.
+fn parse_agent_metrics(raw: &serde_json::Value) -> crate::session::AgentMetrics {
+    use crate::session::AgentMetrics;
+    AgentMetrics {
+        model_id: raw
+            .pointer("/model/id")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        model_display_name: raw
+            .pointer("/model/display_name")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        total_cost_usd: raw.pointer("/cost/total_cost_usd").and_then(|v| v.as_f64()),
+        total_duration_ms: raw
+            .pointer("/cost/total_duration_ms")
+            .and_then(|v| v.as_u64()),
+        total_api_duration_ms: raw
+            .pointer("/cost/total_api_duration_ms")
+            .and_then(|v| v.as_u64()),
+        total_lines_added: raw
+            .pointer("/cost/total_lines_added")
+            .and_then(|v| v.as_u64()),
+        total_lines_removed: raw
+            .pointer("/cost/total_lines_removed")
+            .and_then(|v| v.as_u64()),
+        total_input_tokens: raw
+            .pointer("/cost/total_input_tokens")
+            .and_then(|v| v.as_u64()),
+        total_output_tokens: raw
+            .pointer("/cost/total_output_tokens")
+            .and_then(|v| v.as_u64()),
+        context_window_size: raw
+            .pointer("/context_window/total_tokens")
+            .and_then(|v| v.as_u64()),
+        used_percentage: raw
+            .pointer("/context_window/used_percentage")
+            .and_then(|v| v.as_u64())
+            .map(|v| v.min(100) as u8),
+        current_input_tokens: raw
+            .pointer("/context_window/current_usage/input_tokens")
+            .and_then(|v| v.as_u64()),
+        current_output_tokens: raw
+            .pointer("/context_window/current_usage/output_tokens")
+            .and_then(|v| v.as_u64()),
+        cache_creation_input_tokens: raw
+            .pointer("/context_window/current_usage/cache_creation_input_tokens")
+            .and_then(|v| v.as_u64()),
+        cache_read_input_tokens: raw
+            .pointer("/context_window/current_usage/cache_read_input_tokens")
+            .and_then(|v| v.as_u64()),
+        cli_version: raw
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(String::from),
     }
-    None
 }
 
 /// Build `RolePermissions` with all admin MCP tools pre-allowed.
@@ -496,8 +543,6 @@ pub struct App {
     pending_container_mcp_servers: Option<Vec<crate::session::McpServerConfig>>,
     /// Background container/VM restoration tasks polled by `tick()`.
     pending_restores: Vec<PendingRestore>,
-    /// Reusable buffer for parent→children process map (avoids per-tick allocation).
-    children_map_buf: HashMap<sysinfo::Pid, Vec<sysinfo::Pid>>,
     /// Reusable buffer for session elapsed-ms in the view (avoids per-frame allocation).
     pub(crate) session_elapsed_buf: Vec<u64>,
 }
@@ -739,7 +784,6 @@ impl App {
                 cpu_percent: 0.0,
                 memory_used: 0,
                 memory_total: 0,
-                per_session: Vec::new(),
             },
             deferred_inputs: Vec::new(),
             session_terminal_views: HashMap::new(),
@@ -769,7 +813,6 @@ impl App {
             pending_container_id: None,
             pending_container_mcp_servers: None,
             pending_restores: Vec::new(),
-            children_map_buf: HashMap::new(),
             session_elapsed_buf: Vec::new(),
         }
     }
@@ -869,6 +912,93 @@ impl App {
 
         self.write_mcp_json(&admin_dir);
         self.ensure_admin_project(&admin_dir);
+    }
+
+    /// Set up the statusline script and `~/.claude/settings.json` for agent metrics.
+    ///
+    /// Creates a shell script that the Claude CLI pipes statusline JSON into,
+    /// which writes metrics to per-session files. Also configures the Claude CLI
+    /// global settings to use this script as the statusline handler.
+    pub fn ensure_statusline_setup(&self) {
+        let Some(data_dir) = crate::paths::log_directory() else {
+            return;
+        };
+        let Some(metrics_dir) = crate::paths::metrics_directory() else {
+            return;
+        };
+
+        // Ensure metrics directory exists.
+        if let Err(e) = std::fs::create_dir_all(&metrics_dir) {
+            tracing::warn!("Failed to create metrics directory: {e}");
+            return;
+        }
+
+        // Write statusline shell script.
+        let script_path = data_dir.join("statusline.sh");
+        let script = format!(
+            "#!/bin/sh\n\
+             METRICS_DIR=\"${{THURBOX_METRICS_DIR:-{}}}\"\n\
+             mkdir -p \"$METRICS_DIR\"\n\
+             if [ -n \"$THURBOX_SESSION_ID\" ]; then\n\
+             \tcat > \"$METRICS_DIR/$THURBOX_SESSION_ID.json\"\n\
+             fi\n",
+            metrics_dir.display()
+        );
+        if let Err(e) = std::fs::write(&script_path, &script) {
+            tracing::warn!("Failed to write statusline script: {e}");
+            return;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755));
+        }
+
+        // Configure ~/.claude/settings.json with the statusline command.
+        let home = match std::env::var_os("HOME") {
+            Some(h) => std::path::PathBuf::from(h),
+            None => return,
+        };
+        let settings_path = home.join(".claude").join("settings.json");
+        if let Err(e) = std::fs::create_dir_all(settings_path.parent().unwrap()) {
+            tracing::warn!("Failed to create ~/.claude directory: {e}");
+            return;
+        }
+
+        let mut settings: serde_json::Value = std::fs::read_to_string(&settings_path)
+            .ok()
+            .and_then(|c| serde_json::from_str(&c).ok())
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        // Only write statusLine if not already configured by the user.
+        if settings.get("statusLine").is_none() {
+            settings["statusLine"] = serde_json::json!({
+                "type": "command",
+                "command": script_path.display().to_string()
+            });
+            if let Err(e) = std::fs::write(
+                &settings_path,
+                serde_json::to_string_pretty(&settings).unwrap(),
+            ) {
+                tracing::warn!("Failed to write ~/.claude/settings.json: {e}");
+            }
+        }
+
+        // Clean up stale metrics files (sessions that no longer exist).
+        if let Ok(entries) = std::fs::read_dir(&metrics_dir) {
+            let active_sids: std::collections::HashSet<String> = self
+                .sessions
+                .iter()
+                .filter_map(|s| s.info.agent_session_id.clone())
+                .collect();
+            for entry in entries.flatten() {
+                if let Some(stem) = entry.path().file_stem().and_then(|s| s.to_str()) {
+                    if !active_sids.contains(stem) {
+                        let _ = std::fs::remove_file(entry.path());
+                    }
+                }
+            }
+        }
     }
 
     /// Write `.mcp.json` into the admin directory.
@@ -1137,6 +1267,12 @@ impl App {
     /// so that restored sessions (Ctrl+U) can reuse them without re-cloning.
     fn finalize_pending_delete(&mut self) {
         if let Some(pending) = self.pending_delete.take() {
+            // Clean up agent metrics file.
+            if let Some(ref sid) = pending.session.info.agent_session_id {
+                if let Some(metrics_dir) = crate::paths::metrics_directory() {
+                    let _ = std::fs::remove_file(metrics_dir.join(format!("{sid}.json")));
+                }
+            }
             pending.session.kill();
         }
     }
@@ -1661,6 +1797,20 @@ impl App {
             config.agent_session_id = Some(uuid::Uuid::new_v4().to_string());
         }
 
+        // Inject statusline env vars so the metrics script knows which session this is.
+        if let Some(ref sid) = config.agent_session_id {
+            config
+                .permissions
+                .env
+                .insert("THURBOX_SESSION_ID".into(), sid.clone());
+        }
+        if let Some(metrics_dir) = crate::paths::metrics_directory() {
+            config.permissions.env.insert(
+                "THURBOX_METRICS_DIR".into(),
+                metrics_dir.to_string_lossy().into(),
+            );
+        }
+
         // When a VM was just provisioned, use the VM backend and take the
         // placeholder's name instead of generating a new one.
         let vm_id = self.pending_vm_id.take();
@@ -2007,6 +2157,12 @@ impl App {
         // Close all sessions belonging to this project
         for session_id in session_ids_to_close {
             if let Some(session_pos) = self.sessions.iter().position(|s| s.info.id == session_id) {
+                // Clean up agent metrics file.
+                if let Some(ref sid) = self.sessions[session_pos].info.agent_session_id {
+                    if let Some(metrics_dir) = crate::paths::metrics_directory() {
+                        let _ = std::fs::remove_file(metrics_dir.join(format!("{sid}.json")));
+                    }
+                }
                 self.sessions[session_pos].kill();
                 self.sessions.remove(session_pos);
             }
@@ -2149,135 +2305,34 @@ impl App {
         }
     }
 
-    /// Collect CPU/RAM metrics from sysinfo and per-session process trees.
-    /// Includes ALL sessions across ALL projects.
+    /// Collect CPU/RAM metrics from sysinfo and poll agent metrics files.
     fn refresh_system_metrics(&mut self) {
-        use sysinfo::ProcessesToUpdate;
-
         self.sys.refresh_cpu_all();
         self.sys.refresh_memory();
-        self.sys.refresh_processes(ProcessesToUpdate::All, true);
 
         let cpu_percent = self.sys.global_cpu_usage();
         let memory_used = self.sys.used_memory();
         let memory_total = self.sys.total_memory();
 
-        // Build parent→children map once for all session tree walks
-        Self::build_children_map(&self.sys, &mut self.children_map_buf);
-
-        // Build session_id → project_name lookup
-        let mut session_project: HashMap<SessionId, String> = HashMap::new();
-        for project in &self.projects {
-            for sid in &project.session_ids {
-                session_project.insert(*sid, project.config.name.clone());
-            }
-        }
-
-        let mut per_session = Vec::new();
-
-        for session in &self.sessions {
-            // VM sessions: use the QEMU host PID.
-            // Container sessions: use the container init PID on the host.
-            // Local sessions: use the tmux pane PID.
-            let root_pid = self
-                .db
-                .get_vm_by_session(&session.info.id.to_string())
-                .ok()
-                .flatten()
-                .and_then(|vm| vm.qemu_pid)
-                .or_else(|| {
-                    // For container sessions, look up the container's host init PID.
-                    if let Some(ref cid) = session.info.container_id {
-                        if let Some(ref mgr) = self.container_manager {
-                            if let Ok(mgr) = mgr.lock() {
-                                return mgr.container_host_pid(cid);
-                            }
-                        }
-                    }
-                    None
-                })
-                .or_else(|| session.pane_pid().ok().flatten());
-
-            if let Some(pid) = root_pid {
-                let root = sysinfo::Pid::from_u32(pid);
-                let (cpu, mem) = Self::sum_process_tree(&self.sys, root, &self.children_map_buf);
-                let project_name = session_project
-                    .get(&session.info.id)
-                    .cloned()
-                    .unwrap_or_default();
-                let worktree_branch = session.info.worktrees.first().map(|wt| wt.branch.clone());
-                let is_vm = session.info.vm_id.is_some();
-                let is_container = session.info.container_id.is_some();
-                per_session.push(info_panel::SessionMetrics {
-                    name: session.info.name.clone(),
-                    project_name,
-                    worktree_branch,
-                    is_vm,
-                    is_container,
-                    cpu_percent: cpu,
-                    memory_bytes: mem,
-                });
-            }
-        }
-
         self.system_metrics = info_panel::SystemMetrics {
             cpu_percent,
             memory_used,
             memory_total,
-            per_session,
         };
-    }
 
-    /// Build a parent→children index from the process table into a reusable buffer.
-    fn build_children_map(
-        sys: &sysinfo::System,
-        buf: &mut HashMap<sysinfo::Pid, Vec<sysinfo::Pid>>,
-    ) {
-        buf.clear();
-        for (pid, proc_) in sys.processes() {
-            if let Some(parent) = proc_.parent() {
-                buf.entry(parent).or_default().push(*pid);
-            }
-        }
-    }
-
-    /// Read PSS (Proportional Set Size) from `/proc/{pid}/smaps_rollup`.
-    ///
-    /// PSS divides shared pages proportionally among all processes mapping them,
-    /// avoiding the double-counting that RSS causes when summing across a process tree.
-    fn read_pss(pid: sysinfo::Pid) -> Option<u64> {
-        let path = format!("/proc/{}/smaps_rollup", pid.as_u32());
-        let content = std::fs::read_to_string(path).ok()?;
-        parse_pss_from_smaps(&content)
-    }
-
-    /// Sum CPU% and memory for a process and all its descendants.
-    ///
-    /// Threads are skipped entirely: on Linux, `/proc/{tid}/stat` returns the
-    /// **aggregate** CPU time for the whole process (not per-thread), and
-    /// RSS/PSS is identical across all threads sharing an address space.
-    /// Counting threads would multiply both CPU and memory by the thread count.
-    fn sum_process_tree(
-        sys: &sysinfo::System,
-        root: sysinfo::Pid,
-        children_map: &HashMap<sysinfo::Pid, Vec<sysinfo::Pid>>,
-    ) -> (f32, u64) {
-        let mut cpu = 0.0f32;
-        let mut mem = 0u64;
-        let mut stack = vec![root];
-        while let Some(pid) = stack.pop() {
-            if let Some(proc_) = sys.process(pid) {
-                if proc_.thread_kind().is_some() {
-                    continue;
+        // Poll agent metrics files written by the statusline script.
+        if let Some(metrics_dir) = crate::paths::metrics_directory() {
+            for session in &mut self.sessions {
+                if let Some(ref agent_sid) = session.info.agent_session_id {
+                    let path = metrics_dir.join(format!("{agent_sid}.json"));
+                    if let Ok(content) = std::fs::read_to_string(&path) {
+                        if let Ok(raw) = serde_json::from_str::<serde_json::Value>(&content) {
+                            session.info.agent_metrics = Some(parse_agent_metrics(&raw));
+                        }
+                    }
                 }
-                cpu += proc_.cpu_usage();
-                mem += Self::read_pss(pid).unwrap_or_else(|| proc_.memory());
-            }
-            if let Some(kids) = children_map.get(&pid) {
-                stack.extend(kids);
             }
         }
-        (cpu, mem)
     }
 
     /// Send deferred inputs whose scheduled tick has arrived.
@@ -7145,49 +7200,68 @@ mod tests {
         assert_eq!(super::view::format_time_ago(now + 10_000), "0s ago");
     }
 
-    // --- PSS parsing tests ---
+    // --- parse_agent_metrics tests ---
 
     #[test]
-    fn parse_pss_from_smaps_typical() {
-        let content = "\
-00400000-7fff0000 ---p 00000000 00:00 0                          [rollup]
-Rss:               48000 kB
-Pss:               12345 kB
-Pss_Anon:           8000 kB
-Pss_File:           4345 kB
-Pss_Shmem:             0 kB
-";
-        assert_eq!(super::parse_pss_from_smaps(content), Some(12_345 * 1024));
+    fn parse_agent_metrics_full_json() {
+        let json = serde_json::json!({
+            "version": "1.0.80",
+            "model": { "id": "claude-opus-4-6", "display_name": "Opus" },
+            "cost": {
+                "total_cost_usd": 0.0123,
+                "total_duration_ms": 5000,
+                "total_api_duration_ms": 3000,
+                "total_lines_added": 156,
+                "total_lines_removed": 23,
+                "total_input_tokens": 15200,
+                "total_output_tokens": 4500,
+            },
+            "context_window": {
+                "total_tokens": 200000,
+                "used_percentage": 8,
+                "current_usage": {
+                    "input_tokens": 1200,
+                    "output_tokens": 300,
+                    "cache_creation_input_tokens": 5000,
+                    "cache_read_input_tokens": 2000,
+                }
+            }
+        });
+        let m = super::parse_agent_metrics(&json);
+        assert_eq!(m.model_id.as_deref(), Some("claude-opus-4-6"));
+        assert_eq!(m.model_display_name.as_deref(), Some("Opus"));
+        assert!((m.total_cost_usd.unwrap() - 0.0123).abs() < 1e-6);
+        assert_eq!(m.total_input_tokens, Some(15200));
+        assert_eq!(m.total_output_tokens, Some(4500));
+        assert_eq!(m.context_window_size, Some(200000));
+        assert_eq!(m.used_percentage, Some(8));
+        assert_eq!(m.total_lines_added, Some(156));
+        assert_eq!(m.total_lines_removed, Some(23));
+        assert_eq!(m.cache_read_input_tokens, Some(2000));
+        assert_eq!(m.cache_creation_input_tokens, Some(5000));
+        assert_eq!(m.cli_version.as_deref(), Some("1.0.80"));
     }
 
     #[test]
-    fn parse_pss_from_smaps_missing() {
-        let content = "\
-Rss:               48000 kB
-Shared_Clean:       1000 kB
-";
-        assert_eq!(super::parse_pss_from_smaps(content), None);
+    fn parse_agent_metrics_empty_json() {
+        let json = serde_json::json!({});
+        let m = super::parse_agent_metrics(&json);
+        assert!(m.model_id.is_none());
+        assert!(m.total_cost_usd.is_none());
+        assert!(m.used_percentage.is_none());
     }
 
     #[test]
-    fn parse_pss_from_smaps_empty() {
-        assert_eq!(super::parse_pss_from_smaps(""), None);
-    }
-
-    #[test]
-    fn parse_pss_from_smaps_zero() {
-        let content = "Pss:                   0 kB\n";
-        assert_eq!(super::parse_pss_from_smaps(content), Some(0));
-    }
-
-    #[test]
-    fn parse_pss_from_smaps_ignores_pss_anon() {
-        // Pss_Anon starts with "Pss" but not "Pss:" — must not match.
-        let content = "\
-Pss_Anon:           8000 kB
-Pss_File:           4345 kB
-";
-        assert_eq!(super::parse_pss_from_smaps(content), None);
+    fn parse_agent_metrics_partial_json() {
+        let json = serde_json::json!({
+            "model": { "display_name": "Sonnet" },
+            "cost": { "total_cost_usd": 0.05 }
+        });
+        let m = super::parse_agent_metrics(&json);
+        assert_eq!(m.model_display_name.as_deref(), Some("Sonnet"));
+        assert!(m.model_id.is_none());
+        assert!((m.total_cost_usd.unwrap() - 0.05).abs() < 1e-6);
+        assert!(m.total_input_tokens.is_none());
     }
 
     // --- find_matching_discovered tests ---

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -136,8 +136,6 @@ impl App {
 
         // Info panel
         if let Some(info_area) = areas.info_panel {
-            let active_project = self.projects.get(self.active_project_index);
-
             // Determine the session info to display: real session or VM placeholder.
             let info_session: Option<&SessionInfo> = self
                 .sessions
@@ -164,7 +162,6 @@ impl App {
                     frame,
                     info_area,
                     info,
-                    active_project,
                     vm_details.as_ref(),
                     Some(&self.system_metrics),
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,9 @@ async fn main() -> Result<()> {
     // Ensure admin project exists and .mcp.json is up to date
     app.ensure_admin_setup();
 
+    // Set up statusline script and Claude CLI settings for agent metrics
+    app.ensure_statusline_setup();
+
     let res = run_loop(&mut terminal, &mut app).await;
 
     app.shutdown();

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -56,6 +56,8 @@ pub enum PathKind {
     ContainerfilesDir,
     /// VM images: `~/.local/share/thurbox/admin/images/`
     ImagesDir,
+    /// Agent metrics files: `~/.local/share/thurbox/metrics/`
+    MetricsDir,
 }
 
 /// Path resolution strategy (thread-local).
@@ -199,6 +201,24 @@ fn resolve_xdg(kind: PathKind) -> Option<PathBuf> {
                 p
             })
         }
+        PathKind::MetricsDir => {
+            // Prefer $XDG_DATA_HOME, fall back to $HOME/.local/share
+            if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+                let mut p = PathBuf::from(xdg);
+                p.push(app_dir_name());
+                p.push("metrics");
+                return Some(p);
+            }
+
+            std::env::var_os("HOME").map(|h| {
+                let mut p = PathBuf::from(h);
+                p.push(".local");
+                p.push("share");
+                p.push(app_dir_name());
+                p.push("metrics");
+                p
+            })
+        }
     }
 }
 
@@ -211,6 +231,7 @@ fn resolve_override(base: &Path, kind: PathKind) -> PathBuf {
         PathKind::AdminDir => base.join("admin"),
         PathKind::ContainerfilesDir => base.join("admin").join("containerfiles"),
         PathKind::ImagesDir => base.join("admin").join("images"),
+        PathKind::MetricsDir => base.join("metrics"),
     }
 }
 
@@ -256,6 +277,13 @@ pub fn containerfiles_directory() -> Option<PathBuf> {
 /// `$HOME/.local/share/thurbox/admin/images/`
 pub fn images_directory() -> Option<PathBuf> {
     resolve(PathKind::ImagesDir)
+}
+
+/// Resolve the agent metrics directory path.
+///
+/// Returns: `$XDG_DATA_HOME/thurbox/metrics/` or `$HOME/.local/share/thurbox/metrics/`
+pub fn metrics_directory() -> Option<PathBuf> {
+    resolve(PathKind::MetricsDir)
 }
 
 /// Resolve the path to the `thurbox-mcp` binary.
@@ -499,6 +527,7 @@ mod tests {
             resolve(PathKind::ImagesDir),
             Some(base.join("admin").join("images"))
         );
+        assert_eq!(resolve(PathKind::MetricsDir), Some(base.join("metrics")));
 
         reset_to_xdg();
     }
@@ -659,6 +688,21 @@ mod tests {
             resolve_override(base, PathKind::ImagesDir),
             PathBuf::from("/data/admin/images")
         );
+        assert_eq!(
+            resolve_override(base, PathKind::MetricsDir),
+            PathBuf::from("/data/metrics")
+        );
+    }
+
+    #[test]
+    fn metrics_directory_convenience() {
+        let base = PathBuf::from("/custom");
+        set_test_dir(&base);
+
+        let path = metrics_directory().unwrap();
+        assert!(path.ends_with("metrics"));
+
+        reset_to_xdg();
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -219,6 +219,27 @@ impl fmt::Display for SessionStatus {
     }
 }
 
+/// Agent metrics collected from the Claude CLI statusline mechanism.
+#[derive(Debug, Clone, Default)]
+pub struct AgentMetrics {
+    pub model_id: Option<String>,
+    pub model_display_name: Option<String>,
+    pub total_cost_usd: Option<f64>,
+    pub total_duration_ms: Option<u64>,
+    pub total_api_duration_ms: Option<u64>,
+    pub total_lines_added: Option<u64>,
+    pub total_lines_removed: Option<u64>,
+    pub total_input_tokens: Option<u64>,
+    pub total_output_tokens: Option<u64>,
+    pub context_window_size: Option<u64>,
+    pub used_percentage: Option<u8>,
+    pub current_input_tokens: Option<u64>,
+    pub current_output_tokens: Option<u64>,
+    pub cache_creation_input_tokens: Option<u64>,
+    pub cache_read_input_tokens: Option<u64>,
+    pub cli_version: Option<String>,
+}
+
 pub struct SessionInfo {
     pub id: SessionId,
     pub name: String,
@@ -236,6 +257,8 @@ pub struct SessionInfo {
     pub container_id: Option<String>,
     /// Current provisioning step description (shown while status is `Provisioning`).
     pub provisioning_step: Option<String>,
+    /// Agent metrics from Claude CLI statusline.
+    pub agent_metrics: Option<AgentMetrics>,
 }
 
 impl SessionInfo {
@@ -254,6 +277,7 @@ impl SessionInfo {
             vm_id: None,
             container_id: None,
             provisioning_step: None,
+            agent_metrics: None,
         }
     }
 }

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -6,11 +6,8 @@ use ratatui::{
     Frame,
 };
 
-use std::path::Path;
-
 use super::theme::Theme;
-use crate::project::ProjectInfo;
-use crate::session::{RoleConfig, SessionInfo, SessionStatus};
+use crate::session::{AgentMetrics, SessionInfo, SessionStatus};
 
 /// Rich VM details for the info panel, sourced from the database VM record.
 pub struct VmDetails {
@@ -21,18 +18,7 @@ pub struct VmDetails {
     pub base_image: String,
 }
 
-/// Per-session CPU/memory metrics with context.
-pub struct SessionMetrics {
-    pub name: String,
-    pub project_name: String,
-    pub worktree_branch: Option<String>,
-    pub is_vm: bool,
-    pub is_container: bool,
-    pub cpu_percent: f32,
-    pub memory_bytes: u64,
-}
-
-/// System-wide and per-session resource metrics.
+/// System-wide resource metrics.
 pub struct SystemMetrics {
     /// Overall CPU usage 0-100.
     pub cpu_percent: f32,
@@ -40,15 +26,12 @@ pub struct SystemMetrics {
     pub memory_used: u64,
     /// Total RAM in bytes.
     pub memory_total: u64,
-    /// Per-session resource usage (all projects).
-    pub per_session: Vec<SessionMetrics>,
 }
 
 pub fn render_info_panel(
     frame: &mut Frame,
     area: Rect,
     info: &SessionInfo,
-    project: Option<&ProjectInfo>,
     vm_details: Option<&VmDetails>,
     metrics: Option<&SystemMetrics>,
 ) {
@@ -58,7 +41,6 @@ pub fn render_info_panel(
         .border_style(Style::default().fg(Theme::BORDER_UNFOCUSED));
 
     let inner_width = area.width.saturating_sub(2) as usize;
-    let inner_height = area.height.saturating_sub(2) as usize;
 
     let mut lines = Vec::new();
 
@@ -86,52 +68,9 @@ pub fn render_info_panel(
         ),
     ]));
 
-    // ── Project section ──
-    if let Some(proj) = project {
-        lines.push(separator(inner_width));
-
-        lines.push(Line::from(vec![
-            Span::styled("Project: ", Theme::label()),
-            Span::styled(
-                &proj.config.name,
-                Style::default()
-                    .fg(Theme::ACCENT)
-                    .add_modifier(Modifier::BOLD),
-            ),
-        ]));
-
-        if proj.config.repos.len() == 1 {
-            lines.push(Line::from(vec![
-                Span::styled("Repo: ", Theme::label()),
-                Span::styled(
-                    short_path(&proj.config.repos[0]),
-                    Style::default().fg(Theme::TEXT_MUTED),
-                ),
-            ]));
-        } else {
-            lines.push(Line::from(Span::styled("Repos:", Theme::label())));
-            for repo in &proj.config.repos {
-                lines.push(Line::from(Span::styled(
-                    format!("  {}", short_path(repo)),
-                    Style::default().fg(Theme::TEXT_MUTED),
-                )));
-            }
-        }
-
-        let roles_text = if proj.config.roles.is_empty() {
-            "(none)".to_string()
-        } else {
-            proj.config
-                .roles
-                .iter()
-                .map(|r| r.name.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
-        };
-        lines.push(Line::from(vec![
-            Span::styled("Roles: ", Theme::label()),
-            Span::styled(roles_text, Style::default().fg(Theme::TEXT_PRIMARY)),
-        ]));
+    // ── Agent section (Claude CLI metrics) ──
+    if let Some(ref metrics) = info.agent_metrics {
+        append_agent_section(&mut lines, metrics, inner_width);
     }
 
     // ── System Resources section (global CPU/RAM) ──
@@ -155,49 +94,8 @@ pub fn render_info_panel(
         lines.extend(ram_lines);
     }
 
-    // ── Middle sections (VM, Directories, Worktrees, Role Details) ──
-    append_detail_sections(&mut lines, info, project, vm_details, inner_width);
-
-    // ── Per-session CPU/RAM (all projects, height-capped, always last) ──
-    if let Some(m) = metrics {
-        if !m.per_session.is_empty() {
-            let total = m.per_session.len();
-            let section_header_cost = 2; // separator + "Sessions"
-            let used = lines.len() + section_header_cost;
-            let remaining = inner_height.saturating_sub(used);
-            let fits = remaining / 2; // 2 lines per session
-            let show_count = if fits >= total {
-                total
-            } else {
-                // Reserve 1 line for "+N more"
-                inner_height
-                    .saturating_sub(used + 1)
-                    .checked_div(2)
-                    .unwrap_or(0)
-                    .max(1)
-                    .min(total)
-            };
-
-            lines.push(separator(inner_width));
-            lines.push(Line::from(Span::styled(
-                "Sessions",
-                Theme::section_header(),
-            )));
-
-            let name_width = inner_width.saturating_sub(2);
-            for sm in m.per_session.iter().take(show_count) {
-                lines.push(render_session_name_line(sm, name_width));
-                lines.push(render_session_stats_line(sm));
-            }
-
-            if show_count < total {
-                lines.push(Line::from(Span::styled(
-                    format!("  +{} more", total - show_count),
-                    Style::default().fg(Theme::TEXT_MUTED),
-                )));
-            }
-        }
-    }
+    // ── VM section (for sandboxed sessions) ──
+    append_vm_section(&mut lines, info, vm_details, inner_width);
 
     let paragraph = Paragraph::new(lines)
         .block(block)
@@ -205,173 +103,138 @@ pub fn render_info_panel(
     frame.render_widget(paragraph, area);
 }
 
-/// Render a session's name line with context tags (project, branch, VM).
-fn render_session_name_line<'a>(sm: &'a SessionMetrics, name_width: usize) -> Line<'a> {
-    let mut spans: Vec<Span<'a>> = vec![Span::styled(
-        format!("  {}", truncate_name(&sm.name, name_width)),
-        Style::default().fg(Theme::TEXT_PRIMARY),
-    )];
+/// Append the Agent section showing Claude CLI metrics.
+fn append_agent_section(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner_width: usize) {
+    lines.push(separator(inner_width));
 
-    let mut context = String::new();
-    context.push_str(&sm.project_name);
-    if let Some(ref branch) = sm.worktree_branch {
-        context.push(' ');
-        context.push_str(branch);
-    }
-    if sm.is_vm {
-        context.push_str(" VM");
-    } else if sm.is_container {
-        context.push_str(" Container");
-    }
-    if !context.is_empty() {
-        spans.push(Span::styled(
-            format!(
-                " [{}]",
-                truncate_name(&context, name_width.saturating_sub(4))
-            ),
-            Style::default().fg(Theme::TEXT_MUTED),
-        ));
-    }
+    let header = match (&metrics.model_display_name, &metrics.cli_version) {
+        (Some(model), Some(ver)) => format!("Agent ({model} v{ver})"),
+        (Some(model), None) => format!("Agent ({model})"),
+        (None, Some(ver)) => format!("Agent (v{ver})"),
+        (None, None) => "Agent".to_string(),
+    };
+    lines.push(Line::from(Span::styled(header, Theme::section_header())));
 
-    Line::from(spans)
-}
-
-/// Render a session's CPU% and RAM stats line.
-fn render_session_stats_line(sm: &SessionMetrics) -> Line<'static> {
-    let ram = format_bytes(sm.memory_bytes);
-    Line::from(vec![
-        Span::styled("    ", Style::default()),
-        Span::styled(
-            format!("{:>3}%", sm.cpu_percent as u32),
-            Style::default().fg(Theme::ACCENT),
-        ),
-        Span::styled(" CPU  ", Style::default().fg(Theme::TEXT_MUTED)),
-        Span::styled(ram, Style::default().fg(Theme::ACCENT)),
-        Span::styled(" RAM", Style::default().fg(Theme::TEXT_MUTED)),
-    ])
-}
-
-/// Append detail sections (VM, Directories, Worktrees, Role Details) to `lines`.
-fn append_detail_sections<'a>(
-    lines: &mut Vec<Line<'a>>,
-    info: &'a SessionInfo,
-    project: Option<&'a ProjectInfo>,
-    vm_details: Option<&'a VmDetails>,
-    inner_width: usize,
-) {
-    // ── VM section (for sandboxed sessions) ──
-    if info.vm_id.is_some() {
-        lines.push(separator(inner_width));
-        lines.push(Line::from(Span::styled("VM", Theme::section_header())));
-
-        if let Some(vm) = vm_details {
-            lines.push(Line::from(vec![
-                Span::styled("State: ", Theme::label()),
-                Span::styled(&vm.state, Style::default().fg(Theme::TEXT_PRIMARY)),
-            ]));
-            lines.push(Line::from(vec![
-                Span::styled("CPUs: ", Theme::label()),
-                Span::styled(
-                    vm.cpus.to_string(),
-                    Style::default().fg(Theme::TEXT_PRIMARY),
-                ),
-                Span::styled("  RAM: ", Theme::label()),
-                Span::styled(
-                    format!("{} MB", vm.memory_mb),
-                    Style::default().fg(Theme::TEXT_PRIMARY),
-                ),
-            ]));
-            if vm.ssh_port > 0 {
-                lines.push(Line::from(vec![
-                    Span::styled("SSH: ", Theme::label()),
-                    Span::styled(
-                        format!("localhost:{}", vm.ssh_port),
-                        Style::default().fg(Theme::TEXT_PRIMARY),
-                    ),
-                ]));
-            }
-            lines.push(Line::from(vec![
-                Span::styled("Image: ", Theme::label()),
-                Span::styled(&vm.base_image, Style::default().fg(Theme::TEXT_MUTED)),
-            ]));
-        }
-
-        if info.status == SessionStatus::Provisioning {
-            if let Some(ref step) = info.provisioning_step {
-                lines.push(Line::from(vec![
-                    Span::styled("Step: ", Theme::label()),
-                    Span::styled(step, Style::default().fg(Theme::ACCENT)),
-                ]));
-            }
-        }
-    }
-
-    // ── Directories section ──
-    if info.cwd.is_some() || !info.additional_dirs.is_empty() {
-        lines.push(separator(inner_width));
-        lines.push(Line::from(Span::styled(
-            "Directories",
-            Theme::section_header(),
-        )));
-        if let Some(cwd) = &info.cwd {
-            lines.push(Line::from(Span::styled(
-                format!("  {} (cwd)", short_path(cwd)),
-                Style::default().fg(Theme::TEXT_MUTED),
-            )));
-        }
-        for dir in &info.additional_dirs {
-            lines.push(Line::from(Span::styled(
-                format!("  {}", short_path(dir)),
-                Style::default().fg(Theme::TEXT_MUTED),
-            )));
-        }
-    }
-
-    // ── Worktree section ──
-    if let Some(wt) = info.worktrees.first() {
-        lines.push(separator(inner_width));
+    // Cost
+    if let Some(cost) = metrics.total_cost_usd {
         lines.push(Line::from(vec![
-            Span::styled("Worktree: ", Theme::label()),
-            Span::styled(&wt.branch, Style::default().fg(Theme::BRANCH_NAME)),
+            Span::styled("Cost:    ", Theme::label()),
+            Span::styled(
+                format!("${cost:.4}"),
+                Style::default().fg(Theme::TEXT_PRIMARY),
+            ),
         ]));
     }
 
-    // ── Role Details section ──
-    if let Some(role_config) = project.and_then(|p| find_role(&p.config.roles, &info.role)) {
-        lines.push(separator(inner_width));
-        lines.push(Line::from(Span::styled(
-            "Role Details",
-            Theme::section_header(),
-        )));
+    // Tokens
+    if metrics.total_input_tokens.is_some() || metrics.total_output_tokens.is_some() {
+        let input = metrics
+            .total_input_tokens
+            .map(format_tokens)
+            .unwrap_or_else(|| "-".to_string());
+        let output = metrics
+            .total_output_tokens
+            .map(format_tokens)
+            .unwrap_or_else(|| "-".to_string());
+        lines.push(Line::from(vec![
+            Span::styled("Tokens:  ", Theme::label()),
+            Span::styled(
+                format!("{input} in / {output} out"),
+                Style::default().fg(Theme::TEXT_PRIMARY),
+            ),
+        ]));
+    }
 
-        if let Some(mode) = &role_config.permissions.permission_mode {
-            lines.push(Line::from(vec![
-                Span::styled("Mode: ", Theme::label()),
-                Span::styled(mode, Style::default().fg(Theme::KEYBIND_HINT)),
-            ]));
-        }
+    // Context window gauge
+    if let Some(pct) = metrics.used_percentage {
+        let gauge = render_gauge_lines("Context", pct as f32, None, inner_width);
+        lines.extend(gauge);
+    }
 
-        if !role_config.permissions.allowed_tools.is_empty() {
-            let label = "Allowed: ";
-            let max = inner_width.saturating_sub(label.len());
+    // Lines changed
+    if metrics.total_lines_added.is_some() || metrics.total_lines_removed.is_some() {
+        let added = metrics.total_lines_added.unwrap_or(0);
+        let removed = metrics.total_lines_removed.unwrap_or(0);
+        lines.push(Line::from(vec![
+            Span::styled("Lines:   ", Theme::label()),
+            Span::styled(format!("+{added}"), Style::default().fg(Theme::STATUS_BUSY)),
+            Span::styled(" / ", Style::default().fg(Theme::TEXT_MUTED)),
+            Span::styled(
+                format!("-{removed}"),
+                Style::default().fg(Theme::STATUS_ERROR),
+            ),
+        ]));
+    }
+
+    // Cache stats (only when non-zero)
+    let cache_read = metrics.cache_read_input_tokens.unwrap_or(0);
+    let cache_create = metrics.cache_creation_input_tokens.unwrap_or(0);
+    if cache_read > 0 || cache_create > 0 {
+        lines.push(Line::from(vec![
+            Span::styled("Cache:   ", Theme::label()),
+            Span::styled(
+                format!(
+                    "{} read / {} created",
+                    format_tokens(cache_read),
+                    format_tokens(cache_create)
+                ),
+                Style::default().fg(Theme::TEXT_PRIMARY),
+            ),
+        ]));
+    }
+}
+
+/// Append VM details section (for sandboxed sessions only).
+fn append_vm_section<'a>(
+    lines: &mut Vec<Line<'a>>,
+    info: &'a SessionInfo,
+    vm_details: Option<&'a VmDetails>,
+    inner_width: usize,
+) {
+    if info.vm_id.is_none() {
+        return;
+    }
+
+    lines.push(separator(inner_width));
+    lines.push(Line::from(Span::styled("VM", Theme::section_header())));
+
+    if let Some(vm) = vm_details {
+        lines.push(Line::from(vec![
+            Span::styled("State: ", Theme::label()),
+            Span::styled(&vm.state, Style::default().fg(Theme::TEXT_PRIMARY)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("CPUs: ", Theme::label()),
+            Span::styled(
+                vm.cpus.to_string(),
+                Style::default().fg(Theme::TEXT_PRIMARY),
+            ),
+            Span::styled("  RAM: ", Theme::label()),
+            Span::styled(
+                format!("{} MB", vm.memory_mb),
+                Style::default().fg(Theme::TEXT_PRIMARY),
+            ),
+        ]));
+        if vm.ssh_port > 0 {
             lines.push(Line::from(vec![
-                Span::styled(label, Theme::label()),
+                Span::styled("SSH: ", Theme::label()),
                 Span::styled(
-                    truncate_name(&role_config.permissions.allowed_tools.join(", "), max),
-                    Style::default().fg(Theme::TOOL_ALLOWED),
+                    format!("localhost:{}", vm.ssh_port),
+                    Style::default().fg(Theme::TEXT_PRIMARY),
                 ),
             ]));
         }
+        lines.push(Line::from(vec![
+            Span::styled("Image: ", Theme::label()),
+            Span::styled(&vm.base_image, Style::default().fg(Theme::TEXT_MUTED)),
+        ]));
+    }
 
-        if !role_config.permissions.disallowed_tools.is_empty() {
-            let label = "Disallowed: ";
-            let max = inner_width.saturating_sub(label.len());
+    if info.status == SessionStatus::Provisioning {
+        if let Some(ref step) = info.provisioning_step {
             lines.push(Line::from(vec![
-                Span::styled(label, Theme::label()),
-                Span::styled(
-                    truncate_name(&role_config.permissions.disallowed_tools.join(", "), max),
-                    Style::default().fg(Theme::TOOL_DISALLOWED),
-                ),
+                Span::styled("Step: ", Theme::label()),
+                Span::styled(step, Style::default().fg(Theme::ACCENT)),
             ]));
         }
     }
@@ -382,10 +245,6 @@ fn separator(width: usize) -> Line<'static> {
         "─".repeat(width),
         Style::default().fg(Theme::BORDER_UNFOCUSED),
     ))
-}
-
-fn find_role<'a>(roles: &'a [RoleConfig], name: &str) -> Option<&'a RoleConfig> {
-    roles.iter().find(|r| r.name == name)
 }
 
 /// Render a gauge as two lines:
@@ -424,12 +283,6 @@ fn render_gauge_lines(
     vec![header_line, bar_line]
 }
 
-/// Format bytes as a human-readable string like "1.2 GB".
-fn format_bytes(bytes: u64) -> String {
-    let (val, _, unit) = human_bytes(bytes);
-    format!("{val:.1} {unit}")
-}
-
 /// Format a used/total byte pair like "8.2/16.0 GB".
 fn format_bytes_pair(used: u64, total: u64) -> String {
     let (total_val, divisor, unit) = human_bytes(total);
@@ -453,100 +306,20 @@ fn human_bytes(bytes: u64) -> (f64, f64, &'static str) {
     }
 }
 
-/// Display a path with `$HOME` replaced by `~`.
-fn short_path(path: &Path) -> String {
-    let s = path.display().to_string();
-    if let Ok(home) = std::env::var("HOME") {
-        if let Some(rest) = s.strip_prefix(&home) {
-            return format!("~{rest}");
-        }
-    }
-    s
-}
-
-/// Truncate a name to fit within `max_len` characters, appending "…" if truncated.
-fn truncate_name(name: &str, max_len: usize) -> String {
-    let char_count = name.chars().count();
-    if char_count <= max_len {
-        name.to_string()
+/// Format a token count with human-readable suffixes (e.g., "15.2k", "1.2M").
+fn format_tokens(count: u64) -> String {
+    if count >= 1_000_000 {
+        format!("{:.1}M", count as f64 / 1_000_000.0)
+    } else if count >= 1_000 {
+        format!("{:.1}k", count as f64 / 1_000.0)
     } else {
-        let mut s: String = name.chars().take(max_len - 1).collect();
-        s.push('\u{2026}');
-        s
+        count.to_string()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ── render_session_name_line / render_session_stats_line tests ──
-
-    fn sample_metrics() -> SessionMetrics {
-        SessionMetrics {
-            name: "worker-1".into(),
-            project_name: "myproj".into(),
-            worktree_branch: None,
-            is_vm: false,
-            is_container: false,
-            cpu_percent: 42.0,
-            memory_bytes: 1_073_741_824, // 1 GB
-        }
-    }
-
-    #[test]
-    fn session_name_line_shows_name_and_context() {
-        let sm = sample_metrics();
-        let line = render_session_name_line(&sm, 40);
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(text.contains("worker-1"));
-        assert!(text.contains("[myproj]"));
-    }
-
-    #[test]
-    fn session_name_line_with_branch_and_vm() {
-        let sm = SessionMetrics {
-            worktree_branch: Some("feat-x".into()),
-            is_vm: true,
-            ..sample_metrics()
-        };
-        let line = render_session_name_line(&sm, 50);
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(text.contains("[myproj feat-x VM]"));
-    }
-
-    #[test]
-    fn session_name_line_with_container() {
-        let sm = SessionMetrics {
-            is_container: true,
-            ..sample_metrics()
-        };
-        let line = render_session_name_line(&sm, 50);
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(text.contains("[myproj Container]"));
-    }
-
-    #[test]
-    fn session_name_line_no_context() {
-        let sm = SessionMetrics {
-            project_name: String::new(),
-            ..sample_metrics()
-        };
-        let line = render_session_name_line(&sm, 30);
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(!text.contains('['));
-    }
-
-    #[test]
-    fn session_stats_line_shows_cpu_and_ram() {
-        let sm = sample_metrics();
-        let line = render_session_stats_line(&sm);
-        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(text.contains("42%"));
-        assert!(text.contains("CPU"));
-        assert!(text.contains("1.0 GB"));
-        assert!(text.contains("RAM"));
-    }
 
     // ── human_bytes tests ──
 
@@ -598,32 +371,6 @@ mod tests {
     fn format_bytes_pair_zero_used() {
         let s = format_bytes_pair(0, 17_179_869_184);
         assert_eq!(s, "0.0/16.0 GB");
-    }
-
-    // ── truncate_name tests ──
-
-    #[test]
-    fn truncate_name_short() {
-        assert_eq!(truncate_name("hello", 10), "hello");
-    }
-
-    #[test]
-    fn truncate_name_exact() {
-        assert_eq!(truncate_name("hello", 5), "hello");
-    }
-
-    #[test]
-    fn truncate_name_long() {
-        let result = truncate_name("very-long-session-name", 10);
-        assert_eq!(result, "very-long\u{2026}");
-        assert_eq!(result.chars().count(), 10);
-    }
-
-    #[test]
-    fn truncate_name_multibyte() {
-        let result = truncate_name("caf\u{00e9}-session", 5);
-        assert_eq!(result.chars().count(), 5);
-        assert!(result.ends_with('\u{2026}'));
     }
 
     // ── render_gauge_lines tests ──
@@ -691,33 +438,6 @@ mod tests {
         assert_eq!(bar_content_len, inner_width); // [ + bar_width + ]
     }
 
-    // ── short_path tests ──
-
-    #[test]
-    fn short_path_replaces_home() {
-        let home = std::env::var("HOME").unwrap();
-        let p = std::path::PathBuf::from(format!("{home}/projects/foo"));
-        assert_eq!(short_path(&p), "~/projects/foo");
-    }
-
-    #[test]
-    fn short_path_leaves_non_home_unchanged() {
-        let p = std::path::PathBuf::from("/tmp/something");
-        assert_eq!(short_path(&p), "/tmp/something");
-    }
-
-    // ── format_bytes tests ──
-
-    #[test]
-    fn format_bytes_gb() {
-        assert_eq!(format_bytes(1_073_741_824), "1.0 GB");
-    }
-
-    #[test]
-    fn format_bytes_mb() {
-        assert_eq!(format_bytes(524_288_000), "500.0 MB");
-    }
-
     // ── separator tests ──
 
     #[test]
@@ -726,5 +446,26 @@ mod tests {
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(text.chars().count(), 16);
         assert!(text.chars().all(|c| c == '─'));
+    }
+
+    // ── format_tokens tests ──
+
+    #[test]
+    fn format_tokens_small() {
+        assert_eq!(format_tokens(42), "42");
+        assert_eq!(format_tokens(999), "999");
+    }
+
+    #[test]
+    fn format_tokens_thousands() {
+        assert_eq!(format_tokens(1_000), "1.0k");
+        assert_eq!(format_tokens(15_200), "15.2k");
+        assert_eq!(format_tokens(999_999), "1000.0k");
+    }
+
+    #[test]
+    fn format_tokens_millions() {
+        assert_eq!(format_tokens(1_000_000), "1.0M");
+        assert_eq!(format_tokens(2_500_000), "2.5M");
     }
 }


### PR DESCRIPTION
## Summary

- Adds an **Agent** section to the F2 info panel showing live Claude CLI metrics: model name, total cost, token counts (in/out), context window gauge, lines changed (+/-), and cache stats
- Uses the Claude CLI statusline mechanism: Thurbox writes `~/.local/share/thurbox/statusline.sh` and configures `~/.claude/settings.json` so the CLI pipes JSON metrics to `metrics/{session_id}.json` after each assistant turn
- Injects `THURBOX_SESSION_ID` and `THURBOX_METRICS_DIR` env vars into each spawned session so the script routes metrics to the correct file
- Polls metrics files every ~1s in `refresh_system_metrics()` and updates `SessionInfo.agent_metrics`
- Removes clutter from the info panel: Project, Directories, Worktree, Role Details, and per-session CPU/RAM list sections are gone — only the current session's info is shown
- Adds `MetricsDir` path kind (`~/.local/share/thurbox/metrics/`) with `metrics_directory()` convenience fn
- Cleans up stale metrics files when sessions or projects are deleted

## Test plan

- [x] `cargo check --all` — compiles clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo nextest run --all` — 846 tests pass
- [x] `cargo test --test architecture_rules` — all 8 arch rules pass
- [ ] Manual: run thurbox, create a local session, interact with Claude, press F2 — verify Agent section appears and updates after each turn
- [ ] Manual: delete a session — verify metrics file is cleaned up