### PR TITLE
feat(ui): use bracketed paste for atomic clipboard pasting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -149,7 +149,6 @@ impl App {
 
         // Ctrl+V: paste from clipboard
         if code == KeyCode::Char('v') && mods.contains(KeyModifiers::CONTROL) {
-            self.text_selection = None;
             self.paste_from_clipboard();
             return;
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -347,6 +347,8 @@ impl TextInput {
 
 pub enum AppMessage {
     KeyPress(KeyCode, KeyModifiers),
+    /// Text pasted via the terminal's bracketed paste mode.
+    Paste(String),
     MouseScrollUp,
     MouseScrollDown,
     MouseClick {
@@ -1520,6 +1522,7 @@ impl App {
     pub fn update(&mut self, msg: AppMessage) {
         match msg {
             AppMessage::KeyPress(code, mods) => self.handle_key(code, mods),
+            AppMessage::Paste(text) => self.handle_paste(text),
             AppMessage::MouseScrollUp => self.scroll_terminal_up(MOUSE_SCROLL_LINES),
             AppMessage::MouseScrollDown => self.scroll_terminal_down(MOUSE_SCROLL_LINES),
             AppMessage::MouseClick { x, y, modifiers } => self.handle_mouse_click(x, y, modifiers),
@@ -1708,7 +1711,40 @@ impl App {
         self.set_status(StatusLevel::Info, "Copied to clipboard");
     }
 
+    /// Wrap text in bracketed paste escape sequences and send it to the
+    /// active session (or shell pane, if focused).
+    fn send_paste_to_session(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(session) = self.sessions.get(self.active_index) {
+            let mut paste = b"\x1b[200~".to_vec();
+            paste.extend_from_slice(text.as_bytes());
+            paste.extend_from_slice(b"\x1b[201~");
+            let result = if let (TerminalView::Shell, Some(shell)) =
+                (self.active_terminal_view(), &session.shell_pane)
+            {
+                shell.send_input(paste)
+            } else {
+                session.send_input(paste)
+            };
+            if let Err(e) = result {
+                error!("Failed to send pasted input: {e}");
+            }
+        }
+    }
+
+    /// Handle a native paste event from crossterm's bracketed paste capture.
+    fn handle_paste(&mut self, text: String) {
+        self.text_selection = None;
+        self.selected_text_cache = None;
+        self.send_paste_to_session(&text);
+    }
+
     fn paste_from_clipboard(&mut self) {
+        self.text_selection = None;
+        self.selected_text_cache = None;
+
         let Some(clipboard) = &mut self.clipboard else {
             self.set_error("Clipboard not available");
             return;
@@ -1722,23 +1758,7 @@ impl App {
             }
         };
 
-        if text.is_empty() {
-            return;
-        }
-
-        if let Some(session) = self.sessions.get(self.active_index) {
-            let bytes = text.into_bytes();
-            let result = if let (TerminalView::Shell, Some(shell)) =
-                (self.active_terminal_view(), &session.shell_pane)
-            {
-                shell.send_input(bytes)
-            } else {
-                session.send_input(bytes)
-            };
-            if let Err(e) = result {
-                error!("Failed to send pasted input: {e}");
-            }
-        }
+        self.send_paste_to_session(&text);
     }
 
     pub(crate) fn submit_role_editor(&mut self) {
@@ -7521,5 +7541,55 @@ mod tests {
         // Active session should shift to the remaining one
         assert!(app.has_active_session());
         assert_eq!(app.sessions[app.active_index].info.id, first_session_id);
+    }
+
+    #[test]
+    fn handle_paste_clears_selection() {
+        let mut app = app_with_sessions(1);
+        app.text_selection = Some(Selection::new(
+            TermPos { row: 0, col: 0 },
+            PaneBounds::from_rect(ratatui::layout::Rect::new(0, 0, 80, 24)),
+        ));
+        app.selected_text_cache = Some("old".to_string());
+
+        app.handle_paste("hello".to_string());
+
+        assert!(app.text_selection.is_none());
+        assert!(app.selected_text_cache.is_none());
+    }
+
+    #[test]
+    fn paste_message_dispatches_to_handle_paste() {
+        let mut app = app_with_sessions(1);
+        app.text_selection = Some(Selection::new(
+            TermPos { row: 0, col: 0 },
+            PaneBounds::from_rect(ratatui::layout::Rect::new(0, 0, 80, 24)),
+        ));
+
+        app.update(AppMessage::Paste("pasted text".to_string()));
+
+        assert!(app.text_selection.is_none());
+    }
+
+    #[test]
+    fn send_paste_to_session_noop_when_no_sessions() {
+        let mut app = App::new(
+            24,
+            80,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
+        // Should not panic with no active sessions
+        app.send_paste_to_session("hello");
+    }
+
+    #[test]
+    fn send_paste_to_session_noop_for_empty_text() {
+        let mut app = app_with_sessions(1);
+        // Should return early without error for empty text
+        app.send_paste_to_session("");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use crossterm::event::{
-    self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind, MouseButton, MouseEventKind,
+    self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+    Event, KeyEventKind, MouseButton, MouseEventKind,
 };
 use crossterm::execute;
 
@@ -21,6 +22,11 @@ async fn main() -> Result<()> {
     // Set up panic hook that restores terminal before printing the panic
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
+        let _ = execute!(
+            std::io::stdout(),
+            DisableBracketedPaste,
+            DisableMouseCapture
+        );
         ratatui::restore();
         original_hook(panic_info);
     }));
@@ -105,7 +111,7 @@ async fn main() -> Result<()> {
     let db = Database::open(&db_path).expect("Failed to open database");
 
     let mut terminal = ratatui::init();
-    execute!(std::io::stdout(), EnableMouseCapture)?;
+    execute!(std::io::stdout(), EnableMouseCapture, EnableBracketedPaste)?;
     let size = terminal.size()?;
 
     let mut app = App::new(
@@ -135,7 +141,11 @@ async fn main() -> Result<()> {
     let res = run_loop(&mut terminal, &mut app).await;
 
     app.shutdown();
-    execute!(std::io::stdout(), DisableMouseCapture)?;
+    execute!(
+        std::io::stdout(),
+        DisableBracketedPaste,
+        DisableMouseCapture
+    )?;
     ratatui::restore();
 
     res
@@ -168,6 +178,7 @@ async fn run_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Res
                     }),
                     _ => None,
                 },
+                Event::Paste(text) => Some(AppMessage::Paste(text)),
                 Event::Resize(cols, rows) => Some(AppMessage::Resize(cols, rows)),
                 _ => None,
             };


### PR DESCRIPTION
## Summary
- Wrap pasted text in bracketed paste escape sequences (`ESC[200~` / `ESC[201~`) so receiving terminal programs (bash, vim, Claude CLI) treat it as a single atomic paste instead of processing each character individually
- Enable crossterm's `EnableBracketedPaste` to capture native `Event::Paste` events from terminal emulators that support it
- Add `AppMessage::Paste` variant and `send_paste_to_session` helper, with the Ctrl+V clipboard path as fallback

## Test plan
- [x] 921/921 tests pass (4 new paste tests added)
- [x] 0 clippy warnings
- [x] All architecture rules pass
- [ ] Manual: paste multi-line text into a terminal session — should arrive atomically, not char-by-char