### PR TITLE
fix(core): reload global roles and MCP servers on external DB changes

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1999,8 +1999,23 @@ impl App {
         }
 
         // Poll for external state changes from other thurbox instances (DB-based)
-        if let Ok(Some(delta)) = sync::poll_for_changes(&mut self.sync_state, &mut self.db) {
-            self.handle_external_state_change(delta);
+        if let Ok(Some(result)) = sync::poll_for_changes(&mut self.sync_state, &mut self.db) {
+            if result.db_changed {
+                // Reload global state that lives outside the session/project delta.
+                if let Ok(roles) = self.db.list_global_roles() {
+                    if roles != self.global_roles {
+                        self.global_roles = roles;
+                    }
+                }
+                if let Ok(servers) = self.db.list_global_mcp_servers() {
+                    if servers != self.global_mcp_servers {
+                        self.global_mcp_servers = servers;
+                    }
+                }
+            }
+            if !result.delta.is_empty() {
+                self.handle_external_state_change(result.delta);
+            }
         }
 
         // Poll for VM provisioning results from background thread

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -95,6 +95,16 @@ impl Default for SyncState {
     }
 }
 
+/// Result of polling for external state changes.
+pub struct PollResult {
+    /// Delta between local and DB state (may be empty).
+    pub delta: StateDelta,
+    /// Whether the database was modified externally (e.g. by the MCP server).
+    /// True even when the delta is empty, indicating that non-tracked state
+    /// (such as global roles or MCP servers) may have changed.
+    pub db_changed: bool,
+}
+
 /// Poll for external state changes using the SQLite database.
 ///
 /// Uses `PRAGMA data_version` for change detection, which increments
@@ -102,13 +112,13 @@ impl Default for SyncState {
 ///
 /// # Returns
 ///
-/// - `Ok(Some(delta))` - Changes detected, apply delta to local state
-/// - `Ok(None)` - No changes detected or not time to poll yet
+/// - `Ok(Some(result))` - Poll was executed; check `db_changed` and `delta`
+/// - `Ok(None)` - Not time to poll yet
 /// - `Err(e)` - Error querying database
 pub fn poll_for_changes(
     sync_state: &mut SyncState,
     db: &mut crate::storage::Database,
-) -> std::io::Result<Option<StateDelta>> {
+) -> std::io::Result<Option<PollResult>> {
     if !sync_state.should_poll() {
         return Ok(None);
     }
@@ -120,7 +130,10 @@ pub fn poll_for_changes(
         .map_err(|e| std::io::Error::other(format!("DB check failed: {e}")))?;
 
     if !changed {
-        return Ok(None);
+        return Ok(Some(PollResult {
+            delta: StateDelta::default(),
+            db_changed: false,
+        }));
     }
 
     debug!("External DB change detected via PRAGMA data_version");
@@ -133,7 +146,10 @@ pub fn poll_for_changes(
 
     sync_state.local_state_snapshot = new_state;
 
-    Ok(if delta.is_empty() { None } else { Some(delta) })
+    Ok(Some(PollResult {
+        delta,
+        db_changed: true,
+    }))
 }
 
 #[cfg(test)]

--- a/tests/sync_integration.rs
+++ b/tests/sync_integration.rs
@@ -440,10 +440,11 @@ fn poll_for_changes_returns_none_when_no_external_changes() {
     // Initialize change tracking
     let _ = db.has_external_changes().unwrap();
 
-    // No external changes — should return None
+    // No external changes — db_changed should be false
     std::thread::sleep(std::time::Duration::from_millis(1));
     let result = sync::poll_for_changes(&mut sync_state, &mut db).unwrap();
-    assert!(result.is_none());
+    assert!(result.is_some());
+    assert!(!result.unwrap().db_changed);
 }
 
 #[test]
@@ -467,9 +468,10 @@ fn poll_for_changes_detects_external_session_add() {
     std::thread::sleep(std::time::Duration::from_millis(1));
     let result = sync::poll_for_changes(&mut sync_state, &mut db_poller).unwrap();
     assert!(result.is_some());
-    let delta = result.unwrap();
-    assert_eq!(delta.added_sessions.len(), 1);
-    assert_eq!(delta.added_sessions[0].name, "External Session");
+    let result = result.unwrap();
+    assert!(result.db_changed);
+    assert_eq!(result.delta.added_sessions.len(), 1);
+    assert_eq!(result.delta.added_sessions[0].name, "External Session");
 }
 
 #[test]
@@ -483,4 +485,53 @@ fn poll_for_changes_respects_interval() {
 
     let result = sync::poll_for_changes(&mut sync_state, &mut db).unwrap();
     assert!(result.is_none());
+}
+
+#[test]
+fn poll_detects_global_role_change_even_when_delta_empty() {
+    use thurbox::session::{RoleConfig, RolePermissions};
+
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    let path = temp.path();
+
+    let mut db_poller = Database::open(path).unwrap();
+    let db_writer = Database::open(path).unwrap();
+
+    let mut sync_state = sync::SyncState::with_interval(std::time::Duration::from_millis(0));
+
+    // Initialize change tracking
+    let _ = db_poller.has_external_changes().unwrap();
+    // Set initial snapshot so first poll doesn't see false positives
+    let initial = db_poller.load_shared_state().unwrap();
+    sync_state.set_initial_snapshot(initial);
+
+    // External writer modifies only the global roles table
+    db_writer
+        .replace_global_roles(&[RoleConfig {
+            name: "ops".to_string(),
+            description: "Operations".to_string(),
+            permissions: RolePermissions {
+                allowed_tools: vec!["Bash".to_string(), "Read".to_string()],
+                ..RolePermissions::default()
+            },
+        }])
+        .unwrap();
+
+    // Poll should detect the DB change even though session/project delta is empty
+    std::thread::sleep(std::time::Duration::from_millis(1));
+    let result = sync::poll_for_changes(&mut sync_state, &mut db_poller).unwrap();
+    assert!(result.is_some());
+    let result = result.unwrap();
+    assert!(result.db_changed);
+    // The session/project delta is empty — only global roles changed
+    assert!(result.delta.is_empty());
+
+    // Verify the poller can read the updated global roles
+    let roles = db_poller.list_global_roles().unwrap();
+    assert_eq!(roles.len(), 1);
+    assert_eq!(roles[0].name, "ops");
+    assert_eq!(
+        roles[0].permissions.allowed_tools,
+        vec!["Bash".to_string(), "Read".to_string()]
+    );
 }


### PR DESCRIPTION
## Summary

- Fix sync mechanism silently discarding external DB changes when only global roles or MCP servers were modified (empty session/project delta was treated as "no changes")
- Split `poll_for_changes` return into `PollResult` struct with `db_changed` flag separate from `delta`, so the app can reload global state even when no tracked entities changed
- Reload `global_roles` and `global_mcp_servers` from the database on any external change, fixing MCP `set_roles`/`set_mcp_servers` not being reflected in the TUI

## Test plan

- [x] New integration test `poll_detects_global_role_change_even_when_delta_empty` verifies the fix
- [x] All existing sync tests updated and passing (19 integration + unit tests)
- [x] Full test suite passes (724+ tests)
- [ ] Manual: use MCP `set_roles` to add tools, verify they appear in the TUI role editor