### PR TITLE
Remote SSH sessions: run sessions on remote hosts over SSH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ node_modules/
 
 # Local orchestrator/agent worker workspaces (stray nested checkouts)
 thurbox/
+
+# SSH integration-test fixture (generated keypair + staged build-context key)
+scripts/test-ssh/.keys/
+scripts/test-ssh/authorized_keys

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,50 @@ your own `[[agents]]` entry to support any CLI — no recompile.
 A session stores only its **agent name**; there are no
 per-session model/permission/prompt/tool knobs.
 
+## Remote SSH Sessions
+
+Sessions can run on a **remote host** over SSH while the TUI runs
+locally. Remote hosts are declared as data in
+`~/.config/thurbox/hosts.toml` (seeded commented-out on first run,
+so a fresh install has zero remote hosts and behaves as before):
+
+```toml
+[[hosts]]
+name = "devbox"               # registered as backend "ssh:devbox"
+destination = "me@devbox"     # resolved via ~/.ssh/config
+ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m", "-o", "ServerAliveInterval=15"]
+# socket / session   = optional remote tmux -L / session-name overrides
+# worktrees_dir       = optional absolute remote worktrees dir
+```
+
+How it works: `TmuxBackend` is transport-neutral
+(`agent::transport::TmuxTransport`). The local backend launches
+`tmux -L thurbox …`; a remote backend launches
+`ssh <dest> tmux -L thurbox …`. The tmux **control-mode** protocol
+(`control_mode.rs`) is byte-identical over either transport — only
+the one-time process launch differs. Each host registers a backend
+named `ssh:<name>` (`TmuxBackend::from_host`, registered lazily in
+`main.rs`: a down host must not block startup, so
+`check_available`/`ensure_ready` are deferred to first use via
+`App::backend_for`).
+
+- **Data**: `session::HostDef`/`HostRegistry` (pure data, in
+  `session/` so both `agent` and `git` can use it). **Loading**:
+  `agent::host_config::load_or_seed()`.
+- **Selection**: `SessionConfig.backend` (`ssh:<host>` or `None` =
+  local). The TUI new-session flow shows a **host picker** first
+  (skipped when no hosts are configured); the chosen host runs git
+  worktree creation + branch listing on that host over SSH.
+- **Worktrees**: `git::*_on(host, …)` variants run `git` over
+  `ssh <dest> git -C <repo> …`. Remote worktrees live under the
+  host's `worktrees_dir` (or `$HOME/.local/share/thurbox/worktrees`
+  resolved + cached over ssh).
+- **Persistence/restore**: `backend_type` already round-trips in
+  SQLite; restore discovers windows **per backend** so remote
+  sessions re-adopt against their own host.
+- **Headless**: `thurbox-cli session create --host <name>` spawns
+  remotely (see below).
+
 ## thurbox-cli
 
 A second binary (`thurbox-cli`) drives the same SQLite-backed,
@@ -216,6 +260,9 @@ with the TUI; changes appear via `PRAGMA data_version` polling.
 cargo build --bin thurbox-cli
 thurbox-cli session create --name demo --repo-path /path \
     --agent codex --worktree-branch feat/x
+# Spawn on a remote host from hosts.toml (worktree + tmux live remotely):
+thurbox-cli session create --name demo --repo-path /srv/repo \
+    --host devbox --worktree-branch feat/x
 thurbox-cli session list | jq
 ```
 
@@ -315,14 +362,19 @@ app      ← coordinator, imports all modules
   abstracts CLI command + arg construction; `GenericProvider`
   implements it from a declarative `AgentDef` (loaded via
   `agent_config`). `Session` wraps a `SessionBackend`
-  trait. `BackendRegistry` holds the backends; the only
-  backend is `LocalTmuxBackend` (using `tmux -L thurbox`).
-  Reads output into `Arc<Mutex<vt100::Parser>>`, writes input
-  via mpsc channel. `input.rs` translates crossterm `KeyCode`
-  → xterm ANSI bytes.
+  trait. `BackendRegistry` holds the backends, keyed by name.
+  `TmuxBackend` runs tmux over a `TmuxTransport` (`transport.rs`):
+  `Local` (`tmux -L thurbox`) for the default `local-tmux`
+  backend, or `Ssh` (`ssh <dest> tmux …`) for each remote host
+  in `hosts.toml` (registered as `ssh:<host>`, loaded via
+  `host_config`). The control-mode protocol (`control_mode.rs`)
+  is identical over either transport. Reads output into
+  `Arc<Mutex<vt100::Parser>>`, writes input via mpsc channel.
+  `input.rs` translates crossterm `KeyCode` → xterm ANSI bytes.
 - **`session/`** — Plain data: `SessionId`, `SessionStatus`,
   `SessionInfo` (with `agent` name), `SessionConfig` (agent
-  name, ids, cwd, env), `AgentDef`/`AgentRegistry`.
+  name, backend name, ids, cwd, env), `AgentDef`/`AgentRegistry`,
+  `HostDef`/`HostRegistry` (remote SSH hosts).
   Mostly Display/Default impls plus the agent-arg
   substitution logic.
 - **`ui/`** — Pure rendering functions. `layout.rs` computes
@@ -366,7 +418,9 @@ framework). Install with `prek install`. Stages:
 
 - MSRV: 1.75, Edition 2021
 - Async runtime: tokio (multi-threaded)
-- Session backend: `LocalTmuxBackend` (`tmux -L thurbox`)
+- Session backend: `TmuxBackend` over a `TmuxTransport`
+  (local `tmux -L thurbox`, or `ssh <dest> tmux …` for
+  `ssh:<host>` backends from `hosts.toml`)
 - Output reader runs in `tokio::task::spawn_blocking`
   (blocking I/O), writer in `tokio::spawn` (async)
 - Terminal state parsed by `vt100::Parser`,
@@ -374,7 +428,8 @@ framework). Install with `prek install`. Stages:
 - Sessions persist across restarts (tmux keeps them alive)
 - Session state in SQLite:
   `~/.local/share/thurbox/thurbox.db` (XDG_DATA_HOME respected);
-  agent definitions in `~/.config/thurbox/agents.toml`
+  agent definitions in `~/.config/thurbox/agents.toml`;
+  remote SSH hosts in `~/.config/thurbox/hosts.toml`
 - Requires tmux >= 3.2
 
 ## Keybindings (Vim-Inspired)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,24 @@ cargo test test_name                 # Run single test via cargo test
 bats scripts/install.bats            # Test install script (requires bats-core)
 ```
 
+### Remote SSH integration test
+
+The remote-session path (git-over-ssh + tmux-over-ssh control mode) has an
+**opt-in** end-to-end test, skipped by default so `cargo nextest run --all`
+stays hermetic. It runs against a throwaway sshd+tmux+git container under
+`scripts/test-ssh/`:
+
+```bash
+./scripts/test-ssh/up.sh                                   # build + start sshd on 127.0.0.1:2222
+THURBOX_SSH_IT=1 cargo nextest run --test ssh_integration  # gate: only runs when set
+./scripts/test-ssh/down.sh                                 # tear down
+```
+
+The test (`tests/ssh_integration.rs`) creates a worktree over ssh, spawns a real
+tmux session via `TmuxBackend::from_host`, and asserts a marker appears in the
+live vt100 capture. See `scripts/test-ssh/README.md` (env vars also let it point
+at any reachable host instead of the container).
+
 ## Installation Script
 
 **Location:** `scripts/install.sh`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,8 @@ when multiple PTY sessions are producing concurrent output.
 **Choice**: A `SessionBackend` trait abstracts session lifecycle
 (spawn, adopt, resize, kill, detach, discover). Each session runs
 one coding-agent CLI inside the backend. The default backend is
-`LocalTmuxBackend` (`tmux -L thurbox`).
+local tmux (`tmux -L thurbox`); the same `TmuxBackend` also runs
+over SSH for remote hosts (ADR-13).
 `vt100::Parser` interprets escape sequences,
 `tui_term::PseudoTerminal` renders the parsed screen into ratatui.
 
@@ -261,9 +262,10 @@ struct wraps the trait and manages reader/writer loops once,
 regardless of which backend is active.
 
 **Why**: Keeping session lifecycle behind a trait boundary leaves
-the app layer completely backend-agnostic. The only backend today
-is local tmux (`LocalTmuxBackend`), but the seam means the
-transport can evolve without touching `App`, `Session`, or any UI
+the app layer completely backend-agnostic. The backends today are
+local tmux and one SSH backend per configured host (both
+`TmuxBackend` over a `TmuxTransport`; see ADR-13), and the seam means
+the transport can evolve without touching `App`, `Session`, or any UI
 code.
 
 **Trait methods**: `check_available`, `ensure_ready`, `spawn`,
@@ -355,6 +357,69 @@ delivers pixel-perfect rendering with all original formatting.
   tmux bugs #641/#2989, required `mkfifo`/`stdbuf`/`cat` in the
   data path, no flow control, timing race on initial capture.
 - *Screen/dtach* — less widely available, fewer features.
+
+---
+
+## ADR-13: Remote sessions via an SSH tmux transport
+
+**Choice**: Run agent sessions on a remote host by launching the
+same tmux control-mode protocol over SSH. `LocalTmuxBackend` is
+generalized into `TmuxBackend { transport, socket, session, name }`
+where `transport: TmuxTransport` is either `Local` (a bare
+`Command::new("tmux")`) or `Ssh { destination, ssh_opts }`
+(`ssh <dest> tmux …`). The transport's *only* job is to build the
+`Command`; everything downstream — the control-mode reader/writer
+threads, pane registration, `send-keys`/`%output` — is byte-for-byte
+identical (`control_mode.rs` was already transport-agnostic).
+
+Remote hosts are declared as data in `~/.config/thurbox/hosts.toml`
+(`session::HostDef`/`HostRegistry`, loaded by
+`agent::host_config::load_or_seed`), each registered as a backend
+named `ssh:<host>` via `TmuxBackend::from_host`.
+
+**Why**: The local-vs-remote difference is exactly one line (how the
+tmux process is launched). The per-session control commands travel
+over the stdin pipe, not ssh argv, so only the one-time
+`attach-session` launch crosses the ssh boundary. Relying on the
+system `ssh` binary + `~/.ssh/config` keeps auth/keys/multiplexing
+out of thurbox (ControlMaster/ControlPersist + ServerAliveInterval
+are recommended in the seeded `ssh_opts`).
+
+**Key design decisions**:
+
+- **Lazy registration**: SSH backends are registered but *not*
+  connected at startup (`check_available`/`ensure_ready` deferred to
+  first use via `App::backend_for`), so a down host never blocks the
+  TUI.
+- **Selection**: `SessionConfig.backend` (`ssh:<host>` or `None`).
+  The TUI shows a host picker as the first new-session step (skipped
+  when no hosts are configured); `thurbox-cli session create --host`
+  is the headless equivalent.
+- **Persistence/restore**: `backend_type` already round-trips in
+  SQLite; restore was changed to discover windows **per backend** so
+  remote sessions re-adopt against their own host's tmux.
+- **Remote worktrees**: `git::*_on(host, …)` variants run
+  `ssh <dest> git -C <repo> …`. Remote worktree paths resolve under
+  the host's `worktrees_dir` (or `$HOME/.local/share/thurbox/…`
+  resolved + cached over ssh).
+
+**Module placement**: `HostDef`/`HostRegistry` live in `session/`
+(the dependency sink) so both `agent` (builds the backend) and `git`
+(runs git over SSH) can depend on them without violating the
+module-isolation rules.
+
+**Riskiest area**: SSH reconnect on a flapping link — `reconnect_control`
+reopens the ssh connection; ControlMaster + keepalives mitigate
+stalls. Worth the most manual testing.
+
+**Rejected**:
+
+- *A `TmuxTransport` trait with `Box<dyn>`* — an enum with two
+  variants is simpler; promote to a trait only if a third transport
+  (e.g. container exec) appears.
+- *Embedded SSH library (russh, etc.)* — reimplements `~/.ssh/config`,
+  agent forwarding, and multiplexing that the system `ssh` already
+  provides.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -88,16 +88,21 @@ whichever the agent produces.
 session. Each step has a sensible default and can be skipped when
 not applicable.
 
-1. **Repo picker** — fuzzy-searchable list of bookmarked repo
+1. **Host picker** — choose where the session runs: `local`, or any
+   remote SSH host defined in `hosts.toml`. Skipped entirely when no
+   remote hosts are configured (preserving the local-only flow). For
+   a remote host the repo picker opens to a typed remote path and the
+   worktree + tmux window are created on that host over SSH.
+2. **Repo picker** — fuzzy-searchable list of bookmarked repo
    paths. `Space` toggles selection, `w` marks the selected repo
    as a worktree base, `d` deletes the bookmark, and a path-input
    field with filesystem autocomplete adds new bookmarks. The
    first selected repo becomes the session's `cwd`; the rest may be
    exposed to the agent depending on the agent's own flags.
-2. **Base branch selector** — worktree mode only.
-3. **Session name** — free text identifier shown in the sidebar.
-4. **New branch name** — worktree mode only.
-5. **Agent picker** — choose which coding agent runs in this
+3. **Base branch selector** — worktree mode only.
+4. **Session name** — free text identifier shown in the sidebar.
+5. **New branch name** — worktree mode only.
+6. **Agent picker** — choose which coding agent runs in this
    session. Skipped when only one agent is defined in
    `agents.toml`.
 
