### PR TITLE
docs: note tasks (new) and automations features are still evolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Create one with `Ctrl+N` — pick a repo, name it, choose an agent:
   is fully scriptable headless: `thurbox-cli automation
   create/list/edit/run/tick`.
 
+> **Note:** Automations are stable and good enough for daily use
+> today, but the feature may still evolve.
+
 ![Automations demo](./docs/media/automations-demo.gif)
 
 ### Tasks
@@ -90,6 +93,9 @@ Create one with `Ctrl+N` — pick a repo, name it, choose an agent:
   `create`/`list`/`show`/`edit`/`remove`/`run`. External
   issue-tracker sync (Jira, GitHub Issues) is scaffolded for a
   later release.
+
+> **Note:** Tasks are a new feature — expect the UX and UI to keep
+> evolving in upcoming releases.
 
 ![Tasks demo](./docs/media/tasks-demo.gif)
 

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -213,6 +213,13 @@
             Automations
             <a href="#automations" class="heading-anchor">#</a>
           </h2>
+          <div class="info-box">
+            <p>
+              <strong>Note:</strong>
+              Automations are stable and good enough for daily use today, but the feature may still
+              evolve.
+            </p>
+          </div>
           <p>
             Named, scheduled agent runs. An automation fires on a schedule and either
             <strong>sends</strong>
@@ -277,6 +284,13 @@
             Tasks
             <a href="#tasks" class="heading-anchor">#</a>
           </h2>
+          <div class="info-box warning">
+            <p>
+              <strong>Heads up:</strong>
+              Tasks are a new feature &mdash; expect the UX and UI to keep evolving in upcoming
+              releases.
+            </p>
+          </div>
           <figure class="video-card">
             <div class="terminal-frame">
               <div class="terminal-body">


### PR DESCRIPTION
## Summary

- Add a note that the **Tasks** feature is new and its UX/UI will keep evolving.
- Add a milder note that **Automations** is stable/good-enough today but may still evolve.
- Notes added to `README.md` (blockquotes) and `website/docs/features.html` (reusing the existing `.info-box` component; Tasks uses the `warning` variant).

## Test plan

- `rumdl check` and Prettier/HTMLHint pass on the touched files
- CI checks pass