### PR TITLE
feat(config): configure fork/resume defaults for all built-in agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,9 @@ new_session_args = ["--session-id", "{id}"]  # emitted on a fresh spawn
 [[agents]]
 name = "codex"
 command = "codex"
+resume_args = ["resume", "--last"]      # id-less: resumes the last session in cwd
+fork_args = ["fork", "--last"]
+resume_latest = true
 ```
 
 Each `*_args` group is appended only when its driving value is
@@ -193,6 +196,24 @@ model is ever passed — each agent uses its own default config
 Agents that omit `resume_args` simply start fresh on restart (the
 live tmux process is what carries state across TUI restarts). Add
 your own `[[agents]]` entry to support any CLI — no recompile.
+
+**Session id pinning vs. `resume_latest`.** thurbox generates the
+`agent_session_id` (a UUID) and only `claude` accepts it at creation
+(`--session-id {id}`), so only claude can resume/fork by that exact id.
+The other built-ins (`codex`, `opencode`, `gemini`, `aider`) can't pin
+or report their id, so they set `resume_latest = true` with **id-less**
+resume/fork flags (no `{id}` token): the agent resolves "the last
+session in *this* directory" itself (`codex resume --last`, `opencode
+--continue`, `gemini --resume latest`, `aider --restore-chat-history`).
+This works because restart reuses the session's cwd and a single-repo
+fork reuses the parent's cwd. `resume_latest` only changes *when* the
+resume group fires (see `session_ops::resume_trigger_for`): for these
+agents restart always triggers resume; for claude it still defers to an
+on-disk transcript check. Caveats: agents without `fork_args`
+(`gemini`, `aider` — neither CLI forks) start fresh on `Ctrl+F`; and a
+**multi-repo** fork of a cwd-scoped agent lands in a fresh symlink
+workspace, so `--last`/`--continue` finds no parent session (multi-repo
+*restart* still resumes, since it keeps the same workspace dir).
 
 - **Data type**: `session::AgentDef` / `session::AgentRegistry`
   (`session/agent_def.rs`, pure data + substitution logic).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -500,10 +500,18 @@ codex, gemini, opencode, aider, vibe) on first run via
 `agent::agent_config::load_or_seed`. An `AgentDef` carries a
 `command`, `args` (always passed — bake in flags like a model
 here if you want), and argument-template groups (`resume_args`,
-`fork_args`, `new_session_args`). A single
-`agent::GenericProvider` (an `AgentProvider`) launches any defined
-agent by substituting `{id}` and appending each group only when
-its driving value is present.
+`fork_args`, `new_session_args`), plus a `resume_latest` flag. A
+single `agent::GenericProvider` (an `AgentProvider`) launches any
+defined agent by substituting `{id}` and appending each group only
+when its driving value is present. Only `claude` can be addressed by
+the thurbox-generated id (`--session-id {id}`); the other built-ins
+can't pin or report a session id, so they set `resume_latest = true`
+and use id-less, cwd-scoped flags (`codex resume --last`, `opencode
+--continue`, …) that make the agent resolve "the last session in this
+directory" itself. `resume_latest` only governs *when* the resume
+group fires at restart (`session_ops::resume_trigger_for`): for these
+agents restart always resumes; claude still defers to an on-disk
+transcript check.
 
 **Why**: Thurbox started as Claude-Code-specific, with a hard-coded
 `ClaudeProvider` plus roles, skills, profiles, and an MCP/plugin

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -182,14 +182,26 @@ Each definition (`session::AgentDef`) carries:
 - argument-template groups: `args` (always passed — bake in flags
   like a model here if you want) and `resume_args` / `fork_args` /
   `new_session_args` (with `{id}`).
+- `resume_latest` — when true, restart resumes the agent's most
+  recent session in the launch directory via **id-less** flags
+  (see below).
 
 `agent::GenericProvider` builds the launch arguments by appending
 each group **only when its driving value is present**, substituting
 `{id}` token-by-token. Selection precedence is fork > resume >
 new-session id; static `args` follow. A group with no value is
-simply omitted — no unresolved-placeholder heuristics. Agents that
-declare no `resume_args` (e.g. codex) start fresh on restart
-instead of resuming.
+simply omitted — no unresolved-placeholder heuristics.
+
+Only `claude` accepts the thurbox-generated id at creation
+(`--session-id {id}`), so only it resumes/forks by that exact id.
+The other built-ins can't pin or report their session id, so they
+set `resume_latest = true` and resume/fork via id-less, cwd-scoped
+flags (`codex resume --last`, `opencode --continue`, `gemini
+--resume latest`, `aider --restore-chat-history`); the agent
+resolves "the last session in this directory" itself, which works
+because restart reuses the session cwd and a single-repo fork reuses
+the parent cwd. Agents that declare no `resume_args` start fresh on
+restart instead of resuming.
 
 Example:
 
@@ -206,6 +218,9 @@ new_session_args = ["--session-id", "{id}"]
 [[agents]]
 name = "codex"
 command = "codex"
+resume_args = ["resume", "--last"]   # id-less: last session in cwd
+fork_args = ["fork", "--last"]
+resume_latest = true
 ```
 
 ---
