### PR TITLE
docs: position Thurbox as an agentic IDE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2469,7 +2469,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2526,7 +2526,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2537,9 +2537,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2957,7 +2957,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3815,7 +3815,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Thurbox
 
-A multi-session Claude Code orchestrator for your terminal.
-Run parallel Claude instances in persistent tmux panes — and let
-one of them drive the others.
+An agentic IDE and agent orchestrator for your terminal.
+Run parallel Claude Code instances in persistent tmux panes —
+and let one of them drive the others. Sessions, roles, worktrees,
+skills, and MCP servers are first-class citizens.
 
 [![CI](https://github.com/Thurbeen/thurbox/workflows/CI/badge.svg)](https://github.com/Thurbeen/thurbox/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/website/index.html
+++ b/website/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Thurbox — Multi-Session Agent Orchestrator</title>
+    <title>Thurbox — The Agentic IDE</title>
     <meta
       name="description"
-      content="Run parallel Claude Code instances in persistent tmux panes. Sessions survive crashes and restarts."
+      content="Thurbox is an agentic IDE and agent orchestrator. Run parallel Claude Code instances in persistent tmux panes — sessions, roles, and worktrees as first-class citizens."
     />
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -58,13 +58,13 @@
     <section class="hero section">
       <div class="container">
         <h1>
-          Multi-Session
-          <span class="accent">Agent</span>
-          Orchestrator
+          The
+          <span class="accent">Agentic</span>
+          IDE
         </h1>
         <p class="subtitle">
-          Run parallel Claude instances in persistent tmux panes. Sessions survive crashes and
-          restarts.
+          An agent orchestrator for your terminal. Run parallel Claude Code instances in persistent
+          tmux panes — and let one of them drive the others. Sessions survive crashes and restarts.
         </p>
         <div class="hero-ctas">
           <a href="#installation" class="btn btn-primary">Get Started</a>


### PR DESCRIPTION
## Summary
- Lead README and website with "agentic IDE" framing while preserving the agent-orchestrator description
- Keep the "sessions survive crashes and restarts" line in the hero subtitle
- Bump rustls-webpki to 0.103.12 to clear RUSTSEC-2026-0098 (pulled in via reqwest)

## Test plan
- [x] Pre-commit hooks pass (cargo-deny, rumdl, prettier, htmlhint)
- [ ] Website renders correctly