### PR TITLE
ci: publish Homebrew formula to a tap on release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -266,3 +266,58 @@ jobs:
           commit_email: magicletur@protonmail.com
           ssh_private_key: ${{ env.AUR_SSH_PRIVATE_KEY }}
           commit_message: "Update to ${{ needs.check-release.outputs.version }}"
+
+  # Publish the Homebrew formula to the tap (Thurbeen/homebrew-thurbox).
+  # Runs after `publish` so the release tarballs + checksums.txt exist.
+  # Requires the HOMEBREW_TAP_TOKEN secret (a PAT with `contents:write` on the
+  # tap repo); skipped automatically if unset (e.g. on forks).
+  publish-homebrew:
+    name: Publish Homebrew formula
+    needs: [check-release, create-tag, publish]
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    # Hoisted so the push step can be skipped when the secret is unset
+    # (the `secrets` context cannot be used directly in an `if` condition).
+    env:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+    steps:
+      - name: Checkout code at tag
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.check-release.outputs.version }}
+
+      - name: Download release checksums
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        run: |
+          VERSION="${{ needs.check-release.outputs.version }}"
+          curl -fsSL -o checksums.txt \
+            "https://github.com/${{ github.repository }}/releases/download/${VERSION}/thurbox-${VERSION}-checksums.txt"
+          cat checksums.txt
+
+      - name: Bump formula to the release version
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        run: |
+          python3 packaging/homebrew/bump-formula.py \
+            "${{ needs.check-release.outputs.version }}" \
+            packaging/homebrew/Formula/thurbox.rb \
+            checksums.txt
+          cat packaging/homebrew/Formula/thurbox.rb
+
+      - name: Push formula to the tap
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        run: |
+          VERSION="${{ needs.check-release.outputs.version }}"
+          git clone --depth 1 \
+            "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/Thurbeen/homebrew-thurbox.git" tap
+          mkdir -p tap/Formula
+          cp packaging/homebrew/Formula/thurbox.rb tap/Formula/thurbox.rb
+          cd tap
+          git config user.name thurbox-release-bot
+          git config user.email magicletur@protonmail.com
+          if git diff --quiet; then
+            echo "Formula already up to date; nothing to push."
+            exit 0
+          fi
+          git add Formula/thurbox.rb
+          git commit -m "Update to ${VERSION}"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,22 @@ Each release includes:
 - `thurbox-v{ver}-checksums.txt` (SHA256 sums for verification)
 - Changelog with categorized commits
 
+### Distribution Packages
+
+After the GitHub Release is published, `cd.yml` also updates the downstream
+package channels (each gated on its secret, skipped on forks):
+
+- **Homebrew** (`publish-homebrew`): bumps `version`/`sha256` in
+  `packaging/homebrew/Formula/thurbox.rb` (via `packaging/homebrew/bump-formula.py`,
+  reading the release `checksums.txt`) and pushes it to the
+  `Thurbeen/homebrew-thurbox` tap. Needs `HOMEBREW_TAP_TOKEN`. Install:
+  `brew install thurbeen/thurbox/thurbox`. Supports macOS arm64
+  (`aarch64-apple-darwin`) + Linux x86_64 (`x86_64-unknown-linux-musl`).
+- **AUR** (`publish-aur`): bumps + pushes `thurbox`/`thurbox-bin` PKGBUILDs.
+  Needs `AUR_SSH_PRIVATE_KEY`.
+
+See `packaging/README.md` for the full packaging overview.
+
 ### Commit Types and Versioning
 
 - **feat**: Minor version bump (0.x.0)

--- a/README.md
+++ b/README.md
@@ -212,6 +212,17 @@ INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/Thurbeen
 VERSION=v0.1.0 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
 ```
 
+**Homebrew (macOS / Linux):**
+
+```bash
+brew install thurbeen/thurbox/thurbox
+```
+
+Installs the prebuilt release binaries (`thurbox` + `thurbox-cli`)
+from the [tap](https://github.com/Thurbeen/homebrew-thurbox), with
+`tmux` and `git` pulled in as dependencies. Supports macOS arm64
+(Apple Silicon) and Linux x86_64.
+
 **Arch Linux (AUR):**
 
 Thurbox is on the AUR as
@@ -244,6 +255,7 @@ Remove the binary, depending on how you installed it:
 
 ```bash
 rm ~/.local/bin/thurbox        # curl one-liner / manual install
