### PR TITLE
feat(ui): add manual session naming modal

### DIFF
--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -670,8 +670,9 @@ impl SessionBackend for LocalTmuxBackend {
             .iter()
             .map(|(k, v)| format!(" -e {}", shell_escape(&format!("{k}={v}"))))
             .collect();
+        let escaped_window_name = shell_escape(window_name);
         let cmd = format!(
-            "new-window -t {TMUX_SESSION} -n {window_name} -P -F '#{{pane_id}}'{cwd_part}{env_part} {shell_cmd}"
+            "new-window -t {TMUX_SESSION} -n {escaped_window_name} -P -F '#{{pane_id}}'{cwd_part}{env_part} {shell_cmd}"
         );
         let result = self.ctrl_command(&cmd)?;
         let pane_id = result.trim().to_string();

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -66,6 +66,12 @@ impl App {
             return;
         }
 
+        // Session name modal captures all input
+        if matches!(self.modal, super::modals::Modal::SessionName(_)) {
+            self.handle_session_name_key(code);
+            return;
+        }
+
         // Schedule command modal captures all input
         if matches!(self.modal, super::modals::Modal::ScheduleCommand(_)) {
             self.handle_schedule_command_key(code);
@@ -860,6 +866,44 @@ impl App {
             KeyCode::Home => wn.name.home(),
             KeyCode::End => wn.name.end(),
             KeyCode::Char(c) => wn.name.insert(c),
+            _ => {}
+        }
+    }
+
+    fn handle_session_name_key(&mut self, code: KeyCode) {
+        let super::modals::Modal::SessionName(ref mut sn) = self.modal else {
+            return;
+        };
+        match code {
+            KeyCode::Esc => {
+                self.modal.close();
+                self.pending_spawn_config = None;
+                self.pending_spawn_worktrees.clear();
+                self.pending_spawn_project_index = None;
+                self.pending_vm_id = None;
+                // Undo the counter increment from prepare_spawn().
+                self.session_counter = self.session_counter.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                let name = sn.name.value().trim().to_string();
+                if name.is_empty() {
+                    self.set_error("Session name cannot be empty");
+                    return;
+                }
+                self.modal.close();
+                if let Some(config) = self.pending_spawn_config.take() {
+                    let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
+                    let project_index = self.pending_spawn_project_index.take();
+                    self.finish_prepare_spawn(name, config, worktrees, project_index);
+                }
+            }
+            KeyCode::Backspace => sn.name.backspace(),
+            KeyCode::Delete => sn.name.delete(),
+            KeyCode::Left => sn.name.move_left(),
+            KeyCode::Right => sn.name.move_right(),
+            KeyCode::Home => sn.name.home(),
+            KeyCode::End => sn.name.end(),
+            KeyCode::Char(c) => sn.name.insert(c),
             _ => {}
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1243,7 +1243,7 @@ impl App {
     /// Core spawn logic with an explicit project index for tagging.
     fn prepare_spawn_for_project(
         &mut self,
-        mut config: SessionConfig,
+        config: SessionConfig,
         worktrees: Vec<WorktreeInfo>,
         project_index: Option<usize>,
     ) {
@@ -1251,11 +1251,32 @@ impl App {
         let is_admin = project_index
             .and_then(|i| self.projects.get(i))
             .is_some_and(|p| p.is_admin);
-        let name = if is_admin {
-            format!("admin-{raw_name}")
+
+        if is_admin {
+            // Admin sessions skip the name modal — auto-name and proceed.
+            let name = format!("admin-{raw_name}");
+            self.finish_prepare_spawn(name, config, worktrees, project_index);
         } else {
-            raw_name
-        };
+            // Show session name modal pre-filled with the default name.
+            self.pending_spawn_config = Some(config);
+            self.pending_spawn_worktrees = worktrees;
+            self.pending_spawn_project_index = project_index;
+            let mut modal = modals::SessionNameModal::default();
+            modal.name.set(&raw_name);
+            self.modal = modals::Modal::SessionName(modal);
+        }
+    }
+
+    /// Continue spawn after the user has chosen a session name.
+    ///
+    /// Routes to role selection if 2+ roles exist, otherwise spawns directly.
+    fn finish_prepare_spawn(
+        &mut self,
+        name: String,
+        mut config: SessionConfig,
+        worktrees: Vec<WorktreeInfo>,
+        project_index: Option<usize>,
+    ) {
         let roles = &self.global_roles;
 
         match roles.len() {
@@ -4774,7 +4795,127 @@ mod tests {
         let mut app = App::new(24, 120, stub_backend(), stub_provider(), db, None, None);
         let session_config = SessionConfig::default();
         app.prepare_spawn(session_config, Vec::new());
+        // Session name modal appears first.
+        assert!(matches!(app.modal, modals::Modal::SessionName(_)));
+        // Confirm the default name to proceed to role selector.
+        app.handle_key(KeyCode::Enter, KeyModifiers::NONE);
         assert!(matches!(app.modal, modals::Modal::RoleSelector(_)));
+    }
+
+    #[test]
+    fn prepare_spawn_shows_session_name_modal() {
+        let config = ProjectConfig {
+            name: "test".to_string(),
+            repos: vec![],
+            roles: vec![],
+            mcp_servers: vec![],
+            id: None,
+        };
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db_with_project(&config),
+            None,
+            None,
+        );
+        app.prepare_spawn(SessionConfig::default(), Vec::new());
+        assert!(matches!(app.modal, modals::Modal::SessionName(_)));
+        // Default name should be pre-filled.
+        if let modals::Modal::SessionName(ref sn) = app.modal {
+            assert_eq!(sn.name.value(), "1");
+        }
+    }
+
+    #[test]
+    fn session_name_modal_accepts_custom_name() {
+        let config = ProjectConfig {
+            name: "test".to_string(),
+            repos: vec![],
+            roles: vec![],
+            mcp_servers: vec![],
+            id: None,
+        };
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db_with_project(&config),
+            None,
+            None,
+        );
+        app.prepare_spawn(SessionConfig::default(), Vec::new());
+        assert!(matches!(app.modal, modals::Modal::SessionName(_)));
+        // Clear default and type a custom name with spaces.
+        app.handle_key(KeyCode::Home, KeyModifiers::NONE);
+        app.handle_key(KeyCode::Delete, KeyModifiers::NONE); // delete "1"
+        for c in "Fix MCP Bug".chars() {
+            app.handle_key(KeyCode::Char(c), KeyModifiers::NONE);
+        }
+        if let modals::Modal::SessionName(ref sn) = app.modal {
+            assert_eq!(sn.name.value(), "Fix MCP Bug");
+        } else {
+            panic!("Expected SessionName modal");
+        }
+        app.handle_key(KeyCode::Enter, KeyModifiers::NONE);
+        // Modal closed after accepting the name.
+        assert!(matches!(app.modal, modals::Modal::None));
+    }
+
+    #[test]
+    fn session_name_modal_esc_cancels_and_undoes_counter() {
+        let config = ProjectConfig {
+            name: "test".to_string(),
+            repos: vec![],
+            roles: vec![],
+            mcp_servers: vec![],
+            id: None,
+        };
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db_with_project(&config),
+            None,
+            None,
+        );
+        let counter_before = app.session_counter;
+        app.prepare_spawn(SessionConfig::default(), Vec::new());
+        assert!(matches!(app.modal, modals::Modal::SessionName(_)));
+        app.handle_key(KeyCode::Esc, KeyModifiers::NONE);
+        assert!(matches!(app.modal, modals::Modal::None));
+        assert_eq!(app.session_counter, counter_before);
+    }
+
+    #[test]
+    fn session_name_modal_rejects_empty_name() {
+        let config = ProjectConfig {
+            name: "test".to_string(),
+            repos: vec![],
+            roles: vec![],
+            mcp_servers: vec![],
+            id: None,
+        };
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db_with_project(&config),
+            None,
+            None,
+        );
+        app.prepare_spawn(SessionConfig::default(), Vec::new());
+        // Clear the default name.
+        app.handle_key(KeyCode::Home, KeyModifiers::NONE);
+        app.handle_key(KeyCode::Delete, KeyModifiers::NONE);
+        // Try to submit empty.
+        app.handle_key(KeyCode::Enter, KeyModifiers::NONE);
+        // Modal should still be open.
+        assert!(matches!(app.modal, modals::Modal::SessionName(_)));
     }
 
     #[test]

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -145,6 +145,11 @@ pub struct WorktreeNameModal {
 }
 
 #[derive(Debug, Clone, Default)]
+pub struct SessionNameModal {
+    pub name: TextInput,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct RoleSelectorModal {
     pub index: usize,
 }
@@ -300,6 +305,7 @@ pub enum Modal {
     ScheduleCommand(ScheduleCommandModal),
     ScheduledCommandsList(ScheduledCommandsListModal),
     RepoPicker(RepoPickerModal),
+    SessionName(SessionNameModal),
 }
 
 impl Modal {

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -18,7 +18,7 @@ use crate::ui::{
     add_project_modal, branch_selector_modal, containerfile_picker, delete_project_modal,
     info_panel, layout, project_list, repo_selector_modal, restore_sessions_modal,
     role_editor_modal, role_selector_modal, schedule_command_modal, scheduled_commands_list_modal,
-    session_mode_modal, status_bar, terminal_view, worktree_name_modal,
+    session_mode_modal, session_name_modal, status_bar, terminal_view, worktree_name_modal,
 };
 
 use super::{App, InputFocus, TerminalView};
@@ -267,6 +267,17 @@ impl App {
                     name: wn.name.value(),
                     cursor: wn.name.cursor_pos(),
                     base_branch: base,
+                },
+            );
+        }
+
+        // Session name modal
+        if let super::modals::Modal::SessionName(ref sn) = self.modal {
+            session_name_modal::render_session_name_modal(
+                frame,
+                &session_name_modal::SessionNameState {
+                    name: sn.name.value(),
+                    cursor: sn.name.cursor_pos(),
                 },
             );
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,6 +16,7 @@ pub mod schedule_command_modal;
 pub mod scheduled_commands_list_modal;
 pub mod selection;
 pub mod session_mode_modal;
+pub mod session_name_modal;
 pub mod settings_overlay;
 pub mod status_bar;
 pub mod terminal_view;

--- a/src/ui/session_name_modal.rs
+++ b/src/ui/session_name_modal.rs
@@ -1,0 +1,39 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::centered_fixed_height_rect;
+use super::render_modal_frame;
+use super::theme::Theme;
+
+pub struct SessionNameState<'a> {
+    pub name: &'a str,
+    pub cursor: usize,
+}
+
+pub fn render_session_name_modal(frame: &mut Frame, state: &SessionNameState<'_>) {
+    let area = centered_fixed_height_rect(50, 8, frame.area());
+
+    let inner = render_modal_frame(frame, area, "Session Name");
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Name field
+            Constraint::Min(1),    // Footer
+        ])
+        .split(inner);
+
+    super::render_text_field(frame, chunks[0], "Name", state.name, state.cursor, true);
+
+    let footer = Line::from(vec![
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" confirm  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[1]);
+}


### PR DESCRIPTION
## Summary
- Adds a session name modal that appears before spawning a new session, allowing users to set a custom name
- Pre-fills the name field with a numeric default; supports spaces and special characters via tmux shell escaping
- Admin sessions skip the modal and auto-name as before
- Uses `render_modal_frame()` for consistent styling with other modals (dim overlay, rounded borders)

## Test plan
- [x] 940/940 tests pass including 4 new tests covering custom names, spaces, cancel/undo, and empty rejection
- [x] 8/8 architecture rules pass
- [x] 0 clippy warnings
- [ ] Manual: Ctrl+N → verify session name modal appears with default name
- [ ] Manual: Type custom name with spaces → verify session spawns with that name
- [ ] Manual: Press Esc → verify modal closes and counter is rolled back
- [ ] Manual: Clear name and press Enter → verify error message appears