### PR TITLE
feat(core): task→agent context prompts and related-session navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,11 +337,18 @@ the persistent `App::automation_editor` state (kept in sync by
 
 Thurbox has a **task list**: todo items (title + markdown description +
 status). A task can be **acted on by a coding agent** via a **trigger-time
-picker** (`r`): you choose *Send → a running session* (paste the title) or
-*Spawn new session…* (the normal repo→agent flow, seeded with the title) at
-the moment you act — the action is **not** authored into the task. Triggering
-advances the task to `InProgress`. (`Task.action: Option<AutomationAction>`
-still exists for the CLI / external sync, but the TUI editor never sets it.)
+picker** (`r`): you choose *Send → a running session* or *Spawn new session…*
+(the normal repo→agent flow) at the moment you act — the action is **not**
+authored into the task. Either way the agent is seeded with a **full context
+prompt**, not the bare title: `Task::agent_prompt()` builds an `id + # title +
+markdown description` block plus self-service hints (`thurbox-cli task show
+<id>` to read the full record, `thurbox-cli task edit <id> --status done` to
+close it out). The TUI seeds it via `App::task_agent_prompt` (bracketed-paste
+safe, so the multi-line body never submits early); the headless `task run` path
+builds the same string. Triggering advances the task `Todo → InProgress` (TUI:
+`App::advance_task_to_in_progress`; CLI: `mark_in_progress`).
+(`Task.action: Option<AutomationAction>` still exists for the CLI / external
+sync, but the TUI editor never sets it.)
 
 - **Data** (`session/task.rs`): `Task` (`id`, `title`,
   `description: Option<String>` (free-form markdown notes, `None` when blank),
@@ -366,13 +373,16 @@ still exists for the CLI / external sync, but the TUI editor never sets it.)
   between `terminal` and `file_viewer` at width ≥ 120. Rendered by
   `ui/tasks_panel.rs` (checkbox glyphs ☐/◐/☑) with the shared
   `ui::focus_block` for the highlighted title + accent border, matching the
-  session list / file viewer. `InputFocus::TaskList` is the panel focus.
+  session list / file viewer. `InputFocus::TaskList` is the panel focus. Rows
+  whose task has an **open related session** get a trailing accent `⇄` marker
+  (`TaskPaneEntry::linked`).
 - **Full-screen preview / edit toggle** — the central pane is a clean toggle
   (`view::render_task_workspace`): while the tasks panel is focused
   (`InputFocus::TaskList`) it shows the selected task's **full-screen,
   scrollable** read-only **details + markdown preview** (`ui/task_detail`:
-  agent linkage, status, source, created/updated, then the markdown-rendered
-  description via `ui/markdown::render_markdown`); `PageUp`/`PageDown` scroll it
+  agent linkage, **related session(s)**, status, source, created/updated, then
+  the markdown-rendered description via `ui/markdown::render_markdown`);
+  `PageUp`/`PageDown` scroll it
   (`App::task_preview_scroll`, reset on selection change). Entering the central
   pane (`Enter`/`e` → `InputFocus::TaskEditor`) swaps to the **full-screen
   editor** (`ui/task_editor_modal::render_task_editor_into`); `Esc` returns to
@@ -386,7 +396,9 @@ still exists for the CLI / external sync, but the TUI editor never sets it.)
   **`Ctrl+S` saves from any field**.
 - **Keys** (focused panel): `j`/`k` select (live-preview), `PageUp`/`PageDown`
   scroll the preview, `n` new, `e`/`Enter` open the central-pane editor,
-  `Space` cycle status, `r` open the **trigger-time action picker**, `d`/`Ctrl+D`
+  `Space` cycle status, `r` open the **trigger-time action picker**, `o` **open
+  the task's related session** (`App::open_task_related_session` — jumps to the
+  spawned `task-<id>` window or a Send target, else a status hint), `d`/`Ctrl+D`
   delete, `Esc` back to the session list. In the editor: field nav +
   `Enter`/`Ctrl+S` save (→ back to panel), `Esc` discard; the editor captures
   its keys before global bindings (so `e`/`d` edit text) via

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -880,16 +880,35 @@ impl SessionBackend for LocalTmuxBackend {
     }
 }
 
+/// Wrap `text` in the bracketed-paste escape sequences (`ESC[200~ … ESC[201~`)
+/// so a multi-line prompt is delivered as a single paste — the embedded
+/// newlines insert as text instead of submitting the prompt on the first one.
+/// Mirrors the TUI's `App::send_prompt_to_session`; the trailing `Enter` is
+/// still sent separately by the caller. tmux delivers these bytes literally via
+/// `send-keys -l`.
+fn bracketed_paste(text: &str) -> String {
+    format!("\x1b[200~{text}\x1b[201~")
+}
+
 /// Send text immediately to a session pane (no scheduling), followed by Enter.
 ///
 /// Targets the tmux window named `tb-<session_name>` in the thurbox tmux
