### PR TITLE
refactor: reduce cognitive complexity of SonarCloud-flagged functions

### DIFF
--- a/src/agent/input.rs
+++ b/src/agent/input.rs
@@ -6,19 +6,11 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
     let shift = modifiers.contains(KeyModifiers::SHIFT);
     let alt = modifiers.contains(KeyModifiers::ALT);
     let ctrl = modifiers.contains(KeyModifiers::CONTROL);
+    let modifier_param = xterm_modifier(shift, alt, ctrl);
 
     // Ctrl+letter → control character (0x01..=0x1A), optionally wrapped with ESC for Alt
-    if ctrl && !shift {
-        if let KeyCode::Char(c) = code {
-            if c.is_ascii_alphabetic() {
-                let ctrl_byte = c.to_ascii_lowercase() as u8 - b'a' + 1;
-                return Some(if alt {
-                    vec![0x1b, ctrl_byte]
-                } else {
-                    vec![ctrl_byte]
-                });
-            }
-        }
+    if let Some(bytes) = ctrl_letter_bytes(code, shift, alt, ctrl) {
+        return Some(bytes);
     }
 
     // Shift+Enter → ESC [ 13;2u (xterm modifyOtherKeys / kitty protocol)
@@ -32,22 +24,13 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
     }
 
     // Cursor keys & navigation with modifiers: CSI 1;<mod> X
