### PR TITLE
feat(ui): runtime themes, custom keybindings, chrome polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,12 @@ thurbox-mcp --transport streamable-http --port 9090  # Custom port
 | `cancel_scheduled_command` | Cancel a pending scheduled command |
 | `get_editor_command` | Get the editor command used by Ctrl+O |
 | `set_editor_command` | Set the editor command used by Ctrl+O |
+| `list_themes` | List available built-in TUI theme presets |
+| `get_theme` | Get the active TUI theme preset id |
+| `set_theme` | Set the active TUI theme (live-applied via data-version polling) |
+| `get_keybindings` | Get the user keybindings JSON document (or built-in defaults) |
+| `set_keybindings` | Replace `~/.config/thurbox/keybindings.json` (effective on next TUI start) |
+| `reset_keybindings` | Delete the keybindings override file, restoring defaults |
 
 **Role Management**: Roles are global presets.
 `set_roles` performs an atomic replacement — all existing roles
@@ -346,12 +352,31 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+S` | Sync worktrees with origin/main | **S**ync |
 | `Ctrl+Z` | Undo session delete | **Z** = undo |
 | `Ctrl+U` | Restore deleted sessions | **U**ndelete |
+| `Ctrl+Y` / `F4` | Pick TUI theme | Color **Y**oke |
 | `F1` | Toggle keybindings help | Universal |
 | `F2` | Toggle info panel (visible at width >= 120) | Next to F1 |
+| `F3` | Toggle file viewer | Next to F2 |
 
 List contexts use plain `j`/`k`/`Enter` for navigation.
 Terminal forwards all non-Ctrl keys to the PTY.
 `Shift+arrows/PageUp/PageDown` for scrollback.
+
+These defaults can be overridden by writing
+`~/.config/thurbox/keybindings.json` (or via the MCP
+`set_keybindings` tool). The file maps an `Action` name to one or
+more chord strings, e.g. `{ "QuitApp": ["ctrl+x"] }`. Modal-internal
+keys (j/k/Enter/Esc inside selectors) are not customizable.
+
+## Themes
+
+The TUI ships with eight palettes — four dark (**Default**, **Catppuccin
+Mocha**, **Tokyo Night**, **Gruvbox Dark**) and four light (**Catppuccin
+Latte**, **Tokyo Night Day**, **Gruvbox Light**, **Solarized Light**).
+Pick one with `Ctrl+Y` (or `F4`,
+which avoids terminals that intercept Ctrl+Y as DSUSP); the choice
+is persisted in SQLite under `metadata.active_theme` and survives
+restarts. Other thurbox processes pick up theme changes within one
+tick via `PRAGMA data_version` polling.
 
 ## Design Documentation
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,9 @@ sonar.organization=thurbeen
 sonar.sources=src
 sonar.tests=tests
 sonar.sourceEncoding=UTF-8
+
+# Theme palettes are a data table: each preset declares the same field set
+# with different RGB values. Structural similarity is intentional and the
+# fields are consumed via PaletteSlots::build, so CPD's "duplication" here
+# is not a maintainability concern.
+sonar.cpd.exclusions=src/session/theme_config.rs

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1020,19 +1020,15 @@ impl App {
             KeyCode::Esc => {
                 self.modal.close();
             }
-            KeyCode::Char('j') | KeyCode::Down => {
-                if tp.index + 1 < preset_count {
-                    tp.index += 1;
-                    let preset = presets[tp.index];
-                    crate::ui::theme::set_active(preset.palette());
-                }
+            KeyCode::Char('j') | KeyCode::Down if tp.index + 1 < preset_count => {
+                tp.index += 1;
+                let preset = presets[tp.index];
+                crate::ui::theme::set_active(preset.palette());
             }
-            KeyCode::Char('k') | KeyCode::Up => {
-                if tp.index > 0 {
-                    tp.index -= 1;
-                    let preset = presets[tp.index];
-                    crate::ui::theme::set_active(preset.palette());
-                }
+            KeyCode::Char('k') | KeyCode::Up if tp.index > 0 => {
+                tp.index -= 1;
+                let preset = presets[tp.index];
+                crate::ui::theme::set_active(preset.palette());
             }
             KeyCode::Enter => {
                 let idx = tp.index;

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -143,6 +143,12 @@ impl App {
             return;
         }
 
+        // Theme picker modal captures all input
+        if matches!(self.modal, super::modals::Modal::ThemePicker(_)) {
+            self.handle_theme_picker_key(code);
+            return;
+        }
+
         // Model selector modal captures all input
         if matches!(self.modal, super::modals::Modal::ModelSelector(_)) {
             self.handle_model_selector_key(code);
@@ -191,118 +197,14 @@ impl App {
         // Any key press clears text selection (but the key still performs its action)
         self.text_selection = None;
 
-        // Global keybindings (always active)
-        if mods.contains(KeyModifiers::CONTROL) {
-            match code {
-                KeyCode::Char('q') => {
-                    self.should_quit = true;
-                    return;
-                }
-                KeyCode::Char('n') => {
-                    self.open_repo_picker();
-                    return;
-                }
-                KeyCode::Char('a') => {
-                    self.spawn_admin_session();
-                    return;
-                }
-                KeyCode::Char('d') => match self.focus {
-                    InputFocus::SessionList | InputFocus::FileViewer => {
-                        self.close_active_session();
-                        return;
-                    }
-                    InputFocus::Terminal => {} // forward to PTY
-                },
-                KeyCode::Char('e') => {
-                    self.open_settings();
-                    return;
-                }
-                KeyCode::Char('f') => match self.focus {
-                    InputFocus::Terminal => {} // forward to PTY (shell forward-search)
-                    _ => {
-                        self.fork_active_session();
-                        return;
-                    }
-                },
-                KeyCode::Char('r') => match self.focus {
-                    InputFocus::Terminal => {} // forward to PTY (e.g. bash reverse search)
-                    _ => {
-                        self.restart_active_session();
-                        return;
-                    }
-                },
-                KeyCode::Char('o') => match self.focus {
-                    InputFocus::Terminal => {} // forward to PTY
-                    _ => {
-                        self.open_active_in_editor();
-                        return;
-                    }
-                },
-                KeyCode::Char('p') => {
-                    self.open_scheduled_commands_list();
-                    return;
-                }
-                KeyCode::Char('s') => {
-                    self.start_sync();
-                    return;
-                }
-                KeyCode::Char('t') => {
-                    self.toggle_shell_view();
-                    return;
-                }
-                KeyCode::Char('z') => {
-                    if self.pending_delete.is_some() {
-                        self.undo_delete();
-                    }
-                    return;
-                }
-                KeyCode::Char('u') => {
-                    self.open_restore_sessions_modal();
-                    return;
-                }
-                // Vim navigation: h=cycle-left, j=down, k=up, l=cycle-right
-                KeyCode::Char('h') => {
-                    self.clear_search();
-                    self.focus = self.cycle_focus_backward();
-                    return;
-                }
-                KeyCode::Char('j') => {
-                    self.switch_session_forward();
-                    return;
-                }
-                KeyCode::Char('k') => {
-                    self.switch_session_backward();
-                    return;
-                }
-                KeyCode::Char('l') => {
-                    self.clear_search();
-                    self.focus = self.cycle_focus_forward();
-                    return;
-                }
-                _ => {}
-            }
-        }
-
-        // Function keys (work reliably in all terminals)
-        match code {
-            KeyCode::F(1) => {
-                self.modal = super::modals::Modal::Help;
+        // Global keybindings (always active) — driven by user-customizable
+        // `KeyBindings`. Some actions intentionally yield to the PTY when the
+        // terminal is focused (e.g. Ctrl+R = bash reverse-search) — those are
+        // handled inside `dispatch_action`.
+        if let Some(action) = self.keybindings.lookup(code, mods) {
+            if self.dispatch_action(action) {
                 return;
             }
-            KeyCode::F(2) => {
-                self.show_info_panel = !self.show_info_panel;
-                return;
-            }
-            KeyCode::F(3) => {
-                self.show_file_viewer = !self.show_file_viewer;
-                if self.show_file_viewer {
-                    self.rebuild_file_viewer_for_active();
-                } else if self.focus == InputFocus::FileViewer {
-                    self.focus = InputFocus::SessionList;
-                }
-                return;
-            }
-            _ => {}
         }
 
         match self.focus {
@@ -986,6 +888,160 @@ impl App {
                         let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
                         let is_admin = self.pending_spawn_is_admin;
                         self.maybe_show_model_picker(name, config, worktrees, is_admin);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Execute a global `Action`. Returns `true` when the action was consumed
+    /// and the caller should stop processing the keypress; `false` when the
+    /// action intentionally yielded to the PTY (e.g. Ctrl+R = bash
+    /// reverse-search while the terminal pane is focused).
+    fn dispatch_action(&mut self, action: crate::session::Action) -> bool {
+        use crate::session::Action;
+        match action {
+            Action::QuitApp => {
+                self.should_quit = true;
+                true
+            }
+            Action::NewSession => {
+                self.open_repo_picker();
+                true
+            }
+            Action::SpawnAdminSession => {
+                self.spawn_admin_session();
+                true
+            }
+            Action::DeleteSession => match self.focus {
+                InputFocus::SessionList | InputFocus::FileViewer => {
+                    self.close_active_session();
+                    true
+                }
+                InputFocus::Terminal => false, // forward to PTY
+            },
+            Action::OpenSettings => {
+                self.open_settings();
+                true
+            }
+            Action::OpenInEditor => match self.focus {
+                InputFocus::Terminal => false, // forward to PTY
+                _ => {
+                    self.open_active_in_editor();
+                    true
+                }
+            },
+            Action::OpenScheduledCommands => {
+                self.open_scheduled_commands_list();
+                true
+            }
+            Action::StartSync => {
+                self.start_sync();
+                true
+            }
+            Action::ToggleShell => {
+                self.toggle_shell_view();
+                true
+            }
+            Action::ForkSession => match self.focus {
+                InputFocus::Terminal => false, // PTY: shell forward-search
+                _ => {
+                    self.fork_active_session();
+                    true
+                }
+            },
+            Action::RestartSession => match self.focus {
+                InputFocus::Terminal => false, // PTY: bash reverse-search
+                _ => {
+                    self.restart_active_session();
+                    true
+                }
+            },
+            Action::UndoDelete => {
+                if self.pending_delete.is_some() {
+                    self.undo_delete();
+                }
+                true
+            }
+            Action::OpenRestoreSessions => {
+                self.open_restore_sessions_modal();
+                true
+            }
+            Action::OpenThemePicker => {
+                self.open_theme_picker();
+                true
+            }
+            Action::FocusBackward => {
+                self.clear_search();
+                self.focus = self.cycle_focus_backward();
+                true
+            }
+            Action::FocusForward => {
+                self.clear_search();
+                self.focus = self.cycle_focus_forward();
+                true
+            }
+            Action::NextSession => {
+                self.switch_session_forward();
+                true
+            }
+            Action::PreviousSession => {
+                self.switch_session_backward();
+                true
+            }
+            Action::ToggleHelp => {
+                self.modal = super::modals::Modal::Help;
+                true
+            }
+            Action::ToggleInfoPanel => {
+                self.show_info_panel = !self.show_info_panel;
+                true
+            }
+            Action::ToggleFileViewer => {
+                self.show_file_viewer = !self.show_file_viewer;
+                if self.show_file_viewer {
+                    self.rebuild_file_viewer_for_active();
+                } else if self.focus == InputFocus::FileViewer {
+                    self.focus = InputFocus::SessionList;
+                }
+                true
+            }
+        }
+    }
+
+    fn handle_theme_picker_key(&mut self, code: KeyCode) {
+        let presets = crate::session::ThemePreset::all();
+        let preset_count = presets.len();
+        let super::modals::Modal::ThemePicker(ref mut tp) = self.modal else {
+            return;
+        };
+        match code {
+            KeyCode::Esc => {
+                self.modal.close();
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if tp.index + 1 < preset_count {
+                    tp.index += 1;
+                    let preset = presets[tp.index];
+                    crate::ui::theme::set_active(preset.palette());
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if tp.index > 0 {
+                    tp.index -= 1;
+                    let preset = presets[tp.index];
+                    crate::ui::theme::set_active(preset.palette());
+                }
+            }
+            KeyCode::Enter => {
+                let idx = tp.index;
+                self.modal.close();
+                if let Some(preset) = presets.get(idx) {
+                    crate::ui::theme::set_active(preset.palette());
+                    self.active_theme = *preset;
+                    if let Err(e) = self.db.set_active_theme(preset.as_str()) {
+                        tracing::error!("Failed to persist active theme: {e}");
                     }
                 }
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -621,6 +621,13 @@ pub struct App {
     pub(crate) skill_list_index: usize,
     /// Cached pending scheduled commands, refreshed every ~1 second.
     pub(crate) cached_pending_commands: Vec<ScheduledCommand>,
+    /// Currently active theme preset, cached so the header doesn't hit SQLite
+    /// every render. Kept in sync with `db.set_active_theme` writes.
+    pub(crate) active_theme: crate::session::ThemePreset,
+    /// User-customizable global keybindings. Loaded from
+    /// `~/.config/thurbox/keybindings.json` on startup, falling back to defaults
+    /// when the file is missing or malformed.
+    pub(crate) keybindings: crate::session::KeyBindings,
 }
 
 /// Snapshot of editor field values for dirty detection.
@@ -665,6 +672,28 @@ impl App {
 
         // Load global skills from DB.
         let global_skills = db.list_global_skills().unwrap_or_default();
+
+        // Resolve the persisted active theme (defaults to Default if unset/unknown).
+        let active_theme = db
+            .get_active_theme()
+            .ok()
+            .flatten()
+            .as_deref()
+            .and_then(crate::session::ThemePreset::from_str)
+            .unwrap_or(crate::session::ThemePreset::Default);
+
+        // Load keybindings from JSON config or fall back to defaults.
+        let keybindings = match crate::storage::keybindings::load_keybindings_json() {
+            Ok(Some(json)) => crate::session::KeyBindings::from_json(&json).unwrap_or_else(|e| {
+                tracing::warn!("Failed to parse keybindings.json: {e}; using defaults");
+                crate::session::KeyBindings::default()
+            }),
+            Ok(None) => crate::session::KeyBindings::default(),
+            Err(e) => {
+                tracing::warn!("Failed to read keybindings.json: {e}; using defaults");
+                crate::session::KeyBindings::default()
+            }
+        };
 
         // Load session counter from DB
         let session_counter = db.get_session_counter().unwrap_or(0);
@@ -787,6 +816,8 @@ impl App {
             global_skills,
             skill_list_index: 0,
             cached_pending_commands: Vec::new(),
+            active_theme,
+            keybindings,
         }
     }
 
@@ -1485,6 +1516,18 @@ impl App {
     }
 
     /// Open the restore deleted sessions modal (Ctrl+U).
+    /// Open the theme picker, pre-selecting the currently active preset.
+    fn open_theme_picker(&mut self) {
+        let active = self.db.get_active_theme().ok().flatten();
+        let presets = crate::session::ThemePreset::all();
+        let index = active
+            .as_deref()
+            .and_then(crate::session::ThemePreset::from_str)
+            .and_then(|p| presets.iter().position(|x| *x == p))
+            .unwrap_or(0);
+        self.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index });
+    }
+
     fn open_restore_sessions_modal(&mut self) {
         match self.db.list_deleted_sessions() {
             Ok(list) => {
@@ -2402,6 +2445,16 @@ impl App {
                 if let Ok(skills) = self.db.list_global_skills() {
                     if skills != self.global_skills {
                         self.global_skills = skills;
+                    }
+                }
+                // Pick up theme changes made by other thurbox processes (e.g.
+                // an MCP `set_theme` call from another session).
+                if let Ok(Some(name)) = self.db.get_active_theme() {
+                    if let Some(preset) = crate::session::ThemePreset::from_str(&name) {
+                        if preset != self.active_theme {
+                            crate::ui::theme::set_active(preset.palette());
+                            self.active_theme = preset;
+                        }
                     }
                 }
             }

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -123,6 +123,11 @@ pub struct RoleSelectorModal {
 }
 
 #[derive(Debug, Clone, Default)]
+pub struct ThemePickerModal {
+    pub index: usize,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct ModelSelectorModal {
     pub index: usize,
 }
@@ -300,6 +305,7 @@ pub enum Modal {
     ScheduledCommandsList(ScheduledCommandsListModal),
     RepoPicker(RepoPickerModal),
     SessionName(SessionNameModal),
+    ThemePicker(ThemePickerModal),
 }
 
 impl Modal {

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -19,7 +19,7 @@ use crate::ui::{
     mcp_server_picker_modal, model_picker_modal, project_list, restore_sessions_modal,
     role_editor_modal, role_selector_modal, schedule_command_modal, scheduled_commands_list_modal,
     session_mode_modal, session_name_modal, skill_picker_modal, status_bar, terminal_view,
-    worktree_name_modal,
+    theme_picker_modal, worktree_name_modal,
 };
 
 use super::{App, InputFocus, TerminalView};
@@ -29,7 +29,19 @@ impl App {
         let areas =
             layout::compute_layout(frame.area(), self.show_info_panel, self.show_file_viewer);
 
-        status_bar::render_header(frame, areas.header);
+        let active_name = self
+            .sessions
+            .get(self.active_index)
+            .map(|s| s.info.name.as_str());
+        let theme_label = self.active_theme.display_name();
+        status_bar::render_header(
+            frame,
+            areas.header,
+            Some(status_bar::HeaderBadge {
+                active_session: active_name,
+                theme_label,
+            }),
+        );
 
         // Left panel (flat session list)
         if let Some(left_area) = areas.left_panel {
@@ -291,6 +303,17 @@ impl App {
             );
         }
 
+        // Theme picker modal
+        if let super::modals::Modal::ThemePicker(ref tp) = self.modal {
+            theme_picker_modal::render_theme_picker_modal(
+                frame,
+                &theme_picker_modal::ThemePickerState {
+                    presets: crate::session::ThemePreset::all(),
+                    selected_index: tp.index,
+                },
+            );
+        }
+
         // Model selector modal
         if let super::modals::Modal::ModelSelector(ref msel) = self.modal {
             model_picker_modal::render_model_picker_modal(
@@ -539,10 +562,10 @@ impl App {
             let text = Line::from(vec![
                 Span::styled(
                     " Discard changes? ",
-                    Style::default().fg(Theme::TEXT_PRIMARY),
+                    Style::default().fg(Theme::text_primary()),
                 ),
                 Span::styled("y", Theme::keybind()),
-                Span::styled("/", Style::default().fg(Theme::TEXT_MUTED)),
+                Span::styled("/", Style::default().fg(Theme::text_muted())),
                 Span::styled("n", Theme::keybind()),
             ]);
             frame.render_widget(
@@ -554,11 +577,35 @@ impl App {
             );
         }
 
+        // Repaint cells that fell back to terminal-default colours with the
+        // active theme's background and primary text. Themes whose `app_bg`
+        // is `Color::Reset` (e.g. the ANSI-based Default preset) skip this
+        // step so they continue to honour the user's terminal palette.
+        let app_bg = Theme::app_bg();
+        if app_bg != ratatui::style::Color::Reset {
+            let text_primary = Theme::text_primary();
+            let area = frame.area();
+            let buf = frame.buffer_mut();
+            for y in area.y..area.y + area.height {
+                for x in area.x..area.x + area.width {
+                    let pos = ratatui::layout::Position::new(x, y);
+                    if let Some(cell) = buf.cell_mut(pos) {
+                        if cell.bg == ratatui::style::Color::Reset {
+                            cell.bg = app_bg;
+                        }
+                        if cell.fg == ratatui::style::Color::Reset {
+                            cell.fg = text_primary;
+                        }
+                    }
+                }
+            }
+        }
+
         // Selection highlight and text cache — runs after all rendering.
         if let Some(ref sel) = self.text_selection {
             let sel_style = Style::default()
-                .bg(Theme::SELECTION_BG)
-                .fg(Theme::SELECTION_FG);
+                .bg(Theme::selection_bg())
+                .fg(Theme::selection_fg());
             let sel_clone = sel.clone();
 
             selection::highlight_buffer(frame.buffer_mut(), &sel_clone, sel_style);
@@ -634,7 +681,7 @@ fn render_help_overlay(frame: &mut Frame) {
         Line::from(""),
         Line::from(Span::styled(
             "Press F1 or Esc to close",
-            Style::default().fg(Theme::TEXT_MUTED),
+            Style::default().fg(Theme::text_muted()),
         )),
     ];
 
@@ -648,7 +695,7 @@ fn help_section(title: &str) -> Line<'_> {
 fn help_line<'a>(key: &'a str, desc: &'a str) -> Line<'a> {
     Line::from(vec![
         Span::styled(format!("  {key:<16}"), Theme::keybind()),
-        Span::styled(desc, Style::default().fg(Theme::TEXT_PRIMARY)),
+        Span::styled(desc, Style::default().fg(Theme::text_primary())),
     ])
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,13 @@ async fn main() -> Result<()> {
     });
     let db = Database::open(&db_path).expect("Failed to open database");
 
+    // Activate the persisted theme (falls back to default if unset/unknown).
+    if let Ok(Some(name)) = db.get_active_theme() {
+        thurbox::ui::theme::apply_preset_by_name(&name);
+    } else {
+        thurbox::ui::theme::ensure_initialized();
+    }
+
     let mut terminal = ratatui::init();
     execute!(std::io::stdout(), EnableMouseCapture, EnableBracketedPaste)?;
     let size = terminal.size()?;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -19,9 +19,9 @@ use super::types::{
     ListScheduledCommandsParams, ListSessionsParams, ListVmsParams, McpServerResponse,
     RegisterSkillParams, RestartSessionParams, RestoreSessionParams, RoleResponse,
     ScheduleCommandParams, ScheduledCommandResponse, SendPromptParams, SessionResponse,
-    SetContainerfileTemplateParams, SetEditorCommandParams, SetMcpServersParams, SetRolesParams,
-    SetSkillsParams, SkillResponse, UnregisterSkillParams, VmImageResponse, VmResponse,
-    WorktreeResponse,
+    SetContainerfileTemplateParams, SetEditorCommandParams, SetKeybindingsParams,
+    SetMcpServersParams, SetRolesParams, SetSkillsParams, SetThemeParams, SkillResponse,
+    UnregisterSkillParams, VmImageResponse, VmResponse, WorktreeResponse,
 };
 use super::ThurboxMcp;
 
@@ -198,6 +198,84 @@ impl ThurboxMcp {
             })
             .to_string(),
             Err(e) => error_json(&e.to_string()),
+        }
+    }
+
+    #[tool(
+        description = "List the built-in TUI theme presets. Returns a JSON array of {id, display_name} objects."
+    )]
+    fn list_themes(&self) -> String {
+        let presets: Vec<serde_json::Value> = crate::session::ThemePreset::all()
+            .iter()
+            .map(|p| serde_json::json!({ "id": p.as_str(), "display_name": p.display_name() }))
+            .collect();
+        serde_json::json!(presets).to_string()
+    }
+
+    #[tool(
+        description = "Get the currently active TUI theme. Returns {\"name\": \"...\"} or {\"name\": null} if unset (in which case the Default preset is used)."
+    )]
+    fn get_theme(&self) -> String {
+        let db = self.db.lock().unwrap();
+        match db.get_active_theme() {
+            Ok(name) => serde_json::json!({ "name": name }).to_string(),
+            Err(e) => error_json(&e.to_string()),
+        }
+    }
+
+    #[tool(
+        description = "Set the active TUI theme by preset id. Other Thurbox processes (e.g. the running TUI) pick up the change automatically via SQLite data-version polling."
+    )]
+    fn set_theme(&self, Parameters(params): Parameters<SetThemeParams>) -> String {
+        if crate::session::ThemePreset::from_str(&params.name).is_none() {
+            return error_json(&format!(
+                "Unknown theme preset '{}'. Run list_themes for valid ids.",
+                params.name
+            ));
+        }
+        let db = self.db.lock().unwrap();
+        match db.set_active_theme(&params.name) {
+            Ok(()) => serde_json::json!({ "name": params.name }).to_string(),
+            Err(e) => error_json(&e.to_string()),
+        }
+    }
+
+    #[tool(
+        description = "Get the user's keybindings JSON document, or the default document when no override file exists. Returns {\"json\": \"...\"}."
+    )]
+    fn get_keybindings(&self) -> String {
+        let json = match crate::storage::keybindings::load_keybindings_json() {
+            Ok(Some(s)) => s,
+            Ok(None) => match crate::session::KeyBindings::default().to_json() {
+                Ok(s) => s,
+                Err(e) => return error_json(&e),
+            },
+            Err(e) => return error_json(&e),
+        };
+        serde_json::json!({ "json": json }).to_string()
+    }
+
+    #[tool(
+        description = "Replace the user's keybindings JSON document at ~/.config/thurbox/keybindings.json. Shape: { \"<Action>\": [\"<chord>\", ...] }. Unknown actions and unparseable chords are dropped on load. The change takes effect at the next TUI restart."
+    )]
+    fn set_keybindings(&self, Parameters(params): Parameters<SetKeybindingsParams>) -> String {
+        // Validate by attempting to parse before persisting.
+        if let Err(e) = crate::session::KeyBindings::from_json(&params.json) {
+            return error_json(&format!("Invalid keybindings JSON: {e}"));
+        }
+        match crate::storage::keybindings::save_keybindings_json(&params.json) {
+            Ok(()) => serde_json::json!({ "saved": true }).to_string(),
+            Err(e) => error_json(&e),
+        }
+    }
+
+    #[tool(
+        description = "Delete the user's keybindings override file, restoring built-in defaults at the next TUI restart."
+    )]
+    fn reset_keybindings(&self) -> String {
+        match crate::storage::keybindings::delete_keybindings_json() {
+            Ok(()) => serde_json::json!({ "reset": true }).to_string(),
+            Err(e) => error_json(&e),
         }
     }
 

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -63,6 +63,24 @@ pub struct SetEditorCommandParams {
     pub command: String,
 }
 
+/// Parameters for the `set_theme` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SetThemeParams {
+    #[schemars(
+        description = "Theme preset id. One of: \"default\", \"catppuccin-mocha\", \"tokyo-night\", \"gruvbox-dark\"."
+    )]
+    pub name: String,
+}
+
+/// Parameters for the `set_keybindings` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SetKeybindingsParams {
+    #[schemars(
+        description = "Full keybindings JSON document. Shape: { \"<Action>\": [\"<chord>\", ...] }. Unknown actions and unparseable chords are ignored; missing actions retain their defaults."
+    )]
+    pub json: String,
+}
+
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SetRolesParams {
     #[schemars(

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -41,6 +41,15 @@ fn app_dir_name() -> &'static str {
     }
 }
 
+/// `$XDG_CONFIG_HOME/<app>/<filename>`, falling back to
+/// `$HOME/.config/<app>/<filename>` when `XDG_CONFIG_HOME` is unset.
+fn xdg_config_subpath(filename: &str) -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))?;
+    Some(base.join(app_dir_name()).join(filename))
+}
+
 /// Categories of application paths.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathKind {
@@ -241,23 +250,7 @@ fn resolve_xdg(kind: PathKind) -> Option<PathBuf> {
                 p
             })
         }
-        PathKind::KeybindingsFile => {
-            // Prefer $XDG_CONFIG_HOME, fall back to $HOME/.config
-            if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
-                let mut p = PathBuf::from(xdg);
-                p.push(app_dir_name());
-                p.push("keybindings.json");
-                return Some(p);
-            }
-
-            std::env::var_os("HOME").map(|h| {
-                let mut p = PathBuf::from(h);
-                p.push(".config");
-                p.push(app_dir_name());
-                p.push("keybindings.json");
-                p
-            })
-        }
+        PathKind::KeybindingsFile => xdg_config_subpath("keybindings.json"),
     }
 }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -60,6 +60,8 @@ pub enum PathKind {
     MetricsDir,
     /// Git worktrees: `~/.local/share/thurbox/worktrees/`
     WorktreesDir,
+    /// User keybindings JSON file: `~/.config/thurbox/keybindings.json`
+    KeybindingsFile,
 }
 
 /// Path resolution strategy (thread-local).
@@ -239,6 +241,23 @@ fn resolve_xdg(kind: PathKind) -> Option<PathBuf> {
                 p
             })
         }
+        PathKind::KeybindingsFile => {
+            // Prefer $XDG_CONFIG_HOME, fall back to $HOME/.config
+            if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+                let mut p = PathBuf::from(xdg);
+                p.push(app_dir_name());
+                p.push("keybindings.json");
+                return Some(p);
+            }
+
+            std::env::var_os("HOME").map(|h| {
+                let mut p = PathBuf::from(h);
+                p.push(".config");
+                p.push(app_dir_name());
+                p.push("keybindings.json");
+                p
+            })
+        }
     }
 }
 
@@ -253,6 +272,7 @@ fn resolve_override(base: &Path, kind: PathKind) -> PathBuf {
         PathKind::ImagesDir => base.join("admin").join("images"),
         PathKind::MetricsDir => base.join("metrics"),
         PathKind::WorktreesDir => base.join("worktrees"),
+        PathKind::KeybindingsFile => base.join("keybindings.json"),
     }
 }
 
@@ -397,6 +417,14 @@ pub fn statusline_script_path() -> Option<PathBuf> {
 /// Returns: `$XDG_DATA_HOME/thurbox/worktrees/` or `$HOME/.local/share/thurbox/worktrees/`
 pub fn worktrees_directory() -> Option<PathBuf> {
     resolve(PathKind::WorktreesDir)
+}
+
+/// Resolve the user keybindings file path.
+///
+/// Returns: `$XDG_CONFIG_HOME/thurbox/keybindings.json` or
+/// `$HOME/.config/thurbox/keybindings.json`.
+pub fn keybindings_file() -> Option<PathBuf> {
+    resolve(PathKind::KeybindingsFile)
 }
 
 /// Resolve the path to the `thurbox-mcp` binary.
@@ -718,6 +746,10 @@ mod tests {
         assert_eq!(
             resolve(PathKind::WorktreesDir),
             Some(base.join("worktrees"))
+        );
+        assert_eq!(
+            resolve(PathKind::KeybindingsFile),
+            Some(base.join("keybindings.json"))
         );
 
         reset_to_xdg();

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -1,0 +1,396 @@
+//! User-customizable global keybindings.
+//!
+//! Each global action the TUI exposes (quit, new session, switch session,
+//! ...) maps to one or more `KeyChord`s. Defaults reproduce the table in
+//! `CLAUDE.md`. Users can override via `~/.config/thurbox/keybindings.json`.
+//!
+//! Modal-internal navigation keys (j/k/Enter/Esc inside selectors) are *not*
+//! customizable and remain literal in `key_handlers.rs`.
+
+use std::collections::HashMap;
+
+use crossterm::event::{KeyCode, KeyModifiers};
+use serde::{Deserialize, Serialize};
+
+/// Every user-rebindable global action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Action {
+    QuitApp,
+    NewSession,
+    SpawnAdminSession,
+    DeleteSession,
+    OpenSettings,
+    OpenInEditor,
+    OpenScheduledCommands,
+    StartSync,
+    ToggleShell,
+    ForkSession,
+    RestartSession,
+    UndoDelete,
+    OpenRestoreSessions,
+    OpenThemePicker,
+    FocusBackward,
+    FocusForward,
+    NextSession,
+    PreviousSession,
+    ToggleHelp,
+    ToggleInfoPanel,
+    ToggleFileViewer,
+}
+
+impl Action {
+    /// All actions in stable order — used by the help overlay and config codegen.
+    pub fn all() -> &'static [Action] {
+        &[
+            Action::QuitApp,
+            Action::NewSession,
+            Action::SpawnAdminSession,
+            Action::DeleteSession,
+            Action::OpenSettings,
+            Action::OpenInEditor,
+            Action::OpenScheduledCommands,
+            Action::StartSync,
+            Action::ToggleShell,
+            Action::ForkSession,
+            Action::RestartSession,
+            Action::UndoDelete,
+            Action::OpenRestoreSessions,
+            Action::OpenThemePicker,
+            Action::FocusBackward,
+            Action::FocusForward,
+            Action::NextSession,
+            Action::PreviousSession,
+            Action::ToggleHelp,
+            Action::ToggleInfoPanel,
+            Action::ToggleFileViewer,
+        ]
+    }
+
+    /// Short user-facing label used by the help overlay.
+    pub fn label(self) -> &'static str {
+        match self {
+            Action::QuitApp => "Quit",
+            Action::NewSession => "New session",
+            Action::SpawnAdminSession => "Spawn admin session",
+            Action::DeleteSession => "Delete session",
+            Action::OpenSettings => "Open settings",
+            Action::OpenInEditor => "Open in editor",
+            Action::OpenScheduledCommands => "Scheduled commands",
+            Action::StartSync => "Sync worktrees",
+            Action::ToggleShell => "Toggle shell view",
+            Action::ForkSession => "Fork session",
+            Action::RestartSession => "Restart session",
+            Action::UndoDelete => "Undo delete",
+            Action::OpenRestoreSessions => "Restore deleted sessions",
+            Action::OpenThemePicker => "Pick theme",
+            Action::FocusBackward => "Focus previous pane",
+            Action::FocusForward => "Focus next pane",
+            Action::NextSession => "Next session",
+            Action::PreviousSession => "Previous session",
+            Action::ToggleHelp => "Help",
+            Action::ToggleInfoPanel => "Toggle info panel",
+            Action::ToggleFileViewer => "Toggle file viewer",
+        }
+    }
+}
+
+/// A key chord: modifiers + key code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KeyChord {
+    pub mods: KeyModifiers,
+    pub code: KeyCode,
+}
+
+impl KeyChord {
+    pub fn ctrl(c: char) -> Self {
+        Self {
+            mods: KeyModifiers::CONTROL,
+            code: KeyCode::Char(c),
+        }
+    }
+
+    pub fn function(n: u8) -> Self {
+        Self {
+            mods: KeyModifiers::NONE,
+            code: KeyCode::F(n),
+        }
+    }
+
+    /// Render the chord using the same notation accepted by `parse`.
+    pub fn display(&self) -> String {
+        let mut parts: Vec<&str> = Vec::new();
+        if self.mods.contains(KeyModifiers::CONTROL) {
+            parts.push("ctrl");
+        }
+        if self.mods.contains(KeyModifiers::ALT) {
+            parts.push("alt");
+        }
+        if self.mods.contains(KeyModifiers::SHIFT) {
+            parts.push("shift");
+        }
+        let key = match self.code {
+            KeyCode::Char(c) => c.to_string(),
+            KeyCode::F(n) => format!("f{n}"),
+            KeyCode::Enter => "enter".into(),
+            KeyCode::Esc => "esc".into(),
+            KeyCode::Tab => "tab".into(),
+            KeyCode::BackTab => "backtab".into(),
+            KeyCode::Left => "left".into(),
+            KeyCode::Right => "right".into(),
+            KeyCode::Up => "up".into(),
+            KeyCode::Down => "down".into(),
+            KeyCode::Home => "home".into(),
+            KeyCode::End => "end".into(),
+            KeyCode::PageUp => "pageup".into(),
+            KeyCode::PageDown => "pagedown".into(),
+            KeyCode::Backspace => "backspace".into(),
+            KeyCode::Delete => "delete".into(),
+            KeyCode::Insert => "insert".into(),
+            other => format!("{other:?}").to_lowercase(),
+        };
+        parts.push(&key);
+        parts.join("+")
+    }
+
+    /// Parse `"ctrl+n"`, `"f1"`, `"shift+pageup"`. Case-insensitive.
+    pub fn parse(s: &str) -> Option<Self> {
+        let lc = s.trim().to_ascii_lowercase();
+        if lc.is_empty() {
+            return None;
+        }
+        let parts: Vec<&str> = lc.split('+').map(str::trim).collect();
+        let (key_part, mod_parts) = parts.split_last()?;
+
+        let mut mods = KeyModifiers::NONE;
+        for p in mod_parts {
+            match *p {
+                "ctrl" | "control" => mods |= KeyModifiers::CONTROL,
+                "alt" | "meta" => mods |= KeyModifiers::ALT,
+                "shift" => mods |= KeyModifiers::SHIFT,
+                _ => return None,
+            }
+        }
+
+        let code = match *key_part {
+            "enter" | "return" => KeyCode::Enter,
+            "esc" | "escape" => KeyCode::Esc,
+            "tab" => KeyCode::Tab,
+            "backtab" => KeyCode::BackTab,
+            "left" => KeyCode::Left,
+            "right" => KeyCode::Right,
+            "up" => KeyCode::Up,
+            "down" => KeyCode::Down,
+            "home" => KeyCode::Home,
+            "end" => KeyCode::End,
+            "pageup" => KeyCode::PageUp,
+            "pagedown" => KeyCode::PageDown,
+            "backspace" => KeyCode::Backspace,
+            "delete" | "del" => KeyCode::Delete,
+            "insert" | "ins" => KeyCode::Insert,
+            other if other.starts_with('f') && other.len() <= 3 => {
+                let n: u8 = other[1..].parse().ok()?;
+                KeyCode::F(n)
+            }
+            other if other.chars().count() == 1 => KeyCode::Char(other.chars().next().unwrap()),
+            _ => return None,
+        };
+
+        Some(KeyChord { mods, code })
+    }
+}
+
+/// A user-editable map from `Action` to one or more chords.
+///
+/// JSON shape:
+/// ```json
+/// { "QuitApp": ["ctrl+q"], "NewSession": ["ctrl+n"] }
+/// ```
+#[derive(Debug, Clone)]
+pub struct KeyBindings {
+    map: HashMap<Action, Vec<KeyChord>>,
+}
+
+impl Default for KeyBindings {
+    fn default() -> Self {
+        let mut map: HashMap<Action, Vec<KeyChord>> = HashMap::new();
+        let mut bind = |a: Action, chords: Vec<KeyChord>| {
+            map.insert(a, chords);
+        };
+
+        bind(Action::QuitApp, vec![KeyChord::ctrl('q')]);
+        bind(Action::NewSession, vec![KeyChord::ctrl('n')]);
+        bind(Action::SpawnAdminSession, vec![KeyChord::ctrl('a')]);
+        bind(Action::DeleteSession, vec![KeyChord::ctrl('d')]);
+        bind(Action::OpenSettings, vec![KeyChord::ctrl('e')]);
+        bind(Action::OpenInEditor, vec![KeyChord::ctrl('o')]);
+        bind(Action::OpenScheduledCommands, vec![KeyChord::ctrl('p')]);
+        bind(Action::StartSync, vec![KeyChord::ctrl('s')]);
+        bind(Action::ToggleShell, vec![KeyChord::ctrl('t')]);
+        bind(Action::ForkSession, vec![KeyChord::ctrl('f')]);
+        bind(Action::RestartSession, vec![KeyChord::ctrl('r')]);
+        bind(Action::UndoDelete, vec![KeyChord::ctrl('z')]);
+        bind(Action::OpenRestoreSessions, vec![KeyChord::ctrl('u')]);
+        bind(
+            Action::OpenThemePicker,
+            vec![KeyChord::ctrl('y'), KeyChord::function(4)],
+        );
+        bind(Action::FocusBackward, vec![KeyChord::ctrl('h')]);
+        bind(Action::FocusForward, vec![KeyChord::ctrl('l')]);
+        bind(Action::NextSession, vec![KeyChord::ctrl('j')]);
+        bind(Action::PreviousSession, vec![KeyChord::ctrl('k')]);
+        bind(Action::ToggleHelp, vec![KeyChord::function(1)]);
+        bind(Action::ToggleInfoPanel, vec![KeyChord::function(2)]);
+        bind(Action::ToggleFileViewer, vec![KeyChord::function(3)]);
+
+        Self { map }
+    }
+}
+
+impl KeyBindings {
+    /// First chord for the given action (used by hint rendering).
+    pub fn chord_for(&self, action: Action) -> Option<&KeyChord> {
+        self.map.get(&action).and_then(|v| v.first())
+    }
+
+    /// Reverse lookup: given the keypress, return the bound action.
+    pub fn lookup(&self, code: KeyCode, mods: KeyModifiers) -> Option<Action> {
+        for (action, chords) in &self.map {
+            for chord in chords {
+                if chord.code == code && chord.mods == mods {
+                    return Some(*action);
+                }
+            }
+        }
+        None
+    }
+
+    /// Serialize to the JSON shape `~/.config/thurbox/keybindings.json` uses.
+    pub fn to_json(&self) -> Result<String, String> {
+        let mut out: HashMap<String, Vec<String>> = HashMap::new();
+        for (action, chords) in &self.map {
+            out.insert(
+                serde_json::to_string(action)
+                    .map_err(|e| e.to_string())?
+                    .trim_matches('"')
+                    .to_string(),
+                chords.iter().map(KeyChord::display).collect(),
+            );
+        }
+        serde_json::to_string_pretty(&out).map_err(|e| e.to_string())
+    }
+
+    /// Parse from the JSON shape. Unknown actions are ignored; unknown chords
+    /// are silently dropped. Missing actions fall back to defaults.
+    pub fn from_json(json: &str) -> Result<Self, String> {
+        let parsed: HashMap<String, Vec<String>> =
+            serde_json::from_str(json).map_err(|e| e.to_string())?;
+        let mut bindings = KeyBindings::default();
+        for (key, chord_strs) in parsed {
+            let action: Action = match serde_json::from_str::<Action>(&format!("\"{key}\"")) {
+                Ok(a) => a,
+                Err(_) => continue,
+            };
+            let chords: Vec<KeyChord> = chord_strs
+                .iter()
+                .filter_map(|s| KeyChord::parse(s))
+                .collect();
+            if !chords.is_empty() {
+                bindings.map.insert(action, chords);
+            }
+        }
+        Ok(bindings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chord_parse_round_trip() {
+        let cases = ["ctrl+n", "f1", "shift+pageup", "alt+enter", "q"];
+        for c in cases {
+            let chord = KeyChord::parse(c).expect(c);
+            assert_eq!(chord.display(), c);
+        }
+    }
+
+    #[test]
+    fn chord_parse_is_case_insensitive() {
+        assert_eq!(KeyChord::parse("Ctrl+N"), KeyChord::parse("ctrl+n"));
+        assert_eq!(KeyChord::parse("F1"), KeyChord::parse("f1"));
+    }
+
+    #[test]
+    fn default_bindings_reproduce_claude_md_table() {
+        let kb = KeyBindings::default();
+        assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('q')));
+        assert_eq!(kb.chord_for(Action::NewSession), Some(&KeyChord::ctrl('n')));
+        assert_eq!(
+            kb.chord_for(Action::ToggleHelp),
+            Some(&KeyChord::function(1))
+        );
+    }
+
+    #[test]
+    fn lookup_finds_default_chord() {
+        let kb = KeyBindings::default();
+        assert_eq!(
+            kb.lookup(KeyCode::Char('q'), KeyModifiers::CONTROL),
+            Some(Action::QuitApp)
+        );
+        assert_eq!(
+            kb.lookup(KeyCode::F(1), KeyModifiers::NONE),
+            Some(Action::ToggleHelp)
+        );
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unbound_chord() {
+        let kb = KeyBindings::default();
+        assert_eq!(kb.lookup(KeyCode::Char('x'), KeyModifiers::CONTROL), None);
+    }
+
+    #[test]
+    fn theme_picker_has_dual_chord() {
+        let kb = KeyBindings::default();
+        assert_eq!(
+            kb.lookup(KeyCode::Char('y'), KeyModifiers::CONTROL),
+            Some(Action::OpenThemePicker)
+        );
+        assert_eq!(
+            kb.lookup(KeyCode::F(4), KeyModifiers::NONE),
+            Some(Action::OpenThemePicker)
+        );
+    }
+
+    #[test]
+    fn json_round_trip() {
+        let kb = KeyBindings::default();
+        let json = kb.to_json().unwrap();
+        let parsed = KeyBindings::from_json(&json).unwrap();
+        for action in Action::all() {
+            assert_eq!(
+                kb.chord_for(*action),
+                parsed.chord_for(*action),
+                "{action:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_json_falls_back_for_missing_actions() {
+        let json = r#"{ "QuitApp": ["ctrl+x"] }"#;
+        let kb = KeyBindings::from_json(json).unwrap();
+        assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('x')));
+        // Unmodified actions retain defaults.
+        assert_eq!(kb.chord_for(Action::NewSession), Some(&KeyChord::ctrl('n')));
+    }
+
+    #[test]
+    fn from_json_ignores_unknown_actions_and_invalid_chords() {
+        let json = r#"{ "QuitApp": ["nonsense", "ctrl+x"], "BogusAction": ["ctrl+y"] }"#;
+        let kb = KeyBindings::from_json(json).unwrap();
+        assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('x')));
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,3 +1,9 @@
+pub mod keybindings;
+pub mod theme_config;
+
+pub use keybindings::{Action, KeyBindings, KeyChord};
+pub use theme_config::{ThemePalette, ThemePreset};
+
 use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;

--- a/src/session/theme_config.rs
+++ b/src/session/theme_config.rs
@@ -219,6 +219,70 @@ fn default_palette() -> ThemePalette {
     }
 }
 
