### PR TITLE
feat(ui): add dim overlay and styled modal frames

### DIFF
--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -7,7 +7,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::Paragraph,
     Frame,
 };
 
@@ -414,13 +414,8 @@ impl App {
         // Discard confirmation overlay
         if self.show_discard_confirmation {
             let confirm_area = crate::ui::centered_fixed_height_rect(40, 5, frame.area());
-            frame.render_widget(Clear, confirm_area);
-            let block = Block::default()
-                .title(" Unsaved Changes ")
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(Theme::STATUS_ERROR));
-            let inner = block.inner(confirm_area);
-            frame.render_widget(block, confirm_area);
+            let inner =
+                crate::ui::render_modal_frame_danger(frame, confirm_area, "Unsaved Changes");
             let text = Line::from(vec![
                 Span::styled(
                     " Discard changes? ",
@@ -459,12 +454,7 @@ impl App {
 fn render_help_overlay(frame: &mut Frame) {
     let area = centered_rect(60, 70, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Keybindings ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
+    let inner = crate::ui::render_modal_frame(frame, area, "Keybindings");
 
     let help_lines = vec![
         help_section("Navigation"),
@@ -511,8 +501,7 @@ fn render_help_overlay(frame: &mut Frame) {
         )),
     ];
 
-    let paragraph = Paragraph::new(help_lines).block(block);
-    frame.render_widget(paragraph, area);
+    frame.render_widget(Paragraph::new(help_lines), inner);
 }
 
 fn help_section(title: &str) -> Line<'_> {

--- a/src/ui/add_project_modal.rs
+++ b/src/ui/add_project_modal.rs
@@ -4,10 +4,11 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, Borders, Paragraph},
     Frame,
 };
 
+use super::render_modal_frame;
 use super::theme::Theme;
 use super::{centered_fixed_height_rect, render_text_field, render_text_field_with_suggestion};
 use crate::app::AddProjectField;
@@ -35,15 +36,7 @@ pub fn render_add_project_modal(frame: &mut Frame, state: &AddProjectModalState<
 
     let area = centered_fixed_height_rect(50, total_height, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Add Project ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Add Project");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/branch_selector_modal.rs
+++ b/src/ui/branch_selector_modal.rs
@@ -1,13 +1,13 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
+    widgets::{List, ListItem, ListState, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
 use super::project_list::render_scroll_indicators;
+use super::render_modal_frame;
 use super::theme::Theme;
 
 pub struct BranchSelectorState<'a> {
@@ -19,15 +19,7 @@ pub fn render_branch_selector_modal(frame: &mut Frame, state: &BranchSelectorSta
     let height = (state.branches.len().min(15) + 4) as u16;
     let area = centered_fixed_height_rect(50, height, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Base Branch ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Base Branch");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/containerfile_picker.rs
+++ b/src/ui/containerfile_picker.rs
@@ -1,12 +1,12 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    widgets::{List, ListItem, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::render_modal_frame;
 use super::theme::Theme;
 
 pub struct ContainerfilePickerState<'a> {
@@ -20,15 +20,7 @@ pub fn render_containerfile_picker(frame: &mut Frame, state: &ContainerfilePicke
     let height = (item_count as u16 + 3).min(frame.area().height.saturating_sub(4));
     let area = centered_fixed_height_rect(50, height, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Select Containerfile ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Select Containerfile");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/delete_project_modal.rs
+++ b/src/ui/delete_project_modal.rs
@@ -2,11 +2,12 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, Borders, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::render_modal_frame_danger;
 use super::theme::Theme;
 
 pub struct DeleteProjectModalState<'a> {
@@ -19,15 +20,7 @@ pub struct DeleteProjectModalState<'a> {
 pub fn render_delete_project_modal(frame: &mut Frame, state: &DeleteProjectModalState<'_>) {
     let area = centered_fixed_height_rect(60, 13, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Delete Project ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::DANGER));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame_danger(frame, area, "Delete Project");
 
     // Layout: warning, spacer, confirmation input, error message, help
     let chunks = Layout::default()

--- a/src/ui/mcp_editor_modal.rs
+++ b/src/ui/mcp_editor_modal.rs
@@ -2,10 +2,11 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::Paragraph,
     Frame,
 };
 
+use super::render_modal_frame;
 use super::theme::Theme;
 use super::{centered_fixed_height_rect, render_text_field};
 use crate::app::mcp_editor_modal::McpEditorField;
@@ -47,15 +48,7 @@ pub fn render_mcp_editor_modal(frame: &mut Frame, state: &McpEditorState<'_>) {
     let height = (content_height + 2).min(max_height);
     let area = centered_fixed_height_rect(60, height, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Edit MCP Server ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Edit MCP Server");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -25,7 +25,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, Paragraph},
+    widgets::{Block, BorderType, Borders, Clear, Paragraph},
     Frame,
 };
 
@@ -142,6 +142,52 @@ pub fn centered_fixed_height_rect(percent_x: u16, height: u16, area: Rect) -> Re
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(vertical[1])[1]
+}
+
+/// Render a full-screen dim overlay to visually separate a modal from the background.
+pub fn render_dim_overlay(frame: &mut Frame) {
+    let dim = Block::default().style(Style::default().bg(Theme::MODAL_DIM_BG));
+    frame.render_widget(dim, frame.area());
+}
+
+/// Build a modal [`Block`] with the given title style and border color.
+fn build_modal_block(title: &str, title_style: Style, border_color: Color) -> Block<'_> {
+    Block::default()
+        .title(Line::from(Span::styled(format!(" {title} "), title_style)))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(border_color))
+        .style(Style::default().bg(Theme::MODAL_BG))
+}
+
+/// Build a styled modal [`Block`] with rounded borders and an explicit background.
+pub fn modal_block(title: &str) -> Block<'_> {
+    build_modal_block(title, Theme::modal_title(), Theme::MODAL_BORDER)
+}
+
+/// Build a danger-styled modal [`Block`] with red borders and background.
+pub fn modal_block_danger(title: &str) -> Block<'_> {
+    build_modal_block(title, Theme::modal_title_danger(), Theme::DANGER)
+}
+
+/// Dim the background, clear the modal region, render a styled block, and return the inner area.
+pub fn render_modal_frame(frame: &mut Frame, area: Rect, title: &str) -> Rect {
+    render_dim_overlay(frame);
+    frame.render_widget(Clear, area);
+    let block = modal_block(title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    inner
+}
+
+/// Dim the background, clear the modal region, render a danger-styled block, and return the inner area.
+pub fn render_modal_frame_danger(frame: &mut Frame, area: Rect, title: &str) -> Rect {
+    render_dim_overlay(frame);
+    frame.render_widget(Clear, area);
+    let block = modal_block_danger(title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    inner
 }
 
 /// Render a labeled text input field with cursor visualization and horizontal
@@ -378,5 +424,34 @@ mod tests {
             assert!(inner.width < test_area.width);
             assert!(inner.height < test_area.height);
         }
+    }
+
+    #[test]
+    fn modal_block_produces_valid_block_with_borders() {
+        let test_area = area(40, 10);
+        let block = modal_block("Test Modal");
+        let inner = block.inner(test_area);
+        assert!(inner.width < test_area.width);
+        assert!(inner.height < test_area.height);
+    }
+
+    #[test]
+    fn modal_block_danger_produces_valid_block_with_borders() {
+        let test_area = area(40, 10);
+        let block = modal_block_danger("Delete");
+        let inner = block.inner(test_area);
+        assert!(inner.width < test_area.width);
+        assert!(inner.height < test_area.height);
+    }
+
+    #[test]
+    fn modal_title_matches_focused_title() {
+        assert_eq!(Theme::modal_title(), Theme::focused_title());
+    }
+
+    #[test]
+    fn modal_title_danger_uses_danger_color() {
+        let style = Theme::modal_title_danger();
+        assert_eq!(style.bg, Some(Theme::DANGER));
     }
 }

--- a/src/ui/repo_picker_modal.rs
+++ b/src/ui/repo_picker_modal.rs
@@ -4,10 +4,11 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
     Frame,
 };
 
+use super::render_modal_frame;
 use super::theme::Theme;
 use super::{centered_fixed_height_rect, render_text_field_with_suggestion};
 use crate::app::modals::RepoPickerFocus;
@@ -36,15 +37,7 @@ pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) 
 
     let area = centered_fixed_height_rect(60, total_height, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Select Repos ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Select Repos");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/repo_selector_modal.rs
+++ b/src/ui/repo_selector_modal.rs
@@ -2,13 +2,13 @@ use std::path::PathBuf;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    widgets::{List, ListItem, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::render_modal_frame;
 use super::theme::Theme;
 
 pub struct RepoSelectorState<'a> {
@@ -20,15 +20,7 @@ pub fn render_repo_selector_modal(frame: &mut Frame, state: &RepoSelectorState<'
     let height = (state.repos.len().min(15) + 4) as u16;
     let area = centered_fixed_height_rect(50, height, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Select Repo ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Select Repo");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/restore_sessions_modal.rs
+++ b/src/ui/restore_sessions_modal.rs
@@ -2,11 +2,12 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::Paragraph,
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::render_modal_frame;
 use super::theme::Theme;
 
 /// View-only entry for the restore sessions modal.
@@ -28,15 +29,7 @@ pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsM
     let total_height = (list_height + 5).min(20);
     let area = centered_fixed_height_rect(60, total_height, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Restore Deleted Sessions ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Restore Deleted Sessions");
 
     if state.entries.is_empty() {
         let chunks = Layout::default()

--- a/src/ui/role_editor_modal.rs
+++ b/src/ui/role_editor_modal.rs
@@ -2,10 +2,11 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
     Frame,
 };
 
+use super::render_modal_frame;
 use super::theme::Theme;
 use super::{centered_fixed_height_rect, render_text_field};
 
@@ -79,15 +80,7 @@ pub fn render_role_editor_modal(frame: &mut Frame, state: &RoleEditorState<'_>) 
     let height = (content_height + 2).min(max_height); // +2 for border
     let area = centered_fixed_height_rect(60, height, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Edit Role ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Edit Role");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/role_selector_modal.rs
+++ b/src/ui/role_selector_modal.rs
@@ -2,11 +2,12 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    widgets::{List, ListItem, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::render_modal_frame;
 use super::theme::Theme;
 use crate::session::RoleConfig;
 
@@ -20,15 +21,7 @@ pub fn render_role_selector_modal(frame: &mut Frame, state: &RoleSelectorState<'
     let height = (state.roles.len() as u16) + 4;
     let area = centered_fixed_height_rect(50, height, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Session Role ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Session Role");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/schedule_command_modal.rs
+++ b/src/ui/schedule_command_modal.rs
@@ -1,14 +1,14 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::Paragraph,
     Frame,
 };
 
 use crate::app::ScheduleCommandField;
 
 use super::centered_fixed_height_rect;
+use super::render_modal_frame;
 use super::theme::Theme;
 
 pub struct ScheduleCommandState<'a> {
@@ -23,15 +23,8 @@ pub struct ScheduleCommandState<'a> {
 pub fn render_schedule_command_modal(frame: &mut Frame, state: &ScheduleCommandState<'_>) {
     let area = centered_fixed_height_rect(50, 11, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(format!(" Schedule Command → {} ", state.session_name))
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let title = format!("Schedule Command → {}", state.session_name);
+    let inner = render_modal_frame(frame, area, &title);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/session_mode_modal.rs
+++ b/src/ui/session_mode_modal.rs
@@ -1,12 +1,12 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    widgets::{List, ListItem, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::render_modal_frame;
 use super::theme::Theme;
 
 const MODES_BASE: [&str; 2] = ["Normal", "Worktree"];
@@ -46,15 +46,7 @@ pub fn render_session_mode_modal(frame: &mut Frame, state: &SessionModeState) {
     let height = mode_count as u16 + 3;
     let area = centered_fixed_height_rect(50, height, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Session Mode ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Session Mode");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/settings_overlay.rs
+++ b/src/ui/settings_overlay.rs
@@ -3,11 +3,12 @@
 use ratatui::{
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph},
+    widgets::{List, ListItem, Paragraph},
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::render_modal_frame;
 use super::theme::Theme;
 use crate::app::SettingsTab;
 use crate::session::{McpServerConfig, RoleConfig};
@@ -23,15 +24,7 @@ pub struct SettingsOverlayState<'a> {
 
 pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) {
     let area = centered_fixed_height_rect(60, 22, frame.area());
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(" Settings ")
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let inner = render_modal_frame(frame, area, "Settings");
 
     if inner.height < 4 || inner.width < 10 {
         return;

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -56,6 +56,15 @@ impl Theme {
     pub const SELECTION_BG: Color = Color::Indexed(24);
     pub const SELECTION_FG: Color = Color::White;
 
+    // ── Modal ──────────────────────────────────────────────────────────────
+
+    /// Dark background for the full-screen dim overlay behind modals.
+    pub const MODAL_DIM_BG: Color = Color::Indexed(235); // #262626
+    /// Background color for the modal surface itself.
+    pub const MODAL_BG: Color = Color::Indexed(236); // #303030
+    /// Border color for modal windows.
+    pub const MODAL_BORDER: Color = Color::Cyan;
+
     // ── Background colors ───────────────────────────────────────────────────
 
     pub const INVERTED_FG: Color = Color::Black;
@@ -119,6 +128,19 @@ impl Theme {
     /// Style for project metadata lines (repo info, role count).
     pub fn project_meta() -> Style {
         Style::default().fg(Self::TEXT_MUTED)
+    }
+
+    /// Style for modal titles: bold black on accent background (same as focused panels).
+    pub fn modal_title() -> Style {
+        Self::focused_title()
+    }
+
+    /// Style for danger modal titles: bold white on red background.
+    pub fn modal_title_danger() -> Style {
+        Style::default()
+            .fg(Self::TEXT_PRIMARY)
+            .bg(Self::DANGER)
+            .add_modifier(Modifier::BOLD)
     }
 
     /// Style for the block cursor in text fields.

--- a/src/ui/worktree_name_modal.rs
+++ b/src/ui/worktree_name_modal.rs
@@ -1,12 +1,12 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::Paragraph,
     Frame,
 };
 
 use super::centered_fixed_height_rect;
+use super::render_modal_frame;
 use super::theme::Theme;
 
 pub struct WorktreeNameState<'a> {
@@ -18,15 +18,8 @@ pub struct WorktreeNameState<'a> {
 pub fn render_worktree_name_modal(frame: &mut Frame, state: &WorktreeNameState<'_>) {
     let area = centered_fixed_height_rect(50, 8, frame.area());
 
-    frame.render_widget(Clear, area);
-
-    let block = Block::default()
-        .title(format!(" New Branch (from {}) ", state.base_branch))
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::ACCENT));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+    let title = format!("New Branch (from {})", state.base_branch);
+    let inner = render_modal_frame(frame, area, &title);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)


### PR DESCRIPTION
## Summary
- Add full-screen dim overlay (`Color::Indexed(235)`) behind all modals for visual separation from background
- Add explicit modal surface background (`Color::Indexed(236)`) with rounded borders and badge-style titles
- Extract shared `render_modal_frame()` / `render_modal_frame_danger()` helpers to eliminate boilerplate across 15 modal files
- Add `MODAL_DIM_BG`, `MODAL_BG`, `MODAL_BORDER` theme constants and `modal_title()` / `modal_title_danger()` styles
- Bump `rustls-webpki` to fix RUSTSEC-2026-0049 advisory

## Test plan
- [x] `cargo check --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] `cargo nextest run --all` — 921/921 tests pass (4 new tests for modal helpers)
- [ ] Visual verification: run `cargo run` and open various modals to confirm dim overlay and new styling