### PR TITLE
feat(docs): Doom Eternal retro-arcade website redesign

### DIFF
--- a/website/assets/favicon.svg
+++ b/website/assets/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="#0d1117"/>
-  <rect x="2" y="2" width="28" height="28" rx="4" fill="none" stroke="#30363d" stroke-width="1"/>
-  <text x="6" y="21" font-family="monospace" font-size="14" font-weight="bold" fill="#56d4dd">$_</text>
+  <rect width="32" height="32" rx="6" fill="#1a080a"/>
+  <rect x="2" y="2" width="28" height="28" rx="4" fill="none" stroke="#ff5c54" stroke-width="1"/>
+  <text x="6" y="21" font-family="monospace" font-size="14" font-weight="bold" fill="#6eff6e">$_</text>
 </svg>

--- a/website/css/base.css
+++ b/website/css/base.css
@@ -17,8 +17,27 @@ body {
   line-height: 1.6;
   color: var(--text-primary);
   background-color: var(--bg-primary);
+  background-image: radial-gradient(ellipse at 50% -10%, rgb(255, 59, 48, 0.12), transparent 60%);
+  background-attachment: fixed;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* CRT scanline overlay — single global, click-through */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent 2px,
+    var(--scanline) 3px,
+    var(--scanline) 3px
+  );
+  mix-blend-mode: multiply;
 }
 
 h1,
@@ -33,11 +52,23 @@ h6 {
   color: var(--text-primary);
 }
 
