### PR TITLE
feat(ui): smarter session list, multi-repo workspaces, looped nav

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,28 @@ your own `[[agents]]` entry to support any CLI — no recompile.
 A session stores only its **agent name**; there are no
 per-session model/permission/prompt/tool knobs.
 
+### Multi-repo sessions (symlink workspace)
+
+A session can span several repositories (the repo picker allows
+multiple). Because agent CLIs differ wildly in how — or whether —
+they accept extra directories, thurbox does **not** pass per-agent
+`--add-dir`-style flags. Instead, when a session has more than one
+member directory it is launched in a per-session **symlink
+workspace**: `~/.local/share/thurbox/workspaces/<agent_session_id>/`
+holds one symlink per repo (worktree checkout or plain dir), and the
+agent process is started there (`cwd` = the workspace). Every agent
+then sees each repo as a subdirectory — fully agent-neutral, no
+`agents.toml` changes.
+
+`SessionInfo.cwd` keeps the **primary** repo (for display / editor /
+git context); the workspace is a spawn-time process-cwd detail,
+derived idempotently on every launch from the persisted members and
+never stored. `workspace::ensure_workspace` / `remove_workspace`
+(`src/workspace.rs`) build and tear it down; the member set is the
+single `App::session_member_dirs` list that also feeds the rendered
+repo names, and `App::resolve_process_cwd` picks workspace-vs-primary.
+Single-repo sessions are unchanged (`cwd` = the repo directly).
+
 ## thurbox-cli
 
 A second binary (`thurbox-cli`) drives the same SQLite-backed,
@@ -235,10 +257,13 @@ keeper, and an OS timer never double-fire.
 In the TUI, automations also get a dedicated **Automations pane**
 beneath the session list (left column). It is always present
 (showing `none` when empty) and is treated as **part of the session
-pane**: it forms one continuous vertical list with the session list,
-so pressing `j` past the last session drops focus into the pane and
-`k` at the top automation hands focus back to the last session. It
-is **not** a separate stop in the `Ctrl+H`/`Ctrl+L` cycle (which
+pane**: it forms one continuous, **circular** vertical list with the
+session list. `j` past the last session drops focus into the pane and
+`k` at the top automation hands focus back to the last session; the
+ends wrap too — `j` past the last automation loops to the **top** of
+the session list, and `k` above the first session loops to the
+**last** automation. It is **not** a separate stop in the
+`Ctrl+H`/`Ctrl+L` cycle (which
 treats it like the session list). Once focused, `j`/`k` select,
 `Space`/`r`/`d` toggle/run/delete the selected automation, and `n`
 creates one.
@@ -365,7 +390,11 @@ app      ← coordinator, imports all modules
 - **`ui/`** — Pure rendering functions. `layout.rs` computes
   panel areas (responsive: <80 = terminal only, >=80 = 2-panel,
   >=120 = optional 3-panel). Widgets: `project_list` (session
-  list with repo/branch display), `terminal_view`, `info_panel`,
+  list with repo/branch display; `compute_session_order` is the
+  single comparator that orders sessions by activity/status and
+  groups them by repo under headers — shared with `App`'s
+  `Ctrl+J/K` navigation so the two never drift),
+  `terminal_view`, `info_panel`,
   `status_bar`, `repo_picker_modal` (repo selection with
   worktree toggle). `selection.rs` handles mouse-drag text
   selection, `links.rs` detects clickable URLs for Ctrl+Click.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -63,9 +63,39 @@ used for the window title):
   escape (**OSC 9**, **OSC 777**) means the agent finished or is
   waiting for input. This latches a distinct `Needs attention` status
   (`▲`, accent colour) that shows the notification's message text when
