### PR TITLE
feat(mcp): add MCP server picker and pass config to Claude Code

### DIFF
--- a/src/agent/claude.rs
+++ b/src/agent/claude.rs
@@ -65,6 +65,12 @@ fn build_claude_args(config: &SessionConfig) -> Vec<String> {
         args.push(dir.display().to_string());
     }
 
+    if !config.mcp_servers.is_empty() {
+        let doc = crate::session::McpServerConfig::to_mcp_json(&config.mcp_servers);
+        args.push("--mcp-config".to_string());
+        args.push(doc.to_string());
+    }
+
     args
 }
 
@@ -291,6 +297,33 @@ mod tests {
                 "/extra",
             ]
         );
+    }
+
+    #[test]
+    fn build_args_with_mcp_servers() {
+        use crate::session::McpServerConfig;
+
+        let config = SessionConfig {
+            mcp_servers: vec![McpServerConfig {
+                name: "test-server".to_string(),
+                command: "cmd".to_string(),
+                args: vec![],
+                env: std::collections::HashMap::new(),
+            }],
+            ..SessionConfig::default()
+        };
+        let args = build_claude_args(&config);
+        let idx = args.iter().position(|a| a == "--mcp-config").unwrap();
+        let json: serde_json::Value = serde_json::from_str(&args[idx + 1]).unwrap();
+        // JSON structure correctness is tested in McpServerConfig::to_mcp_json tests.
+        assert!(json["mcpServers"]["test-server"].is_object());
+    }
+
+    #[test]
+    fn build_args_empty_mcp_servers_no_flag() {
+        let config = SessionConfig::default();
+        let args = build_claude_args(&config);
+        assert!(!args.contains(&"--mcp-config".to_string()));
     }
 
     #[test]

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -28,23 +28,7 @@ pub(super) fn write_vm_mcp_json(
         return Ok(());
     }
 
-    // Build the .mcp.json structure Claude Code expects.
-    let mut servers = serde_json::Map::new();
-    for srv in mcp_servers {
-        let mut entry = serde_json::Map::new();
-        entry.insert(
-            "command".to_string(),
-            serde_json::Value::String(srv.command.clone()),
-        );
-        if !srv.args.is_empty() {
-            entry.insert("args".to_string(), serde_json::json!(srv.args));
-        }
-        if !srv.env.is_empty() {
-            entry.insert("env".to_string(), serde_json::json!(srv.env));
-        }
-        servers.insert(srv.name.clone(), serde_json::Value::Object(entry));
-    }
-    let doc = serde_json::json!({ "mcpServers": servers });
+    let doc = crate::session::McpServerConfig::to_mcp_json(mcp_servers);
     let json_str = serde_json::to_string_pretty(&doc)?;
 
     let key_path = instance.ssh_key_path();
