### PR TITLE
feat: richer agentic info panel — cost/time, git stats & /usage rate-limits

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -47,6 +47,16 @@ const DEFERRED_INPUT_DELAY_TICKS: u64 = 10;
 /// How often to refresh system metrics (in ticks). At ~10ms per tick, 100 ≈ 1 second.
 const METRICS_REFRESH_TICKS: u64 = 100;
 
+/// How often to refresh git stats for the active session (in ticks). Git stats
+/// shell out to `git`, so they run on a slower cadence than other metrics
+/// (~5 s) and only for the visible session.
+const GIT_REFRESH_TICKS: u64 = 500;
+
+/// How often to refresh account usage / rate-limits (in ticks). At ~10ms per
+/// tick, 30000 ≈ 5 minutes. Usage windows are coarse and fetching hits the
+/// network, so this is deliberately slow; fires once early then every 5 min.
+const USAGE_REFRESH_TICKS: u64 = 30_000;
+
 /// Parse agent metrics from a Claude CLI statusline JSON value.
 fn parse_agent_metrics(raw: &serde_json::Value) -> crate::session::AgentMetrics {
     use crate::session::AgentMetrics;
@@ -335,6 +345,14 @@ pub struct App {
     /// `~/.config/thurbox/keybindings.json` on startup, falling back to defaults
     /// when the file is missing or malformed.
     pub(crate) keybindings: crate::session::KeyBindings,
+    /// Account-level usage/rate-limit info per agent name (the `/usage`
+    /// equivalent), fetched in the background and shown for the active
+    /// session's agent. Account-global, so keyed by agent rather than session.
+    pub(crate) usage: HashMap<String, crate::session::AgentUsage>,
+    /// Sends background usage-fetch results back to the app loop.
+    usage_tx: mpsc::Sender<(String, crate::session::AgentUsage)>,
+    /// Receives background usage-fetch results, drained each tick.
+    usage_rx: mpsc::Receiver<(String, crate::session::AgentUsage)>,
 }
 
 const EDITOR_NOT_CONFIGURED: &str =
@@ -380,6 +398,8 @@ impl App {
         if let Ok(initial_state) = db.load_shared_state() {
             sync_state.set_initial_snapshot(initial_state);
         }
+
+        let (usage_tx, usage_rx) = mpsc::channel();
 
         Self {
             sessions: Vec::new(),
@@ -437,6 +457,9 @@ impl App {
             automation_panel_index: 0,
             active_theme,
             keybindings,
+            usage: HashMap::new(),
+            usage_tx,
+            usage_rx,
         }
     }
 
@@ -1452,12 +1475,10 @@ impl App {
 
             // Live activity text from the agent-emitted OSC terminal title.
             session.info.agent_activity = session.agent_title();
-            // Surface the notification message only while attention is pending.
-            session.info.notification = if session.info.status == SessionStatus::Attention {
-                session.notification()
-            } else {
-                None
-            };
+            // Retain the agent's latest pushed notification (OSC 9/777) so the
+            // info panel can show it as a persistent "last signal", not only
+            // while the session is in the attention state.
+            session.info.notification = session.notification();
         }
 
         // Poll for sync results from background worktree sync threads
@@ -1513,6 +1534,74 @@ impl App {
         if self.tick_count % METRICS_REFRESH_TICKS == 0 {
             self.refresh_system_metrics();
         }
+
+        // Refresh git stats for the active session on a slower cadence.
+        if self.tick_count % GIT_REFRESH_TICKS == 0 {
+            self.refresh_active_git_stats();
+        }
+
+        // Drain any completed background usage fetches into the cache.
+        while let Ok((agent, usage)) = self.usage_rx.try_recv() {
+            self.usage.insert(agent, usage);
+        }
+        // Kick off usage fetches early and then on a slow cadence.
+        if self.tick_count % USAGE_REFRESH_TICKS == 1 {
+            self.spawn_usage_fetches();
+        }
+    }
+
+    /// Spawn background usage/rate-limit fetches for each distinct supported
+    /// agent currently in the session list. Results return via `usage_tx` and
+    /// are drained in [`Self::tick`]. Network/process work runs off the UI
+    /// thread; unsupported agents are skipped entirely.
+    fn spawn_usage_fetches(&self) {
+        let mut seen = std::collections::HashSet::new();
+        for session in &self.sessions {
+            let agent = session.info.agent.clone();
+            if !crate::usage::is_supported(&agent) || !seen.insert(agent.clone()) {
+                continue;
+            }
+            let tx = self.usage_tx.clone();
+            tokio::spawn(async move {
+                let usage = crate::usage::fetch(&agent).await;
+                let _ = tx.send((agent, usage));
+            });
+        }
+    }
+
+    /// Compute aggregated git stats (diff + dirty + ahead/behind) for the
+    /// active session's worktree(s) and store them on its `SessionInfo`.
+    /// Shells out to `git`, so it runs only for the visible session.
+    fn refresh_active_git_stats(&mut self) {
+        let Some(session) = self.sessions.get_mut(self.active_index) else {
+            return;
+        };
+
+        // Aggregate across all worktrees; fall back to the cwd if there are none.
+        let paths: Vec<std::path::PathBuf> = if session.info.worktrees.is_empty() {
+            session.info.cwd.iter().cloned().collect()
+        } else {
+            session
+                .info
+                .worktrees
+                .iter()
+                .map(|wt| wt.worktree_path.clone())
+                .collect()
+        };
+
+        let mut agg: Option<crate::session::GitStats> = None;
+        for path in &paths {
+            if let Some(stats) = crate::git::worktree_stats(path) {
+                let acc = agg.get_or_insert_with(Default::default);
+                acc.files_changed += stats.files_changed;
+                acc.insertions += stats.insertions;
+                acc.deletions += stats.deletions;
+                acc.dirty |= stats.dirty;
+                acc.ahead += stats.ahead;
+                acc.behind += stats.behind;
+            }
+        }
+        session.info.git_stats = agg;
     }
 
     /// Collect CPU/RAM metrics from sysinfo and poll agent metrics files.

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -137,6 +137,7 @@ impl App {
         if let Some(info_area) = areas.info_panel {
             if let Some(info) = self.sessions.get(self.active_index).map(|s| &s.info) {
                 let now = crate::sync::current_time_millis();
+                let agent_usage = self.usage.get(&info.agent);
                 let automation_entries: Vec<info_panel::AutomationEntry> = self
                     .cached_automations
                     .iter()
@@ -155,6 +156,7 @@ impl App {
                     info,
                     Some(&self.system_metrics),
                     &automation_entries,
+                    agent_usage,
                 );
             }
         }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -512,10 +512,108 @@ pub fn sync_worktree(worktree_path: &Path) -> SyncResult {
     SyncResult::Synced
 }
 
+/// Run `git <args>` in `cwd`, returning stdout on success (`None` otherwise).
+fn run_git_capture(args: &[&str], cwd: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Sum `git diff --numstat` output into `(files_changed, insertions, deletions)`.
+/// Binary files (`-\t-\tpath`) count toward `files_changed` with zero lines.
+fn parse_numstat(out: &str) -> (usize, usize, usize) {
+    let (mut files, mut ins, mut dels) = (0usize, 0usize, 0usize);
+    for line in out.lines() {
+        let mut cols = line.split('\t');
+        let added = cols.next();
+        let deleted = cols.next();
+        let path = cols.next();
+        if path.is_none() {
+            continue;
+        }
+        files += 1;
+        if let Some(n) = added.and_then(|s| s.parse::<usize>().ok()) {
+            ins += n;
+        }
+        if let Some(n) = deleted.and_then(|s| s.parse::<usize>().ok()) {
+            dels += n;
+        }
+    }
+    (files, ins, dels)
+}
+
+/// Whether the worktree has any uncommitted changes (staged, unstaged, or
+/// untracked). Returns `false` if git cannot be queried.
+pub fn worktree_is_dirty(cwd: &Path) -> bool {
+    run_git_capture(&["status", "--porcelain"], cwd)
+        .map(|o| !o.trim().is_empty())
+        .unwrap_or(false)
+}
+
+/// Commits the worktree's HEAD is `(ahead, behind)` relative to its upstream
+/// (`@{upstream}`), falling back to `origin/main` then `origin/master`.
+/// Returns `(0, 0)` when no base can be resolved.
+pub fn ahead_behind(cwd: &Path) -> (usize, usize) {
+    let base = ["@{upstream}", "origin/main", "origin/master"]
+        .into_iter()
+        .find(|r| run_git_capture(&["rev-parse", "--verify", "--quiet", r], cwd).is_some());
+    let Some(base) = base else {
+        return (0, 0);
+    };
+    // `--left-right --count <base>...HEAD` → "<behind>\t<ahead>".
+    let range = format!("{base}...HEAD");
+    let Some(out) = run_git_capture(&["rev-list", "--left-right", "--count", &range], cwd) else {
+        return (0, 0);
+    };
+    let mut parts = out.split_whitespace();
+    let behind = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let ahead = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (ahead, behind)
+}
+
+/// Compute combined git stats (uncommitted diff + dirty + ahead/behind) for a
+/// worktree. Returns `None` when the path is not a usable git worktree.
+pub fn worktree_stats(cwd: &Path) -> Option<crate::session::GitStats> {
+    // Bail early if this path isn't inside a git work tree.
+    run_git_capture(&["rev-parse", "--is-inside-work-tree"], cwd)?;
+    let numstat = run_git_capture(&["diff", "--numstat", "HEAD"], cwd).unwrap_or_default();
+    let (files_changed, insertions, deletions) = parse_numstat(&numstat);
+    let (ahead, behind) = ahead_behind(cwd);
+    Some(crate::session::GitStats {
+        files_changed,
+        insertions,
+        deletions,
+        dirty: worktree_is_dirty(cwd),
+        ahead,
+        behind,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::paths::TestPathGuard;
+
+    #[test]
+    fn parse_numstat_sums_changes() {
+        let (files, ins, dels) = parse_numstat("1\t2\tfile.rs\n3\t4\tother.rs\n-\t-\tbin.png\n");
+        assert_eq!(files, 3);
+        assert_eq!(ins, 4);
+        assert_eq!(dels, 6);
+    }
+
+    #[test]
+    fn parse_numstat_empty_is_zero() {
+        assert_eq!(parse_numstat(""), (0, 0, 0));
+    }
 
     /// Compute the 16-char hex repo hash used in worktree paths.
     fn repo_hash(repo_path: &Path) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,4 @@ pub mod session_ops;
 pub mod storage;
 pub mod sync;
 pub mod ui;
+pub mod usage;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -109,6 +109,52 @@ pub struct AgentMetrics {
     pub cli_version: Option<String>,
 }
 
+/// Real git state for a session's worktree(s), computed by the app/git layer
+/// and surfaced in the info panel. Aggregated across all of a session's
+/// worktrees. Agent-neutral (derived from git, not the agent CLI).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GitStats {
+    pub files_changed: usize,
+    pub insertions: usize,
+    pub deletions: usize,
+    /// Whether the worktree has uncommitted changes.
+    pub dirty: bool,
+    /// Commits ahead of the upstream/base branch.
+    pub ahead: usize,
+    /// Commits behind the upstream/base branch.
+    pub behind: usize,
+}
+
+/// One account-level rate-limit window (e.g. Claude's 5-hour or weekly), as
+/// shown by an agent's `/usage` command. Agent-neutral.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UsageWindow {
+    /// Short label, e.g. "5h", "Week", or a model id.
+    pub label: String,
+    /// Percent of the window consumed, 0–100.
+    pub used_percent: f32,
+    /// Unix epoch seconds when the window resets, if known.
+    pub resets_at: Option<u64>,
+}
+
+/// Account-level usage/rate-limit info for an agent, fetched from the vendor
+/// (the `/usage`-equivalent). Account-global, not per-session. Agent-neutral.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AgentUsage {
+    pub windows: Vec<UsageWindow>,
+    /// Plan/tier label when known (e.g. "max", "pro").
+    pub plan: Option<String>,
+    /// Human note when no windows are available (not logged in, API error…).
+    pub note: Option<String>,
+}
+
+impl AgentUsage {
+    /// Nothing worth rendering (no windows and no note).
+    pub fn is_empty(&self) -> bool {
+        self.windows.is_empty() && self.note.is_none()
+    }
+}
+
 pub struct SessionInfo {
     pub id: SessionId,
     pub name: String,
@@ -129,6 +175,9 @@ pub struct SessionInfo {
     /// Message text from the agent's latest attention notification (OSC 9/777),
     /// shown as the status when `status == SessionStatus::Attention`.
     pub notification: Option<String>,
+    /// Real git state of the session's worktree(s), refreshed periodically by
+    /// the app layer. `None` until first computed (or for non-git sessions).
+    pub git_stats: Option<GitStats>,
     /// Whether this is the admin session (internal, never user-visible).
     pub is_admin: bool,
     /// Cached display names for repos, resolved from git remote or directory name.
@@ -153,6 +202,7 @@ impl SessionInfo {
             agent_metrics: None,
             agent_activity: None,
             notification: None,
+            git_stats: None,
             is_admin: false,
             repo_display_names: Vec::new(),
         }

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -35,6 +35,7 @@ pub fn render_info_panel(
     info: &SessionInfo,
     metrics: Option<&SystemMetrics>,
     automations: &[AutomationEntry],
+    usage: Option<&crate::session::AgentUsage>,
 ) {
     let block = Block::default()
         .title(" Info ")
@@ -75,9 +76,27 @@ pub fn render_info_panel(
             Span::styled(activity, Style::default().fg(Theme::text_secondary())),
         ]));
     }
+    // Latest signal the agent pushed (OSC 9/777 notification). Highlighted while
+    // the session is in the attention state, muted otherwise.
+    if let Some(signal) = info.notification.as_deref() {
+        let value_style = if info.status == crate::session::SessionStatus::Attention {
+            Style::default().fg(super::status_color(info.status))
+        } else {
+            Style::default().fg(Theme::text_muted())
+        };
+        lines.push(Line::from(vec![
+            Span::styled("Signal:   ", Theme::label()),
+            Span::styled(signal, value_style),
+        ]));
+    }
 
     // ── Repos ──
     append_repos_section(&mut lines, info);
+
+    // ── Git change summary (real git state of the worktree) ──
+    if let Some(ref git) = info.git_stats {
+        append_git_section(&mut lines, git);
+    }
 
     // ── Session CPU/RAM ──
     if let Some(m) = metrics {
@@ -98,6 +117,13 @@ pub fn render_info_panel(
     // ── Agent section (Claude CLI metrics) ──
     if let Some(ref metrics) = info.agent_metrics {
         append_agent_section(&mut lines, metrics, inner_width);
+    }
+
+    // ── Usage / rate-limits (account-level, the `/usage` equivalent) ──
+    if let Some(u) = usage {
+        if !u.is_empty() {
+            append_usage_section(&mut lines, u, inner_width);
+        }
     }
 
     // ── System Resources section (global CPU/RAM) ──
@@ -155,6 +181,34 @@ fn append_agent_section(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner
     };
     lines.push(Line::from(Span::styled(header, Theme::section_header())));
 
+    // Cost (headline number, only when the agent reports a non-zero spend).
+    if let Some(cost) = metrics.total_cost_usd {
+        if cost > 0.0 {
+            lines.push(Line::from(vec![
+                Span::styled("Cost:    ", Theme::label()),
+                Span::styled(format_cost(cost), Style::default().fg(Theme::accent())),
+            ]));
+        }
+    }
+
+    // Elapsed wall time, with API time as a muted aside when present.
+    if let Some(ms) = metrics.total_duration_ms {
+        let mut spans = vec![
+            Span::styled("Time:    ", Theme::label()),
+            Span::styled(
+                format_duration(ms),
+                Style::default().fg(Theme::text_primary()),
+            ),
+        ];
+        if let Some(api_ms) = metrics.total_api_duration_ms.filter(|&v| v > 0) {
+            spans.push(Span::styled(
+                format!("  (api {})", format_duration(api_ms)),
+                Style::default().fg(Theme::text_muted()),
+            ));
+        }
+        lines.push(Line::from(spans));
+    }
+
     // Tokens
     if metrics.total_input_tokens.is_some() || metrics.total_output_tokens.is_some() {
         let input = metrics
@@ -174,9 +228,14 @@ fn append_agent_section(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner
         ]));
     }
 
-    // Context window gauge
+    // Context window gauge. When the window size is known, show the gauge as
+    // used/total tokens rather than a bare percentage.
     if let Some(pct) = metrics.used_percentage {
-        let gauge = render_gauge_lines("Context", pct as f32, None, inner_width);
+        let suffix = metrics.context_window_size.map(|size| {
+            let used = (size as f64 * pct as f64 / 100.0).round() as u64;
+            format!("{}/{}", format_tokens(used), format_tokens(size))
+        });
+        let gauge = render_gauge_lines("Context", pct as f32, suffix, inner_width);
         lines.extend(gauge);
     }
 
@@ -266,6 +325,116 @@ fn append_repos_section<'a>(lines: &mut Vec<Line<'a>>, info: &'a SessionInfo) {
     }
 }
 
+/// Append the git change-summary lines (uncommitted diff + sync state).
+fn append_git_section(lines: &mut Vec<Line<'_>>, git: &crate::session::GitStats) {
+    // Changes line: only when there is something uncommitted.
+    if git.files_changed > 0 || git.dirty {
+        let files = if git.files_changed == 1 {
+            "1 file".to_string()
+        } else {
+            format!("{} files", git.files_changed)
+        };
+        let mut spans = vec![
+            Span::styled("Changes: ", Theme::label()),
+            Span::styled(files, Style::default().fg(Theme::text_primary())),
+            Span::raw(" "),
+            Span::styled(
+                format!("+{}", git.insertions),
+                Style::default().fg(Theme::status_busy()),
+            ),
+            Span::styled(" / ", Style::default().fg(Theme::text_muted())),
+            Span::styled(
+                format!("-{}", git.deletions),
+                Style::default().fg(Theme::status_error()),
+            ),
+        ];
+        if git.dirty && git.files_changed == 0 {
+            spans.push(Span::styled(
+                " dirty",
+                Style::default().fg(Theme::text_muted()),
+            ));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    // Sync line: only when ahead of / behind the base branch.
+    if git.ahead > 0 || git.behind > 0 {
+        lines.push(Line::from(vec![
+            Span::styled("Sync:    ", Theme::label()),
+            Span::styled(
+                format!("↑{} ↓{}", git.ahead, git.behind),
+                Style::default().fg(Theme::text_muted()),
+            ),
+        ]));
+    }
+}
+
+/// Current Unix time in seconds (for usage reset countdowns).
+fn epoch_now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Format a seconds countdown compactly: `"now"`, `"5m"`, `"1h 12m"`, `"4d 3h"`.
+fn format_countdown_secs(secs: u64) -> String {
+    if secs == 0 {
+        return "now".to_string();
+    }
+    let days = secs / 86_400;
+    let hours = (secs % 86_400) / 3_600;
+    let mins = (secs % 3_600) / 60;
+    if days > 0 {
+        format!("{days}d {hours}h")
+    } else if hours > 0 {
+        format!("{hours}h {mins}m")
+    } else if mins > 0 {
+        format!("{mins}m")
+    } else {
+        "<1m".to_string()
+    }
+}
+
+/// Append the account-level usage / rate-limit section (the `/usage`
+/// equivalent): one gauge per window with used-% and a reset countdown.
+fn append_usage_section(
+    lines: &mut Vec<Line<'_>>,
+    usage: &crate::session::AgentUsage,
+    width: usize,
+) {
+    lines.push(separator(width));
+    let header = match &usage.plan {
+        Some(plan) => format!("Usage ({plan})"),
+        None => "Usage".to_string(),
+    };
+    lines.push(Line::from(Span::styled(header, Theme::section_header())));
+
+    if usage.windows.is_empty() {
+        if let Some(note) = &usage.note {
+            lines.push(Line::from(Span::styled(
+                note.clone(),
+                Style::default().fg(Theme::text_muted()),
+            )));
+        }
+        return;
+    }
+
+    let now = epoch_now_secs();
+    for w in &usage.windows {
+        let suffix = match w.resets_at {
+            Some(reset) => format!(
+                "{:.0}%  {}",
+                w.used_percent,
+                format_countdown_secs(reset.saturating_sub(now))
+            ),
+            None => format!("{:.0}%", w.used_percent),
+        };
+        let gauge = render_gauge_lines(&w.label, w.used_percent, Some(suffix), width);
+        lines.extend(gauge);
+    }
+}
+
 fn separator(width: usize) -> Line<'static> {
     Line::from(Span::styled(
         "─".repeat(width),
@@ -335,6 +504,34 @@ fn human_bytes(bytes: u64) -> (f64, f64, &'static str) {
         (b / MB, MB, "MB")
     } else {
         (b / KB, KB, "KB")
+    }
+}
+
+/// Format a USD cost like `$0.0423` (4 dp below $1, 2 dp at/above $1).
+fn format_cost(usd: f64) -> String {
+    if usd >= 1.0 {
+        format!("${usd:.2}")
+    } else {
+        format!("${usd:.4}")
+    }
+}
+
+/// Format a millisecond duration as a compact human string:
+/// `"820ms"`, `"45s"`, `"1m 23s"`, `"2h 05m"`.
+fn format_duration(ms: u64) -> String {
+    if ms < 1_000 {
+        return format!("{ms}ms");
+    }
+    let total_secs = ms / 1_000;
+    let secs = total_secs % 60;
+    let mins = (total_secs / 60) % 60;
+    let hours = total_secs / 3_600;
+    if hours > 0 {
+        format!("{hours}h {mins:02}m")
+    } else if mins > 0 {
+        format!("{mins}m {secs:02}s")
+    } else {
+        format!("{secs}s")
     }
 }
 
@@ -511,5 +708,167 @@ mod tests {
     fn format_tokens_millions() {
         assert_eq!(format_tokens(1_000_000), "1.0M");
         assert_eq!(format_tokens(2_500_000), "2.5M");
+    }
+
+    // ── format_cost tests ──
+
+    #[test]
+    fn format_cost_sub_dollar_uses_four_dp() {
+        assert_eq!(format_cost(0.0423), "$0.0423");
+        assert_eq!(format_cost(0.0), "$0.0000");
+    }
+
+    #[test]
+    fn format_cost_dollar_and_above_uses_two_dp() {
+        assert_eq!(format_cost(1.0), "$1.00");
+        assert_eq!(format_cost(12.345), "$12.35");
+    }
+
+    // ── format_duration tests ──
+
+    #[test]
+    fn format_duration_millis() {
+        assert_eq!(format_duration(0), "0ms");
+        assert_eq!(format_duration(820), "820ms");
+    }
+
+    #[test]
+    fn format_duration_seconds() {
+        assert_eq!(format_duration(1_000), "1s");
+        assert_eq!(format_duration(45_000), "45s");
+    }
+
+    #[test]
+    fn format_duration_minutes() {
+        assert_eq!(format_duration(83_000), "1m 23s");
+        assert_eq!(format_duration(600_000), "10m 00s");
+    }
+
+    #[test]
+    fn format_duration_hours() {
+        assert_eq!(format_duration(3_600_000), "1h 00m");
+        assert_eq!(format_duration(7_500_000), "2h 05m");
+    }
+
+    // ── append_git_section tests ──
+
+    fn render_git(git: &crate::session::GitStats) -> String {
+        let mut lines: Vec<Line> = Vec::new();
+        append_git_section(&mut lines, git);
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn git_section_shows_changes_and_sync() {
+        let git = crate::session::GitStats {
+            files_changed: 3,
+            insertions: 120,
+            deletions: 8,
+            dirty: true,
+            ahead: 2,
+            behind: 0,
+        };
+        let out = render_git(&git);
+        assert!(out.contains("Changes:"));
+        assert!(out.contains("3 files"));
+        assert!(out.contains("+120"));
+        assert!(out.contains("-8"));
+        assert!(out.contains("Sync:"));
+        assert!(out.contains("↑2 ↓0"));
+    }
+
+    #[test]
+    fn git_section_singular_file_and_no_sync() {
+        let git = crate::session::GitStats {
+            files_changed: 1,
+            insertions: 5,
+            deletions: 0,
+            dirty: true,
+            ahead: 0,
+            behind: 0,
+        };
+        let out = render_git(&git);
+        assert!(out.contains("1 file"));
+        assert!(!out.contains("files"));
+        assert!(!out.contains("Sync:"));
+    }
+
+    #[test]
+    fn git_section_clean_repo_is_empty() {
+        let git = crate::session::GitStats::default();
+        assert_eq!(render_git(&git), "");
+    }
+
+    // ── usage section tests ──
+
+    #[test]
+    fn format_countdown_variants() {
+        assert_eq!(format_countdown_secs(0), "now");
+        assert_eq!(format_countdown_secs(30), "<1m");
+        assert_eq!(format_countdown_secs(5 * 60), "5m");
+        assert_eq!(format_countdown_secs(3600 + 12 * 60), "1h 12m");
+        assert_eq!(format_countdown_secs(4 * 86400 + 3 * 3600), "4d 3h");
+    }
+
+    fn render_usage(u: &crate::session::AgentUsage) -> String {
+        let mut lines: Vec<Line> = Vec::new();
+        append_usage_section(&mut lines, u, 24);
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn usage_section_renders_plan_and_windows() {
+        let u = crate::session::AgentUsage {
+            windows: vec![
+                crate::session::UsageWindow {
+                    label: "5h".into(),
+                    used_percent: 42.0,
+                    resets_at: None,
+                },
+                crate::session::UsageWindow {
+                    label: "Week".into(),
+                    used_percent: 18.0,
+                    resets_at: None,
+                },
+            ],
+            plan: Some("max".into()),
+            note: None,
+        };
+        let out = render_usage(&u);
+        assert!(out.contains("Usage (max)"));
+        assert!(out.contains("5h"));
+        assert!(out.contains("42%"));
+        assert!(out.contains("Week"));
+        assert!(out.contains("18%"));
+    }
+
+    #[test]
+    fn usage_section_renders_note_when_no_windows() {
+        let u = crate::session::AgentUsage {
+            windows: vec![],
+            plan: None,
+            note: Some("not logged in".into()),
+        };
+        let out = render_usage(&u);
+        assert!(out.contains("Usage"));
+        assert!(out.contains("not logged in"));
     }
 }

--- a/src/usage/mod.rs
+++ b/src/usage/mod.rs
@@ -1,0 +1,433 @@
+//! Account-level usage / rate-limit fetching, per agent.
+//!
+//! Mirrors what an agent's `/usage` (Claude) or `/status` (Codex) command
+//! shows — the rolling rate-limit windows (e.g. 5-hour and weekly) with their
+//! used-percentage and reset time. This data is **account-global**, fetched
+//! directly from the vendor using the user's existing local credentials, the
+//! same way Claude Code and Orca obtain it. Agent-neutral at the type level
+//! ([`crate::session::AgentUsage`] is a plain list of named windows); the
+//! per-agent fetch logic lives here.
+//!
+//! No HTTP client dependency: authenticated requests shell out to `curl`
+//! (config piped over stdin so the bearer token never appears in argv), and
+//! Codex is queried via its `app-server` JSON-RPC subprocess. Everything is
+//! best-effort — any missing credential, absent CLI, or network error yields
+//! an [`AgentUsage`] with a human `note` and no windows.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+
+use crate::session::{AgentUsage, UsageWindow};
+
+/// Agents we know how to fetch usage for. Others are skipped entirely (no
+/// process spawned, no panel section shown).
+const SUPPORTED: &[&str] = &["claude", "codex", "gemini"];
+
+/// Whether [`fetch`] can return real usage for this agent name.
+pub fn is_supported(agent: &str) -> bool {
+    SUPPORTED.contains(&agent)
+}
+
+/// Fetch account usage for `agent`. Best-effort; never errors — unavailability
+/// is reported via [`AgentUsage::note`] with no windows.
+pub async fn fetch(agent: &str) -> AgentUsage {
+    match agent {
+        "claude" => claude().await,
+        "codex" => codex().await,
+        "gemini" => gemini().await,
+        other => AgentUsage {
+            note: Some(format!("usage not supported for '{other}'")),
+            ..Default::default()
+        },
+    }
+}
+
+// ─────────────────────────── shared helpers ───────────────────────────
+
+/// Run `curl` with a config supplied on stdin (keeps tokens out of argv) and
+/// parse stdout as JSON. Returns `None` on spawn/timeout/non-JSON.
+async fn curl_json(config: String) -> Option<serde_json::Value> {
+    let mut child = tokio::process::Command::new("curl")
+        .arg("-sS")
+        .arg("--config")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(config.as_bytes()).await;
+        let _ = stdin.shutdown().await; // close so curl proceeds
+    }
+    let out = tokio::time::timeout(Duration::from_secs(15), child.wait_with_output())
+        .await
+        .ok()?
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    serde_json::from_slice(&out.stdout).ok()
+}
+
+/// Read a JSON file (used for vendor credential files).
+fn read_json_file(path: &PathBuf) -> Option<serde_json::Value> {
+    let text = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// Parse an RFC 3339 timestamp to Unix epoch seconds.
+fn rfc3339_epoch(s: &str) -> Option<u64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp().max(0) as u64)
+}
+
+/// Clamp a vendor "percent used" value to 0–100.
+fn clamp_pct(v: f64) -> f32 {
+    v.clamp(0.0, 100.0) as f32
+}
+
+// ─────────────────────────────── Claude ───────────────────────────────
+
+const CLAUDE_USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
+const CLAUDE_OAUTH_BETA: &str = "oauth-2025-04-20";
+const CLAUDE_USER_AGENT: &str = "claude-code/2.1.0";
+
+/// Locate Claude's credentials file (`$CLAUDE_CONFIG_DIR/.credentials.json`,
+/// else `~/.claude/.credentials.json`).
+fn claude_credentials_path() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        let p = PathBuf::from(dir).join(".credentials.json");
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    let home = std::env::var_os("HOME")?;
+    let p = PathBuf::from(home)
+        .join(".claude")
+        .join(".credentials.json");
+    p.exists().then_some(p)
+}
+
+/// Read the subscription OAuth access token and plan tier from disk.
+fn claude_token() -> Option<(String, Option<String>)> {
+    let v = read_json_file(&claude_credentials_path()?)?;
+    let token = v
+        .pointer("/claudeAiOauth/accessToken")?
+        .as_str()?
+        .to_string();
+    // Reject anything that could break the curl config syntax.
+    if token.contains('"') || token.contains('\n') {
+        return None;
+    }
+    let plan = v
+        .pointer("/claudeAiOauth/subscriptionType")
+        .and_then(|x| x.as_str())
+        .map(str::to_string);
+    Some((token, plan))
+}
+
+async fn claude() -> AgentUsage {
+    let Some((token, plan)) = claude_token() else {
+        return AgentUsage {
+            note: Some("not logged in (no subscription token)".into()),
+            ..Default::default()
+        };
+    };
+    let config = format!(
+        "url = \"{CLAUDE_USAGE_URL}\"\n\
+         header = \"Authorization: Bearer {token}\"\n\
+         header = \"anthropic-beta: {CLAUDE_OAUTH_BETA}\"\n\
+         header = \"User-Agent: {CLAUDE_USER_AGENT}\"\n\
+         max-time = 15\n"
+    );
+    match curl_json(config).await {
+        Some(v) => parse_claude_usage(&v, plan),
+        None => AgentUsage {
+            plan,
+            note: Some("usage unavailable (API error or API-key account)".into()),
+            ..Default::default()
+        },
+    }
+}
+
+/// Pure parser for the `oauth/usage` response:
+/// `{ "five_hour": {utilization, resets_at}, "seven_day": {...} }`.
+/// `utilization` is a percent (0–100), matching what `/usage` renders.
+fn parse_claude_usage(v: &serde_json::Value, plan: Option<String>) -> AgentUsage {
+    let window = |key: &str, label: &str| -> Option<UsageWindow> {
+        let w = v.get(key)?;
+        let util = w.get("utilization").and_then(|x| x.as_f64())?;
+        let resets_at = w
+            .get("resets_at")
+            .and_then(|x| x.as_str())
+            .and_then(rfc3339_epoch);
+        Some(UsageWindow {
+            label: label.to_string(),
+            used_percent: clamp_pct(util),
+            resets_at,
+        })
+    };
+    let windows: Vec<UsageWindow> = [window("five_hour", "5h"), window("seven_day", "Week")]
+        .into_iter()
+        .flatten()
+        .collect();
+    let note = windows.is_empty().then(|| "no rate-limit data".to_string());
+    AgentUsage {
+        windows,
+        plan,
+        note,
+    }
+}
+
+// ─────────────────────────────── Codex ────────────────────────────────
+
+/// Query Codex's `app-server` over JSON-RPC for rate limits. Best-effort:
+/// requires a logged-in `codex` CLI on PATH. Newline-delimited JSON-RPC with a
+/// hard timeout; any framing/auth issue simply yields a note.
+async fn codex() -> AgentUsage {
+    match tokio::time::timeout(Duration::from_secs(15), codex_app_server()).await {
+        Ok(Some(v)) => parse_codex_ratelimits(&v),
+        _ => AgentUsage {
+            note: Some("usage unavailable (codex not logged in?)".into()),
+            ..Default::default()
+        },
+    }
+}
+
+async fn codex_app_server() -> Option<serde_json::Value> {
+    let mut child = tokio::process::Command::new("codex")
+        .args(["-s", "read-only", "-a", "untrusted", "app-server"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let mut stdin = child.stdin.take()?;
+    let stdout = child.stdout.take()?;
+
+    // initialize → initialized → account/rateLimits/read (newline-delimited).
+    let msgs = [
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"clientInfo\":{\"name\":\"thurbox\",\"version\":\"0\"}}}\n",
+        "{\"jsonrpc\":\"2.0\",\"method\":\"initialized\",\"params\":{}}\n",
+        "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"account/rateLimits/read\",\"params\":{}}\n",
+    ];
+    for m in msgs {
+        if stdin.write_all(m.as_bytes()).await.is_err() {
+            break;
+        }
+    }
+    let _ = stdin.flush().await;
+
+    use tokio::io::AsyncBufReadExt;
+    let mut reader = tokio::io::BufReader::new(stdout).lines();
+    let mut result = None;
+    while let Ok(Some(line)) = reader.next_line().await {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+            if v.get("id").and_then(|x| x.as_i64()) == Some(2) {
+                result = v.get("result").cloned();
+                break;
+            }
+        }
+    }
+    let _ = child.kill().await;
+    result
+}
+
+/// Parse `{ "rateLimits": { "primary": {usedPercent, resetsAt}, "secondary": {...} } }`.
+/// `resetsAt` is Unix seconds.
+fn parse_codex_ratelimits(v: &serde_json::Value) -> AgentUsage {
+    let root = v.pointer("/rateLimits").unwrap_or(v);
+    let window = |key: &str, label: &str| -> Option<UsageWindow> {
+        let w = root.get(key)?;
+        let used = w.get("usedPercent").and_then(|x| x.as_f64())?;
+        let resets_at = w
+            .get("resetsAt")
+            .and_then(|x| x.as_u64())
+            .or_else(|| w.get("resetsAt").and_then(|x| x.as_f64()).map(|f| f as u64));
+        Some(UsageWindow {
+            label: label.to_string(),
+            used_percent: clamp_pct(used),
+            resets_at,
+        })
+    };
+    let windows: Vec<UsageWindow> = [window("primary", "5h"), window("secondary", "Week")]
+        .into_iter()
+        .flatten()
+        .collect();
+    let note = windows.is_empty().then(|| "no rate-limit data".to_string());
+    AgentUsage {
+        windows,
+        plan: None,
+        note,
+    }
+}
+
+// ─────────────────────────────── Gemini ───────────────────────────────
+
+const GEMINI_QUOTA_URL: &str = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota";
+
+fn gemini_token() -> Option<String> {
+    let home = std::env::var_os("HOME")?;
+    let v = read_json_file(&PathBuf::from(home).join(".gemini").join("oauth_creds.json"))?;
+    let token = v.get("access_token").and_then(|x| x.as_str())?.to_string();
+    (!token.contains('"') && !token.contains('\n')).then_some(token)
+}
+
+async fn gemini() -> AgentUsage {
+    let Some(token) = gemini_token() else {
+        return AgentUsage {
+            note: Some("not logged in (no Google OAuth creds)".into()),
+            ..Default::default()
+        };
+    };
+    let config = format!(
+        "url = \"{GEMINI_QUOTA_URL}\"\n\
+         request = \"POST\"\n\
+         header = \"Authorization: Bearer {token}\"\n\
+         header = \"Content-Type: application/json\"\n\
+         data = \"{{}}\"\n\
+         max-time = 15\n"
+    );
+    match curl_json(config).await {
+        Some(v) => parse_gemini_quota(&v),
+        None => AgentUsage {
+            note: Some("usage unavailable (API error)".into()),
+            ..Default::default()
+        },
+    }
+}
+
+/// Parse `{ "buckets": [ {modelId, remainingFraction, resetTime}, ... ] }`.
+/// Surfaces the most-constrained bucket (lowest remaining) as a window.
+fn parse_gemini_quota(v: &serde_json::Value) -> AgentUsage {
+    let buckets = v.get("buckets").and_then(|b| b.as_array());
+    let mut best: Option<UsageWindow> = None;
+    if let Some(buckets) = buckets {
+        for b in buckets {
+            let Some(remaining) = b.get("remainingFraction").and_then(|x| x.as_f64()) else {
+                continue;
+            };
+            let used = clamp_pct((1.0 - remaining) * 100.0);
+            let label = b
+                .get("modelId")
+                .and_then(|x| x.as_str())
+                .unwrap_or("Quota")
+                .to_string();
+            let resets_at = b
+                .get("resetTime")
+                .and_then(|x| x.as_str())
+                .and_then(rfc3339_epoch);
+            let candidate = UsageWindow {
+                label,
+                used_percent: used,
+                resets_at,
+            };
+            if best
+                .as_ref()
+                .map(|w| candidate.used_percent > w.used_percent)
+                .unwrap_or(true)
+            {
+                best = Some(candidate);
+            }
+        }
+    }
+    match best {
+        Some(w) => AgentUsage {
+            windows: vec![w],
+            ..Default::default()
+        },
+        None => AgentUsage {
+            note: Some("no quota data".into()),
+            ..Default::default()
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_set() {
+        assert!(is_supported("claude"));
+        assert!(is_supported("codex"));
+        assert!(is_supported("gemini"));
+        assert!(!is_supported("aider"));
+        assert!(!is_supported("shell"));
+    }
+
+    #[test]
+    fn claude_usage_parses_windows_and_resets() {
+        let json = serde_json::json!({
+            "five_hour": { "utilization": 42.0, "resets_at": "2026-06-01T15:00:00Z" },
+            "seven_day": { "utilization": 18.5, "resets_at": "2026-06-05T00:00:00Z" }
+        });
+        let u = parse_claude_usage(&json, Some("max".into()));
+        assert_eq!(u.plan.as_deref(), Some("max"));
+        assert_eq!(u.windows.len(), 2);
+        assert_eq!(u.windows[0].label, "5h");
+        assert!((u.windows[0].used_percent - 42.0).abs() < 0.01);
+        assert!(u.windows[0].resets_at.is_some());
+        assert_eq!(u.windows[1].label, "Week");
+        assert!((u.windows[1].used_percent - 18.5).abs() < 0.01);
+        assert!(u.note.is_none());
+    }
+
+    #[test]
+    fn claude_usage_clamps_and_handles_missing() {
+        let json = serde_json::json!({ "five_hour": { "utilization": 150.0 } });
+        let u = parse_claude_usage(&json, None);
+        assert_eq!(u.windows.len(), 1);
+        assert!((u.windows[0].used_percent - 100.0).abs() < 0.01);
+        assert!(u.windows[0].resets_at.is_none());
+    }
+
+    #[test]
+    fn claude_usage_empty_gives_note() {
+        let u = parse_claude_usage(&serde_json::json!({}), None);
+        assert!(u.windows.is_empty());
+        assert!(u.note.is_some());
+    }
+
+    #[test]
+    fn codex_ratelimits_parses() {
+        let json = serde_json::json!({
+            "rateLimits": {
+                "primary": { "usedPercent": 30, "resetsAt": 1_780_000_000u64 },
+                "secondary": { "usedPercent": 12 }
+            }
+        });
+        let u = parse_codex_ratelimits(&json);
+        assert_eq!(u.windows.len(), 2);
+        assert_eq!(u.windows[0].label, "5h");
+        assert!((u.windows[0].used_percent - 30.0).abs() < 0.01);
+        assert_eq!(u.windows[0].resets_at, Some(1_780_000_000));
+        assert_eq!(u.windows[1].resets_at, None);
+    }
+
+    #[test]
+    fn gemini_quota_picks_most_constrained() {
+        let json = serde_json::json!({
+            "buckets": [
+                { "modelId": "gemini-pro", "remainingFraction": 0.9, "resetTime": "2026-06-02T00:00:00Z" },
+                { "modelId": "gemini-flash", "remainingFraction": 0.25 }
+            ]
+        });
+        let u = parse_gemini_quota(&json);
+        assert_eq!(u.windows.len(), 1);
+        assert_eq!(u.windows[0].label, "gemini-flash");
+        assert!((u.windows[0].used_percent - 75.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn gemini_quota_empty_gives_note() {
+        let u = parse_gemini_quota(&serde_json::json!({ "buckets": [] }));
+        assert!(u.windows.is_empty());
+        assert!(u.note.is_some());
+    }
+}


### PR DESCRIPTION
## Summary

Enriches the info panel with much more live **agentic information**, inspired by [Orca](https://github.com/stablyai/orca), while keeping thurbox agent-neutral and dependency-free.

### Info panel
- **Cost / Time / context size** — surfaces `total_cost_usd`, wall + API duration, and context-window size from agent metrics that were already parsed but never shown.
- **Last signal** — the agent's latest OSC 9/777 notification is retained and shown persistently (not only during the attention state).
- **Git changes** — real git state of the active session's worktree(s): files changed with `+/-` line counts and ahead/behind the base branch. New `session::GitStats` + `git::worktree_stats` (computed in app/git, rendered in ui — module boundaries preserved).

### Usage / rate-limits (`/usage` equivalent) — new `src/usage/` subsystem
Mirrors how Claude Code and Orca obtain usage: read the user's **existing local credentials** and call the vendor directly.

| Agent | Source |
|-------|--------|
| **Claude** | `GET api.anthropic.com/api/oauth/usage` (token from `~/.claude/.credentials.json`) → 5h + weekly `{utilization, resets_at}` |
| **Codex** | `codex … app-server` JSON-RPC `account/rateLimits/read` |
| **Gemini** | `POST cloudcode-pa.googleapis.com/…:retrieveUserQuota` (token from `~/.gemini/oauth_creds.json`) |
| others (opencode, vibe, aider…) | skipped cleanly — no usable usage source (matches Orca) |

- **No new dependencies / no HTTP crate** (license-policy safe): authenticated requests shell out to `curl` with the config piped over **stdin** so the bearer token never appears in `argv`; Codex uses its `app-server` subprocess. Times parsed with the existing `chrono`.
- **Background poller** (`tokio::spawn`) runs once at startup + every ~5 min, only for supported agents present in the session list; results flow over a channel drained in `tick()`. Account-global, keyed by agent.
- Panel renders one gauge per window: `5h [██░░░░] 25% · 4h 12m`, `Week [████░░] 73% · 14h 50m`, with a `Usage (plan)` header and a graceful note when not logged in.

## Why curl instead of an HTTP crate
`cargo-deny`'s license allow-list excludes OpenSSL-style licenses, so `rustls`/`ring`/`aws-lc-rs` all risk failing the policy. `curl` is already assumed present (the installer uses it) and fits thurbox's "spawn CLIs, minimal deps" design.

## Verification
- `cargo test --lib` — **696 passing**
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all` — clean
- `cargo test --test architecture_rules` — 8/8 (ui still imports only `session`)
- Claude usage validated against the **live** `oauth/usage` endpoint (`utilization` is 0–100; RFC3339 resets).

## Notes / caveats
- Codex & Gemini paths are implemented but **not live-tested** (no local creds on the dev box); they degrade to a "not logged in" note. The Codex JSON-RPC framing is a best-effort guess behind a hard timeout.
- Not surfaced yet (possible follow-ups): per-model 7-day windows (`seven_day_opus`/`seven_day_sonnet`), `extra_usage` credits, opencode usage scrape, docs (FEATURES.md/ARCHITECTURE.md).
