### PR TITLE
style(docs): tone down Doom website theme to neutral base

### DIFF
--- a/website/css/base.css
+++ b/website/css/base.css
@@ -17,7 +17,7 @@ body {
   line-height: 1.6;
   color: var(--text-primary);
   background-color: var(--bg-primary);
-  background-image: radial-gradient(ellipse at 50% -10%, rgb(255, 59, 48, 0.12), transparent 60%);
+  background-image: radial-gradient(ellipse at 50% -10%, rgb(255, 59, 48, 0.05), transparent 55%);
   background-attachment: fixed;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/website/css/components.css
+++ b/website/css/components.css
@@ -18,8 +18,7 @@
 
 .nav.scrolled {
   background: var(--bg-nav);
-  border-bottom-color: var(--cyan);
-  box-shadow: 0 0 12px rgb(255, 92, 84, 0.35);
+  border-bottom-color: var(--border);
   backdrop-filter: blur(12px);
 }
 
@@ -158,15 +157,12 @@
 .btn-secondary {
   background: transparent;
   color: var(--cyan);
-  border-color: var(--cyan);
+  border-color: var(--border);
 }
 
 .btn-secondary:hover {
-  color: #fff;
-  border-color: var(--cyan);
-  box-shadow:
-    0 0 16px rgb(255, 92, 84, 0.7),
-    inset 0 0 8px rgb(255, 92, 84, 0.35);
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
   text-shadow: var(--glow-red);
   transform: translateY(-1px);
 }
@@ -183,8 +179,8 @@
 }
 
 .card:hover {
-  border-color: var(--cyan);
-  box-shadow: 0 0 16px rgb(255, 92, 84, 0.35);
+  border-color: var(--text-muted);
+  box-shadow: 0 4px 14px rgb(0, 0, 0, 0.35);
 }
 
 .card-icon {
@@ -227,12 +223,10 @@
 /* ---- Terminal frame ---- */
 .terminal-frame {
   background: var(--bg-code);
-  border: 1px solid var(--cyan);
+  border: 1px solid var(--border);
   border-radius: var(--border-radius);
   overflow: hidden;
-  box-shadow:
-    0 0 30px var(--term-glow),
-    inset 0 0 40px rgb(255, 59, 48, 0.06);
+  box-shadow: 0 8px 30px rgb(0, 0, 0, 0.5);
 }
 
 .terminal-header {

--- a/website/css/docs.css
+++ b/website/css/docs.css
@@ -63,10 +63,10 @@
 }
 
 .docs-sidebar a.active {
-  color: var(--cyan);
-  border-left-color: var(--cyan);
+  color: var(--green);
+  border-left-color: var(--green);
   background: var(--bg-secondary);
-  text-shadow: var(--glow-red);
+  text-shadow: var(--glow-green);
 }
 
 .docs-sidebar a.current-page {
@@ -200,7 +200,7 @@ h3:hover .heading-anchor {
 }
 
 .docs-hub-card:hover .card {
-  border-color: var(--cyan);
+  border-color: var(--text-muted);
 }
 
 .docs-hub-card:hover .card h3 {
@@ -211,7 +211,7 @@ h3:hover .heading-anchor {
 .info-box {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
-  border-left: 3px solid var(--cyan);
+  border-left: 3px solid var(--green);
   border-radius: var(--border-radius-sm);
   padding: var(--space-md) var(--space-lg);
   margin-bottom: var(--space-lg);

--- a/website/css/landing.css
+++ b/website/css/landing.css
@@ -106,9 +106,7 @@
 }
 
 .hero-demo .terminal-frame {
-  box-shadow:
-    0 0 60px var(--term-glow),
-    0 20px 60px rgb(0, 0, 0, 0.5);
+  box-shadow: 0 20px 60px rgb(0, 0, 0, 0.6);
 }
 
 .hero-demo video {

--- a/website/css/landing.css
+++ b/website/css/landing.css
@@ -15,14 +15,14 @@
   z-index: 0;
   pointer-events: none;
   background-image:
-    radial-gradient(ellipse at 50% 0%, rgb(255, 59, 48, 0.18), transparent 55%),
-    linear-gradient(rgb(255, 92, 84, 0.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgb(255, 92, 84, 0.05) 1px, transparent 1px);
+    radial-gradient(ellipse at 50% 0%, rgb(255, 59, 48, 0.08), transparent 50%),
+    linear-gradient(rgb(255, 92, 84, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(255, 92, 84, 0.035) 1px, transparent 1px);
   background-size:
     100% 100%,
-    44px 44px,
-    44px 44px;
-  mask-image: linear-gradient(to bottom, #000 40%, transparent);
+    48px 48px,
+    48px 48px;
+  mask-image: linear-gradient(to bottom, #000 35%, transparent);
 }
 
 .hero .container {

--- a/website/css/variables.css
+++ b/website/css/variables.css
@@ -1,18 +1,18 @@
 :root {
-  /* Backgrounds — Doom Eternal hellish red-black */
-  --bg-primary: #1a080a;
-  --bg-secondary: #2a0f12;
-  --bg-card: #2a0f12;
-  --bg-code: #120607;
-  --bg-hover: #40151e;
-  --bg-nav: rgb(26, 8, 10, 0.92);
+  /* Backgrounds — neutral warm-charcoal (Doom is an accent, not the whole room) */
+  --bg-primary: #15120f;
+  --bg-secondary: #1e1a16;
+  --bg-card: #1e1a16;
+  --bg-code: #0d0b09;
+  --bg-hover: #2a241e;
+  --bg-nav: rgb(21, 18, 15, 0.92);
 
   /* Text */
   --text-primary: #e0e0e0;
   --text-secondary: #a0a0a0;
-  --text-muted: #606060;
+  --text-muted: #6b6358;
 
-  /* Accents — bright red is the primary accent slot (was cyan) */
+  /* Accents — Doom red is the primary accent slot (was cyan) */
   --green: #6eff6e;
   --cyan: #ff5c54;
   --yellow: #ffb627;
@@ -21,20 +21,20 @@
   --blue: #00d9ff;
 
   /* Borders */
-  --border: #40151e;
-  --border-light: #2a0f12;
+  --border: #36302a;
+  --border-light: #26211c;
 
   /* Terminal chrome — classic arcade button colors */
   --term-dot-red: #ff3b30;
   --term-dot-yellow: #ffb627;
   --term-dot-green: #6eff6e;
-  --term-glow: rgb(255, 92, 84, 0.25);
+  --term-glow: rgb(255, 92, 84, 0.16);
 
-  /* Retro neon glows */
-  --glow-red: 0 0 6px rgb(255, 92, 84, 0.9), 0 0 14px rgb(255, 59, 48, 0.55);
-  --glow-green: 0 0 6px rgb(110, 255, 110, 0.9), 0 0 14px rgb(110, 255, 110, 0.5);
-  --glow-cyan: 0 0 6px rgb(0, 217, 255, 0.9), 0 0 14px rgb(0, 217, 255, 0.5);
-  --scanline: rgb(0, 0, 0, 0.28);
+  /* Retro neon glows (used sparingly, as a wink to Doom) */
+  --glow-red: 0 0 5px rgb(255, 92, 84, 0.7), 0 0 12px rgb(255, 59, 48, 0.4);
+  --glow-green: 0 0 5px rgb(110, 255, 110, 0.7), 0 0 12px rgb(110, 255, 110, 0.4);
+  --glow-cyan: 0 0 5px rgb(0, 217, 255, 0.7), 0 0 12px rgb(0, 217, 255, 0.4);
+  --scanline: rgb(0, 0, 0, 0.14);
 
   /* Typography */
   --font-display: 'Press Start 2P', 'JetBrains Mono', monospace;


### PR DESCRIPTION
Follow-up to the Doom website redesign (#404): the hellish red-black background read as too intense. This dials it back to a **neutral warm-charcoal base**, keeping the Doom red / neon-green as *accents* and subtle retro nods rather than flooding every page.

## Changes
- `variables.css` — backgrounds → neutral warm-charcoal (`#15120f` / `#1e1a16`); reduced `--term-glow`, glow strength, and `--scanline` opacity. Doom red stays the primary accent, neon green the CTA.
- `base.css` — body red radial wash dropped from 0.12 → 0.05 opacity.
- `landing.css` — hero CRT grid/ember backdrop softened (red 0.18 → 0.08, grid lines lighter).

Press Start 2P headings, scanlines, and accent glows remain as the "clin d'œil" to Doom. `npm run lint:website` passes.