### PR TITLE
fix(cli): include thurbox-cli binary in release tarball and installer

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -124,7 +124,7 @@ jobs:
           ARCHIVE_NAME="thurbox-${VERSION}-${TARGET}.tar.gz"
 
           cd target/$TARGET/release
-          tar czf "../../../$ARCHIVE_NAME" thurbox thurbox-mcp
+          tar czf "../../../$ARCHIVE_NAME" thurbox thurbox-mcp thurbox-cli
           cd ../../..
 
           # Also package LICENSE

--- a/scripts/install.bats
+++ b/scripts/install.bats
@@ -64,8 +64,8 @@
   grep -q "trap cleanup" "${BATS_TEST_DIRNAME}/install.sh"
 }
 
-@test "script is under 200 lines" {
-  [ $(wc -l < "${BATS_TEST_DIRNAME}/install.sh") -lt 200 ]
+@test "script is under 210 lines" {
+  [ $(wc -l < "${BATS_TEST_DIRNAME}/install.sh") -lt 210 ]
 }
 
 @test "script has logging functions" {
@@ -115,4 +115,22 @@
 
 @test "script conditionally chmods thurbox-mcp" {
   grep -q 'thurbox-mcp.*chmod' "${BATS_TEST_DIRNAME}/install.sh"
+}
+
+@test "do_install chmods all three binaries when thurbox-cli is present" {
+  tmpdir=$(mktemp -d)
+  mkdir -p "$tmpdir/src" "$tmpdir/dest"
+  printf '#!/bin/sh\n' > "$tmpdir/src/thurbox"
+  printf '#!/bin/sh\n' > "$tmpdir/src/thurbox-mcp"
+  printf '#!/bin/sh\n' > "$tmpdir/src/thurbox-cli"
+  tar -czf "$tmpdir/archive.tar.gz" -C "$tmpdir/src" thurbox thurbox-mcp thurbox-cli
+  TEST_TMPDIR=1 sh -c ". '${BATS_TEST_DIRNAME}/install.sh'; do_install '$tmpdir/archive.tar.gz' '$tmpdir/dest'"
+  [ -x "$tmpdir/dest/thurbox" ]
+  [ -x "$tmpdir/dest/thurbox-mcp" ]
+  [ -x "$tmpdir/dest/thurbox-cli" ]
+  rm -rf "$tmpdir"
+}
+
+@test "script conditionally chmods thurbox-cli" {
+  grep -q 'thurbox-cli.*chmod' "${BATS_TEST_DIRNAME}/install.sh"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -154,6 +154,7 @@ do_install() {
   tar -xzf "$tarball" -C "$dir"
   chmod +x "$dir/thurbox"
   if [ -f "$dir/thurbox-mcp" ]; then chmod +x "$dir/thurbox-mcp"; fi
+  if [ -f "$dir/thurbox-cli" ]; then chmod +x "$dir/thurbox-cli"; fi
 }
 
 # Show success message
@@ -169,6 +170,7 @@ show_success() {
   echo "  • Install claude CLI"
   echo "  • Run: thurbox"
   echo "  • MCP server: thurbox-mcp (stdio transport)"
+  echo "  • Scriptable CLI: thurbox-cli"
 }
 
 # Main


### PR DESCRIPTION
## Summary

- Include the `thurbox-cli` binary alongside `thurbox` and `thurbox-mcp` in the release tarball (`cd.yml`).
- Make the installer `chmod +x` `thurbox-cli` when present and mention it in the post-install notes.
- Add bats coverage for the three-binary install path and bump the install.sh line-cap assertion from 200 → 210.

## Test plan

- [x] Manually verified `do_install` chmods all three binaries when present
- [x] Manually verified thurbox-only and mcp-without-cli cases still pass
- [x] `sh -n scripts/install.sh` clean
- [ ] CI bats suite