+/// Compact intermediate representation used to construct the seven RGB-based
+/// palettes without restating the 27-field `ThemePalette` literal in each one.
+///
+/// `build()` derives the symmetric fields (status_idle = text_muted,
+/// border_focused = accent, admin_border = admin_badge, inverted_fg = app_bg)
+/// so each preset only specifies the colours that actually vary between themes.
+struct PaletteSlots {
+    accent: Color,
+    accent_bright: Color,
+    green: Color,
+    yellow: Color,
+    red: Color,
+    text_primary: Color,
+    text_secondary: Color,
+    text_muted: Color,
+    border_unfocused: Color,
+    role_name: Color,
+    branch_name: Color,
+    search_bar: Color,
+    admin_badge: Color,
+    keybind_hint: Color,
+    selection_bg: Color,
+    selection_fg: Color,
+    modal_dim_bg: Color,
+    modal_bg: Color,
+    modal_border: Color,
+    base_bg: Color,
+}
+
+impl PaletteSlots {
+    fn build(self) -> ThemePalette {
+        ThemePalette {
+            accent: self.accent,
+            accent_bright: self.accent_bright,
+            status_busy: self.green,
+            status_waiting: self.yellow,
+            status_idle: self.text_muted,
+            status_error: self.red,
+            text_primary: self.text_primary,
+            text_secondary: self.text_secondary,
+            text_muted: self.text_muted,
+            border_focused: self.accent,
+            border_unfocused: self.border_unfocused,
+            role_name: self.role_name,
+            admin_badge: self.admin_badge,
+            branch_name: self.branch_name,
+            search_bar: self.search_bar,
+            keybind_hint: self.keybind_hint,
+            tool_allowed: self.green,
+            tool_disallowed: self.red,
+            admin_border: self.admin_badge,
+            danger: self.red,
+            selection_bg: self.selection_bg,
+            selection_fg: self.selection_fg,
+            modal_dim_bg: self.modal_dim_bg,
+            modal_bg: self.modal_bg,
+            modal_border: self.modal_border,
+            inverted_fg: self.base_bg,
+            app_bg: self.base_bg,
+            nerd_font_enabled: false,
+        }
+    }
+}
+
 fn catppuccin_mocha_palette() -> ThemePalette {
     let mauve = Color::Rgb(0xCB, 0xA6, 0xF7);
     let pink = Color::Rgb(0xF5, 0xC2, 0xE7);
@@ -233,48 +297,29 @@ fn catppuccin_mocha_palette() -> ThemePalette {
     let surface0 = Color::Rgb(0x31, 0x32, 0x44);
     let surface1 = Color::Rgb(0x45, 0x47, 0x5A);
     let base = Color::Rgb(0x1E, 0x1E, 0x2E);
-
-    ThemePalette {
+    PaletteSlots {
         accent: mauve,
         accent_bright: pink,
-
-        status_busy: green,
-        status_waiting: yellow,
-        status_idle: overlay,
-        status_error: red,
-
+        green,
+        yellow,
+        red,
         text_primary: text,
         text_secondary: subtext,
         text_muted: overlay,
-
-        border_focused: mauve,
         border_unfocused: surface1,
-
         role_name: pink,
-        admin_badge: yellow,
         branch_name: green,
         search_bar: blue,
-
+        admin_badge: yellow,
         keybind_hint: yellow,
-        tool_allowed: green,
-        tool_disallowed: red,
-
-        admin_border: yellow,
-        danger: red,
-
         selection_bg: surface1,
         selection_fg: text,
-
         modal_dim_bg: base,
         modal_bg: surface0,
         modal_border: teal,
-
-        inverted_fg: base,
-
-        app_bg: base,
-
-        nerd_font_enabled: false,
+        base_bg: base,
     }
+    .build()
 }
 
 fn tokyo_night_palette() -> ThemePalette {
@@ -292,48 +337,29 @@ fn tokyo_night_palette() -> ThemePalette {
     let bg = Color::Rgb(0x1A, 0x1B, 0x26);
     let bg_dark = Color::Rgb(0x16, 0x16, 0x1E);
     let bg_highlight = Color::Rgb(0x29, 0x2E, 0x42);
-
-    ThemePalette {
+    PaletteSlots {
         accent: blue,
         accent_bright: cyan,
-
-        status_busy: green,
-        status_waiting: yellow,
-        status_idle: muted,
-        status_error: red,
-
+        green,
+        yellow,
+        red,
         text_primary: text,
         text_secondary: subtext,
         text_muted: muted,
-
-        border_focused: blue,
         border_unfocused: bg_highlight,
-
         role_name: purple,
-        admin_badge: orange,
         branch_name: green,
         search_bar: cyan,
-
+        admin_badge: orange,
         keybind_hint: yellow,
-        tool_allowed: green,
-        tool_disallowed: red,
-
-        admin_border: orange,
-        danger: red,
-
         selection_bg: bg_highlight,
         selection_fg: magenta,
-
         modal_dim_bg: bg_dark,
         modal_bg: bg,
         modal_border: blue,
-
-        inverted_fg: bg,
-
-        app_bg: bg,
-
-        nerd_font_enabled: false,
+        base_bg: bg,
     }
+    .build()
 }
 
 fn gruvbox_dark_palette() -> ThemePalette {
@@ -350,48 +376,29 @@ fn gruvbox_dark_palette() -> ThemePalette {
     let bg0 = Color::Rgb(0x28, 0x28, 0x28);
     let bg1 = Color::Rgb(0x3C, 0x38, 0x36);
     let bg_hard = Color::Rgb(0x1D, 0x20, 0x21);
-
-    ThemePalette {
+    PaletteSlots {
         accent: yellow,
         accent_bright: orange,
-
-        status_busy: green,
-        status_waiting: yellow,
-        status_idle: gray,
-        status_error: red,
-
+        green,
+        yellow,
+        red,
         text_primary: fg,
         text_secondary: fg2,
         text_muted: gray,
-
-        border_focused: yellow,
         border_unfocused: bg1,
-
         role_name: purple,
-        admin_badge: orange,
         branch_name: aqua,
         search_bar: blue,
-
+        admin_badge: orange,
         keybind_hint: orange,
-        tool_allowed: green,
-        tool_disallowed: red,
-
-        admin_border: orange,
-        danger: red,
-
         selection_bg: bg1,
         selection_fg: fg,
-
         modal_dim_bg: bg_hard,
         modal_bg: bg0,
         modal_border: yellow,
-
-        inverted_fg: bg0,
-
-        app_bg: bg0,
-
-        nerd_font_enabled: false,
+        base_bg: bg0,
     }
+    .build()
 }
 
 fn catppuccin_latte_palette() -> ThemePalette {
@@ -409,48 +416,29 @@ fn catppuccin_latte_palette() -> ThemePalette {
     let surface1 = Color::Rgb(0xBC, 0xC0, 0xCC);
     let base = Color::Rgb(0xEF, 0xF1, 0xF5);
     let crust = Color::Rgb(0xDC, 0xE0, 0xE8);
-
-    ThemePalette {
+    PaletteSlots {
         accent: mauve,
         accent_bright: pink,
-
-        status_busy: green,
-        status_waiting: yellow,
-        status_idle: overlay,
-        status_error: red,
-
+        green,
+        yellow,
+        red,
         text_primary: text,
         text_secondary: subtext,
         text_muted: overlay,
-
-        border_focused: mauve,
         border_unfocused: surface1,
-
         role_name: pink,
-        admin_badge: yellow,
         branch_name: green,
         search_bar: blue,
-
+        admin_badge: yellow,
         keybind_hint: yellow,
-        tool_allowed: green,
-        tool_disallowed: red,
-
-        admin_border: yellow,
-        danger: red,
-
         selection_bg: surface0,
         selection_fg: text,
-
         modal_dim_bg: crust,
         modal_bg: base,
         modal_border: teal,
-
-        inverted_fg: base,
-
-        app_bg: base,
-
-        nerd_font_enabled: false,
+        base_bg: base,
     }
+    .build()
 }
 
 fn tokyo_night_day_palette() -> ThemePalette {
@@ -468,48 +456,29 @@ fn tokyo_night_day_palette() -> ThemePalette {
     let bg = Color::Rgb(0xE1, 0xE2, 0xE7);
     let bg_dark = Color::Rgb(0xD0, 0xD5, 0xE1);
     let bg_highlight = Color::Rgb(0xC4, 0xC8, 0xDA);
-
-    ThemePalette {
+    PaletteSlots {
         accent: blue,
         accent_bright: cyan,
-
-        status_busy: green,
-        status_waiting: yellow,
-        status_idle: muted,
-        status_error: red,
-
+        green,
+        yellow,
+        red,
         text_primary: text,
         text_secondary: subtext,
         text_muted: muted,
-
-        border_focused: blue,
         border_unfocused: bg_highlight,
-
         role_name: purple,
-        admin_badge: orange,
         branch_name: green,
         search_bar: cyan,
-
+        admin_badge: orange,
         keybind_hint: orange,
-        tool_allowed: green,
-        tool_disallowed: red,
-
-        admin_border: orange,
-        danger: red,
-
         selection_bg: bg_highlight,
         selection_fg: magenta,
-
         modal_dim_bg: bg_dark,
         modal_bg: bg,
         modal_border: blue,
-
-        inverted_fg: bg,
-
-        app_bg: bg,
-
-        nerd_font_enabled: false,
+        base_bg: bg,
     }
+    .build()
 }
 
 fn gruvbox_light_palette() -> ThemePalette {
@@ -526,48 +495,29 @@ fn gruvbox_light_palette() -> ThemePalette {
     let bg0 = Color::Rgb(0xFB, 0xF1, 0xC7);
     let bg1 = Color::Rgb(0xEB, 0xDB, 0xB2);
     let bg_soft = Color::Rgb(0xF2, 0xE5, 0xBC);
-
-    ThemePalette {
+    PaletteSlots {
         accent: orange,
         accent_bright: yellow,
-
-        status_busy: green,
-        status_waiting: yellow,
-        status_idle: gray,
-        status_error: red,
-
+        green,
+        yellow,
+        red,
         text_primary: fg,
         text_secondary: fg2,
         text_muted: gray,
-
-        border_focused: orange,
         border_unfocused: bg1,
-
         role_name: purple,
-        admin_badge: yellow,
         branch_name: aqua,
         search_bar: blue,
-
+        admin_badge: yellow,
         keybind_hint: yellow,
-        tool_allowed: green,
-        tool_disallowed: red,
-
-        admin_border: yellow,
-        danger: red,
-
         selection_bg: bg1,
         selection_fg: fg,
-
         modal_dim_bg: bg_soft,
         modal_bg: bg0,
         modal_border: orange,
-
-        inverted_fg: bg0,
-
-        app_bg: bg0,
-
-        nerd_font_enabled: false,
+        base_bg: bg0,
     }
+    .build()
 }
 
 fn solarized_light_palette() -> ThemePalette {
@@ -584,48 +534,29 @@ fn solarized_light_palette() -> ThemePalette {
     let base1 = Color::Rgb(0x93, 0xA1, 0xA1);
     let base2 = Color::Rgb(0xEE, 0xE8, 0xD5);
     let base3 = Color::Rgb(0xFD, 0xF6, 0xE3);
-
-    ThemePalette {
+    PaletteSlots {
         accent: blue,
         accent_bright: cyan,
-
-        status_busy: green,
-        status_waiting: yellow,
-        status_idle: base1,
-        status_error: red,
-
+        green,
+        yellow,
+        red,
         text_primary: base01,
         text_secondary: base00,
         text_muted: base1,
-
-        border_focused: blue,
         border_unfocused: base2,
-
         role_name: magenta,
-        admin_badge: orange,
         branch_name: green,
         search_bar: violet,
-
+        admin_badge: orange,
         keybind_hint: orange,
-        tool_allowed: green,
-        tool_disallowed: red,
-
-        admin_border: orange,
-        danger: red,
-
         selection_bg: base2,
         selection_fg: base01,
-
         modal_dim_bg: base2,
         modal_bg: base3,
         modal_border: blue,
-
-        inverted_fg: base3,
-
-        app_bg: base3,
-
-        nerd_font_enabled: false,
+        base_bg: base3,
     }
+    .build()
 }
 
 #[cfg(test)]

--- a/src/session/theme_config.rs
+++ b/src/session/theme_config.rs
@@ -1,0 +1,674 @@
+//! Theme palettes for the Thurbox TUI.
+//!
+//! A `ThemePalette` is the runtime, swappable counterpart to the static colour
+//! constants that used to live in `src/ui/theme.rs`. Widgets read the active
+//! palette via `crate::ui::theme::current()`; users pick one via the theme
+//! picker modal or by setting `active_theme` in the SQLite metadata table.
+
+use ratatui::style::Color;
+
+/// Colour values + glyph preferences for the entire TUI.
+///
+/// Field names match the former `Theme::*` constants one-to-one so the
+/// existing widget code translates cleanly to function calls
+/// (`Theme::accent()` etc.).
+///
+/// Palettes are never persisted directly — only the preset *name* is stored
+/// in the SQLite `metadata.active_theme` row. The runtime palette is
+/// reconstructed from `ThemePreset::palette()` on load.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ThemePalette {
+    pub accent: Color,
+    pub accent_bright: Color,
+
+    pub status_busy: Color,
+    pub status_waiting: Color,
+    pub status_idle: Color,
+    pub status_error: Color,
+
+    pub text_primary: Color,
+    pub text_secondary: Color,
+    pub text_muted: Color,
+
+    pub border_focused: Color,
+    pub border_unfocused: Color,
+
+    pub role_name: Color,
+    pub admin_badge: Color,
+    pub branch_name: Color,
+    pub search_bar: Color,
+
+    pub keybind_hint: Color,
+    pub tool_allowed: Color,
+    pub tool_disallowed: Color,
+
+    pub admin_border: Color,
+    pub danger: Color,
+
+    pub selection_bg: Color,
+    pub selection_fg: Color,
+
+    pub modal_dim_bg: Color,
+    pub modal_bg: Color,
+    pub modal_border: Color,
+
+    pub inverted_fg: Color,
+
+    /// Background colour painted under the entire app (chrome + PTY cells
+    /// that don't set their own bg). Use `Color::Reset` to keep the
+    /// terminal's native background — required for the `Default` preset
+    /// which uses ANSI named colours that adapt to user terminal themes.
+    pub app_bg: Color,
+
+    /// When true, widgets that have nerd-font glyph alternatives use them.
+    /// Defaults to `false` to stay readable on terminals without nerd fonts.
+    pub nerd_font_enabled: bool,
+}
+
+impl Default for ThemePalette {
+    fn default() -> Self {
+        ThemePreset::Default.palette()
+    }
+}
+
+/// Built-in theme presets. The string names are the values stored in the
+/// SQLite `metadata.active_theme` row and accepted by the MCP `set_theme`
+/// tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThemePreset {
+    /// The original cyan-accented palette that shipped first.
+    Default,
+    /// Catppuccin Mocha — warm dark palette with mauve accents.
+    CatppuccinMocha,
+    /// Tokyo Night — cool blue-purple palette popular in Neovim configs.
+    TokyoNight,
+    /// Gruvbox Dark — earthy, high-contrast retro palette.
+    GruvboxDark,
+    /// Catppuccin Latte — light counterpart to Mocha.
+    CatppuccinLatte,
+    /// Tokyo Night Day — light counterpart to Tokyo Night.
+    TokyoNightDay,
+    /// Gruvbox Light — earthy retro palette on a cream background.
+    GruvboxLight,
+    /// Solarized Light — Ethan Schoonover's classic light palette.
+    SolarizedLight,
+}
+
+impl ThemePreset {
+    /// Stable identifier used for storage / MCP / config files.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::CatppuccinMocha => "catppuccin-mocha",
+            Self::TokyoNight => "tokyo-night",
+            Self::GruvboxDark => "gruvbox-dark",
+            Self::CatppuccinLatte => "catppuccin-latte",
+            Self::TokyoNightDay => "tokyo-night-day",
+            Self::GruvboxLight => "gruvbox-light",
+            Self::SolarizedLight => "solarized-light",
+        }
+    }
+
+    /// Human-readable label shown in pickers and the status bar.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::Default => "Default",
+            Self::CatppuccinMocha => "Catppuccin Mocha",
+            Self::TokyoNight => "Tokyo Night",
+            Self::GruvboxDark => "Gruvbox Dark",
+            Self::CatppuccinLatte => "Catppuccin Latte",
+            Self::TokyoNightDay => "Tokyo Night Day",
+            Self::GruvboxLight => "Gruvbox Light",
+            Self::SolarizedLight => "Solarized Light",
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "default" => Some(Self::Default),
+            "catppuccin-mocha" => Some(Self::CatppuccinMocha),
+            "tokyo-night" => Some(Self::TokyoNight),
+            "gruvbox-dark" => Some(Self::GruvboxDark),
+            "catppuccin-latte" => Some(Self::CatppuccinLatte),
+            "tokyo-night-day" => Some(Self::TokyoNightDay),
+            "gruvbox-light" => Some(Self::GruvboxLight),
+            "solarized-light" => Some(Self::SolarizedLight),
+            _ => None,
+        }
+    }
+
+    pub fn all() -> &'static [ThemePreset] {
+        &[
+            Self::Default,
+            Self::CatppuccinMocha,
+            Self::TokyoNight,
+            Self::GruvboxDark,
+            Self::CatppuccinLatte,
+            Self::TokyoNightDay,
+            Self::GruvboxLight,
+            Self::SolarizedLight,
+        ]
+    }
+
+    /// Materialise this preset's colours.
+    pub fn palette(self) -> ThemePalette {
+        match self {
+            Self::Default => default_palette(),
+            Self::CatppuccinMocha => catppuccin_mocha_palette(),
+            Self::TokyoNight => tokyo_night_palette(),
+            Self::GruvboxDark => gruvbox_dark_palette(),
+            Self::CatppuccinLatte => catppuccin_latte_palette(),
+            Self::TokyoNightDay => tokyo_night_day_palette(),
+            Self::GruvboxLight => gruvbox_light_palette(),
+            Self::SolarizedLight => solarized_light_palette(),
+        }
+    }
+
+    /// Whether this preset is intended for terminals with a light background.
+    /// Used by the picker to group dark and light themes.
+    pub fn is_light(self) -> bool {
+        matches!(
+            self,
+            Self::CatppuccinLatte | Self::TokyoNightDay | Self::GruvboxLight | Self::SolarizedLight
+        )
+    }
+}
+
+fn default_palette() -> ThemePalette {
+    ThemePalette {
+        accent: Color::Cyan,
+        accent_bright: Color::LightCyan,
+
+        status_busy: Color::Green,
+        status_waiting: Color::Yellow,
+        status_idle: Color::DarkGray,
+        status_error: Color::Red,
+
+        text_primary: Color::White,
+        text_secondary: Color::Gray,
+        text_muted: Color::DarkGray,
+
+        border_focused: Color::Cyan,
+        border_unfocused: Color::Gray,
+
+        role_name: Color::Magenta,
+        admin_badge: Color::Yellow,
+        branch_name: Color::Green,
+        search_bar: Color::Blue,
+
+        keybind_hint: Color::Yellow,
+        tool_allowed: Color::Green,
+        tool_disallowed: Color::Red,
+
+        admin_border: Color::Yellow,
+        danger: Color::Red,
+
+        selection_bg: Color::Indexed(24),
+        selection_fg: Color::White,
+
+        modal_dim_bg: Color::Indexed(235),
+        modal_bg: Color::Indexed(236),
+        modal_border: Color::Cyan,
+
+        inverted_fg: Color::Black,
+
+        app_bg: Color::Reset,
+
+        nerd_font_enabled: false,
+    }
+}
+
+fn catppuccin_mocha_palette() -> ThemePalette {
+    let mauve = Color::Rgb(0xCB, 0xA6, 0xF7);
+    let pink = Color::Rgb(0xF5, 0xC2, 0xE7);
+    let green = Color::Rgb(0xA6, 0xE3, 0xA1);
+    let yellow = Color::Rgb(0xF9, 0xE2, 0xAF);
+    let red = Color::Rgb(0xF3, 0x8B, 0xA8);
+    let blue = Color::Rgb(0x89, 0xB4, 0xFA);
+    let teal = Color::Rgb(0x94, 0xE2, 0xD5);
+    let text = Color::Rgb(0xCD, 0xD6, 0xF4);
+    let subtext = Color::Rgb(0xA6, 0xAD, 0xC8);
+    let overlay = Color::Rgb(0x6C, 0x70, 0x86);
+    let surface0 = Color::Rgb(0x31, 0x32, 0x44);
+    let surface1 = Color::Rgb(0x45, 0x47, 0x5A);
+    let base = Color::Rgb(0x1E, 0x1E, 0x2E);
+
+    ThemePalette {
+        accent: mauve,
+        accent_bright: pink,
+
+        status_busy: green,
+        status_waiting: yellow,
+        status_idle: overlay,
+        status_error: red,
+
+        text_primary: text,
+        text_secondary: subtext,
+        text_muted: overlay,
+
+        border_focused: mauve,
+        border_unfocused: surface1,
+
+        role_name: pink,
+        admin_badge: yellow,
+        branch_name: green,
+        search_bar: blue,
+
+        keybind_hint: yellow,
+        tool_allowed: green,
+        tool_disallowed: red,
+
+        admin_border: yellow,
+        danger: red,
+
+        selection_bg: surface1,
+        selection_fg: text,
+
+        modal_dim_bg: base,
+        modal_bg: surface0,
+        modal_border: teal,
+
+        inverted_fg: base,
+
+        app_bg: base,
+
+        nerd_font_enabled: false,
+    }
+}
+
+fn tokyo_night_palette() -> ThemePalette {
+    let blue = Color::Rgb(0x7A, 0xA2, 0xF7);
+    let cyan = Color::Rgb(0x7D, 0xCF, 0xFF);
+    let purple = Color::Rgb(0xBB, 0x9A, 0xF7);
+    let green = Color::Rgb(0x9E, 0xCE, 0x6A);
+    let yellow = Color::Rgb(0xE0, 0xAF, 0x68);
+    let orange = Color::Rgb(0xFF, 0x9E, 0x64);
+    let red = Color::Rgb(0xF7, 0x76, 0x8E);
+    let magenta = Color::Rgb(0xC0, 0xCA, 0xF5);
+    let text = Color::Rgb(0xC0, 0xCA, 0xF5);
+    let subtext = Color::Rgb(0x9A, 0xA5, 0xCE);
+    let muted = Color::Rgb(0x56, 0x5F, 0x89);
+    let bg = Color::Rgb(0x1A, 0x1B, 0x26);
+    let bg_dark = Color::Rgb(0x16, 0x16, 0x1E);
+    let bg_highlight = Color::Rgb(0x29, 0x2E, 0x42);
+
+    ThemePalette {
+        accent: blue,
+        accent_bright: cyan,
+
+        status_busy: green,
+        status_waiting: yellow,
+        status_idle: muted,
+        status_error: red,
+
+        text_primary: text,
+        text_secondary: subtext,
+        text_muted: muted,
+
+        border_focused: blue,
+        border_unfocused: bg_highlight,
+
+        role_name: purple,
+        admin_badge: orange,
+        branch_name: green,
+        search_bar: cyan,
+
+        keybind_hint: yellow,
+        tool_allowed: green,
+        tool_disallowed: red,
+
+        admin_border: orange,
+        danger: red,
+
+        selection_bg: bg_highlight,
+        selection_fg: magenta,
+
+        modal_dim_bg: bg_dark,
+        modal_bg: bg,
+        modal_border: blue,
+
+        inverted_fg: bg,
+
+        app_bg: bg,
+
+        nerd_font_enabled: false,
+    }
+}
+
+fn gruvbox_dark_palette() -> ThemePalette {
+    let yellow = Color::Rgb(0xFA, 0xBD, 0x2F);
+    let orange = Color::Rgb(0xFE, 0x80, 0x19);
+    let red = Color::Rgb(0xFB, 0x49, 0x34);
+    let green = Color::Rgb(0xB8, 0xBB, 0x26);
+    let aqua = Color::Rgb(0x8E, 0xC0, 0x7C);
+    let blue = Color::Rgb(0x83, 0xA5, 0x98);
+    let purple = Color::Rgb(0xD3, 0x86, 0x9B);
+    let fg = Color::Rgb(0xEB, 0xDB, 0xB2);
+    let fg2 = Color::Rgb(0xD5, 0xC4, 0xA1);
+    let gray = Color::Rgb(0x92, 0x83, 0x74);
+    let bg0 = Color::Rgb(0x28, 0x28, 0x28);
+    let bg1 = Color::Rgb(0x3C, 0x38, 0x36);
+    let bg_hard = Color::Rgb(0x1D, 0x20, 0x21);
+
+    ThemePalette {
+        accent: yellow,
+        accent_bright: orange,
+
+        status_busy: green,
+        status_waiting: yellow,
+        status_idle: gray,
+        status_error: red,
+
+        text_primary: fg,
+        text_secondary: fg2,
+        text_muted: gray,
+
+        border_focused: yellow,
+        border_unfocused: bg1,
+
+        role_name: purple,
+        admin_badge: orange,
+        branch_name: aqua,
+        search_bar: blue,
+
+        keybind_hint: orange,
+        tool_allowed: green,
+        tool_disallowed: red,
+
+        admin_border: orange,
+        danger: red,
+
+        selection_bg: bg1,
+        selection_fg: fg,
+
+        modal_dim_bg: bg_hard,
+        modal_bg: bg0,
+        modal_border: yellow,
+
+        inverted_fg: bg0,
+
+        app_bg: bg0,
+
+        nerd_font_enabled: false,
+    }
+}
+
+fn catppuccin_latte_palette() -> ThemePalette {
+    let mauve = Color::Rgb(0x88, 0x39, 0xEF);
+    let pink = Color::Rgb(0xEA, 0x76, 0xCB);
+    let green = Color::Rgb(0x40, 0xA0, 0x2B);
+    let yellow = Color::Rgb(0xDF, 0x8E, 0x1D);
+    let red = Color::Rgb(0xD2, 0x0F, 0x39);
+    let blue = Color::Rgb(0x1E, 0x66, 0xF5);
+    let teal = Color::Rgb(0x17, 0x92, 0x99);
+    let text = Color::Rgb(0x4C, 0x4F, 0x69);
+    let subtext = Color::Rgb(0x6C, 0x6F, 0x85);
+    let overlay = Color::Rgb(0x9C, 0xA0, 0xB0);
+    let surface0 = Color::Rgb(0xCC, 0xD0, 0xDA);
+    let surface1 = Color::Rgb(0xBC, 0xC0, 0xCC);
+    let base = Color::Rgb(0xEF, 0xF1, 0xF5);
+    let crust = Color::Rgb(0xDC, 0xE0, 0xE8);
+
+    ThemePalette {
+        accent: mauve,
+        accent_bright: pink,
+
+        status_busy: green,
+        status_waiting: yellow,
+        status_idle: overlay,
+        status_error: red,
+
+        text_primary: text,
+        text_secondary: subtext,
+        text_muted: overlay,
+
+        border_focused: mauve,
+        border_unfocused: surface1,
+
+        role_name: pink,
+        admin_badge: yellow,
+        branch_name: green,
+        search_bar: blue,
+
+        keybind_hint: yellow,
+        tool_allowed: green,
+        tool_disallowed: red,
+
+        admin_border: yellow,
+        danger: red,
+
+        selection_bg: surface0,
+        selection_fg: text,
+
+        modal_dim_bg: crust,
+        modal_bg: base,
+        modal_border: teal,
+
+        inverted_fg: base,
+
+        app_bg: base,
+
+        nerd_font_enabled: false,
+    }
+}
+
+fn tokyo_night_day_palette() -> ThemePalette {
+    let blue = Color::Rgb(0x2E, 0x7D, 0xE9);
+    let cyan = Color::Rgb(0x00, 0x71, 0x97);
+    let purple = Color::Rgb(0x98, 0x54, 0xF1);
+    let magenta = Color::Rgb(0x78, 0x47, 0xBD);
+    let green = Color::Rgb(0x58, 0x75, 0x39);
+    let yellow = Color::Rgb(0x8C, 0x6C, 0x3E);
+    let orange = Color::Rgb(0xB1, 0x5C, 0x00);
+    let red = Color::Rgb(0xF5, 0x2A, 0x65);
+    let text = Color::Rgb(0x37, 0x60, 0xBF);
+    let subtext = Color::Rgb(0x6A, 0x6E, 0x8A);
+    let muted = Color::Rgb(0x84, 0x8C, 0xB5);
+    let bg = Color::Rgb(0xE1, 0xE2, 0xE7);
+    let bg_dark = Color::Rgb(0xD0, 0xD5, 0xE1);
+    let bg_highlight = Color::Rgb(0xC4, 0xC8, 0xDA);
+
+    ThemePalette {
+        accent: blue,
+        accent_bright: cyan,
+
+        status_busy: green,
+        status_waiting: yellow,
+        status_idle: muted,
+        status_error: red,
+
+        text_primary: text,
+        text_secondary: subtext,
+        text_muted: muted,
+
+        border_focused: blue,
+        border_unfocused: bg_highlight,
+
+        role_name: purple,
+        admin_badge: orange,
+        branch_name: green,
+        search_bar: cyan,
+
+        keybind_hint: orange,
+        tool_allowed: green,
+        tool_disallowed: red,
+
+        admin_border: orange,
+        danger: red,
+
+        selection_bg: bg_highlight,
+        selection_fg: magenta,
+
+        modal_dim_bg: bg_dark,
+        modal_bg: bg,
+        modal_border: blue,
+
+        inverted_fg: bg,
+
+        app_bg: bg,
+
+        nerd_font_enabled: false,
+    }
+}
+
+fn gruvbox_light_palette() -> ThemePalette {
+    let yellow = Color::Rgb(0xB5, 0x76, 0x14);
+    let orange = Color::Rgb(0xAF, 0x3A, 0x03);
+    let red = Color::Rgb(0x9D, 0x00, 0x06);
+    let green = Color::Rgb(0x79, 0x74, 0x0E);
+    let aqua = Color::Rgb(0x42, 0x7B, 0x58);
+    let blue = Color::Rgb(0x07, 0x66, 0x78);
+    let purple = Color::Rgb(0x8F, 0x3F, 0x71);
+    let fg = Color::Rgb(0x3C, 0x38, 0x36);
+    let fg2 = Color::Rgb(0x50, 0x49, 0x45);
+    let gray = Color::Rgb(0x7C, 0x6F, 0x64);
+    let bg0 = Color::Rgb(0xFB, 0xF1, 0xC7);
+    let bg1 = Color::Rgb(0xEB, 0xDB, 0xB2);
+    let bg_soft = Color::Rgb(0xF2, 0xE5, 0xBC);
+
+    ThemePalette {
+        accent: orange,
+        accent_bright: yellow,
+
+        status_busy: green,
+        status_waiting: yellow,
+        status_idle: gray,
+        status_error: red,
+
+        text_primary: fg,
+        text_secondary: fg2,
+        text_muted: gray,
+
+        border_focused: orange,
+        border_unfocused: bg1,
+
+        role_name: purple,
+        admin_badge: yellow,
+        branch_name: aqua,
+        search_bar: blue,
+
+        keybind_hint: yellow,
+        tool_allowed: green,
+        tool_disallowed: red,
+
+        admin_border: yellow,
+        danger: red,
+
+        selection_bg: bg1,
+        selection_fg: fg,
+
+        modal_dim_bg: bg_soft,
+        modal_bg: bg0,
+        modal_border: orange,
+
+        inverted_fg: bg0,
+
+        app_bg: bg0,
+
+        nerd_font_enabled: false,
+    }
+}
+
+fn solarized_light_palette() -> ThemePalette {
+    let yellow = Color::Rgb(0xB5, 0x89, 0x00);
+    let orange = Color::Rgb(0xCB, 0x4B, 0x16);
+    let red = Color::Rgb(0xDC, 0x32, 0x2F);
+    let magenta = Color::Rgb(0xD3, 0x36, 0x82);
+    let violet = Color::Rgb(0x6C, 0x71, 0xC4);
+    let blue = Color::Rgb(0x26, 0x8B, 0xD2);
+    let cyan = Color::Rgb(0x2A, 0xA1, 0x98);
+    let green = Color::Rgb(0x85, 0x99, 0x00);
+    let base00 = Color::Rgb(0x65, 0x7B, 0x83);
+    let base01 = Color::Rgb(0x58, 0x6E, 0x75);
+    let base1 = Color::Rgb(0x93, 0xA1, 0xA1);
+    let base2 = Color::Rgb(0xEE, 0xE8, 0xD5);
+    let base3 = Color::Rgb(0xFD, 0xF6, 0xE3);
+
+    ThemePalette {
+        accent: blue,
+        accent_bright: cyan,
+
+        status_busy: green,
+        status_waiting: yellow,
+        status_idle: base1,
+        status_error: red,
+
+        text_primary: base01,
+        text_secondary: base00,
+        text_muted: base1,
+
+        border_focused: blue,
+        border_unfocused: base2,
+
+        role_name: magenta,
+        admin_badge: orange,
+        branch_name: green,
+        search_bar: violet,
+
+        keybind_hint: orange,
+        tool_allowed: green,
+        tool_disallowed: red,
+
+        admin_border: orange,
+        danger: red,
+
+        selection_bg: base2,
+        selection_fg: base01,
+
+        modal_dim_bg: base2,
+        modal_bg: base3,
+        modal_border: blue,
+
+        inverted_fg: base3,
+
+        app_bg: base3,
+
+        nerd_font_enabled: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_presets_round_trip_through_string() {
+        for preset in ThemePreset::all() {
+            let id = preset.as_str();
+            assert_eq!(ThemePreset::from_str(id), Some(*preset));
+        }
+    }
+
+    #[test]
+    fn unknown_preset_returns_none() {
+        assert_eq!(ThemePreset::from_str("nope"), None);
+    }
+
+    #[test]
+    fn default_palette_matches_default_preset() {
+        assert_eq!(ThemePalette::default(), ThemePreset::Default.palette());
+    }
+
+    #[test]
+    fn presets_have_distinct_accents() {
+        let mut accents = std::collections::HashSet::new();
+        for preset in ThemePreset::all() {
+            // Different presets should pick different accent colours so the
+            // theme picker preview swatch shows visible variation.
+            assert!(
+                accents.insert(format!("{:?}", preset.palette().accent)),
+                "preset {preset:?} duplicates an existing accent colour",
+            );
+        }
+    }
+
+    #[test]
+    fn display_names_are_human_readable() {
+        assert_eq!(
+            ThemePreset::CatppuccinMocha.display_name(),
+            "Catppuccin Mocha"
+        );
+        assert_eq!(ThemePreset::TokyoNight.display_name(), "Tokyo Night");
+    }
+}

--- a/src/storage/keybindings.rs
+++ b/src/storage/keybindings.rs
@@ -1,0 +1,78 @@
+//! File IO for the user keybindings JSON file.
+//!
+//! Lives outside SQLite because the file is hand-edited (e.g. via `$EDITOR`)
+//! and version-controlled by the user. The TUI reads it once at startup and
+//! falls back to defaults when the file is missing or malformed.
+
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+use crate::paths;
+
+/// Read the keybindings JSON from disk, or `Ok(None)` if the file doesn't
+/// exist. Errors only on IO failure or unresolved path.
+pub fn load_keybindings_json() -> Result<Option<String>, String> {
+    let path = path()?;
+    match fs::read_to_string(&path) {
+        Ok(s) => Ok(Some(s)),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("read {}: {e}", path.display())),
+    }
+}
+
+/// Write the keybindings JSON to disk, creating parent directories as needed.
+pub fn save_keybindings_json(json: &str) -> Result<(), String> {
+    let path = path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    fs::write(&path, json).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+/// Remove the keybindings JSON file (resets to defaults). Returns `Ok(())`
+/// if the file is already absent.
+pub fn delete_keybindings_json() -> Result<(), String> {
+    let path = path()?;
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("delete {}: {e}", path.display())),
+    }
+}
+
+fn path() -> Result<PathBuf, String> {
+    paths::keybindings_file().ok_or_else(|| "could not resolve keybindings file path".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::TestPathGuard;
+
+    #[test]
+    fn load_returns_none_when_file_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        assert_eq!(load_keybindings_json().unwrap(), None);
+    }
+
+    #[test]
+    fn save_then_load_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let body = r#"{"QuitApp": ["ctrl+x"]}"#;
+        save_keybindings_json(body).unwrap();
+        assert_eq!(load_keybindings_json().unwrap().as_deref(), Some(body));
+    }
+
+    #[test]
+    fn delete_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        delete_keybindings_json().unwrap();
+        save_keybindings_json("{}").unwrap();
+        delete_keybindings_json().unwrap();
+        assert_eq!(load_keybindings_json().unwrap(), None);
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod audit;
 pub mod containers;
+pub mod keybindings;
 mod mcp_servers;
 pub mod repo_bookmarks;
 mod roles;

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -5,6 +5,8 @@ use rusqlite::{params, OptionalExtension};
 use super::Database;
 
 const EDITOR_COMMAND_KEY: &str = "editor_command";
+const THEME_KEY: &str = "active_theme";
+const NERD_FONT_KEY: &str = "nerd_font_glyphs";
 
 impl Database {
     /// Get the configured editor command (e.g. `code`, `nvim --remote-tab`).
@@ -34,6 +36,55 @@ impl Database {
         }
         Ok(())
     }
+
+    /// Get the active theme preset name (e.g. `default`, `catppuccin-mocha`).
+    pub fn get_active_theme(&self) -> rusqlite::Result<Option<String>> {
+        self.conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![THEME_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+    }
+
+    /// Set the active theme preset name. Pass an empty string to reset to default.
+    pub fn set_active_theme(&self, name: &str) -> rusqlite::Result<()> {
+        if name.is_empty() {
+            self.conn
+                .execute("DELETE FROM metadata WHERE key = ?1", params![THEME_KEY])?;
+        } else {
+            self.conn.execute(
+                "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![THEME_KEY, name],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Whether nerd-font glyphs are enabled. Defaults to `false` when unset.
+    pub fn get_nerd_font_enabled(&self) -> rusqlite::Result<bool> {
+        let value: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![NERD_FONT_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(value.as_deref() == Some("1"))
+    }
+
+    /// Toggle nerd-font glyphs. Stored as `"1"` / `"0"`.
+    pub fn set_nerd_font_enabled(&self, enabled: bool) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![NERD_FONT_KEY, if enabled { "1" } else { "0" }],
+        )?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -56,5 +107,38 @@ mod tests {
 
         db.set_editor_command("").unwrap();
         assert_eq!(db.get_editor_command().unwrap(), None);
+    }
+
+    #[test]
+    fn active_theme_round_trip() {
+        let db = Database::open_in_memory().unwrap();
+        assert_eq!(db.get_active_theme().unwrap(), None);
+
+        db.set_active_theme("catppuccin-mocha").unwrap();
+        assert_eq!(
+            db.get_active_theme().unwrap().as_deref(),
+            Some("catppuccin-mocha")
+        );
+
+        db.set_active_theme("tokyo-night").unwrap();
+        assert_eq!(
+            db.get_active_theme().unwrap().as_deref(),
+            Some("tokyo-night")
+        );
+
+        db.set_active_theme("").unwrap();
+        assert_eq!(db.get_active_theme().unwrap(), None);
+    }
+
+    #[test]
+    fn nerd_font_round_trip() {
+        let db = Database::open_in_memory().unwrap();
+        assert!(!db.get_nerd_font_enabled().unwrap());
+
+        db.set_nerd_font_enabled(true).unwrap();
+        assert!(db.get_nerd_font_enabled().unwrap());
+
+        db.set_nerd_font_enabled(false).unwrap();
+        assert!(!db.get_nerd_font_enabled().unwrap());
     }
 }

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -530,7 +530,7 @@ pub fn render_file_viewer(
     if state.roots.is_empty() {
         let p = Paragraph::new(Line::from(Span::styled(
             "No folders",
-            Style::default().fg(Theme::TEXT_MUTED),
+            Style::default().fg(Theme::text_muted()),
         )));
         frame.render_widget(p, list_area);
         return;
@@ -559,20 +559,24 @@ pub fn render_file_viewer(
 }
 
 fn row_marker(row: &FlatRow) -> &'static str {
-    match (row.is_dir, row.expanded) {
-        (true, true) => "▾ ",
-        (true, false) => "▸ ",
-        _ => "  ",
+    let nerd = super::theme::current().nerd_font_enabled;
+    match (row.is_dir, row.expanded, nerd) {
+        (true, true, false) => "▾ ",
+        (true, false, false) => "▸ ",
+        (false, _, false) => "  ",
+        (true, true, true) => "\u{f07c} ",
+        (true, false, true) => "\u{f07b} ",
+        (false, _, true) => "\u{f15b} ",
     }
 }
 
 fn row_label_color(is_match: bool, is_dir: bool) -> ratatui::style::Color {
     if !is_match {
-        Theme::TEXT_MUTED
+        Theme::text_muted()
     } else if is_dir {
-        Theme::ACCENT
+        Theme::accent()
     } else {
-        Theme::TEXT_PRIMARY
+        Theme::text_primary()
     }
 }
 
@@ -585,8 +589,8 @@ fn build_row_line(row: &FlatRow, selected: bool, query_lc: Option<&str>) -> Line
 
     let label_style = if selected {
         Style::default()
-            .bg(Theme::SELECTION_BG)
-            .fg(Theme::SELECTION_FG)
+            .bg(Theme::selection_bg())
+            .fg(Theme::selection_fg())
             .add_modifier(Modifier::BOLD)
     } else {
         let mut s = Style::default().fg(row_label_color(is_match, row.is_dir));
@@ -597,10 +601,10 @@ fn build_row_line(row: &FlatRow, selected: bool, query_lc: Option<&str>) -> Line
     };
     let prefix_style = if selected {
         Style::default()
-            .bg(Theme::SELECTION_BG)
-            .fg(Theme::SELECTION_FG)
+            .bg(Theme::selection_bg())
+            .fg(Theme::selection_fg())
     } else {
-        Style::default().fg(Theme::TEXT_MUTED)
+        Style::default().fg(Theme::text_muted())
     };
 
     Line::from(vec![
@@ -621,9 +625,9 @@ fn render_search_bar(
     use ratatui::widgets::{Block, Borders};
 
     let style = if is_active {
-        Style::default().fg(Theme::SEARCH_BAR)
+        Style::default().fg(Theme::search_bar())
     } else {
-        Style::default().fg(Theme::TEXT_MUTED)
+        Style::default().fg(Theme::text_muted())
     };
 
     let block = Block::default()

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -49,7 +49,7 @@ pub fn render_info_panel(
     let block = Block::default()
         .title(" Info ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::BORDER_UNFOCUSED));
+        .border_style(Style::default().fg(Theme::border_unfocused()));
 
     let inner_width = area.width.saturating_sub(2) as usize;
 
@@ -58,7 +58,7 @@ pub fn render_info_panel(
     // ── Session section (most relevant: "what am I looking at") ──
     lines.push(Line::from(vec![
         Span::styled("Name: ", Theme::label()),
-        Span::styled(&info.name, Style::default().fg(Theme::TEXT_PRIMARY)),
+        Span::styled(&info.name, Style::default().fg(Theme::text_primary())),
     ]));
     lines.push(Line::from(vec![
         Span::styled("Status: ", Theme::label()),
@@ -74,7 +74,7 @@ pub fn render_info_panel(
         Span::styled(
             &info.role,
             Style::default()
-                .fg(Theme::ROLE_NAME)
+                .fg(Theme::role_name())
                 .add_modifier(Modifier::BOLD),
         ),
     ]));
@@ -98,10 +98,10 @@ pub fn render_info_panel(
             lines.extend(cpu_gauge);
 
             lines.push(Line::from(vec![
-                Span::styled("RAM", Style::default().fg(Theme::TEXT_MUTED)),
+                Span::styled("RAM", Style::default().fg(Theme::text_muted())),
                 Span::styled(
                     format!("  {}", format_bytes(m.session_memory_bytes)),
-                    Style::default().fg(Theme::TEXT_PRIMARY),
+                    Style::default().fg(Theme::text_primary()),
                 ),
             ]));
         }
@@ -145,11 +145,11 @@ pub fn render_info_panel(
         )));
         for entry in scheduled_commands {
             lines.push(Line::from(vec![
-                Span::styled(&entry.countdown, Style::default().fg(Theme::ACCENT)),
+                Span::styled(&entry.countdown, Style::default().fg(Theme::accent())),
                 Span::styled("  ", Style::default()),
                 Span::styled(
                     &entry.command_preview,
-                    Style::default().fg(Theme::TEXT_SECONDARY),
+                    Style::default().fg(Theme::text_secondary()),
                 ),
             ]));
         }
@@ -187,7 +187,7 @@ fn append_agent_section(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner
             Span::styled("Tokens:  ", Theme::label()),
             Span::styled(
                 format!("{input} in / {output} out"),
-                Style::default().fg(Theme::TEXT_PRIMARY),
+                Style::default().fg(Theme::text_primary()),
             ),
         ]));
     }
@@ -204,11 +204,14 @@ fn append_agent_section(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner
         let removed = metrics.total_lines_removed.unwrap_or(0);
         lines.push(Line::from(vec![
             Span::styled("Lines:   ", Theme::label()),
-            Span::styled(format!("+{added}"), Style::default().fg(Theme::STATUS_BUSY)),
-            Span::styled(" / ", Style::default().fg(Theme::TEXT_MUTED)),
+            Span::styled(
+                format!("+{added}"),
+                Style::default().fg(Theme::status_busy()),
+            ),
+            Span::styled(" / ", Style::default().fg(Theme::text_muted())),
             Span::styled(
                 format!("-{removed}"),
-                Style::default().fg(Theme::STATUS_ERROR),
+                Style::default().fg(Theme::status_error()),
             ),
         ]));
     }
@@ -225,7 +228,7 @@ fn append_agent_section(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner
                     format_tokens(cache_read),
                     format_tokens(cache_create)
                 ),
-                Style::default().fg(Theme::TEXT_PRIMARY),
+                Style::default().fg(Theme::text_primary()),
             ),
         ]));
     }
@@ -265,17 +268,17 @@ fn append_repos_section<'a>(lines: &mut Vec<Line<'a>>, info: &'a SessionInfo) {
     if extra_names.is_empty() {
         lines.push(Line::from(vec![
             Span::styled("Repos: ", Theme::label()),
-            Span::styled(primary, Style::default().fg(Theme::BRANCH_NAME)),
+            Span::styled(primary, Style::default().fg(Theme::branch_name())),
         ]));
     } else {
         lines.push(Line::from(vec![
             Span::styled("Repos: ", Theme::label()),
-            Span::styled(primary, Style::default().fg(Theme::BRANCH_NAME)),
+            Span::styled(primary, Style::default().fg(Theme::branch_name())),
         ]));
         for name in &extra_names {
             lines.push(Line::from(vec![
                 Span::styled("       ", Theme::label()),
-                Span::styled(*name, Style::default().fg(Theme::BRANCH_NAME)),
+                Span::styled(*name, Style::default().fg(Theme::branch_name())),
             ]));
         }
     }
@@ -298,18 +301,18 @@ fn append_vm_section<'a>(
     if let Some(vm) = vm_details {
         lines.push(Line::from(vec![
             Span::styled("State: ", Theme::label()),
-            Span::styled(&vm.state, Style::default().fg(Theme::TEXT_PRIMARY)),
+            Span::styled(&vm.state, Style::default().fg(Theme::text_primary())),
         ]));
         lines.push(Line::from(vec![
             Span::styled("CPUs: ", Theme::label()),
             Span::styled(
                 vm.cpus.to_string(),
-                Style::default().fg(Theme::TEXT_PRIMARY),
+                Style::default().fg(Theme::text_primary()),
             ),
             Span::styled("  RAM: ", Theme::label()),
             Span::styled(
                 format!("{} MB", vm.memory_mb),
-                Style::default().fg(Theme::TEXT_PRIMARY),
+                Style::default().fg(Theme::text_primary()),
             ),
         ]));
         if vm.ssh_port > 0 {
@@ -317,13 +320,13 @@ fn append_vm_section<'a>(
                 Span::styled("SSH: ", Theme::label()),
                 Span::styled(
                     format!("localhost:{}", vm.ssh_port),
-                    Style::default().fg(Theme::TEXT_PRIMARY),
+                    Style::default().fg(Theme::text_primary()),
                 ),
             ]));
         }
         lines.push(Line::from(vec![
             Span::styled("Image: ", Theme::label()),
-            Span::styled(&vm.base_image, Style::default().fg(Theme::TEXT_MUTED)),
+            Span::styled(&vm.base_image, Style::default().fg(Theme::text_muted())),
         ]));
     }
 
@@ -331,7 +334,7 @@ fn append_vm_section<'a>(
         if let Some(ref step) = info.provisioning_step {
             lines.push(Line::from(vec![
                 Span::styled("Step: ", Theme::label()),
-                Span::styled(step, Style::default().fg(Theme::ACCENT)),
+                Span::styled(step, Style::default().fg(Theme::accent())),
             ]));
         }
     }
@@ -340,7 +343,7 @@ fn append_vm_section<'a>(
 fn separator(width: usize) -> Line<'static> {
     Line::from(Span::styled(
         "─".repeat(width),
-        Style::default().fg(Theme::BORDER_UNFOCUSED),
+        Style::default().fg(Theme::border_unfocused()),
     ))
 }
 
@@ -361,9 +364,9 @@ fn render_gauge_lines(
     let right_len = right_text.chars().count();
     let padding = width.saturating_sub(label_len + right_len);
     let header_line = Line::from(vec![
-        Span::styled(label.to_string(), Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled(label.to_string(), Style::default().fg(Theme::text_muted())),
         Span::raw(" ".repeat(padding)),
-        Span::styled(right_text, Style::default().fg(Theme::TEXT_PRIMARY)),
+        Span::styled(right_text, Style::default().fg(Theme::text_primary())),
     ]);
 
     // Line 2: bar scaled to width - 2 (for [ and ])
@@ -371,10 +374,10 @@ fn render_gauge_lines(
     let filled = ((clamped / 100.0) * bar_width as f32).round() as usize;
     let empty = bar_width.saturating_sub(filled);
     let bar_line = Line::from(vec![
-        Span::styled("[", Style::default().fg(Theme::TEXT_MUTED)),
-        Span::styled("█".repeat(filled), Style::default().fg(Theme::ACCENT)),
-        Span::styled("░".repeat(empty), Style::default().fg(Theme::TEXT_MUTED)),
-        Span::styled("]", Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled("[", Style::default().fg(Theme::text_muted())),
+        Span::styled("█".repeat(filled), Style::default().fg(Theme::accent())),
+        Span::styled("░".repeat(empty), Style::default().fg(Theme::text_muted())),
+        Span::styled("]", Style::default().fg(Theme::text_muted())),
     ]);
 
     vec![header_line, bar_line]

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -15,10 +15,14 @@ pub struct PanelAreas {
 /// At width ≥ 120, the layout becomes `list | info? | terminal | file_viewer?`
 /// with info (15%) and file_viewer (20%) appearing only when requested.
 pub fn compute_layout(area: Rect, show_info_panel: bool, show_file_viewer: bool) -> PanelAreas {
+    // Compact mode: when the terminal is shorter than 20 rows, drop the
+    // header line entirely so the content + footer get every row available.
+    let header_height = if area.height < 20 { 0 } else { 1 };
+
     let vertical = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),
+            Constraint::Length(header_height),
             Constraint::Min(1),
             Constraint::Length(1),
         ])
@@ -165,6 +169,20 @@ mod tests {
         let areas = compute_layout(area(100, 24), false, false);
         assert_eq!(areas.header.height, 1);
         assert_eq!(areas.footer.height, 1);
+    }
+
+    #[test]
+    fn compact_mode_hides_header_below_20_rows() {
+        let areas = compute_layout(area(100, 19), false, false);
+        assert_eq!(areas.header.height, 0);
+        assert_eq!(areas.footer.height, 1);
+        assert!(areas.left_panel.is_some());
+    }
+
+    #[test]
+    fn header_returns_at_20_rows() {
+        let areas = compute_layout(area(100, 20), false, false);
+        assert_eq!(areas.header.height, 1);
     }
 
     #[test]

--- a/src/ui/mcp_editor_modal.rs
+++ b/src/ui/mcp_editor_modal.rs
@@ -68,9 +68,9 @@ pub fn render_mcp_editor_modal(frame: &mut Frame, state: &McpEditorState<'_>) {
         format!("\"{}\"", state.name)
     };
     let breadcrumb = Line::from(vec![
-        Span::styled(" MCP Servers", Style::default().fg(Theme::TEXT_MUTED)),
-        Span::styled(" > ", Style::default().fg(Theme::TEXT_MUTED)),
-        Span::styled(mcp_label, Style::default().fg(Theme::ACCENT)),
+        Span::styled(" MCP Servers", Style::default().fg(Theme::text_muted())),
+        Span::styled(" > ", Style::default().fg(Theme::text_muted())),
+        Span::styled(mcp_label, Style::default().fg(Theme::accent())),
     ]);
     frame.render_widget(Paragraph::new(breadcrumb), chunks[0]);
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -23,6 +23,7 @@ pub mod skill_picker_modal;
 pub mod status_bar;
 pub mod terminal_view;
 pub mod theme;
+pub mod theme_picker_modal;
 pub mod worktree_name_modal;
 
 use ratatui::{
@@ -38,11 +39,11 @@ use theme::Theme;
 
 pub fn status_color(status: SessionStatus) -> Color {
     match status {
-        SessionStatus::Provisioning => Theme::ACCENT,
-        SessionStatus::Busy => Theme::STATUS_BUSY,
-        SessionStatus::Waiting => Theme::STATUS_WAITING,
-        SessionStatus::Idle => Theme::STATUS_IDLE,
-        SessionStatus::Error => Theme::STATUS_ERROR,
+        SessionStatus::Provisioning => Theme::accent(),
+        SessionStatus::Busy => Theme::status_busy(),
+        SessionStatus::Waiting => Theme::status_waiting(),
+        SessionStatus::Idle => Theme::status_idle(),
+        SessionStatus::Error => Theme::status_error(),
     }
 }
 
@@ -58,29 +59,33 @@ pub enum FocusLevel {
 }
 
 /// Build a [`Block`] with tri-state focus styling.
+///
+/// Focus is communicated by colour (bright accent vs plain accent vs gray)
+/// rather than border weight — every level uses rounded borders for a
+/// softer, opencode-style chrome.
 pub fn focus_block(title_text: &str, level: FocusLevel) -> Block<'_> {
     match level {
         FocusLevel::Focused => Block::default()
             .title(Line::from(Span::styled(title_text, Theme::focused_title())))
             .borders(Borders::ALL)
-            .border_type(BorderType::Thick)
-            .border_style(Style::default().fg(Theme::BORDER_FOCUSED)),
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Theme::accent_bright())),
         FocusLevel::Active => Block::default()
             .title(Line::from(Span::styled(
                 title_text,
-                Style::default().fg(Theme::ACCENT),
+                Style::default().fg(Theme::accent()),
             )))
             .borders(Borders::ALL)
-            .border_type(BorderType::Plain)
-            .border_style(Style::default().fg(Theme::ACCENT)),
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Theme::accent())),
         FocusLevel::Inactive => Block::default()
             .title(Line::from(Span::styled(
                 title_text,
                 Theme::unfocused_title(),
             )))
             .borders(Borders::ALL)
-            .border_type(BorderType::Plain)
-            .border_style(Style::default().fg(Theme::BORDER_UNFOCUSED)),
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Theme::border_unfocused())),
     }
 }
 
