### PR TITLE
feat(ui): add per-session model selection

### DIFF
--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -282,6 +282,7 @@ impl Session {
         if !config.role.is_empty() {
             info.role = config.role.clone();
         }
+        info.model = config.model.clone();
         info.backend_id = Some(spawned.backend_id.clone());
         debug!(session_id = %info.id, backend_id = %spawned.backend_id, "Spawned session via backend");
 

--- a/src/agent/claude.rs
+++ b/src/agent/claude.rs
@@ -60,6 +60,11 @@ fn build_claude_args(config: &SessionConfig) -> Vec<String> {
         args.push(prompt.clone());
     }
 
+    if let Some(ref model) = config.model {
+        args.push("--model".to_string());
+        args.push(model.clone());
+    }
+
     for dir in &config.additional_dirs {
         args.push("--add-dir".to_string());
         args.push(dir.display().to_string());
@@ -317,6 +322,26 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&args[idx + 1]).unwrap();
         // JSON structure correctness is tested in McpServerConfig::to_mcp_json tests.
         assert!(json["mcpServers"]["test-server"].is_object());
+    }
+
+    #[test]
+    fn build_args_with_model() {
+        let config = SessionConfig {
+            model: Some("sonnet".to_string()),
+            ..SessionConfig::default()
+        };
+        let args = build_claude_args(&config);
+        assert_eq!(
+            args,
+            vec!["--permission-mode", "default", "--model", "sonnet"]
+        );
+    }
+
+    #[test]
+    fn build_args_no_model_flag_when_none() {
+        let config = SessionConfig::default();
+        let args = build_claude_args(&config);
+        assert!(!args.contains(&"--model".to_string()));
     }
 
     #[test]

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -143,6 +143,12 @@ impl App {
             return;
         }
 
