### PR TITLE
feat(ui): improve scheduled commands UX with list modal and visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,7 +333,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+N` | New session (opens repo picker) | **N**ew |
 | `Ctrl+C` | Copy selection / SIGINT (terminal) | **C**opy |
 | `Ctrl+V` | Paste from clipboard | Paste |
-| `Ctrl+P` | Schedule command for active session | **P**rogram |
+| `Ctrl+P` | Scheduled commands (list/cancel/new) | **P**rogram |
 | `Ctrl+T` | Toggle shell pane | **T**erminal |
 | `Ctrl+H` | Focus previous pane (cycle backward) | Vim: **h** = left |
 | `Ctrl+J` | Select next project or session | Vim: **j** = down |

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -72,6 +72,12 @@ impl App {
             return;
         }
 
+        // Scheduled commands list modal captures all input
+        if matches!(self.modal, super::modals::Modal::ScheduledCommandsList(_)) {
+            self.handle_scheduled_commands_list_key(code);
+            return;
+        }
+
         // Discard confirmation overlay captures all input
         if self.show_discard_confirmation {
             match code {
@@ -190,7 +196,7 @@ impl App {
                     }
                 },
                 KeyCode::Char('p') => {
-                    self.open_schedule_command_modal();
+                    self.open_scheduled_commands_list();
                     return;
                 }
                 KeyCode::Char('s') => {
@@ -891,6 +897,75 @@ impl App {
             KeyCode::End => sc.active_field_mut().end(),
             _ => {}
         }
+    }
+
+    fn handle_scheduled_commands_list_key(&mut self, code: KeyCode) {
+        if let super::modals::Modal::ScheduledCommandsList(ref mut scl) = self.modal {
+            match code {
+                KeyCode::Esc => {
+                    self.modal.close();
+                    return;
+                }
+                KeyCode::Char('j') | KeyCode::Down => {
+                    if scl.index + 1 < scl.commands.len() {
+                        scl.index += 1;
+                    }
+                    return;
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    scl.index = scl.index.saturating_sub(1);
+                    return;
+                }
+                _ => {}
+            }
+        }
+
+        match code {
+            KeyCode::Enter => self.cancel_selected_scheduled_command(),
+            KeyCode::Char('n') => {
+                self.modal.close();
+                self.open_schedule_command_modal();
+            }
+            KeyCode::Char('e') => self.edit_selected_scheduled_command(),
+            _ => {}
+        }
+    }
+
+    /// Cancel the currently selected command in the list modal.
+    fn cancel_selected_scheduled_command(&mut self) {
+        let id = {
+            let super::modals::Modal::ScheduledCommandsList(ref mut scl) = self.modal else {
+                return;
+            };
+            if scl.commands.is_empty() {
+                return;
+            }
+            let entry = scl.commands.remove(scl.index);
+            if scl.index >= scl.commands.len() && scl.index > 0 {
+                scl.index -= 1;
+            }
+            entry.id
+        };
+        self.cancel_scheduled_command_by_id(id);
+        if let super::modals::Modal::ScheduledCommandsList(ref scl) = self.modal {
+            if scl.commands.is_empty() {
+                self.modal.close();
+            }
+        }
+    }
+
+    /// Open the edit modal for the currently selected command in the list.
+    fn edit_selected_scheduled_command(&mut self) {
+        let entry = {
+            let super::modals::Modal::ScheduledCommandsList(ref scl) = self.modal else {
+                return;
+            };
+            if scl.commands.is_empty() {
+                return;
+            }
+            scl.commands[scl.index].clone()
+        };
+        self.open_edit_scheduled_command(entry);
     }
 
     fn handle_role_selector_key(&mut self, code: KeyCode) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,8 +23,8 @@ use crate::paths;
 use crate::project::{ProjectConfig, ProjectId, ProjectInfo};
 use crate::session::{
     default_developer_permissions, default_developer_role, McpServerConfig, RoleConfig,
-    RolePermissions, SessionCommand, SessionConfig, SessionId, SessionInfo, SessionStatus,
-    WorktreeInfo, DEFAULT_ROLE_NAME,
+    RolePermissions, ScheduledCommand, SessionCommand, SessionConfig, SessionId, SessionInfo,
+    SessionStatus, WorktreeInfo, DEFAULT_ROLE_NAME,
 };
 use crate::storage::Database;
 use crate::storage::DeletedSessionInfo;
@@ -574,6 +574,8 @@ pub struct App {
     pub(crate) global_mcp_servers: Vec<McpServerConfig>,
     /// Index into global_mcp_servers for the MCP server list in the edit modal.
     pub(crate) mcp_server_list_index: usize,
+    /// Cached pending scheduled commands, refreshed every ~1 second.
+    pub(crate) cached_pending_commands: Vec<ScheduledCommand>,
 }
 
 /// Snapshot of editor field values for dirty detection.
@@ -856,6 +858,7 @@ impl App {
             global_roles,
             global_mcp_servers,
             mcp_server_list_index: 0,
+            cached_pending_commands: Vec::new(),
         }
     }
 
@@ -2374,6 +2377,11 @@ impl App {
 
         // Process scheduled commands (once per second)
         self.process_scheduled_commands();
+
+        // Refresh cached pending commands for UI (same cadence)
+        if self.tick_count % 100 == 0 {
+            self.refresh_pending_commands();
+        }
 
         // Refresh system metrics periodically
         if self.tick_count % METRICS_REFRESH_TICKS == 0 {
@@ -3909,6 +3917,35 @@ impl App {
         }
     }
 
+    /// Open the scheduled commands list modal showing all pending commands.
+    fn open_scheduled_commands_list(&mut self) {
+        self.refresh_pending_commands();
+        let commands: Vec<modals::ScheduledCommandListEntry> = self
+            .cached_pending_commands
+            .iter()
+            .map(|cmd| {
+                let session_name = self
+                    .sessions
+                    .iter()
+                    .find(|s| s.info.id == cmd.session_id)
+                    .map(|s| s.info.name.clone())
+                    .unwrap_or_else(|| "?".to_string());
+                let now = crate::sync::current_time_millis();
+                let remaining = cmd.scheduled_at.saturating_sub(now);
+                modals::ScheduledCommandListEntry {
+                    id: cmd.id,
+                    session_name,
+                    command_text: cmd.command_text.clone(),
+                    countdown: view::format_countdown(remaining),
+                }
+            })
+            .collect();
+        self.modal = modals::Modal::ScheduledCommandsList(modals::ScheduledCommandsListModal {
+            index: 0,
+            commands,
+        });
+    }
+
     /// Open the schedule-command modal for the active session.
     fn open_schedule_command_modal(&mut self) {
         if self.sessions.is_empty() {
@@ -3916,6 +3953,30 @@ impl App {
             return;
         }
         self.modal = modals::Modal::ScheduleCommand(modals::ScheduleCommandModal::default());
+    }
+
+    /// Open the schedule-command modal pre-filled for editing an existing command.
+    fn open_edit_scheduled_command(&mut self, entry: modals::ScheduledCommandListEntry) {
+        let now = crate::sync::current_time_millis();
+        let cached = self
+            .cached_pending_commands
+            .iter()
+            .find(|cmd| cmd.id == entry.id);
+        let remaining_minutes = cached
+            .map(|cmd| cmd.scheduled_at.saturating_sub(now) / 60_000)
+            .unwrap_or(1)
+            .max(1);
+        let session_id = cached.map(|cmd| cmd.session_id).unwrap_or_default();
+
+        let mut modal = modals::ScheduleCommandModal::default();
+        modal.command.set(&entry.command_text);
+        modal.delay_minutes.set(&remaining_minutes.to_string());
+        modal.editing = Some(modals::EditingCommand {
+            id: entry.id,
+            session_id,
+            session_name: entry.session_name.clone(),
+        });
+        self.modal = modals::Modal::ScheduleCommand(modal);
     }
 
     /// Validate and submit the schedule-command modal.
@@ -3935,48 +3996,101 @@ impl App {
                 return;
             }
         };
+        let editing = sc.editing.clone();
 
-        let session = match self.sessions.get(self.active_index) {
-            Some(s) => s,
-            None => {
-                self.set_error("No active session");
-                return;
-            }
+        let (session_id, session_name) = self.resolve_schedule_session(&editing);
+        let Some(session_id) = session_id else {
+            self.set_error("No active session");
+            return;
         };
-        let session_id = session.info.id;
-        let session_name = session.info.name.clone();
 
         let delay_seconds = delay_minutes * 60;
         let now = crate::sync::current_time_millis();
         let scheduled_at = now + delay_seconds * 1000;
 
-        match self
+        let id = match self
             .db
             .create_scheduled_command(session_id, &command_text, scheduled_at)
         {
-            Ok(id) => {
-                // Set up a tmux timer for external dispatch
-                if let Some(db_path) = crate::paths::database_file() {
-                    if let Err(e) = crate::agent::tmux::schedule_tmux_command(
-                        &session_name,
-                        &command_text,
-                        delay_seconds,
-                        id,
-                        &db_path,
-                    ) {
-                        warn!("Failed to set tmux timer for command {id}: {e}");
-                    }
-                }
-
-                self.modal.close();
-                self.set_status(
-                    StatusLevel::Success,
-                    format!("Command scheduled for {} in {delay_minutes}m", session_name),
-                );
-            }
+            Ok(id) => id,
             Err(e) => {
                 error!("Failed to create scheduled command: {e}");
                 self.set_error("Failed to schedule command");
+                return;
+            }
+        };
+
+        if let Some(ref ed) = editing {
+            let _ = self.db.cancel_scheduled_command(ed.id);
+        }
+        self.setup_tmux_timer(&session_name, &command_text, delay_seconds, id);
+        self.modal.close();
+        self.refresh_pending_commands();
+        let verb = if editing.is_some() {
+            "updated"
+        } else {
+            "scheduled"
+        };
+        self.set_status(
+            StatusLevel::Success,
+            format!("Command {verb} for {session_name} in {delay_minutes}m"),
+        );
+    }
+
+    /// Resolve the target session for a scheduled command (editing or active).
+    fn resolve_schedule_session(
+        &self,
+        editing: &Option<modals::EditingCommand>,
+    ) -> (Option<SessionId>, String) {
+        if let Some(ref ed) = editing {
+            return (Some(ed.session_id), ed.session_name.clone());
+        }
+        match self.sessions.get(self.active_index) {
+            Some(s) => (Some(s.info.id), s.info.name.clone()),
+            None => (None, String::new()),
+        }
+    }
+
+    /// Set up a tmux background timer for a scheduled command.
+    fn setup_tmux_timer(
+        &self,
+        session_name: &str,
+        command_text: &str,
+        delay_seconds: u64,
+        id: i64,
+    ) {
+        if let Some(db_path) = crate::paths::database_file() {
+            if let Err(e) = crate::agent::tmux::schedule_tmux_command(
+                session_name,
+                command_text,
+                delay_seconds,
+                id,
+                &db_path,
+            ) {
+                warn!("Failed to set tmux timer for command {id}: {e}");
+            }
+        }
+    }
+
+    /// Refresh the cached list of pending scheduled commands from the database.
+    fn refresh_pending_commands(&mut self) {
+        match self.db.list_pending_scheduled_commands() {
+            Ok(cmds) => self.cached_pending_commands = cmds,
+            Err(e) => error!("Failed to list pending commands: {e}"),
+        }
+    }
+
+    /// Cancel a scheduled command by ID and refresh the cache.
+    fn cancel_scheduled_command_by_id(&mut self, id: i64) {
+        match self.db.cancel_scheduled_command(id) {
+            Ok(true) => {
+                self.refresh_pending_commands();
+                self.set_status(StatusLevel::Success, "Scheduled command cancelled");
+            }
+            Ok(false) => self.set_error("Command already executed or cancelled"),
+            Err(e) => {
+                error!("Failed to cancel scheduled command {id}: {e}");
+                self.set_error("Failed to cancel command");
             }
         }
     }

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -192,6 +192,17 @@ pub struct ScheduleCommandModal {
     pub command: TextInput,
     pub delay_minutes: TextInput,
     pub field: ScheduleCommandField,
+    /// When editing an existing command, holds the original command ID to cancel on submit
+    /// and the session ID + name to preserve the target session.
+    pub editing: Option<EditingCommand>,
+}
+
+/// State preserved when editing an existing scheduled command.
+#[derive(Debug, Clone)]
+pub struct EditingCommand {
+    pub id: i64,
+    pub session_id: crate::session::SessionId,
+    pub session_name: String,
 }
 
 impl ScheduleCommandModal {
@@ -202,6 +213,24 @@ impl ScheduleCommandModal {
             ScheduleCommandField::Delay => &mut self.delay_minutes,
         }
     }
+}
+
+// ── ScheduledCommandsListModal ──────────────────────────────────────────
+
+/// An entry in the scheduled commands list modal.
+#[derive(Debug, Clone)]
+pub struct ScheduledCommandListEntry {
+    pub id: i64,
+    pub session_name: String,
+    pub command_text: String,
+    pub countdown: String,
+}
+
+/// Modal state for listing and cancelling pending scheduled commands.
+#[derive(Debug, Clone, Default)]
+pub struct ScheduledCommandsListModal {
+    pub index: usize,
+    pub commands: Vec<ScheduledCommandListEntry>,
 }
 
 // ── RepoPickerModal ─────────────────────────────────────────────────────
@@ -269,6 +298,7 @@ pub enum Modal {
     ContainerfilePicker(ContainerfilePickerModal),
     RestoreSessions(RestoreSessionsModal),
     ScheduleCommand(ScheduleCommandModal),
+    ScheduledCommandsList(ScheduledCommandsListModal),
     RepoPicker(RepoPickerModal),
 }
 
@@ -469,5 +499,33 @@ mod tests {
 
         let field = ScheduleCommandField::default();
         assert_eq!(field, ScheduleCommandField::Command);
+    }
+
+    #[test]
+    fn test_schedule_command_modal_editing_default_is_none() {
+        let modal = ScheduleCommandModal::default();
+        assert!(modal.editing.is_none());
+    }
+
+    #[test]
+    fn test_scheduled_commands_list_modal_default() {
+        let modal = ScheduledCommandsListModal::default();
+        assert_eq!(modal.index, 0);
+        assert!(modal.commands.is_empty());
+    }
+
+    #[test]
+    fn test_schedule_command_modal_with_editing() {
+        let mut modal = ScheduleCommandModal::default();
+        modal.command.set("test cmd");
+        modal.delay_minutes.set("5");
+        modal.editing = Some(EditingCommand {
+            id: 42,
+            session_id: "test-session".parse().unwrap_or_default(),
+            session_name: "my-session".to_string(),
+        });
+        assert_eq!(modal.command.value(), "test cmd");
+        assert_eq!(modal.editing.as_ref().unwrap().id, 42);
+        assert_eq!(modal.editing.as_ref().unwrap().session_name, "my-session");
     }
 }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -17,8 +17,8 @@ use crate::ui::theme::Theme;
 use crate::ui::{
     add_project_modal, branch_selector_modal, containerfile_picker, delete_project_modal,
     info_panel, layout, project_list, repo_selector_modal, restore_sessions_modal,
-    role_editor_modal, role_selector_modal, schedule_command_modal, session_mode_modal, status_bar,
-    terminal_view, worktree_name_modal,
+    role_editor_modal, role_selector_modal, schedule_command_modal, scheduled_commands_list_modal,
+    session_mode_modal, status_bar, terminal_view, worktree_name_modal,
 };
 
 use super::{App, InputFocus, TerminalView};
@@ -110,12 +110,26 @@ impl App {
                             base_image: rec.base_image,
                         })
                 });
+                let now = crate::sync::current_time_millis();
+                let scheduled_entries: Vec<info_panel::ScheduledCommandEntry> = self
+                    .cached_pending_commands
+                    .iter()
+                    .filter(|cmd| cmd.session_id == info.id)
+                    .map(|cmd| {
+                        let remaining = cmd.scheduled_at.saturating_sub(now);
+                        info_panel::ScheduledCommandEntry {
+                            command_preview: truncate_str(&cmd.command_text, 30),
+                            countdown: format_countdown(remaining),
+                        }
+                    })
+                    .collect();
                 info_panel::render_info_panel(
                     frame,
                     info_area,
                     info,
                     vm_details.as_ref(),
                     Some(&self.system_metrics),
+                    &scheduled_entries,
                 );
             }
         }
@@ -169,6 +183,7 @@ impl App {
                 container_provisioning: self.container_provisioning,
                 container_provisioning_step: &self.container_provisioning_step,
                 tick_count: self.tick_count,
+                pending_scheduled_count: self.cached_pending_commands.len(),
             },
         );
 
@@ -376,11 +391,16 @@ impl App {
 
         // Schedule command modal
         if let super::modals::Modal::ScheduleCommand(ref sc) = self.modal {
-            let session_name = self
-                .sessions
-                .get(self.active_index)
-                .map(|s| s.info.name.as_str())
-                .unwrap_or("?");
+            let session_name = sc
+                .editing
+                .as_ref()
+                .map(|ed| ed.session_name.as_str())
+                .unwrap_or_else(|| {
+                    self.sessions
+                        .get(self.active_index)
+                        .map(|s| s.info.name.as_str())
+                        .unwrap_or("?")
+                });
             schedule_command_modal::render_schedule_command_modal(
                 frame,
                 &schedule_command_modal::ScheduleCommandState {
@@ -390,6 +410,29 @@ impl App {
                     delay_cursor: sc.delay_minutes.cursor_pos(),
                     focused_field: sc.field,
                     session_name,
+                    editing: sc.editing.is_some(),
+                },
+            );
+        }
+
+        // Scheduled commands list modal
+        if let super::modals::Modal::ScheduledCommandsList(ref scl) = self.modal {
+            let entries: Vec<scheduled_commands_list_modal::ScheduledCommandsListEntry> = scl
+                .commands
+                .iter()
+                .map(
+                    |e| scheduled_commands_list_modal::ScheduledCommandsListEntry {
+                        session_name: e.session_name.clone(),
+                        command_preview: e.command_text.clone(),
+                        countdown: e.countdown.clone(),
+                    },
+                )
+                .collect();
+            scheduled_commands_list_modal::render_scheduled_commands_list_modal(
+                frame,
+                &scheduled_commands_list_modal::ScheduledCommandsListState {
+                    entries: &entries,
+                    selected_index: scl.index,
                 },
             );
         }
@@ -467,7 +510,7 @@ fn render_help_overlay(frame: &mut Frame) {
         help_line("Ctrl+A", "Create admin session"),
         help_line("Ctrl+D", "Delete focused session"),
         help_line("Ctrl+R", "Restart active session"),
-        help_line("Ctrl+P", "Schedule a command for active session"),
+        help_line("Ctrl+P", "Scheduled commands (list/cancel/new)"),
         help_line("Ctrl+Z", "Undo last delete"),
         help_line("Ctrl+U", "Restore deleted sessions"),
         Line::from(""),
@@ -548,5 +591,98 @@ pub(super) fn format_time_ago(millis: u64) -> String {
         format!("{}h ago", elapsed_secs / 3600)
     } else {
         format!("{}d ago", elapsed_secs / 86400)
+    }
+}
+
+/// Format a remaining-milliseconds value as a human-readable countdown.
+pub(super) fn format_countdown(remaining_ms: u64) -> String {
+    let secs = remaining_ms / 1000;
+    if secs == 0 {
+        "due".to_string()
+    } else if secs < 60 {
+        format!("in {secs}s")
+    } else if secs < 3600 {
+        let m = secs / 60;
+        let s = secs % 60;
+        if s == 0 {
+            format!("in {m}m")
+        } else {
+            format!("in {m}m {s}s")
+        }
+    } else {
+        let h = secs / 3600;
+        let m = (secs % 3600) / 60;
+        if m == 0 {
+            format!("in {h}h")
+        } else {
+            format!("in {h}h {m}m")
+        }
+    }
+}
+
+/// Truncate a string to `max_len` characters, appending "..." if truncated.
+fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_len.saturating_sub(3)).collect();
+        format!("{truncated}...")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── format_countdown tests ──
+
+    #[test]
+    fn format_countdown_zero() {
+        assert_eq!(format_countdown(0), "due");
+    }
+
+    #[test]
+    fn format_countdown_sub_minute() {
+        assert_eq!(format_countdown(999), "due");
+        assert_eq!(format_countdown(1_000), "in 1s");
+        assert_eq!(format_countdown(45_000), "in 45s");
+        assert_eq!(format_countdown(59_999), "in 59s");
+    }
+
+    #[test]
+    fn format_countdown_minutes() {
+        assert_eq!(format_countdown(60_000), "in 1m");
+        assert_eq!(format_countdown(90_000), "in 1m 30s");
+        assert_eq!(format_countdown(300_000), "in 5m");
+        assert_eq!(format_countdown(3_599_000), "in 59m 59s");
+    }
+
+    #[test]
+    fn format_countdown_hours() {
+        assert_eq!(format_countdown(3_600_000), "in 1h");
+        assert_eq!(format_countdown(5_400_000), "in 1h 30m");
+        assert_eq!(format_countdown(7_200_000), "in 2h");
+    }
+
+    // ── truncate_str tests ──
+
+    #[test]
+    fn truncate_str_short() {
+        assert_eq!(truncate_str("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_str_exact_fit() {
+        assert_eq!(truncate_str("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_str_needs_truncation() {
+        assert_eq!(truncate_str("hello world", 8), "hello...");
+    }
+
+    #[test]
+    fn truncate_str_empty() {
+        assert_eq!(truncate_str("", 5), "");
     }
 }

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -9,6 +9,12 @@ use ratatui::{
 use super::theme::Theme;
 use crate::session::{AgentMetrics, SessionInfo, SessionStatus};
 
+/// View-only entry for scheduled commands shown in the info panel.
+pub struct ScheduledCommandEntry {
+    pub command_preview: String,
+    pub countdown: String,
+}
+
 /// Rich VM details for the info panel, sourced from the database VM record.
 pub struct VmDetails {
     pub state: String,
@@ -38,6 +44,7 @@ pub fn render_info_panel(
     info: &SessionInfo,
     vm_details: Option<&VmDetails>,
     metrics: Option<&SystemMetrics>,
+    scheduled_commands: &[ScheduledCommandEntry],
 ) {
     let block = Block::default()
         .title(" Info ")
@@ -119,6 +126,25 @@ pub fn render_info_panel(
 
     // ── VM section (for sandboxed sessions) ──
     append_vm_section(&mut lines, info, vm_details, inner_width);
+
+    // ── Scheduled commands section ──
+    if !scheduled_commands.is_empty() {
+        lines.push(separator(inner_width));
+        lines.push(Line::from(Span::styled(
+            format!("Scheduled ({})", scheduled_commands.len()),
+            Theme::section_header(),
+        )));
+        for entry in scheduled_commands {
+            lines.push(Line::from(vec![
+                Span::styled(&entry.countdown, Style::default().fg(Theme::ACCENT)),
+                Span::styled("  ", Style::default()),
+                Span::styled(
+                    &entry.command_preview,
+                    Style::default().fg(Theme::TEXT_SECONDARY),
+                ),
+            ]));
+        }
+    }
 
     let paragraph = Paragraph::new(lines)
         .block(block)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,6 +13,7 @@ pub mod restore_sessions_modal;
 pub mod role_editor_modal;
 pub mod role_selector_modal;
 pub mod schedule_command_modal;
+pub mod scheduled_commands_list_modal;
 pub mod selection;
 pub mod session_mode_modal;
 pub mod settings_overlay;
@@ -188,6 +189,48 @@ pub fn render_modal_frame_danger(frame: &mut Frame, area: Rect, title: &str) -> 
     let inner = block.inner(area);
     frame.render_widget(block, area);
     inner
+}
+
+/// Set up a list modal with dim overlay, styled border, and list + footer split.
+///
+/// If `entry_count` is 0 and `empty_message` is `Some`, renders the empty state
+/// with the given message and footer keybinds, then returns `None`.
+/// Otherwise returns `Some([list_area, footer_area])`.
+pub fn render_list_modal_frame<'a>(
+    frame: &mut Frame,
+    percent_width: u16,
+    title: &str,
+    entry_count: usize,
+    empty_message: Option<&str>,
+    empty_footer: Option<Line<'a>>,
+) -> Option<[Rect; 2]> {
+    let list_height = entry_count.max(1) as u16;
+    let total_height = (list_height + 5).min(20);
+    let area = centered_fixed_height_rect(percent_width, total_height, frame.area());
+    let inner = render_modal_frame(frame, area, title);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    if entry_count == 0 {
+        if let Some(msg) = empty_message {
+            let empty = Paragraph::new(Line::from(Span::styled(
+                msg,
+                Style::default().fg(Theme::TEXT_MUTED),
+            )))
+            .alignment(ratatui::layout::Alignment::Center);
+            frame.render_widget(empty, chunks[0]);
+
+            if let Some(footer) = empty_footer {
+                frame.render_widget(Paragraph::new(footer), chunks[1]);
+            }
+        }
+        return None;
+    }
+
+    Some([chunks[0], chunks[1]])
 }
 
 /// Render a labeled text input field with cursor visualization and horizontal

--- a/src/ui/restore_sessions_modal.rs
+++ b/src/ui/restore_sessions_modal.rs
@@ -1,13 +1,11 @@
 use ratatui::{
-    layout::{Alignment, Constraint, Direction, Layout},
     style::Style,
     text::{Line, Span},
     widgets::Paragraph,
     Frame,
 };
 
-use super::centered_fixed_height_rect;
-use super::render_modal_frame;
+use super::render_list_modal_frame;
 use super::theme::Theme;
 
 /// View-only entry for the restore sessions modal.
@@ -24,38 +22,21 @@ pub struct RestoreSessionsModalState<'a> {
 }
 
 pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsModalState<'_>) {
-    let list_height = state.entries.len().max(1) as u16;
-    // 2 (borders) + list_height + 1 (footer) + 2 (padding)
-    let total_height = (list_height + 5).min(20);
-    let area = centered_fixed_height_rect(60, total_height, frame.area());
+    let empty_footer = Line::from(vec![
+        Span::styled("Esc", Theme::keybind()),
+        Span::raw(" close"),
+    ]);
 
-    let inner = render_modal_frame(frame, area, "Restore Deleted Sessions");
-
-    if state.entries.is_empty() {
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Min(1), Constraint::Length(1)])
-            .split(inner);
-
-        let empty = Paragraph::new(Line::from(Span::styled(
-            "No deleted sessions",
-            Style::default().fg(Theme::TEXT_MUTED),
-        )))
-        .alignment(Alignment::Center);
-        frame.render_widget(empty, chunks[0]);
-
-        let help = Line::from(vec![
-            Span::styled("Esc", Theme::keybind()),
-            Span::raw(" close"),
-        ]);
-        frame.render_widget(Paragraph::new(help), chunks[1]);
+    let Some([list_area, footer_area]) = render_list_modal_frame(
+        frame,
+        60,
+        "Restore Deleted Sessions",
+        state.entries.len(),
+        Some("No deleted sessions"),
+        Some(empty_footer),
+    ) else {
         return;
-    }
-
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
-        .split(inner);
+    };
 
     // Session list
     let lines: Vec<Line<'_>> = state
@@ -80,7 +61,7 @@ pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsM
         })
         .collect();
 
-    frame.render_widget(Paragraph::new(lines), chunks[0]);
+    frame.render_widget(Paragraph::new(lines), list_area);
 
     // Footer
     let help = Line::from(vec![
@@ -89,5 +70,5 @@ pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsM
         Span::styled("Esc", Theme::keybind()),
         Span::raw(" close"),
     ]);
-    frame.render_widget(Paragraph::new(help), chunks[1]);
+    frame.render_widget(Paragraph::new(help), footer_area);
 }

--- a/src/ui/schedule_command_modal.rs
+++ b/src/ui/schedule_command_modal.rs
@@ -18,12 +18,17 @@ pub struct ScheduleCommandState<'a> {
     pub delay_cursor: usize,
     pub focused_field: ScheduleCommandField,
     pub session_name: &'a str,
+    pub editing: bool,
 }
 
 pub fn render_schedule_command_modal(frame: &mut Frame, state: &ScheduleCommandState<'_>) {
     let area = centered_fixed_height_rect(50, 11, frame.area());
 
-    let title = format!("Schedule Command → {}", state.session_name);
+    let title = if state.editing {
+        format!("Edit Command → {}", state.session_name)
+    } else {
+        format!("Schedule Command → {}", state.session_name)
+    };
     let inner = render_modal_frame(frame, area, &title);
 
     let chunks = Layout::default()
@@ -53,11 +58,16 @@ pub fn render_schedule_command_modal(frame: &mut Frame, state: &ScheduleCommandS
         state.focused_field == ScheduleCommandField::Delay,
     );
 
+    let action = if state.editing {
+        " save  "
+    } else {
+        " schedule  "
+    };
     let footer = Line::from(vec![
         Span::styled("Tab", Theme::keybind()),
         Span::styled(" switch  ", Theme::keybind_desc()),
         Span::styled("Enter", Theme::keybind()),
-        Span::styled(" schedule  ", Theme::keybind_desc()),
+        Span::styled(action, Theme::keybind_desc()),
         Span::styled("Esc", Theme::keybind()),
         Span::styled(" cancel", Theme::keybind_desc()),
     ]);

--- a/src/ui/scheduled_commands_list_modal.rs
+++ b/src/ui/scheduled_commands_list_modal.rs
@@ -1,0 +1,94 @@
+use ratatui::{
+    style::Style,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::render_list_modal_frame;
+use super::theme::Theme;
+
+/// View-only entry for the scheduled commands list modal.
+pub struct ScheduledCommandsListEntry {
+    pub session_name: String,
+    pub command_preview: String,
+    pub countdown: String,
+}
+
+pub struct ScheduledCommandsListState<'a> {
+    pub entries: &'a [ScheduledCommandsListEntry],
+    pub selected_index: usize,
+}
+
+pub fn render_scheduled_commands_list_modal(
+    frame: &mut Frame,
+    state: &ScheduledCommandsListState<'_>,
+) {
+    let empty_footer = Line::from(vec![
+        Span::styled("n", Theme::keybind()),
+        Span::styled(" new  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" close", Theme::keybind_desc()),
+    ]);
+
+    let Some([list_area, footer_area]) = render_list_modal_frame(
+        frame,
+        70,
+        "Scheduled Commands",
+        state.entries.len(),
+        Some("No pending scheduled commands"),
+        Some(empty_footer),
+    ) else {
+        return;
+    };
+
+    let inner_width = list_area.width as usize;
+
+    let lines: Vec<Line<'_>> = state
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            let selected = i == state.selected_index;
+            let prefix = format!("[{}] ", entry.session_name);
+            let suffix = format!(" {}", entry.countdown);
+            let cmd_max = inner_width
+                .saturating_sub(prefix.chars().count())
+                .saturating_sub(suffix.chars().count())
+                .saturating_sub(2);
+            let cmd = if entry.command_preview.chars().count() > cmd_max {
+                let truncated: String = entry
+                    .command_preview
+                    .chars()
+                    .take(cmd_max.saturating_sub(3))
+                    .collect();
+                format!("{truncated}...")
+            } else {
+                entry.command_preview.clone()
+            };
+            let text = format!(" {prefix}{cmd}{suffix} ");
+            if selected {
+                Line::from(Span::styled(text, Theme::selected_item()))
+            } else {
+                Line::from(Span::styled(
+                    text,
+                    Style::default().fg(Theme::TEXT_SECONDARY),
+                ))
+            }
+        })
+        .collect();
+
+    frame.render_widget(Paragraph::new(lines), list_area);
+
+    let help = Line::from(vec![
+        Span::styled("n", Theme::keybind()),
+        Span::styled(" new  ", Theme::keybind_desc()),
+        Span::styled("e", Theme::keybind()),
+        Span::styled(" edit  ", Theme::keybind_desc()),
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" cancel  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" close", Theme::keybind_desc()),
+    ]);
+    frame.render_widget(Paragraph::new(help), footer_area);
+}

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -38,6 +38,7 @@ pub struct FooterState<'a> {
     pub container_provisioning: bool,
     pub container_provisioning_step: &'a str,
     pub tick_count: u64,
+    pub pending_scheduled_count: usize,
 }
 
 pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
@@ -103,6 +104,12 @@ pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
             counts,
             Style::default().fg(Theme::TEXT_SECONDARY),
         ));
+        if state.pending_scheduled_count > 0 {
+            spans.push(Span::styled(
+                format!(" {} scheduled ", state.pending_scheduled_count),
+                Style::default().fg(Theme::TEXT_PRIMARY).bg(Theme::ACCENT),
+            ));
+        }
     }
 
     // Always-visible shortcut hints


### PR DESCRIPTION
## Summary

- **Ctrl+P redesigned**: Opens a scheduled commands list modal showing all pending commands across sessions with countdown timers, replacing the direct "schedule new" flow
- **List modal actions**: `n` (new), `e` (edit), `Enter` (cancel), `j`/`k` (navigate), `Esc` (close)
- **Edit support**: Pre-fills the schedule modal with existing command text and remaining delay, cancels the old command on save while preserving the correct target session
- **Status bar badge**: Shows pending scheduled command count when > 0
- **Info panel section**: Displays per-session scheduled commands with live countdowns
- **Cached pending commands**: Refreshed every ~1s in the tick loop for responsive UI updates

## Test plan

- [x] 928/928 tests pass (11 new tests added)
- [x] 8/8 architecture rules pass
- [x] 0 clippy warnings
- [x] All pre-commit hooks pass
- [ ] Manual: Ctrl+P shows list modal with pending commands
- [ ] Manual: `n` opens schedule modal, `e` edits selected command
- [ ] Manual: Enter cancels selected command, modal auto-closes when empty
- [ ] Manual: Status bar shows "N scheduled" badge
- [ ] Manual: Info panel (F2) shows scheduled section with countdowns