-/// session and uses a "type text → brief delay → press Enter" sequence so the
-/// target app has time to process the typed input.
+/// session and uses a "paste text → brief delay → press Enter" sequence so the
+/// target app has time to process the pasted input.
 pub fn send_prompt_now(session_name: &str, text: &str) -> Result<()> {
     let target = window_target(session_name);
+    let payload = bracketed_paste(text);
 
     let status = Command::new("tmux")
-        .args(["-L", TMUX_SOCKET, "send-keys", "-t", &target, text])
+        .args([
+            "-L",
+            TMUX_SOCKET,
+            "send-keys",
+            "-t",
+            &target,
+            "-l",
+            &payload,
+        ])
         .status()
         .context("Failed to run tmux send-keys for prompt text")?;
     if !status.success() {
@@ -959,10 +978,12 @@ pub fn window_exists(session_name: &str) -> bool {
 /// there is no TUI deferred-input queue to lean on. Local-tmux scoped.
 pub fn send_prompt_after_delay(session_name: &str, text: &str, delay_secs: u64) -> Result<()> {
     let escaped_target = shell_escape(&window_target(session_name));
-    let escaped_text = shell_escape(text);
+    // Bracketed-paste wrap (see `bracketed_paste`) so multi-line prompts don't
+    // submit early; `-l` makes tmux deliver the bytes literally.
+    let escaped_text = shell_escape(&bracketed_paste(text));
     // run-shell executes the script via the server's shell; escape accordingly.
     let script = format!(
-        "tmux -L {TMUX_SOCKET} send-keys -t {escaped_target} {escaped_text}; \
+        "tmux -L {TMUX_SOCKET} send-keys -t {escaped_target} -l {escaped_text}; \
          sleep 0.2; \
          tmux -L {TMUX_SOCKET} send-keys -t {escaped_target} Enter"
     );

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -422,29 +422,15 @@ impl App {
             return;
         }
         let count = self.cached_automations.len();
-        // `k`/Up at the top row (or in an empty pane) flows focus back up into
-        // the session list, so the left column behaves as one vertical list.
+        // `k`/Up at the top row (or empty pane) flows focus back up into the
+        // session list; `j`/Down past the last loops to the top of it — so the
+        // left column behaves as one circular vertical list.
         if matches!(code, KeyCode::Char('k') | KeyCode::Up) {
-            if self.automation_panel_index == 0 || count == 0 {
-                self.focus = InputFocus::SessionList;
-                self.select_last_session();
-            } else {
-                self.automation_panel_index -= 1;
-            }
-            self.refresh_automation_view();
+            self.automations_pane_move_up(count);
             return;
         }
-        // `j`/Down past the last automation (or in an empty pane) loops around to
-        // the TOP of the session list, so sessions+automations form one circular
-        // column.
         if matches!(code, KeyCode::Char('j') | KeyCode::Down) {
-            if count == 0 || self.automation_panel_index + 1 >= count {
-                self.focus = InputFocus::SessionList;
-                self.select_first_session();
-            } else {
-                self.automation_panel_index += 1;
-            }
-            self.refresh_automation_view();
+            self.automations_pane_move_down(count);
             return;
         }
         // `Enter`/`e` focuses the central-pane editor (like `Enter` on a session
@@ -465,6 +451,35 @@ impl App {
             self.automation_panel_index = count - 1;
         }
         let id = self.cached_automations[self.automation_panel_index].id;
+        self.handle_automation_pane_action(code, id);
+    }
+
+    /// `k`/Up in the automations pane: step up, or hand focus back to the
+    /// session list (last row) at the top / when empty.
+    fn automations_pane_move_up(&mut self, count: usize) {
+        if self.automation_panel_index == 0 || count == 0 {
+            self.focus = InputFocus::SessionList;
+            self.select_last_session();
+        } else {
+            self.automation_panel_index -= 1;
+        }
+        self.refresh_automation_view();
+    }
+
+    /// `j`/Down in the automations pane: step down, or loop focus to the top of
+    /// the session list past the last row / when empty.
+    fn automations_pane_move_down(&mut self, count: usize) {
+        if count == 0 || self.automation_panel_index + 1 >= count {
+            self.focus = InputFocus::SessionList;
+            self.select_first_session();
+        } else {
+            self.automation_panel_index += 1;
+        }
+        self.refresh_automation_view();
+    }
+
+    /// Toggle / run / delete the selected automation (`Space`/`r`/`d`).
+    fn handle_automation_pane_action(&mut self, code: KeyCode, id: i64) {
         match code {
             KeyCode::Char(' ') => {
                 self.toggle_automation_by_id(id);
@@ -628,36 +643,47 @@ impl App {
             // Scroll the full-screen preview (the list itself uses j/k).
             KeyCode::PageDown => self.scroll_task_preview(5),
             KeyCode::PageUp => self.scroll_task_preview(-5),
-            KeyCode::Char(' ') => {
-                if let Some(task) = self.selected_task().cloned() {
-                    if let Err(e) = self.db.set_task_status(task.id, task.status.cycle()) {
-                        error!("Failed to cycle task {} status: {e}", task.id);
-                    }
-                    self.refresh_tasks();
-                    self.sync_task_editor();
-                }
-            }
+            KeyCode::Char(' ') => self.cycle_selected_task_status(),
             // Open the trigger-time action picker (Send → session / Spawn new).
             KeyCode::Char('r') => {
                 if let Some(task) = self.selected_task().cloned() {
                     self.open_task_action_picker(&task);
                 }
             }
-            KeyCode::Char('d') => {
-                if let Some(id) = self.selected_task().map(|t| t.id) {
-                    if let Err(e) = self.db.soft_delete_task(id) {
-                        error!("Failed to delete task {id}: {e}");
-                    }
-                    self.refresh_tasks();
-                    let new_count = self.filtered_task_indices.len();
-                    if new_count > 0 && self.task_panel_index >= new_count {
-                        self.task_panel_index = new_count - 1;
-                    }
-                    self.refresh_task_view();
-                }
-            }
+            // Jump to the task's related session terminal (the spawned
+            // `task-<id>` window, or a persisted Send target).
+            KeyCode::Char('o') => self.open_task_related_session(),
+            KeyCode::Char('d') => self.delete_selected_task(),
             _ => {}
         }
+    }
+
+    /// Cycle the selected task's status (`Todo → InProgress → Done`) and refresh.
+    fn cycle_selected_task_status(&mut self) {
+        let Some(task) = self.selected_task().cloned() else {
+            return;
+        };
+        if let Err(e) = self.db.set_task_status(task.id, task.status.cycle()) {
+            error!("Failed to cycle task {} status: {e}", task.id);
+        }
+        self.refresh_tasks();
+        self.sync_task_editor();
+    }
+
+    /// Soft-delete the selected task, then clamp the selection and refresh.
+    fn delete_selected_task(&mut self) {
+        let Some(id) = self.selected_task().map(|t| t.id) else {
+            return;
+        };
+        if let Err(e) = self.db.soft_delete_task(id) {
+            error!("Failed to delete task {id}: {e}");
+        }
+        self.refresh_tasks();
+        let new_count = self.filtered_task_indices.len();
+        if new_count > 0 && self.task_panel_index >= new_count {
+            self.task_panel_index = new_count - 1;
+        }
+        self.refresh_task_view();
     }
 
     /// Handle keys while the global-search strip is focused. Typed characters
@@ -1085,54 +1111,13 @@ impl App {
                 true
             }
             Action::NewSession => {
-                // In the automations context, Ctrl+N creates a new automation
-                // (mirrors `n`); elsewhere it starts the new-session wizard.
-                if matches!(
-                    self.focus,
-                    InputFocus::Automations | InputFocus::AutomationEditor
-                ) {
-                    self.new_automation_in_pane();
-                } else {
-                    // A manual new-session must not inherit a task prompt left
-                    // over from a cancelled task-spawn.
-                    self.pending_task_prompt = None;
-                    self.open_repo_picker();
-                }
+                self.act_new_session();
                 true
             }
-            Action::DeleteSession => match self.focus {
-                InputFocus::SessionList | InputFocus::FileViewer => {
-                    self.close_active_session();
-                    true
-                }
-                // On the automations pane, Ctrl+D deletes the selected
-                // automation (mirrors the pane's `d` key).
-                InputFocus::Automations => {
-                    self.handle_automations_pane_key(KeyCode::Char('d'));
-                    true
-                }
-                // On the tasks panel, Ctrl+D deletes the selected task (mirrors
-                // the panel's `d` key).
-                InputFocus::TaskList => {
-                    self.handle_task_list_key(KeyCode::Char('d'));
-                    true
-                }
-                // The editors / run-history / global search capture their own
-                // keys earlier, so this is unreachable for them; yield just in
-                // case.
-                InputFocus::AutomationEditor
-                | InputFocus::AutomationRunHistory
-                | InputFocus::TaskEditor
-                | InputFocus::GlobalSearch => false,
-                InputFocus::Terminal => false, // forward to PTY
-            },
-            Action::OpenInEditor => match self.focus {
-                InputFocus::Terminal => false, // forward to PTY
-                _ => {
-                    self.open_active_in_editor();
-                    true
-                }
-            },
+            Action::DeleteSession => self.act_delete_session(),
+            // Forward to the PTY in the terminal (shell editor / search chords),
+            // else run the action.
+            Action::OpenInEditor => self.act_unless_terminal(Self::open_active_in_editor),
             Action::OpenAutomations => {
                 self.open_automations_list();
                 true
@@ -1145,20 +1130,8 @@ impl App {
                 self.toggle_shell_view();
                 true
             }
-            Action::ForkSession => match self.focus {
-                InputFocus::Terminal => false, // PTY: shell forward-search
-                _ => {
-                    self.fork_active_session();
-                    true
-                }
-            },
-            Action::RestartSession => match self.focus {
-                InputFocus::Terminal => false, // PTY: bash reverse-search
-                _ => {
-                    self.restart_active_session();
-                    true
-                }
-            },
+            Action::ForkSession => self.act_unless_terminal(Self::fork_active_session),
+            Action::RestartSession => self.act_unless_terminal(Self::restart_active_session),
             Action::UndoDelete => {
                 if self.pending_delete.is_some() {
                     self.undo_delete();
@@ -1201,31 +1174,11 @@ impl App {
                 true
             }
             Action::FocusTasks => {
-                // Toggle the tasks panel column, mirroring the file viewer
-                // (`ToggleFileViewer`): showing it also focuses it; hiding it
-                // drops focus back to the session list.
-                self.show_tasks_panel = !self.show_tasks_panel;
-                if self.show_tasks_panel {
-                    self.refresh_tasks();
-                    self.task_panel_index = 0;
-                    self.focus = InputFocus::TaskList;
-                    // Populate the central-pane preview for the selected task
-                    // (without this the workspace shows the empty hint).
-                    self.sync_task_editor();
-                } else if self.focus == InputFocus::TaskList {
-                    self.focus = InputFocus::SessionList;
-                }
-                self.resize_sessions_to_content_area();
+                self.act_toggle_tasks();
                 true
             }
             Action::ToggleFileViewer => {
-                self.show_file_viewer = !self.show_file_viewer;
-                if self.show_file_viewer {
-                    self.rebuild_file_viewer_for_active();
-                } else if self.focus == InputFocus::FileViewer {
-                    self.focus = InputFocus::SessionList;
-                }
-                self.resize_sessions_to_content_area();
+                self.act_toggle_file_viewer();
                 true
             }
             Action::GlobalSearch => {
@@ -1243,7 +1196,7 @@ impl App {
                     self.copy_selection_to_clipboard();
                     true
                 } else {
-                    false
+                    false // no selection → let the terminal send SIGINT
                 }
             }
             Action::Paste => {
@@ -1253,25 +1206,11 @@ impl App {
 
             // ── Session list (scoped) ───────────────────────────────────
             Action::SessionListNext => {
-                // Past the last session, flow into the automations pane so the
-                // left column reads as one continuous list.
-                if self.active_is_last_in_order() {
-                    self.focus = InputFocus::Automations;
-                    self.automation_panel_index = 0;
-                    self.refresh_automation_view();
-                } else {
-                    self.switch_session_forward();
-                }
+                self.act_session_list_next();
                 true
             }
             Action::SessionListPrev => {
-                if self.active_is_first_in_order() {
-                    self.focus = InputFocus::Automations;
-                    self.automation_panel_index = self.cached_automations.len().saturating_sub(1);
-                    self.refresh_automation_view();
-                } else {
-                    self.switch_session_backward();
-                }
+                self.act_session_list_prev();
                 true
             }
             Action::SessionListOpen => {
@@ -1328,6 +1267,110 @@ impl App {
                 self.scroll_terminal_down(amount);
                 true
             }
+        }
+    }
+
+    /// Run `act` unless the terminal is focused (where the chord must forward to
+    /// the PTY — e.g. shell history search). Returns whether the key was
+    /// consumed. Backs the `OpenInEditor`/`ForkSession`/`RestartSession` actions.
+    fn act_unless_terminal(&mut self, act: impl FnOnce(&mut Self)) -> bool {
+        if self.focus == InputFocus::Terminal {
+            return false; // forward to PTY
+        }
+        act(self);
+        true
+    }
+
+    /// `Ctrl+N`: in the automations context create an automation (mirrors `n`),
+    /// else start the new-session wizard (clearing any leftover task prompt).
+    fn act_new_session(&mut self) {
+        if matches!(
+            self.focus,
+            InputFocus::Automations | InputFocus::AutomationEditor
+        ) {
+            self.new_automation_in_pane();
+        } else {
+            // A manual new-session must not inherit a task prompt left over from
+            // a cancelled task-spawn.
+            self.pending_task_prompt = None;
+            self.open_repo_picker();
+        }
+    }
+
+    /// `Ctrl+D`: delete the focused entity (session / automation / task). Editors
+    /// and search capture their own keys earlier, so they yield here.
+    fn act_delete_session(&mut self) -> bool {
+        match self.focus {
+            InputFocus::SessionList | InputFocus::FileViewer => {
+                self.close_active_session();
+                true
+            }
+            InputFocus::Automations => {
+                self.handle_automations_pane_key(KeyCode::Char('d'));
+                true
+            }
+            InputFocus::TaskList => {
+                self.handle_task_list_key(KeyCode::Char('d'));
+                true
+            }
+            InputFocus::AutomationEditor
+            | InputFocus::AutomationRunHistory
+            | InputFocus::TaskEditor
+            | InputFocus::GlobalSearch => false,
+            InputFocus::Terminal => false, // forward to PTY
+        }
+    }
+
+    /// Toggle the tasks panel column (`F5`/`Ctrl+W`), mirroring the file viewer:
+    /// showing it also focuses it; hiding it drops focus back to the list.
+    fn act_toggle_tasks(&mut self) {
+        self.show_tasks_panel = !self.show_tasks_panel;
+        if self.show_tasks_panel {
+            self.refresh_tasks();
+            self.task_panel_index = 0;
+            self.focus = InputFocus::TaskList;
+            // Populate the central-pane preview for the selected task (without
+            // this the workspace shows the empty hint).
+            self.sync_task_editor();
+        } else if self.focus == InputFocus::TaskList {
+            self.focus = InputFocus::SessionList;
+        }
+        self.resize_sessions_to_content_area();
+    }
+
+    /// Toggle the file viewer column; showing it rebuilds it for the active
+    /// session, hiding it returns focus to the session list.
+    fn act_toggle_file_viewer(&mut self) {
+        self.show_file_viewer = !self.show_file_viewer;
+        if self.show_file_viewer {
+            self.rebuild_file_viewer_for_active();
+        } else if self.focus == InputFocus::FileViewer {
+            self.focus = InputFocus::SessionList;
+        }
+        self.resize_sessions_to_content_area();
+    }
+
+    /// Session-list `Ctrl+J`: step to the next session, or flow into the
+    /// automations pane past the last so the left column reads as one list.
+    fn act_session_list_next(&mut self) {
+        if self.active_is_last_in_order() {
+            self.focus = InputFocus::Automations;
+            self.automation_panel_index = 0;
+            self.refresh_automation_view();
+        } else {
+            self.switch_session_forward();
+        }
+    }
+
+    /// Session-list `Ctrl+K`: step to the previous session, or flow into the
+    /// automations pane (last row) above the first.
+    fn act_session_list_prev(&mut self) {
+        if self.active_is_first_in_order() {
+            self.focus = InputFocus::Automations;
+            self.automation_panel_index = self.cached_automations.len().saturating_sub(1);
+            self.refresh_automation_view();
+        } else {
+            self.switch_session_backward();
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -385,6 +385,14 @@ pub struct App {
     /// trigger-time action picker chooses "Spawn new session", consumed by the
     /// spawn flow's success tail to deliver the prompt + advance the task.
     pub(crate) pending_task_prompt: Option<(i64, String)>,
+    /// Live `task id → session id` links recorded when a task is triggered from
+    /// the TUI (Spawn-new or Send). TUI spawns get a user-chosen session name
+    /// rather than the `task-<id>` convention, so the name alone can't recover
+    /// the link — this map does. Consulted by `task_related_session_indices`
+    /// alongside the name convention and any persisted `Send` action. In-memory
+    /// only (the `task-<id>` convention is what survives a restart); stale
+    /// entries are harmless since lookups filter to currently-open sessions.
+    pub(crate) task_session_links: std::collections::HashMap<i64, SessionId>,
     /// Global search strip (`Ctrl+A`): cross-scope search docked at the bottom.
     pub(crate) global_search: search::GlobalSearchState,
     /// Currently active theme preset, cached so the header doesn't hit SQLite
@@ -510,6 +518,7 @@ impl App {
             task_panel_index: 0,
             task_preview_scroll: 0,
             pending_task_prompt: None,
+            task_session_links: std::collections::HashMap::new(),
             filtered_task_indices: Vec::new(),
             task_editor: None,
             global_search: search::GlobalSearchState::default(),
@@ -1369,7 +1378,11 @@ impl App {
                 // then advances the task to in progress.
                 if let Some((task_id, title)) = self.pending_task_prompt.take() {
                     let new_id = self.sessions[self.active_index].info.id;
-                    self.send_prompt_to_session(new_id, &title, AGENT_BOOT_DELAY_TICKS);
+                    // Record the link now — the session was named by the user, so
+                    // the `task-<id>` convention can't recover it later.
+                    self.task_session_links.insert(task_id, new_id);
+                    let prompt = self.task_agent_prompt(task_id, &title);
+                    self.send_prompt_to_session(new_id, &prompt, AGENT_BOOT_DELAY_TICKS);
                     let status = self
                         .cached_tasks
                         .iter()
@@ -2892,6 +2905,60 @@ impl App {
         self.cached_tasks.get(idx)
     }
 
+    /// Indices into `self.sessions` of the **currently-open** sessions a task is
+    /// related to, in display order:
+    ///
+    /// - the session named `task-<id>` — the spawn convention used by the
+    ///   headless `task run` (and what survives a restart);
+    /// - the target of a persisted `Send` action (`task.action`), when one is
+    ///   set via the CLI; and
+    /// - the in-memory `task_session_links` entry recorded when the task was
+    ///   triggered from the TUI this run (TUI spawns get a user-chosen name, not
+    ///   `task-<id>`, so this is how that link is recovered).
+    ///
+    /// Deduplicated. Empty when nothing related is open right now. This is the
+    /// single source of truth for both the details panel and the *open* key.
+    pub(crate) fn task_related_session_indices(&self, task: &crate::session::Task) -> Vec<usize> {
+        let spawn_name = format!("task-{}", task.id);
+        // Persisted `Send` action target (CLI-authored), plus the in-memory link
+        // recorded when this task was triggered from the TUI this run.
+        let send_target = match &task.action {
+            Some(crate::session::AutomationAction::Send { session_id }) => Some(*session_id),
+            _ => None,
+        };
+        let linked = self.task_session_links.get(&task.id).copied();
+        let mut out = Vec::new();
+        for (i, s) in self.sessions.iter().enumerate() {
+            let related = s.info.name == spawn_name
+                || send_target.is_some_and(|t| t == s.info.id)
+                || linked.is_some_and(|t| t == s.info.id);
+            if related && !out.contains(&i) {
+                out.push(i);
+            }
+        }
+        out
+    }
+
+    /// Jump to the task's related session terminal (the first open one). Bound
+    /// to `o` in the focused tasks panel; mirrors `open_run_related_session`.
+    pub(crate) fn open_task_related_session(&mut self) {
+        let Some(task) = self.selected_task().cloned() else {
+            return;
+        };
+        match self.task_related_session_indices(&task).first() {
+            Some(&idx) => {
+                self.active_index = idx;
+                self.focus = InputFocus::Terminal;
+                // Leaving the tasks context clears the editor/preview cache.
+                self.refresh_task_view();
+            }
+            None => self.set_status(
+                StatusLevel::Info,
+                "Task has no open session — run it with r",
+            ),
+        }
+    }
+
     /// Scroll the full-screen task preview by `delta` rows, clamped to the
     /// rendered description length (a slight over-scroll is harmless).
     pub(crate) fn scroll_task_preview(&mut self, delta: i32) {
@@ -2925,7 +2992,21 @@ impl App {
         });
     }
 
-    /// Send a task's title to an existing session and advance it to `InProgress`.
+    /// The full agent prompt for a task (id + title + description + CLI hints),
+    /// falling back to `title` if the task is no longer cached. Keeps the
+    /// trigger paths from seeding an agent with just the bare title — the agent
+    /// gets explicit context that it is solving a Thurbox task and how to fetch
+    /// more / close it out (see [`crate::session::Task::agent_prompt`]).
+    fn task_agent_prompt(&self, task_id: i64, title: &str) -> String {
+        self.cached_tasks
+            .iter()
+            .find(|t| t.id == task_id)
+            .map(|t| t.agent_prompt())
+            .unwrap_or_else(|| title.to_string())
+    }
+
+    /// Send a task's prompt to an existing session and advance it to
+    /// `InProgress`.
     pub(crate) fn send_task_to_session(
         &mut self,
         task_id: i64,
@@ -2942,7 +3023,9 @@ impl App {
             self.set_error("Target session is not running");
             return;
         };
-        self.send_prompt_to_session(session_id, title, 0);
+        let prompt = self.task_agent_prompt(task_id, title);
+        self.send_prompt_to_session(session_id, &prompt, 0);
+        self.task_session_links.insert(task_id, session_id);
         self.advance_task_to_in_progress(task_id, status);
         self.refresh_tasks();
         self.set_status(StatusLevel::Success, format!("Sent task to {name}"));
@@ -3150,17 +3233,28 @@ impl App {
         query: &str,
         with_content: bool,
     ) -> Vec<search::GlobalSearchResult> {
-        use search::{GlobalSearchResult, SearchKind, SearchTarget, MAX_PER_GROUP};
         if query.trim().is_empty() {
             return Vec::new();
         }
         let query_lc = query.to_lowercase();
-        let mut sessions: Vec<GlobalSearchResult> = Vec::new();
-        let mut tasks: Vec<GlobalSearchResult> = Vec::new();
-        let mut automations: Vec<GlobalSearchResult> = Vec::new();
-        let mut files: Vec<GlobalSearchResult> = Vec::new();
+        // Group order: Sessions → Tasks → Automations → Files.
+        let mut out = self.search_sessions(query, &query_lc, with_content);
+        out.extend(self.search_tasks(query, &query_lc));
+        out.extend(self.search_automations(query));
+        out.extend(self.search_files(&query_lc));
+        out
+    }
 
-        // Sessions — metadata (name / agent / branch) via fuzzy.
+    /// Session results: fuzzy metadata (name / agent / branch) plus, on the
+    /// debounced heavy path, a buffer-content scan (skipping metadata matches).
+    fn search_sessions(
+        &self,
+        query: &str,
+        query_lc: &str,
+        with_content: bool,
+    ) -> Vec<search::GlobalSearchResult> {
+        use search::{GlobalSearchResult, SearchKind, SearchTarget, MAX_PER_GROUP};
+        let mut sessions: Vec<GlobalSearchResult> = Vec::new();
         for (i, session) in self.sessions.iter().enumerate() {
             if sessions.len() >= MAX_PER_GROUP {
                 break;
@@ -3169,9 +3263,7 @@ impl App {
             let branch = info.worktrees.first().map(|w| w.branch.as_str());
             let meta_hit = crate::fuzzy::fuzzy_match(query, &info.name).is_some()
                 || crate::fuzzy::fuzzy_match(query, &info.agent).is_some()
-                || branch
-                    .map(|b| crate::fuzzy::fuzzy_match(query, b).is_some())
-                    .unwrap_or(false);
+                || branch.is_some_and(|b| crate::fuzzy::fuzzy_match(query, b).is_some());
             if meta_hit {
                 sessions.push(GlobalSearchResult {
                     kind: SearchKind::Session,
@@ -3181,72 +3273,80 @@ impl App {
                 });
             }
         }
-        // Sessions — buffer content (debounced heavy path). Skip sessions that
-        // already matched on metadata to avoid duplicate rows.
-        if with_content {
-            let already: std::collections::HashSet<usize> = sessions
-                .iter()
-                .filter_map(|r| match r.target {
-                    SearchTarget::Session { index } => Some(index),
-                    _ => None,
-                })
-                .collect();
-            for i in 0..self.sessions.len() {
-                if sessions.len() >= MAX_PER_GROUP {
-                    break;
-                }
-                if already.contains(&i) {
-                    continue;
-                }
-                if let Some(snippet) = self.session_content_match(&query_lc, i) {
-                    sessions.push(GlobalSearchResult {
-                        kind: SearchKind::Session,
-                        label: self.sessions[i].info.name.clone(),
-                        snippet: Some(snippet),
-                        target: SearchTarget::Session { index: i },
-                    });
-                }
+        if !with_content {
+            return sessions;
+        }
+        // Buffer content — skip sessions that already matched on metadata.
+        let already: std::collections::HashSet<usize> = sessions
+            .iter()
+            .filter_map(|r| match r.target {
+                SearchTarget::Session { index } => Some(index),
+                _ => None,
+            })
+            .collect();
+        for i in 0..self.sessions.len() {
+            if sessions.len() >= MAX_PER_GROUP {
+                break;
+            }
+            if already.contains(&i) {
+                continue;
+            }
+            if let Some(snippet) = self.session_content_match(query_lc, i) {
+                sessions.push(GlobalSearchResult {
+                    kind: SearchKind::Session,
+                    label: self.sessions[i].info.name.clone(),
+                    snippet: Some(snippet),
+                    target: SearchTarget::Session { index: i },
+                });
             }
         }
+        sessions
+    }
 
-        // Tasks — title via fuzzy.
+    /// Task results: fuzzy title, falling back to a fuzzy description match with
+    /// a context snippet.
+    fn search_tasks(&self, query: &str, query_lc: &str) -> Vec<search::GlobalSearchResult> {
+        use search::{GlobalSearchResult, SearchKind, SearchTarget, MAX_PER_GROUP};
+        let mut tasks: Vec<GlobalSearchResult> = Vec::new();
         for task in &self.cached_tasks {
             if tasks.len() >= MAX_PER_GROUP {
                 break;
             }
-            if crate::fuzzy::fuzzy_match(query, &task.title).is_some() {
-                tasks.push(GlobalSearchResult {
-                    kind: SearchKind::Task,
-                    label: task.title.clone(),
-                    snippet: None,
-                    target: SearchTarget::Task { id: task.id },
-                });
-            } else if task
-                .description
-                .as_deref()
-                // Title missed — match the description with the same fuzzy
-                // matcher used for titles (so gapped queries hit too).
-                .is_some_and(|d| crate::fuzzy::fuzzy_match(query, d).is_some())
-            {
+            let title_hit = crate::fuzzy::fuzzy_match(query, &task.title).is_some();
+            // Title missed — match the description with the same fuzzy matcher
+            // used for titles (so gapped queries hit too).
+            let desc_hit = !title_hit
+                && task
+                    .description
+                    .as_deref()
+                    .is_some_and(|d| crate::fuzzy::fuzzy_match(query, d).is_some());
+            if !title_hit && !desc_hit {
+                continue;
+            }
+            // Snippet (description hits only): prefer a line containing the query
+            // verbatim, else the first non-empty line, for useful context.
+            let snippet = desc_hit.then(|| {
                 let desc = task.description.as_deref().unwrap_or("");
-                // Snippet: prefer a line that contains the query verbatim, else
-                // the first non-empty line, for useful context.
-                let snippet = desc
-                    .lines()
-                    .find(|l| l.to_lowercase().contains(&query_lc))
+                desc.lines()
+                    .find(|l| l.to_lowercase().contains(query_lc))
                     .or_else(|| desc.lines().find(|l| !l.trim().is_empty()))
                     .map(|l| l.trim().chars().take(120).collect::<String>())
-                    .unwrap_or_default();
-                tasks.push(GlobalSearchResult {
-                    kind: SearchKind::Task,
-                    label: task.title.clone(),
-                    snippet: Some(snippet),
-                    target: SearchTarget::Task { id: task.id },
-                });
-            }
+                    .unwrap_or_default()
+            });
+            tasks.push(GlobalSearchResult {
+                kind: SearchKind::Task,
+                label: task.title.clone(),
+                snippet,
+                target: SearchTarget::Task { id: task.id },
+            });
         }
+        tasks
+    }
 
-        // Automations — name via fuzzy.
+    /// Automation results: fuzzy name.
+    fn search_automations(&self, query: &str) -> Vec<search::GlobalSearchResult> {
+        use search::{GlobalSearchResult, SearchKind, SearchTarget, MAX_PER_GROUP};
+        let mut automations: Vec<GlobalSearchResult> = Vec::new();
         for auto in &self.cached_automations {
             if automations.len() >= MAX_PER_GROUP {
                 break;
@@ -3260,30 +3360,30 @@ impl App {
                 });
             }
         }
+        automations
+    }
 
-        // Files — names from the active session's tree (substring, case-insensitive).
-        if let Some(info) = self.sessions.get(self.active_index).map(|s| &s.info) {
-            for (root, path, name) in crate::ui::file_viewer::enumerate_paths(info) {
-                if files.len() >= MAX_PER_GROUP {
-                    break;
-                }
-                if name.to_lowercase().contains(&query_lc) {
-                    files.push(GlobalSearchResult {
-                        kind: SearchKind::File,
-                        label: name,
-                        snippet: None,
-                        target: SearchTarget::File { root, path },
-                    });
-                }
+    /// File results: case-insensitive substring over the active session's tree.
+    fn search_files(&self, query_lc: &str) -> Vec<search::GlobalSearchResult> {
+        use search::{GlobalSearchResult, SearchKind, SearchTarget, MAX_PER_GROUP};
+        let mut files: Vec<GlobalSearchResult> = Vec::new();
+        let Some(info) = self.sessions.get(self.active_index).map(|s| &s.info) else {
+            return files;
+        };
+        for (root, path, name) in crate::ui::file_viewer::enumerate_paths(info) {
+            if files.len() >= MAX_PER_GROUP {
+                break;
+            }
+            if name.to_lowercase().contains(query_lc) {
+                files.push(GlobalSearchResult {
+                    kind: SearchKind::File,
+                    label: name,
+                    snippet: None,
+                    target: SearchTarget::File { root, path },
+                });
             }
         }
-
-        // Group order: Sessions → Tasks → Automations → Files.
-        let mut out = sessions;
-        out.extend(tasks);
-        out.extend(automations);
-        out.extend(files);
-        out
+        files
     }
 
     /// Search a session's visible buffer for `query_lc`, returning the first
@@ -4904,6 +5004,78 @@ mod tests {
             app.db.get_task(id).unwrap().unwrap().status,
             crate::session::TaskStatus::InProgress
         );
+    }
+
+    #[test]
+    fn task_related_sessions_match_spawn_name_and_send_target() {
+        let mut app = app_with_sessions(2);
+        let id = app
+            .db
+            .create_task(&crate::storage::tasks::NewTask::local("t"))
+            .unwrap();
+        app.refresh_tasks();
+
+        // No related session yet (generic stub names).
+        let task = app.db.get_task(id).unwrap().unwrap();
+        assert!(app.task_related_session_indices(&task).is_empty());
+
+        // Rename session 1 to the spawn convention `task-<id>` → it's related.
+        app.sessions[1].info.name = format!("task-{id}");
+        assert_eq!(app.task_related_session_indices(&task), vec![1]);
+    }
+
+    #[test]
+    fn task_related_sessions_honor_in_memory_link() {
+        // A TUI spawn names the session by the user's choice (not `task-<id>`),
+        // so the relation is recovered via `task_session_links`.
+        let mut app = app_with_sessions(2);
+        let id = app
+            .db
+            .create_task(&crate::storage::tasks::NewTask::local("t"))
+            .unwrap();
+        app.refresh_tasks();
+        let task = app.db.get_task(id).unwrap().unwrap();
+
+        // Session 0 keeps its generic stub name — no name/action match.
+        assert!(app.task_related_session_indices(&task).is_empty());
+
+        // Record the link the spawn tail would set, then it resolves.
+        let sid = app.sessions[0].info.id;
+        app.task_session_links.insert(id, sid);
+        assert_eq!(app.task_related_session_indices(&task), vec![0]);
+    }
+
+    #[test]
+    fn open_task_related_session_focuses_terminal() {
+        let mut app = app_with_sessions(2);
+        let id = app
+            .db
+            .create_task(&crate::storage::tasks::NewTask::local("t"))
+            .unwrap();
+        app.sessions[1].info.name = format!("task-{id}");
+        app.refresh_tasks();
+        app.focus = InputFocus::TaskList;
+        app.task_panel_index = 0;
+
+        app.handle_key(KeyCode::Char('o'), KeyModifiers::NONE);
+        assert_eq!(app.active_index, 1, "jumps to the related session");
+        assert_eq!(app.focus, InputFocus::Terminal);
+    }
+
+    #[test]
+    fn open_task_related_session_no_session_keeps_focus() {
+        let mut app = app_with_sessions(1);
+        let _id = app
+            .db
+            .create_task(&crate::storage::tasks::NewTask::local("t"))
+            .unwrap();
+        app.refresh_tasks();
+        app.focus = InputFocus::TaskList;
+        app.task_panel_index = 0;
+
+        app.handle_key(KeyCode::Char('o'), KeyModifiers::NONE);
+        // Nothing related is open → stay in the panel.
+        assert_eq!(app.focus, InputFocus::TaskList);
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -257,6 +257,7 @@ impl App {
                     status: t.status,
                     match_positions: m.as_ref().map(|m| m.positions.clone()).unwrap_or_default(),
                     dimmed: search.is_some() && m.is_none(),
+                    linked: !self.task_related_session_indices(t).is_empty(),
                 }
             })
             .collect();
@@ -701,12 +702,49 @@ impl App {
     /// full-screen. Shared by the tasks-panel preview and the global-search
     /// task preview (so previewing a task result also fills the central pane).
     fn render_task_detail_pane(&self, frame: &mut Frame, area: Rect, task: &crate::session::Task) {
+        // Related running sessions (spawned `task-<id>` and/or a Send target).
+        let related = self.task_related_session_indices(task);
+        let sessions = if related.is_empty() {
+            "none open".to_string()
+        } else {
+            related
+                .iter()
+                .filter_map(|&i| self.sessions.get(i))
+                .map(|s| s.info.name.clone())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        // Advertise the panel actions only while the tasks panel is focused (not
+        // during a global-search preview); offer `o open` only when there is a
+        // session to open.
+        let focused = self.focus == InputFocus::TaskList;
+        let hints: &[(&str, &str)] = if !focused {
+            &[]
+        } else if related.is_empty() {
+            &[
+                ("e", " edit  "),
+                ("r", " run  "),
+                ("Space", " status  "),
+                ("n", " new  "),
+                ("d", " del"),
+            ]
+        } else {
+            &[
+                ("e", " edit  "),
+                ("r", " run  "),
+                ("o", " open  "),
+                ("Space", " status  "),
+                ("n", " new  "),
+                ("d", " del"),
+            ]
+        };
         crate::ui::task_detail::render_task_detail(
             frame,
             area,
             &crate::ui::task_detail::TaskDetail {
                 title: &task.title,
                 linkage: task_linkage(task),
+                sessions,
                 status: task.status.label(),
                 source: &task.source,
                 description: task.description.as_deref().unwrap_or(""),
@@ -714,19 +752,7 @@ impl App {
                 updated: format_time_ago(task.updated_at),
             },
             self.task_preview_scroll,
-            // Advertise the panel actions (incl. Run) only while the tasks panel
-            // is focused — not during a global-search preview.
-            if self.focus == InputFocus::TaskList {
-                &[
-                    ("e", " edit  "),
-                    ("r", " run  "),
-                    ("Space", " status  "),
-                    ("n", " new  "),
-                    ("d", " del"),
-                ]
-            } else {
-                &[]
-            },
+            hints,
         );
     }
 }

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -151,6 +151,10 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
 /// crate::agent`) to keep the cli module free of an `agent` import — see
 /// tests/architecture_rules.rs::cli_module_isolation.
 fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
+    // Seed the agent with full task context (id + title + description + how to
+    // read more / mark done), not just the bare title — shared with the TUI
+    // dispatch path via `Task::agent_prompt`.
+    let prompt = task.agent_prompt();
     match &task.action {
         None => Ok(json!({ "skipped": "task is not connected to an agent", "id": task.id })),
         Some(AutomationAction::Send { session_id }) => {
@@ -161,8 +165,9 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
             if !crate::agent::tmux::window_exists(&name) {
                 return Err("target session not running".into());
             }
-            crate::agent::tmux::send_prompt_now(&name, &task.title)
+            crate::agent::tmux::send_prompt_now(&name, &prompt)
                 .map_err(|e| format!("send_prompt_now: {e}"))?;
+            mark_in_progress(db, task)?;
             Ok(json!({ "sent": true, "id": task.id, "session_id": session_id.to_string() }))
         }
         Some(AutomationAction::Spawn {
@@ -174,8 +179,9 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
             let name = format!("task-{}", task.id);
             // Reuse an existing session window (re-trigger / restored session).
             if crate::agent::tmux::window_exists(&name) {
-                crate::agent::tmux::send_prompt_now(&name, &task.title)
+                crate::agent::tmux::send_prompt_now(&name, &prompt)
                     .map_err(|e| format!("send_prompt_now: {e}"))?;
+                mark_in_progress(db, task)?;
                 return Ok(json!({ "reused": name, "id": task.id }));
             }
             let req = SpawnRequest {
@@ -187,11 +193,23 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
                 agent_session_id: None,
             };
             crate::session_ops::spawn_session_headless(db, req)?;
-            crate::agent::tmux::send_prompt_after_delay(&name, &task.title, BOOT_DELAY_SECS)
+            crate::agent::tmux::send_prompt_after_delay(&name, &prompt, BOOT_DELAY_SECS)
                 .map_err(|e| format!("spawned {name} but prompt delivery failed: {e}"))?;
+            mark_in_progress(db, task)?;
             Ok(json!({ "spawned": name, "id": task.id }))
         }
     }
+}
+
+/// Advance a freshly-triggered task `Todo → InProgress` (no-op for other
+/// states), mirroring the TUI's `App::advance_task_to_in_progress` so the
+/// headless `task run` path keeps status in sync too.
+fn mark_in_progress(db: &Database, task: &Task) -> Result<(), String> {
+    if task.status == TaskStatus::Todo {
+        db.set_task_status(task.id, TaskStatus::InProgress)
+            .map_err(|e| format!("set_task_status: {e}"))?;
+    }
+    Ok(())
 }
 
 fn load(db: &Database, id: i64) -> Result<Task, String> {

--- a/src/session/task.rs
+++ b/src/session/task.rs
@@ -94,6 +94,39 @@ pub struct Task {
     pub deleted_at: Option<u64>,
 }
 
+impl Task {
+    /// Build the prompt seeded into an agent when this task is triggered
+    /// (`Send` into a running session, or `Spawn` of a fresh one).
+    ///
+    /// Beyond the bare title it gives the agent enough context to act on its
+    /// own: that it is solving a Thurbox task, the markdown description, how to
+    /// fetch the full record (`thurbox-cli task show <id>`), and how to mark the
+    /// task done when finished (the trigger already advances it to *in
+    /// progress*). Shared by the TUI (`app`) and headless (`thurbox-cli task
+    /// run`) dispatch paths so the two never drift.
+    pub fn agent_prompt(&self) -> String {
+        let mut prompt = format!(
+            "You are working on Thurbox task #{id}.\n\n# {title}\n",
+            id = self.id,
+            title = self.title,
+        );
+        if let Some(desc) = self.description.as_deref().map(str::trim) {
+            if !desc.is_empty() {
+                prompt.push('\n');
+                prompt.push_str(desc);
+                prompt.push('\n');
+            }
+        }
+        prompt.push_str(&format!(
+            "\n---\nThis is a Thurbox task. Run `thurbox-cli task show {id}` for the full \
+             record. The task is now marked **in progress**; when you finish, run \
+             `thurbox-cli task edit {id} --status done`.\n",
+            id = self.id,
+        ));
+        prompt
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -123,5 +156,43 @@ mod tests {
         assert_eq!(TaskStatus::Todo.label(), "todo");
         assert_eq!(TaskStatus::InProgress.label(), "in progress");
         assert_eq!(TaskStatus::Done.label(), "done");
+    }
+
+    fn sample_task(description: Option<&str>) -> Task {
+        Task {
+            id: 42,
+            title: "Wire up SSH backend".to_string(),
+            description: description.map(str::to_string),
+            status: TaskStatus::Todo,
+            action: None,
+            source: SOURCE_LOCAL.to_string(),
+            external_id: None,
+            external_url: None,
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn agent_prompt_carries_id_title_and_cli_hints() {
+        let prompt = sample_task(Some("Implement `SshTmuxBackend`.")).agent_prompt();
+        assert!(prompt.contains("Thurbox task #42"));
+        assert!(prompt.contains("# Wire up SSH backend"));
+        assert!(prompt.contains("Implement `SshTmuxBackend`."));
+        // Self-service context: how to read more and how to close it out.
+        assert!(prompt.contains("thurbox-cli task show 42"));
+        assert!(prompt.contains("thurbox-cli task edit 42 --status done"));
+    }
+
+    #[test]
+    fn agent_prompt_omits_empty_description_block() {
+        // No description and a blank-only description both skip the body.
+        for desc in [None, Some("   ")] {
+            let prompt = sample_task(desc).agent_prompt();
+            assert!(prompt.contains("# Wire up SSH backend"));
+            // Title line is immediately followed by the `---` hint separator.
+            assert!(prompt.contains("# Wire up SSH backend\n\n---\n"));
+        }
     }
 }

--- a/src/ui/task_detail.rs
+++ b/src/ui/task_detail.rs
@@ -24,6 +24,10 @@ pub struct TaskDetail<'a> {
     /// How the task connects to an agent, e.g. `"send → claude(feat/x)"`,
     /// `"spawn → repo#branch"`, or `"local todo"`.
     pub linkage: String,
+    /// The task's currently-open related session(s) — names joined with `, `, or
+    /// a muted placeholder when none are open. Shown as its own metadata row so
+    /// the live session behind a task is visible (and `o`-openable) at a glance.
+    pub sessions: String,
     pub status: &'a str,
     pub source: &'a str,
     /// Raw markdown description; rendered beneath the metadata rows. Empty hides
@@ -78,6 +82,7 @@ pub fn render_task_detail(
     let label_style = Style::default().fg(Theme::text_secondary());
     let rows = [
         ("agent", detail.linkage.clone()),
+        ("session", detail.sessions.clone()),
         ("status", detail.status.to_string()),
         ("source", detail.source.to_string()),
         ("created", detail.created.clone()),

--- a/src/ui/tasks_panel.rs
+++ b/src/ui/tasks_panel.rs
@@ -26,7 +26,14 @@ pub struct TaskPaneEntry {
     pub match_positions: Vec<usize>,
     /// When a global search is active, rows that don't match are dimmed.
     pub dimmed: bool,
+    /// The task has at least one currently-open related session (a spawned
+    /// `task-<id>` window or a Send target). Drawn as a trailing `⇄` marker so a
+    /// live task is glanceable in the list; press `o` to jump to it.
+    pub linked: bool,
 }
+
+/// Trailing marker shown on rows whose task has an open related session.
+const LINKED_MARKER: &str = " ⇄";
 
 pub struct TaskPaneState<'a> {
     pub entries: &'a [TaskPaneEntry],
@@ -95,31 +102,53 @@ fn render_task_list(frame: &mut Frame, area: Rect, state: &TaskPaneState<'_>) {
             // global-search preview points here (so the moving cursor is visible
             // even though focus is in the search box).
             let selected = (focused || state.preview_selected) && i == state.selected;
-            let glyph = status_glyph(e.status);
-            // The glyph is its own span; the title follows so highlight byte
-            // offsets (which index `title`) line up.
-            let title = truncate_ellipsis(&e.title, width.saturating_sub(2));
-
-            // Matched characters are layered *on top* of this base (see
-            // `row_base_style`), the same way the session list does it — so a
-            // selected/previewed row still shows its fuzzy-match highlight.
-            let base = super::highlight::row_base_style(
-                selected,
-                e.dimmed,
-                Style::default().fg(status_color(e.status)),
-            );
-            let mut spans = vec![Span::styled(format!("{glyph} "), base)];
-            // Highlight matched chars on every non-dimmed row (including the
-            // selected one); dimmed rows didn't match, so no positions.
-            let positions: &[usize] = if e.dimmed { &[] } else { &e.match_positions };
-            spans.extend(super::highlight::highlighted_spans_owned(
-                &title, positions, base,
-            ));
-            Line::from(spans)
+            task_row_line(e, selected, width)
         })
         .collect();
 
     frame.render_widget(Paragraph::new(lines), area);
+}
+
+/// Build one task row: `<glyph> <title>` with global-search highlighting, plus a
+/// trailing `⇄` marker when the task has a live related session.
+fn task_row_line(e: &TaskPaneEntry, selected: bool, width: usize) -> Line<'_> {
+    let glyph = status_glyph(e.status);
+    // The glyph is its own span; the title follows so highlight byte offsets
+    // (which index `title`) line up. Reserve room for the trailing link marker
+    // so it never pushes the title off-row.
+    let reserved = if e.linked {
+        2 + LINKED_MARKER.chars().count()
+    } else {
+        2
+    };
+    let title = truncate_ellipsis(&e.title, width.saturating_sub(reserved));
+
+    // Matched characters are layered *on top* of this base (see `row_base_style`),
+    // the same way the session list does it — so a selected/previewed row still
+    // shows its fuzzy-match highlight.
+    let base = super::highlight::row_base_style(
+        selected,
+        e.dimmed,
+        Style::default().fg(status_color(e.status)),
+    );
+    let mut spans = vec![Span::styled(format!("{glyph} "), base)];
+    // Highlight matched chars on every non-dimmed row (including the selected
+    // one); dimmed rows didn't match, so no positions.
+    let positions: &[usize] = if e.dimmed { &[] } else { &e.match_positions };
+    spans.extend(super::highlight::highlighted_spans_owned(
+        &title, positions, base,
+    ));
+    // Trailing accent marker for tasks with a live session. Dimmed rows
+    // (non-matches during a search) keep the dim tone for consistency.
+    if e.linked {
+        let marker_style = if e.dimmed {
+            base
+        } else {
+            Style::default().fg(Theme::accent())
+        };
+        spans.push(Span::styled(LINKED_MARKER, marker_style));
+    }
+    Line::from(spans)
 }
 
 fn status_glyph(status: TaskStatus) -> &'static str {


### PR DESCRIPTION
## Summary

Makes the **task list** a real driver of agent work: triggering a task now hands the agent full context (not just the title), keeps task status in sync, and surfaces/opens the sessions a task spawns.

### Richer task→agent dispatch
- New `Task::agent_prompt()` (pure, in `session/task.rs`) builds an `id + # title + markdown description` block plus self-service hints: `thurbox-cli task show <id>` to read the full record and `thurbox-cli task edit <id> --status done` to close it out. Shared by the TUI (`App::task_agent_prompt`) and headless (`thurbox-cli task run`) paths so they never drift.
- Triggering auto-advances the task `Todo → InProgress` on **both** paths (the headless path previously never updated status).
- The headless `send-keys` helpers (`agent/tmux.rs`) now wrap text in **bracketed paste** (`ESC[200~…ESC[201~`, via `send-keys -l`) so the multi-line prompt is inserted as one chunk instead of submitting early on the first newline — this also fixes multi-line **automation** prompts.

### Related-session visibility & quick-open
- **Detail panel** gains a `session` row showing the task's open related session(s), or `none open`.
- **List rows** get a trailing accent **⇄** marker when a task has a live session.
- **`o`** in the focused tasks panel jumps to the related session's terminal (`App::open_task_related_session`); the footer advertises it only when there's a session to open.
- Relations resolve via three sources (`App::task_related_session_indices`): the `task-<id>` spawn name, a persisted `Send` action target, and an **in-memory `task_session_links`** entry recorded when a task is triggered from the TUI — needed because TUI spawns get a *user-chosen* session name rather than `task-<id>`, which was the cause of the "related session not updating after spawn" bug.

### Code-quality (SonarQube S3776)
Reduced cognitive complexity below the 15 threshold in five functions on the touched files, via behavior-preserving extraction (no logic change):
- `ui/tasks_panel.rs::render_task_list` → extracted `task_row_line`
- `app/key_handlers.rs::handle_task_list_key` → extracted `cycle_selected_task_status` / `delete_selected_task`
- `app/key_handlers.rs::handle_automations_pane_key` → extracted nav + action helpers
- `app/key_handlers.rs::dispatch_action` → extracted the focus-dependent arms into small `act_*` helpers
- `app/mod.rs::build_global_search_results` → split into per-scope `search_{sessions,tasks,automations,files}`

## Testing
- `cargo test --lib` — 856 pass (added prompt-builder, related-session, and open-key tests)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --test architecture_rules` — pass
- `cargo fmt --all` — applied

## Notes
- The in-memory task→session link is per-run; the `task-<id>` convention is what survives a restart (the CLI path uses it). Persisting the TUI link is a possible follow-up.
- Docs updated in `CLAUDE.md` (Tasks section: context prompt, status advance, related sessions, `o` key, ⇄ marker).