### PR TITLE
fix: exact-match tmux targets + render-order session navigation

### DIFF
--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -75,9 +75,15 @@ pub(crate) fn shell_window_name(session_name: &str) -> String {
     )
 }
 
-/// Build the `session:window` tmux target for a thurbox agent session.
+/// Build the `session:=window` tmux target for a thurbox agent session.
+///
+/// The `=` prefix forces tmux to match the window name exactly. Without
+/// it tmux falls back to FNMATCH-style prefix matching, so a target of
+/// `tb-foo` would resolve ambiguously when both `tb-foo` and
+/// `tb-foo-bar` exist — `send-keys`/`capture-pane` then fails with
+/// "ambiguous window" and the caller's text is silently dropped.
 fn window_target(session_name: &str) -> String {
-    format!("{TMUX_SESSION}:{}", agent_window_name(session_name))
+    format!("{TMUX_SESSION}:={}", agent_window_name(session_name))
 }
 
 /// Minimum tmux version required.
@@ -1560,5 +1566,14 @@ mod tests {
     fn agent_and_shell_window_names_share_sanitization() {
         assert_eq!(agent_window_name("Foo Bar"), "tb-Foo_Bar");
         assert_eq!(shell_window_name("Foo Bar"), "tbs-Foo_Bar");
+    }
+
+    #[test]
+    fn window_target_uses_exact_match_prefix() {
+        // Without `=`, tmux treats the window name as a pattern and will
+        // resolve `tb-foo` ambiguously when both `tb-foo` and
+        // `tb-foo-bar` exist. The `=` prefix forces exact-match lookup.
+        let t = window_target("foo");
+        assert!(t.ends_with(":=tb-foo"), "got {t}");
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2263,28 +2263,44 @@ impl App {
         }
     }
 
-    /// Switch to the next session in the flat session list (wraps around).
+    /// Indices into `self.sessions` in the order they are rendered.
+    ///
+    /// Mirrors `ui::project_list::OrderedSessions::new`: admin sessions
+    /// are pinned to the top (stable), the rest follow DB order. Used by
+    /// the session-navigation helpers so `Ctrl+J`/`Ctrl+K` step through
+    /// the list the user actually sees.
+    fn render_order_indices(&self) -> Vec<usize> {
+        let mut order: Vec<usize> = (0..self.sessions.len()).collect();
+        order.sort_by_key(|&i| !self.sessions[i].info.is_admin);
+        order
+    }
+
+    /// Switch to the next session in the **rendered** order (wraps around).
     pub(crate) fn switch_session_forward(&mut self) {
         if self.sessions.is_empty() {
             return;
         }
-        if self.active_index + 1 < self.sessions.len() {
-            self.active_index += 1;
-        } else {
-            self.active_index = 0;
-        }
+        let order = self.render_order_indices();
+        let pos = order
+            .iter()
+            .position(|&i| i == self.active_index)
+            .unwrap_or(0);
+        let next = (pos + 1) % order.len();
+        self.active_index = order[next];
     }
 
-    /// Switch to the previous session in the flat session list (wraps around).
+    /// Switch to the previous session in the **rendered** order (wraps around).
     pub(crate) fn switch_session_backward(&mut self) {
         if self.sessions.is_empty() {
             return;
         }
-        if self.active_index > 0 {
-            self.active_index -= 1;
-        } else {
-            self.active_index = self.sessions.len() - 1;
-        }
+        let order = self.render_order_indices();
+        let pos = order
+            .iter()
+            .position(|&i| i == self.active_index)
+            .unwrap_or(0);
+        let prev = if pos == 0 { order.len() - 1 } else { pos - 1 };
+        self.active_index = order[prev];
     }
 
     /// Clear all search/filter state.
@@ -4640,6 +4656,39 @@ mod tests {
         assert_eq!(app.active_index, 0);
         app.switch_session_backward();
         assert_eq!(app.active_index, 0);
+    }
+
+    #[test]
+    fn switch_forward_follows_admin_pinned_render_order() {
+        // Sessions stored in DB order: [normal-0, normal-1, admin-2].
+        // Rendered order (admin pinned): [admin-2, normal-0, normal-1].
+        // Stepping forward from index 0 (normal-0) must visit the *next
+        // rendered row*, normal-1 (index 1), not admin-2. Stepping
+        // forward from normal-1 must wrap to admin-2 (index 2).
+        let mut app = app_with_sessions(3);
+        app.sessions[2].info.is_admin = true;
+
+        app.active_index = 0;
+        app.switch_session_forward();
+        assert_eq!(app.active_index, 1, "normal-0 → normal-1");
+        app.switch_session_forward();
+        assert_eq!(app.active_index, 2, "normal-1 → admin-2 (wrap)");
+        app.switch_session_forward();
+        assert_eq!(app.active_index, 0, "admin-2 → normal-0");
+    }
+
+    #[test]
+    fn switch_backward_follows_admin_pinned_render_order() {
+        let mut app = app_with_sessions(3);
+        app.sessions[2].info.is_admin = true;
+
+        app.active_index = 0; // normal-0, rendered row 1
+        app.switch_session_backward();
+        assert_eq!(app.active_index, 2, "normal-0 → admin-2 (prev row)");
+        app.switch_session_backward();
+        assert_eq!(app.active_index, 1, "admin-2 → normal-1 (wrap)");
+        app.switch_session_backward();
+        assert_eq!(app.active_index, 0, "normal-1 → normal-0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **tmux target ambiguity** — `session:name` target strings used fnmatch/subset matching by default, so `tb-foo` resolved ambiguously when `tb-foo-bar` also existed. Prefix the window with `=` in `window_target()` to force exact-match lookup; fixes silent send-keys/capture drops for all four callers.
- **Session navigation jumped rows** — `OrderedSessions::new` pins admin sessions to the top visually, but `switch_session_forward`/`switch_session_backward` stepped through the unordered DB list, so Ctrl+J/Ctrl+K jumped over rows once admin sat mid-list. Extract the render ordering and step through it, then map back to the DB-order `active_index` the rest of the app uses.

## Test plan
- [x] `cargo test --lib agent::tmux` — new `window_target_uses_exact_match_prefix` test
- [x] `cargo test --lib app::tests::switch` — new admin-pinned-order navigation tests
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --test architecture_rules`
- [ ] Manual: create two sessions whose names are prefix-of each other (`test-a` + `test-a-b`) and verify send_prompt/capture work against both
- [ ] Manual: with an admin + several CLI-spawned sessions, Ctrl+J/Ctrl+K step through the list in the order shown on screen