### PR TITLE
docs: fix drifted claims across CLAUDE.md, README, FEATURES, website

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ Enforced by cocogitto via pre-commit hooks.
 
 - **Types**: feat, fix, perf, refactor, docs, style, test,
   chore, ci, build, revert
-- **Scopes**: cli, ui, git, core, docs, deps, config, agent
+- **Scopes**: api, cli, ui, git, core, docs, deps, config, mcp
 - Use `cog commit feat "message"`
   or `cog commit fix "message" scope`
 
@@ -573,12 +573,12 @@ scripts/demo/record.sh theme automations   # re-record a subset
 `record.sh` records every video pair in one pass: the combined
 hero demo (`thurbox-demo.*` via `agents.tape`), one clip per
 feature (`thurbox-{file-manager,info-panel,theme,session-creation}.*`),
-and the automations demo (`automations-demo.*` via
-`automations.tape`) — one VHS tape each
+and the automations/tasks/search demos (`automations-demo.*`,
+`tasks-demo.*`, `search-demo.*`) — one VHS tape each
 (`scripts/demo/<feature>.tape`). With no args it records all of
 them; pass tape stems to re-record a subset (the `agents` stem is
-the hero, `automations` is the automations clip, every other stem
-maps to `thurbox-<stem>.*`).
+the hero, `automations`/`tasks`/`search` map to `<stem>-demo.*`,
+every other stem maps to `thurbox-<stem>.*`).
 
 Every clip uses **real agent CLIs**: the script seeds one session
 per installed CLI (`claude`, `opencode`, `codex`, `gemini`) in a
@@ -723,7 +723,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+K` | Select previous session | Vim: **k** = up |
 | `Ctrl+L` | Focus next pane (cycle forward) | Vim: **l** = right |
 | `Ctrl+D` | Delete session | Vim: **d** = delete |
-| `Ctrl+O` | Open active session's worktree in editor | **O**pen |
+| `Ctrl+O` | Open active session's working dirs in editor | **O**pen |
 | `Ctrl+R` | Restart active session | **R**estart |
 | `Ctrl+F` | Fork active session | **F**ork |
 | `Ctrl+S` | Sync worktrees with origin/main | **S**ync |
@@ -785,9 +785,10 @@ terminal's catch-all PTY forwarding.
 
 ## Themes
 
-The TUI ships with eight palettes — four dark (**Default**, **Catppuccin
-Mocha**, **Tokyo Night**, **Gruvbox Dark**) and four light (**Catppuccin
-Latte**, **Tokyo Night Day**, **Gruvbox Light**, **Solarized Light**).
+The TUI ships with nine palettes — five dark (**Default**, **Catppuccin
+Mocha**, **Tokyo Night**, **Gruvbox Dark**, **Doom**) and four light
+(**Catppuccin Latte**, **Tokyo Night Day**, **Gruvbox Light**,
+**Solarized Light**).
 Pick one with `Ctrl+Y` (or `F4`,
 which avoids terminals that intercept Ctrl+Y as DSUSP); the choice
 is persisted in SQLite under `metadata.active_theme` and survives

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ tree with fuzzy search:
 
 ![File manager](./docs/media/thurbox-file-manager.gif)
 
-Eight themes (four dark, four light) switch live with `Ctrl+Y`:
+Nine themes (five dark, four light) switch live with `Ctrl+Y`:
 
 ![Theme switcher](./docs/media/thurbox-theme.gif)
 
@@ -350,7 +350,7 @@ command = "codex"
 | `Ctrl+K` | Select previous session | Vim: **k** = up |
 | `Ctrl+L` | Focus next pane (cycle forward) | Vim: **l** = right |
 | `Ctrl+D` | Delete session | Vim: **d** = delete |
-| `Ctrl+O` | Open active session's repos in editor | **O**pen |
+| `Ctrl+O` | Open active session's working dirs in editor | **O**pen |
 | `Ctrl+R` | Restart active session | **R**estart |
 | `Ctrl+F` | Fork active session | **F**ork |
 | `Ctrl+S` | Sync worktrees with origin/main | **S**ync |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -677,9 +677,11 @@ action, `d`/`Ctrl+D` delete, `Esc` leave.
 
 ### Persistence
 
-Tasks live in the `tasks` SQLite table (schema **v25**): `title`,
-`status`, the automation action columns (`action_kind` nullable for
-local todos), `source`/`external_id`/`external_url`, timestamps, and a
+Tasks live in the `tasks` SQLite table (added in schema **v25**; the
+markdown `description` column followed in **v26**): `title`,
+`description`, `status`, the automation action columns (`action_kind`
+nullable for local todos), `source`/`external_id`/`external_url`,
+timestamps, and a
 `deleted_at` soft-delete marker, with a partial index on `status`.
 Mutations are recorded in `audit_log` under `EntityType::Task`. Tasks
 do **not** join the cross-instance `SharedState` (like automations) and
@@ -1048,8 +1050,8 @@ palette. Widget files reference named colors (accent, text, status,
 border) rather than hard-coded `Color::*` values, so the whole UI
 can be re-skinned by swapping the active palette.
 
-Thurbox ships eight built-in presets — four dark (Default,
-Catppuccin Mocha, Tokyo Night, Gruvbox Dark) and four light
+Thurbox ships nine built-in presets — five dark (Default,
+Catppuccin Mocha, Tokyo Night, Gruvbox Dark, Doom) and four light
 (Catppuccin Latte, Tokyo Night Day, Gruvbox Light, Solarized
 Light). Press `Ctrl+Y` (or `F4`, which avoids terminals that
 intercept `Ctrl+Y` as DSUSP) to pick one. The choice is persisted

--- a/website/index.html
+++ b/website/index.html
@@ -519,7 +519,7 @@
               <strong>Themes</strong>
               &mdash;
               <code>Ctrl+Y</code>
-              switches eight light and dark palettes live.
+              switches nine light and dark palettes live.
             </figcaption>
           </figure>
         </div>


### PR DESCRIPTION
## Summary

Docs audit against current code (follow-up to #469/#470). Demo-generation pipeline was reviewed too and found fully consistent (tapes ↔ keybindings ↔ media ↔ README ↔ website ↔ pages.yml) — no media re-recording needed (the theme clip already includes Doom).

Fixed stale claims:
- **Commit scopes** (CLAUDE.md): now matches `cog.toml` — `api, cli, ui, git, core, docs, deps, config, mcp` (`agent` was never valid)
- **Theme count**: nine palettes / five dark — the **Doom** theme was missing from CLAUDE.md, FEATURES.md, README, and the website
- **Demo clips** (CLAUDE.md): inventory now lists the `tasks` and `search` demos
- **Tasks persistence** (FEATURES.md): notes the v26 `description` column and includes it in the column list
- **Ctrl+O**: CLAUDE.md said "worktree", README said "repos" — both now say working dirs (it opens worktrees + cwd + additional dirs)

## Test plan

- `rumdl check` clean on all touched markdown
- `npm run lint:website` clean (Prettier + htmlhint + stylelint + eslint)
- docs-only change; no release