### PR TITLE
refactor: code-quality pass (TextInput dedupe, parameterized queries, cleanups)

### DIFF
--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -43,7 +43,9 @@ impl BackendRegistry {
 
     /// Return the default backend.
     pub fn default_backend(&self) -> &Arc<dyn SessionBackend> {
-        self.backends.get(&self.default_name).unwrap()
+        self.backends
+            .get(&self.default_name)
+            .expect("default backend is always registered in new()")
     }
 
     /// Check whether a backend with the given name is registered.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -115,93 +115,13 @@ fn parse_agent_metrics(raw: &serde_json::Value) -> crate::session::AgentMetrics 
     }
 }
 
-pub use modals::{AutomationActionKind, AutomationField, TaskActionKind, TaskField, TriggerKind};
+pub use modals::{
+    AutomationActionKind, AutomationField, TaskActionKind, TaskField, TextInput, TriggerKind,
+};
 
 /// Ticks (~10 ms each) to wait after spawning a session before pasting its
 /// automation prompt, giving the agent CLI time to come up (~3 s).
 const AGENT_BOOT_DELAY_TICKS: u64 = 300;
-
-pub(crate) struct TextInput {
-    pub(crate) buffer: String,
-    pub(crate) cursor: usize,
-}
-
-#[allow(dead_code)] // some editing methods only exercised by tests
-impl TextInput {
-    fn new() -> Self {
-        Self {
-            buffer: String::new(),
-            cursor: 0,
-        }
-    }
-
-    fn insert(&mut self, c: char) {
-        let byte_pos = self.byte_offset();
-        self.buffer.insert(byte_pos, c);
-        self.cursor += 1;
-    }
-
-    fn backspace(&mut self) {
-        if self.cursor > 0 {
-            self.cursor -= 1;
-            let byte_pos = self.byte_offset();
-            self.buffer.remove(byte_pos);
-        }
-    }
-
-    fn delete(&mut self) {
-        let byte_pos = self.byte_offset();
-        if byte_pos < self.buffer.len() {
-            self.buffer.remove(byte_pos);
-        }
-    }
-
-    fn move_left(&mut self) {
-        self.cursor = self.cursor.saturating_sub(1);
-    }
-
-    fn move_right(&mut self) {
-        let char_count = self.buffer.chars().count();
-        if self.cursor < char_count {
-            self.cursor += 1;
-        }
-    }
-
-    fn home(&mut self) {
-        self.cursor = 0;
-    }
-
-    fn end(&mut self) {
-        self.cursor = self.buffer.chars().count();
-    }
-
-    fn clear(&mut self) {
-        self.buffer.clear();
-        self.cursor = 0;
-    }
-
-    fn set(&mut self, value: &str) {
-        self.buffer = value.to_string();
-        self.cursor = value.chars().count();
-    }
-
-    fn value(&self) -> &str {
-        &self.buffer
-    }
-
-    fn cursor_pos(&self) -> usize {
-        self.cursor
-    }
-
-    /// Convert char-based cursor position to byte offset.
-    fn byte_offset(&self) -> usize {
-        self.buffer
-            .char_indices()
-            .nth(self.cursor)
-            .map(|(i, _)| i)
-            .unwrap_or(self.buffer.len())
-    }
-}
 
 pub enum AppMessage {
     KeyPress(KeyCode, KeyModifiers),
@@ -883,7 +803,6 @@ impl App {
         self.set_status(StatusLevel::Success, format!("Restored '{session_name}'"));
     }
 
-    /// Open the restore deleted sessions modal (Ctrl+U).
     /// Open the theme picker, pre-selecting the currently active preset.
     fn open_theme_picker(&mut self) {
         let active = self.db.get_active_theme().ok().flatten();

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use rusqlite::params;
+use rusqlite::{params, ToSql};
 
 use crate::session::SessionId;
 use crate::sync::{current_time_millis, SharedSession, SharedWorktree};
@@ -156,10 +156,14 @@ impl Database {
 
     /// List all active (non-deleted) sessions.
     pub fn list_active_sessions(&self) -> rusqlite::Result<Vec<SharedSession>> {
-        self.query_sessions("s.deleted_at IS NULL")
+        self.query_sessions("s.deleted_at IS NULL", &[])
     }
 
-    fn query_sessions(&self, condition: &str) -> rusqlite::Result<Vec<SharedSession>> {
+    fn query_sessions(
+        &self,
+        condition: &str,
+        bind: &[&dyn ToSql],
+    ) -> rusqlite::Result<Vec<SharedSession>> {
         let sql = format!(
             "SELECT s.id, s.name, s.agent, s.backend_id, s.backend_type, \
              s.agent_session_id, s.cwd, s.additional_dirs, s.shell_backend_id, \
@@ -171,7 +175,7 @@ impl Database {
         );
 
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map([], row_to_shared_session)?;
+        let rows = stmt.query_map(bind, row_to_shared_session)?;
 
         // Collect rows, merging multiple worktree rows into the same session
         let mut sessions: Vec<SharedSession> = Vec::new();
@@ -226,7 +230,8 @@ impl Database {
 
     /// Get a single active (non-deleted) session by its ID.
     pub fn get_session_by_id(&self, id: SessionId) -> rusqlite::Result<Option<SharedSession>> {
-        let sessions = self.query_sessions(&format!("s.deleted_at IS NULL AND s.id = '{id}'"))?;
+        let sessions =
+            self.query_sessions("s.deleted_at IS NULL AND s.id = ?1", &[&id.to_string()])?;
         Ok(sessions.into_iter().next())
     }
 
@@ -244,7 +249,7 @@ impl Database {
 
     /// List all soft-deleted sessions, most recently deleted first.
     pub fn list_deleted_sessions(&self) -> rusqlite::Result<Vec<DeletedSessionInfo>> {
-        self.query_deleted_sessions("s.deleted_at IS NOT NULL")
+        self.query_deleted_sessions("s.deleted_at IS NOT NULL", &[])
     }
 
     /// Get a single soft-deleted session by its ID.
@@ -252,12 +257,16 @@ impl Database {
         &self,
         id: SessionId,
     ) -> rusqlite::Result<Option<DeletedSessionInfo>> {
-        let sessions =
-            self.query_deleted_sessions(&format!("s.deleted_at IS NOT NULL AND s.id = '{id}'"))?;
+        let sessions = self
+            .query_deleted_sessions("s.deleted_at IS NOT NULL AND s.id = ?1", &[&id.to_string()])?;
         Ok(sessions.into_iter().next())
     }
 
-    fn query_deleted_sessions(&self, condition: &str) -> rusqlite::Result<Vec<DeletedSessionInfo>> {
+    fn query_deleted_sessions(
+        &self,
+        condition: &str,
+        bind: &[&dyn ToSql],
+    ) -> rusqlite::Result<Vec<DeletedSessionInfo>> {
         let sql = format!(
             "SELECT s.id, s.name, s.agent, s.agent_session_id, \
              s.cwd, s.deleted_at, \
@@ -269,7 +278,7 @@ impl Database {
         );
 
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map([], |row| {
+        let rows = stmt.query_map(bind, |row| {
             let id_str: String = row.get(0)?;
             let cwd: Option<String> = row.get(4)?;
             let deleted_at: i64 = row.get(5)?;

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -330,7 +330,7 @@ impl FileViewerState {
     fn flatten(&self) -> Vec<FlatRow> {
         let mut out = Vec::new();
         for (i, root) in self.roots.iter().enumerate() {
-            push_flat(root, vec![i], 0, &mut out, true);
+            push_flat(root, &[i], 0, &mut out, true);
         }
         out
     }
@@ -406,7 +406,7 @@ impl Default for FileViewerState {
 
 fn push_flat(
     node: &FileNode,
-    index_path: Vec<usize>,
+    index_path: &[usize],
     depth: usize,
     out: &mut Vec<FlatRow>,
     is_root: bool,
@@ -421,7 +421,7 @@ fn push_flat(
             .unwrap_or_else(|| node.path.to_string_lossy().into_owned())
     };
     out.push(FlatRow {
-        index_path: index_path.clone(),
+        index_path: index_path.to_vec(),
         depth,
         label,
         is_dir: node.is_dir,
@@ -430,9 +430,9 @@ fn push_flat(
     if node.is_dir && node.expanded {
         if let Some(children) = &node.children {
             for (i, child) in children.iter().enumerate() {
-                let mut ip = index_path.clone();
+                let mut ip = index_path.to_vec();
                 ip.push(i);
-                push_flat(child, ip, depth + 1, out, false);
+                push_flat(child, &ip, depth + 1, out, false);
             }
         }
     }


### PR DESCRIPTION
## Summary

A focused code-quality pass on this branch. Independent, low-risk improvements with no behavior change.

### Changes

1. **`core` — dedupe `TextInput` widget, drop a stale doc comment.** (commit 1)

2. **`storage/sessions.rs` — parameterize id-based session queries.**
   `get_session_by_id` and `get_deleted_session_by_id` built their `WHERE` clause with `format!("… s.id = '{id}'")`. The id is a UUID (`SessionId(Uuid)`), so interpolation was safe *in practice*, but it was inconsistent with the parameterized (`?1` + `params!`) style used right next to it (e.g. `get_session_name`). The two private `query_*` helpers now take a `&[&dyn ToSql]` bind slice, and the id callers pass `?1` + `&[&id.to_string()]`. Removes reliance on the "UUIDs can't contain quotes" invariant.

3. **`agent/registry.rs` — `default_backend()`.**
   Replaced `.unwrap()` with `.expect("default backend is always registered in new()")` to document the invariant.

4. **`ui/file_viewer.rs` — `push_flat` takes `&[usize]`.**
   The recursive tree-flattener took `index_path: Vec<usize>` by value and cloned on entry. It now borrows `&[usize]`, dropping a per-root `Vec` allocation in `flatten()` and clarifying the recursion contract.

### Investigated, intentionally left alone

The review also surfaced candidates that were checked and deliberately not changed: the `O(n²)` `Vec::contains` dedup in `collect_active_session_paths` (lists of 1–5 items — a `HashSet` would be premature and hurt ordering/readability), the `#[allow(dead_code)]` Arc fields in `backend.rs` `ShellPane` (verified to be live peers of the vt100 callback / reader loop — the markers are correct), and caching the lowercased search query in `file_viewer` (marginal vs. the per-row `to_lowercase`, adds invariant risk).

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all` — 856/856 pass (one git integration test is a transient parallel-load timeout; passes in isolation)
- `cargo test --test architecture_rules` — 8/8 pass
- `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc` — clean