@@ -105,23 +89,7 @@ pub(super) fn write_container_mcp_json(
 
     let docker_id = docker_container_id;
 
-    // Build the .mcp.json structure Claude Code expects.
-    let mut servers = serde_json::Map::new();
-    for srv in mcp_servers {
-        let mut entry = serde_json::Map::new();
-        entry.insert(
-            "command".to_string(),
-            serde_json::Value::String(srv.command.clone()),
-        );
-        if !srv.args.is_empty() {
-            entry.insert("args".to_string(), serde_json::json!(srv.args));
-        }
-        if !srv.env.is_empty() {
-            entry.insert("env".to_string(), serde_json::json!(srv.env));
-        }
-        servers.insert(srv.name.clone(), serde_json::Value::Object(entry));
-    }
-    let doc = serde_json::json!({ "mcpServers": servers });
+    let doc = crate::session::McpServerConfig::to_mcp_json(mcp_servers);
     let json_str = serde_json::to_string_pretty(&doc)?;
 
     let dest = container_cwd.join(".mcp.json");

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -137,6 +137,12 @@ impl App {
             return;
         }
 
+        // MCP server picker modal captures all input
+        if matches!(self.modal, super::modals::Modal::McpServerPicker(_)) {
+            self.handle_mcp_server_picker_key(code);
+            return;
+        }
+
         // Repo picker modal captures all input
         if matches!(self.modal, super::modals::Modal::RepoPicker(_)) {
             self.handle_repo_picker_key(code);
@@ -854,6 +860,66 @@ impl App {
                     if let Some(role) = self.global_roles.get(role_index) {
                         config.role = role.name.clone();
                         config.permissions = role.permissions.clone();
+                        let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
+                        self.maybe_show_mcp_picker(name, config, worktrees, false);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_mcp_server_picker_key(&mut self, code: KeyCode) {
+        let server_count = self.global_mcp_servers.len();
+        let super::modals::Modal::McpServerPicker(ref mut msp) = self.modal else {
+            return;
+        };
+        match code {
+            KeyCode::Esc => {
+                self.modal.close();
+                self.pending_spawn_config = None;
+                self.pending_spawn_worktrees.clear();
+                self.pending_spawn_name = None;
+                self.pending_restart = false;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if msp.index + 1 < server_count {
+                    msp.index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                msp.index = msp.index.saturating_sub(1);
+            }
+            KeyCode::Char(' ') => {
+                if let Some(sel) = msp.selected.get_mut(msp.index) {
+                    *sel = !*sel;
+                }
+            }
+            KeyCode::Enter => {
+                // Collect selected MCP servers.
+                let selected_servers: Vec<_> = self
+                    .global_mcp_servers
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| msp.selected.get(*i).copied().unwrap_or(false))
+                    .map(|(_, s)| s.clone())
+                    .collect();
+                self.modal.close();
+
+                if self.pending_restart {
+                    // Restart flow
+                    if let Some(mut config) = self.pending_spawn_config.take() {
+                        config.mcp_servers = selected_servers;
+                        self.do_restart(config);
+                    }
+                    self.pending_restart = false;
+                } else {
+                    // New session / fork flow
+                    if let (Some(mut config), Some(name)) = (
+                        self.pending_spawn_config.take(),
+                        self.pending_spawn_name.take(),
+                    ) {
+                        config.mcp_servers = selected_servers;
                         let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
                         self.do_spawn_session(name, &config, worktrees, false);
                     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -440,6 +440,7 @@ pub struct App {
     pub(crate) pending_spawn_config: Option<SessionConfig>,
     pub(crate) pending_spawn_worktrees: Vec<WorktreeInfo>,
     pub(crate) pending_fork: bool,
+    pub(crate) pending_restart: bool,
     pub(crate) pending_spawn_name: Option<String>,
     pub(crate) show_settings: bool,
     pub(crate) settings_tab: SettingsTab,
@@ -619,6 +620,7 @@ impl App {
             pending_spawn_config: None,
             pending_spawn_worktrees: Vec::new(),
             pending_fork: false,
+            pending_restart: false,
             pending_spawn_name: None,
             show_settings: false,
             settings_tab: SettingsTab::Roles,
@@ -1016,13 +1018,13 @@ impl App {
                 // No roles configured — spawn with default developer permissions.
                 config.role = DEFAULT_ROLE_NAME.to_string();
                 config.permissions = default_developer_permissions();
-                self.do_spawn_session(name, &config, worktrees, false);
+                self.maybe_show_mcp_picker(name, config, worktrees, false);
             }
             1 => {
                 // Exactly one role — auto-assign it.
                 config.role = roles[0].name.clone();
                 config.permissions = roles[0].permissions.clone();
-                self.do_spawn_session(name, &config, worktrees, false);
+                self.maybe_show_mcp_picker(name, config, worktrees, false);
             }
             _ => {
                 // 2+ roles — show the role selector.
@@ -1032,6 +1034,36 @@ impl App {
                 self.modal = modals::Modal::RoleSelector(modals::RoleSelectorModal::default());
             }
         }
+    }
+
+    /// Route through MCP server picker if global MCP servers exist, otherwise spawn directly.
+    ///
+    /// Skipped for admin sessions and VM/container sessions (which get MCP servers
+    /// via `.mcp.json` written during provisioning).
+    fn maybe_show_mcp_picker(
+        &mut self,
+        name: String,
+        config: SessionConfig,
+        worktrees: Vec<WorktreeInfo>,
+        is_admin: bool,
+    ) {
+        let is_vm_or_container =
+            self.pending_vm_id.is_some() || self.pending_container_id.is_some();
+        if is_admin || is_vm_or_container || self.global_mcp_servers.is_empty() {
+            self.do_spawn_session(name, &config, worktrees, is_admin);
+        } else {
+            self.pending_spawn_name = Some(name);
+            self.pending_spawn_config = Some(config);
+            self.pending_spawn_worktrees = worktrees;
+            self.open_mcp_picker();
+        }
+    }
+
+    /// Show the MCP server picker modal with all servers selected by default.
+    fn open_mcp_picker(&mut self) {
+        let selected = vec![true; self.global_mcp_servers.len()];
+        self.modal =
+            modals::Modal::McpServerPicker(modals::McpServerPickerModal { index: 0, selected });
     }
 
     /// Continue admin spawn — auto-assigns admin permissions, bypasses role selector.
@@ -1069,8 +1101,20 @@ impl App {
             vm_id: session.info.vm_id.clone(),
             container_id: session.info.container_id.clone(),
             fork_session_id: None,
+            mcp_servers: vec![],
         };
 
+        if self.global_mcp_servers.is_empty() {
+            self.do_restart(config);
+        } else {
+            self.pending_spawn_config = Some(config);
+            self.pending_restart = true;
+            self.open_mcp_picker();
+        }
+    }
+
+    /// Execute the actual restart with the finalized config.
+    fn do_restart(&mut self, config: SessionConfig) {
         let (rows, cols) = self.content_area_size();
         let session = &mut self.sessions[self.active_index];
         match session.restart(&config, rows, cols) {
@@ -1083,6 +1127,7 @@ impl App {
                 self.set_error(format!("Failed to restart session: {e:#}"));
             }
         }
+        self.pending_restart = false;
     }
 
     fn fork_active_session(&mut self) {
@@ -1110,6 +1155,7 @@ impl App {
             vm_id,
             container_id,
             fork_session_id,
+            mcp_servers: vec![],
         };
 
         self.pending_spawn_config = Some(config);
@@ -1264,6 +1310,7 @@ impl App {
             vm_id: None,
             container_id: None,
             fork_session_id: None,
+            mcp_servers: vec![],
         };
 
         let session_name = deleted.name.clone();
@@ -2379,6 +2426,7 @@ impl App {
                             vm_id: None,
                             container_id: None,
                             fork_session_id: None,
+                            mcp_servers: vec![],
                         };
 
                         let (rows, cols) = self.content_area_size();
@@ -2978,6 +3026,7 @@ impl App {
                 vm_id: None,
                 container_id: None,
                 fork_session_id: None,
+                mcp_servers: vec![],
             };
             self.do_spawn_session(name, &config, worktrees, false);
         }
@@ -3213,6 +3262,7 @@ impl App {
                 vm_id: resolved_vm_id,
                 container_id: resolved_container_id,
                 fork_session_id: None,
+                mcp_servers: vec![],
             };
             self.do_spawn_session(name, &config, worktrees, false);
             info!(session = %session_id, "Session restored (respawned with --resume)");
@@ -3279,6 +3329,7 @@ impl App {
                 vm_id: None,
                 container_id: None,
                 fork_session_id: None,
+                mcp_servers: vec![],
             };
 
             warn!(
@@ -3383,6 +3434,7 @@ impl App {
             vm_id: session.info.vm_id.clone(),
             container_id: session.info.container_id.clone(),
             fork_session_id: None,
+            mcp_servers: vec![],
         };
 
         let (rows, cols) = self.content_area_size();

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -122,6 +122,12 @@ pub struct RoleSelectorModal {
     pub index: usize,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct McpServerPickerModal {
+    pub index: usize,
+    pub selected: Vec<bool>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RoleEditorView {
     List,
@@ -257,6 +263,7 @@ pub enum Modal {
     BranchSelector(BranchSelectorModal),
     WorktreeName(WorktreeNameModal),
     RoleSelector(RoleSelectorModal),
+    McpServerPicker(McpServerPickerModal),
     ContainerfilePicker(ContainerfilePickerModal),
     RestoreSessions(RestoreSessionsModal),
     ScheduleCommand(ScheduleCommandModal),

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -15,10 +15,10 @@ use crate::session::SessionInfo;
 use crate::ui::selection;
 use crate::ui::theme::Theme;
 use crate::ui::{
-    branch_selector_modal, containerfile_picker, info_panel, layout, project_list,
-    restore_sessions_modal, role_editor_modal, role_selector_modal, schedule_command_modal,
-    scheduled_commands_list_modal, session_mode_modal, session_name_modal, status_bar,
-    terminal_view, worktree_name_modal,
+    branch_selector_modal, containerfile_picker, info_panel, layout, mcp_server_picker_modal,
+    project_list, restore_sessions_modal, role_editor_modal, role_selector_modal,
+    schedule_command_modal, scheduled_commands_list_modal, session_mode_modal, session_name_modal,
+    status_bar, terminal_view, worktree_name_modal,
 };
 
 use super::{App, InputFocus, TerminalView};
@@ -256,6 +256,18 @@ impl App {
                 &role_selector_modal::RoleSelectorState {
                     roles: &self.global_roles,
                     selected_index: rsel.index,
+                },
+            );
+        }
+
+        // MCP server picker modal
+        if let super::modals::Modal::McpServerPicker(ref msp) = self.modal {
+            mcp_server_picker_modal::render_mcp_server_picker_modal(
+                frame,
+                &mcp_server_picker_modal::McpServerPickerState {
+                    servers: &self.global_mcp_servers,
+                    selected: &msp.selected,
+                    index: msp.index,
                 },
             );
         }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -156,6 +156,31 @@ pub struct McpServerConfig {
     pub env: HashMap<String, String>,
 }
 
+impl McpServerConfig {
+    /// Build the `{"mcpServers": { ... }}` JSON document that Claude Code expects.
+    ///
+    /// Used by `--mcp-config` CLI flag (local sessions) and `.mcp.json` file
+    /// generation (VM/container sessions).
+    pub fn to_mcp_json(servers: &[Self]) -> serde_json::Value {
+        let mut map = serde_json::Map::new();
+        for srv in servers {
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "command".into(),
+                serde_json::Value::String(srv.command.clone()),
+            );
+            if !srv.args.is_empty() {
+                entry.insert("args".into(), serde_json::json!(srv.args));
+            }
+            if !srv.env.is_empty() {
+                entry.insert("env".into(), serde_json::json!(srv.env));
+            }
+            map.insert(srv.name.clone(), serde_json::Value::Object(entry));
+        }
+        serde_json::json!({ "mcpServers": map })
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
     pub repo_path: PathBuf,
@@ -334,6 +359,12 @@ pub struct SessionConfig {
     /// When set, the CLI is invoked with `--resume <fork_session_id> --fork-session`
     /// to create a new session that branches from the parent's conversation history.
     pub fork_session_id: Option<String>,
+    /// MCP servers to pass to Claude Code via `--mcp-config`.
+    ///
+    /// Populated from the MCP server picker during session creation/restart/fork.
+    /// For local sessions these are passed as a CLI flag; for VM/container sessions
+    /// they are written to `.mcp.json` in the remote working directory.
+    pub mcp_servers: Vec<McpServerConfig>,
 }
 
 /// VM state machine for sandboxed sessions.
@@ -837,5 +868,70 @@ mod tests {
             PathBuf::from("/repo/.git/thurbox-worktrees/feat")
         );
         assert_eq!(wt.branch, "feat");
+    }
+
+    #[test]
+    fn to_mcp_json_with_all_fields() {
+        let servers = vec![McpServerConfig {
+            name: "github".to_string(),
+            command: "npx".to_string(),
+            args: vec!["-y".to_string(), "server-github".to_string()],
+            env: HashMap::from([("TOKEN".to_string(), "ghp_xxx".to_string())]),
+        }];
+        let doc = McpServerConfig::to_mcp_json(&servers);
+        assert_eq!(doc["mcpServers"]["github"]["command"], "npx");
+        assert_eq!(
+            doc["mcpServers"]["github"]["args"],
+            serde_json::json!(["-y", "server-github"])
+        );
+        assert_eq!(
+            doc["mcpServers"]["github"]["env"],
+            serde_json::json!({"TOKEN": "ghp_xxx"})
+        );
+    }
+
+    #[test]
+    fn to_mcp_json_omits_empty_args_and_env() {
+        let servers = vec![McpServerConfig {
+            name: "simple".to_string(),
+            command: "/usr/bin/server".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+        }];
+        let doc = McpServerConfig::to_mcp_json(&servers);
+        assert_eq!(doc["mcpServers"]["simple"]["command"], "/usr/bin/server");
+        assert!(doc["mcpServers"]["simple"].get("args").is_none());
+        assert!(doc["mcpServers"]["simple"].get("env").is_none());
+    }
+
+    #[test]
+    fn to_mcp_json_empty_servers() {
+        let doc = McpServerConfig::to_mcp_json(&[]);
+        assert_eq!(doc["mcpServers"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn to_mcp_json_multiple_servers() {
+        let servers = vec![
+            McpServerConfig {
+                name: "a".to_string(),
+                command: "cmd-a".to_string(),
+                args: vec![],
+                env: HashMap::new(),
+            },
+            McpServerConfig {
+                name: "b".to_string(),
+                command: "cmd-b".to_string(),
+                args: vec!["--flag".to_string()],
+                env: HashMap::new(),
+            },
+        ];
+        let doc = McpServerConfig::to_mcp_json(&servers);
+        assert_eq!(doc["mcpServers"]["a"]["command"], "cmd-a");
+        assert_eq!(doc["mcpServers"]["b"]["command"], "cmd-b");
+        assert_eq!(
+            doc["mcpServers"]["b"]["args"],
+            serde_json::json!(["--flag"])
+        );
     }
 }

--- a/src/ui/mcp_server_picker_modal.rs
+++ b/src/ui/mcp_server_picker_modal.rs
@@ -1,0 +1,65 @@
+use ratatui::{
+    text::{Line, Span},
+    widgets::{List, ListItem, Paragraph},
+    Frame,
+};
+
+use super::render_list_modal_frame;
+use super::theme::Theme;
+use crate::session::McpServerConfig;
+
+pub struct McpServerPickerState<'a> {
+    pub servers: &'a [McpServerConfig],
+    pub selected: &'a [bool],
+    pub index: usize,
+}
+
+pub fn render_mcp_server_picker_modal(frame: &mut Frame, state: &McpServerPickerState<'_>) {
+    let Some(chunks) = render_list_modal_frame(
+        frame,
+        50,
+        "MCP Servers",
+        state.servers.len(),
+        Some("No MCP servers configured"),
+        Some(Line::from(vec![
+            Span::styled("Esc", Theme::keybind()),
+            Span::styled(" close", Theme::keybind_desc()),
+        ])),
+    ) else {
+        return;
+    };
+
+    let items: Vec<ListItem<'_>> = state
+        .servers
+        .iter()
+        .enumerate()
+        .map(|(i, server)| {
+            let style = if i == state.index {
+                Theme::selected_item()
+            } else {
+                Theme::normal_item()
+            };
+            let checked = state.selected.get(i).copied().unwrap_or(false);
+            let checkbox = if checked { "[x]" } else { "[ ]" };
+            let prefix = if i == state.index { "▸ " } else { "  " };
+            ListItem::new(Line::from(Span::styled(
+                format!("{prefix}{checkbox} {}", server.name),
+                style,
+            )))
+        })
+        .collect();
+
+    frame.render_widget(List::new(items), chunks[0]);
+
+    let footer = Line::from(vec![
+        Span::styled("j/k", Theme::keybind()),
+        Span::styled(" navigate  ", Theme::keybind_desc()),
+        Span::styled("Space", Theme::keybind()),
+        Span::styled(" toggle  ", Theme::keybind_desc()),
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" confirm  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[1]);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub mod info_panel;
 pub mod layout;
 pub mod links;
 pub mod mcp_editor_modal;
+pub mod mcp_server_picker_modal;
 pub mod project_list;
 pub mod repo_picker_modal;
 pub mod repo_selector_modal;


### PR DESCRIPTION
## Summary

- MCP servers configured in Thurbox were never passed to local Claude Code sessions — they didn't show up in `/mcp`
- Adds an MCP Server Picker modal (multi-select, all selected by default) shown during session creation, restart (`Ctrl+R`), and fork (`Ctrl+F`) flows
- Selected servers are passed to Claude Code via `--mcp-config` inline JSON flag
- Picker is skipped when no global MCP servers exist, or for admin/VM/container sessions

## Test plan

- [ ] Configure MCP servers in Thurbox settings (`Ctrl+E`)
- [ ] Create a new local session → picker appears after role selection → selected servers show in `/mcp`
- [ ] Restart session (`Ctrl+R`) → picker appears → servers applied
- [ ] Fork session (`Ctrl+F`) → picker appears → servers applied
- [ ] Deselect some servers in picker → only selected ones appear in `/mcp`
- [ ] No global MCP servers → picker is skipped, session spawns normally
- [ ] VM/container sessions → picker is skipped, `.mcp.json` written as before