### PR TITLE
feat(ui): customizable keyboard shortcuts via interactive F1 editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,7 +372,7 @@ plain local todo. Triggering a task runs its action and advances it to
 
 ## Global search (`Ctrl+A`)
 
-A **non-modal bottom strip** (`Ctrl+A`, also `Ctrl+/`) searches **every scope at once**:
+A **non-modal bottom strip** (`Ctrl+A`, rebindable) searches **every scope at once**:
 **sessions** (name/agent/branch + live vt100 **buffer content**), **tasks**
 (title), **automations** (name), and **files** (the active session's file
 tree). `Enter` jumps to the selected result and focuses its pane —
@@ -416,10 +416,8 @@ or the file viewer (revealing the path).
   `PanelAreas::global_search` strip above the footer (shrinking the content
   area like the side panels). Rendered by `src/ui/global_search.rs`.
 - **Binding**: `Action::GlobalSearch` defaults to `Ctrl+A` ("search All"),
-  which encodes reliably on every terminal. A literal intercept in
-  `handle_priority_key` *also* opens it on `Ctrl+/` — whose C0 control
-  (`0x1F`) terminals surface inconsistently as `Char('/')`/`Char('_')`/
-  `Char('7')`+CONTROL — so `Ctrl+/` works where the modifier survives.
+  which encodes reliably on every terminal and is fully rebindable from the
+  F1 editor like any other action (there is no separate hardcoded opener).
   Global search is the **only** search: the per-pane local `/` filters
   (session list, tasks panel) were removed in favour of it. The file
   viewer's `/` (in-file text search) is unrelated and stays.
