### PR TITLE
refactor(core): split search_sessions to cut cognitive complexity

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3253,6 +3253,15 @@ impl App {
         query_lc: &str,
         with_content: bool,
     ) -> Vec<search::GlobalSearchResult> {
+        let mut sessions = self.search_sessions_meta(query);
+        if with_content {
+            self.search_sessions_content(query_lc, &mut sessions);
+        }
+        sessions
+    }
+
+    /// Session metadata matches (name / agent / branch) via fuzzy.
+    fn search_sessions_meta(&self, query: &str) -> Vec<search::GlobalSearchResult> {
         use search::{GlobalSearchResult, SearchKind, SearchTarget, MAX_PER_GROUP};
         let mut sessions: Vec<GlobalSearchResult> = Vec::new();
         for (i, session) in self.sessions.iter().enumerate() {
@@ -3273,10 +3282,17 @@ impl App {
                 });
             }
         }
-        if !with_content {
-            return sessions;
-        }
-        // Buffer content — skip sessions that already matched on metadata.
+        sessions
+    }
+
+    /// Append buffer-content matches to `sessions`, skipping any session that
+    /// already matched on metadata (so a session never yields two rows).
+    fn search_sessions_content(
+        &self,
+        query_lc: &str,
+        sessions: &mut Vec<search::GlobalSearchResult>,
+    ) {
+        use search::{GlobalSearchResult, SearchKind, SearchTarget, MAX_PER_GROUP};
         let already: std::collections::HashSet<usize> = sessions
             .iter()
             .filter_map(|r| match r.target {
@@ -3300,7 +3316,6 @@ impl App {
                 });
             }
         }
-        sessions
     }
 
     /// Task results: fuzzy title, falling back to a fuzzy description match with


### PR DESCRIPTION
## Summary

Follow-up to #435. That PR resolved 4 of the 5 SonarQube `S3776` (cognitive complexity) findings, but was merged just before the 5th fix landed. This clears the last one.

`App::search_sessions` sat at complexity **16** (limit 15) because it ran both the metadata scan and the buffer-content scan inline. Split into two helpers — `search_sessions_meta` and `search_sessions_content` — leaving `search_sessions` a thin two-call wrapper. **No behavior change** (pure extraction).

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --lib global_search` — 18 pass