### PR TITLE
docs: add a dedicated Remote SSH Sessions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,35 @@ Create one with `Ctrl+N` — pick a repo, name it, choose an agent:
   launch the agent inside the worktree. Closing the session removes
   it. `Ctrl+S` syncs all worktree sessions with `origin/main`.
 
+### Remote SSH sessions
+
+- Run an agent on a **remote machine** over SSH while the TUI stays
+  local. Declare hosts in `~/.config/thurbox/hosts.toml` (seeded
+  commented-out, so a fresh install has none); each entry becomes a
+  selectable backend named `ssh:<name>`. The new-session flow shows a
+  **host picker** first, and remote sessions are marked with a `☁`
+  glyph in the list.
+- The agent process, its tmux window, and any git worktrees all live
+  on the remote host. thurbox shells out to your system `ssh`, so
+  authentication, keys, and multiplexing come from `~/.ssh/config` —
+  thurbox never handles credentials. Remote sessions get the same
+  persistence, multi-instance sharing, and restore-on-startup as
+  local ones.
+
+  ```toml
+  # ~/.config/thurbox/hosts.toml
+  [[hosts]]
+  name = "devbox"            # backend "ssh:devbox"; what --host expects
+  destination = "me@devbox"  # ssh target or a ~/.ssh/config alias
+  ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m"]
+  # socket / session  — optional remote tmux -L / session-name overrides
+  # worktrees_dir      — optional absolute remote worktrees dir
+  ```
+
+  Spawn remotely from the CLI with `thurbox-cli session create
+  --host devbox …` (see [Headless CLI](#headless-cli-thurbox-cli)).
+  The remote host needs **tmux >= 3.2** and **git**.
+
 ### Responsive UI
 
 - `< 80` cols: terminal only · `>= 80`: sidebar + terminal ·
@@ -367,7 +396,8 @@ thurbox-cli session create \
   --repo-path /path/to/repo \
   --agent codex \
   --worktree-branch feat/x \
-  --base-branch main
+  --base-branch main \
+  --host devbox          # optional — run on a remote host from hosts.toml
 thurbox-cli session send <uuid> "run the test suite"
 thurbox-cli session capture <uuid> --lines 500
 thurbox-cli session restart <uuid>       # kill + re-spawn with --resume
@@ -378,7 +408,9 @@ thurbox-cli session restore <uuid>       # undo a soft-delete
 - **`create`** runs synchronously — the tmux window is live by the
   time the command returns. `--agent` falls back to the default in
   `agents.toml` when omitted; `--worktree-branch` (off
-  `--base-branch`, default `main`) creates a git worktree.
+  `--base-branch`, default `main`) creates a git worktree; `--host`
+  (a name from `hosts.toml`) creates the worktree and tmux window on
+  that remote host over SSH instead of locally.
 - **`send`** types text into the session's terminal followed by
   Enter; **`capture`** dumps the rendered pane as text (`--lines`
   defaults to 200, max 10000).

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -6,7 +6,7 @@
     <title>Features — Thurbox Docs</title>
     <meta
       name="description"
-      content="Thurbox features: persistent coding-agent sessions, agent definitions, git worktrees, automations, a responsive UI, and a headless CLI."
+      content="Thurbox features: persistent coding-agent sessions, agent definitions, git worktrees, remote SSH sessions, automations, a responsive UI, and a headless CLI."
     />
     <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -76,6 +76,7 @@
             <li><a href="#automations">Automations</a></li>
             <li><a href="#tasks">Tasks</a></li>
             <li><a href="#git-worktrees">Git Worktrees</a></li>
+            <li><a href="#remote-ssh-sessions">Remote SSH Sessions</a></li>
             <li><a href="#worktree-sync">Worktree Sync</a></li>
             <li><a href="#session-forking">Session Forking</a></li>
             <li><a href="#global-search">Global Search</a></li>
@@ -400,6 +401,60 @@
             <code>/</code>
             in branch names is replaced by
             <code>-</code>
+            .
+          </p>
+
+          <h2 id="remote-ssh-sessions">
+            Remote SSH Sessions
+            <a href="#remote-ssh-sessions" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Run an agent on a remote machine over SSH while the TUI stays local. The agent process,
+            its tmux window, and any git worktrees all live on the remote host.
+          </p>
+          <ul>
+            <li>
+              Declare hosts in
+              <code>~/.config/thurbox/hosts.toml</code>
+              (seeded commented-out, so a fresh install has none); each entry registers a selectable
+              backend named
+              <code>ssh:&lt;name&gt;</code>
+            </li>
+            <li>
+              The new-session flow (
+              <code>Ctrl+N</code>
+              ) shows a host picker first; remote sessions are marked with a
+              <code>☁</code>
+              glyph in the session list
+            </li>
+            <li>
+              Thurbox shells out to your system
+              <code>ssh</code>
+              , so authentication, keys, and connection multiplexing come from
+              <code>~/.ssh/config</code>
+              &mdash; thurbox never handles credentials
+            </li>
+            <li>
+              Remote sessions get the same persistence, multi-instance sharing, and
+              restore-on-startup as local ones
+            </li>
+            <li>
+              The remote host needs
+              <strong>tmux &ge; 3.2</strong>
+              and
+              <strong>git</strong>
+            </li>
+          </ul>
+          <pre><code># ~/.config/thurbox/hosts.toml
+[[hosts]]
+name = "devbox"            # backend "ssh:devbox"; what --host expects
+destination = "me@devbox"  # ssh target or a ~/.ssh/config alias
+ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m"]
+# socket / session  — optional remote tmux -L / session-name overrides
+# worktrees_dir      — optional absolute remote worktrees dir</code></pre>
+          <p>
+            Spawn remotely from the CLI with
+            <code>thurbox-cli session create --host devbox …</code>
             .
           </p>
 


### PR DESCRIPTION
## Summary

Adds a dedicated **Remote SSH Sessions** section to the user-facing docs for the now-merged feature:

- **README** — new `### Remote SSH sessions` subsection under Main Features (mirrors *Git worktrees*): covers `hosts.toml`, the host picker, the `☁` indicator, `~/.ssh/config`-based auth, and a config example. The headless-CLI section now documents `--host`.
- **website/docs/features.html** — new `Remote SSH Sessions` section + sidebar TOC entry + meta-description update.

## Test plan

- `rumdl check README.md` — clean
- `npm run lint:website` — clean (prettier/htmlhint/stylelint/eslint)