+/* Press Start 2P for the largest display headings only — wide & blocky */
+h1,
+h2 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  line-height: 1.5;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--cyan);
+  text-shadow: var(--glow-red);
+}
+
 h1 {
-  font-size: 2.5rem;
+  font-size: 2.25rem;
 }
 h2 {
-  font-size: 1.75rem;
+  font-size: 1.4rem;
 }
 h3 {
   font-size: 1.25rem;
@@ -47,13 +78,16 @@ h4 {
 }
 
 a {
-  color: var(--cyan);
+  color: var(--green);
   text-decoration: none;
-  transition: color var(--transition);
+  transition:
+    color var(--transition),
+    text-shadow var(--transition);
 }
 
 a:hover {
   color: var(--green);
+  text-shadow: var(--glow-green);
 }
 
 p {
@@ -134,6 +168,6 @@ hr {
 }
 
 ::selection {
-  background: rgb(86, 212, 221, 0.3);
-  color: var(--text-primary);
+  background: rgb(255, 92, 84, 0.4);
+  color: #fff;
 }

--- a/website/css/components.css
+++ b/website/css/components.css
@@ -18,20 +18,23 @@
 
 .nav.scrolled {
   background: var(--bg-nav);
-  border-bottom-color: var(--border);
+  border-bottom-color: var(--cyan);
+  box-shadow: 0 0 12px rgb(255, 92, 84, 0.35);
   backdrop-filter: blur(12px);
 }
 
 .nav-brand {
-  font-family: var(--font-mono);
-  font-size: 1.25rem;
-  font-weight: 700;
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 400;
+  text-transform: uppercase;
   color: var(--text-primary);
-  letter-spacing: -0.02em;
+  letter-spacing: 0.02em;
 }
 
 .nav-brand span {
   color: var(--cyan);
+  text-shadow: var(--glow-red);
 }
 
 .nav-links {
@@ -115,17 +118,20 @@
   }
 }
 
-/* ---- Buttons ---- */
+/* ---- Buttons — arcade style ---- */
 .btn {
   display: inline-flex;
   align-items: center;
   gap: var(--space-sm);
-  padding: 0.75rem 1.5rem;
-  font-family: var(--font-mono);
-  font-size: 0.875rem;
-  font-weight: 600;
+  padding: 0.85rem 1.5rem;
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 400;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
   border-radius: var(--border-radius);
-  border: 1px solid transparent;
+  border: 2px solid transparent;
   cursor: pointer;
   transition: all var(--transition);
   text-decoration: none;
@@ -133,23 +139,36 @@
 
 .btn-primary {
   background: var(--green);
-  color: var(--bg-primary);
+  color: #0a2e0a;
+  border-color: var(--green);
+  box-shadow:
+    0 0 10px rgb(110, 255, 110, 0.5),
+    inset 0 0 6px rgb(255, 255, 255, 0.25);
 }
 
 .btn-primary:hover {
-  background: #4cc764;
-  color: var(--bg-primary);
+  background: #8cff8c;
+  color: #0a2e0a;
+  box-shadow:
+    0 0 18px rgb(110, 255, 110, 0.85),
+    inset 0 0 8px rgb(255, 255, 255, 0.35);
+  transform: translateY(-1px);
 }
 
 .btn-secondary {
   background: transparent;
-  color: var(--text-primary);
-  border-color: var(--border);
+  color: var(--cyan);
+  border-color: var(--cyan);
 }
 
 .btn-secondary:hover {
-  border-color: var(--text-secondary);
-  color: var(--text-primary);
+  color: #fff;
+  border-color: var(--cyan);
+  box-shadow:
+    0 0 16px rgb(255, 92, 84, 0.7),
+    inset 0 0 8px rgb(255, 92, 84, 0.35);
+  text-shadow: var(--glow-red);
+  transform: translateY(-1px);
 }
 
 /* ---- Cards ---- */
@@ -158,11 +177,14 @@
   border: 1px solid var(--border);
   border-radius: var(--border-radius);
   padding: var(--space-lg);
-  transition: border-color var(--transition);
+  transition:
+    border-color var(--transition),
+    box-shadow var(--transition);
 }
 
 .card:hover {
-  border-color: var(--text-muted);
+  border-color: var(--cyan);
+  box-shadow: 0 0 16px rgb(255, 92, 84, 0.35);
 }
 
 .card-icon {
@@ -205,10 +227,12 @@
 /* ---- Terminal frame ---- */
 .terminal-frame {
   background: var(--bg-code);
-  border: 1px solid var(--border);
+  border: 1px solid var(--cyan);
   border-radius: var(--border-radius);
   overflow: hidden;
-  box-shadow: 0 0 30px var(--term-glow);
+  box-shadow:
+    0 0 30px var(--term-glow),
+    inset 0 0 40px rgb(255, 59, 48, 0.06);
 }
 
 .terminal-header {
@@ -345,6 +369,7 @@
 
 .footer a:hover {
   color: var(--cyan);
+  text-shadow: var(--glow-red);
 }
 
 /* ---- Step numbers ---- */
@@ -354,13 +379,43 @@
   justify-content: center;
   width: 32px;
   height: 32px;
-  background: var(--cyan);
-  color: var(--bg-primary);
-  font-family: var(--font-mono);
-  font-weight: 700;
-  font-size: 0.875rem;
+  background: var(--green);
+  color: #0a2e0a;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 0.7rem;
   border-radius: 50%;
+  box-shadow: var(--glow-green);
   flex-shrink: 0;
+}
+
+/* ---- Retro flicker (brand/hero) ---- */
+@keyframes flicker {
+  0%,
+  19%,
+  21%,
+  23%,
+  25%,
+  54%,
+  56%,
+  100% {
+    opacity: 1;
+  }
+  20%,
+  24%,
+  55% {
+    opacity: 0.82;
+  }
+}
+
+.flicker {
+  animation: flicker 4.5s infinite steps(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .flicker {
+    animation: none;
+  }
 }
 
 /* ---- GitHub icon (inline SVG) ---- */

--- a/website/css/docs.css
+++ b/website/css/docs.css
@@ -66,6 +66,7 @@
   color: var(--cyan);
   border-left-color: var(--cyan);
   background: var(--bg-secondary);
+  text-shadow: var(--glow-red);
 }
 
 .docs-sidebar a.current-page {
@@ -88,7 +89,9 @@
   border-radius: 50%;
   font-size: 1.25rem;
   cursor: pointer;
-  box-shadow: 0 4px 12px rgb(0, 0, 0, 0.4);
+  box-shadow:
+    0 4px 12px rgb(0, 0, 0, 0.4),
+    0 0 16px rgb(255, 92, 84, 0.6);
   align-items: center;
   justify-content: center;
 }

--- a/website/css/landing.css
+++ b/website/css/landing.css
@@ -1,18 +1,51 @@
 /* ---- Hero ---- */
 .hero {
+  position: relative;
   padding-top: calc(var(--nav-height) + var(--space-3xl));
   padding-bottom: var(--space-3xl);
   text-align: center;
+  overflow: hidden;
+}
+
+/* CRT grid + ember backdrop */
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    radial-gradient(ellipse at 50% 0%, rgb(255, 59, 48, 0.18), transparent 55%),
+    linear-gradient(rgb(255, 92, 84, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(255, 92, 84, 0.05) 1px, transparent 1px);
+  background-size:
+    100% 100%,
+    44px 44px,
+    44px 44px;
+  mask-image: linear-gradient(to bottom, #000 40%, transparent);
+}
+
+.hero .container {
+  position: relative;
+  z-index: 1;
 }
 
 .hero h1 {
-  font-size: clamp(2rem, 5vw, 3.25rem);
-  margin-bottom: var(--space-md);
-  letter-spacing: -0.03em;
+  font-size: clamp(1.6rem, 5vw, 2.75rem);
+  margin-bottom: var(--space-lg);
+  letter-spacing: 0.01em;
+  animation: flicker 4.5s infinite steps(1);
 }
 
 .hero h1 .accent {
-  color: var(--cyan);
+  color: var(--green);
+  text-shadow: var(--glow-green);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero h1 {
+    animation: none;
+  }
 }
 
 .hero .subtitle {

--- a/website/css/variables.css
+++ b/website/css/variables.css
@@ -1,36 +1,43 @@
 :root {
-  /* Backgrounds */
-  --bg-primary: #0d1117;
-  --bg-secondary: #161b22;
-  --bg-card: #21262d;
-  --bg-code: #0a0e14;
-  --bg-hover: #30363d;
-  --bg-nav: rgb(13, 17, 23, 0.95);
+  /* Backgrounds — Doom Eternal hellish red-black */
+  --bg-primary: #1a080a;
+  --bg-secondary: #2a0f12;
+  --bg-card: #2a0f12;
+  --bg-code: #120607;
+  --bg-hover: #40151e;
+  --bg-nav: rgb(26, 8, 10, 0.92);
 
   /* Text */
-  --text-primary: #e6edf3;
-  --text-secondary: #8b949e;
-  --text-muted: #484f58;
+  --text-primary: #e0e0e0;
+  --text-secondary: #a0a0a0;
+  --text-muted: #606060;
 
-  /* Accents */
-  --green: #3fb950;
-  --cyan: #56d4dd;
-  --yellow: #d29922;
-  --purple: #bc8cff;
-  --red: #f85149;
-  --blue: #58a6ff;
+  /* Accents — bright red is the primary accent slot (was cyan) */
+  --green: #6eff6e;
+  --cyan: #ff5c54;
+  --yellow: #ffb627;
+  --purple: #ff8c8c;
+  --red: #ff3b30;
+  --blue: #00d9ff;
 
   /* Borders */
-  --border: #30363d;
-  --border-light: #21262d;
+  --border: #40151e;
+  --border-light: #2a0f12;
 
-  /* Terminal chrome */
-  --term-dot-red: #ff5f57;
-  --term-dot-yellow: #febc2e;
-  --term-dot-green: #28c840;
-  --term-glow: rgb(86, 212, 221, 0.15);
+  /* Terminal chrome — classic arcade button colors */
+  --term-dot-red: #ff3b30;
+  --term-dot-yellow: #ffb627;
+  --term-dot-green: #6eff6e;
+  --term-glow: rgb(255, 92, 84, 0.25);
+
+  /* Retro neon glows */
+  --glow-red: 0 0 6px rgb(255, 92, 84, 0.9), 0 0 14px rgb(255, 59, 48, 0.55);
+  --glow-green: 0 0 6px rgb(110, 255, 110, 0.9), 0 0 14px rgb(110, 255, 110, 0.5);
+  --glow-cyan: 0 0 6px rgb(0, 217, 255, 0.9), 0 0 14px rgb(0, 217, 255, 0.5);
+  --scanline: rgb(0, 0, 0, 0.28);
 
   /* Typography */
+  --font-display: 'Press Start 2P', 'JetBrains Mono', monospace;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
   --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 
@@ -47,8 +54,8 @@
   --container-max: 1200px;
   --nav-height: 64px;
   --sidebar-width: 260px;
-  --border-radius: 8px;
-  --border-radius-sm: 4px;
+  --border-radius: 0;
+  --border-radius-sm: 0;
 
   /* Transitions */
   --transition: 200ms ease;

--- a/website/docs/architecture.html
+++ b/website/docs/architecture.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&family=Press+Start+2P&display=swap"
     />
     <link rel="stylesheet" href="../css/variables.css" />
     <link rel="stylesheet" href="../css/base.css" />

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&family=Press+Start+2P&display=swap"
     />
     <link rel="stylesheet" href="../css/variables.css" />
     <link rel="stylesheet" href="../css/base.css" />

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&family=Press+Start+2P&display=swap"
     />
     <link rel="stylesheet" href="../css/variables.css" />
     <link rel="stylesheet" href="../css/base.css" />

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&family=Press+Start+2P&display=swap"
     />
     <link rel="stylesheet" href="../css/variables.css" />
     <link rel="stylesheet" href="../css/base.css" />

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&family=Press+Start+2P&display=swap"
     />
     <link rel="stylesheet" href="../css/variables.css" />
     <link rel="stylesheet" href="../css/base.css" />

--- a/website/index.html
+++ b/website/index.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&family=Press+Start+2P&display=swap"
     />
     <link rel="stylesheet" href="css/variables.css" />
     <link rel="stylesheet" href="css/base.css" />


### PR DESCRIPTION
## Summary

Redesigns the marketing website into a **full retro-arcade Doom Eternal** aesthetic, matching the recently-added TUI Doom theme. Applies across the entire site (landing + all docs pages).

## What changed

- **Palette** (`variables.css`) — reuses the exact TUI `doom_palette()` colors: hellish red-black backgrounds (`#1A080A`/`#2A0F12`), bright-red primary accent (`#FF5C54`), neon-green links/CTAs (`#6EFF6E`), electric cyan. Sharp **zero-radius** edges.
- **CRT scanline overlay** — global, click-through, multiply blend.
- **Press Start 2P** 8-bit font on brand, hero title, and section headings; body & code stay JetBrains Mono/Inter for legibility.
- **Neon glow** text-shadows on headings, links, brand, active sidebar links.
- **Arcade buttons** — sharp, uppercase, glowing; lift on hover.
- **Hero CRT backdrop** — ember radial + faint grid, masked fade; subtle title **flicker** gated by `prefers-reduced-motion`.
- Cards/terminal frames get red borders + glow; favicon recolored.

## Test plan

- `npm run lint:website` passes (Prettier, htmlhint, stylelint, eslint).
- Served locally and visually verified landing + all 4 docs pages; checked mobile width wrapping for the wide pixel font.