### PR TITLE
fix(ui): forward Ctrl+R to PTY when terminal is focused

### DIFF
--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -183,10 +183,13 @@ impl App {
                     self.open_edit_project_modal();
                     return;
                 }
-                KeyCode::Char('r') => {
-                    self.restart_active_session();
-                    return;
-                }
+                KeyCode::Char('r') => match self.focus {
+                    InputFocus::Terminal => {} // forward to PTY (e.g. bash reverse search)
+                    _ => {
+                        self.restart_active_session();
+                        return;
+                    }
+                },
                 KeyCode::Char('p') => {
                     self.open_schedule_command_modal();
                     return;


### PR DESCRIPTION
## Summary
- Ctrl+R was globally intercepted as "restart session", preventing bash/zsh reverse history search (`Ctrl+R`) from working in the terminal pane
- Now forwards Ctrl+R to the PTY when terminal is focused, mirroring the existing Ctrl+D focus-aware pattern
- Non-terminal focus (project/session list) still triggers session restart as before

## Test plan
- [x] `cargo check --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo nextest run --all` — 903/903 tests pass
- [ ] Manual: focus terminal, press Ctrl+R → triggers reverse history search in shell
- [ ] Manual: focus project/session list, press Ctrl+R → restarts active session