### PR TITLE
feat(docs): showcase automations demo on homepage walkthrough

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -316,6 +316,34 @@
                 <div class="terminal-dot red"></div>
                 <div class="terminal-dot yellow"></div>
                 <div class="terminal-dot green"></div>
+                <span class="terminal-title">Automations</span>
+              </div>
+              <div class="terminal-body">
+                <video
+                  src="assets/automations-demo.mp4"
+                  autoplay
+                  loop
+                  muted
+                  playsinline
+                  preload="none"
+                >
+                  Creating and running a scheduled automation from the Ctrl+P pane
+                </video>
+              </div>
+            </div>
+            <figcaption>
+              <strong>Automations</strong>
+              &mdash;
+              <code>Ctrl+P</code>
+              schedules agent runs that fire even when the TUI is closed.
+            </figcaption>
+          </figure>
+          <figure class="video-card">
+            <div class="terminal-frame">
+              <div class="terminal-header">
+                <div class="terminal-dot red"></div>
+                <div class="terminal-dot yellow"></div>
+                <div class="terminal-dot green"></div>
                 <span class="terminal-title">Session creation</span>
               </div>
               <div class="terminal-body">


### PR DESCRIPTION
## Summary

Adds an **Automations** video card to the homepage "Feature walkthrough" section, surfacing the already-generated `automations-demo.mp4` (deployed into `website/assets/` by `pages.yml`) that previously wasn't showcased anywhere on the site.

- New `video-card` mirrors the existing walkthrough cards (Session creation, File viewer, Info panel, Themes) exactly — same `terminal-frame` structure and `<video>` attributes.
- Figcaption: `Ctrl+P` schedules agent runs that fire even when the TUI is closed — consistent with the Features card and keybindings step.

The walkthrough grid now shows 5 cards, with Automations placed first to highlight the flagship feature.

## Test plan

- `npm run lint:website` passes (Prettier, HTMLHint, Stylelint, ESLint)