### PR TITLE
feat: remote SSH sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,16 +254,30 @@ Single-repo sessions are unchanged (`cwd` = the repo directly).
 Sessions can run on a **remote host** over SSH while the TUI runs
 locally. Remote hosts are declared as data in
 `~/.config/thurbox/hosts.toml` (seeded commented-out on first run,
-so a fresh install has zero remote hosts and behaves as before):
+so a fresh install has zero remote hosts and behaves as before). The
+seeded file documents every field inline; the schema:
 
 ```toml
 [[hosts]]
-name = "devbox"               # registered as backend "ssh:devbox"
-destination = "me@devbox"     # resolved via ~/.ssh/config
+name = "devbox"               # required — backend id "ssh:devbox"; what --host expects
+destination = "me@devbox"     # required — ssh target ("user@host" or ~/.ssh/config alias)
 ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m", "-o", "ServerAliveInterval=15"]
-# socket / session   = optional remote tmux -L / session-name overrides
-# worktrees_dir       = optional absolute remote worktrees dir
+                              # optional (default []) — extra ssh flags; no ~ expansion, use abs paths
+socket = "thurbox"            # optional (default "thurbox") — remote `tmux -L` socket
+session = "thurbox"           # optional (default "thurbox") — remote tmux session name
+worktrees_dir = "/home/me/.local/share/thurbox/worktrees"
+                              # optional — abs remote worktrees dir
+                              # (default $HOME/.local/share/thurbox/worktrees, resolved over ssh)
 ```
+
+| Field | Req | Default | Purpose |
+|-------|-----|---------|---------|
+| `name` | yes | — | unique id; registers backend `ssh:<name>` |
+| `destination` | yes | — | ssh target, resolved via `~/.ssh/config` |
+| `ssh_opts` | no | `[]` | extra `ssh` flags (one token per element; no `~` expansion) |
+| `socket` | no | `thurbox` | remote `tmux -L` socket name |
+| `session` | no | `thurbox` | remote tmux session name |
+| `worktrees_dir` | no | `$HOME/.local/share/thurbox/worktrees` | abs remote worktrees dir |
 
 How it works: `TmuxBackend` is transport-neutral
 (`agent::transport::TmuxTransport`). The local backend launches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,50 @@ single `App::session_member_dirs` list that also feeds the rendered
 repo names, and `App::resolve_process_cwd` picks workspace-vs-primary.
 Single-repo sessions are unchanged (`cwd` = the repo directly).
 
+## Remote SSH Sessions
+
+Sessions can run on a **remote host** over SSH while the TUI runs
+locally. Remote hosts are declared as data in
+`~/.config/thurbox/hosts.toml` (seeded commented-out on first run,
+so a fresh install has zero remote hosts and behaves as before):
+
+```toml
+[[hosts]]
+name = "devbox"               # registered as backend "ssh:devbox"
+destination = "me@devbox"     # resolved via ~/.ssh/config
+ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m", "-o", "ServerAliveInterval=15"]
+# socket / session   = optional remote tmux -L / session-name overrides
+# worktrees_dir       = optional absolute remote worktrees dir
+```
+
+How it works: `TmuxBackend` is transport-neutral
+(`agent::transport::TmuxTransport`). The local backend launches
+`tmux -L thurbox …`; a remote backend launches
+`ssh <dest> tmux -L thurbox …`. The tmux **control-mode** protocol
+(`control_mode.rs`) is byte-identical over either transport — only
+the one-time process launch differs. Each host registers a backend
+named `ssh:<name>` (`TmuxBackend::from_host`, registered lazily in
+`main.rs`: a down host must not block startup, so
+`check_available`/`ensure_ready` are deferred to first use via
+`App::backend_for`).
+
+- **Data**: `session::HostDef`/`HostRegistry` (pure data, in
+  `session/` so both `agent` and `git` can use it). **Loading**:
+  `agent::host_config::load_or_seed()`.
+- **Selection**: `SessionConfig.backend` (`ssh:<host>` or `None` =
+  local). The TUI new-session flow shows a **host picker** first
+  (skipped when no hosts are configured); the chosen host runs git
+  worktree creation + branch listing on that host over SSH.
+- **Worktrees**: `git::*_on(host, …)` variants run `git` over
+  `ssh <dest> git -C <repo> …`. Remote worktrees live under the
+  host's `worktrees_dir` (or `$HOME/.local/share/thurbox/worktrees`
+  resolved + cached over ssh).
+- **Persistence/restore**: `backend_type` already round-trips in
+  SQLite; restore discovers windows **per backend** so remote
+  sessions re-adopt against their own host.
+- **Headless**: `thurbox-cli session create --host <name>` spawns
+  remotely (see below).
+
 ## thurbox-cli
 
 A second binary (`thurbox-cli`) drives the same SQLite-backed,
@@ -259,6 +303,9 @@ with the TUI; changes appear via `PRAGMA data_version` polling.
 cargo build --bin thurbox-cli
 thurbox-cli session create --name demo --repo-path /path \
     --agent codex --worktree-branch feat/x
+# Spawn on a remote host from hosts.toml (worktree + tmux live remotely):
+thurbox-cli session create --name demo --repo-path /srv/repo \
+    --host devbox --worktree-branch feat/x
 thurbox-cli session list | jq
 ```
 
@@ -550,14 +597,19 @@ app      ← coordinator, imports all modules
   abstracts CLI command + arg construction; `GenericProvider`
   implements it from a declarative `AgentDef` (loaded via
   `agent_config`). `Session` wraps a `SessionBackend`
-  trait. `BackendRegistry` holds the backends; the only
-  backend is `LocalTmuxBackend` (using `tmux -L thurbox`).
-  Reads output into `Arc<Mutex<vt100::Parser>>`, writes input
-  via mpsc channel. `input.rs` translates crossterm `KeyCode`
-  → xterm ANSI bytes.
+  trait. `BackendRegistry` holds the backends, keyed by name.
+  `TmuxBackend` runs tmux over a `TmuxTransport` (`transport.rs`):
+  `Local` (`tmux -L thurbox`) for the default `local-tmux`
+  backend, or `Ssh` (`ssh <dest> tmux …`) for each remote host
+  in `hosts.toml` (registered as `ssh:<host>`, loaded via
+  `host_config`). The control-mode protocol (`control_mode.rs`)
+  is identical over either transport. Reads output into
+  `Arc<Mutex<vt100::Parser>>`, writes input via mpsc channel.
+  `input.rs` translates crossterm `KeyCode` → xterm ANSI bytes.
 - **`session/`** — Plain data: `SessionId`, `SessionStatus`,
   `SessionInfo` (with `agent` name), `SessionConfig` (agent
-  name, ids, cwd, env), `AgentDef`/`AgentRegistry`.
+  name, backend name, ids, cwd, env), `AgentDef`/`AgentRegistry`,
+  `HostDef`/`HostRegistry` (remote SSH hosts).
   Mostly Display/Default impls plus the agent-arg
   substitution logic.
 - **`ui/`** — Pure rendering functions. `layout.rs` computes
@@ -605,7 +657,9 @@ framework). Install with `prek install`. Stages:
 
 - MSRV: 1.75, Edition 2021
 - Async runtime: tokio (multi-threaded)
-- Session backend: `LocalTmuxBackend` (`tmux -L thurbox`)
+- Session backend: `TmuxBackend` over a `TmuxTransport`
+  (local `tmux -L thurbox`, or `ssh <dest> tmux …` for
+  `ssh:<host>` backends from `hosts.toml`)
 - Output reader runs in `tokio::task::spawn_blocking`
   (blocking I/O), writer in `tokio::spawn` (async)
 - Terminal state parsed by `vt100::Parser`,
@@ -613,7 +667,8 @@ framework). Install with `prek install`. Stages:
 - Sessions persist across restarts (tmux keeps them alive)
 - Session state in SQLite:
   `~/.local/share/thurbox/thurbox.db` (XDG_DATA_HOME respected);
-  agent definitions in `~/.config/thurbox/agents.toml`
+  agent definitions in `~/.config/thurbox/agents.toml`;
+  remote SSH hosts in `~/.config/thurbox/hosts.toml`
 - Requires tmux >= 3.2
 
 ## Keybindings (Vim-Inspired)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,6 +292,11 @@ named `ssh:<name>` (`TmuxBackend::from_host`, registered lazily in
   sessions re-adopt against their own host.
 - **Headless**: `thurbox-cli session create --host <name>` spawns
   remotely (see below).
+- **Local e2e**: `scripts/dev/remote-ssh-test.sh up` spins a
+  throwaway Podman container (sshd + tmux + git) and `… test` runs
+  an isolated headless smoke test asserting a session lands on the
+  `ssh:podman` backend (state under `target/`, never touches your
+  real `~/.ssh`/`~/.config`).
 
 ## thurbox-cli
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,8 @@ when multiple PTY sessions are producing concurrent output.
 **Choice**: A `SessionBackend` trait abstracts session lifecycle
 (spawn, adopt, resize, kill, detach, discover). Each session runs
 one coding-agent CLI inside the backend. The default backend is
-`LocalTmuxBackend` (`tmux -L thurbox`).
+local tmux (`tmux -L thurbox`); the same `TmuxBackend` also runs
+over SSH for remote hosts (ADR-13).
 `vt100::Parser` interprets escape sequences,
 `tui_term::PseudoTerminal` renders the parsed screen into ratatui.
 
@@ -261,9 +262,10 @@ struct wraps the trait and manages reader/writer loops once,
 regardless of which backend is active.
 
 **Why**: Keeping session lifecycle behind a trait boundary leaves
-the app layer completely backend-agnostic. The only backend today
-is local tmux (`LocalTmuxBackend`), but the seam means the
-transport can evolve without touching `App`, `Session`, or any UI
+the app layer completely backend-agnostic. The backends today are
+local tmux and one SSH backend per configured host (both
+`TmuxBackend` over a `TmuxTransport`; see ADR-13), and the seam means
+the transport can evolve without touching `App`, `Session`, or any UI
 code.
 
 **Trait methods**: `check_available`, `ensure_ready`, `spawn`,
@@ -355,6 +357,69 @@ delivers pixel-perfect rendering with all original formatting.
   tmux bugs #641/#2989, required `mkfifo`/`stdbuf`/`cat` in the
   data path, no flow control, timing race on initial capture.
 - *Screen/dtach* — less widely available, fewer features.
+
+---
+
+## ADR-13: Remote sessions via an SSH tmux transport
+
+**Choice**: Run agent sessions on a remote host by launching the
+same tmux control-mode protocol over SSH. `LocalTmuxBackend` is
+generalized into `TmuxBackend { transport, socket, session, name }`
+where `transport: TmuxTransport` is either `Local` (a bare
+`Command::new("tmux")`) or `Ssh { destination, ssh_opts }`
+(`ssh <dest> tmux …`). The transport's *only* job is to build the
+`Command`; everything downstream — the control-mode reader/writer
+threads, pane registration, `send-keys`/`%output` — is byte-for-byte
+identical (`control_mode.rs` was already transport-agnostic).
+
+Remote hosts are declared as data in `~/.config/thurbox/hosts.toml`
+(`session::HostDef`/`HostRegistry`, loaded by
+`agent::host_config::load_or_seed`), each registered as a backend
+named `ssh:<host>` via `TmuxBackend::from_host`.
+
+**Why**: The local-vs-remote difference is exactly one line (how the
+tmux process is launched). The per-session control commands travel
+over the stdin pipe, not ssh argv, so only the one-time
+`attach-session` launch crosses the ssh boundary. Relying on the
+system `ssh` binary + `~/.ssh/config` keeps auth/keys/multiplexing
+out of thurbox (ControlMaster/ControlPersist + ServerAliveInterval
+are recommended in the seeded `ssh_opts`).
+
+**Key design decisions**:
+
+- **Lazy registration**: SSH backends are registered but *not*
+  connected at startup (`check_available`/`ensure_ready` deferred to
+  first use via `App::backend_for`), so a down host never blocks the
+  TUI.
+- **Selection**: `SessionConfig.backend` (`ssh:<host>` or `None`).
+  The TUI shows a host picker as the first new-session step (skipped
+  when no hosts are configured); `thurbox-cli session create --host`
+  is the headless equivalent.
+- **Persistence/restore**: `backend_type` already round-trips in
+  SQLite; restore was changed to discover windows **per backend** so
+  remote sessions re-adopt against their own host's tmux.
+- **Remote worktrees**: `git::*_on(host, …)` variants run
+  `ssh <dest> git -C <repo> …`. Remote worktree paths resolve under
+  the host's `worktrees_dir` (or `$HOME/.local/share/thurbox/…`
+  resolved + cached over ssh).
+
+**Module placement**: `HostDef`/`HostRegistry` live in `session/`
+(the dependency sink) so both `agent` (builds the backend) and `git`
+(runs git over SSH) can depend on them without violating the
+module-isolation rules.
+
+**Riskiest area**: SSH reconnect on a flapping link — `reconnect_control`
+reopens the ssh connection; ControlMaster + keepalives mitigate
+stalls. Worth the most manual testing.
+
+**Rejected**:
+
+- *A `TmuxTransport` trait with `Box<dyn>`* — an enum with two
+  variants is simpler; promote to a trait only if a third transport
+  (e.g. container exec) appears.
+- *Embedded SSH library (russh, etc.)* — reimplements `~/.ssh/config`,
+  agent forwarding, and multiplexing that the system `ssh` already
+  provides.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -245,13 +245,28 @@ destination = "me@devbox"  # resolved via ~/.ssh/config
 ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m"]
 ```
 
+Each `[[hosts]]` entry (`session::HostDef`) has two required fields
+and four optional ones — the seeded `hosts.toml` documents each
+inline:
+
+| Field | Required | Default | Meaning |
+|-------|----------|---------|---------|
+| `name` | yes | — | unique id; registers the backend `ssh:<name>` and is what `--host` expects |
+| `destination` | yes | — | ssh target (`user@host` or a `~/.ssh/config` alias) |
+| `ssh_opts` | no | `[]` | extra `ssh` flags, one token per array element; no `~` expansion (use absolute paths) |
+| `socket` | no | `thurbox` | remote `tmux -L` socket name |
+| `session` | no | `thurbox` | remote tmux session name |
+| `worktrees_dir` | no | `$HOME/.local/share/thurbox/worktrees` | absolute remote dir for git worktrees |
+
 Each host becomes a session backend named `ssh:<name>`. Thurbox
 shells out to the system `ssh` binary, so authentication, keys, and
 connection multiplexing come from your `~/.ssh/config` — thurbox
 never handles credentials. The same tmux control-mode protocol runs
 over the SSH pipe, so remote sessions get identical persistence,
 multi-instance sharing, and restore-on-startup as local ones; the
-worktree and agent process live on the remote host.
+worktree and agent process live on the remote host. In the session
+list a remote session is marked with a `☁` glyph (and the info panel
+shows its `Host:`), mirroring the worktree `⑂` mark.
 
 **Why a config file rather than ad-hoc destinations?** Named hosts
 give the picker stable, readable entries and let `backend_type`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -123,16 +123,21 @@ whichever the agent produces.
 session. Each step has a sensible default and can be skipped when
 not applicable.
 
-1. **Repo picker** — fuzzy-searchable list of bookmarked repo
+1. **Host picker** — choose where the session runs: `local`, or any
+   remote SSH host defined in `hosts.toml`. Skipped entirely when no
+   remote hosts are configured (preserving the local-only flow). For
+   a remote host the repo picker opens to a typed remote path and the
+   worktree + tmux window are created on that host over SSH.
+2. **Repo picker** — fuzzy-searchable list of bookmarked repo
    paths. `Space` toggles selection, `w` marks the selected repo
    as a worktree base, `d` deletes the bookmark, and a path-input
    field with filesystem autocomplete adds new bookmarks. The
    first selected repo becomes the session's `cwd`; the rest may be
    exposed to the agent depending on the agent's own flags.
-2. **Base branch selector** — worktree mode only.
-3. **Session name** — free text identifier shown in the sidebar.
-4. **New branch name** — worktree mode only.
-5. **Agent picker** — choose which coding agent runs in this
+3. **Base branch selector** — worktree mode only.
+4. **Session name** — free text identifier shown in the sidebar.
+5. **New branch name** — worktree mode only.
+6. **Agent picker** — choose which coding agent runs in this
    session. Skipped when only one agent is defined in
    `agents.toml`.
 