@@ -305,7 +320,8 @@ Create (UUID v4) → Running → Idle / Error
 
 Restarts the active session's tmux pane while preserving the
 conversation history. The session is killed and respawned with the
-agent's resume arguments (e.g. `--resume <id>` for Claude),
+agent's resume arguments (e.g. `--resume <id>` for Claude, or
+id-less `resume --last` for a `resume_latest` agent like codex),
 reusing the session's stored agent. Agents that define no
 `resume_args` simply start a fresh conversation.
 

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -13,10 +13,14 @@ use crate::session::AgentRegistry;
 /// Built-in agent definitions, also used to seed `agents.toml` on first run.
 ///
 /// Kept deliberately small per agent: just the command, plus resume/fork/
-/// session-id groups for agents that support them (currently only Claude
-/// Code). Agents without resume groups simply start fresh on restart. No
-/// model is passed — each agent uses its own default config. Bake extra flags
-/// (including a model) into `args` if you want them.
+/// session-id groups. `claude` pins a thurbox-generated id (`--session-id`) so
+/// it can resume/fork by that exact id. The other built-ins can't pin or report
+/// their session id, so they use `resume_latest = true` with id-less,
+/// cwd-scoped flags (`codex resume --last`, `opencode --continue`, …): the agent
+/// resolves "the last session in this directory" itself. Agents without any
+/// resume group simply start fresh on restart. No model is passed — each agent
+/// uses its own default config. Bake extra flags (including a model) into
+/// `args` if you want them.
 pub const BUILTIN_AGENTS_TOML: &str = r#"# Thurbox coding-agent definitions.
 #
 # Each [[agents]] entry describes how to launch one coding-agent CLI. The
@@ -33,21 +37,39 @@ resume_args = ["--resume", "{id}"]
 fork_args = ["--resume", "{id}", "--fork-session"]
 new_session_args = ["--session-id", "{id}"]
 
+# codex can't pin or report its session id, so resume/fork target the most
+# recent session in the launch directory. thurbox keeps that directory stable
+# across restart (same cwd) and single-repo fork (child reuses the parent cwd).
 [[agents]]
 name = "codex"
 command = "codex"
+resume_args = ["resume", "--last"]
+fork_args = ["fork", "--last"]
+resume_latest = true
 
+# gemini resumes the latest session in the launch directory; it has no fork
+# (Ctrl+F falls back to a fresh session).
 [[agents]]
 name = "gemini"
 command = "gemini"
+resume_args = ["--resume", "latest"]
+resume_latest = true
 
+# `--continue` resumes the last session in the cwd; add `--fork` to branch it.
 [[agents]]
 name = "opencode"
 command = "opencode"
+resume_args = ["--continue"]
+fork_args = ["--continue", "--fork"]
+resume_latest = true
 
+# aider restores the chat-history file (.aider.chat.history.md) in the cwd; it
+# has no separate session id and no fork.
 [[agents]]
 name = "aider"
 command = "aider"
+resume_args = ["--restore-chat-history"]
+resume_latest = true
 
 [[agents]]
 name = "vibe"
