### PR TITLE
fix(core): update statusLine when it points to a stale Thurbox path

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -986,8 +986,26 @@ impl App {
             .and_then(|c| serde_json::from_str(&c).ok())
             .unwrap_or_else(|| serde_json::json!({}));
 
-        // Only write statusLine if not already configured by the user.
-        if settings.get("statusLine").is_none() {
+        let should_write = match settings.get("statusLine") {
+            None => true,
+            Some(existing) => {
+                let cmd = existing
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                if cmd.contains("thurbox") && cmd.ends_with("statusline.sh") {
+                    // Thurbox-managed statusLine — update to current path.
+                    true
+                } else {
+                    tracing::warn!(
+                        "statusLine already set to a non-Thurbox command ({cmd}); \
+                         agent monitoring metrics will not be available"
+                    );
+                    false
+                }
+            }
+        };
+        if should_write {
             settings["statusLine"] = serde_json::json!({
                 "type": "command",
                 "command": script_path.display().to_string()


### PR DESCRIPTION
## Summary

- Agent monitoring was silently disabled on devices where `~/.claude/settings.json` already had a `statusLine` entry (e.g. from a previous Thurbox install at a different path)
- Replace the simple `is_none()` guard with three-way logic: no entry → write, Thurbox-owned entry (command contains `thurbox` and ends with `statusline.sh`) → update to current path, user's own entry → skip with a log warning

## Test plan

- [ ] `cargo check --all` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo nextest run --all` passes (877 tests)
- [ ] Manual: delete `statusLine` from `~/.claude/settings.json` → Thurbox writes it on startup
- [ ] Manual: leave Thurbox's own `statusLine` in place → Thurbox updates path without warning
- [ ] Manual: set `statusLine` to a custom command → Thurbox skips it and logs a warning