### PR TITLE
fix: make the release decision robust to cog's no-bump message

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,15 +34,21 @@ jobs:
       - name: Parse release decision
         id: parse
         run: |
-          VERSION="$(cog bump --auto --disable-bump-commit --dry-run)"
-          echo "Detected version: $VERSION"
+          # cog prints the next tag (e.g. "v0.99.1") when a bump is due, but a
+          # human-readable "No conventional commits…" message when none is. Match
+          # only a real semver so that non-bump message never reaches
+          # $GITHUB_OUTPUT — writing its multi-line text there previously failed
+          # this step (and the whole workflow) on every docs/ci/chore push.
+          RAW="$(cog bump --auto --disable-bump-commit --dry-run 2>/dev/null || true)"
+          echo "cog output: $RAW"
+          VERSION="$(printf '%s\n' "$RAW" | grep -oE '^v?[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*' | head -1 || true)"
           if [ -n "$VERSION" ]; then
-            echo "should_release=true" >> $GITHUB_OUTPUT
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             echo "✅ Release needed: $VERSION"
           else
-            echo "should_release=false" >> $GITHUB_OUTPUT
-            echo "version=" >> $GITHUB_OUTPUT
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No releasable commits detected"
           fi
 


### PR DESCRIPTION
## Summary

- The `Parse release decision` step in the Release workflow assumed `cog bump --dry-run` emits an empty string when no release is due. It actually prints a multi-line `No conventional commits…` message, which got written to `$GITHUB_OUTPUT` and **failed the whole Release workflow on every docs/ci/chore push** (observed on the Homebrew packaging merge).
- Fix: extract a real semver from cog's output and only release on a match; otherwise treat it as "no release".
- Being a `fix:`, this also cuts a **patch release (`v0.99.1`)** — intentionally, to validate the new `publish-homebrew` job end-to-end (formula bump + push to the tap).

## Test plan

- Shell logic verified locally against: real bump (`v0.99.1`), bare semver, prerelease (`v1.0.0-rc.1`), the no-bump message, and empty — releases only on real versions.
- YAML validated.
- CI checks pass; after merge, the Release workflow should succeed and publish `v0.99.1` + update the Homebrew tap.