+brew uninstall thurbox         # Homebrew
 paru -R thurbox thurbox-bin    # Arch (AUR)
 ```
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,6 +1,18 @@
 # Packaging
 
-Optional OS-level integration for thurbox.
+Optional OS-level integration and distribution packages for thurbox.
+
+## Distribution packages
+
+| Directory   | Channel                  | Installs                                  |
+| ----------- | ------------------------ | ----------------------------------------- |
+| `homebrew/` | Homebrew tap (macOS/Linux) | prebuilt release binaries — see [`homebrew/README.md`](homebrew/README.md) |
+| `aur/`      | Arch Linux (AUR)         | source + prebuilt binary — see [`aur/README.md`](aur/README.md) |
+
+Both are published automatically on each release by jobs in
+[`.github/workflows/cd.yml`](../.github/workflows/cd.yml). For the
+distro-agnostic one-liner installer, see
+[`scripts/install.sh`](../scripts/install.sh).
 
 ## Reboot-proof automations (`systemd/`, `launchd/`)
 

--- a/packaging/homebrew/Formula/thurbox.rb
+++ b/packaging/homebrew/Formula/thurbox.rb
@@ -1,0 +1,62 @@
+# Homebrew formula for thurbox.
+#
+# This is the canonical source, kept in the main repo. CI (the
+# `publish-homebrew` job in .github/workflows/cd.yml) copies it to the
+# Thurbeen/homebrew-thurbox tap on every release, with `version` and the
+# per-platform `sha256` values bumped to that release. The values below are
+# a last-known-good template — CI overrides them per release.
+#
+#   brew install thurbeen/thurbox/thurbox
+#
+# Only the platforms with a published release artifact are supported:
+#   - macOS arm64 (Apple Silicon) -> aarch64-apple-darwin
+#   - Linux x86_64                -> x86_64-unknown-linux-musl (static)
+# Intel macOS and aarch64 Linux have no release binary, so they are omitted
+# (brew reports "no available formula" on those platforms).
+class Thurbox < Formula
+  desc "TUI for orchestrating multiple coding-agent CLI sessions in persistent tmux panels"
+  homepage "https://github.com/Thurbeen/thurbox"
+  version "0.79.46"
+  license "MIT"
+
+  depends_on "git"
+  depends_on "tmux"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/Thurbeen/thurbox/releases/download/v#{version}/thurbox-v#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "ac7742c30cfa0e36557e2449d9b900c553e4feb30e0f154ada0b8ab2e61ae421"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/Thurbeen/thurbox/releases/download/v#{version}/thurbox-v#{version}-x86_64-unknown-linux-musl.tar.gz"
+      sha256 "182ebaf3a3842bc76bbf0bbe536300bdcfb5ced2c4a302668d4590276d4d51a3"
+    end
+  end
+
+  def install
+    # The release tarball ships both maintained binaries plus LICENSE; install
+    # only the binaries (Homebrew records the license from the formula).
+    bin.install "thurbox"
+    bin.install "thurbox-cli"
+  end
+
+  def caveats
+    <<~EOS
+      thurbox needs tmux >= 3.2 and a coding-agent CLI (claude, codex, gemini,
+      opencode, aider, …) on your PATH. Launch the TUI with `thurbox`; the
+      scriptable headless interface is `thurbox-cli`.
+    EOS
+  end
+
+  test do
+    # The TUI (`thurbox`) has no headless mode, so only assert it is installed
+    # and executable. `thurbox-cli` is a clap CLI: `--version` exits 0 and
+    # prints a semver-shaped marker (the build-time release version is injected
+    # into the TUI's status bar, not into clap's CARGO_PKG_VERSION).
+    assert_predicate bin/"thurbox", :executable?
+    assert_match(/\d+\.\d+\.\d+/, shell_output("#{bin}/thurbox-cli --version"))
+  end
+end

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,100 @@
+# Homebrew packaging
+
+Thurbox ships a [Homebrew](https://brew.sh) formula that installs the
+**prebuilt** release binaries (`thurbox` + `thurbox-cli`) from the GitHub
+Release. It is distributed through a **tap**
+([`Thurbeen/homebrew-thurbox`](https://github.com/Thurbeen/homebrew-thurbox)),
+not homebrew-core.
+
+```bash
+brew install thurbeen/thurbox/thurbox
+# or, equivalently:
+brew tap thurbeen/thurbox
+brew install thurbox
+```
+
+The canonical formula lives here at
+[`Formula/thurbox.rb`](Formula/thurbox.rb); CI copies it into the tap on every
+release. The `version`/`sha256` values committed here are a last-known-good
+template — CI overrides them per release.
+
+## Supported platforms
+
+The formula only declares the platforms that have a published release
+artifact:
+
+| Platform | Release artifact |
+| -------- | ---------------- |
+| macOS arm64 (Apple Silicon) | `aarch64-apple-darwin` |
+| Linux x86_64 | `x86_64-unknown-linux-musl` (static) |
+
+Intel macOS (`x86_64-apple-darwin`) and aarch64 Linux have **no** release
+binary, so `brew install` reports "no available formula" there. Use
+[`scripts/install.sh`](../../scripts/install.sh) or build from source on those
+platforms.
+
+## Runtime dependencies
+
+- `tmux` (>= 3.2) and `git` — declared as formula `depends_on`.
+- A coding-agent CLI (claude-code, codex, gemini, opencode, aider, …) is
+  user-supplied (mentioned in the formula `caveats`).
+
+## Test locally
+
+```bash
+brew install --build-from-source ./Formula/thurbox.rb   # install the local formula
+brew audit --strict --formula ./Formula/thurbox.rb      # lint the recipe
+brew test thurbox                                       # run the formula test block
+```
+
+## Automated publishing (CI)
+
+New releases publish to the tap **automatically**. The `publish-homebrew` job
+in [`.github/workflows/cd.yml`](../../.github/workflows/cd.yml) runs after the
+GitHub Release is created and:
+
+1. downloads the release `thurbox-<version>-checksums.txt`,
+2. runs [`bump-formula.py`](bump-formula.py) to set `version` and each
+   per-platform `sha256` from those checksums, then
+3. clones the tap repo and commits the updated `Formula/thurbox.rb`.
+
+The job is a no-op if the formula is already current, and is skipped entirely
+when the token secret is absent (e.g. on forks).
+
+### One-time setup
+
+1. **Create the tap repo** — a GitHub repo named `homebrew-thurbox` under the
+   `Thurbeen` org (the `homebrew-` prefix is what makes `brew tap
+   thurbeen/thurbox` work). A bare repo with a `Formula/` directory is enough;
+   the first release populates `Formula/thurbox.rb`.
+
+2. **Provide a write token.** Generate a personal access token (fine-grained,
+   `contents: read & write` on `Thurbeen/homebrew-thurbox`) and store it as the
+   `HOMEBREW_TAP_TOKEN` repository secret on the **main** thurbox repo:
+
+   ```bash
+   gh secret set HOMEBREW_TAP_TOKEN   # paste the token when prompted
+   ```
+
+After that, every release updates the tap automatically.
+
+## Manual publishing / initial import
+
+To seed or update the tap by hand:
+
+```bash
+# Bump the local template to a published release, then copy it into the tap.
+curl -fsSL -o /tmp/checksums.txt \
+  "https://github.com/Thurbeen/thurbox/releases/download/v<version>/thurbox-v<version>-checksums.txt"
+python3 bump-formula.py v<version> Formula/thurbox.rb /tmp/checksums.txt
+
+git clone https://github.com/Thurbeen/homebrew-thurbox.git
+mkdir -p homebrew-thurbox/Formula
+cp Formula/thurbox.rb homebrew-thurbox/Formula/thurbox.rb
+cd homebrew-thurbox
+git commit -am "Update to v<version>"
+git push
+```
+
+Pick a `<version>` that has **published release assets** (the formula points at
+release tarballs).

--- a/packaging/homebrew/bump-formula.py
+++ b/packaging/homebrew/bump-formula.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Bump a Homebrew formula to a released version.
+
+Usage: bump-formula.py <version> <formula.rb> <checksums.txt>
+
+Rewrites the formula's `version "..."` and each per-platform `sha256 "..."` to
+match the freshly published release. The url lines use `#{version}`
+interpolation, so each artifact's target triple is read from the url and the
+real filename (`thurbox-v<version>-<target>.tar.gz`) is looked up in the
+release `checksums.txt`. Exits non-zero if a url has no matching checksum, so
+CI fails loudly rather than pushing a stale/partial formula.
+"""
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    version_tag, formula_path, checksums_path = sys.argv[1], sys.argv[2], sys.argv[3]
+    version = version_tag.lstrip("v")
+
+    checks = {}
+    for line in Path(checksums_path).read_text().splitlines():
+        parts = line.split()
+        if len(parts) == 2:
+            checks[parts[1]] = parts[0]
+
+    text = Path(formula_path).read_text()
+    text, n = re.subn(r'version "[^"]*"', f'version "{version}"', text, count=1)
+    if n != 1:
+        print("error: no `version` line found in formula", file=sys.stderr)
+        return 1
+
+    pattern = re.compile(
+        r'(?P<url>url "[^"]*thurbox-v#\{version\}-(?P<target>[^"]+?)\.tar\.gz")'
+        r'(?P<gap>\s*)sha256 "[0-9a-f]*"'
+    )
+
+    missing = []
+
+    def repl(m: "re.Match[str]") -> str:
+        fname = f"thurbox-v{version}-{m.group('target')}.tar.gz"
+        sha = checks.get(fname)
+        if sha is None:
+            missing.append(fname)
+            return m.group(0)
+        return f'{m.group("url")}{m.group("gap")}sha256 "{sha}"'
+
+    text, count = pattern.subn(repl, text)
+    if missing:
+        print(f"error: checksum missing for: {', '.join(missing)}", file=sys.stderr)
+        return 1
+    if count == 0:
+        print("error: no `url`/`sha256` pairs found in formula", file=sys.stderr)
+        return 1
+
+    Path(formula_path).write_text(text)
+    print(f"Bumped {formula_path} to {version} ({count} artifact(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -72,6 +72,7 @@
           <h4>On This Page</h4>
           <ul>
             <li><a href="#from-binary">From Binary</a></li>
+            <li><a href="#homebrew">Homebrew</a></li>
             <li><a href="#arch-linux">Arch Linux (AUR)</a></li>
             <li><a href="#from-source">From Source</a></li>
             <li><a href="#prerequisites">Prerequisites</a></li>
@@ -206,6 +207,39 @@
               </tr>
             </tbody>
           </table>
+
+          <h2 id="homebrew">
+            Homebrew
+            <a href="#homebrew" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            On macOS or Linux, install the prebuilt binaries from the
+            <a href="https://github.com/Thurbeen/homebrew-thurbox">thurbox tap</a>:
+          </p>
+          <div class="terminal-frame">
+            <div class="terminal-header">
+              <div class="terminal-dot red"></div>
+              <div class="terminal-dot yellow"></div>
+              <div class="terminal-dot green"></div>
+              <span class="terminal-title">bash</span>
+            </div>
+            <div class="terminal-body">
+              <button class="copy-btn" data-code="brew install thurbeen/thurbox/thurbox">Copy</button>
+              <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">brew</span> install thurbeen/thurbox/thurbox</code></pre>
+            </div>
+          </div>
+          <p>
+            This installs
+            <code>thurbox</code>
+            and
+            <code>thurbox-cli</code>, pulling in
+            <code>tmux</code>
+            and
+            <code>git</code>
+            as dependencies. Supported on macOS Apple Silicon and Linux x86_64
+            (Intel macOS and aarch64 Linux have no release binary &mdash; use the
+            one-liner or build from source there).
+          </p>
 
           <h2 id="arch-linux">
             Arch Linux (AUR)
@@ -396,6 +430,7 @@ cargo build --release"
             <div class="terminal-body">
               <button class="copy-btn" data-code="rm ~/.local/bin/thurbox">Copy</button>
               <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">rm</span> ~/.local/bin/thurbox        <span class="syn-comment"># curl one-liner / manual install</span>
+<span class="syn-prompt">$</span> <span class="syn-cmd">brew</span> uninstall thurbox         <span class="syn-comment"># Homebrew</span>
 <span class="syn-prompt">$</span> <span class="syn-cmd">paru</span> <span class="syn-flag">-R</span> thurbox thurbox-bin    <span class="syn-comment"># Arch (AUR)</span></code></pre>
             </div>
           </div>

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -214,7 +214,8 @@
           </h2>
           <p>
             On macOS or Linux, install the prebuilt binaries from the
-            <a href="https://github.com/Thurbeen/homebrew-thurbox">thurbox tap</a>:
+            <a href="https://github.com/Thurbeen/homebrew-thurbox">thurbox tap</a>
+            :
           </p>
           <div class="terminal-frame">
             <div class="terminal-header">
@@ -224,7 +225,9 @@
               <span class="terminal-title">bash</span>
             </div>
             <div class="terminal-body">
-              <button class="copy-btn" data-code="brew install thurbeen/thurbox/thurbox">Copy</button>
+              <button class="copy-btn" data-code="brew install thurbeen/thurbox/thurbox">
+                Copy
+              </button>
               <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">brew</span> install thurbeen/thurbox/thurbox</code></pre>
             </div>
           </div>
@@ -232,13 +235,14 @@
             This installs
             <code>thurbox</code>
             and
-            <code>thurbox-cli</code>, pulling in
+            <code>thurbox-cli</code>
+            , pulling in
             <code>tmux</code>
             and
             <code>git</code>
-            as dependencies. Supported on macOS Apple Silicon and Linux x86_64
-            (Intel macOS and aarch64 Linux have no release binary &mdash; use the
-            one-liner or build from source there).
+            as dependencies. Supported on macOS Apple Silicon and Linux x86_64 (Intel macOS and
+            aarch64 Linux have no release binary &mdash; use the one-liner or build from source
+            there).
           </p>
 
           <h2 id="arch-linux">


### PR DESCRIPTION
## Summary

- Add a **Homebrew** distribution channel mirroring the existing AUR setup: `brew install thurbeen/thurbox/thurbox`.
- `packaging/homebrew/Formula/thurbox.rb` installs the prebuilt `thurbox` + `thurbox-cli` release binaries (macOS arm64, Linux x86_64 musl) with `tmux` + `git` deps.
- `packaging/homebrew/bump-formula.py` rewrites `version` + per-platform `sha256` from a release `checksums.txt` (tested: success + missing-checksum paths).
- New `publish-homebrew` job in `cd.yml` runs after the GitHub Release, bumps the formula, and pushes it to the `Thurbeen/homebrew-thurbox` tap (gated on `HOMEBREW_TAP_TOKEN`, skipped on forks).
- Docs updated: README install/uninstall, CLAUDE.md release process, `packaging/README.md`, and a dedicated `packaging/homebrew/README.md`.

The tap repo is already seeded with the v0.79.46 formula, so `brew install` works today.

## Test plan

- `ruby -c` on the formula, `rumdl` on docs, YAML parse on the workflow — all pass.
- `bump-formula.py` verified to reproduce the live tap formula byte-for-byte from the v0.79.46 release checksums.
- CI checks pass.