### PR TITLE
fix(ui): stop capture-pane from displacing terminal cursor

### DIFF
--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -51,8 +51,6 @@ pub struct SpawnedSession {
     pub output: Box<dyn Read + Send>,
     /// Input write handle to send bytes to the session.
     pub input: Box<dyn Write + Send>,
-    /// Captured screen content for parser seeding (output produced before streaming started).
-    pub initial_screen: Vec<u8>,
 }
 
 /// A reconnected session from the backend.
@@ -61,8 +59,6 @@ pub struct AdoptedSession {
     pub output: Box<dyn Read + Send>,
     /// Input write handle to send bytes to the session.
     pub input: Box<dyn Write + Send>,
-    /// Captured screen content for parser seeding.
-    pub initial_screen: Vec<u8>,
 }
 
 /// Trait that all session backends implement. The app layer interacts only through this trait.
@@ -130,7 +126,6 @@ pub trait SessionBackend: Send + Sync {
 struct SessionIo {
     output: Box<dyn Read + Send>,
     input: Box<dyn Write + Send>,
-    initial_screen: Vec<u8>,
     backend_id: String,
 }
 
@@ -297,7 +292,6 @@ impl Session {
             SessionIo {
                 output: spawned.output,
                 input: spawned.input,
-                initial_screen: spawned.initial_screen,
                 backend_id: spawned.backend_id,
             },
             backend,
@@ -320,10 +314,9 @@ impl Session {
 
         debug!(
             backend_id = %backend_id,
-            initial_screen_bytes = adopted.initial_screen.len(),
             parser_rows = rows,
             parser_cols = cols,
-            "Adopting session with initial screen"
+            "Adopting session"
         );
 
         let mut info = SessionInfo::new(name);
@@ -337,7 +330,6 @@ impl Session {
             SessionIo {
                 output: adopted.output,
                 input: adopted.input,
-                initial_screen: adopted.initial_screen,
                 backend_id: backend_id.to_string(),
             },
             backend,
@@ -375,12 +367,6 @@ impl Session {
     /// Create parser, spawn reader/writer loops for the given I/O handles.
     fn wire_up(rows: u16, cols: u16, io: SessionIo) -> (WiredState, String) {
         let parser = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 1000)));
-
-        if !io.initial_screen.is_empty() {
-            if let Ok(mut p) = parser.lock() {
-                p.process(&io.initial_screen);
-            }
-        }
 
         let exited = Arc::new(AtomicBool::new(false));
         let last_output_at = Arc::new(AtomicU64::new(now_millis()));
@@ -558,7 +544,6 @@ impl Session {
             SessionIo {
                 output: spawned.output,
                 input: spawned.input,
-                initial_screen: spawned.initial_screen,
                 backend_id: spawned.backend_id,
             },
         );
@@ -638,7 +623,6 @@ impl Session {
             SessionIo {
                 output: spawned.output,
                 input: spawned.input,
-                initial_screen: spawned.initial_screen,
                 backend_id: spawned.backend_id,
             },
         );
@@ -660,7 +644,6 @@ impl Session {
             SessionIo {
                 output: adopted.output,
                 input: adopted.input,
-                initial_screen: adopted.initial_screen,
                 backend_id: backend_id.to_string(),
             },
         );

--- a/src/agent/devcontainer.rs
+++ b/src/agent/devcontainer.rs
@@ -1340,20 +1340,8 @@ impl DevcontainerBackend {
         })
     }
 
-    /// Capture screen content from a pane.
-    fn capture_pane(&self, container_id: &str, pane_id: &str) -> Vec<u8> {
-        let cmd = format!("capture-pane -t {pane_id} -p -e -S -");
-        let content = self.ctrl_command(container_id, &cmd).unwrap_or_default();
-        debug!(
-            container_id = %container_id,
-            pane_id = %pane_id,
-            bytes = content.len(),
-            "capture-pane result"
-        );
-        content.into_bytes()
-    }
-
-    /// Connect I/O to an existing pane in a container.
+    /// Connect I/O to an existing pane in a container: resize to correct
+    /// dimensions and create writer.
     fn connect_pane(
         &self,
         container_id: &str,
@@ -1366,16 +1354,17 @@ impl DevcontainerBackend {
             container_id,
             &format!("refresh-client -A '{}:on'", pane_id.replace('\'', "'\\''")),
         )?;
-        let initial_screen = self.capture_pane(container_id, pane_id);
-        let writer = self.pane_writer(container_id, pane_id)?;
 
-        // Force resize to trigger repaint.
+        // Resize to TUI panel dimensions. force_resize triggers a SIGWINCH,
+        // making TUI apps repaint via the streaming reader with proper escape
+        // sequences.
         self.force_resize(container_id, pane_id, rows, cols)?;
+
+        let writer = self.pane_writer(container_id, pane_id)?;
 
         Ok(AdoptedSession {
             output: Box::new(reader),
             input: Box::new(writer),
-            initial_screen,
         })
     }
 
@@ -1476,7 +1465,6 @@ impl SessionBackend for DevcontainerBackend {
             backend_id: composite_id,
             output: connected.output,
             input: connected.input,
-            initial_screen: connected.initial_screen,
         })
     }
 

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -517,51 +517,29 @@ impl LocalTmuxBackend {
         })
     }
 
