### PR TITLE
feat(cli): add thurbox-cli with standalone session ops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,10 @@ axum = "0.8"
 name = "thurbox-mcp"
 path = "src/bin/thurbox-mcp.rs"
 
+[[bin]]
+name = "thurbox-cli"
+path = "src/bin/thurbox-cli.rs"
+
 [dev-dependencies]
 tempfile = "3"
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -31,6 +31,15 @@ const TMUX_SESSION: &str = if cfg!(dev_build) {
     "thurbox"
 };
 
+/// Window-name prefix for thurbox-managed tmux windows. Combined with the
+/// session name (`{prefix}{session_name}`) to form the tmux window target.
+pub(crate) const WINDOW_PREFIX: &str = "tb-";
+
+/// Build the `session:window` tmux target for a thurbox session.
+fn window_target(session_name: &str) -> String {
+    format!("{TMUX_SESSION}:{WINDOW_PREFIX}{session_name}")
+}
+
 /// Minimum tmux version required.
 const MIN_TMUX_VERSION: (u32, u32) = (3, 2);
 
@@ -40,6 +49,12 @@ const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// Delay (in seconds) between sending command text and pressing Enter via tmux,
 /// giving the target application time to process the input.
 const SEND_KEYS_ENTER_DELAY_SECS: &str = "0.2";
+
+/// Same delay as a `Duration`, used by the synchronous `send_prompt_now` path.
+const SEND_KEYS_ENTER_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
+
+/// Hard cap on the number of scrollback lines `capture_pane_text` will return.
+const MAX_CAPTURE_LINES: u32 = 10_000;
 
 /// Local tmux backend — sessions persist in `tmux -L thurbox`.
 ///
