### PR TITLE
feat(plugin): install from git URLs via MCP and TUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ thurbox-mcp --transport streamable-http --port 9090  # Custom port
 | `register_plugin` | Register a plugin path (manifest must validate; never touches disk) |
 | `unregister_plugin` | Remove a plugin from the registry (cascades plugin_settings; never touches disk) |
 | `enable_plugin` / `disable_plugin` | Toggle a plugin's enabled flag (shadows disk-only plugins) |
-| `install_plugin` | Copy a plugin source dir into `admin/plugins/<name>/` |
+| `install_plugin` | Install a plugin from a local directory or git URL (`https://`, `git://`, `ssh://`, scp-style) into `admin/plugins/<name>/` |
 | `uninstall_plugin` | Remove a plugin from disk + registry (cascades settings); requires `confirm: true` |
 | `list_plugin_settings` | List a plugin's configuration schema with current effective values |
 | `get_plugin_setting` / `set_plugin_setting` / `reset_plugin_setting` | Read, override, or clear one plugin setting |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ anyhow = "1.0"
 # Clipboard
 arboard = "3"
 
+# Temporary directories for plugin git clones
+tempfile = "3"
+
 # MCP server
 rmcp = { version = "1.0", features = ["server", "transport-io", "transport-streamable-http-server", "schemars"] }
 serde_json = "1"
@@ -85,7 +88,6 @@ name = "sample-mcp-plugin"
 path = "examples/sample_mcp_plugin.rs"
 
 [dev-dependencies]
-tempfile = "3"
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 
 # Development tool requirements (install with `cargo binstall` or `cargo install`)

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -47,6 +47,26 @@ impl App {
             return;
         }
 
