### PR TITLE
feat(ui): richer session list with live agent status

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -48,6 +48,36 @@ the agent ("the codex one"), occasionally the repo path. Indexing
 all four makes the search hit on the first attempt without forcing
 the user to remember which field to type into.
 
+### Live status & "needs attention"
+
+Each row is two lines: `<status-dot> <name>` with a right-aligned
+live status on line 1, and `<agent> · <repo>(<branch>)` on line 2.
+
+The status is richer than raw output-timing. We parse the agent's
+own terminal signals from its PTY (via the `vt100` callbacks already
+used for the window title):
+
+- **OSC title** (`0`/`1`/`2`) → shown as live activity when the agent
+  reports one (e.g. Gemini's `◇ Ready`).
+- **Attention** — a terminal bell (`BEL`) or a desktop-notification
+  escape (**OSC 9**, **OSC 777**) means the agent finished or is
+  waiting for input. This latches a distinct `Needs attention` status
+  (`▲`, accent colour) that shows the notification's message text when
+  present, and **sorts the session to the top of the list** so blocked
+  or finished agents surface first. It clears automatically once you
+  select the session (you're now looking at it).
+
+**Why signals instead of guessing?** Pure output-timing can only say
+"quiet for >1s"; it can't tell a thinking pause from "done" or "needs
+you". The agents already emit these signals — we just read them. This
+mirrors how dashboards like Orca surface working / waiting / finished.
+
+**Caveat (Claude in tmux):** Claude Code only emits the OSC 9 desktop
+notification for Ghostty/Kitty/iTerm2, so inside thurbox's tmux pane
+set `claude config set --global preferredNotifChannel terminal_bell`
+to get the bell we can detect. We capture bell + OSC 9 + OSC 777,
+whichever the agent produces.
+
 ---
 
 ## Session Creation

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -21,6 +21,85 @@ pub(crate) fn now_millis() -> u64 {
         .as_millis() as u64
 }
 
+/// Captures terminal signals the agent emits into shared cells read by the app
+/// layer (mirrors the `last_output_at` side channel). The parser fires these
+/// callbacks while processing the PTY byte stream:
+///
+/// - **Title** (OSC `0`/`1`/`2`) → live activity text.
+/// - **Attention** — a terminal bell (`BEL`) or a desktop-notification escape
+///   (OSC `9`, OSC `777`) means the agent finished or needs input. We record
+///   the time of the latest such signal, plus its message text when the OSC
+///   carries one. This is how we surface a real "needs attention" state instead
+///   of timing-only Busy/Waiting.
+#[derive(Clone, Default)]
+pub struct TermSignals {
+    title: Arc<Mutex<Option<String>>>,
+    /// `now_millis()` of the most recent attention signal; `0` = none yet.
+    attention_at: Arc<AtomicU64>,
+    /// Message text from the most recent OSC 9/777 notification, if any.
+    notification: Arc<Mutex<Option<String>>>,
+}
+
+impl TermSignals {
+    fn store_title(&self, raw: &[u8]) {
+        let s = String::from_utf8_lossy(raw).trim().to_string();
+        if let Ok(mut guard) = self.title.lock() {
+            *guard = (!s.is_empty()).then_some(s);
+        }
+    }
+
+    /// Mark an attention signal, optionally with notification message text.
+    fn signal_attention(&self, message: Option<String>) {
+        self.attention_at.store(now_millis(), Ordering::Relaxed);
+        if let Some(msg) = message {
+            let msg = msg.trim().to_string();
+            if let Ok(mut guard) = self.notification.lock() {
+                *guard = (!msg.is_empty()).then_some(msg);
+            }
+        }
+    }
+}
+
+impl vt100::Callbacks for TermSignals {
+    fn set_window_title(&mut self, _: &mut vt100::Screen, title: &[u8]) {
+        self.store_title(title);
+    }
+
+    fn set_window_icon_name(&mut self, _: &mut vt100::Screen, icon_name: &[u8]) {
+        // Some CLIs emit only OSC `1` (icon name); treat it as the title too.
+        self.store_title(icon_name);
+    }
+
+    fn audible_bell(&mut self, _: &mut vt100::Screen) {
+        // BEL: the cross-agent "done / needs you" signal (e.g. Claude's
+        // `preferredNotifChannel terminal_bell`). No message text.
+        self.signal_attention(None);
+    }
+
+    fn unhandled_osc(&mut self, _: &mut vt100::Screen, params: &[&[u8]]) {
+        // Desktop-notification escapes carry the agent's status message.
+        //   OSC 9 ; <message>
+        //   OSC 777 ; notify ; <title> ; <body>
+        match params {
+            [b"9", msg] => self.signal_attention(Some(String::from_utf8_lossy(msg).into_owned())),
+            [b"777", kind, rest @ ..] if kind.eq_ignore_ascii_case(b"notify") => {
+                let msg = rest
+                    .iter()
+                    .map(|p| String::from_utf8_lossy(p))
+                    .collect::<Vec<_>>()
+                    .join(": ");
+                self.signal_attention(Some(msg));
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Session terminal parser, specialized to capture terminal signals via
+/// [`TermSignals`]. The captured `Screen` is callback-independent, so
+/// rendering is unaffected.
+pub type SessionParser = vt100::Parser<TermSignals>;
+
 /// Metadata returned when discovering existing sessions from the backend.
 #[derive(Clone)]
 pub struct DiscoveredSession {
@@ -110,15 +189,18 @@ struct SessionIo {
 
 /// Wired-up I/O state: parser, channels, and exit tracking.
 struct WiredState {
-    parser: Arc<Mutex<vt100::Parser>>,
+    parser: Arc<Mutex<SessionParser>>,
     input_tx: mpsc::UnboundedSender<Vec<u8>>,
     exited: Arc<AtomicBool>,
     last_output_at: Arc<AtomicU64>,
+    last_title: Arc<Mutex<Option<String>>>,
+    attention_at: Arc<AtomicU64>,
+    notification: Arc<Mutex<Option<String>>>,
 }
 
 /// A companion shell pane running alongside an agent session.
 pub struct ShellPane {
-    pub parser: Arc<Mutex<vt100::Parser>>,
+    pub parser: Arc<Mutex<SessionParser>>,
     input_tx: mpsc::UnboundedSender<Vec<u8>>,
     backend_id: String,
     /// Kept alive so the reader loop's Arc clone has a peer.
@@ -126,6 +208,9 @@ pub struct ShellPane {
     exited: Arc<AtomicBool>,
     #[allow(dead_code)]
     last_output_at: Arc<AtomicU64>,
+    /// Captured OSC title for the shell pane (unused; kept for symmetry).
+    #[allow(dead_code)]
+    last_title: Arc<Mutex<Option<String>>>,
 }
 
 impl ShellPane {
@@ -143,6 +228,7 @@ impl ShellPane {
             backend_id,
             exited: state.exited,
             last_output_at: state.last_output_at,
+            last_title: state.last_title,
         }
     }
 }
@@ -150,13 +236,23 @@ impl ShellPane {
 /// A running session connected to a backend.
 pub struct Session {
     pub info: SessionInfo,
-    pub parser: Arc<Mutex<vt100::Parser>>,
+    pub parser: Arc<Mutex<SessionParser>>,
     input_tx: mpsc::UnboundedSender<Vec<u8>>,
     backend_id: String,
     backend: Arc<dyn SessionBackend>,
     provider: Arc<dyn AgentProvider>,
     exited: Arc<AtomicBool>,
     last_output_at: Arc<AtomicU64>,
+    /// Latest OSC window title the agent emitted (live activity text).
+    last_title: Arc<Mutex<Option<String>>>,
+    /// `now_millis()` of the latest attention signal (bell / OSC 9 / OSC 777).
+    attention_at: Arc<AtomicU64>,
+    /// Message text from the latest OSC 9/777 notification, if any.
+    notification: Arc<Mutex<Option<String>>>,
+    /// `now_millis()` of the last attention acknowledgement (set while the
+    /// session is the active one). Attention is pending when
+    /// `attention_at > attention_ack_at`.
+    attention_ack_at: u64,
     pub shell_pane: Option<ShellPane>,
     /// Session environment variables, passed to shell pane spawns.
     env: HashMap<String, String>,
@@ -251,7 +347,19 @@ impl Session {
 
     /// Create parser, spawn reader/writer loops for the given I/O handles.
     fn wire_up(rows: u16, cols: u16, io: SessionIo) -> (WiredState, String) {
-        let parser = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 1000)));
+        let last_title = Arc::new(Mutex::new(None));
+        let attention_at = Arc::new(AtomicU64::new(0));
+        let notification = Arc::new(Mutex::new(None));
+        let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
+            rows,
+            cols,
+            1000,
+            TermSignals {
+                title: Arc::clone(&last_title),
+                attention_at: Arc::clone(&attention_at),
+                notification: Arc::clone(&notification),
+            },
+        )));
 
         let exited = Arc::new(AtomicBool::new(false));
         let last_output_at = Arc::new(AtomicU64::new(now_millis()));
@@ -271,6 +379,9 @@ impl Session {
             input_tx,
             exited,
             last_output_at,
+            last_title,
+            attention_at,
+            notification,
         };
         (state, io.backend_id)
     }
@@ -295,6 +406,10 @@ impl Session {
             provider: Arc::clone(provider),
             exited: state.exited,
             last_output_at: state.last_output_at,
+            last_title: state.last_title,
+            attention_at: state.attention_at,
+            notification: state.notification,
+            attention_ack_at: 0,
             shell_pane: None,
             env,
         }
@@ -302,7 +417,7 @@ impl Session {
 
     fn reader_loop(
         mut reader: Box<dyn Read + Send>,
-        parser: Arc<Mutex<vt100::Parser>>,
+        parser: Arc<Mutex<SessionParser>>,
         exited: Arc<AtomicBool>,
         last_output_at: Arc<AtomicU64>,
     ) {
@@ -377,6 +492,28 @@ impl Session {
 
     pub fn millis_since_last_output(&self) -> u64 {
         now_millis().saturating_sub(self.last_output_at.load(Ordering::Relaxed))
+    }
+
+    /// Latest OSC window title the agent emitted, if any (live activity text).
+    pub fn agent_title(&self) -> Option<String> {
+        self.last_title.lock().ok().and_then(|t| t.clone())
+    }
+
+    /// Whether the agent has signalled for attention (bell / OSC 9 / OSC 777)
+    /// since it was last acknowledged. Cleared via [`Self::acknowledge_attention`].
+    pub fn needs_attention(&self) -> bool {
+        self.attention_at.load(Ordering::Relaxed) > self.attention_ack_at
+    }
+
+    /// Message text from the latest attention notification, if any.
+    pub fn notification(&self) -> Option<String> {
+        self.notification.lock().ok().and_then(|n| n.clone())
+    }
+
+    /// Acknowledge any pending attention signal (called while the session is
+    /// the active/selected one — the user is already looking at it).
+    pub fn acknowledge_attention(&mut self) {
+        self.attention_ack_at = now_millis();
     }
 
     /// Return the backend-specific session identifier.
@@ -544,13 +681,22 @@ impl Session {
         let (input_tx, _input_rx) = mpsc::unbounded_channel();
         Self {
             info: SessionInfo::new(name.to_string()),
-            parser: Arc::new(Mutex::new(vt100::Parser::new(24, 80, 0))),
+            parser: Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
+                24,
+                80,
+                0,
+                TermSignals::default(),
+            ))),
             input_tx,
             backend_id: String::new(),
             backend: Arc::clone(backend),
             provider: Arc::clone(provider),
             exited: Arc::new(AtomicBool::new(false)),
             last_output_at: Arc::new(AtomicU64::new(now_millis())),
+            last_title: Arc::new(Mutex::new(None)),
+            attention_at: Arc::new(AtomicU64::new(0)),
+            notification: Arc::new(Mutex::new(None)),
+            attention_ack_at: 0,
             shell_pane: None,
             env: HashMap::new(),
         }
@@ -566,5 +712,68 @@ mod tests {
         let ms = now_millis();
         // Should be after 2024-01-01 (1704067200000 ms since epoch).
         assert!(ms > 1_704_067_200_000);
+    }
+
+    #[test]
+    fn title_capture_extracts_osc_title() {
+        let title = Arc::new(Mutex::new(None));
+        let mut parser = vt100::Parser::new_with_callbacks(
+            24,
+            80,
+            0,
+            TermSignals {
+                title: Arc::clone(&title),
+                ..Default::default()
+            },
+        );
+        // OSC 2 (set window title), BEL-terminated.
+        parser.process(b"\x1b]2;working on tests\x07");
+        assert_eq!(title.lock().unwrap().as_deref(), Some("working on tests"));
+
+        // OSC 0 (set icon name + title) updates it too.
+        parser.process(b"\x1b]0;done\x07");
+        assert_eq!(title.lock().unwrap().as_deref(), Some("done"));
+
+        // An empty title clears the cell rather than storing "".
+        parser.process(b"\x1b]2;\x07");
+        assert_eq!(*title.lock().unwrap(), None);
+    }
+
+    #[test]
+    fn attention_signals_are_captured() {
+        let attention_at = Arc::new(AtomicU64::new(0));
+        let notification = Arc::new(Mutex::new(None));
+        let mut parser = vt100::Parser::new_with_callbacks(
+            24,
+            80,
+            0,
+            TermSignals {
+                attention_at: Arc::clone(&attention_at),
+                notification: Arc::clone(&notification),
+                ..Default::default()
+            },
+        );
+
+        // No signal yet.
+        assert_eq!(attention_at.load(Ordering::Relaxed), 0);
+
+        // Terminal bell → attention, no message.
+        parser.process(b"\x07");
+        assert!(attention_at.load(Ordering::Relaxed) > 0);
+        assert_eq!(*notification.lock().unwrap(), None);
+
+        // OSC 9 desktop notification → attention + message text.
+        parser.process(b"\x1b]9;Claude is waiting for your input\x07");
+        assert_eq!(
+            notification.lock().unwrap().as_deref(),
+            Some("Claude is waiting for your input")
+        );
+
+        // OSC 777 notify form → attention + joined title/body.
+        parser.process(b"\x1b]777;notify;Claude;Task done\x07");
+        assert_eq!(
+            notification.lock().unwrap().as_deref(),
+            Some("Claude: Task done")
+        );
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -8,7 +8,7 @@ pub mod provider;
 pub mod registry;
 pub mod tmux;
 
-pub use backend::{Session, SessionBackend};
+pub use backend::{Session, SessionBackend, SessionParser};
 pub use generic::GenericProvider;
 pub use provider::AgentProvider;
 pub use registry::BackendRegistry;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -906,7 +906,7 @@ impl App {
             .unwrap_or(TerminalView::Claude)
     }
 
-    pub(crate) fn with_active_parser(&self, f: impl FnOnce(&mut vt100::Parser)) {
+    pub(crate) fn with_active_parser(&self, f: impl FnOnce(&mut crate::agent::SessionParser)) {
         if let Some(session) = self.sessions.get(self.active_index) {
             let parser_arc = if self.active_terminal_view() == TerminalView::Shell {
                 session.shell_pane.as_ref().map(|sp| &sp.parser)
@@ -1415,13 +1415,34 @@ impl App {
     pub fn tick(&mut self) {
         self.tick_count = self.tick_count.wrapping_add(1);
 
-        for session in &mut self.sessions {
+        let active_index = self.active_index;
+        for (idx, session) in self.sessions.iter_mut().enumerate() {
+            // The active session is being watched, so acknowledge any pending
+            // attention signal (keeps it from flagging itself while focused).
+            if idx == active_index {
+                session.acknowledge_attention();
+            }
+            let needs_attention = session.needs_attention();
+
             session.info.status = if session.has_exited() {
                 SessionStatus::Idle
-            } else if session.millis_since_last_output() > ACTIVITY_TIMEOUT_MS {
-                SessionStatus::Waiting
-            } else {
+            } else if session.millis_since_last_output() <= ACTIVITY_TIMEOUT_MS {
+                // Actively producing output → working, regardless of past signals.
                 SessionStatus::Busy
+            } else if needs_attention {
+                // Quiet after a bell / OSC 9 / OSC 777 → finished or needs input.
+                SessionStatus::Attention
+            } else {
+                SessionStatus::Waiting
+            };
+
+            // Live activity text from the agent-emitted OSC terminal title.
+            session.info.agent_activity = session.agent_title();
+            // Surface the notification message only while attention is pending.
+            session.info.notification = if session.info.status == SessionStatus::Attention {
+                session.notification()
+            } else {
+                None
             };
         }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -54,6 +54,9 @@ pub enum SessionStatus {
     Waiting,
     Idle,
     Error,
+    /// The agent signalled it finished or needs input (bell / OSC 9 / OSC 777).
+    /// Latched until the user looks at the session; sorts to the top of the list.
+    Attention,
 }
 
 impl SessionStatus {
@@ -63,6 +66,7 @@ impl SessionStatus {
             Self::Waiting => "◉",
             Self::Idle => "○",
             Self::Error => "✗",
+            Self::Attention => "▲",
         }
     }
 }
@@ -74,6 +78,7 @@ impl fmt::Display for SessionStatus {
             Self::Waiting => write!(f, "Waiting"),
             Self::Idle => write!(f, "Idle"),
             Self::Error => write!(f, "Error"),
+            Self::Attention => write!(f, "Needs attention"),
         }
     }
 }
@@ -113,6 +118,12 @@ pub struct SessionInfo {
     pub shell_backend_id: Option<String>,
     /// Agent metrics from the agent's statusline (Claude only).
     pub agent_metrics: Option<AgentMetrics>,
+    /// Latest OSC window title the agent emitted (live activity text),
+    /// captured from the terminal and refreshed each tick. Agent-neutral.
+    pub agent_activity: Option<String>,
+    /// Message text from the agent's latest attention notification (OSC 9/777),
+    /// shown as the status when `status == SessionStatus::Attention`.
+    pub notification: Option<String>,
     /// Whether this is the admin session (internal, never user-visible).
     pub is_admin: bool,
     /// Cached display names for repos, resolved from git remote or directory name.
@@ -135,6 +146,8 @@ impl SessionInfo {
             backend_id: None,
             shell_backend_id: None,
             agent_metrics: None,
+            agent_activity: None,
+            notification: None,
             is_admin: false,
             repo_display_names: Vec::new(),
         }
@@ -212,6 +225,10 @@ mod tests {
         assert!(info.agent_session_id.is_none());
         assert!(info.cwd.is_none());
         assert!(info.backend_id.is_none());
+        assert!(info.agent_metrics.is_none());
+        assert!(info.agent_activity.is_none());
+        assert!(info.notification.is_none());
+        assert_eq!(info.status, SessionStatus::Busy);
     }
 
     #[test]

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -68,6 +68,13 @@ pub fn render_info_panel(
                 .add_modifier(Modifier::BOLD),
         ),
     ]));
+    // Live activity from the agent-emitted OSC terminal title.
+    if let Some(activity) = info.agent_activity.as_deref() {
+        lines.push(Line::from(vec![
+            Span::styled("Activity: ", Theme::label()),
+            Span::styled(activity, Style::default().fg(Theme::text_secondary())),
+        ]));
+    }
 
     // ── Repos ──
     append_repos_section(&mut lines, info);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -34,6 +34,7 @@ pub fn status_color(status: SessionStatus) -> Color {
         SessionStatus::Waiting => Theme::status_waiting(),
         SessionStatus::Idle => Theme::status_idle(),
         SessionStatus::Error => Theme::status_error(),
+        SessionStatus::Attention => Theme::accent_bright(),
     }
 }
 
@@ -463,6 +464,11 @@ mod tests {
         assert_eq!(status_color(SessionStatus::Waiting), Color::Yellow);
         assert_eq!(status_color(SessionStatus::Idle), Color::DarkGray);
         assert_eq!(status_color(SessionStatus::Error), Color::Red);
+        // Attention reuses the bright accent (distinct from the four above).
+        assert_eq!(
+            status_color(SessionStatus::Attention),
+            Theme::accent_bright()
+        );
     }
 
     #[test]

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -79,7 +79,16 @@ impl<'a> OrderedSessions<'a> {
     ) -> Self {
         let n = sessions.len();
         let mut order: Vec<usize> = (0..n).collect();
-        order.sort_by_key(|&i| !sessions[i].is_admin);
+        // Admin sessions stay pinned at the top (preserving the divider below
+        // them); within the non-admin group, sessions needing attention float
+        // to the top so finished/blocked agents are seen first. Stable sort
+        // keeps original order among equal keys.
+        order.sort_by_key(|&i| {
+            (
+                !sessions[i].is_admin,
+                sessions[i].status != crate::session::SessionStatus::Attention,
+            )
+        });
 
         let first_non_admin_index = order.iter().position(|&i| !sessions[i].is_admin);
         let ordered_sessions = order.iter().map(|&i| sessions[i]).collect();
@@ -455,10 +464,6 @@ fn render_session_section(
             // Determine if this session is dimmed (search active + no match).
             let session_match = match_positions.get(i).and_then(|m| m.as_ref());
             let is_dimmed = search_active && session_match.is_none();
-            // Expand (show agent + repo) when selected or matched by current search.
-            let is_expanded = is_active || (search_active && session_match.is_some());
-
-            let status_text = format_status_with_elapsed(info.status, elapsed_ms.get(i).copied());
             let name_style = if is_dimmed {
                 Style::default().fg(Theme::text_muted())
             } else if is_active {
@@ -466,32 +471,27 @@ fn render_session_section(
             } else {
                 Theme::normal_item()
             };
-
-            // Build prefix with optional admin badge. The active row is
-            // signalled by the list's highlight background, so no extra
-            // pointer glyph is needed.
-            let prefix_str = if is_admin {
-                format!(" \u{2699} {} ", info.status.icon())
-            } else {
-                format!(" {} ", info.status.icon())
-            };
-            let prefix_width = prefix_str.chars().count();
-            let name_len = info.name.chars().count();
-            let status_len = status_text.chars().count();
-
             let status_style = if is_dimmed {
                 Style::default().fg(Theme::text_muted())
             } else {
                 Style::default().fg(super::status_color(info.status))
             };
 
+            // ── Line 1: <status-dot> <name> ........... <status> ──
+            // The active row is signalled by the list's highlight background,
+            // so no extra pointer glyph is needed; admin sessions keep a gear.
+            let prefix_str = if is_admin {
+                format!(" \u{2699} {} ", info.status.icon())
+            } else {
+                format!(" {} ", info.status.icon())
+            };
             let prefix_style = if is_admin && !is_dimmed {
                 Style::default().fg(Theme::admin_badge())
             } else {
                 status_style
             };
 
-            let mut line1_spans = vec![Span::styled(prefix_str, prefix_style)];
+            let mut line1_spans = vec![Span::styled(prefix_str.clone(), prefix_style)];
             append_name_spans(
                 &mut line1_spans,
                 &info.name,
@@ -499,62 +499,67 @@ fn render_session_section(
                 name_style,
             );
 
-            if is_expanded {
-                let used = prefix_width + name_len + status_len;
-                let gap = if used < inner_width {
-                    inner_width - used
-                } else {
-                    1
-                };
-                line1_spans.push(Span::raw(" ".repeat(gap)));
-                line1_spans.push(Span::styled(status_text.clone(), status_style));
-            }
-            let line1 = Line::from(line1_spans);
-
-            // Default layout (non-expanded): 2 lines — name on line 1, status on line 2.
-            // Expanded (selected or search-matched): 3 lines — name+status on line 1,
-            // agent (or provisioning step) on line 2, optional repo/branch on line 3.
-            let mut item_lines = vec![line1];
-
-            if !is_expanded {
-                // 2-line view: status (with elapsed) on its own line.
-                item_lines.push(Line::from(vec![
-                    Span::raw("   "),
-                    Span::styled(status_text, status_style),
-                ]));
-            } else if is_dimmed {
-                let dimmed = Style::default().fg(Theme::text_muted());
-                item_lines.push(Line::from(vec![Span::styled(
-                    format!("   {}", info.agent),
-                    dimmed,
-                )]));
-                let entries = build_repo_entries(info);
-                if !entries.is_empty() {
-                    let text = format_repo_entries_plain(&entries);
-                    if !text.is_empty() {
-                        item_lines
-                            .push(Line::from(vec![Span::styled(format!("   {text}"), dimmed)]));
-                    }
-                }
+            // Right-aligned live status. Priority:
+            //   1. Attention → the agent's notification message ("Needs attention").
+            //   2. The agent-reported OSC activity title (richer "insight").
+            //   3. Timing-based Busy/Waiting with elapsed time.
+            let status_text = if info.status == crate::session::SessionStatus::Attention {
+                info.notification
+                    .clone()
+                    .unwrap_or_else(|| info.status.to_string())
             } else {
-                let role_style = Style::default().fg(Theme::role_name());
-                let mut line2_spans = vec![Span::raw("   ")];
-                append_name_spans(
-                    &mut line2_spans,
-                    &info.agent,
-                    session_match.and_then(|m| m.positions(&m.agent)),
-                    role_style,
-                );
-                item_lines.push(Line::from(line2_spans));
+                info.agent_activity
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| {
+                        format_status_with_elapsed(info.status, elapsed_ms.get(i).copied())
+                    })
+            };
+            let prefix_w = prefix_str.chars().count();
+            let name_w = info.name.chars().count();
+            let avail = inner_width.saturating_sub(prefix_w + name_w + 1);
+            let status_shown = truncate_ellipsis(&status_text, avail);
+            if !status_shown.is_empty() {
+                let used = prefix_w + name_w + status_shown.chars().count();
+                let gap = inner_width.saturating_sub(used).max(1);
+                line1_spans.push(Span::raw(" ".repeat(gap)));
+                line1_spans.push(Span::styled(status_shown, status_style));
+            }
+            let mut item_lines = vec![Line::from(line1_spans)];
 
-                let entries = build_repo_entries(info);
-                if !entries.is_empty() {
+            // ── Line 2: <agent> · <repo>(<branch>), … ──
+            let entries = build_repo_entries(info);
+            let mut line2_spans: Vec<Span<'static>> = vec![Span::raw("   ")];
+
+            // Agent name (role-coloured, fuzzy-searchable).
+            let agent_style = if is_dimmed {
+                Style::default().fg(Theme::text_muted())
+            } else {
+                Style::default().fg(Theme::role_name())
+            };
+            match session_match.and_then(|m| m.positions(&m.agent)) {
+                Some(positions) if !positions.is_empty() => {
+                    line2_spans.extend(
+                        build_highlighted_spans(&info.agent, positions, agent_style)
+                            .into_iter()
+                            .map(|s| Span::styled(s.content.into_owned(), s.style)),
+                    );
+                }
+                _ => line2_spans.push(Span::styled(info.agent.clone(), agent_style)),
+            }
+
+            // Repos (when any), separated from the agent by " · ".
+            if !entries.is_empty() {
+                let muted = Style::default().fg(Theme::text_muted());
+                line2_spans.push(Span::styled(" · ", muted));
+                if is_dimmed {
+                    line2_spans.push(Span::styled(format_repo_entries_plain(&entries), muted));
+                } else {
                     let repo_style = Style::default().fg(Theme::text_primary());
                     let branch_style = Style::default().fg(Theme::branch_name());
-                    let muted = Style::default().fg(Theme::text_muted());
-                    let mut line3_spans: Vec<Span<'static>> = vec![Span::raw("   ")];
 
-                    // Build the plain text for search matching.
                     let plain = format_repo_entries_plain(&entries);
                     let search_positions = if !search_query.is_empty() {
                         crate::fuzzy::fuzzy_match(search_query, &plain).map(|m| m.positions)
@@ -562,34 +567,32 @@ fn render_session_section(
                         None
                     };
 
-                    if let Some(ref positions) = search_positions {
-                        if !positions.is_empty() {
-                            line3_spans.extend(
+                    match search_positions {
+                        Some(ref positions) if !positions.is_empty() => {
+                            line2_spans.extend(
                                 build_highlighted_spans(&plain, positions, repo_style)
                                     .into_iter()
                                     .map(|s| Span::styled(s.content.into_owned(), s.style)),
                             );
-                        } else {
-                            line3_spans.push(Span::styled(plain, repo_style));
                         }
-                    } else {
-                        // No search — render with colored branches.
-                        for (i, entry) in entries.iter().enumerate() {
-                            if i > 0 {
-                                line3_spans.push(Span::styled(", ", muted));
-                            }
-                            line3_spans.push(Span::styled(entry.name.clone(), repo_style));
-                            if let Some(ref br) = entry.branch {
-                                line3_spans.push(Span::styled("(", branch_style));
-                                line3_spans.push(Span::styled(br.clone(), branch_style));
-                                line3_spans.push(Span::styled(")", branch_style));
+                        _ => {
+                            // No (matching) search — render with colored branches.
+                            for (j, entry) in entries.iter().enumerate() {
+                                if j > 0 {
+                                    line2_spans.push(Span::styled(", ", muted));
+                                }
+                                line2_spans.push(Span::styled(entry.name.clone(), repo_style));
+                                if let Some(ref br) = entry.branch {
+                                    line2_spans.push(Span::styled("(", branch_style));
+                                    line2_spans.push(Span::styled(br.clone(), branch_style));
+                                    line2_spans.push(Span::styled(")", branch_style));
+                                }
                             }
                         }
                     }
-
-                    item_lines.push(Line::from(line3_spans));
                 }
             }
+            item_lines.push(Line::from(line2_spans));
 
             // Prepend a subtle divider above the first non-admin session when
             // admin sessions are pinned above it.
@@ -660,6 +663,20 @@ fn format_repo_entries_plain(entries: &[RepoEntry]) -> String {
     out
 }
 
+/// Truncate `s` to at most `max` display columns, appending `…` when cut.
+/// Returns an empty string when `max` is too small to show anything useful.
+fn truncate_ellipsis(s: &str, max: usize) -> String {
+    let count = s.chars().count();
+    if count <= max {
+        return s.to_string();
+    }
+    if max <= 1 {
+        return String::new();
+    }
+    let kept: String = s.chars().take(max - 1).collect();
+    format!("{kept}…")
+}
+
 /// Format status text with elapsed time for Waiting/Idle sessions.
 fn format_status_with_elapsed(
     status: crate::session::SessionStatus,
@@ -683,6 +700,26 @@ fn format_status_with_elapsed(
 mod tests {
     use super::*;
     use crate::session::SessionStatus;
+
+    #[test]
+    fn attention_sessions_sort_above_normal_ones() {
+        use crate::session::SessionInfo;
+
+        let mut busy = SessionInfo::new("busy".into());
+        busy.status = SessionStatus::Busy;
+        let mut attn = SessionInfo::new("attn".into());
+        attn.status = SessionStatus::Attention;
+
+        let sessions = vec![&busy, &attn];
+        let elapsed = vec![0u64, 0u64];
+        let matches: Vec<Option<SessionMatch>> = vec![None, None];
+        // active_index points at the busy session; the attention one still
+        // floats to the top and active_index is remapped to follow it.
+        let ordered = OrderedSessions::new(&sessions, &elapsed, &matches, 0);
+        assert_eq!(ordered.sessions[0].name, "attn");
+        assert_eq!(ordered.sessions[1].name, "busy");
+        assert_eq!(ordered.active_index, 1);
+    }
 
     // --- format_status_with_elapsed ---
 
@@ -708,6 +745,25 @@ mod tests {
     fn elapsed_not_shown_for_busy() {
         let text = format_status_with_elapsed(SessionStatus::Busy, Some(120_000));
         assert_eq!(text, "Busy");
+    }
+
+    // --- truncate_ellipsis ---
+
+    #[test]
+    fn truncate_keeps_short_strings_intact() {
+        assert_eq!(truncate_ellipsis("hello", 10), "hello");
+        assert_eq!(truncate_ellipsis("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_adds_ellipsis_when_cut() {
+        assert_eq!(truncate_ellipsis("hello world", 5), "hell…");
+    }
+
+    #[test]
+    fn truncate_returns_empty_when_too_narrow() {
+        assert_eq!(truncate_ellipsis("hello", 1), "");
+        assert_eq!(truncate_ellipsis("hello", 0), "");
     }
 
     #[test]

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -14,7 +14,7 @@ use crate::session::SessionInfo;
 pub fn render_terminal(
     frame: &mut Frame,
     area: Rect,
-    parser: &mut vt100::Parser,
+    parser: &mut vt100::Parser<impl vt100::Callbacks>,
     info: &SessionInfo,
     level: FocusLevel,
     is_admin: bool,


### PR DESCRIPTION
## Summary

- Derive session status from the agent's own PTY signals instead of output-timing alone, via `vt100` callbacks (`TermSignals`).
- **Live activity**: capture the OSC window title (OSC 0/1/2) and show it per session and in the info panel (e.g. Gemini's `◇ Ready`).
- **Needs attention**: detect a terminal bell, OSC 9, or OSC 777 notification → a distinct `SessionStatus::Attention` (`▲`, accent colour) that shows the notification message, **sorts the session to the top of the list**, and clears on focus.
- **Layout**: each row is now two lines — `status-dot + name + live status` on line 1, `agent · repo(branch)` on line 2.

## Notes

- Agent-neutral: we read signals agents already emit; no per-agent code.
- Caveat (documented in `docs/FEATURES.md`): inside thurbox's tmux, Claude only emits OSC 9 for Ghostty/Kitty/iTerm2, so set `claude config set --global preferredNotifChannel terminal_bell` to get a catchable bell. We capture bell + OSC 9 + OSC 777.

## Test plan

- 647 lib tests pass (incl. `attention_signals_are_captured`, `attention_sessions_sort_above_normal_ones`, title-capture + truncation tests).
- clippy `-D warnings` clean; fmt clean; architecture rules pass; `rumdl` clean.
- Layouts verified via `ratatui::TestBackend` buffer dumps.
- CI checks pass.