### PR TITLE
feat(ui): add Ctrl+F to fork active session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+D` | Delete session | Vim: **d** = delete |
 | `Ctrl+E` | Edit settings (roles, MCP servers) | **E**dit |
 | `Ctrl+R` | Restart active session | **R**estart |
+| `Ctrl+F` | Fork active session | **F**ork |
 | `Ctrl+S` | Sync worktrees with origin/main | **S**ync |
 | `Ctrl+Z` | Undo session delete | **Z** = undo |
 | `Ctrl+U` | Restore deleted sessions | **U**ndelete |

--- a/src/agent/claude.rs
+++ b/src/agent/claude.rs
@@ -23,7 +23,11 @@ impl AgentProvider for ClaudeProvider {
 fn build_claude_args(config: &SessionConfig) -> Vec<String> {
     let mut args = Vec::new();
 
-    if let Some(ref session_id) = config.resume_session_id {
+    if let Some(ref fork_id) = config.fork_session_id {
+        args.push("--resume".to_string());
+        args.push(fork_id.clone());
+        args.push("--fork-session".to_string());
+    } else if let Some(ref session_id) = config.resume_session_id {
         args.push("--resume".to_string());
         args.push(session_id.clone());
     } else if let Some(ref session_id) = config.agent_session_id {
@@ -102,6 +106,46 @@ mod tests {
         assert_eq!(
             args,
             vec!["--resume", "resume-id", "--permission-mode", "default"]
+        );
+    }
+
+    #[test]
+    fn build_args_fork_session() {
+        let config = SessionConfig {
+            fork_session_id: Some("parent-id".to_string()),
+            agent_session_id: Some("new-id".to_string()),
+            ..SessionConfig::default()
+        };
+        let args = build_claude_args(&config);
+        assert_eq!(
+            args,
+            vec![
+                "--resume",
+                "parent-id",
+                "--fork-session",
+                "--permission-mode",
+                "default"
+            ]
+        );
+    }
+
+    #[test]
+    fn build_args_fork_takes_precedence_over_resume() {
+        let config = SessionConfig {
+            fork_session_id: Some("fork-id".to_string()),
+            resume_session_id: Some("resume-id".to_string()),
+            ..SessionConfig::default()
+        };
+        let args = build_claude_args(&config);
+        assert_eq!(
+            args,
+            vec![
+                "--resume",
+                "fork-id",
+                "--fork-session",
+                "--permission-mode",
+                "default"
+            ]
         );
     }
 

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -193,6 +193,13 @@ impl App {
                     self.open_settings();
                     return;
                 }
+                KeyCode::Char('f') => match self.focus {
+                    InputFocus::Terminal => {} // forward to PTY (shell forward-search)
+                    _ => {
+                        self.fork_active_session();
+                        return;
+                    }
+                },
                 KeyCode::Char('r') => match self.focus {
                     InputFocus::Terminal => {} // forward to PTY (e.g. bash reverse search)
                     _ => {
@@ -672,6 +679,7 @@ impl App {
                     self.pending_spawn_config = None;
                     self.pending_spawn_worktrees.clear();
                     self.pending_vm_id = None;
+                    self.pending_fork = false;
                 }
             }
             KeyCode::Enter => {
@@ -689,9 +697,15 @@ impl App {
                     modal.name.set(&branch);
                     self.modal = super::modals::Modal::WorktreeName(modal);
                 } else if let Some(config) = self.pending_spawn_config.take() {
-                    // Normal flow — proceed to role selection / spawn.
                     let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
-                    self.finish_prepare_spawn(name, config, worktrees);
+                    if self.pending_fork {
+                        // Fork flow — role already set, spawn directly.
+                        self.pending_fork = false;
+                        self.do_spawn_session(name, &config, worktrees, false);
+                    } else {
+                        // Normal flow — proceed to role selection / spawn.
+                        self.finish_prepare_spawn(name, config, worktrees);
+                    }
                 }
             }
             KeyCode::Backspace => sn.name.backspace(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -439,6 +439,7 @@ pub struct App {
     pub(crate) pending_session_name: Option<String>,
     pub(crate) pending_spawn_config: Option<SessionConfig>,
     pub(crate) pending_spawn_worktrees: Vec<WorktreeInfo>,
+    pub(crate) pending_fork: bool,
     pub(crate) pending_spawn_name: Option<String>,
     pub(crate) show_settings: bool,
     pub(crate) settings_tab: SettingsTab,
@@ -617,6 +618,7 @@ impl App {
             pending_session_name: None,
             pending_spawn_config: None,
             pending_spawn_worktrees: Vec::new(),
+            pending_fork: false,
             pending_spawn_name: None,
             show_settings: false,
             settings_tab: SettingsTab::Roles,
@@ -1066,6 +1068,7 @@ impl App {
             permissions,
             vm_id: session.info.vm_id.clone(),
             container_id: session.info.container_id.clone(),
+            fork_session_id: None,
         };
 
         let (rows, cols) = self.content_area_size();
@@ -1080,6 +1083,42 @@ impl App {
                 self.set_error(format!("Failed to restart session: {e:#}"));
             }
         }
+    }
+
+    fn fork_active_session(&mut self) {
+        let Some(session) = self.sessions.get(self.active_index) else {
+            return;
+        };
+
+        let role = session.info.role.clone();
+        let cwd = session.info.cwd.clone();
+        let additional_dirs = session.info.additional_dirs.clone();
+        let worktrees = session.info.worktrees.clone();
+        let vm_id = session.info.vm_id.clone();
+        let container_id = session.info.container_id.clone();
+        let source_name = session.info.name.clone();
+        let fork_session_id = session.info.agent_session_id.clone();
+
+        let permissions = self.resolve_role_permissions(&role);
+        let config = SessionConfig {
+            resume_session_id: None,
+            agent_session_id: None,
+            cwd,
+            additional_dirs,
+            role,
+            permissions,
+            vm_id,
+            container_id,
+            fork_session_id,
+        };
+
+        self.pending_spawn_config = Some(config);
+        self.pending_spawn_worktrees = worktrees;
+        self.pending_fork = true;
+
+        let mut sn = modals::SessionNameModal::default();
+        sn.name.set(&format!("{source_name}-fork"));
+        self.modal = modals::Modal::SessionName(sn);
     }
 
     fn close_active_session(&mut self) {
@@ -1224,6 +1263,7 @@ impl App {
             permissions,
             vm_id: None,
             container_id: None,
+            fork_session_id: None,
         };
 
         let session_name = deleted.name.clone();
@@ -2338,6 +2378,7 @@ impl App {
                             permissions,
                             vm_id: None,
                             container_id: None,
+                            fork_session_id: None,
                         };
 
                         let (rows, cols) = self.content_area_size();
@@ -2936,6 +2977,7 @@ impl App {
                 permissions,
                 vm_id: None,
                 container_id: None,
+                fork_session_id: None,
             };
             self.do_spawn_session(name, &config, worktrees, false);
         }
@@ -3170,6 +3212,7 @@ impl App {
                 permissions,
                 vm_id: resolved_vm_id,
                 container_id: resolved_container_id,
+                fork_session_id: None,
             };
             self.do_spawn_session(name, &config, worktrees, false);
             info!(session = %session_id, "Session restored (respawned with --resume)");
@@ -3235,6 +3278,7 @@ impl App {
                 permissions,
                 vm_id: None,
                 container_id: None,
+                fork_session_id: None,
             };
 
             warn!(
@@ -3338,6 +3382,7 @@ impl App {
             permissions,
             vm_id: session.info.vm_id.clone(),
             container_id: session.info.container_id.clone(),
+            fork_session_id: None,
         };
 
         let (rows, cols) = self.content_area_size();

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -474,6 +474,7 @@ fn render_help_overlay(frame: &mut Frame) {
         help_line("Ctrl+A", "Create admin session"),
         help_line("Ctrl+D", "Delete focused session"),
         help_line("Ctrl+R", "Restart active session"),
+        help_line("Ctrl+F", "Fork active session"),
         help_line("Ctrl+P", "Scheduled commands (list/cancel/new)"),
         help_line("Ctrl+Z", "Undo last delete"),
         help_line("Ctrl+U", "Restore deleted sessions"),

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -329,6 +329,11 @@ pub struct SessionConfig {
     /// When set, the devcontainer backend uses this to spawn the session on the
     /// specific container. Ensures each session is tied to its own container.
     pub container_id: Option<String>,
+    /// Fork from an existing session's conversation.
+    ///
+    /// When set, the CLI is invoked with `--resume <fork_session_id> --fork-session`
+    /// to create a new session that branches from the parent's conversation history.
+    pub fork_session_id: Option<String>,
 }
 
 /// VM state machine for sandboxed sessions.


### PR DESCRIPTION
## Summary

- Adds `Ctrl+F` shortcut to fork the active session, creating a new session that inherits config (cwd, worktrees, role, permissions, vm/container) and conversation history via Claude Code's `--resume --fork-session` flag
- Shows session name modal pre-filled with `"{name}-fork"`, skips role selection (inherits from parent)
- Forwards `Ctrl+F` to PTY when terminal is focused (shell forward-search)

## Test plan

- [ ] `cargo check --all` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all` passes (including 2 new fork arg tests)
- [ ] Manual: create session, chat, press Ctrl+F from session list → name modal pre-filled, Enter → forked session with conversation history
- [ ] Manual: focus terminal, press Ctrl+F → forwards to PTY (no fork)

🤖 Generated with [Claude Code](https://claude.com/claude-code)