@@ -126,9 +148,42 @@ mod tests {
         assert!(reg.get("opencode").is_some());
         assert!(reg.get("aider").is_some());
         assert!(reg.get("vibe").is_some());
-        // Claude carries resume/fork groups; codex does not.
-        assert!(!reg.get("claude").unwrap().resume_args.is_empty());
-        assert!(reg.get("codex").unwrap().resume_args.is_empty());
+
+        // Claude pins a thurbox id and resumes/forks by it.
+        let claude = reg.get("claude").unwrap();
+        assert!(!claude.resume_args.is_empty());
+        assert!(!claude.resume_latest);
+        assert!(claude.resume_args.iter().any(|t| t.contains("{id}")));
+
+        // codex/opencode resume + fork via id-less, cwd-scoped flags.
+        let codex = reg.get("codex").unwrap();
+        assert_eq!(codex.resume_args, ["resume", "--last"]);
+        assert_eq!(codex.fork_args, ["fork", "--last"]);
+        assert!(codex.resume_latest);
+        let opencode = reg.get("opencode").unwrap();
+        assert_eq!(opencode.fork_args, ["--continue", "--fork"]);
+        assert!(opencode.resume_latest);
+
+        // gemini/aider resume their latest session but have no fork group.
+        for name in ["gemini", "aider"] {
+            let a = reg.get(name).unwrap();
+            assert!(a.resume_latest, "{name} should resume latest");
+            assert!(!a.resume_args.is_empty(), "{name} needs resume_args");
+            assert!(a.fork_args.is_empty(), "{name} has no fork");
+        }
+
+        // No non-claude resume/fork token may carry a {id} placeholder — these
+        // agents can't be addressed by a thurbox-known id.
+        for name in ["codex", "gemini", "opencode", "aider"] {
+            let a = reg.get(name).unwrap();
+            assert!(
+                !a.resume_args
+                    .iter()
+                    .chain(&a.fork_args)
+                    .any(|t| t.contains("{id}")),
+                "{name} must use id-less resume/fork flags"
+            );
+        }
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -19,7 +19,7 @@ use tracing::{error, info, warn};
 use crate::agent::{BackendRegistry, GenericProvider, Session, SessionBackend};
 use crate::git;
 use crate::session::{
-    AgentRegistry, Automation, AutomationAction, AutomationRunStatus, AutomationSchedule,
+    AgentDef, AgentRegistry, Automation, AutomationAction, AutomationRunStatus, AutomationSchedule,
     SessionConfig, SessionId, SessionInfo, SessionStatus, WorktreeInfo, DEFAULT_AGENT_NAME,
 };
 use crate::storage::Database;
@@ -516,9 +516,15 @@ impl App {
     /// registry default, then to the built-in default, so a stale/unknown agent
     /// name never breaks spawning.
     pub fn provider_for(&self, config: &SessionConfig) -> Arc<dyn crate::agent::AgentProvider> {
-        let def = self
-            .agents
-            .get(&config.agent)
+        Arc::new(GenericProvider::new(self.agent_def_for(&config.agent)))
+    }
+
+    /// Resolve the [`AgentDef`] for an agent name via the same fallback chain as
+    /// [`Self::provider_for`] (named agent → registry default → built-in
+    /// default). Used to decide resume/fork behaviour at restart time.
+    fn agent_def_for(&self, agent: &str) -> AgentDef {
+        self.agents
+            .get(agent)
             .or_else(|| self.agents.default_agent())
             .cloned()
             .unwrap_or_else(|| {
@@ -526,8 +532,7 @@ impl App {
                     .default_agent()
                     .cloned()
                     .expect("built-in registry always has a default agent")
-            });
-        Arc::new(GenericProvider::new(def))
+            })
     }
 
     /// Open the repo picker modal for creating a new session.
@@ -641,8 +646,9 @@ impl App {
             fork_session_id: None,
             ..SessionConfig::default()
         };
+        let def = self.agent_def_for(&config.agent);
         config.resume_session_id =
-            crate::session_ops::resume_id_if_transcript_exists(&agent_session_id, &config.env);
+            crate::session_ops::resume_trigger_for(&def, &agent_session_id, &config.env);
 
         self.do_restart(config);
     }
@@ -2027,8 +2033,9 @@ impl App {
             fork_session_id: None,
             ..SessionConfig::default()
         };
+        let def = self.agent_def_for(&config.agent);
         config.resume_session_id =
-            crate::session_ops::resume_id_if_transcript_exists(agent_sid, &config.env);
+            crate::session_ops::resume_trigger_for(&def, agent_sid, &config.env);
         let provider = self.provider_for(&config);
 
         if let Ok(mut spawned) = Session::spawn(
@@ -2309,10 +2316,11 @@ impl App {
         }
     }
 
