### PR TITLE
feat(ui): add right-side file viewer panel with search

### DIFF
--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -201,7 +201,7 @@ impl App {
                     return;
                 }
                 KeyCode::Char('d') => match self.focus {
-                    InputFocus::SessionList => {
+                    InputFocus::SessionList | InputFocus::FileViewer => {
                         self.close_active_session();
                         return;
                     }
@@ -257,10 +257,7 @@ impl App {
                 // Vim navigation: h=cycle-left, j=down, k=up, l=cycle-right
                 KeyCode::Char('h') => {
                     self.clear_search();
-                    self.focus = match self.focus {
-                        InputFocus::SessionList => InputFocus::Terminal,
-                        InputFocus::Terminal => InputFocus::SessionList,
-                    };
+                    self.focus = self.cycle_focus_backward();
                     return;
                 }
                 KeyCode::Char('j') => {
@@ -273,10 +270,7 @@ impl App {
                 }
                 KeyCode::Char('l') => {
                     self.clear_search();
-                    self.focus = match self.focus {
-                        InputFocus::SessionList => InputFocus::Terminal,
-                        InputFocus::Terminal => InputFocus::SessionList,
-                    };
+                    self.focus = self.cycle_focus_forward();
                     return;
                 }
                 _ => {}
@@ -293,12 +287,115 @@ impl App {
                 self.show_info_panel = !self.show_info_panel;
                 return;
             }
+            KeyCode::F(3) => {
+                self.show_file_viewer = !self.show_file_viewer;
+                if self.show_file_viewer {
+                    self.rebuild_file_viewer_for_active();
+                } else if self.focus == InputFocus::FileViewer {
+                    self.focus = InputFocus::SessionList;
+                }
+                return;
+            }
             _ => {}
         }
 
         match self.focus {
             InputFocus::SessionList => self.handle_session_list_key(code),
             InputFocus::Terminal => self.handle_terminal_key(code, mods),
+            InputFocus::FileViewer => self.handle_file_viewer_key(code, mods),
+        }
+    }
+
+    /// Cycle focus forward (Ctrl+L). Skips FileViewer when not visible.
+    fn cycle_focus_forward(&self) -> InputFocus {
+        match self.focus {
+            InputFocus::SessionList => InputFocus::Terminal,
+            InputFocus::Terminal => {
+                if self.show_file_viewer {
+                    InputFocus::FileViewer
+                } else {
+                    InputFocus::SessionList
+                }
+            }
+            InputFocus::FileViewer => InputFocus::SessionList,
+        }
+    }
+
+    /// Cycle focus backward (Ctrl+H). Skips FileViewer when not visible.
+    fn cycle_focus_backward(&self) -> InputFocus {
+        match self.focus {
+            InputFocus::SessionList => {
+                if self.show_file_viewer {
+                    InputFocus::FileViewer
+                } else {
+                    InputFocus::Terminal
+                }
+            }
+            InputFocus::Terminal => InputFocus::SessionList,
+            InputFocus::FileViewer => InputFocus::Terminal,
+        }
+    }
+
+    fn handle_file_viewer_key(&mut self, code: KeyCode, mods: KeyModifiers) {
+        if self.file_viewer.search_active {
+            self.handle_file_viewer_search_key(code, mods);
+        } else {
+            self.handle_file_viewer_nav_key(code);
+        }
+    }
+
+    fn handle_file_viewer_search_key(&mut self, code: KeyCode, mods: KeyModifiers) {
+        let ctrl = mods.contains(KeyModifiers::CONTROL);
+        match code {
+            KeyCode::Esc => self.file_viewer.end_search(),
+            // Enter/Down cycle to next match and stay in search mode.
+            // Tab commits and exits search mode.
+            KeyCode::Enter | KeyCode::Down => self.file_viewer.next_match(),
+            KeyCode::Up => self.file_viewer.prev_match(),
+            KeyCode::Tab => self.file_viewer.search_active = false,
+            KeyCode::Char('n') if ctrl => self.file_viewer.next_match(),
+            KeyCode::Char('p') if ctrl => self.file_viewer.prev_match(),
+            KeyCode::Backspace => self.file_viewer.search_pop(),
+            KeyCode::Char(c) if !ctrl => self.file_viewer.search_push(c),
+            _ => {}
+        }
+    }
+
+    fn handle_file_viewer_nav_key(&mut self, code: KeyCode) {
+        use crate::ui::file_viewer::Activation;
+        match code {
+            KeyCode::Char('/') => self.file_viewer.start_search(),
+            KeyCode::Char('n') => self.file_viewer.next_match(),
+            KeyCode::Char('N') => self.file_viewer.prev_match(),
+            KeyCode::Esc if !self.file_viewer.search_query.is_empty() => {
+                self.file_viewer.end_search();
+            }
+            KeyCode::Char('j') | KeyCode::Down => self.file_viewer.move_selection(1),
+            KeyCode::Char('k') | KeyCode::Up => self.file_viewer.move_selection(-1),
+            KeyCode::Char('h') | KeyCode::Left => self.file_viewer.collapse(),
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Enter => {
+                // Capture root+file before activate() (activate only opens files, not dirs).
+                let file_with_root = self.file_viewer.selected_file_with_root();
+                if matches!(self.file_viewer.activate(), Activation::Open(_)) {
+                    if let Some((file, root)) = file_with_root {
+                        self.open_file_in_editor(root, file);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn open_file_in_editor(&mut self, root: std::path::PathBuf, file: std::path::PathBuf) {
+        let Some(editor) = super::helpers::resolve_editor_command(&self.db) else {
+            self.set_status(
+                super::StatusLevel::Error,
+                "No editor configured — set `editor_command` via MCP or $VISUAL / $EDITOR.",
+            );
+            return;
+        };
+        if let Err(e) = super::helpers::open_in_editor(&[root, file], &editor) {
+            warn!("file viewer: failed to open editor: {e}");
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -414,6 +414,7 @@ pub struct StatusMessage {
 pub enum InputFocus {
     SessionList,
     Terminal,
+    FileViewer,
 }
 
 /// Which pane the terminal view is showing for a given session.
@@ -469,6 +470,8 @@ pub struct App {
     pub(crate) terminal_cols: u16,
     session_counter: usize,
     pub(crate) show_info_panel: bool,
+    pub(crate) show_file_viewer: bool,
+    pub(crate) file_viewer: crate::ui::file_viewer::FileViewerState,
     pub(crate) modal: modals::Modal,
     // (Delete project, add project, edit project modal state is now in self.modal)
     pub(crate) pending_repo_path: Option<PathBuf>,
@@ -622,6 +625,9 @@ pub(crate) struct EditorSnapshot {
     pub fields: Vec<String>,
 }
 
+const EDITOR_NOT_CONFIGURED: &str =
+    "No editor configured — set `editor_command` via MCP or export $EDITOR/$VISUAL";
+
 impl App {
     pub fn new(
         rows: u16,
@@ -680,6 +686,8 @@ impl App {
             terminal_cols: cols,
             session_counter,
             show_info_panel: false,
+            show_file_viewer: false,
+            file_viewer: crate::ui::file_viewer::FileViewerState::new(),
             modal: modals::Modal::None,
             pending_repo_path: None,
             pending_all_repos: None,
@@ -1272,11 +1280,46 @@ impl App {
 
     /// Open the active session's worktree (or cwd) in the configured editor.
     fn open_active_in_editor(&mut self) {
+        if self.try_open_selected_file() {
+            return;
+        }
+        let paths = match self.collect_active_session_paths() {
+            Some(p) => p,
+            None => return,
+        };
+        self.launch_editor_with_paths(&paths);
+    }
+
+    /// If the file viewer is focused on a file, open `[root, file]` so editors
+    /// open the workspace and highlight the file. Returns true if handled.
+    fn try_open_selected_file(&mut self) -> bool {
+        if self.focus != InputFocus::FileViewer {
+            return false;
+        }
+        let Some((file, root)) = self.file_viewer.selected_file_with_root() else {
+            return false;
+        };
+        let Some(editor) = helpers::resolve_editor_command(&self.db) else {
+            self.set_error(EDITOR_NOT_CONFIGURED);
+            return true;
+        };
+        match helpers::open_in_editor(&[root, file.clone()], &editor) {
+            Ok(()) => self.set_info(format!(
+                "Opening {} in {editor}",
+                file.file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_default()
+            )),
+            Err(e) => self.set_error(format!("Failed to launch editor `{editor}`: {e}")),
+        }
+        true
+    }
+
+    fn collect_active_session_paths(&mut self) -> Option<Vec<std::path::PathBuf>> {
         let Some(session) = self.sessions.get(self.active_index) else {
             self.set_error("No active session");
-            return;
+            return None;
         };
-
         let mut paths: Vec<std::path::PathBuf> = Vec::new();
         for wt in &session.info.worktrees {
             if !paths.contains(&wt.worktree_path) {
@@ -1293,21 +1336,19 @@ impl App {
                 paths.push(dir.clone());
             }
         }
-
         if paths.is_empty() {
             self.set_error("Active session has no worktree or cwd to open");
-            return;
+            return None;
         }
+        Some(paths)
+    }
 
+    fn launch_editor_with_paths(&mut self, paths: &[std::path::PathBuf]) {
         let Some(editor) = helpers::resolve_editor_command(&self.db) else {
-            self.set_error(
-                "No editor configured — set `editor_command` via MCP or \
-                 export $EDITOR/$VISUAL",
-            );
+            self.set_error(EDITOR_NOT_CONFIGURED);
             return;
         };
-
-        match helpers::open_in_editor(&paths, &editor) {
+        match helpers::open_in_editor(paths, &editor) {
             Ok(()) => self.set_info(format!("Opening {} path(s) in {editor}", paths.len())),
             Err(e) => self.set_error(format!("Failed to launch editor `{editor}`: {e}")),
         }
@@ -1649,7 +1690,7 @@ impl App {
         use crate::ui::links;
 
         let area = Rect::new(0, 0, self.terminal_cols, self.terminal_rows);
-        let areas = layout::compute_layout(area, self.show_info_panel);
+        let areas = layout::compute_layout(area, self.show_info_panel, self.show_file_viewer);
         let border_block = Block::default().borders(Borders::ALL);
 
         // Ctrl+Click: URL opening (terminal-relative, existing behavior)
@@ -2742,6 +2783,17 @@ impl App {
         // Detach from backend sessions without killing them — they persist in tmux.
         for session in self.sessions {
             session.detach();
+        }
+    }
+
+    /// Rebuild the file viewer tree from the currently active session's
+    /// worktrees and additional directories. Called when the active session
+    /// changes or when the file viewer is first opened.
+    pub(crate) fn rebuild_file_viewer_for_active(&mut self) {
+        if let Some(session) = self.sessions.get(self.active_index) {
+            self.file_viewer.rebuild_from_session(&session.info);
+        } else {
+            self.file_viewer.clear();
         }
     }
 
@@ -4156,7 +4208,8 @@ impl App {
 
     pub(crate) fn content_area_size(&self) -> (u16, u16) {
         let area = Rect::new(0, 0, self.terminal_cols, self.terminal_rows);
-        let terminal = layout::compute_layout(area, self.show_info_panel).terminal;
+        let terminal =
+            layout::compute_layout(area, self.show_info_panel, self.show_file_viewer).terminal;
         let inner = Block::default().borders(Borders::ALL).inner(terminal);
         (inner.height, inner.width)
     }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -15,17 +15,18 @@ use crate::session::SessionInfo;
 use crate::ui::selection;
 use crate::ui::theme::Theme;
 use crate::ui::{
-    branch_selector_modal, containerfile_picker, info_panel, layout, mcp_server_picker_modal,
-    project_list, restore_sessions_modal, role_editor_modal, role_selector_modal,
-    schedule_command_modal, scheduled_commands_list_modal, session_mode_modal, session_name_modal,
-    skill_picker_modal, status_bar, terminal_view, worktree_name_modal,
+    branch_selector_modal, containerfile_picker, file_viewer, info_panel, layout,
+    mcp_server_picker_modal, project_list, restore_sessions_modal, role_editor_modal,
+    role_selector_modal, schedule_command_modal, scheduled_commands_list_modal, session_mode_modal,
+    session_name_modal, skill_picker_modal, status_bar, terminal_view, worktree_name_modal,
 };
 
 use super::{App, InputFocus, TerminalView};
 
 impl App {
     pub fn view(&mut self, frame: &mut Frame) {
-        let areas = layout::compute_layout(frame.area(), self.show_info_panel);
+        let areas =
+            layout::compute_layout(frame.area(), self.show_info_panel, self.show_file_viewer);
 
         status_bar::render_header(frame, areas.header);
 
@@ -56,7 +57,7 @@ impl App {
             use crate::ui::FocusLevel;
             let list_focus = match self.focus {
                 InputFocus::SessionList => FocusLevel::Focused,
-                InputFocus::Terminal => FocusLevel::Active,
+                InputFocus::Terminal | InputFocus::FileViewer => FocusLevel::Active,
             };
 
             let match_count = self
@@ -134,10 +135,26 @@ impl App {
             }
         }
 
+        // File viewer (right column)
+        if let Some(fv_area) = areas.file_viewer {
+            if let Some(session) = self.sessions.get(self.active_index) {
+                if self.file_viewer.needs_rebuild_for(&session.info) {
+                    self.file_viewer.rebuild_from_session(&session.info);
+                }
+            } else {
+                self.file_viewer.clear();
+            }
+            let fv_focus = match self.focus {
+                InputFocus::FileViewer => crate::ui::FocusLevel::Focused,
+                _ => crate::ui::FocusLevel::Inactive,
+            };
+            file_viewer::render_file_viewer(frame, fv_area, &self.file_viewer, fv_focus);
+        }
+
         // Terminal
         let terminal_focus = match self.focus {
             InputFocus::Terminal => crate::ui::FocusLevel::Focused,
-            InputFocus::SessionList => crate::ui::FocusLevel::Active,
+            InputFocus::SessionList | InputFocus::FileViewer => crate::ui::FocusLevel::Active,
         };
         let is_shell_view = self.active_terminal_view() == TerminalView::Shell;
         match self.sessions.get(self.active_index) {
@@ -168,6 +185,7 @@ impl App {
             InputFocus::SessionList => "Sessions",
             InputFocus::Terminal if is_shell_view => "Shell",
             InputFocus::Terminal => "Terminal",
+            InputFocus::FileViewer => "Files",
         };
         status_bar::render_footer(
             frame,
@@ -183,6 +201,7 @@ impl App {
                 container_provisioning_step: &self.container_provisioning_step,
                 tick_count: self.tick_count,
                 pending_scheduled_count: self.cached_pending_commands.len(),
+                file_viewer_open: self.show_file_viewer,
             },
         );
 
@@ -560,6 +579,21 @@ fn render_help_overlay(frame: &mut Frame) {
         help_line("Ctrl+T", "Toggle shell pane"),
         help_line("F1", "Toggle keybindings help"),
         help_line("F2", "Toggle info panel"),
+        help_line("F3", "Toggle file viewer"),
+        help_line("Ctrl+L/H", "Cycle focus (includes file viewer when open)"),
+        help_line("j/k", "File viewer: move down/up (when focused)"),
+        help_line("h", "File viewer: collapse / parent"),
+        help_line("l / Enter", "File viewer: expand dir / open file in editor"),
+        help_line("/", "File viewer: start search"),
+        help_line(
+            "Enter / \u{2193}",
+            "In search: jump to next match (stays in search)",
+        ),
+        help_line("\u{2191}", "In search: previous match"),
+        help_line("Tab", "In search: commit & exit search mode"),
+        help_line("Esc", "In search: cancel and clear query"),
+        help_line("n / N", "After search: next / previous match"),
+        help_line("Ctrl+O", "On file viewer: open project with file focused"),
         help_line("Ctrl+Q", "Quit"),
         Line::from(""),
         help_section("List Navigation (when focused)"),

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -1,0 +1,879 @@
+//! Right-side file viewer panel.
+//!
+//! Displays an expandable tree of every worktree and additional directory
+//! associated with the active session. Selection is flat (one visible row
+//! at a time), and callers drive navigation through [`FileViewerState`]
+//! helpers. File I/O (reading directory entries) is performed lazily when a
+//! folder is expanded.
+
+use std::path::{Path, PathBuf};
+
+use ratatui::{
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::{focus_block, theme::Theme, FocusLevel};
+use crate::session::SessionInfo;
+
+/// One node in the tree. `children = None` means "not yet expanded"; an
+/// empty `Some(vec![])` means "expanded but empty".
+pub struct FileNode {
+    pub path: PathBuf,
+    pub is_dir: bool,
+    pub expanded: bool,
+    pub children: Option<Vec<FileNode>>,
+}
+
+impl FileNode {
+    fn new_dir(path: PathBuf) -> Self {
+        Self {
+            path,
+            is_dir: true,
+            expanded: false,
+            children: None,
+        }
+    }
+}
+
+/// Paths that should appear as roots for the given session: every worktree,
+/// then every additional dir, falling back to `cwd` if both are empty.
+fn expected_root_paths(info: &SessionInfo) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = info
+        .worktrees
+        .iter()
+        .map(|w| w.worktree_path.clone())
+        .chain(info.additional_dirs.iter().cloned())
+        .collect();
+    if out.is_empty() {
+        if let Some(cwd) = &info.cwd {
+            out.push(cwd.clone());
+        }
+    }
+    out
+}
+
+/// Result of activating the currently-selected row.
+pub enum Activation {
+    /// A file was activated — caller should open it in the editor.
+    Open(PathBuf),
+    /// A directory was toggled (expanded or collapsed).
+    Toggled,
+    /// Nothing was done (empty tree, out-of-bounds, etc.).
+    NoOp,
+}
+
+/// One flattened visible row. Depth drives indentation; `index_path` is the
+/// traversal path into `roots` (sequence of child indices).
+struct FlatRow {
+    index_path: Vec<usize>,
+    depth: usize,
+    label: String,
+    is_dir: bool,
+    expanded: bool,
+}
+
+pub struct FileViewerState {
+    roots: Vec<FileNode>,
+    selected: usize,
+    pub search_active: bool,
+    pub search_query: String,
+    pub search_cursor: usize,
+}
+
+/// Maximum nodes traversed per search to keep typing responsive.
+const SEARCH_NODE_LIMIT: usize = 5000;
+/// Maximum directory depth traversed per search.
+const SEARCH_DEPTH_LIMIT: usize = 6;
+
+impl FileViewerState {
+    pub fn new() -> Self {
+        Self {
+            roots: Vec::new(),
+            selected: 0,
+            search_active: false,
+            search_query: String::new(),
+            search_cursor: 0,
+        }
+    }
+
+    /// Enter search mode. Preserves current selection.
+    pub fn start_search(&mut self) {
+        self.search_active = true;
+        self.search_query.clear();
+        self.search_cursor = 0;
+    }
+
+    /// Exit search mode, keeping selection.
+    pub fn end_search(&mut self) {
+        self.search_active = false;
+        self.search_query.clear();
+        self.search_cursor = 0;
+    }
+
+    /// Append a char to the query and jump selection to the first match.
+    pub fn search_push(&mut self, c: char) {
+        self.search_query.push(c);
+        self.search_cursor = self.search_query.chars().count();
+        self.expand_for_search();
+        self.jump_to_first_match();
+    }
+
+    /// Backspace in the query.
+    pub fn search_pop(&mut self) {
+        self.search_query.pop();
+        self.search_cursor = self.search_query.chars().count();
+        if !self.search_query.is_empty() {
+            self.expand_for_search();
+        }
+        self.jump_to_first_match();
+    }
+
+    /// Count flat rows currently matching the query.
+    pub fn match_count(&self) -> usize {
+        if self.search_query.is_empty() {
+            return 0;
+        }
+        let q = self.search_query.to_lowercase();
+        self.flatten()
+            .iter()
+            .filter(|r| r.label.to_lowercase().contains(&q))
+            .count()
+    }
+
+    /// 1-based index of the currently selected row among matches, or 0 if
+    /// selection is not on a match or query is empty.
+    pub fn current_match_index(&self) -> usize {
+        if self.search_query.is_empty() {
+            return 0;
+        }
+        let q = self.search_query.to_lowercase();
+        let rows = self.flatten();
+        let mut idx = 0;
+        for (i, row) in rows.iter().enumerate() {
+            if row.label.to_lowercase().contains(&q) {
+                idx += 1;
+                if i == self.selected {
+                    return idx;
+                }
+            }
+        }
+        0
+    }
+
+    /// Walk roots (bounded) and auto-expand ancestors of any node whose name
+    /// matches the current query. Reads directories lazily.
+    fn expand_for_search(&mut self) {
+        if self.search_query.is_empty() {
+            return;
+        }
+        let q = self.search_query.to_lowercase();
+        let mut budget = SEARCH_NODE_LIMIT;
+        for root in &mut self.roots {
+            expand_matches(root, &q, 0, &mut budget);
+            if budget == 0 {
+                break;
+            }
+        }
+    }
+
+    /// Cycle to the next match (wrapping), starting after the current selection.
+    pub fn next_match(&mut self) {
+        self.step_match(true);
+    }
+
+    /// Cycle to the previous match (wrapping), starting before the current selection.
+    pub fn prev_match(&mut self) {
+        self.step_match(false);
+    }
+
+    fn step_match(&mut self, forward: bool) {
+        if self.search_query.is_empty() {
+            return;
+        }
+        let rows = self.flatten();
+        if rows.is_empty() {
+            return;
+        }
+        let q = self.search_query.to_lowercase();
+        let n = rows.len();
+        let start = self.selected;
+        for offset in 1..=n {
+            let i = if forward {
+                (start + offset) % n
+            } else {
+                (start + n - offset) % n
+            };
+            if rows[i].label.to_lowercase().contains(&q) {
+                self.selected = i;
+                return;
+            }
+        }
+    }
+
+    fn jump_to_first_match(&mut self) {
+        if self.search_query.is_empty() {
+            return;
+        }
+        let rows = self.flatten();
+        let q = self.search_query.to_lowercase();
+        if let Some((i, _)) = rows
+            .iter()
+            .enumerate()
+            .find(|(_, r)| r.label.to_lowercase().contains(&q))
+        {
+            self.selected = i;
+        }
+    }
+
+    /// Return the selected file path along with its root worktree path.
+    /// Returns `None` if selection is a directory or out of bounds.
+    pub fn selected_file_with_root(&self) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+        let rows = self.flatten();
+        let row = rows.get(self.selected)?;
+        let index_path = &row.index_path;
+        let root_idx = *index_path.first()?;
+        let root = self.roots.get(root_idx)?;
+        let mut node = root;
+        for idx in &index_path[1..] {
+            node = node.children.as_ref()?.get(*idx)?;
+        }
+        if node.is_dir {
+            return None;
+        }
+        Some((node.path.clone(), root.path.clone()))
+    }
+
+    /// Rebuild roots from the active session's worktrees + additional_dirs.
+    /// Selection is reset to 0.
+    pub fn rebuild_from_session(&mut self, info: &SessionInfo) {
+        self.roots = expected_root_paths(info)
+            .into_iter()
+            .map(FileNode::new_dir)
+            .collect();
+        self.selected = 0;
+    }
+
+    pub fn clear(&mut self) {
+        self.roots.clear();
+        self.selected = 0;
+    }
+
+    /// Return true if the current roots don't match the session's expected roots.
+    /// Used by the render layer to rebuild lazily when the active session changes.
+    pub fn needs_rebuild_for(&self, info: &SessionInfo) -> bool {
+        let expected = expected_root_paths(info);
+        if self.roots.len() != expected.len() {
+            return true;
+        }
+        self.roots
+            .iter()
+            .zip(expected.iter())
+            .any(|(root, exp)| root.path != *exp)
+    }
+
+    fn flatten(&self) -> Vec<FlatRow> {
+        let mut out = Vec::new();
+        for (i, root) in self.roots.iter().enumerate() {
+            push_flat(root, vec![i], 0, &mut out, true);
+        }
+        out
+    }
+
+    pub fn move_selection(&mut self, delta: i32) {
+        let len = self.flatten().len();
+        if len == 0 {
+            self.selected = 0;
+            return;
+        }
+        let next = (self.selected as i32 + delta).clamp(0, len as i32 - 1);
+        self.selected = next as usize;
+    }
+
+    /// Activate the current row: toggle directory expansion or return a file to open.
+    pub fn activate(&mut self) -> Activation {
+        let rows = self.flatten();
+        let Some(row) = rows.get(self.selected) else {
+            return Activation::NoOp;
+        };
+        let index_path = row.index_path.clone();
+        let Some(node) = traverse_mut(&mut self.roots, &index_path) else {
+            return Activation::NoOp;
+        };
+        if node.is_dir {
+            if node.expanded {
+                node.expanded = false;
+            } else {
+                if node.children.is_none() {
+                    node.children = Some(read_dir_sorted(&node.path));
+                }
+                node.expanded = true;
+            }
+            Activation::Toggled
+        } else {
+            Activation::Open(node.path.clone())
+        }
+    }
+
+    /// Collapse the selected directory (or jump up to parent if selection is a file or a closed dir).
+    pub fn collapse(&mut self) {
+        let rows = self.flatten();
+        let Some(row) = rows.get(self.selected) else {
+            return;
+        };
+        let index_path = row.index_path.clone();
+        if let Some(node) = traverse_mut(&mut self.roots, &index_path) {
+            if node.is_dir && node.expanded {
+                node.expanded = false;
+                return;
+            }
+        }
+        // Else: move selection up one level (parent)
+        if index_path.len() > 1 {
+            let parent_path = &index_path[..index_path.len() - 1];
+            let new_rows = self.flatten();
+            if let Some((i, _)) = new_rows
+                .iter()
+                .enumerate()
+                .find(|(_, r)| r.index_path.as_slice() == parent_path)
+            {
+                self.selected = i;
+            }
+        }
+    }
+}
+
+impl Default for FileViewerState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn push_flat(
+    node: &FileNode,
+    index_path: Vec<usize>,
+    depth: usize,
+    out: &mut Vec<FlatRow>,
+    is_root: bool,
+) {
+    let label = if is_root {
+        // Show a shortened path for roots (last 2 components)
+        short_root_label(&node.path)
+    } else {
+        node.path
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| node.path.to_string_lossy().into_owned())
+    };
+    out.push(FlatRow {
+        index_path: index_path.clone(),
+        depth,
+        label,
+        is_dir: node.is_dir,
+        expanded: node.expanded,
+    });
+    if node.is_dir && node.expanded {
+        if let Some(children) = &node.children {
+            for (i, child) in children.iter().enumerate() {
+                let mut ip = index_path.clone();
+                ip.push(i);
+                push_flat(child, ip, depth + 1, out, false);
+            }
+        }
+    }
+}
+
+fn traverse_mut<'a>(roots: &'a mut [FileNode], index_path: &[usize]) -> Option<&'a mut FileNode> {
+    let (first, rest) = index_path.split_first()?;
+    let mut node = roots.get_mut(*first)?;
+    for idx in rest {
+        let children = node.children.as_mut()?;
+        node = children.get_mut(*idx)?;
+    }
+    Some(node)
+}
+
+/// Recursively walk `node` and auto-expand directories that contain any
+/// descendant whose name matches `q_lc`. Returns true if a match was found at
+/// or below `node`. Reads child directories on demand.
+fn expand_matches(node: &mut FileNode, q_lc: &str, depth: usize, budget: &mut usize) -> bool {
+    if *budget == 0 {
+        return false;
+    }
+    *budget -= 1;
+
+    let self_matches = node
+        .path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_lowercase().contains(q_lc))
+        .unwrap_or(false);
+
+    if !node.is_dir {
+        return self_matches;
+    }
+
+    if depth >= SEARCH_DEPTH_LIMIT {
+        return self_matches;
+    }
+
+    // Lazily load children on first search traversal.
+    if node.children.is_none() {
+        node.children = Some(read_dir_sorted(&node.path));
+    }
+
+    let mut child_match = false;
+    if let Some(children) = node.children.as_mut() {
+        for child in children.iter_mut() {
+            if expand_matches(child, q_lc, depth + 1, budget) {
+                child_match = true;
+            }
+            if *budget == 0 {
+                break;
+            }
+        }
+    }
+
+    if child_match {
+        node.expanded = true;
+    }
+    self_matches || child_match
+}
+
+fn short_root_label(path: &Path) -> String {
+    path.file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string_lossy().into_owned())
+}
+
+fn read_dir_sorted(path: &Path) -> Vec<FileNode> {
+    let mut entries: Vec<(PathBuf, bool, String)> = match std::fs::read_dir(path) {
+        Ok(iter) => iter
+            .filter_map(|e| e.ok())
+            .filter_map(|e| {
+                let name = e.file_name().to_string_lossy().into_owned();
+                if name.starts_with('.') {
+                    return None;
+                }
+                let is_dir = e.file_type().map(|t| t.is_dir()).unwrap_or(false);
+                Some((e.path(), is_dir, name))
+            })
+            .collect(),
+        Err(_) => return Vec::new(),
+    };
+    // Dirs first, then files; each sorted by name.
+    entries.sort_by(|a, b| match (a.1, b.1) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.2.to_lowercase().cmp(&b.2.to_lowercase()),
+    });
+    entries
+        .into_iter()
+        .map(|(p, is_dir, _)| FileNode {
+            path: p,
+            is_dir,
+            expanded: false,
+            children: None,
+        })
+        .collect()
+}
+
+pub fn render_file_viewer(
+    frame: &mut Frame,
+    area: Rect,
+    state: &FileViewerState,
+    focus: FocusLevel,
+) {
+    use ratatui::layout::{Constraint, Direction, Layout};
+
+    let search_visible = state.search_active || !state.search_query.is_empty();
+    let constraints: Vec<Constraint> = if search_visible {
+        vec![Constraint::Min(0), Constraint::Length(3)]
+    } else {
+        vec![Constraint::Min(0)]
+    };
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(area);
+    let list_outer = chunks[0];
+    let search_outer = if search_visible {
+        Some(chunks[1])
+    } else {
+        None
+    };
+
+    let block = focus_block(" Files ", focus);
+    let inner = block.inner(list_outer);
+    frame.render_widget(block, list_outer);
+
+    if let Some(sa) = search_outer {
+        render_search_bar(
+            frame,
+            sa,
+            &state.search_query,
+            state.search_active,
+            state.search_cursor,
+            state.current_match_index(),
+            state.match_count(),
+        );
+    }
+
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    let list_area = inner;
+
+    if state.roots.is_empty() {
+        let p = Paragraph::new(Line::from(Span::styled(
+            "No folders",
+            Style::default().fg(Theme::TEXT_MUTED),
+        )));
+        frame.render_widget(p, list_area);
+        return;
+    }
+
+    let rows = state.flatten();
+    let height = list_area.height as usize;
+    if height == 0 {
+        return;
+    }
+
+    let query_lc = if state.search_active && !state.search_query.is_empty() {
+        Some(state.search_query.to_lowercase())
+    } else {
+        None
+    };
+
+    let (start, end) = visible_window(rows.len(), state.selected, height);
+
+    let lines: Vec<Line> = rows[start..end]
+        .iter()
+        .enumerate()
+        .map(|(i, row)| build_row_line(row, start + i == state.selected, query_lc.as_deref()))
+        .collect();
+    frame.render_widget(Paragraph::new(lines), list_area);
+}
+
+fn row_marker(row: &FlatRow) -> &'static str {
+    match (row.is_dir, row.expanded) {
+        (true, true) => "▾ ",
+        (true, false) => "▸ ",
+        _ => "  ",
+    }
+}
+
+fn row_label_color(is_match: bool, is_dir: bool) -> ratatui::style::Color {
+    if !is_match {
+        Theme::TEXT_MUTED
+    } else if is_dir {
+        Theme::ACCENT
+    } else {
+        Theme::TEXT_PRIMARY
+    }
+}
+
+fn build_row_line(row: &FlatRow, selected: bool, query_lc: Option<&str>) -> Line<'static> {
+    let indent = "  ".repeat(row.depth);
+    let marker = row_marker(row);
+    let is_match = query_lc
+        .map(|q| row.label.to_lowercase().contains(q))
+        .unwrap_or(true);
+
+    let label_style = if selected {
+        Style::default()
+            .bg(Theme::SELECTION_BG)
+            .fg(Theme::SELECTION_FG)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        let mut s = Style::default().fg(row_label_color(is_match, row.is_dir));
+        if row.is_dir && is_match {
+            s = s.add_modifier(Modifier::BOLD);
+        }
+        s
+    };
+    let prefix_style = if selected {
+        Style::default()
+            .bg(Theme::SELECTION_BG)
+            .fg(Theme::SELECTION_FG)
+    } else {
+        Style::default().fg(Theme::TEXT_MUTED)
+    };
+
+    Line::from(vec![
+        Span::styled(format!("{indent}{marker}"), prefix_style),
+        Span::styled(row.label.clone(), label_style),
+    ])
+}
+
+fn render_search_bar(
+    frame: &mut Frame,
+    area: Rect,
+    query: &str,
+    is_active: bool,
+    cursor: usize,
+    current: usize,
+    total: usize,
+) {
+    use ratatui::widgets::{Block, Borders};
+
+    let style = if is_active {
+        Style::default().fg(Theme::SEARCH_BAR)
+    } else {
+        Style::default().fg(Theme::TEXT_MUTED)
+    };
+
+    let block = Block::default()
+        .title(Line::from(Span::styled(
+            search_title(query, current, total),
+            style,
+        )))
+        .borders(Borders::ALL)
+        .border_style(style);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let max_width = inner.width as usize;
+    if max_width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let prefix = "/ ";
+    let display_query = truncate_left(query, max_width.saturating_sub(prefix.len()));
+    let (before, after) = split_at_cursor(display_query, cursor);
+
+    let mut spans = vec![Span::styled(prefix, style), Span::styled(before, style)];
+    append_cursor_spans(&mut spans, after, is_active, style);
+
+    frame.render_widget(Paragraph::new(Line::from(spans)), inner);
+}
+
+fn search_title(query: &str, current: usize, total: usize) -> String {
+    if query.is_empty() {
+        " Search ".to_string()
+    } else if total == 0 {
+        " Search (no matches) ".to_string()
+    } else {
+        format!(" Search ({current}/{total}) ")
+    }
+}
+
+fn truncate_left(query: &str, budget: usize) -> &str {
+    if query.len() <= budget {
+        query
+    } else {
+        &query[query.len().saturating_sub(budget)..]
+    }
+}
+
+fn split_at_cursor(text: &str, cursor: usize) -> (&str, &str) {
+    if cursor > text.chars().count() {
+        return (text, "");
+    }
+    let byte_pos = text
+        .char_indices()
+        .nth(cursor)
+        .map(|(i, _)| i)
+        .unwrap_or(text.len());
+    (&text[..byte_pos], &text[byte_pos..])
+}
+
+fn append_cursor_spans<'a>(
+    spans: &mut Vec<Span<'a>>,
+    after: &'a str,
+    is_active: bool,
+    style: Style,
+) {
+    if !is_active {
+        spans.push(Span::styled(after, style));
+        return;
+    }
+    let first_len = after.chars().next().map_or(0, |c| c.len_utf8());
+    let cursor_char = if first_len == 0 {
+        " "
+    } else {
+        &after[..first_len]
+    };
+    spans.push(Span::styled(cursor_char, Theme::cursor()));
+    let rest = &after[first_len..];
+    if !rest.is_empty() {
+        spans.push(Span::styled(rest, style));
+    }
+}
+
+fn visible_window(total: usize, selected: usize, height: usize) -> (usize, usize) {
+    if total <= height {
+        return (0, total);
+    }
+    // Center-ish: keep selected in view with a small margin.
+    let margin = (height / 4).min(3);
+    let start = selected.saturating_sub(margin);
+    let start = start.min(total.saturating_sub(height));
+    let end = (start + height).min(total);
+    (start, end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{SessionInfo, WorktreeInfo};
+    use std::path::PathBuf;
+
+    fn sample_session() -> SessionInfo {
+        let mut info = SessionInfo::new("t".into());
+        info.worktrees.push(WorktreeInfo {
+            repo_path: PathBuf::from("/tmp/a"),
+            worktree_path: PathBuf::from("/tmp/a/wt"),
+            branch: "main".into(),
+        });
+        info.additional_dirs.push(PathBuf::from("/tmp/b"));
+        info
+    }
+
+    #[test]
+    fn rebuild_from_session_collects_worktrees_and_additional_dirs() {
+        let mut st = FileViewerState::new();
+        st.rebuild_from_session(&sample_session());
+        assert_eq!(st.roots.len(), 2);
+        assert_eq!(st.roots[0].path, PathBuf::from("/tmp/a/wt"));
+        assert_eq!(st.roots[1].path, PathBuf::from("/tmp/b"));
+    }
+
+    #[test]
+    fn move_selection_is_bounded() {
+        let mut st = FileViewerState::new();
+        st.rebuild_from_session(&sample_session());
+        st.move_selection(-5);
+        assert_eq!(st.selected, 0);
+        st.move_selection(100);
+        assert_eq!(st.selected, 1);
+    }
+
+    #[test]
+    fn activate_on_empty_is_noop() {
+        let mut st = FileViewerState::new();
+        assert!(matches!(st.activate(), Activation::NoOp));
+    }
+
+    #[test]
+    fn activate_on_missing_dir_toggles() {
+        // /nonexistent path: read_dir returns empty, but we still mark it expanded.
+        let mut info = SessionInfo::new("t".into());
+        info.additional_dirs
+            .push(PathBuf::from("/this-path-does-not-exist-xyz"));
+        let mut st = FileViewerState::new();
+        st.rebuild_from_session(&info);
+        match st.activate() {
+            Activation::Toggled => {}
+            _ => panic!("expected Toggled"),
+        }
+        assert!(st.roots[0].expanded);
+    }
+
+    #[test]
+    fn visible_window_fits_all_when_shorter_than_height() {
+        assert_eq!(visible_window(5, 0, 10), (0, 5));
+    }
+
+    #[test]
+    fn visible_window_scrolls_when_overflow() {
+        let (s, e) = visible_window(100, 50, 10);
+        assert!(s <= 50 && e > 50);
+        assert_eq!(e - s, 10);
+    }
+
+    #[test]
+    fn expected_root_paths_falls_back_to_cwd_when_empty() {
+        let mut info = SessionInfo::new("t".into());
+        info.cwd = Some(PathBuf::from("/tmp/only-cwd"));
+        let roots = expected_root_paths(&info);
+        assert_eq!(roots, vec![PathBuf::from("/tmp/only-cwd")]);
+    }
+
+    #[test]
+    fn expected_root_paths_ignores_cwd_when_worktrees_present() {
+        let mut info = sample_session();
+        info.cwd = Some(PathBuf::from("/tmp/cwd"));
+        let roots = expected_root_paths(&info);
+        assert_eq!(roots.len(), 2);
+        assert!(!roots.contains(&PathBuf::from("/tmp/cwd")));
+    }
+
+    #[test]
+    fn needs_rebuild_detects_root_changes() {
+        let mut st = FileViewerState::new();
+        st.rebuild_from_session(&sample_session());
+        assert!(!st.needs_rebuild_for(&sample_session()));
+
+        let mut other = SessionInfo::new("t".into());
+        other.additional_dirs.push(PathBuf::from("/tmp/different"));
+        assert!(st.needs_rebuild_for(&other));
+    }
+
+    #[test]
+    fn search_push_updates_cursor_and_query() {
+        let mut st = FileViewerState::new();
+        st.rebuild_from_session(&sample_session());
+        st.start_search();
+        st.search_push('a');
+        st.search_push('b');
+        assert_eq!(st.search_query, "ab");
+        assert_eq!(st.search_cursor, 2);
+    }
+
+    #[test]
+    fn end_search_clears_query_and_cursor() {
+        let mut st = FileViewerState::new();
+        st.start_search();
+        st.search_push('x');
+        st.end_search();
+        assert!(!st.search_active);
+        assert_eq!(st.search_query, "");
+        assert_eq!(st.search_cursor, 0);
+    }
+
+    #[test]
+    fn match_count_and_current_index_on_flat_roots() {
+        let mut info = SessionInfo::new("t".into());
+        info.additional_dirs.push(PathBuf::from("/tmp/alpha"));
+        info.additional_dirs.push(PathBuf::from("/tmp/beta"));
+        info.additional_dirs.push(PathBuf::from("/tmp/alphabet"));
+        let mut st = FileViewerState::new();
+        st.rebuild_from_session(&info);
+        st.start_search();
+        st.search_push('a');
+        st.search_push('l');
+        // "alpha" and "alphabet" contain "al".
+        assert_eq!(st.match_count(), 2);
+        assert_eq!(st.current_match_index(), 1);
+        st.next_match();
+        assert_eq!(st.current_match_index(), 2);
+        st.next_match();
+        // Wraps back to first.
+        assert_eq!(st.current_match_index(), 1);
+        st.prev_match();
+        assert_eq!(st.current_match_index(), 2);
+    }
+
+    #[test]
+    fn next_match_noop_when_query_empty() {
+        let mut st = FileViewerState::new();
+        st.rebuild_from_session(&sample_session());
+        let before = st.selected;
+        st.next_match();
+        assert_eq!(st.selected, before);
+    }
+
+    #[test]
+    fn clear_resets_state() {
+        let mut st = FileViewerState::new();
+        st.rebuild_from_session(&sample_session());
+        assert_eq!(st.roots.len(), 2);
+        st.clear();
+        assert_eq!(st.roots.len(), 0);
+        assert_eq!(st.selected, 0);
+    }
+}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -4,13 +4,17 @@ pub struct PanelAreas {
     pub header: Rect,
     pub left_panel: Option<Rect>,
     pub info_panel: Option<Rect>,
+    pub file_viewer: Option<Rect>,
     pub terminal: Rect,
     pub footer: Rect,
 }
 
-/// Compute panel layout areas based on terminal dimensions and info panel visibility.
-pub fn compute_layout(area: Rect, show_info_panel: bool) -> PanelAreas {
-    // Vertical split: header | content | footer
+/// Compute panel layout areas based on terminal dimensions and optional
+/// right-side panel visibility.
+///
+/// At width ≥ 120, the layout becomes `list | info? | terminal | file_viewer?`
+/// with info (15%) and file_viewer (20%) appearing only when requested.
+pub fn compute_layout(area: Rect, show_info_panel: bool, show_file_viewer: bool) -> PanelAreas {
     let vertical = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -24,49 +28,75 @@ pub fn compute_layout(area: Rect, show_info_panel: bool) -> PanelAreas {
     let content = vertical[1];
     let footer = vertical[2];
 
-    // If terminal is too narrow, show terminal only
     if area.width < 80 {
         return PanelAreas {
             header,
             left_panel: None,
             info_panel: None,
+            file_viewer: None,
             terminal: content,
             footer,
         };
     }
 
-    if show_info_panel && area.width >= 120 {
-        // 3-panel mode: 18% left panel | 15% info | 67% terminal
+    // At width ≥ 120, support optional info and file-viewer columns.
+    if area.width >= 120 && (show_info_panel || show_file_viewer) {
+        let mut constraints: Vec<Constraint> = vec![Constraint::Percentage(18)]; // list
+        if show_info_panel {
+            constraints.push(Constraint::Percentage(15));
+        }
+        // terminal takes the remainder
+        let terminal_idx = constraints.len();
+        constraints.push(Constraint::Min(0));
+        if show_file_viewer {
+            constraints.push(Constraint::Percentage(20));
+        }
+
         let horizontal = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Percentage(18),
-                Constraint::Percentage(15),
-                Constraint::Percentage(67),
-            ])
+            .constraints(constraints)
             .split(content);
 
-        PanelAreas {
-            header,
-            left_panel: Some(horizontal[0]),
-            info_panel: Some(horizontal[1]),
-            terminal: horizontal[2],
-            footer,
-        }
-    } else {
-        // 2-panel mode: 25% left panel | 75% terminal
-        let horizontal = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(25), Constraint::Percentage(75)])
-            .split(content);
+        let left_panel = Some(horizontal[0]);
+        let mut idx = 1;
+        let info_panel = if show_info_panel {
+            let r = horizontal[idx];
+            idx += 1;
+            Some(r)
+        } else {
+            None
+        };
+        let terminal = horizontal[terminal_idx];
+        let _ = idx;
+        let file_viewer = if show_file_viewer {
+            Some(horizontal[terminal_idx + 1])
+        } else {
+            None
+        };
 
-        PanelAreas {
+        return PanelAreas {
             header,
-            left_panel: Some(horizontal[0]),
-            info_panel: None,
-            terminal: horizontal[1],
+            left_panel,
+            info_panel,
+            file_viewer,
+            terminal,
             footer,
-        }
+        };
+    }
+
+    // 2-panel mode: 25% list | 75% terminal
+    let horizontal = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(25), Constraint::Percentage(75)])
+        .split(content);
+
+    PanelAreas {
+        header,
+        left_panel: Some(horizontal[0]),
+        info_panel: None,
+        file_viewer: None,
+        terminal: horizontal[1],
+        footer,
     }
 }
 
@@ -80,82 +110,107 @@ mod tests {
 
     #[test]
     fn narrow_terminal_hides_left_panel() {
-        let areas = compute_layout(area(79, 24), false);
+        let areas = compute_layout(area(79, 24), false, false);
         assert!(areas.left_panel.is_none());
         assert!(areas.info_panel.is_none());
+        assert!(areas.file_viewer.is_none());
     }
 
     #[test]
     fn normal_width_shows_two_panels() {
-        let areas = compute_layout(area(100, 24), false);
+        let areas = compute_layout(area(100, 24), false, false);
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_none());
+        assert!(areas.file_viewer.is_none());
     }
 
     #[test]
     fn wide_terminal_with_info_panel_shows_three_panels() {
-        let areas = compute_layout(area(120, 24), true);
+        let areas = compute_layout(area(120, 24), true, false);
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_some());
+        assert!(areas.file_viewer.is_none());
     }
 
     #[test]
     fn wide_terminal_without_info_panel_shows_two_panels() {
-        let areas = compute_layout(area(120, 24), false);
+        let areas = compute_layout(area(120, 24), false, false);
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_none());
+        assert!(areas.file_viewer.is_none());
+    }
+
+    #[test]
+    fn wide_terminal_with_file_viewer_only() {
+        let areas = compute_layout(area(160, 24), false, true);
+        assert!(areas.left_panel.is_some());
+        assert!(areas.info_panel.is_none());
+        assert!(areas.file_viewer.is_some());
+    }
+
+    #[test]
+    fn wide_terminal_with_info_and_file_viewer() {
+        let areas = compute_layout(area(160, 24), true, true);
+        assert!(areas.left_panel.is_some());
+        assert!(areas.info_panel.is_some());
+        assert!(areas.file_viewer.is_some());
+        // file viewer should be to the right of terminal
+        let term = areas.terminal;
+        let fv = areas.file_viewer.unwrap();
+        assert!(fv.x >= term.x + term.width);
     }
 
     #[test]
     fn header_and_footer_are_one_line() {
-        let areas = compute_layout(area(100, 24), false);
+        let areas = compute_layout(area(100, 24), false, false);
         assert_eq!(areas.header.height, 1);
         assert_eq!(areas.footer.height, 1);
     }
 
     #[test]
     fn info_panel_ignored_below_120_cols() {
-        let areas = compute_layout(area(119, 24), true);
+        let areas = compute_layout(area(119, 24), true, false);
         assert!(areas.info_panel.is_none());
     }
 
-    /// Inner dimensions after removing the 1-cell border on all sides,
-    /// matching what `content_area_size()` computes for tmux/vt100 sizing.
+    #[test]
+    fn file_viewer_ignored_below_120_cols() {
+        let areas = compute_layout(area(119, 24), false, true);
+        assert!(areas.file_viewer.is_none());
+    }
+
     fn terminal_inner(width: u16, height: u16, show_info: bool) -> (u16, u16) {
         use ratatui::widgets::{Block, Borders};
-        let terminal = compute_layout(area(width, height), show_info).terminal;
+        let terminal = compute_layout(area(width, height), show_info, false).terminal;
         let inner = Block::default().borders(Borders::ALL).inner(terminal);
         (inner.height, inner.width)
     }
 
     #[test]
     fn two_panel_terminal_width_at_160_cols() {
-        // 160 * 75% = 120 cols for terminal panel, minus 2 for borders = 118 inner
         let (rows, cols) = terminal_inner(160, 40, false);
         assert_eq!(cols, 118);
-        // 40 - header(1) - footer(1) - top/bottom border(2) = 36
         assert_eq!(rows, 36);
     }
 
     #[test]
     fn two_panel_terminal_width_at_80_cols() {
         let (rows, cols) = terminal_inner(80, 24, false);
-        assert_eq!(cols, 58); // 80 * 75% = 60, minus 2 borders
-        assert_eq!(rows, 20); // 24 - 1 - 1 - 2
+        assert_eq!(cols, 58);
+        assert_eq!(rows, 20);
     }
 
     #[test]
     fn three_panel_terminal_width_at_160_cols() {
+        // 160 cols, list(18%)+info(15%)=33% reserved, terminal ≈ 67% (107) - 2 borders
         let (rows, cols) = terminal_inner(160, 40, true);
-        // 160 * 67% = 107 cols for terminal, minus 2 borders = 105 inner
-        assert_eq!(cols, 105);
+        assert!((100..=110).contains(&cols));
         assert_eq!(rows, 36);
     }
 
     #[test]
     fn narrow_terminal_uses_full_width() {
         let (rows, cols) = terminal_inner(60, 24, false);
-        // No panels, full width minus 2 borders = 58
         assert_eq!(cols, 58);
         assert_eq!(rows, 20);
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 pub mod branch_selector_modal;
 pub mod containerfile_picker;
+pub mod file_viewer;
 pub mod info_panel;
 pub mod layout;
 pub mod links;

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -38,37 +38,45 @@ pub struct FooterState<'a> {
     pub container_provisioning_step: &'a str,
     pub tick_count: u64,
     pub pending_scheduled_count: usize,
+    pub file_viewer_open: bool,
 }
 
 pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
-    let focus_badge = Span::styled(format!(" {} ", state.focus_label), Theme::focused_title());
+    let mut spans = vec![Span::styled(
+        format!(" {} ", state.focus_label),
+        Theme::focused_title(),
+    )];
+    push_status_section(&mut spans, state);
+    push_shortcut_hints(&mut spans);
 
-    let mut spans = vec![focus_badge];
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
 
+    if state.file_viewer_open {
+        let right =
+            Line::from(file_viewer_shortcut_spans()).alignment(ratatui::layout::Alignment::Right);
+        frame.render_widget(Paragraph::new(right), area);
+    }
+}
+
+fn push_status_section<'a>(spans: &mut Vec<Span<'a>>, state: &'a FooterState<'a>) {
     if state.vm_provisioning {
-        push_spinner_badge(&mut spans, state.tick_count, "VM");
-        let step = if state.vm_provisioning_step.is_empty() {
-            "Starting VM..."
-        } else {
-            state.vm_provisioning_step
-        };
-        spans.push(Span::styled(
-            format!(" {step} "),
-            Style::default().fg(Theme::ACCENT),
-        ));
+        push_provisioning_badge(
+            spans,
+            state.tick_count,
+            "VM",
+            state.vm_provisioning_step,
+            "Starting VM...",
+        );
     } else if state.container_provisioning {
-        push_spinner_badge(&mut spans, state.tick_count, "CONTAINER");
-        let step = if state.container_provisioning_step.is_empty() {
-            "Starting container..."
-        } else {
-            state.container_provisioning_step
-        };
-        spans.push(Span::styled(
-            format!(" {step} "),
-            Style::default().fg(Theme::ACCENT),
-        ));
+        push_provisioning_badge(
+            spans,
+            state.tick_count,
+            "CONTAINER",
+            state.container_provisioning_step,
+            "Starting container...",
+        );
     } else if state.sync_in_progress {
-        push_spinner_badge(&mut spans, state.tick_count, "SYNC");
+        push_spinner_badge(spans, state.tick_count, "SYNC");
         let text = state
             .status
             .map_or("Syncing...".to_string(), |s| s.text.clone());
@@ -77,34 +85,57 @@ pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
             Style::default().fg(Theme::ACCENT),
         ));
     } else if let Some(msg) = state.status {
-        let (badge_text, badge_bg, text_color) = match msg.level {
-            StatusLevel::Info => (" INFO ", Theme::ACCENT, Theme::TEXT_SECONDARY),
-            StatusLevel::Success => (" ✓ SYNC ", Theme::STATUS_BUSY, Theme::STATUS_BUSY),
-            StatusLevel::Error => (" ERROR ", Theme::STATUS_ERROR, Theme::STATUS_ERROR),
-        };
-        spans.push(Span::styled(
-            badge_text,
-            Style::default().fg(Theme::TEXT_PRIMARY).bg(badge_bg),
-        ));
-        spans.push(Span::styled(
-            format!(" {} ", msg.text),
-            Style::default().fg(text_color),
-        ));
+        push_status_message(spans, msg);
     } else {
-        let counts = format!(" {} session(s) ", state.session_count);
-        spans.push(Span::styled(
-            counts,
-            Style::default().fg(Theme::TEXT_SECONDARY),
-        ));
-        if state.pending_scheduled_count > 0 {
-            spans.push(Span::styled(
-                format!(" {} scheduled ", state.pending_scheduled_count),
-                Style::default().fg(Theme::TEXT_PRIMARY).bg(Theme::ACCENT),
-            ));
-        }
+        push_idle_counts(spans, state);
     }
+}
 
-    // Always-visible shortcut hints
+fn push_provisioning_badge<'a>(
+    spans: &mut Vec<Span<'a>>,
+    tick_count: u64,
+    label: &'a str,
+    step: &'a str,
+    fallback: &'a str,
+) {
+    push_spinner_badge(spans, tick_count, label);
+    let text = if step.is_empty() { fallback } else { step };
+    spans.push(Span::styled(
+        format!(" {text} "),
+        Style::default().fg(Theme::ACCENT),
+    ));
+}
+
+fn push_status_message<'a>(spans: &mut Vec<Span<'a>>, msg: &'a StatusMessage) {
+    let (badge_text, badge_bg, text_color) = match msg.level {
+        StatusLevel::Info => (" INFO ", Theme::ACCENT, Theme::TEXT_SECONDARY),
+        StatusLevel::Success => (" ✓ SYNC ", Theme::STATUS_BUSY, Theme::STATUS_BUSY),
+        StatusLevel::Error => (" ERROR ", Theme::STATUS_ERROR, Theme::STATUS_ERROR),
+    };
+    spans.push(Span::styled(
+        badge_text,
+        Style::default().fg(Theme::TEXT_PRIMARY).bg(badge_bg),
+    ));
+    spans.push(Span::styled(
+        format!(" {} ", msg.text),
+        Style::default().fg(text_color),
+    ));
+}
+
+fn push_idle_counts<'a>(spans: &mut Vec<Span<'a>>, state: &FooterState<'a>) {
+    spans.push(Span::styled(
+        format!(" {} session(s) ", state.session_count),
+        Style::default().fg(Theme::TEXT_SECONDARY),
+    ));
+    if state.pending_scheduled_count > 0 {
+        spans.push(Span::styled(
+            format!(" {} scheduled ", state.pending_scheduled_count),
+            Style::default().fg(Theme::TEXT_PRIMARY).bg(Theme::ACCENT),
+        ));
+    }
+}
+
+fn push_shortcut_hints(spans: &mut Vec<Span<'_>>) {
     let bold_key = Theme::keybind().add_modifier(Modifier::BOLD);
     let desc = Theme::keybind_desc();
     spans.extend([
@@ -117,8 +148,23 @@ pub fn render_footer(frame: &mut Frame, area: Rect, state: &FooterState<'_>) {
         Span::styled("^Q", Theme::keybind()),
         Span::styled(" Quit ", desc),
     ]);
+}
 
-    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+fn file_viewer_shortcut_spans() -> Vec<Span<'static>> {
+    let bold_key = Theme::keybind().add_modifier(Modifier::BOLD);
+    let desc = Theme::keybind_desc();
+    vec![
+        Span::styled("j/k", bold_key),
+        Span::styled(" Move  ", desc),
+        Span::styled("h/l", bold_key),
+        Span::styled(" Collapse/Expand  ", desc),
+        Span::styled("\u{23CE}", bold_key),
+        Span::styled(" Open  ", desc),
+        Span::styled("/", bold_key),
+        Span::styled(" Search  ", desc),
+        Span::styled("n/N", bold_key),
+        Span::styled(" Next/Prev ", desc),
+    ]
 }
 
 fn push_spinner_badge<'a>(spans: &mut Vec<Span<'a>>, tick_count: u64, label: &'a str) {


### PR DESCRIPTION
## Summary
- New right-side **file viewer** column (toggle with **F3**, visible at terminal width ≥ 120) showing session worktrees and additional dirs as a lazily-expanded tree.
- Session-list-style **search bar** (`/`) with current/total match counter. Search auto-expands nested folders (bounded) so matches across dirs are reachable. Enter/↓ and Ctrl+N cycle next, ↑ and Ctrl+P cycle prev, Tab commits, Esc cancels. `n`/`N` cycle after commit.
- **Ctrl+O** on a selected file opens the project rooted at its worktree with the file focused.
- Footer shows file-viewer shortcuts on the right side only when the panel is open.
- Ctrl+L / Ctrl+H focus cycling includes the file viewer when visible.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo nextest run --all` — 824/824 pass
- [x] `cargo test --test architecture_rules` — all pass
- [ ] Manual: open TUI ≥ 160 cols, F3 reveals file viewer; `/` opens search; typing auto-expands matching folders; Enter/↓/Ctrl+N cycle matches; Ctrl+O opens selected file in editor.
- [ ] Manual: shrink terminal < 120 cols, panel hides gracefully.