@@ -164,6 +169,41 @@ new_session_args = ["--session-id", "{id}"]
 name = "codex"
 command = "codex"
 ```
+
+### Remote SSH sessions
+
+Like agents, remote hosts are **data**. A session can run on a
+remote machine over SSH while the TUI stays local. Hosts are
+declared in `~/.config/thurbox/hosts.toml` (seeded commented-out, so
+a fresh install has none and behaves exactly as before):
+
+```toml
+[[hosts]]
+name = "devbox"            # selectable as backend "ssh:devbox"
+destination = "me@devbox"  # resolved via ~/.ssh/config
+ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m"]
+```
+
+Each host becomes a session backend named `ssh:<name>`. Thurbox
+shells out to the system `ssh` binary, so authentication, keys, and
+connection multiplexing come from your `~/.ssh/config` — thurbox
+never handles credentials. The same tmux control-mode protocol runs
+over the SSH pipe, so remote sessions get identical persistence,
+multi-instance sharing, and restore-on-startup as local ones; the
+worktree and agent process live on the remote host.
+
+**Why a config file rather than ad-hoc destinations?** Named hosts
+give the picker stable, readable entries and let `backend_type`
+round-trip cleanly through the database so a remote session re-adopts
+on the correct host after a restart.
+
+**Why lean on `~/.ssh/config`?** Re-implementing SSH auth, agent
+forwarding, and ControlMaster multiplexing would be a large, fragile
+surface. Deferring to the system `ssh` keeps thurbox out of the
+credential path and inherits whatever the user already configured.
+
+Headless: `thurbox-cli session create --host devbox --repo-path
+/srv/repo --worktree-branch feat/x` does the same over the CLI.
 
 ---
 

--- a/scripts/test-ssh/Dockerfile
+++ b/scripts/test-ssh/Dockerfile
@@ -1,0 +1,57 @@
+# Minimal SSH target for exercising thurbox's remote-session path locally.
+#
+# Runs sshd with tmux + git installed and a pre-seeded git repo, so the
+# `ssh_integration` test can drive the real tmux-over-ssh control mode and
+# git-over-ssh worktree code paths against a throwaway container.
+#
+# The container is NOT a security boundary — it accepts a single injected
+# public key and is meant only for `localhost`-bound local/CI testing.
+FROM debian:bookworm-slim
+
+# openssh-server: the sshd thurbox connects to.
+# tmux:          remote session host (control mode).
+# git:           remote worktree operations.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        openssh-server \
+        tmux \
+        git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# tmux >= 3.2 is required by thurbox; bookworm ships 3.3a. Fail the build loudly
+# if that ever regresses so the test target stays valid.
+RUN tmux -V
+
+# Unprivileged user the test logs in as.
+RUN useradd --create-home --shell /bin/bash tester
+
+# sshd runtime dir + hardened-enough config for an ephemeral key-only target.
+RUN mkdir -p /run/sshd \
+    && sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config \
+    && sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config \
+    && sed -i 's/^#\?PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config
+
+# Inject the caller-generated public key (placed in the build context by up.sh).
+COPY authorized_keys /home/tester/.ssh/authorized_keys
+RUN chown -R tester:tester /home/tester/.ssh \
+    && chmod 700 /home/tester/.ssh \
+    && chmod 600 /home/tester/.ssh/authorized_keys
+
+# Pre-seed a git repo on `main` with one commit, plus a worktrees dir, so the
+# test can create worktrees without first bootstrapping a repo over ssh.
+USER tester
+RUN git config --global user.email tester@thurbox.test \
+    && git config --global user.name "thurbox test" \
+    && git config --global init.defaultBranch main \
+    && mkdir -p /home/tester/worktrees \
+    && git init -b main /home/tester/repo \
+    && cd /home/tester/repo \
+    && echo "thurbox ssh test fixture" > README.md \
+    && git add README.md \
+    && git commit -m "seed: initial commit"
+
+USER root
+EXPOSE 22
+# -D: foreground, -e: log to stderr so `docker logs` shows auth failures.
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/scripts/test-ssh/README.md
+++ b/scripts/test-ssh/README.md
@@ -1,0 +1,70 @@
+# Local SSH test target
+
+A throwaway container that runs **sshd + tmux + git**, so thurbox's remote
+SSH-session code paths can be exercised end-to-end on your own machine — no real
+remote host required.
+
+It backs the opt-in integration test [`tests/ssh_integration.rs`](../../tests/ssh_integration.rs),
+which drives the *real* code:
+
+- **git over ssh** — `git::*_on` → `ssh <dest> git -C <repo> …`
+  (`list_branches_on`, `create_worktree_on`, `remove_worktree_on`)
+- **tmux over ssh** — `TmuxBackend::from_host` → `ssh <dest> tmux …` control mode
+  (`ensure_ready`, `spawn`, live vt100 capture, `kill`)
+
+## Requirements
+
+- `docker` (with the `compose` plugin), **or** `podman` + `podman-compose`
+- `ssh` / `ssh-keygen` on the host
+
+## Usage
+
+```sh
+./scripts/test-ssh/up.sh        # generate key, build image, start sshd on 127.0.0.1:2222
+THURBOX_SSH_IT=1 cargo nextest run --test ssh_integration --no-capture
+./scripts/test-ssh/down.sh      # stop + remove the container
+./scripts/test-ssh/down.sh --purge   # also drop the image and the generated keypair
+```
+
+`up.sh` is idempotent and prints the exact env exports it set up. To load them
+into your current shell:
+
+```sh
+eval "$(./scripts/test-ssh/up.sh --export)"
+cargo nextest run --test ssh_integration --no-capture
+```
+
+## What the container ships
+
+- user `tester`, key-only login (the generated public key is injected at build)
+- a seeded git repo at `/home/tester/repo` on branch `main` (one commit)
+- a worktrees dir at `/home/tester/worktrees`
+- tmux ≥ 3.2 (build fails otherwise — thurbox's minimum)
+
+## Configuration
+
+The test reads these env vars; defaults match this container, so
+`THURBOX_SSH_IT=1` alone is enough.
+
+| Env var                 | Default                              |
+|-------------------------|--------------------------------------|
+| `THURBOX_SSH_IT`        | unset → **test skips**               |
+| `THURBOX_SSH_DEST`      | `tester@localhost`                   |
+| `THURBOX_SSH_PORT`      | `2222`                               |
+| `THURBOX_SSH_KEY`       | `scripts/test-ssh/.keys/id_ed25519`  |
+| `THURBOX_SSH_REPO`      | `/home/tester/repo`                  |
+| `THURBOX_SSH_WORKTREES` | `/home/tester/worktrees`             |
+
+The same env vars let you point the test at **any** reachable host instead of
+the container (e.g. a real box from your `~/.ssh/config`) — set
+`THURBOX_SSH_DEST`, drop `THURBOX_SSH_PORT`/`THURBOX_SSH_KEY` if your ssh config
+already covers them, and ensure the repo/worktrees paths exist there.
+
+## Notes
+
+- The port binds to `127.0.0.1` only; the image accepts a single generated key
+  and is **not** a security boundary — it's a disposable test fixture.
+- The generated keypair (`.keys/`) and the staged `authorized_keys` are
+  gitignored.
+- The test is skipped by default, so `cargo nextest run --all` stays hermetic
+  and CI is unaffected unless `THURBOX_SSH_IT=1` is exported.

--- a/scripts/test-ssh/docker-compose.yml
+++ b/scripts/test-ssh/docker-compose.yml
@@ -1,0 +1,17 @@
+# Local SSH target for thurbox's remote-session integration test.
+#
+#   ./scripts/test-ssh/up.sh     # generate key, build, start, print exports
+#   THURBOX_SSH_IT=1 cargo nextest run --test ssh_integration
+#   ./scripts/test-ssh/down.sh   # stop + remove
+#
+# Bound to 127.0.0.1 only — this is a throwaway test fixture, not a server.
+services:
+  sshd:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: thurbox-test-sshd
+    container_name: thurbox-test-sshd
+    ports:
+      - "127.0.0.1:${THURBOX_SSH_PORT:-2222}:22"
+    # No restart policy: this exists only for the duration of a test run.

--- a/scripts/test-ssh/down.sh
+++ b/scripts/test-ssh/down.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Tear down the local SSH test target. Pass --purge to also drop the image and
+# the generated keypair. Uses plain `podman`/`docker` (no compose required).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+IMAGE="thurbox-test-sshd"
+NAME="thurbox-test-sshd"
+
+if command -v podman >/dev/null 2>&1; then
+    ENGINE=podman
+elif command -v docker >/dev/null 2>&1; then
+    ENGINE=docker
+else
+    echo "error: need podman or docker on PATH" >&2
+    exit 1
+fi
+
+"$ENGINE" rm -f "$NAME" >/dev/null 2>&1 || true
+
+# Drop the staged authorized_keys from the build context regardless.
+rm -f "$HERE/authorized_keys"
+
+if [ "${1:-}" = "--purge" ]; then
+    "$ENGINE" rmi -f "$IMAGE" >/dev/null 2>&1 || true
+    rm -rf "$HERE/.keys"
+    echo "purged image and test keypair." >&2
+else
+    echo "stopped $NAME (image kept; use --purge to remove it)." >&2
+fi

--- a/scripts/test-ssh/up.sh
+++ b/scripts/test-ssh/up.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Bring up the local SSH test target (sshd + tmux + git in a container) and
+# print the environment exports needed to run the `ssh_integration` test.
+#
+# Usage:
+#   ./scripts/test-ssh/up.sh
+#   eval "$(./scripts/test-ssh/up.sh --export)"   # set vars in the current shell
+#
+# Idempotent: reuses an existing keypair, rebuilds the image, and replaces the
+# container. Uses plain `podman`/`docker` build+run (no compose required).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+KEY_DIR="$HERE/.keys"
+KEY="$KEY_DIR/id_ed25519"
+PORT="${THURBOX_SSH_PORT:-2222}"
+IMAGE="thurbox-test-sshd"
+NAME="thurbox-test-sshd"
+
+# Pick a container engine: podman (preferred) or docker.
+if command -v podman >/dev/null 2>&1; then
+    ENGINE=podman
+elif command -v docker >/dev/null 2>&1; then
+    ENGINE=docker
+else
+    echo "error: need podman or docker on PATH" >&2
+    exit 1
+fi
+
+# 1. Generate a throwaway keypair (gitignored) if absent.
+mkdir -p "$KEY_DIR"
+chmod 700 "$KEY_DIR"
+if [ ! -f "$KEY" ]; then
+    ssh-keygen -t ed25519 -N "" -C "thurbox-test" -f "$KEY" >/dev/null
+    echo "generated test keypair at $KEY" >&2
+fi
+
+# 2. Stage the public key into the build context for the Dockerfile COPY.
+cp "$KEY.pub" "$HERE/authorized_keys"
+
+# 3. Build the image.
+echo "building image $IMAGE with $ENGINE ..." >&2
+"$ENGINE" build -t "$IMAGE" -f "$HERE/Dockerfile" "$HERE" >&2
+
+# 4. (Re)start the container, bound to localhost only.
+"$ENGINE" rm -f "$NAME" >/dev/null 2>&1 || true
+echo "starting $NAME on 127.0.0.1:$PORT ..." >&2
+"$ENGINE" run -d --name "$NAME" -p "127.0.0.1:$PORT:22" "$IMAGE" >&2
+
+# 5. Wait for sshd to accept the key (up to ~30s).
+echo "waiting for sshd ..." >&2
+for _ in $(seq 1 30); do
+    if ssh -p "$PORT" -i "$KEY" \
+        -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
+        -o BatchMode=yes \
+        -o ConnectTimeout=2 \
+        tester@localhost true 2>/dev/null; then
+        echo "sshd is ready." >&2
+        cat <<EOF >&2
+
+Run the integration test with:
+
+  export THURBOX_SSH_IT=1
+  export THURBOX_SSH_DEST=tester@localhost
+  export THURBOX_SSH_PORT=$PORT
+  export THURBOX_SSH_KEY=$KEY
+  cargo nextest run --test ssh_integration --no-capture
+
+(these defaults match the container, so just THURBOX_SSH_IT=1 is enough)
+EOF
+        # --export prints shell-evalable assignments on stdout.
+        if [ "${1:-}" = "--export" ]; then
+            echo "export THURBOX_SSH_IT=1"
+            echo "export THURBOX_SSH_DEST=tester@localhost"
+            echo "export THURBOX_SSH_PORT=$PORT"
+            echo "export THURBOX_SSH_KEY=$KEY"
+        fi
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "error: sshd did not become ready in time; check '$ENGINE logs $NAME'" >&2
+exit 1

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -1,0 +1,136 @@
+//! Loading and seeding of the remote-host config file.
+//!
+//! Remote SSH hosts are defined declaratively in
+//! `~/.config/thurbox/hosts.toml`. Each entry becomes a selectable session
+//! backend named `ssh:<name>`. On first run the file is seeded with a
+//! commented-out example so a fresh install registers *zero* remote backends
+//! and behaves exactly as before. If the file exists but cannot be read or
+//! parsed, we fall back to an empty registry rather than failing to start.
+
+use std::path::PathBuf;
+
+use crate::session::HostRegistry;
+
+/// Seed contents for `hosts.toml` on first run: documentation + a commented-out
+/// example, but no active hosts.
+pub const SEED_HOSTS_TOML: &str = r#"# Thurbox remote SSH hosts.
+#
+# Each [[hosts]] entry describes a remote machine thurbox can run agent
+# sessions on, over SSH. Each becomes a backend named "ssh:<name>", selectable
+# when creating a session. Authentication and host details resolve via your
+# ~/.ssh/config — thurbox shells out to the system `ssh` binary.
+#
+# Uncomment and edit to add a host:
+#
+# [[hosts]]
+# name = "devbox"
+# destination = "me@devbox"
+# # ControlMaster keeps one SSH connection alive so reconnects are instant;
+# # ServerAliveInterval drops half-open links promptly.
+# ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m", "-o", "ServerAliveInterval=15"]
+# # Optional: absolute remote dir for git worktrees (defaults to
+# # $HOME/.local/share/thurbox/worktrees on the remote).
+# # worktrees_dir = "/home/me/.local/share/thurbox/worktrees"
+"#;
+
+/// Path to the remote-host config file: `~/.config/thurbox/hosts.toml`
+/// (sibling of `config.toml`).
+pub fn hosts_config_path() -> Option<PathBuf> {
+    crate::paths::config_file().map(|p| p.with_file_name("hosts.toml"))
+}
+
+/// Load the remote-host registry, seeding the config file with a commented-out
+/// example when it is absent. Any read/parse error degrades gracefully to an
+/// empty registry so the TUI always starts (with local-only sessions).
+pub fn load_or_seed() -> HostRegistry {
+    let Some(path) = hosts_config_path() else {
+        tracing::warn!("Could not resolve hosts.toml path; no remote hosts");
+        return HostRegistry::default();
+    };
+
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                tracing::warn!(error = %e, "Failed to create config dir for hosts.toml");
+                return HostRegistry::default();
+            }
+        }
+        if let Err(e) = std::fs::write(&path, SEED_HOSTS_TOML) {
+            tracing::warn!(error = %e, "Failed to seed hosts.toml");
+            return HostRegistry::default();
+        }
+        tracing::info!(path = %path.display(), "Seeded hosts.toml (no active hosts)");
+        return HostRegistry::default();
+    }
+
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => match toml::from_str::<HostRegistry>(&contents) {
+            Ok(reg) => reg,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to parse hosts.toml; no remote hosts");
+                HostRegistry::default()
+            }
+        },
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to read hosts.toml; no remote hosts");
+            HostRegistry::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_toml_parses_to_empty_registry() {
+        let reg: HostRegistry = toml::from_str(SEED_HOSTS_TOML).unwrap();
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn load_or_seed_writes_file_when_absent_and_stays_empty() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = hosts_config_path().unwrap();
+        assert!(!path.exists());
+
+        let reg = load_or_seed();
+        assert!(reg.is_empty());
+        assert!(path.exists(), "hosts.toml should have been seeded");
+
+        // Second call reads the seeded file and is still empty.
+        assert!(load_or_seed().is_empty());
+    }
+
+    #[test]
+    fn load_or_seed_falls_back_on_malformed_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "this is not = valid toml {{{").unwrap();
+
+        assert!(load_or_seed().is_empty());
+    }
+
+    #[test]
+    fn load_or_seed_reads_configured_host() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hosts]]\nname = \"devbox\"\ndestination = \"me@devbox\"\n",
+        )
+        .unwrap();
+
+        let reg = load_or_seed();
+        assert_eq!(reg.names(), ["devbox"]);
+        assert_eq!(reg.get("devbox").unwrap().backend_name(), "ssh:devbox");
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3,6 +3,7 @@ pub mod backend;
 pub mod control_mode;
 pub mod demo;
 pub mod generic;
+pub mod host_config;
 pub mod input;
 pub mod provider;
 pub mod registry;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,6 +7,7 @@ pub mod input;
 pub mod provider;
 pub mod registry;
 pub mod tmux;
+pub mod transport;
 
 pub use backend::{Session, SessionBackend, SessionParser};
 pub use generic::GenericProvider;

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -468,6 +468,29 @@ impl TmuxBackend {
         }
     }
 
+    /// Build a remote tmux backend that runs `tmux` over SSH on `host`. The
+    /// backend is named `ssh:<host.name>` and uses the same socket/session
+    /// names as the local backend unless the host overrides them.
+    pub fn from_host(host: &crate::session::HostDef) -> Self {
+        let socket = host
+            .socket
+            .clone()
+            .unwrap_or_else(|| TMUX_SOCKET.to_string());
+        let session = host
+            .session
+            .clone()
+            .unwrap_or_else(|| TMUX_SESSION.to_string());
+        Self::with_transport(
+            TmuxTransport::Ssh {
+                destination: host.destination.clone(),
+                ssh_opts: host.ssh_opts.clone(),
+            },
+            socket,
+            session,
+            host.backend_name(),
+        )
+    }
+
     /// Run a tmux command and return its stdout (used before control mode is available).
     fn tmux_output(&self, args: &[&str]) -> Result<String> {
         let output = self.run_tmux(args)?;
@@ -1616,6 +1639,46 @@ mod tests {
         let backend = LocalTmuxBackend::new();
         let guard = backend.control.lock().unwrap();
         assert!(guard.is_none());
+    }
+
+    #[test]
+    fn local_backend_is_named_local_tmux_with_local_transport() {
+        let backend = LocalTmuxBackend::new();
+        assert_eq!(backend.name(), "local-tmux");
+        assert!(!backend.transport.is_remote());
+    }
+
+    #[test]
+    fn from_host_builds_named_ssh_backend() {
+        let host = crate::session::HostDef {
+            name: "devbox".into(),
+            destination: "me@devbox".into(),
+            socket: None,
+            session: None,
+            ssh_opts: vec!["-o".into(), "ControlMaster=auto".into()],
+            worktrees_dir: None,
+        };
+        let backend = TmuxBackend::from_host(&host);
+        assert_eq!(backend.name(), "ssh:devbox");
+        assert!(backend.transport.is_remote());
+        // Falls back to the default socket/session when the host omits them.
+        assert_eq!(backend.socket, TMUX_SOCKET);
+        assert_eq!(backend.session, TMUX_SESSION);
+    }
+
+    #[test]
+    fn from_host_honors_socket_and_session_overrides() {
+        let host = crate::session::HostDef {
+            name: "vm".into(),
+            destination: "vm".into(),
+            socket: Some("tb-vm".into()),
+            session: Some("sess-vm".into()),
+            ssh_opts: vec![],
+            worktrees_dir: None,
+        };
+        let backend = TmuxBackend::from_host(&host);
+        assert_eq!(backend.socket, "tb-vm");
+        assert_eq!(backend.session, "sess-vm");
     }
 
     #[test]

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -14,6 +14,7 @@ use crate::agent::control_mode::{
     self, shell_escape, CommandResponse, ControlModeReader, ControlModeWriter, Notification,
     PaneSendersMapShared, PANE_CHANNEL_CAPACITY,
 };
+use crate::agent::transport::TmuxTransport;
 
 /// Dedicated tmux socket name — isolates thurbox sessions from the user's tmux.
 /// Dev builds use "thurbox-dev" to avoid interfering with an installed release binary.
@@ -89,6 +90,32 @@ fn window_target(session_name: &str) -> String {
 /// Minimum tmux version required.
 const MIN_TMUX_VERSION: (u32, u32) = (3, 2);
 
+/// Parse a `tmux -V` version string (e.g. `"tmux 3.4"`, `"tmux 3.3a"`) into a
+/// `(major, minor)` pair. Shared by the local and remote backends.
+fn parse_tmux_version(version_str: &str) -> Result<(u32, u32)> {
+    // Parse "tmux X.Y" or "tmux X.Ya" (e.g., "tmux 3.4" or "tmux 3.3a").
+    let version_part = version_str.strip_prefix("tmux ").unwrap_or(version_str);
+
+    let parts: Vec<&str> = version_part.split('.').collect();
+    if parts.len() < 2 {
+        bail!("Cannot parse tmux version from: {version_str}");
+    }
+
+    let major: u32 = parts[0].parse().context(format!(
+        "Cannot parse tmux major version from: {version_str}"
+    ))?;
+    // Minor might have a trailing letter (e.g., "3a"), strip non-digits.
+    let minor_str: String = parts[1]
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    let minor: u32 = minor_str.parse().context(format!(
+        "Cannot parse tmux minor version from: {version_str}"
+    ))?;
+
+    Ok((major, minor))
+}
+
 /// Timeout for waiting for a control mode command response.
 const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
@@ -99,18 +126,32 @@ const SEND_KEYS_ENTER_DELAY: std::time::Duration = std::time::Duration::from_mil
 /// Hard cap on the number of scrollback lines `capture_pane_text` will return.
 const MAX_CAPTURE_LINES: u32 = 10_000;
 
-/// Local tmux backend — sessions persist in `tmux -L thurbox`.
+/// A tmux backend — sessions persist in `tmux -L <socket>` on either the local
+/// machine or a remote host reached over SSH.
 ///
-/// Uses tmux control mode (`-C`) for all I/O after `ensure_ready()`.
-pub struct LocalTmuxBackend {
+/// Uses tmux control mode (`-C`) for all I/O after `ensure_ready()`. The only
+/// thing that differs between local and remote is the [`TmuxTransport`] used to
+/// launch the `tmux` process; the protocol layer is identical.
+pub struct TmuxBackend {
+    /// How `tmux` is launched (local `Command` vs `ssh <dest> tmux …`).
+    transport: TmuxTransport,
+    /// tmux socket name passed via `-L` (e.g. `thurbox`).
+    socket: String,
+    /// tmux session name grouping all thurbox windows.
+    session: String,
+    /// Backend name used by the registry / persisted `backend_type`
+    /// (`local-tmux` or `ssh:<host>`).
+    name: String,
     control: Mutex<Option<ControlMode>>,
 }
 
-impl Default for LocalTmuxBackend {
+/// The local tmux backend. Thin alias-constructor over [`TmuxBackend`] kept for
+/// existing call sites; `LocalTmuxBackend::new()` builds a local-transport backend.
+pub type LocalTmuxBackend = TmuxBackend;
+
+impl Default for TmuxBackend {
     fn default() -> Self {
-        Self {
-            control: Mutex::new(None),
-        }
+        Self::local()
     }
 }
 
@@ -131,17 +172,13 @@ struct ControlMode {
 }
 
 impl ControlMode {
-    /// Start a control mode connection to the thurbox tmux session.
-    fn start() -> Result<Self> {
+    /// Start a control mode connection to the thurbox tmux session over the
+    /// given transport (local or ssh).
+    fn start(transport: &TmuxTransport, socket: &str, session: &str) -> Result<Self> {
         // -C (single C): control mode with echo — works with piped stdin.
         // -CC (double C) requires a TTY and fails with "tcgetattr: Inappropriate ioctl".
-        let mut child = Command::new("tmux")
-            .arg("-L")
-            .arg(TMUX_SOCKET)
-            .arg("-C")
-            .arg("attach-session")
-            .arg("-t")
-            .arg(TMUX_SESSION)
+        let mut child = transport
+            .tmux_command(socket, &["-C", "attach-session", "-t", session])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -398,29 +435,56 @@ fn is_recv_timeout(err: &anyhow::Error) -> bool {
     })
 }
 
-impl LocalTmuxBackend {
+impl TmuxBackend {
+    /// Build the local tmux backend (`tmux -L thurbox`).
     pub fn new() -> Self {
-        Self::default()
+        Self::local()
+    }
+
+    /// Build the local tmux backend, named `local-tmux`.
+    pub fn local() -> Self {
+        Self {
+            transport: TmuxTransport::Local,
+            socket: TMUX_SOCKET.to_string(),
+            session: TMUX_SESSION.to_string(),
+            name: "local-tmux".to_string(),
+            control: Mutex::new(None),
+        }
+    }
+
+    /// Build a tmux backend over an explicit transport (used by the SSH backend).
+    pub fn with_transport(
+        transport: TmuxTransport,
+        socket: impl Into<String>,
+        session: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            transport,
+            socket: socket.into(),
+            session: session.into(),
+            name: name.into(),
+            control: Mutex::new(None),
+        }
     }
 
     /// Run a tmux command and return its stdout (used before control mode is available).
     fn tmux_output(&self, args: &[&str]) -> Result<String> {
-        let output = Self::run_tmux(args)?;
+        let output = self.run_tmux(args)?;
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
     /// Run a tmux command, returning Ok(()) on success (used before control mode is available).
     fn tmux_run(&self, args: &[&str]) -> Result<()> {
-        Self::run_tmux(args)?;
+        self.run_tmux(args)?;
         Ok(())
     }
 
     /// Execute a tmux command on the thurbox socket and check for errors.
-    fn run_tmux(args: &[&str]) -> Result<std::process::Output> {
-        let output = Command::new("tmux")
-            .arg("-L")
-            .arg(TMUX_SOCKET)
-            .args(args)
+    fn run_tmux(&self, args: &[&str]) -> Result<std::process::Output> {
+        let output = self
+            .transport
+            .tmux_command(&self.socket, args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output()
@@ -436,14 +500,16 @@ impl LocalTmuxBackend {
 
     /// Check if the thurbox tmux session exists.
     fn session_exists(&self) -> bool {
-        self.tmux_run(&["has-session", "-t", TMUX_SESSION]).is_ok()
+        self.tmux_run(&["has-session", "-t", &self.session]).is_ok()
     }
 
     /// Apply initial config to the tmux server.
     fn apply_config(&self) -> Result<()> {
         // Use a non-login shell so that macOS path_helper (/etc/zprofile)
         // doesn't clobber PATH additions from ~/.zshenv (e.g. cargo, asdf).
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        // For a remote backend the local `$SHELL` path may not exist on the
+        // remote host, so fall back to a POSIX shell there.
+        let shell = self.config_shell();
         self.tmux_run(&["set-option", "-s", "default-command", &shell])?;
 
         // Server-wide options
@@ -465,10 +531,21 @@ impl LocalTmuxBackend {
             ("window-size", "manual"),
         ];
         for (key, val) in &session_opts {
-            self.tmux_run(&["set-option", "-t", TMUX_SESSION, key, val])?;
+            self.tmux_run(&["set-option", "-t", &self.session, key, val])?;
         }
 
         Ok(())
+    }
+
+    /// The shell tmux should use for `default-command`. Local uses the user's
+    /// `$SHELL`; a remote backend uses a POSIX shell that is guaranteed to exist
+    /// on the remote host.
+    fn config_shell(&self) -> String {
+        if self.transport.is_remote() {
+            "/bin/sh".to_string()
+        } else {
+            std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
+        }
     }
 
     /// Build the shell command string to pass to tmux new-window.
@@ -499,7 +576,11 @@ impl LocalTmuxBackend {
             .lock()
             .map_err(|e| anyhow::anyhow!("control lock: {e}"))?;
         *guard = None; // Drop dead ControlMode (triggers cleanup)
-        *guard = Some(ControlMode::start()?);
+        *guard = Some(ControlMode::start(
+            &self.transport,
+            &self.socket,
+            &self.session,
+        )?);
         debug!("Control mode reconnected successfully");
         Ok(())
     }
@@ -626,44 +707,29 @@ impl LocalTmuxBackend {
     }
 }
 
-impl SessionBackend for LocalTmuxBackend {
+impl SessionBackend for TmuxBackend {
     fn name(&self) -> &str {
-        "local-tmux"
+        &self.name
     }
 
     fn check_available(&self) -> Result<()> {
-        let output = Command::new("tmux")
-            .arg("-V")
+        // `tmux -L <socket> -V` prints the version without connecting, and over
+        // the SSH transport this verifies remote connectivity at the same time.
+        let output = self
+            .transport
+            .tmux_command(&self.socket, &["-V"])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output()
             .context("tmux is not installed or not in PATH")?;
 
         if !output.status.success() {
-            bail!("tmux -V failed");
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("tmux -V failed: {}", stderr.trim());
         }
 
         let version_str = String::from_utf8_lossy(&output.stdout);
-        let version_str = version_str.trim();
-        // Parse "tmux X.Y" or "tmux X.Ya" (e.g., "tmux 3.4" or "tmux 3.3a")
-        let version_part = version_str.strip_prefix("tmux ").unwrap_or(version_str);
-
-        let parts: Vec<&str> = version_part.split('.').collect();
-        if parts.len() < 2 {
-            bail!("Cannot parse tmux version from: {version_str}");
-        }
-
-        let major: u32 = parts[0].parse().context(format!(
-            "Cannot parse tmux major version from: {version_str}"
-        ))?;
-        // Minor might have a trailing letter (e.g., "3a"), strip non-digits.
-        let minor_str: String = parts[1]
-            .chars()
-            .take_while(|c| c.is_ascii_digit())
-            .collect();
-        let minor: u32 = minor_str.parse().context(format!(
-            "Cannot parse tmux minor version from: {version_str}"
-        ))?;
+        let (major, minor) = parse_tmux_version(version_str.trim())?;
 
         if (major, minor) < MIN_TMUX_VERSION {
             bail!(
@@ -673,35 +739,27 @@ impl SessionBackend for LocalTmuxBackend {
             );
         }
 
-        debug!("tmux version: {version_str}");
+        debug!("tmux version: {}", version_str.trim());
         Ok(())
     }
 
     fn ensure_ready(&self) -> Result<()> {
         if !self.session_exists() {
-            debug!("Creating tmux session '{TMUX_SESSION}' on socket '{TMUX_SOCKET}'");
-            let output = Command::new("tmux")
-                .arg("-L")
-                .arg(TMUX_SOCKET)
-                .args([
-                    "new-session",
-                    "-d",
-                    "-s",
-                    TMUX_SESSION,
-                    "-x",
-                    "80",
-                    "-y",
-                    "24",
-                ])
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output()
-                .context("Failed to create tmux session")?;
-
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                bail!("Failed to create tmux session: {}", stderr.trim());
-            }
+            debug!(
+                "Creating tmux session '{}' on socket '{}'",
+                self.session, self.socket
+            );
+            self.run_tmux(&[
+                "new-session",
+                "-d",
+                "-s",
+                &self.session,
+                "-x",
+                "80",
+                "-y",
+                "24",
+            ])
+            .context("Failed to create tmux session")?;
 
             self.apply_config()?;
         }
@@ -713,7 +771,11 @@ impl SessionBackend for LocalTmuxBackend {
             .map_err(|e| anyhow::anyhow!("control lock: {e}"))?;
         if guard.is_none() {
             debug!("Starting tmux control mode");
-            *guard = Some(ControlMode::start()?);
+            *guard = Some(ControlMode::start(
+                &self.transport,
+                &self.socket,
+                &self.session,
+            )?);
         }
 
         Ok(())
@@ -740,8 +802,9 @@ impl SessionBackend for LocalTmuxBackend {
             .map(|(k, v)| format!(" -e {}", shell_escape(&format!("{k}={v}"))))
             .collect();
         let escaped_window_name = shell_escape(window_name);
+        let session = &self.session;
         let cmd = format!(
-            "new-window -t {TMUX_SESSION} -n {escaped_window_name} -P -F '#{{pane_id}}'{cwd_part}{env_part} {shell_cmd}"
+            "new-window -t {session} -n {escaped_window_name} -P -F '#{{pane_id}}'{cwd_part}{env_part} {shell_cmd}"
         );
         let result = self.ctrl_command(&cmd)?;
         let pane_id = result.trim().to_string();
@@ -774,13 +837,14 @@ impl SessionBackend for LocalTmuxBackend {
                 .map_err(|e| anyhow::anyhow!("control lock: {e}"))?;
             if let Some(ref ctrl) = *guard {
                 ctrl.send_command(&format!(
-                    "list-windows -t {TMUX_SESSION} -F '#{{pane_id}}|#{{window_name}}|#{{pane_dead}}'"
+                    "list-windows -t {} -F '#{{pane_id}}|#{{window_name}}|#{{pane_dead}}'",
+                    self.session
                 ))?
             } else {
                 self.tmux_output(&[
                     "list-windows",
                     "-t",
-                    TMUX_SESSION,
+                    &self.session,
                     "-F",
                     "#{pane_id}|#{window_name}|#{pane_dead}",
                 ])?
@@ -1239,6 +1303,28 @@ mod tests {
     #[test]
     fn shell_escape_tool_pattern() {
         assert_eq!(shell_escape("Read Bash(git:*)"), "'Read Bash(git:*)'");
+    }
+
+    // --- parse_tmux_version tests ---
+
+    #[test]
+    fn parse_tmux_version_plain() {
+        assert_eq!(parse_tmux_version("tmux 3.4").unwrap(), (3, 4));
+    }
+
+    #[test]
+    fn parse_tmux_version_trailing_letter() {
+        assert_eq!(parse_tmux_version("tmux 3.3a").unwrap(), (3, 3));
+    }
+
+    #[test]
+    fn parse_tmux_version_without_prefix() {
+        assert_eq!(parse_tmux_version("3.2").unwrap(), (3, 2));
+    }
+
+    #[test]
+    fn parse_tmux_version_rejects_garbage() {
+        assert!(parse_tmux_version("not a version").is_err());
     }
 
     // --- build_shell_command tests ---

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -1259,6 +1259,33 @@ pub fn spawn_window(
     Ok(())
 }
 
+/// Headless spawn of an agent window on a remote host over SSH.
+///
+/// Returns the remote tmux pane id (`%N`). Unlike the local [`spawn_window`]
+/// (which leaves `backend_id` empty for the TUI to resolve by name), this drives
+/// the SSH backend's control mode to learn the real pane id up front. The
+/// control-mode connection is dropped when this returns; the remote tmux keeps
+/// the window alive for the TUI to adopt later.
+pub fn spawn_window_remote(
+    host: &crate::session::HostDef,
+    session_name: &str,
+    command: &str,
+    args: &[String],
+    cwd: Option<&Path>,
+    env: &HashMap<String, String>,
+) -> Result<String> {
+    let backend = TmuxBackend::from_host(host);
+    backend
+        .check_available()
+        .context("remote host is unreachable or tmux is missing")?;
+    backend.ensure_ready()?;
+    let window_name = agent_window_name(session_name);
+    // Headless: no live terminal, so use a sane default geometry. The TUI
+    // resizes the pane to its real dimensions when it adopts the session.
+    let spawned = backend.spawn(&window_name, command, args, cwd, env, 24, 80)?;
+    Ok(spawned.backend_id)
+}
+
 /// Kill the tmux window `tb-<session_name>` if it exists.
 pub fn kill_window(session_name: &str) -> Result<()> {
     let target = window_target(session_name);

--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -1,0 +1,123 @@
+//! Transport seam for the tmux backend.
+//!
+//! The tmux control-mode protocol is identical whether tmux runs on the local
+//! machine or on a remote host reached over SSH (see [`crate::agent::control_mode`]).
+//! The *only* thing that differs is how the `tmux` process is launched: a bare
+//! `Command::new("tmux")` locally, or `ssh <dest> tmux …` remotely.
+//!
+//! [`TmuxTransport`] captures exactly that difference and nothing else. It builds
+//! [`Command`]s; it never touches I/O, threading, or the protocol.
+
+use std::process::Command;
+
+use crate::agent::control_mode::shell_escape;
+
+/// How to launch `tmux` for a backend: directly, or wrapped in `ssh`.
+#[derive(Debug, Clone)]
+pub enum TmuxTransport {
+    /// Run tmux on the local machine.
+    Local,
+    /// Run tmux on a remote host over SSH. `destination` is an ssh target
+    /// (resolved via the user's `~/.ssh/config`); `ssh_opts` are extra flags
+    /// (e.g. `-o ControlMaster=auto`) inserted before the destination.
+    Ssh {
+        destination: String,
+        ssh_opts: Vec<String>,
+    },
+}
+
+impl TmuxTransport {
+    /// Build a [`Command`] running `tmux -L <socket> <args…>`, wrapped in `ssh`
+    /// for the remote variant.
+    ///
+    /// For the SSH variant the remote command tokens are re-split by the remote
+    /// login shell, so each token is shell-escaped to survive intact. Simple
+    /// tokens (`tmux`, `-L`, the socket name) pass through unquoted.
+    pub fn tmux_command(&self, socket: &str, args: &[&str]) -> Command {
+        match self {
+            TmuxTransport::Local => {
+                let mut cmd = Command::new("tmux");
+                cmd.arg("-L").arg(socket).args(args);
+                cmd
+            }
+            TmuxTransport::Ssh {
+                destination,
+                ssh_opts,
+            } => {
+                let mut cmd = Command::new("ssh");
+                cmd.args(ssh_opts);
+                cmd.arg(destination);
+                cmd.arg(shell_escape("tmux"));
+                cmd.arg(shell_escape("-L"));
+                cmd.arg(shell_escape(socket));
+                for a in args {
+                    cmd.arg(shell_escape(a));
+                }
+                cmd
+            }
+        }
+    }
+
+    /// Whether this transport reaches tmux over SSH.
+    pub fn is_remote(&self) -> bool {
+        matches!(self, TmuxTransport::Ssh { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn program_and_args(cmd: &Command) -> (String, Vec<String>) {
+        let prog = cmd.get_program().to_string_lossy().into_owned();
+        let args = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        (prog, args)
+    }
+
+    #[test]
+    fn local_builds_bare_tmux() {
+        let t = TmuxTransport::Local;
+        let cmd = t.tmux_command("thurbox", &["has-session", "-t", "thurbox"]);
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "tmux");
+        assert_eq!(args, ["-L", "thurbox", "has-session", "-t", "thurbox"]);
+    }
+
+    #[test]
+    fn ssh_wraps_tmux_with_opts_and_destination() {
+        let t = TmuxTransport::Ssh {
+            destination: "me@devbox".into(),
+            ssh_opts: vec!["-o".into(), "ControlMaster=auto".into()],
+        };
+        let cmd = t.tmux_command("thurbox", &["has-session", "-t", "thurbox"]);
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "ssh");
+        assert_eq!(
+            args,
+            [
+                "-o",
+                "ControlMaster=auto",
+                "me@devbox",
+                "tmux",
+                "-L",
+                "thurbox",
+                "has-session",
+                "-t",
+                "thurbox",
+            ]
+        );
+    }
+
+    #[test]
+    fn is_remote_reflects_variant() {
+        assert!(!TmuxTransport::Local.is_remote());
+        assert!(TmuxTransport::Ssh {
+            destination: "h".into(),
+            ssh_opts: vec![],
+        }
+        .is_remote());
+    }
+}

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -108,6 +108,12 @@ impl App {
             return;
         }
 
+        // Host picker modal captures all input
+        if matches!(self.modal, super::modals::Modal::HostPicker(_)) {
+            self.handle_host_picker_key(code);
+            return;
+        }
+
         // Theme picker modal captures all input
         if matches!(self.modal, super::modals::Modal::ThemePicker(_)) {
             self.handle_theme_picker_key(code);
@@ -699,6 +705,41 @@ impl App {
         }
     }
 
+    fn handle_host_picker_key(&mut self, code: KeyCode) {
+        let super::modals::Modal::HostPicker(ref mut hp) = self.modal else {
+            return;
+        };
+        let choice_count = hp.choices.len();
+        match code {
+            KeyCode::Esc => {
+                self.modal.close();
+                self.pending_backend = None;
+            }
+            KeyCode::Char('j') | KeyCode::Down if hp.selected_index + 1 < choice_count => {
+                hp.selected_index += 1;
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                hp.selected_index = hp.selected_index.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                let backend = hp
+                    .choices
+                    .get(hp.selected_index)
+                    .map(|c| c.backend.clone())
+                    .unwrap_or_default();
+                self.modal.close();
+                // Empty backend == local default.
+                self.pending_backend = if backend.is_empty() {
+                    None
+                } else {
+                    Some(backend)
+                };
+                self.open_repo_picker();
+            }
+            _ => {}
+        }
+    }
+
     fn handle_agent_picker_key(&mut self, code: KeyCode) {
         let super::modals::Modal::AgentPicker(ref mut ap) = self.modal else {
             return;
@@ -747,7 +788,7 @@ impl App {
                 if self.focus == InputFocus::Automations {
                     self.open_automation_editor();
                 } else {
-                    self.open_repo_picker();
+                    self.start_new_session();
                 }
                 true
             }
@@ -887,17 +928,25 @@ impl App {
     }
 
     pub(crate) fn start_branch_selection(&mut self) {
-        let Some(repo_path) = self.pending_repo_path.as_ref() else {
+        // Resolve the remote host (if any) so branch listing targets the
+        // session's machine. Cloned so we don't hold a borrow on `self`.
+        let host = self
+            .host_for_backend(self.pending_backend.as_deref())
+            .cloned();
+        let host = host.as_ref();
+
+        let Some(repo_path) = self.pending_repo_path.clone() else {
             return;
         };
+        let repo_path = repo_path.as_path();
 
         // Fetch origin so branches are up-to-date. Non-fatal on failure.
-        if let Err(e) = crate::git::git_fetch(repo_path) {
+        if let Err(e) = crate::git::git_fetch_on(host, repo_path) {
             warn!("git fetch origin failed (continuing): {e:#}");
         }
-        if let Some(ref all_repos) = self.pending_all_repos {
+        if let Some(all_repos) = self.pending_all_repos.clone() {
             for extra_repo in all_repos.iter().skip(1) {
-                if let Err(e) = crate::git::git_fetch(extra_repo) {
+                if let Err(e) = crate::git::git_fetch_on(host, extra_repo) {
                     warn!(
                         "git fetch origin failed for {} (continuing): {e:#}",
                         extra_repo.display()
@@ -906,14 +955,14 @@ impl App {
             }
         }
 
-        match crate::git::list_branches(repo_path) {
+        match crate::git::list_branches_on(host, repo_path) {
             Ok(branches) if branches.is_empty() => {
                 self.set_error("No branches found in repository");
                 self.pending_repo_path = None;
             }
             Ok(mut branches) => {
                 // Move the default branch to front so it's pre-selected.
-                if let Some(default) = crate::git::default_branch(repo_path, &branches) {
+                if let Some(default) = crate::git::default_branch_on(host, repo_path, &branches) {
                     if let Some(pos) = branches.iter().position(|b| b == &default) {
                         let branch = branches.remove(pos);
                         branches.insert(0, branch);
@@ -921,11 +970,11 @@ impl App {
                 }
 
                 // Insert origin/<default> at position 0 for remote-based branching.
-                let remote_ref = crate::git::default_branch_from_remote(repo_path)
+                let remote_ref = crate::git::default_branch_from_remote_on(host, repo_path)
                     .map(|name| format!("origin/{name}"))
                     .or_else(|| {
                         for candidate in ["origin/main", "origin/master"] {
-                            if crate::git::branch_exists(repo_path, candidate) {
+                            if crate::git::branch_exists_on(host, repo_path, candidate) {
                                 return Some(candidate.to_string());
                             }
                         }
@@ -1053,9 +1102,19 @@ impl App {
                 return;
             }
             KeyCode::Enter => {
+                // For a remote target the path is a remote path: don't expand
+                // `~` against the local home, and don't pollute local bookmarks.
+                let remote = self.pending_backend.is_some();
+                let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
+                    return;
+                };
                 let path = rp.path_input.value().trim().to_string();
                 if !path.is_empty() {
-                    let expanded = paths::expand_tilde(&path);
+                    let expanded = if remote {
+                        std::path::PathBuf::from(&path)
+                    } else {
+                        paths::expand_tilde(&path)
+                    };
                     // Add to bookmarks list if not already present
                     if !rp.bookmarks.contains(&expanded) {
                         rp.bookmarks.push(expanded.clone());
@@ -1067,9 +1126,11 @@ impl App {
                             rp.selected[idx] = true;
                         }
                     }
-                    // Persist as bookmark
-                    if let Err(e) = self.db.upsert_repo_bookmark(&expanded) {
-                        error!("Failed to save repo bookmark: {e}");
+                    // Persist as bookmark (local targets only).
+                    if !remote {
+                        if let Err(e) = self.db.upsert_repo_bookmark(&expanded) {
+                            error!("Failed to save repo bookmark: {e}");
+                        }
                     }
                     let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
                         return;
@@ -1193,10 +1254,14 @@ impl App {
         self.modal.close();
 
         if worktree_repos.is_empty() && normal_repos.is_empty() {
-            // No repos selected — spawn with HOME as cwd
+            // No repos selected — spawn with HOME as cwd. For a remote target,
+            // leave cwd unset so the remote session starts in its own default
+            // directory (local $HOME is meaningless there).
             let mut config = SessionConfig::default();
-            if let Some(home) = std::env::var_os("HOME") {
-                config.cwd = Some(std::path::PathBuf::from(home));
+            if self.pending_backend.is_none() {
+                if let Some(home) = std::env::var_os("HOME") {
+                    config.cwd = Some(std::path::PathBuf::from(home));
+                }
             }
             self.spawn_session_with_config(&config);
         } else if !worktree_repos.is_empty() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1204,6 +1204,30 @@ impl App {
         }
     }
 
+    /// Resolve the backend a session should spawn on, ensuring it is ready.
+    ///
+    /// Looks up `config.backend` in the registry (falling back to the default
+    /// local backend), then calls `ensure_ready()` so a remote backend's SSH
+    /// control-mode connection is established lazily on first use. Returns a
+    /// status-line-friendly error if the backend is unknown or unreachable.
+    pub(crate) fn backend_for(
+        &self,
+        config: &SessionConfig,
+    ) -> Result<Arc<dyn SessionBackend>, String> {
+        let backend = match config.backend.as_deref() {
+            Some(name) if !name.is_empty() => self
+                .backends
+                .get(name)
+                .cloned()
+                .ok_or_else(|| format!("Unknown backend '{name}'"))?,
+            _ => self.backends.default_backend().clone(),
+        };
+        backend
+            .ensure_ready()
+            .map_err(|e| format!("Backend '{}' not ready: {e:#}", backend.name()))?;
+        Ok(backend)
+    }
+
     pub(crate) fn do_spawn_session(
         &mut self,
         name: String,
@@ -1234,7 +1258,14 @@ impl App {
             );
         }
 
-        let backend: Arc<dyn SessionBackend> = Arc::clone(self.backends.default_backend());
+        let backend = match self.backend_for(&config) {
+            Ok(b) => b,
+            Err(e) => {
+                error!("Failed to select backend: {e}");
+                self.set_error(e);
+                return;
+            }
+        };
 
         let provider = self.provider_for(&config);
         match Session::spawn(name, rows, cols, &config, &backend, &provider) {
@@ -2878,6 +2909,38 @@ mod tests {
             app.active_index = 0;
         }
         app
+    }
+
+    #[test]
+    fn backend_for_defaults_to_registry_default() {
+        let app = app_with_sessions(0);
+        let config = SessionConfig::default();
+        let backend = app.backend_for(&config).expect("default backend");
+        assert_eq!(backend.name(), "stub");
+    }
+
+    #[test]
+    fn backend_for_empty_name_uses_default() {
+        let app = app_with_sessions(0);
+        let config = SessionConfig {
+            backend: Some(String::new()),
+            ..SessionConfig::default()
+        };
+        let backend = app.backend_for(&config).expect("default backend");
+        assert_eq!(backend.name(), "stub");
+    }
+
+    #[test]
+    fn backend_for_unknown_backend_errors() {
+        let app = app_with_sessions(0);
+        let config = SessionConfig {
+            backend: Some("ssh:does-not-exist".into()),
+            ..SessionConfig::default()
+        };
+        match app.backend_for(&config) {
+            Ok(b) => panic!("expected error, got backend {}", b.name()),
+            Err(err) => assert!(err.contains("Unknown backend"), "got: {err}"),
+        }
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1802,7 +1802,20 @@ impl App {
 
             let discovered = discovered_by_backend
                 .entry(shared_session.backend_type.clone())
-                .or_insert_with(|| backend.discover().unwrap_or_default());
+                .or_insert_with(|| {
+                    // A remote backend needs its control-mode connection up
+                    // before adopt(); ready it lazily on first use here.
+                    match backend.ensure_ready() {
+                        Ok(()) => backend.discover().unwrap_or_default(),
+                        Err(e) => {
+                            tracing::warn!(
+                                backend = backend.name(),
+                                "Backend not ready for adopted session: {e}"
+                            );
+                            Vec::new()
+                        }
+                    }
+                });
             let matching_discovered = Self::find_matching_discovered(&shared_session, discovered);
 
             let (rows, cols) = self.content_area_size();
@@ -2015,34 +2028,62 @@ impl App {
 
     /// Restore sessions from the database on startup.
     ///
-    /// All sessions live on the local-tmux backend and are restored
-    /// synchronously by querying tmux for existing windows.
+    /// Sessions are restored synchronously by querying each session's backend
+    /// for its existing tmux windows. Sessions persisted with a remote
+    /// (`ssh:<host>`) `backend_type` are matched against that host's tmux, not
+    /// the local one; a remote backend whose host is unreachable degrades to
+    /// "no discovered windows" so its sessions are skipped rather than blocking
+    /// startup.
     pub fn restore_sessions(&mut self, sessions: Vec<sync::SharedSession>, session_counter: usize) {
         self.session_counter = session_counter;
 
-        let mut local_sessions = Vec::new();
-        for shared in sessions {
-            if shared.agent_session_id.is_none() {
-                continue; // Skip sessions without a claude session ID
+        // Only sessions with an agent_session_id are resumable.
+        let resumable: Vec<sync::SharedSession> = sessions
+            .into_iter()
+            .filter(|s| s.agent_session_id.is_some())
+            .collect();
+
+        // Discover existing windows per backend. Each distinct backend_type is
+        // readied + discovered at most once (a remote backend needs its
+        // control-mode connection up before adopt()).
+        let mut discovered_by_backend: HashMap<
+            String,
+            Vec<crate::agent::backend::DiscoveredSession>,
+        > = HashMap::new();
+        for shared in &resumable {
+            if discovered_by_backend.contains_key(&shared.backend_type) {
+                continue;
             }
-            local_sessions.push(shared);
+            let backend = self
+                .backends
+                .get(&shared.backend_type)
+                .cloned()
+                .unwrap_or_else(|| self.backends.default_backend().clone());
+
+            let disc = match backend.ensure_ready() {
+                Ok(()) => backend.discover().unwrap_or_else(|e| {
+                    warn!(
+                        backend = backend.name(),
+                        "Failed to discover sessions from backend: {e}"
+                    );
+                    Vec::new()
+                }),
+                Err(e) => {
+                    warn!(
+                        backend = backend.name(),
+                        "Backend not ready during restore; skipping its sessions: {e}"
+                    );
+                    Vec::new()
+                }
+            };
+            discovered_by_backend.insert(shared.backend_type.clone(), disc);
         }
 
-        // --- Local-tmux sessions: restore synchronously (fast) ---
-        // Discover existing sessions from the default (local-tmux) backend only.
-        let mut discovered = Vec::new();
-        let default_backend = self.backends.default_backend().clone();
-        match default_backend.discover() {
-            Ok(disc) => discovered.extend(disc),
-            Err(e) => {
-                warn!(
-                    backend = default_backend.name(),
-                    "Failed to discover sessions from backend: {e}"
-                );
-            }
-        }
-
-        for shared in local_sessions {
+        for shared in resumable {
+            let discovered = discovered_by_backend
+                .get(&shared.backend_type)
+                .cloned()
+                .unwrap_or_default();
             self.restore_single_session(shared, &discovered);
         }
 
@@ -2050,7 +2091,8 @@ impl App {
         self.save_state();
     }
 
-    /// Restore a single local-tmux session synchronously (used during startup).
+    /// Restore a single session synchronously (used during startup). The
+    /// backend is selected from the session's persisted `backend_type`.
     fn restore_single_session(
         &mut self,
         shared: sync::SharedSession,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -260,6 +260,13 @@ pub struct App {
     /// Registry of declarative agent definitions, used to build providers per
     /// session at spawn/restart time.
     pub(crate) agents: AgentRegistry,
+    /// Configured remote SSH hosts (from `hosts.toml`), used to resolve the
+    /// `HostDef` for a session's `ssh:<host>` backend when running git over SSH.
+    pub(crate) hosts: crate::session::HostRegistry,
+    /// Backend chosen for the in-progress new-session flow (`ssh:<host>`), or
+    /// `None` for the local default. Set by the host picker, cleared when the
+    /// flow completes or is cancelled.
+    pub(crate) pending_backend: Option<String>,
     pub(crate) db: Database,
     pub(crate) focus: InputFocus,
     pub(crate) should_quit: bool,
@@ -386,6 +393,8 @@ impl App {
             active_index: 0,
             backends,
             agents,
+            hosts: crate::session::HostRegistry::default(),
+            pending_backend: None,
             db,
             focus: InputFocus::SessionList,
             should_quit: false,
@@ -459,22 +468,66 @@ impl App {
         Arc::new(GenericProvider::new(def))
     }
 
+    /// Entry point for the new-session wizard.
+    ///
+    /// When remote hosts are configured (`hosts.toml`), first shows the host
+    /// picker so the user can choose where the session runs; otherwise goes
+    /// straight to the repo picker (preserving the local-only UX).
+    pub(crate) fn start_new_session(&mut self) {
+        // Clear any choice left over from a previously cancelled flow.
+        self.pending_backend = None;
+
+        if self.hosts.is_empty() {
+            self.open_repo_picker();
+            return;
+        }
+
+        let mut choices = vec![crate::ui::host_picker_modal::HostChoice {
+            label: "local".to_string(),
+            backend: String::new(),
+        }];
+        for host in &self.hosts.hosts {
+            choices.push(crate::ui::host_picker_modal::HostChoice {
+                label: format!("{}  ({})", host.name, host.destination),
+                backend: host.backend_name(),
+            });
+        }
+        self.modal = modals::Modal::HostPicker(crate::ui::host_picker_modal::HostPickerState {
+            choices,
+            selected_index: 0,
+        });
+    }
+
     /// Open the repo picker modal for creating a new session.
     ///
     /// Loads bookmarks from the database, pre-selects repos from the active
-    /// project (if any), and shows the repo picker modal.
+    /// project (if any), and shows the repo picker modal. For a remote target
+    /// (`pending_backend` set) local bookmarks don't apply, so the picker opens
+    /// empty with the path input focused for a typed remote path.
     pub(crate) fn open_repo_picker(&mut self) {
-        let bookmarks = match self.db.list_repo_bookmarks() {
-            Ok(b) => b.into_iter().map(|bm| bm.repo_path).collect::<Vec<_>>(),
-            Err(e) => {
-                tracing::error!("Failed to load repo bookmarks: {e}");
-                Vec::new()
+        // Local bookmarks point at local paths, so they're meaningless for a
+        // remote target: open the picker empty with the path input focused.
+        let remote = self.pending_backend.is_some();
+        let bookmarks = if remote {
+            Vec::new()
+        } else {
+            match self.db.list_repo_bookmarks() {
+                Ok(b) => b.into_iter().map(|bm| bm.repo_path).collect::<Vec<_>>(),
+                Err(e) => {
+                    tracing::error!("Failed to load repo bookmarks: {e}");
+                    Vec::new()
+                }
             }
         };
 
         let selected = vec![false; bookmarks.len()];
         let worktree = vec![false; bookmarks.len()];
         let filtered_indices = (0..bookmarks.len()).collect();
+        let focus = if remote {
+            modals::RepoPickerFocus::Input
+        } else {
+            modals::RepoPickerFocus::default()
+        };
         self.modal = modals::Modal::RepoPicker(modals::RepoPickerModal {
             bookmarks,
             selected,
@@ -482,7 +535,7 @@ impl App {
             list_index: 0,
             path_input: modals::TextInput::new(),
             path_suggestion: None,
-            focus: modals::RepoPickerFocus::default(),
+            focus,
             search_input: modals::TextInput::new(),
             filtered_indices,
         });
@@ -495,7 +548,12 @@ impl App {
     }
 
     pub(crate) fn spawn_session_with_config(&mut self, config: &SessionConfig) {
-        self.prepare_spawn(config.clone(), Vec::new());
+        let mut config = config.clone();
+        // Apply the host chosen in the new-session wizard (None = local).
+        if config.backend.is_none() {
+            config.backend = self.pending_backend.take();
+        }
+        self.prepare_spawn(config, Vec::new());
     }
 
     /// Route session creation through the name modal, then agent selection.
@@ -1158,11 +1216,16 @@ impl App {
         base_branch: &str,
         session_name: Option<String>,
     ) {
+        // Resolve the remote host (if any) so worktrees are created on the
+        // session's target machine over SSH. Consume the wizard's choice.
+        let backend = self.pending_backend.take();
+        let host = self.host_for_backend(backend.as_deref()).cloned();
+
         let mut worktree_infos = Vec::new();
         let mut worktree_paths = Vec::new();
 
         for repo_path in repo_paths {
-            match git::create_worktree(repo_path, new_branch, base_branch) {
+            match git::create_worktree_on(host.as_ref(), repo_path, new_branch, base_branch) {
                 Ok(worktree_path) => {
                     worktree_infos.push(WorktreeInfo {
                         repo_path: repo_path.clone(),
@@ -1174,8 +1237,11 @@ impl App {
                 Err(e) => {
                     // Roll back already-created worktrees
                     for info in &worktree_infos {
-                        if let Err(re) = git::remove_worktree(&info.repo_path, &info.worktree_path)
-                        {
+                        if let Err(re) = git::remove_worktree_on(
+                            host.as_ref(),
+                            &info.repo_path,
+                            &info.worktree_path,
+                        ) {
                             error!("Failed to roll back worktree: {re}");
                         }
                     }
@@ -1193,6 +1259,7 @@ impl App {
         self.pending_additional_dirs = additional_dirs;
         let config = SessionConfig {
             cwd: Some(worktree_paths[0].clone()),
+            backend,
             ..SessionConfig::default()
         };
 
@@ -1201,6 +1268,29 @@ impl App {
             self.finish_prepare_spawn(name, config, worktree_infos);
         } else {
             self.prepare_spawn(config, worktree_infos);
+        }
+    }
+
+    /// Install the configured remote-host registry (from `hosts.toml`). Called
+    /// once at startup after the SSH backends are registered.
+    pub fn set_hosts(&mut self, hosts: crate::session::HostRegistry) {
+        self.hosts = hosts;
+    }
+
+    /// Resolve the [`HostDef`] for a backend name, or `None` for the local
+    /// backend. Used to run git operations (worktree create/remove, branch
+    /// listing) on the correct host.
+    ///
+    /// [`HostDef`]: crate::session::HostDef
+    pub(crate) fn host_for_backend(
+        &self,
+        backend: Option<&str>,
+    ) -> Option<&crate::session::HostDef> {
+        let name = backend?;
+        if name.starts_with(crate::session::SSH_BACKEND_PREFIX) {
+            self.hosts.get_by_backend(name)
+        } else {
+            None
         }
     }
 
@@ -2951,6 +3041,64 @@ mod tests {
             app.active_index = 0;
         }
         app
+    }
+
+    #[test]
+    fn start_new_session_skips_host_picker_when_no_hosts() {
+        let mut app = app_with_sessions(0);
+        app.start_new_session();
+        // No hosts configured → straight to the repo picker, no host step.
+        assert!(matches!(app.modal, modals::Modal::RepoPicker(_)));
+        assert!(app.pending_backend.is_none());
+    }
+
+    #[test]
+    fn start_new_session_shows_host_picker_with_hosts() {
+        let mut app = app_with_sessions(0);
+        app.set_hosts(crate::session::HostRegistry {
+            hosts: vec![crate::session::HostDef {
+                name: "devbox".into(),
+                destination: "me@devbox".into(),
+                socket: None,
+                session: None,
+                ssh_opts: vec![],
+                worktrees_dir: None,
+            }],
+        });
+        app.start_new_session();
+        match app.modal {
+            modals::Modal::HostPicker(ref hp) => {
+                // "local" first, then each ssh host.
+                assert_eq!(hp.choices.len(), 2);
+                assert_eq!(hp.choices[0].backend, "");
+                assert_eq!(hp.choices[1].backend, "ssh:devbox");
+            }
+            ref other => panic!("expected host picker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn host_for_backend_resolves_ssh_only() {
+        let mut app = app_with_sessions(0);
+        app.set_hosts(crate::session::HostRegistry {
+            hosts: vec![crate::session::HostDef {
+                name: "devbox".into(),
+                destination: "me@devbox".into(),
+                socket: None,
+                session: None,
+                ssh_opts: vec![],
+                worktrees_dir: None,
+            }],
+        });
+        assert!(app.host_for_backend(None).is_none());
+        assert!(app.host_for_backend(Some("local-tmux")).is_none());
+        assert_eq!(
+            app.host_for_backend(Some("ssh:devbox"))
+                .unwrap()
+                .destination,
+            "me@devbox"
+        );
+        assert!(app.host_for_backend(Some("ssh:unknown")).is_none());
     }
 
     #[test]

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -600,6 +600,7 @@ pub enum Modal {
     BranchSelector(BranchSelectorModal),
     WorktreeName(WorktreeNameModal),
     AgentPicker(crate::ui::agent_picker_modal::AgentPickerState),
+    HostPicker(crate::ui::host_picker_modal::HostPickerState),
     RestoreSessions(RestoreSessionsModal),
     AutomationEditor(AutomationEditorModal),
     AutomationsList(AutomationsListModal),

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -273,6 +273,11 @@ impl App {
             agent_picker_modal::render_agent_picker_modal(frame, ap);
         }
 
+        // Host picker modal
+        if let super::modals::Modal::HostPicker(ref hp) = self.modal {
+            crate::ui::host_picker_modal::render_host_picker_modal(frame, hp);
+        }
+
         // Theme picker modal
         if let super::modals::Modal::ThemePicker(ref tp) = self.modal {
             theme_picker_modal::render_theme_picker_modal(

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -321,6 +321,7 @@ fn fire_headless(db: &Database, auto: &Automation) -> (AutomationRunStatus, Stri
                 base_branch: base_branch.clone(),
                 agent: agent.clone(),
                 agent_session_id: None,
+                host: None,
             };
             match crate::session_ops::spawn_session_headless(db, req) {
                 Ok(_) => {

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -36,6 +36,10 @@ pub enum Action {
         /// Base branch for the worktree (default: main).
         #[arg(long)]
         base_branch: Option<String>,
+        /// Remote host to run the session on (name from `hosts.toml`). The
+        /// worktree and tmux window are created on that host over SSH.
+        #[arg(long)]
+        host: Option<String>,
     },
     /// Soft-delete a session.
     ///
@@ -99,6 +103,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             agent,
             worktree_branch,
             base_branch,
+            host,
         } => {
             let req = crate::session_ops::SpawnRequest {
                 name,
@@ -107,6 +112,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 base_branch,
                 agent,
                 agent_session_id: None,
+                host,
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
             Ok(json!({

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -422,9 +422,12 @@ fn git_stash(worktree_path: &Path) -> Result<bool> {
 
 /// Fetch from origin.
 pub fn git_fetch(worktree_path: &Path) -> Result<()> {
-    let output = Command::new("git")
-        .args(["fetch", "origin"])
-        .current_dir(worktree_path)
+    git_fetch_on(None, worktree_path)
+}
+
+/// [`git_fetch`], optionally on a remote `host`.
+pub fn git_fetch_on(host: Option<&HostDef>, worktree_path: &Path) -> Result<()> {
+    let output = git_command(host, worktree_path, &["fetch", "origin"])
         .output()
         .context("failed to run git fetch")?;
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -3,13 +3,114 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tracing::warn;
 
 use crate::paths;
+use crate::session::HostDef;
+
+/// POSIX single-quote escaping for a token sent to a remote shell over SSH.
+/// Simple tokens (paths, branch names, flags) pass through unquoted.
+fn sh_quote(s: &str) -> String {
+    if !s.is_empty()
+        && s.bytes().all(|b| {
+            b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'/' | b':' | b'=' | b',')
+        })
+    {
+        return s.to_string();
+    }
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Build a `git` [`Command`] targeting `cwd`, run either locally or over SSH.
+///
+/// For the remote variant the command becomes
+/// `ssh <opts> <dest> git -C <cwd> <args…>`, with each remote token
+/// shell-escaped so it survives the remote login shell's re-splitting.
+fn git_command(host: Option<&HostDef>, cwd: &Path, args: &[&str]) -> Command {
+    match host {
+        None => {
+            let mut cmd = Command::new("git");
+            cmd.current_dir(cwd);
+            cmd.args(args);
+            cmd
+        }
+        Some(h) => {
+            let mut cmd = Command::new("ssh");
+            cmd.args(&h.ssh_opts);
+            cmd.arg(&h.destination);
+            cmd.arg(sh_quote("git"));
+            cmd.arg(sh_quote("-C"));
+            cmd.arg(sh_quote(&cwd.to_string_lossy()));
+            for a in args {
+                cmd.arg(sh_quote(a));
+            }
+            cmd
+        }
+    }
+}
+
+/// Cache of resolved remote `$HOME` directories, keyed by ssh destination, so
+/// we only pay one round-trip per host.
+fn remote_home_cache() -> &'static Mutex<HashMap<String, String>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Resolve the remote `$HOME` for a host, caching the result.
+fn remote_home(host: &HostDef) -> Result<String> {
+    if let Ok(guard) = remote_home_cache().lock() {
+        if let Some(home) = guard.get(&host.destination) {
+            return Ok(home.clone());
+        }
+    }
+    let mut cmd = Command::new("ssh");
+    cmd.args(&host.ssh_opts);
+    cmd.arg(&host.destination);
+    // The remote shell expands $HOME; we pass it literally.
+    cmd.arg("echo").arg("$HOME");
+    let output = cmd
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to resolve remote $HOME over ssh")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("ssh echo $HOME failed: {}", stderr.trim());
+    }
+    let home = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if home.is_empty() {
+        anyhow::bail!("remote $HOME resolved empty for {}", host.destination);
+    }
+    if let Ok(mut guard) = remote_home_cache().lock() {
+        guard.insert(host.destination.clone(), home.clone());
+    }
+    Ok(home)
+}
+
+/// Deterministic worktree directory path for a repo + branch on the given host.
+///
+/// Local hosts use [`worktree_path`]. Remote hosts place worktrees under the
+/// host's `worktrees_dir` (or `$HOME/.local/share/thurbox/worktrees` resolved
+/// over ssh), preserving the same `<repo-hash>/<sanitized-branch>` layout.
+fn worktree_path_for(host: Option<&HostDef>, repo_path: &Path, branch: &str) -> Result<PathBuf> {
+    match host {
+        None => worktree_path(repo_path, branch).context("failed to resolve worktrees directory"),
+        Some(h) => {
+            let base = match &h.worktrees_dir {
+                Some(dir) => dir.clone(),
+                None => format!("{}/.local/share/thurbox/worktrees", remote_home(h)?),
+            };
+            let mut hasher = DefaultHasher::new();
+            repo_path.display().to_string().hash(&mut hasher);
+            let repo_hash = format!("{:016x}", hasher.finish());
+            let sanitized = branch.replace('/', "-");
+            Ok(PathBuf::from(base).join(repo_hash).join(sanitized))
+        }
+    }
+}
 
 /// Global cache for repo display names (path → name).
 static REPO_NAME_CACHE: std::sync::OnceLock<Mutex<HashMap<PathBuf, String>>> =
@@ -82,9 +183,12 @@ fn parse_repo_name_from_url(url: &str) -> Option<String> {
 
 /// List local branch names for a repo.
 pub fn list_branches(repo_path: &Path) -> Result<Vec<String>> {
-    let output = Command::new("git")
-        .args(["branch", "--format=%(refname:short)"])
-        .current_dir(repo_path)
+    list_branches_on(None, repo_path)
+}
+
+/// [`list_branches`], optionally on a remote `host`.
+pub fn list_branches_on(host: Option<&HostDef>, repo_path: &Path) -> Result<Vec<String>> {
+    let output = git_command(host, repo_path, &["branch", "--format=%(refname:short)"])
         .output()
         .context("failed to run git branch")?;
 
@@ -107,21 +211,34 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<String>> {
 /// Creates `new_branch` starting from `base_branch`.
 /// Path format: `~/.local/share/thurbox/worktrees/<repo-hash>/<sanitized-branch>`
 pub fn create_worktree(repo_path: &Path, new_branch: &str, base_branch: &str) -> Result<PathBuf> {
-    let wt_path =
-        worktree_path(repo_path, new_branch).context("failed to resolve worktrees directory")?;
+    create_worktree_on(None, repo_path, new_branch, base_branch)
+}
 
-    let output = Command::new("git")
-        .args([
+/// [`create_worktree`], optionally on a remote `host` (via `ssh <dest> git …`).
+/// On a remote host the worktree is created under the host's remote worktrees
+/// directory and the returned path is a remote path.
+pub fn create_worktree_on(
+    host: Option<&HostDef>,
+    repo_path: &Path,
+    new_branch: &str,
+    base_branch: &str,
+) -> Result<PathBuf> {
+    let wt_path = worktree_path_for(host, repo_path, new_branch)?;
+
+    let output = git_command(
+        host,
+        repo_path,
+        &[
             "worktree",
             "add",
             "-b",
             new_branch,
             &wt_path.display().to_string(),
             base_branch,
-        ])
-        .current_dir(repo_path)
-        .output()
-        .context("failed to run git worktree add")?;
+        ],
+    )
+    .output()
+    .context("failed to run git worktree add")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -133,16 +250,27 @@ pub fn create_worktree(repo_path: &Path, new_branch: &str, base_branch: &str) ->
 
 /// Remove a git worktree (force removal).
 pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
-    let output = Command::new("git")
-        .args([
+    remove_worktree_on(None, repo_path, worktree_path)
+}
+
+/// [`remove_worktree`], optionally on a remote `host`.
+pub fn remove_worktree_on(
+    host: Option<&HostDef>,
+    repo_path: &Path,
+    worktree_path: &Path,
+) -> Result<()> {
+    let output = git_command(
+        host,
+        repo_path,
+        &[
             "worktree",
             "remove",
             "--force",
             &worktree_path.display().to_string(),
-        ])
-        .current_dir(repo_path)
-        .output()
-        .context("failed to run git worktree remove")?;
+        ],
+    )
+    .output()
+    .context("failed to run git worktree remove")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -157,7 +285,16 @@ pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
 /// Tries `git symbolic-ref refs/remotes/origin/HEAD` first (most reliable),
 /// then falls back to checking for `main` or `master` among local branches.
 pub fn default_branch(repo_path: &Path, local_branches: &[String]) -> Option<String> {
-    if let Some(name) = default_branch_from_remote(repo_path) {
+    default_branch_on(None, repo_path, local_branches)
+}
+
+/// [`default_branch`], optionally on a remote `host`.
+pub fn default_branch_on(
+    host: Option<&HostDef>,
+    repo_path: &Path,
+    local_branches: &[String],
+) -> Option<String> {
+    if let Some(name) = default_branch_from_remote_on(host, repo_path) {
         if local_branches.iter().any(|b| b == &name) {
             return Some(name);
         }
@@ -175,12 +312,19 @@ pub fn default_branch(repo_path: &Path, local_branches: &[String]) -> Option<Str
 
 /// Query the remote's default branch via `git symbolic-ref`.
 pub fn default_branch_from_remote(repo_path: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
-        .current_dir(repo_path)
-        .stderr(Stdio::null())
-        .output()
-        .ok()?;
+    default_branch_from_remote_on(None, repo_path)
+}
+
+/// [`default_branch_from_remote`], optionally on a remote `host`.
+pub fn default_branch_from_remote_on(host: Option<&HostDef>, repo_path: &Path) -> Option<String> {
+    let output = git_command(
+        host,
+        repo_path,
+        &["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+    )
+    .stderr(Stdio::null())
+    .output()
+    .ok()?;
 
     if !output.status.success() {
         return None;
@@ -218,9 +362,12 @@ pub fn add_existing_worktree(repo_path: &Path, branch: &str) -> Result<PathBuf> 
 
 /// Check whether a local branch exists in the repository.
 pub fn branch_exists(repo_path: &Path, branch: &str) -> bool {
-    Command::new("git")
-        .args(["rev-parse", "--verify", branch])
-        .current_dir(repo_path)
+    branch_exists_on(None, repo_path, branch)
+}
+
+/// [`branch_exists`], optionally on a remote `host`.
+pub fn branch_exists_on(host: Option<&HostDef>, repo_path: &Path, branch: &str) -> bool {
+    git_command(host, repo_path, &["rev-parse", "--verify", branch])
         .stderr(Stdio::null())
         .stdout(Stdio::null())
         .status()
@@ -721,6 +868,99 @@ mod tests {
 
         try_remove_by_age(&lock);
         assert!(lock.exists(), "fresh lock should be preserved");
+    }
+
+    // ── remote / ssh helpers ────────────────────────────────────────
+
+    fn host(dest: &str, wt_dir: Option<&str>) -> HostDef {
+        HostDef {
+            name: "h".into(),
+            destination: dest.into(),
+            socket: None,
+            session: None,
+            ssh_opts: vec!["-o".into(), "ControlMaster=auto".into()],
+            worktrees_dir: wt_dir.map(|s| s.to_string()),
+        }
+    }
+
+    fn program_and_args(cmd: &Command) -> (String, Vec<String>) {
+        (
+            cmd.get_program().to_string_lossy().into_owned(),
+            cmd.get_args()
+                .map(|a| a.to_string_lossy().into_owned())
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn sh_quote_passes_simple_tokens() {
+        assert_eq!(sh_quote("feat-x"), "feat-x");
+        assert_eq!(sh_quote("/home/me/repo"), "/home/me/repo");
+    }
+
+    #[test]
+    fn sh_quote_wraps_specials() {
+        assert_eq!(sh_quote("a b"), "'a b'");
+        assert_eq!(sh_quote("it's"), "'it'\\''s'");
+        assert_eq!(sh_quote(""), "''");
+    }
+
+    #[test]
+    fn git_command_local_uses_git_with_args() {
+        let cmd = git_command(None, Path::new("/repo"), &["branch", "--list"]);
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "git");
+        assert_eq!(args, ["branch", "--list"]);
+        assert_eq!(cmd.get_current_dir(), Some(Path::new("/repo")));
+    }
+
+    #[test]
+    fn git_command_remote_wraps_in_ssh() {
+        let h = host("me@box", None);
+        let cmd = git_command(
+            Some(&h),
+            Path::new("/srv/repo"),
+            &["worktree", "add", "-b", "x"],
+        );
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "ssh");
+        assert_eq!(
+            args,
+            [
+                "-o",
+                "ControlMaster=auto",
+                "me@box",
+                "git",
+                "-C",
+                "/srv/repo",
+                "worktree",
+                "add",
+                "-b",
+                "x",
+            ]
+        );
+        // No local current_dir is set for the remote variant.
+        assert_eq!(cmd.get_current_dir(), None);
+    }
+
+    #[test]
+    fn worktree_path_for_remote_uses_configured_dir() {
+        let h = host("me@box", Some("/data/wt"));
+        let path = worktree_path_for(Some(&h), Path::new("/srv/repo"), "feature/foo").unwrap();
+        // base / <repo-hash> / <sanitized-branch>
+        let s = path.display().to_string();
+        assert!(s.starts_with("/data/wt/"), "got {s}");
+        assert!(s.ends_with("/feature-foo"), "got {s}");
+    }
+
+    #[test]
+    fn worktree_path_for_local_matches_worktree_path() {
+        let base = PathBuf::from("/test/data");
+        let _guard = TestPathGuard::new(&base);
+        let repo = Path::new("/home/user/repo");
+        let via_for = worktree_path_for(None, repo, "main").unwrap();
+        let direct = worktree_path(repo, "main").unwrap();
+        assert_eq!(via_for, direct);
     }
 
     // ── parse_repo_name_from_url ────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,9 +62,10 @@ async fn main() -> Result<()> {
     // (~/.config/thurbox/hosts.toml). These are registered lazily: a down or
     // slow host must not block TUI startup, so check_available()/ensure_ready()
     // are deferred to first spawn/restore (see App::backend_for).
-    for host in thurbox::agent::host_config::load_or_seed().hosts {
+    let hosts = thurbox::agent::host_config::load_or_seed();
+    for host in &hosts.hosts {
         tracing::debug!(host = %host.name, dest = %host.destination, "Registering SSH backend");
-        backends.register(Arc::new(TmuxBackend::from_host(&host)));
+        backends.register(Arc::new(TmuxBackend::from_host(host)));
     }
 
     // Load (or seed) the coding-agent registry from ~/.config/thurbox/agents.toml.
@@ -94,6 +95,7 @@ async fn main() -> Result<()> {
     let size = terminal.size()?;
 
     let mut app = App::new(size.height, size.width, backends, agents, db);
+    app.set_hosts(hosts);
 
     // Load session state from DB and restore
     if let Some((sessions, counter)) = app.load_persisted_state_from_db() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use crossterm::event::{
 };
 use crossterm::execute;
 
-use thurbox::agent::tmux::LocalTmuxBackend;
+use thurbox::agent::tmux::{LocalTmuxBackend, TmuxBackend};
 use thurbox::agent::{BackendRegistry, SessionBackend};
 use thurbox::app::{App, AppMessage};
 use thurbox::storage::Database;
@@ -56,7 +56,16 @@ async fn main() -> Result<()> {
     let local_tmux: Arc<dyn SessionBackend> = Arc::new(LocalTmuxBackend::new());
     local_tmux.check_available()?;
     local_tmux.ensure_ready()?;
-    let backends = BackendRegistry::new(local_tmux);
+    let mut backends = BackendRegistry::new(local_tmux);
+
+    // Register one SSH backend per configured remote host
+    // (~/.config/thurbox/hosts.toml). These are registered lazily: a down or
+    // slow host must not block TUI startup, so check_available()/ensure_ready()
+    // are deferred to first spawn/restore (see App::backend_for).
+    for host in thurbox::agent::host_config::load_or_seed().hosts {
+        tracing::debug!(host = %host.name, dest = %host.destination, "Registering SSH backend");
+        backends.register(Arc::new(TmuxBackend::from_host(&host)));
+    }
 
     // Load (or seed) the coding-agent registry from ~/.config/thurbox/agents.toml.
     let agents = thurbox::agent::agent_config::load_or_seed();

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -1,0 +1,140 @@
+//! Remote-host definitions — pure data describing SSH targets thurbox can run
+//! sessions on.
+//!
+//! Loaded from `~/.config/thurbox/hosts.toml` by
+//! [`crate::agent::host_config`]. Kept here in `session` (the dependency sink)
+//! so both `agent` (which builds the SSH tmux backend) and `git` (which runs
+//! `git` over SSH for remote worktrees) can depend on the same type without
+//! crossing the module-isolation rules.
+
+use serde::{Deserialize, Serialize};
+
+/// The backend-name prefix for SSH hosts. A host named `devbox` is registered
+/// (and persisted in `backend_type`) as `ssh:devbox`.
+pub const SSH_BACKEND_PREFIX: &str = "ssh:";
+
+/// A single remote host reachable over SSH.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostDef {
+    /// Short, unique name. The backend is registered as `ssh:<name>`.
+    pub name: String,
+    /// SSH destination (e.g. `me@devbox`), resolved via the user's
+    /// `~/.ssh/config`.
+    pub destination: String,
+    /// Optional override for the remote `tmux -L` socket name. Defaults to the
+    /// same socket thurbox uses locally.
+    #[serde(default)]
+    pub socket: Option<String>,
+    /// Optional override for the remote tmux session name.
+    #[serde(default)]
+    pub session: Option<String>,
+    /// Extra `ssh` flags inserted before the destination (e.g.
+    /// `["-o", "ControlMaster=auto"]`).
+    #[serde(default)]
+    pub ssh_opts: Vec<String>,
+    /// Optional absolute remote directory under which git worktrees are
+    /// created. When unset, the remote `$HOME/.local/share/thurbox/worktrees`
+    /// is resolved at spawn time.
+    #[serde(default)]
+    pub worktrees_dir: Option<String>,
+}
+
+impl HostDef {
+    /// The backend name this host registers under: `ssh:<name>`.
+    pub fn backend_name(&self) -> String {
+        format!("{SSH_BACKEND_PREFIX}{}", self.name)
+    }
+}
+
+/// All configured remote hosts, in declaration order.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostRegistry {
+    #[serde(default)]
+    pub hosts: Vec<HostDef>,
+}
+
+impl HostRegistry {
+    /// Look up a host by its bare name (not the `ssh:` backend name).
+    pub fn get(&self, name: &str) -> Option<&HostDef> {
+        self.hosts.iter().find(|h| h.name == name)
+    }
+
+    /// Look up a host by its `ssh:<name>` backend name.
+    pub fn get_by_backend(&self, backend_name: &str) -> Option<&HostDef> {
+        let bare = backend_name.strip_prefix(SSH_BACKEND_PREFIX)?;
+        self.get(bare)
+    }
+
+    /// All host names in declaration order.
+    pub fn names(&self) -> Vec<&str> {
+        self.hosts.iter().map(|h| h.name.as_str()).collect()
+    }
+
+    /// Whether any remote hosts are configured.
+    pub fn is_empty(&self) -> bool {
+        self.hosts.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_name_prefixes_with_ssh() {
+        let h = HostDef {
+            name: "devbox".into(),
+            destination: "me@devbox".into(),
+            socket: None,
+            session: None,
+            ssh_opts: vec![],
+            worktrees_dir: None,
+        };
+        assert_eq!(h.backend_name(), "ssh:devbox");
+    }
+
+    #[test]
+    fn registry_lookup_by_name_and_backend() {
+        let reg = HostRegistry {
+            hosts: vec![HostDef {
+                name: "devbox".into(),
+                destination: "me@devbox".into(),
+                socket: None,
+                session: None,
+                ssh_opts: vec![],
+                worktrees_dir: None,
+            }],
+        };
+        assert_eq!(reg.get("devbox").unwrap().destination, "me@devbox");
+        assert_eq!(reg.get_by_backend("ssh:devbox").unwrap().name, "devbox");
+        assert!(reg.get_by_backend("devbox").is_none());
+        assert!(reg.get_by_backend("local-tmux").is_none());
+    }
+
+    #[test]
+    fn parses_minimal_and_full_toml() {
+        let toml = r#"
+[[hosts]]
+name = "minimal"
+destination = "host1"
+
+[[hosts]]
+name = "full"
+destination = "me@host2"
+socket = "tb2"
+session = "tb2"
+ssh_opts = ["-o", "ControlMaster=auto"]
+worktrees_dir = "/home/me/wt"
+"#;
+        let reg: HostRegistry = toml::from_str(toml).unwrap();
+        assert_eq!(reg.hosts.len(), 2);
+        let minimal = reg.get("minimal").unwrap();
+        assert_eq!(minimal.destination, "host1");
+        assert!(minimal.socket.is_none());
+        assert!(minimal.ssh_opts.is_empty());
+        let full = reg.get("full").unwrap();
+        assert_eq!(full.socket.as_deref(), Some("tb2"));
+        assert_eq!(full.ssh_opts, ["-o", "ControlMaster=auto"]);
+        assert_eq!(full.worktrees_dir.as_deref(), Some("/home/me/wt"));
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -179,6 +179,9 @@ pub struct SessionConfig {
     pub cwd: Option<PathBuf>,
     /// Name of the agent definition to launch (looked up in the registry).
     pub agent: String,
+    /// Backend to spawn on (registry name, e.g. `ssh:devbox`). `None`/empty
+    /// selects the registry default (`local-tmux`).
+    pub backend: Option<String>,
     /// Fork from an existing session's conversation (agents that support it).
     pub fork_session_id: Option<String>,
     /// Environment variables injected into the spawned session process

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_def;
 pub mod automation;
+pub mod host_def;
 pub mod keybindings;
 pub mod theme_config;
 
@@ -8,6 +9,7 @@ pub use automation::{
     parse_hhmm, preset_to_cron, Automation, AutomationAction, AutomationRun, AutomationRunStatus,
     AutomationSchedule, SchedulePreset,
 };
+pub use host_def::{HostDef, HostRegistry, SSH_BACKEND_PREFIX};
 pub use keybindings::{Action, Category, KeyBindings, KeyChord};
 pub use theme_config::{ThemePalette, ThemePreset};
 

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use crate::session::{SessionConfig, SessionId, DEFAULT_AGENT_NAME};
+use crate::session::{HostDef, SessionConfig, SessionId, DEFAULT_AGENT_NAME};
 use crate::storage::Database;
 use crate::sync::{SharedSession, SharedWorktree};
 
@@ -31,6 +31,9 @@ pub struct SpawnRequest {
     /// Optional pre-generated agent session UUID. When unset one is generated
     /// so callers can return it to the user immediately.
     pub agent_session_id: Option<String>,
+    /// Optional remote host name (from `hosts.toml`). When set, the session is
+    /// created on that host over SSH (worktree + tmux window live remotely).
+    pub host: Option<String>,
 }
 
 /// Result returned on successful headless spawn.
@@ -50,7 +53,11 @@ pub fn spawn_session_headless(_db: &Database, req: SpawnRequest) -> Result<Spawn
     validate_session_name(&req.name)?;
 
     let agent_name = resolve_agent_name(req.agent.as_deref());
-    let (cwd, worktrees) = resolve_cwd(&req)?;
+
+    // Resolve the optional remote host. `backend_type` is `local-tmux` or
+    // `ssh:<host>`; `host` is the matching HostDef for remote git/tmux ops.
+    let (backend_type, host) = resolve_host(req.host.as_deref())?;
+    let (cwd, worktrees) = resolve_cwd(&req, host.as_ref())?;
 
     let agent_session_id = req
         .agent_session_id
@@ -61,25 +68,39 @@ pub fn spawn_session_headless(_db: &Database, req: SpawnRequest) -> Result<Spawn
         agent_session_id: Some(agent_session_id.clone()),
         cwd: Some(cwd.clone()),
         agent: agent_name.clone(),
+        backend: (backend_type != LOCAL_TMUX_BACKEND_TYPE).then(|| backend_type.clone()),
         ..SessionConfig::default()
     };
     super::inject_thurbox_env(&mut config, &agent_session_id);
 
     let (command, args) = super::build_agent_invocation(&config);
 
-    crate::agent::tmux::spawn_window(&req.name, &command, &args, Some(&cwd), &config.env)
-        .map_err(|e| format!("Failed to spawn tmux window: {e}"))?;
+    // Remote spawns drive the SSH backend's control mode to learn the real pane
+    // id; local spawns leave `backend_id` empty for the TUI to resolve by name.
+    let backend_id = match host.as_ref() {
+        Some(h) => crate::agent::tmux::spawn_window_remote(
+            h,
+            &req.name,
+            &command,
+            &args,
+            Some(&cwd),
+            &config.env,
+        )
+        .map_err(|e| format!("Failed to spawn remote tmux window: {e:#}"))?,
+        None => {
+            crate::agent::tmux::spawn_window(&req.name, &command, &args, Some(&cwd), &config.env)
+                .map_err(|e| format!("Failed to spawn tmux window: {e}"))?;
+            String::new()
+        }
+    };
 
     let session_id = SessionId::default();
     let shared = SharedSession {
         id: session_id,
         name: req.name.clone(),
         agent: agent_name.clone(),
-        // No pane_id is available without control mode. Leave `backend_id`
-        // empty so `App::find_matching_discovered` falls back to matching by
-        // the sanitized window name.
-        backend_id: String::new(),
-        backend_type: LOCAL_TMUX_BACKEND_TYPE.to_string(),
+        backend_id,
+        backend_type,
         agent_session_id: Some(agent_session_id.clone()),
         cwd: Some(cwd.clone()),
         additional_dirs: Vec::new(),
@@ -126,12 +147,15 @@ fn resolve_agent_name(requested: Option<&str>) -> String {
 /// Returns the bare repo path when no worktree branch is given; otherwise
 /// creates the worktree and returns its path plus a single
 /// [`SharedWorktree`] entry.
-fn resolve_cwd(req: &SpawnRequest) -> Result<(PathBuf, Vec<SharedWorktree>), String> {
+fn resolve_cwd(
+    req: &SpawnRequest,
+    host: Option<&HostDef>,
+) -> Result<(PathBuf, Vec<SharedWorktree>), String> {
     let Some(branch) = req.worktree_branch.as_deref() else {
         return Ok((req.repo_path.clone(), Vec::new()));
     };
     let base_branch = req.base_branch.as_deref().unwrap_or(DEFAULT_BASE_BRANCH);
-    let path = crate::git::create_worktree(&req.repo_path, branch, base_branch)
+    let path = crate::git::create_worktree_on(host, &req.repo_path, branch, base_branch)
         .map_err(|e| format!("Failed to create worktree {branch} off {base_branch}: {e}"))?;
     let wt = SharedWorktree {
         repo_path: req.repo_path.clone(),
@@ -139,6 +163,26 @@ fn resolve_cwd(req: &SpawnRequest) -> Result<(PathBuf, Vec<SharedWorktree>), Str
         branch: branch.to_string(),
     };
     Ok((path, vec![wt]))
+}
+
+/// Resolve `--host` to `(backend_type, host)`.
+///
+/// `None`/empty → the local backend. A named host must exist in `hosts.toml`,
+/// otherwise an error is returned listing the available hosts.
+fn resolve_host(host_name: Option<&str>) -> Result<(String, Option<HostDef>), String> {
+    let Some(name) = host_name.filter(|n| !n.is_empty()) else {
+        return Ok((LOCAL_TMUX_BACKEND_TYPE.to_string(), None));
+    };
+    let registry = crate::agent::host_config::load_or_seed();
+    match registry.get(name) {
+        Some(h) => Ok((h.backend_name(), Some(h.clone()))),
+        None => {
+            let available = registry.names().join(", ");
+            Err(format!(
+                "Unknown host '{name}'. Configure it in hosts.toml. Available: [{available}]"
+            ))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -158,6 +202,7 @@ mod tests {
             base_branch: None,
             agent: None,
             agent_session_id: None,
+            host: None,
         }
     }
 
@@ -183,5 +228,42 @@ mod tests {
     fn resolve_agent_name_uses_explicit() {
         assert_eq!(resolve_agent_name(Some("codex")), "codex");
         assert_eq!(resolve_agent_name(Some("")), DEFAULT_AGENT_NAME);
+    }
+
+    #[test]
+    fn resolve_host_none_is_local() {
+        let (backend_type, host) = resolve_host(None).unwrap();
+        assert_eq!(backend_type, LOCAL_TMUX_BACKEND_TYPE);
+        assert!(host.is_none());
+        // Empty string is treated the same as None.
+        let (backend_type, host) = resolve_host(Some("")).unwrap();
+        assert_eq!(backend_type, LOCAL_TMUX_BACKEND_TYPE);
+        assert!(host.is_none());
+    }
+
+    #[test]
+    fn resolve_host_unknown_errors_with_guidance() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let err = resolve_host(Some("nope")).unwrap_err();
+        assert!(err.contains("Unknown host 'nope'"), "got: {err}");
+        assert!(err.contains("hosts.toml"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_host_reads_configured_host() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let path = crate::agent::host_config::hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hosts]]\nname = \"devbox\"\ndestination = \"me@devbox\"\n",
+        )
+        .unwrap();
+
+        let (backend_type, host) = resolve_host(Some("devbox")).unwrap();
+        assert_eq!(backend_type, "ssh:devbox");
+        assert_eq!(host.unwrap().destination, "me@devbox");
     }
 }

--- a/src/ui/host_picker_modal.rs
+++ b/src/ui/host_picker_modal.rs
@@ -1,0 +1,47 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    widgets::{List, ListItem, Paragraph},
+    Frame,
+};
+
+use super::{
+    centered_fixed_height_rect, render_modal_frame, selector_list_item, selector_nav_footer,
+};
+
+/// One selectable host row: display label + the backend name it maps to
+/// (`local-tmux` or `ssh:<host>`).
+#[derive(Debug, Clone, Default)]
+pub struct HostChoice {
+    /// Display label (e.g. `local` or `devbox  (me@devbox)`).
+    pub label: String,
+    /// Backend name spawned on. Empty string means the local default backend.
+    pub backend: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HostPickerState {
+    pub choices: Vec<HostChoice>,
+    pub selected_index: usize,
+}
+
+pub fn render_host_picker_modal(frame: &mut Frame, state: &HostPickerState) {
+    let height = (state.choices.len() as u16) + 3;
+    let area = centered_fixed_height_rect(50, height, frame.area());
+
+    let inner = render_modal_frame(frame, area, "Run On");
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let items: Vec<ListItem<'_>> = state
+        .choices
+        .iter()
+        .enumerate()
+        .map(|(i, c)| selector_list_item(&c.label, i == state.selected_index))
+        .collect();
+
+    frame.render_widget(List::new(items), chunks[0]);
+    frame.render_widget(Paragraph::new(selector_nav_footer()), chunks[1]);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub mod automations_list_modal;
 pub mod automations_panel;
 pub mod branch_selector_modal;
 pub mod file_viewer;
+pub mod host_picker_modal;
 pub mod info_panel;
 pub mod layout;
 pub mod links;

--- a/tests/ssh_integration.rs
+++ b/tests/ssh_integration.rs
@@ -1,0 +1,296 @@
+//! End-to-end integration test for thurbox's **remote SSH session** path.
+//!
+//! This exercises the *real* code — `git::*_on` over `ssh <dest> git …` and
+//! `TmuxBackend::from_host` driving tmux control mode over `ssh <dest> tmux …`
+//! — against a live sshd. It is **opt-in** and **skipped by default** so the
+//! normal `cargo nextest run` stays hermetic: it runs only when
+//! `THURBOX_SSH_IT=1` is set.
+//!
+//! ## Running it
+//!
+//! ```sh
+//! ./scripts/test-ssh/up.sh                 # sshd + tmux + git in a container
+//! THURBOX_SSH_IT=1 cargo nextest run --test ssh_integration --no-capture
+//! ./scripts/test-ssh/down.sh
+//! ```
+//!
+//! The container (see `scripts/test-ssh/`) listens on `127.0.0.1:2222`, accepts
+//! a generated key, and ships a pre-seeded git repo at `/home/tester/repo`
+//! (branch `main`) plus a worktrees dir at `/home/tester/worktrees`. The env
+//! vars below default to that container, so `THURBOX_SSH_IT=1` alone is enough.
+//!
+//! | Env var               | Default              | Meaning                          |
+//! |-----------------------|----------------------|----------------------------------|
+//! | `THURBOX_SSH_IT`      | (unset → skip)       | gate; must be `1` to run         |
+//! | `THURBOX_SSH_DEST`    | `tester@localhost`   | ssh destination                  |
+//! | `THURBOX_SSH_PORT`    | `2222`               | ssh port                         |
+//! | `THURBOX_SSH_KEY`     | `scripts/test-ssh/.keys/id_ed25519` | identity file     |
+//! | `THURBOX_SSH_REPO`    | `/home/tester/repo`  | remote git repo                  |
+//! | `THURBOX_SSH_WORKTREES` | `/home/tester/worktrees` | remote worktrees dir       |
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant, SystemTime};
+
+use thurbox::agent::tmux::TmuxBackend;
+use thurbox::agent::{GenericProvider, Session, SessionBackend};
+use thurbox::git;
+use thurbox::session::{AgentDef, HostDef, SessionConfig};
+
+/// Read the integration-test configuration from the environment, returning
+/// `None` (which means *skip*) unless `THURBOX_SSH_IT=1`.
+fn config_from_env() -> Option<ItConfig> {
+    if std::env::var("THURBOX_SSH_IT").ok().as_deref() != Some("1") {
+        return None;
+    }
+    let key = std::env::var("THURBOX_SSH_KEY").unwrap_or_else(|_| {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("scripts/test-ssh/.keys/id_ed25519")
+            .display()
+            .to_string()
+    });
+    Some(ItConfig {
+        destination: std::env::var("THURBOX_SSH_DEST")
+            .unwrap_or_else(|_| "tester@localhost".to_string()),
+        port: std::env::var("THURBOX_SSH_PORT").unwrap_or_else(|_| "2222".to_string()),
+        key,
+        repo: std::env::var("THURBOX_SSH_REPO").unwrap_or_else(|_| "/home/tester/repo".to_string()),
+        worktrees: std::env::var("THURBOX_SSH_WORKTREES")
+            .unwrap_or_else(|_| "/home/tester/worktrees".to_string()),
+    })
+}
+
+struct ItConfig {
+    destination: String,
+    port: String,
+    key: String,
+    repo: String,
+    worktrees: String,
+}
+
+impl ItConfig {
+    /// Non-interactive ssh options pinned for a throwaway localhost container:
+    /// explicit port + key, no host-key prompts, and a multiplexed master so
+    /// the many short ssh calls share one TCP/auth round-trip.
+    fn ssh_opts(&self) -> Vec<String> {
+        vec![
+            "-p".into(),
+            self.port.clone(),
+            "-i".into(),
+            self.key.clone(),
+            "-o".into(),
+            "StrictHostKeyChecking=no".into(),
+            "-o".into(),
+            "UserKnownHostsFile=/dev/null".into(),
+            "-o".into(),
+            "BatchMode=yes".into(),
+            "-o".into(),
+            "ControlMaster=auto".into(),
+            "-o".into(),
+            "ControlPersist=10m".into(),
+        ]
+    }
+
+    fn host(&self) -> HostDef {
+        HostDef {
+            name: "test-docker".into(),
+            destination: self.destination.clone(),
+            socket: None,
+            session: None,
+            ssh_opts: self.ssh_opts(),
+            // Pin the worktrees dir so we don't depend on remote $HOME resolution.
+            worktrees_dir: Some(self.worktrees.clone()),
+        }
+    }
+}
+
+/// Run a raw `ssh … <cmd>` and return stdout, asserting success. Used only for
+/// test assertions/cleanup, never for the code under test.
+fn ssh_exec(cfg: &ItConfig, remote_cmd: &str) -> String {
+    let output = Command::new("ssh")
+        .args(cfg.ssh_opts())
+        .arg(&cfg.destination)
+        .arg(remote_cmd)
+        .output()
+        .expect("spawn ssh");
+    assert!(
+        output.status.success(),
+        "remote `{remote_cmd}` failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// A process-unique, slash-free branch/marker suffix (no external rng needed).
+fn unique_suffix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{}-{nanos}", std::process::id())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_ssh_full_path_worktree_then_tmux_capture() {
+    let Some(cfg) = config_from_env() else {
+        eprintln!("THURBOX_SSH_IT != 1 — skipping remote ssh integration test");
+        return;
+    };
+
+    let host = cfg.host();
+    let repo = PathBuf::from(&cfg.repo);
+
+    // 0. Connectivity + fixture sanity: the seeded repo lists `main` over ssh.
+    //    This is the `git::*_on` path: `ssh <dest> git -C <repo> branch …`.
+    let branches = git::list_branches_on(Some(&host), &repo)
+        .expect("list_branches_on over ssh (is the container up? run scripts/test-ssh/up.sh)");
+    assert!(
+        branches.iter().any(|b| b == "main"),
+        "expected seeded `main` branch, got {branches:?}"
+    );
+
+    let suffix = unique_suffix();
+    let branch = format!("it/{suffix}");
+    let marker = format!("THURBOX_REMOTE_MARKER_{suffix}");
+
+    // 1. Create a worktree on a new branch over ssh.
+    let wt_path = git::create_worktree_on(Some(&host), &repo, &branch, "main")
+        .expect("create_worktree_on over ssh");
+
+    // The returned path lives under the host's configured worktrees dir.
+    let wt_str = wt_path.display().to_string();
+    assert!(
+        wt_str.starts_with(&cfg.worktrees),
+        "worktree {wt_str} not under {}",
+        cfg.worktrees
+    );
+
+    // Guard the rest of the test so the worktree is always cleaned up.
+    let result = run_session_and_capture(&cfg, &host, &wt_path, &marker).await;
+
+    // 2. Cleanup: remove the worktree (over ssh) and prune the branch.
+    let _ = git::remove_worktree_on(Some(&host), &repo, &wt_path);
+    let _ = ssh_exec(
+        &cfg,
+        &format!(
+            "git -C {} branch -D {} || true",
+            shell_word(&cfg.repo),
+            shell_word(&branch)
+        ),
+    );
+
+    // The worktree dir should be gone after removal.
+    let still_there = Command::new("ssh")
+        .args(cfg.ssh_opts())
+        .arg(&cfg.destination)
+        .arg(format!("test -d {}", shell_word(&wt_str)))
+        .status()
+        .expect("spawn ssh")
+        .success();
+    assert!(!still_there, "worktree dir {wt_str} survived removal");
+
+    // Surface any failure from the guarded section.
+    result.expect("remote tmux session did not produce the expected marker");
+}
+
+/// Spawn a tmux session over ssh in the worktree, running a command that prints
+/// `marker`, then poll the live vt100 parser until the marker appears.
+async fn run_session_and_capture(
+    cfg: &ItConfig,
+    host: &HostDef,
+    wt_path: &Path,
+    marker: &str,
+) -> anyhow::Result<()> {
+    // Before spawning, confirm the worktree really exists remotely.
+    let exists = Command::new("ssh")
+        .args(cfg.ssh_opts())
+        .arg(&cfg.destination)
+        .arg(format!(
+            "test -d {}",
+            shell_word(&wt_path.display().to_string())
+        ))
+        .status()
+        .expect("spawn ssh")
+        .success();
+    anyhow::ensure!(exists, "worktree was not created on the remote host");
+
+    // Build the SSH-backed tmux backend for this host and start its session +
+    // control mode — the byte-identical control-mode protocol, over ssh.
+    let backend: std::sync::Arc<dyn SessionBackend> =
+        std::sync::Arc::new(TmuxBackend::from_host(host));
+    backend
+        .check_available()
+        .map_err(|e| anyhow::anyhow!("remote tmux check_available failed: {e:#}"))?;
+    backend
+        .ensure_ready()
+        .map_err(|e| anyhow::anyhow!("remote tmux ensure_ready failed: {e:#}"))?;
+
+    // A trivial stand-in agent. It must emit the marker *continuously*, not
+    // once: tmux control mode streams a pane's output via `%output` events only
+    // for output produced *after* `connect_pane` subscribes (`refresh-client
+    // -A :on`). A single print at startup would land in the pane's screen
+    // buffer before we subscribe and never reach the live parser — whereas a
+    // real agent repaints continuously. So loop the marker on a short interval.
+    // `sh -c` runs as the window's foreground process.
+    let provider: std::sync::Arc<dyn thurbox::agent::AgentProvider> =
+        std::sync::Arc::new(GenericProvider::new(AgentDef {
+            name: "it-shell".into(),
+            command: "sh".into(),
+            args: vec![
+                "-c".into(),
+                format!(
+                    "i=0; while [ $i -lt 60 ]; do printf '%s\\n' {}; sleep 1; i=$((i+1)); done",
+                    shell_word(marker)
+                ),
+            ],
+            resume_args: vec![],
+            fork_args: vec![],
+            new_session_args: vec![],
+        }));
+
+    let config = SessionConfig {
+        cwd: Some(wt_path.to_path_buf()),
+        agent: "it-shell".into(),
+        backend: Some(host.backend_name()),
+        ..Default::default()
+    };
+
+    let session = Session::spawn(
+        format!("ssh-it-{}", std::process::id()),
+        24,
+        80,
+        &config,
+        &backend,
+        &provider,
+    )
+    .map_err(|e| anyhow::anyhow!("remote Session::spawn failed: {e:#}"))?;
+
+    // Poll the live parser (fed by the control-mode reader over ssh) for the
+    // marker. Generous deadline to absorb image cold-start + ssh latency.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut found = false;
+    while Instant::now() < deadline {
+        if let Ok(parser) = session.parser.lock() {
+            if parser.screen().contents().contains(marker) {
+                found = true;
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Kill the remote pane regardless of outcome.
+    session.kill();
+
+    anyhow::ensure!(
+        found,
+        "marker `{marker}` never appeared in remote pane output"
+    );
+    Ok(())
+}
+
+/// POSIX single-quote a token for embedding in a raw `ssh … <cmd>` string used
+/// by the test harness (assertions/cleanup only).
+fn shell_word(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}


### PR DESCRIPTION
Run thurbox sessions on a **remote host over SSH** while the TUI runs locally, and add an end-to-end test that exercises the remote path against a real sshd.

## Feature

Hosts are declared as data in `~/.config/thurbox/hosts.toml` (seeded commented-out, so a fresh install has zero remote hosts and behaves exactly as before). Each host registers a backend named `ssh:<name>`.

- **Transport seam** (`agent::transport::TmuxTransport`) — `TmuxBackend` is transport-neutral. Local launches `tmux -L thurbox …`; a remote host launches `ssh <dest> tmux …`. The tmux control-mode protocol is byte-identical over either transport — only the one-time process launch differs.
- **Backend** — `TmuxBackend::from_host` builds the SSH-backed backend; hosts are registered lazily in `main.rs` so a down host can't block startup (`check_available`/`ensure_ready` deferred to first use via `App::backend_for`).
- **Git over SSH** — `git::*_on` variants run `git` via `ssh <dest> git -C <repo> …` for remote worktree create/remove and branch listing. Remote worktrees live under the host's `worktrees_dir` (or `$HOME/.local/share/thurbox/worktrees`, resolved + cached over ssh).
- **UI** — the new-session flow shows a host picker first (skipped when no hosts are configured); the chosen host runs worktree creation + branch listing over SSH.
- **CLI** — `thurbox-cli session create --host <name>` spawns remotely.
- **Persistence/restore** — `backend_type` round-trips in SQLite; restore discovers windows per backend so remote sessions re-adopt against their own host.

## Test fixture (this session's addition)

An **opt-in** end-to-end integration test (`tests/ssh_integration.rs`), skipped by default so the suite and CI stay hermetic — runs only when `THURBOX_SSH_IT=1`. It drives the real code:

1. `git::list_branches_on` / `create_worktree_on` over ssh
2. `TmuxBackend::from_host` → tmux control mode over ssh → `Session::spawn`
3. asserts a unique marker streams back through the live `vt100` parser
4. cleans up the worktree + branch, verifying removal over ssh

`scripts/test-ssh/` provides the throwaway target — a Dockerfile (sshd + tmux ≥ 3.2 + git, seeded repo on `main`) and `up.sh`/`down.sh` that build+run it via plain **podman or docker** (no compose required; a compose file is included as an alternative). Generated keypair + staged `authorized_keys` are gitignored.

```sh
./scripts/test-ssh/up.sh
THURBOX_SSH_IT=1 cargo nextest run --test ssh_integration
./scripts/test-ssh/down.sh
```

## Verification

- Remote integration test **passes** end-to-end against the podman container (worktree-over-ssh → tmux-over-ssh → live capture → cleanup).
- Skips green by default; `cargo fmt --all --check` and `cargo clippy --test ssh_integration -- -D warnings` clean.

## Notes

- Architecture rules preserved: `agent`/`ui` still import `session` only; `HostDef`/`HostRegistry` live in `session` so both `agent` and `git` can depend on them.
- Docs updated: `CLAUDE.md` (remote SSH section + test instructions) and `docs/`.