### PR TITLE
docs: document thurbox-cli commands and session delete semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,16 @@ create/list/show/edit/remove/run/runs/tick), `task` (alias `todo`:
 create/list/show/edit/remove/run), `editor`. Pass
 `--pretty` for indented JSON.
 
+`session delete <uuid>` **soft-deletes** by default — only the DB
+row is marked deleted (the TUI tears down the tmux window/worktree
+on its next sync), and `session restore` revives it. Pass `--force`
+(`session_ops::delete_session_headless`) to also kill the tmux
+window, remove worktrees + the symlink workspace, and disable
+`send` automations targeting the session — for headless cleanup
+when no TUI is running. Teardown is best-effort (failures land in
+the JSON report); the row is always soft-deleted last, so even a
+forced delete stays restorable.
+
 Automations fire even when the TUI is closed: a tmux heartbeat
 keeper window (`automation-heartbeat`, armed on TUI startup and on
 `automation create`) loops `automation tick` every 60 s and keeps

--- a/README.md
+++ b/README.md
@@ -335,22 +335,106 @@ Session search matches against name, agent, and branch.
 
 The `thurbox-cli` binary drives Thurbox without the TUI — useful
 for scripting and automation. It shares the same SQLite database
-as the TUI, so changes appear live.
+and `tmux -L thurbox` server as the TUI, so changes made by either
+appear live in the other (the TUI polls `PRAGMA data_version`).
+
+Every command prints a JSON result to stdout; pass the global
+`--pretty` flag for indented output. The binary is intentionally
+thin — it parses arguments, calls into the database / tmux helpers,
+and prints the result. There is no TUI and no event loop.
 
 ```bash
 cargo build --bin thurbox-cli
-thurbox-cli session list
+```
+
+### Sessions
+
+```bash
+thurbox-cli session list                 # all active sessions
+thurbox-cli session get <uuid>           # one session by UUID
 thurbox-cli session create \
   --name reviewer \
   --repo-path /path/to/repo \
-  --agent codex
+  --agent codex \
+  --worktree-branch feat/x \
+  --base-branch main
 thurbox-cli session send <uuid> "run the test suite"
-thurbox-cli session capture <uuid>
+thurbox-cli session capture <uuid> --lines 500
+thurbox-cli session restart <uuid>       # kill + re-spawn with --resume
+thurbox-cli session delete <uuid>        # soft-delete (see below)
+thurbox-cli session restore <uuid>       # undo a soft-delete
 ```
 
