### PR TITLE
feat(ui): extend session search to role & branch, anchor bar below section

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,10 @@ The binary will be available at `target/release/thurbox`.
 |-----|--------|
 | `j` / `Down` | Next item |
 | `k` / `Up` | Previous item |
+| `/` | Fuzzy search (projects or sessions) |
 | `Enter` | Select / focus |
+
+Session search matches against name, role, and branch.
 
 ### Terminal Scrollback and Selection
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -142,6 +142,10 @@ for actions (`C`=close, `D`=delete, `N`=new, `R`=restart, `Q`=quit).
 | `j` / `Down` | Project list | Next project | |
 | `k` / `Up` | Project list | Previous project | |
 | `Enter` | Project list | Focus session list | |
+| `/` | Project list | Open project search (fuzzy filter by name) | Vim search |
+| `/` | Session list | Open session search (fuzzy filter by name, role, or branch) | Vim search |
+| `Enter` | Search bar | Confirm and close search | |
+| `Esc` | Search bar | Cancel search | |
 | `j` / `Down` | Session list | Next session | |
 | `k` / `Up` | Session list | Previous session | |
 | `Enter` | Session list | Focus terminal | |

--- a/src/app/fuzzy.rs
+++ b/src/app/fuzzy.rs
@@ -1,0 +1,87 @@
+/// Result of a successful fuzzy match.
+pub(crate) struct FuzzyMatch {
+    /// Byte positions of matched characters in the haystack.
+    pub positions: Vec<usize>,
+}
+
+/// Greedy left-to-right fuzzy match (case-insensitive).
+///
+/// Returns `Some` if every character in `query` appears in `haystack` in order.
+/// An empty query matches everything with an empty positions vec.
+pub(crate) fn fuzzy_match(query: &str, haystack: &str) -> Option<FuzzyMatch> {
+    if query.is_empty() {
+        return Some(FuzzyMatch {
+            positions: Vec::new(),
+        });
+    }
+
+    let mut positions = Vec::with_capacity(query.len());
+    let mut haystack_chars = haystack.char_indices().peekable();
+    for qc in query.chars() {
+        let qc_lower = qc.to_lowercase().next()?;
+        loop {
+            match haystack_chars.next() {
+                Some((byte_pos, hc)) => {
+                    if hc.to_lowercase().next() == Some(qc_lower) {
+                        positions.push(byte_pos);
+                        break;
+                    }
+                }
+                None => return None,
+            }
+        }
+    }
+
+    Some(FuzzyMatch { positions })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_match() {
+        let m = fuzzy_match("fb", "foo-bar").unwrap();
+        assert_eq!(m.positions, vec![0, 4]);
+    }
+
+    #[test]
+    fn no_match() {
+        assert!(fuzzy_match("xyz", "foo-bar").is_none());
+    }
+
+    #[test]
+    fn case_insensitive() {
+        let m = fuzzy_match("FB", "Foo-Bar").unwrap();
+        assert_eq!(m.positions, vec![0, 4]);
+    }
+
+    #[test]
+    fn empty_query_matches_everything() {
+        let m = fuzzy_match("", "anything").unwrap();
+        assert!(m.positions.is_empty());
+    }
+
+    #[test]
+    fn empty_haystack_no_match() {
+        assert!(fuzzy_match("a", "").is_none());
+    }
+
+    #[test]
+    fn exact_match() {
+        let m = fuzzy_match("abc", "abc").unwrap();
+        assert_eq!(m.positions, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn partial_match_fails() {
+        assert!(fuzzy_match("abz", "abc").is_none());
+    }
+
+    #[test]
+    fn multibyte_characters() {
+        let m = fuzzy_match("aé", "café").unwrap();
+        // 'c'=0, 'a'=1, 'f'=2, 'é'=3 (byte pos 3, 2-byte char)
+        assert_eq!(m.positions, vec![1, 3]);
+    }
+}

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -126,6 +126,12 @@ impl App {
             return;
         }
 
+        // Search input captures all keys when active
+        if self.search_active {
+            self.handle_search_key(code, mods);
+            return;
+        }
+
         // Ctrl+C: copy selection if active, otherwise forward to terminal as SIGINT
         if code == KeyCode::Char('c')
             && mods.contains(KeyModifiers::CONTROL)
@@ -205,6 +211,7 @@ impl App {
                 }
                 // Vim navigation: h=cycle-left, j=down, k=up, l=cycle-right
                 KeyCode::Char('h') => {
+                    self.clear_search();
                     self.focus = match self.focus {
                         InputFocus::ProjectList => InputFocus::Terminal,
                         InputFocus::SessionList => InputFocus::ProjectList,
@@ -229,6 +236,7 @@ impl App {
                     return;
                 }
                 KeyCode::Char('l') => {
+                    self.clear_search();
                     self.focus = match self.focus {
                         InputFocus::ProjectList => InputFocus::SessionList,
                         InputFocus::SessionList => InputFocus::Terminal,
@@ -271,6 +279,13 @@ impl App {
             KeyCode::Enter => {
                 self.focus = InputFocus::SessionList;
             }
+            KeyCode::Char('/') => {
+                self.search_active = true;
+                self.search_target = super::SearchTarget::Projects;
+                self.search_input.buffer.clear();
+                self.search_input.cursor = 0;
+                self.project_match_positions.clear();
+            }
             _ => {}
         }
     }
@@ -285,6 +300,61 @@ impl App {
             }
             KeyCode::Enter => {
                 self.focus = InputFocus::Terminal;
+            }
+            KeyCode::Char('/') => {
+                self.search_active = true;
+                self.search_target = super::SearchTarget::Sessions;
+                self.search_input.buffer.clear();
+                self.search_input.cursor = 0;
+                self.session_match_positions.clear();
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_search_key(&mut self, code: KeyCode, mods: KeyModifiers) {
+        // Allow Ctrl+Q to quit even during search
+        if code == KeyCode::Char('q') && mods.contains(KeyModifiers::CONTROL) {
+            self.should_quit = true;
+            return;
+        }
+
+        match code {
+            KeyCode::Esc => {
+                // Cancel search and clear filter
+                self.clear_search();
+            }
+            KeyCode::Enter => {
+                // Confirm search: exit input mode but keep filter active
+                self.search_active = false;
+            }
+            KeyCode::Backspace => {
+                self.search_input.backspace();
+                self.recompute_search_filter();
+            }
+            KeyCode::Left => {
+                self.search_input.move_left();
+            }
+            KeyCode::Right => {
+                self.search_input.move_right();
+            }
+            KeyCode::Up => {
+                self.search_navigate_backward();
+            }
+            KeyCode::Down => {
+                self.search_navigate_forward();
+            }
+            KeyCode::Char('j') if mods.contains(KeyModifiers::CONTROL) => {
+                self.search_navigate_forward();
+            }
+            KeyCode::Char('k') if mods.contains(KeyModifiers::CONTROL) => {
+                self.search_navigate_backward();
+            }
+            KeyCode::Char(c) => {
+                if !mods.contains(KeyModifiers::CONTROL) {
+                    self.search_input.insert(c);
+                    self.recompute_search_filter();
+                }
             }
             _ => {}
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+mod fuzzy;
 mod helpers;
 mod key_handlers;
 pub(crate) mod mcp_editor_modal;
@@ -30,7 +31,7 @@ use crate::storage::Database;
 use crate::storage::DeletedSessionInfo;
 use crate::sync::{self, SharedWorktree, StateDelta, SyncState};
 use crate::ui::selection::{PaneBounds, Selection, TermPos};
-use crate::ui::{info_panel, layout, role_editor_modal};
+use crate::ui::{info_panel, layout, project_list, role_editor_modal};
 
 const MOUSE_SCROLL_LINES: usize = 3;
 
@@ -403,6 +404,13 @@ pub(crate) enum TerminalView {
     Shell,
 }
 
+/// Which list section is being searched/filtered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SearchTarget {
+    Projects,
+    Sessions,
+}
+
 /// Holds a recently deleted session for undo (Ctrl+Z) support.
 struct PendingDelete {
     session: Session,
@@ -551,6 +559,22 @@ pub struct App {
     pending_restores: Vec<PendingRestore>,
     /// Reusable buffer for session elapsed-ms in the view (avoids per-frame allocation).
     pub(crate) session_elapsed_buf: Vec<u64>,
+    /// Persistent list state for the project section (preserves scroll offset).
+    pub(crate) project_list_state: ratatui::widgets::ListState,
+    /// Persistent list state for the session section (preserves scroll offset).
+    pub(crate) session_list_state: ratatui::widgets::ListState,
+    /// Whether the search input is active (accepting keystrokes).
+    pub(crate) search_active: bool,
+    /// Which list section is being searched.
+    pub(crate) search_target: SearchTarget,
+    /// Search input buffer.
+    pub(crate) search_input: TextInput,
+    /// Per-project fuzzy match positions: None = no match (dim), Some(positions) = match.
+    /// Empty vec means no search is active.
+    pub(crate) project_match_positions: Vec<Option<Vec<usize>>>,
+    /// Per-session fuzzy match positions (local indices within active project's session list).
+    /// Empty vec means no search is active.
+    pub(crate) session_match_positions: Vec<Option<project_list::SessionMatch>>,
 }
 
 /// Snapshot of editor field values for dirty detection.
@@ -822,6 +846,13 @@ impl App {
             pending_container_mcp_servers: None,
             pending_restores: Vec::new(),
             session_elapsed_buf: Vec::new(),
+            project_list_state: ratatui::widgets::ListState::default(),
+            session_list_state: ratatui::widgets::ListState::default(),
+            search_active: false,
+            search_target: SearchTarget::Projects,
+            search_input: TextInput::new(),
+            project_match_positions: Vec::new(),
+            session_match_positions: Vec::new(),
         }
     }
 
@@ -2278,6 +2309,176 @@ impl App {
         let new_pos = current_pos as isize + offset;
         if new_pos >= 0 && (new_pos as usize) < project_sessions.len() {
             self.active_index = project_sessions[new_pos as usize];
+        }
+    }
+
+    /// Clear all search/filter state.
+    pub(crate) fn clear_search(&mut self) {
+        self.search_active = false;
+        self.search_input.buffer.clear();
+        self.search_input.cursor = 0;
+        self.project_match_positions.clear();
+        self.session_match_positions.clear();
+    }
+
+    /// Recompute fuzzy match positions based on the current search query and
+    /// snap selection to the first match if the current selection is a non-match.
+    pub(crate) fn recompute_search_filter(&mut self) {
+        let query = &self.search_input.buffer;
+        if query.is_empty() {
+            self.project_match_positions.clear();
+            self.session_match_positions.clear();
+            return;
+        }
+        match self.search_target {
+            SearchTarget::Projects => {
+                self.project_match_positions = self
+                    .projects
+                    .iter()
+                    .map(|p| fuzzy::fuzzy_match(query, &p.config.name).map(|m| m.positions))
+                    .collect();
+                // Snap to first match if current selection is a non-match.
+                let current_matches = self
+                    .project_match_positions
+                    .get(self.active_project_index)
+                    .map(|m| m.is_some())
+                    .unwrap_or(false);
+                if !current_matches {
+                    if let Some(first) = self
+                        .project_match_positions
+                        .iter()
+                        .position(|m| m.is_some())
+                    {
+                        self.active_project_index = first;
+                        self.sync_active_session_to_project();
+                    }
+                }
+            }
+            SearchTarget::Sessions => {
+                let project_sessions = self.active_project_sessions();
+                self.session_match_positions = project_sessions
+                    .iter()
+                    .map(|&global_idx| {
+                        let info = &self.sessions[global_idx].info;
+                        let name = fuzzy::fuzzy_match(query, &info.name).map(|m| m.positions);
+                        let role = fuzzy::fuzzy_match(query, &info.role).map(|m| m.positions);
+                        let branch = info
+                            .worktrees
+                            .first()
+                            .and_then(|wt| fuzzy::fuzzy_match(query, &wt.branch))
+                            .map(|m| m.positions);
+                        project_list::SessionMatch::from_matches(name, role, branch)
+                    })
+                    .collect();
+                // Snap to first match if current selection is a non-match.
+                let current_local = self.active_session_in_project();
+                let current_matches = self
+                    .session_match_positions
+                    .get(current_local)
+                    .map(|m| m.is_some())
+                    .unwrap_or(false);
+                if !current_matches {
+                    if let Some(first_local) = self
+                        .session_match_positions
+                        .iter()
+                        .position(|m| m.is_some())
+                    {
+                        if let Some(&global_idx) = project_sessions.get(first_local) {
+                            self.active_index = global_idx;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Navigate forward to the next matching item during search.
+    pub(crate) fn search_navigate_forward(&mut self) {
+        match self.search_target {
+            SearchTarget::Projects => {
+                if self.project_match_positions.is_empty() {
+                    self.switch_project_forward();
+                    return;
+                }
+                let start = self.active_project_index + 1;
+                let len = self.project_match_positions.len();
+                for offset in 0..len {
+                    let idx = (start + offset) % len;
+                    if self.project_match_positions[idx].is_some() {
+                        self.active_project_index = idx;
+                        self.sync_active_session_to_project();
+                        return;
+                    }
+                }
+            }
+            SearchTarget::Sessions => {
+                if self.session_match_positions.is_empty() {
+                    self.switch_session_forward();
+                    return;
+                }
+                let project_sessions = self.active_project_sessions();
+                let current_local = self.active_session_in_project();
+                let start = current_local + 1;
+                let len = self.session_match_positions.len();
+                for offset in 0..len {
+                    let idx = (start + offset) % len;
+                    if self.session_match_positions[idx].is_some() {
+                        if let Some(&global_idx) = project_sessions.get(idx) {
+                            self.active_index = global_idx;
+                        }
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Navigate backward to the previous matching item during search.
+    pub(crate) fn search_navigate_backward(&mut self) {
+        match self.search_target {
+            SearchTarget::Projects => {
+                if self.project_match_positions.is_empty() {
+                    self.switch_project_backward();
+                    return;
+                }
+                let len = self.project_match_positions.len();
+                let start = if self.active_project_index == 0 {
+                    len - 1
+                } else {
+                    self.active_project_index - 1
+                };
+                for offset in 0..len {
+                    let idx = (start + len - offset) % len;
+                    if self.project_match_positions[idx].is_some() {
+                        self.active_project_index = idx;
+                        self.sync_active_session_to_project();
+                        return;
+                    }
+                }
+            }
+            SearchTarget::Sessions => {
+                if self.session_match_positions.is_empty() {
+                    self.switch_session_backward();
+                    return;
+                }
+                let project_sessions = self.active_project_sessions();
+                let current_local = self.active_session_in_project();
+                let len = self.session_match_positions.len();
+                let start = if current_local == 0 {
+                    len - 1
+                } else {
+                    current_local - 1
+                };
+                for offset in 0..len {
+                    let idx = (start + len - offset) % len;
+                    if self.session_match_positions[idx].is_some() {
+                        if let Some(&global_idx) = project_sessions.get(idx) {
+                            self.active_index = global_idx;
+                        }
+                        return;
+                    }
+                }
+            }
         }
     }
 

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -31,7 +31,7 @@ impl App {
 
         // Left panel (projects + sessions)
         if let Some(left_area) = areas.left_panel {
-            let project_entries: Vec<project_list::ProjectEntry<'_>> = self
+            let mut project_entries: Vec<project_list::ProjectEntry<'_>> = self
                 .projects
                 .iter()
                 .map(|p| {
@@ -67,9 +67,18 @@ impl App {
                         busy_count,
                         waiting_count,
                         error_count,
+                        match_positions: None, // set below
                     }
                 })
                 .collect();
+
+            // Attach fuzzy match positions to each project entry.
+            for (i, entry) in project_entries.iter_mut().enumerate() {
+                entry.match_positions = self
+                    .project_match_positions
+                    .get(i)
+                    .and_then(|m| m.as_deref());
+            }
 
             let project_session_indices = self.active_project_sessions();
             let mut project_sessions: Vec<&SessionInfo> = project_session_indices
@@ -102,6 +111,8 @@ impl App {
                 }
             }
 
+            let session_elapsed_buf = self.session_elapsed_buf.clone();
+
             let panel_focus = match self.focus {
                 InputFocus::ProjectList => project_list::LeftPanelFocus::Projects,
                 InputFocus::SessionList | InputFocus::Terminal => {
@@ -120,16 +131,25 @@ impl App {
             project_list::render_left_panel(
                 frame,
                 left_area,
-                &project_list::LeftPanelState {
+                &mut project_list::LeftPanelState {
                     projects: &project_entries,
                     active_project: self.active_project_index,
                     sessions: &project_sessions,
                     active_session: self.active_session_in_project(),
-                    session_elapsed_ms: &self.session_elapsed_buf,
+                    session_elapsed_ms: &session_elapsed_buf,
                     focus: panel_focus,
                     panel_focused: self.focus != InputFocus::Terminal,
                     project_focus,
                     session_focus,
+                    project_list_state: &mut self.project_list_state,
+                    session_list_state: &mut self.session_list_state,
+                    search_query: &self.search_input.buffer,
+                    search_active: self.search_active,
+                    search_cursor: self.search_input.cursor,
+                    session_match_positions: &self.session_match_positions,
+                    search_targets_projects: self.search_target == super::SearchTarget::Projects,
+                    project_search_active: !self.project_match_positions.is_empty(),
+                    session_search_active: !self.session_match_positions.is_empty(),
                 },
             );
         }

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -2,7 +2,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{List, ListItem, ListState, Paragraph},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
     Frame,
 };
 
@@ -10,6 +10,41 @@ use super::focus_block;
 use super::theme::Theme;
 use super::FocusLevel;
 use crate::session::SessionInfo;
+
+/// Per-field fuzzy match positions for a session entry.
+pub struct SessionMatch {
+    pub name: Vec<usize>,
+    pub role: Vec<usize>,
+    pub branch: Vec<usize>,
+}
+
+impl SessionMatch {
+    /// Build a `SessionMatch` from fuzzy match results, returning `None` if nothing matched.
+    pub fn from_matches(
+        name: Option<Vec<usize>>,
+        role: Option<Vec<usize>>,
+        branch: Option<Vec<usize>>,
+    ) -> Option<Self> {
+        if name.is_some() || role.is_some() || branch.is_some() {
+            Some(Self {
+                name: name.unwrap_or_default(),
+                role: role.unwrap_or_default(),
+                branch: branch.unwrap_or_default(),
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Extract non-empty positions for a field, suitable for `append_name_spans`.
+    fn positions<'a>(&self, field: &'a [usize]) -> Option<&'a [usize]> {
+        if field.is_empty() {
+            None
+        } else {
+            Some(field)
+        }
+    }
+}
 
 pub struct ProjectEntry<'a> {
     pub name: &'a str,
@@ -20,6 +55,8 @@ pub struct ProjectEntry<'a> {
     pub busy_count: usize,
     pub waiting_count: usize,
     pub error_count: usize,
+    /// Fuzzy match byte positions (None = no match / dim, Some = highlight).
+    pub match_positions: Option<&'a [usize]>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,43 +78,205 @@ pub struct LeftPanelState<'a> {
     pub project_focus: FocusLevel,
     /// Focus level for the session sub-section.
     pub session_focus: FocusLevel,
+    /// Persistent list state for the project section.
+    pub project_list_state: &'a mut ListState,
+    /// Persistent list state for the session section.
+    pub session_list_state: &'a mut ListState,
+    /// Active search query (empty = no search).
+    pub search_query: &'a str,
+    /// Whether the search input is actively receiving keystrokes.
+    pub search_active: bool,
+    /// Cursor position within the search query.
+    pub search_cursor: usize,
+    /// Per-session fuzzy match positions (parallel to sessions slice).
+    pub session_match_positions: &'a [Option<SessionMatch>],
+    /// Whether the search targets the project section (else sessions).
+    pub search_targets_projects: bool,
+    /// Whether a project search is active (non-empty project_match_positions).
+    pub project_search_active: bool,
+    /// Whether a session search is active (non-empty session_match_positions).
+    pub session_search_active: bool,
 }
 
-pub fn render_left_panel(frame: &mut Frame, area: Rect, state: &LeftPanelState<'_>) {
+pub fn render_left_panel(frame: &mut Frame, area: Rect, state: &mut LeftPanelState<'_>) {
     // All projects in a single list (admin is first, already guaranteed by app)
     let all_projects: Vec<(usize, &ProjectEntry<'_>)> = state.projects.iter().enumerate().collect();
 
-    // 2 lines per project, +1 separator line per admin entry, +2 for borders
-    let admin_count = all_projects.iter().filter(|(_, p)| p.is_admin).count() as u16;
-    let projects_content = all_projects.len() as u16 * 2 + admin_count;
-    let projects_height = projects_content + 2;
+    let search_visible = state.search_active || !state.search_query.is_empty();
+    let search_below_projects = search_visible && state.search_targets_projects;
+    let search_below_sessions = search_visible && !search_below_projects;
 
-    let constraints = vec![
-        Constraint::Length(projects_height),
-        Constraint::Min(4), // sessions
-    ];
+    let constraints = if search_below_projects {
+        vec![
+            Constraint::Percentage(33), // projects
+            Constraint::Length(3),      // search bar (below projects)
+            Constraint::Percentage(67), // sessions
+        ]
+    } else if search_below_sessions {
+        vec![
+            Constraint::Percentage(33), // projects
+            Constraint::Percentage(67), // sessions
+            Constraint::Length(3),      // search bar (below sessions)
+        ]
+    } else {
+        vec![
+            Constraint::Percentage(33), // projects
+            Constraint::Percentage(67), // sessions
+        ]
+    };
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints(constraints)
         .split(area);
 
+    let (project_area, search_area, session_area) = if search_below_projects {
+        (chunks[0], Some(chunks[1]), chunks[2])
+    } else if search_below_sessions {
+        (chunks[0], Some(chunks[2]), chunks[1])
+    } else {
+        (chunks[0], None, chunks[1])
+    };
+
     render_project_section(
         frame,
-        chunks[0],
+        project_area,
         &all_projects,
         state.active_project,
         state.project_focus,
+        state.project_list_state,
+        state.project_search_active,
     );
 
     render_session_section(
         frame,
-        chunks[1],
+        session_area,
         state.sessions,
         state.active_session,
         state.session_elapsed_ms,
         state.session_focus,
+        state.session_list_state,
+        state.session_match_positions,
+        state.session_search_active,
     );
+
+    if let Some(area) = search_area {
+        render_search_bar(
+            frame,
+            area,
+            state.search_query,
+            state.search_active,
+            state.search_cursor,
+        );
+    }
+}
+
+/// Overlay scroll indicators ("▲ N" / "▼ N") on the block borders when items
+/// are clipped above or below. Renders right-aligned on the top/bottom border
+/// lines, consuming no content space.
+fn render_scroll_indicators(
+    frame: &mut Frame,
+    block_area: Rect,
+    total_items: usize,
+    list_state: &ListState,
+    item_height: u16,
+) {
+    let offset = list_state.offset();
+    // Inner height = block_area.height - 2 (top + bottom border)
+    let inner_height = block_area.height.saturating_sub(2);
+    let visible_count = if item_height > 0 {
+        (inner_height / item_height) as usize
+    } else {
+        0
+    };
+
+    let items_above = offset;
+    let items_below = total_items.saturating_sub(offset + visible_count);
+
+    let indicator_style = Style::default().fg(Theme::TEXT_MUTED);
+
+    if items_above > 0 {
+        let text = format!("▲ {items_above} ");
+        let text_len = text.chars().count() as u16;
+        let x = block_area
+            .x
+            .saturating_add(block_area.width.saturating_sub(text_len + 1));
+        let area = Rect::new(x, block_area.y, text_len, 1);
+        frame.render_widget(Paragraph::new(text).style(indicator_style), area);
+    }
+
+    if items_below > 0 {
+        let text = format!("▼ {items_below} ");
+        let text_len = text.chars().count() as u16;
+        let x = block_area
+            .x
+            .saturating_add(block_area.width.saturating_sub(text_len + 1));
+        let y = block_area
+            .y
+            .saturating_add(block_area.height.saturating_sub(1));
+        let area = Rect::new(x, y, text_len, 1);
+        frame.render_widget(Paragraph::new(text).style(indicator_style), area);
+    }
+}
+
+/// Render a bordered search bar block.
+fn render_search_bar(frame: &mut Frame, area: Rect, query: &str, is_active: bool, cursor: usize) {
+    let style = if is_active {
+        Style::default().fg(Theme::ACCENT)
+    } else {
+        Style::default().fg(Theme::TEXT_MUTED)
+    };
+
+    let block = Block::default()
+        .title(Line::from(Span::styled(" Search ", style)))
+        .borders(Borders::ALL)
+        .border_style(style);
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let max_width = inner.width as usize;
+    if max_width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let prefix = "/ ";
+    let display_query = if query.len() + prefix.len() > max_width {
+        &query[query.len().saturating_sub(max_width - prefix.len())..]
+    } else {
+        query
+    };
+
+    let (before, after) = if cursor <= display_query.chars().count() {
+        let byte_pos = display_query
+            .char_indices()
+            .nth(cursor)
+            .map(|(i, _)| i)
+            .unwrap_or(display_query.len());
+        (&display_query[..byte_pos], &display_query[byte_pos..])
+    } else {
+        (display_query, "")
+    };
+
+    let mut spans = vec![Span::styled(prefix, style), Span::styled(before, style)];
+
+    if is_active {
+        let first_char_len = after.chars().next().map_or(0, |c| c.len_utf8());
+        let cursor_char = if first_char_len == 0 {
+            " "
+        } else {
+            &after[..first_char_len]
+        };
+        spans.push(Span::styled(cursor_char, Theme::cursor()));
+        let rest = &after[first_char_len..];
+        if !rest.is_empty() {
+            spans.push(Span::styled(rest, style));
+        }
+    } else {
+        spans.push(Span::styled(after, style));
+    }
+
+    frame.render_widget(Paragraph::new(Line::from(spans)), inner);
 }
 
 /// Build status dot spans for a project's aggregate session statuses.
@@ -99,7 +298,7 @@ fn status_dots<'a>(project: &ProjectEntry<'a>) -> Vec<Span<'a>> {
 }
 
 /// Build the metadata line (line 2) for a regular project entry.
-fn project_meta_line<'a>(project: &ProjectEntry<'a>) -> Line<'a> {
+fn project_meta_line<'a>(project: &ProjectEntry<'a>, style: Style) -> Line<'a> {
     let repo_text = if project.repo_count == 1 {
         project.repo_short.unwrap_or("1 repo").to_string()
     } else if project.repo_count > 1 {
@@ -116,8 +315,57 @@ fn project_meta_line<'a>(project: &ProjectEntry<'a>) -> Line<'a> {
 
     Line::from(vec![Span::styled(
         format!("    {repo_text} · {role_text}"),
-        Theme::project_meta(),
+        style,
     )])
+}
+
+/// Build spans for a name with fuzzy-matched characters highlighted.
+fn build_highlighted_spans<'a>(
+    name: &'a str,
+    positions: &[usize],
+    base_style: Style,
+) -> Vec<Span<'a>> {
+    let highlight_style = base_style
+        .fg(Theme::ACCENT)
+        .add_modifier(Modifier::BOLD | Modifier::UNDERLINED);
+
+    let mut spans = Vec::new();
+    let mut last_end = 0;
+    for &byte_pos in positions {
+        if byte_pos > name.len() {
+            break;
+        }
+        if let Some(ch) = name[byte_pos..].chars().next() {
+            let char_len = ch.len_utf8();
+            if byte_pos > last_end {
+                spans.push(Span::styled(&name[last_end..byte_pos], base_style));
+            }
+            spans.push(Span::styled(
+                &name[byte_pos..byte_pos + char_len],
+                highlight_style,
+            ));
+            last_end = byte_pos + char_len;
+        }
+    }
+    if last_end < name.len() {
+        spans.push(Span::styled(&name[last_end..], base_style));
+    }
+    spans
+}
+
+/// Append name spans to `out`, using fuzzy-highlight positions when available.
+fn append_name_spans<'a>(
+    out: &mut Vec<Span<'a>>,
+    name: &'a str,
+    match_positions: Option<&[usize]>,
+    style: Style,
+) {
+    match match_positions {
+        Some(positions) if !positions.is_empty() => {
+            out.extend(build_highlighted_spans(name, positions, style));
+        }
+        _ => out.push(Span::styled(name, style)),
+    }
 }
 
 fn render_project_section(
@@ -126,6 +374,8 @@ fn render_project_section(
     projects: &[(usize, &ProjectEntry<'_>)],
     active_index: usize,
     level: FocusLevel,
+    list_state: &mut ListState,
+    search_active: bool,
 ) {
     let block = focus_block(" Projects ", level);
     let inner_width = area.width.saturating_sub(2) as usize;
@@ -136,7 +386,18 @@ fn render_project_section(
             let is_active = orig_idx == active_index;
             let indicator = if is_active { "▸" } else { " " };
 
-            let (prefix, name_color) = if project.is_admin {
+            let is_dimmed = search_active && project.match_positions.is_none();
+
+            let (prefix, name_color) = if is_dimmed {
+                (
+                    if project.is_admin {
+                        format!("{indicator} ⚙ ")
+                    } else {
+                        format!("{indicator} ")
+                    },
+                    Theme::TEXT_MUTED,
+                )
+            } else if project.is_admin {
                 (format!("{indicator} ⚙ "), Theme::ADMIN_BADGE)
             } else {
                 (
@@ -149,29 +410,42 @@ fn render_project_section(
                 )
             };
 
-            let name_style = if is_active {
+            let name_style = if is_dimmed {
+                Style::default().fg(Theme::TEXT_MUTED)
+            } else if is_active {
                 Style::default().fg(name_color).add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(name_color)
             };
 
-            let mut line1_spans = vec![
-                Span::styled(prefix, name_style),
-                Span::styled(project.name, name_style),
-                Span::raw("  "),
-            ];
-            line1_spans.extend(status_dots(project));
+            let mut line1_spans = vec![Span::styled(prefix, name_style)];
+            append_name_spans(
+                &mut line1_spans,
+                project.name,
+                project.match_positions,
+                name_style,
+            );
+            line1_spans.push(Span::raw("  "));
+            if !is_dimmed {
+                line1_spans.extend(status_dots(project));
+            }
             let line1 = Line::from(line1_spans);
 
+            let meta_style = if is_dimmed {
+                Style::default().fg(Theme::TEXT_MUTED)
+            } else {
+                Theme::project_meta()
+            };
+
             let lines = if project.is_admin {
-                let line2 = Line::from(Span::styled("    admin", Theme::project_meta()));
+                let line2 = Line::from(Span::styled("    admin", meta_style));
                 let separator = Line::from(Span::styled(
                     "─ ".repeat(inner_width / 2),
                     Style::default().fg(Theme::BORDER_UNFOCUSED),
                 ));
                 vec![line1, line2, separator]
             } else {
-                vec![line1, project_meta_line(project)]
+                vec![line1, project_meta_line(project, meta_style)]
             };
 
             ListItem::new(lines)
@@ -189,11 +463,15 @@ fn render_project_section(
             .add_modifier(Modifier::BOLD),
     );
 
-    let mut list_state = ListState::default();
     list_state.select(list_active);
-    frame.render_stateful_widget(list, area, &mut list_state);
+    frame.render_stateful_widget(list, area, list_state);
+
+    // Admin entries are 3 lines, regular are 2. Use 2 as the base height
+    // since most items are regular projects.
+    render_scroll_indicators(frame, area, projects.len(), list_state, 2);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_session_section(
     frame: &mut Frame,
     area: Rect,
@@ -201,6 +479,9 @@ fn render_session_section(
     active_index: usize,
     elapsed_ms: &[u64],
     level: FocusLevel,
+    list_state: &mut ListState,
+    match_positions: &[Option<SessionMatch>],
+    search_active: bool,
 ) {
     let block = focus_block(" Sessions ", level);
 
@@ -222,8 +503,14 @@ fn render_session_section(
             let is_active = i == active_index;
             let prefix = if is_active { "▸" } else { " " };
 
+            // Determine if this session is dimmed (search active + no match).
+            let session_match = match_positions.get(i).and_then(|m| m.as_ref());
+            let is_dimmed = search_active && session_match.is_none();
+
             let status_text = format_status_with_elapsed(info.status, elapsed_ms.get(i).copied());
-            let name_style = if is_active {
+            let name_style = if is_dimmed {
+                Style::default().fg(Theme::TEXT_MUTED)
+            } else if is_active {
                 Theme::selected_item()
             } else {
                 Theme::normal_item()
@@ -240,32 +527,64 @@ fn render_session_section(
                 1
             };
 
-            let status_style = Style::default().fg(super::status_color(info.status));
-            let line1 = Line::from(vec![
-                Span::styled(format!("{prefix} {} ", info.status.icon()), status_style),
-                Span::styled(&info.name, name_style),
-                Span::raw(" ".repeat(gap)),
-                Span::styled(status_text, status_style),
-            ]);
+            let status_style = if is_dimmed {
+                Style::default().fg(Theme::TEXT_MUTED)
+            } else {
+                Style::default().fg(super::status_color(info.status))
+            };
+
+            let mut line1_spans = vec![Span::styled(
+                format!("{prefix} {} ", info.status.icon()),
+                status_style,
+            )];
+            append_name_spans(
+                &mut line1_spans,
+                &info.name,
+                session_match.and_then(|m| m.positions(&m.name)),
+                name_style,
+            );
+
+            line1_spans.push(Span::raw(" ".repeat(gap)));
+            line1_spans.push(Span::styled(status_text, status_style));
+            let line1 = Line::from(line1_spans);
 
             // Line 2: provisioning step (if provisioning) or role · branch/VM
-            let line2 = if info.status == crate::session::SessionStatus::Provisioning {
+            let line2 = if is_dimmed {
+                let mut line2_spans = vec![Span::styled(
+                    format!("    {}", info.role),
+                    Style::default().fg(Theme::TEXT_MUTED),
+                )];
+                if let Some(wt) = info.worktrees.first() {
+                    line2_spans.push(Span::styled(
+                        format!(" · {}", wt.branch),
+                        Style::default().fg(Theme::TEXT_MUTED),
+                    ));
+                }
+                Line::from(line2_spans)
+            } else if info.status == crate::session::SessionStatus::Provisioning {
                 let step_text = info.provisioning_step.as_deref().unwrap_or("Starting...");
                 Line::from(vec![
                     Span::styled("    ⟳ ", Style::default().fg(Theme::ACCENT)),
                     Span::styled(step_text, Style::default().fg(Theme::ACCENT)),
                 ])
             } else {
-                let mut line2_spans = vec![Span::styled(
-                    format!("    {}", info.role),
-                    Style::default().fg(Theme::ROLE_NAME),
-                )];
+                let role_style = Style::default().fg(Theme::ROLE_NAME);
+                let mut line2_spans = vec![Span::raw("    ")];
+                append_name_spans(
+                    &mut line2_spans,
+                    &info.role,
+                    session_match.and_then(|m| m.positions(&m.role)),
+                    role_style,
+                );
                 if let Some(wt) = info.worktrees.first() {
                     line2_spans.push(Span::styled(" · ", Style::default().fg(Theme::TEXT_MUTED)));
-                    line2_spans.push(Span::styled(
+                    let branch_style = Style::default().fg(Theme::BRANCH_NAME);
+                    append_name_spans(
+                        &mut line2_spans,
                         &wt.branch,
-                        Style::default().fg(Theme::BRANCH_NAME),
-                    ));
+                        session_match.and_then(|m| m.positions(&m.branch)),
+                        branch_style,
+                    );
                 }
                 if info.vm_id.is_some() {
                     line2_spans.push(Span::styled(" · ", Style::default().fg(Theme::TEXT_MUTED)));
@@ -290,9 +609,11 @@ fn render_session_section(
             .add_modifier(Modifier::BOLD),
     );
 
-    let mut state = ListState::default();
-    state.select(Some(active_index));
-    frame.render_stateful_widget(list, area, &mut state);
+    list_state.select(Some(active_index));
+    frame.render_stateful_widget(list, area, list_state);
+
+    // Sessions are 2 lines per item.
+    render_scroll_indicators(frame, area, sessions.len(), list_state, 2);
 }
 
 /// Format status text with elapsed time for Waiting/Idle sessions.
@@ -337,6 +658,7 @@ mod tests {
             busy_count: busy,
             waiting_count: waiting,
             error_count: error,
+            match_positions: None,
         }
     }
 
@@ -355,6 +677,7 @@ mod tests {
             busy_count: busy,
             waiting_count: waiting,
             error_count: error,
+            match_positions: None,
         }
     }
 
@@ -400,7 +723,7 @@ mod tests {
     #[test]
     fn meta_line_single_repo_shows_name() {
         let entry = test_entry("P", 0, 0, 0, 1, Some("myrepo"), 2);
-        let line = project_meta_line(&entry);
+        let line = project_meta_line(&entry, Theme::project_meta());
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("myrepo"));
         assert!(text.contains("2 roles"));
@@ -409,7 +732,7 @@ mod tests {
     #[test]
     fn meta_line_multiple_repos_shows_count() {
         let entry = test_entry("P", 0, 0, 0, 3, None, 1);
-        let line = project_meta_line(&entry);
+        let line = project_meta_line(&entry, Theme::project_meta());
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("3 repos"));
         assert!(text.contains("1 role"));
@@ -418,7 +741,7 @@ mod tests {
     #[test]
     fn meta_line_no_repos() {
         let entry = test_entry("P", 0, 0, 0, 0, None, 0);
-        let line = project_meta_line(&entry);
+        let line = project_meta_line(&entry, Theme::project_meta());
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("no repos"));
         assert!(text.contains("0 roles"));
@@ -427,7 +750,7 @@ mod tests {
     #[test]
     fn meta_line_single_repo_without_short_name() {
         let entry = test_entry("P", 0, 0, 0, 1, None, 1);
-        let line = project_meta_line(&entry);
+        let line = project_meta_line(&entry, Theme::project_meta());
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("1 repo"));
         assert!(text.contains("1 role"));
@@ -463,5 +786,134 @@ mod tests {
     fn elapsed_none_shows_plain_status() {
         let text = format_status_with_elapsed(SessionStatus::Error, None);
         assert_eq!(text, "Error");
+    }
+
+    // --- build_highlighted_spans ---
+
+    #[test]
+    fn highlighted_spans_basic() {
+        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let spans = build_highlighted_spans("foo-bar", &[0, 4], style);
+        // Should produce: "f" (highlighted), "oo-" (normal), "b" (highlighted), "ar" (normal)
+        assert_eq!(spans.len(), 4);
+        assert_eq!(spans[0].content, "f");
+        assert_eq!(spans[1].content, "oo-");
+        assert_eq!(spans[2].content, "b");
+        assert_eq!(spans[3].content, "ar");
+    }
+
+    #[test]
+    fn highlighted_spans_empty_positions() {
+        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let spans = build_highlighted_spans("hello", &[], style);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content, "hello");
+    }
+
+    #[test]
+    fn highlighted_spans_all_chars() {
+        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let spans = build_highlighted_spans("abc", &[0, 1, 2], style);
+        // All chars highlighted, no normal spans between them.
+        assert_eq!(spans.len(), 3);
+        assert_eq!(spans[0].content, "a");
+        assert_eq!(spans[1].content, "b");
+        assert_eq!(spans[2].content, "c");
+    }
+
+    // --- append_name_spans ---
+
+    #[test]
+    fn append_name_spans_no_match_positions() {
+        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let mut spans = Vec::new();
+        append_name_spans(&mut spans, "hello", None, style);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content, "hello");
+    }
+
+    #[test]
+    fn append_name_spans_empty_positions() {
+        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let mut spans = Vec::new();
+        append_name_spans(&mut spans, "hello", Some(&[]), style);
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content, "hello");
+    }
+
+    #[test]
+    fn append_name_spans_with_highlights() {
+        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let mut spans = vec![Span::raw("prefix ")];
+        append_name_spans(&mut spans, "foo-bar", Some(&[0, 4]), style);
+        // prefix + "f" (highlighted) + "oo-" (normal) + "b" (highlighted) + "ar" (normal)
+        assert_eq!(spans.len(), 5);
+        assert_eq!(spans[0].content, "prefix ");
+        assert_eq!(spans[1].content, "f");
+        assert_eq!(spans[2].content, "oo-");
+        assert_eq!(spans[3].content, "b");
+        assert_eq!(spans[4].content, "ar");
+    }
+
+    // --- SessionMatch ---
+
+    #[test]
+    fn session_match_from_matches_all_none_returns_none() {
+        assert!(SessionMatch::from_matches(None, None, None).is_none());
+    }
+
+    #[test]
+    fn session_match_from_matches_name_only() {
+        let m = SessionMatch::from_matches(Some(vec![0, 1]), None, None).unwrap();
+        assert_eq!(m.name, vec![0, 1]);
+        assert!(m.role.is_empty());
+        assert!(m.branch.is_empty());
+    }
+
+    #[test]
+    fn session_match_from_matches_role_only() {
+        let m = SessionMatch::from_matches(None, Some(vec![2]), None).unwrap();
+        assert!(m.name.is_empty());
+        assert_eq!(m.role, vec![2]);
+        assert!(m.branch.is_empty());
+    }
+
+    #[test]
+    fn session_match_from_matches_branch_only() {
+        let m = SessionMatch::from_matches(None, None, Some(vec![3, 5])).unwrap();
+        assert!(m.name.is_empty());
+        assert!(m.role.is_empty());
+        assert_eq!(m.branch, vec![3, 5]);
+    }
+
+    #[test]
+    fn session_match_from_matches_all_fields() {
+        let m = SessionMatch::from_matches(Some(vec![0]), Some(vec![1]), Some(vec![2])).unwrap();
+        assert_eq!(m.name, vec![0]);
+        assert_eq!(m.role, vec![1]);
+        assert_eq!(m.branch, vec![2]);
+    }
+
+    #[test]
+    fn session_match_positions_empty_returns_none() {
+        let m = SessionMatch::from_matches(Some(vec![0]), None, None).unwrap();
+        assert!(m.positions(&m.role).is_none());
+        assert!(m.positions(&m.branch).is_none());
+    }
+
+    #[test]
+    fn session_match_positions_non_empty_returns_some() {
+        let m = SessionMatch::from_matches(Some(vec![0, 4]), None, None).unwrap();
+        assert_eq!(m.positions(&m.name), Some(&[0, 4][..]));
+    }
+
+    // --- project_meta_line with custom style ---
+
+    #[test]
+    fn meta_line_uses_provided_style() {
+        let entry = test_entry("P", 0, 0, 0, 1, Some("myrepo"), 1);
+        let muted = Style::default().fg(Theme::TEXT_MUTED);
+        let line = project_meta_line(&entry, muted);
+        assert_eq!(line.spans[0].style, muted);
     }
 }

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -77,6 +77,7 @@
             <li><a href="#container-sessions">Container Sessions</a></li>
             <li><a href="#vm-sessions">VM Sessions</a></li>
             <li><a href="#role-system">Role System</a></li>
+            <li><a href="#fuzzy-search">Fuzzy Search</a></li>
             <li><a href="#responsive-ui">Responsive UI</a></li>
             <li><a href="#session-persistence">Session Persistence</a></li>
           </ul>
@@ -504,6 +505,42 @@
             <a href="roles.html">Role Configuration</a>
             for the full guide.
           </p>
+
+          <h2 id="fuzzy-search">
+            Fuzzy Search
+            <a href="#fuzzy-search" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Press
+            <code>/</code>
+            in the project or session list to open a fuzzy search bar. The bar appears directly
+            below the section being searched.
+          </p>
+          <ul>
+            <li>
+              <strong>Project search</strong>
+              filters by project name.
+            </li>
+            <li>
+              <strong>Session search</strong>
+              filters by session name, role name, or worktree branch &mdash; the three fields
+              visible in each session entry.
+            </li>
+            <li>
+              Matched characters are highlighted with accent color. Non-matching entries are dimmed
+              but remain visible.
+            </li>
+            <li>
+              <code>j</code>
+              /
+              <code>k</code>
+              jump between matches,
+              <code>Enter</code>
+              confirms,
+              <code>Esc</code>
+              cancels.
+            </li>
+          </ul>
 
           <h2 id="responsive-ui">
             Responsive UI

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -72,6 +72,7 @@
             <li><a href="#design">Design Philosophy</a></li>
             <li><a href="#global-keys">Global Keys</a></li>
             <li><a href="#list-navigation">List Navigation</a></li>
+            <li><a href="#search">Search</a></li>
             <li><a href="#terminal-scrollback">Terminal Scrollback</a></li>
             <li><a href="#modals">Modal Keybindings</a></li>
             <li><a href="#scheduled-commands">Scheduled Commands</a></li>
@@ -305,11 +306,47 @@
                 <td>Previous item</td>
               </tr>
               <tr>
+                <td><code>/</code></td>
+                <td>Open fuzzy search</td>
+              </tr>
+              <tr>
                 <td><code>Enter</code></td>
                 <td>Select / focus</td>
               </tr>
             </tbody>
           </table>
+
+          <h2 id="search">
+            Search
+            <a href="#search" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Press
+            <code>/</code>
+            in the project or session list to open a fuzzy search bar. The search bar appears below
+            the active section.
+          </p>
+          <ul>
+            <li>
+              <strong>Project search</strong>
+              matches against the project name.
+            </li>
+            <li>
+              <strong>Session search</strong>
+              matches against the session name, role, and worktree branch.
+            </li>
+          </ul>
+          <p>
+            Matched characters are highlighted inline. Non-matching entries are dimmed. Use
+            <code>j</code>
+            /
+            <code>k</code>
+            to jump between matches,
+            <code>Enter</code>
+            to confirm, or
+            <code>Esc</code>
+            to cancel.
+          </p>
 
           <h2 id="terminal-scrollback">
             Terminal Scrollback &amp; Selection


### PR DESCRIPTION
## Summary

- Session fuzzy search now matches name, role name, and worktree branch (all three fields visible on line 2 of each session entry)
- Search bar is anchored below whichever section is being searched — below projects for project search, below sessions for session search — from the moment `/` is pressed (not dependent on match state)
- Introduced `SessionMatch` struct with per-field match positions and `from_matches` / `positions` helpers
- Updated README, `docs/FEATURES.md`, and website (`features.html`, `keybindings.html`) with search keybinding and behaviour description

## Test plan

- [x] All 903 existing + new tests pass (`cargo nextest run --all`)
- [x] Clippy clean
- [x] 7 new unit tests for `SessionMatch::from_matches` and `positions`
- [ ] Manual: type `/` in session list, search for a role name → sessions with that role highlighted, non-matching sessions dimmed
- [ ] Manual: search for a branch name → sessions on that branch highlighted
- [ ] Manual: search for a session name → still works as before
- [ ] Manual: type `/` in project list → search bar appears below projects; type `/` in session list → search bar appears below sessions, bar does not jump on first keystroke