### PR TITLE
feat: surface plugin-contributed roles at spawn time

### DIFF
--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -846,10 +846,10 @@ impl App {
     }
 
     fn handle_role_selector_key(&mut self, code: KeyCode) {
-        let role_count = self.global_roles.len();
         let super::modals::Modal::RoleSelector(ref mut rsel) = self.modal else {
             return;
         };
+        let role_count = rsel.roles.len();
         match code {
             KeyCode::Esc => {
                 self.modal.close();
@@ -866,19 +866,18 @@ impl App {
                 rsel.index = rsel.index.saturating_sub(1);
             }
             KeyCode::Enter => {
-                let role_index = rsel.index;
+                let selected = rsel.roles.get(rsel.index).cloned();
                 self.modal.close();
-                if let (Some(mut config), Some(name)) = (
+                if let (Some(mut config), Some(name), Some(role)) = (
                     self.pending_spawn_config.take(),
                     self.pending_spawn_name.take(),
+                    selected,
                 ) {
-                    if let Some(role) = self.global_roles.get(role_index) {
-                        config.role = role.name.clone();
-                        config.permissions = role.permissions.clone();
-                        let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
-                        let is_admin = self.pending_spawn_is_admin;
-                        self.maybe_show_model_picker(name, config, worktrees, is_admin);
-                    }
+                    config.role = role.name;
+                    config.permissions = role.permissions;
+                    let worktrees = std::mem::take(&mut self.pending_spawn_worktrees);
+                    let is_admin = self.pending_spawn_is_admin;
+                    self.maybe_show_model_picker(name, config, worktrees, is_admin);
                 }
             }
             _ => {}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1168,7 +1168,7 @@ impl App {
         mut config: SessionConfig,
         worktrees: Vec<WorktreeInfo>,
     ) {
-        let roles = &self.global_roles;
+        let roles = self.effective_roles();
 
         match roles.len() {
             0 => {
@@ -1188,7 +1188,8 @@ impl App {
                 self.pending_spawn_name = Some(name);
                 self.pending_spawn_config = Some(config);
                 self.pending_spawn_worktrees = worktrees;
-                self.modal = modals::Modal::RoleSelector(modals::RoleSelectorModal::default());
+                self.modal =
+                    modals::Modal::RoleSelector(modals::RoleSelectorModal { index: 0, roles });
             }
         }
     }
@@ -1312,6 +1313,17 @@ impl App {
             .collect()
     }
 
+    /// Registry roles + plugin-contributed roles (registry wins on name
+    /// collision — matches `Database::list_effective_roles`). Used by the
+    /// role-selector modal so plugin-contributed roles are pickable; falls
+    /// back to the editable `self.global_roles` cache if the DB read fails.
+    pub(crate) fn effective_roles(&self) -> Vec<RoleConfig> {
+        self.db
+            .list_effective_roles()
+            .map(|rows| rows.into_iter().map(|(r, _src)| r).collect())
+            .unwrap_or_else(|_| self.global_roles.clone())
+    }
+
     /// Continue admin spawn — routes through the normal picker chain (role →
     /// MCP → skill) with admin-specific defaults preselected. The user can
     /// override any default before the session spawns.
@@ -1321,8 +1333,8 @@ impl App {
         config: SessionConfig,
         worktrees: Vec<WorktreeInfo>,
     ) {
-        let admin_index = self
-            .global_roles
+        let roles = self.effective_roles();
+        let admin_index = roles
             .iter()
             .position(|r| r.name == ADMIN_ROLE_NAME)
             .unwrap_or(0);
@@ -1330,7 +1342,10 @@ impl App {
         self.pending_spawn_name = Some(name);
         self.pending_spawn_config = Some(config);
         self.pending_spawn_worktrees = worktrees;
-        self.modal = modals::Modal::RoleSelector(modals::RoleSelectorModal { index: admin_index });
+        self.modal = modals::Modal::RoleSelector(modals::RoleSelectorModal {
+            index: admin_index,
+            roles,
+        });
     }
 
     fn restart_active_session(&mut self) {
@@ -4025,19 +4040,22 @@ impl App {
             .find(|d| d.name == expected_name && d.is_alive)
     }
 
-    /// Resolve a role name to its permissions from global roles.
+    /// Resolve a role name to its permissions, preferring registry roles over
+    /// plugin-contributed ones (matches `Database::list_effective_roles`
+    /// precedence). `self.global_roles` is the editable DB cache and excludes
+    /// plugin contributions, so we re-merge here on each spawn — role lookups
+    /// are infrequent and roles are tiny.
     fn resolve_role_permissions(&self, role_name: &str) -> RolePermissions {
-        self.global_roles
-            .iter()
-            .find(|r| r.name == role_name)
-            .map(|r| r.permissions.clone())
-            .unwrap_or_else(|| {
-                if role_name == DEFAULT_ROLE_NAME {
-                    default_developer_permissions()
-                } else {
-                    RolePermissions::default()
-                }
-            })
+        if let Ok(effective) = self.db.list_effective_roles() {
+            if let Some((role, _src)) = effective.iter().find(|(r, _)| r.name == role_name) {
+                return role.permissions.clone();
+            }
+        }
+        if role_name == DEFAULT_ROLE_NAME {
+            default_developer_permissions()
+        } else {
+            RolePermissions::default()
+        }
     }
 
     /// Process pending session commands from the MCP command queue.
@@ -5028,6 +5046,99 @@ mod tests {
     }
 
     // --- Role editor tests ---
+
+    /// Regression: plugin-contributed roles appear in the session-create
+    /// role-selector modal, not just registry roles. Without this, picking
+    /// the "orchestrator" role at session creation isn't possible through
+    /// the TUI.
+    #[test]
+    fn finish_prepare_spawn_surfaces_plugin_roles_in_picker() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let plugins_dir = crate::paths::plugins_directory().unwrap();
+        let p = plugins_dir.join("orch-bundle");
+        std::fs::create_dir_all(p.join("roles")).unwrap();
+        std::fs::write(
+            p.join("roles/role.toml"),
+            "name = \"orchestrator\"\ndescription = \"from plugin\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            p.join("thurbox-plugin.toml"),
+            "name = \"orch-bundle\"\nversion = \"0.1.0\"\nthurbox_plugin_api = 1\n\
+             [[contributes.roles]]\nname = \"orchestrator\"\npath = \"roles/role.toml\"\n",
+        )
+        .unwrap();
+
+        let mut app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
+        app.finish_prepare_spawn(
+            "session-1".to_string(),
+            SessionConfig::default(),
+            Vec::new(),
+        );
+        match app.modal {
+            super::modals::Modal::RoleSelector(ref m) => {
+                assert!(
+                    m.roles.iter().any(|r| r.name == "orchestrator"),
+                    "role picker should include plugin-contributed 'orchestrator'"
+                );
+            }
+            _ => panic!("expected RoleSelector modal"),
+        }
+    }
+
+    /// Regression: `resolve_role_permissions` must pick up plugin-contributed
+    /// roles (e.g. `orchestrator` role contributed by the orchestrator plugin)
+    /// so that tools like Write/Edit are actually blocked at session spawn.
+    #[test]
+    fn resolve_role_permissions_picks_up_plugin_contributed_role() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let plugins_dir = crate::paths::plugins_directory().unwrap();
+        let p = plugins_dir.join("orch-bundle");
+        std::fs::create_dir_all(p.join("roles")).unwrap();
+        std::fs::write(
+            p.join("roles/role.toml"),
+            "name = \"orchestrator\"\n\
+             description = \"test\"\n\
+             disallowed_tools = [\"Write\", \"Edit\", \"MultiEdit\", \"NotebookEdit\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            p.join("thurbox-plugin.toml"),
+            "name = \"orch-bundle\"\nversion = \"0.1.0\"\nthurbox_plugin_api = 1\n\
+             [[contributes.roles]]\nname = \"orchestrator\"\npath = \"roles/role.toml\"\n",
+        )
+        .unwrap();
+
+        let app = App::new(
+            24,
+            120,
+            stub_backend(),
+            stub_provider(),
+            test_db(),
+            None,
+            None,
+        );
+        let perms = app.resolve_role_permissions("orchestrator");
+        assert_eq!(
+            perms.disallowed_tools,
+            vec![
+                "Write".to_string(),
+                "Edit".to_string(),
+                "MultiEdit".to_string(),
+                "NotebookEdit".to_string(),
+            ]
+        );
+    }
 
     #[test]
     fn open_role_editor_has_seeded_developer_role() {
@@ -6468,9 +6579,10 @@ mod tests {
             None,
             None,
         );
-        // Seeded roles: developer at [0], admin at [1].
-        let admin_index = app
-            .global_roles
+        // Admin must be among the effective roles (the source the picker
+        // uses) at a predictable position.
+        let effective = app.effective_roles();
+        let admin_index = effective
             .iter()
             .position(|r| r.name == ADMIN_ROLE_NAME)
             .unwrap();
@@ -6478,7 +6590,10 @@ mod tests {
         app.finish_prepare_spawn_admin("admin-1".to_string(), SessionConfig::default(), Vec::new());
 
         match app.modal {
-            super::modals::Modal::RoleSelector(ref m) => assert_eq!(m.index, admin_index),
+            super::modals::Modal::RoleSelector(ref m) => {
+                assert_eq!(m.index, admin_index);
+                assert_eq!(m.roles.len(), effective.len());
+            }
             _ => panic!("expected RoleSelector modal"),
         }
         assert!(app.pending_spawn_is_admin);

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -120,6 +120,11 @@ pub struct SessionNameModal {
 #[derive(Debug, Clone, Default)]
 pub struct RoleSelectorModal {
     pub index: usize,
+    /// Roles offered to the user at modal-open time — the merged view of the
+    /// SQLite registry + plugin-contributed roles. Stored on the modal rather
+    /// than read from `App::global_roles` so the picker also surfaces
+    /// plugin-contributed roles that aren't registry rows.
+    pub roles: Vec<crate::session::RoleConfig>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -297,7 +297,7 @@ impl App {
             role_selector_modal::render_role_selector_modal(
                 frame,
                 &role_selector_modal::RoleSelectorState {
-                    roles: &self.global_roles,
+                    roles: &rsel.roles,
                     selected_index: rsel.index,
                 },
             );

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -65,13 +65,13 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
 /// Look up permissions for `role_name`, falling back to the seeded default
 /// developer role (or empty permissions for any other unknown role).
 fn lookup_role_permissions(db: &Database, role_name: &str) -> Result<RolePermissions, String> {
-    let global_roles = db
-        .list_global_roles()
+    let effective_roles = db
+        .list_effective_roles()
         .map_err(|e| format!("Failed to load roles: {e}"))?;
-    Ok(global_roles
+    Ok(effective_roles
         .iter()
-        .find(|r| r.name == role_name)
-        .map(|r| r.permissions.clone())
+        .find(|(r, _src)| r.name == role_name)
+        .map(|(r, _src)| r.permissions.clone())
         .unwrap_or_else(|| {
             if role_name == DEFAULT_ROLE_NAME {
                 default_developer_permissions()

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -139,19 +139,25 @@ fn resolve_role(
     db: &Database,
     requested: Option<&str>,
 ) -> Result<(String, RolePermissions), String> {
-    let global_roles = db
-        .list_global_roles()
-        .map_err(|e| format!("Failed to load roles: {e}"))?;
-
+    // Explicit role: search effective roles so plugin-contributed roles can be
+    // opted into. Plugin roles are NEVER picked up by the unscoped auto-fallback
+    // below — that only consults the registry, so installing a plugin can't
+    // silently change the default permissions of new sessions.
     if let Some(name) = requested.filter(|n| !n.is_empty()) {
-        let perms = global_roles
+        let effective_roles = db
+            .list_effective_roles()
+            .map_err(|e| format!("Failed to load roles: {e}"))?;
+        let perms = effective_roles
             .iter()
-            .find(|r| r.name == name)
-            .map(|r| r.permissions.clone())
+            .find(|(r, _src)| r.name == name)
+            .map(|(r, _src)| r.permissions.clone())
             .unwrap_or_else(|| default_permissions_for(name));
         return Ok((name.to_string(), perms));
     }
 
+    let global_roles = db
+        .list_global_roles()
+        .map_err(|e| format!("Failed to load roles: {e}"))?;
     Ok(match global_roles.as_slice() {
         [only] => (only.name.clone(), only.permissions.clone()),
         _ => (
@@ -352,5 +358,84 @@ mod tests {
         let (name, perms) = resolve_role(&db, Some("alpha")).unwrap();
         assert_eq!(name, "alpha");
         assert_eq!(perms.permission_mode.as_deref(), Some("plan"));
+    }
+
+    /// Regression: plugin-contributed roles are reachable via `--role <name>`.
+    #[test]
+    fn resolve_role_matches_plugin_contributed_role_by_name() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let plugins_dir = crate::paths::plugins_directory().unwrap();
+        seed_plugin_with_role(
+            &plugins_dir,
+            "orch-bundle",
+            "orchestrator",
+            "Write,Edit,MultiEdit,NotebookEdit",
+        );
+
+        let db = empty_db();
+        let (name, perms) = resolve_role(&db, Some("orchestrator")).unwrap();
+        assert_eq!(name, "orchestrator");
+        assert_eq!(
+            perms.disallowed_tools,
+            vec![
+                "Write".to_string(),
+                "Edit".to_string(),
+                "MultiEdit".to_string(),
+                "NotebookEdit".to_string(),
+            ]
+        );
+    }
+
+    /// Regression: a plugin-contributed role must NOT be silently auto-picked
+    /// when no role is requested — installing a plugin can't change the
+    /// default permissions of new sessions.
+    #[test]
+    fn resolve_role_ignores_plugin_role_when_unscoped() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let plugins_dir = crate::paths::plugins_directory().unwrap();
+        seed_plugin_with_role(&plugins_dir, "orch-bundle", "orchestrator", "Write");
+
+        let db = empty_db();
+        let (name, perms) = resolve_role(&db, None).unwrap();
+        assert_eq!(name, DEFAULT_ROLE_NAME);
+        assert_eq!(
+            perms.permission_mode,
+            default_developer_permissions().permission_mode
+        );
+    }
+
+    fn seed_plugin_with_role(
+        plugins_dir: &std::path::Path,
+        plugin_name: &str,
+        role_name: &str,
+        disallowed_csv: &str,
+    ) -> PathBuf {
+        let p = plugins_dir.join(plugin_name);
+        std::fs::create_dir_all(p.join("roles")).unwrap();
+        let disallowed_toml = disallowed_csv
+            .split(',')
+            .map(|t| format!("\"{t}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        std::fs::write(
+            p.join("roles/role.toml"),
+            format!(
+                "name = \"{role_name}\"\n\
+                 description = \"test\"\n\
+                 disallowed_tools = [{disallowed_toml}]\n"
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            p.join("thurbox-plugin.toml"),
+            format!(
+                "name = \"{plugin_name}\"\nversion = \"0.1.0\"\nthurbox_plugin_api = 1\n\
+                 [[contributes.roles]]\nname = \"{role_name}\"\npath = \"roles/role.toml\"\n"
+            ),
+        )
+        .unwrap();
+        p
     }
 }


### PR DESCRIPTION
## Summary
- `resolve_role` (spawn) and `lookup_role_permissions` (restart) now consult `list_effective_roles()` for explicit `--role <name>` lookups, so plugin-contributed roles can actually be opted into. The unscoped auto-pick fallback still uses only `list_global_roles()` — installing a plugin must not silently change the default permissions of new sessions.
- TUI: `App::resolve_role_permissions` queries the merged effective set, and a new `App::effective_roles()` helper feeds the role picker. `finish_prepare_spawn` / `finish_prepare_spawn_admin` snapshot the list onto a new `RoleSelectorModal::roles` field (mirroring `SkillPickerModal`), so plugin roles appear in the picker for both Ctrl+N and admin spawn flows.

## Why
Without this, a plugin like `thurbox-plugin-orchestrator` can ship a role via `[[contributes.roles]]`, but `--role orchestrator` silently falls back to default permissions and the role doesn't show up in the TUI picker.

## Test plan
- [x] `cargo test -p thurbox session_ops::spawn::tests`
- [x] `cargo test -p thurbox session_ops::restart::tests`
- [x] `cargo test -p thurbox app::tests` (new picker + permission-resolution regressions)
- [ ] Manual: install a plugin with a contributed role, confirm it appears in the Ctrl+N role picker and that `--role <name>` applies its permissions.