@@ -225,6 +230,41 @@ resume_args = ["resume", "--last"]   # id-less: last session in cwd
 fork_args = ["fork", "--last"]
 resume_latest = true
 ```
+
+### Remote SSH sessions
+
+Like agents, remote hosts are **data**. A session can run on a
+remote machine over SSH while the TUI stays local. Hosts are
+declared in `~/.config/thurbox/hosts.toml` (seeded commented-out, so
+a fresh install has none and behaves exactly as before):
+
+```toml
+[[hosts]]
+name = "devbox"            # selectable as backend "ssh:devbox"
+destination = "me@devbox"  # resolved via ~/.ssh/config
+ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m"]
+```
+
+Each host becomes a session backend named `ssh:<name>`. Thurbox
+shells out to the system `ssh` binary, so authentication, keys, and
+connection multiplexing come from your `~/.ssh/config` — thurbox
+never handles credentials. The same tmux control-mode protocol runs
+over the SSH pipe, so remote sessions get identical persistence,
+multi-instance sharing, and restore-on-startup as local ones; the
+worktree and agent process live on the remote host.
+
+**Why a config file rather than ad-hoc destinations?** Named hosts
+give the picker stable, readable entries and let `backend_type`
+round-trip cleanly through the database so a remote session re-adopts
+on the correct host after a restart.
+
+**Why lean on `~/.ssh/config`?** Re-implementing SSH auth, agent
+forwarding, and ControlMaster multiplexing would be a large, fragile
+surface. Deferring to the system `ssh` keeps thurbox out of the
+credential path and inherits whatever the user already configured.
+
+Headless: `thurbox-cli session create --host devbox --repo-path
+/srv/repo --worktree-branch feat/x` does the same over the CLI.
 
 ---
 

--- a/scripts/dev/remote-ssh-test.sh
+++ b/scripts/dev/remote-ssh-test.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# Exercise thurbox's remote-SSH backend end-to-end against a throwaway Podman
+# container that runs sshd + tmux + git — without touching your real ~/.ssh or
+# ~/.config. All state lives under target/remote-ssh-test/ (gitignored) and, for
+# the automated smoke test, an isolated XDG home in a temp dir.
+#
+# Usage:
+#   scripts/dev/remote-ssh-test.sh up        # build image + start container
+#   scripts/dev/remote-ssh-test.sh test      # isolated headless e2e (asserts ssh:podman)
+#   scripts/dev/remote-ssh-test.sh hosts     # print the hosts.toml block for manual TUI testing
+#   scripts/dev/remote-ssh-test.sh ssh       # open a shell on the container
+#   scripts/dev/remote-ssh-test.sh down      # remove the container
+#   scripts/dev/remote-ssh-test.sh clean     # remove container + all local state
+#
+# Env overrides: THURBOX_SSH_TEST_PORT (default 2222),
+#                THURBOX_SSH_TEST_DIR  (default <repo>/target/remote-ssh-test)
+#
+# Requires: podman, ssh-keygen, cargo, python3.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKDIR="${THURBOX_SSH_TEST_DIR:-$REPO_ROOT/target/remote-ssh-test}"
+IMAGE="thurbox-remote-test"
+CONTAINER="thurbox-remote"
+PORT="${THURBOX_SSH_TEST_PORT:-2222}"
+KEY="$WORKDIR/id_ed25519"
+REMOTE_REPO="/srv/repo"
+
+log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+ssh_remote() {
+  ssh -p "$PORT" -i "$KEY" \
+    -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=4 \
+    root@localhost "$@"
+}
+
+# Emit a hosts.toml [[hosts]] block pointing at the container. Absolute paths
+# only — thurbox passes ssh_opts to `ssh` via Command (no shell ~ expansion).
+hosts_block() {
+  cat <<EOF
+[[hosts]]
+name = "podman"
+destination = "root@localhost"
+ssh_opts = [
+  "-p", "$PORT",
+  "-i", "$KEY",
+  "-o", "IdentitiesOnly=yes",
+  "-o", "StrictHostKeyChecking=no",
+  "-o", "UserKnownHostsFile=/dev/null",
+  "-o", "LogLevel=ERROR",
+  "-o", "ControlMaster=auto",
+  "-o", "ControlPersist=10m",
+  "-o", "ServerAliveInterval=15",
+]
+EOF
+}
+
+cmd_up() {
+  command -v podman >/dev/null || die "podman not found"
+  mkdir -p "$WORKDIR"
+  if [ ! -f "$KEY" ]; then
+    log "generating throwaway keypair at $KEY"
+    ssh-keygen -t ed25519 -N "" -C thurbox-remote-test -f "$KEY" >/dev/null
+  fi
+  cp "$KEY.pub" "$WORKDIR/authorized_keys"
+
+  cat > "$WORKDIR/Containerfile" <<'EOF'
+FROM docker.io/library/debian:bookworm-slim
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openssh-server tmux git ca-certificates procps && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh
+COPY authorized_keys /root/.ssh/authorized_keys
+RUN chmod 600 /root/.ssh/authorized_keys && \
+    git config --global user.email test@thurbox && \
+    git config --global user.name thurbox-test && \
+    git config --global init.defaultBranch main && \
+    mkdir -p /srv/repo && cd /srv/repo && git init -q && \
+    printf '# remote test repo\n' > README.md && \
+    git add -A && git commit -qm "init" && \
+    git branch -f feature/example main
+EXPOSE 22
+CMD ["/usr/sbin/sshd","-D","-e"]
+EOF
+
+  log "building image $IMAGE"
+  podman build -t "$IMAGE" "$WORKDIR" >/dev/null
+  podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  log "starting container $CONTAINER on port $PORT"
+  podman run -d --name "$CONTAINER" --hostname thurbox-remote -p "$PORT:22" "$IMAGE" >/dev/null
+
+  log "waiting for sshd"
+  for _ in $(seq 1 20); do ssh_remote true 2>/dev/null && break; sleep 1; done
+  ssh_remote true 2>/dev/null || die "container did not become reachable"
+  log "ready: $(ssh_remote 'hostname; tmux -V' | tr '\n' ' ')"
+  echo
+  log "add this to ~/.config/thurbox-dev/hosts.toml for manual TUI testing:"
+  hosts_block
+}
+
+cmd_hosts() { hosts_block; }
+
+cmd_ssh() { ssh_remote "${@:-bash -l}"; }
+
+# Remove any worktrees/branches/tmux state the test left on the container.
+remote_reset() {
+  ssh_remote '
+    cd /srv/repo || exit 0
+    git worktree list --porcelain | awk "/^worktree/ {print \$2}" | grep -v "^/srv/repo$" \
+      | while read -r w; do git worktree remove --force "$w"; done
+    git worktree prune
+    git branch -D test/e2e 2>/dev/null || true
+    tmux -L thurbox-dev kill-server 2>/dev/null || true
+  ' 2>/dev/null || true
+}
+
+cmd_test() {
+  command -v python3 >/dev/null || die "python3 not found"
+  ssh_remote true 2>/dev/null || die "container not reachable — run '$0 up' first"
+
+  # Fully isolated XDG home: never touches the user's real config/db, and no
+  # running TUI watches this database.
+  local xdg; xdg="$(mktemp -d)"
+  trap 'rm -rf "$xdg"; remote_reset' RETURN
+  mkdir -p "$xdg/config/thurbox-dev"
+  hosts_block > "$xdg/config/thurbox-dev/hosts.toml"
+  cat > "$xdg/config/thurbox-dev/agents.toml" <<'EOF'
+default = "shell"
+[[agents]]
+name = "shell"
+command = "bash"
+EOF
+
+  remote_reset
+  log "creating a remote session via thurbox-cli (isolated DB)"
+  local out
+  out="$(cd "$REPO_ROOT" && \
+    XDG_CONFIG_HOME="$xdg/config" XDG_DATA_HOME="$xdg/data" \
+    cargo run -q --bin thurbox-cli -- session create \
+      --name e2e --host podman --repo-path "$REMOTE_REPO" \
+      --agent shell --worktree-branch test/e2e --base-branch main 2>/dev/null)"
+
+  local id backend_type
+  id="$(printf '%s' "$out" | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])')" \
+    || die "session create failed: $out"
+  backend_type="$(cd "$REPO_ROOT" && \
+    XDG_CONFIG_HOME="$xdg/config" XDG_DATA_HOME="$xdg/data" \
+    cargo run -q --bin thurbox-cli -- session get "$id" 2>/dev/null \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin).get("backend_type",""))')"
+
+  # Confirm the artifacts really live on the remote.
+  local remote_window remote_wt
+  remote_window="$(ssh_remote 'tmux -L thurbox-dev list-windows -t thurbox-dev -F "#{window_name}" 2>/dev/null' | grep -c '^tb-e2e$' || true)"
+  remote_wt="$(ssh_remote 'cd /srv/repo && git worktree list | grep -c test-e2e' 2>/dev/null || echo 0)"
+
+  echo
+  log "backend_type = $backend_type   remote tb-e2e windows = $remote_window   remote worktrees = $remote_wt"
+  if [ "$backend_type" = "ssh:podman" ] && [ "$remote_window" -ge 1 ] && [ "$remote_wt" -ge 1 ]; then
+    printf '\033[1;32mPASS\033[0m remote SSH session created on the container\n'
+  else
+    printf '\033[1;31mFAIL\033[0m expected ssh:podman + remote window + remote worktree\n'
+    return 1
+  fi
+}
+
+cmd_down() {
+  podman rm -f "$CONTAINER" >/dev/null 2>&1 && log "removed container $CONTAINER" || log "no container to remove"
+}
+
+cmd_clean() {
+  cmd_down
+  podman rmi -f "$IMAGE" >/dev/null 2>&1 || true
+  rm -rf "$WORKDIR"
+  log "removed image + $WORKDIR"
+}
+
+case "${1:-}" in
+  up)    cmd_up ;;
+  test)  cmd_test ;;
+  hosts) cmd_hosts ;;
+  ssh)   shift; cmd_ssh "$@" ;;
+  down)  cmd_down ;;
+  clean) cmd_clean ;;
+  *) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 1 ;;
+esac

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -256,6 +256,16 @@ impl ShellPane {
     }
 }
 
+/// The bare remote host name for a session's backend (e.g. `devbox` for an
+/// `ssh:devbox` backend), or `None` for local backends. Drives the session
+/// list's remote indicator.
+fn remote_host_from_backend(backend: &Arc<dyn SessionBackend>) -> Option<String> {
+    backend
+        .name()
+        .strip_prefix(crate::session::SSH_BACKEND_PREFIX)
+        .map(str::to_string)
+}
+
 /// A running session connected to a backend.
 pub struct Session {
     pub info: SessionInfo,
@@ -313,6 +323,7 @@ impl Session {
             info.agent = config.agent.clone();
         }
         info.backend_id = Some(spawned.backend_id.clone());
+        info.remote_host = remote_host_from_backend(backend);
         debug!(session_id = %info.id, backend_id = %spawned.backend_id, "Spawned session via backend");
 
         Ok(Self::wire_io(
@@ -352,6 +363,7 @@ impl Session {
 
         let mut info = SessionInfo::new(name);
         info.backend_id = Some(backend_id.to_string());
+        info.remote_host = remote_host_from_backend(backend);
         debug!(session_id = %info.id, backend_id = %backend_id, "Adopted session via backend");
 
         Ok(Self::wire_io(
@@ -744,6 +756,24 @@ mod tests {
         let ms = now_millis();
         // Should be after 2024-01-01 (1704067200000 ms since epoch).
         assert!(ms > 1_704_067_200_000);
+    }
+
+    #[test]
+    fn remote_host_from_backend_strips_ssh_prefix() {
+        let host = crate::session::HostDef {
+            name: "devbox".into(),
+            destination: "me@devbox".into(),
+            socket: None,
+            session: None,
+            ssh_opts: vec![],
+            worktrees_dir: None,
+        };
+        let ssh: Arc<dyn SessionBackend> =
+            Arc::new(crate::agent::tmux::TmuxBackend::from_host(&host));
+        assert_eq!(remote_host_from_backend(&ssh).as_deref(), Some("devbox"));
+
+        let local: Arc<dyn SessionBackend> = Arc::new(crate::agent::tmux::TmuxBackend::local());
+        assert_eq!(remote_host_from_backend(&local), None);
     }
 
     #[test]

--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -211,20 +211,9 @@ pub fn format_send_keys(pane_id: &str, bytes: &[u8]) -> String {
 /// Literal newlines in arguments (e.g. `--append-system-prompt`) would split
 /// the command and corrupt the protocol, so they are replaced with spaces.
 pub fn shell_escape(s: &str) -> String {
-    if s.is_empty() {
-        return "''".to_string();
-    }
-    // Replace newlines with spaces — tmux control mode is line-delimited,
-    // so embedded newlines would break the protocol.
-    let s = s.replace('\n', " ");
-    // If the string contains no special characters, return as-is.
-    if s.chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':' | '=' | ','))
-    {
-        return s;
-    }
-    // Wrap in single quotes, escaping existing single quotes.
-    format!("'{}'", s.replace('\'', "'\\''"))
+    // Strip the protocol-breaking newlines, then apply standard POSIX
+    // single-quote escaping (shared with the SSH/git paths).
+    crate::shell::posix_quote(&s.replace('\n', " "))
 }
 
 #[cfg(test)]

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -11,25 +11,65 @@ use std::path::PathBuf;
 
 use crate::session::HostRegistry;
 
-/// Seed contents for `hosts.toml` on first run: documentation + a commented-out
-/// example, but no active hosts.
-pub const SEED_HOSTS_TOML: &str = r#"# Thurbox remote SSH hosts.
+/// Seed contents for `hosts.toml` on first run: full field documentation plus a
+/// commented-out example, but no active hosts.
+pub const SEED_HOSTS_TOML: &str = r#"# Thurbox remote SSH hosts  —  ~/.config/thurbox/hosts.toml
 #
-# Each [[hosts]] entry describes a remote machine thurbox can run agent
-# sessions on, over SSH. Each becomes a backend named "ssh:<name>", selectable
-# when creating a session. Authentication and host details resolve via your
-# ~/.ssh/config — thurbox shells out to the system `ssh` binary.
+# Each [[hosts]] entry describes a remote machine thurbox can run agent sessions
+# on, over SSH. A host named "<name>" registers a session backend called
+# "ssh:<name>", offered in the new-session host picker (TUI) and selectable with
+# `thurbox-cli session create --host <name>`. The agent process, its tmux
+# window, and any git worktrees all live on the remote host; only the TUI runs
+# locally.
 #
-# Uncomment and edit to add a host:
+# thurbox shells out to the system `ssh` binary, so authentication, keys, and
+# connection details all come from your ~/.ssh/config — thurbox never handles
+# credentials itself. The remote host needs `tmux` >= 3.2 and `git`.
+#
+# This file starts empty (every entry below is commented out), so a fresh
+# install registers zero remote hosts and behaves exactly like a local-only
+# setup. Uncomment and edit an entry to add a host.
+#
+# Fields per [[hosts]] entry:
+#
+#   name           (string, required)
+#       Short, unique identifier. Registers the backend as "ssh:<name>" and is
+#       the value `--host` expects. Example: "devbox".
+#
+#   destination    (string, required)
+#       SSH target passed straight to `ssh`. Either "user@host" or a Host alias
+#       defined in your ~/.ssh/config. Example: "me@devbox".
+#
+#   ssh_opts       (array of strings, optional, default: [])
+#       Extra flags inserted before the destination, one token per array
+#       element (e.g. "-p" then "2222"). thurbox does NOT expand `~`, so use
+#       absolute paths for things like `-i <keyfile>`.
+#
+#   socket         (string, optional, default: "thurbox")
+#       Remote `tmux -L` socket name. Override only to avoid colliding with
+#       another thurbox/tmux server on the same remote host.
+#
+#   session        (string, optional, default: "thurbox")
+#       Remote tmux session name that groups thurbox's windows.
+#
+#   worktrees_dir  (string, optional)
+#       Absolute remote directory under which git worktrees are created. When
+#       unset, thurbox uses $HOME/.local/share/thurbox/worktrees on the remote
+#       (the remote $HOME is resolved over ssh on first use).
+#
+# Example (uncomment and edit):
 #
 # [[hosts]]
 # name = "devbox"
 # destination = "me@devbox"
-# # ControlMaster keeps one SSH connection alive so reconnects are instant;
-# # ServerAliveInterval drops half-open links promptly.
+#
+# # ControlMaster reuses one SSH connection so reconnects are instant;
+# # ControlPersist keeps it warm; ServerAliveInterval drops half-open links.
 # ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m", "-o", "ServerAliveInterval=15"]
-# # Optional: absolute remote dir for git worktrees (defaults to
-# # $HOME/.local/share/thurbox/worktrees on the remote).
+#
+# # Optional overrides, shown with their defaults:
+# # socket = "thurbox"
+# # session = "thurbox"
 # # worktrees_dir = "/home/me/.local/share/thurbox/worktrees"
 "#;
 
@@ -86,6 +126,26 @@ mod tests {
     fn seed_toml_parses_to_empty_registry() {
         let reg: HostRegistry = toml::from_str(SEED_HOSTS_TOML).unwrap();
         assert!(reg.is_empty());
+    }
+
+    /// The seeded `hosts.toml` is the primary documentation users see, so it
+    /// must describe every configurable field. Guards against adding a
+    /// `HostDef` field without documenting it here.
+    #[test]
+    fn seed_toml_documents_every_host_field() {
+        for field in [
+            "name",
+            "destination",
+            "ssh_opts",
+            "socket",
+            "session",
+            "worktrees_dir",
+        ] {
+            assert!(
+                SEED_HOSTS_TOML.contains(field),
+                "hosts.toml seed must document the '{field}' field"
+            );
+        }
     }
 
     #[test]

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -1,0 +1,136 @@
+//! Loading and seeding of the remote-host config file.
+//!
+//! Remote SSH hosts are defined declaratively in
+//! `~/.config/thurbox/hosts.toml`. Each entry becomes a selectable session
+//! backend named `ssh:<name>`. On first run the file is seeded with a
+//! commented-out example so a fresh install registers *zero* remote backends
+//! and behaves exactly as before. If the file exists but cannot be read or
+//! parsed, we fall back to an empty registry rather than failing to start.
+
+use std::path::PathBuf;
+
+use crate::session::HostRegistry;
+
+/// Seed contents for `hosts.toml` on first run: documentation + a commented-out
+/// example, but no active hosts.
+pub const SEED_HOSTS_TOML: &str = r#"# Thurbox remote SSH hosts.
+#
+# Each [[hosts]] entry describes a remote machine thurbox can run agent
+# sessions on, over SSH. Each becomes a backend named "ssh:<name>", selectable
+# when creating a session. Authentication and host details resolve via your
+# ~/.ssh/config — thurbox shells out to the system `ssh` binary.
+#
+# Uncomment and edit to add a host:
+#
+# [[hosts]]
+# name = "devbox"
+# destination = "me@devbox"
+# # ControlMaster keeps one SSH connection alive so reconnects are instant;
+# # ServerAliveInterval drops half-open links promptly.
+# ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m", "-o", "ServerAliveInterval=15"]
+# # Optional: absolute remote dir for git worktrees (defaults to
+# # $HOME/.local/share/thurbox/worktrees on the remote).
+# # worktrees_dir = "/home/me/.local/share/thurbox/worktrees"
+"#;
+
+/// Path to the remote-host config file: `~/.config/thurbox/hosts.toml`
+/// (sibling of `config.toml`).
+pub fn hosts_config_path() -> Option<PathBuf> {
+    crate::paths::config_file().map(|p| p.with_file_name("hosts.toml"))
+}
+
+/// Load the remote-host registry, seeding the config file with a commented-out
+/// example when it is absent. Any read/parse error degrades gracefully to an
+/// empty registry so the TUI always starts (with local-only sessions).
+pub fn load_or_seed() -> HostRegistry {
+    let Some(path) = hosts_config_path() else {
+        tracing::warn!("Could not resolve hosts.toml path; no remote hosts");
+        return HostRegistry::default();
+    };
+
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                tracing::warn!(error = %e, "Failed to create config dir for hosts.toml");
+                return HostRegistry::default();
+            }
+        }
+        if let Err(e) = std::fs::write(&path, SEED_HOSTS_TOML) {
+            tracing::warn!(error = %e, "Failed to seed hosts.toml");
+            return HostRegistry::default();
+        }
+        tracing::info!(path = %path.display(), "Seeded hosts.toml (no active hosts)");
+        return HostRegistry::default();
+    }
+
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => match toml::from_str::<HostRegistry>(&contents) {
+            Ok(reg) => reg,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to parse hosts.toml; no remote hosts");
+                HostRegistry::default()
+            }
+        },
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to read hosts.toml; no remote hosts");
+            HostRegistry::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_toml_parses_to_empty_registry() {
+        let reg: HostRegistry = toml::from_str(SEED_HOSTS_TOML).unwrap();
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn load_or_seed_writes_file_when_absent_and_stays_empty() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = hosts_config_path().unwrap();
+        assert!(!path.exists());
+
+        let reg = load_or_seed();
+        assert!(reg.is_empty());
+        assert!(path.exists(), "hosts.toml should have been seeded");
+
+        // Second call reads the seeded file and is still empty.
+        assert!(load_or_seed().is_empty());
+    }
+
+    #[test]
+    fn load_or_seed_falls_back_on_malformed_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "this is not = valid toml {{{").unwrap();
+
+        assert!(load_or_seed().is_empty());
+    }
+
+    #[test]
+    fn load_or_seed_reads_configured_host() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hosts]]\nname = \"devbox\"\ndestination = \"me@devbox\"\n",
+        )
+        .unwrap();
+
+        let reg = load_or_seed();
+        assert_eq!(reg.names(), ["devbox"]);
+        assert_eq!(reg.get("devbox").unwrap().backend_name(), "ssh:devbox");
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3,6 +3,7 @@ pub mod backend;
 pub mod control_mode;
 pub mod demo;
 pub mod generic;
+pub mod host_config;
 pub mod input;
 pub mod provider;
 pub mod registry;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,6 +7,7 @@ pub mod input;
 pub mod provider;
 pub mod registry;
 pub mod tmux;
+pub mod transport;
 
 pub use backend::{Session, SessionBackend, SessionParser};
 pub use generic::GenericProvider;

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -1304,6 +1304,33 @@ pub fn spawn_window(
     Ok(())
 }
 
+/// Headless spawn of an agent window on a remote host over SSH.
+///
+/// Returns the remote tmux pane id (`%N`). Unlike the local [`spawn_window`]
+/// (which leaves `backend_id` empty for the TUI to resolve by name), this drives
+/// the SSH backend's control mode to learn the real pane id up front. The
+/// control-mode connection is dropped when this returns; the remote tmux keeps
+/// the window alive for the TUI to adopt later.
+pub fn spawn_window_remote(
+    host: &crate::session::HostDef,
+    session_name: &str,
+    command: &str,
+    args: &[String],
+    cwd: Option<&Path>,
+    env: &HashMap<String, String>,
+) -> Result<String> {
+    let backend = TmuxBackend::from_host(host);
+    backend
+        .check_available()
+        .context("remote host is unreachable or tmux is missing")?;
+    backend.ensure_ready()?;
+    let window_name = agent_window_name(session_name);
+    // Headless: no live terminal, so use a sane default geometry. The TUI
+    // resizes the pane to its real dimensions when it adopts the session.
+    let spawned = backend.spawn(&window_name, command, args, cwd, env, 24, 80)?;
+    Ok(spawned.backend_id)
+}
+
 /// Kill the tmux window `tb-<session_name>` if it exists.
 pub fn kill_window(session_name: &str) -> Result<()> {
     let target = window_target(session_name);

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -490,6 +490,29 @@ impl TmuxBackend {
         }
     }
 
+    /// Build a remote tmux backend that runs `tmux` over SSH on `host`. The
+    /// backend is named `ssh:<host.name>` and uses the same socket/session
+    /// names as the local backend unless the host overrides them.
+    pub fn from_host(host: &crate::session::HostDef) -> Self {
+        let socket = host
+            .socket
+            .clone()
+            .unwrap_or_else(|| TMUX_SOCKET.to_string());
+        let session = host
+            .session
+            .clone()
+            .unwrap_or_else(|| TMUX_SESSION.to_string());
+        Self::with_transport(
+            TmuxTransport::Ssh {
+                destination: host.destination.clone(),
+                ssh_opts: host.ssh_opts.clone(),
+            },
+            socket,
+            session,
+            host.backend_name(),
+        )
+    }
+
     /// Run a tmux command and return its stdout (used before control mode is available).
     fn tmux_output(&self, args: &[&str]) -> Result<String> {
         let output = self.run_tmux(args)?;
@@ -1661,6 +1684,46 @@ mod tests {
         let backend = LocalTmuxBackend::new();
         let guard = backend.control.lock().unwrap();
         assert!(guard.is_none());
+    }
+
+    #[test]
+    fn local_backend_is_named_local_tmux_with_local_transport() {
+        let backend = LocalTmuxBackend::new();
+        assert_eq!(backend.name(), "local-tmux");
+        assert!(!backend.transport.is_remote());
+    }
+
+    #[test]
+    fn from_host_builds_named_ssh_backend() {
+        let host = crate::session::HostDef {
+            name: "devbox".into(),
+            destination: "me@devbox".into(),
+            socket: None,
+            session: None,
+            ssh_opts: vec!["-o".into(), "ControlMaster=auto".into()],
+            worktrees_dir: None,
+        };
+        let backend = TmuxBackend::from_host(&host);
+        assert_eq!(backend.name(), "ssh:devbox");
+        assert!(backend.transport.is_remote());
+        // Falls back to the default socket/session when the host omits them.
+        assert_eq!(backend.socket, TMUX_SOCKET);
+        assert_eq!(backend.session, TMUX_SESSION);
+    }
+
+    #[test]
+    fn from_host_honors_socket_and_session_overrides() {
+        let host = crate::session::HostDef {
+            name: "vm".into(),
+            destination: "vm".into(),
+            socket: Some("tb-vm".into()),
+            session: Some("sess-vm".into()),
+            ssh_opts: vec![],
+            worktrees_dir: None,
+        };
+        let backend = TmuxBackend::from_host(&host);
+        assert_eq!(backend.socket, "tb-vm");
+        assert_eq!(backend.session, "sess-vm");
     }
 
     #[test]

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -14,6 +14,7 @@ use crate::agent::control_mode::{
     self, shell_escape, CommandResponse, ControlModeReader, ControlModeWriter, Notification,
     PaneSendersMapShared, PANE_CHANNEL_CAPACITY,
 };
+use crate::agent::transport::TmuxTransport;
 
 /// Dedicated tmux socket name — isolates thurbox sessions from the user's tmux.
 /// Dev builds use "thurbox-dev" to avoid interfering with an installed release binary.
@@ -89,6 +90,32 @@ fn window_target(session_name: &str) -> String {
 /// Minimum tmux version required.
 const MIN_TMUX_VERSION: (u32, u32) = (3, 2);
 
+/// Parse a `tmux -V` version string (e.g. `"tmux 3.4"`, `"tmux 3.3a"`) into a
+/// `(major, minor)` pair. Shared by the local and remote backends.
+fn parse_tmux_version(version_str: &str) -> Result<(u32, u32)> {
+    // Parse "tmux X.Y" or "tmux X.Ya" (e.g., "tmux 3.4" or "tmux 3.3a").
+    let version_part = version_str.strip_prefix("tmux ").unwrap_or(version_str);
+
+    let parts: Vec<&str> = version_part.split('.').collect();
+    if parts.len() < 2 {
+        bail!("Cannot parse tmux version from: {version_str}");
+    }
+
+    let major: u32 = parts[0].parse().context(format!(
+        "Cannot parse tmux major version from: {version_str}"
+    ))?;
+    // Minor might have a trailing letter (e.g., "3a"), strip non-digits.
+    let minor_str: String = parts[1]
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    let minor: u32 = minor_str.parse().context(format!(
+        "Cannot parse tmux minor version from: {version_str}"
+    ))?;
+
+    Ok((major, minor))
+}
+
 /// Timeout for waiting for a control mode command response.
 const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
@@ -99,18 +126,32 @@ const SEND_KEYS_ENTER_DELAY: std::time::Duration = std::time::Duration::from_mil
 /// Hard cap on the number of scrollback lines `capture_pane_text` will return.
 const MAX_CAPTURE_LINES: u32 = 10_000;
 
-/// Local tmux backend — sessions persist in `tmux -L thurbox`.
+/// A tmux backend — sessions persist in `tmux -L <socket>` on either the local
+/// machine or a remote host reached over SSH.
 ///
-/// Uses tmux control mode (`-C`) for all I/O after `ensure_ready()`.
-pub struct LocalTmuxBackend {
+/// Uses tmux control mode (`-C`) for all I/O after `ensure_ready()`. The only
+/// thing that differs between local and remote is the [`TmuxTransport`] used to
+/// launch the `tmux` process; the protocol layer is identical.
+pub struct TmuxBackend {
+    /// How `tmux` is launched (local `Command` vs `ssh <dest> tmux …`).
+    transport: TmuxTransport,
+    /// tmux socket name passed via `-L` (e.g. `thurbox`).
+    socket: String,
+    /// tmux session name grouping all thurbox windows.
+    session: String,
+    /// Backend name used by the registry / persisted `backend_type`
+    /// (`local-tmux` or `ssh:<host>`).
+    name: String,
     control: Mutex<Option<ControlMode>>,
 }
 
-impl Default for LocalTmuxBackend {
+/// The local tmux backend. Thin alias-constructor over [`TmuxBackend`] kept for
+/// existing call sites; `LocalTmuxBackend::new()` builds a local-transport backend.
+pub type LocalTmuxBackend = TmuxBackend;
+
+impl Default for TmuxBackend {
     fn default() -> Self {
-        Self {
-            control: Mutex::new(None),
-        }
+        Self::local()
     }
 }
 
@@ -131,17 +172,13 @@ struct ControlMode {
 }
 
 impl ControlMode {
-    /// Start a control mode connection to the thurbox tmux session.
-    fn start() -> Result<Self> {
+    /// Start a control mode connection to the thurbox tmux session over the
+    /// given transport (local or ssh).
+    fn start(transport: &TmuxTransport, socket: &str, session: &str) -> Result<Self> {
         // -C (single C): control mode with echo — works with piped stdin.
         // -CC (double C) requires a TTY and fails with "tcgetattr: Inappropriate ioctl".
-        let mut child = Command::new("tmux")
-            .arg("-L")
-            .arg(TMUX_SOCKET)
-            .arg("-C")
-            .arg("attach-session")
-            .arg("-t")
-            .arg(TMUX_SESSION)
+        let mut child = transport
+            .tmux_command(socket, &["-C", "attach-session", "-t", session])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -420,29 +457,56 @@ fn is_recv_timeout(err: &anyhow::Error) -> bool {
     })
 }
 
-impl LocalTmuxBackend {
+impl TmuxBackend {
+    /// Build the local tmux backend (`tmux -L thurbox`).
     pub fn new() -> Self {
-        Self::default()
+        Self::local()
+    }
+
+    /// Build the local tmux backend, named `local-tmux`.
+    pub fn local() -> Self {
+        Self {
+            transport: TmuxTransport::Local,
+            socket: TMUX_SOCKET.to_string(),
+            session: TMUX_SESSION.to_string(),
+            name: "local-tmux".to_string(),
+            control: Mutex::new(None),
+        }
+    }
+
+    /// Build a tmux backend over an explicit transport (used by the SSH backend).
+    pub fn with_transport(
+        transport: TmuxTransport,
+        socket: impl Into<String>,
+        session: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            transport,
+            socket: socket.into(),
+            session: session.into(),
+            name: name.into(),
+            control: Mutex::new(None),
+        }
     }
 
     /// Run a tmux command and return its stdout (used before control mode is available).
     fn tmux_output(&self, args: &[&str]) -> Result<String> {
-        let output = Self::run_tmux(args)?;
+        let output = self.run_tmux(args)?;
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
     /// Run a tmux command, returning Ok(()) on success (used before control mode is available).
     fn tmux_run(&self, args: &[&str]) -> Result<()> {
-        Self::run_tmux(args)?;
+        self.run_tmux(args)?;
         Ok(())
     }
 
     /// Execute a tmux command on the thurbox socket and check for errors.
-    fn run_tmux(args: &[&str]) -> Result<std::process::Output> {
-        let output = Command::new("tmux")
-            .arg("-L")
-            .arg(TMUX_SOCKET)
-            .args(args)
+    fn run_tmux(&self, args: &[&str]) -> Result<std::process::Output> {
+        let output = self
+            .transport
+            .tmux_command(&self.socket, args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output()
@@ -458,14 +522,16 @@ impl LocalTmuxBackend {
 
     /// Check if the thurbox tmux session exists.
     fn session_exists(&self) -> bool {
-        self.tmux_run(&["has-session", "-t", TMUX_SESSION]).is_ok()
+        self.tmux_run(&["has-session", "-t", &self.session]).is_ok()
     }
 
     /// Apply initial config to the tmux server.
     fn apply_config(&self) -> Result<()> {
         // Use a non-login shell so that macOS path_helper (/etc/zprofile)
         // doesn't clobber PATH additions from ~/.zshenv (e.g. cargo, asdf).
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        // For a remote backend the local `$SHELL` path may not exist on the
+        // remote host, so fall back to a POSIX shell there.
+        let shell = self.config_shell();
         self.tmux_run(&["set-option", "-s", "default-command", &shell])?;
 
         // Server-wide options
@@ -487,10 +553,21 @@ impl LocalTmuxBackend {
             ("window-size", "manual"),
         ];
         for (key, val) in &session_opts {
-            self.tmux_run(&["set-option", "-t", TMUX_SESSION, key, val])?;
+            self.tmux_run(&["set-option", "-t", &self.session, key, val])?;
         }
 
         Ok(())
+    }
+
+    /// The shell tmux should use for `default-command`. Local uses the user's
+    /// `$SHELL`; a remote backend uses a POSIX shell that is guaranteed to exist
+    /// on the remote host.
+    fn config_shell(&self) -> String {
+        if self.transport.is_remote() {
+            "/bin/sh".to_string()
+        } else {
+            std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
+        }
     }
 
     /// Build the shell command string to pass to tmux new-window.
@@ -532,7 +609,11 @@ impl LocalTmuxBackend {
             .lock()
             .map_err(|e| anyhow::anyhow!("control lock: {e}"))?;
         *guard = None; // Drop dead ControlMode (triggers cleanup)
-        *guard = Some(ControlMode::start()?);
+        *guard = Some(ControlMode::start(
+            &self.transport,
+            &self.socket,
+            &self.session,
+        )?);
         debug!("Control mode reconnected successfully");
         Ok(())
     }
@@ -650,44 +731,29 @@ impl LocalTmuxBackend {
     }
 }
 
-impl SessionBackend for LocalTmuxBackend {
+impl SessionBackend for TmuxBackend {
     fn name(&self) -> &str {
-        "local-tmux"
+        &self.name
     }
 
     fn check_available(&self) -> Result<()> {
-        let output = Command::new("tmux")
-            .arg("-V")
+        // `tmux -L <socket> -V` prints the version without connecting, and over
+        // the SSH transport this verifies remote connectivity at the same time.
+        let output = self
+            .transport
+            .tmux_command(&self.socket, &["-V"])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .output()
             .context("tmux is not installed or not in PATH")?;
 
         if !output.status.success() {
-            bail!("tmux -V failed");
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("tmux -V failed: {}", stderr.trim());
         }
 
         let version_str = String::from_utf8_lossy(&output.stdout);
-        let version_str = version_str.trim();
-        // Parse "tmux X.Y" or "tmux X.Ya" (e.g., "tmux 3.4" or "tmux 3.3a")
-        let version_part = version_str.strip_prefix("tmux ").unwrap_or(version_str);
-
-        let parts: Vec<&str> = version_part.split('.').collect();
-        if parts.len() < 2 {
-            bail!("Cannot parse tmux version from: {version_str}");
-        }
-
-        let major: u32 = parts[0].parse().context(format!(
-            "Cannot parse tmux major version from: {version_str}"
-        ))?;
-        // Minor might have a trailing letter (e.g., "3a"), strip non-digits.
-        let minor_str: String = parts[1]
-            .chars()
-            .take_while(|c| c.is_ascii_digit())
-            .collect();
-        let minor: u32 = minor_str.parse().context(format!(
-            "Cannot parse tmux minor version from: {version_str}"
-        ))?;
+        let (major, minor) = parse_tmux_version(version_str.trim())?;
 
         if (major, minor) < MIN_TMUX_VERSION {
             bail!(
@@ -697,35 +763,27 @@ impl SessionBackend for LocalTmuxBackend {
             );
         }
 
-        debug!("tmux version: {version_str}");
+        debug!("tmux version: {}", version_str.trim());
         Ok(())
     }
 
     fn ensure_ready(&self) -> Result<()> {
         if !self.session_exists() {
-            debug!("Creating tmux session '{TMUX_SESSION}' on socket '{TMUX_SOCKET}'");
-            let output = Command::new("tmux")
-                .arg("-L")
-                .arg(TMUX_SOCKET)
-                .args([
-                    "new-session",
-                    "-d",
-                    "-s",
-                    TMUX_SESSION,
-                    "-x",
-                    "80",
-                    "-y",
-                    "24",
-                ])
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output()
-                .context("Failed to create tmux session")?;
-
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                bail!("Failed to create tmux session: {}", stderr.trim());
-            }
+            debug!(
+                "Creating tmux session '{}' on socket '{}'",
+                self.session, self.socket
+            );
+            self.run_tmux(&[
+                "new-session",
+                "-d",
+                "-s",
+                &self.session,
+                "-x",
+                "80",
+                "-y",
+                "24",
+            ])
+            .context("Failed to create tmux session")?;
 
             self.apply_config()?;
         }
@@ -737,7 +795,11 @@ impl SessionBackend for LocalTmuxBackend {
             .map_err(|e| anyhow::anyhow!("control lock: {e}"))?;
         if guard.is_none() {
             debug!("Starting tmux control mode");
-            *guard = Some(ControlMode::start()?);
+            *guard = Some(ControlMode::start(
+                &self.transport,
+                &self.socket,
+                &self.session,
+            )?);
         }
 
         Ok(())
@@ -764,8 +826,9 @@ impl SessionBackend for LocalTmuxBackend {
             .map(|(k, v)| format!(" -e {}", shell_escape(&format!("{k}={v}"))))
             .collect();
         let escaped_window_name = shell_escape(window_name);
+        let session = &self.session;
         let cmd = format!(
-            "new-window -t {TMUX_SESSION} -n {escaped_window_name} -P -F '#{{pane_id}}'{cwd_part}{env_part} {shell_cmd}"
+            "new-window -t {session} -n {escaped_window_name} -P -F '#{{pane_id}}'{cwd_part}{env_part} {shell_cmd}"
         );
         let result = self.ctrl_command(&cmd)?;
         let pane_id = result.trim().to_string();
@@ -798,13 +861,14 @@ impl SessionBackend for LocalTmuxBackend {
                 .map_err(|e| anyhow::anyhow!("control lock: {e}"))?;
             if let Some(ref ctrl) = *guard {
                 ctrl.send_command(&format!(
-                    "list-windows -t {TMUX_SESSION} -F '#{{pane_id}}|#{{window_name}}|#{{pane_dead}}'"
+                    "list-windows -t {} -F '#{{pane_id}}|#{{window_name}}|#{{pane_dead}}'",
+                    self.session
                 ))?
             } else {
                 self.tmux_output(&[
                     "list-windows",
                     "-t",
-                    TMUX_SESSION,
+                    &self.session,
                     "-F",
                     "#{pane_id}|#{window_name}|#{pane_dead}",
                 ])?
@@ -1284,6 +1348,28 @@ mod tests {
     #[test]
     fn shell_escape_tool_pattern() {
         assert_eq!(shell_escape("Read Bash(git:*)"), "'Read Bash(git:*)'");
+    }
+
+    // --- parse_tmux_version tests ---
+
+    #[test]
+    fn parse_tmux_version_plain() {
+        assert_eq!(parse_tmux_version("tmux 3.4").unwrap(), (3, 4));
+    }
+
+    #[test]
+    fn parse_tmux_version_trailing_letter() {
+        assert_eq!(parse_tmux_version("tmux 3.3a").unwrap(), (3, 3));
+    }
+
+    #[test]
+    fn parse_tmux_version_without_prefix() {
+        assert_eq!(parse_tmux_version("3.2").unwrap(), (3, 2));
+    }
+
+    #[test]
+    fn parse_tmux_version_rejects_garbage() {
+        assert!(parse_tmux_version("not a version").is_err());
     }
 
     // --- build_shell_command tests ---

--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -10,7 +10,7 @@
 
 use std::process::Command;
 
-use crate::agent::control_mode::shell_escape;
+use crate::shell::{posix_quote, ssh_command};
 
 /// How to launch `tmux` for a backend: directly, or wrapped in `ssh`.
 #[derive(Debug, Clone)]
@@ -44,14 +44,12 @@ impl TmuxTransport {
                 destination,
                 ssh_opts,
             } => {
-                let mut cmd = Command::new("ssh");
-                cmd.args(ssh_opts);
-                cmd.arg(destination);
-                cmd.arg(shell_escape("tmux"));
-                cmd.arg(shell_escape("-L"));
-                cmd.arg(shell_escape(socket));
+                let mut cmd = ssh_command(destination, ssh_opts);
+                cmd.arg(posix_quote("tmux"));
+                cmd.arg(posix_quote("-L"));
+                cmd.arg(posix_quote(socket));
                 for a in args {
-                    cmd.arg(shell_escape(a));
+                    cmd.arg(posix_quote(a));
                 }
                 cmd
             }

--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -1,0 +1,123 @@
+//! Transport seam for the tmux backend.
+//!
+//! The tmux control-mode protocol is identical whether tmux runs on the local
+//! machine or on a remote host reached over SSH (see [`crate::agent::control_mode`]).
+//! The *only* thing that differs is how the `tmux` process is launched: a bare
+//! `Command::new("tmux")` locally, or `ssh <dest> tmux …` remotely.
+//!
+//! [`TmuxTransport`] captures exactly that difference and nothing else. It builds
+//! [`Command`]s; it never touches I/O, threading, or the protocol.
+
+use std::process::Command;
+
+use crate::agent::control_mode::shell_escape;
+
+/// How to launch `tmux` for a backend: directly, or wrapped in `ssh`.
+#[derive(Debug, Clone)]
+pub enum TmuxTransport {
+    /// Run tmux on the local machine.
+    Local,
+    /// Run tmux on a remote host over SSH. `destination` is an ssh target
+    /// (resolved via the user's `~/.ssh/config`); `ssh_opts` are extra flags
+    /// (e.g. `-o ControlMaster=auto`) inserted before the destination.
+    Ssh {
+        destination: String,
+        ssh_opts: Vec<String>,
+    },
+}
+
+impl TmuxTransport {
+    /// Build a [`Command`] running `tmux -L <socket> <args…>`, wrapped in `ssh`
+    /// for the remote variant.
+    ///
+    /// For the SSH variant the remote command tokens are re-split by the remote
+    /// login shell, so each token is shell-escaped to survive intact. Simple
+    /// tokens (`tmux`, `-L`, the socket name) pass through unquoted.
+    pub fn tmux_command(&self, socket: &str, args: &[&str]) -> Command {
+        match self {
+            TmuxTransport::Local => {
+                let mut cmd = Command::new("tmux");
+                cmd.arg("-L").arg(socket).args(args);
+                cmd
+            }
+            TmuxTransport::Ssh {
+                destination,
+                ssh_opts,
+            } => {
+                let mut cmd = Command::new("ssh");
+                cmd.args(ssh_opts);
+                cmd.arg(destination);
+                cmd.arg(shell_escape("tmux"));
+                cmd.arg(shell_escape("-L"));
+                cmd.arg(shell_escape(socket));
+                for a in args {
+                    cmd.arg(shell_escape(a));
+                }
+                cmd
+            }
+        }
+    }
+
+    /// Whether this transport reaches tmux over SSH.
+    pub fn is_remote(&self) -> bool {
+        matches!(self, TmuxTransport::Ssh { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn program_and_args(cmd: &Command) -> (String, Vec<String>) {
+        let prog = cmd.get_program().to_string_lossy().into_owned();
+        let args = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        (prog, args)
+    }
+
+    #[test]
+    fn local_builds_bare_tmux() {
+        let t = TmuxTransport::Local;
+        let cmd = t.tmux_command("thurbox", &["has-session", "-t", "thurbox"]);
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "tmux");
+        assert_eq!(args, ["-L", "thurbox", "has-session", "-t", "thurbox"]);
+    }
+
+    #[test]
+    fn ssh_wraps_tmux_with_opts_and_destination() {
+        let t = TmuxTransport::Ssh {
+            destination: "me@devbox".into(),
+            ssh_opts: vec!["-o".into(), "ControlMaster=auto".into()],
+        };
+        let cmd = t.tmux_command("thurbox", &["has-session", "-t", "thurbox"]);
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "ssh");
+        assert_eq!(
+            args,
+            [
+                "-o",
+                "ControlMaster=auto",
+                "me@devbox",
+                "tmux",
+                "-L",
+                "thurbox",
+                "has-session",
+                "-t",
+                "thurbox",
+            ]
+        );
+    }
+
+    #[test]
+    fn is_remote_reflects_variant() {
+        assert!(!TmuxTransport::Local.is_remote());
+        assert!(TmuxTransport::Ssh {
+            destination: "h".into(),
+            ssh_opts: vec![],
+        }
+        .is_remote());
+    }
+}

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -240,6 +240,7 @@ impl App {
             Modal::AutomationEditor(_) => self.handle_automation_editor_key(code, mods),
             Modal::AutomationsList(_) => self.handle_automations_list_key(code),
             Modal::AgentPicker(_) => self.handle_agent_picker_key(code),
+            Modal::HostPicker(_) => self.handle_host_picker_key(code),
             Modal::ThemePicker(_) => self.handle_theme_picker_key(code),
             Modal::RepoPicker(_) => self.handle_repo_picker_key(code, mods),
             Modal::TaskActionPicker(_) => self.handle_task_action_picker_key(code),
@@ -1066,6 +1067,41 @@ impl App {
         }
     }
 
+    fn handle_host_picker_key(&mut self, code: KeyCode) {
+        let super::modals::Modal::HostPicker(ref mut hp) = self.modal else {
+            return;
+        };
+        let choice_count = hp.choices.len();
+        match code {
+            KeyCode::Esc => {
+                self.modal.close();
+                self.pending_backend = None;
+            }
+            KeyCode::Char('j') | KeyCode::Down if hp.selected_index + 1 < choice_count => {
+                hp.selected_index += 1;
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                hp.selected_index = hp.selected_index.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                let backend = hp
+                    .choices
+                    .get(hp.selected_index)
+                    .map(|c| c.backend.clone())
+                    .unwrap_or_default();
+                self.modal.close();
+                // Empty backend == local default.
+                self.pending_backend = if backend.is_empty() {
+                    None
+                } else {
+                    Some(backend)
+                };
+                self.open_repo_picker();
+            }
+            _ => {}
+        }
+    }
+
     fn handle_agent_picker_key(&mut self, code: KeyCode) {
         let super::modals::Modal::AgentPicker(ref mut ap) = self.modal else {
             return;
@@ -1291,7 +1327,7 @@ impl App {
             // A manual new-session must not inherit a task prompt left over from
             // a cancelled task-spawn.
             self.pending_task_prompt = None;
-            self.open_repo_picker();
+            self.start_new_session();
         }
     }
 
@@ -1421,19 +1457,27 @@ impl App {
     }
 
     pub(crate) fn start_branch_selection(&mut self) {
+        // Resolve the remote host (if any) so branch listing targets the
+        // session's machine. Cloned so we don't hold a borrow on `self`.
+        let host = self
+            .host_for_backend(self.pending_backend.as_deref())
+            .cloned();
+        let host = host.as_ref();
+
         let Some(repo_path) = self.pending_repo_path.clone() else {
             return;
         };
+        let repo_path = repo_path.as_path();
 
-        Self::fetch_pending_repos(&repo_path, self.pending_all_repos.as_ref());
+        Self::fetch_pending_repos(host, repo_path, self.pending_all_repos.as_ref());
 
-        match crate::git::list_branches(&repo_path) {
+        match crate::git::list_branches_on(host, repo_path) {
             Ok(branches) if branches.is_empty() => {
                 self.set_error("No branches found in repository");
                 self.pending_repo_path = None;
             }
             Ok(branches) => {
-                let branches = Self::ordered_branch_list(&repo_path, branches);
+                let branches = Self::ordered_branch_list(host, repo_path, branches);
                 self.modal =
                     super::modals::Modal::BranchSelector(super::modals::BranchSelectorModal {
                         index: 0,
@@ -1451,17 +1495,18 @@ impl App {
     /// Fetch origin for the primary repo and any extra worktree repos so
     /// branch lists are up-to-date. Failures are non-fatal (logged only).
     fn fetch_pending_repos(
+        host: Option<&crate::session::HostDef>,
         repo_path: &std::path::Path,
         all_repos: Option<&Vec<std::path::PathBuf>>,
     ) {
-        if let Err(e) = crate::git::git_fetch(repo_path) {
+        if let Err(e) = crate::git::git_fetch_on(host, repo_path) {
             warn!("git fetch origin failed (continuing): {e:#}");
         }
         let Some(all_repos) = all_repos else {
             return;
         };
         for extra_repo in all_repos.iter().skip(1) {
-            if let Err(e) = crate::git::git_fetch(extra_repo) {
+            if let Err(e) = crate::git::git_fetch_on(host, extra_repo) {
                 warn!(
                     "git fetch origin failed for {} (continuing): {e:#}",
                     extra_repo.display()
@@ -1472,9 +1517,13 @@ impl App {
 
     /// Order a branch list for the selector: the local default branch first,
     /// then `origin/<default>` (remote-based branching) pinned at the very top.
-    fn ordered_branch_list(repo_path: &std::path::Path, mut branches: Vec<String>) -> Vec<String> {
+    fn ordered_branch_list(
+        host: Option<&crate::session::HostDef>,
+        repo_path: &std::path::Path,
+        mut branches: Vec<String>,
+    ) -> Vec<String> {
         // Move the default branch to front so it's pre-selected.
-        if let Some(default) = crate::git::default_branch(repo_path, &branches) {
+        if let Some(default) = crate::git::default_branch_on(host, repo_path, &branches) {
             if let Some(pos) = branches.iter().position(|b| b == &default) {
                 let branch = branches.remove(pos);
                 branches.insert(0, branch);
@@ -1482,11 +1531,11 @@ impl App {
         }
 
         // Insert origin/<default> at position 0 for remote-based branching.
-        let remote_ref = crate::git::default_branch_from_remote(repo_path)
+        let remote_ref = crate::git::default_branch_from_remote_on(host, repo_path)
             .map(|name| format!("origin/{name}"))
             .or_else(|| {
                 for candidate in ["origin/main", "origin/master"] {
-                    if crate::git::branch_exists(repo_path, candidate) {
+                    if crate::git::branch_exists_on(host, repo_path, candidate) {
                         return Some(candidate.to_string());
                     }
                 }
@@ -1684,6 +1733,9 @@ impl App {
     /// Commit the typed path in the repo-picker input: add or re-select the
     /// bookmark, persist it, clear the input, and refresh the filter.
     fn repo_picker_commit_path_input(&mut self) {
+        // For a remote target the path is a remote path: don't expand `~`
+        // against the local home, and don't persist it as a local bookmark.
+        let remote = self.pending_backend.is_some();
         let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
             return;
         };
@@ -1692,7 +1744,11 @@ impl App {
             self.recompute_repo_filter();
             return;
         }
-        let expanded = paths::expand_tilde(&path);
+        let expanded = if remote {
+            std::path::PathBuf::from(&path)
+        } else {
+            paths::expand_tilde(&path)
+        };
         // If the path is already represented, just select it (no duplicate row
         // and no duplicate DB entry). A path already shown as a parent's child
         // must NOT also be persisted as a standalone bookmark.
@@ -1709,7 +1765,7 @@ impl App {
             rp.push_row(expanded.clone(), true, false, false); // auto-select newly added
             true
         };
-        if persist {
+        if persist && !remote {
             if let Err(e) = self.db.upsert_repo_bookmark(&expanded) {
                 error!("Failed to save repo bookmark: {e}");
             }
@@ -1817,10 +1873,14 @@ impl App {
         self.modal.close();
 
         if worktree_repos.is_empty() && normal_repos.is_empty() {
-            // No repos selected — spawn with HOME as cwd
+            // No repos selected — spawn with HOME as cwd. For a remote target,
+            // leave cwd unset so the remote session starts in its own default
+            // directory (local $HOME is meaningless there).
             let mut config = SessionConfig::default();
-            if let Some(home) = std::env::var_os("HOME") {
-                config.cwd = Some(std::path::PathBuf::from(home));
+            if self.pending_backend.is_none() {
+                if let Some(home) = std::env::var_os("HOME") {
+                    config.cwd = Some(std::path::PathBuf::from(home));
+                }
             }
             self.spawn_session_with_config(&config);
         } else if !worktree_repos.is_empty() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -287,6 +287,13 @@ pub struct App {
     /// Registry of declarative agent definitions, used to build providers per
     /// session at spawn/restart time.
     pub(crate) agents: AgentRegistry,
+    /// Configured remote SSH hosts (from `hosts.toml`), used to resolve the
+    /// `HostDef` for a session's `ssh:<host>` backend when running git over SSH.
+    pub(crate) hosts: crate::session::HostRegistry,
+    /// Backend chosen for the in-progress new-session flow (`ssh:<host>`), or
+    /// `None` for the local default. Set by the host picker, cleared when the
+    /// flow completes or is cancelled.
+    pub(crate) pending_backend: Option<String>,
     pub(crate) db: Database,
     pub(crate) focus: InputFocus,
     pub(crate) should_quit: bool,
@@ -463,6 +470,8 @@ impl App {
             active_index: 0,
             backends,
             agents,
+            hosts: crate::session::HostRegistry::default(),
+            pending_backend: None,
             db,
             focus: InputFocus::SessionList,
             should_quit: false,
@@ -554,14 +563,56 @@ impl App {
             })
     }
 
+    /// Entry point for the new-session wizard.
+    ///
+    /// When remote hosts are configured (`hosts.toml`), first shows the host
+    /// picker so the user can choose where the session runs; otherwise goes
+    /// straight to the repo picker (preserving the local-only UX).
+    pub(crate) fn start_new_session(&mut self) {
+        // Clear any choice left over from a previously cancelled flow.
+        self.pending_backend = None;
+
+        if self.hosts.is_empty() {
+            self.open_repo_picker();
+            return;
+        }
+
+        let mut choices = vec![crate::ui::host_picker_modal::HostChoice {
+            label: "local".to_string(),
+            backend: String::new(),
+        }];
+        for host in &self.hosts.hosts {
+            choices.push(crate::ui::host_picker_modal::HostChoice {
+                label: format!("{}  ({})", host.name, host.destination),
+                backend: host.backend_name(),
+            });
+        }
+        self.modal = modals::Modal::HostPicker(crate::ui::host_picker_modal::HostPickerState {
+            choices,
+            selected_index: 0,
+        });
+    }
+
     /// Open the repo picker modal for creating a new session.
     ///
     /// Loads bookmarks from the database, pre-selects repos from the active
-    /// project (if any), and shows the repo picker modal.
+    /// project (if any), and shows the repo picker modal. For a remote target
+    /// (`pending_backend` set) local bookmarks don't apply, so the picker opens
+    /// empty with the path input focused for a typed remote path.
     pub(crate) fn open_repo_picker(&mut self) {
-        let bookmarks = self.load_repo_bookmarks();
+        // Local bookmarks point at local paths, so they're meaningless for a
+        // remote target: open the picker empty with the path input focused.
+        let remote = self.pending_backend.is_some();
+        let bookmarks = if remote {
+            Vec::new()
+        } else {
+            self.load_repo_bookmarks()
+        };
         let mut rp = modals::RepoPickerModal::default();
         Self::rebuild_repo_picker_rows(&mut rp, bookmarks);
+        if remote {
+            rp.focus = modals::RepoPickerFocus::Input;
+        }
         self.modal = modals::Modal::RepoPicker(rp);
     }
 
@@ -656,7 +707,12 @@ impl App {
     }
 
     pub(crate) fn spawn_session_with_config(&mut self, config: &SessionConfig) {
-        self.prepare_spawn(config.clone(), Vec::new());
+        let mut config = config.clone();
+        // Apply the host chosen in the new-session wizard (None = local).
+        if config.backend.is_none() {
+            config.backend = self.pending_backend.take();
+        }
+        self.prepare_spawn(config, Vec::new());
     }
 
     /// Route session creation through the name modal, then agent selection.
@@ -1330,11 +1386,16 @@ impl App {
         base_branch: &str,
         session_name: Option<String>,
     ) {
+        // Resolve the remote host (if any) so worktrees are created on the
+        // session's target machine over SSH. Consume the wizard's choice.
+        let backend = self.pending_backend.take();
+        let host = self.host_for_backend(backend.as_deref()).cloned();
+
         let mut worktree_infos = Vec::new();
         let mut worktree_paths = Vec::new();
 
         for repo_path in repo_paths {
-            match git::create_worktree(repo_path, new_branch, base_branch) {
+            match git::create_worktree_on(host.as_ref(), repo_path, new_branch, base_branch) {
                 Ok(worktree_path) => {
                     worktree_infos.push(WorktreeInfo {
                         repo_path: repo_path.clone(),
@@ -1346,8 +1407,11 @@ impl App {
                 Err(e) => {
                     // Roll back already-created worktrees
                     for info in &worktree_infos {
-                        if let Err(re) = git::remove_worktree(&info.repo_path, &info.worktree_path)
-                        {
+                        if let Err(re) = git::remove_worktree_on(
+                            host.as_ref(),
+                            &info.repo_path,
+                            &info.worktree_path,
+                        ) {
                             error!("Failed to roll back worktree: {re}");
                         }
                     }
@@ -1365,6 +1429,7 @@ impl App {
         self.pending_additional_dirs = additional_dirs;
         let config = SessionConfig {
             cwd: Some(worktree_paths[0].clone()),
+            backend,
             ..SessionConfig::default()
         };
 
@@ -1373,6 +1438,29 @@ impl App {
             self.finish_prepare_spawn(name, config, worktree_infos);
         } else {
             self.prepare_spawn(config, worktree_infos);
+        }
+    }
+
+    /// Install the configured remote-host registry (from `hosts.toml`). Called
+    /// once at startup after the SSH backends are registered.
+    pub fn set_hosts(&mut self, hosts: crate::session::HostRegistry) {
+        self.hosts = hosts;
+    }
+
+    /// Resolve the [`HostDef`] for a backend name, or `None` for the local
+    /// backend. Used to run git operations (worktree create/remove, branch
+    /// listing) on the correct host.
+    ///
+    /// [`HostDef`]: crate::session::HostDef
+    pub(crate) fn host_for_backend(
+        &self,
+        backend: Option<&str>,
+    ) -> Option<&crate::session::HostDef> {
+        let name = backend?;
+        if name.starts_with(crate::session::SSH_BACKEND_PREFIX) {
+            self.hosts.get_by_backend(name)
+        } else {
+            None
         }
     }
 
@@ -4186,6 +4274,64 @@ mod tests {
             app.active_index = 0;
         }
         app
+    }
+
+    #[test]
+    fn start_new_session_skips_host_picker_when_no_hosts() {
+        let mut app = app_with_sessions(0);
+        app.start_new_session();
+        // No hosts configured → straight to the repo picker, no host step.
+        assert!(matches!(app.modal, modals::Modal::RepoPicker(_)));
+        assert!(app.pending_backend.is_none());
+    }
+
+    #[test]
+    fn start_new_session_shows_host_picker_with_hosts() {
+        let mut app = app_with_sessions(0);
+        app.set_hosts(crate::session::HostRegistry {
+            hosts: vec![crate::session::HostDef {
+                name: "devbox".into(),
+                destination: "me@devbox".into(),
+                socket: None,
+                session: None,
+                ssh_opts: vec![],
+                worktrees_dir: None,
+            }],
+        });
+        app.start_new_session();
+        match app.modal {
+            modals::Modal::HostPicker(ref hp) => {
+                // "local" first, then each ssh host.
+                assert_eq!(hp.choices.len(), 2);
+                assert_eq!(hp.choices[0].backend, "");
+                assert_eq!(hp.choices[1].backend, "ssh:devbox");
+            }
+            ref other => panic!("expected host picker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn host_for_backend_resolves_ssh_only() {
+        let mut app = app_with_sessions(0);
+        app.set_hosts(crate::session::HostRegistry {
+            hosts: vec![crate::session::HostDef {
+                name: "devbox".into(),
+                destination: "me@devbox".into(),
+                socket: None,
+                session: None,
+                ssh_opts: vec![],
+                worktrees_dir: None,
+            }],
+        });
+        assert!(app.host_for_backend(None).is_none());
+        assert!(app.host_for_backend(Some("local-tmux")).is_none());
+        assert_eq!(
+            app.host_for_backend(Some("ssh:devbox"))
+                .unwrap()
+                .destination,
+            "me@devbox"
+        );
+        assert!(app.host_for_backend(Some("ssh:unknown")).is_none());
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1376,6 +1376,30 @@ impl App {
         }
     }
 
+    /// Resolve the backend a session should spawn on, ensuring it is ready.
+    ///
+    /// Looks up `config.backend` in the registry (falling back to the default
+    /// local backend), then calls `ensure_ready()` so a remote backend's SSH
+    /// control-mode connection is established lazily on first use. Returns a
+    /// status-line-friendly error if the backend is unknown or unreachable.
+    pub(crate) fn backend_for(
+        &self,
+        config: &SessionConfig,
+    ) -> Result<Arc<dyn SessionBackend>, String> {
+        let backend = match config.backend.as_deref() {
+            Some(name) if !name.is_empty() => self
+                .backends
+                .get(name)
+                .cloned()
+                .ok_or_else(|| format!("Unknown backend '{name}'"))?,
+            _ => self.backends.default_backend().clone(),
+        };
+        backend
+            .ensure_ready()
+            .map_err(|e| format!("Backend '{}' not ready: {e:#}", backend.name()))?;
+        Ok(backend)
+    }
+
     pub(crate) fn do_spawn_session(
         &mut self,
         name: String,
@@ -1416,7 +1440,14 @@ impl App {
             &additional_dirs,
         );
 
-        let backend: Arc<dyn SessionBackend> = Arc::clone(self.backends.default_backend());
+        let backend = match self.backend_for(&config) {
+            Ok(b) => b,
+            Err(e) => {
+                error!("Failed to select backend: {e}");
+                self.set_error(e);
+                return;
+            }
+        };
 
         let provider = self.provider_for(&config);
         match Session::spawn(name, rows, cols, &config, &backend, &provider) {
@@ -4113,6 +4144,38 @@ mod tests {
             app.active_index = 0;
         }
         app
+    }
+
+    #[test]
+    fn backend_for_defaults_to_registry_default() {
+        let app = app_with_sessions(0);
+        let config = SessionConfig::default();
+        let backend = app.backend_for(&config).expect("default backend");
+        assert_eq!(backend.name(), "stub");
+    }
+
+    #[test]
+    fn backend_for_empty_name_uses_default() {
+        let app = app_with_sessions(0);
+        let config = SessionConfig {
+            backend: Some(String::new()),
+            ..SessionConfig::default()
+        };
+        let backend = app.backend_for(&config).expect("default backend");
+        assert_eq!(backend.name(), "stub");
+    }
+
+    #[test]
+    fn backend_for_unknown_backend_errors() {
+        let app = app_with_sessions(0);
+        let config = SessionConfig {
+            backend: Some("ssh:does-not-exist".into()),
+            ..SessionConfig::default()
+        };
+        match app.backend_for(&config) {
+            Ok(b) => panic!("expected error, got backend {}", b.name()),
+            Err(err) => assert!(err.contains("Unknown backend"), "got: {err}"),
+        }
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2058,7 +2058,20 @@ impl App {
             let matching_backend_id = {
                 let discovered = discovered_by_backend
                     .entry(shared_session.backend_type.clone())
-                    .or_insert_with(|| backend.discover().unwrap_or_default());
+                    .or_insert_with(|| {
+                        // A remote backend needs its control-mode connection up
+                        // before adopt(); ready it lazily on first use here.
+                        match backend.ensure_ready() {
+                            Ok(()) => backend.discover().unwrap_or_default(),
+                            Err(e) => {
+                                tracing::warn!(
+                                    backend = backend.name(),
+                                    "Backend not ready for adopted session: {e}"
+                                );
+                                Vec::new()
+                            }
+                        }
+                    });
                 Self::find_matching_discovered(&shared_session, discovered)
                     .map(|disc| disc.backend_id.clone())
             };
@@ -2300,34 +2313,62 @@ impl App {
 
     /// Restore sessions from the database on startup.
     ///
-    /// All sessions live on the local-tmux backend and are restored
-    /// synchronously by querying tmux for existing windows.
+    /// Sessions are restored synchronously by querying each session's backend
+    /// for its existing tmux windows. Sessions persisted with a remote
+    /// (`ssh:<host>`) `backend_type` are matched against that host's tmux, not
+    /// the local one; a remote backend whose host is unreachable degrades to
+    /// "no discovered windows" so its sessions are skipped rather than blocking
+    /// startup.
     pub fn restore_sessions(&mut self, sessions: Vec<sync::SharedSession>, session_counter: usize) {
         self.session_counter = session_counter;
 
-        let mut local_sessions = Vec::new();
-        for shared in sessions {
-            if shared.agent_session_id.is_none() {
-                continue; // Skip sessions without a claude session ID
+        // Only sessions with an agent_session_id are resumable.
+        let resumable: Vec<sync::SharedSession> = sessions
+            .into_iter()
+            .filter(|s| s.agent_session_id.is_some())
+            .collect();
+
+        // Discover existing windows per backend. Each distinct backend_type is
+        // readied + discovered at most once (a remote backend needs its
+        // control-mode connection up before adopt()).
+        let mut discovered_by_backend: HashMap<
+            String,
+            Vec<crate::agent::backend::DiscoveredSession>,
+        > = HashMap::new();
+        for shared in &resumable {
+            if discovered_by_backend.contains_key(&shared.backend_type) {
+                continue;
             }
-            local_sessions.push(shared);
+            let backend = self
+                .backends
+                .get(&shared.backend_type)
+                .cloned()
+                .unwrap_or_else(|| self.backends.default_backend().clone());
+
+            let disc = match backend.ensure_ready() {
+                Ok(()) => backend.discover().unwrap_or_else(|e| {
+                    warn!(
+                        backend = backend.name(),
+                        "Failed to discover sessions from backend: {e}"
+                    );
+                    Vec::new()
+                }),
+                Err(e) => {
+                    warn!(
+                        backend = backend.name(),
+                        "Backend not ready during restore; skipping its sessions: {e}"
+                    );
+                    Vec::new()
+                }
+            };
+            discovered_by_backend.insert(shared.backend_type.clone(), disc);
         }
 
-        // --- Local-tmux sessions: restore synchronously (fast) ---
-        // Discover existing sessions from the default (local-tmux) backend only.
-        let mut discovered = Vec::new();
-        let default_backend = self.backends.default_backend().clone();
-        match default_backend.discover() {
-            Ok(disc) => discovered.extend(disc),
-            Err(e) => {
-                warn!(
-                    backend = default_backend.name(),
-                    "Failed to discover sessions from backend: {e}"
-                );
-            }
-        }
-
-        for shared in local_sessions {
+        for shared in resumable {
+            let discovered = discovered_by_backend
+                .get(&shared.backend_type)
+                .cloned()
+                .unwrap_or_default();
             self.restore_single_session(shared, &discovered);
         }
 
@@ -2335,7 +2376,8 @@ impl App {
         self.save_state();
     }
 
-    /// Restore a single local-tmux session synchronously (used during startup).
+    /// Restore a single session synchronously (used during startup). The
+    /// backend is selected from the session's persisted `backend_type`.
     fn restore_single_session(
         &mut self,
         shared: sync::SharedSession,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1464,6 +1464,29 @@ impl App {
         }
     }
 
+    /// Resolve the backend for a *persisted* session by its `backend_type`, or
+    /// `None` when this instance cannot manage it.
+    ///
+    /// An unknown `ssh:<host>` backend (e.g. a host this instance hasn't loaded
+    /// from `hosts.toml`, or another instance configured) is **skipped** rather
+    /// than falling back to local — adopting a remote session on the local
+    /// backend would corrupt its `backend_type` and risk a pane-id collision
+    /// (tmux numbers panes `%N` per server, so a remote `%1` can match an
+    /// unrelated local `%1`). Legacy/local values (empty, `tmux`, `local-tmux`)
+    /// still fall back to the default local backend.
+    pub(crate) fn resolve_persisted_backend(
+        &self,
+        backend_type: &str,
+    ) -> Option<Arc<dyn SessionBackend>> {
+        if let Some(b) = self.backends.get(backend_type) {
+            return Some(b.clone());
+        }
+        if backend_type.starts_with(crate::session::SSH_BACKEND_PREFIX) {
+            return None;
+        }
+        Some(self.backends.default_backend().clone())
+    }
+
     /// Resolve the backend a session should spawn on, ensuring it is ready.
     ///
     /// Looks up `config.backend` in the registry (falling back to the default
@@ -2137,11 +2160,12 @@ impl App {
                 continue;
             }
 
-            let backend = self
-                .backends
-                .get(&shared_session.backend_type)
-                .cloned()
-                .unwrap_or_else(|| self.backends.default_backend().clone());
+            // Skip sessions whose backend this instance can't manage (e.g. a
+            // remote host not in our hosts.toml) — adopting them locally would
+            // corrupt backend_type and risk a pane-id collision.
+            let Some(backend) = self.resolve_persisted_backend(&shared_session.backend_type) else {
+                continue;
+            };
 
             let matching_backend_id = {
                 let discovered = discovered_by_backend
@@ -2427,11 +2451,13 @@ impl App {
             if discovered_by_backend.contains_key(&shared.backend_type) {
                 continue;
             }
-            let backend = self
-                .backends
-                .get(&shared.backend_type)
-                .cloned()
-                .unwrap_or_else(|| self.backends.default_backend().clone());
+            // Skip discovery for backends this instance can't manage (unknown
+            // remote hosts); their sessions are left un-adopted rather than
+            // misadopted on local.
+            let Some(backend) = self.resolve_persisted_backend(&shared.backend_type) else {
+                discovered_by_backend.insert(shared.backend_type.clone(), Vec::new());
+                continue;
+            };
 
             let disc = match backend.ensure_ready() {
                 Ok(()) => backend.discover().unwrap_or_else(|e| {
@@ -2489,11 +2515,11 @@ impl App {
         let matching_discovered = Self::find_matching_discovered(&shared, discovered);
 
         // Select the correct backend based on the persisted backend_type.
-        let backend = self
-            .backends
-            .get(&shared.backend_type)
-            .cloned()
-            .unwrap_or_else(|| self.backends.default_backend().clone());
+        // Skip sessions on a backend this instance can't manage (unknown remote
+        // host) rather than misadopting them on local.
+        let Some(backend) = self.resolve_persisted_backend(&shared.backend_type) else {
+            return;
+        };
 
         // Try to adopt the existing backend session.
         let provider = self.provider_for(&SessionConfig {
@@ -4332,6 +4358,28 @@ mod tests {
             "me@devbox"
         );
         assert!(app.host_for_backend(Some("ssh:unknown")).is_none());
+    }
+
+    #[test]
+    fn resolve_persisted_backend_skips_unknown_ssh_but_falls_back_for_local() {
+        let app = app_with_sessions(0);
+        // Known backend → resolved.
+        assert_eq!(
+            app.resolve_persisted_backend("stub")
+                .map(|b| b.name().to_string()),
+            Some("stub".to_string())
+        );
+        // Legacy/local values fall back to the default backend.
+        for legacy in ["", "tmux", "local-tmux"] {
+            assert_eq!(
+                app.resolve_persisted_backend(legacy)
+                    .map(|b| b.name().to_string()),
+                Some("stub".to_string()),
+                "legacy '{legacy}' should fall back to default"
+            );
+        }
+        // Unknown remote backend → skipped (None), never misadopted on local.
+        assert!(app.resolve_persisted_backend("ssh:nope").is_none());
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1456,12 +1456,8 @@ impl App {
         &self,
         backend: Option<&str>,
     ) -> Option<&crate::session::HostDef> {
-        let name = backend?;
-        if name.starts_with(crate::session::SSH_BACKEND_PREFIX) {
-            self.hosts.get_by_backend(name)
-        } else {
-            None
-        }
+        // `get_by_backend` already returns `None` for non-`ssh:` names.
+        self.hosts.get_by_backend(backend?)
     }
 
     /// Resolve the backend for a *persisted* session by its `backend_type`, or
@@ -1481,7 +1477,7 @@ impl App {
         if let Some(b) = self.backends.get(backend_type) {
             return Some(b.clone());
         }
-        if backend_type.starts_with(crate::session::SSH_BACKEND_PREFIX) {
+        if crate::session::is_ssh_backend(backend_type) {
             return None;
         }
         Some(self.backends.default_backend().clone())

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -1113,6 +1113,7 @@ pub enum Modal {
     BranchSelector(BranchSelectorModal),
     WorktreeName(WorktreeNameModal),
     AgentPicker(crate::ui::agent_picker_modal::AgentPickerState),
+    HostPicker(crate::ui::host_picker_modal::HostPickerState),
     RestoreSessions(RestoreSessionsModal),
     AutomationEditor(AutomationEditorModal),
     AutomationsList(AutomationsListModal),

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -449,6 +449,11 @@ impl App {
             agent_picker_modal::render_agent_picker_modal(frame, ap);
         }
 
+        // Host picker modal
+        if let super::modals::Modal::HostPicker(ref hp) = self.modal {
+            crate::ui::host_picker_modal::render_host_picker_modal(frame, hp);
+        }
+
         // Theme picker modal
         if let super::modals::Modal::ThemePicker(ref tp) = self.modal {
             theme_picker_modal::render_theme_picker_modal(

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -321,6 +321,7 @@ fn fire_headless(db: &Database, auto: &Automation) -> (AutomationRunStatus, Stri
                 base_branch: base_branch.clone(),
                 agent: agent.clone(),
                 agent_session_id: None,
+                host: None,
             };
             match crate::session_ops::spawn_session_headless(db, req) {
                 Ok(_) => {

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -36,6 +36,10 @@ pub enum Action {
         /// Base branch for the worktree (default: main).
         #[arg(long)]
         base_branch: Option<String>,
+        /// Remote host to run the session on (name from `hosts.toml`). The
+        /// worktree and tmux window are created on that host over SSH.
+        #[arg(long)]
+        host: Option<String>,
     },
     /// Soft-delete a session.
     ///
@@ -99,6 +103,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             agent,
             worktree_branch,
             base_branch,
+            host,
         } => {
             let req = crate::session_ops::SpawnRequest {
                 name,
@@ -107,6 +112,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 base_branch,
                 agent,
                 agent_session_id: None,
+                host,
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
             Ok(json!({

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -191,6 +191,7 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
                 base_branch: base_branch.clone(),
                 agent: agent.clone(),
                 agent_session_id: None,
+                host: None,
             };
             crate::session_ops::spawn_session_headless(db, req)?;
             crate::agent::tmux::send_prompt_after_delay(&name, &prompt, BOOT_DELAY_SECS)

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -478,9 +478,12 @@ fn git_stash(worktree_path: &Path) -> Result<bool> {
 
 /// Fetch from origin.
 pub fn git_fetch(worktree_path: &Path) -> Result<()> {
-    let output = Command::new("git")
-        .args(["fetch", "origin"])
-        .current_dir(worktree_path)
+    git_fetch_on(None, worktree_path)
+}
+
+/// [`git_fetch`], optionally on a remote `host`.
+pub fn git_fetch_on(host: Option<&HostDef>, worktree_path: &Path) -> Result<()> {
+    let output = git_command(host, worktree_path, &["fetch", "origin"])
         .output()
         .context("failed to run git fetch")?;
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -3,13 +3,114 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use tracing::warn;
 
 use crate::paths;
+use crate::session::HostDef;
+
+/// POSIX single-quote escaping for a token sent to a remote shell over SSH.
+/// Simple tokens (paths, branch names, flags) pass through unquoted.
+fn sh_quote(s: &str) -> String {
+    if !s.is_empty()
+        && s.bytes().all(|b| {
+            b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'/' | b':' | b'=' | b',')
+        })
+    {
+        return s.to_string();
+    }
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Build a `git` [`Command`] targeting `cwd`, run either locally or over SSH.
+///
+/// For the remote variant the command becomes
+/// `ssh <opts> <dest> git -C <cwd> <args…>`, with each remote token
+/// shell-escaped so it survives the remote login shell's re-splitting.
+fn git_command(host: Option<&HostDef>, cwd: &Path, args: &[&str]) -> Command {
+    match host {
+        None => {
+            let mut cmd = Command::new("git");
+            cmd.current_dir(cwd);
+            cmd.args(args);
+            cmd
+        }
+        Some(h) => {
+            let mut cmd = Command::new("ssh");
+            cmd.args(&h.ssh_opts);
+            cmd.arg(&h.destination);
+            cmd.arg(sh_quote("git"));
+            cmd.arg(sh_quote("-C"));
+            cmd.arg(sh_quote(&cwd.to_string_lossy()));
+            for a in args {
+                cmd.arg(sh_quote(a));
+            }
+            cmd
+        }
+    }
+}
+
+/// Cache of resolved remote `$HOME` directories, keyed by ssh destination, so
+/// we only pay one round-trip per host.
+fn remote_home_cache() -> &'static Mutex<HashMap<String, String>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Resolve the remote `$HOME` for a host, caching the result.
+fn remote_home(host: &HostDef) -> Result<String> {
+    if let Ok(guard) = remote_home_cache().lock() {
+        if let Some(home) = guard.get(&host.destination) {
+            return Ok(home.clone());
+        }
+    }
+    let mut cmd = Command::new("ssh");
+    cmd.args(&host.ssh_opts);
+    cmd.arg(&host.destination);
+    // The remote shell expands $HOME; we pass it literally.
+    cmd.arg("echo").arg("$HOME");
+    let output = cmd
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to resolve remote $HOME over ssh")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("ssh echo $HOME failed: {}", stderr.trim());
+    }
+    let home = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if home.is_empty() {
+        anyhow::bail!("remote $HOME resolved empty for {}", host.destination);
+    }
+    if let Ok(mut guard) = remote_home_cache().lock() {
+        guard.insert(host.destination.clone(), home.clone());
+    }
+    Ok(home)
+}
+
+/// Deterministic worktree directory path for a repo + branch on the given host.
+///
+/// Local hosts use [`worktree_path`]. Remote hosts place worktrees under the
+/// host's `worktrees_dir` (or `$HOME/.local/share/thurbox/worktrees` resolved
+/// over ssh), preserving the same `<repo-hash>/<sanitized-branch>` layout.
+fn worktree_path_for(host: Option<&HostDef>, repo_path: &Path, branch: &str) -> Result<PathBuf> {
+    match host {
+        None => worktree_path(repo_path, branch).context("failed to resolve worktrees directory"),
+        Some(h) => {
+            let base = match &h.worktrees_dir {
+                Some(dir) => dir.clone(),
+                None => format!("{}/.local/share/thurbox/worktrees", remote_home(h)?),
+            };
+            let mut hasher = DefaultHasher::new();
+            repo_path.display().to_string().hash(&mut hasher);
+            let repo_hash = format!("{:016x}", hasher.finish());
+            let sanitized = branch.replace('/', "-");
+            Ok(PathBuf::from(base).join(repo_hash).join(sanitized))
+        }
+    }
+}
 
 /// Global cache for repo display names (path → name).
 static REPO_NAME_CACHE: std::sync::OnceLock<Mutex<HashMap<PathBuf, String>>> =
@@ -112,9 +213,12 @@ fn parse_repo_name_from_url(url: &str) -> Option<String> {
 
 /// List local branch names for a repo.
 pub fn list_branches(repo_path: &Path) -> Result<Vec<String>> {
-    let output = Command::new("git")
-        .args(["branch", "--format=%(refname:short)"])
-        .current_dir(repo_path)
+    list_branches_on(None, repo_path)
+}
+
+/// [`list_branches`], optionally on a remote `host`.
+pub fn list_branches_on(host: Option<&HostDef>, repo_path: &Path) -> Result<Vec<String>> {
+    let output = git_command(host, repo_path, &["branch", "--format=%(refname:short)"])
         .output()
         .context("failed to run git branch")?;
 
@@ -137,21 +241,34 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<String>> {
 /// Creates `new_branch` starting from `base_branch`.
 /// Path format: `~/.local/share/thurbox/worktrees/<repo-hash>/<sanitized-branch>`
 pub fn create_worktree(repo_path: &Path, new_branch: &str, base_branch: &str) -> Result<PathBuf> {
-    let wt_path =
-        worktree_path(repo_path, new_branch).context("failed to resolve worktrees directory")?;
+    create_worktree_on(None, repo_path, new_branch, base_branch)
+}
 
-    let output = Command::new("git")
-        .args([
+/// [`create_worktree`], optionally on a remote `host` (via `ssh <dest> git …`).
+/// On a remote host the worktree is created under the host's remote worktrees
+/// directory and the returned path is a remote path.
+pub fn create_worktree_on(
+    host: Option<&HostDef>,
+    repo_path: &Path,
+    new_branch: &str,
+    base_branch: &str,
+) -> Result<PathBuf> {
+    let wt_path = worktree_path_for(host, repo_path, new_branch)?;
+
+    let output = git_command(
+        host,
+        repo_path,
+        &[
             "worktree",
             "add",
             "-b",
             new_branch,
             &wt_path.display().to_string(),
             base_branch,
-        ])
-        .current_dir(repo_path)
-        .output()
-        .context("failed to run git worktree add")?;
+        ],
+    )
+    .output()
+    .context("failed to run git worktree add")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -189,16 +306,27 @@ pub fn create_or_attach_worktree(
 
 /// Remove a git worktree (force removal).
 pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
-    let output = Command::new("git")
-        .args([
+    remove_worktree_on(None, repo_path, worktree_path)
+}
+
+/// [`remove_worktree`], optionally on a remote `host`.
+pub fn remove_worktree_on(
+    host: Option<&HostDef>,
+    repo_path: &Path,
+    worktree_path: &Path,
+) -> Result<()> {
+    let output = git_command(
+        host,
+        repo_path,
+        &[
             "worktree",
             "remove",
             "--force",
             &worktree_path.display().to_string(),
-        ])
-        .current_dir(repo_path)
-        .output()
-        .context("failed to run git worktree remove")?;
+        ],
+    )
+    .output()
+    .context("failed to run git worktree remove")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -213,7 +341,16 @@ pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
 /// Tries `git symbolic-ref refs/remotes/origin/HEAD` first (most reliable),
 /// then falls back to checking for `main` or `master` among local branches.
 pub fn default_branch(repo_path: &Path, local_branches: &[String]) -> Option<String> {
-    if let Some(name) = default_branch_from_remote(repo_path) {
+    default_branch_on(None, repo_path, local_branches)
+}
+
+/// [`default_branch`], optionally on a remote `host`.
+pub fn default_branch_on(
+    host: Option<&HostDef>,
+    repo_path: &Path,
+    local_branches: &[String],
+) -> Option<String> {
+    if let Some(name) = default_branch_from_remote_on(host, repo_path) {
         if local_branches.iter().any(|b| b == &name) {
             return Some(name);
         }
@@ -231,12 +368,19 @@ pub fn default_branch(repo_path: &Path, local_branches: &[String]) -> Option<Str
 
 /// Query the remote's default branch via `git symbolic-ref`.
 pub fn default_branch_from_remote(repo_path: &Path) -> Option<String> {
-    let output = Command::new("git")
-        .args(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
-        .current_dir(repo_path)
-        .stderr(Stdio::null())
-        .output()
-        .ok()?;
+    default_branch_from_remote_on(None, repo_path)
+}
+
+/// [`default_branch_from_remote`], optionally on a remote `host`.
+pub fn default_branch_from_remote_on(host: Option<&HostDef>, repo_path: &Path) -> Option<String> {
+    let output = git_command(
+        host,
+        repo_path,
+        &["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+    )
+    .stderr(Stdio::null())
+    .output()
+    .ok()?;
 
     if !output.status.success() {
         return None;
@@ -274,9 +418,12 @@ pub fn add_existing_worktree(repo_path: &Path, branch: &str) -> Result<PathBuf> 
 
 /// Check whether a local branch exists in the repository.
 pub fn branch_exists(repo_path: &Path, branch: &str) -> bool {
-    Command::new("git")
-        .args(["rev-parse", "--verify", branch])
-        .current_dir(repo_path)
+    branch_exists_on(None, repo_path, branch)
+}
+
+/// [`branch_exists`], optionally on a remote `host`.
+pub fn branch_exists_on(host: Option<&HostDef>, repo_path: &Path, branch: &str) -> bool {
+    git_command(host, repo_path, &["rev-parse", "--verify", branch])
         .stderr(Stdio::null())
         .stdout(Stdio::null())
         .status()
@@ -957,6 +1104,99 @@ mod tests {
 
         try_remove_by_age(&lock);
         assert!(lock.exists(), "fresh lock should be preserved");
+    }
+
+    // ── remote / ssh helpers ────────────────────────────────────────
+
+    fn host(dest: &str, wt_dir: Option<&str>) -> HostDef {
+        HostDef {
+            name: "h".into(),
+            destination: dest.into(),
+            socket: None,
+            session: None,
+            ssh_opts: vec!["-o".into(), "ControlMaster=auto".into()],
+            worktrees_dir: wt_dir.map(|s| s.to_string()),
+        }
+    }
+
+    fn program_and_args(cmd: &Command) -> (String, Vec<String>) {
+        (
+            cmd.get_program().to_string_lossy().into_owned(),
+            cmd.get_args()
+                .map(|a| a.to_string_lossy().into_owned())
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn sh_quote_passes_simple_tokens() {
+        assert_eq!(sh_quote("feat-x"), "feat-x");
+        assert_eq!(sh_quote("/home/me/repo"), "/home/me/repo");
+    }
+
+    #[test]
+    fn sh_quote_wraps_specials() {
+        assert_eq!(sh_quote("a b"), "'a b'");
+        assert_eq!(sh_quote("it's"), "'it'\\''s'");
+        assert_eq!(sh_quote(""), "''");
+    }
+
+    #[test]
+    fn git_command_local_uses_git_with_args() {
+        let cmd = git_command(None, Path::new("/repo"), &["branch", "--list"]);
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "git");
+        assert_eq!(args, ["branch", "--list"]);
+        assert_eq!(cmd.get_current_dir(), Some(Path::new("/repo")));
+    }
+
+    #[test]
+    fn git_command_remote_wraps_in_ssh() {
+        let h = host("me@box", None);
+        let cmd = git_command(
+            Some(&h),
+            Path::new("/srv/repo"),
+            &["worktree", "add", "-b", "x"],
+        );
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "ssh");
+        assert_eq!(
+            args,
+            [
+                "-o",
+                "ControlMaster=auto",
+                "me@box",
+                "git",
+                "-C",
+                "/srv/repo",
+                "worktree",
+                "add",
+                "-b",
+                "x",
+            ]
+        );
+        // No local current_dir is set for the remote variant.
+        assert_eq!(cmd.get_current_dir(), None);
+    }
+
+    #[test]
+    fn worktree_path_for_remote_uses_configured_dir() {
+        let h = host("me@box", Some("/data/wt"));
+        let path = worktree_path_for(Some(&h), Path::new("/srv/repo"), "feature/foo").unwrap();
+        // base / <repo-hash> / <sanitized-branch>
+        let s = path.display().to_string();
+        assert!(s.starts_with("/data/wt/"), "got {s}");
+        assert!(s.ends_with("/feature-foo"), "got {s}");
+    }
+
+    #[test]
+    fn worktree_path_for_local_matches_worktree_path() {
+        let base = PathBuf::from("/test/data");
+        let _guard = TestPathGuard::new(&base);
+        let repo = Path::new("/home/user/repo");
+        let via_for = worktree_path_for(None, repo, "main").unwrap();
+        let direct = worktree_path(repo, "main").unwrap();
+        assert_eq!(via_for, direct);
     }
 
     // ── parse_repo_name_from_url ────────────────────────────────────

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -11,19 +11,7 @@ use tracing::warn;
 
 use crate::paths;
 use crate::session::HostDef;
-
-/// POSIX single-quote escaping for a token sent to a remote shell over SSH.
-/// Simple tokens (paths, branch names, flags) pass through unquoted.
-fn sh_quote(s: &str) -> String {
-    if !s.is_empty()
-        && s.bytes().all(|b| {
-            b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'/' | b':' | b'=' | b',')
-        })
-    {
-        return s.to_string();
-    }
-    format!("'{}'", s.replace('\'', "'\\''"))
-}
+use crate::shell::{posix_quote, ssh_command};
 
 /// Build a `git` [`Command`] targeting `cwd`, run either locally or over SSH.
 ///
@@ -39,14 +27,12 @@ fn git_command(host: Option<&HostDef>, cwd: &Path, args: &[&str]) -> Command {
             cmd
         }
         Some(h) => {
-            let mut cmd = Command::new("ssh");
-            cmd.args(&h.ssh_opts);
-            cmd.arg(&h.destination);
-            cmd.arg(sh_quote("git"));
-            cmd.arg(sh_quote("-C"));
-            cmd.arg(sh_quote(&cwd.to_string_lossy()));
+            let mut cmd = ssh_command(&h.destination, &h.ssh_opts);
+            cmd.arg(posix_quote("git"));
+            cmd.arg(posix_quote("-C"));
+            cmd.arg(posix_quote(&cwd.to_string_lossy()));
             for a in args {
-                cmd.arg(sh_quote(a));
+                cmd.arg(posix_quote(a));
             }
             cmd
         }
@@ -67,9 +53,7 @@ fn remote_home(host: &HostDef) -> Result<String> {
             return Ok(home.clone());
         }
     }
-    let mut cmd = Command::new("ssh");
-    cmd.args(&host.ssh_opts);
-    cmd.arg(&host.destination);
+    let mut cmd = ssh_command(&host.destination, &host.ssh_opts);
     // The remote shell expands $HOME; we pass it literally.
     cmd.arg("echo").arg("$HOME");
     let output = cmd
@@ -103,11 +87,7 @@ fn worktree_path_for(host: Option<&HostDef>, repo_path: &Path, branch: &str) -> 
                 Some(dir) => dir.clone(),
                 None => format!("{}/.local/share/thurbox/worktrees", remote_home(h)?),
             };
-            let mut hasher = DefaultHasher::new();
-            repo_path.display().to_string().hash(&mut hasher);
-            let repo_hash = format!("{:016x}", hasher.finish());
-            let sanitized = branch.replace('/', "-");
-            Ok(PathBuf::from(base).join(repo_hash).join(sanitized))
+            Ok(worktree_subpath(PathBuf::from(base), repo_path, branch))
         }
     }
 }
@@ -439,12 +419,22 @@ pub fn branch_exists_on(host: Option<&HostDef>, repo_path: &Path, branch: &str) 
 ///
 /// Path format: `~/.local/share/thurbox/worktrees/<repo-hash>/<sanitized-branch>`
 fn worktree_path(repo_path: &Path, branch: &str) -> Option<PathBuf> {
-    let base = paths::worktrees_directory()?;
+    Some(worktree_subpath(
+        paths::worktrees_directory()?,
+        repo_path,
+        branch,
+    ))
+}
+
+/// The deterministic `<base>/<repo-hash>/<sanitized-branch>` worktree layout,
+/// shared by local ([`worktree_path`]) and remote ([`worktree_path_for`])
+/// resolution so both produce identical sub-paths under their own base.
+fn worktree_subpath(base: PathBuf, repo_path: &Path, branch: &str) -> PathBuf {
     let mut hasher = DefaultHasher::new();
     repo_path.display().to_string().hash(&mut hasher);
     let repo_hash = format!("{:016x}", hasher.finish());
     let sanitized = branch.replace('/', "-");
-    Some(base.join(repo_hash).join(sanitized))
+    base.join(repo_hash).join(sanitized)
 }
 
 /// Result of attempting to sync a worktree with origin/main.
@@ -1129,19 +1119,6 @@ mod tests {
                 .map(|a| a.to_string_lossy().into_owned())
                 .collect(),
         )
-    }
-
-    #[test]
-    fn sh_quote_passes_simple_tokens() {
-        assert_eq!(sh_quote("feat-x"), "feat-x");
-        assert_eq!(sh_quote("/home/me/repo"), "/home/me/repo");
-    }
-
-    #[test]
-    fn sh_quote_wraps_specials() {
-        assert_eq!(sh_quote("a b"), "'a b'");
-        assert_eq!(sh_quote("it's"), "'it'\\''s'");
-        assert_eq!(sh_quote(""), "''");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod git;
 pub mod paths;
 pub mod session;
 pub mod session_ops;
+pub mod shell;
 pub mod storage;
 pub mod sync;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,9 +62,10 @@ async fn main() -> Result<()> {
     // (~/.config/thurbox/hosts.toml). These are registered lazily: a down or
     // slow host must not block TUI startup, so check_available()/ensure_ready()
     // are deferred to first spawn/restore (see App::backend_for).
-    for host in thurbox::agent::host_config::load_or_seed().hosts {
+    let hosts = thurbox::agent::host_config::load_or_seed();
+    for host in &hosts.hosts {
         tracing::debug!(host = %host.name, dest = %host.destination, "Registering SSH backend");
-        backends.register(Arc::new(TmuxBackend::from_host(&host)));
+        backends.register(Arc::new(TmuxBackend::from_host(host)));
     }
 
     // Load (or seed) the coding-agent registry from ~/.config/thurbox/agents.toml.
@@ -94,6 +95,7 @@ async fn main() -> Result<()> {
     let size = terminal.size()?;
 
     let mut app = App::new(size.height, size.width, backends, agents, db);
+    app.set_hosts(hosts);
 
     // Load session state from DB and restore
     if let Some((sessions, counter)) = app.load_persisted_state_from_db() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use crossterm::event::{
 };
 use crossterm::execute;
 
-use thurbox::agent::tmux::LocalTmuxBackend;
+use thurbox::agent::tmux::{LocalTmuxBackend, TmuxBackend};
 use thurbox::agent::{BackendRegistry, SessionBackend};
 use thurbox::app::{App, AppMessage};
 use thurbox::storage::Database;
@@ -56,7 +56,16 @@ async fn main() -> Result<()> {
     let local_tmux: Arc<dyn SessionBackend> = Arc::new(LocalTmuxBackend::new());
     local_tmux.check_available()?;
     local_tmux.ensure_ready()?;
-    let backends = BackendRegistry::new(local_tmux);
+    let mut backends = BackendRegistry::new(local_tmux);
+
+    // Register one SSH backend per configured remote host
+    // (~/.config/thurbox/hosts.toml). These are registered lazily: a down or
+    // slow host must not block TUI startup, so check_available()/ensure_ready()
+    // are deferred to first spawn/restore (see App::backend_for).
+    for host in thurbox::agent::host_config::load_or_seed().hosts {
+        tracing::debug!(host = %host.name, dest = %host.destination, "Registering SSH backend");
+        backends.register(Arc::new(TmuxBackend::from_host(&host)));
+    }
 
     // Load (or seed) the coding-agent registry from ~/.config/thurbox/agents.toml.
     let agents = thurbox::agent::agent_config::load_or_seed();

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -13,6 +13,11 @@ use serde::{Deserialize, Serialize};
 /// (and persisted in `backend_type`) as `ssh:devbox`.
 pub const SSH_BACKEND_PREFIX: &str = "ssh:";
 
+/// Whether a backend name refers to a remote SSH host (`ssh:<name>`).
+pub fn is_ssh_backend(backend_name: &str) -> bool {
+    backend_name.starts_with(SSH_BACKEND_PREFIX)
+}
+
 /// A single remote host reachable over SSH.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HostDef {

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -1,0 +1,140 @@
+//! Remote-host definitions — pure data describing SSH targets thurbox can run
+//! sessions on.
+//!
+//! Loaded from `~/.config/thurbox/hosts.toml` by
+//! [`crate::agent::host_config`]. Kept here in `session` (the dependency sink)
+//! so both `agent` (which builds the SSH tmux backend) and `git` (which runs
+//! `git` over SSH for remote worktrees) can depend on the same type without
+//! crossing the module-isolation rules.
+
+use serde::{Deserialize, Serialize};
+
+/// The backend-name prefix for SSH hosts. A host named `devbox` is registered
+/// (and persisted in `backend_type`) as `ssh:devbox`.
+pub const SSH_BACKEND_PREFIX: &str = "ssh:";
+
+/// A single remote host reachable over SSH.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostDef {
+    /// Short, unique name. The backend is registered as `ssh:<name>`.
+    pub name: String,
+    /// SSH destination (e.g. `me@devbox`), resolved via the user's
+    /// `~/.ssh/config`.
+    pub destination: String,
+    /// Optional override for the remote `tmux -L` socket name. Defaults to the
+    /// same socket thurbox uses locally.
+    #[serde(default)]
+    pub socket: Option<String>,
+    /// Optional override for the remote tmux session name.
+    #[serde(default)]
+    pub session: Option<String>,
+    /// Extra `ssh` flags inserted before the destination (e.g.
+    /// `["-o", "ControlMaster=auto"]`).
+    #[serde(default)]
+    pub ssh_opts: Vec<String>,
+    /// Optional absolute remote directory under which git worktrees are
+    /// created. When unset, the remote `$HOME/.local/share/thurbox/worktrees`
+    /// is resolved at spawn time.
+    #[serde(default)]
+    pub worktrees_dir: Option<String>,
+}
+
+impl HostDef {
+    /// The backend name this host registers under: `ssh:<name>`.
+    pub fn backend_name(&self) -> String {
+        format!("{SSH_BACKEND_PREFIX}{}", self.name)
+    }
+}
+
+/// All configured remote hosts, in declaration order.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostRegistry {
+    #[serde(default)]
+    pub hosts: Vec<HostDef>,
+}
+
+impl HostRegistry {
+    /// Look up a host by its bare name (not the `ssh:` backend name).
+    pub fn get(&self, name: &str) -> Option<&HostDef> {
+        self.hosts.iter().find(|h| h.name == name)
+    }
+
+    /// Look up a host by its `ssh:<name>` backend name.
+    pub fn get_by_backend(&self, backend_name: &str) -> Option<&HostDef> {
+        let bare = backend_name.strip_prefix(SSH_BACKEND_PREFIX)?;
+        self.get(bare)
+    }
+
+    /// All host names in declaration order.
+    pub fn names(&self) -> Vec<&str> {
+        self.hosts.iter().map(|h| h.name.as_str()).collect()
+    }
+
+    /// Whether any remote hosts are configured.
+    pub fn is_empty(&self) -> bool {
+        self.hosts.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_name_prefixes_with_ssh() {
+        let h = HostDef {
+            name: "devbox".into(),
+            destination: "me@devbox".into(),
+            socket: None,
+            session: None,
+            ssh_opts: vec![],
+            worktrees_dir: None,
+        };
+        assert_eq!(h.backend_name(), "ssh:devbox");
+    }
+
+    #[test]
+    fn registry_lookup_by_name_and_backend() {
+        let reg = HostRegistry {
+            hosts: vec![HostDef {
+                name: "devbox".into(),
+                destination: "me@devbox".into(),
+                socket: None,
+                session: None,
+                ssh_opts: vec![],
+                worktrees_dir: None,
+            }],
+        };
+        assert_eq!(reg.get("devbox").unwrap().destination, "me@devbox");
+        assert_eq!(reg.get_by_backend("ssh:devbox").unwrap().name, "devbox");
+        assert!(reg.get_by_backend("devbox").is_none());
+        assert!(reg.get_by_backend("local-tmux").is_none());
+    }
+
+    #[test]
+    fn parses_minimal_and_full_toml() {
+        let toml = r#"
+[[hosts]]
+name = "minimal"
+destination = "host1"
+
+[[hosts]]
+name = "full"
+destination = "me@host2"
+socket = "tb2"
+session = "tb2"
+ssh_opts = ["-o", "ControlMaster=auto"]
+worktrees_dir = "/home/me/wt"
+"#;
+        let reg: HostRegistry = toml::from_str(toml).unwrap();
+        assert_eq!(reg.hosts.len(), 2);
+        let minimal = reg.get("minimal").unwrap();
+        assert_eq!(minimal.destination, "host1");
+        assert!(minimal.socket.is_none());
+        assert!(minimal.ssh_opts.is_empty());
+        let full = reg.get("full").unwrap();
+        assert_eq!(full.socket.as_deref(), Some("tb2"));
+        assert_eq!(full.ssh_opts, ["-o", "ControlMaster=auto"]);
+        assert_eq!(full.worktrees_dir.as_deref(), Some("/home/me/wt"));
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_def;
 pub mod automation;
+pub mod host_def;
 pub mod keybindings;
 pub mod task;
 pub mod theme_config;
@@ -9,6 +10,7 @@ pub use automation::{
     parse_hhmm, preset_to_cron, Automation, AutomationAction, AutomationRun, AutomationRunStatus,
     AutomationSchedule, SchedulePreset,
 };
+pub use host_def::{HostDef, HostRegistry, SSH_BACKEND_PREFIX};
 pub use keybindings::{Action, KeyBindings, KeyChord, KeyContext};
 pub use task::{Task, TaskStatus, SOURCE_LOCAL};
 pub use theme_config::{ThemePalette, ThemePreset};

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -228,6 +228,9 @@ pub struct SessionConfig {
     pub cwd: Option<PathBuf>,
     /// Name of the agent definition to launch (looked up in the registry).
     pub agent: String,
+    /// Backend to spawn on (registry name, e.g. `ssh:devbox`). `None`/empty
+    /// selects the registry default (`local-tmux`).
+    pub backend: Option<String>,
     /// Fork from an existing session's conversation (agents that support it).
     pub fork_session_id: Option<String>,
     /// Environment variables injected into the spawned session process

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -10,7 +10,7 @@ pub use automation::{
     parse_hhmm, preset_to_cron, Automation, AutomationAction, AutomationRun, AutomationRunStatus,
     AutomationSchedule, SchedulePreset,
 };
-pub use host_def::{HostDef, HostRegistry, SSH_BACKEND_PREFIX};
+pub use host_def::{is_ssh_backend, HostDef, HostRegistry, SSH_BACKEND_PREFIX};
 pub use keybindings::{Action, KeyBindings, KeyChord, KeyContext};
 pub use task::{Task, TaskStatus, SOURCE_LOCAL};
 pub use theme_config::{ThemePalette, ThemePreset};
@@ -171,6 +171,10 @@ pub struct SessionInfo {
     pub additional_dirs: Vec<PathBuf>,
     pub backend_id: Option<String>,
     pub shell_backend_id: Option<String>,
+    /// Bare host name (e.g. `devbox`) when the session runs on a remote
+    /// `ssh:<host>` backend; `None` for local sessions. Drives the remote
+    /// indicator in the session list. Set by the agent layer at spawn/adopt.
+    pub remote_host: Option<String>,
     /// Agent metrics from the agent's statusline (Claude only).
     pub agent_metrics: Option<AgentMetrics>,
     /// Latest OSC window title the agent emitted (live activity text),
@@ -201,6 +205,7 @@ impl SessionInfo {
             additional_dirs: Vec::new(),
             backend_id: None,
             shell_backend_id: None,
+            remote_host: None,
             agent_metrics: None,
             agent_activity: None,
             notification: None,

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use crate::session::{SessionConfig, SessionId, DEFAULT_AGENT_NAME};
+use crate::session::{HostDef, SessionConfig, SessionId, DEFAULT_AGENT_NAME};
 use crate::storage::Database;
 use crate::sync::{SharedSession, SharedWorktree};
 
@@ -31,6 +31,9 @@ pub struct SpawnRequest {
     /// Optional pre-generated agent session UUID. When unset one is generated
     /// so callers can return it to the user immediately.
     pub agent_session_id: Option<String>,
+    /// Optional remote host name (from `hosts.toml`). When set, the session is
+    /// created on that host over SSH (worktree + tmux window live remotely).
+    pub host: Option<String>,
 }
 
 /// Result returned on successful headless spawn.
@@ -50,7 +53,11 @@ pub fn spawn_session_headless(_db: &Database, req: SpawnRequest) -> Result<Spawn
     validate_session_name(&req.name)?;
 
     let agent_name = resolve_agent_name(req.agent.as_deref());
-    let (cwd, worktrees) = resolve_cwd(&req)?;
+
+    // Resolve the optional remote host. `backend_type` is `local-tmux` or
+    // `ssh:<host>`; `host` is the matching HostDef for remote git/tmux ops.
+    let (backend_type, host) = resolve_host(req.host.as_deref())?;
+    let (cwd, worktrees) = resolve_cwd(&req, host.as_ref())?;
 
     let agent_session_id = req
         .agent_session_id
@@ -61,25 +68,39 @@ pub fn spawn_session_headless(_db: &Database, req: SpawnRequest) -> Result<Spawn
         agent_session_id: Some(agent_session_id.clone()),
         cwd: Some(cwd.clone()),
         agent: agent_name.clone(),
+        backend: (backend_type != LOCAL_TMUX_BACKEND_TYPE).then(|| backend_type.clone()),
         ..SessionConfig::default()
     };
     super::inject_thurbox_env(&mut config, &agent_session_id);
 
     let (command, args) = super::build_agent_invocation(&config);
 
-    crate::agent::tmux::spawn_window(&req.name, &command, &args, Some(&cwd), &config.env)
-        .map_err(|e| format!("Failed to spawn tmux window: {e}"))?;
+    // Remote spawns drive the SSH backend's control mode to learn the real pane
+    // id; local spawns leave `backend_id` empty for the TUI to resolve by name.
+    let backend_id = match host.as_ref() {
+        Some(h) => crate::agent::tmux::spawn_window_remote(
+            h,
+            &req.name,
+            &command,
+            &args,
+            Some(&cwd),
+            &config.env,
+        )
+        .map_err(|e| format!("Failed to spawn remote tmux window: {e:#}"))?,
+        None => {
+            crate::agent::tmux::spawn_window(&req.name, &command, &args, Some(&cwd), &config.env)
+                .map_err(|e| format!("Failed to spawn tmux window: {e}"))?;
+            String::new()
+        }
+    };
 
     let session_id = SessionId::default();
     let shared = SharedSession {
         id: session_id,
         name: req.name.clone(),
         agent: agent_name.clone(),
-        // No pane_id is available without control mode. Leave `backend_id`
-        // empty so `App::find_matching_discovered` falls back to matching by
-        // the sanitized window name.
-        backend_id: String::new(),
-        backend_type: LOCAL_TMUX_BACKEND_TYPE.to_string(),
+        backend_id,
+        backend_type,
         agent_session_id: Some(agent_session_id.clone()),
         cwd: Some(cwd.clone()),
         additional_dirs: Vec::new(),
@@ -126,12 +147,15 @@ fn resolve_agent_name(requested: Option<&str>) -> String {
 /// Returns the bare repo path when no worktree branch is given; otherwise
 /// creates the worktree and returns its path plus a single
 /// [`SharedWorktree`] entry.
-fn resolve_cwd(req: &SpawnRequest) -> Result<(PathBuf, Vec<SharedWorktree>), String> {
+fn resolve_cwd(
+    req: &SpawnRequest,
+    host: Option<&HostDef>,
+) -> Result<(PathBuf, Vec<SharedWorktree>), String> {
     let Some(branch) = req.worktree_branch.as_deref() else {
         return Ok((req.repo_path.clone(), Vec::new()));
     };
     let base_branch = req.base_branch.as_deref().unwrap_or(DEFAULT_BASE_BRANCH);
-    let path = crate::git::create_worktree(&req.repo_path, branch, base_branch)
+    let path = crate::git::create_worktree_on(host, &req.repo_path, branch, base_branch)
         .map_err(|e| format!("Failed to create worktree {branch} off {base_branch}: {e}"))?;
     let wt = SharedWorktree {
         repo_path: req.repo_path.clone(),
@@ -139,6 +163,26 @@ fn resolve_cwd(req: &SpawnRequest) -> Result<(PathBuf, Vec<SharedWorktree>), Str
         branch: branch.to_string(),
     };
     Ok((path, vec![wt]))
+}
+
+/// Resolve `--host` to `(backend_type, host)`.
+///
+/// `None`/empty → the local backend. A named host must exist in `hosts.toml`,
+/// otherwise an error is returned listing the available hosts.
+fn resolve_host(host_name: Option<&str>) -> Result<(String, Option<HostDef>), String> {
+    let Some(name) = host_name.filter(|n| !n.is_empty()) else {
+        return Ok((LOCAL_TMUX_BACKEND_TYPE.to_string(), None));
+    };
+    let registry = crate::agent::host_config::load_or_seed();
+    match registry.get(name) {
+        Some(h) => Ok((h.backend_name(), Some(h.clone()))),
+        None => {
+            let available = registry.names().join(", ");
+            Err(format!(
+                "Unknown host '{name}'. Configure it in hosts.toml. Available: [{available}]"
+            ))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -158,6 +202,7 @@ mod tests {
             base_branch: None,
             agent: None,
             agent_session_id: None,
+            host: None,
         }
     }
 
@@ -183,5 +228,42 @@ mod tests {
     fn resolve_agent_name_uses_explicit() {
         assert_eq!(resolve_agent_name(Some("codex")), "codex");
         assert_eq!(resolve_agent_name(Some("")), DEFAULT_AGENT_NAME);
+    }
+
+    #[test]
+    fn resolve_host_none_is_local() {
+        let (backend_type, host) = resolve_host(None).unwrap();
+        assert_eq!(backend_type, LOCAL_TMUX_BACKEND_TYPE);
+        assert!(host.is_none());
+        // Empty string is treated the same as None.
+        let (backend_type, host) = resolve_host(Some("")).unwrap();
+        assert_eq!(backend_type, LOCAL_TMUX_BACKEND_TYPE);
+        assert!(host.is_none());
+    }
+
+    #[test]
+    fn resolve_host_unknown_errors_with_guidance() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let err = resolve_host(Some("nope")).unwrap_err();
+        assert!(err.contains("Unknown host 'nope'"), "got: {err}");
+        assert!(err.contains("hosts.toml"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_host_reads_configured_host() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let path = crate::agent::host_config::hosts_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[hosts]]\nname = \"devbox\"\ndestination = \"me@devbox\"\n",
+        )
+        .unwrap();
+
+        let (backend_type, host) = resolve_host(Some("devbox")).unwrap();
+        assert_eq!(backend_type, "ssh:devbox");
+        assert_eq!(host.unwrap().destination, "me@devbox");
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,68 @@
+//! Small shell/SSH command helpers shared across modules.
+//!
+//! Centralizes two things that would otherwise be duplicated wherever thurbox
+//! shells out over SSH: POSIX single-quote escaping for tokens that a remote
+//! login shell will re-split, and construction of the `ssh <opts> <dest>`
+//! command prefix.
+
+use std::process::Command;
+
+/// Characters that never need quoting in a POSIX shell word.
+fn is_safe_shell_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '/' | ':' | '=' | ',')
+}
+
+/// POSIX single-quote escaping for one shell word.
+///
+/// Simple tokens (paths, branch names, flags) pass through unquoted; anything
+/// with whitespace or shell metacharacters is wrapped in single quotes (with
+/// embedded quotes escaped). An empty string becomes `''`.
+///
+/// Note: this does **not** strip newlines. Callers feeding a line-delimited
+/// protocol (e.g. tmux control mode) must handle newlines themselves before
+/// quoting — see [`crate::agent::control_mode::shell_escape`].
+pub fn posix_quote(s: &str) -> String {
+    if !s.is_empty() && s.chars().all(is_safe_shell_char) {
+        return s.to_string();
+    }
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Build an `ssh <opts> <destination>` [`Command`], ready for the caller to
+/// append the remote command and its arguments.
+pub fn ssh_command(destination: &str, ssh_opts: &[String]) -> Command {
+    let mut cmd = Command::new("ssh");
+    cmd.args(ssh_opts);
+    cmd.arg(destination);
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn posix_quote_passes_simple_tokens() {
+        assert_eq!(posix_quote("feat-x"), "feat-x");
+        assert_eq!(posix_quote("/home/me/repo"), "/home/me/repo");
+        assert_eq!(posix_quote("-L"), "-L");
+    }
+
+    #[test]
+    fn posix_quote_wraps_specials_and_empty() {
+        assert_eq!(posix_quote("a b"), "'a b'");
+        assert_eq!(posix_quote("it's"), "'it'\\''s'");
+        assert_eq!(posix_quote(""), "''");
+    }
+
+    #[test]
+    fn ssh_command_sets_program_opts_and_destination() {
+        let cmd = ssh_command("me@box", &["-p".into(), "2222".into()]);
+        assert_eq!(cmd.get_program().to_string_lossy(), "ssh");
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, ["-p", "2222", "me@box"]);
+    }
+}

--- a/src/ui/host_picker_modal.rs
+++ b/src/ui/host_picker_modal.rs
@@ -1,0 +1,47 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    widgets::{List, ListItem, Paragraph},
+    Frame,
+};
+
+use super::{
+    centered_fixed_height_rect, render_modal_frame, selector_list_item, selector_nav_footer,
+};
+
+/// One selectable host row: display label + the backend name it maps to
+/// (`local-tmux` or `ssh:<host>`).
+#[derive(Debug, Clone, Default)]
+pub struct HostChoice {
+    /// Display label (e.g. `local` or `devbox  (me@devbox)`).
+    pub label: String,
+    /// Backend name spawned on. Empty string means the local default backend.
+    pub backend: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HostPickerState {
+    pub choices: Vec<HostChoice>,
+    pub selected_index: usize,
+}
+
+pub fn render_host_picker_modal(frame: &mut Frame, state: &HostPickerState) {
+    let height = (state.choices.len() as u16) + 3;
+    let area = centered_fixed_height_rect(50, height, frame.area());
+
+    let inner = render_modal_frame(frame, area, "Run On");
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let items: Vec<ListItem<'_>> = state
+        .choices
+        .iter()
+        .enumerate()
+        .map(|(i, c)| selector_list_item(&c.label, i == state.selected_index))
+        .collect();
+
+    frame.render_widget(List::new(items), chunks[0]);
+    frame.render_widget(Paragraph::new(selector_nav_footer()), chunks[1]);
+}

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -69,6 +69,16 @@ pub fn render_info_panel(
                 .add_modifier(Modifier::BOLD),
         ),
     ]));
+    // Remote host (ssh:<host>); omitted entirely for local sessions.
+    if let Some(host) = info.remote_host.as_deref() {
+        lines.push(Line::from(vec![
+            Span::styled("Host:  ", Theme::label()),
+            Span::styled(
+                format!("\u{2601} {host}"),
+                Style::default().fg(Theme::accent()),
+            ),
+        ]));
+    }
     // Live activity from the agent-emitted OSC terminal title.
     if let Some(activity) = info.agent_activity.as_deref() {
         lines.push(Line::from(vec![

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ pub mod branch_selector_modal;
 pub mod file_viewer;
 pub mod global_search;
 pub mod highlight;
+pub mod host_picker_modal;
 pub mod info_panel;
 pub mod layout;
 pub mod links;

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -522,11 +522,12 @@ fn session_status_text(info: &SessionInfo, elapsed: Option<u64>) -> String {
         .unwrap_or_else(|| format_status_with_elapsed(info.status, elapsed))
 }
 
-/// Build line 1 of a session entry: `<status-dot> [⑂] <name>`.
+/// Build line 1 of a session entry: `<status-dot> [☁] [⑂] <name>`.
 ///
 /// The active row is signalled by the list's highlight background, so no extra
-/// pointer glyph is needed. Sessions running in a git worktree get a `⑂` mark
-/// between the status dot and the name. The live status itself lives on line 2.
+/// pointer glyph is needed. Remote (`ssh:<host>`) sessions get a `☁` mark and
+/// sessions running in a git worktree get a `⑂` mark, both between the status
+/// dot and the name. The live status itself lives on line 2.
 fn build_session_line1<'a>(
     info: &'a SessionInfo,
     session_match: Option<&SessionMatch>,
@@ -550,6 +551,17 @@ fn build_session_line1<'a>(
         format!(" {} ", info.status.icon()),
         status_style,
     )];
+
+    // Remote (ssh:<host>) sessions get a cloud mark so it's clear at a glance
+    // the agent runs on another machine. Sits right after the status dot.
+    if info.remote_host.is_some() {
+        let remote_style = if is_dimmed {
+            Style::default().fg(Theme::text_muted())
+        } else {
+            Style::default().fg(Theme::accent())
+        };
+        line1_spans.push(Span::styled("\u{2601} ", remote_style));
+    }
 
     // Worktree sessions get a dedicated mark, subordinate to the status dot.
     if !info.worktrees.is_empty() {
@@ -857,6 +869,21 @@ mod tests {
         let s = info("plain");
         let line = build_session_line1(&s, None, false, false);
         assert!(!line_text(&line).contains('\u{2442}'));
+    }
+
+    #[test]
+    fn line1_shows_remote_glyph_when_remote_host_present() {
+        let mut s = info("remote");
+        s.remote_host = Some("devbox".to_string());
+        let line = build_session_line1(&s, None, false, false);
+        assert!(line_text(&line).contains('\u{2601}'));
+    }
+
+    #[test]
+    fn line1_no_remote_glyph_for_local_session() {
+        let s = info("local");
+        let line = build_session_line1(&s, None, false, false);
+        assert!(!line_text(&line).contains('\u{2601}'));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Run agent sessions on a **remote host over SSH** while the TUI stays local. Hosts are declared as data in `~/.config/thurbox/hosts.toml` (seeded commented-out, so a fresh install registers zero remote backends and behaves exactly as before).

The tmux control-mode protocol is byte-identical over a local pipe or `ssh <dest> tmux …` — the only difference is one `Command` construction. Auth/keys/multiplexing come from the user's `~/.ssh/config`; thurbox never handles credentials. Each host becomes a backend named `ssh:<name>`; the worktree and agent process live on the remote host.

## How it works

- **Transport seam** (`agent::transport::TmuxTransport`): `Local` (`tmux -L thurbox`) or `Ssh { destination, ssh_opts }`. `LocalTmuxBackend` is now a thin alias over a generic `TmuxBackend { transport, socket, session, name }`. The control-mode reader/writer machinery is unchanged.
- **Config**: `session::HostDef`/`HostRegistry` (in `session/` so both `agent` and `git` can use it), loaded by `agent::host_config::load_or_seed`.
- **Selection**: `SessionConfig.backend` (`ssh:<host>` or `None`). SSH backends are registered **lazily** — a down host can't block TUI startup (`check_available`/`ensure_ready` deferred to first use via `App::backend_for`).
- **Restore**: discovers windows **per backend** so remote sessions re-adopt against their own host's tmux (`backend_type` already round-tripped in SQLite).
- **Remote worktrees**: `git::*_on(host, …)` variants run `ssh <dest> git -C <repo> …`; remote worktree paths resolve under the host's `worktrees_dir` (or `$HOME/.local/share/thurbox/worktrees` resolved + cached over ssh).
- **TUI**: host picker as the first new-session step (skipped when no hosts configured).
- **CLI**: `thurbox-cli session create --host <name> …` spawns remotely.

```toml
# ~/.config/thurbox/hosts.toml
[[hosts]]
name = "devbox"
destination = "me@devbox"
ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m", "-o", "ServerAliveInterval=15"]
```

## Staging

9 commits, each independently reviewable: transport refactor (no-op) → host config → SSH backend → backend selection → restore fix → remote worktrees → TUI picker → CLI flag → docs.

## Testing

- 713 tests pass (707 without the unrelated working-tree change), strict clippy clean, all 8 architecture rules hold, both binaries build.
- **Not yet run: `ssh localhost` end-to-end** — no SSH server in the dev environment. To validate manually, add a `hosts.toml` with `destination = "localhost"` and create a session (local + remote), restart to confirm re-adoption, then `thurbox-cli session create --host localhost`.

## Riskiest area

SSH reconnect on a flapping link — `reconnect_control` reopens the ssh connection; ControlMaster + keepalives in the seeded `ssh_opts` mitigate stalls. Documented in ADR-13.

## Docs

CLAUDE.md (backend layer, hosts.toml, CLI), `docs/ARCHITECTURE.md` (new ADR-13; refreshed ADR-2/11), `docs/FEATURES.md` (host-picker step + remote sessions subsection).