@@ -812,7 +827,7 @@ pub fn schedule_tmux_command(
 ) -> Result<()> {
     let escaped_text = shell_escape(command_text);
     let escaped_db = shell_escape(&db_path.display().to_string());
-    let target = format!("{TMUX_SESSION}:tb-{session_name}");
+    let target = window_target(session_name);
     let escaped_target = shell_escape(&target);
 
     // Shell script that checks cancellation before sending, then marks executed.
@@ -858,7 +873,7 @@ pub fn schedule_tmux_command(
 /// "type text → brief delay → press Enter" sequence that `schedule_tmux_command`
 /// uses so the target app has time to process the typed input.
 pub fn send_prompt_now(session_name: &str, text: &str) -> Result<()> {
-    let target = format!("{TMUX_SESSION}:tb-{session_name}");
+    let target = window_target(session_name);
 
     let status = Command::new("tmux")
         .args(["-L", TMUX_SOCKET, "send-keys", "-t", &target, text])
@@ -868,7 +883,7 @@ pub fn send_prompt_now(session_name: &str, text: &str) -> Result<()> {
         bail!("tmux send-keys (text) exited with status {status}");
     }
 
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    std::thread::sleep(SEND_KEYS_ENTER_DELAY);
 
     let status = Command::new("tmux")
         .args(["-L", TMUX_SOCKET, "send-keys", "-t", &target, "Enter"])
@@ -885,8 +900,8 @@ pub fn send_prompt_now(session_name: &str, text: &str) -> Result<()> {
 /// Returns the visible terminal text. `lines` controls how many lines of
 /// scrollback to include before the visible region (capped to a sane max).
 pub fn capture_pane_text(session_name: &str, lines: u32) -> Result<String> {
-    let target = format!("{TMUX_SESSION}:tb-{session_name}");
-    let lines = lines.min(10_000);
+    let target = window_target(session_name);
+    let lines = lines.min(MAX_CAPTURE_LINES);
     let start = format!("-{lines}");
 
     let output = Command::new("tmux")
@@ -911,6 +926,149 @@ pub fn capture_pane_text(session_name: &str, lines: u32) -> Result<String> {
         );
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Session-level tmux options applied to the thurbox tmux session.
+///
+/// Mirrored by [`LocalTmuxBackend::apply_config`] for the TUI path; the
+/// headless path applies only this subset.
+const HEADLESS_SESSION_OPTS: &[(&str, &str)] = &[
+    ("remain-on-exit", "on"),
+    ("status", "off"),
+    ("history-limit", "5000"),
+    // Allow each window to size independently of the smallest attached client.
+    ("window-size", "manual"),
+];
+
+/// Run `tmux has-session -t <thurbox session>` and return whether it exists.
+fn tmux_session_exists() -> Result<bool> {
+    let status = Command::new("tmux")
+        .args(["-L", TMUX_SOCKET, "has-session", "-t", TMUX_SESSION])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("Failed to run tmux has-session")?;
+    Ok(status.success())
+}
+
+/// Create the thurbox tmux session (`-d -s <name>`) at a default 80x24 size.
+fn tmux_create_session() -> Result<()> {
+    let output = Command::new("tmux")
+        .args([
+            "-L",
+            TMUX_SOCKET,
+            "new-session",
+            "-d",
+            "-s",
+            TMUX_SESSION,
+            "-x",
+            "80",
+            "-y",
+            "24",
+        ])
+        .output()
+        .context("Failed to create tmux session")?;
+    if !output.status.success() {
+        bail!(
+            "Failed to create tmux session: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Ensure the thurbox tmux session exists (headless — no control mode).
+///
+/// Used by [`spawn_window`] so callers that don't hold a
+/// [`LocalTmuxBackend`] can still create sessions safely.
+fn ensure_tmux_session_headless() -> Result<()> {
+    if tmux_session_exists()? {
+        return Ok(());
+    }
+    tmux_create_session()?;
+    for (k, v) in HEADLESS_SESSION_OPTS {
+        let _ = Command::new("tmux")
+            .args(["-L", TMUX_SOCKET, "set-option", "-t", TMUX_SESSION, k, v])
+            .status();
+    }
+    Ok(())
+}
+
+/// Spawn a new tmux window running `command` with `args` in `cwd`.
+///
+/// Thin helper for headless callers (CLI, MCP) that don't need PTY I/O
+/// streams. Returns on success once the window exists; the command runs
+/// inside it. Window name is `tb-<session_name>`.
+pub fn spawn_window(
+    session_name: &str,
+    command: &str,
+    args: &[String],
+    cwd: Option<&Path>,
+    env: &HashMap<String, String>,
+) -> Result<()> {
+    ensure_tmux_session_headless()?;
+
+    let window_name = format!("{WINDOW_PREFIX}{session_name}");
+    let mut tmux = Command::new("tmux");
+    tmux.args([
+        "-L",
+        TMUX_SOCKET,
+        "new-window",
+        "-d",
+        "-t",
+        &format!("{TMUX_SESSION}:"),
+        "-n",
+        &window_name,
+    ]);
+    if let Some(dir) = cwd {
+        tmux.args(["-c", &dir.to_string_lossy()]);
+    }
+    for (k, v) in env {
+        tmux.args(["-e", &format!("{k}={v}")]);
+    }
+    // Pass the command + args as a single argv list. tmux treats trailing args
+    // as the command to run inside the window.
+    tmux.arg(command);
+    for a in args {
+        tmux.arg(a);
+    }
+
+    let output = tmux
+        .output()
+        .context("Failed to run tmux new-window for headless spawn")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "tmux new-window exited {} for window {}: {}",
+            output.status,
+            window_name,
+            stderr.trim()
+        );
+    }
+    Ok(())
+}
+
+/// Kill the tmux window `tb-<session_name>` if it exists.
+pub fn kill_window(session_name: &str) -> Result<()> {
+    let target = window_target(session_name);
+    let output = Command::new("tmux")
+        .args(["-L", TMUX_SOCKET, "kill-window", "-t", &target])
+        .output()
+        .context("Failed to run tmux kill-window")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // It's fine if the window is already gone.
+        if stderr.contains("can't find window") || stderr.contains("window not found") {
+            return Ok(());
+        }
+        bail!(
+            "tmux kill-window exited {} for {}: {}",
+            output.status,
+            target,
+            stderr.trim()
+        );
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2676,7 +2676,10 @@ impl App {
                     );
 
                     // If adopt failed but session has an agent_session_id,
-                    // try spawning with --resume (e.g. restored via MCP).
+                    // spawn using `--session-id` so claude creates the
+                    // conversation if it doesn't yet exist (e.g. sessions
+                    // created via the CLI whose claude process never
+                    // persisted a conversation before we first adopt them).
                     if let Some(ref agent_sid) = shared_session.agent_session_id {
                         let worktree_infos = Self::recreate_worktrees(&shared_session.worktrees);
                         let cwd = worktree_infos
@@ -2686,7 +2689,7 @@ impl App {
 
                         let permissions = self.resolve_role_permissions(&shared_session.role);
                         let config = SessionConfig {
-                            resume_session_id: Some(agent_sid.clone()),
+                            resume_session_id: None,
                             agent_session_id: Some(agent_sid.clone()),
                             cwd,
                             additional_dirs: shared_session.additional_dirs.clone(),
@@ -3339,7 +3342,10 @@ impl App {
             self.active_index = self.sessions.len() - 1;
             self.focus = InputFocus::Terminal;
         } else {
-            // No matching backend session or adopt failed — spawn new with --resume.
+            // No matching backend session or adopt failed — spawn fresh using
+            // `--session-id` so claude creates the conversation if one doesn't
+            // yet exist for this agent_session_id (e.g. CLI-created sessions
+            // whose claude process never persisted a conversation).
             if let Err(e) = self.db.soft_delete_session(session_id) {
                 error!("Failed to soft-delete stale session {session_id}: {e}");
             }
@@ -3347,7 +3353,7 @@ impl App {
             let permissions = self.resolve_role_permissions(&role);
 
             let config = SessionConfig {
-                resume_session_id: Some(agent_session_id.clone()),
+                resume_session_id: None,
                 agent_session_id: Some(agent_session_id),
                 cwd: shared.cwd,
                 additional_dirs: shared.additional_dirs,
@@ -3584,7 +3590,7 @@ impl App {
             }
 
             let config = SessionConfig {
-                resume_session_id: Some(agent_session_id.clone()),
+                resume_session_id: None,
                 agent_session_id: Some(agent_session_id),
                 cwd: shared.cwd,
                 additional_dirs: shared.additional_dirs,
@@ -3597,7 +3603,7 @@ impl App {
                 skills: vec![],
             };
             self.do_spawn_session(name, &config, worktrees, false);
-            info!(session = %session_id, "Session restored (respawned with --resume)");
+            info!(session = %session_id, "Session restored (respawned with --session-id)");
         }
 
         self.save_state();
@@ -3652,7 +3658,7 @@ impl App {
             let permissions = self.resolve_role_permissions(&role);
 
             let config = SessionConfig {
-                resume_session_id: Some(agent_session_id.clone()),
+                resume_session_id: None,
                 agent_session_id: Some(agent_session_id.clone()),
                 cwd: shared.cwd,
                 additional_dirs: shared.additional_dirs,

--- a/src/bin/thurbox-cli.rs
+++ b/src/bin/thurbox-cli.rs
@@ -1,0 +1,41 @@
+//! Thurbox CLI binary — scriptable access to the same state exposed by the
+//! MCP server and the TUI. Every subcommand works without the TUI running.
+
+use clap::Parser;
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::WARN.into()),
+        )
+        .init();
+
+    let cli = thurbox::cli::Cli::parse();
+
+    let db_path = match thurbox::paths::database_file() {
+        Some(p) => p,
+        None => {
+            eprintln!("error: cannot resolve database path (is HOME set?)");
+            std::process::exit(2);
+        }
+    };
+
+    let db = match thurbox::storage::Database::open(&db_path) {
+        Ok(db) => db,
+        Err(e) => {
+            eprintln!(
+                "error: failed to open database at {}: {e}",
+                db_path.display()
+            );
+            std::process::exit(2);
+        }
+    };
+
+    if let Err(e) = thurbox::cli::run(cli, &db) {
+        let msg = serde_json::json!({ "error": e }).to_string();
+        eprintln!("{msg}");
+        std::process::exit(1);
+    }
+}

--- a/src/cli/containerfiles.rs
+++ b/src/cli/containerfiles.rs
@@ -1,0 +1,149 @@
+//! Containerfile template subcommands.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+use serde_json::{json, Value};
+
+use super::validate_safe_name;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// List templates with their files.
+    List,
+    /// Print a template's Containerfile content + list support files.
+    Get {
+        /// Template name.
+        name: String,
+    },
+    /// Create or update a template.
+    Set {
+        /// Template name.
+        name: String,
+        /// Path to the Containerfile content.
+        #[arg(long)]
+        file: PathBuf,
+        /// Support file as `filename=path` (repeatable).
+        #[command(flatten)]
+        support: SupportFiles,
+    },
+    /// Delete a template (refuses to delete "default").
+    Delete {
+        /// Template name.
+        name: String,
+    },
+}
+
+#[derive(Args, Debug)]
+pub struct SupportFiles {
+    /// Support file spec `filename=path`, repeatable.
+    ///
+    /// On the CLI we can't accept arbitrary file *contents* as a single
+    /// argument, so each flag gives a `filename=host_path` pair.
+    #[arg(long = "support-file")]
+    pub files: Vec<String>,
+}
+
+pub fn run(action: Action) -> Result<Value, String> {
+    match action {
+        Action::List => {
+            let dir = crate::paths::containerfiles_directory()
+                .ok_or_else(|| "Could not resolve containerfiles directory".to_string())?;
+            if !dir.exists() {
+                return Ok(Value::Array(Vec::new()));
+            }
+            let entries = std::fs::read_dir(&dir)
+                .map_err(|e| format!("Failed to read containerfiles directory: {e}"))?;
+            let mut templates = Vec::new();
+            for entry in entries.flatten() {
+                if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().to_string();
+                let mut files = Vec::new();
+                if let Ok(children) = std::fs::read_dir(entry.path()) {
+                    for child in children.flatten() {
+                        if child.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+                            files.push(child.file_name().to_string_lossy().to_string());
+                        }
+                    }
+                }
+                files.sort();
+                templates.push(json!({ "name": name, "files": files }));
+            }
+            templates.sort_by_key(|v| v["name"].as_str().unwrap_or("").to_string());
+            Ok(Value::Array(templates))
+        }
+        Action::Get { name } => {
+            validate_safe_name(&name)?;
+            let dir = crate::paths::containerfiles_directory()
+                .ok_or_else(|| "Could not resolve containerfiles directory".to_string())?;
+            let tdir = dir.join(&name);
+            if !tdir.is_dir() {
+                return Err(format!("Template not found: {name}"));
+            }
+            let content = std::fs::read_to_string(tdir.join("Containerfile"))
+                .map_err(|_| format!("Template '{name}' has no Containerfile"))?;
+            let mut support = Vec::new();
+            if let Ok(entries) = std::fs::read_dir(&tdir) {
+                for entry in entries.flatten() {
+                    if entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+                        let fname = entry.file_name().to_string_lossy().to_string();
+                        if fname != "Containerfile" {
+                            support.push(fname);
+                        }
+                    }
+                }
+            }
+            support.sort();
+            Ok(json!({
+                "name": name,
+                "containerfile_content": content,
+                "support_files": support,
+            }))
+        }
+        Action::Set {
+            name,
+            file,
+            support,
+        } => {
+            validate_safe_name(&name)?;
+            let dir = crate::paths::containerfiles_directory()
+                .ok_or_else(|| "Could not resolve containerfiles directory".to_string())?;
+            let tdir = dir.join(&name);
+            std::fs::create_dir_all(&tdir)
+                .map_err(|e| format!("Failed to create template directory: {e}"))?;
+            let content = super::read_file(&file)?;
+            std::fs::write(tdir.join("Containerfile"), &content)
+                .map_err(|e| format!("Failed to write Containerfile: {e}"))?;
+            let mut all_files = vec!["Containerfile".to_string()];
+            for spec in &support.files {
+                let (fname, src) = spec
+                    .split_once('=')
+                    .ok_or_else(|| format!("Invalid --support-file {spec} (expected name=path)"))?;
+                validate_safe_name(fname)?;
+                let body = super::read_file(&PathBuf::from(src))?;
+                std::fs::write(tdir.join(fname), body)
+                    .map_err(|e| format!("Failed to write {fname}: {e}"))?;
+                all_files.push(fname.to_string());
+            }
+            all_files.sort();
+            Ok(json!({ "name": name, "files": all_files }))
+        }
+        Action::Delete { name } => {
+            validate_safe_name(&name)?;
+            if name == "default" {
+                return Err("Cannot delete the 'default' template".into());
+            }
+            let dir = crate::paths::containerfiles_directory()
+                .ok_or_else(|| "Could not resolve containerfiles directory".to_string())?;
+            let tdir = dir.join(&name);
+            if !tdir.is_dir() {
+                return Err(format!("Template not found: {name}"));
+            }
+            std::fs::remove_dir_all(&tdir)
+                .map_err(|e| format!("Failed to delete template: {e}"))?;
+            Ok(json!({ "deleted": true, "name": name }))
+        }
+    }
+}

--- a/src/cli/containerfiles.rs
+++ b/src/cli/containerfiles.rs
@@ -47,31 +47,10 @@ pub struct SupportFiles {
 pub fn run(action: Action) -> Result<Value, String> {
     match action {
         Action::List => {
-            let dir = crate::paths::containerfiles_directory()
-                .ok_or_else(|| "Could not resolve containerfiles directory".to_string())?;
-            if !dir.exists() {
-                return Ok(Value::Array(Vec::new()));
-            }
-            let entries = std::fs::read_dir(&dir)
-                .map_err(|e| format!("Failed to read containerfiles directory: {e}"))?;
-            let mut templates = Vec::new();
-            for entry in entries.flatten() {
-                if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
-                    continue;
-                }
-                let name = entry.file_name().to_string_lossy().to_string();
-                let mut files = Vec::new();
-                if let Ok(children) = std::fs::read_dir(entry.path()) {
-                    for child in children.flatten() {
-                        if child.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
-                            files.push(child.file_name().to_string_lossy().to_string());
-                        }
-                    }
-                }
-                files.sort();
-                templates.push(json!({ "name": name, "files": files }));
-            }
-            templates.sort_by_key(|v| v["name"].as_str().unwrap_or("").to_string());
+            let templates: Vec<Value> = crate::paths::list_containerfile_templates()?
+                .into_iter()
+                .map(|(name, files)| json!({ "name": name, "files": files }))
+                .collect();
             Ok(Value::Array(templates))
         }
         Action::Get { name } => {

--- a/src/cli/editor.rs
+++ b/src/cli/editor.rs
@@ -1,0 +1,86 @@
+//! Editor command get/set subcommands.
+
+use clap::Subcommand;
+use serde_json::Value;
+
+use crate::storage::Database;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// Print the configured editor command (or null).
+    Get,
+    /// Set the editor command (pass empty string to clear).
+    Set {
+        /// Command line template. The worktree path is appended as a final arg.
+        command: String,
+    },
+}
+
+pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+    match action {
+        Action::Get => {
+            let cmd = db
+                .get_editor_command()
+                .map_err(|e| format!("get_editor_command: {e}"))?;
+            Ok(serde_json::json!({ "command": cmd }))
+        }
+        Action::Set { command } => {
+            db.set_editor_command(&command)
+                .map_err(|e| format!("set_editor_command: {e}"))?;
+            Ok(serde_json::json!({
+                "command": if command.is_empty() { None } else { Some(command) }
+            }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    #[test]
+    fn get_returns_null_when_unset() {
+        let db = db();
+        let v = run(Action::Get, &db).unwrap();
+        assert!(v.get("command").unwrap().is_null());
+    }
+
+    #[test]
+    fn set_then_get_roundtrips() {
+        let db = db();
+        let v = run(
+            Action::Set {
+                command: "code --wait".into(),
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(v["command"].as_str(), Some("code --wait"));
+        let v = run(Action::Get, &db).unwrap();
+        assert_eq!(v["command"].as_str(), Some("code --wait"));
+    }
+
+    #[test]
+    fn set_empty_clears() {
+        let db = db();
+        run(
+            Action::Set {
+                command: "vim".into(),
+            },
+            &db,
+        )
+        .unwrap();
+        let v = run(
+            Action::Set {
+                command: String::new(),
+            },
+            &db,
+        )
+        .unwrap();
+        assert!(v["command"].is_null());
+    }
+}

--- a/src/cli/mcp_servers.rs
+++ b/src/cli/mcp_servers.rs
@@ -1,0 +1,90 @@
+//! MCP server CRUD subcommands.
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+use serde_json::Value;
+
+use crate::session::McpServerConfig;
+use crate::storage::Database;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// List all global MCP servers.
+    List,
+    /// Atomically replace all global MCP servers from a JSON file.
+    Set {
+        /// Path to a JSON file. Accepts `[server...]` or `{"servers":[...]}`.
+        #[arg(long)]
+        file: PathBuf,
+    },
+}
+
+pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+    match action {
+        Action::List => {
+            let servers = db
+                .list_global_mcp_servers()
+                .map_err(|e| format!("list_global_mcp_servers: {e}"))?;
+            Ok(serde_json::to_value(servers).map_err(|e| e.to_string())?)
+        }
+        Action::Set { file } => {
+            let content = super::read_file(&file)?;
+            let value: Value =
+                serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON: {e}"))?;
+            let arr = match &value {
+                Value::Array(a) => a.clone(),
+                Value::Object(o) => match o.get("servers") {
+                    Some(Value::Array(a)) => a.clone(),
+                    _ => return Err("JSON must be an array or {\"servers\":[...]}".into()),
+                },
+                _ => return Err("JSON must be an array or {\"servers\":[...]}".into()),
+            };
+
+            let servers: Vec<McpServerConfig> = arr
+                .into_iter()
+                .map(|v| -> Result<McpServerConfig, String> {
+                    let name = v
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .ok_or("server.name required")?
+                        .to_string();
+                    let command = v
+                        .get("command")
+                        .and_then(Value::as_str)
+                        .ok_or("server.command required")?
+                        .to_string();
+                    let args = v
+                        .get("args")
+                        .and_then(Value::as_array)
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|x| x.as_str().map(str::to_string))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let env = v
+                        .get("env")
+                        .and_then(Value::as_object)
+                        .map(|o| {
+                            o.iter()
+                                .filter_map(|(k, val)| {
+                                    val.as_str().map(|s| (k.clone(), s.to_string()))
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    Ok(McpServerConfig {
+                        name,
+                        command,
+                        args,
+                        env,
+                    })
+                })
+                .collect::<Result<_, _>>()?;
+            db.replace_global_mcp_servers(&servers)
+                .map_err(|e| format!("replace_global_mcp_servers: {e}"))?;
+            Ok(serde_json::to_value(&servers).map_err(|e| e.to_string())?)
+        }
+    }
+}

--- a/src/cli/mcp_servers.rs
+++ b/src/cli/mcp_servers.rs
@@ -30,17 +30,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
         }
         Action::Set { file } => {
             let content = super::read_file(&file)?;
-            let value: Value =
-                serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON: {e}"))?;
-            let arr = match &value {
-                Value::Array(a) => a.clone(),
-                Value::Object(o) => match o.get("servers") {
-                    Some(Value::Array(a)) => a.clone(),
-                    _ => return Err("JSON must be an array or {\"servers\":[...]}".into()),
-                },
-                _ => return Err("JSON must be an array or {\"servers\":[...]}".into()),
-            };
-
+            let arr = super::parse_array_or_wrapper(&content, "servers")?;
             let servers: Vec<McpServerConfig> = arr
                 .into_iter()
                 .map(|v| -> Result<McpServerConfig, String> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,309 @@
+//! Command-line interface dispatcher for the `thurbox-cli` binary.
+//!
+//! Each subcommand mirrors a tool exposed by the MCP server. Output is JSON
+//! matching the MCP tool result shape. Pass `--pretty` to pretty-print.
+//!
+//! The CLI is intentionally thin: it parses arguments, calls into
+//! `storage::Database`, `session_ops`, or the tmux helpers in
+//! `agent::tmux`, and prints the result. No TUI, no event loop.
+
+use clap::{Parser, Subcommand};
+
+use crate::storage::Database;
+
+pub mod containerfiles;
+pub mod editor;
+pub mod mcp_servers;
+pub mod roles;
+pub mod scheduled;
+pub mod sessions;
+pub mod vm_images;
+pub mod vms;
+
+/// Thurbox CLI — manage roles, sessions, scheduled commands, and more.
+#[derive(Parser, Debug)]
+#[command(name = "thurbox-cli", version, about)]
+pub struct Cli {
+    /// Pretty-print JSON output.
+    #[arg(long, global = true)]
+    pub pretty: bool,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Manage global roles.
+    Role {
+        #[command(subcommand)]
+        action: roles::Action,
+    },
+    /// Manage global MCP servers.
+    #[command(name = "mcp-server")]
+    McpServer {
+        #[command(subcommand)]
+        action: mcp_servers::Action,
+    },
+    /// Get/set the editor command (Ctrl+O in the TUI).
+    Editor {
+        #[command(subcommand)]
+        action: editor::Action,
+    },
+    /// Manage sessions.
+    Session {
+        #[command(subcommand)]
+        action: sessions::Action,
+    },
+    /// Manage scheduled commands.
+    Schedule {
+        #[command(subcommand)]
+        action: scheduled::Action,
+    },
+    /// Manage VMs (read-only).
+    Vm {
+        #[command(subcommand)]
+        action: vms::Action,
+    },
+    /// Manage cached VM images.
+    #[command(name = "vm-image")]
+    VmImage {
+        #[command(subcommand)]
+        action: vm_images::Action,
+    },
+    /// Manage Containerfile templates.
+    Containerfile {
+        #[command(subcommand)]
+        action: containerfiles::Action,
+    },
+}
+
+/// Run a parsed CLI invocation against `db` and write JSON to stdout.
+pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
+    let value = match cli.command {
+        Command::Role { action } => roles::run(action, db),
+        Command::McpServer { action } => mcp_servers::run(action, db),
+        Command::Editor { action } => editor::run(action, db),
+        Command::Session { action } => sessions::run(action, db),
+        Command::Schedule { action } => scheduled::run(action, db),
+        Command::Vm { action } => vms::run(action, db),
+        Command::VmImage { action } => vm_images::run(action),
+        Command::Containerfile { action } => containerfiles::run(action),
+    }?;
+
+    let text = if cli.pretty {
+        serde_json::to_string_pretty(&value).unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
+    } else {
+        serde_json::to_string(&value).unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
+    };
+    println!("{text}");
+    Ok(())
+}
+
+// ── Shared helpers ─────────────────────────────────────────────────
+
+/// Read a file's contents as a UTF-8 string, returning a CLI-style error.
+pub(crate) fn read_file(path: &std::path::Path) -> Result<String, String> {
+    std::fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {e}", path.display()))
+}
+
+/// Validate that `name` is a safe single-segment filename (no slashes,
+/// dot-prefix, or `..`) — used by VM-image and Containerfile commands.
+pub(crate) fn validate_safe_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Name cannot be empty".into());
+    }
+    if name.len() > 64 {
+        return Err("Name too long (max 64 characters)".into());
+    }
+    if name.starts_with('.') {
+        return Err("Name cannot start with '.'".into());
+    }
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        return Err("Name contains invalid characters".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn parse_role_list() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "role", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Role {
+                action: roles::Action::List
+            }
+        ));
+        assert!(!cli.pretty);
+    }
+
+    #[test]
+    fn pretty_flag_is_global() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "session", "list", "--pretty"]).unwrap();
+        assert!(cli.pretty);
+        assert!(matches!(
+            cli.command,
+            Command::Session {
+                action: sessions::Action::List
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_session_create_requires_name_and_repo() {
+        // Missing required args fails.
+        assert!(Cli::try_parse_from(["thurbox-cli", "session", "create"]).is_err());
+
+        // Full happy path.
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "session",
+            "create",
+            "--name",
+            "demo",
+            "--repo-path",
+            "/tmp/repo",
+            "--worktree-branch",
+            "feat/x",
+            "--mcp-server",
+            "fs",
+            "--mcp-server",
+            "github",
+            "--skill",
+            "review",
+        ])
+        .unwrap();
+        let Command::Session {
+            action:
+                sessions::Action::Create {
+                    name,
+                    repo_path,
+                    mcp_servers,
+                    skills,
+                    worktree_branch,
+                    ..
+                },
+        } = cli.command
+        else {
+            panic!("expected Session::Create");
+        };
+        assert_eq!(name, "demo");
+        assert_eq!(repo_path.to_string_lossy(), "/tmp/repo");
+        assert_eq!(worktree_branch.as_deref(), Some("feat/x"));
+        assert_eq!(mcp_servers, vec!["fs", "github"]);
+        assert_eq!(skills, vec!["review"]);
+    }
+
+    #[test]
+    fn parse_editor_set_and_get() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "editor", "get"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Editor {
+                action: editor::Action::Get
+            }
+        ));
+        let cli = Cli::try_parse_from(["thurbox-cli", "editor", "set", "code --wait"]).unwrap();
+        let Command::Editor {
+            action: editor::Action::Set { command },
+        } = cli.command
+        else {
+            panic!("expected Editor::Set");
+        };
+        assert_eq!(command, "code --wait");
+    }
+
+    #[test]
+    fn parse_schedule_create_requires_args() {
+        assert!(
+            Cli::try_parse_from(["thurbox-cli", "schedule", "create"]).is_err(),
+            "missing required args should fail"
+        );
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "schedule",
+            "create",
+            "--session",
+            "00000000-0000-0000-0000-000000000000",
+            "--at",
+            "9999999999999",
+            "--command",
+            "ls",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Schedule {
+                action: scheduled::Action::Create { .. }
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_vm_image_download() {
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "vm-image",
+            "download",
+            "https://example.com/img.qcow2",
+            "--filename",
+            "img.qcow2",
+        ])
+        .unwrap();
+        let Command::VmImage {
+            action:
+                vm_images::Action::Download {
+                    url,
+                    filename: Some(f),
+                },
+        } = cli.command
+        else {
+            panic!("expected VmImage::Download with filename");
+        };
+        assert_eq!(url, "https://example.com/img.qcow2");
+        assert_eq!(f, "img.qcow2");
+    }
+
+    #[test]
+    fn parse_containerfile_set_with_support_files() {
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "containerfile",
+            "set",
+            "mytpl",
+            "--file",
+            "/tmp/Containerfile",
+            "--support-file",
+            "entrypoint.sh=/tmp/entry.sh",
+        ])
+        .unwrap();
+        let Command::Containerfile {
+            action:
+                containerfiles::Action::Set {
+                    name,
+                    file,
+                    support,
+                },
+        } = cli.command
+        else {
+            panic!("expected Containerfile::Set");
+        };
+        assert_eq!(name, "mytpl");
+        assert_eq!(file.to_string_lossy(), "/tmp/Containerfile");
+        assert_eq!(support.files, vec!["entrypoint.sh=/tmp/entry.sh"]);
+    }
+
+    #[test]
+    fn validate_safe_name_basics() {
+        assert!(validate_safe_name("ok-name").is_ok());
+        assert!(validate_safe_name("").is_err());
+        assert!(validate_safe_name(".dot").is_err());
+        assert!(validate_safe_name("a/b").is_err());
+        assert!(validate_safe_name(&"x".repeat(65)).is_err());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -107,22 +107,30 @@ pub(crate) fn read_file(path: &std::path::Path) -> Result<String, String> {
     std::fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {e}", path.display()))
 }
 
+/// Parse a JSON document that may be either a bare array or an object
+/// with a single `wrapper_key` field whose value is an array. Returns the
+/// array items. Used by `role set` / `mcp-server set` CLI commands.
+pub(crate) fn parse_array_or_wrapper(
+    content: &str,
+    wrapper_key: &str,
+) -> Result<Vec<serde_json::Value>, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(content).map_err(|e| format!("Failed to parse JSON: {e}"))?;
+    let err = || format!("JSON must be an array or {{\"{wrapper_key}\":[...]}}");
+    match value {
+        serde_json::Value::Array(a) => Ok(a),
+        serde_json::Value::Object(mut o) => match o.remove(wrapper_key) {
+            Some(serde_json::Value::Array(a)) => Ok(a),
+            _ => Err(err()),
+        },
+        _ => Err(err()),
+    }
+}
+
 /// Validate that `name` is a safe single-segment filename (no slashes,
 /// dot-prefix, or `..`) — used by VM-image and Containerfile commands.
 pub(crate) fn validate_safe_name(name: &str) -> Result<(), String> {
-    if name.is_empty() {
-        return Err("Name cannot be empty".into());
-    }
-    if name.len() > 64 {
-        return Err("Name too long (max 64 characters)".into());
-    }
-    if name.starts_with('.') {
-        return Err("Name cannot start with '.'".into());
-    }
-    if name.contains('/') || name.contains('\\') || name.contains("..") {
-        return Err("Name contains invalid characters".into());
-    }
-    Ok(())
+    crate::paths::validate_safe_name(name)
 }
 
 #[cfg(test)]

--- a/src/cli/roles.rs
+++ b/src/cli/roles.rs
@@ -33,18 +33,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
         }
         Action::Set { file } => {
             let content = super::read_file(&file)?;
-            // Accept either `[RoleInput...]` or `{"roles":[RoleInput...]}`.
-            let value: Value =
-                serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON: {e}"))?;
-            let arr = match &value {
-                Value::Array(a) => a.clone(),
-                Value::Object(o) => match o.get("roles") {
-                    Some(Value::Array(a)) => a.clone(),
-                    _ => return Err("JSON must be an array or {\"roles\":[...]}".into()),
-                },
-                _ => return Err("JSON must be an array or {\"roles\":[...]}".into()),
-            };
-
+            let arr = super::parse_array_or_wrapper(&content, "roles")?;
             let roles: Vec<RoleConfig> = arr
                 .into_iter()
                 .map(|v| -> Result<RoleConfig, String> {

--- a/src/cli/roles.rs
+++ b/src/cli/roles.rs
@@ -1,0 +1,148 @@
+//! Role CRUD subcommands.
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+use serde_json::Value;
+
+use crate::session::{RoleConfig, RolePermissions};
+use crate::storage::Database;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// List all global roles.
+    List,
+    /// Atomically replace all global roles from a JSON file.
+    ///
+    /// The file must contain an array of role objects matching the MCP
+    /// `set_roles` schema (see docs/MCP_ROLES.md).
+    Set {
+        /// Path to a JSON file containing a role array.
+        #[arg(long)]
+        file: PathBuf,
+    },
+}
+
+pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+    match action {
+        Action::List => {
+            let roles = db
+                .list_global_roles()
+                .map_err(|e| format!("list_global_roles: {e}"))?;
+            Ok(serde_json::to_value(roles).map_err(|e| e.to_string())?)
+        }
+        Action::Set { file } => {
+            let content = super::read_file(&file)?;
+            // Accept either `[RoleInput...]` or `{"roles":[RoleInput...]}`.
+            let value: Value =
+                serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON: {e}"))?;
+            let arr = match &value {
+                Value::Array(a) => a.clone(),
+                Value::Object(o) => match o.get("roles") {
+                    Some(Value::Array(a)) => a.clone(),
+                    _ => return Err("JSON must be an array or {\"roles\":[...]}".into()),
+                },
+                _ => return Err("JSON must be an array or {\"roles\":[...]}".into()),
+            };
+
+            let roles: Vec<RoleConfig> = arr
+                .into_iter()
+                .map(|v| -> Result<RoleConfig, String> {
+                    let name = v
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .ok_or("role.name required")?
+                        .to_string();
+                    let description = v
+                        .get("description")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    let permission_mode = v
+                        .get("permission_mode")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    let allowed_tools = str_vec(v.get("allowed_tools"));
+                    let disallowed_tools = str_vec(v.get("disallowed_tools"));
+                    let tools = v.get("tools").and_then(Value::as_str).map(str::to_string);
+                    let append_system_prompt = v
+                        .get("append_system_prompt")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    let env = str_map(v.get("env"));
+                    Ok(RoleConfig {
+                        name,
+                        description,
+                        permissions: RolePermissions {
+                            permission_mode,
+                            allowed_tools,
+                            disallowed_tools,
+                            tools,
+                            append_system_prompt,
+                            env,
+                        },
+                    })
+                })
+                .collect::<Result<_, _>>()?;
+            db.replace_global_roles(&roles)
+                .map_err(|e| format!("replace_global_roles: {e}"))?;
+            Ok(serde_json::to_value(&roles).map_err(|e| e.to_string())?)
+        }
+    }
+}
+
+fn str_vec(v: Option<&Value>) -> Vec<String> {
+    v.and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn str_map(v: Option<&Value>) -> std::collections::HashMap<String, String> {
+    v.and_then(Value::as_object)
+        .map(|o| {
+            o.iter()
+                .filter_map(|(k, val)| val.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    #[test]
+    fn list_returns_empty_array_when_no_roles() {
+        let db = db();
+        let v = run(Action::List, &db).unwrap();
+        assert!(v.is_array(), "got {v}");
+        assert_eq!(v.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn list_returns_seeded_role() {
+        let db = db();
+        let role = RoleConfig {
+            name: "dev".into(),
+            description: "developer".into(),
+            permissions: RolePermissions {
+                permission_mode: Some("plan".into()),
+                ..RolePermissions::default()
+            },
+        };
+        db.replace_global_roles(&[role]).unwrap();
+        let v = run(Action::List, &db).unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"].as_str(), Some("dev"));
+        assert_eq!(arr[0]["description"].as_str(), Some("developer"));
+    }
+}

--- a/src/cli/scheduled.rs
+++ b/src/cli/scheduled.rs
@@ -1,0 +1,131 @@
+//! Scheduled-command CRUD subcommands.
+
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+use crate::session::{ScheduledCommand, SessionId};
+use crate::storage::Database;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// Schedule a command.
+    Create {
+        /// Session UUID.
+        #[arg(long)]
+        session: String,
+        /// Unix-millisecond timestamp at which to send.
+        #[arg(long)]
+        at: u64,
+        /// Command text to type into the terminal.
+        #[arg(long)]
+        command: String,
+    },
+    /// List pending commands (optionally filtered by session).
+    List {
+        /// Optional session UUID filter.
+        #[arg(long)]
+        session: Option<String>,
+    },
+    /// Get a scheduled command by ID.
+    Get {
+        /// Command ID.
+        id: i64,
+    },
+    /// Cancel a pending scheduled command.
+    Cancel {
+        /// Command ID.
+        id: i64,
+    },
+}
+
+pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+    match action {
+        Action::Create {
+            session,
+            at,
+            command,
+        } => {
+            let session_id: SessionId = session
+                .parse()
+                .map_err(|_| format!("Invalid session UUID: {session}"))?;
+            let info = db
+                .get_session_by_id(session_id)
+                .map_err(|e| format!("get_session_by_id: {e}"))?
+                .ok_or_else(|| format!("Session not found: {session}"))?;
+            if command.is_empty() {
+                return Err("command must not be empty".into());
+            }
+            let now = crate::sync::current_time_millis();
+            if at <= now {
+                return Err("at must be in the future (unix millis)".into());
+            }
+            let id = db
+                .create_scheduled_command(session_id, &command, at)
+                .map_err(|e| format!("create_scheduled_command: {e}"))?;
+            let db_path = crate::paths::database_file()
+                .ok_or_else(|| "Cannot resolve database path".to_string())?;
+            let delay_secs = at.saturating_sub(now) / 1000;
+            if let Err(e) = crate::agent::tmux::schedule_tmux_command(
+                &info.name, &command, delay_secs, id, &db_path,
+            ) {
+                eprintln!("warning: failed to set tmux timer for command {id}: {e}");
+            }
+            let cmd = ScheduledCommand {
+                id,
+                session_id,
+                command_text: command,
+                scheduled_at: at,
+                created_at: now,
+                executed_at: None,
+                cancelled_at: None,
+            };
+            Ok(scheduled_to_json(&cmd))
+        }
+        Action::List { session } => {
+            let cmds = db
+                .list_pending_scheduled_commands()
+                .map_err(|e| format!("list_pending_scheduled_commands: {e}"))?;
+            let filtered: Vec<_> = if let Some(s) = session {
+                let id: SessionId = s
+                    .parse()
+                    .map_err(|_| format!("Invalid session UUID: {s}"))?;
+                cmds.into_iter().filter(|c| c.session_id == id).collect()
+            } else {
+                cmds
+            };
+            Ok(Value::Array(
+                filtered.iter().map(scheduled_to_json).collect(),
+            ))
+        }
+        Action::Get { id } => {
+            let cmd = db
+                .get_scheduled_command(id)
+                .map_err(|e| format!("get_scheduled_command: {e}"))?
+                .ok_or_else(|| format!("Scheduled command not found: {id}"))?;
+            Ok(scheduled_to_json(&cmd))
+        }
+        Action::Cancel { id } => match db.cancel_scheduled_command(id) {
+            Ok(true) => Ok(json!({ "cancelled": true, "id": id })),
+            Ok(false) => Err("Command not found or already executed/cancelled".into()),
+            Err(e) => Err(format!("cancel_scheduled_command: {e}")),
+        },
+    }
+}
+
+fn scheduled_to_json(cmd: &ScheduledCommand) -> Value {
+    let status = if cmd.cancelled_at.is_some() {
+        "cancelled"
+    } else if cmd.executed_at.is_some() {
+        "executed"
+    } else {
+        "pending"
+    };
+    json!({
+        "id": cmd.id,
+        "session_id": cmd.session_id.to_string(),
+        "command_text": cmd.command_text,
+        "scheduled_at": cmd.scheduled_at,
+        "created_at": cmd.created_at,
+        "status": status,
+    })
+}

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -1,0 +1,297 @@
+//! Session CRUD and orchestration subcommands.
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+use crate::session::SessionId;
+use crate::storage::Database;
+use crate::sync::SharedSession;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// List all active sessions.
+    List,
+    /// Get a session by UUID.
+    Get {
+        /// Session UUID.
+        uuid: String,
+    },
+    /// Create a new session (runs synchronously — tmux window live on return).
+    Create {
+        /// Session name (1-64 chars, no slashes or leading '.').
+        #[arg(long)]
+        name: String,
+        /// Absolute path to the repository or working directory.
+        #[arg(long)]
+        repo_path: PathBuf,
+        /// Optional role name (falls back to the default developer role).
+        #[arg(long)]
+        role: Option<String>,
+        /// If set, create a git worktree on this branch off --base-branch.
+        #[arg(long)]
+        worktree_branch: Option<String>,
+        /// Base branch for the worktree (default: main).
+        #[arg(long)]
+        base_branch: Option<String>,
+        /// Attach a global MCP server by name (repeatable).
+        #[arg(long = "mcp-server")]
+        mcp_servers: Vec<String>,
+        /// Stage a global skill by name (repeatable).
+        #[arg(long = "skill")]
+        skills: Vec<String>,
+    },
+    /// Soft-delete a session.
+    Delete {
+        /// Session UUID.
+        uuid: String,
+    },
+    /// Restore a soft-deleted session.
+    Restore {
+        /// Session UUID.
+        uuid: String,
+    },
+    /// Restart a session in-place (kills the window, re-spawns with --resume).
+    Restart {
+        /// Session UUID.
+        uuid: String,
+    },
+    /// Type text into a session's terminal, followed by Enter.
+    Send {
+        /// Session UUID.
+        uuid: String,
+        /// Text to send.
+        text: String,
+    },
+    /// Capture rendered pane contents as text.
+    Capture {
+        /// Session UUID.
+        uuid: String,
+        /// Scrollback lines to include (default 200, max 10000).
+        #[arg(long, default_value_t = 200)]
+        lines: u32,
+    },
+}
+
+pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+    match action {
+        Action::List => {
+            let sessions = db
+                .list_active_sessions()
+                .map_err(|e| format!("list_active_sessions: {e}"))?;
+            Ok(Value::Array(
+                sessions.iter().map(shared_session_to_json).collect(),
+            ))
+        }
+        Action::Get { uuid } => {
+            let session = resolve(db, &uuid)?;
+            Ok(shared_session_to_json(&session))
+        }
+        Action::Create {
+            name,
+            repo_path,
+            role,
+            worktree_branch,
+            base_branch,
+            mcp_servers,
+            skills,
+        } => {
+            let req = crate::session_ops::SpawnRequest {
+                name,
+                repo_path,
+                worktree_branch,
+                base_branch,
+                role,
+                mcp_servers,
+                skills,
+                agent_session_id: None,
+            };
+            let res = crate::session_ops::spawn_session_headless(db, req)?;
+            Ok(json!({
+                "id": res.session_id.to_string(),
+                "name": res.name,
+                "role": res.role,
+                "agent_session_id": res.agent_session_id,
+                "cwd": res.cwd.display().to_string(),
+            }))
+        }
+        Action::Delete { uuid } => {
+            let session = resolve(db, &uuid)?;
+            db.soft_delete_session(session.id)
+                .map_err(|e| format!("soft_delete_session: {e}"))?;
+            Ok(json!({
+                "deleted": true,
+                "id": session.id.to_string(),
+                "name": session.name,
+            }))
+        }
+        Action::Restore { uuid } => {
+            let id: SessionId = uuid
+                .parse()
+                .map_err(|_| format!("Invalid session UUID: {uuid}"))?;
+            let deleted = db
+                .get_deleted_session_by_id(id)
+                .map_err(|e| format!("get_deleted_session_by_id: {e}"))?
+                .ok_or_else(|| format!("Deleted session not found: {uuid}"))?;
+            db.restore_session(deleted.id)
+                .map_err(|e| format!("restore_session: {e}"))?;
+            Ok(json!({
+                "restored": true,
+                "id": deleted.id.to_string(),
+                "name": deleted.name,
+            }))
+        }
+        Action::Restart { uuid } => {
+            let session = resolve(db, &uuid)?;
+            crate::session_ops::restart_session_headless(db, session.id)?;
+            Ok(json!({
+                "restarted": true,
+                "session_id": session.id.to_string(),
+                "session_name": session.name,
+            }))
+        }
+        Action::Send { uuid, text } => {
+            let session = resolve(db, &uuid)?;
+            if text.is_empty() {
+                return Err("text must not be empty".into());
+            }
+            crate::agent::tmux::send_prompt_now(&session.name, &text)
+                .map_err(|e| format!("send_prompt_now: {e}"))?;
+            Ok(json!({
+                "sent": true,
+                "session_id": session.id.to_string(),
+                "session_name": session.name,
+            }))
+        }
+        Action::Capture { uuid, lines } => {
+            let session = resolve(db, &uuid)?;
+            let output = crate::agent::tmux::capture_pane_text(&session.name, lines)
+                .map_err(|e| format!("capture_pane_text: {e}"))?;
+            Ok(json!({
+                "session_id": session.id.to_string(),
+                "session_name": session.name,
+                "lines": lines,
+                "output": output,
+            }))
+        }
+    }
+}
+
+fn resolve(db: &Database, uuid: &str) -> Result<SharedSession, String> {
+    let id: SessionId = uuid
+        .parse()
+        .map_err(|_| format!("Invalid session UUID: {uuid}"))?;
+    db.get_session_by_id(id)
+        .map_err(|e| format!("get_session_by_id: {e}"))?
+        .ok_or_else(|| format!("Session not found: {uuid}"))
+}
+
+fn shared_session_to_json(s: &SharedSession) -> Value {
+    json!({
+        "id": s.id.to_string(),
+        "name": s.name,
+        "role": s.role,
+        "backend_type": s.backend_type,
+        "agent_session_id": s.agent_session_id,
+        "cwd": s.cwd.as_ref().map(|p| p.display().to_string()),
+        "worktrees": s.worktrees.iter().map(|w| json!({
+            "repo_path": w.repo_path.display().to_string(),
+            "worktree_path": w.worktree_path.display().to_string(),
+            "branch": w.branch,
+        })).collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn db() -> Database {
+        Database::open_in_memory().unwrap()
+    }
+
+    #[test]
+    fn list_empty_returns_array() {
+        let db = db();
+        let v = run(Action::List, &db).unwrap();
+        assert!(v.is_array(), "got {v}");
+        assert_eq!(v.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn list_returns_session_with_expected_shape() {
+        let db = db();
+        let id = SessionId::default();
+        let shared = SharedSession {
+            id,
+            name: "demo".into(),
+            role: "dev".into(),
+            backend_id: "tb-demo".into(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: Some("agent-1".into()),
+            cwd: Some(std::path::PathBuf::from("/tmp/repo")),
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        db.upsert_session(&shared).unwrap();
+
+        let v = run(Action::List, &db).unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let s = &arr[0];
+        assert_eq!(s["id"].as_str(), Some(id.to_string().as_str()));
+        assert_eq!(s["name"].as_str(), Some("demo"));
+        assert_eq!(s["role"].as_str(), Some("dev"));
+        assert_eq!(s["backend_type"].as_str(), Some("local-tmux"));
+        assert_eq!(s["agent_session_id"].as_str(), Some("agent-1"));
+        assert_eq!(s["cwd"].as_str(), Some("/tmp/repo"));
+        assert!(s["worktrees"].is_array());
+    }
+
+    #[test]
+    fn get_unknown_uuid_errors() {
+        let db = db();
+        let err = run(
+            Action::Get {
+                uuid: "not-a-uuid".into(),
+            },
+            &db,
+        )
+        .unwrap_err();
+        assert!(err.contains("Invalid session UUID"), "got {err}");
+    }
+
+    #[test]
+    fn send_rejects_empty_text() {
+        let db = db();
+        let id = SessionId::default();
+        let shared = SharedSession {
+            id,
+            name: "demo".into(),
+            role: "dev".into(),
+            backend_id: "tb-demo".into(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        db.upsert_session(&shared).unwrap();
+        let err = run(
+            Action::Send {
+                uuid: id.to_string(),
+                text: String::new(),
+            },
+            &db,
+        )
+        .unwrap_err();
+        assert!(err.contains("text"), "got {err}");
+    }
+}

--- a/src/cli/vm_images.rs
+++ b/src/cli/vm_images.rs
@@ -1,0 +1,109 @@
+//! VM image management subcommands.
+
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+use super::validate_safe_name;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// List downloaded VM images.
+    List,
+    /// Download a VM image from an HTTPS URL.
+    Download {
+        /// HTTPS URL to download from.
+        url: String,
+        /// Filename to save as (default: derived from URL).
+        #[arg(long)]
+        filename: Option<String>,
+    },
+    /// Delete a cached VM image.
+    Delete {
+        /// Filename of the image to delete.
+        filename: String,
+    },
+}
+
+pub fn run(action: Action) -> Result<Value, String> {
+    match action {
+        Action::List => {
+            let dir = crate::paths::images_directory()
+                .ok_or_else(|| "Could not resolve images directory".to_string())?;
+            if !dir.exists() {
+                return Ok(Value::Array(Vec::new()));
+            }
+            let entries = std::fs::read_dir(&dir)
+                .map_err(|e| format!("Failed to read images directory: {e}"))?;
+            let mut images = Vec::new();
+            for entry in entries.flatten() {
+                if entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+                    let filename = entry.file_name().to_string_lossy().to_string();
+                    if filename.ends_with(".partial") {
+                        continue;
+                    }
+                    let size_bytes = entry.metadata().map(|m| m.len()).unwrap_or(0);
+                    images.push(json!({ "filename": filename, "size_bytes": size_bytes }));
+                }
+            }
+            images.sort_by_key(|v| v["filename"].as_str().unwrap_or("").to_string());
+            Ok(Value::Array(images))
+        }
+        Action::Download { url, filename } => {
+            if !url.starts_with("https://") {
+                return Err("Only HTTPS URLs are allowed".into());
+            }
+            let filename = match filename {
+                Some(f) => {
+                    validate_safe_name(&f)?;
+                    f
+                }
+                None => {
+                    let f = url
+                        .rsplit('/')
+                        .next()
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.split('?').next().unwrap_or(s).to_string())
+                        .ok_or_else(|| {
+                            "Cannot derive filename from URL; provide --filename".to_string()
+                        })?;
+                    validate_safe_name(&f)?;
+                    f
+                }
+            };
+            let dir = crate::paths::images_directory()
+                .ok_or_else(|| "Could not resolve images directory".to_string())?;
+            std::fs::create_dir_all(&dir)
+                .map_err(|e| format!("Failed to create images directory: {e}"))?;
+            let partial = dir.join(format!("{filename}.partial"));
+            let final_path = dir.join(&filename);
+            let result = std::process::Command::new("curl")
+                .args(["-fSL", "--output", &partial.to_string_lossy(), &url])
+                .output()
+                .map_err(|e| format!("Failed to run curl: {e}"))?;
+            if !result.status.success() {
+                let _ = std::fs::remove_file(&partial);
+                return Err(format!(
+                    "Download failed: {}",
+                    String::from_utf8_lossy(&result.stderr)
+                ));
+            }
+            std::fs::rename(&partial, &final_path).map_err(|e| {
+                let _ = std::fs::remove_file(&partial);
+                format!("Failed to finalize download: {e}")
+            })?;
+            let size = std::fs::metadata(&final_path).map(|m| m.len()).unwrap_or(0);
+            Ok(json!({ "filename": filename, "size_bytes": size }))
+        }
+        Action::Delete { filename } => {
+            validate_safe_name(&filename)?;
+            let dir = crate::paths::images_directory()
+                .ok_or_else(|| "Could not resolve images directory".to_string())?;
+            let path = dir.join(&filename);
+            if !path.is_file() {
+                return Err(format!("Image not found: {filename}"));
+            }
+            std::fs::remove_file(&path).map_err(|e| format!("Failed to delete image: {e}"))?;
+            Ok(json!({ "deleted": true, "filename": filename }))
+        }
+    }
+}

--- a/src/cli/vms.rs
+++ b/src/cli/vms.rs
@@ -1,0 +1,45 @@
+//! VM read-only subcommands.
+
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+use crate::storage::vms::VmRecord;
+use crate::storage::Database;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// List all VMs.
+    List,
+    /// Get a VM by UUID.
+    Get {
+        /// VM UUID.
+        uuid: String,
+    },
+}
+
+pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+    match action {
+        Action::List => {
+            let vms = db.list_vms().map_err(|e| format!("list_vms: {e}"))?;
+            Ok(Value::Array(vms.iter().map(vm_to_json).collect()))
+        }
+        Action::Get { uuid } => match db.get_vm(&uuid).map_err(|e| format!("get_vm: {e}"))? {
+            Some(vm) => Ok(vm_to_json(&vm)),
+            None => Err(format!("VM not found: {uuid}")),
+        },
+    }
+}
+
+fn vm_to_json(r: &VmRecord) -> Value {
+    json!({
+        "id": r.id,
+        "session_id": r.session_id,
+        "state": r.state.to_string(),
+        "ssh_port": r.ssh_port,
+        "base_image": r.base_image,
+        "cpus": r.cpus,
+        "memory_mb": r.memory_mb,
+        "disk_gb": r.disk_gb,
+        "error_msg": r.error_msg,
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,13 @@
 
 pub mod agent;
 pub mod app;
+pub mod cli;
 pub(crate) mod fuzzy;
 pub mod git;
 pub mod mcp;
 pub mod paths;
 pub mod session;
+pub mod session_ops;
 pub mod storage;
 pub mod sync;
 pub mod ui;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -445,39 +445,16 @@ impl ThurboxMcp {
 
     #[tool(description = "List all Containerfile templates with their files")]
     fn list_containerfile_templates(&self) -> String {
-        let dir = match crate::paths::containerfiles_directory() {
-            Some(d) => d,
-            None => return error_json("Could not resolve containerfiles directory"),
-        };
-
-        if !dir.exists() {
-            return json_text(&Vec::<ContainerfileTemplateSummary>::new());
-        }
-
-        let mut templates = Vec::new();
-        let entries = match std::fs::read_dir(&dir) {
-            Ok(e) => e,
-            Err(e) => return error_json(&format!("Failed to read directory: {e}")),
-        };
-
-        for entry in entries.flatten() {
-            if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
-                continue;
+        match crate::paths::list_containerfile_templates() {
+            Ok(rows) => {
+                let templates: Vec<ContainerfileTemplateSummary> = rows
+                    .into_iter()
+                    .map(|(name, files)| ContainerfileTemplateSummary { name, files })
+                    .collect();
+                json_text(&templates)
             }
-            let name = entry.file_name().to_string_lossy().to_string();
-            let mut files = Vec::new();
-            if let Ok(children) = std::fs::read_dir(entry.path()) {
-                for child in children.flatten() {
-                    if child.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
-                        files.push(child.file_name().to_string_lossy().to_string());
-                    }
-                }
-            }
-            files.sort();
-            templates.push(ContainerfileTemplateSummary { name, files });
+            Err(e) => error_json(&e),
         }
-        templates.sort_by(|a, b| a.name.cmp(&b.name));
-        json_text(&templates)
     }
 
     #[tool(description = "Get a Containerfile template's content and list its support files")]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -279,7 +279,7 @@ impl ThurboxMcp {
     }
 
     #[tool(
-        description = "Restart a session by queuing a restart command. The TUI will process the command and restart the session with its existing Claude session ID."
+        description = "Restart a session in-place — kills its tmux window and re-spawns the claude CLI with --resume. Runs synchronously; the session is live once this returns."
     )]
     fn restart_session(&self, Parameters(params): Parameters<RestartSessionParams>) -> String {
         let db = self.db.lock().unwrap();
@@ -288,22 +288,21 @@ impl ThurboxMcp {
             Err(e) => return e,
         };
 
-        match db.enqueue_session_command(session.id, "restart") {
-            Ok(command_id) => serde_json::json!({
-                "queued": true,
-                "command_id": command_id,
+        match crate::session_ops::restart_session_headless(&db, session.id) {
+            Ok(()) => serde_json::json!({
+                "restarted": true,
                 "session_id": session.id.to_string(),
                 "session_name": session.name,
             })
             .to_string(),
-            Err(e) => error_json(&e.to_string()),
+            Err(e) => error_json(&e),
         }
     }
 
     // ── Orchestrator Tools ────────────────────────────────────
 
     #[tool(
-        description = "Create a new local-tmux session programmatically. Optionally creates a git worktree off a base branch. The session spawn is queued via the session command queue; poll `list_sessions` or `get_session` with the returned UUID until the session appears. Returns `{id, name, queued: true}`."
+        description = "Create a new local-tmux session programmatically. Runs synchronously — by the time this returns, the tmux window is live and the session row is in the database. Optionally creates a git worktree off a base branch. Returns `{id, name, agent_session_id, cwd}`."
     )]
     fn create_session(&self, Parameters(params): Parameters<CreateSessionParams>) -> String {
         if let Err(e) = validate_safe_name(&params.name) {
@@ -312,30 +311,29 @@ impl ThurboxMcp {
         if params.repo_path.is_empty() {
             return error_json("repo_path must not be empty");
         }
-        // Generate the session UUID up front so we can return it immediately.
-        let session_id = SessionId::default();
-        let payload = serde_json::json!({
-            "name": params.name,
-            "repo_path": params.repo_path,
-            "role": params.role,
-            "worktree_branch": params.worktree_branch,
-            "base_branch": params.base_branch,
-            "mcp_servers": params.mcp_servers,
-            "skills": params.skills,
-            "agent_session_id": session_id.to_string(),
-        });
-        let command = format!("spawn:{}", payload);
+
+        let req = crate::session_ops::SpawnRequest {
+            name: params.name.clone(),
+            repo_path: std::path::PathBuf::from(&params.repo_path),
+            worktree_branch: params.worktree_branch,
+            base_branch: params.base_branch,
+            role: params.role,
+            mcp_servers: params.mcp_servers,
+            skills: params.skills,
+            agent_session_id: None,
+        };
 
         let db = self.db.lock().unwrap();
-        match db.enqueue_session_command(session_id, &command) {
-            Ok(command_id) => serde_json::json!({
-                "queued": true,
-                "command_id": command_id,
-                "session_id": session_id.to_string(),
-                "name": params.name,
+        match crate::session_ops::spawn_session_headless(&db, req) {
+            Ok(res) => serde_json::json!({
+                "id": res.session_id.to_string(),
+                "name": res.name,
+                "role": res.role,
+                "agent_session_id": res.agent_session_id,
+                "cwd": res.cwd.display().to_string(),
             })
             .to_string(),
-            Err(e) => error_json(&e.to_string()),
+            Err(e) => error_json(&e),
         }
     }
 
@@ -1300,7 +1298,13 @@ mod tests {
     }
 
     #[test]
-    fn restart_session_queues_command() {
+    fn restart_session_resolves_session_synchronously() {
+        // Headless restart runs inline rather than enqueuing a command.
+        // In environments without a live tmux server the tmux call fails,
+        // which surfaces as a JSON `{"error": ...}` — but crucially the
+        // handler no longer returns `queued: true`. We also verify that
+        // unknown session IDs are reported as such (see
+        // `restart_session_not_found`).
         let server = test_server();
         let sid = insert_test_session(&server);
 
@@ -1308,16 +1312,11 @@ mod tests {
             session: sid.to_string(),
         }));
         let v = parse_json(&result);
-        assert_eq!(v["queued"], true);
-        assert_eq!(v["session_id"], sid.to_string());
-        assert!(v["command_id"].as_i64().unwrap() > 0);
-
-        // Verify command exists in DB
-        let db = server.db.lock().unwrap();
-        let cmds = db.pending_session_commands().unwrap();
-        assert_eq!(cmds.len(), 1);
-        assert_eq!(cmds[0].command, "restart");
-        assert_eq!(cmds[0].session_id, sid);
+        assert!(v.get("queued").is_none(), "should not enqueue any more");
+        // Either the restart succeeded (tmux available) or it surfaced a
+        // synchronous error — never a `queued` response.
+        let has_result = v.get("restarted").is_some() || v.get("error").is_some();
+        assert!(has_result, "expected restarted or error, got {v}");
     }
 
     // ── Restore session tests ────────────────────────────────────

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -292,6 +292,60 @@ pub fn containerfiles_directory() -> Option<PathBuf> {
     resolve(PathKind::ContainerfilesDir)
 }
 
+/// Validate that `name` is a safe single-segment identifier — non-empty,
+/// no dot-prefix, no slashes / backslashes / `..`, max 64 chars. Shared by
+/// `session_ops::spawn`, the MCP `create_session` tool, and CLI commands
+/// that name on-disk resources (VM images, Containerfile templates).
+pub fn validate_safe_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Name cannot be empty".into());
+    }
+    if name.len() > 64 {
+        return Err("Name too long (max 64 characters)".into());
+    }
+    if name.starts_with('.') {
+        return Err("Name cannot start with '.'".into());
+    }
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        return Err("Name contains invalid characters".into());
+    }
+    Ok(())
+}
+
+/// List Containerfile templates on disk as `(name, files)` pairs sorted by name.
+///
+/// Returns an empty vector when the directory doesn't exist. Used by the MCP
+/// `list_containerfile_templates` tool and the `thurbox-cli containerfile list`
+/// subcommand so both share the same scan logic.
+pub fn list_containerfile_templates() -> Result<Vec<(String, Vec<String>)>, String> {
+    let Some(dir) = containerfiles_directory() else {
+        return Err("Could not resolve containerfiles directory".into());
+    };
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let entries = std::fs::read_dir(&dir).map_err(|e| format!("Failed to read directory: {e}"))?;
+    let mut templates = Vec::new();
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        let mut files = Vec::new();
+        if let Ok(children) = std::fs::read_dir(entry.path()) {
+            for child in children.flatten() {
+                if child.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+                    files.push(child.file_name().to_string_lossy().to_string());
+                }
+            }
+        }
+        files.sort();
+        templates.push((name, files));
+    }
+    templates.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(templates)
+}
+
 /// Resolve the VM images directory path.
 ///
 /// Returns: `$XDG_DATA_HOME/thurbox/admin/images/` or

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -1,0 +1,45 @@
+//! Headless session operations — spawn and restart sessions without the TUI.
+//!
+//! Callers (MCP, CLI) use these helpers to drive the same local-tmux-backed
+//! sessions the TUI manages, without requiring the TUI event loop. All
+//! operations are synchronous against the SQLite database and the `tmux -L
+//! thurbox` server.
+
+pub mod restart;
+pub mod spawn;
+
+pub use restart::restart_session_headless;
+pub use spawn::{spawn_session_headless, SpawnRequest, SpawnResult};
+
+use crate::session::SessionConfig;
+
+/// Build the (command, args) invocation for the default `ClaudeProvider`
+/// from a fully populated [`SessionConfig`].
+///
+/// Centralised here so spawn and restart agree on the args and so the
+/// `<P as AgentProvider>::method(&p, ...)` turbofish lives in one place.
+fn build_claude_invocation(config: &SessionConfig) -> (String, Vec<String>) {
+    let provider = crate::agent::claude::ClaudeProvider;
+    type P = crate::agent::claude::ClaudeProvider;
+    let command = <P as crate::agent::provider::AgentProvider>::command(&provider).to_string();
+    let args = <P as crate::agent::provider::AgentProvider>::build_args(&provider, config);
+    (command, args)
+}
+
+/// Inject the standard thurbox env hints (`THURBOX_SESSION_ID`,
+/// `THURBOX_METRICS_DIR`) into a session config.
+///
+/// Mirrors `App::do_spawn_session` so headless and TUI sessions look
+/// identical to the spawned process.
+fn inject_thurbox_env(config: &mut SessionConfig, agent_session_id: &str) {
+    config
+        .permissions
+        .env
+        .insert("THURBOX_SESSION_ID".into(), agent_session_id.into());
+    if let Some(dir) = crate::paths::metrics_directory() {
+        config
+            .permissions
+            .env
+            .insert("THURBOX_METRICS_DIR".into(), dir.to_string_lossy().into());
+    }
+}

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -1,0 +1,74 @@
+//! Headless session restart — tears down the tmux window and re-launches
+//! the claude CLI with `--resume <agent_session_id>`.
+
+use crate::session::{
+    default_developer_permissions, RolePermissions, SessionConfig, SessionId, DEFAULT_ROLE_NAME,
+};
+use crate::storage::Database;
+
+/// Restart an existing session in-place — kills its tmux window and
+/// re-spawns the claude CLI with `--resume <agent_session_id>`.
+///
+/// MCP servers + skills are intentionally not re-attached on restart — the
+/// TUI has the same behaviour (see `App::handle_restart_command`). Delete
+/// and recreate the session to change attached configuration.
+pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<(), String> {
+    let session = db
+        .get_session_by_id(session_id)
+        .map_err(|e| format!("Failed to load session: {e}"))?
+        .ok_or_else(|| format!("Session not found: {session_id}"))?;
+
+    let agent_session_id = session
+        .agent_session_id
+        .clone()
+        .ok_or_else(|| format!("Cannot restart session {session_id} without agent_session_id"))?;
+
+    let permissions = lookup_role_permissions(db, &session.role)?;
+
+    let mut config = SessionConfig {
+        resume_session_id: Some(agent_session_id.clone()),
+        agent_session_id: Some(agent_session_id.clone()),
+        cwd: session.cwd.clone(),
+        additional_dirs: session.additional_dirs.clone(),
+        role: session.role.clone(),
+        permissions,
+        mcp_servers: Vec::new(),
+        skills: Vec::new(),
+        ..SessionConfig::default()
+    };
+    super::inject_thurbox_env(&mut config, &agent_session_id);
+
+    let (command, args) = super::build_claude_invocation(&config);
+
+    crate::agent::tmux::kill_window(&session.name)
+        .map_err(|e| format!("Failed to kill tmux window: {e}"))?;
+    crate::agent::tmux::spawn_window(
+        &session.name,
+        &command,
+        &args,
+        config.cwd.as_deref(),
+        &config.permissions.env,
+    )
+    .map_err(|e| format!("Failed to re-spawn tmux window: {e}"))?;
+
+    Ok(())
+}
+
+/// Look up permissions for `role_name`, falling back to the seeded default
+/// developer role (or empty permissions for any other unknown role).
+fn lookup_role_permissions(db: &Database, role_name: &str) -> Result<RolePermissions, String> {
+    let global_roles = db
+        .list_global_roles()
+        .map_err(|e| format!("Failed to load roles: {e}"))?;
+    Ok(global_roles
+        .iter()
+        .find(|r| r.name == role_name)
+        .map(|r| r.permissions.clone())
+        .unwrap_or_else(|| {
+            if role_name == DEFAULT_ROLE_NAME {
+                default_developer_permissions()
+            } else {
+                RolePermissions::default()
+            }
+        }))
+}

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -118,22 +118,10 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     })
 }
 
-/// Validate a session name — same rules as the MCP `validate_safe_name`
-/// guard so both code paths reject the same inputs.
+/// Validate a session name. Delegates to the shared `paths::validate_safe_name`
+/// so MCP and CLI reject the same inputs.
 fn validate_session_name(name: &str) -> Result<(), String> {
-    if name.is_empty() {
-        return Err("Name cannot be empty".into());
-    }
-    if name.len() > 64 {
-        return Err("Name too long (max 64 characters)".into());
-    }
-    if name.starts_with('.') {
-        return Err("Name cannot start with '.'".into());
-    }
-    if name.contains('/') || name.contains('\\') || name.contains("..") {
-        return Err("Name contains invalid characters".into());
-    }
-    Ok(())
+    crate::paths::validate_safe_name(name)
 }
 
 /// Resolve a role name to its concrete permissions.

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -1,0 +1,314 @@
+//! Headless session spawn — creates a local-tmux session without requiring
+//! the TUI event loop.
+
+use std::path::PathBuf;
+
+use crate::session::{
+    default_developer_permissions, McpServerConfig, RolePermissions, SessionConfig, SessionId,
+    SkillConfig, DEFAULT_ROLE_NAME,
+};
+use crate::storage::Database;
+use crate::sync::{SharedSession, SharedWorktree};
+
+/// Default base branch for `--worktree-branch` when none is given.
+const DEFAULT_BASE_BRANCH: &str = "main";
+
+/// Backend identifier for the local-tmux backend (matches `LocalTmuxBackend`).
+const LOCAL_TMUX_BACKEND_TYPE: &str = "local-tmux";
+
+/// Request to create a new headless session.
+#[derive(Debug, Clone)]
+pub struct SpawnRequest {
+    /// Session name (used for the tmux window `tb-<name>`).
+    pub name: String,
+    /// Directory the claude process should `cd` into.
+    pub repo_path: PathBuf,
+    /// Optional branch name — when set, a git worktree is created at
+    /// `repo_path/worktrees/<name>` and used as the cwd instead of
+    /// `repo_path` itself.
+    pub worktree_branch: Option<String>,
+    /// Base branch to create the worktree from (default `main`).
+    pub base_branch: Option<String>,
+    /// Optional role name — falls back to the default developer role.
+    pub role: Option<String>,
+    /// Names of global MCP servers to attach to the session.
+    pub mcp_servers: Vec<String>,
+    /// Names of global skills to stage into the session.
+    pub skills: Vec<String>,
+    /// Optional pre-generated agent session UUID. When unset one is generated
+    /// so callers can return it to the user immediately.
+    pub agent_session_id: Option<String>,
+}
+
+/// Result returned on successful headless spawn.
+#[derive(Debug, Clone)]
+pub struct SpawnResult {
+    pub session_id: SessionId,
+    pub name: String,
+    pub role: String,
+    pub agent_session_id: String,
+    pub cwd: PathBuf,
+    pub worktrees: Vec<SharedWorktree>,
+}
+
+/// Spawn a new session inside `tmux -L thurbox`, persisting its state to the
+/// shared SQLite database.
+pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnResult, String> {
+    validate_session_name(&req.name)?;
+
+    let (role_name, permissions) = resolve_role(db, req.role.as_deref())?;
+    let (mcp_servers, skills) = resolve_attachments(db, &req.mcp_servers, &req.skills)?;
+    let (cwd, worktrees) = resolve_cwd(&req)?;
+
+    let agent_session_id = req
+        .agent_session_id
+        .clone()
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    let mut config = SessionConfig {
+        agent_session_id: Some(agent_session_id.clone()),
+        cwd: Some(cwd.clone()),
+        role: role_name.clone(),
+        permissions,
+        mcp_servers,
+        skills,
+        ..SessionConfig::default()
+    };
+    super::inject_thurbox_env(&mut config, &agent_session_id);
+
+    let (command, args) = super::build_claude_invocation(&config);
+
+    crate::agent::tmux::spawn_window(
+        &req.name,
+        &command,
+        &args,
+        Some(&cwd),
+        &config.permissions.env,
+    )
+    .map_err(|e| format!("Failed to spawn tmux window: {e}"))?;
+
+    let session_id = SessionId::default();
+    let shared = SharedSession {
+        id: session_id,
+        name: req.name.clone(),
+        role: role_name.clone(),
+        // No pane_id is available without control mode; the window-target
+        // string is stored so the TUI can re-discover the live pane on its
+        // next startup.
+        backend_id: format!("{}{}", crate::agent::tmux::WINDOW_PREFIX, req.name),
+        backend_type: LOCAL_TMUX_BACKEND_TYPE.to_string(),
+        agent_session_id: Some(agent_session_id.clone()),
+        cwd: Some(cwd.clone()),
+        additional_dirs: Vec::new(),
+        worktrees: worktrees.clone(),
+        shell_backend_id: None,
+        tombstone: false,
+        tombstone_at: None,
+    };
+    db.upsert_session(&shared)
+        .map_err(|e| format!("Failed to persist session: {e}"))?;
+
+    Ok(SpawnResult {
+        session_id,
+        name: req.name,
+        role: role_name,
+        agent_session_id,
+        cwd,
+        worktrees,
+    })
+}
+
+/// Validate a session name — same rules as the MCP `validate_safe_name`
+/// guard so both code paths reject the same inputs.
+fn validate_session_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Name cannot be empty".into());
+    }
+    if name.len() > 64 {
+        return Err("Name too long (max 64 characters)".into());
+    }
+    if name.starts_with('.') {
+        return Err("Name cannot start with '.'".into());
+    }
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        return Err("Name contains invalid characters".into());
+    }
+    Ok(())
+}
+
+/// Resolve a role name to its concrete permissions.
+///
+/// Falls back to the single configured role (if exactly one exists) or to the
+/// seeded developer role otherwise — same precedence as the TUI.
+fn resolve_role(
+    db: &Database,
+    requested: Option<&str>,
+) -> Result<(String, RolePermissions), String> {
+    let global_roles = db
+        .list_global_roles()
+        .map_err(|e| format!("Failed to load roles: {e}"))?;
+
+    if let Some(name) = requested.filter(|n| !n.is_empty()) {
+        let perms = global_roles
+            .iter()
+            .find(|r| r.name == name)
+            .map(|r| r.permissions.clone())
+            .unwrap_or_else(|| default_permissions_for(name));
+        return Ok((name.to_string(), perms));
+    }
+
+    Ok(match global_roles.as_slice() {
+        [only] => (only.name.clone(), only.permissions.clone()),
+        _ => (
+            DEFAULT_ROLE_NAME.to_string(),
+            default_developer_permissions(),
+        ),
+    })
+}
+
+fn default_permissions_for(role_name: &str) -> RolePermissions {
+    if role_name == DEFAULT_ROLE_NAME {
+        default_developer_permissions()
+    } else {
+        RolePermissions::default()
+    }
+}
+
+/// Filter the global MCP-server / skill lists to those the request asks for.
+fn resolve_attachments(
+    db: &Database,
+    wanted_servers: &[String],
+    wanted_skills: &[String],
+) -> Result<(Vec<McpServerConfig>, Vec<SkillConfig>), String> {
+    let mcp_servers = db
+        .list_global_mcp_servers()
+        .map_err(|e| format!("Failed to load MCP servers: {e}"))?
+        .into_iter()
+        .filter(|s| wanted_servers.iter().any(|n| n == &s.name))
+        .collect();
+
+    let skills = db
+        .list_global_skills()
+        .map_err(|e| format!("Failed to load skills: {e}"))?
+        .into_iter()
+        .filter(|s| wanted_skills.iter().any(|n| n == &s.name))
+        .collect();
+
+    Ok((mcp_servers, skills))
+}
+
+/// Resolve the working directory and worktree records.
+///
+/// Returns the bare repo path when no worktree branch is given; otherwise
+/// creates the worktree and returns its path plus a single
+/// [`SharedWorktree`] entry.
+fn resolve_cwd(req: &SpawnRequest) -> Result<(PathBuf, Vec<SharedWorktree>), String> {
+    let Some(branch) = req.worktree_branch.as_deref() else {
+        return Ok((req.repo_path.clone(), Vec::new()));
+    };
+    let base_branch = req.base_branch.as_deref().unwrap_or(DEFAULT_BASE_BRANCH);
+    let path = crate::git::create_worktree(&req.repo_path, branch, base_branch)
+        .map_err(|e| format!("Failed to create worktree {branch} off {base_branch}: {e}"))?;
+    let wt = SharedWorktree {
+        repo_path: req.repo_path.clone(),
+        worktree_path: path.clone(),
+        branch: branch.to_string(),
+    };
+    Ok((path, vec![wt]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::RoleConfig;
+    use crate::storage::Database;
+
+    fn empty_db() -> Database {
+        Database::open_in_memory().expect("open in-memory db")
+    }
+
+    #[test]
+    fn empty_name_is_rejected() {
+        let db = empty_db();
+        let req = SpawnRequest {
+            name: String::new(),
+            repo_path: PathBuf::from("/tmp"),
+            worktree_branch: None,
+            base_branch: None,
+            role: None,
+            mcp_servers: Vec::new(),
+            skills: Vec::new(),
+            agent_session_id: None,
+        };
+        let err = spawn_session_headless(&db, req).unwrap_err();
+        assert!(err.to_lowercase().contains("name"), "got {err}");
+    }
+
+    #[test]
+    fn unsafe_names_are_rejected() {
+        let db = empty_db();
+        for bad in [".hidden", "foo/bar", "foo..bar", "foo\\bar"] {
+            let req = SpawnRequest {
+                name: bad.into(),
+                repo_path: PathBuf::from("/tmp"),
+                worktree_branch: None,
+                base_branch: None,
+                role: None,
+                mcp_servers: Vec::new(),
+                skills: Vec::new(),
+                agent_session_id: None,
+            };
+            assert!(
+                spawn_session_headless(&db, req).is_err(),
+                "should reject {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_role_falls_back_to_default_developer() {
+        let db = empty_db();
+        let (name, perms) = resolve_role(&db, None).unwrap();
+        assert_eq!(name, DEFAULT_ROLE_NAME);
+        // Default developer role has a non-default permission_mode set.
+        assert_eq!(
+            perms.permission_mode,
+            default_developer_permissions().permission_mode
+        );
+    }
+
+    #[test]
+    fn resolve_role_prefers_single_existing_role() {
+        let db = empty_db();
+        let role = RoleConfig {
+            name: "solo".into(),
+            description: String::new(),
+            permissions: RolePermissions::default(),
+        };
+        db.replace_global_roles(&[role]).unwrap();
+        let (name, _) = resolve_role(&db, None).unwrap();
+        assert_eq!(name, "solo");
+    }
+
+    #[test]
+    fn resolve_role_uses_explicit_match() {
+        let db = empty_db();
+        let r1 = RoleConfig {
+            name: "alpha".into(),
+            description: String::new(),
+            permissions: RolePermissions {
+                permission_mode: Some("plan".into()),
+                ..RolePermissions::default()
+            },
+        };
+        let r2 = RoleConfig {
+            name: "beta".into(),
+            description: String::new(),
+            permissions: RolePermissions::default(),
+        };
+        db.replace_global_roles(&[r1, r2]).unwrap();
+        let (name, perms) = resolve_role(&db, Some("alpha")).unwrap();
+        assert_eq!(name, "alpha");
+        assert_eq!(perms.permission_mode.as_deref(), Some("plan"));
+    }
+}

--- a/tests/architecture_rules.rs
+++ b/tests/architecture_rules.rs
@@ -136,6 +136,33 @@ fn mcp_module_isolation() {
 }
 
 #[test]
+fn session_ops_module_isolation() {
+    let module_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/session_ops");
+    // session_ops must not pull in TUI state or the PTY-attached backend.
+    // It talks to tmux through the narrow helpers in `agent::tmux` via
+    // fully-qualified paths (not `use`), same pattern as the mcp module.
+    let violations = check_no_imports(&module_dir, &["app", "ui", "agent"]);
+    assert!(
+        violations.is_empty(),
+        "{}",
+        format_violations("session_ops", &violations)
+    );
+}
+
+#[test]
+fn cli_module_isolation() {
+    let module_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/cli");
+    // cli is a thin argument parser — must not depend on TUI or the live
+    // session backend. Tmux helpers are reached via fully-qualified paths.
+    let violations = check_no_imports(&module_dir, &["app", "ui", "agent"]);
+    assert!(
+        violations.is_empty(),
+        "{}",
+        format_violations("cli", &violations)
+    );
+}
+
+#[test]
 fn app_module_structure() {
     // Verify that app/ module can be split into multiple files
     // Each file should maintain proper module organization


### PR DESCRIPTION
## Summary

- New `thurbox-cli` binary mirrors the `thurbox-mcp` tool surface as shell subcommands, usable without a running TUI
- Refactors `create_session` / `restart_session` to execute inline against tmux + DB (no more queueing for the TUI event loop); MCP and CLI now return final state synchronously
- New `session_ops` module (headless `spawn`, `restart`) extracted from `App` handlers; new `agent::tmux::{spawn_window, kill_window}` helpers
- TUI restore-fallback paths now use `--session-id` instead of `--resume` so claude creates the conversation when none exists yet (fixes "No conversation found" when adopting a CLI-created session for the first time)
- Architecture rules enforce `cli` and `session_ops` isolation
- Bumps `rustls-webpki` to 0.103.12 (RUSTSEC-2026-0098)

## Test plan

- [x] `cargo build --bin thurbox-cli --bin thurbox-mcp`
- [x] `cargo nextest run --all` — 839/839 pass (18 new)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --test architecture_rules` — 9/9 pass
- [ ] Manual: `thurbox-cli session create` → start TUI → session adopted cleanly (no "No conversation found")
- [ ] Manual: `thurbox-cli schedule create --at <now+10s>` delivers text to the target tmux window without TUI running