### PR TITLE
docs: note session list display is evolving and agent-dependent

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ adds:
   clipboard, automations (`Ctrl+P`), soft-delete with undo
   (`Ctrl+Z`) and restore (`Ctrl+U`).
 
+> **Note:** The session list display is not yet perfect and will
+> keep improving. What it can show is heavily dependent on the
+> signals each agent CLI exposes.
+
 Create one with `Ctrl+N` — pick a repo, name it, choose an agent:
 
 ![Session creation workflow](./docs/media/thurbox-session-creation.gif)

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -105,6 +105,13 @@
             Sessions
             <a href="#session-orchestration" class="heading-anchor">#</a>
           </h2>
+          <div class="info-box warning">
+            <p>
+              <strong>Heads up:</strong>
+              The session list display is not yet perfect and will keep improving &mdash; what it
+              can show is heavily dependent on the signals each agent CLI exposes.
+            </p>
+          </div>
           <figure class="video-card">
             <div class="terminal-frame">
               <div class="terminal-body">


### PR DESCRIPTION
## Summary

- Add a note that the **session list display** is not yet perfect and will keep improving.
- Clarify that what the list can show is heavily dependent on the signals each agent CLI exposes.
- Notes added to `README.md` (Sessions section) and `website/docs/features.html` (reusing the existing `.info-box warning` component).

## Test plan

- `rumdl check` and Prettier pass on the touched files
- CI checks pass