### PR TITLE
feat(ui): add skill selection for Claude Code sessions

### DIFF
--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -125,6 +125,12 @@ impl App {
             return;
         }
 
+        // Skill editor detail form captures all input
+        if self.show_skill_editor {
+            self.handle_skill_editor_key(code);
+            return;
+        }
+
         // Settings overlay (tabbed list of roles / MCP servers) captures all input
         if self.show_settings {
             self.handle_settings_key(code);
@@ -140,6 +146,12 @@ impl App {
         // MCP server picker modal captures all input
         if matches!(self.modal, super::modals::Modal::McpServerPicker(_)) {
             self.handle_mcp_server_picker_key(code);
+            return;
+        }
+
+        // Skill picker modal captures all input
+        if matches!(self.modal, super::modals::Modal::SkillPicker(_)) {
+            self.handle_skill_picker_key(code);
             return;
         }
 
@@ -914,15 +926,64 @@ impl App {
                     }
                     self.pending_restart = false;
                 } else {
-                    // New session / fork flow
+                    // New session / fork flow → chain to skill picker
                     if let (Some(mut config), Some(name)) = (
                         self.pending_spawn_config.take(),
                         self.pending_spawn_name.take(),
                     ) {
                         config.mcp_servers = selected_servers;
                         let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
-                        self.do_spawn_session(name, &config, worktrees, false);
+                        self.maybe_show_skill_picker(name, config, worktrees, false);
                     }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_skill_picker_key(&mut self, code: KeyCode) {
+        let skill_count = self.global_skills.len();
+        let super::modals::Modal::SkillPicker(ref mut sp) = self.modal else {
+            return;
+        };
+        match code {
+            KeyCode::Esc => {
+                self.modal.close();
+                self.pending_spawn_config = None;
+                self.pending_spawn_worktrees.clear();
+                self.pending_spawn_name = None;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if sp.index + 1 < skill_count {
+                    sp.index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                sp.index = sp.index.saturating_sub(1);
+            }
+            KeyCode::Char(' ') => {
+                if let Some(sel) = sp.selected.get_mut(sp.index) {
+                    *sel = !*sel;
+                }
+            }
+            KeyCode::Enter => {
+                // Collect selected skills.
+                let selected_skills: Vec<_> = self
+                    .global_skills
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| sp.selected.get(*i).copied().unwrap_or(false))
+                    .map(|(_, s)| s.clone())
+                    .collect();
+                self.modal.close();
+
+                if let (Some(mut config), Some(name)) = (
+                    self.pending_spawn_config.take(),
+                    self.pending_spawn_name.take(),
+                ) {
+                    config.skills = selected_skills;
+                    let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
+                    self.do_spawn_session(name, &config, worktrees, false);
                 }
             }
             _ => {}
@@ -1098,17 +1159,22 @@ impl App {
                 if let Err(e) = self.db.replace_global_mcp_servers(&self.global_mcp_servers) {
                     tracing::error!("Failed to save global MCP servers: {e}");
                 }
+                if let Err(e) = self.db.replace_global_skills(&self.global_skills) {
+                    tracing::error!("Failed to save global skills: {e}");
+                }
                 self.show_settings = false;
             }
             KeyCode::Tab | KeyCode::BackTab => {
                 self.settings_tab = match self.settings_tab {
                     super::SettingsTab::Roles => super::SettingsTab::McpServers,
-                    super::SettingsTab::McpServers => super::SettingsTab::Roles,
+                    super::SettingsTab::McpServers => super::SettingsTab::Skills,
+                    super::SettingsTab::Skills => super::SettingsTab::Roles,
                 };
             }
             _ => match self.settings_tab {
                 super::SettingsTab::Roles => self.handle_settings_roles_key(code),
                 super::SettingsTab::McpServers => self.handle_settings_mcp_key(code),
+                super::SettingsTab::Skills => self.handle_settings_skills_key(code),
             },
         }
     }
@@ -1187,6 +1253,41 @@ impl App {
         }
     }
 
+    fn handle_settings_skills_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if !self.global_skills.is_empty()
+                    && self.skill_list_index + 1 < self.global_skills.len()
+                {
+                    self.skill_list_index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.skill_list_index = self.skill_list_index.saturating_sub(1);
+            }
+            KeyCode::Char('a') => {
+                self.open_new_skill_editor();
+            }
+            KeyCode::Char('e') | KeyCode::Enter => {
+                if !self.global_skills.is_empty() {
+                    let idx = self.skill_list_index;
+                    self.open_skill_for_editing(idx);
+                }
+            }
+            KeyCode::Char('d') => {
+                if !self.global_skills.is_empty() {
+                    self.global_skills.remove(self.skill_list_index);
+                    if self.skill_list_index >= self.global_skills.len()
+                        && self.skill_list_index > 0
+                    {
+                        self.skill_list_index -= 1;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Open the MCP editor for a new server.
     fn open_new_mcp_editor(&mut self) {
         self.prepare_new_mcp_editor();
@@ -1197,6 +1298,79 @@ impl App {
     fn open_mcp_for_editing(&mut self, idx: usize) {
         self.open_mcp_server_for_editing(idx);
         self.show_mcp_editor = true;
+    }
+
+    fn handle_skill_editor_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => {
+                self.close_skill_editor();
+                return;
+            }
+            KeyCode::Tab => {
+                // On path field: accept suggestion if available, else switch field.
+                if self.skill_editor_field == super::SkillEditorField::Path {
+                    if let Some(suggestion) = self.skill_editor_path_suggestion.take() {
+                        for c in suggestion.chars() {
+                            self.skill_editor_path.insert(c);
+                        }
+                    } else {
+                        self.skill_editor_field = super::SkillEditorField::Name;
+                        return;
+                    }
+                } else {
+                    self.skill_editor_field = super::SkillEditorField::Path;
+                    self.update_skill_editor_path_suggestion();
+                    return;
+                }
+            }
+            KeyCode::BackTab => {
+                self.skill_editor_field = match self.skill_editor_field {
+                    super::SkillEditorField::Name => super::SkillEditorField::Path,
+                    super::SkillEditorField::Path => super::SkillEditorField::Name,
+                };
+                if self.skill_editor_field == super::SkillEditorField::Path {
+                    self.update_skill_editor_path_suggestion();
+                }
+                return;
+            }
+            KeyCode::Enter => {
+                self.submit_skill_editor();
+                return;
+            }
+            KeyCode::Backspace => match self.skill_editor_field {
+                super::SkillEditorField::Name => self.skill_editor_name.backspace(),
+                super::SkillEditorField::Path => self.skill_editor_path.backspace(),
+            },
+            KeyCode::Delete => match self.skill_editor_field {
+                super::SkillEditorField::Name => self.skill_editor_name.delete(),
+                super::SkillEditorField::Path => self.skill_editor_path.delete(),
+            },
+            KeyCode::Left => match self.skill_editor_field {
+                super::SkillEditorField::Name => self.skill_editor_name.move_left(),
+                super::SkillEditorField::Path => self.skill_editor_path.move_left(),
+            },
+            KeyCode::Right => match self.skill_editor_field {
+                super::SkillEditorField::Name => self.skill_editor_name.move_right(),
+                super::SkillEditorField::Path => self.skill_editor_path.move_right(),
+            },
+            KeyCode::Home => match self.skill_editor_field {
+                super::SkillEditorField::Name => self.skill_editor_name.home(),
+                super::SkillEditorField::Path => self.skill_editor_path.home(),
+            },
+            KeyCode::End => match self.skill_editor_field {
+                super::SkillEditorField::Name => self.skill_editor_name.end(),
+                super::SkillEditorField::Path => self.skill_editor_path.end(),
+            },
+            KeyCode::Char(c) => match self.skill_editor_field {
+                super::SkillEditorField::Name => self.skill_editor_name.insert(c),
+                super::SkillEditorField::Path => self.skill_editor_path.insert(c),
+            },
+            _ => return,
+        }
+        // After any path input change, recompute the suggestion.
+        if self.skill_editor_field == super::SkillEditorField::Path {
+            self.update_skill_editor_path_suggestion();
+        }
     }
 
     /// Open the global role editor (list view).

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -22,7 +22,7 @@ use crate::git;
 use crate::session::{
     default_developer_permissions, default_developer_role, McpServerConfig, RoleConfig,
     RolePermissions, ScheduledCommand, SessionCommand, SessionConfig, SessionId, SessionInfo,
-    SessionStatus, WorktreeInfo, DEFAULT_ROLE_NAME,
+    SessionStatus, SkillConfig, WorktreeInfo, DEFAULT_ROLE_NAME,
 };
 use crate::storage::Database;
 use crate::storage::DeletedSessionInfo;
@@ -389,6 +389,14 @@ pub(crate) enum TerminalView {
     Shell,
 }
 
+/// Which field is focused in the skill editor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum SkillEditorField {
+    #[default]
+    Name,
+    Path,
+}
+
 /// Holds a recently deleted session for undo (Ctrl+Z) support.
 struct PendingDelete {
     session: Session,
@@ -463,6 +471,12 @@ pub struct App {
     pub(crate) mcp_editor_args: ToolListState,
     pub(crate) mcp_editor_env: ToolListState,
     pub(crate) mcp_editor_editing_index: Option<usize>,
+    pub(crate) show_skill_editor: bool,
+    pub(crate) skill_editor_name: TextInput,
+    pub(crate) skill_editor_path: TextInput,
+    pub(crate) skill_editor_field: SkillEditorField,
+    pub(crate) skill_editor_editing_index: Option<usize>,
+    pub(crate) skill_editor_path_suggestion: Option<String>,
     /// Snapshot of role editor fields at open time for dirty detection.
     pub(crate) role_editor_snapshot: Option<EditorSnapshot>,
     /// Snapshot of MCP editor fields at open time for dirty detection.
@@ -556,6 +570,10 @@ pub struct App {
     pub(crate) global_mcp_servers: Vec<McpServerConfig>,
     /// Index into global_mcp_servers for the MCP server list in the edit modal.
     pub(crate) mcp_server_list_index: usize,
+    /// Cached global skills (loaded from DB, used for session spawning and editing).
+    pub(crate) global_skills: Vec<SkillConfig>,
+    /// Index into global_skills for the skill list in the edit modal.
+    pub(crate) skill_list_index: usize,
     /// Cached pending scheduled commands, refreshed every ~1 second.
     pub(crate) cached_pending_commands: Vec<ScheduledCommand>,
 }
@@ -585,6 +603,9 @@ impl App {
 
         // Load global MCP servers from DB.
         let global_mcp_servers = db.list_global_mcp_servers().unwrap_or_default();
+
+        // Load global skills from DB.
+        let global_skills = db.list_global_skills().unwrap_or_default();
 
         // Load session counter from DB
         let session_counter = db.get_session_counter().unwrap_or(0);
@@ -642,6 +663,12 @@ impl App {
             mcp_editor_args: ToolListState::new(),
             mcp_editor_env: ToolListState::new(),
             mcp_editor_editing_index: None,
+            show_skill_editor: false,
+            skill_editor_name: TextInput::new(),
+            skill_editor_path: TextInput::new(),
+            skill_editor_field: SkillEditorField::Name,
+            skill_editor_editing_index: None,
+            skill_editor_path_suggestion: None,
             role_editor_snapshot: None,
             mcp_editor_snapshot: None,
             show_discard_confirmation: false,
@@ -695,6 +722,8 @@ impl App {
             global_roles,
             global_mcp_servers,
             mcp_server_list_index: 0,
+            global_skills,
+            skill_list_index: 0,
             cached_pending_commands: Vec::new(),
         }
     }
@@ -1050,7 +1079,7 @@ impl App {
         let is_vm_or_container =
             self.pending_vm_id.is_some() || self.pending_container_id.is_some();
         if is_admin || is_vm_or_container || self.global_mcp_servers.is_empty() {
-            self.do_spawn_session(name, &config, worktrees, is_admin);
+            self.maybe_show_skill_picker(name, config, worktrees, is_admin);
         } else {
             self.pending_spawn_name = Some(name);
             self.pending_spawn_config = Some(config);
@@ -1064,6 +1093,33 @@ impl App {
         let selected = vec![true; self.global_mcp_servers.len()];
         self.modal =
             modals::Modal::McpServerPicker(modals::McpServerPickerModal { index: 0, selected });
+    }
+
+    /// Show the skill picker if skills are configured, otherwise spawn directly.
+    ///
+    /// Inserted between MCP picker and `do_spawn_session()` in the creation chain.
+    /// Skipped for admin sessions (which don't need skill customization).
+    fn maybe_show_skill_picker(
+        &mut self,
+        name: String,
+        config: SessionConfig,
+        worktrees: Vec<WorktreeInfo>,
+        is_admin: bool,
+    ) {
+        if is_admin || self.global_skills.is_empty() {
+            self.do_spawn_session(name, &config, worktrees, is_admin);
+        } else {
+            self.pending_spawn_name = Some(name);
+            self.pending_spawn_config = Some(config);
+            self.pending_spawn_worktrees = worktrees;
+            self.open_skill_picker();
+        }
+    }
+
+    /// Show the skill picker modal with all skills selected by default.
+    fn open_skill_picker(&mut self) {
+        let selected = vec![true; self.global_skills.len()];
+        self.modal = modals::Modal::SkillPicker(modals::SkillPickerModal { index: 0, selected });
     }
 
     /// Continue admin spawn — auto-assigns admin permissions, bypasses role selector.
@@ -1102,6 +1158,7 @@ impl App {
             container_id: session.info.container_id.clone(),
             fork_session_id: None,
             mcp_servers: vec![],
+            skills: vec![],
         };
 
         if self.global_mcp_servers.is_empty() {
@@ -1156,6 +1213,7 @@ impl App {
             container_id,
             fork_session_id,
             mcp_servers: vec![],
+            skills: vec![],
         };
 
         self.pending_spawn_config = Some(config);
@@ -1311,6 +1369,7 @@ impl App {
             container_id: None,
             fork_session_id: None,
             mcp_servers: vec![],
+            skills: vec![],
         };
 
         let session_name = deleted.name.clone();
@@ -1808,6 +1867,29 @@ impl App {
             (Arc::clone(self.backends.default_backend()), name)
         };
 
+        // Symlink selected skills into .claude/skills/ before spawning so
+        // Claude Code auto-discovers them on startup.
+        if !config.skills.is_empty() {
+            if let Some(ref cwd) = config.cwd {
+                let skills_dir = cwd.join(".claude").join("skills");
+                if let Err(e) = std::fs::create_dir_all(&skills_dir) {
+                    warn!("Failed to create .claude/skills/: {e}");
+                } else {
+                    for skill in &config.skills {
+                        let link_path = skills_dir.join(&skill.name);
+                        if link_path.exists() || link_path.symlink_metadata().is_ok() {
+                            tracing::debug!(skill = %skill.name, "Skill already exists, skipping");
+                            continue;
+                        }
+                        #[cfg(unix)]
+                        if let Err(e) = std::os::unix::fs::symlink(&skill.path, &link_path) {
+                            warn!(skill = %skill.name, "Failed to symlink skill: {e}");
+                        }
+                    }
+                }
+            }
+        }
+
         match Session::spawn(spawn_name, rows, cols, &config, &backend, &self.provider) {
             Ok(mut session) => {
                 session.info.worktrees = worktrees;
@@ -2103,6 +2185,11 @@ impl App {
                 if let Ok(servers) = self.db.list_global_mcp_servers() {
                     if servers != self.global_mcp_servers {
                         self.global_mcp_servers = servers;
+                    }
+                }
+                if let Ok(skills) = self.db.list_global_skills() {
+                    if skills != self.global_skills {
+                        self.global_skills = skills;
                     }
                 }
             }
@@ -2427,6 +2514,7 @@ impl App {
                             container_id: None,
                             fork_session_id: None,
                             mcp_servers: vec![],
+                            skills: vec![],
                         };
 
                         let (rows, cols) = self.content_area_size();
@@ -2540,6 +2628,66 @@ impl App {
         self.mcp_editor_snapshot = None;
         self.show_discard_confirmation = false;
         self.mcp_editor_field = crate::app::mcp_editor_modal::McpEditorField::Name;
+    }
+
+    /// Open the skill editor for a new skill.
+    fn open_new_skill_editor(&mut self) {
+        self.skill_editor_name.set("");
+        self.skill_editor_path.set("");
+        self.skill_editor_field = SkillEditorField::Name;
+        self.skill_editor_editing_index = None;
+        self.skill_editor_path_suggestion = None;
+        self.show_skill_editor = true;
+    }
+
+    /// Open the skill editor for an existing skill at the given index.
+    fn open_skill_for_editing(&mut self, idx: usize) {
+        if let Some(skill) = self.global_skills.get(idx) {
+            self.skill_editor_name.set(&skill.name);
+            self.skill_editor_path.set(&skill.path.to_string_lossy());
+            self.skill_editor_field = SkillEditorField::Name;
+            self.skill_editor_editing_index = Some(idx);
+            self.skill_editor_path_suggestion = None;
+            self.show_skill_editor = true;
+        }
+    }
+
+    /// Save the current skill editor state and close.
+    fn submit_skill_editor(&mut self) {
+        let name = self.skill_editor_name.value().trim().to_string();
+        let path = self.skill_editor_path.value().trim().to_string();
+        if name.is_empty() || path.is_empty() {
+            return;
+        }
+        let skill = SkillConfig {
+            name,
+            path: PathBuf::from(path),
+        };
+        if let Some(idx) = self.skill_editor_editing_index {
+            if idx < self.global_skills.len() {
+                self.global_skills[idx] = skill;
+            }
+        } else {
+            self.global_skills.push(skill);
+        }
+        self.show_skill_editor = false;
+    }
+
+    /// Close the skill editor without saving.
+    fn close_skill_editor(&mut self) {
+        self.show_skill_editor = false;
+        self.skill_editor_path_suggestion = None;
+    }
+
+    /// Recompute the path suggestion for the skill editor's path field.
+    fn update_skill_editor_path_suggestion(&mut self) {
+        let value = self.skill_editor_path.value().to_string();
+        let at_end = self.skill_editor_path.cursor_pos() == value.chars().count();
+        if at_end && !value.is_empty() {
+            self.skill_editor_path_suggestion = crate::paths::complete_directory_path(&value);
+        } else {
+            self.skill_editor_path_suggestion = None;
+        }
     }
 
     /// Persist session state to the SQLite database.
@@ -3027,6 +3175,7 @@ impl App {
                 container_id: None,
                 fork_session_id: None,
                 mcp_servers: vec![],
+                skills: vec![],
             };
             self.do_spawn_session(name, &config, worktrees, false);
         }
@@ -3263,6 +3412,7 @@ impl App {
                 container_id: resolved_container_id,
                 fork_session_id: None,
                 mcp_servers: vec![],
+                skills: vec![],
             };
             self.do_spawn_session(name, &config, worktrees, false);
             info!(session = %session_id, "Session restored (respawned with --resume)");
@@ -3330,6 +3480,7 @@ impl App {
                 container_id: None,
                 fork_session_id: None,
                 mcp_servers: vec![],
+                skills: vec![],
             };
 
             warn!(
@@ -3435,6 +3586,7 @@ impl App {
             container_id: session.info.container_id.clone(),
             fork_session_id: None,
             mcp_servers: vec![],
+            skills: vec![],
         };
 
         let (rows, cols) = self.content_area_size();

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -128,6 +128,12 @@ pub struct McpServerPickerModal {
     pub selected: Vec<bool>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct SkillPickerModal {
+    pub index: usize,
+    pub selected: Vec<bool>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RoleEditorView {
     List,
@@ -242,6 +248,7 @@ pub enum SettingsTab {
     #[default]
     Roles,
     McpServers,
+    Skills,
 }
 
 // ── Main Modal Enum ────────────────────────────────────────────────────────
@@ -264,6 +271,7 @@ pub enum Modal {
     WorktreeName(WorktreeNameModal),
     RoleSelector(RoleSelectorModal),
     McpServerPicker(McpServerPickerModal),
+    SkillPicker(SkillPickerModal),
     ContainerfilePicker(ContainerfilePickerModal),
     RestoreSessions(RestoreSessionsModal),
     ScheduleCommand(ScheduleCommandModal),

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -18,7 +18,7 @@ use crate::ui::{
     branch_selector_modal, containerfile_picker, info_panel, layout, mcp_server_picker_modal,
     project_list, restore_sessions_modal, role_editor_modal, role_selector_modal,
     schedule_command_modal, scheduled_commands_list_modal, session_mode_modal, session_name_modal,
-    status_bar, terminal_view, worktree_name_modal,
+    skill_picker_modal, status_bar, terminal_view, worktree_name_modal,
 };
 
 use super::{App, InputFocus, TerminalView};
@@ -272,8 +272,24 @@ impl App {
             );
         }
 
-        // Settings overlay (tabbed list of roles / MCP servers)
-        if self.show_settings && !self.show_role_editor && !self.show_mcp_editor {
+        // Skill picker modal
+        if let super::modals::Modal::SkillPicker(ref sp) = self.modal {
+            skill_picker_modal::render_skill_picker_modal(
+                frame,
+                &skill_picker_modal::SkillPickerState {
+                    skills: &self.global_skills,
+                    selected: &sp.selected,
+                    index: sp.index,
+                },
+            );
+        }
+
+        // Settings overlay (tabbed list of roles / MCP servers / skills)
+        if self.show_settings
+            && !self.show_role_editor
+            && !self.show_mcp_editor
+            && !self.show_skill_editor
+        {
             crate::ui::settings_overlay::render_settings_overlay(
                 frame,
                 &crate::ui::settings_overlay::SettingsOverlayState {
@@ -282,6 +298,8 @@ impl App {
                     role_index: self.role_editor_list_index,
                     mcp_servers: &self.global_mcp_servers,
                     mcp_index: self.mcp_server_list_index,
+                    skills: &self.global_skills,
+                    skill_index: self.skill_list_index,
                 },
             );
         }
@@ -318,6 +336,43 @@ impl App {
                     focused_field: self.role_editor_field,
                 },
             );
+        }
+
+        // Skill editor modal (detail form for global skills)
+        if self.show_skill_editor {
+            use crate::ui::{
+                centered_fixed_height_rect, render_modal_frame, render_text_field,
+                render_text_field_with_suggestion,
+            };
+            let area = centered_fixed_height_rect(50, 8, frame.area());
+            let inner = render_modal_frame(frame, area, "Skill Editor");
+            if inner.height >= 4 && inner.width >= 10 {
+                let chunks = ratatui::layout::Layout::default()
+                    .direction(ratatui::layout::Direction::Vertical)
+                    .constraints([
+                        ratatui::layout::Constraint::Length(3),
+                        ratatui::layout::Constraint::Length(3),
+                    ])
+                    .split(inner);
+
+                render_text_field(
+                    frame,
+                    chunks[0],
+                    "Name",
+                    self.skill_editor_name.value(),
+                    self.skill_editor_name.cursor_pos(),
+                    self.skill_editor_field == super::SkillEditorField::Name,
+                );
+                render_text_field_with_suggestion(
+                    frame,
+                    chunks[1],
+                    "Path",
+                    self.skill_editor_path.value(),
+                    self.skill_editor_path.cursor_pos(),
+                    self.skill_editor_field == super::SkillEditorField::Path,
+                    self.skill_editor_path_suggestion.as_deref(),
+                );
+            }
         }
 
         // MCP editor modal (detail form for global MCP servers)

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -145,6 +145,18 @@ pub struct RoleConfig {
     pub permissions: RolePermissions,
 }
 
+/// Skill configuration — a named reference to a local skill directory.
+///
+/// Skills are directories containing a `SKILL.md` file that Claude Code
+/// auto-discovers from `~/.claude/skills/` (global) or `.claude/skills/`
+/// (project-level). Thurbox symlinks selected skills into the session's
+/// `.claude/skills/` before spawning.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillConfig {
+    pub name: String,
+    pub path: PathBuf,
+}
+
 /// MCP server configuration matching Claude Code's `mcpServers` format.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct McpServerConfig {
@@ -365,6 +377,12 @@ pub struct SessionConfig {
     /// For local sessions these are passed as a CLI flag; for VM/container sessions
     /// they are written to `.mcp.json` in the remote working directory.
     pub mcp_servers: Vec<McpServerConfig>,
+    /// Skills to symlink into the session's `.claude/skills/` directory.
+    ///
+    /// Populated from the skill picker during session creation. Each skill
+    /// directory is symlinked into the working directory before spawning
+    /// so Claude Code auto-discovers them.
+    pub skills: Vec<SkillConfig>,
 }
 
 /// VM state machine for sandboxed sessions.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -18,6 +18,7 @@ mod roles;
 mod scheduled_commands;
 mod schema;
 mod sessions;
+mod skills;
 pub use sessions::DeletedSessionInfo;
 pub mod sync;
 pub mod vms;

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1,7 +1,7 @@
 use rusqlite::Connection;
 
 /// Current schema version. Incremented when schema changes.
-pub const SCHEMA_VERSION: u32 = 16;
+pub const SCHEMA_VERSION: u32 = 17;
 
 /// Create all tables and indexes if they don't exist.
 pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
@@ -79,6 +79,13 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             env         TEXT NOT NULL DEFAULT '',
             created_at  INTEGER NOT NULL,
             updated_at  INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS skills (
+            skill_name TEXT PRIMARY KEY,
+            path       TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
         );
 
         CREATE TABLE IF NOT EXISTS session_commands (
@@ -561,6 +568,18 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         )?;
     }
 
+    if version < 17 {
+        // v16 → v17: add skills table for global skill management
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS skills (
+                skill_name TEXT PRIMARY KEY,
+                path       TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            );",
+        )?;
+    }
+
     if version < SCHEMA_VERSION {
         conn.execute(
             "UPDATE metadata SET value = ?1 WHERE key = 'schema_version'",
@@ -598,6 +617,7 @@ mod tests {
         assert!(tables.contains(&"containers".to_string()));
         assert!(tables.contains(&"scheduled_commands".to_string()));
         assert!(tables.contains(&"repo_bookmarks".to_string()));
+        assert!(tables.contains(&"skills".to_string()));
         // Project tables should NOT exist
         assert!(!tables.contains(&"projects".to_string()));
         assert!(!tables.contains(&"project_repos".to_string()));

--- a/src/storage/skills.rs
+++ b/src/storage/skills.rs
@@ -1,0 +1,172 @@
+use std::path::PathBuf;
+
+use rusqlite::params;
+
+use crate::session::SkillConfig;
+use crate::sync::current_time_millis;
+
+use super::Database;
+
+/// Parse a row with columns (skill_name, path) into SkillConfig.
+fn row_to_skill_config(row: &rusqlite::Row<'_>) -> rusqlite::Result<SkillConfig> {
+    let name: String = row.get(0)?;
+    let path: String = row.get(1)?;
+
+    Ok(SkillConfig {
+        name,
+        path: PathBuf::from(path),
+    })
+}
+
+impl Database {
+    /// List all global skills.
+    pub fn list_global_skills(&self) -> rusqlite::Result<Vec<SkillConfig>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT skill_name, path \
+             FROM skills ORDER BY skill_name",
+        )?;
+
+        let skills = stmt
+            .query_map([], row_to_skill_config)?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(skills)
+    }
+
+    /// Atomically replace all global skills (delete existing + insert new).
+    pub fn replace_global_skills(&self, skills: &[SkillConfig]) -> rusqlite::Result<()> {
+        let now = current_time_millis() as i64;
+
+        self.conn.execute("DELETE FROM skills", [])?;
+
+        for skill in skills {
+            self.conn.execute(
+                "INSERT INTO skills \
+                 (skill_name, path, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![skill.name, skill.path.to_string_lossy().as_ref(), now, now,],
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Insert or update a single global skill.
+    pub fn upsert_global_skill(&self, skill: &SkillConfig) -> rusqlite::Result<()> {
+        let now = current_time_millis() as i64;
+        self.conn.execute(
+            "INSERT INTO skills \
+             (skill_name, path, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT(skill_name) DO UPDATE SET \
+                 path = excluded.path, \
+                 updated_at = excluded.updated_at",
+            params![skill.name, skill.path.to_string_lossy().as_ref(), now, now,],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a single global skill by name. Returns true if it existed.
+    pub fn delete_global_skill(&self, name: &str) -> rusqlite::Result<bool> {
+        let count = self
+            .conn
+            .execute("DELETE FROM skills WHERE skill_name = ?1", params![name])?;
+        Ok(count > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_global_skills_empty() {
+        let db = Database::open_in_memory().unwrap();
+        let skills = db.list_global_skills().unwrap();
+        assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn replace_and_list_global_skills() {
+        let db = Database::open_in_memory().unwrap();
+        let skills = vec![
+            SkillConfig {
+                name: "domain-cli".to_string(),
+                path: PathBuf::from("/home/user/.claude/skills/domain-cli"),
+            },
+            SkillConfig {
+                name: "m01-ownership".to_string(),
+                path: PathBuf::from("/home/user/.claude/skills/m01-ownership"),
+            },
+        ];
+
+        db.replace_global_skills(&skills).unwrap();
+        let loaded = db.list_global_skills().unwrap();
+
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].name, "domain-cli");
+        assert_eq!(loaded[1].name, "m01-ownership");
+        assert_eq!(
+            loaded[1].path,
+            PathBuf::from("/home/user/.claude/skills/m01-ownership")
+        );
+    }
+
+    #[test]
+    fn replace_global_skills_overwrites() {
+        let db = Database::open_in_memory().unwrap();
+        db.replace_global_skills(&[SkillConfig {
+            name: "old".to_string(),
+            path: PathBuf::from("/old/path"),
+        }])
+        .unwrap();
+
+        db.replace_global_skills(&[SkillConfig {
+            name: "new".to_string(),
+            path: PathBuf::from("/new/path"),
+        }])
+        .unwrap();
+
+        let loaded = db.list_global_skills().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "new");
+    }
+
+    #[test]
+    fn upsert_global_skill_insert_and_update() {
+        let db = Database::open_in_memory().unwrap();
+        let skill = SkillConfig {
+            name: "test-skill".to_string(),
+            path: PathBuf::from("/path/v1"),
+        };
+        db.upsert_global_skill(&skill).unwrap();
+
+        let loaded = db.list_global_skills().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].path, PathBuf::from("/path/v1"));
+
+        let updated = SkillConfig {
+            name: "test-skill".to_string(),
+            path: PathBuf::from("/path/v2"),
+        };
+        db.upsert_global_skill(&updated).unwrap();
+
+        let loaded = db.list_global_skills().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].path, PathBuf::from("/path/v2"));
+    }
+
+    #[test]
+    fn delete_global_skill() {
+        let db = Database::open_in_memory().unwrap();
+        db.upsert_global_skill(&SkillConfig {
+            name: "to-delete".to_string(),
+            path: PathBuf::from("/path"),
+        })
+        .unwrap();
+
+        assert!(db.delete_global_skill("to-delete").unwrap());
+        assert!(!db.delete_global_skill("to-delete").unwrap());
+        assert!(db.list_global_skills().unwrap().is_empty());
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -17,6 +17,7 @@ pub mod selection;
 pub mod session_mode_modal;
 pub mod session_name_modal;
 pub mod settings_overlay;
+pub mod skill_picker_modal;
 pub mod status_bar;
 pub mod terminal_view;
 pub mod theme;

--- a/src/ui/settings_overlay.rs
+++ b/src/ui/settings_overlay.rs
@@ -1,4 +1,4 @@
-//! Settings overlay: tabbed list of global Roles and MCP Servers.
+//! Settings overlay: tabbed list of global Roles, MCP Servers, and Skills.
 
 use ratatui::{
     style::Style,
@@ -11,7 +11,7 @@ use super::centered_fixed_height_rect;
 use super::render_modal_frame;
 use super::theme::Theme;
 use crate::app::SettingsTab;
-use crate::session::{McpServerConfig, RoleConfig};
+use crate::session::{McpServerConfig, RoleConfig, SkillConfig};
 
 /// State needed to render the settings overlay.
 pub struct SettingsOverlayState<'a> {
@@ -20,6 +20,8 @@ pub struct SettingsOverlayState<'a> {
     pub role_index: usize,
     pub mcp_servers: &'a [McpServerConfig],
     pub mcp_index: usize,
+    pub skills: &'a [SkillConfig],
+    pub skill_index: usize,
 }
 
 pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) {
@@ -43,11 +45,18 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
     } else {
         Style::default().fg(Theme::TEXT_MUTED)
     };
+    let skills_style = if state.tab == SettingsTab::Skills {
+        Theme::focused_title()
+    } else {
+        Style::default().fg(Theme::TEXT_MUTED)
+    };
 
     let tab_line = Line::from(vec![
         Span::styled(" [Roles] ", roles_style),
         Span::styled("  ", Style::default()),
         Span::styled("[MCP Servers] ", mcp_style),
+        Span::styled("  ", Style::default()),
+        Span::styled("[Skills] ", skills_style),
     ]);
     frame.render_widget(Paragraph::new(tab_line), tab_area);
 
@@ -110,6 +119,37 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
                             format!("{prefix}{}", server.name),
                             style,
                         )))
+                    })
+                    .collect();
+                frame.render_widget(List::new(items), list_area);
+            }
+        }
+        SettingsTab::Skills => {
+            if state.skills.is_empty() {
+                let empty = Paragraph::new(Line::from(Span::styled(
+                    "  No skills configured. Press 'a' to add.",
+                    Style::default().fg(Theme::TEXT_MUTED),
+                )));
+                frame.render_widget(empty, list_area);
+            } else {
+                let items: Vec<ListItem> = state
+                    .skills
+                    .iter()
+                    .enumerate()
+                    .map(|(i, skill)| {
+                        let style = if i == state.skill_index {
+                            Theme::focused_title()
+                        } else {
+                            Style::default().fg(Theme::TEXT_PRIMARY)
+                        };
+                        let prefix = if i == state.skill_index { "▸ " } else { "  " };
+                        ListItem::new(Line::from(vec![
+                            Span::styled(format!("{prefix}{}", skill.name), style),
+                            Span::styled(
+                                format!("  {}", skill.path.display()),
+                                Style::default().fg(Theme::TEXT_MUTED),
+                            ),
+                        ]))
                     })
                     .collect();
                 frame.render_widget(List::new(items), list_area);

--- a/src/ui/skill_picker_modal.rs
+++ b/src/ui/skill_picker_modal.rs
@@ -1,0 +1,65 @@
+use ratatui::{
+    text::{Line, Span},
+    widgets::{List, ListItem, Paragraph},
+    Frame,
+};
+
+use super::render_list_modal_frame;
+use super::theme::Theme;
+use crate::session::SkillConfig;
+
+pub struct SkillPickerState<'a> {
+    pub skills: &'a [SkillConfig],
+    pub selected: &'a [bool],
+    pub index: usize,
+}
+
+pub fn render_skill_picker_modal(frame: &mut Frame, state: &SkillPickerState<'_>) {
+    let Some(chunks) = render_list_modal_frame(
+        frame,
+        50,
+        "Skills",
+        state.skills.len(),
+        Some("No skills configured"),
+        Some(Line::from(vec![
+            Span::styled("Esc", Theme::keybind()),
+            Span::styled(" close", Theme::keybind_desc()),
+        ])),
+    ) else {
+        return;
+    };
+
+    let items: Vec<ListItem<'_>> = state
+        .skills
+        .iter()
+        .enumerate()
+        .map(|(i, skill)| {
+            let style = if i == state.index {
+                Theme::selected_item()
+            } else {
+                Theme::normal_item()
+            };
+            let checked = state.selected.get(i).copied().unwrap_or(false);
+            let checkbox = if checked { "[x]" } else { "[ ]" };
+            let prefix = if i == state.index { "▸ " } else { "  " };
+            ListItem::new(Line::from(Span::styled(
+                format!("{prefix}{checkbox} {}", skill.name),
+                style,
+            )))
+        })
+        .collect();
+
+    frame.render_widget(List::new(items), chunks[0]);
+
+    let footer = Line::from(vec![
+        Span::styled("j/k", Theme::keybind()),
+        Span::styled(" navigate  ", Theme::keybind_desc()),
+        Span::styled("Space", Theme::keybind()),
+        Span::styled(" toggle  ", Theme::keybind_desc()),
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" confirm  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[1]);
+}


### PR DESCRIPTION
## Summary

- Add skill picker modal to the session creation flow (between MCP picker and spawn)
- Skills are stored in SQLite with full CRUD via Ctrl+E Settings → Skills tab
- Selected skills are symlinked into `.claude/skills/` in the session's working directory before spawning
- Path autocompletion in the skill editor (same fish-style Tab completion as repo picker)

## Test plan

- [ ] Ctrl+E → Skills tab → add a skill (name + path with Tab autocomplete)
- [ ] Ctrl+N → create session → verify skill picker appears after MCP picker
- [ ] Verify `.claude/skills/{name}` symlink created in session cwd
- [ ] Verify existing project skills are not clobbered
- [ ] All 786 tests pass, 0 clippy warnings, 8/8 architecture rules