+        // Ctrl+V: paste. Routed before modal handlers so they don't swallow
+        // the literal 'v' — `paste_from_clipboard` knows whether a modal text
+        // input is open and routes the text accordingly.
+        if code == KeyCode::Char('v') && mods.contains(KeyModifiers::CONTROL) {
+            self.paste_from_clipboard();
+            return;
+        }
+
+        // Ctrl+C: copy active mouse-drag selection. Routed before modal
+        // handlers so users can copy text from inside any modal. Without an
+        // active selection, falls through to the normal handlers (e.g. SIGINT
+        // when the terminal is focused).
+        if code == KeyCode::Char('c')
+            && mods.contains(KeyModifiers::CONTROL)
+            && self.text_selection.is_some()
+        {
+            self.copy_selection_to_clipboard();
+            return;
+        }
+
         // Restore sessions modal captures all input
         if matches!(self.modal, super::modals::Modal::RestoreSessions(_)) {
             self.handle_restore_sessions_key(code);
@@ -176,21 +196,6 @@ impl App {
         // Search input captures all keys when active
         if self.search_active {
             self.handle_search_key(code, mods);
-            return;
-        }
-
-        // Ctrl+C: copy selection if active, otherwise forward to terminal as SIGINT
-        if code == KeyCode::Char('c')
-            && mods.contains(KeyModifiers::CONTROL)
-            && self.text_selection.is_some()
-        {
-            self.copy_selection_to_clipboard();
-            return;
-        }
-
-        // Ctrl+V: paste from clipboard
-        if code == KeyCode::Char('v') && mods.contains(KeyModifiers::CONTROL) {
-            self.paste_from_clipboard();
             return;
         }
 
@@ -1342,6 +1347,17 @@ impl App {
 
     /// Handle input in the settings overlay (tabbed list view).
     pub(crate) fn handle_settings_key(&mut self, code: KeyCode) {
+        // Plugin install modal overlays the Plugins tab — capture all input first.
+        if self.show_plugin_install_modal {
+            self.handle_plugin_install_modal_key(code);
+            return;
+        }
+        // Plugin uninstall confirm prompt is modal too.
+        if self.plugin_uninstall_confirm.is_some() {
+            self.handle_plugin_uninstall_confirm_key(code);
+            return;
+        }
+
         match code {
             KeyCode::Esc => {
                 // Save and close settings
@@ -1356,12 +1372,20 @@ impl App {
                 }
                 self.show_settings = false;
             }
-            KeyCode::Tab | KeyCode::BackTab => {
+            KeyCode::Tab => {
                 self.settings_tab = match self.settings_tab {
                     super::SettingsTab::Roles => super::SettingsTab::McpServers,
                     super::SettingsTab::McpServers => super::SettingsTab::Skills,
                     super::SettingsTab::Skills => super::SettingsTab::Plugins,
                     super::SettingsTab::Plugins => super::SettingsTab::Roles,
+                };
+            }
+            KeyCode::BackTab => {
+                self.settings_tab = match self.settings_tab {
+                    super::SettingsTab::Roles => super::SettingsTab::Plugins,
+                    super::SettingsTab::McpServers => super::SettingsTab::Roles,
+                    super::SettingsTab::Skills => super::SettingsTab::McpServers,
+                    super::SettingsTab::Plugins => super::SettingsTab::Skills,
                 };
             }
             _ => match self.settings_tab {
@@ -1467,10 +1491,9 @@ impl App {
 
     /// Handle keys for the Plugins tab in the settings overlay.
     ///
-    /// The TUI is read-only for plugins beyond the enable/disable toggle —
-    /// install/uninstall and configuration are managed via MCP. The richer
-    /// per-plugin details pane (logs / configuration form) is gated on the
-    /// process runtime and will land alongside it.
+    /// Beyond j/k navigation and Space (toggle enable), `i` opens the install
+    /// modal and `d` triggers an uninstall confirm. Plugin configuration still
+    /// lives in MCP — the TUI only owns lifecycle (install / enable / remove).
     fn handle_settings_plugins_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('j') | KeyCode::Down
@@ -1492,6 +1515,102 @@ impl App {
                 } else if let Ok(plugins) = self.db.list_effective_plugins() {
                     self.effective_plugins = plugins;
                 }
+            }
+            KeyCode::Char('i') => {
+                self.open_plugin_install_modal();
+            }
+            KeyCode::Char('d') if !self.effective_plugins.is_empty() => {
+                let idx = self.plugin_list_index;
+                let name = self.effective_plugins[idx].0.name.clone();
+                self.plugin_uninstall_confirm = Some(name);
+            }
+            _ => {}
+        }
+    }
+
+    /// Reset and open the plugin install modal.
+    pub(crate) fn open_plugin_install_modal(&mut self) {
+        self.plugin_install_input.clear();
+        self.plugin_install_status = super::PluginInstallStatus::Idle;
+        self.show_plugin_install_modal = true;
+    }
+
+    /// Handle keys inside the plugin install modal. `Enter` kicks off the
+    /// install on a background thread; `Esc` closes the modal (in-flight
+    /// installs continue and update the plugin list when they finish).
+    fn handle_plugin_install_modal_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => {
+                self.show_plugin_install_modal = false;
+            }
+            KeyCode::Enter => {
+                let source = self.plugin_install_input.value().trim().to_string();
+                if source.is_empty() {
+                    self.plugin_install_status =
+                        super::PluginInstallStatus::Error("Source cannot be empty".to_string());
+                    return;
+                }
+                if self.plugin_install_rx.is_some() {
+                    return;
+                }
+                self.start_plugin_install(source);
+            }
+            KeyCode::Backspace => self.plugin_install_input.backspace(),
+            KeyCode::Delete => self.plugin_install_input.delete(),
+            KeyCode::Left => self.plugin_install_input.move_left(),
+            KeyCode::Right => self.plugin_install_input.move_right(),
+            KeyCode::Home => self.plugin_install_input.home(),
+            KeyCode::End => self.plugin_install_input.end(),
+            KeyCode::Char(c) => self.plugin_install_input.insert(c),
+            _ => {}
+        }
+    }
+
+    /// Spawn the install on a background thread (git clone can take seconds —
+    /// must not block the UI loop). Result delivered via `mpsc` and polled in
+    /// `tick()`.
+    fn start_plugin_install(&mut self, source: String) {
+        use std::sync::mpsc;
+        self.plugin_install_status = super::PluginInstallStatus::InProgress;
+        let (tx, rx) = mpsc::channel();
+        self.plugin_install_rx = Some(rx);
+        std::thread::spawn(move || {
+            let result =
+                crate::paths::install_plugin_from_source(&source, None).map_err(|e| e.to_string());
+            let _ = tx.send(result);
+        });
+    }
+
+    /// Handle keys inside the uninstall confirmation prompt.
+    fn handle_plugin_uninstall_confirm_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                let Some(name) = self.plugin_uninstall_confirm.take() else {
+                    return;
+                };
+                match self.db.uninstall_plugin_with_disk(&name) {
+                    Ok(_) => {
+                        self.set_status(
+                            super::StatusLevel::Success,
+                            format!("Uninstalled plugin '{name}'"),
+                        );
+                        if let Ok(plugins) = self.db.list_effective_plugins() {
+                            if self.plugin_list_index >= plugins.len() {
+                                self.plugin_list_index = plugins.len().saturating_sub(1);
+                            }
+                            self.effective_plugins = plugins;
+                        }
+                    }
+                    Err(e) => {
+                        self.set_status(
+                            super::StatusLevel::Error,
+                            format!("Failed to uninstall '{name}': {e}"),
+                        );
+                    }
+                }
+            }
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                self.plugin_uninstall_confirm = None;
             }
             _ => {}
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -19,6 +19,7 @@ use tracing::{error, info, warn};
 
 use crate::agent::{BackendRegistry, Session, SessionBackend};
 use crate::git;
+use crate::paths;
 use crate::session::{
     default_developer_permissions, default_developer_role, McpServerConfig, PluginConfig,
     RoleConfig, RolePermissions, ScheduledCommand, SessionCommand, SessionConfig, SessionId,
@@ -476,6 +477,16 @@ pub(crate) enum SkillEditorField {
     Path,
 }
 
+/// Lifecycle of a plugin install triggered from the TUI install modal.
+#[derive(Debug, Clone, Default)]
+pub(crate) enum PluginInstallStatus {
+    #[default]
+    Idle,
+    InProgress,
+    Success(String),
+    Error(String),
+}
+
 /// Holds a recently deleted session for undo (Ctrl+Z) support.
 struct PendingDelete {
     session: Session,
@@ -663,6 +674,17 @@ pub struct App {
     pub(crate) effective_plugins: Vec<(PluginConfig, PluginSource)>,
     /// Index into effective_plugins for the Plugins settings tab.
     pub(crate) plugin_list_index: usize,
+    /// Whether the plugin install modal is open (overlays the settings overlay).
+    pub(crate) show_plugin_install_modal: bool,
+    /// Buffer for the install modal's path/URL input.
+    pub(crate) plugin_install_input: TextInput,
+    /// Live status shown at the bottom of the install modal.
+    pub(crate) plugin_install_status: PluginInstallStatus,
+    /// Receiver for the result of an in-flight install (background thread).
+    pub(crate) plugin_install_rx: Option<mpsc::Receiver<Result<paths::InstallSummary, String>>>,
+    /// Name of the plugin pending uninstall confirmation. `None` when no
+    /// confirmation prompt is showing.
+    pub(crate) plugin_uninstall_confirm: Option<String>,
     /// Cached pending scheduled commands, refreshed every ~1 second.
     pub(crate) cached_pending_commands: Vec<ScheduledCommand>,
     /// Currently active theme preset, cached so the header doesn't hit SQLite
@@ -879,6 +901,11 @@ impl App {
             skill_list_index: 0,
             effective_plugins,
             plugin_list_index: 0,
+            show_plugin_install_modal: false,
+            plugin_install_input: TextInput::new(),
+            plugin_install_status: PluginInstallStatus::Idle,
+            plugin_install_rx: None,
+            plugin_uninstall_confirm: None,
             plugin_runtime: None,
             plugin_setting_snapshot: HashMap::new(),
             cached_pending_commands: Vec::new(),
@@ -1932,10 +1959,13 @@ impl App {
     fn handle_paste(&mut self, text: String) {
         self.text_selection = None;
         self.selected_text_cache = None;
+        if self.try_paste_into_modal_input(&text) {
+            return;
+        }
         self.send_paste_to_session(&text);
     }
 
-    fn paste_from_clipboard(&mut self) {
+    pub(crate) fn paste_from_clipboard(&mut self) {
         self.text_selection = None;
         self.selected_text_cache = None;
 
@@ -1952,7 +1982,26 @@ impl App {
             }
         };
 
+        if self.try_paste_into_modal_input(&text) {
+            return;
+        }
         self.send_paste_to_session(&text);
+    }
+
+    /// Route pasted text into the focused modal text input when one is open.
+    /// Returns `true` when consumed, signalling the caller to skip the default
+    /// "send to session" behaviour. New modals with text inputs should add
+    /// their target here so paste works inside them.
+    fn try_paste_into_modal_input(&mut self, text: &str) -> bool {
+        if self.show_plugin_install_modal {
+            for c in text.chars() {
+                if !c.is_control() {
+                    self.plugin_install_input.insert(c);
+                }
+            }
+            return true;
+        }
+        false
     }
 
     pub(crate) fn submit_role_editor(&mut self) {
@@ -2594,6 +2643,9 @@ impl App {
             }
         }
 
+        // Poll for plugin install results from background thread
+        self.poll_plugin_install();
+
         // Poll for VM provisioning results from background thread
         self.poll_vm_provision();
 
@@ -2617,6 +2669,40 @@ impl App {
         // Refresh system metrics periodically
         if self.tick_count % METRICS_REFRESH_TICKS == 0 {
             self.refresh_system_metrics();
+        }
+    }
+
+    /// Drain the plugin install result channel. On success, refresh the
+    /// effective plugins list so the new entry shows up in the Plugins tab.
+    fn poll_plugin_install(&mut self) {
+        let Some(rx) = self.plugin_install_rx.as_ref() else {
+            return;
+        };
+        let result = match rx.try_recv() {
+            Ok(r) => r,
+            Err(mpsc::TryRecvError::Empty) => return,
+            Err(mpsc::TryRecvError::Disconnected) => Err("install thread died".to_string()),
+        };
+        self.plugin_install_rx = None;
+
+        match result {
+            Ok(summary) => {
+                self.plugin_install_status =
+                    PluginInstallStatus::Success(format!("Installed '{}'", summary.name));
+                self.set_status(
+                    StatusLevel::Success,
+                    format!("Installed plugin '{}'", summary.name),
+                );
+                if let Ok(plugins) = self.db.list_effective_plugins() {
+                    self.effective_plugins = plugins;
+                }
+                // Auto-close the modal after a successful install.
+                self.show_plugin_install_modal = false;
+                self.plugin_install_input.clear();
+            }
+            Err(msg) => {
+                self.plugin_install_status = PluginInstallStatus::Error(msg);
+            }
         }
     }
 

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -370,6 +370,61 @@ impl App {
             );
         }
 
+        // Plugin install modal (overlays the settings overlay's Plugins tab)
+        if self.show_plugin_install_modal {
+            use crate::ui::plugin_install_modal::{
+                render_plugin_install_modal, PluginInstallModalState, PluginInstallStatusView,
+            };
+            let status = match &self.plugin_install_status {
+                super::PluginInstallStatus::Idle => PluginInstallStatusView::Idle,
+                super::PluginInstallStatus::InProgress => {
+                    PluginInstallStatusView::InProgress("Installing… (cloning + copying)")
+                }
+                super::PluginInstallStatus::Success(msg) => {
+                    PluginInstallStatusView::Success(msg.as_str())
+                }
+                super::PluginInstallStatus::Error(msg) => {
+                    PluginInstallStatusView::Error(msg.as_str())
+                }
+            };
+            render_plugin_install_modal(
+                frame,
+                &PluginInstallModalState {
+                    input: self.plugin_install_input.value(),
+                    cursor: self.plugin_install_input.cursor_pos(),
+                    status,
+                },
+            );
+        }
+
+        // Plugin uninstall confirmation (overlays the Plugins tab)
+        if let Some(ref name) = self.plugin_uninstall_confirm {
+            let area = crate::ui::centered_fixed_height_rect(50, 5, frame.area());
+            let inner = crate::ui::render_modal_frame_danger(frame, area, "Uninstall Plugin");
+            let path_display = self
+                .effective_plugins
+                .iter()
+                .find(|(p, _)| &p.name == name)
+                .map(|(p, _)| p.path.display().to_string())
+                .unwrap_or_default();
+            let text = Line::from(vec![
+                Span::styled(
+                    format!(" Uninstall '{name}'? Deletes {path_display}  "),
+                    Style::default().fg(Theme::text_primary()),
+                ),
+                Span::styled("y", Theme::keybind()),
+                Span::styled("/", Style::default().fg(Theme::text_muted())),
+                Span::styled("n", Theme::keybind()),
+            ]);
+            frame.render_widget(
+                Paragraph::new(text),
+                Rect {
+                    y: inner.y + inner.height / 2,
+                    ..inner
+                },
+            );
+        }
+
         // Role editor modal (detail form, overlays edit-project modal)
         if self.show_role_editor {
             role_editor_modal::render_role_editor_modal(

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -282,24 +282,6 @@ fn plugin_to_response(
     response
 }
 
-/// Recursively copy `src` into `dst` (which must not yet exist). Mirrors
-/// `cp -r src dst` semantics. Used by `install_plugin`.
-fn copy_dir_all(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let ft = entry.file_type()?;
-        let target = dst.join(entry.file_name());
-        if ft.is_dir() {
-            copy_dir_all(&entry.path(), &target)?;
-        } else if ft.is_file() {
-            std::fs::copy(entry.path(), target)?;
-        }
-        // Ignore symlinks and special files — plugins are TOML/text/exec.
-    }
-    Ok(())
-}
-
 // ── Tool implementations ────────────────────────────────────────
 
 #[tool_router(vis = "pub(super)")]
@@ -1060,51 +1042,19 @@ impl ThurboxMcp {
     }
 
     #[tool(
-        description = "Install a plugin by copying a source directory into ~/.local/share/thurbox/admin/plugins/<name>/. The source must contain a valid thurbox-plugin.toml. Returns an error if the destination already exists. After install, the plugin is auto-discovered (no register call needed)."
+        description = "Install a plugin from a local directory or git URL into ~/.local/share/thurbox/admin/plugins/<name>/. Accepts a path, http(s)://, git://, ssh://, or scp-style git@host:repo URL. Git sources are shallow-cloned to a temp dir before install. Returns an error if the destination already exists. After install, the plugin is auto-discovered (no register call needed)."
     )]
     fn install_plugin(&self, Parameters(params): Parameters<InstallPluginParams>) -> String {
-        let source = std::path::PathBuf::from(&params.source_path);
-        if !source.is_dir() {
-            return error_json("source_path must be an existing directory");
+        match crate::paths::install_plugin_from_source(&params.source, params.name.as_deref()) {
+            Ok(summary) => serde_json::json!({
+                "installed": true,
+                "name": summary.name,
+                "path": summary.path.to_string_lossy(),
+                "source_kind": summary.source_kind,
+            })
+            .to_string(),
+            Err(e) => error_json(&e.to_string()),
         }
-        let manifest = match crate::session::PluginManifest::load(&source) {
-            Ok(m) => m,
-            Err(e) => return error_json(&format!("Invalid plugin: {e}")),
-        };
-        let install_name = params.name.unwrap_or_else(|| manifest.name.clone());
-        if let Err(e) = validate_safe_name(&install_name) {
-            return e;
-        }
-        let plugins_dir = match crate::paths::plugins_directory() {
-            Some(d) => d,
-            None => return error_json("Could not resolve plugins directory"),
-        };
-        if let Err(e) = std::fs::create_dir_all(&plugins_dir) {
-            return error_json(&format!("Failed to create plugins directory: {e}"));
-        }
-        let dest = plugins_dir.join(&install_name);
-        if dest.exists() {
-            return error_json(&format!(
-                "Plugin already installed at {} — uninstall first or pick a different name",
-                dest.display()
-            ));
-        }
-        if let Err(e) = copy_dir_all(&source, &dest) {
-            // Best-effort cleanup on partial copy.
-            let _ = std::fs::remove_dir_all(&dest);
-            return error_json(&format!("Copy failed: {e}"));
-        }
-        // Re-validate after copy in case something didn't survive.
-        if let Err(e) = crate::session::PluginManifest::load(&dest) {
-            let _ = std::fs::remove_dir_all(&dest);
-            return error_json(&format!("Post-install validation failed: {e}"));
-        }
-        serde_json::json!({
-            "installed": true,
-            "name": install_name,
-            "path": dest.to_string_lossy(),
-        })
-        .to_string()
     }
 
     #[tool(
@@ -1118,40 +1068,16 @@ impl ThurboxMcp {
             return e;
         }
         let db = self.db.lock().unwrap();
-        // Resolve the path: registry takes precedence, else assume admin dir.
-        let registered = match db.list_global_plugins() {
-            Ok(rows) => rows.into_iter().find(|p| p.name == params.name),
-            Err(e) => return error_json(&e.to_string()),
-        };
-        let plugins_dir = match crate::paths::plugins_directory() {
-            Some(d) => d,
-            None => return error_json("Could not resolve plugins directory"),
-        };
-        let disk_path = registered
-            .as_ref()
-            .map(|p| p.path.clone())
-            .unwrap_or_else(|| plugins_dir.join(&params.name));
-        let mut removed_disk = false;
-        if disk_path.starts_with(&plugins_dir) && disk_path.exists() {
-            if let Err(e) = std::fs::remove_dir_all(&disk_path) {
-                return error_json(&format!("Failed to remove plugin directory: {e}"));
-            }
-            removed_disk = true;
+        match db.uninstall_plugin_with_disk(&params.name) {
+            Ok(summary) => serde_json::json!({
+                "uninstalled": true,
+                "name": summary.name,
+                "removed_disk": summary.removed_disk,
+                "removed_registry": summary.removed_registry,
+            })
+            .to_string(),
+            Err(e) => error_json(&e),
         }
-        let removed_row = match db.delete_global_plugin(&params.name) {
-            Ok(b) => b,
-            Err(e) => return error_json(&e.to_string()),
-        };
-        if !removed_disk && !removed_row {
-            return error_json(&format!("Plugin not found: {}", params.name));
-        }
-        serde_json::json!({
-            "uninstalled": true,
-            "name": params.name,
-            "removed_disk": removed_disk,
-            "removed_registry": removed_row,
-        })
-        .to_string()
     }
 
     // ── Plugin Configuration Tools ──────────────────────────────
@@ -2609,12 +2535,27 @@ mod tests {
 
         let server = test_server();
         let v = parse_json(&server.install_plugin(Parameters(InstallPluginParams {
-            source_path: source.to_string_lossy().into_owned(),
+            source: source.to_string_lossy().into_owned(),
             name: None,
         })));
         assert_eq!(v["installed"], true);
         let dest = crate::paths::plugins_directory().unwrap().join("source");
         assert!(dest.join("thurbox-plugin.toml").is_file());
+    }
+
+    #[test]
+    fn install_plugin_params_accepts_source_path_alias() {
+        // Backwards-compat: callers using the old `source_path` field should
+        // still deserialize successfully into the renamed `source` field.
+        let parsed: InstallPluginParams =
+            serde_json::from_value(serde_json::json!({ "source_path": "/tmp/x" })).unwrap();
+        assert_eq!(parsed.source, "/tmp/x");
+        assert!(parsed.name.is_none());
+
+        let parsed: InstallPluginParams =
+            serde_json::from_value(serde_json::json!({ "source": "/tmp/y", "name": "z" })).unwrap();
+        assert_eq!(parsed.source, "/tmp/y");
+        assert_eq!(parsed.name.as_deref(), Some("z"));
     }
 
     #[test]
@@ -2625,11 +2566,11 @@ mod tests {
 
         let server = test_server();
         server.install_plugin(Parameters(InstallPluginParams {
-            source_path: source.to_string_lossy().into_owned(),
+            source: source.to_string_lossy().into_owned(),
             name: None,
         }));
         let v = parse_json(&server.install_plugin(Parameters(InstallPluginParams {
-            source_path: source.to_string_lossy().into_owned(),
+            source: source.to_string_lossy().into_owned(),
             name: None,
         })));
         assert!(v["error"].as_str().unwrap().contains("already installed"));

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -299,10 +299,11 @@ pub struct DisablePluginParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct InstallPluginParams {
+    #[serde(alias = "source_path")]
     #[schemars(
-        description = "Absolute path to a plugin source directory containing thurbox-plugin.toml. Will be copied into ~/.local/share/thurbox/admin/plugins/<name>/."
+        description = "Plugin source — either an absolute path to a directory containing thurbox-plugin.toml, or a git URL (https://, git://, ssh://, or scp-style git@host:repo). Git URLs are shallow-cloned to a temp dir before install. Accepted as `source` or (deprecated) `source_path`."
     )]
-    pub source_path: String,
+    pub source: String,
     #[serde(default)]
     #[schemars(
         description = "Optional override for the install directory name. Defaults to the manifest's name field."

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -425,6 +425,251 @@ pub fn list_disk_plugins() -> Vec<crate::session::PluginConfig> {
     plugins
 }
 
+// ── Plugin install (path or git URL) ─────────────────────────────────
+//
+// Shared by the MCP `install_plugin` tool and the TUI Plugins-tab install
+// modal so both surfaces accept the same inputs and produce the same on-disk
+// layout.
+
+/// Where a plugin install is sourced from.
+pub enum InstallSource<'a> {
+    /// A directory already on disk (the original behaviour).
+    LocalPath(&'a Path),
+    /// A git URL — http(s)://, git://, ssh://, or scp-style `user@host:path`.
+    GitUrl(&'a str),
+}
+
+/// Result of a successful install.
+#[derive(Debug)]
+pub struct InstallSummary {
+    pub name: String,
+    pub path: PathBuf,
+    pub source_kind: &'static str,
+}
+
+/// Granular failure mode so callers can render context-appropriate messages.
+#[derive(Debug)]
+pub enum InstallError {
+    SourceNotFound(String),
+    InvalidManifest(String),
+    UnsafeName(String),
+    AlreadyInstalled(PathBuf),
+    GitNotAvailable,
+    GitCloneFailed(String),
+    PluginsDirUnresolvable,
+    CopyFailed(String),
+    PostInstallValidation(String),
+}
+
+impl std::fmt::Display for InstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SourceNotFound(s) => write!(f, "Source not found: {s}"),
+            Self::InvalidManifest(e) => write!(f, "Invalid plugin: {e}"),
+            Self::UnsafeName(e) => write!(f, "{e}"),
+            Self::AlreadyInstalled(p) => write!(
+                f,
+                "Plugin already installed at {} — uninstall first or pick a different name",
+                p.display()
+            ),
+            Self::GitNotAvailable => {
+                write!(
+                    f,
+                    "git executable not found on PATH — install git to use git URLs"
+                )
+            }
+            Self::GitCloneFailed(e) => write!(f, "git clone failed: {e}"),
+            Self::PluginsDirUnresolvable => write!(f, "Could not resolve plugins directory"),
+            Self::CopyFailed(e) => write!(f, "Copy failed: {e}"),
+            Self::PostInstallValidation(e) => write!(f, "Post-install validation failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for InstallError {}
+
+/// Decide whether `s` looks like a git URL or a local path. URL detection is
+/// intentionally permissive — anything with a recognised scheme or the
+/// `user@host:path` shape is treated as a clone target.
+pub fn classify_source(s: &str) -> InstallSource<'_> {
+    let trimmed = s.trim();
+    if trimmed.starts_with("http://")
+        || trimmed.starts_with("https://")
+        || trimmed.starts_with("git://")
+        || trimmed.starts_with("ssh://")
+        || trimmed.starts_with("file://")
+        || trimmed.starts_with("git+http://")
+        || trimmed.starts_with("git+https://")
+        || is_scp_style_git_url(trimmed)
+    {
+        InstallSource::GitUrl(trimmed)
+    } else {
+        InstallSource::LocalPath(Path::new(trimmed))
+    }
+}
+
+/// Match the `user@host:path` form that ssh-style git URLs use, e.g.
+/// `git@github.com:Thurbeen/thurbox-plugin-orchestrator.git`. Excludes Windows
+/// drive letters (`C:\…`) by requiring an `@` before the colon.
+fn is_scp_style_git_url(s: &str) -> bool {
+    let Some(colon) = s.find(':') else {
+        return false;
+    };
+    let head = &s[..colon];
+    head.contains('@') && !head.contains('/') && !head.contains('\\')
+}
+
+/// Install a plugin from a local directory or a git URL. Copies the source
+/// (or clones it first) into `~/.local/share/thurbox/admin/plugins/<name>/`.
+///
+/// `name_override` lets callers force the install directory name; defaults to
+/// the manifest's `name` field. Always re-validates the manifest after copy
+/// so a partial transfer cannot leave a half-installed plugin behind.
+pub fn install_plugin_from_source(
+    source: &str,
+    name_override: Option<&str>,
+) -> Result<InstallSummary, InstallError> {
+    let (source_dir, source_kind, _tempdir_guard): (
+        PathBuf,
+        &'static str,
+        Option<tempfile::TempDir>,
+    ) = match classify_source(source) {
+        InstallSource::LocalPath(p) => {
+            if !p.is_dir() {
+                return Err(InstallError::SourceNotFound(p.display().to_string()));
+            }
+            (p.to_path_buf(), "path", None)
+        }
+        InstallSource::GitUrl(url) => {
+            let tmp =
+                tempfile::TempDir::new().map_err(|e| InstallError::CopyFailed(e.to_string()))?;
+            let clone_dir = tmp.path().join("plugin");
+            git_shallow_clone(url, &clone_dir)?;
+            (clone_dir, "git", Some(tmp))
+        }
+    };
+
+    // Look for the manifest at the source root. If absent, fall back to a
+    // single-level subdir search — many plugin repos are monorepos that put
+    // the payload under `plugin/`, `dist/`, or similar instead of the repo
+    // root. Pick the first matching subdir to avoid ambiguity.
+    let payload_dir = locate_manifest_dir(&source_dir)
+        .ok_or_else(|| InstallError::InvalidManifest(missing_manifest_message(&source_dir)))?;
+    let manifest = crate::session::PluginManifest::load(&payload_dir)
+        .map_err(|e| InstallError::InvalidManifest(e.to_string()))?;
+
+    let install_name = name_override
+        .map(str::to_string)
+        .unwrap_or_else(|| manifest.name.clone());
+    validate_safe_name(&install_name).map_err(InstallError::UnsafeName)?;
+
+    let plugins_dir = plugins_directory().ok_or(InstallError::PluginsDirUnresolvable)?;
+    std::fs::create_dir_all(&plugins_dir).map_err(|e| InstallError::CopyFailed(e.to_string()))?;
+
+    let dest = plugins_dir.join(&install_name);
+    if dest.exists() {
+        return Err(InstallError::AlreadyInstalled(dest));
+    }
+
+    if let Err(e) = copy_dir_all(&payload_dir, &dest) {
+        let _ = std::fs::remove_dir_all(&dest);
+        return Err(InstallError::CopyFailed(e.to_string()));
+    }
+
+    if let Err(e) = crate::session::PluginManifest::load(&dest) {
+        let _ = std::fs::remove_dir_all(&dest);
+        return Err(InstallError::PostInstallValidation(e.to_string()));
+    }
+
+    Ok(InstallSummary {
+        name: install_name,
+        path: dest,
+        source_kind,
+    })
+}
+
+/// Subdirectory names checked when the manifest isn't at the source root.
+/// Ordered by community convention; first match wins. Repos that don't follow
+/// this layout still work by pointing the source at the right directory
+/// directly.
+const MANIFEST_FALLBACK_SUBDIRS: &[&str] = &["plugin", "dist", "payload"];
+
+/// Find the directory containing `thurbox-plugin.toml`. Checks the root first,
+/// then a small allowlist of conventional subdirectories.
+fn locate_manifest_dir(root: &Path) -> Option<PathBuf> {
+    let filename = crate::session::PluginManifest::FILENAME;
+    if root.join(filename).is_file() {
+        return Some(root.to_path_buf());
+    }
+    for sub in MANIFEST_FALLBACK_SUBDIRS {
+        let candidate = root.join(sub);
+        if candidate.join(filename).is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Build the "manifest not found" error message, listing the locations checked
+/// so users see immediately which subdirectory layouts are supported.
+fn missing_manifest_message(root: &Path) -> String {
+    let filename = crate::session::PluginManifest::FILENAME;
+    let mut tried = vec![root.join(filename).display().to_string()];
+    for sub in MANIFEST_FALLBACK_SUBDIRS {
+        tried.push(root.join(sub).join(filename).display().to_string());
+    }
+    format!(
+        "{filename} not found. Checked: {}. \
+         Plugins typically live at the repo root or under one of: {}",
+        tried.join(", "),
+        MANIFEST_FALLBACK_SUBDIRS.join(", ")
+    )
+}
+
+/// Shallow `git clone --depth 1 <url> <dest>`. Returns `GitNotAvailable` when
+/// the binary is missing, otherwise `GitCloneFailed` carrying stderr.
+fn git_shallow_clone(url: &str, dest: &Path) -> Result<(), InstallError> {
+    let output = std::process::Command::new("git")
+        .args(["clone", "--depth", "1", "--quiet", url])
+        .arg(dest)
+        .output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                InstallError::GitNotAvailable
+            } else {
+                InstallError::GitCloneFailed(e.to_string())
+            }
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("exit status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(InstallError::GitCloneFailed(msg));
+    }
+    Ok(())
+}
+
+/// Recursively copy `src` into `dst` (which must not yet exist). Mirrors
+/// `cp -r src dst` semantics — symlinks and special files are skipped because
+/// plugins are TOML/text/exec only.
+fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ft = entry.file_type()?;
+        let target = dst.join(entry.file_name());
+        if ft.is_dir() {
+            copy_dir_all(&entry.path(), &target)?;
+        } else if ft.is_file() {
+            std::fs::copy(entry.path(), target)?;
+        }
+    }
+    Ok(())
+}
+
 /// Resolve the VM images directory path.
 ///
 /// Returns: `$XDG_DATA_HOME/thurbox/admin/images/` or
@@ -1429,5 +1674,203 @@ mod tests {
         if let Some(s) = complete_directory_path("~/") {
             assert!(!s.starts_with('/'));
         }
+    }
+
+    // ── plugin install ──────────────────────────────────────────────
+
+    fn write_plugin_dir(root: &Path, name: &str) -> PathBuf {
+        let p = root.join(name);
+        std::fs::create_dir_all(&p).unwrap();
+        std::fs::write(
+            p.join("thurbox-plugin.toml"),
+            format!("name = \"{name}\"\nversion = \"0.1.0\"\nthurbox_plugin_api = 1\n"),
+        )
+        .unwrap();
+        p
+    }
+
+    #[test]
+    fn classify_source_recognises_url_schemes() {
+        assert!(matches!(
+            classify_source("https://github.com/x/y"),
+            InstallSource::GitUrl(_)
+        ));
+        assert!(matches!(
+            classify_source("http://example.com/x.git"),
+            InstallSource::GitUrl(_)
+        ));
+        assert!(matches!(
+            classify_source("git://example.com/x.git"),
+            InstallSource::GitUrl(_)
+        ));
+        assert!(matches!(
+            classify_source("ssh://git@example.com/x.git"),
+            InstallSource::GitUrl(_)
+        ));
+        assert!(matches!(
+            classify_source("git@github.com:Thurbeen/thurbox-plugin-orchestrator.git"),
+            InstallSource::GitUrl(_)
+        ));
+    }
+
+    #[test]
+    fn classify_source_treats_paths_as_local() {
+        assert!(matches!(
+            classify_source("/tmp/plugin"),
+            InstallSource::LocalPath(_)
+        ));
+        assert!(matches!(
+            classify_source("./relative"),
+            InstallSource::LocalPath(_)
+        ));
+        // Windows drive letters must not be misread as scp-style URLs.
+        assert!(matches!(
+            classify_source("C:\\path\\plugin"),
+            InstallSource::LocalPath(_)
+        ));
+    }
+
+    #[test]
+    fn install_plugin_from_local_path_copies_into_admin_dir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = TestPathGuard::new(temp.path());
+        let source = write_plugin_dir(temp.path(), "alpha");
+
+        let summary = install_plugin_from_source(&source.to_string_lossy(), None).unwrap();
+        assert_eq!(summary.name, "alpha");
+        assert_eq!(summary.source_kind, "path");
+        let dest = plugins_directory().unwrap().join("alpha");
+        assert_eq!(summary.path, dest);
+        assert!(dest.join("thurbox-plugin.toml").is_file());
+    }
+
+    #[test]
+    fn install_plugin_rejects_existing_destination() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = TestPathGuard::new(temp.path());
+        let source = write_plugin_dir(temp.path(), "dup");
+
+        install_plugin_from_source(&source.to_string_lossy(), None).unwrap();
+        let err = install_plugin_from_source(&source.to_string_lossy(), None).unwrap_err();
+        assert!(matches!(err, InstallError::AlreadyInstalled(_)));
+    }
+
+    #[test]
+    fn install_plugin_rejects_missing_source() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = TestPathGuard::new(temp.path());
+
+        let err =
+            install_plugin_from_source(&temp.path().join("does-not-exist").to_string_lossy(), None)
+                .unwrap_err();
+        assert!(matches!(err, InstallError::SourceNotFound(_)));
+    }
+
+    #[test]
+    fn install_plugin_rejects_missing_manifest() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = TestPathGuard::new(temp.path());
+        let bare = temp.path().join("bare");
+        std::fs::create_dir_all(&bare).unwrap();
+
+        let err = install_plugin_from_source(&bare.to_string_lossy(), None).unwrap_err();
+        assert!(matches!(err, InstallError::InvalidManifest(_)));
+    }
+
+    #[test]
+    fn install_plugin_finds_manifest_in_plugin_subdir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = TestPathGuard::new(temp.path());
+        // Repo-style layout: manifest lives under plugin/, repo root has other files.
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::write(repo.join("README.md"), "repo readme").unwrap();
+        write_plugin_dir(&repo, "plugin");
+        // Rename inner manifest's `name` field to confirm the inner manifest
+        // (not the repo dir name) determines install_name.
+        std::fs::write(
+            repo.join("plugin").join("thurbox-plugin.toml"),
+            "name = \"orchestrator\"\nversion = \"0.1.0\"\nthurbox_plugin_api = 1\n",
+        )
+        .unwrap();
+
+        let summary = install_plugin_from_source(&repo.to_string_lossy(), None).unwrap();
+        assert_eq!(summary.name, "orchestrator");
+        let dest = plugins_directory().unwrap().join("orchestrator");
+        assert_eq!(summary.path, dest);
+        assert!(dest.join("thurbox-plugin.toml").is_file());
+        // Repo-root README should NOT have been copied — only the plugin/ payload.
+        assert!(!dest.join("README.md").is_file());
+    }
+
+    #[test]
+    fn install_plugin_honors_name_override() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = TestPathGuard::new(temp.path());
+        let source = write_plugin_dir(temp.path(), "alpha");
+
+        let summary =
+            install_plugin_from_source(&source.to_string_lossy(), Some("renamed")).unwrap();
+        assert_eq!(summary.name, "renamed");
+        assert!(plugins_directory()
+            .unwrap()
+            .join("renamed")
+            .join("thurbox-plugin.toml")
+            .is_file());
+    }
+
+    #[test]
+    fn install_plugin_from_git_url_clones_and_installs() {
+        // Skip when git isn't available — not all CI runners include it.
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return;
+        }
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = TestPathGuard::new(temp.path());
+
+        // Build a bare git repo with a valid plugin manifest committed.
+        let work = temp.path().join("source-work");
+        let work_plugin = write_plugin_dir(&work, "from-git");
+        // The test plugin lives under source-work/from-git/. We commit the
+        // contents of that directory so the clone lands a flat layout.
+        let run = |args: &[&str], cwd: &Path| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .output()
+                .unwrap()
+        };
+        run(&["init", "-q", "-b", "main"], &work_plugin);
+        run(&["config", "user.email", "test@example.com"], &work_plugin);
+        run(&["config", "user.name", "Test"], &work_plugin);
+        run(&["add", "."], &work_plugin);
+        run(&["commit", "-q", "-m", "init"], &work_plugin);
+
+        let url = format!("file://{}", work_plugin.display());
+        let summary = install_plugin_from_source(&url, None).unwrap();
+        assert_eq!(summary.source_kind, "git");
+        assert_eq!(summary.name, "from-git");
+        assert!(summary.path.join("thurbox-plugin.toml").is_file());
+    }
+
+    #[test]
+    fn install_plugin_surfaces_git_clone_failure() {
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return;
+        }
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = TestPathGuard::new(temp.path());
+
+        let bogus = format!("file://{}/does-not-exist.git", temp.path().display());
+        let err = install_plugin_from_source(&bogus, None).unwrap_err();
+        assert!(matches!(err, InstallError::GitCloneFailed(_)));
     }
 }

