### PR TITLE
docs: add website badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ sessions survive crashes and restarts.
 
 [![CI](https://github.com/Thurbeen/thurbox/workflows/CI/badge.svg)](https://github.com/Thurbeen/thurbox/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Website](https://img.shields.io/badge/Website-thurbox.thurbeen.eu-blue)](https://thurbox.thurbeen.eu/)
 
 ![Thurbox Demo](./docs/media/thurbox-demo.gif)
 


### PR DESCRIPTION
## Summary

- Adds a website badge linking to https://thurbox.thurbeen.eu/ in the README header
- Placed alongside existing CI and License badges

## Test plan

- [ ] Verify badge renders correctly on GitHub
- [ ] Verify link opens the correct URL