### PR TITLE
docs: update for session-centric workflow and global roles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,10 +178,10 @@ thurbox-mcp --transport streamable-http --port 9090  # Custom port
 | `create_project` | Create a new project with name and repo paths |
 | `update_project` | Update project name and/or repos (partial update) |
 | `delete_project` | Soft-delete a project (preserves for undo) |
-| `list_roles` | List all roles for a project (by name or UUID) |
-| `set_roles` | Atomically replace all roles for a project |
-| `list_mcp_servers` | List MCP servers for a project |
-| `set_mcp_servers` | Set MCP servers for a project |
+| `list_roles` | List all global roles |
+| `set_roles` | Atomically replace all global roles |
+| `list_mcp_servers` | List all global MCP servers |
+| `set_mcp_servers` | Set global MCP servers |
 | `list_sessions` | List sessions, optionally filtered by project |
 | `get_session` | Get a session by UUID |
 | `delete_session` | Soft-delete a session (TUI cleans up tmux/worktree) |
@@ -203,9 +203,10 @@ thurbox-mcp --transport streamable-http --port 9090  # Custom port
 | `get_scheduled_command` | Get a scheduled command by ID |
 | `cancel_scheduled_command` | Cancel a pending scheduled command |
 
-**Role Management**: `set_roles` performs an atomic replacement —
-all existing roles are deleted and replaced in a single transaction.
-To add a role, include all existing roles plus the new one.
+**Role Management**: Roles are global presets (not per-project).
+`set_roles` performs an atomic replacement — all existing roles
+are deleted and replaced in a single transaction. To add a role,
+include all existing roles plus the new one.
 See [`docs/MCP_ROLES.md`](docs/MCP_ROLES.md) for the complete
 role configuration guide including permission modes, tool name
 format, and example role patterns.
@@ -271,10 +272,11 @@ app      ← coordinator, imports all modules
   `ProjectConfig`, `ProjectInfo`. Imports `session` only.
 - **`ui/`** — Pure rendering functions. `layout.rs` computes
   panel areas (responsive: <80 = terminal only, >=80 = 2-panel,
-  >=120 = optional 3-panel). Widgets: `project_list` (two-section
-  left panel), `terminal_view`, `info_panel`, `status_bar`.
-  `selection.rs` handles mouse-drag text selection,
-  `links.rs` detects and highlights clickable URLs.
+  >=120 = optional 3-panel). Widgets: `project_list` (session
+  list with repo/branch display), `terminal_view`, `info_panel`,
+  `status_bar`, `repo_picker_modal` (repo selection with
+  worktree toggle). `selection.rs` handles mouse-drag text
+  selection, `links.rs` detects and highlights clickable URLs.
 - **`mcp/`** — MCP server (`thurbox-mcp` binary). Exposes
   project/role/session/VM CRUD over stdio or Streamable HTTP
   JSON-RPC. Shares the same SQLite database as the TUI.
@@ -328,7 +330,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | Key | Action | Mnemonic |
 |-----|--------|----------|
 | `Ctrl+Q` | Quit (detach sessions) | **Q**uit |
-| `Ctrl+N` | New project/session | **N**ew |
+| `Ctrl+N` | New session (opens repo picker) | **N**ew |
 | `Ctrl+C` | Copy selection / SIGINT (terminal) | **C**opy |
 | `Ctrl+V` | Paste from clipboard | Paste |
 | `Ctrl+P` | Schedule command for active session | **P**rogram |