-    /// Capture the full screen content (including scrollback) from a pane.
-    ///
-    /// `-S -` starts from the beginning of scrollback history,
-    /// `-e` includes ANSI escape sequences (colors, bold, etc.),
-    /// `-p` prints to stdout (captured via control mode response).
-    fn capture_pane(&self, pane_id: &str) -> Vec<u8> {
-        let cmd = format!("capture-pane -t {pane_id} -p -e -S -");
-        let content = self.ctrl_command(&cmd).unwrap_or_default();
-        debug!(
-            pane_id = %pane_id,
-            bytes = content.len(),
-            lines = content.lines().count(),
-            "capture-pane result"
-        );
-        content.into_bytes()
-    }
-
-    /// Connect I/O to an existing pane: start monitoring, capture screen,
-    /// resize (triggers app redraw), and create writer.
+    /// Connect I/O to an existing pane: start monitoring, resize to correct
+    /// dimensions, and create writer.
     fn connect_pane(&self, pane_id: &str, rows: u16, cols: u16) -> Result<AdoptedSession> {
         let reader = self.register_pane(pane_id)?;
         // Must use send_command (waited) here — a nowait call would leave an
         // unclaimed %begin/%end response in the stream that steals the next
-        // send_command waiter (e.g., capture-pane below).
+        // send_command waiter.
         self.ctrl_command(&format!(
             "refresh-client -A '{}:on'",
             pane_id.replace('\'', "'\\''")
         ))?;
-        // Capture the current screen as a quick initial approximation (colors
-        // and backgrounds may be approximate since capture-pane -p renders text
-        // rather than replaying the original escape sequences).
-        let initial_screen = self.capture_pane(pane_id);
-        let writer = self.pane_writer(pane_id)?;
 
-        // Resize to the target dimensions. If the pane was already at this
-        // size, force a SIGWINCH by briefly shrinking by one row and resizing
-        // back. This makes TUI applications (like claude) repaint their full
-        // screen through the normal output stream, which the reader_loop
-        // processes with all escape sequences intact.
+        // Resize to the TUI panel dimensions. force_resize triggers a
+        // SIGWINCH, making TUI applications (like claude) repaint at the
+        // correct dimensions through the normal output stream, which the
+        // reader_loop processes with all escape sequences intact.
         self.force_resize(pane_id, rows, cols)?;
+
+        let writer = self.pane_writer(pane_id)?;
 
         Ok(AdoptedSession {
             output: Box::new(reader),
             input: Box::new(writer),
-            initial_screen,
         })
     }
 
@@ -706,7 +684,6 @@ impl SessionBackend for LocalTmuxBackend {
             backend_id: pane_id,
             output: connected.output,
             input: connected.input,
-            initial_screen: connected.initial_screen,
         })
     }
 

--- a/src/agent/vm.rs
+++ b/src/agent/vm.rs
@@ -1490,20 +1490,8 @@ impl QemuVmBackend {
         })
     }
 
-    /// Capture screen content from a pane.
-    fn capture_pane(&self, vm_id: &str, pane_id: &str) -> Vec<u8> {
-        let cmd = format!("capture-pane -t {pane_id} -p -e -S -");
-        let content = self.ctrl_command(vm_id, &cmd).unwrap_or_default();
-        debug!(
-            vm_id = %vm_id,
-            pane_id = %pane_id,
-            bytes = content.len(),
-            "capture-pane result"
-        );
-        content.into_bytes()
-    }
-
-    /// Connect I/O to an existing pane in a VM.
+    /// Connect I/O to an existing pane in a VM: resize to correct
+    /// dimensions and create writer.
     fn connect_pane(
         &self,
         vm_id: &str,
@@ -1516,16 +1504,17 @@ impl QemuVmBackend {
             vm_id,
             &format!("refresh-client -A '{}:on'", pane_id.replace('\'', "'\\''")),
         )?;
-        let initial_screen = self.capture_pane(vm_id, pane_id);
-        let writer = self.pane_writer(vm_id, pane_id)?;
 
-        // Force resize to trigger repaint.
+        // Resize to TUI panel dimensions. force_resize triggers a SIGWINCH,
+        // making TUI apps repaint via the streaming reader with proper escape
+        // sequences.
         self.force_resize(vm_id, pane_id, rows, cols)?;
+
+        let writer = self.pane_writer(vm_id, pane_id)?;
 
         Ok(AdoptedSession {
             output: Box::new(reader),
             input: Box::new(writer),
-            initial_screen,
         })
     }
 
@@ -1625,7 +1614,6 @@ impl SessionBackend for QemuVmBackend {
             backend_id: composite_id,
             output: connected.output,
             input: connected.input,
-            initial_screen: connected.initial_screen,
         })
     }
 


### PR DESCRIPTION
## Summary

- Remove `capture-pane` / `initial_screen` mechanism that was pushing the cursor to the bottom of the terminal panel
- `capture-pane -p` renders the visible screen as rows of text with newlines — processing this through the vt100 parser displaces the cursor to the last row
- The `force_resize` SIGWINCH already triggers a full repaint via the streaming reader with proper escape sequences (including cursor positioning), making `capture-pane` seeding unnecessary

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo nextest run --all` — 871 tests pass
- [x] All pre-commit hooks pass (fmt, clippy, check, nextest, architecture, deny, doc)
- [ ] Manual: start Thurbox → Ctrl+N new session → cursor appears at top
- [ ] Manual: quit (Ctrl+Q) → restart → adopted sessions show cursor at top
- [ ] Manual: resize terminal window → content reflows correctly