### PR TITLE
feat(git): auto-fetch and offer origin/main for worktree creation

### DIFF
--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -12,7 +12,7 @@ use super::{App, InputFocus, RoleEditorView, TerminalView};
 use crate::agent::input;
 use crate::paths;
 use crossterm::event::{KeyCode, KeyModifiers};
-use tracing::error;
+use tracing::{error, warn};
 
 /// Convert a session name into a git-branch-friendly name.
 ///
@@ -1389,6 +1389,22 @@ impl App {
         let Some(repo_path) = self.pending_repo_path.as_ref() else {
             return;
         };
+
+        // Fetch origin so branches are up-to-date. Non-fatal on failure.
+        if let Err(e) = crate::git::git_fetch(repo_path) {
+            warn!("git fetch origin failed (continuing): {e:#}");
+        }
+        if let Some(ref all_repos) = self.pending_all_repos {
+            for extra_repo in all_repos.iter().skip(1) {
+                if let Err(e) = crate::git::git_fetch(extra_repo) {
+                    warn!(
+                        "git fetch origin failed for {} (continuing): {e:#}",
+                        extra_repo.display()
+                    );
+                }
+            }
+        }
+
         match crate::git::list_branches(repo_path) {
             Ok(branches) if branches.is_empty() => {
                 self.set_error("No branches found in repository");
@@ -1402,6 +1418,24 @@ impl App {
                         branches.insert(0, branch);
                     }
                 }
+
+                // Insert origin/<default> at position 0 for remote-based branching.
+                let remote_ref = crate::git::default_branch_from_remote(repo_path)
+                    .map(|name| format!("origin/{name}"))
+                    .or_else(|| {
+                        for candidate in ["origin/main", "origin/master"] {
+                            if crate::git::branch_exists(repo_path, candidate) {
+                                return Some(candidate.to_string());
+                            }
+                        }
+                        None
+                    });
+                if let Some(ref remote) = remote_ref {
+                    if !branches.contains(remote) {
+                        branches.insert(0, remote.clone());
+                    }
+                }
+
                 self.modal =
                     super::modals::Modal::BranchSelector(super::modals::BranchSelectorModal {
                         index: 0,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -174,7 +174,7 @@ pub fn default_branch(repo_path: &Path, local_branches: &[String]) -> Option<Str
 }
 
 /// Query the remote's default branch via `git symbolic-ref`.
-fn default_branch_from_remote(repo_path: &Path) -> Option<String> {
+pub fn default_branch_from_remote(repo_path: &Path) -> Option<String> {
     let output = Command::new("git")
         .args(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
         .current_dir(repo_path)
@@ -274,7 +274,7 @@ fn git_stash(worktree_path: &Path) -> Result<bool> {
 }
 
 /// Fetch from origin.
-fn git_fetch(worktree_path: &Path) -> Result<()> {
+pub fn git_fetch(worktree_path: &Path) -> Result<()> {
     let output = Command::new("git")
         .args(["fetch", "origin"])
         .current_dir(worktree_path)


### PR DESCRIPTION
## Summary
- Run `git fetch origin` before branch selection when creating worktrees, so refs are current
- Add `origin/<default>` (e.g., `origin/main`) as the first option in the base branch selector
- Fetch failures are non-fatal (logged as warnings) so offline usage still works

## Test plan
- [x] `cargo check --all` passes
- [x] `cargo clippy` — 0 warnings
- [x] `cargo nextest run --all` — 775/775 pass
- [ ] Manual: create a worktree, verify `origin/main` appears first in branch list
- [ ] Manual: disconnect network, verify worktree creation still works with local branches