### PR TITLE
feat(config): add Vibe (Mistral) as a built-in agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ Enforced by cocogitto via pre-commit hooks.
 
 The set of launchable coding agents is declared **as data** in
 `~/.config/thurbox/agents.toml`, seeded with built-ins
-(`claude`, `codex`, `gemini`, `opencode`, `aider`) on first run.
+(`claude`, `codex`, `gemini`, `opencode`, `aider`, `vibe`) on first run.
 Each `[[agents]]` entry is an `AgentDef`:
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ adds:
   repo(s) and branch, each running the agent you chose.
 - **Any agent** — a session runs one coding-agent CLI selected at
   creation time. Built-ins (claude, codex, gemini, opencode,
-  aider) are seeded into `~/.config/thurbox/agents.toml`; add your
+  aider, vibe) are seeded into `~/.config/thurbox/agents.toml`; add your
   own without recompiling.
 - **Git worktree isolation** — each session can spawn on a fresh
   worktree; `Ctrl+S` syncs them with `origin/main` and asks the
@@ -211,8 +211,8 @@ See the full [keybindings](#keybindings) below.
 
 A session launches exactly one coding-agent CLI. Agents are
 described as data in `~/.config/thurbox/agents.toml`, which is
-seeded with built-ins (claude, codex, gemini, opencode, aider) on
-first run. Edit the file to tweak an agent or add a new one — no
+seeded with built-ins (claude, codex, gemini, opencode, aider,
+vibe) on first run. Edit the file to tweak an agent or add a new one — no
 recompile required.
 
 Each `[[agents]]` entry maps the resume / fork / new-session ids

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -496,7 +496,7 @@ trivially testable. Composite styles (e.g., `focused_title()`) are
 at creation time; each agent runs with its own default config.
 Agents are described as **data** in `~/.config/thurbox/agents.toml`
 (sibling of any other config), seeded with built-ins (claude,
-codex, gemini, opencode, aider) on first run via
+codex, gemini, opencode, aider, vibe) on first run via
 `agent::agent_config::load_or_seed`. An `AgentDef` carries a
 `command`, `args` (always passed — bake in flags like a model
 here if you want), and argument-template groups (`resume_args`,

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -127,7 +127,7 @@ from accumulating stale entries.
 
 The set of available agents is **data**, not code. On first run
 Thurbox seeds `~/.config/thurbox/agents.toml` with built-in
-definitions for claude, codex, gemini, opencode, and aider
+definitions for claude, codex, gemini, opencode, aider, and vibe
 (`agent::agent_config::load_or_seed`). Editing the file — adding an
 `[[agents]]` entry or tweaking an existing one — extends the agent
 picker with no recompile.

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -48,6 +48,10 @@ command = "opencode"
 [[agents]]
 name = "aider"
 command = "aider"
+
+[[agents]]
+name = "vibe"
+command = "vibe"
 "#;
 
 /// Path to the agent-definition config file:
@@ -121,6 +125,7 @@ mod tests {
         assert!(reg.get("gemini").is_some());
         assert!(reg.get("opencode").is_some());
         assert!(reg.get("aider").is_some());
+        assert!(reg.get("vibe").is_some());
         // Claude carries resume/fork groups; codex does not.
         assert!(!reg.get("claude").unwrap().resume_args.is_empty());
         assert!(reg.get("codex").unwrap().resume_args.is_empty());

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -122,9 +122,9 @@
           </figure>
           <p>
             Run multiple coding-agent CLIs side-by-side, each in its own tmux pane. A session runs
-            one agent (Claude Code, Codex, Gemini CLI, opencode, aider, or your own), each with its
-            own default config. Sessions persist across crashes, restarts, and even multiple
-            concurrent Thurbox instances &mdash; tmux keeps them alive in the background.
+            one agent (Claude Code, Codex, Gemini CLI, opencode, aider, Vibe, or your own), each
+            with its own default config. Sessions persist across crashes, restarts, and even
+            multiple concurrent Thurbox instances &mdash; tmux keeps them alive in the background.
           </p>
           <ul>
             <li>
@@ -171,8 +171,8 @@
           <p>
             The set of available agents is data, not code. On first run Thurbox seeds
             <code>~/.config/thurbox/agents.toml</code>
-            with built-ins (claude, codex, gemini, opencode, aider). Edit the file to tweak an agent
-            or add a new one &mdash; no recompile required.
+            with built-ins (claude, codex, gemini, opencode, aider, vibe). Edit the file to tweak an
+            agent or add a new one &mdash; no recompile required.
           </p>
           <ul>
             <li>

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -300,7 +300,7 @@ cargo build --release"
                   >
                     claude
                   </a>
-                  , codex, gemini, opencode, or aider &mdash; whichever agents you plan to run
+                  , codex, gemini, opencode, aider, or vibe &mdash; whichever agents you plan to run
                 </td>
               </tr>
               <tr>

--- a/website/index.html
+++ b/website/index.html
@@ -6,7 +6,7 @@
     <title>Thurbox — TUI Agentic IDE</title>
     <meta
       name="description"
-      content="Thurbox runs any coding-agent CLI (Claude Code, Codex, Gemini CLI, opencode, aider) in persistent tmux panes — sessions, agents, and git worktrees as first-class citizens."
+      content="Thurbox runs any coding-agent CLI (Claude Code, Codex, Gemini CLI, opencode, aider, Vibe) in persistent tmux panes — sessions, agents, and git worktrees as first-class citizens."
     />
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -64,8 +64,8 @@
         </h1>
         <p class="subtitle">
           A multi-session orchestrator for your terminal. Run any coding-agent CLI — Claude Code,
-          Codex, Gemini CLI, opencode, aider, or your own — in parallel, persistent tmux panes that
-          survive crashes and restarts.
+          Codex, Gemini CLI, opencode, aider, Vibe, or your own — in parallel, persistent tmux panes
+          that survive crashes and restarts.
         </p>
         <p class="agent-support">
           Built-in agent support for
@@ -74,6 +74,7 @@
           <span>Gemini CLI</span>
           <span>opencode</span>
           <span>aider</span>
+          <span>Vibe</span>
           <span class="agent-support-any">plus any CLI agent</span>
         </p>
         <div class="hero-ctas">
@@ -133,8 +134,8 @@
             <h3>Any Coding Agent</h3>
             <p>
               A session runs one agent of your choice &mdash; Claude Code, Codex, Gemini CLI,
-              opencode, aider, or any CLI you describe. Each agent runs with its own default config.
-              Mix different agents across the sidebar.
+              opencode, aider, Vibe, or any CLI you describe. Each agent runs with its own default
+              config. Mix different agents across the sidebar.
             </p>
           </div>
           <div class="card">
@@ -484,7 +485,7 @@
                 <a href="https://github.com/anthropics/claude-code" target="_blank" rel="noopener">
                   claude
                 </a>
-                , codex, gemini, opencode, or aider
+                , codex, gemini, opencode, aider, or vibe
               </li>
               <li>
                 <strong>git</strong>


### PR DESCRIPTION
## Summary

Adds **Vibe** (Mistral's coding-agent CLI) as a seeded built-in agent, alongside `claude`, `codex`, `gemini`, `opencode`, and `aider`.

## Changes

- `src/agent/agent_config.rs` — new `[[agents]]` entry (`name = "vibe"`, `command = "vibe"`) in `BUILTIN_AGENTS_TOML`; extended the built-in registry test to assert `vibe` is present. Like codex/gemini/opencode/aider it carries no resume/fork args, so it starts fresh on restart (the live tmux process carries state across TUI restarts).
- Docs — updated the built-in lists in `CLAUDE.md`, `README.md`, `docs/ARCHITECTURE.md`, `docs/FEATURES.md`.
- Website — added Vibe to the agent chips and prose in `website/index.html`, `website/docs/features.html`, `website/docs/installation.html`.

## Notes

- Assumes the CLI executable is `vibe`. If Mistral's CLI uses a different command name, the `command` field needs adjusting.

## Test plan

- `cargo test --lib agent_config` → 4/4 pass
- `cargo fmt --all --check` clean