### PR TITLE
fix(config): make renovate deps trigger patch releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,8 @@
   "extends": ["config:recommended"],
   "labels": ["dependencies"],
   "automerge": true,
+  "semanticCommitType": "fix",
+  "semanticCommitScope": "deps",
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Summary
- Change Renovate semantic commit type from `chore` to `fix` so dependency updates (`fix(deps): ...`) trigger cocogitto auto-bump patch releases
- Previously, `chore(deps)` commits had no bump config and were silently skipped

## Test plan
- [ ] Verify next Renovate PR creates `fix(deps): ...` commit messages
- [ ] Verify cocogitto `cog bump --auto --dry-run` detects the new commit type as releasable