### PR TITLE
ci: auto-publish AUR packages on release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -222,3 +222,47 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Publish the Arch Linux AUR packages.
+  # Runs after `publish` so the GitHub Release assets (needed by thurbox-bin)
+  # and the tag's source tarball (needed by thurbox) are both available.
+  # Requires the AUR_SSH_PRIVATE_KEY secret; skipped automatically if unset.
+  publish-aur:
+    name: Publish AUR (${{ matrix.pkgname }})
+    needs: [check-release, create-tag, publish]
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    # Hoisted so the publish step can be skipped when the secret is unset
+    # (the `secrets` context cannot be used directly in an `if` condition).
+    env:
+      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+    strategy:
+      fail-fast: false
+      matrix:
+        pkgname: [thurbox, thurbox-bin]
+    steps:
+      - name: Checkout code at tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.check-release.outputs.version }}
+
+      - name: Bump pkgver to the release version
+        run: |
+          PKGVER="${{ needs.check-release.outputs.version }}"
+          PKGVER="${PKGVER#v}"   # PKGBUILD pkgver is the bare semver
+          PKGBUILD="packaging/aur/${{ matrix.pkgname }}/PKGBUILD"
+          sed -i "s/^pkgver=.*/pkgver=${PKGVER}/" "$PKGBUILD"
+          sed -i "s/^pkgrel=.*/pkgrel=1/" "$PKGBUILD"
+          echo "Set ${{ matrix.pkgname }} to pkgver=${PKGVER}"
+
+      - name: Publish to the AUR
+        if: env.AUR_SSH_PRIVATE_KEY != ''
+        uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
+        with:
+          pkgname: ${{ matrix.pkgname }}
+          pkgbuild: packaging/aur/${{ matrix.pkgname }}/PKGBUILD
+          updpkgsums: true   # recompute sha256sums from the freshly released sources
+          commit_username: thurbox-release-bot
+          commit_email: magicletur@protonmail.com
+          ssh_private_key: ${{ env.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ needs.check-release.outputs.version }}"

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -48,21 +48,46 @@ namcap PKGBUILD     # lint the recipe (if namcap is installed)
 namcap *.pkg.tar.zst
 ```
 
-## Bumping to a new release
+## Automated publishing (CI)
 
-1. Set `pkgver` to the new version (drop the `v` prefix) and reset
-   `pkgrel=1` in the relevant `PKGBUILD`.
-2. Refresh checksums: `updpkgsums`.
-3. Regenerate the metadata: `makepkg --printsrcinfo > .SRCINFO`.
-4. Rebuild to confirm: `makepkg -f`.
+New releases publish to the AUR **automatically**. The `publish-aur` job
+in [`.github/workflows/cd.yml`](../../.github/workflows/cd.yml) runs after
+the GitHub Release is created and, for each package:
 
-Pick a `pkgver` that has **published release assets** (check the GitHub
-releases page) — some tags exist without a completed binary release.
+1. bumps `pkgver` to the release version and resets `pkgrel=1`,
+2. recomputes `sha256sums` (`updpkgsums`) from the freshly released sources,
+3. regenerates `.SRCINFO`, and
+4. commits + pushes to the package's AUR git repo.
 
-## Publishing to the AUR
+The `pkgver`/`sha256sums` committed in this directory are therefore just a
+template/last-known-good — CI overrides them per release. The job is a
+no-op if nothing changed, and is skipped entirely when the SSH secret is
+absent (e.g. on forks).
 
-The AUR holds each package in its own git repo; this directory is just
-the source of truth. To publish/update:
+### One-time setup
+
+The job needs an SSH key that is registered on the AUR account and stored
+as the `AUR_SSH_PRIVATE_KEY` repository secret:
+
+```bash
+# 1. Generate a dedicated CI key (no passphrase)
+ssh-keygen -t ed25519 -C "thurbox-ci@aur" -f aur_ci -N ""
+
+# 2. Store the PRIVATE key as a GitHub Actions secret
+gh secret set AUR_SSH_PRIVATE_KEY < aur_ci
+
+# 3. Add the PUBLIC key (aur_ci.pub) to your AUR account at
+#    https://aur.archlinux.org/account  ->  "SSH Public Key"
+#    (paste it on a new line, keeping any existing keys)
+```
+
+The package must already exist on the AUR (initial import is manual, see
+below). After that, every release updates it automatically.
+
+## Manual publishing / initial import
+
+The AUR holds each package in its own git repo. For the first import (or a
+manual update):
 
 ```bash
 git clone ssh://aur@aur.archlinux.org/thurbox.git aur-thurbox
@@ -73,3 +98,8 @@ git push
 ```
 
 Repeat with `thurbox-bin/` against the `thurbox-bin.git` AUR repo.
+
+When bumping manually: set `pkgver` (drop the `v` prefix), reset
+`pkgrel=1`, run `updpkgsums`, regenerate `.SRCINFO`
+(`makepkg --printsrcinfo > .SRCINFO`), and confirm with `makepkg -f`.
+Pick a `pkgver` that has **published release assets** for `thurbox-bin`.


### PR DESCRIPTION
Adds a `publish-aur` job to the release workflow that automatically updates the `thurbox` and `thurbox-bin` AUR packages whenever a release is published.

## What it does
For each package, after the GitHub Release exists, the job:
1. bumps `pkgver` to the release version (resets `pkgrel=1`),
2. recomputes `sha256sums` via `updpkgsums`,
3. regenerates `.SRCINFO`, and
4. commits + pushes to the package's AUR git repo (via [KSXGitHub/github-actions-deploy-aur](https://github.com/KSXGitHub/github-actions-deploy-aur), SHA-pinned to v4.1.3).

Runs after `publish` so both the release binaries (for `thurbox-bin`) and the tag source tarball (for `thurbox`) are available. No-op when nothing changed; skipped on forks where the secret is absent.

## Setup
Requires the `AUR_SSH_PRIVATE_KEY` repo secret (already set) whose public key is registered on the AUR account. Documented in `packaging/aur/README.md`.