### PR TITLE
feat(ui): draggable scrollbars, pane-aware wheel, task preview slider

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -10,7 +10,7 @@ pub mod registry;
 pub mod tmux;
 pub mod transport;
 
-pub use backend::{Session, SessionBackend, SessionParser};
+pub use backend::{Session, SessionBackend, SessionParser, TermSignals};
 pub use generic::GenericProvider;
 pub use provider::AgentProvider;
 pub use registry::BackendRegistry;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -30,6 +30,7 @@ use crate::storage::Database;
 use crate::storage::DeletedSessionInfo;
 use crate::sync::{self, SharedWorktree, StateDelta, SyncState};
 use crate::ui::layout;
+use crate::ui::scrollbar::ScrollbarGeom;
 use crate::ui::selection::{PaneBounds, Selection, TermPos};
 
 const MOUSE_SCROLL_LINES: usize = 3;
@@ -372,8 +373,16 @@ pub enum AppMessage {
     KeyPress(KeyCode, KeyModifiers),
     /// Text pasted via the terminal's bracketed paste mode.
     Paste(String),
-    MouseScrollUp,
-    MouseScrollDown,
+    /// Mouse wheel up/down, carrying the cursor position so the scroll can be
+    /// routed to whichever pane is under the cursor.
+    MouseScrollUp {
+        x: u16,
+        y: u16,
+    },
+    MouseScrollDown {
+        x: u16,
+        y: u16,
+    },
     MouseClick {
         x: u16,
         y: u16,
@@ -396,6 +405,39 @@ pub enum StatusLevel {
     Info,
     Success,
     Error,
+}
+
+/// Which scroll state a rendered scrollbar drives. Recorded per-frame in
+/// [`App::scrollbar_hits`] so mouse clicks/drags on a track can be routed back
+/// to the right pane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScrollTarget {
+    Terminal,
+    TaskPreview,
+    FileViewer,
+    RunHistory,
+}
+
+/// One scrollbar rendered this frame: its geometry plus the scroll state it
+/// drives. Built in [`App::view`], hit-tested by the mouse handlers.
+pub(crate) struct ScrollbarHit {
+    pub(crate) geom: ScrollbarGeom,
+    pub(crate) target: ScrollTarget,
+}
+
+/// A scrollable pane identified by hit-testing the cursor against the layout,
+/// used to route a mouse-wheel tick to the pane under the cursor. Broader than
+/// [`ScrollTarget`] because the wheel also scrolls the selection-driven list
+/// panes (which have no draggable scrollbar of their own).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScrollPane {
+    Terminal,
+    TaskPreview,
+    FileViewer,
+    RunHistory,
+    SessionList,
+    TasksList,
+    Automations,
 }
 
 #[derive(Debug, Clone)]