@@ -94,21 +99,21 @@ pub fn admin_block(title_text: &str, level: FocusLevel) -> Block<'_> {
         FocusLevel::Focused => Block::default()
             .title(Line::from(Span::styled(title_text, Theme::admin_title())))
             .borders(Borders::ALL)
-            .border_type(BorderType::Thick)
-            .border_style(Style::default().fg(Theme::ADMIN_BORDER)),
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Theme::admin_border())),
         FocusLevel::Active => Block::default()
             .title(Line::from(Span::styled(title_text, Theme::admin_title())))
             .borders(Borders::ALL)
-            .border_type(BorderType::Plain)
-            .border_style(Style::default().fg(Theme::ADMIN_BORDER)),
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Theme::admin_border())),
         FocusLevel::Inactive => Block::default()
             .title(Line::from(Span::styled(
                 title_text,
                 Theme::unfocused_title(),
             )))
             .borders(Borders::ALL)
-            .border_type(BorderType::Plain)
-            .border_style(Style::default().fg(Theme::BORDER_UNFOCUSED)),
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Theme::border_unfocused())),
     }
 }
 
@@ -150,7 +155,7 @@ pub fn centered_fixed_height_rect(percent_x: u16, height: u16, area: Rect) -> Re
 
 /// Render a full-screen dim overlay to visually separate a modal from the background.
 pub fn render_dim_overlay(frame: &mut Frame) {
-    let dim = Block::default().style(Style::default().bg(Theme::MODAL_DIM_BG));
+    let dim = Block::default().style(Style::default().bg(Theme::modal_dim_bg()));
     frame.render_widget(dim, frame.area());
 }
 
