### PR TITLE
docs: update documentation and website to match codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,7 +330,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+K` | Select previous session | Vim: **k** = up |
 | `Ctrl+L` | Focus next pane (cycle forward) | Vim: **l** = right |
 | `Ctrl+D` | Delete session | Vim: **d** = delete |
-| `Ctrl+E` | Edit settings (roles, MCP servers) | **E**dit |
+| `Ctrl+E` | Edit settings (roles, MCP servers, skills) | **E**dit |
 | `Ctrl+R` | Restart active session | **R**estart |
 | `Ctrl+F` | Fork active session | **F**ork |
 | `Ctrl+S` | Sync worktrees with origin/main | **S**ync |

--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ settings. The two-section left sidebar shows all projects on top
 and the active project's sessions below. Projects support
 multiple repositories — the first repo becomes the working
 directory and the rest are passed via `--add-dir`. Edit
-projects on the fly with `Ctrl+E` (name, repos) without
-losing running sessions. Soft-deleted
-projects and sessions can be restored via the Admin session
-or MCP API. A built-in Admin project (pinned at index 0)
+global settings with `Ctrl+E` (roles, MCP servers, skills).
+Soft-deleted projects and sessions can be restored via the Admin
+session or MCP API. A built-in Admin project (pinned at index 0)
 provides conversational access to Thurbox management via MCP.
 
 ### Git Worktree Support
@@ -91,14 +90,22 @@ optional system prompt text. Manage roles programmatically through
 the MCP server. When two or more roles exist, a role selector
 appears at session creation.
 
+### Skill Management
+
+Attach Claude Code skills to sessions at creation time. Skills
+are symlinked into the session's `.claude/skills/` directory
+and auto-discovered by Claude Code. Manage skills globally via
+`Ctrl+E` (Settings → Skills tab).
+
 ### MCP Server
 
-The `thurbox-mcp` binary exposes 16 tools over the Model Context
-Protocol for managing projects, roles, sessions, VMs, and MCP
-server configurations. The Admin session auto-configures `thurbox-mcp`,
-so you can manage everything conversationally — "create a
-reviewer role for my-app with read-only access." See
-[MCP Server](#mcp-server-1) below for the full tool reference.
+The `thurbox-mcp` binary exposes 22 tools over the Model Context
+Protocol for managing roles, sessions, VMs, containers, scheduled
+commands, and MCP server configurations. The Admin session
+auto-configures `thurbox-mcp`, so you can manage everything
+conversationally — "create a reviewer role with read-only
+access." See [MCP Server](#mcp-server-1) below for the full
+tool reference.
 
 ### Responsive UI
 
@@ -165,14 +172,15 @@ The binary will be available at `target/release/thurbox`.
    session appears automatically in the sidebar.
 2. **Create a session** — press `Ctrl+N` to open the repo picker.
    Select repos from bookmarks (Space to toggle, `w` to mark as
-   worktree), then choose a session mode and optionally a role.
+   worktree), then choose a session mode, optionally a role,
+   MCP servers, and skills.
 3. **Work with Claude** — the terminal panel shows the live
    Claude Code session. All keys are forwarded to the PTY.
 4. **Navigate** — `Ctrl+L` cycles focus (project list → session
    list → terminal). `Ctrl+H` jumps to the project list.
    `Ctrl+J` / `Ctrl+K` switch projects or sessions.
-5. **Manage projects** — `Ctrl+E` edits the active project
-   (name, repos). `Ctrl+D` deletes a session or project.
+5. **Manage settings** — `Ctrl+E` opens settings (roles, MCP
+   servers, skills). `Ctrl+D` deletes a session.
 6. **Restart a session** — `Ctrl+R` restarts with `--resume` to
    preserve conversation history while picking up new
    role permissions.
@@ -187,18 +195,20 @@ The binary will be available at `target/release/thurbox`.
 |-----|--------|----------|
 | `Ctrl+Q` | Quit (detach sessions) | **Q**uit |
 | `Ctrl+N` | New session (opens repo picker) | **N**ew |
-| `Ctrl+C` | Close session / copy selection | **C**lose / **C**opy |
+| `Ctrl+C` | Copy selection / SIGINT (terminal) | **C**opy |
 | `Ctrl+V` | Paste from clipboard | Paste |
+| `Ctrl+P` | Scheduled commands (list/cancel/new) | **P**rogram |
 | `Ctrl+T` | Toggle shell pane | **T**erminal |
-| `Ctrl+H` | Focus project list | Vim: **h** = left |
-| `Ctrl+J` | Next project (project list) / session | Vim: **j** = down |
-| `Ctrl+K` | Previous project (project list) / session | Vim: **k** = up |
-| `Ctrl+L` | Cycle focus | Vim: **l** = right |
-| `Ctrl+D` | Delete session or project | Vim: **d** = delete |
-| `Ctrl+E` | Edit active project | **E**dit |
+| `Ctrl+H` | Focus previous pane (cycle backward) | Vim: **h** = left |
+| `Ctrl+J` | Select next session | Vim: **j** = down |
+| `Ctrl+K` | Select previous session | Vim: **k** = up |
+| `Ctrl+L` | Focus next pane (cycle forward) | Vim: **l** = right |
+| `Ctrl+D` | Delete session | Vim: **d** = delete |
+| `Ctrl+E` | Edit settings (roles, MCP servers, skills) | **E**dit |
 | `Ctrl+R` | Restart active session | **R**estart |
+| `Ctrl+F` | Fork active session | **F**ork |
 | `Ctrl+S` | Sync worktrees with origin/main | **S**ync |
-| `Ctrl+Z` | Undo session/project delete | **Z** = undo |
+| `Ctrl+Z` | Undo session delete | **Z** = undo |
 | `Ctrl+U` | Restore deleted sessions | **U**ndelete |
 | `F1` | Help overlay | Universal |
 | `F2` | Toggle info panel | Next to F1 |
@@ -242,22 +252,28 @@ thurbox-mcp --transport streamable-http --port 9090  # custom port
 
 | Tool | Description |
 |------|-------------|
-| `list_projects` | List all active projects |
-| `get_project` | Get a project by name or UUID |
-| `create_project` | Create a new project with name and repo paths |
-| `update_project` | Update project name and/or repos |
-| `delete_project` | Soft-delete a project |
-| `list_roles` | List all roles for a project |
-| `set_roles` | Atomically replace all roles for a project |
-| `list_mcp_servers` | List MCP servers for a project |
-| `set_mcp_servers` | Set MCP servers for a project |
-| `list_sessions` | List sessions, optionally filtered by project |
+| `list_roles` | List all global roles |
+| `set_roles` | Atomically replace all global roles |
+| `list_mcp_servers` | List all global MCP servers |
+| `set_mcp_servers` | Set global MCP servers |
+| `list_sessions` | List all active sessions |
 | `get_session` | Get a session by UUID |
-| `delete_session` | Soft-delete a session |
-| `restart_session` | Queue a session restart |
+| `delete_session` | Soft-delete a session (TUI cleans up tmux/worktree) |
+| `restart_session` | Queue a session restart (TUI processes the command) |
 | `restore_session` | Restore a soft-deleted session |
-| `list_vms` | List active VMs, optionally by project |
+| `list_vms` | List active VMs |
 | `get_vm` | Get a VM by UUID |
+| `list_containerfile_templates` | List template names + files in each |
+| `get_containerfile_template` | Read a template's Containerfile content and list support files |
+| `set_containerfile_template` | Create/update a template (Containerfile + optional support files) |
+| `delete_containerfile_template` | Delete a template (refuses to delete "default") |
+| `list_vm_images` | List downloaded VM images with file sizes |
+| `download_vm_image` | Download a VM image from an HTTPS URL |
+| `delete_vm_image` | Delete a cached VM image |
+| `schedule_command` | Schedule text to be sent to a session at a future time |
+| `list_scheduled_commands` | List pending scheduled commands, optionally by session |
+| `get_scheduled_command` | Get a scheduled command by ID |
+| `cancel_scheduled_command` | Cancel a pending scheduled command |
 
 ### Admin Session
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,25 +158,32 @@ specifically for `perf` / `flamegraph` workflows.
 
 ---
 
-## ADR-8: Config file format — TOML
+## ADR-8: State storage — SQLite
 
-**Choice**: Project configuration uses TOML format, loaded from
-`~/.config/thurbox/config.toml` (respects `$XDG_CONFIG_HOME`).
+**Choice**: All persistent state (projects, sessions, roles,
+MCP servers, worktrees, VMs, containers, scheduled commands)
+is stored in a single SQLite database at
+`~/.local/share/thurbox/thurbox.db` (respects `$XDG_DATA_HOME`).
+WAL mode enables concurrent multi-instance access.
 
-**Why**: TOML is human-readable, easy to hand-edit, and has
-first-class Rust support via the `toml` crate (already a
-transitive dependency). The XDG convention is standard on Linux
-and avoids cluttering `$HOME` with dotfiles.
+*This supersedes the original TOML file-based approach
+(`~/.config/thurbox/config.toml`), which was eliminated after
+the SQLite migration.*
+
+**Why**: SQLite provides atomic transactions, concurrent access
+via WAL mode, and a single source of truth. Multi-instance sync
+uses `PRAGMA data_version` polling (see ADR-7b). The TUI provides
+all editing UI — there is no need for a human-editable config file.
 
 **Rejected**:
 
-- *JSON* — verbose for config (requires quoting keys, no comments),
-  though great for machine interchange.
-- *YAML* — indentation-sensitive, surprising edge cases
-  (the Norway problem: `NO` parses as boolean `false`).
-  Not worth the risk for a config file.
+- *TOML config file (previous)* — race conditions when multiple
+  instances write concurrently; split source of truth between
+  config.toml (roles) and state files (sessions); no atomic
+  multi-key updates.
+- *JSON* — verbose for config, no atomic writes without
+  temp-file-rename pattern.
 - *CLI flags only* — doesn't scale to multiple projects.
-  Users would need wrapper scripts or shell aliases.
 - *Embedded in CLAUDE.md* — mixes project-specific AI guidance
   with application configuration; wrong separation of concerns.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -48,18 +48,19 @@ are shown in the session list.
 
 Projects (name, repos, roles) are stored in the SQLite database
 at `~/.local/share/thurbox/thurbox.db` (`$XDG_DATA_HOME` respected).
-Projects are created and edited via the TUI (add-project modal
-with `Ctrl+N`, edit with `Ctrl+E`).
+Projects are created via `Ctrl+N`. Global settings (roles,
+MCP servers, skills) are edited via `Ctrl+E`.
 
 If the database is empty on first launch, only the built-in
 Admin project is present. Users create their first project via
 `Ctrl+N` or through the Admin session.
 
-### Edit project modal
+### Settings overlay
 
-`Ctrl+E` opens a pre-populated modal for editing the active
-project's name and repositories. Roles and MCP servers are
-managed globally (see Role Editor and MCP Server sections).
+`Ctrl+E` opens the settings overlay with three tabs: **Roles**,
+**MCP Servers**, and **Skills**. Use `Tab` to cycle between tabs.
+Roles and MCP servers are global presets shared across all
+sessions. Skills are symlinked into sessions at creation time.
 
 **Why not just delete and recreate?**
 
@@ -82,8 +83,11 @@ managed globally (see Role Editor and MCP Server sections).
    If any repo is marked as worktree, skips directly to branch
    selection.
 3. **Branch selector** — pick base branch (worktree mode only).
-4. **Branch name** — enter new branch name (worktree mode only).
-5. **Role selector** — pick from global roles (if 2+ defined).
+4. **Session name** — enter a name for the session.
+5. **Branch name** — enter new branch name (worktree mode only).
+6. **Role selector** — pick from global roles (if 2+ defined).
+7. **MCP server picker** — select MCP servers to attach.
+8. **Skill picker** — select skills to attach to the session.
 
 Mixed sessions are supported: worktree repos get a new branch
 while normal repos are added as-is via `--add-dir`.
@@ -131,8 +135,9 @@ for actions (`C`=close, `D`=delete, `N`=new, `R`=restart, `Q`=quit).
 | `Ctrl+L` | Global | Focus next pane (cycle forward) | Vim: **l** = right |
 | `Ctrl+D` | Session list | Close active session | Vim: **d** = delete |
 | `Ctrl+D` | Project list | Delete selected project | Vim: **d** = delete |
-| `Ctrl+E` | Global | Edit active project (name, repos) | **E**dit |
+| `Ctrl+E` | Global | Edit settings (roles, MCP servers, skills) | **E**dit |
 | `Ctrl+R` | Global | Restart active session | **R**estart |
+| `Ctrl+F` | Global | Fork active session | **F**ork |
 | `Ctrl+S` | Global | Sync all worktree sessions with origin/main | **S**ync |
 | `Ctrl+Z` | Global | Undo session/project delete | **Z** = undo |
 | `Ctrl+U` | Global | Restore deleted sessions | **U**ndelete |

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -77,6 +77,8 @@
             <li><a href="#container-sessions">Container Sessions</a></li>
             <li><a href="#vm-sessions">VM Sessions</a></li>
             <li><a href="#role-system">Role System</a></li>
+            <li><a href="#skill-management">Skill Management</a></li>
+            <li><a href="#session-forking">Session Forking</a></li>
             <li><a href="#fuzzy-search">Fuzzy Search</a></li>
             <li><a href="#responsive-ui">Responsive UI</a></li>
             <li><a href="#session-persistence">Session Persistence</a></li>
@@ -150,9 +152,9 @@
               <code>--add-dir</code>
             </li>
             <li>
-              Edit projects on the fly with
+              Edit global settings with
               <code>Ctrl+E</code>
-              (name, repos) without losing running sessions
+              (roles, MCP servers, skills)
             </li>
             <li>Soft-deleted projects and sessions can be restored via Admin session or MCP API</li>
             <li>
@@ -305,19 +307,14 @@
 
           <h3>Template management via MCP</h3>
           <p>
-            Six MCP tools provide programmatic access to templates and per-project container
-            configuration:
+            Four MCP tools provide programmatic access to templates:
             <code>list_containerfile_templates</code>
             ,
             <code>get_containerfile_template</code>
             ,
             <code>set_containerfile_template</code>
-            ,
-            <code>delete_containerfile_template</code>
-            ,
-            <code>configure_project_container</code>
             , and
-            <code>get_project_container_config</code>
+            <code>delete_containerfile_template</code>
             . Template names are validated to prevent path traversal.
           </p>
 
@@ -503,6 +500,38 @@
             . See
             <a href="roles.html">Role Configuration</a>
             for the full guide.
+          </p>
+
+          <h2 id="skill-management">
+            Skill Management
+            <a href="#skill-management" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Attach Claude Code skills to sessions at creation time. Skills are symlinked into each
+            session's
+            <code>.claude/skills/</code>
+            directory and auto-discovered by Claude Code.
+          </p>
+          <ul>
+            <li>
+              Manage skills globally via
+              <code>Ctrl+E</code>
+              (Settings &rarr; Skills tab)
+            </li>
+            <li>Select which skills to attach during session creation flow</li>
+            <li>Skills are shared across all projects</li>
+          </ul>
+
+          <h2 id="session-forking">
+            Session Forking
+            <a href="#session-forking" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Press
+            <code>Ctrl+F</code>
+            to fork the active session. This creates a new session that resumes from the same
+            conversation history, allowing you to explore alternative approaches without losing the
+            original session's context.
           </p>
 
           <h2 id="fuzzy-search">

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -225,7 +225,7 @@
               </tr>
               <tr>
                 <td><code>Ctrl+E</code></td>
-                <td>Edit active project</td>
+                <td>Edit settings (roles, MCP servers, skills)</td>
                 <td>
                   <strong>E</strong>
                   dit
@@ -237,6 +237,14 @@
                 <td>
                   <strong>R</strong>
                   estart
+                </td>
+              </tr>
+              <tr>
+                <td><code>Ctrl+F</code></td>
+                <td>Fork active session</td>
+                <td>
+                  <strong>F</strong>
+                  ork
                 </td>
               </tr>
               <tr>
@@ -531,7 +539,7 @@
             <a href="#role-editor" class="heading-anchor">#</a>
           </h2>
 
-          <h3>Role list (inside edit project)</h3>
+          <h3>Role list (inside settings overlay)</h3>
           <table>
             <thead>
               <tr>

--- a/website/docs/mcp.html
+++ b/website/docs/mcp.html
@@ -152,38 +152,6 @@
             <a href="#available-tools" class="heading-anchor">#</a>
           </h2>
 
-          <h3>Project management</h3>
-          <table>
-            <thead>
-              <tr>
-                <th>Tool</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code>list_projects</code></td>
-                <td>List all active projects</td>
-              </tr>
-              <tr>
-                <td><code>get_project</code></td>
-                <td>Get a project by name or UUID</td>
-              </tr>
-              <tr>
-                <td><code>create_project</code></td>
-                <td>Create a new project with name and repo paths</td>
-              </tr>
-              <tr>
-                <td><code>update_project</code></td>
-                <td>Update project name and/or repos (partial update)</td>
-              </tr>
-              <tr>
-                <td><code>delete_project</code></td>
-                <td>Soft-delete a project (preserves for undo)</td>
-              </tr>
-            </tbody>
-          </table>
-
           <h3>Role management</h3>
           <table>
             <thead>
@@ -312,7 +280,7 @@
             </tbody>
           </table>
 
-          <h3>Container configuration</h3>
+          <h3>Containerfile templates</h3>
           <table>
             <thead>
               <tr>
@@ -327,23 +295,15 @@
               </tr>
               <tr>
                 <td><code>get_containerfile_template</code></td>
-                <td>Read a template's Containerfile content</td>
+                <td>Read a template's Containerfile content and list support files</td>
               </tr>
               <tr>
                 <td><code>set_containerfile_template</code></td>
-                <td>Create/update a template</td>
+                <td>Create/update a template (Containerfile + optional support files)</td>
               </tr>
               <tr>
                 <td><code>delete_containerfile_template</code></td>
-                <td>Delete a template (refuses "default")</td>
-              </tr>
-              <tr>
-                <td><code>configure_project_container</code></td>
-                <td>Set project container defaults</td>
-              </tr>
-              <tr>
-                <td><code>get_project_container_config</code></td>
-                <td>Read current project container config</td>
+                <td>Delete a template (refuses to delete "default")</td>
               </tr>
             </tbody>
           </table>

--- a/website/docs/roles.html
+++ b/website/docs/roles.html
@@ -489,8 +489,10 @@
           <p>
             Press
             <code>Ctrl+E</code>
-            to edit a project. Navigate to the Roles field to add, edit, or delete roles using the
-            built-in role editor.
+            to open settings. The Roles tab lets you add, edit, or delete roles using the built-in
+            role editor. Use
+            <code>Tab</code>
+            to cycle between Roles, MCP Servers, and Skills tabs.
           </p>
 
           <h3>From Claude Code CLI</h3>

--- a/website/index.html
+++ b/website/index.html
@@ -156,13 +156,26 @@
             </p>
           </div>
           <div class="card">
+            <div class="card-icon">&#x1f9e9;</div>
+            <h3>Skill Management</h3>
+            <p>
+              Attach Claude Code skills to sessions at creation time. Skills are symlinked into each
+              session's
+              <code>.claude/skills/</code>
+              directory and auto-discovered by Claude Code. Manage skills globally via
+              <code>Ctrl+E</code>
+              .
+            </p>
+          </div>
+          <div class="card">
             <div class="card-icon">&#x1f50c;</div>
             <h3>MCP Server</h3>
             <p>
               The
               <code>thurbox-mcp</code>
-              binary exposes project, role, session, and scheduled command management over the Model
-              Context Protocol. Manage everything conversationally via the Admin session.
+              binary exposes 22 tools for managing roles, sessions, VMs, containers, and scheduled
+              commands over the Model Context Protocol. Manage everything conversationally via the
+              Admin session.
             </p>
           </div>
         </div>
@@ -269,7 +282,8 @@
 <span class="syn-keyword">Ctrl+J</span>  <span class="syn-comment">Switch between sessions</span>
 <span class="syn-keyword">Ctrl+S</span>  <span class="syn-comment">Sync worktrees with origin/main</span>
 <span class="syn-keyword">Ctrl+P</span>  <span class="syn-comment">Schedule a command for later</span>
-<span class="syn-keyword">Ctrl+E</span>  <span class="syn-comment">Edit project (roles, repos)</span></code></pre>
+<span class="syn-keyword">Ctrl+E</span>  <span class="syn-comment">Edit settings (roles, MCP, skills)</span>
+<span class="syn-keyword">Ctrl+F</span>  <span class="syn-comment">Fork active session</span></code></pre>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- Fix MCP tools table across README, website, and docs (remove non-existent project management tools, add 11 missing tools for containerfiles, VM images, and scheduled commands)
- Correct Ctrl+E description everywhere from "edit project" to "edit settings (roles, MCP servers, skills)"
- Add missing Ctrl+F (fork) and Ctrl+P (scheduled commands) keybindings to all docs and website
- Document skill management feature (new section in README, FEATURES.md, and website)
- Update ADR-8 in ARCHITECTURE.md from outdated TOML config to current SQLite storage
- Add session forking section to website features page

## Test plan

- [x] `rumdl check .` passes (markdown lint)
- [x] `npm run lint:website` passes (prettier, htmlhint, stylelint, eslint)
- [x] All pre-commit hooks pass
- [ ] Visual review of website pages