@@ -532,6 +574,13 @@ pub struct App {
     // (Restore sessions modal state is now in self.modal)
     /// Active text selection (click+drag), uses screen-absolute coordinates.
     pub(crate) text_selection: Option<Selection>,
+    /// Scrollbars rendered this frame, with the scroll state each drives.
+    /// Cleared and rebuilt every [`App::view`]; hit-tested by the mouse handlers
+    /// so a click/drag on a track scrolls the owning pane.
+    pub(crate) scrollbar_hits: Vec<ScrollbarHit>,
+    /// The scrollbar currently being dragged, if any. Set when a click lands on
+    /// a track, cleared on mouse-up, so drags keep driving the same pane.
+    pub(crate) dragging_scrollbar: Option<ScrollTarget>,
     /// Cached text extracted from the frame buffer for the current selection.
     selected_text_cache: Option<String>,
     /// Persistent clipboard handle to avoid "dropped too quickly" warnings on Linux.
@@ -656,6 +705,8 @@ impl App {
             session_terminal_views: HashMap::new(),
             pending_delete: None,
             text_selection: None,
+            scrollbar_hits: Vec::new(),
+            dragging_scrollbar: None,
             selected_text_cache: None,
             clipboard: arboard::Clipboard::new().ok(),
             session_elapsed_buf: Vec::new(),
@@ -1263,8 +1314,8 @@ impl App {
         match msg {
             AppMessage::KeyPress(code, mods) => self.handle_key(code, mods),
             AppMessage::Paste(text) => self.handle_paste(text),
-            AppMessage::MouseScrollUp => self.scroll_terminal_up(MOUSE_SCROLL_LINES),
-            AppMessage::MouseScrollDown => self.scroll_terminal_down(MOUSE_SCROLL_LINES),
+            AppMessage::MouseScrollUp { x, y } => self.handle_mouse_scroll(x, y, true),
+            AppMessage::MouseScrollDown { x, y } => self.handle_mouse_scroll(x, y, false),
             AppMessage::MouseClick { x, y, modifiers } => self.handle_mouse_click(x, y, modifiers),
             AppMessage::MouseDrag { x, y } => self.handle_mouse_drag(x, y),
             AppMessage::MouseUp { x, y } => self.handle_mouse_up(x, y),
@@ -1393,6 +1444,18 @@ impl App {
             return;
         }
 
+        // Grab a scrollbar thumb: a click on any rendered track starts a drag of
+        // that pane's scroll state (and never starts a text selection).
+        if let Some(hit) = self.scrollbar_hits.iter().find(|h| h.geom.contains(x, y)) {
+            let target = hit.target;
+            let pos = hit.geom.position_for_y(y);
+            let content_len = hit.geom.content_len;
+            self.text_selection = None;
+            self.dragging_scrollbar = Some(target);
+            self.apply_scrollbar_position(target, pos, content_len);
+            return;
+        }
+
         // Find which pane was clicked; use inner area (excluding borders).
         let pos = Position::new(x, y);
         let pane_rects = [Some(areas.terminal), areas.left_panel, areas.info_panel];
@@ -1416,6 +1479,17 @@ impl App {
     }
 
     fn handle_mouse_drag(&mut self, x: u16, y: u16) {
+        // A scrollbar drag takes precedence: keep driving the grabbed pane's
+        // scroll state (y can leave the track — `position_for_y` clamps it).
+        if let Some(target) = self.dragging_scrollbar {
+            if let Some(hit) = self.scrollbar_hits.iter().find(|h| h.target == target) {
+                let pos = hit.geom.position_for_y(y);
+                let content_len = hit.geom.content_len;
+                self.apply_scrollbar_position(target, pos, content_len);
+            }
+            return;
+        }
+
         if let Some(ref mut sel) = self.text_selection {
             let (cx, cy) = sel.pane.clamp(x, y);
             sel.cursor = TermPos {
@@ -1426,6 +1500,11 @@ impl App {
     }
 
     fn handle_mouse_up(&mut self, x: u16, y: u16) {
+        // End an in-progress scrollbar drag without touching the text selection.
+        if self.dragging_scrollbar.take().is_some() {
+            return;
+        }
+
         self.handle_mouse_drag(x, y);
 
         if let Some(ref mut sel) = self.text_selection {
@@ -1436,6 +1515,152 @@ impl App {
                 self.text_selection = None;
             }
         }
+    }
+
+    /// Apply a scrollbar position (in `0..content_len`) to the scroll state it
+    /// drives. `content_len` is passed in (read from the hit) so the terminal
+    /// arm can invert without re-borrowing `scrollbar_hits` across
+    /// `with_active_parser`.
+    fn apply_scrollbar_position(&mut self, target: ScrollTarget, pos: usize, content_len: usize) {
+        match target {
+            ScrollTarget::Terminal => {
+                // The scrollbar position is inverted vs. scrollback (0 = bottom):
+                // render uses `position = total - scrollback`, so invert back.
+                let scrollback = content_len.saturating_sub(pos);
+                self.text_selection = None;
+                self.with_active_parser(|parser| {
+                    parser.screen_mut().set_scrollback(scrollback);
+                });
+            }
+            ScrollTarget::TaskPreview => {
+                let max = self.task_preview_max_scroll();
+                self.task_ui.task_preview_scroll = (pos as u16).min(max);
+            }
+            ScrollTarget::FileViewer => {
+                self.file_viewer.select_index(pos);
+            }
+            ScrollTarget::RunHistory => {
+                let max = self
+                    .automation_ui
+                    .cached_automation_runs
+                    .len()
+                    .saturating_sub(1);
+                self.automation_ui.automation_run_index = pos.min(max);
+            }
+        }
+    }
+
+    /// Route a mouse-wheel tick to whichever pane is under the cursor, so the
+    /// wheel scrolls the hovered pane (terminal, task preview, file viewer, run
+    /// history, or a list pane) rather than always the terminal.
+    fn handle_mouse_scroll(&mut self, x: u16, y: u16, up: bool) {
+        let step: i32 = if up { -1 } else { 1 };
+        match self.pane_at(x, y) {
+            Some(ScrollPane::Terminal) | None => {
+                if up {
+                    self.scroll_terminal_up(MOUSE_SCROLL_LINES);
+                } else {
+                    self.scroll_terminal_down(MOUSE_SCROLL_LINES);
+                }
+            }
+            Some(ScrollPane::TaskPreview) => {
+                self.scroll_task_preview(step * MOUSE_SCROLL_LINES as i32)
+            }
+            Some(ScrollPane::FileViewer) => self
+                .file_viewer
+                .move_selection(step * MOUSE_SCROLL_LINES as i32),
+            Some(ScrollPane::RunHistory) => self.move_run_history_selection(step),
+            Some(ScrollPane::SessionList) => {
+                if up {
+                    self.switch_session_backward();
+                } else {
+                    self.switch_session_forward();
+                }
+            }
+            Some(ScrollPane::TasksList) => self.move_task_selection(step),
+            Some(ScrollPane::Automations) => self.move_automation_selection(step),
+        }
+    }
+
+    /// Step the run-history selection by `delta`, clamped to the run count.
+    fn move_run_history_selection(&mut self, delta: i32) {
+        let len = self.automation_ui.cached_automation_runs.len();
+        if len == 0 {
+            self.automation_ui.automation_run_index = 0;
+            return;
+        }
+        let next =
+            (self.automation_ui.automation_run_index as i32 + delta).clamp(0, len as i32 - 1);
+        self.automation_ui.automation_run_index = next as usize;
+    }
+
+    /// Step the tasks-panel selection by `delta`, clamped, refreshing the preview.
+    fn move_task_selection(&mut self, delta: i32) {
+        let len = self.task_ui.filtered_task_indices.len();
+        if len == 0 {
+            return;
+        }
+        let next = (self.task_ui.task_panel_index as i32 + delta).clamp(0, len as i32 - 1);
+        let next = next as usize;
+        if next != self.task_ui.task_panel_index {
+            self.task_ui.task_panel_index = next;
+            self.refresh_task_view();
+        }
+    }
+
+    /// Step the automations-pane selection by `delta`, clamped, refreshing the
+    /// preview.
+    fn move_automation_selection(&mut self, delta: i32) {
+        let len = self.automation_ui.cached_automations.len();
+        if len == 0 {
+            return;
+        }
+        let next =
+            (self.automation_ui.automation_panel_index as i32 + delta).clamp(0, len as i32 - 1);
+        let next = next as usize;
+        if next != self.automation_ui.automation_panel_index {
+            self.automation_ui.automation_panel_index = next;
+            self.refresh_automation_view();
+        }
+    }
+
+    /// Hit-test `(x, y)` against the current layout to find the scrollable pane
+    /// under the cursor (used for pane-aware wheel scrolling).
+    fn pane_at(&self, x: u16, y: u16) -> Option<ScrollPane> {
+        let area = Rect::new(0, 0, self.terminal_cols, self.terminal_rows);
+        let areas = layout::compute_layout(
+            area,
+            self.show_info_panel,
+            self.show_tasks_panel,
+            self.show_file_viewer,
+            self.global_search.active,
+            self.automation_ui.cached_automations.len(),
+        );
+        let pos = Position::new(x, y);
+        let hit = |r: Option<Rect>| r.map(|r| r.contains(pos)).unwrap_or(false);
+
+        if hit(areas.file_viewer) {
+            return Some(ScrollPane::FileViewer);
+        }
+        if hit(areas.tasks_panel) {
+            return Some(ScrollPane::TasksList);
+        }
+        if hit(areas.automations_panel) {
+            return Some(ScrollPane::Automations);
+        }
+        if hit(areas.left_panel) {
+            return Some(ScrollPane::SessionList);
+        }
+        if areas.terminal.contains(pos) {
+            // The central pane hosts the terminal, the task preview, or the
+            // automation run-history depending on focus.
+            return Some(match self.focus {
+                InputFocus::TaskList | InputFocus::TaskEditor => ScrollPane::TaskPreview,
+                InputFocus::AutomationRunHistory => ScrollPane::RunHistory,
+                _ => ScrollPane::Terminal,
+            });
+        }
+        None
     }
 
     fn copy_selection_to_clipboard(&mut self) {
@@ -3593,15 +3818,26 @@ impl App {
     /// Scroll the full-screen task preview by `delta` rows, clamped to the
     /// rendered description length (a slight over-scroll is harmless).
     pub(crate) fn scroll_task_preview(&mut self, delta: i32) {
-        let max = self
-            .selected_task()
-            .and_then(|t| t.description.as_deref())
-            .map(|d| crate::ui::markdown::render_markdown(d).len() as i32)
-            .unwrap_or(0)
-            .saturating_sub(1)
-            .max(0);
+        let max = self.task_preview_max_scroll() as i32;
         let next = (self.task_ui.task_preview_scroll as i32 + delta).clamp(0, max);
         self.task_ui.task_preview_scroll = next as u16;
+    }
+
+    /// Largest valid `task_preview_scroll` for the selected task's description.
+    ///
+    /// Matches the line set that `ui::task_detail::render_task_detail` scrolls:
+    /// the rendered markdown plus the one-row `description` header it prepends.
+    /// Shared by keyboard (`PageUp`/`PageDown`), the wheel, and the scrollbar
+    /// drag so all three agree on the clamp.
+    pub(crate) fn task_preview_max_scroll(&self) -> u16 {
+        let body = self
+            .selected_task()
+            .and_then(|t| t.description.as_deref())
+            .filter(|d| !d.trim().is_empty())
+            .map(|d| crate::ui::markdown::render_markdown(d).len())
+            .unwrap_or(0);
+        // `content_len = body + 1` (the header row); max index is `content_len - 1`.
+        body as u16
     }
 
     /// Open the trigger-time action picker for `task`: one **Send** entry per
@@ -5848,6 +6084,133 @@ mod tests {
         // Over-scroll down is clamped to the rendered line count.
         app.scroll_task_preview(1000);
         assert!(app.task_ui.task_preview_scroll <= 3);
+    }
+
+    #[test]
+    fn apply_scrollbar_position_task_preview_clamps() {
+        let mut app = app_with_sessions(1);
+        app.db
+            .create_task(&crate::storage::tasks::NewTask {
+                description: Some("a\nb\nc".into()),
+                ..crate::storage::tasks::NewTask::local("t")
+            })
+            .unwrap();
+        app.refresh_tasks();
+        app.focus = InputFocus::TaskList;
+        app.task_ui.task_panel_index = 0;
+
+        let max = app.task_preview_max_scroll();
+        // A position past the end clamps to the max.
+        app.apply_scrollbar_position(ScrollTarget::TaskPreview, 1000, 1000);
+        assert_eq!(app.task_ui.task_preview_scroll, max);
+        // Position 0 returns to the top.
+        app.apply_scrollbar_position(ScrollTarget::TaskPreview, 0, 1000);
+        assert_eq!(app.task_ui.task_preview_scroll, 0);
+    }
+
+    #[test]
+    fn apply_scrollbar_position_terminal_inverts() {
+        let mut app = app_with_sessions(1);
+        // The stub parser keeps zero scrollback; swap in one that retains it.
+        app.sessions[0].parser = Arc::new(std::sync::Mutex::new(
+            vt100::Parser::new_with_callbacks(24, 80, 100, crate::agent::TermSignals::default()),
+        ));
+        // Seed the active session's parser with scrollback content.
+        app.with_active_parser(|p| {
+            for i in 0..50 {
+                p.process(format!("line {i}\r\n").as_bytes());
+            }
+        });
+        // Probe the total scrollback (the scrollbar's `content_len`).
+        let mut total = 0usize;
+        app.with_active_parser(|p| {
+            let saved = p.screen().scrollback();
+            p.screen_mut().set_scrollback(usize::MAX);
+            total = p.screen().scrollback();
+            p.screen_mut().set_scrollback(saved);
+        });
+        assert!(total > 0, "expected scrollback content");
+
+        // Thumb at the top (pos 0) → fully scrolled up (scrollback == total).
+        app.apply_scrollbar_position(ScrollTarget::Terminal, 0, total);
+        let mut at_top = 0usize;
+        app.with_active_parser(|p| at_top = p.screen().scrollback());
+        assert_eq!(at_top, total);
+
+        // Thumb at the bottom (pos == total) → back to the live tail (0).
+        app.apply_scrollbar_position(ScrollTarget::Terminal, total, total);
+        let mut at_bottom = 1usize;
+        app.with_active_parser(|p| at_bottom = p.screen().scrollback());
+        assert_eq!(at_bottom, 0);
+    }
+
+    #[test]
+    fn scrollbar_click_starts_drag_not_selection() {
+        let mut app = app_with_sessions(1);
+        // Record a scrollbar track at a known location (as `view()` would).
+        let track = Rect::new(40, 5, 1, 10);
+        app.scrollbar_hits.push(ScrollbarHit {
+            geom: ScrollbarGeom {
+                track,
+                content_len: 100,
+                viewport: 10,
+            },
+            target: ScrollTarget::Terminal,
+        });
+
+        // A click on the track grabs the thumb — no text selection starts.
+        app.handle_mouse_click(40, 7, KeyModifiers::NONE);
+        assert_eq!(app.dragging_scrollbar, Some(ScrollTarget::Terminal));
+        assert!(app.text_selection.is_none());
+
+        // Mouse-up ends the drag.
+        app.handle_mouse_up(40, 7);
+        assert!(app.dragging_scrollbar.is_none());
+    }
+
+    #[test]
+    fn pane_at_central_pane_follows_focus() {
+        let mut app = app_with_sessions(1);
+        // Pick a point guaranteed to be inside the central (terminal) pane.
+        let areas = layout::compute_layout(
+            Rect::new(0, 0, app.terminal_cols, app.terminal_rows),
+            app.show_info_panel,
+            app.show_tasks_panel,
+            app.show_file_viewer,
+            app.global_search.active,
+            app.automation_ui.cached_automations.len(),
+        );
+        let cx = areas.terminal.x + areas.terminal.width / 2;
+        let cy = areas.terminal.y + areas.terminal.height / 2;
+
+        // The same central-pane point routes the wheel by focus.
+        app.focus = InputFocus::Terminal;
+        assert_eq!(app.pane_at(cx, cy), Some(ScrollPane::Terminal));
+
+        app.focus = InputFocus::TaskList;
+        assert_eq!(app.pane_at(cx, cy), Some(ScrollPane::TaskPreview));
+
+        app.focus = InputFocus::AutomationRunHistory;
+        assert_eq!(app.pane_at(cx, cy), Some(ScrollPane::RunHistory));
+    }
+
+    #[test]
+    fn click_outside_scrollbar_starts_selection() {
+        let mut app = app_with_sessions(1);
+        app.focus = InputFocus::Terminal;
+        app.scrollbar_hits.push(ScrollbarHit {
+            geom: ScrollbarGeom {
+                track: Rect::new(118, 1, 1, 20),
+                content_len: 100,
+                viewport: 10,
+            },
+            target: ScrollTarget::Terminal,
+        });
+
+        // A click well away from the track falls through to text selection.
+        app.handle_mouse_click(10, 10, KeyModifiers::NONE);
+        assert!(app.dragging_scrollbar.is_none());
+        assert!(app.text_selection.is_some());
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -21,10 +21,15 @@ use crate::ui::{
     terminal_view, theme_picker_modal, worktree_name_modal,
 };
 
-use super::{App, InputFocus, TerminalView};
+use super::{App, InputFocus, ScrollTarget, ScrollbarHit, TerminalView};
+use crate::ui::scrollbar::ScrollbarGeom;
 
 impl App {
     pub fn view(&mut self, frame: &mut Frame) {
+        // Rebuilt fresh each frame: every scrollbar drawn below records its
+        // geometry + drag target here for the mouse handlers to hit-test.
+        self.scrollbar_hits.clear();
+
         let areas = layout::compute_layout(
             frame.area(),
             self.show_info_panel,
@@ -285,6 +290,13 @@ impl App {
         );
     }
 
+    /// Record a scrollbar drawn this frame as a drag target, if one was drawn.
+    fn record_scrollbar(&mut self, geom: Option<ScrollbarGeom>, target: ScrollTarget) {
+        if let Some(geom) = geom {
+            self.scrollbar_hits.push(ScrollbarHit { geom, target });
+        }
+    }
+
     /// Render the file viewer in the right column (when present).
     fn render_file_viewer(&mut self, frame: &mut Frame, fv_area: Option<Rect>) {
         let Some(fv_area) = fv_area else {
@@ -301,7 +313,8 @@ impl App {
             InputFocus::FileViewer => crate::ui::FocusLevel::Focused,
             _ => crate::ui::FocusLevel::Inactive,
         };
-        file_viewer::render_file_viewer(frame, fv_area, &self.file_viewer, fv_focus);
+        let geom = file_viewer::render_file_viewer(frame, fv_area, &self.file_viewer, fv_focus);
+        self.record_scrollbar(geom, ScrollTarget::FileViewer);
     }
 
     /// Render the central pane. In the automations context (the pane or its
@@ -316,24 +329,32 @@ impl App {
                 | InputFocus::AutomationEditor
                 | InputFocus::AutomationRunHistory
         ) {
-            self.render_automation_workspace(frame, terminal);
+            let geom = self.render_automation_workspace(frame, terminal);
+            self.record_scrollbar(geom, ScrollTarget::RunHistory);
             return;
         }
         // In the tasks context the central pane shows the task editor (a live
         // preview while the panel is focused, editable once the editor is) with
         // the task's details beneath it.
         if matches!(self.focus, InputFocus::TaskList | InputFocus::TaskEditor) {
-            self.render_task_workspace(frame, terminal);
+            let geom = self.render_task_workspace(frame, terminal);
+            self.record_scrollbar(geom, ScrollTarget::TaskPreview);
             return;
         }
         // While the global-search strip previews a task result, mirror that in
         // the central pane (focus stays in the strip, so the normal task-context
         // branch above doesn't fire).
-        if self.global_search_preview_kind() == Some(crate::app::search::SearchKind::Task) {
-            if let Some(task) = self.selected_task() {
-                self.render_task_detail_pane(frame, terminal, task);
-                return;
-            }
+        if self.global_search_preview_kind() == Some(crate::app::search::SearchKind::Task)
+            && self.selected_task().is_some()
+        {
+            // Scope the immutable `task` borrow so it ends before the
+            // `&mut self` record_scrollbar call.
+            let geom = {
+                let task = self.selected_task().expect("checked is_some");
+                self.render_task_detail_pane(frame, terminal, task)
+            };
+            self.record_scrollbar(geom, ScrollTarget::TaskPreview);
+            return;
         }
 
         let terminal_focus = match self.focus {
@@ -349,26 +370,33 @@ impl App {
         };
         let is_shell_view = self.active_terminal_view() == TerminalView::Shell;
 
-        let Some(session) = self.sessions.get(self.active_index) else {
-            terminal_view::render_empty_terminal(frame, terminal);
-            return;
+        // Scope the immutable `session` borrow so it ends before the
+        // `&mut self` record_scrollbar call below.
+        let geom = {
+            let Some(session) = self.sessions.get(self.active_index) else {
+                terminal_view::render_empty_terminal(frame, terminal);
+                return;
+            };
+            let parser_arc = if is_shell_view {
+                session.shell_pane.as_ref().map(|sp| &sp.parser)
+            } else {
+                None
+            }
+            .unwrap_or(&session.parser);
+            if let Ok(mut parser) = parser_arc.lock() {
+                terminal_view::render_terminal(
+                    frame,
+                    terminal,
+                    &mut parser,
+                    &session.info,
+                    terminal_focus,
+                    is_shell_view,
+                )
+            } else {
+                None
+            }
         };
-        let parser_arc = if is_shell_view {
-            session.shell_pane.as_ref().map(|sp| &sp.parser)
-        } else {
-            None
-        }
-        .unwrap_or(&session.parser);
-        if let Ok(mut parser) = parser_arc.lock() {
-            terminal_view::render_terminal(
-                frame,
-                terminal,
-                &mut parser,
-                &session.info,
-                terminal_focus,
-                is_shell_view,
-            );
-        }
+        self.record_scrollbar(geom, ScrollTarget::Terminal);
     }
 
     /// Render the bottom status-bar footer.
@@ -602,7 +630,7 @@ impl App {
     /// scoped automation (a preview while the list is focused, editable once the
     /// editor is focused), with the automation's run history beneath it. Shows a
     /// discoverability hint when there's nothing to edit.
-    fn render_automation_workspace(&self, frame: &mut Frame, area: Rect) {
+    fn render_automation_workspace(&self, frame: &mut Frame, area: Rect) -> Option<ScrollbarGeom> {
         let editing = self.focus == InputFocus::AutomationEditor;
 
         let Some(m) = self.automation_ui.automation_editor.as_ref() else {
@@ -613,7 +641,7 @@ impl App {
                 "No automations yet — press n to create one.",
                 editing,
             );
-            return;
+            return None;
         };
 
         // Run history for the automation being edited (existing automations
@@ -668,7 +696,9 @@ impl App {
                 &runs,
                 self.automation_ui.automation_run_index,
                 history_focus,
-            );
+            )
+        } else {
+            None
         }
     }
 
@@ -676,7 +706,7 @@ impl App {
     /// toggle**: while the editor is focused (`TaskEditor`) it shows the
     /// editor full-screen; while the tasks panel is focused (`TaskList`) it
     /// shows the selected task's read-only, scrollable markdown preview.
-    fn render_task_workspace(&self, frame: &mut Frame, area: Rect) {
+    fn render_task_workspace(&self, frame: &mut Frame, area: Rect) -> Option<ScrollbarGeom> {
         let editing = self.focus == InputFocus::TaskEditor;
 
         let Some(m) = self.task_ui.task_editor.as_ref() else {
@@ -687,7 +717,7 @@ impl App {
                 "No tasks yet — press n to create one.",
                 editing,
             );
-            return;
+            return None;
         };
 
         if editing {
@@ -697,7 +727,7 @@ impl App {
                 area,
                 &task_editor_modal::TaskEditorState::from_modal(m, true),
             );
-            return;
+            return None;
         }
 
         // Preview mode: render the selected (scoped) task's details + markdown
@@ -708,16 +738,21 @@ impl App {
             .and_then(|id| self.task_ui.cached_tasks.iter().find(|t| t.id == id));
         let Some(task) = scoped else {
             render_empty_workspace_hint(frame, area, " Task ", "No task selected.", false);
-            return;
+            return None;
         };
 
-        self.render_task_detail_pane(frame, area, task);
+        self.render_task_detail_pane(frame, area, task)
     }
 
     /// Render a single task's read-only details + scrollable markdown preview
     /// full-screen. Shared by the tasks-panel preview and the global-search
     /// task preview (so previewing a task result also fills the central pane).
-    fn render_task_detail_pane(&self, frame: &mut Frame, area: Rect, task: &crate::session::Task) {
+    fn render_task_detail_pane(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        task: &crate::session::Task,
+    ) -> Option<ScrollbarGeom> {
         // Related running sessions (spawned `task-<id>` and/or a Send target).
         let related = self.task_related_session_indices(task);
         let sessions = if related.is_empty() {
@@ -769,7 +804,7 @@ impl App {
             },
             self.task_ui.task_preview_scroll,
             hints,
-        );
+        )
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,8 +134,14 @@ async fn run_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Res
                     Some(AppMessage::KeyPress(k.code, k.modifiers))
                 }
                 Event::Mouse(m) => match m.kind {
-                    MouseEventKind::ScrollUp => Some(AppMessage::MouseScrollUp),
-                    MouseEventKind::ScrollDown => Some(AppMessage::MouseScrollDown),
+                    MouseEventKind::ScrollUp => Some(AppMessage::MouseScrollUp {
+                        x: m.column,
+                        y: m.row,
+                    }),
+                    MouseEventKind::ScrollDown => Some(AppMessage::MouseScrollDown {
+                        x: m.column,
+                        y: m.row,
+                    }),
                     MouseEventKind::Down(MouseButton::Left) => Some(AppMessage::MouseClick {
                         x: m.column,
                         y: m.row,

--- a/src/ui/automation_detail.rs
+++ b/src/ui/automation_detail.rs
@@ -15,6 +15,7 @@ use ratatui::{
 
 use crate::session::AutomationRunStatus;
 
+use super::scrollbar::{self, ScrollbarGeom};
 use super::theme::Theme;
 use super::FocusLevel;
 
@@ -38,7 +39,7 @@ pub fn render_run_history(
     runs: &[AutomationRunRow<'_>],
     selected: usize,
     focus: FocusLevel,
-) {
+) -> Option<ScrollbarGeom> {
     let focused = matches!(focus, FocusLevel::Focused);
     let border_color = if focused {
         Theme::border_focused()
@@ -77,51 +78,59 @@ pub fn render_run_history(
             ))),
             list_area,
         );
-    } else {
-        let lines: Vec<Line> = runs
-            .iter()
-            .enumerate()
-            .map(|(i, run)| {
-                let (glyph, word, color) = match run.status {
-                    AutomationRunStatus::Success => ("✓", "ok", Theme::status_idle()),
-                    AutomationRunStatus::Error => ("✗", "error", Theme::status_error()),
-                    AutomationRunStatus::Skipped => ("–", "skipped", Theme::status_waiting()),
-                };
-                let is_selected = focused && i == selected;
-                let pointer = if is_selected { "▸" } else { " " };
-                let mut spans = vec![
-                    // Status — colour + bold so each outcome stands out.
-                    Span::styled(
-                        format!("{pointer}{glyph} {word:<7}"),
-                        Style::default().fg(color).add_modifier(Modifier::BOLD),
-                    ),
-                    // Absolute clock time, then the relative age.
-                    Span::styled(
-                        format!("{:<11} ", run.at),
-                        Style::default().fg(Theme::text_secondary()),
-                    ),
-                    Span::styled(
-                        format!("{:<9} ", run.when),
-                        Style::default().fg(Theme::text_muted()),
-                    ),
-                ];
-                if !run.detail.is_empty() {
-                    spans.push(Span::styled(
-                        run.detail.to_string(),
-                        Style::default().fg(Theme::text_primary()),
-                    ));
-                }
-                let line = Line::from(spans);
-                if is_selected {
-                    line.style(Style::default().bg(Theme::selection_bg()))
-                } else {
-                    line
-                }
-            })
-            .collect();
-
-        frame.render_widget(Paragraph::new(lines), list_area);
+        return None;
     }
+
+    // Window the runs so the selected row stays visible, reserving the rightmost
+    // column for a scrollbar when the history overflows.
+    let height = list_area.height as usize;
+    let (rows_area, track) = scrollbar::reserve_track(list_area, runs.len(), height);
+    let (start, end) = super::file_viewer::visible_window(runs.len(), selected, height.max(1));
+
+    let lines: Vec<Line> = runs[start..end]
+        .iter()
+        .enumerate()
+        .map(|(offset, run)| {
+            let i = start + offset;
+            let (glyph, word, color) = match run.status {
+                AutomationRunStatus::Success => ("✓", "ok", Theme::status_idle()),
+                AutomationRunStatus::Error => ("✗", "error", Theme::status_error()),
+                AutomationRunStatus::Skipped => ("–", "skipped", Theme::status_waiting()),
+            };
+            let is_selected = focused && i == selected;
+            let pointer = if is_selected { "▸" } else { " " };
+            let mut spans = vec![
+                // Status — colour + bold so each outcome stands out.
+                Span::styled(
+                    format!("{pointer}{glyph} {word:<7}"),
+                    Style::default().fg(color).add_modifier(Modifier::BOLD),
+                ),
+                // Absolute clock time, then the relative age.
+                Span::styled(
+                    format!("{:<11} ", run.at),
+                    Style::default().fg(Theme::text_secondary()),
+                ),
+                Span::styled(
+                    format!("{:<9} ", run.when),
+                    Style::default().fg(Theme::text_muted()),
+                ),
+            ];
+            if !run.detail.is_empty() {
+                spans.push(Span::styled(
+                    run.detail.to_string(),
+                    Style::default().fg(Theme::text_primary()),
+                ));
+            }
+            let line = Line::from(spans);
+            if is_selected {
+                line.style(Style::default().bg(Theme::selection_bg()))
+            } else {
+                line
+            }
+        })
+        .collect();
+
+    frame.render_widget(Paragraph::new(lines), rows_area);
 
     if let Some(hint_area) = hint_area {
         let hint = Line::from(vec![
@@ -136,4 +145,6 @@ pub fn render_run_history(
         ]);
         frame.render_widget(Paragraph::new(hint), hint_area);
     }
+
+    track.and_then(|track| scrollbar::render_into(frame, track, runs.len(), height, selected))
 }

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -16,6 +16,7 @@ use ratatui::{
     Frame,
 };
 
+use super::scrollbar::{self, ScrollbarGeom};
 use super::{focus_block, theme::Theme, FocusLevel};
 use crate::session::SessionInfo;
 
@@ -345,6 +346,13 @@ impl FileViewerState {
         self.selected = next as usize;
     }
 
+    /// Select the row at `index`, clamped to the current row count. Used by the
+    /// scrollbar drag to jump the selection to a mapped position.
+    pub fn select_index(&mut self, index: usize) {
+        let len = self.flatten().len();
+        self.selected = if len == 0 { 0 } else { index.min(len - 1) };
+    }
+
     /// Activate the current row: toggle directory expansion or return a file to open.
     pub fn activate(&mut self) -> Activation {
         let rows = self.flatten();
@@ -575,12 +583,15 @@ fn read_dir_sorted(path: &Path) -> Vec<FileNode> {
         .collect()
 }
 
+/// Render the file-tree viewer. Returns the scrollbar geometry when the tree
+/// overflows the visible area (so the caller can record it as a drag target),
+/// else `None`.
 pub fn render_file_viewer(
     frame: &mut Frame,
     area: Rect,
     state: &FileViewerState,
     focus: FocusLevel,
-) {
+) -> Option<ScrollbarGeom> {
     use ratatui::layout::{Constraint, Direction, Layout};
 
     let search_visible = state.search_active || !state.search_query.is_empty();
@@ -617,7 +628,7 @@ pub fn render_file_viewer(
     }
 
     if inner.height == 0 || inner.width == 0 {
-        return;
+        return None;
     }
 
     let list_area = inner;
@@ -628,13 +639,13 @@ pub fn render_file_viewer(
             Style::default().fg(Theme::text_muted()),
         )));
         frame.render_widget(p, list_area);
-        return;
+        return None;
     }
 
     let rows = state.flatten();
     let height = list_area.height as usize;
     if height == 0 {
-        return;
+        return None;
     }
 
     let query_lc = if state.search_active && !state.search_query.is_empty() {
@@ -643,6 +654,9 @@ pub fn render_file_viewer(
         None
     };
 
+    // Reserve the rightmost column for a scrollbar when the tree overflows.
+    let (rows_area, track) = scrollbar::reserve_track(list_area, rows.len(), height);
+
     let (start, end) = visible_window(rows.len(), state.selected, height);
 
     let lines: Vec<Line> = rows[start..end]
@@ -650,7 +664,9 @@ pub fn render_file_viewer(
         .enumerate()
         .map(|(i, row)| build_row_line(row, start + i == state.selected, query_lc.as_deref()))
         .collect();
-    frame.render_widget(Paragraph::new(lines), list_area);
+    frame.render_widget(Paragraph::new(lines), rows_area);
+
+    track.and_then(|track| scrollbar::render_into(frame, track, rows.len(), height, state.selected))
 }
 
 fn row_marker(row: &FlatRow) -> &'static str {
@@ -803,7 +819,10 @@ fn append_cursor_spans<'a>(
     }
 }
 
-fn visible_window(total: usize, selected: usize, height: usize) -> (usize, usize) {
+/// Compute the `start..end` slice of a `total`-row list that keeps `selected`
+/// visible within a `height`-row viewport (with a small margin). Shared by the
+/// file tree and the automation run-history list.
+pub(crate) fn visible_window(total: usize, selected: usize, height: usize) -> (usize, usize) {
     if total <= height {
         return (0, total);
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,6 +15,7 @@ pub mod markdown;
 pub mod project_list;
 pub mod repo_picker_modal;
 pub mod restore_sessions_modal;
+pub mod scrollbar;
 pub mod selection;
 pub mod session_name_modal;
 pub mod status_bar;

--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -1,0 +1,196 @@
+//! Shared scrollbar geometry + rendering for every scrollable pane.
+//!
+//! A single [`ScrollbarGeom`] describes one rendered scrollbar: the track rect
+//! it occupies, the total scrollable `content_len`, and the visible `viewport`.
+//! Renderers build it (via [`render_into`]) and the app records each one per
+//! frame so mouse handlers can hit-test the track and map a click/drag `y` back
+//! to a scroll position ([`ScrollbarGeom::position_for_y`]). Keeping the render
+//! and the hit-test driven by the same struct guarantees they never drift.
+//!
+//! This module is pure geometry/rendering — it has no knowledge of *which*
+//! pane a scrollbar drives (that mapping lives in `app`).
+
+use ratatui::{
+    layout::{Position, Rect},
+    style::Style,
+    widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState},
+    Frame,
+};
+
+use super::theme::Theme;
+
+/// The geometry + metrics of one rendered scrollbar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrollbarGeom {
+    /// The rect the scrollbar track occupies (its rightmost column carries the
+    /// thumb). Mouse hit-testing is against this rect.
+    pub track: Rect,
+    /// Total number of scrollable units (rows of content).
+    pub content_len: usize,
+    /// Number of visible units (rows that fit in the viewport).
+    pub viewport: usize,
+}
+
+impl ScrollbarGeom {
+    /// Whether a screen-absolute `(x, y)` falls inside the track.
+    pub fn contains(&self, x: u16, y: u16) -> bool {
+        self.track.contains(Position::new(x, y))
+    }
+
+    /// Map a mouse `y` inside the track to a content position in
+    /// `0..=content_len-1`. Clamps `y` to the track, and is safe for degenerate
+    /// tracks (`height <= 1`) and empty content.
+    pub fn position_for_y(&self, y: u16) -> usize {
+        if self.content_len == 0 {
+            return 0;
+        }
+        let max = self.content_len - 1;
+        if self.track.height <= 1 {
+            // A one-row (or zero-row) track can't express intermediate
+            // positions; snap to the end so a click still does something sane.
+            return max;
+        }
+        let top = self.track.y;
+        let bottom = self.track.y + self.track.height - 1;
+        let y = y.clamp(top, bottom);
+        let rel = (y - top) as f64 / (self.track.height - 1) as f64;
+        (rel * max as f64).round() as usize
+    }
+}
+
+/// Split `area` to make room for a right-edge scrollbar when the content
+/// overflows the viewport. Returns the (possibly narrowed) content rect plus the
+/// one-column track rect to hand to [`render_into`] — or `None` for the track
+/// when everything fits or the area is too narrow to spare a column.
+///
+/// Centralizes the "scrollbar lives in the rightmost column" convention so every
+/// pane reserves space and positions the bar identically.
+pub fn reserve_track(area: Rect, content_len: usize, viewport: usize) -> (Rect, Option<Rect>) {
+    if content_len <= viewport || area.width <= 1 {
+        return (area, None);
+    }
+    let content = Rect {
+        width: area.width - 1,
+        ..area
+    };
+    let track = Rect {
+        x: area.x + area.width - 1,
+        width: 1,
+        ..area
+    };
+    (content, Some(track))
+}
+
+/// Render a vertical scrollbar into `track` and return its geometry. Callers
+/// decide *whether* there's overflow (via [`reserve_track`]) before calling;
+/// this just draws the bar and hands back the geometry to record as a drag
+/// target. Returns `None` only for a zero-height track.
+///
+/// `position` is the current scroll position in the same `0..content_len` space
+/// that [`ScrollbarGeom::position_for_y`] maps back to.
+pub fn render_into(
+    frame: &mut Frame,
+    track: Rect,
+    content_len: usize,
+    viewport: usize,
+    position: usize,
+) -> Option<ScrollbarGeom> {
+    if track.height == 0 {
+        return None;
+    }
+
+    let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+        .thumb_style(Style::default().fg(Theme::accent()))
+        .track_style(Style::default().fg(Theme::text_muted()));
+
+    let mut state = ScrollbarState::new(content_len)
+        .position(position)
+        .viewport_content_length(viewport);
+    frame.render_stateful_widget(scrollbar, track, &mut state);
+
+    Some(ScrollbarGeom {
+        track,
+        content_len,
+        viewport,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn geom(y: u16, height: u16, content_len: usize) -> ScrollbarGeom {
+        ScrollbarGeom {
+            track: Rect::new(10, y, 1, height),
+            content_len,
+            viewport: 5,
+        }
+    }
+
+    #[test]
+    fn position_for_y_endpoints() {
+        let g = geom(5, 10, 100);
+        // Top of the track maps to 0, bottom maps to the last index.
+        assert_eq!(g.position_for_y(5), 0);
+        assert_eq!(g.position_for_y(14), 99);
+    }
+
+    #[test]
+    fn position_for_y_midpoint() {
+        let g = geom(0, 11, 101);
+        // Exact middle row → exact middle position.
+        assert_eq!(g.position_for_y(5), 50);
+    }
+
+    #[test]
+    fn position_for_y_clamps_out_of_range() {
+        let g = geom(5, 10, 100);
+        // Above the track clamps to 0, below clamps to the max.
+        assert_eq!(g.position_for_y(0), 0);
+        assert_eq!(g.position_for_y(255), 99);
+    }
+
+    #[test]
+    fn position_for_y_degenerate_track() {
+        assert_eq!(geom(5, 1, 100).position_for_y(5), 99);
+        assert_eq!(geom(5, 0, 100).position_for_y(5), 99);
+    }
+
+    #[test]
+    fn position_for_y_empty_content() {
+        assert_eq!(geom(5, 10, 0).position_for_y(8), 0);
+    }
+
+    #[test]
+    fn contains_matches_track() {
+        let g = geom(5, 10, 100);
+        assert!(g.contains(10, 5));
+        assert!(g.contains(10, 14));
+        assert!(!g.contains(9, 5));
+        assert!(!g.contains(10, 15));
+    }
+
+    #[test]
+    fn reserve_track_splits_when_overflowing() {
+        let area = Rect::new(4, 2, 20, 10);
+        let (content, track) = reserve_track(area, 100, 10);
+        // Content loses its rightmost column; the track claims it.
+        assert_eq!(content, Rect::new(4, 2, 19, 10));
+        assert_eq!(track, Some(Rect::new(23, 2, 1, 10)));
+    }
+
+    #[test]
+    fn reserve_track_keeps_full_area_when_fitting() {
+        let area = Rect::new(4, 2, 20, 10);
+        // content_len <= viewport → no scrollbar, full content area.
+        assert_eq!(reserve_track(area, 10, 10), (area, None));
+        assert_eq!(reserve_track(area, 5, 10), (area, None));
+    }
+
+    #[test]
+    fn reserve_track_skips_when_too_narrow() {
+        let area = Rect::new(4, 2, 1, 10);
+        // A one-column area can't spare a column for the bar.
+        assert_eq!(reserve_track(area, 100, 10), (area, None));
+    }
+}

--- a/src/ui/task_detail.rs
+++ b/src/ui/task_detail.rs
@@ -14,6 +14,7 @@ use ratatui::{
     Frame,
 };
 
+use super::scrollbar::{self, ScrollbarGeom};
 use super::theme::Theme;
 use super::truncate_ellipsis;
 
@@ -51,7 +52,7 @@ pub fn render_task_detail(
     detail: &TaskDetail<'_>,
     scroll: u16,
     hints: &[(&str, &str)],
-) {
+) -> Option<ScrollbarGeom> {
     // The task title *is* the panel heading (bold accent in the border) — no
     // separate in-content title row, so there is one clear heading.
     let title = truncate_ellipsis(detail.title, area.width.saturating_sub(4) as usize);
@@ -67,7 +68,7 @@ pub fn render_task_detail(
     let mut inner = block.inner(area);
     frame.render_widget(block, area);
     if inner.height == 0 {
-        return;
+        return None;
     }
 
     // Reserve the bottom row for the key-hint footer when there's room.
@@ -113,7 +114,7 @@ pub fn render_task_detail(
             Style::default().fg(Theme::text_muted()),
         )));
         frame.render_widget(Paragraph::new(meta_lines), inner);
-        return;
+        return None;
     }
 
     // Split: fixed metadata rows on top, the rendered markdown below.
@@ -126,10 +127,20 @@ pub fn render_task_detail(
 
     let mut md = vec![Line::from(Span::styled("  description", label_style))];
     md.extend(super::markdown::render_markdown(detail.description));
+    let content_len = md.len();
+    let md_area = parts[1];
+    let viewport = md_area.height as usize;
+
+    // Reserve the rightmost column for the scrollbar when the description
+    // overflows, so the wrapped text never renders under the thumb.
+    let (text_area, track) = scrollbar::reserve_track(md_area, content_len, viewport);
     frame.render_widget(
         Paragraph::new(md)
             .wrap(Wrap { trim: false })
             .scroll((scroll, 0)),
-        parts[1],
+        text_area,
     );
+    track.and_then(|track| {
+        scrollbar::render_into(frame, track, content_len, viewport, scroll as usize)
+    })
 }

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -1,16 +1,19 @@
 use ratatui::{
     layout::{Margin, Rect},
     style::{Color, Style},
-    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{Block, Borders, Paragraph},
     Frame,
 };
 use tui_term::widget::{Cursor, PseudoTerminal};
 
 use super::focus_block;
+use super::scrollbar::{self, ScrollbarGeom};
 use super::theme::Theme;
 use super::FocusLevel;
 use crate::session::SessionInfo;
 
+/// Render the terminal pane. Returns the scrollbar geometry when scrollback is
+/// present (so the caller can record it as a drag target), else `None`.
 pub fn render_terminal(
     frame: &mut Frame,
     area: Rect,
@@ -18,7 +21,7 @@ pub fn render_terminal(
     info: &SessionInfo,
     level: FocusLevel,
     is_shell: bool,
-) {
+) -> Option<ScrollbarGeom> {
     let scroll_offset = parser.screen().scrollback();
 
     // Compute total scrollback by temporarily setting to max and reading back
@@ -64,27 +67,25 @@ pub fn render_terminal(
 
     frame.render_widget(pseudo_term, area);
 
-    // Render scrollbar when there's scrollback content
-    if total_scrollback > 0 {
-        // Position scrollbar inside the block border
-        let scrollbar_area = area.inner(Margin {
-            vertical: 1,
-            horizontal: 0,
-        });
-
-        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
-            .thumb_style(Style::default().fg(Theme::accent()))
-            .track_style(Style::default().fg(Theme::text_muted()));
-
-        // Invert: offset 0 (bottom) → position at max, offset max (top) → position at 0
-        let position = total_scrollback.saturating_sub(scroll_offset);
-        let (rows, _) = parser.screen().size();
-        let mut scrollbar_state = ScrollbarState::new(total_scrollback)
-            .position(position)
-            .viewport_content_length(rows as usize);
-
-        frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
+    // Render scrollbar when there's scrollback content.
+    if total_scrollback == 0 {
+        return None;
     }
+    // Position scrollbar inside the block border.
+    let scrollbar_area = area.inner(Margin {
+        vertical: 1,
+        horizontal: 0,
+    });
+    // Invert: offset 0 (bottom) → position at max, offset max (top) → position at 0.
+    let position = total_scrollback.saturating_sub(scroll_offset);
+    let (rows, _) = parser.screen().size();
+    scrollbar::render_into(
+        frame,
+        scrollbar_area,
+        total_scrollback,
+        rows as usize,
+        position,
+    )
 }
 
 pub fn render_empty_terminal(frame: &mut Frame, area: Rect) {


### PR DESCRIPTION
## Summary

- Add a shared `ScrollbarGeom` + `reserve_track`/`render_into` helper (`src/ui/scrollbar.rs`) and render **draggable** scrollbars on the terminal, task description preview, file viewer, and automation run-history panes. Clicking/dragging a thumb scrolls the owning pane; geometry is recorded per-frame so render and hit-test never drift.
- Add a visible scrollbar to the **task description preview** so long descriptions are discoverable and scrollable by mouse (previously PageUp/PageDown only, no indicator).
- Make the **mouse wheel pane-aware**: it now scrolls whichever pane is under the cursor (terminal, task preview, file viewer, run history, or a list pane) instead of always the terminal. Wheel events now carry cursor coordinates.

## Test plan

- New unit tests: `position_for_y` mapping/clamping, `reserve_track` split, terminal scrollback inversion, task-preview clamp, click-vs-selection precedence, and `pane_at` focus routing.
- `cargo test --lib`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --test architecture_rules`, and `RUSTDOCFLAGS=-D warnings cargo doc` all pass.
- CI checks pass.