### PR TITLE
feat(ui): add dedicated search bar color

### DIFF
--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -222,7 +222,7 @@ fn render_scroll_indicators(
 /// Render a bordered search bar block.
 fn render_search_bar(frame: &mut Frame, area: Rect, query: &str, is_active: bool, cursor: usize) {
     let style = if is_active {
-        Style::default().fg(Theme::ACCENT)
+        Style::default().fg(Theme::SEARCH_BAR)
     } else {
         Style::default().fg(Theme::TEXT_MUTED)
     };

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -35,6 +35,7 @@ impl Theme {
     pub const ROLE_NAME: Color = Color::Magenta;
     pub const ADMIN_BADGE: Color = Color::Yellow;
     pub const BRANCH_NAME: Color = Color::Green;
+    pub const SEARCH_BAR: Color = Color::Blue;
 
     // ── Keybind hints / tool permissions ─────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Add `Theme::SEARCH_BAR` constant (`Color::Blue`) to `src/ui/theme.rs`
- Update `render_search_bar()` to use `Theme::SEARCH_BAR` instead of `Theme::ACCENT` when active
- The search bar is now visually distinct from cyan focus indicators and fuzzy-match highlights

## Test plan

- [ ] Launch Thurbox and trigger search (type `/` in the project or session list)
- [ ] Confirm the search bar border and text render in blue when active
- [ ] Confirm the search bar renders in muted gray when inactive/dismissed
- [ ] All 903 unit tests pass (`cargo nextest run --all`)