@@ -592,7 +590,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+Z` | Undo session delete | **Z** = undo |
 | `Ctrl+U` | Restore deleted sessions | **U**ndelete |
 | `Ctrl+Y` / `F4` | Pick TUI theme | Color **Y**oke |
-| `F1` | Toggle keybindings help | Universal |
+| `F1` / `Ctrl+G` | Keybindings help + interactive editor | Universal |
 | `F2` | Toggle info panel (visible at width >= 120) | Next to F1 |
 | `F3` | Toggle file viewer | Next to F2 |
 | `F5` | Toggle tasks panel (visible at width >= 120) | Next to F4 |
@@ -601,11 +599,49 @@ List contexts use plain `j`/`k`/`Enter` for navigation.
 Terminal forwards all non-Ctrl keys to the PTY.
 `Shift+arrows/PageUp/PageDown` for scrollback.
 
-These defaults can be overridden by writing
-`~/.config/thurbox/keybindings.json`. The file maps an `Action`
-name to one or more chord strings, e.g. `{ "QuitApp": ["ctrl+x"] }`.
-Modal-internal keys (j/k/Enter/Esc inside selectors) are not
-customizable.
+These defaults can be overridden two ways, both writing the same
+`~/.config/thurbox/keybindings.json` (an `Action` name → one or more
+chord strings, e.g. `{ "QuitApp": ["ctrl+x"] }`):
+
+- **Interactively** from the F1 panel, which is a live editor rather
+  than a read-only overlay. `j`/`k` select an action, `Enter`/`r`
+  starts capture (the **next physical keypress** — including chords
+  like `ctrl+q` — becomes that action's sole binding), `d` resets the
+  selected action to its built-in default, and `Shift+D` resets **all**
+  actions (via `App::reset_all_keybindings`, which deletes the override
+  file so defaults stay authoritative). If the captured chord was already
+  bound elsewhere it is reassigned (stolen from the other action) and a
+  status toast reports the move. Each change is persisted immediately
+  via `KeyBindings::{rebind,reset}` + `storage::keybindings::save_keybindings_json`
+  and takes effect on the next keystroke — no restart. The editor lives
+  in `Modal::Help(HelpModal { selected, capturing })`; capture input is
+  routed through `App::handle_help_key` inside `handle_priority_key`
+  (**before** the global `keybindings.lookup`, so capturing `ctrl+q`
+  rebinds instead of quitting). Selection indices match
+  `Action::rebindable_in_order()` — the flattened
+  `keybindings::help_sections()`, the shared order used by
+  `render_help_overlay`.
+- **By hand-editing** the JSON file (e.g. via `$EDITOR`); read once at
+  startup.
+
+**Context-scoped bindings.** Each `Action` has a `KeyContext` (`Global`,
+`SessionList`, `FileViewer`, `Terminal`). Global actions are active
+everywhere; scoped actions fire only while their pane is focused, so a
+single-letter key like `j` can drive both the file viewer and the session
+list (and the terminal still forwards it to the PTY). `handle_key` resolves
+keys via `KeyBindings::lookup_in(App::focus_key_context(), …)`, dispatched
+through `dispatch_action`. Conflict detection (`KeyBindings::rebind`) only
+steals a chord between actions whose scopes overlap (`contexts_overlap`) —
+global-vs-anything, or same scope. Capital/shift-letter chords are
+canonicalized via `KeyChord::normalized` (e.g. `Shift+N` → `{shift, n}`) so
+capture, lookup, and the JSON round-trip agree regardless of how the
+terminal encodes them. **Copy/Paste** are global rebindable actions handled
+early in `handle_priority_key` (so Paste reaches modal text inputs).
+
+A few stateful keys stay literal (the F1 panel lists them under
+**Fixed (not rebindable)**): modal selectors (j/k/Enter/Esc), the
+automations/tasks panes, the file-viewer **search sub-mode**, and the
+terminal's catch-all PTY forwarding.
 
 ## Themes
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -256,9 +256,14 @@ applicable: `h/j/k/l` for navigation, semantic letters for actions
 | `Ctrl+Z` | Global | Undo session delete | **Z** = undo |
 | `Ctrl+U` | Global | Restore deleted sessions list | **U**ndelete |
 | `Ctrl+Y` / `F4` | Global | Pick TUI theme | Color **Y**oke |
-| `F1` | Global | Toggle keybindings help | Universal help |
+| `F1` / `Ctrl+G` | Global | Keybindings help + interactive editor | Universal help |
 | `F2` | Global | Toggle info panel | Next to F1 |
 | `F3` | Global | Toggle file viewer | Next to F2 |
+| `j` / `k` | F1 editor | Select action to rebind | |
+| `Enter` / `r` | F1 editor | Capture a new chord for the selected action | **R**ebind |
+| `d` | F1 editor | Reset selected action to its default chord(s) | **D**efault |
+| `Shift+D` | F1 editor | Reset all actions to their defaults | Reset all |
+| `Esc` | F1 editor | Close (or cancel an in-progress capture) | |
 | `j` / `Down` | Lists | Next item | |
 | `k` / `Up` | Lists | Previous item | |
 | `Enter` | Global search | Jump to selected result | |
@@ -278,6 +283,30 @@ applicable: `h/j/k/l` for navigation, semantic letters for actions
 | `Shift+PageDown` | Focused terminal | Scroll down half page | |
 | Mouse wheel | Focused terminal | Scroll up/down 3 lines | |
 | All other keys | Focused terminal | Forwarded to PTY (snaps to bottom if scrolled) | |
+
+### Customizing shortcuts
+
+Nearly every shortcut can be remapped, including copy/paste, file-viewer
+navigation, session-list navigation, and terminal scroll. The F1 panel doubles
+as a live editor: select an action with `j`/`k`, press `Enter`/`r`, then press
+the chord you want — the next physical keypress (including chords like
+`Ctrl+Q`) becomes that action's sole binding. `d` restores the selected
+action's defaults, and `Shift+D` resets every action at once (removing the
+override file). If the chord conflicts it is reassigned from the other action
+and a status toast reports the move. Changes persist immediately to
+`~/.config/thurbox/keybindings.json` (`Action` name → chord strings, e.g.
+`{ "QuitApp": ["ctrl+x"] }`) and take effect on the next keystroke — no
+restart. The file can also be hand-edited directly.
+
+**Context-scoped keys.** Each action belongs to a scope — `Global`,
+`SessionList`, `FileViewer`, or `Terminal`. Global actions fire anywhere;
+scoped actions fire only while their pane is focused, so the same single-letter
+key (e.g. `j`) can drive both the file viewer and the session list while the
+terminal still forwards it to the shell. Conflicts are only flagged between
+actions whose scopes overlap. A handful of stateful keys stay fixed (shown in
+the F1 panel under *Fixed (not rebindable)*): modal selectors
+(`j`/`k`/`Enter`/`Esc`), the automations/tasks panes, the file-viewer search
+sub-mode, and the terminal's catch-all PTY forwarding.
 
 ---
 
@@ -603,7 +632,8 @@ task's Send/Spawn action headlessly (spawned sessions are named
 
 `Ctrl+A` ("search **A**ll") opens a **non-modal bottom strip** that
 searches every scope at once — a single place to find and jump to
-anything. (`Ctrl+/` also opens it where the terminal delivers that chord.)
+anything. The opener is fully rebindable from the F1 editor
+(`Action::GlobalSearch`).
 
 ### Scopes
 
@@ -669,10 +699,8 @@ last ≤ 500 lines per session) so typing never stalls.
 Type to filter; `Up`/`Down` (or `Ctrl+P`/`Ctrl+N`) move the selection so
 plain letters still edit the query; `Enter` jumps; `Esc` closes and
 restores the previous focus. The default chord is `Ctrl+A`
-(`Action::GlobalSearch`), which encodes reliably everywhere — unlike
-`Ctrl+/`, whose C0 control (`0x1F`) terminals surface inconsistently as
-`/`, `_`, or `7` (with Ctrl). A literal intercept opens the strip on all
-three `Ctrl+/` forms too, so it works wherever the modifier survives.
+(`Action::GlobalSearch`), which encodes reliably on every terminal and is
+fully rebindable from the F1 editor like any other action.
 
 Global search is the **only** list search now: the old per-pane `/`
 filters (session list, tasks panel) were removed in its favour. The file

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -64,11 +64,13 @@ impl App {
             return;
         }
 
-        // Global keybindings (always active) — driven by user-customizable
-        // `KeyBindings`. Some actions intentionally yield to the PTY when the
+        // Keybinding lookup, scoped to the focused pane: global actions plus
+        // any scoped to the current context (file viewer, session list,
+        // terminal). Some actions intentionally yield to the PTY when the
         // terminal is focused (e.g. Ctrl+R = bash reverse-search) — those are
         // handled inside `dispatch_action`.
-        if let Some(action) = self.keybindings.lookup(code, mods) {
+        let context = self.focus_key_context();
+        if let Some(action) = self.keybindings.lookup_in(context, code, mods) {
             if self.dispatch_action(action) {
                 return;
             }
@@ -89,55 +91,141 @@ impl App {
         }
     }
 
+    /// The keybinding [`KeyContext`](crate::session::KeyContext) for the
+    /// current focus, used to scope the lookup. Single-letter scoped actions
+    /// (file viewer / session list) only resolve here, so the terminal keeps
+    /// forwarding those keys to the PTY. While the file-viewer search field is
+    /// active we fall back to `Global` so typed letters edit the query instead
+    /// of navigating.
+    pub(crate) fn focus_key_context(&self) -> crate::session::KeyContext {
+        use crate::session::KeyContext;
+        match self.focus {
+            InputFocus::SessionList => KeyContext::SessionList,
+            InputFocus::FileViewer if !self.file_viewer.search_active => KeyContext::FileViewer,
+            InputFocus::Terminal => KeyContext::Terminal,
+            _ => KeyContext::Global,
+        }
+    }
+
     /// Help-overlay dismissal and clipboard chords, routed ahead of modal
     /// handlers. Returns `true` if the key was consumed.
     fn handle_priority_key(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
-        // Dismiss help overlay with Esc or F1 (toggle)
-        if matches!(self.modal, super::modals::Modal::Help) {
-            if code == KeyCode::Esc || code == KeyCode::F(1) {
-                self.modal.close();
+        // The interactive help/keybinding editor captures all input — routed
+        // ahead of the global keybinding lookup so a chord being captured
+        // (e.g. ctrl+q) rebinds rather than triggering its action (quit).
+        if matches!(self.modal, super::modals::Modal::Help(_)) {
+            return self.handle_help_key(code, mods);
+        }
+
+        // Clipboard chords (Copy/Paste) are user-rebindable global actions but
+        // routed here, ahead of modal handlers, so Paste reaches modal/terminal
+        // text inputs and Copy works from inside any modal. Resolved via the
+        // (global) keybindings so a user's rebind takes effect.
+        match self.keybindings.lookup(code, mods) {
+            // Paste always consumes — `paste_from_clipboard` knows whether a
+            // modal text input is open and routes the text accordingly.
+            Some(crate::session::Action::Paste) => {
+                self.paste_from_clipboard();
+                return true;
+            }
+            // Copy consumes only with an active selection; otherwise it falls
+            // through to the normal handlers (e.g. SIGINT when the terminal is
+            // focused — see `dispatch_action`'s `Copy` arm).
+            Some(crate::session::Action::Copy) if self.text_selection.is_some() => {
+                self.copy_selection_to_clipboard();
+                return true;
+            }
+            _ => {}
+        }
+
+        false
+    }
+
+    /// Interactive F1 help / keybinding editor. Always consumes input while
+    /// the help modal is open (returns `true`).
+    ///
+    /// Navigation mode: `j`/`k` (or arrows) move the selection, `Enter`/`r`
+    /// begins capturing a new chord for the selected action, `d` resets the
+    /// selected action to its default(s), `Shift+D` resets *all* actions, and
+    /// `F1`/`Esc` close the overlay.
+    ///
+    /// Capture mode: the next keypress (any chord, including `ctrl+q` or `f1`)
+    /// becomes the action's sole binding; `Esc` cancels without rebinding.
+    fn handle_help_key(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
+        use crate::session::{Action, KeyChord};
+
+        let actions = Action::rebindable_in_order();
+        let super::modals::Modal::Help(ref mut help) = self.modal else {
+            return true;
+        };
+
+        if help.capturing {
+            if code == KeyCode::Esc {
+                help.capturing = false;
+                return true;
+            }
+            let chord = KeyChord { mods, code };
+            let selected = help.selected.min(actions.len().saturating_sub(1));
+            help.capturing = false;
+            let action = actions[selected];
+            let stolen = self.keybindings.rebind(action, chord);
+            self.persist_keybindings();
+            if let Some(other) = stolen {
+                self.set_info(format!(
+                    "{} reassigned from '{}'",
+                    chord.display(),
+                    other.label()
+                ));
             }
             return true;
         }
 
-        // Ctrl+V: paste. Routed before modal handlers so they don't swallow
-        // the literal 'v' — `paste_from_clipboard` knows whether a modal text
-        // input is open and routes the text accordingly.
-        if code == KeyCode::Char('v') && mods.contains(KeyModifiers::CONTROL) {
-            self.paste_from_clipboard();
-            return true;
+        match code {
+            KeyCode::Esc | KeyCode::F(1) => self.modal.close(),
+            KeyCode::Char('j') | KeyCode::Down => {
+                help.selected = (help.selected + 1).min(actions.len().saturating_sub(1));
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                help.selected = help.selected.saturating_sub(1);
+            }
+            KeyCode::Enter | KeyCode::Char('r') => help.capturing = true,
+            KeyCode::Char('d') => {
+                let selected = help.selected.min(actions.len().saturating_sub(1));
+                let action = actions[selected];
+                self.keybindings.reset(action);
+                self.persist_keybindings();
+            }
+            // Shift+D resets every action to its built-in default.
+            KeyCode::Char('D') => self.reset_all_keybindings(),
+            _ => {}
         }
+        true
+    }
 
-        // Ctrl+C: copy active mouse-drag selection. Routed before modal
-        // handlers so users can copy text from inside any modal. Without an
-        // active selection, falls through to the normal handlers (e.g. SIGINT
-        // when the terminal is focused).
-        if code == KeyCode::Char('c')
-            && mods.contains(KeyModifiers::CONTROL)
-            && self.text_selection.is_some()
-        {
-            self.copy_selection_to_clipboard();
-            return true;
+    /// Restore every keybinding to its compiled-in default and remove the
+    /// user override file so defaults remain authoritative. Surfaces failures
+    /// via the status bar; the in-memory map is reset regardless.
+    fn reset_all_keybindings(&mut self) {
+        self.keybindings = crate::session::KeyBindings::default();
+        if let Err(e) = crate::storage::keybindings::delete_keybindings_json() {
+            self.set_error(format!("Failed to reset keybindings: {e}"));
+        } else {
+            self.set_info("All keybindings reset to defaults");
         }
+    }
 
-        // Ctrl+/ is a *bonus* opener for global search (the reliable default is
-        // Ctrl+A — see `Action::GlobalSearch`). Terminals encode `Ctrl+/` as the
-        // C0 control 0x1F and surface it inconsistently: `Char('/')`, `Char('_')`,
-        // or `Char('7')`, each with the CONTROL modifier. Intercept all three
-        // here (only when the modifier survives — a bare `7` must still type a
-        // digit). Skipped while the strip is already open.
-        if mods.contains(KeyModifiers::CONTROL)
-            && matches!(
-                code,
-                KeyCode::Char('/') | KeyCode::Char('_') | KeyCode::Char('7')
-            )
-            && !self.global_search.active
-        {
-            self.open_global_search();
-            return true;
+    /// Serialize the current keybindings and write them to
+    /// `~/.config/thurbox/keybindings.json`. Surfaces failures via the status
+    /// bar rather than aborting — the in-memory map is already updated.
+    fn persist_keybindings(&mut self) {
+        match self.keybindings.to_json() {
+            Ok(json) => {
+                if let Err(e) = crate::storage::keybindings::save_keybindings_json(&json) {
+                    self.set_error(format!("Failed to save keybindings: {e}"));
+                }
+            }
+            Err(e) => self.set_error(format!("Failed to serialize keybindings: {e}")),
         }
-
-        false
     }
 
     /// Route the key to the open modal's handler, if any. Returns `true` if a
@@ -236,8 +324,9 @@ impl App {
             // `TaskList → editor` (like the automation editor): cycling out of
             // the editor returns to the tasks panel, never off to a session.
             TaskEditor => vec![TaskList, TaskEditor],
-            // The global-search strip is entered/left only via `Ctrl+/`/`Esc`,
-            // so `Ctrl+L`/`Ctrl+H` are no-ops while it's open.
+            // The global-search strip is entered/left only via its keybinding
+            // (`Ctrl+A` by default) / `Esc`, so `Ctrl+L`/`Ctrl+H` are no-ops
+            // while it's open.
             GlobalSearch => vec![GlobalSearch],
         }
     }
@@ -591,27 +680,11 @@ impl App {
     }
 
     fn handle_file_viewer_nav_key(&mut self, code: KeyCode) {
-        use crate::ui::file_viewer::Activation;
-        match code {
-            KeyCode::Char('/') => self.file_viewer.start_search(),
-            KeyCode::Char('n') => self.file_viewer.next_match(),
-            KeyCode::Char('N') => self.file_viewer.prev_match(),
-            KeyCode::Esc if !self.file_viewer.search_query.is_empty() => {
-                self.file_viewer.end_search();
-            }
-            KeyCode::Char('j') | KeyCode::Down => self.file_viewer.move_selection(1),
-            KeyCode::Char('k') | KeyCode::Up => self.file_viewer.move_selection(-1),
-            KeyCode::Char('h') | KeyCode::Left => self.file_viewer.collapse(),
-            KeyCode::Char('l') | KeyCode::Right | KeyCode::Enter => {
-                // Capture root+file before activate() (activate only opens files, not dirs).
-                let file_with_root = self.file_viewer.selected_file_with_root();
-                if matches!(self.file_viewer.activate(), Activation::Open(_)) {
-                    if let Some((file, root)) = file_with_root {
-                        self.open_file_in_editor(root, file);
-                    }
-                }
-            }
-            _ => {}
+        // Navigation/search/expand keys are rebindable `FileViewer`-scoped
+        // actions, resolved by the context lookup in `handle_key` before this
+        // runs. Only the fixed "Esc clears an active query" shortcut remains.
+        if matches!(code, KeyCode::Esc) && !self.file_viewer.search_query.is_empty() {
+            self.file_viewer.end_search();
         }
     }
 
@@ -628,62 +701,15 @@ impl App {
         }
     }
 
-    pub(crate) fn handle_session_list_key(&mut self, code: KeyCode) {
-        match code {
-            KeyCode::Char('j') | KeyCode::Down => {
-                // Past the last session, flow down into the automations pane so
-                // the left column reads as one continuous list.
-                if self.active_is_last_in_order() {
-                    self.focus = InputFocus::Automations;
-                    self.automation_panel_index = 0;
-                    self.refresh_automation_view();
-                } else {
-                    self.switch_session_forward();
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                // Above the first session, loop around to the bottom of the
-                // column: the last automation (its pane is always present).
-                if self.active_is_first_in_order() {
-                    self.focus = InputFocus::Automations;
-                    self.automation_panel_index = self.cached_automations.len().saturating_sub(1);
-                    self.refresh_automation_view();
-                } else {
-                    self.switch_session_backward();
-                }
-            }
-            KeyCode::Enter => {
-                self.focus = InputFocus::Terminal;
-            }
-            _ => {}
-        }
-    }
+    /// Session-list keys are all rebindable `SessionList`-scoped actions
+    /// (`SessionListNext`/`Prev`/`Open`), resolved by the context lookup in
+    /// `handle_key` before this runs — so nothing remains to handle here.
+    pub(crate) fn handle_session_list_key(&mut self, _code: KeyCode) {}
 
     fn handle_terminal_key(&mut self, code: KeyCode, mods: KeyModifiers) {
-        // Scroll keybindings (Shift + navigation keys)
-        if mods.contains(KeyModifiers::SHIFT) {
-            match code {
-                KeyCode::Up => {
-                    self.scroll_terminal_up(1);
-                    return;
-                }
-                KeyCode::Down => {
-                    self.scroll_terminal_down(1);
-                    return;
-                }
-                KeyCode::PageUp => {
-                    let amount = self.page_scroll_amount();
-                    self.scroll_terminal_up(amount);
-                    return;
-                }
-                KeyCode::PageDown => {
-                    let amount = self.page_scroll_amount();
-                    self.scroll_terminal_down(amount);
-                    return;
-                }
-                _ => {}
-            }
-        }
+        // Terminal scroll is handled by the rebindable `TerminalScroll*`
+        // actions in `handle_key` before this runs; everything else snaps to
+        // the bottom and is forwarded to the PTY.
 
         // Snap to bottom on any non-scroll key when scrolled up
         self.with_active_parser(|parser| {
@@ -1110,7 +1136,7 @@ impl App {
                 true
             }
             Action::ToggleHelp => {
-                self.modal = super::modals::Modal::Help;
+                self.modal = super::modals::Modal::Help(super::modals::HelpModal::default());
                 true
             }
             Action::ToggleInfoPanel => {
@@ -1146,6 +1172,115 @@ impl App {
             Action::GlobalSearch => {
                 self.open_global_search();
                 true
+            }
+
+            // ── Clipboard (global) ──────────────────────────────────────
+            // Copy only consumes the key when there's a selection; otherwise
+            // it yields (false) so the terminal can send SIGINT. Paste is
+            // normally intercepted earlier (so it reaches modal text inputs);
+            // this arm covers the plain-terminal path.
+            Action::Copy => {
+                if self.text_selection.is_some() {
+                    self.copy_selection_to_clipboard();
+                    true
+                } else {
+                    false
+                }
+            }
+            Action::Paste => {
+                self.paste_from_clipboard();
+                true
+            }
+
+            // ── Session list (scoped) ───────────────────────────────────
+            Action::SessionListNext => {
+                // Past the last session, flow into the automations pane so the
+                // left column reads as one continuous list.
+                if self.active_is_last_in_order() {
+                    self.focus = InputFocus::Automations;
+                    self.automation_panel_index = 0;
+                    self.refresh_automation_view();
+                } else {
+                    self.switch_session_forward();
+                }
+                true
+            }
+            Action::SessionListPrev => {
+                if self.active_is_first_in_order() {
+                    self.focus = InputFocus::Automations;
+                    self.automation_panel_index = self.cached_automations.len().saturating_sub(1);
+                    self.refresh_automation_view();
+                } else {
+                    self.switch_session_backward();
+                }
+                true
+            }
+            Action::SessionListOpen => {
+                self.focus = InputFocus::Terminal;
+                true
+            }
+
+            // ── File viewer (scoped) ────────────────────────────────────
+            Action::FileViewerDown => {
+                self.file_viewer.move_selection(1);
+                true
+            }
+            Action::FileViewerUp => {
+                self.file_viewer.move_selection(-1);
+                true
+            }
+            Action::FileViewerCollapse => {
+                self.file_viewer.collapse();
+                true
+            }
+            Action::FileViewerExpand => {
+                self.file_viewer_expand();
+                true
+            }
+            Action::FileViewerSearch => {
+                self.file_viewer.start_search();
+                true
+            }
+            Action::FileViewerNextMatch => {
+                self.file_viewer.next_match();
+                true
+            }
+            Action::FileViewerPrevMatch => {
+                self.file_viewer.prev_match();
+                true
+            }
+
+            // ── Terminal scroll (scoped) ────────────────────────────────
+            Action::TerminalScrollUp => {
+                self.scroll_terminal_up(1);
+                true
+            }
+            Action::TerminalScrollDown => {
+                self.scroll_terminal_down(1);
+                true
+            }
+            Action::TerminalPageUp => {
+                let amount = self.page_scroll_amount();
+                self.scroll_terminal_up(amount);
+                true
+            }
+            Action::TerminalPageDown => {
+                let amount = self.page_scroll_amount();
+                self.scroll_terminal_down(amount);
+                true
+            }
+        }
+    }
+
+    /// Expand the selected file-viewer node, opening it in the editor when it's
+    /// a file (dirs just toggle). Shared by the `FileViewerExpand` action.
+    fn file_viewer_expand(&mut self) {
+        use crate::ui::file_viewer::Activation;
+        // Capture root+file before activate() (activate only opens files, not dirs).
+        let file_with_root = self.file_viewer.selected_file_with_root();
+        if matches!(self.file_viewer.activate(), Activation::Open(_)) {
+            if let Some((file, root)) = file_with_root {
+                self.open_file_in_editor(root, file);
             }
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -257,8 +257,9 @@ pub enum InputFocus {
     /// Editing the scoped task in the central pane (like a session's terminal —
     /// reached with `Enter`/`e` from the tasks panel; `Esc` returns to it).
     TaskEditor,
-    /// The global search strip docked along the bottom (`Ctrl+/`). Captures all
-    /// input while active; entered/left only via `Ctrl+/` / `Esc`.
+    /// The global search strip docked along the bottom (`Ctrl+A` by default).
+    /// Captures all input while active; entered/left only via its keybinding /
+    /// `Esc`.
     GlobalSearch,
     Terminal,
     FileViewer,
@@ -377,7 +378,7 @@ pub struct App {
     /// while [`InputFocus::TaskEditor`] is focused it holds the in-progress
     /// edits. `None` when no task is scoped. Mirrors `automation_editor`.
     pub(crate) task_editor: Option<modals::TaskEditorModal>,
-    /// Global search strip (`Ctrl+/`): cross-scope search docked at the bottom.
+    /// Global search strip (`Ctrl+A`): cross-scope search docked at the bottom.
     pub(crate) global_search: search::GlobalSearchState,
     /// Currently active theme preset, cached so the header doesn't hit SQLite
     /// every render. Kept in sync with `db.set_active_theme` writes.
@@ -3012,7 +3013,7 @@ impl App {
         true
     }
 
-    // ---- Global search (Ctrl+/ bottom strip) -----------------------------
+    // ---- Global search (Ctrl+A bottom strip) -----------------------------
 
     /// Open the global-search strip: snapshot the current UI state (so cancel
     /// can restore it), clear the query, focus the strip, and seed the (cheap)
@@ -4155,7 +4156,7 @@ mod tests {
         // Down past the last session drops into the automations pane.
         app.focus = InputFocus::SessionList;
         app.active_index = 1; // last session in render order
-        app.handle_session_list_key(KeyCode::Char('j'));
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE);
         assert_eq!(app.focus, InputFocus::Automations);
         assert_eq!(app.automation_panel_index, 0);
 
@@ -4167,7 +4168,7 @@ mod tests {
         assert_eq!(app.active_index, 0, "looped to first session");
 
         // Up from the first session loops to the LAST automation.
-        app.handle_session_list_key(KeyCode::Char('k'));
+        app.handle_key(KeyCode::Char('k'), KeyModifiers::NONE);
         assert_eq!(app.focus, InputFocus::Automations);
         assert_eq!(app.automation_panel_index, 1, "looped to last automation");
 
@@ -4301,7 +4302,7 @@ mod tests {
             app.focus = focus;
             app.handle_key(KeyCode::F(1), KeyModifiers::NONE);
             assert!(
-                matches!(app.modal, modals::Modal::Help),
+                matches!(app.modal, modals::Modal::Help(_)),
                 "F1 should show help from {focus:?}"
             );
         }
@@ -4312,7 +4313,215 @@ mod tests {
         let mut app = app_with_sessions(0);
         app.modal = modals::Modal::RepoPicker(modals::RepoPickerModal::default());
         app.handle_key(KeyCode::F(1), KeyModifiers::NONE);
-        assert!(!matches!(app.modal, modals::Modal::Help));
+        assert!(!matches!(app.modal, modals::Modal::Help(_)));
+    }
+
+    #[test]
+    fn help_modal_navigation_clamps() {
+        let mut app = app_with_sessions(0);
+        app.modal = modals::Modal::Help(modals::HelpModal::default());
+
+        // `k` at the top stays at index 0.
+        app.handle_key(KeyCode::Char('k'), KeyModifiers::NONE);
+        let modals::Modal::Help(ref h) = app.modal else {
+            panic!("help modal closed unexpectedly");
+        };
+        assert_eq!(h.selected, 0);
+
+        // `j` past the end clamps to the last rebindable action.
+        let last = crate::session::Action::rebindable_in_order().len() - 1;
+        for _ in 0..50 {
+            app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE);
+        }
+        let modals::Modal::Help(ref h) = app.modal else {
+            panic!("help modal closed unexpectedly");
+        };
+        assert_eq!(h.selected, last);
+    }
+
+    #[test]
+    fn help_capture_then_key_rebinds_and_clears_capturing() {
+        let base = std::env::temp_dir().join("thurbox-help-rebind-test");
+        let _ = std::fs::remove_dir_all(&base);
+        let _g = crate::paths::TestPathGuard::new(&base);
+
+        let mut app = app_with_sessions(0);
+        app.handle_key(KeyCode::F(1), KeyModifiers::NONE); // open help (selected = 0)
+        app.handle_key(KeyCode::Char('r'), KeyModifiers::NONE); // begin capture
+        app.handle_key(KeyCode::Char('x'), KeyModifiers::CONTROL); // bind ctrl+x
+
+        let action = crate::session::Action::rebindable_in_order()[0];
+        assert_eq!(
+            app.keybindings
+                .lookup(KeyCode::Char('x'), KeyModifiers::CONTROL),
+            Some(action)
+        );
+        let modals::Modal::Help(ref h) = app.modal else {
+            panic!("help modal closed unexpectedly");
+        };
+        assert!(!h.capturing, "capture flag should clear after binding");
+    }
+
+    #[test]
+    fn help_capture_esc_cancels_without_rebinding() {
+        let mut app = app_with_sessions(0);
+        app.handle_key(KeyCode::F(1), KeyModifiers::NONE);
+        app.handle_key(KeyCode::Char('r'), KeyModifiers::NONE); // begin capture
+        app.handle_key(KeyCode::Esc, KeyModifiers::NONE); // cancel capture
+
+        // Still in the help modal, no longer capturing, and nothing was bound.
+        let modals::Modal::Help(ref h) = app.modal else {
+            panic!("Esc during capture should not close the help modal");
+        };
+        assert!(!h.capturing);
+        assert_eq!(
+            app.keybindings
+                .lookup(KeyCode::Char('x'), KeyModifiers::CONTROL),
+            None
+        );
+    }
+
+    #[test]
+    fn help_capturing_ctrl_q_rebinds_not_quits() {
+        let base = std::env::temp_dir().join("thurbox-help-ctrlq-test");
+        let _ = std::fs::remove_dir_all(&base);
+        let _g = crate::paths::TestPathGuard::new(&base);
+
+        let mut app = app_with_sessions(0);
+        app.handle_key(KeyCode::F(1), KeyModifiers::NONE);
+        app.handle_key(KeyCode::Char('r'), KeyModifiers::NONE); // begin capture
+        app.handle_key(KeyCode::Char('q'), KeyModifiers::CONTROL); // would normally quit
+
+        assert!(!app.should_quit, "capturing ctrl+q must rebind, not quit");
+        let action = crate::session::Action::rebindable_in_order()[0];
+        assert_eq!(
+            app.keybindings
+                .lookup(KeyCode::Char('q'), KeyModifiers::CONTROL),
+            Some(action)
+        );
+    }
+
+    #[test]
+    fn help_reset_d_restores_defaults() {
+        let base = std::env::temp_dir().join("thurbox-help-reset-test");
+        let _ = std::fs::remove_dir_all(&base);
+        let _g = crate::paths::TestPathGuard::new(&base);
+
+        let mut app = app_with_sessions(0);
+        app.handle_key(KeyCode::F(1), KeyModifiers::NONE);
+        let action = crate::session::Action::rebindable_in_order()[0];
+
+        // Rebind the selected action to ctrl+x...
+        app.handle_key(KeyCode::Char('r'), KeyModifiers::NONE);
+        app.handle_key(KeyCode::Char('x'), KeyModifiers::CONTROL);
+        assert_eq!(
+            app.keybindings
+                .lookup(KeyCode::Char('x'), KeyModifiers::CONTROL),
+            Some(action)
+        );
+
+        // ...then `d` restores its compiled-in defaults.
+        app.handle_key(KeyCode::Char('d'), KeyModifiers::NONE);
+        assert_eq!(
+            app.keybindings.chords_for(action),
+            action.default_chords().as_slice()
+        );
+    }
+
+    #[test]
+    fn help_reset_all_restores_every_default() {
+        let base = std::env::temp_dir().join("thurbox-help-reset-all-test");
+        let _ = std::fs::remove_dir_all(&base);
+        let _g = crate::paths::TestPathGuard::new(&base);
+
+        let mut app = app_with_sessions(0);
+        app.handle_key(KeyCode::F(1), KeyModifiers::NONE);
+
+        // Rebind two distinct actions away from their defaults.
+        let actions = crate::session::Action::rebindable_in_order();
+        app.keybindings
+            .rebind(actions[0], crate::session::KeyChord::ctrl('x'));
+        app.keybindings
+            .rebind(actions[1], crate::session::KeyChord::ctrl('y'));
+
+        // Shift+D resets everything.
+        app.handle_key(KeyCode::Char('D'), KeyModifiers::SHIFT);
+
+        for action in crate::session::Action::all() {
+            assert_eq!(
+                app.keybindings.chords_for(*action),
+                action.default_chords().as_slice(),
+                "{action:?} should be reset to defaults"
+            );
+        }
+        // The override file is gone, so defaults stay authoritative.
+        assert_eq!(
+            crate::storage::keybindings::load_keybindings_json().unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn focus_key_context_maps_focus_to_scope() {
+        use crate::session::KeyContext;
+        let mut app = app_with_sessions(1);
+
+        app.focus = InputFocus::SessionList;
+        assert_eq!(app.focus_key_context(), KeyContext::SessionList);
+        app.focus = InputFocus::Terminal;
+        assert_eq!(app.focus_key_context(), KeyContext::Terminal);
+        app.focus = InputFocus::FileViewer;
+        assert_eq!(app.focus_key_context(), KeyContext::FileViewer);
+
+        // While the file-viewer search field is active, fall back to Global so
+        // typed letters edit the query instead of navigating the tree.
+        app.file_viewer.search_active = true;
+        assert_eq!(app.focus_key_context(), KeyContext::Global);
+        app.file_viewer.search_active = false;
+
+        // Automations / tasks / editors are not a scoped keybinding context.
+        app.focus = InputFocus::Automations;
+        assert_eq!(app.focus_key_context(), KeyContext::Global);
+    }
+
+    #[test]
+    fn file_viewer_scoped_keys_route_through_keybindings() {
+        let mut app = app_with_sessions(1);
+        app.focus = InputFocus::FileViewer;
+        assert!(!app.file_viewer.search_active);
+
+        // `/` is the rebindable FileViewerSearch action.
+        app.handle_key(KeyCode::Char('/'), KeyModifiers::NONE);
+        assert!(app.file_viewer.search_active, "'/' should start the search");
+
+        // Now in search mode the context falls back to Global, so plain letters
+        // edit the query (routed to the literal search handler) rather than
+        // triggering FileViewerDown etc.
+        app.handle_key(KeyCode::Char('a'), KeyModifiers::NONE);
+        app.handle_key(KeyCode::Char('b'), KeyModifiers::NONE);
+        assert_eq!(app.file_viewer.search_query, "ab");
+    }
+
+    #[test]
+    fn file_viewer_search_action_is_rebindable() {
+        let base = std::env::temp_dir().join("thurbox-fv-rebind-test");
+        let _ = std::fs::remove_dir_all(&base);
+        let _g = crate::paths::TestPathGuard::new(&base);
+
+        let mut app = app_with_sessions(1);
+        // Rebind FileViewerSearch from `/` to `s`.
+        app.keybindings.rebind(
+            crate::session::Action::FileViewerSearch,
+            crate::session::KeyChord::plain('s'),
+        );
+        app.focus = InputFocus::FileViewer;
+
+        // `/` no longer opens search...
+        app.handle_key(KeyCode::Char('/'), KeyModifiers::NONE);
+        assert!(!app.file_viewer.search_active);
+        // ...the new `s` chord does.
+        app.handle_key(KeyCode::Char('s'), KeyModifiers::NONE);
+        assert!(app.file_viewer.search_active);
     }
 
     #[test]
@@ -4486,13 +4695,13 @@ mod tests {
         assert_eq!(app.focus, InputFocus::TaskEditor);
     }
 
-    // --- Global search (Ctrl+A, also Ctrl+/) tests ---
+    // --- Global search (Ctrl+A, fully rebindable) tests ---
 
     #[test]
     fn ctrl_a_opens_global_search() {
         let mut app = app_with_sessions(1);
         app.focus = InputFocus::SessionList;
-        // Ctrl+A is the reliable default binding.
+        // Ctrl+A is the default binding.
         app.handle_key(KeyCode::Char('a'), KeyModifiers::CONTROL);
         assert!(app.global_search.active);
         assert_eq!(app.focus, InputFocus::GlobalSearch);
@@ -4503,20 +4712,42 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_slash_encodings_open_global_search() {
-        // The literal intercept opens search on every Ctrl+/ encoding terminals
-        // emit (`/`, `_`, `7`), but only with the CONTROL modifier present.
+    fn ctrl_slash_no_longer_opens_global_search() {
+        // The hardcoded Ctrl+/ intercept was removed: global search is opened
+        // solely via the (rebindable) `Action::GlobalSearch` chord. The former
+        // Ctrl+/ encodings (`/`, `_`, `7`) must no longer open the strip.
         for c in ['/', '_', '7'] {
             let mut app = app_with_sessions(1);
             app.focus = InputFocus::SessionList;
             app.handle_key(KeyCode::Char(c), KeyModifiers::CONTROL);
-            assert!(app.global_search.active, "Ctrl+{c} should open search");
+            assert!(
+                !app.global_search.active,
+                "Ctrl+{c} must not open search anymore"
+            );
         }
-        // A bare digit still types normally (no modifier → not intercepted).
+    }
+
+    #[test]
+    fn global_search_chord_is_rebindable() {
+        let base = std::env::temp_dir().join("thurbox-gs-rebind-test");
+        let _ = std::fs::remove_dir_all(&base);
+        let _g = crate::paths::TestPathGuard::new(&base);
+
         let mut app = app_with_sessions(1);
+        // Rebind global search from Ctrl+A to Ctrl+X via the F1 editor.
+        app.keybindings.rebind(
+            crate::session::Action::GlobalSearch,
+            crate::session::KeyChord::ctrl('x'),
+        );
+
+        // The old chord no longer opens it...
         app.focus = InputFocus::SessionList;
-        app.handle_key(KeyCode::Char('7'), KeyModifiers::NONE);
-        assert!(!app.global_search.active, "bare 7 must not open search");
+        app.handle_key(KeyCode::Char('a'), KeyModifiers::CONTROL);
+        assert!(!app.global_search.active, "old Ctrl+A must not open search");
+
+        // ...and the new chord does.
+        app.handle_key(KeyCode::Char('x'), KeyModifiers::CONTROL);
+        assert!(app.global_search.active, "new Ctrl+X should open search");
     }
 
     #[test]

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -988,6 +988,20 @@ impl TaskEditorModal {
     }
 }
 
+// ── Help / Keybinding Editor Modal ──────────────────────────────────────────
+
+/// State for the interactive F1 keybinding editor.
+///
+/// `selected` indexes into [`Action::rebindable_in_order`], which matches the
+/// row order rendered by `render_help_overlay`. When `capturing` is set, the
+/// next keypress is captured as the new chord for the selected action rather
+/// than being interpreted normally.
+#[derive(Debug, Clone, Default)]
+pub struct HelpModal {
+    pub selected: usize,
+    pub capturing: bool,
+}
+
 // ── Main Modal Enum ────────────────────────────────────────────────────────
 
 /// Single, discriminated union replacing boolean flags for modal state.
@@ -996,7 +1010,7 @@ impl TaskEditorModal {
 pub enum Modal {
     #[default]
     None,
-    Help,
+    Help(HelpModal),
     BranchSelector(BranchSelectorModal),
     WorktreeName(WorktreeNameModal),
     AgentPicker(crate::ui::agent_picker_modal::AgentPickerState),
@@ -1095,13 +1109,13 @@ mod tests {
 
     #[test]
     fn test_modal_help_is_open() {
-        let modal = Modal::Help;
+        let modal = Modal::Help(HelpModal::default());
         assert!(!matches!(modal, Modal::None));
     }
 
     #[test]
     fn test_modal_close() {
-        let mut modal = Modal::Help;
+        let mut modal = Modal::Help(HelpModal::default());
         assert!(!matches!(modal, Modal::None));
         modal.close();
         assert!(matches!(modal, Modal::None));
@@ -1131,7 +1145,7 @@ mod tests {
         let mut modal = Modal::None;
         assert!(matches!(modal, Modal::None));
 
-        modal = Modal::Help;
+        modal = Modal::Help(HelpModal::default());
         assert!(!matches!(modal, Modal::None));
 
         modal.close();

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -1,4 +1,4 @@
-//! Global search — a non-modal bottom strip (`Ctrl+A`, also `Ctrl+/`) that
+//! Global search — a non-modal bottom strip (`Ctrl+A` by default) that
 //! searches across every scope at once: session metadata + live buffer
 //! **content**, automation names, task titles, and the active session's file
 //! tree.

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -11,7 +11,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::session::{Action, Category, KeyBindings, KeyChord, SessionInfo};
+use crate::session::{KeyBindings, KeyChord, SessionInfo};
 use crate::ui::selection;
 use crate::ui::theme::Theme;
 use crate::ui::{
@@ -394,8 +394,8 @@ impl App {
     /// Render any active modal overlay on top of everything else.
     fn render_modals(&self, frame: &mut Frame) {
         // Help overlay (rendered last, on top of everything)
-        if matches!(self.modal, super::modals::Modal::Help) {
-            render_help_overlay(frame, &self.keybindings);
+        if let super::modals::Modal::Help(ref help) = self.modal {
+            render_help_overlay(frame, &self.keybindings, help);
         }
 
         // Worktree name modal
@@ -796,85 +796,91 @@ fn editor_preview(m: &super::modals::AutomationEditorModal, now: u64) -> String 
     }
 }
 
-fn render_help_overlay(frame: &mut Frame, keybindings: &KeyBindings) {
+fn render_help_overlay(
+    frame: &mut Frame,
+    keybindings: &KeyBindings,
+    help: &super::modals::HelpModal,
+) {
     let area = centered_rect(60, 70, frame.area());
 
     let inner = crate::ui::render_modal_frame(frame, area, "Keybindings");
 
     let mut help_lines: Vec<Line<'static>> = Vec::new();
 
-    // Action-driven sections — every variant of `Action` shows up here
-    // automatically. Adding a new variant is a compile error in
-    // `Action::category()` and `Action::default_chords()`.
-    for category in Category::all() {
-        help_lines.push(help_section(category.title()));
-        for action in Action::all().iter().filter(|a| a.category() == *category) {
-            let key = chords_display(keybindings.chords_for(*action));
-            help_lines.push(help_line(key, action.label()));
+    // Editable sections — driven by `keybindings::help_sections()`, the same
+    // ordering as `Action::rebindable_in_order()`, so `idx` lines up with
+    // `help.selected` from the interactive editor. EVERY row here is rebindable.
+    let mut idx = 0usize;
+    // Line index of the selected action row, so the body can scroll to keep it
+    // visible on short terminals.
+    let mut selected_line = 0usize;
+    for (title, actions) in crate::session::keybindings::help_sections() {
+        help_lines.push(help_section(title));
+        for action in actions {
+            let selected = idx == help.selected;
+            let key = if selected && help.capturing {
+                "Press the new shortcut… (Esc cancels)".to_string()
+            } else {
+                chords_display(keybindings.chords_for(action))
+            };
+            if selected {
+                selected_line = help_lines.len();
+            }
+            help_lines.push(help_row(key, action.label(), selected));
+            idx += 1;
         }
         help_lines.push(Line::from(""));
     }
 
-    // Non-Action keys (modal-internal, terminal forwarding, file viewer).
-    // These are not user-rebindable and don't drift with the `Action` enum.
-    help_lines.push(help_section("List Navigation (when focused)"));
-    help_lines.push(help_line("j / Down".into(), "Select next item"));
-    help_lines.push(help_line("k / Up".into(), "Select previous item"));
-    help_lines.push(help_line("Enter".into(), "Focus next pane"));
-    help_lines.push(Line::from(""));
-
-    help_lines.push(help_section("File Viewer (when focused)"));
-    help_lines.push(help_line("j/k".into(), "Move down/up"));
-    help_lines.push(help_line("h".into(), "Collapse / parent"));
+    // Fixed keys that are NOT rebindable: stateful sub-modes (file-viewer
+    // search, modal selectors) and terminal pass-through. Shown for reference,
+    // never selectable.
+    help_lines.push(help_section("Fixed (not rebindable)"));
     help_lines.push(help_line(
-        "l / Enter".into(),
-        "Expand dir / open file in editor",
-    ));
-    help_lines.push(help_line("/".into(), "Start search"));
-    help_lines.push(help_line(
-        "Enter / \u{2193}".into(),
-        "In search: jump to next match (stays in search)",
-    ));
-    help_lines.push(help_line("\u{2191}".into(), "In search: previous match"));
-    help_lines.push(help_line(
-        "Tab".into(),
-        "In search: commit & exit search mode",
-    ));
-    help_lines.push(help_line("Esc".into(), "In search: cancel and clear query"));
-    help_lines.push(help_line(
-        "n / N".into(),
-        "After search: next / previous match",
-    ));
-    help_lines.push(Line::from(""));
-
-    help_lines.push(help_section("Terminal (when focused)"));
-    help_lines.push(help_line(
-        "Ctrl+C".into(),
-        "Copy selection, or send SIGINT if none",
-    ));
-    help_lines.push(help_line("Ctrl+V".into(), "Paste from clipboard"));
-    help_lines.push(help_line(
-        "Shift+\u{2191}/\u{2193}".into(),
-        "Scroll up/down one line",
+        "/ then type".into(),
+        "File viewer: search; Enter/↑/↓ cycle matches, Tab commits, Esc cancels",
     ));
     help_lines.push(help_line(
-        "Shift+PgUp/PgDn".into(),
-        "Scroll up/down half page",
+        "j/k/Enter/Esc".into(),
+        "Automations & tasks panes, and modal selectors",
     ));
     help_lines.push(help_line(
         "Mouse wheel".into(),
-        "Scroll up/down three lines",
+        "Terminal: scroll three lines",
     ));
     help_lines.push(help_line("Click+drag".into(), "Select text"));
-    help_lines.push(help_line("*".into(), "All other keys forwarded to session"));
-    help_lines.push(Line::from(""));
+    help_lines.push(help_line(
+        "*".into(),
+        "Terminal: all other keys forwarded to session",
+    ));
 
-    help_lines.push(Line::from(Span::styled(
-        "Press F1 or Esc to close",
-        Style::default().fg(Theme::text_muted()),
-    )));
+    // Reserve the bottom row for the controls footer so it stays visible even
+    // when the body overflows the modal height (the body scrolls, the footer
+    // never does).
+    let [body, footer] = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .areas(inner);
 
-    frame.render_widget(Paragraph::new(help_lines), inner);
+    // On short terminals the body overflows; scroll it so the selected action
+    // row stays visible (roughly centered), clamped to the real content range.
+    let total = help_lines.len();
+    let body_h = body.height as usize;
+    let scroll = if total <= body_h {
+        0
+    } else {
+        let max_scroll = total - body_h;
+        selected_line.saturating_sub(body_h / 2).min(max_scroll)
+    };
+
+    frame.render_widget(Paragraph::new(help_lines).scroll((scroll as u16, 0)), body);
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "j/k move · Enter/r rebind · d reset · shift+D reset all · Esc close",
+            Style::default().fg(Theme::text_muted()),
+        ))),
+        footer,
+    );
 }
 
 /// Format a slice of chords as the F1-help key column, e.g.
@@ -901,6 +907,20 @@ fn help_line(key: String, desc: &'static str) -> Line<'static> {
         Span::styled(format!("  {key:<16}"), Theme::keybind()),
         Span::styled(desc, Style::default().fg(Theme::text_primary())),
     ])
+}
+
+/// A rebindable keybinding row in the interactive help editor. When
+/// `selected`, the row is rendered with the active-item style and a `›`
+/// marker so the user can see which action a captured chord will bind to.
+fn help_row(key: String, desc: &'static str, selected: bool) -> Line<'static> {
+    if selected {
+        Line::from(vec![
+            Span::styled(format!("› {key:<16}"), Theme::selected_item()),
+            Span::styled(desc, Theme::selected_item()),
+        ])
+    } else {
+        help_line(key, desc)
+    }
 }
 
 /// Create a centered rectangle within the given area.

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -1,20 +1,33 @@
-//! User-customizable global keybindings.
+//! User-customizable keybindings.
 //!
-//! Each global action the TUI exposes (quit, new session, switch session,
-//! ...) maps to one or more `KeyChord`s. Defaults reproduce the table in
-//! `CLAUDE.md`. Users can override via `~/.config/thurbox/keybindings.json`.
+//! Each action the TUI exposes maps to one or more `KeyChord`s and carries a
+//! [`KeyContext`]. **Global** actions (quit, new session, copy/paste, …) are
+//! active everywhere; **scoped** actions (file viewer / session list nav,
+//! terminal scroll) fire only while their pane is focused — so single-letter
+//! keys like `j`/`k` can be rebound per-pane without stealing them from the
+//! terminal, which forwards everything to the PTY. Defaults reproduce the
+//! table in `CLAUDE.md`; users override via the F1 editor or by hand-editing
+//! `~/.config/thurbox/keybindings.json`.
 //!
-//! Modal-internal navigation keys (j/k/Enter/Esc inside selectors) are *not*
-//! customizable and remain literal in `key_handlers.rs`.
+//! A few stateful keys remain literal in `key_handlers.rs` and are *not*
+//! rebindable: modal-internal selectors (j/k/Enter/Esc), the automations/tasks
+//! panes, and the file-viewer search sub-mode.
 
 use std::collections::HashMap;
 
 use crossterm::event::{KeyCode, KeyModifiers};
 use serde::{Deserialize, Serialize};
 
-/// Every user-rebindable global action.
+/// Every user-rebindable action.
+///
+/// Each action has a [`KeyContext`] (see [`Action::context`]). **Global**
+/// actions are active everywhere; **scoped** actions only fire while their
+/// pane is focused — which is why single-letter keys (`j`/`k`/`h`/`l`) can be
+/// rebound for the file viewer / session list without stealing them from the
+/// terminal (which forwards everything to the PTY).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Action {
+    // ── Global ──────────────────────────────────────────────────────────
     QuitApp,
     NewSession,
     DeleteSession,
@@ -36,6 +49,40 @@ pub enum Action {
     ToggleFileViewer,
     FocusTasks,
     GlobalSearch,
+    /// Copy the active mouse selection (falls through to terminal SIGINT when
+    /// there is no selection).
+    Copy,
+    /// Paste the clipboard into the focused text input / terminal.
+    Paste,
+    // ── Session list (scoped) ───────────────────────────────────────────
+    SessionListNext,
+    SessionListPrev,
+    SessionListOpen,
+    // ── File viewer (scoped) ────────────────────────────────────────────
+    FileViewerDown,
+    FileViewerUp,
+    FileViewerCollapse,
+    FileViewerExpand,
+    FileViewerSearch,
+    FileViewerNextMatch,
+    FileViewerPrevMatch,
+    // ── Terminal (scoped) ───────────────────────────────────────────────
+    TerminalScrollUp,
+    TerminalScrollDown,
+    TerminalPageUp,
+    TerminalPageDown,
+}
+
+/// The focus scope in which an [`Action`] is active. `Global` actions fire in
+/// any context; scoped actions fire only while their pane is focused, so the
+/// same chord can mean different things in different panes (and stays free for
+/// the terminal to forward to the PTY).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KeyContext {
+    Global,
+    SessionList,
+    FileViewer,
+    Terminal,
 }
 
 impl Action {
@@ -63,6 +110,22 @@ impl Action {
             Action::ToggleFileViewer,
             Action::FocusTasks,
             Action::GlobalSearch,
+            Action::Copy,
+            Action::Paste,
+            Action::SessionListNext,
+            Action::SessionListPrev,
+            Action::SessionListOpen,
+            Action::FileViewerDown,
+            Action::FileViewerUp,
+            Action::FileViewerCollapse,
+            Action::FileViewerExpand,
+            Action::FileViewerSearch,
+            Action::FileViewerNextMatch,
+            Action::FileViewerPrevMatch,
+            Action::TerminalScrollUp,
+            Action::TerminalScrollDown,
+            Action::TerminalPageUp,
+            Action::TerminalPageDown,
         ]
     }
 
@@ -90,37 +153,48 @@ impl Action {
             Action::ToggleFileViewer => "Toggle file viewer",
             Action::FocusTasks => "Tasks",
             Action::GlobalSearch => "Global search",
+            Action::Copy => "Copy selection",
+            Action::Paste => "Paste",
+            Action::SessionListNext => "Next item",
+            Action::SessionListPrev => "Previous item",
+            Action::SessionListOpen => "Focus terminal",
+            Action::FileViewerDown => "Move down",
+            Action::FileViewerUp => "Move up",
+            Action::FileViewerCollapse => "Collapse / parent",
+            Action::FileViewerExpand => "Expand / open file",
+            Action::FileViewerSearch => "Start search",
+            Action::FileViewerNextMatch => "Next match",
+            Action::FileViewerPrevMatch => "Previous match",
+            Action::TerminalScrollUp => "Scroll up one line",
+            Action::TerminalScrollDown => "Scroll down one line",
+            Action::TerminalPageUp => "Scroll up half page",
+            Action::TerminalPageDown => "Scroll down half page",
         }
     }
 
-    /// Section grouping used by the F1 help overlay. Exhaustive match —
-    /// adding a new `Action` variant without classifying it here is a
-    /// compile error, which is the entire point of this method.
-    pub fn category(self) -> Category {
+    /// The focus scope in which this action is active. Exhaustive match —
+    /// adding a new `Action` variant without classifying it here is a compile
+    /// error, which is the entire point of this method. Drives both the
+    /// context-aware [`KeyBindings::lookup_in`] and the conflict rules in
+    /// [`KeyBindings::rebind`].
+    pub fn context(self) -> KeyContext {
         match self {
-            Action::FocusBackward
-            | Action::FocusForward
-            | Action::NextSession
-            | Action::PreviousSession => Category::Navigation,
-
-            Action::NewSession
-            | Action::DeleteSession
-            | Action::RestartSession
-            | Action::ForkSession
-            | Action::OpenAutomations
-            | Action::UndoDelete
-            | Action::OpenRestoreSessions => Category::Sessions,
-
-            Action::OpenInEditor | Action::StartSync => Category::Project,
-
-            Action::QuitApp
-            | Action::ToggleShell
-            | Action::ToggleHelp
-            | Action::ToggleInfoPanel
-            | Action::ToggleFileViewer
-            | Action::FocusTasks
-            | Action::GlobalSearch
-            | Action::OpenThemePicker => Category::Ui,
+            Action::SessionListNext | Action::SessionListPrev | Action::SessionListOpen => {
+                KeyContext::SessionList
+            }
+            Action::FileViewerDown
+            | Action::FileViewerUp
+            | Action::FileViewerCollapse
+            | Action::FileViewerExpand
+            | Action::FileViewerSearch
+            | Action::FileViewerNextMatch
+            | Action::FileViewerPrevMatch => KeyContext::FileViewer,
+            Action::TerminalScrollUp
+            | Action::TerminalScrollDown
+            | Action::TerminalPageUp
+            | Action::TerminalPageDown => KeyContext::Terminal,
+            // Everything else is a global action, active in every context.
+            _ => KeyContext::Global,
         }
     }
 
@@ -149,47 +223,114 @@ impl Action {
             Action::ToggleInfoPanel => vec![KeyChord::ctrl('b'), KeyChord::function(2)],
             Action::ToggleFileViewer => vec![KeyChord::ctrl('e'), KeyChord::function(3)],
             Action::FocusTasks => vec![KeyChord::ctrl('w'), KeyChord::function(5)],
-            // Ctrl+A ("search All") is the reliable default — it encodes
-            // identically on every terminal, unlike Ctrl+/ (which many terminals
-            // deliver as a bare `7`/`_` or drop the modifier). The Ctrl+/
-            // encodings are still caught by a literal intercept in
-            // `handle_priority_key`.
+            // Ctrl+A ("search All") — encodes identically on every terminal,
+            // so it's a reliable, fully-rebindable opener.
             Action::GlobalSearch => vec![KeyChord::ctrl('a')],
+            Action::Copy => vec![KeyChord::ctrl('c')],
+            Action::Paste => vec![KeyChord::ctrl('v')],
+            // Scoped single-letter / arrow nav. These only fire while their
+            // pane is focused, so they don't collide with the terminal.
+            Action::SessionListNext => vec![KeyChord::plain('j'), KeyChord::key(KeyCode::Down)],
+            Action::SessionListPrev => vec![KeyChord::plain('k'), KeyChord::key(KeyCode::Up)],
+            Action::SessionListOpen => vec![KeyChord::key(KeyCode::Enter)],
+            Action::FileViewerDown => vec![KeyChord::plain('j'), KeyChord::key(KeyCode::Down)],
+            Action::FileViewerUp => vec![KeyChord::plain('k'), KeyChord::key(KeyCode::Up)],
+            Action::FileViewerCollapse => vec![KeyChord::plain('h'), KeyChord::key(KeyCode::Left)],
+            Action::FileViewerExpand => vec![
+                KeyChord::plain('l'),
+                KeyChord::key(KeyCode::Right),
+                KeyChord::key(KeyCode::Enter),
+            ],
+            Action::FileViewerSearch => vec![KeyChord::plain('/')],
+            Action::FileViewerNextMatch => vec![KeyChord::plain('n')],
+            // Shift+N — normalized so it round-trips through display/parse.
+            Action::FileViewerPrevMatch => {
+                vec![KeyChord::normalized(KeyModifiers::NONE, KeyCode::Char('N'))]
+            }
+            Action::TerminalScrollUp => vec![KeyChord::shift(KeyCode::Up)],
+            Action::TerminalScrollDown => vec![KeyChord::shift(KeyCode::Down)],
+            Action::TerminalPageUp => vec![KeyChord::shift(KeyCode::PageUp)],
+            Action::TerminalPageDown => vec![KeyChord::shift(KeyCode::PageDown)],
         }
+    }
+
+    /// Rebindable actions in F1 help render order — the flattened
+    /// [`help_sections`]. The interactive help editor indexes its selection
+    /// into this list, so it must match the render order in
+    /// `render_help_overlay`.
+    pub fn rebindable_in_order() -> Vec<Action> {
+        help_sections()
+            .into_iter()
+            .flat_map(|(_, actions)| actions)
+            .collect()
     }
 }
 
-/// Section grouping for the F1 help overlay.
-///
-/// Order of variants in `all()` is the order sections render in.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Category {
-    Navigation,
-    Sessions,
-    Project,
-    Ui,
-}
-
-impl Category {
-    /// Section header text shown above the entries.
-    pub fn title(self) -> &'static str {
-        match self {
-            Category::Navigation => "Navigation",
-            Category::Sessions => "Sessions",
-            Category::Project => "Project",
-            Category::Ui => "UI",
-        }
-    }
-
-    /// Every category in render order.
-    pub fn all() -> &'static [Category] {
-        &[
-            Category::Navigation,
-            Category::Sessions,
-            Category::Project,
-            Category::Ui,
-        ]
-    }
+/// The F1 help overlay's editable sections, in render order: a section title
+/// and the actions shown under it. Global actions come first (grouped by
+/// theme), then the scoped panes (`… (when focused)`). This is the single
+/// source of truth for both [`Action::rebindable_in_order`] and the overlay
+/// renderer, so the editor's selection index and the rendered rows never drift.
+pub fn help_sections() -> Vec<(&'static str, Vec<Action>)> {
+    use Action::*;
+    vec![
+        (
+            "Navigation",
+            vec![FocusBackward, FocusForward, NextSession, PreviousSession],
+        ),
+        (
+            "Sessions",
+            vec![
+                NewSession,
+                DeleteSession,
+                RestartSession,
+                ForkSession,
+                OpenAutomations,
+                FocusTasks,
+                UndoDelete,
+                OpenRestoreSessions,
+            ],
+        ),
+        ("Project", vec![OpenInEditor, StartSync]),
+        (
+            "UI",
+            vec![
+                QuitApp,
+                ToggleShell,
+                ToggleHelp,
+                ToggleInfoPanel,
+                ToggleFileViewer,
+                OpenThemePicker,
+                GlobalSearch,
+            ],
+        ),
+        ("Clipboard", vec![Copy, Paste]),
+        (
+            "Session list (when focused)",
+            vec![SessionListNext, SessionListPrev, SessionListOpen],
+        ),
+        (
+            "File viewer (when focused)",
+            vec![
+                FileViewerDown,
+                FileViewerUp,
+                FileViewerCollapse,
+                FileViewerExpand,
+                FileViewerSearch,
+                FileViewerNextMatch,
+                FileViewerPrevMatch,
+            ],
+        ),
+        (
+            "Terminal (when focused)",
+            vec![
+                TerminalScrollUp,
+                TerminalScrollDown,
+                TerminalPageUp,
+                TerminalPageDown,
+            ],
+        ),
+    ]
 }
 
 /// A key chord: modifiers + key code.
@@ -212,6 +353,38 @@ impl KeyChord {
             mods: KeyModifiers::NONE,
             code: KeyCode::F(n),
         }
+    }
+
+    /// A plain (unmodified) character key, e.g. `j` or `/`.
+    pub fn plain(c: char) -> Self {
+        Self::normalized(KeyModifiers::NONE, KeyCode::Char(c))
+    }
+
+    /// A bare key code with no modifiers (e.g. `Enter`, `Down`).
+    pub fn key(code: KeyCode) -> Self {
+        Self::normalized(KeyModifiers::NONE, code)
+    }
+
+    /// A `Shift`+key chord (e.g. `Shift+Up`).
+    pub fn shift(code: KeyCode) -> Self {
+        Self::normalized(KeyModifiers::SHIFT, code)
+    }
+
+    /// Build a chord, normalizing the Shift+letter encoding ambiguity:
+    /// terminals deliver e.g. Shift+n as `Char('N')` (sometimes with the SHIFT
+    /// modifier, sometimes without), and `KeyChord::parse` lowercases letters.
+    /// We canonicalize every uppercase `Char` to `Shift` + the lowercase letter
+    /// so capture, lookup, and the JSON round-trip all agree.
+    pub fn normalized(mods: KeyModifiers, code: KeyCode) -> Self {
+        if let KeyCode::Char(c) = code {
+            if c.is_ascii_uppercase() {
+                return Self {
+                    mods: mods | KeyModifiers::SHIFT,
+                    code: KeyCode::Char(c.to_ascii_lowercase()),
+                };
+            }
+        }
+        Self { mods, code }
     }
 
     /// Render the chord using the same notation accepted by `parse`.
@@ -293,8 +466,16 @@ impl KeyChord {
             _ => return None,
         };
 
-        Some(KeyChord { mods, code })
+        Some(KeyChord::normalized(mods, code))
     }
+}
+
+/// Two actions' active scopes overlap (and so their chords would collide) when
+/// either is global, or they share the same scope. Distinct scoped contexts
+/// (e.g. session list vs file viewer) never collide — they are never focused
+/// at the same time.
+pub fn contexts_overlap(a: KeyContext, b: KeyContext) -> bool {
+    a == KeyContext::Global || b == KeyContext::Global || a == b
 }
 
 /// A user-editable map from `Action` to one or more chords.
@@ -331,16 +512,70 @@ impl KeyBindings {
         self.map.get(&action).map(Vec::as_slice).unwrap_or(&[])
     }
 
-    /// Reverse lookup: given the keypress, return the bound action.
+    /// Reverse lookup restricted to **global** actions (active in every
+    /// context). Used by the early clipboard routing and the global dispatch.
     pub fn lookup(&self, code: KeyCode, mods: KeyModifiers) -> Option<Action> {
+        self.lookup_in(KeyContext::Global, code, mods)
+    }
+
+    /// Context-aware reverse lookup: match a chord against actions that are
+    /// active in `context` — i.e. global actions plus those scoped to
+    /// `context`. The keypress is normalized first so Shift+letter encodings
+    /// match regardless of how the terminal delivered them.
+    pub fn lookup_in(
+        &self,
+        context: KeyContext,
+        code: KeyCode,
+        mods: KeyModifiers,
+    ) -> Option<Action> {
+        let target = KeyChord::normalized(mods, code);
         for (action, chords) in &self.map {
-            for chord in chords {
-                if chord.code == code && chord.mods == mods {
-                    return Some(*action);
-                }
+            let ctx = action.context();
+            if ctx != KeyContext::Global && ctx != context {
+                continue;
+            }
+            if chords
+                .iter()
+                .any(|c| c.code == target.code && c.mods == target.mods)
+            {
+                return Some(*action);
             }
         }
         None
+    }
+
+    /// Replace all chords for `action` with the single `chord`. If the chord
+    /// was already bound to a *conflicting* action (one whose context overlaps
+    /// — see [`contexts_overlap`]), unbind it there and return that action so
+    /// the caller can report the reassignment. Bindings in non-overlapping
+    /// scopes are left untouched, so e.g. `j` can drive both the session list
+    /// and the file viewer.
+    pub fn rebind(&mut self, action: Action, chord: KeyChord) -> Option<Action> {
+        let chord = KeyChord::normalized(chord.mods, chord.code);
+        let stolen = self.map.iter().find_map(|(a, chords)| {
+            if *a != action
+                && contexts_overlap(a.context(), action.context())
+                && chords
+                    .iter()
+                    .any(|c| c.code == chord.code && c.mods == chord.mods)
+            {
+                Some(*a)
+            } else {
+                None
+            }
+        });
+        if let Some(other) = stolen {
+            if let Some(v) = self.map.get_mut(&other) {
+                v.retain(|c| !(c.code == chord.code && c.mods == chord.mods));
+            }
+        }
+        self.map.insert(action, vec![chord]);
+        stolen
+    }
+
+    /// Restore `action`'s chords to its compiled-in defaults.
+    pub fn reset(&mut self, action: Action) {
+        self.map.insert(action, action.default_chords());
     }
 
     /// Serialize to the JSON shape `~/.config/thurbox/keybindings.json` uses.
@@ -489,16 +724,16 @@ mod tests {
     }
 
     #[test]
-    fn every_action_has_default_chord_and_category() {
+    fn every_action_has_default_chord_and_context() {
         let kb = KeyBindings::default();
         for action in Action::all() {
             assert!(
                 !kb.chords_for(*action).is_empty(),
                 "Action::{action:?} has no default chord binding"
             );
-            // `category()` is exhaustive at compile time, but calling it
-            // here catches any panic-on-call and keeps test coverage honest.
-            let _ = action.category();
+            // `context()` is exhaustive at compile time; calling it here keeps
+            // coverage honest.
+            let _ = action.context();
         }
     }
 
@@ -534,14 +769,194 @@ mod tests {
                 Action::ToggleFileViewer => 0,
                 Action::FocusTasks => 0,
                 Action::GlobalSearch => 0,
+                Action::Copy => 0,
+                Action::Paste => 0,
+                Action::SessionListNext => 0,
+                Action::SessionListPrev => 0,
+                Action::SessionListOpen => 0,
+                Action::FileViewerDown => 0,
+                Action::FileViewerUp => 0,
+                Action::FileViewerCollapse => 0,
+                Action::FileViewerExpand => 0,
+                Action::FileViewerSearch => 0,
+                Action::FileViewerNextMatch => 0,
+                Action::FileViewerPrevMatch => 0,
+                Action::TerminalScrollUp => 0,
+                Action::TerminalScrollDown => 0,
+                Action::TerminalPageUp => 0,
+                Action::TerminalPageDown => 0,
             }
         }
-        // 21 listed variants must equal Action::all().len(). If you add
+        // 37 listed variants must equal Action::all().len(). If you add
         // a variant, update both `Action::all()` and the match above.
-        const EXPECTED: usize = 21;
+        const EXPECTED: usize = 37;
         assert_eq!(Action::all().len(), EXPECTED);
         for a in Action::all() {
             classify(*a);
+        }
+    }
+
+    #[test]
+    fn rebind_replaces_all_chords() {
+        let mut kb = KeyBindings::default();
+        let chord = KeyChord::ctrl('x');
+        assert_eq!(kb.rebind(Action::ToggleHelp, chord), None);
+        assert_eq!(kb.chords_for(Action::ToggleHelp), &[chord]);
+        assert_eq!(
+            kb.lookup(KeyCode::Char('x'), KeyModifiers::CONTROL),
+            Some(Action::ToggleHelp)
+        );
+        // The old dual F-key fallback is gone after a single-chord rebind.
+        assert_eq!(kb.lookup(KeyCode::F(1), KeyModifiers::NONE), None);
+    }
+
+    #[test]
+    fn rebind_steals_chord_from_other_action() {
+        let mut kb = KeyBindings::default();
+        // ctrl+q is QuitApp's default; reassign it to NewSession.
+        let chord = KeyChord::ctrl('q');
+        assert_eq!(kb.rebind(Action::NewSession, chord), Some(Action::QuitApp));
+        assert_eq!(
+            kb.lookup(KeyCode::Char('q'), KeyModifiers::CONTROL),
+            Some(Action::NewSession)
+        );
+        // QuitApp no longer owns ctrl+q.
+        assert!(!kb.chords_for(Action::QuitApp).contains(&chord));
+    }
+
+    #[test]
+    fn rebind_to_json_roundtrip() {
+        let mut kb = KeyBindings::default();
+        let chord = KeyChord::ctrl('x');
+        kb.rebind(Action::QuitApp, chord);
+        let parsed = KeyBindings::from_json(&kb.to_json().unwrap()).unwrap();
+        assert_eq!(parsed.chords_for(Action::QuitApp), &[chord]);
+    }
+
+    #[test]
+    fn reset_restores_default_chords() {
+        let mut kb = KeyBindings::default();
+        kb.rebind(Action::OpenThemePicker, KeyChord::ctrl('x'));
+        kb.reset(Action::OpenThemePicker);
+        assert_eq!(
+            kb.chords_for(Action::OpenThemePicker),
+            Action::OpenThemePicker.default_chords().as_slice()
+        );
+        // The dual F-key fallback is restored.
+        assert_eq!(
+            kb.lookup(KeyCode::F(4), KeyModifiers::NONE),
+            Some(Action::OpenThemePicker)
+        );
+    }
+
+    #[test]
+    fn rebindable_in_order_is_permutation_of_all() {
+        let ordered = Action::rebindable_in_order();
+        assert_eq!(ordered.len(), Action::all().len());
+        for action in Action::all() {
+            assert!(ordered.contains(action), "{action:?} missing from order");
+        }
+    }
+
+    #[test]
+    fn lookup_in_scopes_to_context() {
+        let kb = KeyBindings::default();
+        // `j` is a scoped action — only resolves in its own pane.
+        assert_eq!(
+            kb.lookup_in(
+                KeyContext::FileViewer,
+                KeyCode::Char('j'),
+                KeyModifiers::NONE
+            ),
+            Some(Action::FileViewerDown)
+        );
+        assert_eq!(
+            kb.lookup_in(
+                KeyContext::SessionList,
+                KeyCode::Char('j'),
+                KeyModifiers::NONE
+            ),
+            Some(Action::SessionListNext)
+        );
+        // The terminal never resolves `j` — it forwards it to the PTY.
+        assert_eq!(
+            kb.lookup_in(KeyContext::Terminal, KeyCode::Char('j'), KeyModifiers::NONE),
+            None
+        );
+        // Global actions resolve in every context.
+        assert_eq!(
+            kb.lookup_in(
+                KeyContext::Terminal,
+                KeyCode::Char('q'),
+                KeyModifiers::CONTROL
+            ),
+            Some(Action::QuitApp)
+        );
+    }
+
+    #[test]
+    fn same_chord_reused_across_distinct_scopes_without_conflict() {
+        let mut kb = KeyBindings::default();
+        // `j` is bound in both file viewer and session list by default — no steal.
+        assert_eq!(
+            kb.rebind(Action::FileViewerDown, KeyChord::plain('j')),
+            None,
+            "distinct scopes must not collide"
+        );
+        // Both still resolve in their own context.
+        assert_eq!(
+            kb.lookup_in(
+                KeyContext::SessionList,
+                KeyCode::Char('j'),
+                KeyModifiers::NONE
+            ),
+            Some(Action::SessionListNext)
+        );
+        assert_eq!(
+            kb.lookup_in(
+                KeyContext::FileViewer,
+                KeyCode::Char('j'),
+                KeyModifiers::NONE
+            ),
+            Some(Action::FileViewerDown)
+        );
+    }
+
+    #[test]
+    fn rebind_steals_within_same_scope() {
+        let mut kb = KeyBindings::default();
+        // Bind FileViewerUp to `j` — already FileViewerDown's chord (same scope).
+        assert_eq!(
+            kb.rebind(Action::FileViewerUp, KeyChord::plain('j')),
+            Some(Action::FileViewerDown)
+        );
+    }
+
+    #[test]
+    fn global_chord_conflicts_with_every_scope() {
+        let mut kb = KeyBindings::default();
+        // A scoped action grabbing a global chord steals it from the global action.
+        assert_eq!(
+            kb.rebind(Action::FileViewerDown, KeyChord::ctrl('q')),
+            Some(Action::QuitApp)
+        );
+    }
+
+    #[test]
+    fn normalized_shift_letter_round_trips() {
+        // Shift+N normalizes to {SHIFT, 'n'} and survives display/parse.
+        let chord = KeyChord::normalized(KeyModifiers::NONE, KeyCode::Char('N'));
+        assert_eq!(chord.mods, KeyModifiers::SHIFT);
+        assert_eq!(chord.code, KeyCode::Char('n'));
+        assert_eq!(KeyChord::parse(&chord.display()), Some(chord));
+        // Lookup matches whether the terminal delivers Char('N') with or
+        // without the SHIFT modifier.
+        let kb = KeyBindings::default();
+        for mods in [KeyModifiers::NONE, KeyModifiers::SHIFT] {
+            assert_eq!(
+                kb.lookup_in(KeyContext::FileViewer, KeyCode::Char('N'), mods),
+                Some(Action::FileViewerPrevMatch)
+            );
         }
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -9,7 +9,7 @@ pub use automation::{
     parse_hhmm, preset_to_cron, Automation, AutomationAction, AutomationRun, AutomationRunStatus,
     AutomationSchedule, SchedulePreset,
 };
-pub use keybindings::{Action, Category, KeyBindings, KeyChord};
+pub use keybindings::{Action, KeyBindings, KeyChord, KeyContext};
 pub use task::{Task, TaskStatus, SOURCE_LOCAL};
 pub use theme_config::{ThemePalette, ThemePreset};
 


### PR DESCRIPTION
## Summary

Turns the **F1 help panel into a live keybinding editor** and makes nearly every shortcut rebindable, persisted to `~/.config/thurbox/keybindings.json`. No restart — changes take effect on the next keystroke.

### Interactive editor
- `j`/`k` select an action, `Enter`/`r` capture the **next physical chord** (including `Ctrl+Q`), `d` resets the selected action, `Shift+D` resets all (removes the override file).
- Conflicting chords are reassigned from the other action with a status toast.
- Persisted immediately via `KeyBindings::{rebind,reset}` + `storage::keybindings`.
- Panel scrolls to keep the selected row visible on short terminals, with a pinned controls footer.

### Context-scoped keybindings
Each `Action` carries a `KeyContext` (`Global` / `SessionList` / `FileViewer` / `Terminal`). Scoped actions fire only while their pane is focused, so single-letter keys (`j`/`k`/`h`/`l`) can be rebound per-pane **without stealing them from the terminal** (which forwards to the PTY).

- Context-aware lookup: `KeyBindings::lookup_in` + `App::focus_key_context`.
- Conflict detection (`rebind`) only steals between overlapping scopes (`contexts_overlap`).
- `KeyChord::normalized` canonicalizes Shift+letter encodings so capture / lookup / JSON round-trip agree across terminals.

### Newly editable
Copy/Paste (global, handled early so Paste reaches modal inputs), file-viewer nav/search/expand, session-list nav, terminal scroll. Stateful keys (modal selectors, automations/tasks panes, file-viewer search sub-mode) stay fixed and are listed under **Fixed (not rebindable)** in the panel.

### Also
- Global search opener is now solely the rebindable `Ctrl+A` action — the hardcoded `Ctrl+/` intercept was removed.

## Testing
- `cargo test --lib`: 822 pass (the lone `git::tests::create_or_attach_worktree_is_idempotent` failure is pre-existing/environmental — fails on a clean tree in this sandbox).
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt`, `rumdl`, and `architecture_rules` all pass; both binaries build.
- Added unit + handler tests for scoped lookup, cross-context chord reuse, conflict rules, Shift-letter normalization, and the editor flows.

Docs updated: `CLAUDE.md`, `docs/FEATURES.md`.