-    let modifier_param = xterm_modifier(shift, alt, ctrl);
-    if let Some(suffix) = cursor_key_suffix(code) {
-        return if modifier_param > 1 {
-            Some(format!("\x1b[1;{modifier_param}{suffix}").into_bytes())
-        } else {
-            Some(format!("\x1b[{suffix}").into_bytes())
-        };
+    if let Some(bytes) = cursor_key_bytes(code, modifier_param) {
+        return Some(bytes);
     }
 
     // Extended keys with modifiers: CSI <num>;<mod> ~
-    if let Some(num) = extended_key_num(code) {
-        return if modifier_param > 1 {
-            Some(format!("\x1b[{num};{modifier_param}~").into_bytes())
-        } else {
-            Some(format!("\x1b[{num}~").into_bytes())
-        };
+    if let Some(bytes) = extended_key_bytes(code, modifier_param) {
+        return Some(bytes);
     }
 
     // F-keys
@@ -57,40 +40,80 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
 
     // Alt wraps the inner byte with ESC prefix
     if alt {
-        if let KeyCode::Char(c) = code {
-            let mut buf = [0u8; 4];
-            let s = c.encode_utf8(&mut buf);
-            let mut result = vec![0x1b];
-            result.extend_from_slice(s.as_bytes());
-            return Some(result);
-        }
-        // Alt+Enter, Alt+Backspace, etc.
-        let inner = unmodified_key(code)?;
-        let mut result = vec![0x1b];
-        result.extend(inner);
-        return Some(result);
+        return alt_bytes(code);
     }
 
     // Shift+Char: just send the character (already uppercase/shifted by crossterm)
     if shift {
         if let KeyCode::Char(c) = code {
-            let mut buf = [0u8; 4];
-            let s = c.encode_utf8(&mut buf);
-            return Some(s.as_bytes().to_vec());
+            return Some(char_bytes(c));
         }
     }
 
     unmodified_key(code)
 }
 
+/// Encode a `char` as its UTF-8 bytes.
+fn char_bytes(c: char) -> Vec<u8> {
+    let mut buf = [0u8; 4];
+    c.encode_utf8(&mut buf).as_bytes().to_vec()
+}
+
+/// Ctrl+letter → control character (0x01..=0x1A), optionally ESC-wrapped for Alt.
+fn ctrl_letter_bytes(code: KeyCode, shift: bool, alt: bool, ctrl: bool) -> Option<Vec<u8>> {
+    if !ctrl || shift {
+        return None;
+    }
+    let KeyCode::Char(c) = code else {
+        return None;
+    };
+    if !c.is_ascii_alphabetic() {
+        return None;
+    }
+    let ctrl_byte = c.to_ascii_lowercase() as u8 - b'a' + 1;
+    Some(if alt {
+        vec![0x1b, ctrl_byte]
+    } else {
+        vec![ctrl_byte]
+    })
+}
+
+/// Cursor/navigation keys: CSI 1;<mod> X (or CSI X when unmodified).
+fn cursor_key_bytes(code: KeyCode, modifier_param: u8) -> Option<Vec<u8>> {
+    let suffix = cursor_key_suffix(code)?;
+    Some(if modifier_param > 1 {
+        format!("\x1b[1;{modifier_param}{suffix}").into_bytes()
+    } else {
+        format!("\x1b[{suffix}").into_bytes()
+    })
+}
+
+/// Extended keys (Insert/Delete/PageUp/PageDown): CSI <num>;<mod> ~ (or CSI <num> ~).
+fn extended_key_bytes(code: KeyCode, modifier_param: u8) -> Option<Vec<u8>> {
+    let num = extended_key_num(code)?;
+    Some(if modifier_param > 1 {
+        format!("\x1b[{num};{modifier_param}~").into_bytes()
+    } else {
+        format!("\x1b[{num}~").into_bytes()
+    })
+}
+
+/// Alt-modified key: ESC prefix wrapping the inner (unmodified) byte sequence.
+fn alt_bytes(code: KeyCode) -> Option<Vec<u8>> {
+    let inner = match code {
+        KeyCode::Char(c) => char_bytes(c),
+        // Alt+Enter, Alt+Backspace, etc.
+        _ => unmodified_key(code)?,
+    };
+    let mut result = vec![0x1b];
+    result.extend(inner);
+    Some(result)
+}
+
 /// Plain key without modifiers.
 fn unmodified_key(code: KeyCode) -> Option<Vec<u8>> {
     match code {
-        KeyCode::Char(c) => {
-            let mut buf = [0u8; 4];
-            let s = c.encode_utf8(&mut buf);
-            Some(s.as_bytes().to_vec())
-        }
+        KeyCode::Char(c) => Some(char_bytes(c)),
         KeyCode::Enter => Some(vec![b'\r']),
         KeyCode::Backspace => Some(vec![0x7f]),
         KeyCode::Tab => Some(vec![b'\t']),

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -235,50 +235,18 @@ impl ControlMode {
 
             match control_mode::parse_notification(&line) {
                 Notification::Output { pane_id, data } => {
-                    if let Ok(senders) = pane_senders.lock() {
-                        if let Some(tx_vec) = senders.get(&pane_id) {
-                            // Broadcast output to all registered instances
-                            for tx in tx_vec {
-                                match tx.try_send(data.clone()) {
-                                    Ok(()) => {}
-                                    Err(std::sync::mpsc::TrySendError::Full(_dropped)) => {
-                                        // Channel full — drop this chunk rather than blocking.
-                                        // The reader thread MUST stay unblocked to handle
-                                        // %pause notifications and avoid deadlock.
-                                        debug!(
-                                            pane_id = %pane_id,
-                                            "Pane output channel full, dropping chunk"
-                                        );
-                                    }
-                                    Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {}
-                                }
-                            }
-                        }
-                    }
+                    Self::dispatch_output(&pane_senders, &pane_id, data);
                 }
                 Notification::Begin => {
                     collecting = Some(Vec::new());
                 }
                 end_or_error @ (Notification::End | Notification::Error) => {
                     let lines = collecting.take().unwrap_or_default();
-                    if let Ok(mut queue) = response_queue.lock() {
-                        if let Some(tx) = queue.pop_front() {
-                            let _ = tx.send(CommandResponse {
-                                lines,
-                                is_error: matches!(end_or_error, Notification::Error),
-                            });
-                        }
-                    }
+                    let is_error = matches!(end_or_error, Notification::Error);
+                    Self::deliver_response(&response_queue, lines, is_error);
                 }
                 Notification::Pause { pane_id } => {
-                    let cmd = format!(
-                        "refresh-client -A '{}:continue'\n",
-                        pane_id.replace('\'', "'\\''")
-                    );
-                    if let Ok(mut s) = stdin.lock() {
-                        let _ = s.write_all(cmd.as_bytes());
-                        let _ = s.flush();
-                    }
+                    Self::resume_pane(&stdin, &pane_id);
                 }
                 Notification::Other(text) => {
                     if let Some(ref mut lines) = collecting {
@@ -292,6 +260,60 @@ impl ControlMode {
         debug!("Control reader thread exiting");
         if let Ok(mut senders) = pane_senders.lock() {
             senders.clear();
+        }
+    }
+
+    /// Broadcast a `%output` payload to every reader registered for `pane_id`.
+    ///
+    /// Uses `try_send` so the reader thread never blocks: a full channel drops
+    /// the chunk rather than stalling (which would deadlock `%pause` handling).
+    fn dispatch_output(pane_senders: &PaneSendersMapShared, pane_id: &str, data: Vec<u8>) {
+        let Ok(senders) = pane_senders.lock() else {
+            return;
+        };
+        let Some(tx_vec) = senders.get(pane_id) else {
+            return;
+        };
+        // Broadcast output to all registered instances
+        for tx in tx_vec {
+            match tx.try_send(data.clone()) {
+                Ok(()) => {}
+                Err(std::sync::mpsc::TrySendError::Full(_dropped)) => {
+                    // Channel full — drop this chunk rather than blocking.
+                    // The reader thread MUST stay unblocked to handle
+                    // %pause notifications and avoid deadlock.
+                    debug!(pane_id = %pane_id, "Pane output channel full, dropping chunk");
+                }
+                Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {}
+            }
+        }
+    }
+
+    /// Deliver a completed `%begin`/`%end`(`%error`) block to the next waiter.
+    ///
+    /// Responses with no waiter in the queue (e.g. from `send_command_nowait`)
+    /// are simply discarded.
+    fn deliver_response(
+        response_queue: &Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
+        lines: Vec<String>,
+        is_error: bool,
+    ) {
+        if let Ok(mut queue) = response_queue.lock() {
+            if let Some(tx) = queue.pop_front() {
+                let _ = tx.send(CommandResponse { lines, is_error });
+            }
+        }
+    }
+
+    /// Respond to a `%pause` by asking tmux to resume output for the pane.
+    fn resume_pane(stdin: &Arc<Mutex<ChildStdin>>, pane_id: &str) {
+        let cmd = format!(
+            "refresh-client -A '{}:continue'\n",
+            pane_id.replace('\'', "'\\''")
+        );
+        if let Ok(mut s) = stdin.lock() {
+            let _ = s.write_all(cmd.as_bytes());
+            let _ = s.flush();
         }
     }
 

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -38,85 +38,13 @@ impl App {
     /// 2. Global keybindings (Ctrl+Q, Ctrl+N, etc.)
     /// 3. Focus-based handlers (ProjectList, SessionList, Terminal)
     pub(crate) fn handle_key(&mut self, code: KeyCode, mods: KeyModifiers) {
-        // Dismiss help overlay with Esc or F1 (toggle)
-        if matches!(self.modal, super::modals::Modal::Help) {
-            if code == KeyCode::Esc || code == KeyCode::F(1) {
-                self.modal.close();
-            }
+        // Help overlay + clipboard chords are routed before any modal handler.
+        if self.handle_priority_key(code, mods) {
             return;
         }
 
-        // Ctrl+V: paste. Routed before modal handlers so they don't swallow
-        // the literal 'v' — `paste_from_clipboard` knows whether a modal text
-        // input is open and routes the text accordingly.
-        if code == KeyCode::Char('v') && mods.contains(KeyModifiers::CONTROL) {
-            self.paste_from_clipboard();
-            return;
-        }
-
-        // Ctrl+C: copy active mouse-drag selection. Routed before modal
-        // handlers so users can copy text from inside any modal. Without an
-        // active selection, falls through to the normal handlers (e.g. SIGINT
-        // when the terminal is focused).
-        if code == KeyCode::Char('c')
-            && mods.contains(KeyModifiers::CONTROL)
-            && self.text_selection.is_some()
-        {
-            self.copy_selection_to_clipboard();
-            return;
-        }
-
-        // Restore sessions modal captures all input
-        if matches!(self.modal, super::modals::Modal::RestoreSessions(_)) {
-            self.handle_restore_sessions_key(code);
-            return;
-        }
-
-        // Branch selector modal captures all input
-        if matches!(self.modal, super::modals::Modal::BranchSelector(_)) {
-            self.handle_branch_selector_key(code);
-            return;
-        }
-
-        // Worktree name modal captures all input
-        if matches!(self.modal, super::modals::Modal::WorktreeName(_)) {
-            self.handle_worktree_name_key(code);
-            return;
-        }
-
-        // Session name modal captures all input
-        if matches!(self.modal, super::modals::Modal::SessionName(_)) {
-            self.handle_session_name_key(code);
-            return;
-        }
-
-        // Automation editor modal captures all input
-        if matches!(self.modal, super::modals::Modal::AutomationEditor(_)) {
-            self.handle_automation_editor_key(code, mods);
-            return;
-        }
-
-        // Automations list modal captures all input
-        if matches!(self.modal, super::modals::Modal::AutomationsList(_)) {
-            self.handle_automations_list_key(code);
-            return;
-        }
-
-        // Agent picker modal captures all input
-        if matches!(self.modal, super::modals::Modal::AgentPicker(_)) {
-            self.handle_agent_picker_key(code);
-            return;
-        }
-
-        // Theme picker modal captures all input
-        if matches!(self.modal, super::modals::Modal::ThemePicker(_)) {
-            self.handle_theme_picker_key(code);
-            return;
-        }
-
-        // Repo picker modal captures all input
-        if matches!(self.modal, super::modals::Modal::RepoPicker(_)) {
-            self.handle_repo_picker_key(code);
+        // An open modal captures all input.
+        if self.handle_modal_key_if_open(code, mods) {
             return;
         }
 
@@ -130,34 +58,9 @@ impl App {
         self.text_selection = None;
 
         // The in-pane automation editor / run-history capture input like the
-        // overlay modal — so editor chords (e.g. Ctrl+E to toggle enabled) reach
-        // the form instead of firing a global binding (Ctrl+E = file viewer).
-        // Focus navigation (Ctrl+L/H) and quit still pass through to the global
-        // handler so you can move between panes.
-        if matches!(
-            self.focus,
-            InputFocus::AutomationEditor | InputFocus::AutomationRunHistory
-        ) {
-            let passthrough = matches!(
-                self.keybindings.lookup(code, mods),
-                Some(
-                    crate::session::Action::FocusForward
-                        | crate::session::Action::FocusBackward
-                        | crate::session::Action::QuitApp
-                )
-            );
-            if !passthrough {
-                match self.focus {
-                    InputFocus::AutomationEditor => {
-                        self.handle_automation_editor_pane_key(code, mods)
-                    }
-                    InputFocus::AutomationRunHistory => {
-                        self.handle_automation_run_history_key(code)
-                    }
-                    _ => unreachable!(),
-                }
-                return;
-            }
+        // overlay modal (see `handle_automation_pane_capture`).
+        if self.handle_automation_pane_capture(code, mods) {
+            return;
         }
 
         // Global keybindings (always active) — driven by user-customizable
@@ -178,6 +81,90 @@ impl App {
             InputFocus::Terminal => self.handle_terminal_key(code, mods),
             InputFocus::FileViewer => self.handle_file_viewer_key(code, mods),
         }
+    }
+
+    /// Help-overlay dismissal and clipboard chords, routed ahead of modal
+    /// handlers. Returns `true` if the key was consumed.
+    fn handle_priority_key(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
+        // Dismiss help overlay with Esc or F1 (toggle)
+        if matches!(self.modal, super::modals::Modal::Help) {
+            if code == KeyCode::Esc || code == KeyCode::F(1) {
+                self.modal.close();
+            }
+            return true;
+        }
+
+        // Ctrl+V: paste. Routed before modal handlers so they don't swallow
+        // the literal 'v' — `paste_from_clipboard` knows whether a modal text
+        // input is open and routes the text accordingly.
+        if code == KeyCode::Char('v') && mods.contains(KeyModifiers::CONTROL) {
+            self.paste_from_clipboard();
+            return true;
+        }
+
+        // Ctrl+C: copy active mouse-drag selection. Routed before modal
+        // handlers so users can copy text from inside any modal. Without an
+        // active selection, falls through to the normal handlers (e.g. SIGINT
+        // when the terminal is focused).
+        if code == KeyCode::Char('c')
+            && mods.contains(KeyModifiers::CONTROL)
+            && self.text_selection.is_some()
+        {
+            self.copy_selection_to_clipboard();
+            return true;
+        }
+
+        false
+    }
+
+    /// Route the key to the open modal's handler, if any. Returns `true` if a
+    /// modal was open and consumed the key.
+    fn handle_modal_key_if_open(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
+        use super::modals::Modal;
+        match self.modal {
+            Modal::RestoreSessions(_) => self.handle_restore_sessions_key(code),
+            Modal::BranchSelector(_) => self.handle_branch_selector_key(code),
+            Modal::WorktreeName(_) => self.handle_worktree_name_key(code),
+            Modal::SessionName(_) => self.handle_session_name_key(code),
+            Modal::AutomationEditor(_) => self.handle_automation_editor_key(code, mods),
+            Modal::AutomationsList(_) => self.handle_automations_list_key(code),
+            Modal::AgentPicker(_) => self.handle_agent_picker_key(code),
+            Modal::ThemePicker(_) => self.handle_theme_picker_key(code),
+            Modal::RepoPicker(_) => self.handle_repo_picker_key(code),
+            _ => return false,
+        }
+        true
+    }
+
+    /// The in-pane automation editor / run-history capture input like the
+    /// overlay modal — so editor chords (e.g. Ctrl+E to toggle enabled) reach
+    /// the form instead of firing a global binding (Ctrl+E = file viewer).
+    /// Focus navigation (Ctrl+L/H) and quit still pass through to the global
+    /// handler so you can move between panes. Returns `true` if consumed.
+    fn handle_automation_pane_capture(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
+        if !matches!(
+            self.focus,
+            InputFocus::AutomationEditor | InputFocus::AutomationRunHistory
+        ) {
+            return false;
+        }
+        let passthrough = matches!(
+            self.keybindings.lookup(code, mods),
+            Some(
+                crate::session::Action::FocusForward
+                    | crate::session::Action::FocusBackward
+                    | crate::session::Action::QuitApp
+            )
+        );
+        if passthrough {
+            return false;
+        }
+        match self.focus {
+            InputFocus::AutomationEditor => self.handle_automation_editor_pane_key(code, mods),
+            InputFocus::AutomationRunHistory => self.handle_automation_run_history_key(code),
+            _ => unreachable!(),
+        }
+        true
     }
 
     /// The ordered focus ring for the **current context**. `Ctrl+L`/`Ctrl+H`
@@ -1012,56 +999,19 @@ impl App {
     }
 
     pub(crate) fn start_branch_selection(&mut self) {
-        let Some(repo_path) = self.pending_repo_path.as_ref() else {
+        let Some(repo_path) = self.pending_repo_path.clone() else {
             return;
         };
 
-        // Fetch origin so branches are up-to-date. Non-fatal on failure.
-        if let Err(e) = crate::git::git_fetch(repo_path) {
-            warn!("git fetch origin failed (continuing): {e:#}");
-        }
-        if let Some(ref all_repos) = self.pending_all_repos {
-            for extra_repo in all_repos.iter().skip(1) {
-                if let Err(e) = crate::git::git_fetch(extra_repo) {
-                    warn!(
-                        "git fetch origin failed for {} (continuing): {e:#}",
-                        extra_repo.display()
-                    );
-                }
-            }
-        }
+        Self::fetch_pending_repos(&repo_path, self.pending_all_repos.as_ref());
 
-        match crate::git::list_branches(repo_path) {
+        match crate::git::list_branches(&repo_path) {
             Ok(branches) if branches.is_empty() => {
                 self.set_error("No branches found in repository");
                 self.pending_repo_path = None;
             }
-            Ok(mut branches) => {
-                // Move the default branch to front so it's pre-selected.
-                if let Some(default) = crate::git::default_branch(repo_path, &branches) {
-                    if let Some(pos) = branches.iter().position(|b| b == &default) {
-                        let branch = branches.remove(pos);
-                        branches.insert(0, branch);
-                    }
-                }
-
-                // Insert origin/<default> at position 0 for remote-based branching.
-                let remote_ref = crate::git::default_branch_from_remote(repo_path)
-                    .map(|name| format!("origin/{name}"))
-                    .or_else(|| {
-                        for candidate in ["origin/main", "origin/master"] {
-                            if crate::git::branch_exists(repo_path, candidate) {
-                                return Some(candidate.to_string());
-                            }
-                        }
-                        None
-                    });
-                if let Some(ref remote) = remote_ref {
-                    if !branches.contains(remote) {
-                        branches.insert(0, remote.clone());
-                    }
-                }
-
+            Ok(branches) => {
+                let branches = Self::ordered_branch_list(&repo_path, branches);
                 self.modal =
                     super::modals::Modal::BranchSelector(super::modals::BranchSelectorModal {
                         index: 0,
@@ -1074,6 +1024,59 @@ impl App {
                 self.pending_repo_path = None;
             }
         }
+    }
+
+    /// Fetch origin for the primary repo and any extra worktree repos so
+    /// branch lists are up-to-date. Failures are non-fatal (logged only).
+    fn fetch_pending_repos(
+        repo_path: &std::path::Path,
+        all_repos: Option<&Vec<std::path::PathBuf>>,
+    ) {
+        if let Err(e) = crate::git::git_fetch(repo_path) {
+            warn!("git fetch origin failed (continuing): {e:#}");
+        }
+        let Some(all_repos) = all_repos else {
+            return;
+        };
+        for extra_repo in all_repos.iter().skip(1) {
+            if let Err(e) = crate::git::git_fetch(extra_repo) {
+                warn!(
+                    "git fetch origin failed for {} (continuing): {e:#}",
+                    extra_repo.display()
+                );
+            }
+        }
+    }
+
+    /// Order a branch list for the selector: the local default branch first,
+    /// then `origin/<default>` (remote-based branching) pinned at the very top.
+    fn ordered_branch_list(repo_path: &std::path::Path, mut branches: Vec<String>) -> Vec<String> {
+        // Move the default branch to front so it's pre-selected.
+        if let Some(default) = crate::git::default_branch(repo_path, &branches) {
+            if let Some(pos) = branches.iter().position(|b| b == &default) {
+                let branch = branches.remove(pos);
+                branches.insert(0, branch);
+            }
+        }
+
+        // Insert origin/<default> at position 0 for remote-based branching.
+        let remote_ref = crate::git::default_branch_from_remote(repo_path)
+            .map(|name| format!("origin/{name}"))
+            .or_else(|| {
+                for candidate in ["origin/main", "origin/master"] {
+                    if crate::git::branch_exists(repo_path, candidate) {
+                        return Some(candidate.to_string());
+                    }
+                }
+                None
+            });
+        if let Some(ref remote) = remote_ref {
+            if !branches.contains(remote) {
+                branches.insert(0, remote.clone());
+            }
+        }
+
+        branches
     }
 
     // ── Repo Picker Modal ────────────────────────────────────────────────
@@ -1110,46 +1113,69 @@ impl App {
             KeyCode::Char('k') | KeyCode::Up => {
                 rp.list_index = rp.list_index.saturating_sub(1);
             }
-            KeyCode::Char(' ') => {
-                if let Some(&real_idx) = rp.filtered_indices.get(rp.list_index) {
-                    if let Some(sel) = rp.selected.get_mut(real_idx) {
-                        *sel = !*sel;
-                    }
-                }
-            }
-            KeyCode::Char('w') => {
-                if let Some(&real_idx) = rp.filtered_indices.get(rp.list_index) {
-                    if let Some(wt) = rp.worktree.get_mut(real_idx) {
-                        *wt = !*wt;
-                        // Auto-select when toggling worktree on
-                        if *wt {
-                            if let Some(sel) = rp.selected.get_mut(real_idx) {
-                                *sel = true;
-                            }
-                        }
-                    }
-                }
-            }
-            KeyCode::Char('d') => {
-                if let Some(&real_idx) = rp.filtered_indices.get(rp.list_index) {
-                    let path = rp.bookmarks[real_idx].clone();
-                    if let Err(e) = self.db.delete_repo_bookmark(&path) {
-                        error!("Failed to delete repo bookmark: {e}");
-                    }
-                    let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
-                        return;
-                    };
-                    rp.bookmarks.remove(real_idx);
-                    rp.selected.remove(real_idx);
-                    rp.worktree.remove(real_idx);
-                    self.recompute_repo_filter();
-                }
-            }
+            KeyCode::Char(' ') => self.repo_picker_toggle_selected(),
+            KeyCode::Char('w') => self.repo_picker_toggle_worktree(),
+            KeyCode::Char('d') => self.repo_picker_delete_bookmark(),
             KeyCode::Enter => {
                 self.submit_repo_picker();
             }
             _ => {}
         }
+    }
+
+    /// Toggle the selected flag of the repo under the list cursor.
+    fn repo_picker_toggle_selected(&mut self) {
+        let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
+            return;
+        };
+        let Some(&real_idx) = rp.filtered_indices.get(rp.list_index) else {
+            return;
+        };
+        if let Some(sel) = rp.selected.get_mut(real_idx) {
+            *sel = !*sel;
+        }
+    }
+
+    /// Toggle the worktree flag of the repo under the cursor, auto-selecting it
+    /// when worktree mode is turned on.
+    fn repo_picker_toggle_worktree(&mut self) {
+        let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
+            return;
+        };
+        let Some(&real_idx) = rp.filtered_indices.get(rp.list_index) else {
+            return;
+        };
+        let Some(wt) = rp.worktree.get_mut(real_idx) else {
+            return;
+        };
+        *wt = !*wt;
+        // Auto-select when toggling worktree on
+        if *wt {
+            if let Some(sel) = rp.selected.get_mut(real_idx) {
+                *sel = true;
+            }
+        }
+    }
+
+    /// Delete the bookmark under the cursor from the DB and the modal lists.
+    fn repo_picker_delete_bookmark(&mut self) {
+        let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
+            return;
+        };
+        let Some(&real_idx) = rp.filtered_indices.get(rp.list_index) else {
+            return;
+        };
+        let path = rp.bookmarks[real_idx].clone();
+        if let Err(e) = self.db.delete_repo_bookmark(&path) {
+            error!("Failed to delete repo bookmark: {e}");
+        }
+        let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
+            return;
+        };
+        rp.bookmarks.remove(real_idx);
+        rp.selected.remove(real_idx);
+        rp.worktree.remove(real_idx);
+        self.recompute_repo_filter();
     }
 
     fn handle_repo_picker_input_key(&mut self, code: KeyCode) {
@@ -1178,31 +1204,7 @@ impl App {
                 return;
             }
             KeyCode::Enter => {
-                let path = rp.path_input.value().trim().to_string();
-                if !path.is_empty() {
-                    let expanded = paths::expand_tilde(&path);
-                    // Add to bookmarks list if not already present
-                    if !rp.bookmarks.contains(&expanded) {
-                        rp.bookmarks.push(expanded.clone());
-                        rp.selected.push(true); // auto-select newly added
-                        rp.worktree.push(false);
-                    } else {
-                        // Already in list — just select it
-                        if let Some(idx) = rp.bookmarks.iter().position(|p| p == &expanded) {
-                            rp.selected[idx] = true;
-                        }
-                    }
-                    // Persist as bookmark
-                    if let Err(e) = self.db.upsert_repo_bookmark(&expanded) {
-                        error!("Failed to save repo bookmark: {e}");
-                    }
-                    let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
-                        return;
-                    };
-                    rp.path_input.clear();
-                    rp.path_suggestion = None;
-                }
-                self.recompute_repo_filter();
+                self.repo_picker_commit_path_input();
                 return;
             }
             KeyCode::Backspace => rp.path_input.backspace(),
@@ -1215,6 +1217,39 @@ impl App {
             _ => return,
         }
         self.update_repo_picker_path_suggestion();
+    }
+
+    /// Commit the typed path in the repo-picker input: add or re-select the
+    /// bookmark, persist it, clear the input, and refresh the filter.
+    fn repo_picker_commit_path_input(&mut self) {
+        let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
+            return;
+        };
+        let path = rp.path_input.value().trim().to_string();
+        if path.is_empty() {
+            self.recompute_repo_filter();
+            return;
+        }
+        let expanded = paths::expand_tilde(&path);
+        // Add to bookmarks list if not already present
+        if !rp.bookmarks.contains(&expanded) {
+            rp.bookmarks.push(expanded.clone());
+            rp.selected.push(true); // auto-select newly added
+            rp.worktree.push(false);
+        } else if let Some(idx) = rp.bookmarks.iter().position(|p| p == &expanded) {
+            // Already in list — just select it
+            rp.selected[idx] = true;
+        }
+        // Persist as bookmark
+        if let Err(e) = self.db.upsert_repo_bookmark(&expanded) {
+            error!("Failed to save repo bookmark: {e}");
+        }
+        let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
+            return;
+        };
+        rp.path_input.clear();
+        rp.path_suggestion = None;
+        self.recompute_repo_filter();
     }
 
     fn update_repo_picker_path_suggestion(&mut self) {
@@ -1292,21 +1327,7 @@ impl App {
             return;
         };
 
-        // Partition selected repos into worktree and normal sets.
-        let mut worktree_repos: Vec<std::path::PathBuf> = Vec::new();
-        let mut normal_repos: Vec<std::path::PathBuf> = Vec::new();
-        for (i, path) in rp.bookmarks.iter().enumerate() {
-            let selected = rp.selected.get(i).copied().unwrap_or(false);
-            if !selected {
-                continue;
-            }
-            let is_worktree = rp.worktree.get(i).copied().unwrap_or(false);
-            if is_worktree {
-                worktree_repos.push(path.clone());
-            } else {
-                normal_repos.push(path.clone());
-            }
-        }
+        let (worktree_repos, normal_repos) = Self::partition_selected_repos(rp);
 
         // Touch all selected bookmarks so they stay sorted by recency.
         for repo in worktree_repos.iter().chain(normal_repos.iter()) {
@@ -1345,6 +1366,25 @@ impl App {
             };
             self.spawn_session_with_config(&config);
         }
+    }
+
+    /// Split the selected bookmarks into (worktree repos, normal repos).
+    fn partition_selected_repos(
+        rp: &super::modals::RepoPickerModal,
+    ) -> (Vec<std::path::PathBuf>, Vec<std::path::PathBuf>) {
+        let mut worktree_repos: Vec<std::path::PathBuf> = Vec::new();
+        let mut normal_repos: Vec<std::path::PathBuf> = Vec::new();
+        for (i, path) in rp.bookmarks.iter().enumerate() {
+            if !rp.selected.get(i).copied().unwrap_or(false) {
+                continue;
+            }
+            if rp.worktree.get(i).copied().unwrap_or(false) {
+                worktree_repos.push(path.clone());
+            } else {
+                normal_repos.push(path.clone());
+            }
+        }
+        (worktree_repos, normal_repos)
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1506,34 +1506,7 @@ impl App {
     pub fn tick(&mut self) {
         self.tick_count = self.tick_count.wrapping_add(1);
 
-        let active_index = self.active_index;
-        for (idx, session) in self.sessions.iter_mut().enumerate() {
-            // The active session is being watched, so acknowledge any pending
-            // attention signal (keeps it from flagging itself while focused).
-            if idx == active_index {
-                session.acknowledge_attention();
-            }
-            let needs_attention = session.needs_attention();
-
-            session.info.status = if session.has_exited() {
-                SessionStatus::Idle
-            } else if session.millis_since_last_output() <= ACTIVITY_TIMEOUT_MS {
-                // Actively producing output → working, regardless of past signals.
-                SessionStatus::Busy
-            } else if needs_attention {
-                // Quiet after a bell / OSC 9 / OSC 777 → finished or needs input.
-                SessionStatus::Attention
-            } else {
-                SessionStatus::Waiting
-            };
-
-            // Live activity text from the agent-emitted OSC terminal title.
-            session.info.agent_activity = session.agent_title();
-            // Retain the agent's latest pushed notification (OSC 9/777) so the
-            // info panel can show it as a persistent "last signal", not only
-            // while the session is in the attention state.
-            session.info.notification = session.notification();
-        }
+        self.refresh_session_statuses();
 
         // Poll for sync results from background worktree sync threads
         self.poll_sync_results();
@@ -1555,24 +1528,7 @@ impl App {
             }
         }
 
-        // Poll for external state changes from other thurbox instances (DB-based)
-        if let Ok(Some(result)) = sync::poll_for_changes(&mut self.sync_state, &mut self.db) {
-            if result.db_changed {
-                // Pick up theme changes made by other thurbox processes (e.g.
-                // an MCP `set_theme` call from another session).
-                if let Ok(Some(name)) = self.db.get_active_theme() {
-                    if let Some(preset) = crate::session::ThemePreset::from_str(&name) {
-                        if preset != self.active_theme {
-                            crate::ui::theme::set_active(preset.palette());
-                            self.active_theme = preset;
-                        }
-                    }
-                }
-            }
-            if !result.delta.is_empty() {
-                self.handle_external_state_change(result.delta);
-            }
-        }
+        self.poll_external_changes();
 
         // Fire due automations. The first tick forces an immediate catch-up
         // pass so automations missed while the TUI was down run right away;
@@ -1601,6 +1557,67 @@ impl App {
         // Kick off usage fetches early and then on a slow cadence.
         if self.tick_count % USAGE_REFRESH_TICKS == 1 {
             self.spawn_usage_fetches();
+        }
+    }
+
+    /// Recompute each session's status/activity/notification for this tick.
+    fn refresh_session_statuses(&mut self) {
+        let active_index = self.active_index;
+        for (idx, session) in self.sessions.iter_mut().enumerate() {
+            // The active session is being watched, so acknowledge any pending
+            // attention signal (keeps it from flagging itself while focused).
+            if idx == active_index {
+                session.acknowledge_attention();
+            }
+            let needs_attention = session.needs_attention();
+
+            session.info.status = if session.has_exited() {
+                SessionStatus::Idle
+            } else if session.millis_since_last_output() <= ACTIVITY_TIMEOUT_MS {
+                // Actively producing output → working, regardless of past signals.
+                SessionStatus::Busy
+            } else if needs_attention {
+                // Quiet after a bell / OSC 9 / OSC 777 → finished or needs input.
+                SessionStatus::Attention
+            } else {
+                SessionStatus::Waiting
+            };
+
+            // Live activity text from the agent-emitted OSC terminal title.
+            session.info.agent_activity = session.agent_title();
+            // Retain the agent's latest pushed notification (OSC 9/777) so the
+            // info panel can show it as a persistent "last signal", not only
+            // while the session is in the attention state.
+            session.info.notification = session.notification();
+        }
+    }
+
+    /// Poll for external state changes from other thurbox instances (DB-based)
+    /// and apply any theme change / session delta they produced.
+    fn poll_external_changes(&mut self) {
+        let Ok(Some(result)) = sync::poll_for_changes(&mut self.sync_state, &mut self.db) else {
+            return;
+        };
+        if result.db_changed {
+            self.apply_external_theme_change();
+        }
+        if !result.delta.is_empty() {
+            self.handle_external_state_change(result.delta);
+        }
+    }
+
+    /// Pick up theme changes made by other thurbox processes (e.g. an MCP
+    /// `set_theme` call from another session).
+    fn apply_external_theme_change(&mut self) {
+        let Ok(Some(name)) = self.db.get_active_theme() else {
+            return;
+        };
+        let Some(preset) = crate::session::ThemePreset::from_str(&name) else {
+            return;
+        };
+        if preset != self.active_theme {
+            crate::ui::theme::set_active(preset.palette());
+            self.active_theme = preset;
         }
     }
 
@@ -1862,9 +1879,14 @@ impl App {
     fn handle_external_state_change(&mut self, delta: StateDelta) {
         // Update session counter to avoid conflicts
         self.session_counter = self.session_counter.max(delta.counter_increment);
+        self.apply_removed_sessions(delta.removed_sessions);
+        self.apply_updated_sessions(delta.updated_sessions);
+        self.apply_added_sessions(delta.added_sessions);
+    }
 
-        // Handle removed sessions (deleted by other instances)
-        for session_id in delta.removed_sessions {
+    /// Drop sessions deleted by other instances.
+    fn apply_removed_sessions(&mut self, removed: Vec<SessionId>) {
+        for session_id in removed {
             if let Some(pos) = self.sessions.iter().position(|s| s.info.id == session_id) {
                 self.sessions.remove(pos);
                 if self.active_index >= self.sessions.len() {
@@ -1872,9 +1894,11 @@ impl App {
                 }
             }
         }
+    }
 
-        // Handle updated sessions (metadata changed by other instances)
-        for shared_session in delta.updated_sessions {
+    /// Apply metadata changes made to existing sessions by other instances.
+    fn apply_updated_sessions(&mut self, updated: Vec<sync::SharedSession>) {
+        for shared_session in updated {
             if let Some(session) = self
                 .sessions
                 .iter_mut()
@@ -1883,24 +1907,26 @@ impl App {
                 Self::apply_shared_session_metadata(session, &shared_session);
             }
         }
+    }
 
-        // Handle added sessions from other instances.
-        //
-        // Headless spawns (CLI/MCP) persist the DB row with an empty
-        // `backend_id` because only the TUI knows the real tmux pane id
-        // (`%N`). Before spawning, call `discover()` and look up the
-        // existing window by sanitized name — otherwise we'd create a
-        // duplicate `tb-<name>` window for the one the CLI already
-        // opened, and exact-match `send-keys` would then fail on
-        // "ambiguous window".
-        //
-        // `discover()` is cached per backend_type so a burst of added
-        // sessions only hits tmux once per backend.
+    /// Adopt or spawn sessions added by other instances.
+    ///
+    /// Headless spawns (CLI/MCP) persist the DB row with an empty
+    /// `backend_id` because only the TUI knows the real tmux pane id
+    /// (`%N`). Before spawning, call `discover()` and look up the
+    /// existing window by sanitized name — otherwise we'd create a
+    /// duplicate `tb-<name>` window for the one the CLI already
+    /// opened, and exact-match `send-keys` would then fail on
+    /// "ambiguous window".
+    ///
+    /// `discover()` is cached per backend_type so a burst of added
+    /// sessions only hits tmux once per backend.
+    fn apply_added_sessions(&mut self, added: Vec<sync::SharedSession>) {
         let mut discovered_by_backend: HashMap<
             String,
             Vec<crate::agent::backend::DiscoveredSession>,
         > = HashMap::new();
-        for shared_session in delta.added_sessions {
+        for shared_session in added {
             // Skip if we already have this session
             if self.sessions.iter().any(|s| s.info.id == shared_session.id) {
                 continue;
@@ -1912,59 +1938,21 @@ impl App {
                 .cloned()
                 .unwrap_or_else(|| self.backends.default_backend().clone());
 
-            let discovered = discovered_by_backend
-                .entry(shared_session.backend_type.clone())
-                .or_insert_with(|| backend.discover().unwrap_or_default());
-            let matching_discovered = Self::find_matching_discovered(&shared_session, discovered);
+            let matching_backend_id = {
+                let discovered = discovered_by_backend
+                    .entry(shared_session.backend_type.clone())
+                    .or_insert_with(|| backend.discover().unwrap_or_default());
+                Self::find_matching_discovered(&shared_session, discovered)
+                    .map(|disc| disc.backend_id.clone())
+            };
 
             let (rows, cols) = self.content_area_size();
-            if let Some(disc) = matching_discovered {
-                let provider = {
-                    let cfg = SessionConfig {
-                        agent: shared_session.agent.clone(),
-                        ..SessionConfig::default()
-                    };
-                    self.provider_for(&cfg)
-                };
-                match Session::adopt(
-                    shared_session.name.clone(),
-                    rows,
-                    cols,
-                    &disc.backend_id,
-                    &backend,
-                    &provider,
-                    HashMap::new(),
-                ) {
-                    Ok(mut adopted_session) => {
-                        // Preserve the original session ID from shared
-                        // state (Session::adopt creates a new one, but we
-                        // need the consistent ID).
-                        adopted_session.info.id = shared_session.id;
-                        Self::apply_shared_session_metadata(&mut adopted_session, &shared_session);
-                        self.sessions.push(adopted_session);
-                        // Persist the real pane_id (`%N`) back to the DB
-                        // so future lookups short-circuit on the
-                        // backend_id match instead of always falling back
-                        // to name matching.
-                        self.save_state();
-                        tracing::debug!(
-                            "Adopted session {} from another instance",
-                            shared_session.name
-                        );
-                    }
-                    Err(e) => {
-                        tracing::debug!(
-                            "Failed to adopt session {} by discovered id {}: {}",
-                            shared_session.name,
-                            disc.backend_id,
-                            e
-                        );
-                    }
-                }
-                // Either adoption succeeded or the discovered window
-                // already exists and adoption failed transiently — in
-                // both cases we must NOT fall through to spawn, because
-                // that would create a second window with the same name.
+            if let Some(backend_id) = matching_backend_id {
+                // Either adoption succeeds or the discovered window already
+                // exists and adoption fails transiently — in both cases we
+                // must NOT fall through to spawn, because that would create
+                // a second window with the same name.
+                self.adopt_shared_session(&shared_session, &backend_id, &backend, rows, cols);
                 continue;
             }
 
@@ -1973,44 +1961,111 @@ impl App {
             // `--session-id` so claude creates the conversation (e.g.
             // CLI-created sessions whose claude process never persisted
             // a conversation before we first adopt them).
-            if let Some(ref agent_sid) = shared_session.agent_session_id {
-                let worktree_infos = Self::recreate_worktrees(&shared_session.worktrees);
-                let cwd = worktree_infos
-                    .first()
-                    .map(|wt| wt.worktree_path.clone())
-                    .or(shared_session.cwd.clone());
-
-                let mut config = SessionConfig {
-                    resume_session_id: None,
-                    agent_session_id: Some(agent_sid.clone()),
-                    cwd,
-                    agent: shared_session.agent.clone(),
-                    fork_session_id: None,
-                    ..SessionConfig::default()
-                };
-                config.resume_session_id =
-                    crate::session_ops::resume_id_if_transcript_exists(agent_sid, &config.env);
-                let provider = self.provider_for(&config);
-
-                if let Ok(mut spawned) = Session::spawn(
-                    shared_session.name.clone(),
-                    rows,
-                    cols,
-                    &config,
-                    &backend,
-                    &provider,
-                ) {
-                    spawned.info.id = shared_session.id;
-                    spawned.info.worktrees = worktree_infos;
-                    spawned.info.additional_dirs = shared_session.additional_dirs.clone();
-                    self.sessions.push(spawned);
-                    self.save_state();
-                    tracing::debug!(
-                        "Spawned restored session {} with --resume",
-                        shared_session.name
-                    );
-                }
+            if shared_session.agent_session_id.is_some() {
+                self.spawn_restored_session(&shared_session, &backend, rows, cols);
             }
+        }
+    }
+
+    /// Adopt an already-running discovered window into our session list.
+    fn adopt_shared_session(
+        &mut self,
+        shared_session: &sync::SharedSession,
+        backend_id: &str,
+        backend: &Arc<dyn crate::agent::backend::SessionBackend>,
+        rows: u16,
+        cols: u16,
+    ) {
+        let provider = {
+            let cfg = SessionConfig {
+                agent: shared_session.agent.clone(),
+                ..SessionConfig::default()
+            };
+            self.provider_for(&cfg)
+        };
+        match Session::adopt(
+            shared_session.name.clone(),
+            rows,
+            cols,
+            backend_id,
+            backend,
+            &provider,
+            HashMap::new(),
+        ) {
+            Ok(mut adopted_session) => {
+                // Preserve the original session ID from shared state
+                // (Session::adopt creates a new one, but we need the
+                // consistent ID).
+                adopted_session.info.id = shared_session.id;
+                Self::apply_shared_session_metadata(&mut adopted_session, shared_session);
+                self.sessions.push(adopted_session);
+                // Persist the real pane_id (`%N`) back to the DB so future
+                // lookups short-circuit on the backend_id match instead of
+                // always falling back to name matching.
+                self.save_state();
+                tracing::debug!(
+                    "Adopted session {} from another instance",
+                    shared_session.name
+                );
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "Failed to adopt session {} by discovered id {}: {}",
+                    shared_session.name,
+                    backend_id,
+                    e
+                );
+            }
+        }
+    }
+
+    /// Spawn a fresh window for a restored session that has an
+    /// `agent_session_id` but no matching discovered window.
+    fn spawn_restored_session(
+        &mut self,
+        shared_session: &sync::SharedSession,
+        backend: &Arc<dyn crate::agent::backend::SessionBackend>,
+        rows: u16,
+        cols: u16,
+    ) {
+        let Some(agent_sid) = shared_session.agent_session_id.as_ref() else {
+            return;
+        };
+        let worktree_infos = Self::recreate_worktrees(&shared_session.worktrees);
+        let cwd = worktree_infos
+            .first()
+            .map(|wt| wt.worktree_path.clone())
+            .or(shared_session.cwd.clone());
+
+        let mut config = SessionConfig {
+            resume_session_id: None,
+            agent_session_id: Some(agent_sid.clone()),
+            cwd,
+            agent: shared_session.agent.clone(),
+            fork_session_id: None,
+            ..SessionConfig::default()
+        };
+        config.resume_session_id =
+            crate::session_ops::resume_id_if_transcript_exists(agent_sid, &config.env);
+        let provider = self.provider_for(&config);
+
+        if let Ok(mut spawned) = Session::spawn(
+            shared_session.name.clone(),
+            rows,
+            cols,
+            &config,
+            backend,
+            &provider,
+        ) {
+            spawned.info.id = shared_session.id;
+            spawned.info.worktrees = worktree_infos;
+            spawned.info.additional_dirs = shared_session.additional_dirs.clone();
+            self.sessions.push(spawned);
+            self.save_state();
+            tracing::debug!(
+                "Spawned restored session {} with --resume",
+                shared_session.name
+            );
         }
     }
 
@@ -2169,7 +2224,6 @@ impl App {
         discovered: &[crate::agent::backend::DiscoveredSession],
     ) {
         let name = shared.name.clone();
-        let session_id = shared.id;
 
         let agent = if shared.agent.is_empty() {
             DEFAULT_AGENT_NAME.to_string()
@@ -2180,9 +2234,8 @@ impl App {
         let worktrees: Vec<WorktreeInfo> =
             shared.worktrees.iter().cloned().map(Into::into).collect();
 
-        let agent_session_id = match shared.agent_session_id {
-            Some(ref id) => id.clone(),
-            None => return,
+        let Some(agent_session_id) = shared.agent_session_id.clone() else {
+            return;
         };
 
         let matching_discovered = Self::find_matching_discovered(&shared, discovered);
@@ -2218,54 +2271,90 @@ impl App {
             }
         });
 
-        if let Some(mut session) = adopted {
-            session.info.id = session_id;
-            session.info.agent_session_id = Some(agent_session_id.clone());
-            session.info.cwd = shared.cwd.clone();
-            session.info.additional_dirs = shared.additional_dirs.clone();
-            session.info.agent = agent;
-            session.info.worktrees = worktrees.clone();
-            resolve_repo_display_names(&mut session.info);
-
-            // Re-adopt shell pane if one was persisted
-            if let Some(shell_bid) = &shared.shell_backend_id {
-                if discovered
-                    .iter()
-                    .any(|d| d.backend_id == *shell_bid && d.is_alive)
-                {
-                    let (rows, cols) = self.content_area_size();
-                    if let Err(e) = session.adopt_shell_pane(shell_bid, rows, cols) {
-                        tracing::warn!("Failed to re-adopt shell pane: {e}");
-                    }
-                }
-            }
-
-            self.sessions.push(session);
-            self.active_index = self.sessions.len() - 1;
-            self.focus = InputFocus::Terminal;
+        if let Some(session) = adopted {
+            self.finish_adopted_session(session, &shared, agent, worktrees, discovered);
         } else {
-            // No matching backend session or adopt failed — respawn with
-            // `--resume` when a transcript already exists for this
-            // agent_session_id, otherwise `--session-id` so claude creates
-            // the conversation (e.g. CLI-created sessions whose claude
-            // process never persisted a conversation).
-            if let Err(e) = self.db.soft_delete_session(session_id) {
-                error!("Failed to soft-delete stale session {session_id}: {e}");
-            }
-
-            let mut config = SessionConfig {
-                resume_session_id: None,
-                agent_session_id: Some(agent_session_id.clone()),
-                cwd: shared.cwd,
-                agent,
-                fork_session_id: None,
-                ..SessionConfig::default()
-            };
-            config.resume_session_id =
-                crate::session_ops::resume_id_if_transcript_exists(&agent_session_id, &config.env);
-            self.pending_additional_dirs = shared.additional_dirs;
-            self.do_spawn_session(name, &config, worktrees, false);
+            self.respawn_stale_session(name, shared, agent, agent_session_id, worktrees);
         }
+    }
+
+    /// Wire a freshly-adopted backend session into the app: copy persisted
+    /// metadata, re-adopt its shell pane, and make it the active session.
+    fn finish_adopted_session(
+        &mut self,
+        mut session: Session,
+        shared: &sync::SharedSession,
+        agent: String,
+        worktrees: Vec<WorktreeInfo>,
+        discovered: &[crate::agent::backend::DiscoveredSession],
+    ) {
+        session.info.id = shared.id;
+        session.info.agent_session_id = shared.agent_session_id.clone();
+        session.info.cwd = shared.cwd.clone();
+        session.info.additional_dirs = shared.additional_dirs.clone();
+        session.info.agent = agent;
+        session.info.worktrees = worktrees;
+        resolve_repo_display_names(&mut session.info);
+
+        // Re-adopt shell pane if one was persisted
+        if let Some(shell_bid) = &shared.shell_backend_id {
+            let (rows, cols) = self.content_area_size();
+            Self::readopt_shell_pane(&mut session, shell_bid, discovered, rows, cols);
+        }
+
+        self.sessions.push(session);
+        self.active_index = self.sessions.len() - 1;
+        self.focus = InputFocus::Terminal;
+    }
+
+    /// Re-adopt a persisted shell pane onto `session` if its backend window is
+    /// still alive. Failures are non-fatal (logged only).
+    fn readopt_shell_pane(
+        session: &mut Session,
+        shell_bid: &str,
+        discovered: &[crate::agent::backend::DiscoveredSession],
+        rows: u16,
+        cols: u16,
+    ) {
+        if !discovered
+            .iter()
+            .any(|d| d.backend_id == *shell_bid && d.is_alive)
+        {
+            return;
+        }
+        if let Err(e) = session.adopt_shell_pane(shell_bid, rows, cols) {
+            tracing::warn!("Failed to re-adopt shell pane: {e}");
+        }
+    }
+
+    /// No matching backend session or adopt failed — respawn with `--resume`
+    /// when a transcript already exists for this `agent_session_id`, otherwise
+    /// `--session-id` so claude creates the conversation (e.g. CLI-created
+    /// sessions whose claude process never persisted a conversation).
+    fn respawn_stale_session(
+        &mut self,
+        name: String,
+        shared: sync::SharedSession,
+        agent: String,
+        agent_session_id: String,
+        worktrees: Vec<WorktreeInfo>,
+    ) {
+        if let Err(e) = self.db.soft_delete_session(shared.id) {
+            error!("Failed to soft-delete stale session {}: {e}", shared.id);
+        }
+
+        let mut config = SessionConfig {
+            resume_session_id: None,
+            agent_session_id: Some(agent_session_id.clone()),
+            cwd: shared.cwd,
+            agent,
+            fork_session_id: None,
+            ..SessionConfig::default()
+        };
+        config.resume_session_id =
+            crate::session_ops::resume_id_if_transcript_exists(&agent_session_id, &config.env);
+        self.pending_additional_dirs = shared.additional_dirs;
+        self.do_spawn_session(name, &config, worktrees, false);
     }
 
     /// Find a discovered backend session matching a shared session.

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -31,6 +31,20 @@ impl App {
             self.cached_automations.len(),
         );
 
+        self.render_header(frame, areas.header);
+        self.render_left_panel(frame, areas.left_panel);
+        self.render_automations_pane(frame, areas.automations_panel);
+        self.render_info_panel(frame, areas.info_panel);
+        self.render_file_viewer(frame, areas.file_viewer);
+        self.render_central_pane(frame, areas.terminal);
+        self.render_footer(frame, areas.footer);
+        self.render_modals(frame);
+        self.repaint_theme_background(frame);
+        self.apply_selection_highlight(frame);
+    }
+
+    /// Render the top status-bar header with the active-session/theme badge.
+    fn render_header(&self, frame: &mut Frame, header: Rect) {
         let active_name = self
             .sessions
             .get(self.active_index)
@@ -38,168 +52,193 @@ impl App {
         let theme_label = self.active_theme.display_name();
         status_bar::render_header(
             frame,
-            areas.header,
+            header,
             Some(status_bar::HeaderBadge {
                 active_session: active_name,
                 theme_label,
             }),
         );
+    }
 
-        // Left panel (flat session list)
-        if let Some(left_area) = areas.left_panel {
-            // Build flat session list: all sessions, with tag names from projects
-            let all_sessions: Vec<&SessionInfo> = self.sessions.iter().map(|s| &s.info).collect();
-            self.session_elapsed_buf.clear();
-            for s in &self.sessions {
-                self.session_elapsed_buf.push(s.millis_since_last_output());
-            }
-
-            let session_elapsed_buf = self.session_elapsed_buf.clone();
-
-            // Pin admin sessions to the top of the list. All parallel arrays
-            // (elapsed, match_positions) and active_index are remapped so they
-            // stay aligned with the rendered order.
-            let ordered = project_list::OrderedSessions::new(
-                &all_sessions,
-                &session_elapsed_buf,
-                &self.session_match_positions,
-                self.active_index,
-            );
-
-            use crate::ui::FocusLevel;
-            let in_automation_context = matches!(
-                self.focus,
-                InputFocus::Automations
-                    | InputFocus::AutomationEditor
-                    | InputFocus::AutomationRunHistory
-            );
-            let list_focus = match self.focus {
-                InputFocus::SessionList => FocusLevel::Focused,
-                // In the automations context the central pane shows the
-                // automation, not a session — so the session list reads as fully
-                // unfocused (no accent border, no selected-row highlight; see
-                // `show_selection`).
-                _ if in_automation_context => FocusLevel::Inactive,
-                InputFocus::Terminal | InputFocus::FileViewer => FocusLevel::Active,
-                _ => FocusLevel::Active,
-            };
-            // Suppress the active-session row highlight while the automations
-            // context is active — the active session is irrelevant there.
-            let show_selection = !in_automation_context;
-
-            let match_count = self
-                .session_match_positions
-                .iter()
-                .filter(|m| m.is_some())
-                .count();
-            let total_count = ordered.sessions.len();
-
-            project_list::render_left_panel(
-                frame,
-                left_area,
-                &mut project_list::LeftPanelState {
-                    sessions: &ordered.sessions,
-                    active_session: ordered.active_index,
-                    show_selection,
-                    session_elapsed_ms: &ordered.elapsed_ms,
-                    session_focus: list_focus,
-                    session_list_state: &mut self.session_list_state,
-                    search_query: &self.search_input.buffer,
-                    search_active: self.search_active,
-                    search_cursor: self.search_input.cursor,
-                    session_match_positions: &ordered.match_positions,
-                    session_search_active: !self.session_match_positions.is_empty(),
-                    match_count,
-                    total_count,
-                    first_non_admin_index: ordered.first_non_admin_index,
-                },
-            );
+    /// Render the flat session list in the left panel (when present).
+    fn render_left_panel(&mut self, frame: &mut Frame, left_area: Option<Rect>) {
+        let Some(left_area) = left_area else {
+            return;
+        };
+        // Build flat session list: all sessions, with tag names from projects
+        let all_sessions: Vec<&SessionInfo> = self.sessions.iter().map(|s| &s.info).collect();
+        self.session_elapsed_buf.clear();
+        for s in &self.sessions {
+            self.session_elapsed_buf.push(s.millis_since_last_output());
         }
 
-        // Automations pane (beneath the session list in the left column)
-        if let Some(auto_area) = areas.automations_panel {
-            let now = crate::sync::current_time_millis();
-            let entries: Vec<automations_panel::AutomationPaneEntry> = self
-                .cached_automations
-                .iter()
-                .map(|a| automations_panel::AutomationPaneEntry {
-                    name: a.name.clone(),
-                    summary: super::format_automation_summary(a, now),
-                    enabled: a.enabled,
-                })
-                .collect();
-            let focus = match self.focus {
-                InputFocus::Automations => crate::ui::FocusLevel::Focused,
-                // While editing / browsing history in the central pane, keep the
-                // pane "active" so the row being worked on stays marked.
-                InputFocus::AutomationEditor | InputFocus::AutomationRunHistory => {
-                    crate::ui::FocusLevel::Active
+        let session_elapsed_buf = self.session_elapsed_buf.clone();
+
+        // Pin admin sessions to the top of the list. All parallel arrays
+        // (elapsed, match_positions) and active_index are remapped so they
+        // stay aligned with the rendered order.
+        let ordered = project_list::OrderedSessions::new(
+            &all_sessions,
+            &session_elapsed_buf,
+            &self.session_match_positions,
+            self.active_index,
+        );
+
+        use crate::ui::FocusLevel;
+        let in_automation_context = matches!(
+            self.focus,
+            InputFocus::Automations
+                | InputFocus::AutomationEditor
+                | InputFocus::AutomationRunHistory
+        );
+        let list_focus = match self.focus {
+            InputFocus::SessionList => FocusLevel::Focused,
+            // In the automations context the central pane shows the
+            // automation, not a session — so the session list reads as fully
+            // unfocused (no accent border, no selected-row highlight; see
+            // `show_selection`).
+            _ if in_automation_context => FocusLevel::Inactive,
+            InputFocus::Terminal | InputFocus::FileViewer => FocusLevel::Active,
+            _ => FocusLevel::Active,
+        };
+        // Suppress the active-session row highlight while the automations
+        // context is active — the active session is irrelevant there.
+        let show_selection = !in_automation_context;
+
+        let match_count = self
+            .session_match_positions
+            .iter()
+            .filter(|m| m.is_some())
+            .count();
+        let total_count = ordered.sessions.len();
+
+        project_list::render_left_panel(
+            frame,
+            left_area,
+            &mut project_list::LeftPanelState {
+                sessions: &ordered.sessions,
+                active_session: ordered.active_index,
+                show_selection,
+                session_elapsed_ms: &ordered.elapsed_ms,
+                session_focus: list_focus,
+                session_list_state: &mut self.session_list_state,
+                search_query: &self.search_input.buffer,
+                search_active: self.search_active,
+                search_cursor: self.search_input.cursor,
+                session_match_positions: &ordered.match_positions,
+                session_search_active: !self.session_match_positions.is_empty(),
+                match_count,
+                total_count,
+                first_non_admin_index: ordered.first_non_admin_index,
+            },
+        );
+    }
+
+    /// Render the automations pane beneath the session list (when present).
+    fn render_automations_pane(&self, frame: &mut Frame, auto_area: Option<Rect>) {
+        let Some(auto_area) = auto_area else {
+            return;
+        };
+        let now = crate::sync::current_time_millis();
+        let entries: Vec<automations_panel::AutomationPaneEntry> = self
+            .cached_automations
+            .iter()
+            .map(|a| automations_panel::AutomationPaneEntry {
+                name: a.name.clone(),
+                summary: super::format_automation_summary(a, now),
+                enabled: a.enabled,
+            })
+            .collect();
+        let focus = match self.focus {
+            InputFocus::Automations => crate::ui::FocusLevel::Focused,
+            // While editing / browsing history in the central pane, keep the
+            // pane "active" so the row being worked on stays marked.
+            InputFocus::AutomationEditor | InputFocus::AutomationRunHistory => {
+                crate::ui::FocusLevel::Active
+            }
+            _ => crate::ui::FocusLevel::Inactive,
+        };
+        let selected = self
+            .automation_panel_index
+            .min(entries.len().saturating_sub(1));
+        automations_panel::render_automations_pane(
+            frame,
+            auto_area,
+            &automations_panel::AutomationsPaneState {
+                entries: &entries,
+                selected,
+                focus,
+            },
+        );
+    }
+
+    /// Render the info panel for the active session (when present).
+    fn render_info_panel(&self, frame: &mut Frame, info_area: Option<Rect>) {
+        let Some(info_area) = info_area else {
+            return;
+        };
+        let Some(info) = self.sessions.get(self.active_index).map(|s| &s.info) else {
+            return;
+        };
+        let now = crate::sync::current_time_millis();
+        let agent_usage = self.usage.get(&info.agent);
+        let automation_entries: Vec<info_panel::AutomationEntry> = self
+            .cached_automations
+            .iter()
+            .filter(|a| a.enabled && a.next_run_at.is_some())
+            .map(|a| {
+                let remaining = a.next_run_at.unwrap_or(now).saturating_sub(now);
+                info_panel::AutomationEntry {
+                    label: truncate_str(&a.name, 30),
+                    countdown: format_countdown(remaining),
                 }
-                _ => crate::ui::FocusLevel::Inactive,
-            };
-            let selected = self
-                .automation_panel_index
-                .min(entries.len().saturating_sub(1));
-            automations_panel::render_automations_pane(
-                frame,
-                auto_area,
-                &automations_panel::AutomationsPaneState {
-                    entries: &entries,
-                    selected,
-                    focus,
-                },
-            );
-        }
+            })
+            .collect();
+        info_panel::render_info_panel(
+            frame,
+            info_area,
+            info,
+            Some(&self.system_metrics),
+            &automation_entries,
+            agent_usage,
+        );
+    }
 
-        // Info panel
-        if let Some(info_area) = areas.info_panel {
-            if let Some(info) = self.sessions.get(self.active_index).map(|s| &s.info) {
-                let now = crate::sync::current_time_millis();
-                let agent_usage = self.usage.get(&info.agent);
-                let automation_entries: Vec<info_panel::AutomationEntry> = self
-                    .cached_automations
-                    .iter()
-                    .filter(|a| a.enabled && a.next_run_at.is_some())
-                    .map(|a| {
-                        let remaining = a.next_run_at.unwrap_or(now).saturating_sub(now);
-                        info_panel::AutomationEntry {
-                            label: truncate_str(&a.name, 30),
-                            countdown: format_countdown(remaining),
-                        }
-                    })
-                    .collect();
-                info_panel::render_info_panel(
-                    frame,
-                    info_area,
-                    info,
-                    Some(&self.system_metrics),
-                    &automation_entries,
-                    agent_usage,
-                );
+    /// Render the file viewer in the right column (when present).
+    fn render_file_viewer(&mut self, frame: &mut Frame, fv_area: Option<Rect>) {
+        let Some(fv_area) = fv_area else {
+            return;
+        };
+        if let Some(session) = self.sessions.get(self.active_index) {
+            if self.file_viewer.needs_rebuild_for(&session.info) {
+                self.file_viewer.rebuild_from_session(&session.info);
             }
+        } else {
+            self.file_viewer.clear();
+        }
+        let fv_focus = match self.focus {
+            InputFocus::FileViewer => crate::ui::FocusLevel::Focused,
+            _ => crate::ui::FocusLevel::Inactive,
+        };
+        file_viewer::render_file_viewer(frame, fv_area, &self.file_viewer, fv_focus);
+    }
+
+    /// Render the central pane. In the automations context (the pane or its
+    /// editor is focused) it shows a single automation editor — a live preview
+    /// while the list is focused, editable once the editor itself is focused —
+    /// with the scoped automation's run history beneath it. Everything else
+    /// shows the session terminal.
+    fn render_central_pane(&mut self, frame: &mut Frame, terminal: Rect) {
+        if matches!(
+            self.focus,
+            InputFocus::Automations
+                | InputFocus::AutomationEditor
+                | InputFocus::AutomationRunHistory
+        ) {
+            self.render_automation_workspace(frame, terminal);
+            return;
         }
 
-        // File viewer (right column)
-        if let Some(fv_area) = areas.file_viewer {
-            if let Some(session) = self.sessions.get(self.active_index) {
-                if self.file_viewer.needs_rebuild_for(&session.info) {
-                    self.file_viewer.rebuild_from_session(&session.info);
-                }
-            } else {
-                self.file_viewer.clear();
-            }
-            let fv_focus = match self.focus {
-                InputFocus::FileViewer => crate::ui::FocusLevel::Focused,
-                _ => crate::ui::FocusLevel::Inactive,
-            };
-            file_viewer::render_file_viewer(frame, fv_area, &self.file_viewer, fv_focus);
-        }
-
-        // Central pane. In the automations context (the pane or its editor is
-        // focused) it shows a single automation editor — a live preview while
-        // the list is focused, editable once the editor itself is focused — with
-        // the scoped automation's run history beneath it. Everything else shows
-        // the session terminal.
         let terminal_focus = match self.focus {
             InputFocus::Terminal => crate::ui::FocusLevel::Focused,
             InputFocus::SessionList
@@ -210,39 +249,33 @@ impl App {
         };
         let is_shell_view = self.active_terminal_view() == TerminalView::Shell;
 
-        if matches!(
-            self.focus,
-            InputFocus::Automations
-                | InputFocus::AutomationEditor
-                | InputFocus::AutomationRunHistory
-        ) {
-            self.render_automation_workspace(frame, areas.terminal);
+        let Some(session) = self.sessions.get(self.active_index) else {
+            terminal_view::render_empty_terminal(frame, terminal);
+            return;
+        };
+        let is_admin_project = session.info.is_admin;
+        let parser_arc = if is_shell_view {
+            session.shell_pane.as_ref().map(|sp| &sp.parser)
         } else {
-            match self.sessions.get(self.active_index) {
-                Some(session) => {
-                    let is_admin_project = session.info.is_admin;
-                    let parser_arc = if is_shell_view {
-                        session.shell_pane.as_ref().map(|sp| &sp.parser)
-                    } else {
-                        None
-                    }
-                    .unwrap_or(&session.parser);
-                    if let Ok(mut parser) = parser_arc.lock() {
-                        terminal_view::render_terminal(
-                            frame,
-                            areas.terminal,
-                            &mut parser,
-                            &session.info,
-                            terminal_focus,
-                            is_admin_project,
-                            is_shell_view,
-                        );
-                    }
-                }
-                None => terminal_view::render_empty_terminal(frame, areas.terminal),
-            }
+            None
         }
+        .unwrap_or(&session.parser);
+        if let Ok(mut parser) = parser_arc.lock() {
+            terminal_view::render_terminal(
+                frame,
+                terminal,
+                &mut parser,
+                &session.info,
+                terminal_focus,
+                is_admin_project,
+                is_shell_view,
+            );
+        }
+    }
 
+    /// Render the bottom status-bar footer.
+    fn render_footer(&self, frame: &mut Frame, footer: Rect) {
+        let is_shell_view = self.active_terminal_view() == TerminalView::Shell;
         let focus_label = match self.focus {
             InputFocus::SessionList => "Sessions",
             InputFocus::Automations => "Automations",
@@ -254,7 +287,7 @@ impl App {
         };
         status_bar::render_footer(
             frame,
-            areas.footer,
+            footer,
             &status_bar::FooterState {
                 session_count: self.sessions.len(),
                 status: self.status_message.as_ref(),
@@ -265,7 +298,10 @@ impl App {
                 file_viewer_open: self.show_file_viewer,
             },
         );
+    }
 
+    /// Render any active modal overlay on top of everything else.
+    fn render_modals(&self, frame: &mut Frame) {
         // Help overlay (rendered last, on top of everything)
         if matches!(self.modal, super::modals::Modal::Help) {
             render_help_overlay(frame, &self.keybindings);
@@ -416,45 +452,51 @@ impl App {
                 },
             );
         }
+    }
 
-        // Repaint cells that fell back to terminal-default colours with the
-        // active theme's background and primary text. Themes whose `app_bg`
-        // is `Color::Reset` (e.g. the ANSI-based Default preset) skip this
-        // step so they continue to honour the user's terminal palette.
+    /// Repaint cells that fell back to terminal-default colours with the
+    /// active theme's background and primary text. Themes whose `app_bg`
+    /// is `Color::Reset` (e.g. the ANSI-based Default preset) skip this
+    /// step so they continue to honour the user's terminal palette.
+    fn repaint_theme_background(&self, frame: &mut Frame) {
         let app_bg = Theme::app_bg();
-        if app_bg != ratatui::style::Color::Reset {
-            let text_primary = Theme::text_primary();
-            let area = frame.area();
-            let buf = frame.buffer_mut();
-            for y in area.y..area.y + area.height {
-                for x in area.x..area.x + area.width {
-                    let pos = ratatui::layout::Position::new(x, y);
-                    if let Some(cell) = buf.cell_mut(pos) {
-                        if cell.bg == ratatui::style::Color::Reset {
-                            cell.bg = app_bg;
-                        }
-                        if cell.fg == ratatui::style::Color::Reset {
-                            cell.fg = text_primary;
-                        }
+        if app_bg == ratatui::style::Color::Reset {
+            return;
+        }
+        let text_primary = Theme::text_primary();
+        let area = frame.area();
+        let buf = frame.buffer_mut();
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                let pos = ratatui::layout::Position::new(x, y);
+                if let Some(cell) = buf.cell_mut(pos) {
+                    if cell.bg == ratatui::style::Color::Reset {
+                        cell.bg = app_bg;
+                    }
+                    if cell.fg == ratatui::style::Color::Reset {
+                        cell.fg = text_primary;
                     }
                 }
             }
         }
+    }
 
-        // Selection highlight and text cache — runs after all rendering.
-        if let Some(ref sel) = self.text_selection {
-            let sel_style = Style::default()
-                .bg(Theme::selection_bg())
-                .fg(Theme::selection_fg());
-            let sel_clone = sel.clone();
-
-            selection::highlight_buffer(frame.buffer_mut(), &sel_clone, sel_style);
-
-            let text = selection::extract_text_from_buffer(frame.buffer_mut(), &sel_clone);
-            self.selected_text_cache = if text.is_empty() { None } else { Some(text) };
-        } else {
+    /// Apply the selection highlight and refresh the selected-text cache —
+    /// runs after all rendering.
+    fn apply_selection_highlight(&mut self, frame: &mut Frame) {
+        let Some(ref sel) = self.text_selection else {
             self.selected_text_cache = None;
-        }
+            return;
+        };
+        let sel_style = Style::default()
+            .bg(Theme::selection_bg())
+            .fg(Theme::selection_fg());
+        let sel_clone = sel.clone();
+
+        selection::highlight_buffer(frame.buffer_mut(), &sel_clone, sel_style);
+
+        let text = selection::extract_text_from_buffer(frame.buffer_mut(), &sel_clone);
+        self.selected_text_cache = if text.is_empty() { None } else { Some(text) };
     }
 
     /// Render the single central-pane automation view: the editor for the

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -342,6 +342,27 @@ fn longest_common_prefix(strings: &[String]) -> String {
     first[..prefix_len].to_string()
 }
 
+/// Directory names directly under `parent` that start with `prefix`. Hidden
+/// entries (`.`-prefixed) are included only when `prefix` itself is hidden.
+/// Returns an empty vec when `parent` can't be read.
+fn matching_dir_names(parent: &Path, prefix: &str) -> Vec<String> {
+    let show_hidden = prefix.starts_with('.');
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+        .filter_map(|e| {
+            let name = e.file_name().to_str()?.to_string();
+            if !show_hidden && name.starts_with('.') {
+                return None;
+            }
+            name.starts_with(prefix).then_some(name)
+        })
+        .collect()
+}
+
 /// Fish-style directory path completion.
 ///
 /// Given a partial path input, returns the suffix to complete it.
@@ -374,25 +395,7 @@ pub fn complete_directory_path(input: &str) -> Option<String> {
         (parent, file_name.to_string())
     };
 
-    let entries = std::fs::read_dir(&parent).ok()?;
-
-    let show_hidden = prefix.starts_with('.');
-
-    let matches: Vec<String> = entries
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
-        .filter_map(|e| {
-            let name = e.file_name().to_str()?.to_string();
-            if !show_hidden && name.starts_with('.') {
-                return None;
-            }
-            if name.starts_with(&prefix) {
-                Some(name)
-            } else {
-                None
-            }
-        })
-        .collect();
+    let matches = matching_dir_names(&parent, &prefix);
 
     if matches.is_empty() {
         return None;

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -3,6 +3,9 @@ use rusqlite::Connection;
 /// Current schema version. Incremented when schema changes.
 pub const SCHEMA_VERSION: u32 = 24;
 
+/// A single migration step: applied when the stored version is below `target`.
+type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
+
 /// Create all tables and indexes if they don't exist.
 pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch("PRAGMA journal_mode = WAL;")?;
@@ -129,544 +132,35 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         )
         .unwrap_or(0);
 
-    if version < 3 {
-        // v2 → v3: add additional_dirs column to sessions
-        let _ = conn.execute(
-            "ALTER TABLE sessions ADD COLUMN additional_dirs TEXT NOT NULL DEFAULT ''",
-            [],
-        );
-    }
+    // Each migration step is gated on the stored version and applied in order.
+    // Steps are extracted into helpers to keep this dispatcher flat.
+    let steps: &[MigrationStep] = &[
+        (3, migrate_v3_additional_dirs),
+        (4, migrate_v4_project_mcp_servers),
+        (5, migrate_v5_session_commands),
+        (6, migrate_v6_worktrees_pk),
+        (7, migrate_v7_shell_backend_id),
+        (8, migrate_v8_vms),
+        (9, migrate_v9_agent_session_id),
+        (10, migrate_v10_containers),
+        (11, migrate_v11_containerfile),
+        (12, migrate_v12_scheduled_commands),
+        (13, migrate_v13_roles),
+        (14, migrate_v14_mcp_servers),
+        (15, migrate_v15_nullable_project_id),
+        (16, migrate_v16_drop_projects),
+        (17, migrate_v17_skills),
+        (19, migrate_v19_plugins),
+        (20, migrate_v20_profiles),
+        (21, migrate_v21_drop_model),
+        (22, migrate_v22_drop_subsystems),
+        (23, migrate_v23_generic_agent),
+        (24, migrate_v24_automations),
+    ];
 
-    if version < 4 {
-        // v3 → v4: add project_mcp_servers table
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS project_mcp_servers (
-                project_id  TEXT NOT NULL REFERENCES projects(id),
-                server_name TEXT NOT NULL,
-                command     TEXT NOT NULL DEFAULT '',
-                args        TEXT NOT NULL DEFAULT '',
-                env         TEXT NOT NULL DEFAULT '',
-                created_at  INTEGER NOT NULL,
-                updated_at  INTEGER NOT NULL,
-                PRIMARY KEY (project_id, server_name)
-            );",
-        )?;
-    }
-
-    if version < 5 {
-        // v4 → v5: add session_commands table for MCP-driven session operations
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS session_commands (
-                id           INTEGER PRIMARY KEY AUTOINCREMENT,
-                session_id   TEXT NOT NULL,
-                command      TEXT NOT NULL,
-                created_at   INTEGER NOT NULL,
-                processed_at INTEGER
-            );
-            CREATE INDEX IF NOT EXISTS idx_session_commands_pending
-                ON session_commands(id) WHERE processed_at IS NULL;",
-        )?;
-    }
-
-    if version < 6 {
-        // v5 → v6: change worktrees PK from session_id to (session_id, repo_path)
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS worktrees_new (
-                session_id    TEXT NOT NULL REFERENCES sessions(id),
-                repo_path     TEXT NOT NULL,
-                worktree_path TEXT NOT NULL,
-                branch        TEXT NOT NULL,
-                created_at    INTEGER NOT NULL,
-                deleted_at    INTEGER,
-                PRIMARY KEY (session_id, repo_path)
-            );
-            INSERT OR IGNORE INTO worktrees_new
-                SELECT session_id, repo_path, worktree_path, branch, created_at, deleted_at
-                FROM worktrees;
-            DROP TABLE IF EXISTS worktrees;
-            ALTER TABLE worktrees_new RENAME TO worktrees;",
-        )?;
-    }
-
-    if version < 7 {
-        // v6 → v7: add shell_backend_id column to sessions
-        let _ = conn.execute("ALTER TABLE sessions ADD COLUMN shell_backend_id TEXT", []);
-    }
-
-    if version < 8 {
-        // v7 → v8: add env column to project_roles, add VM tables for sandboxed sessions
-        let _ = conn.execute(
-            "ALTER TABLE project_roles ADD COLUMN env TEXT NOT NULL DEFAULT ''",
-            [],
-        );
-
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS vms (
-                id          TEXT PRIMARY KEY,
-                session_id  TEXT REFERENCES sessions(id),
-                project_id  TEXT REFERENCES projects(id),
-                state       TEXT NOT NULL DEFAULT 'stopped',
-                ssh_port    INTEGER NOT NULL,
-                base_image  TEXT NOT NULL,
-                cpus        INTEGER NOT NULL DEFAULT 2,
-                memory_mb   INTEGER NOT NULL DEFAULT 2048,
-                disk_gb     INTEGER NOT NULL DEFAULT 10,
-                qemu_pid    INTEGER,
-                error_msg   TEXT,
-                created_at  INTEGER NOT NULL,
-                updated_at  INTEGER NOT NULL,
-                deleted_at  INTEGER
-            );
-
-            CREATE TABLE IF NOT EXISTS project_vm_config (
-                project_id   TEXT PRIMARY KEY REFERENCES projects(id),
-                base_image   TEXT,
-                cpus         INTEGER,
-                memory_mb    INTEGER,
-                disk_gb      INTEGER,
-                setup_script TEXT,
-                updated_at   INTEGER NOT NULL
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_vms_session
-                ON vms(session_id) WHERE deleted_at IS NULL;
-            CREATE INDEX IF NOT EXISTS idx_vms_project
-                ON vms(project_id) WHERE deleted_at IS NULL;",
-        )?;
-    }
-
-    if version < 9 {
-        // v8 → v9: rename claude_session_id → agent_session_id
-        let _ = conn.execute(
-            "ALTER TABLE sessions RENAME COLUMN claude_session_id TO agent_session_id",
-            [],
-        );
-    }
-
-    if version < 10 {
-        // v9 → v10: add containers and project_container_config tables
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS containers (
-                id                  TEXT PRIMARY KEY,
-                session_id          TEXT REFERENCES sessions(id),
-                project_id          TEXT REFERENCES projects(id),
-                state               TEXT NOT NULL DEFAULT 'stopped',
-                docker_container_id TEXT,
-                image               TEXT,
-                cpus                INTEGER NOT NULL DEFAULT 2,
-                memory_mb           INTEGER NOT NULL DEFAULT 2048,
-                firewall_enabled    INTEGER NOT NULL DEFAULT 1,
-                error_msg           TEXT,
-                created_at          INTEGER NOT NULL,
-                updated_at          INTEGER NOT NULL,
-                deleted_at          INTEGER
-            );
-
-            CREATE TABLE IF NOT EXISTS project_container_config (
-                project_id       TEXT PRIMARY KEY REFERENCES projects(id),
-                image            TEXT,
-                cpus             INTEGER,
-                memory_mb        INTEGER,
-                firewall_enabled INTEGER,
-                updated_at       INTEGER NOT NULL
-            );
-
-            CREATE INDEX IF NOT EXISTS idx_containers_session
-                ON containers(session_id) WHERE deleted_at IS NULL;
-            CREATE INDEX IF NOT EXISTS idx_containers_project
-                ON containers(project_id) WHERE deleted_at IS NULL;",
-        )?;
-    }
-
-    if version < 11 {
-        // v10 → v11: add containerfile column to containers and project_container_config
-        let _ = conn.execute("ALTER TABLE containers ADD COLUMN containerfile TEXT", []);
-        let _ = conn.execute(
-            "ALTER TABLE project_container_config ADD COLUMN containerfile TEXT",
-            [],
-        );
-    }
-
-    if version < 12 {
-        // v11 → v12: add scheduled_commands table for time-scheduled session inputs
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS scheduled_commands (
-                id             INTEGER PRIMARY KEY AUTOINCREMENT,
-                session_id     TEXT NOT NULL,
-                command_text   TEXT NOT NULL,
-                scheduled_at   INTEGER NOT NULL,
-                created_at     INTEGER NOT NULL,
-                executed_at    INTEGER,
-                cancelled_at   INTEGER
-            );
-            CREATE INDEX IF NOT EXISTS idx_scheduled_commands_pending
-                ON scheduled_commands(scheduled_at)
-                WHERE executed_at IS NULL AND cancelled_at IS NULL;",
-        )?;
-    }
-
-    if version < 13 {
-        // v12 → v13: add global `roles` table and seed from project_roles
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS roles (
-                role_name           TEXT PRIMARY KEY,
-                description         TEXT NOT NULL DEFAULT '',
-                permission_mode     TEXT,
-                allowed_tools       TEXT NOT NULL DEFAULT '',
-                disallowed_tools    TEXT NOT NULL DEFAULT '',
-                tools               TEXT,
-                append_system_prompt TEXT,
-                env                 TEXT NOT NULL DEFAULT '',
-                created_at          INTEGER NOT NULL,
-                updated_at          INTEGER NOT NULL
-            );
-            INSERT OR IGNORE INTO roles
-                (role_name, description, permission_mode, allowed_tools,
-                 disallowed_tools, tools, append_system_prompt, env,
-                 created_at, updated_at)
-                SELECT DISTINCT role_name, description, permission_mode, allowed_tools,
-                       disallowed_tools, tools, append_system_prompt, env,
-                       created_at, updated_at
-                FROM project_roles;",
-        )?;
-    }
-
-    if version < 14 {
-        // v13 → v14: add global `mcp_servers` table and seed from project_mcp_servers
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS mcp_servers (
-                server_name TEXT PRIMARY KEY,
-                command     TEXT NOT NULL DEFAULT '',
-                args        TEXT NOT NULL DEFAULT '',
-                env         TEXT NOT NULL DEFAULT '',
-                created_at  INTEGER NOT NULL,
-                updated_at  INTEGER NOT NULL
-            );
-            INSERT OR IGNORE INTO mcp_servers
-                (server_name, command, args, env, created_at, updated_at)
-                SELECT DISTINCT server_name, command, args, env,
-                       created_at, updated_at
-                FROM project_mcp_servers;",
-        )?;
-    }
-
-    if version < 15 {
-        // v14 → v15: make project_id nullable on sessions, add repo_bookmarks table
-        conn.execute_batch(
-            "DROP TABLE IF EXISTS sessions_new;
-            CREATE TABLE sessions_new (
-                id                TEXT PRIMARY KEY,
-                name              TEXT NOT NULL,
-                project_id        TEXT REFERENCES projects(id),
-                role              TEXT NOT NULL DEFAULT 'developer',
-                backend_id        TEXT NOT NULL DEFAULT '',
-                backend_type      TEXT NOT NULL DEFAULT 'tmux',
-                agent_session_id  TEXT,
-                cwd               TEXT,
-                additional_dirs   TEXT NOT NULL DEFAULT '',
-                shell_backend_id  TEXT,
-                created_at        INTEGER NOT NULL,
-                updated_at        INTEGER NOT NULL,
-                deleted_at        INTEGER
-            );
-            PRAGMA foreign_keys = OFF;
-            INSERT INTO sessions_new (id, name, project_id, role, backend_id,
-                backend_type, agent_session_id, cwd, additional_dirs,
-                shell_backend_id, created_at, updated_at, deleted_at)
-                SELECT id, name,
-                    CASE WHEN project_id IN (SELECT id FROM projects) THEN project_id ELSE NULL END,
-                    role, backend_id,
-                    backend_type, agent_session_id, cwd, additional_dirs,
-                    shell_backend_id,
-                    COALESCE(created_at, 0),
-                    COALESCE(updated_at, 0),
-                    deleted_at
-                FROM sessions;
-            DROP TABLE sessions;
-            ALTER TABLE sessions_new RENAME TO sessions;
-            PRAGMA foreign_keys = ON;
-            CREATE INDEX IF NOT EXISTS idx_sessions_project
-                ON sessions(project_id) WHERE deleted_at IS NULL;
-            CREATE INDEX IF NOT EXISTS idx_sessions_active
-                ON sessions(id) WHERE deleted_at IS NULL;
-
-            CREATE TABLE IF NOT EXISTS repo_bookmarks (
-                repo_path    TEXT PRIMARY KEY,
-                label        TEXT,
-                last_used_at INTEGER NOT NULL,
-                use_count    INTEGER NOT NULL DEFAULT 1
-            );
-
-            INSERT OR IGNORE INTO repo_bookmarks (repo_path, last_used_at, use_count)
-                SELECT DISTINCT repo_path,
-                       COALESCE((SELECT MAX(s.updated_at) FROM sessions s
-                                  INNER JOIN projects p ON p.id = s.project_id
-                                  INNER JOIN project_repos pr ON pr.project_id = p.id
-                                  AND pr.repo_path = project_repos.repo_path), 0),
-                       1
-                FROM project_repos;",
-        )?;
-    }
-
-    if version < 16 {
-        // v15 → v16: remove project tables and project_id columns from sessions/vms/containers
-        conn.execute_batch(
-            "PRAGMA foreign_keys = OFF;
-
-            -- Recreate sessions without project_id
-            DROP TABLE IF EXISTS sessions_new;
-            CREATE TABLE sessions_new (
-                id                TEXT PRIMARY KEY,
-                name              TEXT NOT NULL,
-                role              TEXT NOT NULL DEFAULT 'developer',
-                backend_id        TEXT NOT NULL DEFAULT '',
-                backend_type      TEXT NOT NULL DEFAULT 'tmux',
-                agent_session_id  TEXT,
-                cwd               TEXT,
-                additional_dirs   TEXT NOT NULL DEFAULT '',
-                shell_backend_id  TEXT,
-                created_at        INTEGER NOT NULL,
-                updated_at        INTEGER NOT NULL,
-                deleted_at        INTEGER
-            );
-            INSERT INTO sessions_new (id, name, role, backend_id, backend_type,
-                agent_session_id, cwd, additional_dirs, shell_backend_id,
-                created_at, updated_at, deleted_at)
-                SELECT id, name, role, backend_id, backend_type,
-                    agent_session_id, cwd, additional_dirs, shell_backend_id,
-                    created_at, updated_at, deleted_at
-                FROM sessions;
-            DROP TABLE sessions;
-            ALTER TABLE sessions_new RENAME TO sessions;
-            CREATE INDEX IF NOT EXISTS idx_sessions_active
-                ON sessions(id) WHERE deleted_at IS NULL;
-
-            -- Recreate vms without project_id
-            DROP TABLE IF EXISTS vms_new;
-            CREATE TABLE vms_new (
-                id          TEXT PRIMARY KEY,
-                session_id  TEXT REFERENCES sessions(id),
-                state       TEXT NOT NULL DEFAULT 'stopped',
-                ssh_port    INTEGER NOT NULL,
-                base_image  TEXT NOT NULL,
-                cpus        INTEGER NOT NULL DEFAULT 2,
-                memory_mb   INTEGER NOT NULL DEFAULT 2048,
-                disk_gb     INTEGER NOT NULL DEFAULT 10,
-                qemu_pid    INTEGER,
-                error_msg   TEXT,
-                created_at  INTEGER NOT NULL,
-                updated_at  INTEGER NOT NULL,
-                deleted_at  INTEGER
-            );
-            INSERT INTO vms_new (id, session_id, state, ssh_port, base_image,
-                cpus, memory_mb, disk_gb, qemu_pid, error_msg,
-                created_at, updated_at, deleted_at)
-                SELECT id, session_id, state, ssh_port, base_image,
-                    cpus, memory_mb, disk_gb, qemu_pid, error_msg,
-                    created_at, updated_at, deleted_at
-                FROM vms;
-            DROP TABLE IF EXISTS vms;
-            ALTER TABLE vms_new RENAME TO vms;
-            CREATE INDEX IF NOT EXISTS idx_vms_session
-                ON vms(session_id) WHERE deleted_at IS NULL;
-
-            -- Recreate containers without project_id
-            DROP TABLE IF EXISTS containers_new;
-            CREATE TABLE containers_new (
-                id                  TEXT PRIMARY KEY,
-                session_id          TEXT REFERENCES sessions(id),
-                state               TEXT NOT NULL DEFAULT 'stopped',
-                docker_container_id TEXT,
-                image               TEXT,
-                cpus                INTEGER NOT NULL DEFAULT 2,
-                memory_mb           INTEGER NOT NULL DEFAULT 2048,
-                firewall_enabled    INTEGER NOT NULL DEFAULT 1,
-                containerfile       TEXT,
-                error_msg           TEXT,
-                created_at          INTEGER NOT NULL,
-                updated_at          INTEGER NOT NULL,
-                deleted_at          INTEGER
-            );
-            INSERT INTO containers_new (id, session_id, state, docker_container_id,
-                image, cpus, memory_mb, firewall_enabled, containerfile,
-                error_msg, created_at, updated_at, deleted_at)
-                SELECT id, session_id, state, docker_container_id,
-                    image, cpus, memory_mb, firewall_enabled, containerfile,
-                    error_msg, created_at, updated_at, deleted_at
-                FROM containers;
-            DROP TABLE IF EXISTS containers;
-            ALTER TABLE containers_new RENAME TO containers;
-            CREATE INDEX IF NOT EXISTS idx_containers_session
-                ON containers(session_id) WHERE deleted_at IS NULL;
-
-            -- Drop project tables
-            DROP TABLE IF EXISTS project_container_config;
-            DROP TABLE IF EXISTS project_vm_config;
-            DROP TABLE IF EXISTS project_mcp_servers;
-            DROP TABLE IF EXISTS project_roles;
-            DROP TABLE IF EXISTS project_repos;
-            DROP TABLE IF EXISTS projects;
-
-            PRAGMA foreign_keys = ON;",
-        )?;
-    }
-
-    if version < 17 {
-        // v16 → v17: add skills table for global skill management
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS skills (
-                skill_name TEXT PRIMARY KEY,
-                path       TEXT NOT NULL,
-                created_at INTEGER NOT NULL,
-                updated_at INTEGER NOT NULL
-            );",
-        )?;
-    }
-
-    if version < 19 {
-        // v18 → v19: add plugins + plugin_settings tables for the plugin bundle system
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS plugins (
-                plugin_name TEXT PRIMARY KEY,
-                path        TEXT NOT NULL,
-                version     TEXT NOT NULL DEFAULT '',
-                enabled     INTEGER NOT NULL DEFAULT 1,
-                created_at  INTEGER NOT NULL,
-                updated_at  INTEGER NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS plugin_settings (
-                plugin_name TEXT NOT NULL,
-                key         TEXT NOT NULL,
-                value_json  TEXT NOT NULL,
-                updated_at  INTEGER NOT NULL,
-                PRIMARY KEY (plugin_name, key),
-                FOREIGN KEY (plugin_name) REFERENCES plugins(plugin_name) ON DELETE CASCADE
-            );",
-        )?;
-    }
-
-    if version < 20 {
-        // v19 → v20: add profiles table bundling roles + MCP servers + skills
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS profiles (
-                profile_name      TEXT PRIMARY KEY,
-                description       TEXT NOT NULL DEFAULT '',
-                role_names        TEXT NOT NULL DEFAULT '',
-                mcp_server_names  TEXT NOT NULL DEFAULT '',
-                skill_names       TEXT NOT NULL DEFAULT '',
-                created_at        INTEGER NOT NULL,
-                updated_at        INTEGER NOT NULL
-            );",
-        )?;
-    }
-
-    if version < 21 {
-        // v20 → v21: drop the sessions.model column. Model selection was
-        // removed from the product — the agent picks its own model now.
-        // Use ignore-on-error in case an older SQLite (<3.35) lacks DROP
-        // COLUMN support; the unused column is harmless.
-        let _ = conn.execute("ALTER TABLE sessions DROP COLUMN model", []);
-    }
-
-    if version < 22 {
-        // v21 → v22: drop tables for removed subsystems. VM, devcontainer,
-        // and process-plugin subsystems were removed to focus thurbox on
-        // the TUI surface; the session_commands queue is unused now that
-        // MCP `restart_session` / `create_session` run synchronously.
-        conn.execute_batch(
-            "DROP TABLE IF EXISTS plugin_settings;
-             DROP TABLE IF EXISTS plugins;
-             DROP TABLE IF EXISTS vms;
-             DROP TABLE IF EXISTS containers;
-             DROP TABLE IF EXISTS project_vm_config;
-             DROP TABLE IF EXISTS project_container_config;
-             DROP TABLE IF EXISTS session_commands;",
-        )?;
-    }
-
-    if version < 23 {
-        // v22 → v23: pivot to a generic per-session agent. Add the `agent`
-        // column to sessions (existing rows default to "claude") and drop the
-        // now-unused Claude-config tables. Existing sessions/worktrees are kept.
-        let has_agent_col: bool = conn
-            .prepare("SELECT 1 FROM pragma_table_info('sessions') WHERE name = 'agent'")?
-            .exists([])?;
-        if !has_agent_col {
-            conn.execute_batch(
-                "ALTER TABLE sessions ADD COLUMN agent TEXT NOT NULL DEFAULT 'claude';",
-            )?;
-        }
-        conn.execute_batch(
-            "DROP TABLE IF EXISTS profiles;
-             DROP TABLE IF EXISTS skills;
-             DROP TABLE IF EXISTS mcp_servers;
-             DROP TABLE IF EXISTS roles;
-             DELETE FROM metadata WHERE key = 'profiles_seeded';",
-        )?;
-    }
-
-    if version < 24 {
-        // v23 → v24: replace the one-shot `scheduled_commands` table with the
-        // unified `automations` concept (one-shot OR recurring cron, send OR
-        // spawn actions) plus a `automation_runs` history table. Pending
-        // one-shot scheduled commands are migrated forward as `once`/`send`
-        // automations; executed/cancelled ones are dropped with the table.
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS automations (
-                id              INTEGER PRIMARY KEY AUTOINCREMENT,
-                name            TEXT NOT NULL,
-                enabled         INTEGER NOT NULL DEFAULT 1,
-                schedule_kind   TEXT NOT NULL,
-                schedule_spec   TEXT NOT NULL,
-                timezone        TEXT,
-                action_kind     TEXT NOT NULL,
-                target_session  TEXT,
-                repo_path       TEXT,
-                worktree_branch TEXT,
-                base_branch     TEXT,
-                agent           TEXT,
-                prompt          TEXT NOT NULL,
-                created_at      INTEGER NOT NULL,
-                updated_at      INTEGER NOT NULL,
-                last_run_at     INTEGER,
-                next_run_at     INTEGER
-            );
-            CREATE INDEX IF NOT EXISTS idx_automations_due
-                ON automations(next_run_at)
-                WHERE enabled = 1 AND next_run_at IS NOT NULL;
-            CREATE TABLE IF NOT EXISTS automation_runs (
-                id            INTEGER PRIMARY KEY AUTOINCREMENT,
-                automation_id INTEGER NOT NULL,
-                started_at    INTEGER NOT NULL,
-                status        TEXT NOT NULL,
-                detail        TEXT NOT NULL DEFAULT ''
-            );
-            CREATE INDEX IF NOT EXISTS idx_automation_runs_automation
-                ON automation_runs(automation_id, started_at);",
-        )?;
-
-        // Only migrate if the legacy table is present (fresh DBs created at v24
-        // never had it).
-        let has_legacy: bool = conn
-            .prepare(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='scheduled_commands'",
-            )?
-            .exists([])?;
-        if has_legacy {
-            conn.execute_batch(
-                "INSERT INTO automations
-                    (name, enabled, schedule_kind, schedule_spec, timezone,
-                     action_kind, target_session, prompt,
-                     created_at, updated_at, last_run_at, next_run_at)
-                 SELECT
-                    'migrated-' || id, 1, 'once', CAST(scheduled_at AS TEXT), NULL,
-                    'send', session_id, command_text,
-                    created_at, created_at, NULL, scheduled_at
-                 FROM scheduled_commands
-                 WHERE executed_at IS NULL AND cancelled_at IS NULL;
-                 DROP TABLE IF EXISTS scheduled_commands;",
-            )?;
+    for &(target, step) in steps {
+        if version < target {
+            step(conn)?;
         }
     }
 
@@ -677,6 +171,551 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         )?;
     }
 
+    Ok(())
+}
+
+/// v2 → v3: add additional_dirs column to sessions
+fn migrate_v3_additional_dirs(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute(
+        "ALTER TABLE sessions ADD COLUMN additional_dirs TEXT NOT NULL DEFAULT ''",
+        [],
+    );
+    Ok(())
+}
+
+/// v3 → v4: add project_mcp_servers table
+fn migrate_v4_project_mcp_servers(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS project_mcp_servers (
+            project_id  TEXT NOT NULL REFERENCES projects(id),
+            server_name TEXT NOT NULL,
+            command     TEXT NOT NULL DEFAULT '',
+            args        TEXT NOT NULL DEFAULT '',
+            env         TEXT NOT NULL DEFAULT '',
+            created_at  INTEGER NOT NULL,
+            updated_at  INTEGER NOT NULL,
+            PRIMARY KEY (project_id, server_name)
+        );",
+    )
+}
+
+/// v4 → v5: add session_commands table for MCP-driven session operations
+fn migrate_v5_session_commands(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS session_commands (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id   TEXT NOT NULL,
+            command      TEXT NOT NULL,
+            created_at   INTEGER NOT NULL,
+            processed_at INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_session_commands_pending
+            ON session_commands(id) WHERE processed_at IS NULL;",
+    )
+}
+
+/// v5 → v6: change worktrees PK from session_id to (session_id, repo_path)
+fn migrate_v6_worktrees_pk(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS worktrees_new (
+            session_id    TEXT NOT NULL REFERENCES sessions(id),
+            repo_path     TEXT NOT NULL,
+            worktree_path TEXT NOT NULL,
+            branch        TEXT NOT NULL,
+            created_at    INTEGER NOT NULL,
+            deleted_at    INTEGER,
+            PRIMARY KEY (session_id, repo_path)
+        );
+        INSERT OR IGNORE INTO worktrees_new
+            SELECT session_id, repo_path, worktree_path, branch, created_at, deleted_at
+            FROM worktrees;
+        DROP TABLE IF EXISTS worktrees;
+        ALTER TABLE worktrees_new RENAME TO worktrees;",
+    )
+}
+
+/// v6 → v7: add shell_backend_id column to sessions
+fn migrate_v7_shell_backend_id(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN shell_backend_id TEXT", []);
+    Ok(())
+}
+
+/// v7 → v8: add env column to project_roles, add VM tables for sandboxed sessions
+fn migrate_v8_vms(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute(
+        "ALTER TABLE project_roles ADD COLUMN env TEXT NOT NULL DEFAULT ''",
+        [],
+    );
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS vms (
+            id          TEXT PRIMARY KEY,
+            session_id  TEXT REFERENCES sessions(id),
+            project_id  TEXT REFERENCES projects(id),
+            state       TEXT NOT NULL DEFAULT 'stopped',
+            ssh_port    INTEGER NOT NULL,
+            base_image  TEXT NOT NULL,
+            cpus        INTEGER NOT NULL DEFAULT 2,
+            memory_mb   INTEGER NOT NULL DEFAULT 2048,
+            disk_gb     INTEGER NOT NULL DEFAULT 10,
+            qemu_pid    INTEGER,
+            error_msg   TEXT,
+            created_at  INTEGER NOT NULL,
+            updated_at  INTEGER NOT NULL,
+            deleted_at  INTEGER
+        );
+
+        CREATE TABLE IF NOT EXISTS project_vm_config (
+            project_id   TEXT PRIMARY KEY REFERENCES projects(id),
+            base_image   TEXT,
+            cpus         INTEGER,
+            memory_mb    INTEGER,
+            disk_gb      INTEGER,
+            setup_script TEXT,
+            updated_at   INTEGER NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_vms_session
+            ON vms(session_id) WHERE deleted_at IS NULL;
+        CREATE INDEX IF NOT EXISTS idx_vms_project
+            ON vms(project_id) WHERE deleted_at IS NULL;",
+    )
+}
+
+/// v8 → v9: rename claude_session_id → agent_session_id
+fn migrate_v9_agent_session_id(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute(
+        "ALTER TABLE sessions RENAME COLUMN claude_session_id TO agent_session_id",
+        [],
+    );
+    Ok(())
+}
+
+/// v9 → v10: add containers and project_container_config tables
+fn migrate_v10_containers(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS containers (
+            id                  TEXT PRIMARY KEY,
+            session_id          TEXT REFERENCES sessions(id),
+            project_id          TEXT REFERENCES projects(id),
+            state               TEXT NOT NULL DEFAULT 'stopped',
+            docker_container_id TEXT,
+            image               TEXT,
+            cpus                INTEGER NOT NULL DEFAULT 2,
+            memory_mb           INTEGER NOT NULL DEFAULT 2048,
+            firewall_enabled    INTEGER NOT NULL DEFAULT 1,
+            error_msg           TEXT,
+            created_at          INTEGER NOT NULL,
+            updated_at          INTEGER NOT NULL,
+            deleted_at          INTEGER
+        );
+
+        CREATE TABLE IF NOT EXISTS project_container_config (
+            project_id       TEXT PRIMARY KEY REFERENCES projects(id),
+            image            TEXT,
+            cpus             INTEGER,
+            memory_mb        INTEGER,
+            firewall_enabled INTEGER,
+            updated_at       INTEGER NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_containers_session
+            ON containers(session_id) WHERE deleted_at IS NULL;
+        CREATE INDEX IF NOT EXISTS idx_containers_project
+            ON containers(project_id) WHERE deleted_at IS NULL;",
+    )
+}
+
+/// v10 → v11: add containerfile column to containers and project_container_config
+fn migrate_v11_containerfile(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute("ALTER TABLE containers ADD COLUMN containerfile TEXT", []);
+    let _ = conn.execute(
+        "ALTER TABLE project_container_config ADD COLUMN containerfile TEXT",
+        [],
+    );
+    Ok(())
+}
+
+/// v11 → v12: add scheduled_commands table for time-scheduled session inputs
+fn migrate_v12_scheduled_commands(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS scheduled_commands (
+            id             INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id     TEXT NOT NULL,
+            command_text   TEXT NOT NULL,
+            scheduled_at   INTEGER NOT NULL,
+            created_at     INTEGER NOT NULL,
+            executed_at    INTEGER,
+            cancelled_at   INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_scheduled_commands_pending
+            ON scheduled_commands(scheduled_at)
+            WHERE executed_at IS NULL AND cancelled_at IS NULL;",
+    )
+}
+
+/// v12 → v13: add global `roles` table and seed from project_roles
+fn migrate_v13_roles(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS roles (
+            role_name           TEXT PRIMARY KEY,
+            description         TEXT NOT NULL DEFAULT '',
+            permission_mode     TEXT,
+            allowed_tools       TEXT NOT NULL DEFAULT '',
+            disallowed_tools    TEXT NOT NULL DEFAULT '',
+            tools               TEXT,
+            append_system_prompt TEXT,
+            env                 TEXT NOT NULL DEFAULT '',
+            created_at          INTEGER NOT NULL,
+            updated_at          INTEGER NOT NULL
+        );
+        INSERT OR IGNORE INTO roles
+            (role_name, description, permission_mode, allowed_tools,
+             disallowed_tools, tools, append_system_prompt, env,
+             created_at, updated_at)
+            SELECT DISTINCT role_name, description, permission_mode, allowed_tools,
+                   disallowed_tools, tools, append_system_prompt, env,
+                   created_at, updated_at
+            FROM project_roles;",
+    )
+}
+
+/// v13 → v14: add global `mcp_servers` table and seed from project_mcp_servers
+fn migrate_v14_mcp_servers(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS mcp_servers (
+            server_name TEXT PRIMARY KEY,
+            command     TEXT NOT NULL DEFAULT '',
+            args        TEXT NOT NULL DEFAULT '',
+            env         TEXT NOT NULL DEFAULT '',
+            created_at  INTEGER NOT NULL,
+            updated_at  INTEGER NOT NULL
+        );
+        INSERT OR IGNORE INTO mcp_servers
+            (server_name, command, args, env, created_at, updated_at)
+            SELECT DISTINCT server_name, command, args, env,
+                   created_at, updated_at
+            FROM project_mcp_servers;",
+    )
+}
+
+/// v14 → v15: make project_id nullable on sessions, add repo_bookmarks table
+fn migrate_v15_nullable_project_id(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS sessions_new;
+        CREATE TABLE sessions_new (
+            id                TEXT PRIMARY KEY,
+            name              TEXT NOT NULL,
+            project_id        TEXT REFERENCES projects(id),
+            role              TEXT NOT NULL DEFAULT 'developer',
+            backend_id        TEXT NOT NULL DEFAULT '',
+            backend_type      TEXT NOT NULL DEFAULT 'tmux',
+            agent_session_id  TEXT,
+            cwd               TEXT,
+            additional_dirs   TEXT NOT NULL DEFAULT '',
+            shell_backend_id  TEXT,
+            created_at        INTEGER NOT NULL,
+            updated_at        INTEGER NOT NULL,
+            deleted_at        INTEGER
+        );
+        PRAGMA foreign_keys = OFF;
+        INSERT INTO sessions_new (id, name, project_id, role, backend_id,
+            backend_type, agent_session_id, cwd, additional_dirs,
+            shell_backend_id, created_at, updated_at, deleted_at)
+            SELECT id, name,
+                CASE WHEN project_id IN (SELECT id FROM projects) THEN project_id ELSE NULL END,
+                role, backend_id,
+                backend_type, agent_session_id, cwd, additional_dirs,
+                shell_backend_id,
+                COALESCE(created_at, 0),
+                COALESCE(updated_at, 0),
+                deleted_at
+            FROM sessions;
+        DROP TABLE sessions;
+        ALTER TABLE sessions_new RENAME TO sessions;
+        PRAGMA foreign_keys = ON;
+        CREATE INDEX IF NOT EXISTS idx_sessions_project
+            ON sessions(project_id) WHERE deleted_at IS NULL;
+        CREATE INDEX IF NOT EXISTS idx_sessions_active
+            ON sessions(id) WHERE deleted_at IS NULL;
+
+        CREATE TABLE IF NOT EXISTS repo_bookmarks (
+            repo_path    TEXT PRIMARY KEY,
+            label        TEXT,
+            last_used_at INTEGER NOT NULL,
+            use_count    INTEGER NOT NULL DEFAULT 1
+        );
+
+        INSERT OR IGNORE INTO repo_bookmarks (repo_path, last_used_at, use_count)
+            SELECT DISTINCT repo_path,
+                   COALESCE((SELECT MAX(s.updated_at) FROM sessions s
+                              INNER JOIN projects p ON p.id = s.project_id
+                              INNER JOIN project_repos pr ON pr.project_id = p.id
+                              AND pr.repo_path = project_repos.repo_path), 0),
+                   1
+            FROM project_repos;",
+    )
+}
+
+/// v15 → v16: remove project tables and project_id columns from sessions/vms/containers
+fn migrate_v16_drop_projects(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "PRAGMA foreign_keys = OFF;
+
+        -- Recreate sessions without project_id
+        DROP TABLE IF EXISTS sessions_new;
+        CREATE TABLE sessions_new (
+            id                TEXT PRIMARY KEY,
+            name              TEXT NOT NULL,
+            role              TEXT NOT NULL DEFAULT 'developer',
+            backend_id        TEXT NOT NULL DEFAULT '',
+            backend_type      TEXT NOT NULL DEFAULT 'tmux',
+            agent_session_id  TEXT,
+            cwd               TEXT,
+            additional_dirs   TEXT NOT NULL DEFAULT '',
+            shell_backend_id  TEXT,
+            created_at        INTEGER NOT NULL,
+            updated_at        INTEGER NOT NULL,
+            deleted_at        INTEGER
+        );
+        INSERT INTO sessions_new (id, name, role, backend_id, backend_type,
+            agent_session_id, cwd, additional_dirs, shell_backend_id,
+            created_at, updated_at, deleted_at)
+            SELECT id, name, role, backend_id, backend_type,
+                agent_session_id, cwd, additional_dirs, shell_backend_id,
+                created_at, updated_at, deleted_at
+            FROM sessions;
+        DROP TABLE sessions;
+        ALTER TABLE sessions_new RENAME TO sessions;
+        CREATE INDEX IF NOT EXISTS idx_sessions_active
+            ON sessions(id) WHERE deleted_at IS NULL;
+
+        -- Recreate vms without project_id
+        DROP TABLE IF EXISTS vms_new;
+        CREATE TABLE vms_new (
+            id          TEXT PRIMARY KEY,
+            session_id  TEXT REFERENCES sessions(id),
+            state       TEXT NOT NULL DEFAULT 'stopped',
+            ssh_port    INTEGER NOT NULL,
+            base_image  TEXT NOT NULL,
+            cpus        INTEGER NOT NULL DEFAULT 2,
+            memory_mb   INTEGER NOT NULL DEFAULT 2048,
+            disk_gb     INTEGER NOT NULL DEFAULT 10,
+            qemu_pid    INTEGER,
+            error_msg   TEXT,
+            created_at  INTEGER NOT NULL,
+            updated_at  INTEGER NOT NULL,
+            deleted_at  INTEGER
+        );
+        INSERT INTO vms_new (id, session_id, state, ssh_port, base_image,
+            cpus, memory_mb, disk_gb, qemu_pid, error_msg,
+            created_at, updated_at, deleted_at)
+            SELECT id, session_id, state, ssh_port, base_image,
+                cpus, memory_mb, disk_gb, qemu_pid, error_msg,
+                created_at, updated_at, deleted_at
+            FROM vms;
+        DROP TABLE IF EXISTS vms;
+        ALTER TABLE vms_new RENAME TO vms;
+        CREATE INDEX IF NOT EXISTS idx_vms_session
+            ON vms(session_id) WHERE deleted_at IS NULL;
+
+        -- Recreate containers without project_id
+        DROP TABLE IF EXISTS containers_new;
+        CREATE TABLE containers_new (
+            id                  TEXT PRIMARY KEY,
+            session_id          TEXT REFERENCES sessions(id),
+            state               TEXT NOT NULL DEFAULT 'stopped',
+            docker_container_id TEXT,
+            image               TEXT,
+            cpus                INTEGER NOT NULL DEFAULT 2,
+            memory_mb           INTEGER NOT NULL DEFAULT 2048,
+            firewall_enabled    INTEGER NOT NULL DEFAULT 1,
+            containerfile       TEXT,
+            error_msg           TEXT,
+            created_at          INTEGER NOT NULL,
+            updated_at          INTEGER NOT NULL,
+            deleted_at          INTEGER
+        );
+        INSERT INTO containers_new (id, session_id, state, docker_container_id,
+            image, cpus, memory_mb, firewall_enabled, containerfile,
+            error_msg, created_at, updated_at, deleted_at)
+            SELECT id, session_id, state, docker_container_id,
+                image, cpus, memory_mb, firewall_enabled, containerfile,
+                error_msg, created_at, updated_at, deleted_at
+            FROM containers;
+        DROP TABLE IF EXISTS containers;
+        ALTER TABLE containers_new RENAME TO containers;
+        CREATE INDEX IF NOT EXISTS idx_containers_session
+            ON containers(session_id) WHERE deleted_at IS NULL;
+
+        -- Drop project tables
+        DROP TABLE IF EXISTS project_container_config;
+        DROP TABLE IF EXISTS project_vm_config;
+        DROP TABLE IF EXISTS project_mcp_servers;
+        DROP TABLE IF EXISTS project_roles;
+        DROP TABLE IF EXISTS project_repos;
+        DROP TABLE IF EXISTS projects;
+
+        PRAGMA foreign_keys = ON;",
+    )
+}
+
+/// v16 → v17: add skills table for global skill management
+fn migrate_v17_skills(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS skills (
+            skill_name TEXT PRIMARY KEY,
+            path       TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        );",
+    )
+}
+
+/// v18 → v19: add plugins + plugin_settings tables for the plugin bundle system
+fn migrate_v19_plugins(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS plugins (
+            plugin_name TEXT PRIMARY KEY,
+            path        TEXT NOT NULL,
+            version     TEXT NOT NULL DEFAULT '',
+            enabled     INTEGER NOT NULL DEFAULT 1,
+            created_at  INTEGER NOT NULL,
+            updated_at  INTEGER NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS plugin_settings (
+            plugin_name TEXT NOT NULL,
+            key         TEXT NOT NULL,
+            value_json  TEXT NOT NULL,
+            updated_at  INTEGER NOT NULL,
+            PRIMARY KEY (plugin_name, key),
+            FOREIGN KEY (plugin_name) REFERENCES plugins(plugin_name) ON DELETE CASCADE
+        );",
+    )
+}
+
+/// v19 → v20: add profiles table bundling roles + MCP servers + skills
+fn migrate_v20_profiles(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS profiles (
+            profile_name      TEXT PRIMARY KEY,
+            description       TEXT NOT NULL DEFAULT '',
+            role_names        TEXT NOT NULL DEFAULT '',
+            mcp_server_names  TEXT NOT NULL DEFAULT '',
+            skill_names       TEXT NOT NULL DEFAULT '',
+            created_at        INTEGER NOT NULL,
+            updated_at        INTEGER NOT NULL
+        );",
+    )
+}
+
+/// v20 → v21: drop the sessions.model column. Model selection was
+/// removed from the product — the agent picks its own model now.
+/// Use ignore-on-error in case an older SQLite (<3.35) lacks DROP
+/// COLUMN support; the unused column is harmless.
+fn migrate_v21_drop_model(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute("ALTER TABLE sessions DROP COLUMN model", []);
+    Ok(())
+}
+
+/// v21 → v22: drop tables for removed subsystems. VM, devcontainer,
+/// and process-plugin subsystems were removed to focus thurbox on
+/// the TUI surface; the session_commands queue is unused now that
+/// MCP `restart_session` / `create_session` run synchronously.
+fn migrate_v22_drop_subsystems(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS plugin_settings;
+         DROP TABLE IF EXISTS plugins;
+         DROP TABLE IF EXISTS vms;
+         DROP TABLE IF EXISTS containers;
+         DROP TABLE IF EXISTS project_vm_config;
+         DROP TABLE IF EXISTS project_container_config;
+         DROP TABLE IF EXISTS session_commands;",
+    )
+}
+
+/// v22 → v23: pivot to a generic per-session agent. Add the `agent`
+/// column to sessions (existing rows default to "claude") and drop the
+/// now-unused Claude-config tables. Existing sessions/worktrees are kept.
+fn migrate_v23_generic_agent(conn: &Connection) -> rusqlite::Result<()> {
+    let has_agent_col: bool = conn
+        .prepare("SELECT 1 FROM pragma_table_info('sessions') WHERE name = 'agent'")?
+        .exists([])?;
+    if !has_agent_col {
+        conn.execute_batch(
+            "ALTER TABLE sessions ADD COLUMN agent TEXT NOT NULL DEFAULT 'claude';",
+        )?;
+    }
+    conn.execute_batch(
+        "DROP TABLE IF EXISTS profiles;
+         DROP TABLE IF EXISTS skills;
+         DROP TABLE IF EXISTS mcp_servers;
+         DROP TABLE IF EXISTS roles;
+         DELETE FROM metadata WHERE key = 'profiles_seeded';",
+    )
+}
+
+/// v23 → v24: replace the one-shot `scheduled_commands` table with the
+/// unified `automations` concept (one-shot OR recurring cron, send OR
+/// spawn actions) plus a `automation_runs` history table. Pending
+/// one-shot scheduled commands are migrated forward as `once`/`send`
+/// automations; executed/cancelled ones are dropped with the table.
+fn migrate_v24_automations(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS automations (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            name            TEXT NOT NULL,
+            enabled         INTEGER NOT NULL DEFAULT 1,
+            schedule_kind   TEXT NOT NULL,
+            schedule_spec   TEXT NOT NULL,
+            timezone        TEXT,
+            action_kind     TEXT NOT NULL,
+            target_session  TEXT,
+            repo_path       TEXT,
+            worktree_branch TEXT,
+            base_branch     TEXT,
+            agent           TEXT,
+            prompt          TEXT NOT NULL,
+            created_at      INTEGER NOT NULL,
+            updated_at      INTEGER NOT NULL,
+            last_run_at     INTEGER,
+            next_run_at     INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_automations_due
+            ON automations(next_run_at)
+            WHERE enabled = 1 AND next_run_at IS NOT NULL;
+        CREATE TABLE IF NOT EXISTS automation_runs (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            automation_id INTEGER NOT NULL,
+            started_at    INTEGER NOT NULL,
+            status        TEXT NOT NULL,
+            detail        TEXT NOT NULL DEFAULT ''
+        );
+        CREATE INDEX IF NOT EXISTS idx_automation_runs_automation
+            ON automation_runs(automation_id, started_at);",
+    )?;
+
+    // Only migrate if the legacy table is present (fresh DBs created at v24
+    // never had it).
+    let has_legacy: bool = conn
+        .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='scheduled_commands'")?
+        .exists([])?;
+    if has_legacy {
+        conn.execute_batch(
+            "INSERT INTO automations
+                (name, enabled, schedule_kind, schedule_spec, timezone,
+                 action_kind, target_session, prompt,
+                 created_at, updated_at, last_run_at, next_run_at)
+             SELECT
+                'migrated-' || id, 1, 'once', CAST(scheduled_at AS TEXT), NULL,
+                'send', session_id, command_text,
+                created_at, created_at, NULL, scheduled_at
+             FROM scheduled_commands
+             WHERE executed_at IS NULL AND cancelled_at IS NULL;
+             DROP TABLE IF EXISTS scheduled_commands;",
+        )?;
+    }
     Ok(())
 }
 

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -171,48 +171,7 @@ impl Database {
         );
 
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map([], |row| {
-            let id_str: String = row.get(0)?;
-            let cwd: Option<String> = row.get(6)?;
-            let dirs_str: String = row.get(7)?;
-            let shell_backend_id: Option<String> = row.get(8)?;
-            let wt_repo: Option<String> = row.get(9)?;
-            let wt_path: Option<String> = row.get(10)?;
-            let wt_branch: Option<String> = row.get(11)?;
-
-            let additional_dirs: Vec<PathBuf> = if dirs_str.is_empty() {
-                Vec::new()
-            } else {
-                dirs_str.split('\n').map(PathBuf::from).collect()
-            };
-
-            let worktree = match (wt_repo, wt_path, wt_branch) {
-                (Some(repo), Some(path), Some(branch)) => Some(SharedWorktree {
-                    repo_path: PathBuf::from(repo),
-                    worktree_path: PathBuf::from(path),
-                    branch,
-                }),
-                _ => None,
-            };
-
-            Ok((
-                SharedSession {
-                    id: id_str.parse().unwrap_or_default(),
-                    name: row.get(1)?,
-                    agent: row.get(2)?,
-                    backend_id: row.get(3)?,
-                    backend_type: row.get(4)?,
-                    agent_session_id: row.get(5)?,
-                    cwd: cwd.map(PathBuf::from),
-                    additional_dirs,
-                    worktrees: Vec::new(),
-                    shell_backend_id,
-                    tombstone: false,
-                    tombstone_at: None,
-                },
-                worktree,
-            ))
-        })?;
+        let rows = stmt.query_map([], row_to_shared_session)?;
 
         // Collect rows, merging multiple worktree rows into the same session
         let mut sessions: Vec<SharedSession> = Vec::new();
@@ -318,14 +277,7 @@ impl Database {
             let wt_path: Option<String> = row.get(7)?;
             let wt_branch: Option<String> = row.get(8)?;
 
-            let worktree = match (wt_repo, wt_path, wt_branch) {
-                (Some(repo), Some(path), Some(branch)) => Some(SharedWorktree {
-                    repo_path: PathBuf::from(repo),
-                    worktree_path: PathBuf::from(path),
-                    branch,
-                }),
-                _ => None,
-            };
+            let worktree = worktree_from_cols(wt_repo, wt_path, wt_branch);
 
             Ok((
                 DeletedSessionInfo {
@@ -361,6 +313,63 @@ impl Database {
 
         Ok(sessions)
     }
+}
+
+/// Build an optional [`SharedWorktree`] from the three nullable worktree
+/// columns of a joined row. Returns `None` unless all three are present.
+fn worktree_from_cols(
+    repo: Option<String>,
+    path: Option<String>,
+    branch: Option<String>,
+) -> Option<SharedWorktree> {
+    match (repo, path, branch) {
+        (Some(repo), Some(path), Some(branch)) => Some(SharedWorktree {
+            repo_path: PathBuf::from(repo),
+            worktree_path: PathBuf::from(path),
+            branch,
+        }),
+        _ => None,
+    }
+}
+
+/// Map a single joined `sessions × worktrees` row into a [`SharedSession`]
+/// plus its optional worktree (see `query_sessions` for the column order).
+fn row_to_shared_session(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<(SharedSession, Option<SharedWorktree>)> {
+    let id_str: String = row.get(0)?;
+    let cwd: Option<String> = row.get(6)?;
+    let dirs_str: String = row.get(7)?;
+    let shell_backend_id: Option<String> = row.get(8)?;
+    let wt_repo: Option<String> = row.get(9)?;
+    let wt_path: Option<String> = row.get(10)?;
+    let wt_branch: Option<String> = row.get(11)?;
+
+    let additional_dirs: Vec<PathBuf> = if dirs_str.is_empty() {
+        Vec::new()
+    } else {
+        dirs_str.split('\n').map(PathBuf::from).collect()
+    };
+
+    let worktree = worktree_from_cols(wt_repo, wt_path, wt_branch);
+
+    Ok((
+        SharedSession {
+            id: id_str.parse().unwrap_or_default(),
+            name: row.get(1)?,
+            agent: row.get(2)?,
+            backend_id: row.get(3)?,
+            backend_type: row.get(4)?,
+            agent_session_id: row.get(5)?,
+            cwd: cwd.map(PathBuf::from),
+            additional_dirs,
+            worktrees: Vec::new(),
+            shell_backend_id,
+            tombstone: false,
+            tombstone_at: None,
+        },
+        worktree,
+    ))
 }
 
 #[cfg(test)]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -313,115 +313,174 @@ pub fn render_text_field_with_suggestion(
     let cursor = cursor.min(chars.len());
 
     let display = if focused && width > 0 {
-        let at_end = cursor == chars.len();
-        let suggestion_text = if at_end { suggestion.unwrap_or("") } else { "" };
-
-        let has_left_overflow;
-        let has_right_overflow;
-
-        let viewport_start = if chars.len() < width {
-            has_left_overflow = false;
-            has_right_overflow = false;
-            0
+        let suggestion_text = if cursor == chars.len() {
+            suggestion.unwrap_or("")
         } else {
-            let usable = width.saturating_sub(1);
-            let start = if cursor < usable {
-                0
-            } else {
-                cursor - usable + 1
-            };
-            has_left_overflow = start > 0;
-            has_right_overflow = start + width < chars.len() + 1;
-            start
+            ""
         };
-
-        let content_start = if has_left_overflow {
-            viewport_start + 1
-        } else {
-            viewport_start
-        };
-        let content_width =
-            width - if has_left_overflow { 1 } else { 0 } - if has_right_overflow { 1 } else { 0 };
-
-        let mut spans = Vec::new();
-
-        if has_left_overflow {
-            spans.push(Span::styled("◀", Style::default().fg(Theme::text_muted())));
-        }
-
-        let visible_end = (content_start + content_width).min(chars.len());
-
-        if cursor >= content_start && cursor <= visible_end {
-            let before: String = chars[content_start..cursor].iter().collect();
-            let cursor_char = if cursor < chars.len() {
-                chars[cursor].to_string()
-            } else {
-                " ".to_string()
-            };
-            let after_start = (cursor + 1).min(chars.len());
-            let after_end = visible_end.min(chars.len());
-            let after: String = chars[after_start..after_end].iter().collect();
-            let after_len = after.len();
-
-            if !before.is_empty() {
-                spans.push(Span::styled(
-                    before,
-                    Style::default().fg(Theme::text_primary()),
-                ));
-            }
-            spans.push(Span::styled(cursor_char, Theme::cursor()));
-            if !after.is_empty() {
-                spans.push(Span::styled(
-                    after,
-                    Style::default().fg(Theme::text_primary()),
-                ));
-            }
-
-            if !suggestion_text.is_empty() {
-                let used = if has_left_overflow { 1 } else { 0 }
-                    + (cursor - content_start)
-                    + 1 // cursor block
-                    + after_len;
-                let remaining = content_width.saturating_sub(used);
-                if remaining > 0 {
-                    let sug: String = suggestion_text.chars().take(remaining).collect();
-                    if !sug.is_empty() {
-                        spans.push(Span::styled(sug, Style::default().fg(Theme::text_muted())));
-                    }
-                }
-            }
-        } else {
-            let visible: String = chars[content_start..visible_end].iter().collect();
-            spans.push(Span::styled(
-                visible,
-                Style::default().fg(Theme::text_primary()),
-            ));
-        }
-
-        if has_right_overflow {
-            spans.push(Span::styled("▶", Style::default().fg(Theme::text_muted())));
-        }
-
-        Line::from(spans)
+        render_focused_field_line(&chars, cursor, width, suggestion_text)
     } else if width > 0 {
-        if chars.len() > width {
-            let truncated: String = chars[..width - 1].iter().collect();
-            Line::from(vec![
-                Span::styled(truncated, Style::default().fg(Theme::text_primary())),
-                Span::styled("…", Style::default().fg(Theme::text_muted())),
-            ])
-        } else {
-            Line::from(Span::styled(
-                value,
-                Style::default().fg(Theme::text_primary()),
-            ))
-        }
+        render_unfocused_field_line(value, &chars, width)
     } else {
         Line::from("")
     };
 
     frame.render_widget(block, area);
     frame.render_widget(Paragraph::new(display), inner);
+}
+
+/// Computed scroll viewport for a focused text field.
+struct Viewport {
+    /// First character index of the scrolled-in viewport (before overflow trim).
+    start: usize,
+    has_left_overflow: bool,
+    has_right_overflow: bool,
+}
+
+/// Compute the scroll viewport (and overflow indicators) for a focused field.
+fn compute_viewport(chars_len: usize, width: usize, cursor: usize) -> Viewport {
+    if chars_len < width {
+        return Viewport {
+            start: 0,
+            has_left_overflow: false,
+            has_right_overflow: false,
+        };
+    }
+    let usable = width.saturating_sub(1);
+    let start = if cursor < usable {
+        0
+    } else {
+        cursor - usable + 1
+    };
+    Viewport {
+        start,
+        has_left_overflow: start > 0,
+        has_right_overflow: start + width < chars_len + 1,
+    }
+}
+
+/// Build the rendered line for a focused text field (with cursor block and
+/// optional inline suggestion / overflow indicators).
+fn render_focused_field_line(
+    chars: &[char],
+    cursor: usize,
+    width: usize,
+    suggestion_text: &str,
+) -> Line<'static> {
+    let vp = compute_viewport(chars.len(), width, cursor);
+
+    let content_start = if vp.has_left_overflow {
+        vp.start + 1
+    } else {
+        vp.start
+    };
+    let content_width = width
+        - if vp.has_left_overflow { 1 } else { 0 }
+        - if vp.has_right_overflow { 1 } else { 0 };
+
+    let mut spans = Vec::new();
+
+    if vp.has_left_overflow {
+        spans.push(Span::styled("◀", Style::default().fg(Theme::text_muted())));
+    }
+
+    let visible_end = (content_start + content_width).min(chars.len());
+
+    if cursor >= content_start && cursor <= visible_end {
+        push_cursor_spans(
+            &mut spans,
+            chars,
+            content_start,
+            cursor,
+            visible_end,
+            content_width,
+            vp.has_left_overflow,
+            suggestion_text,
+        );
+    } else {
+        let visible: String = chars[content_start..visible_end].iter().collect();
+        spans.push(Span::styled(
+            visible,
+            Style::default().fg(Theme::text_primary()),
+        ));
+    }
+
+    if vp.has_right_overflow {
+        spans.push(Span::styled("▶", Style::default().fg(Theme::text_muted())));
+    }
+
+    Line::from(spans)
+}
+
+/// Push the before/cursor/after text spans and an optional trailing suggestion
+/// for the segment of the field that contains the cursor.
+#[allow(clippy::too_many_arguments)]
+fn push_cursor_spans(
+    spans: &mut Vec<Span<'static>>,
+    chars: &[char],
+    content_start: usize,
+    cursor: usize,
+    visible_end: usize,
+    content_width: usize,
+    has_left_overflow: bool,
+    suggestion_text: &str,
+) {
+    let before: String = chars[content_start..cursor].iter().collect();
+    let cursor_char = if cursor < chars.len() {
+        chars[cursor].to_string()
+    } else {
+        " ".to_string()
+    };
+    let after_start = (cursor + 1).min(chars.len());
+    let after_end = visible_end.min(chars.len());
+    let after: String = chars[after_start..after_end].iter().collect();
+    let after_len = after.len();
+
+    if !before.is_empty() {
+        spans.push(Span::styled(
+            before,
+            Style::default().fg(Theme::text_primary()),
+        ));
+    }
+    spans.push(Span::styled(cursor_char, Theme::cursor()));
+    if !after.is_empty() {
+        spans.push(Span::styled(
+            after,
+            Style::default().fg(Theme::text_primary()),
+        ));
+    }
+
+    if suggestion_text.is_empty() {
+        return;
+    }
+    let used = if has_left_overflow { 1 } else { 0 }
+        + (cursor - content_start)
+        + 1 // cursor block
+        + after_len;
+    let remaining = content_width.saturating_sub(used);
+    if remaining == 0 {
+        return;
+    }
+    let sug: String = suggestion_text.chars().take(remaining).collect();
+    if !sug.is_empty() {
+        spans.push(Span::styled(sug, Style::default().fg(Theme::text_muted())));
+    }
+}
+
+/// Build the rendered line for an unfocused text field (plain text, truncated
+/// with an ellipsis when it exceeds the visible width).
+fn render_unfocused_field_line(value: &str, chars: &[char], width: usize) -> Line<'static> {
+    if chars.len() > width {
+        let truncated: String = chars[..width - 1].iter().collect();
+        return Line::from(vec![
+            Span::styled(truncated, Style::default().fg(Theme::text_primary())),
+            Span::styled("…", Style::default().fg(Theme::text_muted())),
+        ]);
+    }
+    Line::from(Span::styled(
+        value.to_string(),
+        Style::default().fg(Theme::text_primary()),
+    ))
 }
 
 #[cfg(test)]

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -326,36 +326,49 @@ fn render_search_bar(
         query
     };
 
-    let (before, after) = if cursor <= display_query.chars().count() {
-        let byte_pos = display_query
-            .char_indices()
-            .nth(cursor)
-            .map(|(i, _)| i)
-            .unwrap_or(display_query.len());
-        (&display_query[..byte_pos], &display_query[byte_pos..])
-    } else {
-        (display_query, "")
-    };
+    let (before, after) = split_query_at_cursor(display_query, cursor);
 
     let mut spans = vec![Span::styled(prefix, style), Span::styled(before, style)];
-
-    if is_active {
-        let first_char_len = after.chars().next().map_or(0, |c| c.len_utf8());
-        let cursor_char = if first_char_len == 0 {
-            " "
-        } else {
-            &after[..first_char_len]
-        };
-        spans.push(Span::styled(cursor_char, Theme::cursor()));
-        let rest = &after[first_char_len..];
-        if !rest.is_empty() {
-            spans.push(Span::styled(rest, style));
-        }
-    } else {
-        spans.push(Span::styled(after, style));
-    }
+    push_search_after_spans(&mut spans, after, is_active, style);
 
     frame.render_widget(Paragraph::new(Line::from(spans)), inner);
+}
+
+/// Split a display query into the slices before and after the cursor.
+fn split_query_at_cursor(display_query: &str, cursor: usize) -> (&str, &str) {
+    if cursor > display_query.chars().count() {
+        return (display_query, "");
+    }
+    let byte_pos = display_query
+        .char_indices()
+        .nth(cursor)
+        .map(|(i, _)| i)
+        .unwrap_or(display_query.len());
+    (&display_query[..byte_pos], &display_query[byte_pos..])
+}
+
+/// Append the post-cursor spans, drawing the cursor cell when the bar is active.
+fn push_search_after_spans<'a>(
+    spans: &mut Vec<Span<'a>>,
+    after: &'a str,
+    is_active: bool,
+    style: Style,
+) {
+    if !is_active {
+        spans.push(Span::styled(after, style));
+        return;
+    }
+    let first_char_len = after.chars().next().map_or(0, |c| c.len_utf8());
+    let cursor_char = if first_char_len == 0 {
+        " "
+    } else {
+        &after[..first_char_len]
+    };
+    spans.push(Span::styled(cursor_char, Theme::cursor()));
+    let rest = &after[first_char_len..];
+    if !rest.is_empty() {
+        spans.push(Span::styled(rest, style));
+    }
 }
 
 /// Build spans for a name with fuzzy-matched characters highlighted.
@@ -438,20 +451,7 @@ fn render_session_section(
     }
 
     if sessions.is_empty() {
-        let text = Paragraph::new(vec![
-            Line::from(""),
-            Line::from(Span::styled(
-                "No sessions yet",
-                Style::default().fg(Theme::text_muted()),
-            )),
-            Line::from(Span::styled(
-                "Press Ctrl+N to create one",
-                Style::default().fg(Theme::text_muted()),
-            )),
-        ])
-        .block(block)
-        .alignment(ratatui::layout::Alignment::Center);
-        frame.render_widget(text, area);
+        render_empty_sessions(frame, area, block);
         return;
     }
 
@@ -465,150 +465,26 @@ fn render_session_section(
         .enumerate()
         .map(|(i, info)| {
             let is_active = i == active_index && show_selection;
-            let is_admin = info.is_admin;
-
-            // Determine if this session is dimmed (search active + no match).
             let session_match = match_positions.get(i).and_then(|m| m.as_ref());
             let is_dimmed = search_active && session_match.is_none();
-            let name_style = if is_dimmed {
-                Style::default().fg(Theme::text_muted())
-            } else if is_active {
-                Theme::selected_item()
-            } else {
-                Theme::normal_item()
-            };
-            let status_style = if is_dimmed {
-                Style::default().fg(Theme::text_muted())
-            } else {
-                Style::default().fg(super::status_color(info.status))
-            };
 
-            // ── Line 1: <status-dot> <name> ........... <status> ──
-            // The active row is signalled by the list's highlight background,
-            // so no extra pointer glyph is needed; admin sessions keep a gear.
-            let prefix_str = if is_admin {
-                format!(" \u{2699} {} ", info.status.icon())
-            } else {
-                format!(" {} ", info.status.icon())
-            };
-            let prefix_style = if is_admin && !is_dimmed {
-                Style::default().fg(Theme::admin_badge())
-            } else {
-                status_style
-            };
-
-            let mut line1_spans = vec![Span::styled(prefix_str.clone(), prefix_style)];
-            append_name_spans(
-                &mut line1_spans,
-                &info.name,
-                session_match.and_then(|m| m.positions(&m.name)),
-                name_style,
-            );
-
-            // Right-aligned live status. Priority:
-            //   1. Attention → the agent's notification message ("Needs attention").
-            //   2. The agent-reported OSC activity title (richer "insight").
-            //   3. Timing-based Busy/Waiting with elapsed time.
-            let status_text = if info.status == crate::session::SessionStatus::Attention {
-                info.notification
-                    .clone()
-                    .unwrap_or_else(|| info.status.to_string())
-            } else {
-                info.agent_activity
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty())
-                    .map(str::to_string)
-                    .unwrap_or_else(|| {
-                        format_status_with_elapsed(info.status, elapsed_ms.get(i).copied())
-                    })
-            };
-            let prefix_w = prefix_str.chars().count();
-            let name_w = info.name.chars().count();
-            let avail = inner_width.saturating_sub(prefix_w + name_w + 1);
-            let status_shown = truncate_ellipsis(&status_text, avail);
-            if !status_shown.is_empty() {
-                let used = prefix_w + name_w + status_shown.chars().count();
-                let gap = inner_width.saturating_sub(used).max(1);
-                line1_spans.push(Span::raw(" ".repeat(gap)));
-                line1_spans.push(Span::styled(status_shown, status_style));
-            }
-            let mut item_lines = vec![Line::from(line1_spans)];
-
-            // ── Line 2: <agent> · <repo>(<branch>), … ──
-            let entries = build_repo_entries(info);
-            let mut line2_spans: Vec<Span<'static>> = vec![Span::raw("   ")];
-
-            // Agent name (role-coloured, fuzzy-searchable).
-            let agent_style = if is_dimmed {
-                Style::default().fg(Theme::text_muted())
-            } else {
-                Style::default().fg(Theme::role_name())
-            };
-            match session_match.and_then(|m| m.positions(&m.agent)) {
-                Some(positions) if !positions.is_empty() => {
-                    line2_spans.extend(
-                        build_highlighted_spans(&info.agent, positions, agent_style)
-                            .into_iter()
-                            .map(|s| Span::styled(s.content.into_owned(), s.style)),
-                    );
-                }
-                _ => line2_spans.push(Span::styled(info.agent.clone(), agent_style)),
-            }
-
-            // Repos (when any), separated from the agent by " · ".
-            if !entries.is_empty() {
-                let muted = Style::default().fg(Theme::text_muted());
-                line2_spans.push(Span::styled(" · ", muted));
-                if is_dimmed {
-                    line2_spans.push(Span::styled(format_repo_entries_plain(&entries), muted));
-                } else {
-                    let repo_style = Style::default().fg(Theme::text_primary());
-                    let branch_style = Style::default().fg(Theme::branch_name());
-
-                    let plain = format_repo_entries_plain(&entries);
-                    let search_positions = if !search_query.is_empty() {
-                        crate::fuzzy::fuzzy_match(search_query, &plain).map(|m| m.positions)
-                    } else {
-                        None
-                    };
-
-                    match search_positions {
-                        Some(ref positions) if !positions.is_empty() => {
-                            line2_spans.extend(
-                                build_highlighted_spans(&plain, positions, repo_style)
-                                    .into_iter()
-                                    .map(|s| Span::styled(s.content.into_owned(), s.style)),
-                            );
-                        }
-                        _ => {
-                            // No (matching) search — render with colored branches.
-                            for (j, entry) in entries.iter().enumerate() {
-                                if j > 0 {
-                                    line2_spans.push(Span::styled(", ", muted));
-                                }
-                                line2_spans.push(Span::styled(entry.name.clone(), repo_style));
-                                if let Some(ref br) = entry.branch {
-                                    line2_spans.push(Span::styled("(", branch_style));
-                                    line2_spans.push(Span::styled(br.clone(), branch_style));
-                                    line2_spans.push(Span::styled(")", branch_style));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            item_lines.push(Line::from(line2_spans));
+            let mut item_lines = vec![
+                build_session_line1(
+                    info,
+                    i,
+                    session_match,
+                    is_active,
+                    is_dimmed,
+                    elapsed_ms,
+                    inner_width,
+                ),
+                build_session_line2(info, session_match, is_dimmed, search_query),
+            ];
 
             // Prepend a subtle divider above the first non-admin session when
             // admin sessions are pinned above it.
             if first_non_admin_index == Some(i) && i > 0 {
-                let divider_width = inner_width.max(1);
-                let divider = Line::from(Span::styled(
-                    "\u{2500}".repeat(divider_width),
-                    Style::default().fg(Theme::text_muted()),
-                ));
-                item_lines.insert(0, divider);
+                item_lines.insert(0, divider_line(inner_width));
             }
 
             item_heights.push(item_lines.len() as u16);
@@ -627,6 +503,202 @@ fn render_session_section(
     frame.render_stateful_widget(list, area, list_state);
 
     render_scroll_indicators_variable(frame, area, list_state, &item_heights);
+}
+
+/// Render the centered "no sessions yet" placeholder inside the given block.
+fn render_empty_sessions(frame: &mut Frame, area: Rect, block: ratatui::widgets::Block) {
+    let text = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "No sessions yet",
+            Style::default().fg(Theme::text_muted()),
+        )),
+        Line::from(Span::styled(
+            "Press Ctrl+N to create one",
+            Style::default().fg(Theme::text_muted()),
+        )),
+    ])
+    .block(block)
+    .alignment(ratatui::layout::Alignment::Center);
+    frame.render_widget(text, area);
+}
+
+/// A subtle full-width divider used above the first non-admin session.
+fn divider_line(inner_width: usize) -> Line<'static> {
+    let divider_width = inner_width.max(1);
+    Line::from(Span::styled(
+        "\u{2500}".repeat(divider_width),
+        Style::default().fg(Theme::text_muted()),
+    ))
+}
+
+/// Resolve the right-aligned live status text for a session row. Priority:
+///   1. Attention → the agent's notification message ("Needs attention").
+///   2. The agent-reported OSC activity title (richer "insight").
+///   3. Timing-based Busy/Waiting with elapsed time.
+fn session_status_text(info: &SessionInfo, elapsed: Option<u64>) -> String {
+    if info.status == crate::session::SessionStatus::Attention {
+        return info
+            .notification
+            .clone()
+            .unwrap_or_else(|| info.status.to_string());
+    }
+    info.agent_activity
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format_status_with_elapsed(info.status, elapsed))
+}
+
+/// Build line 1 of a session entry: `<status-dot> <name> ........... <status>`.
+///
+/// The active row is signalled by the list's highlight background, so no extra
+/// pointer glyph is needed; admin sessions keep a gear.
+fn build_session_line1<'a>(
+    info: &'a SessionInfo,
+    i: usize,
+    session_match: Option<&SessionMatch>,
+    is_active: bool,
+    is_dimmed: bool,
+    elapsed_ms: &[u64],
+    inner_width: usize,
+) -> Line<'a> {
+    let name_style = if is_dimmed {
+        Style::default().fg(Theme::text_muted())
+    } else if is_active {
+        Theme::selected_item()
+    } else {
+        Theme::normal_item()
+    };
+    let status_style = if is_dimmed {
+        Style::default().fg(Theme::text_muted())
+    } else {
+        Style::default().fg(super::status_color(info.status))
+    };
+
+    let prefix_str = if info.is_admin {
+        format!(" \u{2699} {} ", info.status.icon())
+    } else {
+        format!(" {} ", info.status.icon())
+    };
+    let prefix_style = if info.is_admin && !is_dimmed {
+        Style::default().fg(Theme::admin_badge())
+    } else {
+        status_style
+    };
+
+    let mut line1_spans = vec![Span::styled(prefix_str.clone(), prefix_style)];
+    append_name_spans(
+        &mut line1_spans,
+        &info.name,
+        session_match.and_then(|m| m.positions(&m.name)),
+        name_style,
+    );
+
+    let status_text = session_status_text(info, elapsed_ms.get(i).copied());
+    let prefix_w = prefix_str.chars().count();
+    let name_w = info.name.chars().count();
+    let avail = inner_width.saturating_sub(prefix_w + name_w + 1);
+    let status_shown = truncate_ellipsis(&status_text, avail);
+    if !status_shown.is_empty() {
+        let used = prefix_w + name_w + status_shown.chars().count();
+        let gap = inner_width.saturating_sub(used).max(1);
+        line1_spans.push(Span::raw(" ".repeat(gap)));
+        line1_spans.push(Span::styled(status_shown, status_style));
+    }
+    Line::from(line1_spans)
+}
+
+/// Append the agent name (role-coloured, fuzzy-searchable) to line 2.
+fn push_agent_spans(
+    line2_spans: &mut Vec<Span<'static>>,
+    info: &SessionInfo,
+    session_match: Option<&SessionMatch>,
+    is_dimmed: bool,
+) {
+    let agent_style = if is_dimmed {
+        Style::default().fg(Theme::text_muted())
+    } else {
+        Style::default().fg(Theme::role_name())
+    };
+    match session_match.and_then(|m| m.positions(&m.agent)) {
+        Some(positions) if !positions.is_empty() => {
+            line2_spans.extend(
+                build_highlighted_spans(&info.agent, positions, agent_style)
+                    .into_iter()
+                    .map(|s| Span::styled(s.content.into_owned(), s.style)),
+            );
+        }
+        _ => line2_spans.push(Span::styled(info.agent.clone(), agent_style)),
+    }
+}
+
+/// Append the repo entries (with branches) to line 2, after a " · " separator.
+fn push_repo_spans(
+    line2_spans: &mut Vec<Span<'static>>,
+    entries: &[RepoEntry],
+    is_dimmed: bool,
+    search_query: &str,
+) {
+    let muted = Style::default().fg(Theme::text_muted());
+    line2_spans.push(Span::styled(" · ", muted));
+
+    if is_dimmed {
+        line2_spans.push(Span::styled(format_repo_entries_plain(entries), muted));
+        return;
+    }
+
+    let repo_style = Style::default().fg(Theme::text_primary());
+    let branch_style = Style::default().fg(Theme::branch_name());
+
+    let plain = format_repo_entries_plain(entries);
+    let search_positions = if !search_query.is_empty() {
+        crate::fuzzy::fuzzy_match(search_query, &plain).map(|m| m.positions)
+    } else {
+        None
+    };
+
+    if let Some(positions) = search_positions.filter(|p| !p.is_empty()) {
+        line2_spans.extend(
+            build_highlighted_spans(&plain, &positions, repo_style)
+                .into_iter()
+                .map(|s| Span::styled(s.content.into_owned(), s.style)),
+        );
+        return;
+    }
+
+    // No (matching) search — render with colored branches.
+    for (j, entry) in entries.iter().enumerate() {
+        if j > 0 {
+            line2_spans.push(Span::styled(", ", muted));
+        }
+        line2_spans.push(Span::styled(entry.name.clone(), repo_style));
+        if let Some(ref br) = entry.branch {
+            line2_spans.push(Span::styled("(", branch_style));
+            line2_spans.push(Span::styled(br.clone(), branch_style));
+            line2_spans.push(Span::styled(")", branch_style));
+        }
+    }
+}
+
+/// Build line 2 of a session entry: `<agent> · <repo>(<branch>), …`.
+fn build_session_line2(
+    info: &SessionInfo,
+    session_match: Option<&SessionMatch>,
+    is_dimmed: bool,
+    search_query: &str,
+) -> Line<'static> {
+    let entries = build_repo_entries(info);
+    let mut line2_spans: Vec<Span<'static>> = vec![Span::raw("   ")];
+
+    push_agent_spans(&mut line2_spans, info, session_match, is_dimmed);
+
+    if !entries.is_empty() {
+        push_repo_spans(&mut line2_spans, &entries, is_dimmed, search_query);
+    }
+
+    Line::from(line2_spans)
 }
 
 /// A single repo entry with an optional branch (for worktree repos).

--- a/src/ui/repo_picker_modal.rs
+++ b/src/ui/repo_picker_modal.rs
@@ -67,22 +67,50 @@ pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) 
 
     // Search bar (when active)
     if let Some(area) = search_area {
-        let match_label = format!(
-            "Search ({}/{})",
-            state.filtered_indices.len(),
-            state.bookmarks.len()
-        );
-        render_text_field(
-            frame,
-            area,
-            &match_label,
-            state.search_query,
-            state.search_cursor,
-            state.focus == RepoPickerFocus::Search,
-        );
+        render_search_bar(frame, area, state);
     }
 
     // Bookmark list with checkboxes
+    render_bookmark_list(frame, list_area, state);
+
+    // Path input
+    render_text_field_with_suggestion(
+        frame,
+        input_area,
+        "Add Repo Path",
+        state.path_input,
+        state.path_cursor,
+        state.focus == RepoPickerFocus::Input,
+        state.path_suggestion,
+    );
+
+    // Footer
+    frame.render_widget(Paragraph::new(footer_line(state)), footer_area);
+}
+
+/// Render the search bar at the top of the modal (only shown when search is active).
+fn render_search_bar(frame: &mut Frame, area: ratatui::layout::Rect, state: &RepoPickerState<'_>) {
+    let match_label = format!(
+        "Search ({}/{})",
+        state.filtered_indices.len(),
+        state.bookmarks.len()
+    );
+    render_text_field(
+        frame,
+        area,
+        &match_label,
+        state.search_query,
+        state.search_cursor,
+        state.focus == RepoPickerFocus::Search,
+    );
+}
+
+/// Render the bookmark list with checkboxes, fuzzy highlighting, and scrolling.
+fn render_bookmark_list(
+    frame: &mut Frame,
+    list_area: ratatui::layout::Rect,
+    state: &RepoPickerState<'_>,
+) {
     let list_focused = state.focus == RepoPickerFocus::List;
     let border_color = if list_focused {
         Theme::border_focused()
@@ -111,88 +139,92 @@ pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) 
             Style::default().fg(Theme::text_muted()),
         )));
         frame.render_widget(placeholder, list_inner_area);
-    } else {
-        let visible_count = list_inner_area.height as usize;
-        let scroll_offset = if state.list_index >= visible_count {
-            state.list_index - visible_count + 1
-        } else {
-            0
-        };
-
-        let items: Vec<ListItem<'_>> = state
-            .filtered_indices
-            .iter()
-            .enumerate()
-            .skip(scroll_offset)
-            .take(visible_count)
-            .map(|(vi, &real_idx)| {
-                let path = &state.bookmarks[real_idx];
-                let checked = state.selected[real_idx];
-                let is_wt = state.worktree[real_idx];
-                let is_cursor = vi == state.list_index && list_focused;
-
-                let style = if is_cursor {
-                    Theme::selected_item()
-                } else {
-                    Theme::normal_item()
-                };
-
-                let check = if checked { "[x] " } else { "[ ] " };
-                let display = path.display().to_string();
-
-                let mut spans = if !state.search_query.is_empty() {
-                    // Build spans with fuzzy highlight
-                    let positions = crate::fuzzy::fuzzy_match(state.search_query, &display)
-                        .map(|m| m.positions)
-                        .unwrap_or_default();
-                    let mut result = vec![Span::styled(check, style)];
-                    let mut last = 0;
-                    for &pos in &positions {
-                        if pos > last {
-                            result.push(Span::styled(display[last..pos].to_string(), style));
-                        }
-                        let end = display[pos..]
-                            .chars()
-                            .next()
-                            .map(|c| pos + c.len_utf8())
-                            .unwrap_or(pos + 1);
-                        result.push(Span::styled(
-                            display[pos..end].to_string(),
-                            Style::default().fg(Theme::accent()),
-                        ));
-                        last = end;
-                    }
-                    if last < display.len() {
-                        result.push(Span::styled(display[last..].to_string(), style));
-                    }
-                    result
-                } else {
-                    vec![Span::styled(format!("{check}{display}"), style)]
-                };
-
-                if checked && is_wt {
-                    spans.push(Span::styled(" [wt]", Style::default().fg(Theme::accent())));
-                }
-                ListItem::new(Line::from(spans))
-            })
-            .collect();
-
-        frame.render_widget(List::new(items), list_inner_area);
+        return;
     }
 
-    // Path input
-    render_text_field_with_suggestion(
-        frame,
-        input_area,
-        "Add Repo Path",
-        state.path_input,
-        state.path_cursor,
-        state.focus == RepoPickerFocus::Input,
-        state.path_suggestion,
-    );
+    let visible_count = list_inner_area.height as usize;
+    let scroll_offset = if state.list_index >= visible_count {
+        state.list_index - visible_count + 1
+    } else {
+        0
+    };
 
-    // Footer
-    let footer = match state.focus {
+    let items: Vec<ListItem<'_>> = state
+        .filtered_indices
+        .iter()
+        .enumerate()
+        .skip(scroll_offset)
+        .take(visible_count)
+        .map(|(vi, &real_idx)| bookmark_item(state, vi, real_idx, list_focused))
+        .collect();
+
+    frame.render_widget(List::new(items), list_inner_area);
+}
+
+/// Build a single bookmark list item (checkbox + path + optional `[wt]` marker).
+fn bookmark_item<'a>(
+    state: &RepoPickerState<'a>,
+    visible_index: usize,
+    real_idx: usize,
+    list_focused: bool,
+) -> ListItem<'a> {
+    let path = &state.bookmarks[real_idx];
+    let checked = state.selected[real_idx];
+    let is_wt = state.worktree[real_idx];
+    let is_cursor = visible_index == state.list_index && list_focused;
+
+    let style = if is_cursor {
+        Theme::selected_item()
+    } else {
+        Theme::normal_item()
+    };
+
+    let check = if checked { "[x] " } else { "[ ] " };
+    let display = path.display().to_string();
+
+    let mut spans = if state.search_query.is_empty() {
+        vec![Span::styled(format!("{check}{display}"), style)]
+    } else {
+        highlighted_spans(state.search_query, check, &display, style)
+    };
+
+    if checked && is_wt {
+        spans.push(Span::styled(" [wt]", Style::default().fg(Theme::accent())));
+    }
+    ListItem::new(Line::from(spans))
+}
+
+/// Build spans for a bookmark with fuzzy-match positions highlighted in the accent color.
+fn highlighted_spans(query: &str, check: &str, display: &str, style: Style) -> Vec<Span<'static>> {
+    let positions = crate::fuzzy::fuzzy_match(query, display)
+        .map(|m| m.positions)
+        .unwrap_or_default();
+    let mut result = vec![Span::styled(check.to_string(), style)];
+    let mut last = 0;
+    for &pos in &positions {
+        if pos > last {
+            result.push(Span::styled(display[last..pos].to_string(), style));
+        }
+        let end = display[pos..]
+            .chars()
+            .next()
+            .map(|c| pos + c.len_utf8())
+            .unwrap_or(pos + 1);
+        result.push(Span::styled(
+            display[pos..end].to_string(),
+            Style::default().fg(Theme::accent()),
+        ));
+        last = end;
+    }
+    if last < display.len() {
+        result.push(Span::styled(display[last..].to_string(), style));
+    }
+    result
+}
+
+/// Build the footer hint line for the current focus.
+fn footer_line(state: &RepoPickerState<'_>) -> Line<'static> {
+    match state.focus {
         RepoPickerFocus::List => Line::from(vec![
             Span::styled("j/k", Theme::keybind()),
             Span::styled(" nav  ", Theme::keybind_desc()),
@@ -230,6 +262,5 @@ pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) 
             Span::styled("Esc", Theme::keybind()),
             Span::styled(" clear  ", Theme::keybind_desc()),
         ]),
-    };
-    frame.render_widget(Paragraph::new(footer), footer_area);
+    }
 }


### PR DESCRIPTION
## Summary

Reduces cognitive complexity (SonarCloud `rust:S3776`) in the hot functions that are *still present* in the current tree. SonarCloud's last analysis is ~7 weeks stale: most of its 35 open S3776 issues reference code deleted in the "simplify to TUI-first orchestrator" refactor (devcontainer/vm/provisioning/skill-staging/settings-overlay/role-editor) and will auto-resolve on the next scan. This PR targets the genuine survivors.

Behavior-preserving extraction of private helpers + guard clauses to flatten nesting:

- **app/mod.rs** — split `handle_external_state_change`, `tick`, `restore_single_session`
- **app/key_handlers.rs** — decompose `handle_key` (priority/modal/automation routing) and the repo-picker / branch-selection handlers
- **app/view.rs** — split the frame renderer into per-region methods
- **ui/mod.rs, ui/project_list.rs, ui/repo_picker_modal.rs** — extract nested rendering blocks
- **agent/input.rs** — split `key_to_bytes` by key category
- **agent/tmux.rs** — extract `reader_thread` match-arm bodies
- **storage/schema.rs** — drive `migrate` from an ordered step table
- **storage/sessions.rs, paths.rs** — extract row-mapping / dir-matching helpers

Duplication was left as-is (3.5% overall): the high-duplication files SonarCloud flagged were deleted in the same refactor, and the surviving modals already share helpers.

## Test plan

- `cargo fmt --all --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- clippy cognitive-complexity over 15: **0 functions** (was 7)
- 722 unit tests + integration tests pass; architecture-rules + migration tests pass