+        // Model selector modal captures all input
+        if matches!(self.modal, super::modals::Modal::ModelSelector(_)) {
+            self.handle_model_selector_key(code);
+            return;
+        }
+
         // MCP server picker modal captures all input
         if matches!(self.modal, super::modals::Modal::McpServerPicker(_)) {
             self.handle_mcp_server_picker_key(code);
@@ -979,8 +985,49 @@ impl App {
                         config.permissions = role.permissions.clone();
                         let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
                         let is_admin = self.pending_spawn_is_admin;
-                        self.maybe_show_mcp_picker(name, config, worktrees, is_admin);
+                        self.maybe_show_model_picker(name, config, worktrees, is_admin);
                     }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_model_selector_key(&mut self, code: KeyCode) {
+        let choice_count = crate::session::MODEL_CHOICES.len();
+        let super::modals::Modal::ModelSelector(ref mut msel) = self.modal else {
+            return;
+        };
+        match code {
+            KeyCode::Esc => {
+                self.modal.close();
+                self.pending_spawn_config = None;
+                self.pending_spawn_worktrees.clear();
+                self.pending_spawn_name = None;
+                self.pending_spawn_is_admin = false;
+                self.pending_vm_id = None;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if msel.index + 1 < choice_count {
+                    msel.index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                msel.index = msel.index.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                let idx = msel.index;
+                self.modal.close();
+                if let (Some(mut config), Some(name)) = (
+                    self.pending_spawn_config.take(),
+                    self.pending_spawn_name.take(),
+                ) {
+                    if let Some((id, _)) = crate::session::MODEL_CHOICES.get(idx) {
+                        config.model = id.map(|s| s.to_string());
+                    }
+                    let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
+                    let is_admin = self.pending_spawn_is_admin;
+                    self.maybe_show_mcp_picker(name, config, worktrees, is_admin);
                 }
             }
             _ => {}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1109,13 +1109,13 @@ impl App {
                 // No roles configured — spawn with default developer permissions.
                 config.role = DEFAULT_ROLE_NAME.to_string();
                 config.permissions = default_developer_permissions();
-                self.maybe_show_mcp_picker(name, config, worktrees, false);
+                self.maybe_show_model_picker(name, config, worktrees, false);
             }
             1 => {
                 // Exactly one role — auto-assign it.
                 config.role = roles[0].name.clone();
                 config.permissions = roles[0].permissions.clone();
-                self.maybe_show_mcp_picker(name, config, worktrees, false);
+                self.maybe_show_model_picker(name, config, worktrees, false);
             }
             _ => {
                 // 2+ roles — show the role selector.
@@ -1125,6 +1125,27 @@ impl App {
                 self.modal = modals::Modal::RoleSelector(modals::RoleSelectorModal::default());
             }
         }
+    }
+
+    /// Show the model selector modal, or proceed directly for admin sessions.
+    ///
+    /// Admin sessions bypass the model picker — they aren't user-created.
+    fn maybe_show_model_picker(
+        &mut self,
+        name: String,
+        config: SessionConfig,
+        worktrees: Vec<WorktreeInfo>,
+        is_admin: bool,
+    ) {
+        if is_admin {
+            self.maybe_show_mcp_picker(name, config, worktrees, is_admin);
+            return;
+        }
+        self.pending_spawn_name = Some(name);
+        self.pending_spawn_config = Some(config);
+        self.pending_spawn_worktrees = worktrees;
+        self.pending_spawn_is_admin = is_admin;
+        self.modal = modals::Modal::ModelSelector(modals::ModelSelectorModal::default());
     }
 
     /// Route through MCP server picker if global MCP servers exist, otherwise spawn directly.
@@ -1250,6 +1271,7 @@ impl App {
             fork_session_id: None,
             mcp_servers: vec![],
             skills: vec![],
+            model: session.info.model.clone(),
         };
 
         if self.global_mcp_servers.is_empty() {
@@ -1367,6 +1389,7 @@ impl App {
         let container_id = session.info.container_id.clone();
         let source_name = session.info.name.clone();
         let fork_session_id = session.info.agent_session_id.clone();
+        let model = session.info.model.clone();
 
         let permissions = self.resolve_role_permissions(&role);
         let config = SessionConfig {
@@ -1381,6 +1404,7 @@ impl App {
             fork_session_id,
             mcp_servers: vec![],
             skills: vec![],
+            model,
         };
 
         self.pending_spawn_config = Some(config);
@@ -1542,6 +1566,7 @@ impl App {
             fork_session_id: None,
             mcp_servers: vec![],
             skills: vec![],
+            model: deleted.model,
         };
 
         let session_name = deleted.name.clone();
@@ -1583,6 +1608,7 @@ impl App {
         session.info.additional_dirs = shared.additional_dirs.clone();
         session.info.agent_session_id = shared.agent_session_id.clone();
         session.info.worktrees = shared.worktrees.iter().cloned().map(Into::into).collect();
+        session.info.model = shared.model.clone();
         resolve_repo_display_names(&mut session.info);
     }
 
@@ -2745,6 +2771,7 @@ impl App {
                             fork_session_id: None,
                             mcp_servers: vec![],
                             skills: vec![],
+                            model: shared_session.model.clone(),
                         };
 
                         let (rows, cols) = self.content_area_size();
@@ -2972,6 +2999,7 @@ impl App {
             shell_backend_id: session.info.shell_backend_id.clone(),
             tombstone: false,
             tombstone_at: None,
+            model: session.info.model.clone(),
         }
     }
 
@@ -3420,6 +3448,7 @@ impl App {
                 fork_session_id: None,
                 mcp_servers: vec![],
                 skills: vec![],
+                model: shared.model,
             };
             self.do_spawn_session(name, &config, worktrees, false);
         }
@@ -3657,6 +3686,7 @@ impl App {
                 fork_session_id: None,
                 mcp_servers: vec![],
                 skills: vec![],
+                model: shared.model,
             };
             self.do_spawn_session(name, &config, worktrees, false);
             info!(session = %session_id, "Session restored (respawned with --session-id)");
@@ -3725,6 +3755,7 @@ impl App {
                 fork_session_id: None,
                 mcp_servers: vec![],
                 skills: vec![],
+                model: shared.model,
             };
 
             warn!(
@@ -3956,6 +3987,7 @@ impl App {
             fork_session_id: None,
             mcp_servers: vec![],
             skills: vec![],
+            model: session.info.model.clone(),
         };
 
         let (rows, cols) = self.content_area_size();
@@ -6411,6 +6443,7 @@ mod tests {
             shell_backend_id: None,
             tombstone: false,
             tombstone_at: None,
+            model: None,
         }
     }
 

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -123,6 +123,11 @@ pub struct RoleSelectorModal {
 }
 
 #[derive(Debug, Clone, Default)]
+pub struct ModelSelectorModal {
+    pub index: usize,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct McpServerPickerModal {
     pub index: usize,
     pub selected: Vec<bool>,
@@ -286,6 +291,7 @@ pub enum Modal {
     BranchSelector(BranchSelectorModal),
     WorktreeName(WorktreeNameModal),
     RoleSelector(RoleSelectorModal),
+    ModelSelector(ModelSelectorModal),
     McpServerPicker(McpServerPickerModal),
     SkillPicker(SkillPickerModal),
     ContainerfilePicker(ContainerfilePickerModal),

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -16,9 +16,10 @@ use crate::ui::selection;
 use crate::ui::theme::Theme;
 use crate::ui::{
     branch_selector_modal, containerfile_picker, file_viewer, info_panel, layout,
-    mcp_server_picker_modal, project_list, restore_sessions_modal, role_editor_modal,
-    role_selector_modal, schedule_command_modal, scheduled_commands_list_modal, session_mode_modal,
-    session_name_modal, skill_picker_modal, status_bar, terminal_view, worktree_name_modal,
+    mcp_server_picker_modal, model_picker_modal, project_list, restore_sessions_modal,
+    role_editor_modal, role_selector_modal, schedule_command_modal, scheduled_commands_list_modal,
+    session_mode_modal, session_name_modal, skill_picker_modal, status_bar, terminal_view,
+    worktree_name_modal,
 };
 
 use super::{App, InputFocus, TerminalView};
@@ -275,6 +276,16 @@ impl App {
                 &role_selector_modal::RoleSelectorState {
                     roles: &self.global_roles,
                     selected_index: rsel.index,
+                },
+            );
+        }
+
+        // Model selector modal
+        if let super::modals::Modal::ModelSelector(ref msel) = self.modal {
+            model_picker_modal::render_model_picker_modal(
+                frame,
+                &model_picker_modal::ModelPickerState {
+                    selected_index: msel.index,
                 },
             );
         }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -41,6 +41,9 @@ pub enum Action {
         /// Stage a global skill by name (repeatable).
         #[arg(long = "skill")]
         skills: Vec<String>,
+        /// Model id passed via `claude --model` (e.g. "opus", "sonnet", "haiku").
+        #[arg(long)]
+        model: Option<String>,
     },
     /// Soft-delete a session.
     Delete {
@@ -96,6 +99,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             base_branch,
             mcp_servers,
             skills,
+            model,
         } => {
             let req = crate::session_ops::SpawnRequest {
                 name,
@@ -106,6 +110,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 mcp_servers,
                 skills,
                 agent_session_id: None,
+                model,
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
             Ok(json!({
@@ -236,6 +241,7 @@ mod tests {
             shell_backend_id: None,
             tombstone: false,
             tombstone_at: None,
+            model: None,
         };
         db.upsert_session(&shared).unwrap();
 
@@ -282,6 +288,7 @@ mod tests {
             shell_backend_id: None,
             tombstone: false,
             tombstone_at: None,
+            model: None,
         };
         db.upsert_session(&shared).unwrap();
         let err = run(

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -329,6 +329,7 @@ impl ThurboxMcp {
             mcp_servers: params.mcp_servers,
             skills: params.skills,
             agent_session_id: None,
+            model: params.model,
         };
 
         let db = self.db.lock().unwrap();
@@ -1268,6 +1269,7 @@ mod tests {
             shell_backend_id: None,
             tombstone: false,
             tombstone_at: None,
+            model: None,
         };
         let sid = session.id;
         db.upsert_session(&session).unwrap();

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -286,6 +286,11 @@ pub struct CreateSessionParams {
     #[serde(default)]
     #[schemars(description = "Optional list of global skill names to stage into the session.")]
     pub skills: Vec<String>,
+    #[serde(default)]
+    #[schemars(
+        description = "Model id passed via `claude --model` (e.g. \"opus\", \"sonnet\", \"haiku\"). Omit for the CLI default."
+    )]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -302,6 +302,8 @@ pub struct SessionInfo {
     /// Order: worktree repos first, then non-worktree additional dirs.
     /// Populated by the app layer at spawn/restore time.
     pub repo_display_names: Vec<String>,
+    /// Model id passed to the Claude CLI via `--model`. `None` means the CLI default.
+    pub model: Option<String>,
 }
 
 impl SessionInfo {
@@ -323,8 +325,30 @@ impl SessionInfo {
             agent_metrics: None,
             is_admin: false,
             repo_display_names: Vec::new(),
+            model: None,
         }
     }
+}
+
+/// Available model choices shown in the new-session picker.
+/// The id is passed to `claude --model`; `None` means CLI default (no flag).
+pub const MODEL_CHOICES: &[(Option<&str>, &str)] = &[
+    (None, "CLI default"),
+    (Some("opus"), "Opus 4.6"),
+    (Some("sonnet"), "Sonnet 4.6"),
+    (Some("haiku"), "Haiku 4.5"),
+];
+
+/// Human-readable display name for a model id. Falls back to the id itself
+/// when the id isn't in `MODEL_CHOICES` (e.g. custom ids via MCP).
+pub fn model_display_name(id: &str) -> String {
+    MODEL_CHOICES
+        .iter()
+        .find_map(|(maybe_id, name)| match maybe_id {
+            Some(known) if *known == id => Some(name.to_string()),
+            _ => None,
+        })
+        .unwrap_or_else(|| id.to_string())
 }
 
 /// A queued command for a session, inserted by MCP and processed by the TUI.
@@ -383,6 +407,8 @@ pub struct SessionConfig {
     /// directory is symlinked into the working directory before spawning
     /// so Claude Code auto-discovers them.
     pub skills: Vec<SkillConfig>,
+    /// Model id to pass via `claude --model`. `None` means CLI default (no flag).
+    pub model: Option<String>,
 }
 
 /// VM state machine for sandboxed sessions.

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -38,6 +38,8 @@ pub struct SpawnRequest {
     /// Optional pre-generated agent session UUID. When unset one is generated
     /// so callers can return it to the user immediately.
     pub agent_session_id: Option<String>,
+    /// Optional model id to pass via `claude --model`. `None` = CLI default.
+    pub model: Option<String>,
 }
 
 /// Result returned on successful headless spawn.
@@ -72,6 +74,7 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         permissions,
         mcp_servers,
         skills,
+        model: req.model.clone(),
         ..SessionConfig::default()
     };
     super::inject_thurbox_env(&mut config, &agent_session_id);
@@ -104,6 +107,7 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         shell_backend_id: None,
         tombstone: false,
         tombstone_at: None,
+        model: req.model.clone(),
     };
     db.upsert_session(&shared)
         .map_err(|e| format!("Failed to persist session: {e}"))?;
@@ -227,6 +231,7 @@ mod tests {
             mcp_servers: Vec::new(),
             skills: Vec::new(),
             agent_session_id: None,
+            model: None,
         };
         let err = spawn_session_headless(&db, req).unwrap_err();
         assert!(err.to_lowercase().contains("name"), "got {err}");
@@ -245,6 +250,7 @@ mod tests {
                 mcp_servers: Vec::new(),
                 skills: Vec::new(),
                 agent_session_id: None,
+                model: None,
             };
             assert!(
                 spawn_session_headless(&db, req).is_err(),

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1,7 +1,7 @@
 use rusqlite::Connection;
 
 /// Current schema version. Incremented when schema changes.
-pub const SCHEMA_VERSION: u32 = 17;
+pub const SCHEMA_VERSION: u32 = 18;
 
 /// Create all tables and indexes if they don't exist.
 pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
@@ -25,6 +25,7 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             cwd               TEXT,
             additional_dirs   TEXT NOT NULL DEFAULT '',
             shell_backend_id  TEXT,
+            model             TEXT,
             created_at        INTEGER NOT NULL,
             updated_at        INTEGER NOT NULL,
             deleted_at        INTEGER
@@ -578,6 +579,11 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
                 updated_at INTEGER NOT NULL
             );",
         )?;
+    }
+
+    if version < 18 {
+        // v17 → v18: add model column to sessions for per-session model selection
+        let _ = conn.execute("ALTER TABLE sessions ADD COLUMN model TEXT", []);
     }
 
     if version < SCHEMA_VERSION {

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -18,6 +18,7 @@ pub struct DeletedSessionInfo {
     pub cwd: Option<PathBuf>,
     pub deleted_at: u64,
     pub worktrees: Vec<SharedWorktree>,
+    pub model: Option<String>,
 }
 
 impl Database {
@@ -47,8 +48,8 @@ impl Database {
                 "UPDATE sessions SET name = ?1, role = ?2, \
                  backend_id = ?3, backend_type = ?4, agent_session_id = ?5, \
                  cwd = ?6, additional_dirs = ?7, shell_backend_id = ?8, \
-                 updated_at = ?9, deleted_at = NULL \
-                 WHERE id = ?10",
+                 model = ?9, updated_at = ?10, deleted_at = NULL \
+                 WHERE id = ?11",
                 params![
                     session.name,
                     session.role,
@@ -58,6 +59,7 @@ impl Database {
                     session.cwd.as_ref().map(|p| p.display().to_string()),
                     additional_dirs_str,
                     session.shell_backend_id,
+                    session.model,
                     now,
                     id_str,
                 ],
@@ -74,8 +76,9 @@ impl Database {
         } else {
             self.conn.execute(
                 "INSERT INTO sessions (id, name, role, backend_id, backend_type, \
-                 agent_session_id, cwd, additional_dirs, shell_backend_id, created_at, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                 agent_session_id, cwd, additional_dirs, shell_backend_id, model, \
+                 created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
                 params![
                     id_str,
                     session.name,
@@ -86,6 +89,7 @@ impl Database {
                     session.cwd.as_ref().map(|p| p.display().to_string()),
                     additional_dirs_str,
                     session.shell_backend_id,
+                    session.model,
                     now,
                     now,
                 ],
@@ -162,6 +166,7 @@ impl Database {
         let sql = format!(
             "SELECT s.id, s.name, s.role, s.backend_id, s.backend_type, \
              s.agent_session_id, s.cwd, s.additional_dirs, s.shell_backend_id, \
+             s.model, \
              w.repo_path, w.worktree_path, w.branch \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id AND w.deleted_at IS NULL \
@@ -175,9 +180,10 @@ impl Database {
             let cwd: Option<String> = row.get(6)?;
             let dirs_str: String = row.get(7)?;
             let shell_backend_id: Option<String> = row.get(8)?;
-            let wt_repo: Option<String> = row.get(9)?;
-            let wt_path: Option<String> = row.get(10)?;
-            let wt_branch: Option<String> = row.get(11)?;
+            let model: Option<String> = row.get(9)?;
+            let wt_repo: Option<String> = row.get(10)?;
+            let wt_path: Option<String> = row.get(11)?;
+            let wt_branch: Option<String> = row.get(12)?;
 
             let additional_dirs: Vec<PathBuf> = if dirs_str.is_empty() {
                 Vec::new()
@@ -208,6 +214,7 @@ impl Database {
                     shell_backend_id,
                     tombstone: false,
                     tombstone_at: None,
+                    model,
                 },
                 worktree,
             ))
@@ -300,7 +307,7 @@ impl Database {
     fn query_deleted_sessions(&self, condition: &str) -> rusqlite::Result<Vec<DeletedSessionInfo>> {
         let sql = format!(
             "SELECT s.id, s.name, s.role, s.agent_session_id, \
-             s.cwd, s.deleted_at, \
+             s.cwd, s.deleted_at, s.model, \
              w.repo_path, w.worktree_path, w.branch \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id \
@@ -313,9 +320,10 @@ impl Database {
             let id_str: String = row.get(0)?;
             let cwd: Option<String> = row.get(4)?;
             let deleted_at: i64 = row.get(5)?;
-            let wt_repo: Option<String> = row.get(6)?;
-            let wt_path: Option<String> = row.get(7)?;
-            let wt_branch: Option<String> = row.get(8)?;
+            let model: Option<String> = row.get(6)?;
+            let wt_repo: Option<String> = row.get(7)?;
+            let wt_path: Option<String> = row.get(8)?;
+            let wt_branch: Option<String> = row.get(9)?;
 
             let worktree = match (wt_repo, wt_path, wt_branch) {
                 (Some(repo), Some(path), Some(branch)) => Some(SharedWorktree {
@@ -335,6 +343,7 @@ impl Database {
                     cwd: cwd.map(PathBuf::from),
                     deleted_at: deleted_at as u64,
                     worktrees: Vec::new(),
+                    model,
                 },
                 worktree,
             ))
@@ -425,7 +434,26 @@ mod tests {
             shell_backend_id: None,
             tombstone: false,
             tombstone_at: None,
+            model: None,
         }
+    }
+
+    #[test]
+    fn session_model_roundtrip() {
+        let db = Database::open_in_memory().unwrap();
+        let mut session = make_session("S");
+        session.model = Some("sonnet".to_string());
+        db.upsert_session(&session).unwrap();
+
+        let loaded = db.list_active_sessions().unwrap();
+        assert_eq!(loaded[0].model, Some("sonnet".to_string()));
+
+        // Update path: clear model
+        let mut s2 = loaded[0].clone();
+        s2.model = None;
+        db.upsert_session(&s2).unwrap();
+        let loaded2 = db.list_active_sessions().unwrap();
+        assert_eq!(loaded2[0].model, None);
     }
 
     #[test]

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -58,6 +58,7 @@ mod tests {
             shell_backend_id: None,
             tombstone: false,
             tombstone_at: None,
+            model: None,
         }
     }
 

--- a/src/storage/worktrees.rs
+++ b/src/storage/worktrees.rs
@@ -134,6 +134,7 @@ mod tests {
             shell_backend_id: None,
             tombstone: false,
             tombstone_at: None,
+            model: None,
         };
         let sid = session.id;
         db.upsert_session(&session).unwrap();

--- a/src/sync/delta.rs
+++ b/src/sync/delta.rs
@@ -95,6 +95,7 @@ fn session_changed(old: &SharedSession, new: &SharedSession) -> bool {
         || old.cwd != new.cwd
         || old.additional_dirs != new.additional_dirs
         || old.worktrees != new.worktrees
+        || old.model != new.model
 }
 
 #[cfg(test)]
@@ -116,6 +117,7 @@ mod tests {
             shell_backend_id: None,
             tombstone: false,
             tombstone_at: None,
+            model: None,
         }
     }
 

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -83,6 +83,9 @@ pub struct SharedSession {
 
     /// Timestamp when this session was tombstoned (millis since epoch).
     pub tombstone_at: Option<u64>,
+
+    /// Model id passed to the Claude CLI via `--model`. `None` means CLI default.
+    pub model: Option<String>,
 }
 
 /// Worktree information embedded in shared session.

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -78,6 +78,15 @@ pub fn render_info_panel(
                 .add_modifier(Modifier::BOLD),
         ),
     ]));
+    if let Some(ref model) = info.model {
+        lines.push(Line::from(vec![
+            Span::styled("Model: ", Theme::label()),
+            Span::styled(
+                crate::session::model_display_name(model),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+        ]));
+    }
 
     // ── Repos ──
     append_repos_section(&mut lines, info);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,6 +6,7 @@ pub mod layout;
 pub mod links;
 pub mod mcp_editor_modal;
 pub mod mcp_server_picker_modal;
+pub mod model_picker_modal;
 pub mod project_list;
 pub mod repo_picker_modal;
 pub mod repo_selector_modal;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -236,6 +236,31 @@ pub fn render_list_modal_frame<'a>(
     Some([chunks[0], chunks[1]])
 }
 
+/// Standard "j/k navigate · Enter select · Esc cancel" footer used by selector
+/// modals.
+pub fn selector_nav_footer() -> Line<'static> {
+    Line::from(vec![
+        Span::styled("j/k", Theme::keybind()),
+        Span::styled(" navigate  ", Theme::keybind_desc()),
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" select  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
+    ])
+}
+
+/// Build a selector list item with the standard "▸ " selected prefix and
+/// selected/normal theme styles.
+pub fn selector_list_item<'a>(label: &str, selected: bool) -> ratatui::widgets::ListItem<'a> {
+    let style = if selected {
+        Theme::selected_item()
+    } else {
+        Theme::normal_item()
+    };
+    let prefix = if selected { "▸ " } else { "  " };
+    ratatui::widgets::ListItem::new(Line::from(Span::styled(format!("{prefix}{label}"), style)))
+}
+
 /// Render a labeled text input field with cursor visualization and horizontal
 /// viewport scrolling.
 ///

--- a/src/ui/model_picker_modal.rs
+++ b/src/ui/model_picker_modal.rs
@@ -1,13 +1,12 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    text::{Line, Span},
     widgets::{List, ListItem, Paragraph},
     Frame,
 };
 
-use super::centered_fixed_height_rect;
-use super::render_modal_frame;
-use super::theme::Theme;
+use super::{
+    centered_fixed_height_rect, render_modal_frame, selector_list_item, selector_nav_footer,
+};
 use crate::session::MODEL_CHOICES;
 
 pub struct ModelPickerState {
@@ -28,30 +27,9 @@ pub fn render_model_picker_modal(frame: &mut Frame, state: &ModelPickerState) {
     let items: Vec<ListItem<'_>> = MODEL_CHOICES
         .iter()
         .enumerate()
-        .map(|(i, (_, name))| {
-            let style = if i == state.selected_index {
-                Theme::selected_item()
-            } else {
-                Theme::normal_item()
-            };
-            let prefix = if i == state.selected_index {
-                "▸ "
-            } else {
-                "  "
-            };
-            ListItem::new(Line::from(Span::styled(format!("{prefix}{name}"), style)))
-        })
+        .map(|(i, (_, name))| selector_list_item(name, i == state.selected_index))
         .collect();
 
     frame.render_widget(List::new(items), chunks[0]);
-
-    let footer = Line::from(vec![
-        Span::styled("j/k", Theme::keybind()),
-        Span::styled(" navigate  ", Theme::keybind_desc()),
-        Span::styled("Enter", Theme::keybind()),
-        Span::styled(" select  ", Theme::keybind_desc()),
-        Span::styled("Esc", Theme::keybind()),
-        Span::styled(" cancel", Theme::keybind_desc()),
-    ]);
-    frame.render_widget(Paragraph::new(footer), chunks[1]);
+    frame.render_widget(Paragraph::new(selector_nav_footer()), chunks[1]);
 }

--- a/src/ui/model_picker_modal.rs
+++ b/src/ui/model_picker_modal.rs
@@ -1,0 +1,57 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    text::{Line, Span},
+    widgets::{List, ListItem, Paragraph},
+    Frame,
+};
+
+use super::centered_fixed_height_rect;
+use super::render_modal_frame;
+use super::theme::Theme;
+use crate::session::MODEL_CHOICES;
+
+pub struct ModelPickerState {
+    pub selected_index: usize,
+}
+
+pub fn render_model_picker_modal(frame: &mut Frame, state: &ModelPickerState) {
+    let height = (MODEL_CHOICES.len() as u16) + 3;
+    let area = centered_fixed_height_rect(50, height, frame.area());
+
+    let inner = render_modal_frame(frame, area, "Session Model");
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let items: Vec<ListItem<'_>> = MODEL_CHOICES
+        .iter()
+        .enumerate()
+        .map(|(i, (_, name))| {
+            let style = if i == state.selected_index {
+                Theme::selected_item()
+            } else {
+                Theme::normal_item()
+            };
+            let prefix = if i == state.selected_index {
+                "▸ "
+            } else {
+                "  "
+            };
+            ListItem::new(Line::from(Span::styled(format!("{prefix}{name}"), style)))
+        })
+        .collect();
+
+    frame.render_widget(List::new(items), chunks[0]);
+
+    let footer = Line::from(vec![
+        Span::styled("j/k", Theme::keybind()),
+        Span::styled(" navigate  ", Theme::keybind_desc()),
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" select  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[1]);
+}

--- a/src/ui/role_selector_modal.rs
+++ b/src/ui/role_selector_modal.rs
@@ -6,9 +6,10 @@ use ratatui::{
     Frame,
 };
 
-use super::centered_fixed_height_rect;
-use super::render_modal_frame;
-use super::theme::Theme;
+use super::{
+    centered_fixed_height_rect, render_modal_frame, selector_list_item, selector_nav_footer,
+    theme::Theme,
+};
 use crate::session::RoleConfig;
 
 pub struct RoleSelectorState<'a> {
@@ -17,7 +18,6 @@ pub struct RoleSelectorState<'a> {
 }
 
 pub fn render_role_selector_modal(frame: &mut Frame, state: &RoleSelectorState<'_>) {
-    // 2 (border) + roles count + 1 (description) + 1 (footer)
     let height = (state.roles.len() as u16) + 4;
     let area = centered_fixed_height_rect(50, height, frame.area());
 
@@ -26,9 +26,9 @@ pub fn render_role_selector_modal(frame: &mut Frame, state: &RoleSelectorState<'
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(1),    // Role list
-            Constraint::Length(1), // Description
-            Constraint::Length(1), // Footer
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
         ])
         .split(inner);
 
@@ -36,28 +36,11 @@ pub fn render_role_selector_modal(frame: &mut Frame, state: &RoleSelectorState<'
         .roles
         .iter()
         .enumerate()
-        .map(|(i, role)| {
-            let style = if i == state.selected_index {
-                Theme::selected_item()
-            } else {
-                Theme::normal_item()
-            };
-            let prefix = if i == state.selected_index {
-                "▸ "
-            } else {
-                "  "
-            };
-            ListItem::new(Line::from(Span::styled(
-                format!("{prefix}{}", role.name),
-                style,
-            )))
-        })
+        .map(|(i, role)| selector_list_item(&role.name, i == state.selected_index))
         .collect();
 
-    let list = List::new(items);
-    frame.render_widget(list, chunks[0]);
+    frame.render_widget(List::new(items), chunks[0]);
 
-    // Description of selected role
     if let Some(role) = state.roles.get(state.selected_index) {
         let desc = Line::from(Span::styled(
             &role.description,
@@ -66,13 +49,5 @@ pub fn render_role_selector_modal(frame: &mut Frame, state: &RoleSelectorState<'
         frame.render_widget(Paragraph::new(desc), chunks[1]);
     }
 
-    let footer = Line::from(vec![
-        Span::styled("j/k", Theme::keybind()),
-        Span::styled(" navigate  ", Theme::keybind_desc()),
-        Span::styled("Enter", Theme::keybind()),
-        Span::styled(" select  ", Theme::keybind_desc()),
-        Span::styled("Esc", Theme::keybind()),
-        Span::styled(" cancel", Theme::keybind_desc()),
-    ]);
-    frame.render_widget(Paragraph::new(footer), chunks[2]);
+    frame.render_widget(Paragraph::new(selector_nav_footer()), chunks[2]);
 }

--- a/tests/sync_integration.rs
+++ b/tests/sync_integration.rs
@@ -23,6 +23,7 @@ fn make_session(id: SessionId, name: &str) -> SharedSession {
         shell_backend_id: None,
         tombstone: false,
         tombstone_at: None,
+        model: None,
     }
 }
 
@@ -368,6 +369,7 @@ fn db_session_metadata_preserved_across_instances() {
         shell_backend_id: None,
         tombstone: false,
         tombstone_at: None,
+        model: None,
     };
     db_a.upsert_session(&session).unwrap();
 


### PR DESCRIPTION
## Summary
- Add a model picker modal to the new-session flow (Opus/Sonnet/Haiku/CLI default)
- Persist the choice per-session in SQLite (schema v18) and pass `--model` to the `claude` CLI
- Expose `model` through the `create_session` MCP tool and `thurbox-cli sessions create`

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --all` (873/873)
- [x] `cargo test --test architecture_rules` (9/9)
- [ ] Manual: Ctrl+N → pick repo → role → model picker → session spawns with chosen model
- [ ] Manual: restart Thurbox → session restores with same model shown in info panel
- [ ] MCP: `create_session` with `"model":"haiku"` spawns with `--model haiku`