--- a/src/storage/plugins.rs
+++ b/src/storage/plugins.rs
@@ -28,6 +28,15 @@ pub enum PluginSource {
     Registered,
 }
 
+/// Outcome of [`Database::uninstall_plugin_with_disk`].
+#[derive(Debug, Clone)]
+pub struct UninstallSummary {
+    pub name: String,
+    pub removed_disk: bool,
+    pub removed_registry: bool,
+    pub disk_path: PathBuf,
+}
+
 fn row_to_plugin_config(row: &rusqlite::Row<'_>) -> rusqlite::Result<PluginConfig> {
     let name: String = row.get(0)?;
     let path: String = row.get(1)?;
@@ -104,6 +113,46 @@ impl Database {
             .conn
             .execute("DELETE FROM plugins WHERE plugin_name = ?1", params![name])?;
         Ok(count > 0)
+    }
+
+    /// Uninstall a plugin: removes the directory under
+    /// `~/.local/share/thurbox/admin/plugins/` (when applicable) AND deletes
+    /// the registry row (cascades `plugin_settings`). For plugins registered
+    /// outside the admin dir, only the registry row is removed.
+    ///
+    /// Shared by the MCP `uninstall_plugin` tool and the TUI Plugins-tab
+    /// uninstall affordance so both surfaces apply identical rules.
+    pub fn uninstall_plugin_with_disk(&self, name: &str) -> Result<UninstallSummary, String> {
+        let registered = self
+            .list_global_plugins()
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .find(|p| p.name == name);
+        let plugins_dir =
+            crate::paths::plugins_directory().ok_or("Could not resolve plugins directory")?;
+        let disk_path = registered
+            .as_ref()
+            .map(|p| p.path.clone())
+            .unwrap_or_else(|| plugins_dir.join(name));
+
+        let mut removed_disk = false;
+        if disk_path.starts_with(&plugins_dir) && disk_path.exists() {
+            std::fs::remove_dir_all(&disk_path)
+                .map_err(|e| format!("Failed to remove plugin directory: {e}"))?;
+            removed_disk = true;
+        }
+        let removed_registry = self.delete_global_plugin(name).map_err(|e| e.to_string())?;
+
+        if !removed_disk && !removed_registry {
+            return Err(format!("Plugin not found: {name}"));
+        }
+
+        Ok(UninstallSummary {
+            name: name.to_string(),
+            removed_disk,
+            removed_registry,
+            disk_path,
+        })
     }
 
     /// Set the `enabled` flag for a plugin by name.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ pub mod links;
 pub mod mcp_editor_modal;
 pub mod mcp_server_picker_modal;
 pub mod model_picker_modal;
+pub mod plugin_install_modal;
 pub mod project_list;
 pub mod repo_picker_modal;
 pub mod repo_selector_modal;

--- a/src/ui/plugin_install_modal.rs
+++ b/src/ui/plugin_install_modal.rs
@@ -1,0 +1,70 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::Style,
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::theme::Theme;
+use super::{centered_fixed_height_rect, render_modal_frame, render_text_field};
+
+/// Status line shown at the bottom of the install modal. Drives the colour
+/// (idle = muted, in-progress = accent, success = idle status, error = danger).
+#[derive(Debug, Clone)]
+pub enum PluginInstallStatusView<'a> {
+    Idle,
+    InProgress(&'a str),
+    Success(&'a str),
+    Error(&'a str),
+}
+
+pub struct PluginInstallModalState<'a> {
+    pub input: &'a str,
+    pub cursor: usize,
+    pub status: PluginInstallStatusView<'a>,
+}
+
+pub fn render_plugin_install_modal(frame: &mut Frame, state: &PluginInstallModalState<'_>) {
+    // input(3) + status(1) + footer(1) = 5 rows + outer border(2)
+    let area = centered_fixed_height_rect(60, 7, frame.area());
+    let inner = render_modal_frame(frame, area, "Install Plugin");
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Min(1),
+        ])
+        .split(inner);
+
+    render_text_field(
+        frame,
+        chunks[0],
+        "Source (path or git URL)",
+        state.input,
+        state.cursor,
+        true,
+    );
+
+    let (label, color) = match state.status {
+        PluginInstallStatusView::Idle => (
+            "Paste a local path or a git URL (https://, git@…, ssh://).".to_string(),
+            Theme::text_muted(),
+        ),
+        PluginInstallStatusView::InProgress(msg) => (msg.to_string(), Theme::accent()),
+        PluginInstallStatusView::Success(msg) => (msg.to_string(), Theme::status_busy()),
+        PluginInstallStatusView::Error(msg) => (msg.to_string(), Theme::danger()),
+    };
+    let status = Paragraph::new(Line::from(Span::styled(label, Style::default().fg(color))));
+    frame.render_widget(status, chunks[1]);
+
+    let footer = Line::from(vec![
+        Span::styled("Enter", Theme::keybind()),
+        Span::styled(" install  ", Theme::keybind_desc()),
+        Span::styled("Esc", Theme::keybind()),
+        Span::styled(" close", Theme::keybind_desc()),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[2]);
+}

--- a/src/ui/settings_overlay.rs
+++ b/src/ui/settings_overlay.rs
@@ -168,7 +168,7 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
         SettingsTab::Plugins => {
             if state.plugins.is_empty() {
                 let empty = Paragraph::new(Line::from(Span::styled(
-                    "  No plugins installed. Drop one under ~/.local/share/thurbox/admin/plugins/",
+                    "  No plugins installed. Press 'i' to install from a path or git URL.",
                     Style::default().fg(Theme::text_muted()),
                 )));
                 frame.render_widget(empty, list_area);
@@ -240,6 +240,10 @@ pub fn render_settings_overlay(frame: &mut Frame, state: &SettingsOverlayState) 
                 ": toggle enable  ",
                 Style::default().fg(Theme::text_muted()),
             ),
+            Span::styled("i", Theme::keybind()),
+            Span::styled(": install  ", Style::default().fg(Theme::text_muted())),
+            Span::styled("d", Theme::keybind()),
+            Span::styled(": uninstall  ", Style::default().fg(Theme::text_muted())),
             Span::styled("Esc", Theme::keybind()),
             Span::styled(": close", Style::default().fg(Theme::text_muted())),
         ])