@@ -338,7 +340,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+K` | Select previous project or session | Vim: **k** = up |
 | `Ctrl+L` | Focus next pane (cycle forward) | Vim: **l** = right |
 | `Ctrl+D` | Delete session/project | Vim: **d** = delete |
-| `Ctrl+E` | Edit active project (name, repos, roles, MCP servers) | **E**dit |
+| `Ctrl+E` | Edit active project (name, repos) | **E**dit |
 | `Ctrl+R` | Restart active session | **R**estart |
 | `Ctrl+S` | Sync worktrees with origin/main | **S**ync |
 | `Ctrl+Z` | Undo session/project delete | **Z** = undo |

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ settings. The two-section left sidebar shows all projects on top
 and the active project's sessions below. Projects support
 multiple repositories — the first repo becomes the working
 directory and the rest are passed via `--add-dir`. Edit
-projects on the fly with `Ctrl+E` (name, repos, roles, MCP
-servers) without losing running sessions. Soft-deleted
+projects on the fly with `Ctrl+E` (name, repos) without
+losing running sessions. Soft-deleted
 projects and sessions can be restored via the Admin session
 or MCP API. A built-in Admin project (pinned at index 0)
 provides conversational access to Thurbox management via MCP.
@@ -83,14 +83,13 @@ and `genisoimage` (or `mkisofs`).
 
 ### Role System
 
-Define per-project permission profiles that control Claude's
-behavior. Each role specifies a permission mode (`default`,
-`plan`, `acceptEdits`, `dontAsk`, `bypassPermissions`), lists
-of allowed and disallowed tools with scope patterns like
-`Bash(git:*)`, and optional system prompt text. Manage roles
-from the TUI via `Ctrl+E` or programmatically through the MCP
-server. When a project has roles, a role selector appears at
-session creation.
+Define global permission presets that control Claude's behavior.
+Each role specifies a permission mode (`default`, `plan`,
+`acceptEdits`, `dontAsk`, `bypassPermissions`), lists of allowed
+and disallowed tools with scope patterns like `Bash(git:*)`, and
+optional system prompt text. Manage roles programmatically through
+the MCP server. When two or more roles exist, a role selector
+appears at session creation.
 
 ### MCP Server
 
@@ -164,23 +163,20 @@ The binary will be available at `target/release/thurbox`.
 
 1. **Launch Thurbox** — run `thurbox` in your terminal. The Admin
    session appears automatically in the sidebar.
-2. **Create a project** — press `Ctrl+N` with the project list
-   focused. Enter a name and one or more repository paths.
-3. **Create a session** — select your project, then press
-   `Ctrl+N` again. Choose a session mode (Normal, Worktree,
-   Container, or VM) and optionally select a role.
-4. **Work with Claude** — the terminal panel shows the live
+2. **Create a session** — press `Ctrl+N` to open the repo picker.
+   Select repos from bookmarks (Space to toggle, `w` to mark as
+   worktree), then choose a session mode and optionally a role.
+3. **Work with Claude** — the terminal panel shows the live
    Claude Code session. All keys are forwarded to the PTY.
-5. **Navigate** — `Ctrl+L` cycles focus (project list → session
+4. **Navigate** — `Ctrl+L` cycles focus (project list → session
    list → terminal). `Ctrl+H` jumps to the project list.
    `Ctrl+J` / `Ctrl+K` switch projects or sessions.
-6. **Manage projects** — `Ctrl+E` edits the active project
-   (name, repos, roles, MCP servers). `Ctrl+D` deletes a
-   session or project.
-7. **Restart a session** — `Ctrl+R` restarts with `--resume` to
+5. **Manage projects** — `Ctrl+E` edits the active project
+   (name, repos). `Ctrl+D` deletes a session or project.
+6. **Restart a session** — `Ctrl+R` restarts with `--resume` to
    preserve conversation history while picking up new
    role permissions.
-8. **Quit** — `Ctrl+Q` detaches all sessions (tmux keeps them
+7. **Quit** — `Ctrl+Q` detaches all sessions (tmux keeps them
    running). They resume automatically on next launch.
 
 ## Keybindings
@@ -190,7 +186,7 @@ The binary will be available at `target/release/thurbox`.
 | Key | Action | Mnemonic |
 |-----|--------|----------|
 | `Ctrl+Q` | Quit (detach sessions) | **Q**uit |
-| `Ctrl+N` | New project or session | **N**ew |
+| `Ctrl+N` | New session (opens repo picker) | **N**ew |
 | `Ctrl+C` | Close session / copy selection | **C**lose / **C**opy |
 | `Ctrl+V` | Paste from clipboard | Paste |
 | `Ctrl+T` | Toggle shell pane | **T**erminal |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -58,9 +58,8 @@ Admin project is present. Users create their first project via
 ### Edit project modal
 
 `Ctrl+E` opens a pre-populated modal for editing the active
-project's name, repositories, and roles. The modal mirrors the
-add-project flow (Name → Path → RepoList) with an inline Roles
-list that supports j/k navigation, add/edit/delete operations.
+project's name and repositories. Roles and MCP servers are
+managed globally (see Role Editor and MCP Server sections).
 
 **Why not just delete and recreate?**
 
@@ -72,22 +71,22 @@ list that supports j/k navigation, add/edit/delete operations.
   creation time never changes, even when the project is renamed.
 - Users can fix typos or add repos without losing active work.
 
-**Why a separate modal from add-project?**
+### Session creation flow
 
-- The edit modal needs pre-populated fields and a Roles section.
-  Overloading the add modal with "mode" logic would complicate
-  both the state machine and the key handlers.
-- Separate modals keep each flow simple and independently testable.
+`Ctrl+N` opens the repo picker modal:
 
-#### Roles field behavior
+1. **Repo picker** — select repos from bookmarks (Space to
+   toggle, `w` to mark as worktree). Add new paths via text
+   input with filesystem autocomplete.
+2. **Session mode** — Normal / Worktree / Container / VM.
+   If any repo is marked as worktree, skips directly to branch
+   selection.
+3. **Branch selector** — pick base branch (worktree mode only).
+4. **Branch name** — enter new branch name (worktree mode only).
+5. **Role selector** — pick from global roles (if 2+ defined).
 
-- The Roles field shows an inline list of configured roles with
-  j/k navigation, `a` to add, `e`/`Enter` to edit, `d` to delete.
-- Editing or adding a role opens the role editor detail form as
-  an overlay. `Esc` from the role editor returns to the Roles
-  field in the edit-project modal.
-- `Esc` from the Roles field saves all changes (name, repos,
-  roles) and closes the modal.
+Mixed sessions are supported: worktree repos get a new branch
+while normal repos are added as-is via `--add-dir`.
 
 ---
 
@@ -132,7 +131,7 @@ for actions (`C`=close, `D`=delete, `N`=new, `R`=restart, `Q`=quit).
 | `Ctrl+L` | Global | Focus next pane (cycle forward) | Vim: **l** = right |
 | `Ctrl+D` | Session list | Close active session | Vim: **d** = delete |
 | `Ctrl+D` | Project list | Delete selected project | Vim: **d** = delete |
-| `Ctrl+E` | Global | Edit active project (name, repos, roles, MCP servers) | **E**dit |
+| `Ctrl+E` | Global | Edit active project (name, repos) | **E**dit |
 | `Ctrl+R` | Global | Restart active session | **R**estart |
 | `Ctrl+S` | Global | Sync all worktree sessions with origin/main | **S**ync |
 | `Ctrl+Z` | Global | Undo session/project delete | **Z** = undo |
@@ -149,10 +148,13 @@ for actions (`C`=close, `D`=delete, `N`=new, `R`=restart, `Q`=quit).
 | `j` / `Down` | Session list | Next session | |
 | `k` / `Up` | Session list | Previous session | |
 | `Enter` | Session list | Focus terminal | |
-| `j` / `Down` | Repo selector | Next repo | |
-| `k` / `Up` | Repo selector | Previous repo | |
-| `Enter` | Repo selector | Select repo and spawn session | |
-| `Esc` | Repo selector | Cancel selection | |
+| `j` / `Down` | Repo picker | Next repo | |
+| `k` / `Up` | Repo picker | Previous repo | |
+| `Space` | Repo picker | Toggle repo selection | |
+| `w` | Repo picker | Toggle worktree mode for repo | |
+| `Tab` | Repo picker | Switch to path input | |
+| `Enter` | Repo picker | Confirm selection | |
+| `Esc` | Repo picker | Cancel | |
 | `j` / `Down` | Session mode modal | Next mode | |
 | `k` / `Up` | Session mode modal | Previous mode | |
 | `Enter` | Session mode modal | Select mode | |
@@ -581,17 +583,17 @@ noise in historical output.
 
 ## Role Editor
 
-Roles can be managed from the TUI via the edit project modal
-(`Ctrl+E`). The Roles field provides an inline list with
-add/edit/delete capabilities; editing a role opens a detail form.
+Roles are global presets shared across all sessions (not
+per-project). They can be managed via the MCP server or the
+settings overlay.
 
 For programmatic role management via the MCP server, see
 [MCP_ROLES.md](MCP_ROLES.md).
 
-New projects are seeded with a built-in "developer" role
-(`permission_mode: acceptEdits`, no tool restrictions). Users
-can edit, remove, or add roles as needed. When creating a
-session, a role selector appears if the project has roles.
+A built-in "developer" role (`permission_mode: acceptEdits`,
+no tool restrictions) is used as the default when no roles are
+configured. When creating a session, a role selector appears
+if 2+ global roles are defined.
 
 ### Allow / Ask / Deny Semantics
 
@@ -609,10 +611,9 @@ are supported in both allowed and disallowed tool lists.
 
 ### Role List View
 
-Shows all roles for the active project. Supports
-add (`a`), edit (`e` / `Enter`), and delete (`d`).
-Pressing `Esc` saves changes to the database and
-closes the modal.
+Shows all global roles. Supports add (`a`), edit
+(`e` / `Enter`), and delete (`d`). Pressing `Esc`
+saves changes to the database and closes the modal.
 
 ### Role Editor View
 

--- a/docs/MCP_ROLES.md
+++ b/docs/MCP_ROLES.md
@@ -12,9 +12,9 @@ For TUI-based role editing, see the
 
 ## Overview
 
-Roles are per-project permission profiles stored in Thurbox's
-SQLite database. When a session starts, its assigned role
-determines the Claude CLI flags passed at spawn time:
+Roles are global permission presets stored in Thurbox's SQLite
+database. When a session starts, its assigned role determines
+the Claude CLI flags passed at spawn time:
 
 ```text
 claude --permission-mode <mode> \
