### PR TITLE
fix(ui): fix focus after deleting last session in project

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1278,11 +1278,7 @@ impl App {
             project.session_ids.retain(|id| *id != session_id);
         }
 
-        if self.sessions.is_empty() {
-            self.active_index = 0;
-        } else if self.active_index >= self.sessions.len() {
-            self.active_index = self.sessions.len() - 1;
-        }
+        self.sync_active_session_to_project();
 
         // Finalize any existing pending delete before storing the new one
         self.finalize_pending_delete();
@@ -8368,5 +8364,22 @@ mod tests {
 
         // active_index should be invalidated (no sessions left in project)
         assert!(!app.has_active_session());
+    }
+
+    #[test]
+    fn close_active_session_invalidates_when_deleting_last_in_project() {
+        let mut app = app_with_two_projects(1);
+        // Start on first project with one session
+        app.active_project_index = 0;
+        app.active_index = 0;
+        assert!(app.has_active_session());
+
+        // Delete the only session in the project
+        app.close_active_session();
+
+        // After deletion, active_index should be invalidated (no active session)
+        assert!(!app.has_active_session());
+        // Project should still exist but have no sessions
+        assert_eq!(app.projects[0].session_ids.len(), 0);
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8382,4 +8382,23 @@ mod tests {
         // Project should still exist but have no sessions
         assert_eq!(app.projects[0].session_ids.len(), 0);
     }
+
+    #[test]
+    fn close_active_session_focuses_first_remaining_when_multiple_exist() {
+        let mut app = app_with_two_projects(2);
+        // Start on first project with two sessions, active on second
+        app.active_project_index = 0;
+        app.active_index = 1; // Second session in global list
+        assert!(app.has_active_session());
+        let first_session_id = app.sessions[0].info.id;
+
+        // Delete the active session
+        app.close_active_session();
+
+        // Should have one session left in project
+        assert_eq!(app.projects[0].session_ids.len(), 1);
+        // Active session should shift to the remaining one (first in project)
+        assert!(app.has_active_session());
+        assert_eq!(app.sessions[app.active_index].info.id, first_session_id);
+    }
 }


### PR DESCRIPTION
## Summary
- Fix focus landing on wrong project's session after deleting last session in current project
- Replace naive index bounds checking with context-aware `sync_active_session_to_project()` helper
- Add comprehensive test coverage for single-session and multi-session deletion scenarios

## Test plan
- [x] Unit tests: `cargo nextest run --all` (905 tests passing)
- [x] New test 1: Verify focus invalidates when deleting only session in project
- [x] New test 2: Verify focus shifts to first remaining session when multiple exist
- [x] Pre-commit hooks: All passing (fmt, clippy, check, nextest, architecture, deny, doc)
- [x] No regressions: All 905 tests pass