@@ -161,17 +166,17 @@ fn build_modal_block(title: &str, title_style: Style, border_color: Color) -> Bl
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(border_color))
-        .style(Style::default().bg(Theme::MODAL_BG))
+        .style(Style::default().bg(Theme::modal_bg()))
 }
 
 /// Build a styled modal [`Block`] with rounded borders and an explicit background.
 pub fn modal_block(title: &str) -> Block<'_> {
-    build_modal_block(title, Theme::modal_title(), Theme::MODAL_BORDER)
+    build_modal_block(title, Theme::modal_title(), Theme::modal_border())
 }
 
 /// Build a danger-styled modal [`Block`] with red borders and background.
 pub fn modal_block_danger(title: &str) -> Block<'_> {
-    build_modal_block(title, Theme::modal_title_danger(), Theme::DANGER)
+    build_modal_block(title, Theme::modal_title_danger(), Theme::danger())
 }
 
 /// Dim the background, clear the modal region, render a styled block, and return the inner area.
@@ -221,7 +226,7 @@ pub fn render_list_modal_frame<'a>(
         if let Some(msg) = empty_message {
             let empty = Paragraph::new(Line::from(Span::styled(
                 msg,
-                Style::default().fg(Theme::TEXT_MUTED),
+                Style::default().fg(Theme::text_muted()),
             )))
             .alignment(ratatui::layout::Alignment::Center);
             frame.render_widget(empty, chunks[0]);
@@ -294,9 +299,9 @@ pub fn render_text_field_with_suggestion(
     suggestion: Option<&str>,
 ) {
     let border_color = if focused {
-        Theme::BORDER_FOCUSED
+        Theme::border_focused()
     } else {
-        Theme::BORDER_UNFOCUSED
+        Theme::border_unfocused()
     };
 
     let block = Block::default()
@@ -344,7 +349,7 @@ pub fn render_text_field_with_suggestion(
         let mut spans = Vec::new();
 
         if has_left_overflow {
-            spans.push(Span::styled("◀", Style::default().fg(Theme::TEXT_MUTED)));
+            spans.push(Span::styled("◀", Style::default().fg(Theme::text_muted())));
         }
 
         let visible_end = (content_start + content_width).min(chars.len());
@@ -364,14 +369,14 @@ pub fn render_text_field_with_suggestion(
             if !before.is_empty() {
                 spans.push(Span::styled(
                     before,
-                    Style::default().fg(Theme::TEXT_PRIMARY),
+                    Style::default().fg(Theme::text_primary()),
                 ));
             }
             spans.push(Span::styled(cursor_char, Theme::cursor()));
             if !after.is_empty() {
                 spans.push(Span::styled(
                     after,
-                    Style::default().fg(Theme::TEXT_PRIMARY),
+                    Style::default().fg(Theme::text_primary()),
                 ));
             }
 
@@ -384,7 +389,7 @@ pub fn render_text_field_with_suggestion(
                 if remaining > 0 {
                     let sug: String = suggestion_text.chars().take(remaining).collect();
                     if !sug.is_empty() {
-                        spans.push(Span::styled(sug, Style::default().fg(Theme::TEXT_MUTED)));
+                        spans.push(Span::styled(sug, Style::default().fg(Theme::text_muted())));
                     }
                 }
             }
@@ -392,12 +397,12 @@ pub fn render_text_field_with_suggestion(
             let visible: String = chars[content_start..visible_end].iter().collect();
             spans.push(Span::styled(
                 visible,
-                Style::default().fg(Theme::TEXT_PRIMARY),
+                Style::default().fg(Theme::text_primary()),
             ));
         }
 
         if has_right_overflow {
-            spans.push(Span::styled("▶", Style::default().fg(Theme::TEXT_MUTED)));
+            spans.push(Span::styled("▶", Style::default().fg(Theme::text_muted())));
         }
 
         Line::from(spans)
@@ -405,13 +410,13 @@ pub fn render_text_field_with_suggestion(
         if chars.len() > width {
             let truncated: String = chars[..width - 1].iter().collect();
             Line::from(vec![
-                Span::styled(truncated, Style::default().fg(Theme::TEXT_PRIMARY)),
-                Span::styled("…", Style::default().fg(Theme::TEXT_MUTED)),
+                Span::styled(truncated, Style::default().fg(Theme::text_primary())),
+                Span::styled("…", Style::default().fg(Theme::text_muted())),
             ])
         } else {
             Line::from(Span::styled(
                 value,
-                Style::default().fg(Theme::TEXT_PRIMARY),
+                Style::default().fg(Theme::text_primary()),
             ))
         }
     } else {
@@ -523,6 +528,6 @@ mod tests {
     #[test]
     fn modal_title_danger_uses_danger_color() {
         let style = Theme::modal_title_danger();
-        assert_eq!(style.bg, Some(Theme::DANGER));
+        assert_eq!(style.bg, Some(Theme::danger()));
     }
 }

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{List, ListItem, ListState, Paragraph},
     Frame,
@@ -198,7 +198,7 @@ pub(super) fn render_scroll_indicators(
     let items_above = offset;
     let items_below = total_items.saturating_sub(offset + visible_count);
 
-    let indicator_style = Style::default().fg(Theme::TEXT_MUTED);
+    let indicator_style = Style::default().fg(Theme::text_muted());
 
     if items_above > 0 {
         let text = format!("\u{25b2} {items_above} ");
@@ -237,9 +237,9 @@ fn render_search_bar(
     use ratatui::widgets::{Block, Borders};
 
     let style = if is_active {
-        Style::default().fg(Theme::SEARCH_BAR)
+        Style::default().fg(Theme::search_bar())
     } else {
-        Style::default().fg(Theme::TEXT_MUTED)
+        Style::default().fg(Theme::text_muted())
     };
 
     let title = if !query.is_empty() {
@@ -307,7 +307,7 @@ fn build_highlighted_spans<'a>(
     base_style: Style,
 ) -> Vec<Span<'a>> {
     let highlight_style = base_style
-        .fg(Theme::ACCENT)
+        .fg(Theme::accent())
         .add_modifier(Modifier::BOLD | Modifier::UNDERLINED);
 
     let mut spans = Vec::new();
@@ -383,11 +383,11 @@ fn render_session_section(
             Line::from(""),
             Line::from(Span::styled(
                 "No sessions yet",
-                Style::default().fg(Theme::TEXT_MUTED),
+                Style::default().fg(Theme::text_muted()),
             )),
             Line::from(Span::styled(
                 "Press Ctrl+N to create one",
-                Style::default().fg(Theme::TEXT_MUTED),
+                Style::default().fg(Theme::text_muted()),
             )),
         ])
         .block(block)
@@ -404,7 +404,6 @@ fn render_session_section(
         .enumerate()
         .map(|(i, info)| {
             let is_active = i == active_index;
-            let prefix = if is_active { "\u{25b8}" } else { " " };
             let is_admin = info.is_admin;
 
             // Determine if this session is dimmed (search active + no match).
@@ -413,18 +412,20 @@ fn render_session_section(
 
             let status_text = format_status_with_elapsed(info.status, elapsed_ms.get(i).copied());
             let name_style = if is_dimmed {
-                Style::default().fg(Theme::TEXT_MUTED)
+                Style::default().fg(Theme::text_muted())
             } else if is_active {
                 Theme::selected_item()
             } else {
                 Theme::normal_item()
             };
 
-            // Build prefix with optional admin badge
+            // Build prefix with optional admin badge. The active row is
+            // signalled by the list's highlight background, so no extra
+            // pointer glyph is needed.
             let prefix_str = if is_admin {
-                format!("{prefix} \u{2699} {} ", info.status.icon())
+                format!(" \u{2699} {} ", info.status.icon())
             } else {
-                format!("{prefix} {} ", info.status.icon())
+                format!(" {} ", info.status.icon())
             };
             let prefix_width = prefix_str.chars().count();
             let name_len = info.name.chars().count();
@@ -437,13 +438,13 @@ fn render_session_section(
             };
 
             let status_style = if is_dimmed {
-                Style::default().fg(Theme::TEXT_MUTED)
+                Style::default().fg(Theme::text_muted())
             } else {
                 Style::default().fg(super::status_color(info.status))
             };
 
             let prefix_style = if is_admin && !is_dimmed {
-                Style::default().fg(Theme::ADMIN_BADGE)
+                Style::default().fg(Theme::admin_badge())
             } else {
                 status_style
             };
@@ -465,9 +466,9 @@ fn render_session_section(
             let mut item_lines = vec![line1];
 
             if is_dimmed {
-                let dimmed = Style::default().fg(Theme::TEXT_MUTED);
+                let dimmed = Style::default().fg(Theme::text_muted());
                 item_lines.push(Line::from(vec![Span::styled(
-                    format!("    {}", info.role),
+                    format!("   {}", info.role),
                     dimmed,
                 )]));
                 let entries = build_repo_entries(info);
@@ -475,7 +476,7 @@ fn render_session_section(
                     let text = format_repo_entries_plain(&entries);
                     if !text.is_empty() {
                         item_lines.push(Line::from(vec![Span::styled(
-                            format!("    {text}"),
+                            format!("   {text}"),
                             dimmed,
                         )]));
                     }
@@ -483,12 +484,12 @@ fn render_session_section(
             } else if info.status == crate::session::SessionStatus::Provisioning {
                 let step_text = info.provisioning_step.as_deref().unwrap_or("Starting...");
                 item_lines.push(Line::from(vec![
-                    Span::styled("    \u{27f3} ", Style::default().fg(Theme::ACCENT)),
-                    Span::styled(step_text, Style::default().fg(Theme::ACCENT)),
+                    Span::styled("   \u{27f3} ", Style::default().fg(Theme::accent())),
+                    Span::styled(step_text, Style::default().fg(Theme::accent())),
                 ]));
             } else {
-                let role_style = Style::default().fg(Theme::ROLE_NAME);
-                let mut line2_spans = vec![Span::raw("    ")];
+                let role_style = Style::default().fg(Theme::role_name());
+                let mut line2_spans = vec![Span::raw("   ")];
                 append_name_spans(
                     &mut line2_spans,
                     &info.role,
@@ -498,27 +499,27 @@ fn render_session_section(
                 if info.vm_id.is_some() {
                     line2_spans.push(Span::styled(
                         " \u{00b7} ",
-                        Style::default().fg(Theme::TEXT_MUTED),
+                        Style::default().fg(Theme::text_muted()),
                     ));
-                    line2_spans.push(Span::styled("VM", Style::default().fg(Theme::ACCENT)));
+                    line2_spans.push(Span::styled("VM", Style::default().fg(Theme::accent())));
                 } else if info.container_id.is_some() {
                     line2_spans.push(Span::styled(
                         " \u{00b7} ",
-                        Style::default().fg(Theme::TEXT_MUTED),
+                        Style::default().fg(Theme::text_muted()),
                     ));
                     line2_spans.push(Span::styled(
                         "Container",
-                        Style::default().fg(Theme::ACCENT),
+                        Style::default().fg(Theme::accent()),
                     ));
                 }
                 item_lines.push(Line::from(line2_spans));
 
                 let entries = build_repo_entries(info);
                 if !entries.is_empty() {
-                    let repo_style = Style::default().fg(Theme::TEXT_PRIMARY);
-                    let branch_style = Style::default().fg(Theme::BRANCH_NAME);
-                    let muted = Style::default().fg(Theme::TEXT_MUTED);
-                    let mut line3_spans: Vec<Span<'static>> = vec![Span::raw("    ")];
+                    let repo_style = Style::default().fg(Theme::text_primary());
+                    let branch_style = Style::default().fg(Theme::branch_name());
+                    let muted = Style::default().fg(Theme::text_muted());
+                    let mut line3_spans: Vec<Span<'static>> = vec![Span::raw("   ")];
 
                     // Build the plain text for search matching.
                     let plain = format_repo_entries_plain(&entries);
@@ -563,7 +564,7 @@ fn render_session_section(
                 let divider_width = inner_width.max(1);
                 let divider = Line::from(Span::styled(
                     "\u{2500}".repeat(divider_width),
-                    Style::default().fg(Theme::TEXT_MUTED),
+                    Style::default().fg(Theme::text_muted()),
                 ));
                 item_lines.insert(0, divider);
             }
@@ -574,7 +575,8 @@ fn render_session_section(
 
     let list = List::new(items).block(block).highlight_style(
         Style::default()
-            .bg(Color::DarkGray)
+            .bg(Theme::selection_bg())
+            .fg(Theme::selection_fg())
             .add_modifier(Modifier::BOLD),
     );
 
@@ -685,7 +687,7 @@ mod tests {
 
     #[test]
     fn highlighted_spans_basic() {
-        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let style = Style::default().fg(Theme::text_primary());
         let spans = build_highlighted_spans("foo-bar", &[0, 4], style);
         // Should produce: "f" (highlighted), "oo-" (normal), "b" (highlighted), "ar" (normal)
         assert_eq!(spans.len(), 4);
@@ -697,7 +699,7 @@ mod tests {
 
     #[test]
     fn highlighted_spans_empty_positions() {
-        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let style = Style::default().fg(Theme::text_primary());
         let spans = build_highlighted_spans("hello", &[], style);
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].content, "hello");
@@ -705,7 +707,7 @@ mod tests {
 
     #[test]
     fn highlighted_spans_all_chars() {
-        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let style = Style::default().fg(Theme::text_primary());
         let spans = build_highlighted_spans("abc", &[0, 1, 2], style);
         // All chars highlighted, no normal spans between them.
         assert_eq!(spans.len(), 3);
@@ -718,7 +720,7 @@ mod tests {
 
     #[test]
     fn append_name_spans_no_match_positions() {
-        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let style = Style::default().fg(Theme::text_primary());
         let mut spans = Vec::new();
         append_name_spans(&mut spans, "hello", None, style);
         assert_eq!(spans.len(), 1);
@@ -727,7 +729,7 @@ mod tests {
 
     #[test]
     fn append_name_spans_empty_positions() {
-        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let style = Style::default().fg(Theme::text_primary());
         let mut spans = Vec::new();
         append_name_spans(&mut spans, "hello", Some(&[]), style);
         assert_eq!(spans.len(), 1);
@@ -736,7 +738,7 @@ mod tests {
 
     #[test]
     fn append_name_spans_with_highlights() {
-        let style = Style::default().fg(Theme::TEXT_PRIMARY);
+        let style = Style::default().fg(Theme::text_primary());
         let mut spans = vec![Span::raw("prefix ")];
         append_name_spans(&mut spans, "foo-bar", Some(&[0, 4]), style);
         // prefix + "f" (highlighted) + "oo-" (normal) + "b" (highlighted) + "ar" (normal)

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -475,10 +475,8 @@ fn render_session_section(
                 if !entries.is_empty() {
                     let text = format_repo_entries_plain(&entries);
                     if !text.is_empty() {
-                        item_lines.push(Line::from(vec![Span::styled(
-                            format!("   {text}"),
-                            dimmed,
-                        )]));
+                        item_lines
+                            .push(Line::from(vec![Span::styled(format!("   {text}"), dimmed)]));
                     }
                 }
             } else if info.status == crate::session::SessionStatus::Provisioning {

--- a/src/ui/repo_picker_modal.rs
+++ b/src/ui/repo_picker_modal.rs
@@ -85,9 +85,9 @@ pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) 
     // Bookmark list with checkboxes
     let list_focused = state.focus == RepoPickerFocus::List;
     let border_color = if list_focused {
-        Theme::BORDER_FOCUSED
+        Theme::border_focused()
     } else {
-        Theme::BORDER_UNFOCUSED
+        Theme::border_unfocused()
     };
 
     let title = format!(" Repos ({}) ", state.bookmarks.len());
@@ -108,7 +108,7 @@ pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) 
         };
         let placeholder = Paragraph::new(Line::from(Span::styled(
             msg,
-            Style::default().fg(Theme::TEXT_MUTED),
+            Style::default().fg(Theme::text_muted()),
         )));
         frame.render_widget(placeholder, list_inner_area);
     } else {
@@ -158,7 +158,7 @@ pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) 
                             .unwrap_or(pos + 1);
                         result.push(Span::styled(
                             display[pos..end].to_string(),
-                            Style::default().fg(Theme::ACCENT),
+                            Style::default().fg(Theme::accent()),
                         ));
                         last = end;
                     }
@@ -171,7 +171,7 @@ pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) 
                 };
 
                 if checked && is_wt {
-                    spans.push(Span::styled(" [wt]", Style::default().fg(Theme::ACCENT)));
+                    spans.push(Span::styled(" [wt]", Style::default().fg(Theme::accent())));
                 }
                 ListItem::new(Line::from(spans))
             })

--- a/src/ui/restore_sessions_modal.rs
+++ b/src/ui/restore_sessions_modal.rs
@@ -55,7 +55,7 @@ pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsM
             } else {
                 Line::from(Span::styled(
                     text,
-                    Style::default().fg(Theme::TEXT_SECONDARY),
+                    Style::default().fg(Theme::text_secondary()),
                 ))
             }
         })

--- a/src/ui/role_editor_modal.rs
+++ b/src/ui/role_editor_modal.rs
@@ -102,9 +102,9 @@ pub fn render_role_editor_modal(frame: &mut Frame, state: &RoleEditorState<'_>) 
         format!("\"{}\"", state.name)
     };
     let breadcrumb = Line::from(vec![
-        Span::styled(" Roles", Style::default().fg(Theme::TEXT_MUTED)),
-        Span::styled(" > ", Style::default().fg(Theme::TEXT_MUTED)),
-        Span::styled(role_label, Style::default().fg(Theme::ACCENT)),
+        Span::styled(" Roles", Style::default().fg(Theme::text_muted())),
+        Span::styled(" > ", Style::default().fg(Theme::text_muted())),
+        Span::styled(role_label, Style::default().fg(Theme::accent())),
     ]);
     frame.render_widget(Paragraph::new(breadcrumb), chunks[0]);
 
@@ -251,9 +251,9 @@ pub fn render_tool_list(
     focused: bool,
 ) {
     let border_color = if focused {
-        Theme::BORDER_FOCUSED
+        Theme::border_focused()
     } else {
-        Theme::BORDER_UNFOCUSED
+        Theme::border_unfocused()
     };
     let block = Block::default()
         .title(format!(" {label} "))
@@ -279,7 +279,7 @@ pub fn render_tool_list(
     if tools.is_empty() {
         let empty = Paragraph::new(Line::from(Span::styled(
             "  (none)",
-            Style::default().fg(Theme::TEXT_MUTED),
+            Style::default().fg(Theme::text_muted()),
         )));
         frame.render_widget(empty, parts[0]);
     } else {
@@ -329,10 +329,10 @@ fn render_inline_input(frame: &mut Frame, area: ratatui::layout::Rect, value: &s
     };
 
     let line = Line::from(vec![
-        Span::styled("+ ", Style::default().fg(Theme::TOOL_ALLOWED)),
-        Span::styled(before, Style::default().fg(Theme::TEXT_PRIMARY)),
+        Span::styled("+ ", Style::default().fg(Theme::tool_allowed())),
+        Span::styled(before, Style::default().fg(Theme::text_primary())),
         Span::styled(cursor_char, Theme::cursor()),
-        Span::styled(after, Style::default().fg(Theme::TEXT_PRIMARY)),
+        Span::styled(after, Style::default().fg(Theme::text_primary())),
     ]);
 
     frame.render_widget(Paragraph::new(line), area);

--- a/src/ui/role_selector_modal.rs
+++ b/src/ui/role_selector_modal.rs
@@ -44,7 +44,7 @@ pub fn render_role_selector_modal(frame: &mut Frame, state: &RoleSelectorState<'
     if let Some(role) = state.roles.get(state.selected_index) {
         let desc = Line::from(Span::styled(
             &role.description,
-            Style::default().fg(Theme::TEXT_MUTED),
+            Style::default().fg(Theme::text_muted()),
         ));
         frame.render_widget(Paragraph::new(desc), chunks[1]);
     }

--- a/src/ui/scheduled_commands_list_modal.rs
+++ b/src/ui/scheduled_commands_list_modal.rs
@@ -72,7 +72,7 @@ pub fn render_scheduled_commands_list_modal(
             } else {
                 Line::from(Span::styled(
                     text,
-                    Style::default().fg(Theme::TEXT_SECONDARY),
+                    Style::default().fg(Theme::text_secondary()),
                 ))
             }
         })

--- a/src/ui/settings_overlay.rs
+++ b/src/ui/settings_overlay.rs
@@ -38,17 +38,17 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
     let roles_style = if state.tab == SettingsTab::Roles {
         Theme::focused_title()
     } else {
-        Style::default().fg(Theme::TEXT_MUTED)
+        Style::default().fg(Theme::text_muted())
     };
     let mcp_style = if state.tab == SettingsTab::McpServers {
         Theme::focused_title()
     } else {
-        Style::default().fg(Theme::TEXT_MUTED)
+        Style::default().fg(Theme::text_muted())
     };
     let skills_style = if state.tab == SettingsTab::Skills {
         Theme::focused_title()
     } else {
-        Style::default().fg(Theme::TEXT_MUTED)
+        Style::default().fg(Theme::text_muted())
     };
 
     let tab_line = Line::from(vec![
@@ -72,7 +72,7 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
             if state.roles.is_empty() {
                 let empty = Paragraph::new(Line::from(Span::styled(
                     "  No roles configured. Press 'a' to add.",
-                    Style::default().fg(Theme::TEXT_MUTED),
+                    Style::default().fg(Theme::text_muted()),
                 )));
                 frame.render_widget(empty, list_area);
             } else {
@@ -84,7 +84,7 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
                         let style = if i == state.role_index {
                             Theme::focused_title()
                         } else {
-                            Style::default().fg(Theme::TEXT_PRIMARY)
+                            Style::default().fg(Theme::text_primary())
                         };
                         let prefix = if i == state.role_index { "▸ " } else { "  " };
                         ListItem::new(Line::from(Span::styled(
@@ -100,7 +100,7 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
             if state.mcp_servers.is_empty() {
                 let empty = Paragraph::new(Line::from(Span::styled(
                     "  No MCP servers configured. Press 'a' to add.",
-                    Style::default().fg(Theme::TEXT_MUTED),
+                    Style::default().fg(Theme::text_muted()),
                 )));
                 frame.render_widget(empty, list_area);
             } else {
@@ -112,7 +112,7 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
                         let style = if i == state.mcp_index {
                             Theme::focused_title()
                         } else {
-                            Style::default().fg(Theme::TEXT_PRIMARY)
+                            Style::default().fg(Theme::text_primary())
                         };
                         let prefix = if i == state.mcp_index { "▸ " } else { "  " };
                         ListItem::new(Line::from(Span::styled(
@@ -128,7 +128,7 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
             if state.skills.is_empty() {
                 let empty = Paragraph::new(Line::from(Span::styled(
                     "  No skills configured. Press 'a' to add.",
-                    Style::default().fg(Theme::TEXT_MUTED),
+                    Style::default().fg(Theme::text_muted()),
                 )));
                 frame.render_widget(empty, list_area);
             } else {
@@ -140,14 +140,14 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
                         let style = if i == state.skill_index {
                             Theme::focused_title()
                         } else {
-                            Style::default().fg(Theme::TEXT_PRIMARY)
+                            Style::default().fg(Theme::text_primary())
                         };
                         let prefix = if i == state.skill_index { "▸ " } else { "  " };
                         ListItem::new(Line::from(vec![
                             Span::styled(format!("{prefix}{}", skill.name), style),
                             Span::styled(
                                 format!("  {}", skill.path.display()),
-                                Style::default().fg(Theme::TEXT_MUTED),
+                                Style::default().fg(Theme::text_muted()),
                             ),
                         ]))
                     })
@@ -166,15 +166,15 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
 
     let hints = Line::from(vec![
         Span::styled(" Tab", Theme::keybind()),
-        Span::styled(": switch  ", Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled(": switch  ", Style::default().fg(Theme::text_muted())),
         Span::styled("a", Theme::keybind()),
-        Span::styled(": add  ", Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled(": add  ", Style::default().fg(Theme::text_muted())),
         Span::styled("e", Theme::keybind()),
-        Span::styled(": edit  ", Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled(": edit  ", Style::default().fg(Theme::text_muted())),
         Span::styled("d", Theme::keybind()),
-        Span::styled(": delete  ", Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled(": delete  ", Style::default().fg(Theme::text_muted())),
         Span::styled("Esc", Theme::keybind()),
-        Span::styled(": close", Style::default().fg(Theme::TEXT_MUTED)),
+        Span::styled(": close", Style::default().fg(Theme::text_muted())),
     ]);
     frame.render_widget(Paragraph::new(hints), hints_area);
 }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -9,21 +9,53 @@ use ratatui::{
 use super::theme::Theme;
 use crate::app::{StatusLevel, StatusMessage};
 
+fn brand_style() -> Style {
+    Style::default()
+        .fg(Theme::accent())
+        .add_modifier(Modifier::BOLD)
+}
+
 const SPINNER_CHARS: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
-pub fn render_header(frame: &mut Frame, area: Rect) {
+pub fn render_header(frame: &mut Frame, area: Rect, badge: Option<HeaderBadge<'_>>) {
+    if area.height == 0 {
+        return;
+    }
     let header = Paragraph::new(Line::from(vec![
-        Span::styled(" thurbox ", Theme::focused_title()),
+        Span::styled(" thurbox", brand_style()),
         Span::styled(
-            " Multi-Session Agent Orchestrator",
-            Style::default().fg(Theme::TEXT_SECONDARY),
+            "  Multi-Session Agent Orchestrator",
+            Style::default().fg(Theme::text_secondary()),
         ),
         Span::styled(
             concat!("  v", env!("THURBOX_VERSION")),
-            Style::default().fg(Theme::TEXT_MUTED),
+            Style::default().fg(Theme::text_muted()),
         ),
     ]));
     frame.render_widget(header, area);
+
+    if let Some(badge) = badge {
+        let mut spans: Vec<Span<'_>> = Vec::new();
+        if let Some(name) = badge.active_session {
+            spans.push(Span::styled(
+                name.to_string(),
+                Style::default().fg(Theme::text_primary()),
+            ));
+            spans.push(Span::raw("  "));
+        }
+        spans.push(Span::styled(
+            format!("◐ {} ", badge.theme_label),
+            Style::default().fg(Theme::accent()),
+        ));
+        let right = Line::from(spans).alignment(ratatui::layout::Alignment::Right);
+        frame.render_widget(Paragraph::new(right), area);
+    }
+}
+
+/// Right-aligned overlay rendered on top of the header.
+pub struct HeaderBadge<'a> {
+    pub active_session: Option<&'a str>,
+    pub theme_label: &'a str,
 }
 
 /// State needed to render the footer bar.
@@ -82,7 +114,7 @@ fn push_status_section<'a>(spans: &mut Vec<Span<'a>>, state: &'a FooterState<'a>
             .map_or("Syncing...".to_string(), |s| s.text.clone());
         spans.push(Span::styled(
             format!(" {text} "),
-            Style::default().fg(Theme::ACCENT),
+            Style::default().fg(Theme::accent()),
         ));
     } else if let Some(msg) = state.status {
         push_status_message(spans, msg);
@@ -102,19 +134,19 @@ fn push_provisioning_badge<'a>(
     let text = if step.is_empty() { fallback } else { step };
     spans.push(Span::styled(
         format!(" {text} "),
-        Style::default().fg(Theme::ACCENT),
+        Style::default().fg(Theme::accent()),
     ));
 }
 
 fn push_status_message<'a>(spans: &mut Vec<Span<'a>>, msg: &'a StatusMessage) {
     let (badge_text, badge_bg, text_color) = match msg.level {
-        StatusLevel::Info => (" INFO ", Theme::ACCENT, Theme::TEXT_SECONDARY),
-        StatusLevel::Success => (" ✓ SYNC ", Theme::STATUS_BUSY, Theme::STATUS_BUSY),
-        StatusLevel::Error => (" ERROR ", Theme::STATUS_ERROR, Theme::STATUS_ERROR),
+        StatusLevel::Info => (" INFO ", Theme::accent(), Theme::text_secondary()),
+        StatusLevel::Success => (" ✓ SYNC ", Theme::status_busy(), Theme::status_busy()),
+        StatusLevel::Error => (" ERROR ", Theme::status_error(), Theme::status_error()),
     };
     spans.push(Span::styled(
         badge_text,
-        Style::default().fg(Theme::TEXT_PRIMARY).bg(badge_bg),
+        Style::default().fg(Theme::text_primary()).bg(badge_bg),
     ));
     spans.push(Span::styled(
         format!(" {} ", msg.text),
@@ -125,12 +157,14 @@ fn push_status_message<'a>(spans: &mut Vec<Span<'a>>, msg: &'a StatusMessage) {
 fn push_idle_counts<'a>(spans: &mut Vec<Span<'a>>, state: &FooterState<'a>) {
     spans.push(Span::styled(
         format!(" {} session(s) ", state.session_count),
-        Style::default().fg(Theme::TEXT_SECONDARY),
+        Style::default().fg(Theme::text_secondary()),
     ));
     if state.pending_scheduled_count > 0 {
         spans.push(Span::styled(
             format!(" {} scheduled ", state.pending_scheduled_count),
-            Style::default().fg(Theme::TEXT_PRIMARY).bg(Theme::ACCENT),
+            Style::default()
+                .fg(Theme::text_primary())
+                .bg(Theme::accent()),
         ));
     }
 }
@@ -172,6 +206,8 @@ fn push_spinner_badge<'a>(spans: &mut Vec<Span<'a>>, tick_count: u64, label: &'a
     let spinner = SPINNER_CHARS[idx];
     spans.push(Span::styled(
         format!(" {spinner} {label} "),
-        Style::default().fg(Theme::TEXT_PRIMARY).bg(Theme::ACCENT),
+        Style::default()
+            .fg(Theme::text_primary())
+            .bg(Theme::accent()),
     ));
 }

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -58,7 +58,7 @@ pub fn render_terminal(
 
     let mut pseudo_term = PseudoTerminal::new(parser.screen())
         .block(block)
-        .style(Style::default().fg(Theme::TEXT_PRIMARY).bg(Color::Reset));
+        .style(Style::default().fg(Theme::text_primary()).bg(Color::Reset));
 
     // Hide cursor when scrolled up
     if scroll_offset > 0 {
@@ -80,8 +80,8 @@ pub fn render_terminal(
         });
 
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .thumb_style(Style::default().fg(Theme::ACCENT))
-            .track_style(Style::default().fg(Theme::TEXT_MUTED));
+            .thumb_style(Style::default().fg(Theme::accent()))
+            .track_style(Style::default().fg(Theme::text_muted()));
 
         // Invert: offset 0 (bottom) → position at max, offset max (top) → position at 0
         let position = total_scrollback.saturating_sub(scroll_offset);
@@ -131,7 +131,7 @@ pub fn render_empty_terminal(frame: &mut Frame, area: Rect) {
     let block = Block::default()
         .title(" No Session ")
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Theme::TEXT_MUTED));
+        .border_style(Style::default().fg(Theme::text_muted()));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -161,7 +161,7 @@ pub fn render_empty_terminal(frame: &mut Frame, area: Rect) {
 
         let hint_block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(Theme::BORDER_UNFOCUSED));
+            .border_style(Style::default().fg(Theme::border_unfocused()));
 
         let hint_inner = hint_block.inner(center);
         frame.render_widget(hint_block, center);
@@ -169,16 +169,16 @@ pub fn render_empty_terminal(frame: &mut Frame, area: Rect) {
         let lines = vec![
             Line::from(Span::styled(
                 "No active sessions",
-                Style::default().fg(Theme::TEXT_SECONDARY),
+                Style::default().fg(Theme::text_secondary()),
             )),
             Line::from(""),
             Line::from(vec![
                 Span::styled("  Ctrl+N", Theme::keybind()),
-                Span::styled("  New session", Style::default().fg(Theme::TEXT_MUTED)),
+                Span::styled("  New session", Style::default().fg(Theme::text_muted())),
             ]),
             Line::from(vec![
                 Span::styled("  F1    ", Theme::keybind()),
-                Span::styled("  Help", Style::default().fg(Theme::TEXT_MUTED)),
+                Span::styled("  Help", Style::default().fg(Theme::text_muted())),
             ]),
         ];
         frame.render_widget(Paragraph::new(lines).alignment(Alignment::Left), hint_inner);

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,127 +1,235 @@
+//! Runtime-swappable theme accessors for the Thurbox UI.
+//!
+//! Widgets read colours via `Theme::accent()` etc. — function calls that
+//! resolve through a global `OnceLock<RwLock<ThemePalette>>`. Switching a
+//! theme is a single `Theme::set_active(palette)` call; the next render
+//! frame picks it up.
+//!
+//! Initialise the active theme exactly once at startup
+//! (see `Theme::ensure_initialized`). Tests that paint frames must call
+//! `ensure_initialized()` first or use `Theme::set_active(...)` explicitly.
+
+use std::sync::{OnceLock, RwLock};
+
 use ratatui::style::{Color, Modifier, Style};
 
-/// Centralized color and style constants for the Thurbox UI.
+use crate::session::{ThemePalette, ThemePreset};
+
+static ACTIVE_THEME: OnceLock<RwLock<ThemePalette>> = OnceLock::new();
+
+/// Snapshot of the currently active palette.
 ///
-/// All widget files reference these constants instead of hard-coding colors,
-/// enabling consistent theming and single-line visual changes.
+/// Cheap (one `RwLock` read + a `Clone`) so widgets can call this freely
+/// inside their render functions.
+pub fn current() -> ThemePalette {
+    ensure_initialized();
+    ACTIVE_THEME.get().unwrap().read().unwrap().clone()
+}
+
+/// Replace the active palette in place. The next render reflects the change.
+pub fn set_active(palette: ThemePalette) {
+    let cell = ACTIVE_THEME.get_or_init(|| RwLock::new(palette.clone()));
+    *cell.write().unwrap() = palette;
+}
+
+/// Idempotent: install the default palette if none has been set yet.
+///
+/// Safe to call from any render path; prevents the first widget that fires
+/// during a test from panicking on an uninitialised `OnceLock`.
+pub fn ensure_initialized() {
+    ACTIVE_THEME.get_or_init(|| RwLock::new(ThemePalette::default()));
+}
+
+/// Convenience: load a built-in preset by name and activate it. Falls back
+/// to `Default` for unknown names. Returns the preset that was actually
+/// applied so callers can persist it back to storage.
+pub fn apply_preset_by_name(name: &str) -> ThemePreset {
+    let preset = ThemePreset::from_str(name).unwrap_or(ThemePreset::Default);
+    set_active(preset.palette());
+    preset
+}
+
+/// Centralised colour and style accessors for the Thurbox UI.
+///
+/// All widget files reference `Theme::accent()` etc. instead of hard-coding
+/// colours, so swapping themes only takes one `set_active()` call.
 pub struct Theme;
 
 impl Theme {
     // ── Accent ──────────────────────────────────────────────────────────────
 
-    /// Primary accent color used for focused borders, selected items, branding.
-    pub const ACCENT: Color = Color::Cyan;
+    pub fn accent() -> Color {
+        current().accent
+    }
 
-    // ── Status colors ───────────────────────────────────────────────────────
+    pub fn accent_bright() -> Color {
+        current().accent_bright
+    }
 
-    pub const STATUS_BUSY: Color = Color::Green;
-    pub const STATUS_WAITING: Color = Color::Yellow;
-    pub const STATUS_IDLE: Color = Color::DarkGray;
-    pub const STATUS_ERROR: Color = Color::Red;
+    // ── Status colours ──────────────────────────────────────────────────────
+
+    pub fn status_busy() -> Color {
+        current().status_busy
+    }
+    pub fn status_waiting() -> Color {
+        current().status_waiting
+    }
+    pub fn status_idle() -> Color {
+        current().status_idle
+    }
+    pub fn status_error() -> Color {
+        current().status_error
+    }
 
     // ── Text hierarchy ──────────────────────────────────────────────────────
 
-    pub const TEXT_PRIMARY: Color = Color::White;
-    pub const TEXT_SECONDARY: Color = Color::Gray;
-    pub const TEXT_MUTED: Color = Color::DarkGray;
+    pub fn text_primary() -> Color {
+        current().text_primary
+    }
+    pub fn text_secondary() -> Color {
+        current().text_secondary
+    }
+    pub fn text_muted() -> Color {
+        current().text_muted
+    }
 
     // ── Borders ─────────────────────────────────────────────────────────────
 
-    pub const BORDER_FOCUSED: Color = Color::Cyan;
-    pub const BORDER_UNFOCUSED: Color = Color::Gray;
+    pub fn border_focused() -> Color {
+        current().border_focused
+    }
+    pub fn border_unfocused() -> Color {
+        current().border_unfocused
+    }
 
-    // ── Domain-specific colors ──────────────────────────────────────────────
+    // ── Domain-specific ─────────────────────────────────────────────────────
 
-    pub const ROLE_NAME: Color = Color::Magenta;
-    pub const ADMIN_BADGE: Color = Color::Yellow;
-    pub const BRANCH_NAME: Color = Color::Green;
-    pub const SEARCH_BAR: Color = Color::Blue;
+    pub fn role_name() -> Color {
+        current().role_name
+    }
+    pub fn admin_badge() -> Color {
+        current().admin_badge
+    }
+    pub fn branch_name() -> Color {
+        current().branch_name
+    }
+    pub fn search_bar() -> Color {
+        current().search_bar
+    }
 
-    // ── Keybind hints / tool permissions ─────────────────────────────────────
+    // ── Keybind hints / tool permissions ────────────────────────────────────
 
-    pub const KEYBIND_HINT: Color = Color::Yellow;
-    pub const TOOL_ALLOWED: Color = Color::Green;
-    pub const TOOL_DISALLOWED: Color = Color::Red;
+    pub fn keybind_hint() -> Color {
+        current().keybind_hint
+    }
+    pub fn tool_allowed() -> Color {
+        current().tool_allowed
+    }
+    pub fn tool_disallowed() -> Color {
+        current().tool_disallowed
+    }
 
-    // ── Admin ─────────────────────────────────────────────────────────────
+    // ── Admin / danger ──────────────────────────────────────────────────────
 
-    pub const ADMIN_BORDER: Color = Color::Yellow;
+    pub fn admin_border() -> Color {
+        current().admin_border
+    }
+    pub fn danger() -> Color {
+        current().danger
+    }
 
-    // ── Danger / destructive ────────────────────────────────────────────────
+    // ── Selection ───────────────────────────────────────────────────────────
 
-    pub const DANGER: Color = Color::Red;
+    pub fn selection_bg() -> Color {
+        current().selection_bg
+    }
+    pub fn selection_fg() -> Color {
+        current().selection_fg
+    }
 
-    // ── Selection ──────────────────────────────────────────────────────────
+    // ── Modal ───────────────────────────────────────────────────────────────
 
-    pub const SELECTION_BG: Color = Color::Indexed(24);
-    pub const SELECTION_FG: Color = Color::White;
+    pub fn modal_dim_bg() -> Color {
+        current().modal_dim_bg
+    }
+    pub fn modal_bg() -> Color {
+        current().modal_bg
+    }
+    pub fn modal_border() -> Color {
+        current().modal_border
+    }
 
-    // ── Modal ──────────────────────────────────────────────────────────────
+    // ── Background colours ──────────────────────────────────────────────────
 
-    /// Dark background for the full-screen dim overlay behind modals.
-    pub const MODAL_DIM_BG: Color = Color::Indexed(235); // #262626
-    /// Background color for the modal surface itself.
-    pub const MODAL_BG: Color = Color::Indexed(236); // #303030
-    /// Border color for modal windows.
-    pub const MODAL_BORDER: Color = Color::Cyan;
+    pub fn inverted_fg() -> Color {
+        current().inverted_fg
+    }
 
-    // ── Background colors ───────────────────────────────────────────────────
+    /// Background colour for the entire app surface (chrome + PTY cells
+    /// without their own bg). `Color::Reset` keeps the terminal's native
+    /// background.
+    pub fn app_bg() -> Color {
+        current().app_bg
+    }
 
-    pub const INVERTED_FG: Color = Color::Black;
+    /// Whether nerd-font glyphs should be used for icons.
+    pub fn nerd_font_enabled() -> bool {
+        current().nerd_font_enabled
+    }
 
     // ── Composite styles ────────────────────────────────────────────────────
 
     /// Style for a focused panel/modal title: bold black on accent background.
     pub fn focused_title() -> Style {
         Style::default()
-            .fg(Self::INVERTED_FG)
-            .bg(Self::ACCENT)
+            .fg(Self::inverted_fg())
+            .bg(Self::accent())
             .add_modifier(Modifier::BOLD)
     }
 
     /// Style for an unfocused panel title: dimmed secondary text.
     pub fn unfocused_title() -> Style {
-        Style::default().fg(Self::BORDER_UNFOCUSED)
+        Style::default().fg(Self::border_unfocused())
     }
 
     /// Style for section headers (e.g. info panel sections, help overlay).
     pub fn section_header() -> Style {
         Style::default()
-            .fg(Self::ACCENT)
+            .fg(Self::accent())
             .add_modifier(Modifier::BOLD)
     }
 
     /// Style for labels in info panels and status displays.
     pub fn label() -> Style {
-        Style::default().fg(Self::TEXT_MUTED)
+        Style::default().fg(Self::text_muted())
     }
 
     /// Style for keybind hint keys in modal footers.
     pub fn keybind() -> Style {
-        Style::default().fg(Self::KEYBIND_HINT)
+        Style::default().fg(Self::keybind_hint())
     }
 
     /// Style for keybind descriptions in modal footers.
     pub fn keybind_desc() -> Style {
-        Style::default().fg(Self::TEXT_MUTED)
+        Style::default().fg(Self::text_muted())
     }
 
     /// Style for selected/active list items.
     pub fn selected_item() -> Style {
         Style::default()
-            .fg(Self::ACCENT)
+            .fg(Self::accent())
             .add_modifier(Modifier::BOLD)
     }
 
     /// Style for normal (unselected) list items.
     pub fn normal_item() -> Style {
-        Style::default().fg(Self::TEXT_PRIMARY)
+        Style::default().fg(Self::text_primary())
     }
 
     /// Style for admin section title: yellow bold.
     pub fn admin_title() -> Style {
         Style::default()
-            .fg(Self::ADMIN_BORDER)
+            .fg(Self::admin_border())
             .add_modifier(Modifier::BOLD)
     }
 
@@ -133,15 +241,47 @@ impl Theme {
     /// Style for danger modal titles: bold white on red background.
     pub fn modal_title_danger() -> Style {
         Style::default()
-            .fg(Self::TEXT_PRIMARY)
-            .bg(Self::DANGER)
+            .fg(Self::text_primary())
+            .bg(Self::danger())
             .add_modifier(Modifier::BOLD)
     }
 
     /// Style for the block cursor in text fields.
     pub fn cursor() -> Style {
         Style::default()
-            .fg(Self::INVERTED_FG)
-            .bg(Self::TEXT_PRIMARY)
+            .fg(Self::inverted_fg())
+            .bg(Self::text_primary())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_initialized_is_idempotent() {
+        ensure_initialized();
+        ensure_initialized();
+        // Just confirm reading the palette doesn't panic and returns the
+        // default accent on a fresh init.
+        assert_eq!(Theme::accent(), ThemePalette::default().accent);
+    }
+
+    #[test]
+    fn set_active_switches_palette() {
+        set_active(ThemePreset::CatppuccinMocha.palette());
+        assert_eq!(
+            Theme::accent(),
+            ThemePreset::CatppuccinMocha.palette().accent
+        );
+
+        // Restore default for any later test that depends on it.
+        set_active(ThemePalette::default());
+    }
+
+    #[test]
+    fn apply_preset_falls_back_to_default_for_unknown_name() {
+        let applied = apply_preset_by_name("does-not-exist");
+        assert_eq!(applied, ThemePreset::Default);
     }
 }

--- a/src/ui/theme_picker_modal.rs
+++ b/src/ui/theme_picker_modal.rs
@@ -1,0 +1,105 @@
+//! Modal that lets the user pick a built-in theme preset.
+//!
+//! Renders the preset list on the left and a small live colour swatch for
+//! the highlighted preset on the right, so users can preview the palette
+//! before committing.
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::Style,
+    text::{Line, Span},
+    widgets::{List, ListItem, Paragraph},
+    Frame,
+};
+
+use super::{
+    centered_fixed_height_rect, render_modal_frame, selector_list_item, selector_nav_footer,
+    theme::Theme,
+};
+use crate::session::ThemePreset;
+
+pub struct ThemePickerState<'a> {
+    pub presets: &'a [ThemePreset],
+    pub selected_index: usize,
+}
+
+pub fn render_theme_picker_modal(frame: &mut Frame, state: &ThemePickerState<'_>) {
+    let height = (state.presets.len() as u16).max(4) + 6;
+    let area = centered_fixed_height_rect(60, height, frame.area());
+
+    let inner = render_modal_frame(frame, area, "Theme");
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+        .split(chunks[0]);
+
+    let items: Vec<ListItem<'_>> = state
+        .presets
+        .iter()
+        .enumerate()
+        .map(|(i, preset)| {
+            let label = if preset.is_light() {
+                format!("{} (light)", preset.display_name())
+            } else {
+                preset.display_name().to_string()
+            };
+            selector_list_item(&label, i == state.selected_index)
+        })
+        .collect();
+
+    frame.render_widget(List::new(items), columns[0]);
+
+    if let Some(preset) = state.presets.get(state.selected_index) {
+        let palette = preset.palette();
+        let swatch = vec![
+            Line::from(vec![
+                Span::styled("  Accent      ", Style::default().fg(Theme::text_muted())),
+                Span::styled("█████", Style::default().fg(palette.accent)),
+                Span::styled(" ", Style::default()),
+                Span::styled("█████", Style::default().fg(palette.accent_bright)),
+            ]),
+            Line::from(vec![
+                Span::styled("  Status      ", Style::default().fg(Theme::text_muted())),
+                Span::styled("●", Style::default().fg(palette.status_busy)),
+                Span::styled(" ", Style::default()),
+                Span::styled("◉", Style::default().fg(palette.status_waiting)),
+                Span::styled(" ", Style::default()),
+                Span::styled("○", Style::default().fg(palette.status_idle)),
+                Span::styled(" ", Style::default()),
+                Span::styled("✗", Style::default().fg(palette.status_error)),
+            ]),
+            Line::from(vec![
+                Span::styled("  Border      ", Style::default().fg(Theme::text_muted())),
+                Span::styled("╭─────╮", Style::default().fg(palette.border_focused)),
+            ]),
+            Line::from(vec![
+                Span::styled("  Modal bg    ", Style::default().fg(Theme::text_muted())),
+                Span::styled(
+                    "         ",
+                    Style::default()
+                        .bg(palette.modal_bg)
+                        .fg(palette.text_primary),
+                ),
+            ]),
+        ];
+        frame.render_widget(Paragraph::new(swatch), columns[1]);
+
+        let id = Line::from(Span::styled(
+            format!("  preset id: {}", preset.as_str()),
+            Style::default().fg(Theme::text_muted()),
+        ));
+        frame.render_widget(Paragraph::new(id), chunks[1]);
+    }
+
+    frame.render_widget(Paragraph::new(selector_nav_footer()), chunks[2]);
+}


### PR DESCRIPTION
## Summary

Cohesive TUI overhaul covering three pillars:

- **Themes** — 8 runtime-swappable presets (Default + Catppuccin Mocha/Latte, Tokyo Night/Day, Gruvbox Dark/Light, Solarized Light) selectable via `Ctrl+Y` / `F4` or the new MCP `set_theme` tool. Choice persists in SQLite (`metadata.active_theme`) and other thurbox processes pick up changes within one tick via `PRAGMA data_version` polling. A post-process repaints `Color::Reset` cells with each theme's `app_bg`/`text_primary` so light themes actually look light across chrome and PTY.
- **Customizable keybindings** — `~/.config/thurbox/keybindings.json` maps `Action` names to chord lists (`"QuitApp": ["ctrl+x"]`). Action-based dispatch in `key_handlers.rs` replaces the giant Ctrl-key match. New MCP tools: `get_keybindings`, `set_keybindings`, `reset_keybindings`. Modal-internal keys (j/k/Enter/Esc) stay literal.
- **Chrome polish** — Header has a right-aligned `<session>  ◐ <theme>` badge, collapses to 0 height below 20 rows. Brand `thurbox` is now bold accent text (no chip) so it doesn't visually collide with the focused panel title chip. Footer trimmed. Session list highlight uses `Theme::selection_bg/fg`, dropped the redundant `▸` active marker, indent re-aligned under the name. File viewer + status icons gain optional nerd-font glyphs.

## Test plan

- [x] `cargo check --all` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --test architecture_rules` — 9 pass
- [x] `cargo test --lib -- --test-threads=1` — 878 pass (theme palette serde, KeyChord parse round-trip, KeyBindings JSON round-trip, settings round-trip, compact-mode layout)
- [ ] Manual: `Ctrl+Y` cycles themes, persists across restart
- [ ] Manual: edit `~/.config/thurbox/keybindings.json` → `QuitApp` rebound to `ctrl+x` → F1 overlay reflects it
- [ ] Manual: `thurbox-mcp` `set_theme {"name":"tokyo-night-day"}` from a separate process is reflected in running TUI ≤ 1s
- [ ] Manual: shrink terminal to 19 rows — header disappears; resize back — header returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)