### PR DESCRIPTION
## Summary

- MCP `install_plugin` now accepts http(s)://, git://, ssh:// and scp-style (`git@host:owner/repo`) URLs in addition to local paths. `source_path` kept as a serde alias.
- New TUI install flow under `Ctrl+E` → **Plugins**: `i` opens a modal accepting a path or URL; git clone runs on a background thread so the UI never blocks. `d` opens an inline uninstall confirm.
- Manifest auto-discovery in `plugin/`, `dist/`, or `payload/` subdirs when not at clone root, so plugins don't need their manifest at the repo root.
- Shared install/uninstall logic lives in `paths::install_plugin_from_source` / `uninstall_plugin_by_name` — one code path for MCP + TUI.

### Fixes along the way

- Clipboard paste (`Ctrl+V` + bracketed paste) was being routed to the session terminal even when a modal had focus. Added a `try_paste_into_modal_input` hook + moved `Ctrl+V`/`Ctrl+C` above modal dispatchers.
- Settings overlay `Tab`/`BackTab` split — Shift+Tab actually cycles backward now.

## Test plan

- [x] `cargo test --lib install_plugin` — 13 tests covering URL classification, git clone success/failure, subdir discovery, name collision, missing source/manifest, `source_path` alias.
- [x] `cargo test --test architecture_rules` — module isolation unchanged.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] End-to-end install of refactored `thurbox-plugin-orchestrator` (https://github.com/Thurbeen/thurbox-plugin-orchestrator) via MCP against a fresh `XDG_DATA_HOME` produces the expected tree.
- [ ] TUI smoke: `Ctrl+E` → Plugins → `i` → paste URL → `Enter` → "Installed orchestrator" appears; `d` → `y` removes it.