-`session create` takes `--name`, `--repo-path`, `--agent`,
-`--worktree-branch`, and `--base-branch`; the agent falls back to
-the default in `agents.toml` when omitted.
+- **`create`** runs synchronously — the tmux window is live by the
+  time the command returns. `--agent` falls back to the default in
+  `agents.toml` when omitted; `--worktree-branch` (off
+  `--base-branch`, default `main`) creates a git worktree.
+- **`send`** types text into the session's terminal followed by
+  Enter; **`capture`** dumps the rendered pane as text (`--lines`
+  defaults to 200, max 10000).
+
+#### How session delete is handled
+
+`session delete <uuid>` is a **soft-delete**: by default it only
+marks the database row as deleted. The tmux window, any git
+worktrees, and pending scheduled commands are **left untouched** —
+the running TUI cleans those up on its next sync, and the session
+stays recoverable with `session restore <uuid>` (the TUI's `Ctrl+U`
+/ `Ctrl+Z` undo path). Restore revives the metadata; the TUI
+re-spawns a fresh window for it.
+
+Pass **`--force`** to also tear down the session's runtime resources
+in the same call — useful for headless cleanup when no TUI is
+running to observe the deletion. With `--force` the command:
+
+- kills the tmux window,
+- removes the session's git worktrees (the underlying repos are left
+  intact),
+- removes the multi-repo symlink workspace, if any (only the
+  symlinks — never the linked repos), and
+- disables any `send` automations that target the session.
+
+Teardown is **best-effort**: individual tmux/worktree failures are
+recorded in the JSON report (`killed_window`, `removed_worktrees`,
+`worktree_errors`, `disabled_automations`) but never abort the
+delete. The DB row is always soft-deleted last, so even a forced
+delete remains restorable (it just re-spawns from a clean slate).
+
+### Automations (alias `auto`)
+
+Scheduled agent runs, persisted to the shared DB. See
+[Automations](#automations) for the model.
+
+```bash
+thurbox-cli automation create \
+  --name nightly-triage \
+  --trigger weekdays --time 09:00 \
+  --session <uuid> --prompt "triage new issues"
+thurbox-cli automation list
+thurbox-cli automation show <id>
+thurbox-cli automation edit <id> --prompt "..." --disabled
+thurbox-cli automation remove <id>
+thurbox-cli automation run <id>          # mark due for the next tick
+thurbox-cli automation runs <id> --limit 20   # run history
+thurbox-cli automation tick              # fire all due automations now
+```
+
+`--trigger` accepts `hourly`, `daily`, `weekdays`, `weekly`,
+`cron:"<expr>"`, or `at:<unix_millis>`. A `--session` makes it a
+*send* automation; a `--repo` (with optional `--worktree` / `--base`
+/ `--agent`) makes it a *spawn* automation. `automation tick` is the
+headless entry point the tmux heartbeat keeper and any
+systemd/cron timer call to fire due automations without a TUI.
+
+### Editor
+
+```bash
+thurbox-cli editor get                   # print configured command
+thurbox-cli editor set "code --wait"     # set (empty string clears)
+```
+
+This is the command `Ctrl+O` runs in the TUI; the worktree path is
+appended as the final argument.
 
 ## Architecture
 

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -6,7 +6,7 @@
     <title>Features — Thurbox Docs</title>
     <meta
       name="description"
-      content="Thurbox features: persistent coding-agent sessions, agent definitions, git worktrees, automations, and a responsive UI."
+      content="Thurbox features: persistent coding-agent sessions, agent definitions, git worktrees, automations, a responsive UI, and a headless CLI."
     />
     <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -78,6 +78,7 @@
             <li><a href="#responsive-ui">Responsive UI</a></li>
             <li><a href="#themes">Themes</a></li>
             <li><a href="#session-persistence">Session Persistence</a></li>
+            <li><a href="#headless-cli">Headless CLI</a></li>
           </ul>
         </aside>
 
@@ -657,6 +658,134 @@
               </tr>
             </tbody>
           </table>
+
+          <h2 id="headless-cli">
+            Headless CLI
+            <a href="#headless-cli" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            The
+            <code>thurbox-cli</code>
+            binary drives the same sessions, automations, and editor settings without the TUI
+            &mdash; ideal for scripting. It shares the TUI's SQLite database and
+            <code>tmux -L thurbox</code>
+            server, so changes made by either show up live in the other. Every command prints JSON;
+            pass the global
+            <code>--pretty</code>
+            flag for indented output.
+          </p>
+          <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> session list
+<span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> session create <span class="syn-flag">--name</span> reviewer <span class="syn-flag">--repo-path</span> <span class="syn-string">/path/to/repo</span> <span class="syn-flag">--agent</span> codex
+<span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> session send <span class="syn-string">&lt;uuid&gt;</span> <span class="syn-string">"run the test suite"</span>
+<span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> session capture <span class="syn-string">&lt;uuid&gt;</span> <span class="syn-flag">--lines</span> 500</code></pre>
+          <ul>
+            <li>
+              <strong>session</strong>
+              &mdash;
+              <code>list</code>
+              ,
+              <code>get</code>
+              ,
+              <code>create</code>
+              (synchronous &mdash; the tmux window is live on return; supports
+              <code>--worktree-branch</code>
+              /
+              <code>--base-branch</code>
+              ),
+              <code>send</code>
+              ,
+              <code>capture</code>
+              ,
+              <code>restart</code>
+              ,
+              <code>delete</code>
+              ,
+              <code>restore</code>
+              .
+            </li>
+            <li>
+              <strong>automation</strong>
+              (alias
+              <code>auto</code>
+              ) &mdash;
+              <code>create</code>
+              /
+              <code>list</code>
+              /
+              <code>show</code>
+              /
+              <code>edit</code>
+              /
+              <code>remove</code>
+              /
+              <code>run</code>
+              /
+              <code>runs</code>
+              , plus
+              <code>tick</code>
+              (the headless entry point that fires all due automations &mdash; what the tmux
+              heartbeat keeper and any systemd/cron timer call).
+            </li>
+            <li>
+              <strong>editor</strong>
+              &mdash;
+              <code>get</code>
+              /
+              <code>set</code>
+              the command
+              <code>Ctrl+O</code>
+              runs (the worktree path is appended as the final argument).
+            </li>
+          </ul>
+
+          <h3>How session delete is handled</h3>
+          <p>
+            <code>session delete &lt;uuid&gt;</code>
+            is a
+            <strong>soft-delete</strong>
+            by default: it only marks the database row deleted. The tmux window, git worktrees, and
+            any pending scheduled commands are left untouched &mdash; the running TUI cleans those
+            up on its next sync, and the session stays recoverable with
+            <code>session restore &lt;uuid&gt;</code>
+            (the TUI's
+            <code>Ctrl+U</code>
+            /
+            <code>Ctrl+Z</code>
+            undo). Restore revives the metadata; the TUI re-spawns a fresh window for it.
+          </p>
+          <p>
+            Pass
+            <code>--force</code>
+            to tear down the session's runtime resources in the same call &mdash; for headless
+            cleanup when no TUI is running to observe the deletion. A forced delete also:
+          </p>
+          <ul>
+            <li>kills the tmux window,</li>
+            <li>removes the session's git worktrees (the underlying repos are left intact),</li>
+            <li>
+              removes the multi-repo symlink workspace, if any (only the symlinks &mdash; never the
+              linked repos), and
+            </li>
+            <li>
+              disables any
+              <strong>send</strong>
+              automations that target the session.
+            </li>
+          </ul>
+          <p>
+            Teardown is
+            <strong>best-effort</strong>
+            : individual tmux/worktree failures are recorded in the JSON report (
+            <code>killed_window</code>
+            ,
+            <code>removed_worktrees</code>
+            ,
+            <code>worktree_errors</code>
+            ,
+            <code>disabled_automations</code>
+            ) but never abort the delete. The DB row is always soft-deleted last, so even a forced
+            delete stays restorable &mdash; it just re-spawns from a clean slate.
+          </p>
         </main>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Expands documentation for the `thurbox-cli` headless binary and clarifies how session delete is handled, across the README, CLAUDE.md, and the website docs.

- **README.md** — restructures the "Headless CLI" section into Sessions / Automations / Editor subsections covering every subcommand, and adds a dedicated **"How session delete is handled"** subsection (soft-delete by default; `--force` tears down tmux window, worktrees, symlink workspace, and `send` automations; best-effort teardown reported in JSON; row soft-deleted last so even forced deletes stay restorable).
- **CLAUDE.md** — adds a concise note on the same soft-delete vs `--force` semantics (pointing at `session_ops::delete_session_headless`).
- **website/docs/features.html** — adds a new `#headless-cli` section (with sidebar entry) mirroring the README CLI reference and delete semantics; updates the page meta description.

Docs-only change — verified with `rumdl` (Markdown), `prettier` + `htmlhint` (website), and `cargo doc`.

## Test plan

- CI checks pass