-    /// No matching backend session or adopt failed — respawn with `--resume`
-    /// when a transcript already exists for this `agent_session_id`, otherwise
-    /// `--session-id` so claude creates the conversation (e.g. CLI-created
-    /// sessions whose claude process never persisted a conversation).
+    /// No matching backend session or adopt failed — respawn resuming when the
+    /// agent supports it (a claude transcript exists for this
+    /// `agent_session_id`, or a `resume_latest` agent resumes its last session
+    /// in the cwd), otherwise start fresh (e.g. claude with `--session-id` so it
+    /// creates the conversation, or any agent whose process never persisted one).
     fn respawn_stale_session(
         &mut self,
         name: String,
@@ -2333,8 +2341,9 @@ impl App {
             fork_session_id: None,
             ..SessionConfig::default()
         };
+        let def = self.agent_def_for(&config.agent);
         config.resume_session_id =
-            crate::session_ops::resume_id_if_transcript_exists(&agent_session_id, &config.env);
+            crate::session_ops::resume_trigger_for(&def, &agent_session_id, &config.env);
         self.pending_additional_dirs = shared.additional_dirs;
         self.do_spawn_session(name, &config, worktrees, false);
     }

--- a/src/session/agent_def.rs
+++ b/src/session/agent_def.rs
@@ -41,6 +41,14 @@ pub struct AgentDef {
     /// Emitted on a fresh spawn to pin a session id; `{id}` is substituted.
     #[serde(default)]
     pub new_session_args: Vec<String>,
+    /// When true, this agent resumes its most-recent session in the launch
+    /// directory using id-less `resume_args` (no `{id}` token). thurbox cannot
+    /// pin or read back the agent's real session id for these CLIs, so restart
+    /// relies on the agent's own "last session in this directory" resolution
+    /// (e.g. `codex resume --last`, `opencode --continue`). Agents that pin ids
+    /// (claude) leave this `false` and resume by a thurbox-known id instead.
+    #[serde(default)]
+    pub resume_latest: bool,
 }
 
 impl AgentDef {
@@ -69,6 +77,14 @@ impl AgentDef {
         out.extend(self.args.iter().cloned());
 
         out
+    }
+
+    /// Whether a restart should trigger this agent's resume group via
+    /// "latest session in the launch directory" semantics rather than a
+    /// thurbox-known session id. True only when [`Self::resume_latest`] is set
+    /// and there are `resume_args` to emit.
+    pub fn resumes_latest(&self) -> bool {
+        self.resume_latest && !self.resume_args.is_empty()
     }
 }
 
@@ -128,6 +144,7 @@ mod tests {
             resume_args: vec!["--resume".into(), "{id}".into()],
             fork_args: vec!["--resume".into(), "{id}".into(), "--fork-session".into()],
             new_session_args: vec!["--session-id".into(), "{id}".into()],
+            resume_latest: false,
         }
     }
 
@@ -163,9 +180,55 @@ mod tests {
             resume_args: vec![],
             fork_args: vec![],
             new_session_args: vec![],
+            resume_latest: false,
         };
         let args = d.build_args(None, None, Some("ignored"));
         assert_eq!(args, vec!["--quiet"]);
+    }
+
+    #[test]
+    fn idless_resume_and_fork_pass_tokens_verbatim() {
+        // Mirrors the seeded codex definition: id-less resume/fork groups that
+        // resolve "latest in cwd" inside the agent and ignore any supplied id.
+        let d = AgentDef {
+            name: "codex".into(),
+            command: "codex".into(),
+            args: vec![],
+            resume_args: vec!["resume".into(), "--last".into()],
+            fork_args: vec!["fork".into(), "--last".into()],
+            new_session_args: vec![],
+            resume_latest: true,
+        };
+        // resume id present, but no {id} token -> tokens unchanged.
+        assert_eq!(
+            d.build_args(Some("ignored-uuid"), None, None),
+            vec!["resume", "--last"]
+        );
+        // fork wins over resume, still id-less.
+        assert_eq!(
+            d.build_args(Some("ignored-uuid"), Some("also-ignored"), None),
+            vec!["fork", "--last"]
+        );
+        assert!(d.resumes_latest());
+    }
+
+    #[test]
+    fn resumes_latest_requires_flag_and_resume_args() {
+        let mut d = AgentDef {
+            name: "x".into(),
+            command: "x".into(),
+            args: vec![],
+            resume_args: vec![],
+            fork_args: vec![],
+            new_session_args: vec![],
+            resume_latest: true,
+        };
+        // Flag set but no resume_args -> nothing to emit, so not "resumes latest".
+        assert!(!d.resumes_latest());
+        d.resume_args = vec!["--continue".into()];
+        assert!(d.resumes_latest());
+        d.resume_latest = false;
+        assert!(!d.resumes_latest());
     }
 
     #[test]
