### PR TITLE
fix(git): move worktrees to XDG data dir to prevent duplicate skills

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,9 +1,13 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tracing::warn;
+
+use crate::paths;
 
 /// List local branch names for a repo.
 pub fn list_branches(repo_path: &Path) -> Result<Vec<String>> {
@@ -30,9 +34,10 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<String>> {
 /// Create a git worktree on a new branch and return the worktree directory path.
 ///
 /// Creates `new_branch` starting from `base_branch`.
-/// Path format: `<repo>/.git/thurbox-worktrees/<sanitized-new-branch>`
+/// Path format: `~/.local/share/thurbox/worktrees/<repo-hash>/<sanitized-branch>`
 pub fn create_worktree(repo_path: &Path, new_branch: &str, base_branch: &str) -> Result<PathBuf> {
-    let wt_path = worktree_path(repo_path, new_branch);
+    let wt_path =
+        worktree_path(repo_path, new_branch).context("failed to resolve worktrees directory")?;
 
     let output = Command::new("git")
         .args([
@@ -119,7 +124,8 @@ fn default_branch_from_remote(repo_path: &Path) -> Option<String> {
 /// Returns the worktree directory path. If the worktree path already exists on
 /// disk the function returns early with `Ok(path)`.
 pub fn add_existing_worktree(repo_path: &Path, branch: &str) -> Result<PathBuf> {
-    let wt_path = worktree_path(repo_path, branch);
+    let wt_path =
+        worktree_path(repo_path, branch).context("failed to resolve worktrees directory")?;
 
     if wt_path.exists() {
         return Ok(wt_path);
@@ -152,12 +158,19 @@ pub fn branch_exists(repo_path: &Path, branch: &str) -> bool {
 }
 
 /// Deterministic worktree directory path for a repo + branch.
-fn worktree_path(repo_path: &Path, branch: &str) -> PathBuf {
+///
+/// Worktrees are placed under the XDG data directory to avoid being inside
+/// the source repo (which would cause Claude Code to discover duplicate
+/// `.claude/commands/` skill files).
+///
+/// Path format: `~/.local/share/thurbox/worktrees/<repo-hash>/<sanitized-branch>`
+fn worktree_path(repo_path: &Path, branch: &str) -> Option<PathBuf> {
+    let base = paths::worktrees_directory()?;
+    let mut hasher = DefaultHasher::new();
+    repo_path.display().to_string().hash(&mut hasher);
+    let repo_hash = format!("{:016x}", hasher.finish());
     let sanitized = branch.replace('/', "-");
-    repo_path
-        .join(".git")
-        .join("thurbox-worktrees")
-        .join(sanitized)
+    Some(base.join(repo_hash).join(sanitized))
 }
 
 /// Result of attempting to sync a worktree with origin/main.
@@ -431,65 +444,100 @@ pub fn sync_worktree(worktree_path: &Path) -> SyncResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::TestPathGuard;
+
+    /// Compute the 16-char hex repo hash used in worktree paths.
+    fn repo_hash(repo_path: &Path) -> String {
+        let mut hasher = DefaultHasher::new();
+        repo_path.display().to_string().hash(&mut hasher);
+        format!("{:016x}", hasher.finish())
+    }
 
     #[test]
     fn worktree_path_simple_branch() {
+        let base = PathBuf::from("/test/data");
+        let _guard = TestPathGuard::new(&base);
         let repo = Path::new("/home/user/repo");
-        let result = worktree_path(repo, "main");
-        assert_eq!(
-            result,
-            PathBuf::from("/home/user/repo/.git/thurbox-worktrees/main")
-        );
+        let result = worktree_path(repo, "main").unwrap();
+        let hash = repo_hash(repo);
+        assert_eq!(result, base.join("worktrees").join(&hash).join("main"));
     }
 
     #[test]
     fn worktree_path_slash_branch() {
+        let base = PathBuf::from("/test/data");
+        let _guard = TestPathGuard::new(&base);
         let repo = Path::new("/home/user/repo");
-        let result = worktree_path(repo, "feature/foo");
+        let result = worktree_path(repo, "feature/foo").unwrap();
+        let hash = repo_hash(repo);
         assert_eq!(
             result,
-            PathBuf::from("/home/user/repo/.git/thurbox-worktrees/feature-foo")
+            base.join("worktrees").join(&hash).join("feature-foo")
         );
     }
 
     #[test]
     fn worktree_path_nested_slashes() {
+        let base = PathBuf::from("/test/data");
+        let _guard = TestPathGuard::new(&base);
         let repo = Path::new("/home/user/repo");
-        let result = worktree_path(repo, "feature/team/task");
+        let result = worktree_path(repo, "feature/team/task").unwrap();
+        let hash = repo_hash(repo);
         assert_eq!(
             result,
-            PathBuf::from("/home/user/repo/.git/thurbox-worktrees/feature-team-task")
+            base.join("worktrees").join(&hash).join("feature-team-task")
         );
     }
 
     #[test]
     fn worktree_path_no_slashes_unchanged() {
+        let base = PathBuf::from("/test/data");
+        let _guard = TestPathGuard::new(&base);
         let repo = Path::new("/repo");
-        let result = worktree_path(repo, "my-branch");
-        assert_eq!(
-            result,
-            PathBuf::from("/repo/.git/thurbox-worktrees/my-branch")
-        );
+        let result = worktree_path(repo, "my-branch").unwrap();
+        let hash = repo_hash(repo);
+        assert_eq!(result, base.join("worktrees").join(&hash).join("my-branch"));
     }
 
     #[test]
     fn worktree_path_trailing_slash() {
+        let base = PathBuf::from("/test/data");
+        let _guard = TestPathGuard::new(&base);
         let repo = Path::new("/repo");
-        let result = worktree_path(repo, "branch/");
-        assert_eq!(
-            result,
-            PathBuf::from("/repo/.git/thurbox-worktrees/branch-")
-        );
+        let result = worktree_path(repo, "branch/").unwrap();
+        let hash = repo_hash(repo);
+        assert_eq!(result, base.join("worktrees").join(&hash).join("branch-"));
     }
 
     #[test]
     fn worktree_path_leading_slash() {
+        let base = PathBuf::from("/test/data");
+        let _guard = TestPathGuard::new(&base);
         let repo = Path::new("/repo");
-        let result = worktree_path(repo, "/branch");
-        assert_eq!(
-            result,
-            PathBuf::from("/repo/.git/thurbox-worktrees/-branch")
-        );
+        let result = worktree_path(repo, "/branch").unwrap();
+        let hash = repo_hash(repo);
+        assert_eq!(result, base.join("worktrees").join(&hash).join("-branch"));
+    }
+
+    #[test]
+    fn worktree_path_different_repos_produce_different_hashes() {
+        let base = PathBuf::from("/test/data");
+        let _guard = TestPathGuard::new(&base);
+        let path_a = worktree_path(Path::new("/repo/a"), "main").unwrap();
+        let path_b = worktree_path(Path::new("/repo/b"), "main").unwrap();
+        assert_ne!(path_a, path_b);
+        // Both end with the same branch name
+        assert_eq!(path_a.file_name(), path_b.file_name());
+    }
+
+    #[test]
+    fn worktree_path_same_repo_is_deterministic() {
+        let base = PathBuf::from("/test/data");
+        let _guard = TestPathGuard::new(&base);
+        let repo = Path::new("/home/user/repo");
+        let first = worktree_path(repo, "main").unwrap();
+        let second = worktree_path(repo, "main").unwrap();
+        assert_eq!(first, second);
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -58,6 +58,8 @@ pub enum PathKind {
     ImagesDir,
     /// Agent metrics files: `~/.local/share/thurbox/metrics/`
     MetricsDir,
+    /// Git worktrees: `~/.local/share/thurbox/worktrees/`
+    WorktreesDir,
 }
 
 /// Path resolution strategy (thread-local).
@@ -219,6 +221,24 @@ fn resolve_xdg(kind: PathKind) -> Option<PathBuf> {
                 p
             })
         }
+        PathKind::WorktreesDir => {
+            // Prefer $XDG_DATA_HOME, fall back to $HOME/.local/share
+            if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+                let mut p = PathBuf::from(xdg);
+                p.push(app_dir_name());
+                p.push("worktrees");
+                return Some(p);
+            }
+
+            std::env::var_os("HOME").map(|h| {
+                let mut p = PathBuf::from(h);
+                p.push(".local");
+                p.push("share");
+                p.push(app_dir_name());
+                p.push("worktrees");
+                p
+            })
+        }
     }
 }
 
@@ -232,6 +252,7 @@ fn resolve_override(base: &Path, kind: PathKind) -> PathBuf {
         PathKind::ContainerfilesDir => base.join("admin").join("containerfiles"),
         PathKind::ImagesDir => base.join("admin").join("images"),
         PathKind::MetricsDir => base.join("metrics"),
+        PathKind::WorktreesDir => base.join("worktrees"),
     }
 }
 
@@ -284,6 +305,13 @@ pub fn images_directory() -> Option<PathBuf> {
 /// Returns: `$XDG_DATA_HOME/thurbox/metrics/` or `$HOME/.local/share/thurbox/metrics/`
 pub fn metrics_directory() -> Option<PathBuf> {
     resolve(PathKind::MetricsDir)
+}
+
+/// Resolve the worktrees directory path.
+///
+/// Returns: `$XDG_DATA_HOME/thurbox/worktrees/` or `$HOME/.local/share/thurbox/worktrees/`
+pub fn worktrees_directory() -> Option<PathBuf> {
+    resolve(PathKind::WorktreesDir)
 }
 
 /// Resolve the path to the `thurbox-mcp` binary.
@@ -550,6 +578,10 @@ mod tests {
             Some(base.join("admin").join("images"))
         );
         assert_eq!(resolve(PathKind::MetricsDir), Some(base.join("metrics")));
+        assert_eq!(
+            resolve(PathKind::WorktreesDir),
+            Some(base.join("worktrees"))
+        );
 
         reset_to_xdg();
     }
@@ -714,6 +746,10 @@ mod tests {
             resolve_override(base, PathKind::MetricsDir),
             PathBuf::from("/data/metrics")
         );
+        assert_eq!(
+            resolve_override(base, PathKind::WorktreesDir),
+            PathBuf::from("/data/worktrees")
+        );
     }
 
     #[test]
@@ -723,6 +759,17 @@ mod tests {
 
         let path = metrics_directory().unwrap();
         assert!(path.ends_with("metrics"));
+
+        reset_to_xdg();
+    }
+
+    #[test]
+    fn worktrees_directory_convenience() {
+        let base = PathBuf::from("/custom");
+        set_test_dir(&base);
+
+        let path = worktrees_directory().unwrap();
+        assert!(path.ends_with("worktrees"));
 
         reset_to_xdg();
     }


### PR DESCRIPTION
## Summary

- Worktrees were placed inside the repo at `.git/thurbox-worktrees/`, causing Claude Code's directory-walking skill discovery to find `.claude/commands/` from both the worktree and the parent repo, resulting in duplicate skills (e.g., `refactor`, `ship`, `sync` appearing twice)
- Worktrees now live at `~/.local/share/thurbox/worktrees/<repo-hash>/<branch>`, completely outside any source repo
- The repo hash is a 16-char hex `DefaultHasher` digest of the repo path, providing isolation between repos with no new dependencies
- Added `PathKind::WorktreesDir` to `src/paths.rs` with full XDG resolution, override support, convenience function, and tests
- Old sessions continue using their stored paths — no migration needed, graceful transition

## Test plan

- [ ] All existing tests pass (`cargo nextest run --all`)
- [ ] New `worktree_path_*` tests verify correct path structure under `~/.local/share/thurbox/worktrees/`
- [ ] `worktree_path_different_repos_produce_different_hashes` — repo isolation
- [ ] `worktree_path_same_repo_is_deterministic` — hash stability
- [ ] `worktrees_directory_convenience` — XDG path kind resolves correctly