### PR TITLE
Fix containerfile path, promote scheduled commands and worktree sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Thurbox builds a container image from a Containerfile template,
 runs the container with optional firewall-restricted network
 egress (nftables/iptables allowlist), and spawns the Claude
 session inside it. Templates are stored at
-`~/.local/share/thurbox/containerfiles/` — a `default/` template
+`~/.local/share/thurbox/admin/containerfiles/` — a `default/` template
 (Debian Bookworm-based) is seeded on first run. Add custom
 templates by creating folders with a `Containerfile` and any
 support files. Containers are auto-detected (Podman preferred,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -566,7 +566,7 @@ the firewall allowlist restricts network egress by default.
   `ControlModeReader`/`ControlModeWriter` abstraction as the
   SSH-based VM backend.
 - Containerfile templates at
-  `~/.local/share/thurbox/containerfiles/<name>/`. A `default/`
+  `~/.local/share/thurbox/admin/containerfiles/<name>/`. A `default/`
   template (Debian Bookworm-based) is seeded on first run.
 
 **Container state persistence**: The `containers` table stores

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -829,13 +829,13 @@ The runtime is detected once at startup via `detect_runtime()`.
 ### Containerfile templates
 
 User-editable templates live in
-`~/.local/share/thurbox/containerfiles/`. Each template is
+`~/.local/share/thurbox/admin/containerfiles/`. Each template is
 a folder containing a `Containerfile` and any support files
 (e.g., `init-firewall.sh`). The entire folder is used as the
 build context.
 
 ```text
-~/.local/share/thurbox/containerfiles/
+~/.local/share/thurbox/admin/containerfiles/
   default/
     Containerfile
     init-firewall.sh

--- a/src/agent/devcontainer.rs
+++ b/src/agent/devcontainer.rs
@@ -13,13 +13,13 @@
 //!
 //! ## Containerfile templates
 //!
-//! User-editable templates live in `~/.local/share/thurbox/containerfiles/`.
+//! User-editable templates live in `~/.local/share/thurbox/admin/containerfiles/`.
 //! Each template is a **folder** containing a `Containerfile` and any support
 //! files (e.g. `init-firewall.sh`). The entire folder is used as the build
 //! context.
 //!
 //! ```text
-//! ~/.local/share/thurbox/containerfiles/
+//! ~/.local/share/thurbox/admin/containerfiles/
 //!   default/
 //!     Containerfile
 //!     init-firewall.sh

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -102,7 +102,7 @@ You can:
 - Configure per-project container defaults (image, cpus, memory, firewall, template)
 - List, download, and delete VM images for sandbox sessions
 
-Containerfile templates live in ~/.local/share/thurbox/containerfiles/. Each \
+Containerfile templates live in ~/.local/share/thurbox/admin/containerfiles/. Each \
 template is a folder containing a Containerfile and any support files (e.g. \
 init-firewall.sh). The default/ template includes Node.js LTS, tmux, git, \
 iptables, and claude-code. Use the containerfile template tools to list, read, \
@@ -825,7 +825,7 @@ impl App {
 
     /// Ensure the containerfiles template directory exists and is seeded with defaults.
     ///
-    /// Creates `~/.local/share/thurbox/containerfiles/default/` containing:
+    /// Creates `~/.local/share/thurbox/admin/containerfiles/default/` containing:
     /// - `Containerfile` — the default container image definition
     /// - `init-firewall.sh` — the firewall script referenced by the Containerfile
     ///

--- a/website/docs/architecture.html
+++ b/website/docs/architecture.html
@@ -23,10 +23,8 @@
   </head>
   <body>
     <nav class="nav scrolled" id="nav">
-      <a href="../index.html" class="nav-brand">
-        thur
-        <span>box</span>
-      </a>
+      <!-- prettier-ignore -->
+      <a href="../index.html" class="nav-brand">thur<span>box</span></a>
       <button class="hamburger" id="hamburger" aria-label="Toggle menu">
         <span></span>
         <span></span>

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -23,10 +23,8 @@
   </head>
   <body>
     <nav class="nav scrolled" id="nav">
-      <a href="../index.html" class="nav-brand">
-        thur
-        <span>box</span>
-      </a>
+      <!-- prettier-ignore -->
+      <a href="../index.html" class="nav-brand">thur<span>box</span></a>
       <button class="hamburger" id="hamburger" aria-label="Toggle menu">
         <span></span>
         <span></span>
@@ -289,7 +287,7 @@
           <h3>Templates</h3>
           <p>
             Templates are stored at
-            <code>~/.local/share/thurbox/containerfiles/</code>
+            <code>~/.local/share/thurbox/admin/containerfiles/</code>
             . A
             <code>default/</code>
             template (Debian Bookworm-based) is seeded on first run. It installs tmux, git,

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -23,10 +23,8 @@
   </head>
   <body>
     <nav class="nav scrolled" id="nav">
-      <a href="../index.html" class="nav-brand">
-        thur
-        <span>box</span>
-      </a>
+      <!-- prettier-ignore -->
+      <a href="../index.html" class="nav-brand">thur<span>box</span></a>
       <button class="hamburger" id="hamburger" aria-label="Toggle menu">
         <span></span>
         <span></span>

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -23,10 +23,8 @@
   </head>
   <body>
     <nav class="nav scrolled" id="nav">
-      <a href="../index.html" class="nav-brand">
-        thur
-        <span>box</span>
-      </a>
+      <!-- prettier-ignore -->
+      <a href="../index.html" class="nav-brand">thur<span>box</span></a>
       <button class="hamburger" id="hamburger" aria-label="Toggle menu">
         <span></span>
         <span></span>
@@ -380,7 +378,7 @@ cargo build --release"
 
           <p>
             Container templates are stored at
-            <code>~/.local/share/thurbox/containerfiles/</code>
+            <code>~/.local/share/thurbox/admin/containerfiles/</code>
             . A
             <code>default/</code>
             template (Debian Bookworm-based) is created on first run.

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -23,10 +23,8 @@
   </head>
   <body>
     <nav class="nav scrolled" id="nav">
-      <a href="../index.html" class="nav-brand">
-        thur
-        <span>box</span>
-      </a>
+      <!-- prettier-ignore -->
+      <a href="../index.html" class="nav-brand">thur<span>box</span></a>
       <button class="hamburger" id="hamburger" aria-label="Toggle menu">
         <span></span>
         <span></span>

--- a/website/docs/mcp.html
+++ b/website/docs/mcp.html
@@ -23,10 +23,8 @@
   </head>
   <body>
     <nav class="nav scrolled" id="nav">
-      <a href="../index.html" class="nav-brand">
-        thur
-        <span>box</span>
-      </a>
+      <!-- prettier-ignore -->
+      <a href="../index.html" class="nav-brand">thur<span>box</span></a>
       <button class="hamburger" id="hamburger" aria-label="Toggle menu">
         <span></span>
         <span></span>
@@ -262,6 +260,34 @@
               <tr>
                 <td><code>restore_session</code></td>
                 <td>Restore a soft-deleted session</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h3>Scheduled commands</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Tool</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>schedule_command</code></td>
+                <td>Schedule text to be sent to a session at a future time</td>
+              </tr>
+              <tr>
+                <td><code>list_scheduled_commands</code></td>
+                <td>List pending scheduled commands, optionally by session</td>
+              </tr>
+              <tr>
+                <td><code>get_scheduled_command</code></td>
+                <td>Get a scheduled command by ID</td>
+              </tr>
+              <tr>
+                <td><code>cancel_scheduled_command</code></td>
+                <td>Cancel a pending scheduled command</td>
               </tr>
             </tbody>
           </table>

--- a/website/docs/roles.html
+++ b/website/docs/roles.html
@@ -23,10 +23,8 @@
   </head>
   <body>
     <nav class="nav scrolled" id="nav">
-      <a href="../index.html" class="nav-brand">
-        thur
-        <span>box</span>
-      </a>
+      <!-- prettier-ignore -->
+      <a href="../index.html" class="nav-brand">thur<span>box</span></a>
       <button class="hamburger" id="hamburger" aria-label="Toggle menu">
         <span></span>
         <span></span>

--- a/website/index.html
+++ b/website/index.html
@@ -24,10 +24,8 @@
   <body>
     <!-- Navigation -->
     <nav class="nav" id="nav">
-      <a href="index.html" class="nav-brand">
-        thur
-        <span>box</span>
-      </a>
+      <!-- prettier-ignore -->
+      <a href="index.html" class="nav-brand">thur<span>box</span></a>
       <button class="hamburger" id="hamburger" aria-label="Toggle menu">
         <span></span>
         <span></span>
@@ -112,10 +110,12 @@
           </div>
           <div class="card">
             <div class="card-icon">&#x1f333;</div>
-            <h3>Git Worktrees</h3>
+            <h3>Git Worktrees &amp; Sync</h3>
             <p>
-              Spawn sessions in isolated git worktrees for branch-level isolation. Auto-sync with
-              origin/main and automatic worktree cleanup on session close.
+              Spawn sessions in isolated git worktrees for branch-level isolation. One-key sync (
+              <code>Ctrl+S</code>
+              ) rebases all worktrees from origin/main, with automatic conflict resolution and
+              worktree cleanup on session close.
             </p>
           </div>
           <div class="card">
@@ -145,13 +145,24 @@
             </p>
           </div>
           <div class="card">
+            <div class="card-icon">&#x23f0;</div>
+            <h3>Scheduled Commands</h3>
+            <p>
+              Press
+              <code>Ctrl+P</code>
+              to queue follow-up prompts or pace multi-step workflows. Commands fire via a
+              dual-track timer (tmux + app-level) that survives crashes, and are fully manageable
+              through MCP.
+            </p>
+          </div>
+          <div class="card">
             <div class="card-icon">&#x1f50c;</div>
             <h3>MCP Server</h3>
             <p>
               The
               <code>thurbox-mcp</code>
-              binary exposes project, role, and session management over the Model Context Protocol.
-              Manage everything conversationally via the Admin session.
+              binary exposes project, role, session, and scheduled command management over the Model
+              Context Protocol. Manage everything conversationally via the Admin session.
             </p>
           </div>
         </div>
@@ -256,6 +267,8 @@
                   <pre><code><span class="syn-keyword">Ctrl+N</span>  <span class="syn-comment">New session (select mode)</span>
 <span class="syn-keyword">Ctrl+L</span>  <span class="syn-comment">Cycle focus to terminal</span>
 <span class="syn-keyword">Ctrl+J</span>  <span class="syn-comment">Switch between sessions</span>
+<span class="syn-keyword">Ctrl+S</span>  <span class="syn-comment">Sync worktrees with origin/main</span>
+<span class="syn-keyword">Ctrl+P</span>  <span class="syn-comment">Schedule a command for later</span>
 <span class="syn-keyword">Ctrl+E</span>  <span class="syn-comment">Edit project (roles, repos)</span></code></pre>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- **Fix containerfile template path** across 8 files (docs, source comments, website) from `~/.local/share/thurbox/containerfiles/` to `~/.local/share/thurbox/admin/containerfiles/` to match the actual implementation in `src/paths.rs`
- **Promote Scheduled Commands**: add dedicated feature card on landing page, add 4 missing MCP tools to `website/docs/mcp.html`, add `Ctrl+P` to How It Works step 4
- **Promote Worktree Sync**: rename Git Worktrees card to "Git Worktrees & Sync" with `Ctrl+S` highlight, add `Ctrl+S` to How It Works step 4
- **Fix nav brand whitespace**: prevent Prettier from splitting "thurbox" into "thur box" across all 8 HTML pages using `<!-- prettier-ignore -->`

## Test plan

- [x] `rumdl check .` — all 10 markdown files pass
- [x] `npm run lint:website` — Prettier, HTMLHint, Stylelint, ESLint all pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — no warnings
- [x] `cargo test --test architecture_rules` — all 8 rules pass
- [x] All 16 pre-commit hooks pass