@@ -181,6 +244,7 @@ mod tests {
                     resume_args: vec![],
                     fork_args: vec![],
                     new_session_args: vec![],
+                    resume_latest: false,
                 },
             ],
         };

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -37,15 +37,38 @@ pub(crate) fn resume_id_if_transcript_exists(
         .then(|| agent_session_id.to_string())
 }
 
-/// Build the `(command, args)` invocation for the agent named by
-/// `config.agent`, looked up in the on-disk agent registry (falling back to
-/// the registry default, then to the built-in default).
+/// Decide the `resume_session_id` to use when restarting a session, given the
+/// agent's definition.
 ///
-/// Centralised here so headless spawn and restart agree on the args.
-fn build_agent_invocation(config: &SessionConfig) -> (String, Vec<String>) {
+/// - Agents that resume "the latest session in the launch directory"
+///   ([`AgentDef::resumes_latest`]) get the session id back as a non-`None`
+///   *trigger*: their `resume_args` are id-less (no `{id}` token), so the value
+///   itself is ignored — its presence is what makes [`AgentDef::build_args`]
+///   emit the resume group. Restart always reuses the session's directory, so
+///   the agent's own "last in cwd" resolution targets the right conversation.
+/// - Everyone else (claude) falls back to the transcript check, which returns
+///   the pinned id only when a resumable transcript exists on disk.
+///
+/// Shared by the headless restart path and `App`'s restart/restore paths so
+/// they agree on when to resume vs. start fresh.
+pub(crate) fn resume_trigger_for(
+    def: &crate::session::AgentDef,
+    agent_session_id: &str,
+    env: &HashMap<String, String>,
+) -> Option<String> {
+    if def.resumes_latest() {
+        return Some(agent_session_id.to_string());
+    }
+    resume_id_if_transcript_exists(agent_session_id, env)
+}
+
+/// Resolve the [`AgentDef`](crate::session::AgentDef) for an agent name from
+/// the on-disk registry, mirroring [`build_agent_invocation`]'s fallback chain
+/// (named agent → registry default → built-in default).
+pub(crate) fn resolve_agent_def(agent: &str) -> crate::session::AgentDef {
     let registry = crate::agent::agent_config::load_or_seed();
-    let def = registry
-        .get(&config.agent)
+    registry
+        .get(agent)
         .or_else(|| registry.default_agent())
         .cloned()
         .unwrap_or_else(|| {
@@ -53,7 +76,16 @@ fn build_agent_invocation(config: &SessionConfig) -> (String, Vec<String>) {
                 .default_agent()
                 .cloned()
                 .expect("built-in registry always has a default agent")
-        });
+        })
+}
+
+/// Build the `(command, args)` invocation for the agent named by
+/// `config.agent`, looked up in the on-disk agent registry (falling back to
+/// the registry default, then to the built-in default).
+///
+/// Centralised here so headless spawn and restart agree on the args.
+fn build_agent_invocation(config: &SessionConfig) -> (String, Vec<String>) {
+    let def = resolve_agent_def(&config.agent);
     let provider = crate::agent::GenericProvider::new(def);
     // Reach the provider trait methods via fully-qualified call syntax so this
     // module imports nothing from the agent module (architecture rule:
@@ -107,6 +139,49 @@ mod tests {
         env.insert("CLAUDE_CONFIG_DIR".into(), tmp.path().display().to_string());
         assert_eq!(
             resume_id_if_transcript_exists(sid, &env),
+            Some(sid.to_string())
+        );
+    }
+
+    #[test]
+    fn resume_trigger_latest_agent_always_triggers() {
+        // A resume_latest agent (codex) triggers resume regardless of any
+        // on-disk claude transcript; the returned id is just the trigger.
+        let codex = crate::agent::agent_config::builtin_registry()
+            .get("codex")
+            .unwrap()
+            .clone();
+        assert!(codex.resumes_latest());
+        let env = HashMap::new();
+        assert_eq!(
+            resume_trigger_for(&codex, "thurbox-uuid", &env),
+            Some("thurbox-uuid".to_string())
+        );
+    }
+
+    #[test]
+    fn resume_trigger_claude_defers_to_transcript() {
+        // claude is not resume_latest, so it only resumes when a transcript
+        // exists — same behaviour as resume_id_if_transcript_exists.
+        let claude = crate::agent::agent_config::builtin_registry()
+            .get("claude")
+            .unwrap()
+            .clone();
+        assert!(!claude.resumes_latest());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut env = HashMap::new();
+        env.insert("CLAUDE_CONFIG_DIR".into(), tmp.path().display().to_string());
+        // No transcript yet -> no resume.
+        assert_eq!(resume_trigger_for(&claude, "missing", &env), None);
+
+        // With a transcript -> resume by the pinned id.
+        let sid = "11111111-2222-3333-4444-555555555555";
+        let proj = tmp.path().join("projects").join("-slug");
+        std::fs::create_dir_all(&proj).unwrap();
+        std::fs::write(proj.join(format!("{sid}.jsonl")), b"").unwrap();
+        assert_eq!(
+            resume_trigger_for(&claude, sid, &env),
             Some(sid.to_string())
         );
     }

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -10,8 +10,9 @@ use crate::storage::Database;
 ///
 /// For the `claude` agent, uses its resume group when a transcript for the
 /// session id exists on disk, otherwise pins the same id for a fresh start.
-/// For other agents the resume decision degrades to "start fresh" (the live
-/// tmux process is what carries state across TUI restarts).
+/// For `resume_latest` agents (codex, opencode, gemini, aider) it resumes the
+/// latest session in the (unchanged) launch directory. Other agents degrade to
+/// "start fresh" (the live tmux process is what carries state across restarts).
 pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<(), String> {
     let session = db
         .get_session_by_id(session_id)
@@ -30,8 +31,8 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
         ..SessionConfig::default()
     };
     super::inject_thurbox_env(&mut config, &agent_session_id);
-    config.resume_session_id =
-        super::resume_id_if_transcript_exists(&agent_session_id, &config.env);
+    let def = super::resolve_agent_def(&config.agent);
+    config.resume_session_id = super::resume_trigger_for(&def, &agent_session_id, &config.env);
 
     let (command, args) = super::build_agent_invocation(&config);
 


### PR DESCRIPTION
## Summary

Previously only `claude` had `resume_args` / `fork_args` / `new_session_args` configured, so **codex, gemini, opencode and aider started fresh on every `Ctrl+R` restart and `Ctrl+F` fork**. This wires up fork + resume defaults for all built-in agents.

### The constraint
thurbox generates the `agent_session_id` itself and only `claude` accepts a pinned id (`--session-id`). The other CLIs generate their own ids that thurbox never learns, so they **cannot** be resumed/forked *by id*. Rather than scrape each agent's private on-disk session store (brittle, breaks agent-neutrality), this uses the agents' own **id-less, cwd-scoped flags** — they resolve "the last session in this directory" internally.

### Changes
- **`AgentDef`**: new `resume_latest: bool` field + `resumes_latest()` helper (`build_args` already passes id-less tokens through verbatim).
- **Seeded `agents.toml`** (`builtin_registry`): codex `resume --last`/`fork --last`, opencode `--continue`/`--continue --fork`, gemini `--resume latest`, aider `--restore-chat-history` — all with `resume_latest = true`. `vibe` left unconfigured (unknown CLI).
- **Resume trigger** (`session_ops::resume_trigger_for`): `resume_latest` agents trigger resume on restart; `claude` still defers to its on-disk transcript check. Deduped agent-def resolution (`resolve_agent_def`, `App::agent_def_for`). Updated all four call sites (TUI restart, two restore paths, headless restart).
- **Docs**: `CLAUDE.md`, `docs/ARCHITECTURE.md`, `docs/FEATURES.md` document `resume_latest`, the id-less model, and known limitations (gemini/aider have no fork; multi-repo fork of a cwd-scoped agent lands in a fresh workspace dir so `--last` finds no parent — multi-repo *restart* still resumes).

## Test plan
- `cargo check --all` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean
- New tests: id-less resume/fork passthrough, the `resumes_latest` gate, and `resume_trigger_for`'s latest-vs-transcript branches
- All agent_def / agent_config / session_ops / generic / architecture tests pass; `rumdl` clean on all three docs
- CI checks pass