-  present, and **sorts the session to the top of the list** so blocked
-  or finished agents surface first. It clears automatically once you
-  select the session (you're now looking at it).
+  present, and **floats the session to the top** so blocked or finished
+  agents surface first (see *Smart ordering* below). It clears
+  automatically once you select the session (you're now looking at it).
+
+### Smart ordering & repo groups
+
+The list is ordered by **activity and status**, then **grouped by
+repository** under subtle headers (`── webapp ─────`):
+
+- Within a group, sessions sort by status rank
+  (`Attention → running → Idle → Error`), tie-broken by stable insertion
+  order. `Busy` and `Waiting` deliberately **share one "running" rank**: a
+  live agent flickers across the ~1s output boundary every tick, so ranking
+  them apart (or sorting by live recency) would make active sessions churn up
+  and down the list endlessly. Ordering is a pure function of *status* and
+  *stable order*, never of live timing — so the list only re-sorts on a real
+  transition (a session needs attention, or exits).
+- Groups are ordered by their **most-urgent member**, then by name, so a repo
+  holding an `Attention` session bubbles above a merely-running one.
+- The group key is the **set of repos a session spans** (order-independent), so
+  a multi-repo session forms its own group with a combined header
+  (`webapp + infra`) rather than being filed arbitrarily under one repo;
+  sessions touching the same set cluster together. Sessions with no repo share a
+  `(no repo)` group.
+- The **admin** session stays pinned at the very top, headerless.
+
+**Why group by repo?** With several parallel agents the dominant question
+is "which project is this?" — clustering same-repo sessions answers it at a
+glance while urgency still wins globally (an `Attention` session never hides
+below a quiet repo). A single comparator
+(`ui::project_list::compute_session_order`) drives both rendering and
+`Ctrl+J`/`Ctrl+K` navigation, so the keyboard always steps through the exact
+order shown.
 
 **Why signals instead of guessing?** Pure output-timing can only say
 "quiet for >1s"; it can't tell a thinking pause from "done" or "needs
@@ -111,6 +141,17 @@ so it makes sense to pick repos at creation time rather than
 inheriting from a parent grouping. Mixed sessions are supported:
 some repos may be worktree-based (new branch created) while others
 are added as-is.
+
+**How does one agent reach multiple repos?** Agent CLIs disagree on
+how (or whether) to accept extra directories, so thurbox stays
+agent-neutral: a multi-repo session is launched in a per-session
+**symlink workspace** (`~/.local/share/thurbox/workspaces/<id>/`)
+holding one symlink per repo, with the agent's cwd set there. Every
+agent then sees each repo as a subdirectory — no per-agent flags and
+no `agents.toml` changes. The workspace is only symlinks, rebuilt
+idempotently on each launch and removed (without touching the repos)
+when the session is deleted. Single-repo sessions launch directly in
+the repo as before.
 
 **Why per-session agent?** Different tasks suit different agents.
 Choosing the agent at creation time keeps each session

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -600,11 +600,20 @@ impl Session {
         debug!("Session detached");
     }
 
-    /// Lazily spawn a companion shell pane in the same cwd.
+    /// Lazily spawn a companion shell pane.
     ///
-    /// Uses `$SHELL` (fallback `/bin/sh`) as the command.
-    /// The window name uses `tbs-` prefix to distinguish from the agent's `tb-` windows.
-    pub fn ensure_shell_pane(&mut self, rows: u16, cols: u16) -> Result<()> {
+    /// `cwd` is the directory the shell starts in — the caller passes the
+    /// session's *launch* cwd (the multi-repo symlink workspace when there is
+    /// one, so the shell lands where the agent does), falling back to the
+    /// primary repo (`info.cwd`) when `None`. Uses `$SHELL` (fallback `/bin/sh`)
+    /// as the command. The window name uses the `tbs-` prefix to distinguish
+    /// from the agent's `tb-` windows.
+    pub fn ensure_shell_pane(
+        &mut self,
+        rows: u16,
+        cols: u16,
+        cwd: Option<&std::path::Path>,
+    ) -> Result<()> {
         if self.shell_pane.is_some() {
             return Ok(());
         }
@@ -613,16 +622,11 @@ impl Session {
         let window_name = crate::agent::tmux::shell_window_name(&self.info.name);
 
         let env = self.env.clone();
+        let cwd = cwd.or(self.info.cwd.as_deref());
 
-        let spawned = self.backend.spawn(
-            &window_name,
-            &shell_cmd,
-            &[],
-            self.info.cwd.as_deref(),
-            &env,
-            rows,
-            cols,
-        )?;
+        let spawned = self
+            .backend
+            .spawn(&window_name, &shell_cmd, &[], cwd, &env, rows, cols)?;
 
         let (state, backend_id) = Self::wire_up(
             rows,

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -246,6 +246,19 @@ impl App {
             self.refresh_automation_view();
             return;
         }
+        // `j`/Down past the last automation (or in an empty pane) loops around to
+        // the TOP of the session list, so sessions+automations form one circular
+        // column.
+        if matches!(code, KeyCode::Char('j') | KeyCode::Down) {
+            if count == 0 || self.automation_panel_index + 1 >= count {
+                self.focus = InputFocus::SessionList;
+                self.select_first_session();
+            } else {
+                self.automation_panel_index += 1;
+            }
+            self.refresh_automation_view();
+            return;
+        }
         // `Enter`/`e` focuses the central-pane editor (like `Enter` on a session
         // focuses its terminal); on an empty pane it starts a new automation.
         if matches!(code, KeyCode::Enter | KeyCode::Char('e')) {
@@ -265,14 +278,6 @@ impl App {
         }
         let id = self.cached_automations[self.automation_panel_index].id;
         match code {
-            KeyCode::Char('j') | KeyCode::Down => {
-                // Stay put at the bottom — the automations pane is the last
-                // section of the left column.
-                if self.automation_panel_index + 1 < count {
-                    self.automation_panel_index += 1;
-                    self.refresh_automation_view();
-                }
-            }
             KeyCode::Char(' ') => {
                 self.toggle_automation_by_id(id);
                 self.sync_automation_editor();
@@ -421,7 +426,7 @@ impl App {
         }
     }
 
-    fn handle_session_list_key(&mut self, code: KeyCode) {
+    pub(crate) fn handle_session_list_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
                 // Past the last session, flow down into the automations pane so
@@ -435,8 +440,13 @@ impl App {
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                // Top of the column — stay put (don't wrap around).
-                if !self.active_is_first_in_order() {
+                // Above the first session, loop around to the bottom of the
+                // column: the last automation (its pane is always present).
+                if self.active_is_first_in_order() {
+                    self.focus = InputFocus::Automations;
+                    self.automation_panel_index = self.cached_automations.len().saturating_sub(1);
+                    self.refresh_automation_view();
+                } else {
                     self.switch_session_backward();
                 }
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -608,7 +608,9 @@ impl App {
         };
 
         let agent = session.info.agent.clone();
-        let cwd = session.info.cwd.clone();
+        // Rebuild the process cwd: the primary repo for a single-repo session,
+        // or the (idempotently rebuilt) symlink workspace for a multi-repo one.
+        let cwd = session_process_cwd(&session.info);
 
         let mut config = SessionConfig {
             resume_session_id: None,
@@ -820,11 +822,14 @@ impl App {
     /// so that restored sessions (Ctrl+U) can reuse them without re-cloning.
     fn finalize_pending_delete(&mut self) {
         if let Some(pending) = self.pending_delete.take() {
-            // Clean up agent metrics file.
+            // Clean up derived per-session artifacts (rebuilt on restore): the
+            // agent metrics file and the multi-repo symlink workspace. Worktrees
+            // are intentionally left on disk for Ctrl+U restore.
             if let Some(ref sid) = pending.session.info.agent_session_id {
                 if let Some(metrics_dir) = crate::paths::metrics_directory() {
                     let _ = std::fs::remove_file(metrics_dir.join(format!("{sid}.json")));
                 }
+                let _ = crate::workspace::remove_workspace(sid);
             }
             pending.session.kill();
         }
@@ -996,11 +1001,14 @@ impl App {
 
         match current {
             TerminalView::Claude => {
-                // Lazily create the shell pane if it doesn't exist
+                // Lazily create the shell pane if it doesn't exist. Start it in
+                // the same launch cwd as the agent (the multi-repo workspace when
+                // there is one), so switching to the terminal lands you there.
                 if needs_shell {
                     let (rows, cols) = self.content_area_size();
+                    let shell_cwd = session_process_cwd(&self.sessions[self.active_index].info);
                     let session = &mut self.sessions[self.active_index];
-                    if let Err(e) = session.ensure_shell_pane(rows, cols) {
+                    if let Err(e) = session.ensure_shell_pane(rows, cols, shell_cwd.as_deref()) {
                         error!("Failed to create shell pane: {e}");
                         self.set_error(format!("Failed to create shell: {e:#}"));
                         return;
@@ -1284,11 +1292,23 @@ impl App {
             );
         }
 
+        // For a multi-repo session, launch the agent in a symlink workspace that
+        // gathers every member dir; `info.cwd` keeps the primary repo (restored
+        // after spawn). Single-repo sessions are unchanged.
+        let primary_cwd = config.cwd.clone();
+        config.cwd = resolve_process_cwd(
+            config.agent_session_id.as_deref(),
+            primary_cwd.clone(),
+            &worktrees,
+            &additional_dirs,
+        );
+
         let backend: Arc<dyn SessionBackend> = Arc::clone(self.backends.default_backend());
 
         let provider = self.provider_for(&config);
         match Session::spawn(name, rows, cols, &config, &backend, &provider) {
             Ok(mut session) => {
+                session.info.cwd = primary_cwd;
                 session.info.worktrees = worktrees;
                 session.info.additional_dirs = additional_dirs;
 
@@ -1325,14 +1345,14 @@ impl App {
 
     /// Indices into `self.sessions` in the order they are rendered.
     ///
-    /// Mirrors `ui::project_list::OrderedSessions::new`: admin sessions
-    /// are pinned to the top (stable), the rest follow DB order. Used by
-    /// the session-navigation helpers so `Ctrl+J`/`Ctrl+K` step through
-    /// the list the user actually sees.
+    /// Delegates to the same `ui::project_list::compute_session_order` the
+    /// rendering widget uses, so `Ctrl+J`/`Ctrl+K` step through the list in the
+    /// exact order the user sees (admin pinned, then repo groups ordered by
+    /// activity/status).
     fn render_order_indices(&self) -> Vec<usize> {
-        let mut order: Vec<usize> = (0..self.sessions.len()).collect();
-        order.sort_by_key(|&i| !self.sessions[i].info.is_admin);
-        order
+        let infos: Vec<&crate::session::SessionInfo> =
+            self.sessions.iter().map(|s| &s.info).collect();
+        crate::ui::project_list::compute_session_order(&infos).order
     }
 
     /// Whether the active session is the first row in render order (top of the
@@ -1359,6 +1379,14 @@ impl App {
     pub(crate) fn select_last_session(&mut self) {
         if let Some(&last) = self.render_order_indices().last() {
             self.active_index = last;
+        }
+    }
+
+    /// Select the first session in render order — used when looping down out of
+    /// the automations pane back to the top of the session list.
+    pub(crate) fn select_first_session(&mut self) {
+        if let Some(&first) = self.render_order_indices().first() {
+            self.active_index = first;
         }
     }
 
@@ -2965,42 +2993,106 @@ fn format_automation_summary(auto: &Automation, now: u64) -> String {
 /// Populate `repo_display_names` on a session from worktree repo paths,
 /// cwd, and additional_dirs, using git remote names where available.
 ///
-/// The order matches `build_repo_entries`: worktree repos first (by their
-/// original `repo_path`), then non-worktree additional dirs.
+/// Thin wrapper over [`session_member_dirs`] — the single source of truth for
+/// *which* directories a session spans and in what order — keeping the displayed
+/// repo names and the workspace symlink set from ever drifting.
 fn resolve_repo_display_names(info: &mut SessionInfo) {
-    let mut names = Vec::new();
+    info.repo_display_names =
+        session_member_dirs(info.cwd.as_deref(), &info.worktrees, &info.additional_dirs)
+            .into_iter()
+            .filter_map(|(name, _)| name)
+            .collect();
+}
 
-    // Collect worktree checkout paths for filtering additional_dirs later.
-    let wt_paths: std::collections::HashSet<&std::path::Path> = info
-        .worktrees
+/// The `(display_name, directory)` pairs a session spans, in display order:
+/// worktree repos first (name from the original `repo_path`, dir = the checkout),
+/// then non-worktree `additional_dirs`; or the lone `cwd` repo when there are no
+/// worktrees. `name` is `None` only for pathological paths with no resolvable
+/// name. This is the canonical member set used for both the repo-name display and
+/// the multi-repo symlink workspace.
+fn session_member_dirs(
+    cwd: Option<&std::path::Path>,
+    worktrees: &[WorktreeInfo],
+    additional_dirs: &[PathBuf],
+) -> Vec<(Option<String>, PathBuf)> {
+    let mut members: Vec<(Option<String>, PathBuf)> = Vec::new();
+
+    let wt_paths: std::collections::HashSet<&std::path::Path> = worktrees
         .iter()
         .map(|wt| wt.worktree_path.as_path())
         .collect();
 
-    if !info.worktrees.is_empty() {
-        // Worktree repos: resolve from original repo_path (has git remote).
-        for wt in &info.worktrees {
-            if let Some(name) = git::repo_display_name(&wt.repo_path) {
-                names.push(name);
-            }
+    if !worktrees.is_empty() {
+        for wt in worktrees {
+            members.push((
+                git::repo_display_name(&wt.repo_path),
+                wt.worktree_path.clone(),
+            ));
         }
-    } else if let Some(ref cwd) = info.cwd {
-        // No worktrees: use cwd as the primary repo.
-        if let Some(name) = git::repo_display_name(cwd) {
-            names.push(name);
-        }
+    } else if let Some(cwd) = cwd {
+        members.push((git::repo_display_name(cwd), cwd.to_path_buf()));
     }
 
-    // Non-worktree additional dirs (skip paths that are worktree checkouts).
-    for dir in &info.additional_dirs {
+    for dir in additional_dirs {
         if !wt_paths.contains(dir.as_path()) {
-            if let Some(name) = git::repo_display_name(dir) {
-                names.push(name);
-            }
+            members.push((git::repo_display_name(dir), dir.clone()));
         }
     }
 
-    info.repo_display_names = names;
+    members
+}
+
+/// The directory the agent process should launch in.
+///
+/// For a single-member session that's the member itself (`primary_cwd`). For a
+/// multi-member session it is a per-session **symlink workspace** (built
+/// idempotently from the members) so the agent sees every repo as a
+/// subdirectory — agent-neutral, needing no per-CLI flag. On any failure it
+/// falls back to `primary_cwd`.
+fn resolve_process_cwd(
+    agent_session_id: Option<&str>,
+    primary_cwd: Option<PathBuf>,
+    worktrees: &[WorktreeInfo],
+    additional_dirs: &[PathBuf],
+) -> Option<PathBuf> {
+    let members = session_member_dirs(primary_cwd.as_deref(), worktrees, additional_dirs);
+    if members.len() < 2 {
+        return primary_cwd;
+    }
+    let Some(id) = agent_session_id else {
+        return primary_cwd;
+    };
+
+    let pairs: Vec<(String, PathBuf)> = members
+        .into_iter()
+        .map(|(name, dir)| {
+            let label = name
+                .or_else(|| dir.file_name().and_then(|s| s.to_str()).map(String::from))
+                .unwrap_or_else(|| "repo".to_string());
+            (label, dir)
+        })
+        .collect();
+
+    match crate::workspace::ensure_workspace(id, &pairs) {
+        Ok(ws) => Some(ws),
+        Err(e) => {
+            error!("Failed to build multi-repo workspace: {e}");
+            primary_cwd
+        }
+    }
+}
+
+/// The launch cwd for an *existing* session, derived from its persisted
+/// `SessionInfo`: the multi-repo symlink workspace, or the primary repo when
+/// single-repo. Used by the restart and shell-pane paths, which must agree on
+/// the cwd so the companion shell lands exactly where the agent runs.
+fn session_process_cwd(info: &SessionInfo) -> Option<PathBuf> {
+    resolve_process_cwd(
+        info.agent_session_id.as_deref(),
+        info.cwd.clone(),
+        &info.worktrees,
+        &info.additional_dirs,
+    )
 }
 
 #[cfg(test)]
@@ -3349,6 +3441,28 @@ mod tests {
     }
 
     #[test]
+    fn switch_follows_activity_and_repo_group_order() {
+        use crate::session::SessionStatus;
+        // DB order: [webapp/Busy, infra/Attention, webapp/Busy].
+        let mut app = app_with_sessions(3);
+        app.sessions[0].info.repo_display_names = vec!["webapp".to_string()];
+        app.sessions[0].info.status = SessionStatus::Busy;
+        app.sessions[1].info.repo_display_names = vec!["infra".to_string()];
+        app.sessions[1].info.status = SessionStatus::Attention;
+        app.sessions[2].info.repo_display_names = vec!["webapp".to_string()];
+        app.sessions[2].info.status = SessionStatus::Busy;
+
+        // Rendered order: infra group (Attention) first → [1], then webapp → [0, 2].
+        app.active_index = 1;
+        app.switch_session_forward();
+        assert_eq!(app.active_index, 0, "infra/attn → webapp/0");
+        app.switch_session_forward();
+        assert_eq!(app.active_index, 2, "webapp/0 → webapp/2");
+        app.switch_session_forward();
+        assert_eq!(app.active_index, 1, "webapp/2 → wrap to infra/attn");
+    }
+
+    #[test]
     fn switch_with_single_session_is_noop() {
         let mut app = app_with_sessions(1);
         app.active_index = 0;
@@ -3491,16 +3605,66 @@ mod tests {
         app.focus = InputFocus::AutomationEditor;
         assert_eq!(app.cycle_focus_backward(), InputFocus::Automations);
 
-        // j/k navigate, clamped to the list bounds.
+        // j/k navigate within the pane; past either end they loop out into the
+        // session list (the column is circular).
         app.cached_automations = vec![make(1, "a"), make(2, "b")];
         app.focus = InputFocus::Automations;
         app.automation_panel_index = 0;
         app.handle_automations_pane_key(KeyCode::Char('j'));
         assert_eq!(app.automation_panel_index, 1);
-        app.handle_automations_pane_key(KeyCode::Char('j'));
-        assert_eq!(app.automation_panel_index, 1, "clamped at last");
         app.handle_automations_pane_key(KeyCode::Char('k'));
         assert_eq!(app.automation_panel_index, 0);
+        // j past the last automation loops out to the session list.
+        app.automation_panel_index = 1;
+        app.handle_automations_pane_key(KeyCode::Char('j'));
+        assert_eq!(app.focus, InputFocus::SessionList);
+    }
+
+    #[test]
+    fn session_and_automation_navigation_forms_a_loop() {
+        use crate::session::{AutomationAction, AutomationSchedule};
+        let make = |id: i64, name: &str| Automation {
+            id,
+            name: name.into(),
+            enabled: true,
+            schedule: AutomationSchedule::Once { at: 0 },
+            timezone: None,
+            action: AutomationAction::Send {
+                session_id: SessionId::default(),
+            },
+            prompt: "p".into(),
+            created_at: 0,
+            updated_at: 0,
+            last_run_at: None,
+            next_run_at: None,
+        };
+        let mut app = app_with_sessions(2);
+        app.cached_automations = vec![make(1, "a"), make(2, "b")];
+
+        // Down past the last session drops into the automations pane.
+        app.focus = InputFocus::SessionList;
+        app.active_index = 1; // last session in render order
+        app.handle_session_list_key(KeyCode::Char('j'));
+        assert_eq!(app.focus, InputFocus::Automations);
+        assert_eq!(app.automation_panel_index, 0);
+
+        // Down past the last automation loops to the TOP session.
+        app.handle_automations_pane_key(KeyCode::Char('j')); // a → b
+        assert_eq!(app.automation_panel_index, 1);
+        app.handle_automations_pane_key(KeyCode::Char('j')); // past last → top session
+        assert_eq!(app.focus, InputFocus::SessionList);
+        assert_eq!(app.active_index, 0, "looped to first session");
+
+        // Up from the first session loops to the LAST automation.
+        app.handle_session_list_key(KeyCode::Char('k'));
+        assert_eq!(app.focus, InputFocus::Automations);
+        assert_eq!(app.automation_panel_index, 1, "looped to last automation");
+
+        // And k at the top automation hands back up to the last session.
+        app.automation_panel_index = 0;
+        app.handle_automations_pane_key(KeyCode::Char('k'));
+        assert_eq!(app.focus, InputFocus::SessionList);
+        assert_eq!(app.active_index, 1, "back to last session");
     }
 
     // --- Role editor tests ---
@@ -3788,13 +3952,17 @@ mod tests {
     }
 
     #[test]
-    fn k_at_first_session_does_not_wrap() {
+    fn k_at_first_session_loops_to_last_automation() {
         let mut app = app_with_sessions(3);
+        add_test_automation(&mut app, "a");
+        add_test_automation(&mut app, "b");
         app.focus = InputFocus::SessionList;
         app.active_index = 0;
         app.handle_key(KeyCode::Char('k'), KeyModifiers::NONE);
-        assert_eq!(app.focus, InputFocus::SessionList);
-        assert_eq!(app.active_index, 0);
+        // Above the first session the column loops to the bottom: the last
+        // automation in the pane.
+        assert_eq!(app.focus, InputFocus::Automations);
+        assert_eq!(app.automation_panel_index, 1);
     }
 
     #[test]
@@ -3817,14 +3985,16 @@ mod tests {
     }
 
     #[test]
-    fn j_at_bottom_automation_stays_put() {
-        let mut app = app_with_sessions(1);
+    fn j_at_bottom_automation_loops_to_first_session() {
+        let mut app = app_with_sessions(2);
         add_test_automation(&mut app, "a");
         app.focus = InputFocus::Automations;
-        app.automation_panel_index = 0;
+        app.active_index = 1;
+        app.automation_panel_index = 0; // the only (= last) automation
         app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE);
-        assert_eq!(app.focus, InputFocus::Automations);
-        assert_eq!(app.automation_panel_index, 0);
+        // Past the last automation the column loops back to the top session.
+        assert_eq!(app.focus, InputFocus::SessionList);
+        assert_eq!(app.active_index, 0, "looped to first session");
     }
 
     #[test]
@@ -4317,6 +4487,87 @@ mod tests {
         assert_eq!(shared.additional_dirs[0], PathBuf::from("/repo2"));
         assert_eq!(shared.additional_dirs[1], PathBuf::from("/repo3"));
     }
+
+    // --- multi-repo member resolution + workspace cwd ---
+
+    #[test]
+    fn member_dirs_worktree_first_then_additional() {
+        let worktrees = vec![WorktreeInfo {
+            repo_path: PathBuf::from("/src/webapp"),
+            worktree_path: PathBuf::from("/wt/webapp/feat"),
+            branch: "feat".into(),
+        }];
+        let additional = vec![PathBuf::from("/src/infra")];
+        let members = session_member_dirs(None, &worktrees, &additional);
+
+        // Worktree repo: name from repo_path, dir = the checkout. Then the
+        // non-worktree additional dir.
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0].0.as_deref(), Some("webapp"));
+        assert_eq!(members[0].1, PathBuf::from("/wt/webapp/feat"));
+        assert_eq!(members[1].0.as_deref(), Some("infra"));
+        assert_eq!(members[1].1, PathBuf::from("/src/infra"));
+    }
+
+    #[test]
+    fn member_dirs_no_worktrees_uses_cwd_first() {
+        let cwd = PathBuf::from("/src/primary");
+        let additional = vec![PathBuf::from("/src/other")];
+        let members = session_member_dirs(Some(&cwd), &[], &additional);
+
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0].1, PathBuf::from("/src/primary"));
+        assert_eq!(members[1].1, PathBuf::from("/src/other"));
+    }
+
+    #[test]
+    fn process_cwd_single_member_is_primary() {
+        let cwd = PathBuf::from("/src/only");
+        let out = resolve_process_cwd(Some("id-1"), Some(cwd.clone()), &[], &[]);
+        assert_eq!(out, Some(cwd));
+    }
+
+    #[test]
+    fn process_cwd_multi_member_is_workspace() {
+        let base = std::env::temp_dir().join("thurbox-procwd-test");
+        let _ = std::fs::remove_dir_all(&base);
+        let _g = crate::paths::TestPathGuard::new(&base);
+
+        let primary = base.join("repo-a");
+        let other = base.join("repo-b");
+        std::fs::create_dir_all(&primary).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+
+        let out = resolve_process_cwd(
+            Some("sess-x"),
+            Some(primary.clone()),
+            &[],
+            std::slice::from_ref(&other),
+        )
+        .unwrap();
+
+        // cwd is now a workspace under the workspaces root, with a symlink per repo.
+        let ws_root = crate::paths::workspaces_directory().unwrap();
+        assert!(out.starts_with(&ws_root), "{out:?} not under {ws_root:?}");
+        assert_eq!(std::fs::read_link(out.join("repo-a")).unwrap(), primary);
+        assert_eq!(std::fs::read_link(out.join("repo-b")).unwrap(), other);
+    }
+
+    #[test]
+    fn process_cwd_multi_member_without_session_id_falls_back_to_primary() {
+        // No agent_session_id → no stable name for a workspace → use the primary
+        // repo (and don't touch the filesystem).
+        let primary = PathBuf::from("/src/a");
+        let other = PathBuf::from("/src/b");
+        let out = resolve_process_cwd(
+            None,
+            Some(primary.clone()),
+            &[],
+            std::slice::from_ref(&other),
+        );
+        assert_eq!(out, Some(primary));
+    }
+
     #[test]
     fn set_error_creates_error_status() {
         let mut app = App::new(24, 80, stub_backend(), stub_agents(), test_db());

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -129,7 +129,7 @@ impl App {
                 session_search_active: !self.session_match_positions.is_empty(),
                 match_count,
                 total_count,
-                first_non_admin_index: ordered.first_non_admin_index,
+                headers: &ordered.headers,
             },
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,4 @@ pub mod storage;
 pub mod sync;
 pub mod ui;
 pub mod usage;
+pub mod workspace;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -78,6 +78,9 @@ pub enum PathKind {
     MetricsDir,
     /// Git worktrees: `~/.local/share/thurbox/worktrees/`
     WorktreesDir,
+    /// Per-session multi-repo symlink workspaces:
+    /// `~/.local/share/thurbox/workspaces/`
+    WorkspacesDir,
     /// User keybindings JSON file: `~/.config/thurbox/keybindings.json`
     KeybindingsFile,
 }
@@ -135,6 +138,7 @@ fn resolve_xdg(kind: PathKind) -> Option<PathBuf> {
         PathKind::LogDir => xdg_data_subpath(&[]),
         PathKind::MetricsDir => xdg_data_subpath(&["metrics"]),
         PathKind::WorktreesDir => xdg_data_subpath(&["worktrees"]),
+        PathKind::WorkspacesDir => xdg_data_subpath(&["workspaces"]),
         PathKind::KeybindingsFile => xdg_config_subpath("keybindings.json"),
     }
 }
@@ -147,6 +151,7 @@ fn resolve_override(base: &Path, kind: PathKind) -> PathBuf {
         PathKind::Database => base.join("thurbox.db"),
         PathKind::MetricsDir => base.join("metrics"),
         PathKind::WorktreesDir => base.join("worktrees"),
+        PathKind::WorkspacesDir => base.join("workspaces"),
         PathKind::KeybindingsFile => base.join("keybindings.json"),
     }
 }
@@ -203,6 +208,14 @@ pub fn metrics_directory() -> Option<PathBuf> {
 /// Returns: `$XDG_DATA_HOME/thurbox/worktrees/` or `$HOME/.local/share/thurbox/worktrees/`
 pub fn worktrees_directory() -> Option<PathBuf> {
     resolve(PathKind::WorktreesDir)
+}
+
+/// Resolve the multi-repo workspaces directory path.
+///
+/// Returns: `$XDG_DATA_HOME/thurbox/workspaces/` or
+/// `$HOME/.local/share/thurbox/workspaces/`
+pub fn workspaces_directory() -> Option<PathBuf> {
+    resolve(PathKind::WorkspacesDir)
 }
 
 /// Resolve the user keybindings file path.

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -52,6 +52,14 @@ pub fn delete_session_headless(
             }
         }
 
+        // Tear down the multi-repo symlink workspace (if any). Only the symlinks
+        // are removed — the underlying repos are untouched.
+        if let Some(asid) = &session.agent_session_id {
+            if let Err(e) = crate::workspace::remove_workspace(asid) {
+                tracing::warn!("remove_workspace({asid}) failed: {e}");
+            }
+        }
+
         report.disabled_automations = db
             .disable_send_automations_for_session(session_id)
             .map_err(|e| format!("disable_send_automations_for_session: {e}"))?;

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -68,7 +68,10 @@ pub struct SharedSession {
     /// Working directory (if specified).
     pub cwd: Option<PathBuf>,
 
-    /// Additional directories the agent CLI has access to via `--add-dir`.
+    /// Extra directories (beyond `cwd`) this session spans. When a session has
+    /// more than one member dir, the agent is launched in a per-session symlink
+    /// workspace gathering them all (see `crate::workspace`), so every agent —
+    /// not just those with an `--add-dir`-style flag — can reach them.
     pub additional_dirs: Vec<PathBuf>,
 
     /// Worktree information (if session uses git worktrees).

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -57,40 +57,183 @@ impl SessionMatch {
     }
 }
 
-/// Display-ordered view of the session list with admin sessions pinned to the
-/// top. All fields are parallel arrays aligned to the rendered order.
+/// Rank a session status for ordering. Lower ranks sort closer to the top:
+/// sessions that need you first, then running, then exited, then errored.
+///
+/// `Busy` and `Waiting` share one **running** rank on purpose. A live agent
+/// flickers across the ~1s "recent output" boundary every tick (`Busy` while
+/// emitting, `Waiting` in the gaps), so ranking them apart would make active
+/// sessions churn up and down the list endlessly. The status *dot* still shows
+/// the distinction; only the ordering ignores it.
+fn status_rank(status: crate::session::SessionStatus) -> u8 {
+    use crate::session::SessionStatus::{Attention, Busy, Error, Idle, Waiting};
+    match status {
+        Attention => 0,
+        Busy | Waiting => 1,
+        Idle => 2,
+        Error => 3,
+    }
+}
+
+/// Fallback label/key for a session that spans no repos.
+const NO_REPO_GROUP: &str = "(no repo)";
+
+/// The canonical grouping **key** for a non-admin session: the *set* of repos it
+/// spans (sorted + de-duplicated), so sessions touching the same repos cluster
+/// together regardless of selection order (`{infra, webapp}` == `{webapp,
+/// infra}`). Multi-repo sessions thus form their own group, distinct from the
+/// single-repo groups of their constituent repos. Falls back to a shared
+/// `(no repo)` bucket.
+///
+/// The `\0` join separator can't occur in a repo name, so distinct sets never
+/// collide. This is only a map key — never displayed (see [`group_display`]).
+fn group_key(info: &SessionInfo) -> String {
+    if info.repo_display_names.is_empty() {
+        return NO_REPO_GROUP.to_string();
+    }
+    let mut names: Vec<&str> = info.repo_display_names.iter().map(String::as_str).collect();
+    names.sort_unstable();
+    names.dedup();
+    names.join("\0")
+}
+
+/// The header **label** shown for a session's repo group: its repos joined with
+/// ` + ` in the session's natural order (primary repo first), de-duplicated.
+/// Falls back to `(no repo)`.
+fn group_display(info: &SessionInfo) -> String {
+    if info.repo_display_names.is_empty() {
+        return NO_REPO_GROUP.to_string();
+    }
+    let mut seen = std::collections::HashSet::new();
+    let parts: Vec<&str> = info
+        .repo_display_names
+        .iter()
+        .map(String::as_str)
+        .filter(|n| seen.insert(*n))
+        .collect();
+    parts.join(" + ")
+}
+
+/// Canonical render order for the session list, shared by the rendering widget
+/// (`OrderedSessions`) and keyboard navigation (`App::render_order_indices`) so
+/// the two never drift.
+///
+/// Ordering (top → bottom):
+///   1. Admin session(s) pinned at the top, headerless.
+///   2. Repo groups, each ordered by its most-urgent member (and then by name),
+///      so a repo holding an `Attention` session bubbles above a merely-running
+///      one. Each group's first row carries the repo header label.
+///   3. Within a group: by status rank, then original index for stability.
+///
+/// The order is intentionally a pure function of *status* and *stable insertion
+/// order* — never of live recency. Recency (`millis_since_last_output`) changes
+/// every tick for active sessions, so using it as a sort key made `Busy`
+/// sessions reorder endlessly. Status changes are discrete and meaningful
+/// (→`Attention`, →`Idle`), so the list only re-sorts when something real
+/// happens. See [`status_rank`] for why `Busy`/`Waiting` are not split.
+pub struct SessionOrder {
+    /// Input indices in render order.
+    pub order: Vec<usize>,
+    /// Parallel to `order`: `Some(label)` on each group's first row, else `None`.
+    /// Admin rows are always `None` (no header).
+    pub headers: Vec<Option<String>>,
+}
+
+pub fn compute_session_order(sessions: &[&SessionInfo]) -> SessionOrder {
+    struct Group {
+        /// Header label, or `None` for the admin bucket (rendered headerless).
+        label: Option<String>,
+        is_admin: bool,
+        members: Vec<usize>,
+    }
+
+    let mut groups: Vec<Group> = Vec::new();
+    let mut admin_idx: Option<usize> = None;
+    let mut key_to_idx: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+
+    for (i, info) in sessions.iter().enumerate() {
+        let gi = if info.is_admin {
+            *admin_idx.get_or_insert_with(|| {
+                groups.push(Group {
+                    label: None,
+                    is_admin: true,
+                    members: Vec::new(),
+                });
+                groups.len() - 1
+            })
+        } else {
+            // Group by the canonical repo-set key; the header shows the
+            // natural-order ` + ` join from the first session in the group.
+            *key_to_idx.entry(group_key(info)).or_insert_with(|| {
+                groups.push(Group {
+                    label: Some(group_display(info)),
+                    is_admin: false,
+                    members: Vec::new(),
+                });
+                groups.len() - 1
+            })
+        };
+        groups[gi].members.push(i);
+    }
+
+    // Within each group: status rank, then original index (stable — no recency).
+    for g in &mut groups {
+        g.members
+            .sort_by_key(|&i| (status_rank(sessions[i].status), i));
+    }
+
+    // Groups: admin first; then by most-urgent member (min status rank), then
+    // label for determinism. No recency term, so active groups don't churn.
+    groups.sort_by(|a, b| {
+        let key = |g: &Group| {
+            let rank = g
+                .members
+                .iter()
+                .map(|&i| status_rank(sessions[i].status))
+                .min()
+                .unwrap_or(u8::MAX);
+            (!g.is_admin, rank, g.label.clone().unwrap_or_default())
+        };
+        key(a).cmp(&key(b))
+    });
+
+    let mut order = Vec::with_capacity(sessions.len());
+    let mut headers = Vec::with_capacity(sessions.len());
+    for g in &groups {
+        for (j, &i) in g.members.iter().enumerate() {
+            order.push(i);
+            headers.push(if j == 0 { g.label.clone() } else { None });
+        }
+    }
+
+    SessionOrder { order, headers }
+}
+
+/// Display-ordered view of the session list. All fields are parallel arrays
+/// aligned to the rendered order produced by [`compute_session_order`].
 pub struct OrderedSessions<'a> {
     pub sessions: Vec<&'a SessionInfo>,
     pub elapsed_ms: Vec<u64>,
     pub match_positions: Vec<Option<SessionMatch>>,
     pub active_index: usize,
-    /// Index of the first non-admin row, or `None` if no non-admin sessions.
-    pub first_non_admin_index: Option<usize>,
+    /// Parallel to `sessions`: `Some(label)` on each repo group's first row,
+    /// used to render a subtle header above it. `None` elsewhere.
+    pub headers: Vec<Option<String>>,
 }
 
 impl<'a> OrderedSessions<'a> {
-    /// Reorder the parallel arrays so admin sessions come first (stable), and
-    /// remap `active_index` and `match_positions` to follow the new order.
+    /// Reorder the parallel arrays into render order, remapping `active_index`
+    /// and `match_positions` to follow it.
     pub fn new(
         sessions: &[&'a SessionInfo],
         elapsed_ms: &[u64],
         match_positions: &[Option<SessionMatch>],
         active_index: usize,
     ) -> Self {
-        let n = sessions.len();
-        let mut order: Vec<usize> = (0..n).collect();
-        // Admin sessions stay pinned at the top (preserving the divider below
-        // them); within the non-admin group, sessions needing attention float
-        // to the top so finished/blocked agents are seen first. Stable sort
-        // keeps original order among equal keys.
-        order.sort_by_key(|&i| {
-            (
-                !sessions[i].is_admin,
-                sessions[i].status != crate::session::SessionStatus::Attention,
-            )
-        });
+        // Ordering depends only on status + stable index, never on `elapsed_ms`
+        // (which is still used below for the per-row elapsed display).
+        let SessionOrder { order, headers } = compute_session_order(sessions);
 
-        let first_non_admin_index = order.iter().position(|&i| !sessions[i].is_admin);
         let ordered_sessions = order.iter().map(|&i| sessions[i]).collect();
         let ordered_elapsed = order.iter().map(|&i| elapsed_ms[i]).collect();
         let ordered_matches = order
@@ -104,7 +247,7 @@ impl<'a> OrderedSessions<'a> {
             elapsed_ms: ordered_elapsed,
             match_positions: ordered_matches,
             active_index: new_active,
-            first_non_admin_index,
+            headers,
         }
     }
 }
@@ -136,10 +279,9 @@ pub struct LeftPanelState<'a> {
     pub match_count: usize,
     /// Total number of sessions (for search count display).
     pub total_count: usize,
-    /// Index of the first non-admin session in the ordered list. When `Some`
-    /// and > 0, a subtle divider is rendered above that row to separate admin
-    /// sessions (pinned at the top) from the rest.
-    pub first_non_admin_index: Option<usize>,
+    /// Parallel to `sessions`: `Some(label)` on each repo group's first row,
+    /// rendered as a subtle header above that row. `None` elsewhere.
+    pub headers: &'a [Option<String>],
 }
 
 pub fn render_left_panel(frame: &mut Frame, area: Rect, state: &mut LeftPanelState<'_>) {
@@ -178,7 +320,7 @@ pub fn render_left_panel(frame: &mut Frame, area: Rect, state: &mut LeftPanelSta
         state.session_match_positions,
         state.session_search_active,
         state.search_query,
-        state.first_non_admin_index,
+        state.headers,
     );
 
     if let Some(area) = search_area {
@@ -433,7 +575,7 @@ fn render_session_section(
     match_positions: &[Option<SessionMatch>],
     search_active: bool,
     search_query: &str,
-    first_non_admin_index: Option<usize>,
+    headers: &[Option<String>],
 ) {
     let mut block = focus_block(" Sessions ", level);
 
@@ -458,6 +600,13 @@ fn render_session_section(
     // Available width inside the block (subtract 2 for borders)
     let inner_width = area.width.saturating_sub(2) as usize;
 
+    // Header row that each row belongs to, so a group's header highlights
+    // whenever *any* of its members is the active row — not just the first.
+    let group_of = header_group_of(headers);
+    let active_group = show_selection
+        .then(|| group_of.get(active_index).copied())
+        .flatten();
+
     let mut item_heights: Vec<u16> = Vec::with_capacity(sessions.len());
 
     let items: Vec<ListItem> = sessions
@@ -481,10 +630,13 @@ fn render_session_section(
                 build_session_line2(info, session_match, is_dimmed, search_query),
             ];
 
-            // Prepend a subtle divider above the first non-admin session when
-            // admin sessions are pinned above it.
-            if first_non_admin_index == Some(i) && i > 0 {
-                item_lines.insert(0, divider_line(inner_width));
+            // Prepend a subtle repo-group header above the first session of
+            // each group. The first non-admin header also separates the pinned
+            // admin block from the rest. The header is highlighted when the
+            // active row lives anywhere in its group.
+            if let Some(Some(label)) = headers.get(i) {
+                let selected = active_group == Some(i);
+                item_lines.insert(0, group_header_line(label, inner_width, selected));
             }
 
             item_heights.push(item_lines.len() as u16);
@@ -523,13 +675,39 @@ fn render_empty_sessions(frame: &mut Frame, area: Rect, block: ratatui::widgets:
     frame.render_widget(text, area);
 }
 
-/// A subtle full-width divider used above the first non-admin session.
-fn divider_line(inner_width: usize) -> Line<'static> {
-    let divider_width = inner_width.max(1);
-    Line::from(Span::styled(
-        "\u{2500}".repeat(divider_width),
-        Style::default().fg(Theme::text_muted()),
-    ))
+/// For each row, the index of the group header row it belongs to. Lets a group's
+/// header highlight whenever *any* member row is the active one, not just the
+/// group's first row. Rows before the first header (e.g. the pinned admin block)
+/// map to row 0, which is harmless since those rows carry no header.
+fn header_group_of(headers: &[Option<String>]) -> Vec<usize> {
+    let mut out = Vec::with_capacity(headers.len());
+    let mut current = 0;
+    for (i, h) in headers.iter().enumerate() {
+        if h.is_some() {
+            current = i;
+        }
+        out.push(current);
+    }
+    out
+}
+
+/// A full-width repo-group header: `── label ──────────`. Muted by default;
+/// painted with the selection background when the active row is in its group.
+fn group_header_line(label: &str, inner_width: usize, selected: bool) -> Line<'static> {
+    let style = if selected {
+        Style::default()
+            .bg(Theme::selection_bg())
+            .fg(Theme::selection_fg())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Theme::text_muted())
+    };
+    let mut text = format!("\u{2500}\u{2500} {label} ");
+    let used = text.chars().count();
+    if inner_width > used {
+        text.push_str(&"\u{2500}".repeat(inner_width - used));
+    }
+    Line::from(Span::styled(text, style))
 }
 
 /// Resolve the right-aligned live status text for a session row. Priority:
@@ -1118,7 +1296,12 @@ mod tests {
         let names: Vec<_> = ordered.sessions.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, vec!["admin-a", "admin-b", "normal-1", "normal-2"]);
         assert_eq!(ordered.elapsed_ms, vec![20, 40, 10, 30]);
-        assert_eq!(ordered.first_non_admin_index, Some(2));
+        // Admin rows are headerless; the single non-admin "(no repo)" group
+        // carries its header on its first row.
+        assert_eq!(
+            ordered.headers,
+            vec![None, None, Some("(no repo)".to_string()), None]
+        );
     }
 
     #[test]
@@ -1138,22 +1321,22 @@ mod tests {
     }
 
     #[test]
-    fn ordered_sessions_no_admins_has_no_divider_beyond_zero() {
+    fn ordered_sessions_no_admins_header_on_first_row() {
         let n1 = info("n1", false);
         let n2 = info("n2", false);
         let sessions = vec![&n1, &n2];
         let ordered = OrderedSessions::new(&sessions, &[0, 0], &[None, None], 0);
-        // Divider is gated by `Some(i) && i > 0`; with no admins the index is 0.
-        assert_eq!(ordered.first_non_admin_index, Some(0));
+        // Single "(no repo)" group: header on row 0, none after.
+        assert_eq!(ordered.headers, vec![Some("(no repo)".to_string()), None]);
     }
 
     #[test]
-    fn ordered_sessions_all_admins_has_no_non_admin_index() {
+    fn ordered_sessions_all_admins_have_no_headers() {
         let a1 = info("a1", true);
         let a2 = info("a2", true);
         let sessions = vec![&a1, &a2];
         let ordered = OrderedSessions::new(&sessions, &[0, 0], &[None, None], 0);
-        assert_eq!(ordered.first_non_admin_index, None);
+        assert_eq!(ordered.headers, vec![None, None]);
     }
 
     #[test]
@@ -1162,7 +1345,7 @@ mod tests {
         let ordered = OrderedSessions::new(&sessions, &[], &[], 0);
         assert!(ordered.sessions.is_empty());
         assert_eq!(ordered.active_index, 0);
-        assert_eq!(ordered.first_non_admin_index, None);
+        assert!(ordered.headers.is_empty());
     }
 
     #[test]
@@ -1186,6 +1369,198 @@ mod tests {
             ordered.match_positions[1].as_ref().map(|m| m.name.clone()),
             Some(vec![0, 1])
         );
+    }
+
+    // --- compute_session_order (grouping + activity) ---
+
+    fn info_repo(name: &str, repo: &str, status: SessionStatus) -> SessionInfo {
+        info_repos(name, &[repo], status)
+    }
+
+    fn info_repos(name: &str, repos: &[&str], status: SessionStatus) -> SessionInfo {
+        let mut s = SessionInfo::new(name.to_string());
+        s.status = status;
+        s.repo_display_names = repos.iter().map(|r| r.to_string()).collect();
+        s
+    }
+
+    fn order_names<'a>(sessions: &[&'a SessionInfo]) -> Vec<&'a str> {
+        compute_session_order(sessions)
+            .order
+            .into_iter()
+            .map(|i| sessions[i].name.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn groups_keep_same_repo_sessions_together() {
+        let a = info_repo("a", "webapp", SessionStatus::Waiting);
+        let b = info_repo("b", "infra", SessionStatus::Waiting);
+        let c = info_repo("c", "webapp", SessionStatus::Waiting);
+        let sessions = vec![&a, &b, &c];
+        // Equal status: groups ordered by label ("infra" < "webapp"),
+        // members of each group adjacent.
+        let names = order_names(&sessions);
+        assert_eq!(names, vec!["b", "a", "c"]);
+    }
+
+    #[test]
+    fn group_with_more_urgent_member_bubbles_up() {
+        // "infra" only has a Waiting session; "webapp" has an Attention one, so
+        // the webapp group sorts above infra even though infra sorts first by name.
+        let waiting = info_repo("infra-1", "infra", SessionStatus::Waiting);
+        let attn = info_repo("web-attn", "webapp", SessionStatus::Attention);
+        let busy = info_repo("web-busy", "webapp", SessionStatus::Busy);
+        let sessions = vec![&waiting, &attn, &busy];
+        let names = order_names(&sessions);
+        // webapp group first (has Attention), ordered Attention then running within.
+        assert_eq!(names, vec!["web-attn", "web-busy", "infra-1"]);
+    }
+
+    #[test]
+    fn busy_and_waiting_share_a_rank_and_keep_stable_order() {
+        // A live agent flickers Busy↔Waiting every tick; that must not reorder
+        // the list. Both rank as "running", so order stays the insertion order.
+        let a = info_repo("a", "webapp", SessionStatus::Busy);
+        let b = info_repo("b", "webapp", SessionStatus::Waiting);
+        let c = info_repo("c", "webapp", SessionStatus::Busy);
+        let sessions = vec![&a, &b, &c];
+        assert_eq!(order_names(&sessions), vec!["a", "b", "c"]);
+
+        // Flip a's status Busy→Waiting and b's Waiting→Busy: order is unchanged.
+        let a2 = info_repo("a", "webapp", SessionStatus::Waiting);
+        let b2 = info_repo("b", "webapp", SessionStatus::Busy);
+        let flipped = vec![&a2, &b2, &c];
+        assert_eq!(order_names(&flipped), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn admin_pinned_above_all_repo_groups_headerless() {
+        let mut admin = info_repo("admin", "webapp", SessionStatus::Idle);
+        admin.is_admin = true;
+        let attn = info_repo("web-attn", "webapp", SessionStatus::Attention);
+        let sessions = vec![&attn, &admin];
+        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        let names: Vec<_> = order.iter().map(|&i| sessions[i].name.as_str()).collect();
+        // Admin first despite being Idle and despite the attention session.
+        assert_eq!(names, vec!["admin", "web-attn"]);
+        // Admin row headerless; the webapp group header sits on its first row.
+        assert_eq!(headers, vec![None, Some("webapp".to_string())]);
+    }
+
+    #[test]
+    fn headers_label_only_first_row_of_each_group() {
+        let a = info_repo("a", "webapp", SessionStatus::Busy);
+        let b = info_repo("b", "webapp", SessionStatus::Busy);
+        let c = info_repo("c", "infra", SessionStatus::Attention);
+        let sessions = vec![&a, &b, &c];
+        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        let labelled: Vec<(&str, Option<String>)> = order
+            .iter()
+            .zip(headers.iter())
+            .map(|(&i, h)| (sessions[i].name.as_str(), h.clone()))
+            .collect();
+        // infra (Attention) group first with its header, then webapp group.
+        assert_eq!(
+            labelled,
+            vec![
+                ("c", Some("infra".to_string())),
+                ("a", Some("webapp".to_string())),
+                ("b", None),
+            ]
+        );
+    }
+
+    #[test]
+    fn no_repo_sessions_share_one_group() {
+        let a = info("a", false);
+        let b = info("b", false);
+        let sessions = vec![&a, &b];
+        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        assert_eq!(order, vec![0, 1]);
+        assert_eq!(headers, vec![Some("(no repo)".to_string()), None]);
+    }
+
+    #[test]
+    fn multi_repo_session_forms_its_own_composite_group() {
+        // A {webapp}, B {webapp, infra}, C {infra}: three distinct groups, the
+        // multi-repo session is NOT folded into either single-repo group.
+        let a = info_repo("a", "webapp", SessionStatus::Waiting);
+        let b = info_repos("b", &["webapp", "infra"], SessionStatus::Waiting);
+        let c = info_repo("c", "infra", SessionStatus::Waiting);
+        let sessions = vec![&a, &b, &c];
+
+        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        let labelled: Vec<(&str, Option<String>)> = order
+            .iter()
+            .zip(headers.iter())
+            .map(|(&i, h)| (sessions[i].name.as_str(), h.clone()))
+            .collect();
+        // Groups ordered by label: "infra" < "webapp" < "webapp + infra".
+        assert_eq!(
+            labelled,
+            vec![
+                ("c", Some("infra".to_string())),
+                ("a", Some("webapp".to_string())),
+                ("b", Some("webapp + infra".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn duplicate_repos_collapse_to_one_group() {
+        // A repo set with the same repo twice (e.g. two worktrees of one repo)
+        // groups under that single repo, alongside a plain single-repo session.
+        let multi = info_repos("multi", &["webapp", "webapp"], SessionStatus::Waiting);
+        let single = info_repo("single", "webapp", SessionStatus::Waiting);
+        let sessions = vec![&multi, &single];
+
+        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        // Same canonical key → one group; header is the de-duplicated display.
+        assert_eq!(order, vec![0, 1]);
+        assert_eq!(headers, vec![Some("webapp".to_string()), None]);
+    }
+
+    #[test]
+    fn multi_repo_grouping_is_order_independent() {
+        // Same repo *set*, different selection order → one group; the header
+        // reflects the first session's natural order.
+        let b = info_repos("b", &["webapp", "infra"], SessionStatus::Waiting);
+        let d = info_repos("d", &["infra", "webapp"], SessionStatus::Waiting);
+        let sessions = vec![&b, &d];
+
+        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        assert_eq!(
+            order
+                .iter()
+                .map(|&i| sessions[i].name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["b", "d"]
+        );
+        // Single composite group, header from the first member ("b").
+        assert_eq!(headers, vec![Some("webapp + infra".to_string()), None]);
+    }
+
+    // --- header_group_of (group-header highlight membership) ---
+
+    #[test]
+    fn header_group_of_maps_each_row_to_its_header() {
+        // Two groups: rows 0-1 under header 0, rows 2-4 under header 2.
+        let headers = vec![
+            Some("a".to_string()),
+            None,
+            Some("b".to_string()),
+            None,
+            None,
+        ];
+        assert_eq!(header_group_of(&headers), vec![0, 0, 2, 2, 2]);
+    }
+
+    #[test]
+    fn header_group_of_admin_rows_before_first_header_map_to_zero() {
+        // Admin rows (no header) precede the first group header at row 2.
+        let headers = vec![None, None, Some("repo".to_string()), None];
+        assert_eq!(header_group_of(&headers), vec![0, 0, 2, 2]);
     }
 
     // --- visible_count_from_heights ---

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -130,7 +130,7 @@ fn group_display(info: &SessionInfo) -> String {
 /// every tick for active sessions, so using it as a sort key made `Busy`
 /// sessions reorder endlessly. Status changes are discrete and meaningful
 /// (→`Attention`, →`Idle`), so the list only re-sorts when something real
-/// happens. See [`status_rank`] for why `Busy`/`Waiting` are not split.
+/// happens. See `status_rank` for why `Busy`/`Waiting` are not split.
 pub struct SessionOrder {
     /// Input indices in render order.
     pub order: Vec<usize>,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,239 @@
+//! Per-session multi-repo **symlink workspaces**.
+//!
+//! When a session spans more than one directory (multiple repos, or a repo plus
+//! an extra access dir), the agent process can only be launched in a single
+//! `cwd`. Rather than teach every agent CLI a different `--add-dir`-style flag
+//! (many have none), thurbox builds one workspace directory full of symlinks —
+//! one per member dir — and launches the agent there. The agent then sees every
+//! repo as a subdirectory, with no per-agent configuration.
+//!
+//! ```text
+//! ~/.local/share/thurbox/workspaces/<agent_session_id>/
+//!     webapp  -> …/worktrees/<hash>/feat-x   (symlink)
+//!     infra   -> /home/me/repos/infra        (symlink)
+//! ```
+//!
+//! The directory only ever contains symlinks, so tearing it down (or rebuilding
+//! it) never touches the underlying repositories. The path is derived from the
+//! session's stable `agent_session_id`, so it is rebuilt idempotently on every
+//! launch and needs no separate persistence.
+
+use std::collections::HashSet;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::paths;
+
+/// Resolve the workspace directory for a session id, ensuring it stays a single
+/// segment under the workspaces root (defensive — the id is a UUID in practice).
+fn workspace_dir(id: &str) -> io::Result<PathBuf> {
+    let base = paths::workspaces_directory().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "could not resolve workspaces directory",
+        )
+    })?;
+    let segment = sanitize_segment(id);
+    if segment.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "empty workspace id",
+        ));
+    }
+    Ok(base.join(segment))
+}
+
+/// (Re)build the symlink workspace for `id` from `members` and return its path.
+///
+/// Idempotent: any existing workspace dir is removed first (it holds only
+/// symlinks, so targets are untouched) and recreated from scratch, so adding or
+/// removing a member between launches is reflected. Each member is symlinked
+/// under a sanitized, de-duplicated name (collisions get a `-2`, `-3`, … suffix).
+pub fn ensure_workspace(id: &str, members: &[(String, PathBuf)]) -> io::Result<PathBuf> {
+    let dir = workspace_dir(id)?;
+    remove_dir_under_root(&dir)?;
+    std::fs::create_dir_all(&dir)?;
+
+    let mut used: HashSet<String> = HashSet::new();
+    for (name, target) in members {
+        let link_name = unique_link_name(name, &mut used);
+        let link_path = dir.join(&link_name);
+        symlink(target, &link_path)?;
+    }
+
+    Ok(dir)
+}
+
+/// Remove the workspace directory for `id`, if present. Only the symlinks are
+/// removed; the directories they point at are untouched. A missing workspace is
+/// not an error.
+pub fn remove_workspace(id: &str) -> io::Result<()> {
+    let dir = workspace_dir(id)?;
+    remove_dir_under_root(&dir)
+}
+
+/// Remove `dir` (recursively) only when it really sits under the workspaces
+/// root, so a bad id can never delete something outside it. `remove_dir_all`
+/// unlinks symlink entries without following them, so member repos are safe.
+fn remove_dir_under_root(dir: &Path) -> io::Result<()> {
+    let Some(base) = paths::workspaces_directory() else {
+        return Ok(());
+    };
+    if !dir.starts_with(&base) || dir == base {
+        return Ok(());
+    }
+    match std::fs::remove_dir_all(dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Create a symlink at `link` pointing to `target` (Unix; thurbox targets
+/// Linux + macOS only).
+fn symlink(target: &Path, link: &Path) -> io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+/// Reduce a repo display name to a safe single path segment for a link name.
+fn sanitize_segment(name: &str) -> String {
+    let cleaned: String = name
+        .trim()
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' => '-',
+            c if c.is_whitespace() => '-',
+            c => c,
+        })
+        .collect();
+    cleaned.trim_matches(['.', '-']).to_string()
+}
+
+/// Sanitize `name` and make it unique within `used` by appending `-2`, `-3`, …
+fn unique_link_name(name: &str, used: &mut HashSet<String>) -> String {
+    let base = {
+        let s = sanitize_segment(name);
+        if s.is_empty() {
+            "repo".to_string()
+        } else {
+            s
+        }
+    };
+    if used.insert(base.clone()) {
+        return base;
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{base}-{n}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::TestPathGuard;
+
+    fn temp_base() -> PathBuf {
+        // Unique-ish per test via the thread name; avoids Date/rand (forbidden).
+        let mut p = std::env::temp_dir();
+        let t = std::thread::current();
+        let name = t.name().unwrap_or("ws").replace("::", "-");
+        p.push(format!("thurbox-ws-test-{name}"));
+        let _ = std::fs::remove_dir_all(&p);
+        p
+    }
+
+    #[test]
+    fn ensure_creates_one_symlink_per_member() {
+        let base = temp_base();
+        let _g = TestPathGuard::new(&base);
+        let repo_a = base.join("src-a");
+        let repo_b = base.join("src-b");
+        std::fs::create_dir_all(&repo_a).unwrap();
+        std::fs::create_dir_all(&repo_b).unwrap();
+
+        let ws = ensure_workspace(
+            "sess-1",
+            &[
+                ("webapp".to_string(), repo_a.clone()),
+                ("infra".to_string(), repo_b.clone()),
+            ],
+        )
+        .unwrap();
+
+        assert!(ws.ends_with("workspaces/sess-1"));
+        assert_eq!(std::fs::read_link(ws.join("webapp")).unwrap(), repo_a);
+        assert_eq!(std::fs::read_link(ws.join("infra")).unwrap(), repo_b);
+    }
+
+    #[test]
+    fn ensure_is_idempotent_and_reflects_new_members() {
+        let base = temp_base();
+        let _g = TestPathGuard::new(&base);
+        let a = base.join("a");
+        let b = base.join("b");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+
+        ensure_workspace("s", &[("a".into(), a.clone())]).unwrap();
+        let ws =
+            ensure_workspace("s", &[("a".into(), a.clone()), ("b".into(), b.clone())]).unwrap();
+
+        assert!(ws.join("a").exists());
+        assert!(ws.join("b").exists());
+    }
+
+    #[test]
+    fn colliding_names_are_disambiguated() {
+        let base = temp_base();
+        let _g = TestPathGuard::new(&base);
+        let a = base.join("one");
+        let b = base.join("two");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+
+        let ws = ensure_workspace(
+            "s",
+            &[("repo".into(), a.clone()), ("repo".into(), b.clone())],
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read_link(ws.join("repo")).unwrap(), a);
+        assert_eq!(std::fs::read_link(ws.join("repo-2")).unwrap(), b);
+    }
+
+    #[test]
+    fn remove_deletes_links_not_targets() {
+        let base = temp_base();
+        let _g = TestPathGuard::new(&base);
+        let repo = base.join("keepme");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::write(repo.join("file.txt"), b"data").unwrap();
+
+        let ws = ensure_workspace("s", &[("repo".into(), repo.clone())]).unwrap();
+        assert!(ws.exists());
+
+        remove_workspace("s").unwrap();
+        assert!(!ws.exists());
+        // Target survived.
+        assert!(repo.join("file.txt").exists());
+    }
+
+    #[test]
+    fn remove_missing_workspace_is_ok() {
+        let base = temp_base();
+        let _g = TestPathGuard::new(&base);
+        assert!(remove_workspace("never-made").is_ok());
+    }
+
+    #[test]
+    fn sanitize_strips_separators_and_dots() {
+        assert_eq!(sanitize_segment("a/b\\c:d"), "a-b-c-d");
+        assert_eq!(sanitize_segment("  .git  "), "git");
+        assert_eq!(sanitize_segment("my repo"), "my-repo");
+    }
+}


### PR DESCRIPTION
## Summary

Three related improvements to the multi-session left column.

### Smarter session list
- Orders sessions by **activity & status** (`Attention → running → Idle → Error`), then groups them by repository under subtle `── repo ──` headers.
- `Busy`/`Waiting` share one *running* rank and live recency is dropped from the sort key, so active sessions no longer churn endlessly. The order is a pure function of status + stable insertion order; one comparator (`compute_session_order`) drives both rendering and `Ctrl+J/K` navigation.
- **Multi-repo sessions** form composite repo-set groups (order-independent, `webapp + infra`), and a group's header highlights whenever *any* of its members is the selected row.

### Multi-repo symlink workspaces
- A session spanning ≥2 dirs now launches in a per-session symlink workspace (`~/.local/share/thurbox/workspaces/<id>/`) gathering every repo, so the agent **and its shell pane** start there and see each repo as a subdirectory.
- Fully **agent-neutral** — no per-CLI `--add-dir` flags, no `agents.toml` changes. `SessionInfo.cwd` keeps the primary repo; the workspace is derived, rebuilt idempotently on spawn/restart, and removed (symlinks only — repos untouched) on delete.

### Circular session ↔ automation navigation
- The session list and automations pane are now one circular column: `j` past the last automation loops to the top session; `k` above the first session loops to the last automation.

## Test plan
- 746 lib unit tests pass (new coverage for grouping, multi-repo workspace symlinks, process-cwd resolution, and loop navigation).
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, and `cargo test --test architecture_rules` all clean.
- Docs updated (CLAUDE.md, docs/FEATURES.md).