### PR TITLE
ci: push the Homebrew tap over SSH with a deploy key

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -275,8 +275,10 @@ jobs:
 
   # Publish the Homebrew formula to the tap (Thurbeen/homebrew-thurbox).
   # Runs after `publish` so the release tarballs + checksums.txt exist.
-  # Requires the HOMEBREW_TAP_TOKEN secret (a PAT with `contents:write` on the
-  # tap repo); skipped automatically if unset (e.g. on forks).
+  # Pushes over SSH using HOMEBREW_TAP_DEPLOY_KEY — a write-enabled deploy key
+  # registered on the tap repo (the Thurbeen org blocks cross-repo PATs, so a
+  # repo-scoped deploy key is the credential). Skipped automatically if the
+  # secret is unset (e.g. on forks).
   publish-homebrew:
     name: Publish Homebrew formula
     needs: [check-release, create-tag, publish]
@@ -285,7 +287,7 @@ jobs:
     # Hoisted so the push step can be skipped when the secret is unset
     # (the `secrets` context cannot be used directly in an `if` condition).
     env:
-      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
     steps:
       - name: Checkout code at tag
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -293,7 +295,7 @@ jobs:
           ref: ${{ needs.check-release.outputs.version }}
 
       - name: Download release checksums
-        if: env.HOMEBREW_TAP_TOKEN != ''
+        if: env.HOMEBREW_TAP_DEPLOY_KEY != ''
         run: |
           VERSION="${{ needs.check-release.outputs.version }}"
           curl -fsSL -o checksums.txt \
@@ -301,7 +303,7 @@ jobs:
           cat checksums.txt
 
       - name: Bump formula to the release version
-        if: env.HOMEBREW_TAP_TOKEN != ''
+        if: env.HOMEBREW_TAP_DEPLOY_KEY != ''
         run: |
           python3 packaging/homebrew/bump-formula.py \
             "${{ needs.check-release.outputs.version }}" \
@@ -310,11 +312,15 @@ jobs:
           cat packaging/homebrew/Formula/thurbox.rb
 
       - name: Push formula to the tap
-        if: env.HOMEBREW_TAP_TOKEN != ''
+        if: env.HOMEBREW_TAP_DEPLOY_KEY != ''
         run: |
           VERSION="${{ needs.check-release.outputs.version }}"
-          git clone --depth 1 \
-            "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/Thurbeen/homebrew-thurbox.git" tap
+          mkdir -p ~/.ssh
+          printf '%s\n' "$HOMEBREW_TAP_DEPLOY_KEY" > ~/.ssh/tap_key
+          chmod 600 ~/.ssh/tap_key
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/tap_key -o IdentitiesOnly=yes"
+          git clone --depth 1 git@github.com:Thurbeen/homebrew-thurbox.git tap
           mkdir -p tap/Formula
           cp packaging/homebrew/Formula/thurbox.rb tap/Formula/thurbox.rb
           cd tap
@@ -326,4 +332,4 @@ jobs:
           fi
           git add Formula/thurbox.rb
           git commit -m "Update to ${VERSION}"
-          git push
+          git push origin HEAD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,9 @@ package channels (each gated on its secret, skipped on forks):
 - **Homebrew** (`publish-homebrew`): bumps `version`/`sha256` in
   `packaging/homebrew/Formula/thurbox.rb` (via `packaging/homebrew/bump-formula.py`,
   reading the release `checksums.txt`) and pushes it to the
-  `Thurbeen/homebrew-thurbox` tap. Needs `HOMEBREW_TAP_TOKEN`. Install:
-  `brew install thurbeen/thurbox/thurbox`. Supports macOS arm64
+  `Thurbeen/homebrew-thurbox` tap over SSH. Needs the `HOMEBREW_TAP_DEPLOY_KEY`
+  secret (a write deploy key on the tap repo; the org blocks cross-repo PATs).
+  Install: `brew install thurbeen/thurbox/thurbox`. Supports macOS arm64
   (`aarch64-apple-darwin`) + Linux x86_64 (`x86_64-unknown-linux-musl`).
 - **AUR** (`publish-aur`): bumps + pushes `thurbox`/`thurbox-bin` PKGBUILDs.
   Needs `AUR_SSH_PRIVATE_KEY`.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -59,7 +59,12 @@ GitHub Release is created and:
 3. clones the tap repo and commits the updated `Formula/thurbox.rb`.
 
 The job is a no-op if the formula is already current, and is skipped entirely
-when the token secret is absent (e.g. on forks).
+when the deploy-key secret is absent (e.g. on forks).
+
+The push uses **SSH with a write-enabled deploy key** rather than a PAT: the
+`Thurbeen` org blocks cross-repo personal access tokens, so a repo-scoped
+deploy key is both the working credential and the least-privilege one (it can
+write to the tap repo and nothing else).
 
 ### One-time setup
 
@@ -68,13 +73,21 @@ when the token secret is absent (e.g. on forks).
    thurbeen/thurbox` work). A bare repo with a `Formula/` directory is enough;
    the first release populates `Formula/thurbox.rb`.
 
-2. **Provide a write token.** Generate a personal access token (fine-grained,
-   `contents: read & write` on `Thurbeen/homebrew-thurbox`) and store it as the
-   `HOMEBREW_TAP_TOKEN` repository secret on the **main** thurbox repo:
+2. **Add a write deploy key.** Generate a dedicated key, register the **public**
+   half on the tap repo with write access, and store the **private** half as the
+   `HOMEBREW_TAP_DEPLOY_KEY` secret on the **main** thurbox repo:
 
    ```bash
-   gh secret set HOMEBREW_TAP_TOKEN   # paste the token when prompted
+   ssh-keygen -t ed25519 -C "thurbox-release-ci@homebrew-tap" -f tap_key -N ""
+   gh repo deploy-key add tap_key.pub --repo Thurbeen/homebrew-thurbox \
+     --title thurbox-release-ci --allow-write
+   gh secret set HOMEBREW_TAP_DEPLOY_KEY --repo Thurbeen/thurbox < tap_key
+   rm -f tap_key tap_key.pub   # don't leave the private key on disk
    ```
+
+   > Org-owned repos disable deploy keys by default. If `deploy-key add` reports
+   > *"Deploy keys are disabled for this repository"*, an org owner must enable
+   > them under **Org Settings → Repository → Repository deploy keys** first.
 
 After that, every release updates the tap automatically.
 


### PR DESCRIPTION
## Summary

The first real release (`v0.99.1`) exposed that the `publish-homebrew` job's HTTPS push with `HOMEBREW_TAP_TOKEN` failed (`Invalid username or token`) — the **Thurbeen org blocks cross-repo PATs**. The bump/commit worked; only the push was rejected.

- Switch the job to **clone/push the tap over SSH** using `HOMEBREW_TAP_DEPLOY_KEY`, a write-enabled deploy key scoped to only the tap repo (least privilege, no org PAT policy involved).
- Update `packaging/homebrew/README.md` + `CLAUDE.md` setup notes (deploy-key creation, org "deploy keys disabled" gotcha).

Validated out-of-band: the deploy key was used to push the `v0.99.1` bump to the tap, so **the tap is already at `v0.99.1`** and `brew install thurbeen/thurbox/thurbox` installs the latest. This PR makes the *next* release do that automatically.

## Test plan

- YAML validated; docs rumdl-clean.
- Deploy-key SSH push confirmed working manually against the tap.
- CI checks pass. (Release-neutral `ci` change — no new release triggered.)