@@ -28,9 +28,9 @@ injected into the session's tmux pane at spawn time via
 `tmux new-window -e KEY=VALUE`. This is useful for API keys,
 custom paths, or feature flags.
 
-Each project can have zero or more roles. Sessions select a role
-at creation time. If no roles are defined, sessions spawn with
-default (empty) permissions.
+Roles are shared across all projects and sessions. Sessions
+select a role at creation time. If no roles are defined, sessions
+spawn with the built-in "developer" role (`acceptEdits` mode).
 
 ---
 
@@ -133,7 +133,7 @@ Tool lists are JSON arrays of strings:
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `name` | string | yes | — | Role identifier, unique per project. 1-64 chars, trimmed. |
+| `name` | string | yes | — | Role identifier, globally unique. 1-64 chars, trimmed. |
 | `description` | string | yes | — | Human-readable summary of the role's purpose. |
 | `permission_mode` | string \| null | no | `null` | One of: `default`, `plan`, `acceptEdits`, `dontAsk`, `bypassPermissions`. |
 | `allowed_tools` | string[] | no | `[]` | Tools that auto-approve. See [Tool Name Format](#tool-name-format). |
@@ -159,13 +159,9 @@ Tool lists are JSON arrays of strings:
 
 ### list_roles
 
-List all roles for a project.
+List all global roles.
 
-**Parameters**:
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `project` | string | yes | Project name (case-insensitive) or UUID |
+**Parameters**: None required.
 
 **Response**: JSON array of role objects.
 
@@ -176,9 +172,7 @@ List all roles for a project.
   "method": "tools/call",
   "params": {
     "name": "list_roles",
-    "arguments": {
-      "project": "my-app"
-    }
+    "arguments": {}
   }
 }
 ```
@@ -208,13 +202,12 @@ List all roles for a project.
 
 ### set_roles
 
-Atomically replace all roles for a project.
+Atomically replace all global roles.
 
 **Parameters**:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `project` | string | yes | Project name (case-insensitive) or UUID |
 | `roles` | RoleInput[] | yes | Complete list of roles (replaces all existing) |
 
 **Behavior**:
@@ -235,7 +228,6 @@ Atomically replace all roles for a project.
   "params": {
     "name": "set_roles",
     "arguments": {
-      "project": "my-app",
       "roles": [
         {
           "name": "developer",
@@ -262,7 +254,6 @@ Atomically replace all roles for a project.
 
 **Error cases**:
 
-- Project not found: `{"error": "Project not found: <name>"}`
 - Database error: `{"error": "<sqlite error message>"}`
 
 ---
@@ -384,4 +375,4 @@ Configure `thurbox-mcp` in `.mcp.json`:
 Then use the `set_roles` and `list_roles` tools directly.
 After setting roles, new sessions can select any configured role.
 The role selector appears when creating a session (`Ctrl+N`)
-in a project with multiple roles defined.
+if two or more global roles are defined.

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -152,7 +152,7 @@
             <li>
               Edit projects on the fly with
               <code>Ctrl+E</code>
-              (name, repos, roles, MCP servers) without losing running sessions
+              (name, repos) without losing running sessions
             </li>
             <li>Soft-deleted projects and sessions can be restored via Admin session or MCP API</li>
             <li>
@@ -458,8 +458,7 @@
             <a href="#role-system" class="heading-anchor">#</a>
           </h2>
           <p>
-            Define per-project permission profiles that control Claude's behavior. Each role
-            specifies:
+            Define global permission presets that control Claude's behavior. Each role specifies:
           </p>
           <ul>
             <li>

--- a/website/docs/mcp.html
+++ b/website/docs/mcp.html
@@ -195,11 +195,11 @@
             <tbody>
               <tr>
                 <td><code>list_roles</code></td>
-                <td>List all roles for a project</td>
+                <td>List all global roles</td>
               </tr>
               <tr>
                 <td><code>set_roles</code></td>
-                <td>Atomically replace all roles for a project</td>
+                <td>Atomically replace all global roles</td>
               </tr>
             </tbody>
           </table>
@@ -223,11 +223,11 @@
             <tbody>
               <tr>
                 <td><code>list_mcp_servers</code></td>
-                <td>List MCP servers for a project</td>
+                <td>List all global MCP servers</td>
               </tr>
               <tr>
                 <td><code>set_mcp_servers</code></td>
-                <td>Set MCP servers for a project</td>
+                <td>Set global MCP servers</td>
               </tr>
             </tbody>
           </table>

--- a/website/docs/roles.html
+++ b/website/docs/roles.html
@@ -99,8 +99,8 @@
             <a href="#overview" class="heading-anchor">#</a>
           </h2>
           <p>
-            Roles are per-project permission profiles stored in Thurbox's SQLite database. When a
-            session starts, its assigned role determines the Claude CLI flags passed at spawn time:
+            Roles are global permission presets stored in Thurbox's SQLite database. When a session
+            starts, its assigned role determines the Claude CLI flags passed at spawn time:
           </p>
           <div class="terminal-frame">
             <div class="terminal-header">

--- a/website/index.html
+++ b/website/index.html
@@ -138,8 +138,8 @@
             <div class="card-icon">&#x1f6e1;</div>
             <h3>Role System</h3>
             <p>
-              Define per-project permission profiles that control Claude's behavior. Configure
-              permission modes, allowed/denied tools, and scope patterns like
+              Define global permission presets that control Claude's behavior. Configure permission
+              modes, allowed/denied tools, and scope patterns like
               <code>Bash(git:*)</code>
               .
             </p>


### PR DESCRIPTION
## Summary

- Update all docs and website to reflect session-centric workflow changes
- Roles described as global presets (not per-project) across CLAUDE.md, README, FEATURES.md, MCP_ROLES.md
- MCP tool descriptions updated (list_roles, set_roles, list_mcp_servers, set_mcp_servers)
- Session creation flow documented (repo picker with worktree toggle)
- Keybindings updated (Ctrl+N → repo picker, Ctrl+E → name/repos only)
- Website pages updated (features, roles, mcp, index)

## Test plan

- [x] `rumdl check .` — 0 markdown lint issues
- [x] `npm run lint:website` — all website linters pass (prettier, htmlhint, eslint)
- [x] All pre-commit hooks pass