### PR TITLE
fix(core): prevent ControlMode::Drop from blocking indefinitely

### DIFF
--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -297,16 +297,27 @@ impl Drop for ControlMode {
             let _ = stdin.flush();
         }
 
-        // Join the reader thread.
+        // Give the child a moment to exit gracefully, then force-kill so the
+        // reader thread gets EOF promptly and we never block indefinitely.
+        if let Ok(mut child) = self.child.lock() {
+            let exited = (0..3).any(|_| {
+                if matches!(child.try_wait(), Ok(Some(_))) {
+                    return true;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                false
+            });
+            if !exited {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+
+        // Reader thread should exit now that the child is dead (stdout closed).
         if let Ok(mut handle) = self.reader_handle.lock() {
             if let Some(h) = handle.take() {
                 let _ = h.join();
             }
-        }
-
-        // Ensure the child process is cleaned up.
-        if let Ok(mut child) = self.child.lock() {
-            let _ = child.wait();
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fix `ControlMode::Drop` in `src/agent/tmux.rs` to use bounded cleanup instead of infinite blocking
- The old impl called `child.wait()` and `h.join()` with no timeout, which could block forever when tmux control mode error recovery triggered `reconnect_control()`
- This caused the TUI to freeze permanently when spawning sessions (e.g. admin session via Ctrl+A)
- Replace with `try_wait()` polling loop (3x 100ms) + `child.kill()` fallback, bounding worst-case Drop to ~300ms

## Test plan

- [ ] `cargo check --all` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes
- [ ] Manual: spawn admin session via Ctrl+A — TUI should not freeze
- [ ] Manual: spawn regular sessions via Ctrl+N — no regression