### PR TITLE
feat(config): startup diagnostics, settings.toml, custom themes, live reload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -802,6 +802,7 @@ For rationale behind decisions, see `docs/`:
 - `docs/CONSTITUTION.md` — Core principles and non-negotiable rules
 - `docs/ARCHITECTURE.md` — Architectural decisions with rationale
 - `docs/FEATURES.md` — Feature-level design choices
+- `docs/CONFIG.md` — Every config file/env var/DB setting in one place
 
 **Rule**: If a code change invalidates or extends a documented
 decision, update the relevant doc in the same PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -790,7 +790,13 @@ terminal's catch-all PTY forwarding.
 The TUI ships with nine palettes — five dark (**Default**, **Catppuccin
 Mocha**, **Tokyo Night**, **Gruvbox Dark**, **Doom**) and four light
 (**Catppuccin Latte**, **Tokyo Night Day**, **Gruvbox Light**,
-**Solarized Light**).
+**Solarized Light**). Users can add **custom themes** in
+`~/.config/thurbox/themes.toml` (a built-in `base` plus per-colour
+overrides — see `docs/CONFIG.md`); they appear in the picker after the
+built-ins and persist by name exactly like a preset
+(`session::theme_config::CustomThemeDef` → `ThemeEntry`, loaded by
+`agent::themes_config::load_or_seed_with_warnings`, published via
+`ui::theme::set_custom_themes`).
 Pick one with `Ctrl+Y` (or `F4`,
 which avoids terminals that intercept Ctrl+Y as DSUSP); the choice
 is persisted in SQLite under `metadata.active_theme` and survives

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,7 +348,9 @@ thurbox-cli session list | jq
 Subcommands: `session` (create/list/get/delete/restore/restart/
 send/capture), `automation` (alias `auto`:
 create/list/show/edit/remove/run/runs/tick), `task` (alias `todo`:
-create/list/show/edit/remove/run), `editor`. Pass
+create/list/show/edit/remove/run), `editor`, `config`
+(validate/show — strict-parses every config file / prints the
+effective resolved config; see `docs/CONFIG.md`). Pass
 `--pretty` for indented JSON.
 
 `session delete <uuid>` **soft-deletes** by default — only the DB

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,7 +569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1752,7 +1752,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1807,6 +1807,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2017,10 +2027,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2151,6 +2161,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "serde",
+ "serde_ignored",
  "serde_json",
  "sysinfo",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz = "0.10"
 cron = "0.16"
+serde_ignored = "0.1.14"
 
 [[bin]]
 name = "thurbox-cli"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -17,6 +17,7 @@ development checkout never touches your real setup.
 | `~/.config/thurbox/agents.toml` | TOML | you | startup | coding-agent CLI definitions |
 | `~/.config/thurbox/hosts.toml` | TOML | you | startup | remote SSH hosts |
 | `~/.config/thurbox/settings.toml` | TOML | you | startup | scalar tuning knobs |
+| `~/.config/thurbox/themes.toml` | TOML | you | startup | custom theme palettes |
 | `~/.config/thurbox/keybindings.json` | JSON | F1 editor (or you) | startup | key chord overrides |
 | `~/.local/share/thurbox/thurbox.db` | SQLite | thurbox | live | sessions, automations, tasks, theme, editor command |
 | `~/.local/share/thurbox/thurbox.log` | text | thurbox | — | logs (incl. config warnings) |
@@ -99,6 +100,27 @@ hardcoded.
 | `two_panel_min_cols` | `80` | width below which only the terminal renders |
 | `three_panel_min_cols` | `120` | width unlocking the optional third column |
 | `audit_retention_days` | `90` | audit-log history kept (pruned on startup) |
+
+## themes.toml
+
+User-defined themes, offered in the `Ctrl+Y` picker alongside the nine
+built-in presets and persisted by `name` like any preset. Each
+`[[themes]]` entry starts from a built-in `base` and overrides only the
+colours it names:
+
+```toml
+[[themes]]
+name = "my-mocha"            # stable id; must not shadow a built-in
+display_name = "My Mocha"    # picker label (default: name)
+base = "catppuccin-mocha"    # starting palette (default: default)
+accent = "#fab387"
+app_bg = "reset"             # keep the terminal's native background
+```
+
+Colours accept anything ratatui parses: `#rrggbb`, ANSI names (`red`,
+`lightcyan`), indexed (`14`), or `reset`. The seeded file lists every
+overridable key. Bad colours and built-in name collisions degrade to
+startup warnings (the base colour / the built-in stays in effect).
 
 ## keybindings.json
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,128 @@
+# Configuration Reference
+
+Every knob thurbox reads, where it lives, and how it behaves. One file
+per audience/lifecycle: hand-edited registries are TOML, the
+machine-written keybindings are JSON, and concurrently-written runtime
+state lives in SQLite (see ADR-8/ADR-19 in `ARCHITECTURE.md` for the
+rationale).
+
+Dev builds (version `0.0.0-dev`) use `thurbox-dev` in place of
+`thurbox` in every path below, plus a `thurbox-dev` tmux socket, so a
+development checkout never touches your real setup.
+
+## Files at a glance
+
+| File | Format | Edited by | Read | Purpose |
+|------|--------|-----------|------|---------|
+| `~/.config/thurbox/agents.toml` | TOML | you | startup | coding-agent CLI definitions |
+| `~/.config/thurbox/hosts.toml` | TOML | you | startup | remote SSH hosts |
+| `~/.config/thurbox/keybindings.json` | JSON | F1 editor (or you) | startup | key chord overrides |
+| `~/.local/share/thurbox/thurbox.db` | SQLite | thurbox | live | sessions, automations, tasks, theme, editor command |
+| `~/.local/share/thurbox/thurbox.log` | text | thurbox | — | logs (incl. config warnings) |
+
+All paths respect `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME`.
+
+Config problems are **not silent**: parse errors, unknown fields,
+invalid chords, and chord conflicts surface as a status-bar toast on
+startup (and in the log file). Parsing of the TOML files is strict — a
+typo'd field name fails the parse and falls back to built-ins (agents)
+or zero hosts, with the error naming the bad field.
+
+## agents.toml
+
+Declares the launchable coding agents. Seeded with the built-ins
+(`claude`, `codex`, `gemini`, `opencode`, `aider`, `vibe`) on first
+run; edit or add `[[agents]]` entries to support any CLI — no
+recompile. Malformed file → built-ins are used and the error is shown.
+
+```toml
+config_version = 1
+default = "claude"          # agent preselected in the picker / headless spawns
+
+[[agents]]
+name = "claude"             # display + lookup name (unique)
+command = "claude"          # executable
+args = []                   # always passed; bake a model here if you want one
+resume_args = ["--resume", "{id}"]            # emitted when resuming
+fork_args = ["--resume", "{id}", "--fork-session"]
+new_session_args = ["--session-id", "{id}"]   # emitted on a fresh spawn
+resume_latest = false       # true = id-less "resume last session in cwd"
+```
+
+`{id}` is substituted with the thurbox-generated session UUID. Groups
+are emitted only when their driving value exists; precedence is
+fork > resume > new-session. See the seeded file's comments and
+CLAUDE.md's *Agent Definitions* section for the `resume_latest`
+semantics.
+
+## hosts.toml
+
+Declares remote SSH hosts; each `[[hosts]]` entry registers a session
+backend named `ssh:<name>`. Seeded fully commented-out (fresh installs
+are local-only). Malformed file → zero remote hosts, error shown.
+
+| Field | Required | Default | Purpose |
+|-------|----------|---------|---------|
+| `name` | yes | — | backend id `ssh:<name>`; what `--host` expects |
+| `destination` | yes | — | ssh target (`user@host` or `~/.ssh/config` alias) |
+| `ssh_opts` | no | `[]` | extra ssh flags, one token per element |
+| `socket` | no | `thurbox` | remote `tmux -L` socket |
+| `session` | no | `thurbox` | remote tmux session name |
+| `worktrees_dir` | no | remote `$HOME/.local/share/thurbox/worktrees` | absolute remote worktrees dir |
+
+Auth comes entirely from your `~/.ssh/config`; thurbox never handles
+credentials. Host changes require a restart (the registry is read once
+and the remote `$HOME` is cached per destination for the process
+lifetime).
+
+## keybindings.json
+
+Maps `Action` names to one or more chord strings:
+
+```json
+{ "QuitApp": ["ctrl+x"], "OpenThemePicker": ["ctrl+y", "f4"] }
+```
+
+- Preferred editing path is the **F1 panel** (live capture, conflict
+  stealing, immediate persistence). Hand-edits are read at startup.
+- Chord syntax: `[ctrl+][alt+][shift+]<key>` where `<key>` is a letter,
+  `f1`–`f12`, or a named key (`enter`, `esc`, `tab`, arrows, `home`,
+  `end`, `pageup`, `pagedown`, `backspace`, `delete`, `insert`).
+  Case-insensitive.
+- Unknown action names, invalid chords, and the same chord bound to two
+  actions in overlapping contexts are reported at startup (the file
+  still loads; bad entries fall back to defaults).
+- Action names and defaults: see the table in CLAUDE.md / README, or
+  `src/session/keybindings.rs`.
+
+## SQLite-backed settings
+
+Live in the `metadata` table and apply immediately (no restart):
+
+| Key | Set via | Purpose |
+|-----|---------|---------|
+| `active_theme` | `Ctrl+Y` / `F4` picker | TUI palette (nine built-ins) |
+| `editor_command` | `thurbox-cli editor set "<cmd>"` | what `Ctrl+O` runs |
+
+These are in the DB rather than a file because they are written
+concurrently by multiple thurbox processes (TUI, CLI, MCP) and picked
+up live via `PRAGMA data_version` polling.
+
+## Environment variables
+
+| Variable | Used for |
+|----------|----------|
+| `XDG_CONFIG_HOME`, `XDG_DATA_HOME` | config/data roots |
+| `VISUAL`, then `EDITOR` | `Ctrl+O` editor when `editor_command` is unset |
+| `SHELL` | the `Ctrl+T` companion shell pane (fallback `/bin/sh`) |
+| `RUST_LOG` | log filter for `thurbox.log` |
+
+Editor resolution order: DB `editor_command` → `$VISUAL` → `$EDITOR` →
+error toast.
+
+## Versioning
+
+The SQLite schema migrates automatically (`schema_version` in
+`metadata`). The TOML files carry a `config_version = 1` marker so a
+future format change can migrate them too; current files are version 1
+and the field is optional.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -14,13 +14,18 @@ development checkout never touches your real setup.
 
 | File | Format | Edited by | Read | Purpose |
 |------|--------|-----------|------|---------|
-| `~/.config/thurbox/agents.toml` | TOML | you | startup | coding-agent CLI definitions |
+| `~/.config/thurbox/agents.toml` | TOML | you | **live** (mtime poll) | coding-agent CLI definitions |
 | `~/.config/thurbox/hosts.toml` | TOML | you | startup | remote SSH hosts |
 | `~/.config/thurbox/settings.toml` | TOML | you | startup | scalar tuning knobs |
 | `~/.config/thurbox/themes.toml` | TOML | you | startup | custom theme palettes |
-| `~/.config/thurbox/keybindings.json` | JSON | F1 editor (or you) | startup | key chord overrides |
+| `~/.config/thurbox/keybindings.json` | JSON | F1 editor (or you) | **live** (mtime poll) | key chord overrides |
 | `~/.local/share/thurbox/thurbox.db` | SQLite | thurbox | live | sessions, automations, tasks, theme, editor command |
 | `~/.local/share/thurbox/thurbox.log` | text | thurbox | — | logs (incl. config warnings) |
+
+`agents.toml` and `keybindings.json` reload **live**: the TUI polls
+their mtime (~1/s) and applies edits with a confirmation toast — no
+restart. `hosts.toml` (SSH backends register at startup),
+`settings.toml`, and `themes.toml` need a restart.
 
 All paths respect `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME`.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -16,6 +16,7 @@ development checkout never touches your real setup.
 |------|--------|-----------|------|---------|
 | `~/.config/thurbox/agents.toml` | TOML | you | startup | coding-agent CLI definitions |
 | `~/.config/thurbox/hosts.toml` | TOML | you | startup | remote SSH hosts |
+| `~/.config/thurbox/settings.toml` | TOML | you | startup | scalar tuning knobs |
 | `~/.config/thurbox/keybindings.json` | JSON | F1 editor (or you) | startup | key chord overrides |
 | `~/.local/share/thurbox/thurbox.db` | SQLite | thurbox | live | sessions, automations, tasks, theme, editor command |
 | `~/.local/share/thurbox/thurbox.log` | text | thurbox | — | logs (incl. config warnings) |
@@ -24,9 +25,20 @@ All paths respect `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME`.
 
 Config problems are **not silent**: parse errors, unknown fields,
 invalid chords, and chord conflicts surface as a status-bar toast on
-startup (and in the log file). Parsing of the TOML files is strict — a
-typo'd field name fails the parse and falls back to built-ins (agents)
-or zero hosts, with the error naming the bad field.
+startup (and in the log file). Unknown TOML keys are tolerated —
+stale keys from older versions or typos are *reported by name* but
+your file still loads — while syntax/type errors fall back to
+built-ins (agents), zero hosts, or defaults (settings).
+
+Check everything from the command line:
+
+```bash
+thurbox-cli config validate   # strict parse of every file; exit 1 on problems
+thurbox-cli config show       # effective config + where each value came from
+```
+
+`validate` fails on unknown keys (they are typos or leftovers either
+way), making it usable as a dotfiles CI gate.
 
 ## agents.toml
 
@@ -74,6 +86,19 @@ Auth comes entirely from your `~/.ssh/config`; thurbox never handles
 credentials. Host changes require a restart (the registry is read once
 and the remote `$HOME` is cached per destination for the process
 lifetime).
+
+## settings.toml
+
+Scalar tuning knobs, seeded fully commented-out (defaults apply when
+absent). Only knobs a user plausibly wants are exposed; internals stay
+hardcoded.
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `scrollback_lines` | `1000` | terminal scrollback kept per session |
+| `two_panel_min_cols` | `80` | width below which only the terminal renders |
+| `three_panel_min_cols` | `120` | width unlocking the optional third column |
+| `audit_retention_days` | `90` | audit-log history kept (pruned on startup) |
 
 ## keybindings.json
 

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -27,7 +27,11 @@ pub const BUILTIN_AGENTS_TOML: &str = r#"# Thurbox coding-agent definitions.
 # `*_args` groups are appended only when their value is present, with {id}
 # substituted. `args` is always passed — put any extra flags (e.g. a model)
 # there. Add your own [[agents]] entries to support any CLI.
+#
+# Field names are checked strictly: a typo'd key fails the parse (thurbox
+# reports it on startup and falls back to the built-in agents).
 
+config_version = 1
 default = "claude"
 
 [[agents]]
@@ -86,6 +90,7 @@ pub fn agents_config_path() -> Option<PathBuf> {
 /// valid document); falls back to an empty registry if that ever changes.
 pub fn builtin_registry() -> AgentRegistry {
     toml::from_str(BUILTIN_AGENTS_TOML).unwrap_or(AgentRegistry {
+        config_version: None,
         default: String::new(),
         agents: Vec::new(),
     })
@@ -93,44 +98,82 @@ pub fn builtin_registry() -> AgentRegistry {
 
 /// Load the agent registry, seeding the config file with built-ins when it is
 /// absent. Any read/parse error degrades gracefully to the built-in registry
-/// so the TUI always starts with at least the bundled agents.
+/// so the TUI always starts with at least the bundled agents; the warnings are
+/// logged here (headless callers) — the TUI uses
+/// [`load_or_seed_with_warnings`] to surface them in the status bar too.
 pub fn load_or_seed() -> AgentRegistry {
+    let (registry, warnings) = load_or_seed_with_warnings();
+    for w in &warnings {
+        tracing::warn!("{w}");
+    }
+    registry
+}
+
+/// [`load_or_seed`], also returning user-facing warnings for anything that
+/// silently degraded (parse error → built-ins, seed failure, …).
+pub fn load_or_seed_with_warnings() -> (AgentRegistry, Vec<String>) {
     let Some(path) = agents_config_path() else {
-        tracing::warn!("Could not resolve agents.toml path; using built-in agents");
-        return builtin_registry();
+        return (
+            builtin_registry(),
+            vec!["Could not resolve agents.toml path; using built-in agents".into()],
+        );
     };
 
     if !path.exists() {
         if let Some(parent) = path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
-                tracing::warn!(error = %e, "Failed to create config dir for agents.toml");
-                return builtin_registry();
+                return (
+                    builtin_registry(),
+                    vec![format!("Failed to create config dir for agents.toml: {e}")],
+                );
             }
         }
         if let Err(e) = std::fs::write(&path, BUILTIN_AGENTS_TOML) {
-            tracing::warn!(error = %e, "Failed to seed agents.toml; using built-in agents");
-            return builtin_registry();
+            return (
+                builtin_registry(),
+                vec![format!("Failed to seed agents.toml: {e}")],
+            );
         }
         tracing::info!(path = %path.display(), "Seeded agents.toml with built-in agents");
-        return builtin_registry();
+        return (builtin_registry(), Vec::new());
     }
 
     match std::fs::read_to_string(&path) {
         Ok(contents) => match toml::from_str::<AgentRegistry>(&contents) {
-            Ok(reg) if !reg.agents.is_empty() => reg,
-            Ok(_) => {
-                tracing::warn!("agents.toml has no agents; using built-in agents");
-                builtin_registry()
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to parse agents.toml; using built-in agents");
-                builtin_registry()
-            }
+            Ok(reg) if !reg.agents.is_empty() => (reg, Vec::new()),
+            Ok(_) => (
+                builtin_registry(),
+                vec!["agents.toml has no agents; using built-in agents".into()],
+            ),
+            Err(e) => (
+                builtin_registry(),
+                vec![format!(
+                    "agents.toml: {}; using built-in agents",
+                    compact_toml_error(&e.to_string())
+                )],
+            ),
         },
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to read agents.toml; using built-in agents");
-            builtin_registry()
-        }
+        Err(e) => (
+            builtin_registry(),
+            vec![format!("Failed to read agents.toml: {e}")],
+        ),
+    }
+}
+
+/// Collapse a (possibly multi-line) toml error to "<position>: <message>" for
+/// compact status-bar display. toml errors render as a header line with the
+/// position, a source snippet, then the message — keep the first and last
+/// meaningful lines and drop the snippet in between.
+pub(crate) fn compact_toml_error(s: &str) -> String {
+    let lines: Vec<&str> = s
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('|') && !l.starts_with(char::is_numeric))
+        .collect();
+    match (lines.first(), lines.last()) {
+        (Some(first), Some(last)) if first != last => format!("{first}: {last}"),
+        (Some(first), _) => (*first).to_string(),
+        _ => s.to_string(),
     }
 }
 
@@ -214,6 +257,41 @@ mod tests {
 
         let reg = load_or_seed();
         assert_eq!(reg.default, "claude");
+    }
+
+    #[test]
+    fn load_or_seed_rejects_unknown_field_with_warning() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = agents_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Typo'd field: `resumeargs` instead of `resume_args`.
+        std::fs::write(
+            &path,
+            "default = \"mine\"\n[[agents]]\nname = \"mine\"\ncommand = \"x\"\nresumeargs = []\n",
+        )
+        .unwrap();
+
+        let (reg, warnings) = load_or_seed_with_warnings();
+        assert_eq!(reg.default, "claude", "must fall back to built-ins");
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains("resumeargs"),
+            "warning must name the unknown field: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn compact_toml_error_keeps_position_and_message() {
+        let err = toml::from_str::<AgentRegistry>(
+            "[[agents]]\nname = \"a\"\ncommand = \"c\"\nbogus = 1\n",
+        )
+        .unwrap_err();
+        let compact = compact_toml_error(&err.to_string());
+        assert!(compact.contains("bogus"), "got: {compact}");
+        assert!(!compact.contains('\n'), "must be one line: {compact}");
     }
 
     #[test]

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -28,8 +28,8 @@ pub const BUILTIN_AGENTS_TOML: &str = r#"# Thurbox coding-agent definitions.
 # substituted. `args` is always passed — put any extra flags (e.g. a model)
 # there. Add your own [[agents]] entries to support any CLI.
 #
-# Field names are checked strictly: a typo'd key fails the parse (thurbox
-# reports it on startup and falls back to the built-in agents).
+# Unknown keys are reported on startup (and fail `thurbox-cli config
+# validate`) but don't break the load — your agents stay in effect.
 
 config_version = 1
 default = "claude"
@@ -139,25 +139,43 @@ pub fn load_or_seed_with_warnings() -> (AgentRegistry, Vec<String>) {
     }
 
     match std::fs::read_to_string(&path) {
-        Ok(contents) => match toml::from_str::<AgentRegistry>(&contents) {
-            Ok(reg) if !reg.agents.is_empty() => (reg, Vec::new()),
-            Ok(_) => (
-                builtin_registry(),
-                vec!["agents.toml has no agents; using built-in agents".into()],
-            ),
-            Err(e) => (
-                builtin_registry(),
-                vec![format!(
-                    "agents.toml: {}; using built-in agents",
-                    compact_toml_error(&e.to_string())
-                )],
-            ),
-        },
+        Ok(contents) => {
+            match parse_toml_reporting_unknown::<AgentRegistry>(&contents, "agents.toml") {
+                Ok((reg, warnings)) if !reg.agents.is_empty() => (reg, warnings),
+                Ok(_) => (
+                    builtin_registry(),
+                    vec!["agents.toml has no agents; using built-in agents".into()],
+                ),
+                Err(e) => (
+                    builtin_registry(),
+                    vec![format!(
+                        "agents.toml: {}; using built-in agents",
+                        compact_toml_error(&e.to_string())
+                    )],
+                ),
+            }
+        }
         Err(e) => (
             builtin_registry(),
             vec![format!("Failed to read agents.toml: {e}")],
         ),
     }
+}
+
+/// Parse a TOML config document leniently, reporting every unknown field by
+/// path instead of failing on it. Stale keys from older thurbox versions and
+/// typos both surface as warnings without stranding the user on defaults; a
+/// real syntax/type error still fails the parse.
+pub(crate) fn parse_toml_reporting_unknown<T: serde::de::DeserializeOwned>(
+    contents: &str,
+    file_label: &str,
+) -> Result<(T, Vec<String>), toml::de::Error> {
+    let mut warnings = Vec::new();
+    let de = toml::de::Deserializer::parse(contents)?;
+    let value = serde_ignored::deserialize(de, |path| {
+        warnings.push(format!("{file_label}: unknown field `{path}` (ignored)"));
+    })?;
+    Ok((value, warnings))
 }
 
 /// Collapse a (possibly multi-line) toml error to "<position>: <message>" for
@@ -260,13 +278,15 @@ mod tests {
     }
 
     #[test]
-    fn load_or_seed_rejects_unknown_field_with_warning() {
+    fn load_or_seed_reports_unknown_field_but_keeps_agents() {
         let temp = tempfile::TempDir::new().unwrap();
         let _guard = crate::paths::TestPathGuard::new(temp.path());
 
         let path = agents_config_path().unwrap();
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        // Typo'd field: `resumeargs` instead of `resume_args`.
+        // Typo'd field: `resumeargs` instead of `resume_args`. The user's
+        // agents must stay in effect (stale keys from older thurbox versions
+        // are common); the warning names the bad key.
         std::fs::write(
             &path,
             "default = \"mine\"\n[[agents]]\nname = \"mine\"\ncommand = \"x\"\nresumeargs = []\n",
@@ -274,7 +294,7 @@ mod tests {
         .unwrap();
 
         let (reg, warnings) = load_or_seed_with_warnings();
-        assert_eq!(reg.default, "claude", "must fall back to built-ins");
+        assert_eq!(reg.default, "mine", "user agents must stay in effect");
         assert_eq!(warnings.len(), 1);
         assert!(
             warnings[0].contains("resumeargs"),
@@ -285,12 +305,10 @@ mod tests {
 
     #[test]
     fn compact_toml_error_keeps_position_and_message() {
-        let err = toml::from_str::<AgentRegistry>(
-            "[[agents]]\nname = \"a\"\ncommand = \"c\"\nbogus = 1\n",
-        )
-        .unwrap_err();
+        // A type error (string field given an integer) still fails the parse.
+        let err = toml::from_str::<AgentRegistry>("default = 1\n").unwrap_err();
         let compact = compact_toml_error(&err.to_string());
-        assert!(compact.contains("bogus"), "got: {compact}");
+        assert!(compact.contains("string"), "got: {compact}");
         assert!(!compact.contains('\n'), "must be one line: {compact}");
     }
 

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -404,7 +404,7 @@ impl Session {
         let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
             rows,
             cols,
-            1000,
+            crate::session::settings::global().scrollback_lines,
             TermSignals {
                 title: Arc::clone(&last_title),
                 attention_at: Arc::clone(&attention_at),

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -30,6 +30,9 @@ pub const SEED_HOSTS_TOML: &str = r#"# Thurbox remote SSH hosts  —  ~/.config/
 # install registers zero remote hosts and behaves exactly like a local-only
 # setup. Uncomment and edit an entry to add a host.
 #
+# Field names are checked strictly: a typo'd key fails the parse (thurbox
+# reports it on startup and falls back to zero remote hosts).
+#
 # Fields per [[hosts]] entry:
 #
 #   name           (string, required)
@@ -57,6 +60,8 @@ pub const SEED_HOSTS_TOML: &str = r#"# Thurbox remote SSH hosts  —  ~/.config/
 #       unset, thurbox uses $HOME/.local/share/thurbox/worktrees on the remote
 #       (the remote $HOME is resolved over ssh on first use).
 #
+config_version = 1
+
 # Example (uncomment and edit):
 #
 # [[hosts]]
@@ -81,40 +86,61 @@ pub fn hosts_config_path() -> Option<PathBuf> {
 
 /// Load the remote-host registry, seeding the config file with a commented-out
 /// example when it is absent. Any read/parse error degrades gracefully to an
-/// empty registry so the TUI always starts (with local-only sessions).
+/// empty registry so the TUI always starts (with local-only sessions); the
+/// warnings are logged here (headless callers) — the TUI uses
+/// [`load_or_seed_with_warnings`] to surface them in the status bar too.
 pub fn load_or_seed() -> HostRegistry {
+    let (registry, warnings) = load_or_seed_with_warnings();
+    for w in &warnings {
+        tracing::warn!("{w}");
+    }
+    registry
+}
+
+/// [`load_or_seed`], also returning user-facing warnings for anything that
+/// silently degraded (parse error → no remote hosts, seed failure, …).
+pub fn load_or_seed_with_warnings() -> (HostRegistry, Vec<String>) {
     let Some(path) = hosts_config_path() else {
-        tracing::warn!("Could not resolve hosts.toml path; no remote hosts");
-        return HostRegistry::default();
+        return (
+            HostRegistry::default(),
+            vec!["Could not resolve hosts.toml path; no remote hosts".into()],
+        );
     };
 
     if !path.exists() {
         if let Some(parent) = path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
-                tracing::warn!(error = %e, "Failed to create config dir for hosts.toml");
-                return HostRegistry::default();
+                return (
+                    HostRegistry::default(),
+                    vec![format!("Failed to create config dir for hosts.toml: {e}")],
+                );
             }
         }
         if let Err(e) = std::fs::write(&path, SEED_HOSTS_TOML) {
-            tracing::warn!(error = %e, "Failed to seed hosts.toml");
-            return HostRegistry::default();
+            return (
+                HostRegistry::default(),
+                vec![format!("Failed to seed hosts.toml: {e}")],
+            );
         }
         tracing::info!(path = %path.display(), "Seeded hosts.toml (no active hosts)");
-        return HostRegistry::default();
+        return (HostRegistry::default(), Vec::new());
     }
 
     match std::fs::read_to_string(&path) {
         Ok(contents) => match toml::from_str::<HostRegistry>(&contents) {
-            Ok(reg) => reg,
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to parse hosts.toml; no remote hosts");
-                HostRegistry::default()
-            }
+            Ok(reg) => (reg, Vec::new()),
+            Err(e) => (
+                HostRegistry::default(),
+                vec![format!(
+                    "hosts.toml: {}; no remote hosts",
+                    super::agent_config::compact_toml_error(&e.to_string())
+                )],
+            ),
         },
-        Err(e) => {
-            tracing::warn!(error = %e, "Failed to read hosts.toml; no remote hosts");
-            HostRegistry::default()
-        }
+        Err(e) => (
+            HostRegistry::default(),
+            vec![format!("Failed to read hosts.toml: {e}")],
+        ),
     }
 }
 

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -30,8 +30,8 @@ pub const SEED_HOSTS_TOML: &str = r#"# Thurbox remote SSH hosts  —  ~/.config/
 # install registers zero remote hosts and behaves exactly like a local-only
 # setup. Uncomment and edit an entry to add a host.
 #
-# Field names are checked strictly: a typo'd key fails the parse (thurbox
-# reports it on startup and falls back to zero remote hosts).
+# Unknown keys are reported on startup (and fail `thurbox-cli config
+# validate`) but don't break the load.
 #
 # Fields per [[hosts]] entry:
 #
@@ -127,16 +127,21 @@ pub fn load_or_seed_with_warnings() -> (HostRegistry, Vec<String>) {
     }
 
     match std::fs::read_to_string(&path) {
-        Ok(contents) => match toml::from_str::<HostRegistry>(&contents) {
-            Ok(reg) => (reg, Vec::new()),
-            Err(e) => (
-                HostRegistry::default(),
-                vec![format!(
-                    "hosts.toml: {}; no remote hosts",
-                    super::agent_config::compact_toml_error(&e.to_string())
-                )],
-            ),
-        },
+        Ok(contents) => {
+            match super::agent_config::parse_toml_reporting_unknown::<HostRegistry>(
+                &contents,
+                "hosts.toml",
+            ) {
+                Ok((reg, warnings)) => (reg, warnings),
+                Err(e) => (
+                    HostRegistry::default(),
+                    vec![format!(
+                        "hosts.toml: {}; no remote hosts",
+                        super::agent_config::compact_toml_error(&e.to_string())
+                    )],
+                ),
+            }
+        }
         Err(e) => (
             HostRegistry::default(),
             vec![format!("Failed to read hosts.toml: {e}")],

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,6 +7,7 @@ pub mod input;
 pub mod provider;
 pub mod registry;
 pub mod settings_config;
+pub mod themes_config;
 pub mod tmux;
 pub mod transport;
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,6 +6,7 @@ pub mod host_config;
 pub mod input;
 pub mod provider;
 pub mod registry;
+pub mod settings_config;
 pub mod tmux;
 pub mod transport;
 

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -1,0 +1,177 @@
+//! Loading and seeding of the scalar-settings config file.
+//!
+//! `~/.config/thurbox/settings.toml` holds the few user-tunable scalars (see
+//! [`crate::session::settings::Settings`]). On first run the file is seeded
+//! fully commented-out, so a fresh install runs on the built-in defaults. A
+//! malformed file degrades to the defaults with a startup warning.
+
+use std::path::PathBuf;
+
+use crate::session::settings::Settings;
+
+/// Seed contents for `settings.toml` on first run: every knob documented with
+/// its default, all commented out.
+pub const SEED_SETTINGS_TOML: &str = r#"# Thurbox settings  —  ~/.config/thurbox/settings.toml
+#
+# Scalar tuning knobs. Every entry below is commented out and shows its
+# default; uncomment to change. Read once at startup.
+#
+# Unknown keys are reported on startup (and fail `thurbox-cli config
+# validate`) but don't break the load.
+
+config_version = 1
+
+# Scrollback lines kept per session terminal.
+# scrollback_lines = 1000
+
+# Terminal width (columns) below which only the terminal pane renders.
+# two_panel_min_cols = 80
+
+# Terminal width (columns) at which the optional third column
+# (info panel / tasks / file viewer) becomes available.
+# three_panel_min_cols = 120
+
+# Days of audit-log history kept (pruned on startup).
+# audit_retention_days = 90
+"#;
+
+/// Path to the settings file: `~/.config/thurbox/settings.toml`.
+pub fn settings_config_path() -> Option<PathBuf> {
+    crate::paths::config_file().map(|p| p.with_file_name("settings.toml"))
+}
+
+/// Load the settings, seeding the config file with commented-out defaults
+/// when it is absent. Any read/parse error degrades gracefully to the
+/// defaults; warnings are returned for the TUI status bar and logged by
+/// headless callers.
+pub fn load_or_seed_with_warnings() -> (Settings, Vec<String>) {
+    let Some(path) = settings_config_path() else {
+        return (
+            Settings::default(),
+            vec!["Could not resolve settings.toml path; using defaults".into()],
+        );
+    };
+
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                return (
+                    Settings::default(),
+                    vec![format!(
+                        "Failed to create config dir for settings.toml: {e}"
+                    )],
+                );
+            }
+        }
+        if let Err(e) = std::fs::write(&path, SEED_SETTINGS_TOML) {
+            return (
+                Settings::default(),
+                vec![format!("Failed to seed settings.toml: {e}")],
+            );
+        }
+        tracing::info!(path = %path.display(), "Seeded settings.toml (defaults)");
+        return (Settings::default(), Vec::new());
+    }
+
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            match super::agent_config::parse_toml_reporting_unknown::<Settings>(
+                &contents,
+                "settings.toml",
+            ) {
+                Ok((settings, warnings)) => (settings, warnings),
+                Err(e) => (
+                    Settings::default(),
+                    vec![format!(
+                        "settings.toml: {}; using defaults",
+                        super::agent_config::compact_toml_error(&e.to_string())
+                    )],
+                ),
+            }
+        }
+        Err(e) => (
+            Settings::default(),
+            vec![format!("Failed to read settings.toml: {e}")],
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_toml_parses_to_defaults() {
+        let s: Settings = toml::from_str(SEED_SETTINGS_TOML).unwrap();
+        assert_eq!(
+            Settings {
+                config_version: None,
+                ..s.clone()
+            },
+            Settings::default()
+        );
+        assert_eq!(s.config_version, Some(1));
+    }
+
+    /// The seeded `settings.toml` is the primary documentation users see, so
+    /// it must mention every field.
+    #[test]
+    fn seed_toml_documents_every_field() {
+        for field in [
+            "scrollback_lines",
+            "two_panel_min_cols",
+            "three_panel_min_cols",
+            "audit_retention_days",
+        ] {
+            assert!(
+                SEED_SETTINGS_TOML.contains(field),
+                "settings.toml seed must document '{field}'"
+            );
+        }
+    }
+
+    #[test]
+    fn load_or_seed_writes_file_when_absent() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = settings_config_path().unwrap();
+        assert!(!path.exists());
+
+        let (s, warnings) = load_or_seed_with_warnings();
+        assert!(warnings.is_empty(), "got: {warnings:?}");
+        assert_eq!(s, Settings::default());
+        assert!(path.exists(), "settings.toml should have been seeded");
+    }
+
+    #[test]
+    fn load_or_seed_falls_back_on_malformed_file_with_warning() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = settings_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "scrollback_lines = \"many\"").unwrap();
+
+        let (s, warnings) = load_or_seed_with_warnings();
+        assert_eq!(s, Settings::default());
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("settings.toml"));
+    }
+
+    #[test]
+    fn load_or_seed_reads_overrides() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = settings_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "scrollback_lines = 4000\naudit_retention_days = 7\n").unwrap();
+
+        let (s, warnings) = load_or_seed_with_warnings();
+        assert!(warnings.is_empty());
+        assert_eq!(s.scrollback_lines, 4000);
+        assert_eq!(s.audit_retention_days, 7);
+        assert_eq!(s.two_panel_min_cols, 80);
+    }
+}

--- a/src/agent/themes_config.rs
+++ b/src/agent/themes_config.rs
@@ -1,0 +1,252 @@
+//! Loading and seeding of the custom-themes config file.
+//!
+//! `~/.config/thurbox/themes.toml` defines user themes as a base preset plus
+//! per-colour overrides (see [`crate::session::theme_config::CustomThemeDef`]).
+//! Seeded with a fully commented-out example, so a fresh install ships only
+//! the built-in presets. Resolution problems (bad colours, name collisions)
+//! degrade to warnings, never to a startup failure.
+
+use std::path::PathBuf;
+
+use crate::session::theme_config::{ThemeEntry, ThemesFile};
+use crate::session::ThemePreset;
+
+/// Seed contents for `themes.toml` on first run.
+pub const SEED_THEMES_TOML: &str = r##"# Thurbox custom themes  —  ~/.config/thurbox/themes.toml
+#
+# Each [[themes]] entry defines a theme offered in the Ctrl+Y picker alongside
+# the built-in presets. Start from a built-in `base` and override only the
+# colours you want; everything else inherits from the base.
+#
+# Colours accept anything ratatui parses: "#rrggbb", ANSI names ("red",
+# "lightcyan"), indexed ("14"), or "reset" (terminal default — useful for
+# app_bg). Bases: default, catppuccin-mocha, tokyo-night, gruvbox-dark, doom,
+# catppuccin-latte, tokyo-night-day, gruvbox-light, solarized-light.
+#
+# Overridable colour keys: accent, accent_bright, status_busy, status_waiting,
+# status_idle, status_error, text_primary, text_secondary, text_muted,
+# border_focused, border_unfocused, role_name, branch_name, search_bar,
+# keybind_hint, tool_allowed, tool_disallowed, danger, selection_bg,
+# selection_fg, modal_dim_bg, modal_bg, modal_border, inverted_fg, app_bg.
+# Plus: display_name (string), light (bool), nerd_font (bool).
+#
+# Unknown keys are reported on startup (and fail `thurbox-cli config
+# validate`) but don't break the load.
+
+config_version = 1
+
+# Example (uncomment and edit):
+#
+# [[themes]]
+# name = "my-mocha"
+# display_name = "My Mocha"
+# base = "catppuccin-mocha"
+# accent = "#fab387"
+# app_bg = "reset"
+"##;
+
+/// Path to the custom-themes file: `~/.config/thurbox/themes.toml`.
+pub fn themes_config_path() -> Option<PathBuf> {
+    crate::paths::config_file().map(|p| p.with_file_name("themes.toml"))
+}
+
+/// Load and resolve the custom themes, seeding the file when absent.
+/// Collisions with built-in preset names and duplicate custom names are
+/// skipped with a warning (the persisted `active_theme` must stay
+/// unambiguous).
+pub fn load_or_seed_with_warnings() -> (Vec<ThemeEntry>, Vec<String>) {
+    let Some(path) = themes_config_path() else {
+        return (
+            Vec::new(),
+            vec!["Could not resolve themes.toml path; no custom themes".into()],
+        );
+    };
+
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                return (
+                    Vec::new(),
+                    vec![format!("Failed to create config dir for themes.toml: {e}")],
+                );
+            }
+        }
+        if let Err(e) = std::fs::write(&path, SEED_THEMES_TOML) {
+            return (Vec::new(), vec![format!("Failed to seed themes.toml: {e}")]);
+        }
+        tracing::info!(path = %path.display(), "Seeded themes.toml (no custom themes)");
+        return (Vec::new(), Vec::new());
+    }
+
+    let file = match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            match super::agent_config::parse_toml_reporting_unknown::<ThemesFile>(
+                &contents,
+                "themes.toml",
+            ) {
+                Ok((file, warnings)) => return_resolved(file, warnings),
+                Err(e) => {
+                    return (
+                        Vec::new(),
+                        vec![format!(
+                            "themes.toml: {}; no custom themes",
+                            super::agent_config::compact_toml_error(&e.to_string())
+                        )],
+                    )
+                }
+            }
+        }
+        Err(e) => return (Vec::new(), vec![format!("Failed to read themes.toml: {e}")]),
+    };
+    file
+}
+
+fn return_resolved(file: ThemesFile, mut warnings: Vec<String>) -> (Vec<ThemeEntry>, Vec<String>) {
+    let mut entries: Vec<ThemeEntry> = Vec::new();
+    for def in &file.themes {
+        if def.name.is_empty() {
+            warnings.push("themes.toml: a theme without a name was skipped".into());
+            continue;
+        }
+        if ThemePreset::from_str(&def.name).is_some() {
+            warnings.push(format!(
+                "theme \"{}\" shadows a built-in preset name (skipped)",
+                def.name
+            ));
+            continue;
+        }
+        if entries.iter().any(|t| t.name == def.name) {
+            warnings.push(format!("duplicate theme name \"{}\" (skipped)", def.name));
+            continue;
+        }
+        let (entry, theme_warnings) = def.resolve();
+        warnings.extend(theme_warnings);
+        entries.push(entry);
+    }
+    (entries, warnings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_toml_parses_to_no_themes() {
+        let file: ThemesFile = toml::from_str(SEED_THEMES_TOML).unwrap();
+        assert!(file.themes.is_empty());
+        assert_eq!(file.config_version, Some(1));
+    }
+
+    /// The seeded `themes.toml` is the primary documentation users see, so it
+    /// must mention every overridable palette key. Guards against adding a
+    /// `ThemePalette` colour without documenting it here.
+    #[test]
+    fn seed_toml_documents_every_palette_key() {
+        for field in [
+            "accent",
+            "accent_bright",
+            "status_busy",
+            "status_waiting",
+            "status_idle",
+            "status_error",
+            "text_primary",
+            "text_secondary",
+            "text_muted",
+            "border_focused",
+            "border_unfocused",
+            "role_name",
+            "branch_name",
+            "search_bar",
+            "keybind_hint",
+            "tool_allowed",
+            "tool_disallowed",
+            "danger",
+            "selection_bg",
+            "selection_fg",
+            "modal_dim_bg",
+            "modal_bg",
+            "modal_border",
+            "inverted_fg",
+            "app_bg",
+            "display_name",
+            "light",
+            "nerd_font",
+        ] {
+            assert!(
+                SEED_THEMES_TOML.contains(field),
+                "themes.toml seed must document '{field}'"
+            );
+        }
+    }
+
+    #[test]
+    fn load_or_seed_writes_file_when_absent() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = themes_config_path().unwrap();
+        assert!(!path.exists());
+
+        let (themes, warnings) = load_or_seed_with_warnings();
+        assert!(themes.is_empty());
+        assert!(warnings.is_empty(), "got: {warnings:?}");
+        assert!(path.exists(), "themes.toml should have been seeded");
+    }
+
+    #[test]
+    fn load_resolves_custom_theme_with_base_and_overrides() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = themes_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "[[themes]]\nname = \"mine\"\nbase = \"catppuccin-mocha\"\naccent = \"#ff00ff\"\n",
+        )
+        .unwrap();
+
+        let (themes, warnings) = load_or_seed_with_warnings();
+        assert!(warnings.is_empty(), "got: {warnings:?}");
+        assert_eq!(themes.len(), 1);
+        assert_eq!(themes[0].name, "mine");
+        assert_eq!(
+            themes[0].palette.accent,
+            ratatui::style::Color::Rgb(0xff, 0x00, 0xff)
+        );
+        // Untouched colours inherit from the base.
+        assert_eq!(
+            themes[0].palette.text_primary,
+            ThemePreset::CatppuccinMocha.palette().text_primary
+        );
+        assert!(!themes[0].is_light);
+    }
+
+    #[test]
+    fn load_skips_builtin_shadow_and_warns_on_bad_colour() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = themes_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            concat!(
+                "[[themes]]\nname = \"doom\"\n",
+                "[[themes]]\nname = \"ok\"\naccent = \"not-a-colour\"\n",
+            ),
+        )
+        .unwrap();
+
+        let (themes, warnings) = load_or_seed_with_warnings();
+        assert_eq!(themes.len(), 1, "shadowing entry must be skipped");
+        assert_eq!(themes[0].name, "ok");
+        assert!(warnings.iter().any(|w| w.contains("shadows a built-in")));
+        assert!(warnings.iter().any(|w| w.contains("not-a-colour")));
+        // The bad colour kept the base value.
+        assert_eq!(
+            themes[0].palette.accent,
+            ThemePreset::Default.palette().accent
+        );
+    }
+}

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -1,0 +1,36 @@
+//! Live reload of hand-edited config files.
+//!
+//! Grouped out of the [`App`](super::App) god object. `tick` polls the
+//! mtimes of `agents.toml` and `keybindings.json` (~1/s, two `stat` calls)
+//! and reloads them in place on change — no restart needed after editing.
+//!
+//! Deliberately *not* reloaded live: `hosts.toml` (SSH backends are
+//! registered in main's `BackendRegistry` at startup) and `settings.toml`
+//! (published through a write-once global so values can't drift mid-frame).
+//! Both stay restart-only, as documented in `docs/CONFIG.md`.
+
+use std::path::Path;
+use std::time::SystemTime;
+
+/// Last-seen mtimes of the live-reloadable config files.
+#[derive(Default)]
+pub(crate) struct ConfigReloadState {
+    pub(crate) agents_mtime: Option<SystemTime>,
+    pub(crate) keybindings_mtime: Option<SystemTime>,
+}
+
+/// The file's modification time, `None` when it is absent/unreadable.
+pub(crate) fn mtime(path: Option<&Path>) -> Option<SystemTime> {
+    path.and_then(|p| std::fs::metadata(p).ok())
+        .and_then(|m| m.modified().ok())
+}
+
+/// Current mtime of `agents.toml`.
+pub(crate) fn agents_mtime() -> Option<SystemTime> {
+    mtime(crate::agent::agent_config::agents_config_path().as_deref())
+}
+
+/// Current mtime of `keybindings.json`.
+pub(crate) fn keybindings_mtime() -> Option<SystemTime> {
+    mtime(crate::paths::keybindings_file().as_deref())
+}

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1429,8 +1429,8 @@ impl App {
     }
 
     fn handle_theme_picker_key(&mut self, code: KeyCode) {
-        let presets = crate::session::ThemePreset::all();
-        let preset_count = presets.len();
+        let entries = crate::ui::theme::all_theme_entries();
+        let entry_count = entries.len();
         let super::modals::Modal::ThemePicker(ref mut tp) = self.modal else {
             return;
         };
@@ -1438,25 +1438,23 @@ impl App {
             KeyCode::Esc => {
                 self.modal.close();
             }
-            KeyCode::Char('j') | KeyCode::Down if tp.index + 1 < preset_count => {
+            KeyCode::Char('j') | KeyCode::Down if tp.index + 1 < entry_count => {
                 tp.index += 1;
-                let preset = presets[tp.index];
-                crate::ui::theme::set_active(preset.palette());
+                crate::ui::theme::set_active(entries[tp.index].palette.clone());
             }
             KeyCode::Char('k') | KeyCode::Up if tp.index > 0 => {
                 tp.index -= 1;
-                let preset = presets[tp.index];
-                crate::ui::theme::set_active(preset.palette());
+                crate::ui::theme::set_active(entries[tp.index].palette.clone());
             }
             KeyCode::Enter => {
                 let idx = tp.index;
                 self.modal.close();
-                if let Some(preset) = presets.get(idx) {
-                    crate::ui::theme::set_active(preset.palette());
-                    self.active_theme = *preset;
-                    if let Err(e) = self.db.set_active_theme(preset.as_str()) {
+                if let Some(entry) = entries.into_iter().nth(idx) {
+                    crate::ui::theme::set_active(entry.palette.clone());
+                    if let Err(e) = self.db.set_active_theme(&entry.name) {
                         tracing::error!("Failed to persist active theme: {e}");
                     }
+                    self.active_theme = entry;
                 }
             }
             _ => {}

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -212,6 +212,7 @@ impl App {
         } else {
             self.set_info("All keybindings reset to defaults");
         }
+        self.mark_keybindings_saved();
     }
 
     /// Serialize the current keybindings and write them to
@@ -226,6 +227,7 @@ impl App {
             }
             Err(e) => self.set_error(format!("Failed to serialize keybindings: {e}")),
         }
+        self.mark_keybindings_saved();
     }
 
     /// Route the key to the open modal's handler, if any. Returns `true` if a

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -491,7 +491,8 @@ pub struct App {
     pub(crate) global_search: search::GlobalSearchState,
     /// Currently active theme preset, cached so the header doesn't hit SQLite
     /// every render. Kept in sync with `db.set_active_theme` writes.
-    pub(crate) active_theme: crate::session::ThemePreset,
+    /// Currently active theme (built-in preset or custom from themes.toml).
+    pub(crate) active_theme: crate::session::theme_config::ThemeEntry,
     /// User-customizable global keybindings. Loaded from
     /// `~/.config/thurbox/keybindings.json` on startup, falling back to defaults
     /// when the file is missing or malformed.
@@ -521,14 +522,19 @@ impl App {
         agents: AgentRegistry,
         db: Database,
     ) -> Self {
-        // Resolve the persisted active theme (defaults to Default if unset/unknown).
+        // Resolve the persisted active theme — built-in or custom — defaulting
+        // to the Default preset when unset/unknown.
         let active_theme = db
             .get_active_theme()
             .ok()
             .flatten()
             .as_deref()
-            .and_then(crate::session::ThemePreset::from_str)
-            .unwrap_or(crate::session::ThemePreset::Default);
+            .and_then(crate::ui::theme::find_theme_entry)
+            .unwrap_or_else(|| {
+                crate::session::theme_config::ThemeEntry::from_preset(
+                    crate::session::ThemePreset::Default,
+                )
+            });
 
         // Load keybindings from JSON config or fall back to defaults. Problems
         // are collected into `config_warnings` so the first frame can surface
@@ -1132,14 +1138,14 @@ impl App {
     }
 
     /// Open the restore deleted sessions modal (Ctrl+U).
-    /// Open the theme picker, pre-selecting the currently active preset.
+    /// Open the theme picker, pre-selecting the currently active theme
+    /// (built-in preset or custom from themes.toml).
     fn open_theme_picker(&mut self) {
         let active = self.db.get_active_theme().ok().flatten();
-        let presets = crate::session::ThemePreset::all();
+        let entries = crate::ui::theme::all_theme_entries();
         let index = active
             .as_deref()
-            .and_then(crate::session::ThemePreset::from_str)
-            .and_then(|p| presets.iter().position(|x| *x == p))
+            .and_then(|name| entries.iter().position(|e| e.name == name))
             .unwrap_or(0);
         self.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index });
     }
@@ -2294,13 +2300,14 @@ impl App {
         let Ok(Some(name)) = self.db.get_active_theme() else {
             return;
         };
-        let Some(preset) = crate::session::ThemePreset::from_str(&name) else {
+        if name == self.active_theme.name {
+            return;
+        }
+        let Some(entry) = crate::ui::theme::find_theme_entry(&name) else {
             return;
         };
-        if preset != self.active_theme {
-            crate::ui::theme::set_active(preset.palette());
-            self.active_theme = preset;
-        }
+        crate::ui::theme::set_active(entry.palette.clone());
+        self.active_theme = entry;
     }
 
     /// Spawn background usage/rate-limit fetches for each distinct supported
@@ -7931,7 +7938,7 @@ mod tests {
         app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE);
         app.handle_key(KeyCode::Enter, KeyModifiers::NONE);
         assert!(matches!(app.modal, modals::Modal::None));
-        assert_eq!(app.active_theme, presets[1]);
+        assert_eq!(app.active_theme.name, presets[1].as_str());
         assert_eq!(
             app.db.get_active_theme().unwrap().as_deref(),
             Some(presets[1].as_str())

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,6 @@
 mod automation_state;
 mod background;
+mod config_reload;
 mod helpers;
 mod key_handlers;
 mod metrics_state;
@@ -59,6 +60,10 @@ const METRICS_REFRESH_TICKS: u64 = 100;
 /// shell out to `git`, so they run on a slower cadence than other metrics
 /// (~5 s) and only for the visible session.
 const GIT_REFRESH_TICKS: u64 = 500;
+
+/// Ticks (~10 ms each) between config-file mtime polls (~1 s). Cheap: two
+/// `stat` calls per poll.
+const CONFIG_RELOAD_TICKS: u64 = 100;
 
 /// How often to refresh account usage / rate-limits (in ticks). At ~10ms per
 /// tick, 30000 ≈ 5 minutes. Usage windows are coarse and fetching hits the
@@ -509,6 +514,9 @@ pub struct App {
     /// agents.toml/hosts.toml reported by main), shown joined in one status
     /// toast via [`Self::report_config_warnings`].
     config_warnings: Vec<String>,
+    /// Last-seen mtimes of the live-reloadable config files (see
+    /// [`Self::poll_config_reload`]).
+    config_reload: config_reload::ConfigReloadState,
 }
 
 const EDITOR_NOT_CONFIGURED: &str =
@@ -623,6 +631,10 @@ impl App {
             usage_tx,
             usage_rx,
             config_warnings: Vec::new(),
+            config_reload: config_reload::ConfigReloadState {
+                agents_mtime: config_reload::agents_mtime(),
+                keybindings_mtime: config_reload::keybindings_mtime(),
+            },
         };
         app.report_config_warnings(config_warnings);
         app
@@ -639,6 +651,75 @@ impl App {
         self.config_warnings.extend(warnings);
         let text = format!("Config: {}", self.config_warnings.join(" · "));
         self.set_status(StatusLevel::Error, text);
+    }
+
+    /// Reload `agents.toml` / `keybindings.json` in place when their mtime
+    /// changes — editing either takes effect without a restart. Self-writes
+    /// (the F1 editor persisting a rebind) refresh the stored mtime at save
+    /// time, so they don't re-toast here.
+    fn poll_config_reload(&mut self) {
+        if config_reload::agents_mtime() != self.config_reload.agents_mtime {
+            let (registry, warnings) = crate::agent::agent_config::load_or_seed_with_warnings();
+            self.agents = registry;
+            // Re-stat after the load: a missing file gets re-seeded by it.
+            self.config_reload.agents_mtime = config_reload::agents_mtime();
+            if warnings.is_empty() {
+                self.set_status(StatusLevel::Info, "agents.toml reloaded");
+            } else {
+                self.set_status(
+                    StatusLevel::Error,
+                    format!("Config: {}", warnings.join(" · ")),
+                );
+            }
+            for w in &warnings {
+                warn!("{w}");
+            }
+        }
+
+        let kb_mtime = config_reload::keybindings_mtime();
+        if kb_mtime != self.config_reload.keybindings_mtime {
+            self.config_reload.keybindings_mtime = kb_mtime;
+            let (bindings, warnings) = match crate::storage::keybindings::load_keybindings_json() {
+                Ok(Some(json)) => {
+                    match crate::session::KeyBindings::from_json_with_warnings(&json) {
+                        Ok((bindings, warnings)) => (
+                            bindings,
+                            warnings
+                                .into_iter()
+                                .map(|w| format!("keybindings.json: {w}"))
+                                .collect(),
+                        ),
+                        Err(e) => (
+                            crate::session::KeyBindings::default(),
+                            vec![format!("keybindings.json: {e}; using default keybindings")],
+                        ),
+                    }
+                }
+                Ok(None) => (crate::session::KeyBindings::default(), Vec::new()),
+                Err(e) => (
+                    crate::session::KeyBindings::default(),
+                    vec![format!("keybindings.json: {e}; using default keybindings")],
+                ),
+            };
+            self.keybindings = bindings;
+            if warnings.is_empty() {
+                self.set_status(StatusLevel::Info, "keybindings.json reloaded");
+            } else {
+                self.set_status(
+                    StatusLevel::Error,
+                    format!("Config: {}", warnings.join(" · ")),
+                );
+            }
+            for w in &warnings {
+                warn!("{w}");
+            }
+        }
+    }
+
+    /// Record the current `keybindings.json` mtime so the next reload poll
+    /// doesn't treat our own write as an external edit.
+    pub(crate) fn mark_keybindings_saved(&mut self) {
+        self.config_reload.keybindings_mtime = config_reload::keybindings_mtime();
     }
 
     /// Build an [`AgentProvider`](crate::agent::AgentProvider) for a session
@@ -2236,6 +2317,9 @@ impl App {
         }
         if self.metrics.tick_count % GIT_REFRESH_TICKS == 0 {
             self.start_git_stats_refresh();
+        }
+        if self.metrics.tick_count % CONFIG_RELOAD_TICKS == 0 {
+            self.poll_config_reload();
         }
 
         // Drain any completed background usage fetches into the cache.
@@ -4681,6 +4765,64 @@ mod tests {
 
     fn test_db() -> Database {
         Database::open_in_memory().unwrap()
+    }
+
+    #[test]
+    fn poll_config_reload_picks_up_agents_toml_edit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = crate::paths::TestPathGuard::new(tmp.path());
+        let mut app = app_with_sessions(0);
+        app.status_message = None;
+
+        // No change → no reload, no toast.
+        app.poll_config_reload();
+        assert!(app.status_message.is_none());
+
+        // An external edit appears on the next poll without a restart.
+        let path = crate::agent::agent_config::agents_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "default = \"mine\"\n[[agents]]\nname = \"mine\"\ncommand = \"x\"\n",
+        )
+        .unwrap();
+
+        app.poll_config_reload();
+        assert_eq!(app.agents.default, "mine");
+        assert_eq!(
+            app.status_message.as_ref().map(|m| m.level),
+            Some(StatusLevel::Info)
+        );
+
+        // Stable afterwards: no repeated toasts.
+        app.status_message = None;
+        app.poll_config_reload();
+        assert!(app.status_message.is_none());
+    }
+
+    #[test]
+    fn poll_config_reload_picks_up_keybindings_edit_but_not_self_writes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = crate::paths::TestPathGuard::new(tmp.path());
+        let mut app = app_with_sessions(0);
+        app.status_message = None;
+
+        // External edit → rebind applies live.
+        crate::storage::keybindings::save_keybindings_json(r#"{ "QuitApp": ["ctrl+x"] }"#).unwrap();
+        app.poll_config_reload();
+        assert_eq!(
+            app.keybindings.chord_for(crate::session::Action::QuitApp),
+            Some(&crate::session::KeyChord::ctrl('x'))
+        );
+        assert!(app.status_message.is_some());
+
+        // A self-write (the F1 editor persisting) refreshes the stored mtime,
+        // so the next poll stays quiet.
+        app.status_message = None;
+        crate::storage::keybindings::save_keybindings_json(r#"{ "QuitApp": ["ctrl+z"] }"#).unwrap();
+        app.mark_keybindings_saved();
+        app.poll_config_reload();
+        assert!(app.status_message.is_none());
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -504,6 +504,10 @@ pub struct App {
     usage_tx: mpsc::Sender<(String, crate::session::AgentUsage)>,
     /// Receives background usage-fetch results, drained each tick.
     usage_rx: mpsc::Receiver<(String, crate::session::AgentUsage)>,
+    /// Config-load problems collected at startup (keybindings.json here,
+    /// agents.toml/hosts.toml reported by main), shown joined in one status
+    /// toast via [`Self::report_config_warnings`].
+    config_warnings: Vec<String>,
 }
 
 const EDITOR_NOT_CONFIGURED: &str =
@@ -526,18 +530,32 @@ impl App {
             .and_then(crate::session::ThemePreset::from_str)
             .unwrap_or(crate::session::ThemePreset::Default);
 
-        // Load keybindings from JSON config or fall back to defaults.
+        // Load keybindings from JSON config or fall back to defaults. Problems
+        // are collected into `config_warnings` so the first frame can surface
+        // them in the status bar (a log-only warning is invisible in a TUI).
+        let mut config_warnings: Vec<String> = Vec::new();
         let keybindings = match crate::storage::keybindings::load_keybindings_json() {
-            Ok(Some(json)) => crate::session::KeyBindings::from_json(&json).unwrap_or_else(|e| {
-                tracing::warn!("Failed to parse keybindings.json: {e}; using defaults");
-                crate::session::KeyBindings::default()
-            }),
+            Ok(Some(json)) => match crate::session::KeyBindings::from_json_with_warnings(&json) {
+                Ok((bindings, warnings)) => {
+                    config_warnings
+                        .extend(warnings.iter().map(|w| format!("keybindings.json: {w}")));
+                    bindings
+                }
+                Err(e) => {
+                    config_warnings
+                        .push(format!("keybindings.json: {e}; using default keybindings"));
+                    crate::session::KeyBindings::default()
+                }
+            },
             Ok(None) => crate::session::KeyBindings::default(),
             Err(e) => {
-                tracing::warn!("Failed to read keybindings.json: {e}; using defaults");
+                config_warnings.push(format!("keybindings.json: {e}; using default keybindings"));
                 crate::session::KeyBindings::default()
             }
         };
+        for w in &config_warnings {
+            tracing::warn!("{w}");
+        }
 
         // Load session counter from DB
         let session_counter = db.get_session_counter().unwrap_or(0);
@@ -552,7 +570,7 @@ impl App {
 
         let (usage_tx, usage_rx) = mpsc::channel();
 
-        Self {
+        let mut app = Self {
             sessions: Vec::new(),
             active_index: 0,
             backends,
@@ -598,7 +616,23 @@ impl App {
             usage: HashMap::new(),
             usage_tx,
             usage_rx,
+            config_warnings: Vec::new(),
+        };
+        app.report_config_warnings(config_warnings);
+        app
+    }
+
+    /// Surface config-load warnings in the status bar (they are otherwise only
+    /// visible in the log file, which nobody watches while the TUI owns the
+    /// screen). Accumulates across calls — main reports agents.toml/hosts.toml
+    /// problems after construction — and shows them joined in one toast.
+    pub fn report_config_warnings(&mut self, warnings: Vec<String>) {
+        if warnings.is_empty() {
+            return;
         }
+        self.config_warnings.extend(warnings);
+        let text = format!("Config: {}", self.config_warnings.join(" · "));
+        self.set_status(StatusLevel::Error, text);
     }
 
     /// Build an [`AgentProvider`](crate::agent::AgentProvider) for a session
@@ -4706,6 +4740,7 @@ mod tests {
     fn start_new_session_shows_host_picker_with_hosts() {
         let mut app = app_with_sessions(0);
         app.set_hosts(crate::session::HostRegistry {
+            config_version: None,
             hosts: vec![crate::session::HostDef {
                 name: "devbox".into(),
                 destination: "me@devbox".into(),
@@ -4731,6 +4766,7 @@ mod tests {
     fn host_for_backend_resolves_ssh_only() {
         let mut app = app_with_sessions(0);
         app.set_hosts(crate::session::HostRegistry {
+            config_version: None,
             hosts: vec![crate::session::HostDef {
                 name: "devbox".into(),
                 destination: "me@devbox".into(),
@@ -5166,6 +5202,9 @@ mod tests {
     #[test]
     fn ctrl_r_no_crash_without_sessions() {
         let mut app = app_with_sessions(0);
+        // App::new may toast warnings from the developer's real keybindings
+        // file; this test only cares that Ctrl+R itself stays silent.
+        app.status_message = None;
         app.focus = InputFocus::Terminal;
         // Should not crash when there are no sessions
         app.handle_key(KeyCode::Char('r'), KeyModifiers::CONTROL);
@@ -6908,6 +6947,9 @@ mod tests {
     #[test]
     fn ctrl_r_no_op_without_agent_session_id() {
         let mut app = app_with_sessions(1);
+        // App::new may toast warnings from the developer's real keybindings
+        // file; this test only cares that Ctrl+R itself stays silent.
+        app.status_message = None;
         // Session exists but has no agent_session_id
         app.sessions[0].info.agent_session_id = None;
         app.focus = InputFocus::Terminal;

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -71,7 +71,7 @@ impl App {
             .sessions
             .get(self.active_index)
             .map(|s| s.info.name.as_str());
-        let theme_label = self.active_theme.display_name();
+        let theme_label = self.active_theme.display_name.as_str();
         status_bar::render_header(
             frame,
             header,
@@ -496,7 +496,7 @@ impl App {
             theme_picker_modal::render_theme_picker_modal(
                 frame,
                 &theme_picker_modal::ThemePickerState {
-                    presets: crate::session::ThemePreset::all(),
+                    entries: &crate::ui::theme::all_theme_entries(),
                     selected_index: tp.index,
                 },
             );

--- a/src/bin/thurbox-cli.rs
+++ b/src/bin/thurbox-cli.rs
@@ -14,6 +14,12 @@ fn main() {
 
     let cli = thurbox::cli::Cli::parse();
 
+    // Publish settings before Database::open (audit pruning reads retention).
+    // Warnings go to the WARN-level stderr logger; `config validate` is the
+    // loud path.
+    let (settings, _) = thurbox::agent::settings_config::load_or_seed_with_warnings();
+    thurbox::session::settings::init(settings);
+
     let db_path = match thurbox::paths::database_file() {
         Some(p) => p,
         None => {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -96,12 +96,17 @@ fn validate() -> Result<Value, String> {
         crate::agent::settings_config::settings_config_path(),
         "settings.toml",
     );
+    let (themes, themes_ok) = validate_toml::<crate::session::theme_config::ThemesFile>(
+        crate::agent::themes_config::themes_config_path(),
+        "themes.toml",
+    );
     let (keybindings, kb_ok) = validate_keybindings();
 
     let failed: Vec<&str> = [
         ("agents.toml", agents_ok),
         ("hosts.toml", hosts_ok),
         ("settings.toml", settings_ok),
+        ("themes.toml", themes_ok),
         ("keybindings.json", kb_ok),
     ]
     .iter()
@@ -114,6 +119,7 @@ fn validate() -> Result<Value, String> {
         "agents_toml": agents,
         "hosts_toml": hosts,
         "settings_toml": settings,
+        "themes_toml": themes,
         "keybindings_json": keybindings,
     });
     if failed.is_empty() {
@@ -134,6 +140,7 @@ fn show(db: &Database) -> Result<Value, String> {
     let agents = crate::agent::agent_config::load_or_seed();
     let hosts = crate::agent::host_config::load_or_seed();
     let settings = crate::session::settings::global();
+    let (custom_themes, _) = crate::agent::themes_config::load_or_seed_with_warnings();
 
     // Editor resolution mirrors the TUI's Ctrl+O chain: DB → $VISUAL → $EDITOR.
     let db_editor = db.get_editor_command().ok().flatten();
@@ -170,6 +177,8 @@ fn show(db: &Database) -> Result<Value, String> {
                 .map(|p| p.display().to_string()),
             "settings_toml": crate::agent::settings_config::settings_config_path()
                 .map(|p| p.display().to_string()),
+            "themes_toml": crate::agent::themes_config::themes_config_path()
+                .map(|p| p.display().to_string()),
             "keybindings_json": crate::paths::keybindings_file()
                 .map(|p| p.display().to_string()),
             "database": crate::paths::database_file().map(|p| p.display().to_string()),
@@ -180,6 +189,7 @@ fn show(db: &Database) -> Result<Value, String> {
         "keybindings": { "overridden_actions": overridden_actions },
         "editor": { "command": editor, "source": editor_source },
         "theme": db.get_active_theme().ok().flatten(),
+        "custom_themes": custom_themes.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
     }))
 }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,0 +1,237 @@
+//! Config introspection subcommands: `validate` and `show`.
+//!
+//! `validate` strictly parses every config file and fails (exit 1) when any
+//! is invalid — usable as a dotfiles CI check. `show` prints the *effective*
+//! resolved configuration and where each value came from.
+//!
+//! The agent module's loaders are reached via fully-qualified paths (no
+//! `use crate::agent`) to keep the cli module free of an `agent` import —
+//! see tests/architecture_rules.rs::cli_module_isolation.
+
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+use crate::storage::Database;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// Parse every config file strictly; non-zero exit when any is invalid.
+    Validate,
+    /// Print the effective configuration and where each value came from.
+    Show,
+}
+
+pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+    match action {
+        Action::Validate => validate(),
+        Action::Show => show(db),
+    }
+}
+
+/// One file's validation outcome.
+fn file_report(path: Option<std::path::PathBuf>, problems: Vec<String>, exists: bool) -> Value {
+    json!({
+        "path": path.map(|p| p.display().to_string()),
+        "exists": exists,
+        "valid": problems.is_empty(),
+        "problems": problems,
+    })
+}
+
+/// Validate one TOML config file against `T`. Absent files are valid
+/// (defaults/seeding apply). Unknown fields don't fail the *load* at startup,
+/// but they do fail *validation* — they are typos or stale keys either way.
+fn validate_toml<T: serde::de::DeserializeOwned>(
+    path: Option<std::path::PathBuf>,
+    label: &str,
+) -> (Value, bool) {
+    let Some(path) = path else {
+        return (
+            file_report(None, vec!["could not resolve path".into()], false),
+            false,
+        );
+    };
+    if !path.exists() {
+        return (file_report(Some(path), Vec::new(), false), true);
+    }
+    let problems = match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            match crate::agent::agent_config::parse_toml_reporting_unknown::<T>(&contents, label) {
+                Ok((_, warnings)) => warnings,
+                Err(e) => vec![e.to_string()],
+            }
+        }
+        Err(e) => vec![format!("read failed: {e}")],
+    };
+    let ok = problems.is_empty();
+    (file_report(Some(path), problems, true), ok)
+}
+
+fn validate_keybindings() -> (Value, bool) {
+    let path = crate::paths::keybindings_file();
+    match crate::storage::keybindings::load_keybindings_json() {
+        Ok(Some(jsonbody)) => {
+            let problems = match crate::session::KeyBindings::from_json_with_warnings(&jsonbody) {
+                Ok((_, warnings)) => warnings,
+                Err(e) => vec![e],
+            };
+            let ok = problems.is_empty();
+            (file_report(path, problems, true), ok)
+        }
+        Ok(None) => (file_report(path, Vec::new(), false), true),
+        Err(e) => (file_report(path, vec![e], true), false),
+    }
+}
+
+fn validate() -> Result<Value, String> {
+    let (agents, agents_ok) = validate_toml::<crate::session::AgentRegistry>(
+        crate::agent::agent_config::agents_config_path(),
+        "agents.toml",
+    );
+    let (hosts, hosts_ok) = validate_toml::<crate::session::HostRegistry>(
+        crate::agent::host_config::hosts_config_path(),
+        "hosts.toml",
+    );
+    let (settings, settings_ok) = validate_toml::<crate::session::settings::Settings>(
+        crate::agent::settings_config::settings_config_path(),
+        "settings.toml",
+    );
+    let (keybindings, kb_ok) = validate_keybindings();
+
+    let failed: Vec<&str> = [
+        ("agents.toml", agents_ok),
+        ("hosts.toml", hosts_ok),
+        ("settings.toml", settings_ok),
+        ("keybindings.json", kb_ok),
+    ]
+    .iter()
+    .filter(|(_, ok)| !ok)
+    .map(|(name, _)| *name)
+    .collect();
+
+    let report = json!({
+        "valid": failed.is_empty(),
+        "agents_toml": agents,
+        "hosts_toml": hosts,
+        "settings_toml": settings,
+        "keybindings_json": keybindings,
+    });
+    if failed.is_empty() {
+        Ok(report)
+    } else {
+        // Print the full report on stdout (like the Ok path would), then fail
+        // with a one-line error so the process exits non-zero — usable as a
+        // dotfiles CI gate.
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).unwrap_or_else(|_| report.to_string())
+        );
+        Err(format!("config invalid: {}", failed.join(", ")))
+    }
+}
+
+fn show(db: &Database) -> Result<Value, String> {
+    let agents = crate::agent::agent_config::load_or_seed();
+    let hosts = crate::agent::host_config::load_or_seed();
+    let settings = crate::session::settings::global();
+
+    // Editor resolution mirrors the TUI's Ctrl+O chain: DB → $VISUAL → $EDITOR.
+    let db_editor = db.get_editor_command().ok().flatten();
+    let (editor, editor_source) = match db_editor {
+        Some(cmd) if !cmd.is_empty() => (Some(cmd), "database (editor_command)"),
+        _ => match std::env::var("VISUAL") {
+            Ok(v) if !v.is_empty() => (Some(v), "$VISUAL"),
+            _ => match std::env::var("EDITOR") {
+                Ok(v) if !v.is_empty() => (Some(v), "$EDITOR"),
+                _ => (None, "unset"),
+            },
+        },
+    };
+
+    let overridden_actions: Vec<String> = match crate::storage::keybindings::load_keybindings_json()
+    {
+        Ok(Some(jsonbody)) => {
+            serde_json::from_str::<std::collections::HashMap<String, Vec<String>>>(&jsonbody)
+                .map(|m| {
+                    let mut keys: Vec<String> = m.into_keys().collect();
+                    keys.sort();
+                    keys
+                })
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    };
+
+    Ok(json!({
+        "paths": {
+            "agents_toml": crate::agent::agent_config::agents_config_path()
+                .map(|p| p.display().to_string()),
+            "hosts_toml": crate::agent::host_config::hosts_config_path()
+                .map(|p| p.display().to_string()),
+            "settings_toml": crate::agent::settings_config::settings_config_path()
+                .map(|p| p.display().to_string()),
+            "keybindings_json": crate::paths::keybindings_file()
+                .map(|p| p.display().to_string()),
+            "database": crate::paths::database_file().map(|p| p.display().to_string()),
+        },
+        "agents": { "default": agents.default_name(), "names": agents.names() },
+        "hosts": { "names": hosts.names() },
+        "settings": settings,
+        "keybindings": { "overridden_actions": overridden_actions },
+        "editor": { "command": editor, "source": editor_source },
+        "theme": db.get_active_theme().ok().flatten(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::TestPathGuard;
+
+    #[test]
+    fn validate_passes_on_fresh_environment() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let v = validate().unwrap();
+        assert_eq!(v["valid"], json!(true));
+    }
+
+    #[test]
+    fn validate_fails_with_exit_error_on_malformed_agents_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let path = crate::agent::agent_config::agents_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "not toml {{{").unwrap();
+
+        let err = validate().unwrap_err();
+        assert!(err.contains("agents.toml"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_reports_keybinding_conflicts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        crate::storage::keybindings::save_keybindings_json(
+            r#"{ "QuitApp": ["ctrl+x"], "NewSession": ["ctrl+x"] }"#,
+        )
+        .unwrap();
+
+        let err = validate().unwrap_err();
+        assert!(err.contains("keybindings.json"), "got: {err}");
+    }
+
+    #[test]
+    fn show_reports_effective_settings_and_editor_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let db = Database::open_in_memory().unwrap();
+        db.set_editor_command("code --wait").unwrap();
+
+        let v = show(&db).unwrap();
+        assert_eq!(v["editor"]["command"], json!("code --wait"));
+        assert_eq!(v["editor"]["source"], json!("database (editor_command)"));
+        assert!(v["settings"]["scrollback_lines"].is_number());
+        assert_eq!(v["agents"]["default"], json!("claude"));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand};
 use crate::storage::Database;
 
 pub mod automations;
+pub mod config;
 pub mod editor;
 pub mod sessions;
 pub mod tasks;
@@ -51,6 +52,11 @@ pub enum Command {
         #[command(subcommand)]
         action: tasks::Action,
     },
+    /// Validate or inspect the config files.
+    Config {
+        #[command(subcommand)]
+        action: config::Action,
+    },
 }
 
 /// Run a parsed CLI invocation against `db` and write JSON to stdout.
@@ -60,6 +66,7 @@ pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
         Command::Session { action } => sessions::run(action, db),
         Command::Automation { action } => automations::run(action, db),
         Command::Task { action } => tasks::run(action, db),
+        Command::Config { action } => config::run(action, db),
     }?;
 
     let text = if cli.pretty {

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,14 @@ async fn main() -> Result<()> {
     // Load (or seed) the coding-agent registry from ~/.config/thurbox/agents.toml.
     let (agents, agent_warnings) = thurbox::agent::agent_config::load_or_seed_with_warnings();
     config_warnings.extend(agent_warnings);
+
+    // Load (or seed) custom themes and publish them so the picker and the
+    // persisted-theme lookup below can resolve them by name.
+    let (custom_themes, theme_warnings) =
+        thurbox::agent::themes_config::load_or_seed_with_warnings();
+    config_warnings.extend(theme_warnings);
+    thurbox::ui::theme::set_custom_themes(custom_themes);
+
     for w in &config_warnings {
         tracing::warn!("{w}");
     }
@@ -83,9 +91,10 @@ async fn main() -> Result<()> {
     });
     let db = Database::open(&db_path).expect("Failed to open database");
 
-    // Activate the persisted theme (falls back to default if unset/unknown).
+    // Activate the persisted theme — built-in or custom — falling back to
+    // default when unset/unknown.
     if let Ok(Some(name)) = db.get_active_theme() {
-        thurbox::ui::theme::apply_preset_by_name(&name);
+        thurbox::ui::theme::apply_theme_by_name(&name);
     } else {
         thurbox::ui::theme::ensure_initialized();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,14 +50,18 @@ async fn main() -> Result<()> {
     // (~/.config/thurbox/hosts.toml). These are registered lazily: a down or
     // slow host must not block TUI startup, so check_available()/ensure_ready()
     // are deferred to first spawn/restore (see App::backend_for).
-    let hosts = thurbox::agent::host_config::load_or_seed();
+    let (hosts, mut config_warnings) = thurbox::agent::host_config::load_or_seed_with_warnings();
     for host in &hosts.hosts {
         tracing::debug!(host = %host.name, dest = %host.destination, "Registering SSH backend");
         backends.register(Arc::new(TmuxBackend::from_host(host)));
     }
 
     // Load (or seed) the coding-agent registry from ~/.config/thurbox/agents.toml.
-    let agents = thurbox::agent::agent_config::load_or_seed();
+    let (agents, agent_warnings) = thurbox::agent::agent_config::load_or_seed_with_warnings();
+    config_warnings.extend(agent_warnings);
+    for w in &config_warnings {
+        tracing::warn!("{w}");
+    }
 
     // Open SQLite database for persistent state
     let db_path = thurbox::paths::database_file().unwrap_or_else(|| {
@@ -84,6 +88,9 @@ async fn main() -> Result<()> {
 
     let mut app = App::new(size.height, size.width, backends, agents, db);
     app.set_hosts(hosts);
+    // Surface agents.toml/hosts.toml load problems in the status bar — the
+    // tracing::warn above only reaches the log file the TUI hides.
+    app.report_config_warnings(config_warnings);
 
     // Load session state from DB and restore
     if let Some((sessions, counter)) = app.load_persisted_state_from_db() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,15 @@ async fn main() -> Result<()> {
     // (~/.config/thurbox/hosts.toml). These are registered lazily: a down or
     // slow host must not block TUI startup, so check_available()/ensure_ready()
     // are deferred to first spawn/restore (see App::backend_for).
-    let (hosts, mut config_warnings) = thurbox::agent::host_config::load_or_seed_with_warnings();
+    // Load (or seed) the scalar settings and publish them process-wide before
+    // anything reads them (Database::open prunes the audit log; layout and
+    // terminal wiring read breakpoints/scrollback).
+    let (settings, mut config_warnings) =
+        thurbox::agent::settings_config::load_or_seed_with_warnings();
+    thurbox::session::settings::init(settings);
+
+    let (hosts, host_warnings) = thurbox::agent::host_config::load_or_seed_with_warnings();
+    config_warnings.extend(host_warnings);
     for host in &hosts.hosts {
         tracing::debug!(host = %host.name, dest = %host.destination, "Registering SSH backend");
         backends.register(Arc::new(TmuxBackend::from_host(host)));

--- a/src/session/agent_def.rs
+++ b/src/session/agent_def.rs
@@ -23,6 +23,7 @@ const ID_PLACEHOLDER: &str = "{id}";
 /// etc.), with `{model}` / `{id}` substituted token-by-token. This avoids any
 /// "unresolved placeholder" heuristics: a group with no value is simply omitted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentDef {
     /// Display + lookup name (e.g. `"claude"`). Unique within a registry.
     pub name: String,
@@ -97,8 +98,16 @@ fn subst(tokens: &[String], placeholder: &str, value: &str) -> Vec<String> {
 }
 
 /// A set of agent definitions plus the name of the default agent.
+///
+/// Parsing is strict (`deny_unknown_fields`): a typo'd field name fails the
+/// parse loudly (surfaced as a startup warning + built-in fallback) instead of
+/// being silently ignored.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentRegistry {
+    /// Config-format version, for future migrations. Currently `1`.
+    #[serde(default)]
+    pub config_version: Option<u32>,
     /// Name of the agent selected by default in the picker / headless spawns.
     #[serde(default)]
     pub default: String,
@@ -234,6 +243,7 @@ mod tests {
     #[test]
     fn registry_lookup_and_default() {
         let reg = AgentRegistry {
+            config_version: None,
             default: "codex".into(),
             agents: vec![
                 claude(),
@@ -256,6 +266,7 @@ mod tests {
     #[test]
     fn registry_default_falls_back_to_first() {
         let reg = AgentRegistry {
+            config_version: None,
             default: "missing".into(),
             agents: vec![claude()],
         };

--- a/src/session/agent_def.rs
+++ b/src/session/agent_def.rs
@@ -23,7 +23,6 @@ const ID_PLACEHOLDER: &str = "{id}";
 /// etc.), with `{model}` / `{id}` substituted token-by-token. This avoids any
 /// "unresolved placeholder" heuristics: a group with no value is simply omitted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct AgentDef {
     /// Display + lookup name (e.g. `"claude"`). Unique within a registry.
     pub name: String,
@@ -99,11 +98,10 @@ fn subst(tokens: &[String], placeholder: &str, value: &str) -> Vec<String> {
 
 /// A set of agent definitions plus the name of the default agent.
 ///
-/// Parsing is strict (`deny_unknown_fields`): a typo'd field name fails the
-/// parse loudly (surfaced as a startup warning + built-in fallback) instead of
-/// being silently ignored.
+/// Unknown fields are tolerated but reported: the loader names every
+/// unrecognized key in a startup warning (stale keys from older versions and
+/// typos both surface without stranding the user on built-ins).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct AgentRegistry {
     /// Config-format version, for future migrations. Currently `1`.
     #[serde(default)]

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -20,6 +20,7 @@ pub fn is_ssh_backend(backend_name: &str) -> bool {
 
 /// A single remote host reachable over SSH.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HostDef {
     /// Short, unique name. The backend is registered as `ssh:<name>`.
     pub name: String,
@@ -52,8 +53,16 @@ impl HostDef {
 }
 
 /// All configured remote hosts, in declaration order.
+///
+/// Parsing is strict (`deny_unknown_fields`): a typo'd field name fails the
+/// parse loudly (surfaced as a startup warning + empty-registry fallback)
+/// instead of being silently ignored.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HostRegistry {
+    /// Config-format version, for future migrations. Currently `1`.
+    #[serde(default)]
+    pub config_version: Option<u32>,
     #[serde(default)]
     pub hosts: Vec<HostDef>,
 }
@@ -101,6 +110,7 @@ mod tests {
     #[test]
     fn registry_lookup_by_name_and_backend() {
         let reg = HostRegistry {
+            config_version: None,
             hosts: vec![HostDef {
                 name: "devbox".into(),
                 destination: "me@devbox".into(),

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -20,7 +20,6 @@ pub fn is_ssh_backend(backend_name: &str) -> bool {
 
 /// A single remote host reachable over SSH.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct HostDef {
     /// Short, unique name. The backend is registered as `ssh:<name>`.
     pub name: String,
@@ -54,11 +53,9 @@ impl HostDef {
 
 /// All configured remote hosts, in declaration order.
 ///
-/// Parsing is strict (`deny_unknown_fields`): a typo'd field name fails the
-/// parse loudly (surfaced as a startup warning + empty-registry fallback)
-/// instead of being silently ignored.
+/// Unknown fields are tolerated but reported: the loader names every
+/// unrecognized key in a startup warning.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct HostRegistry {
     /// Config-format version, for future migrations. Currently `1`.
     #[serde(default)]

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -458,7 +458,14 @@ impl KeyChord {
             "backspace" => KeyCode::Backspace,
             "delete" | "del" => KeyCode::Delete,
             "insert" | "ins" => KeyCode::Insert,
-            other if other.starts_with('f') && other.len() <= 3 => {
+            // "f1".."f12" — but NOT a bare "f", which is the letter key (the
+            // `[1..].parse()` on "" used to fail and reject "ctrl+f" entirely).
+            other
+                if other.len() >= 2
+                    && other.len() <= 3
+                    && other.starts_with('f')
+                    && other[1..].bytes().all(|b| b.is_ascii_digit()) =>
+            {
                 let n: u8 = other[1..].parse().ok()?;
                 KeyCode::F(n)
             }
@@ -671,6 +678,26 @@ mod tests {
             let chord = KeyChord::parse(c).expect(c);
             assert_eq!(chord.display(), c);
         }
+    }
+
+    #[test]
+    fn chord_parse_bare_f_is_the_letter_not_a_function_key() {
+        // Regression: "f" used to enter the F-key branch and fail the parse,
+        // silently dropping bindings like "ctrl+f" from keybindings.json.
+        assert_eq!(
+            KeyChord::parse("ctrl+f"),
+            Some(KeyChord::ctrl('f')),
+            "ctrl+f must parse as the letter key"
+        );
+        assert_eq!(
+            KeyChord::parse("f"),
+            Some(KeyChord::normalized(KeyModifiers::NONE, KeyCode::Char('f')))
+        );
+        assert_eq!(
+            KeyChord::parse("f12"),
+            Some(KeyChord::normalized(KeyModifiers::NONE, KeyCode::F(12)))
+        );
+        assert_eq!(KeyChord::parse("fx"), None, "non-digit suffix is invalid");
     }
 
     #[test]

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -596,23 +596,67 @@ impl KeyBindings {
     /// Parse from the JSON shape. Unknown actions are ignored; unknown chords
     /// are silently dropped. Missing actions fall back to defaults.
     pub fn from_json(json: &str) -> Result<Self, String> {
+        Self::from_json_with_warnings(json).map(|(bindings, _)| bindings)
+    }
+
+    /// Parse from the JSON shape, reporting everything that would otherwise be
+    /// silently skipped: unknown action names, unparsable chord strings, and
+    /// chords bound to more than one action in overlapping contexts (lookup
+    /// order over a HashMap is arbitrary, so a conflict means one of the two
+    /// actions nondeterministically wins). Missing actions fall back to
+    /// defaults; the parse itself only fails on malformed JSON.
+    pub fn from_json_with_warnings(json: &str) -> Result<(Self, Vec<String>), String> {
         let parsed: HashMap<String, Vec<String>> =
             serde_json::from_str(json).map_err(|e| e.to_string())?;
+        let mut warnings = Vec::new();
         let mut bindings = KeyBindings::default();
         for (key, chord_strs) in parsed {
             let action: Action = match serde_json::from_str::<Action>(&format!("\"{key}\"")) {
                 Ok(a) => a,
-                Err(_) => continue,
+                Err(_) => {
+                    warnings.push(format!("unknown action \"{key}\""));
+                    continue;
+                }
             };
-            let chords: Vec<KeyChord> = chord_strs
-                .iter()
-                .filter_map(|s| KeyChord::parse(s))
-                .collect();
+            let mut chords: Vec<KeyChord> = Vec::new();
+            for s in &chord_strs {
+                match KeyChord::parse(s) {
+                    Some(chord) => chords.push(chord),
+                    None => warnings.push(format!("invalid chord \"{s}\" for {key}")),
+                }
+            }
             if !chords.is_empty() {
                 bindings.map.insert(action, chords);
             }
         }
-        Ok(bindings)
+        warnings.extend(bindings.conflict_warnings());
+        Ok((bindings, warnings))
+    }
+
+    /// Chords bound to more than one action whose contexts overlap. The F1
+    /// editor prevents these by stealing chords; a hand-edited file can still
+    /// introduce them.
+    fn conflict_warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+        let mut entries: Vec<(&Action, &KeyChord)> = self
+            .map
+            .iter()
+            .flat_map(|(action, chords)| chords.iter().map(move |c| (action, c)))
+            .collect();
+        entries.sort_by_key(|(a, _)| a.label());
+        for (i, (action_a, chord)) in entries.iter().enumerate() {
+            for (action_b, other) in &entries[i + 1..] {
+                if chord == other && contexts_overlap(action_a.context(), action_b.context()) {
+                    warnings.push(format!(
+                        "chord \"{}\" is bound to both {} and {} (one will be ignored)",
+                        chord.display(),
+                        action_a.label(),
+                        action_b.label(),
+                    ));
+                }
+            }
+        }
+        warnings
     }
 }
 
@@ -720,6 +764,41 @@ mod tests {
     fn from_json_ignores_unknown_actions_and_invalid_chords() {
         let json = r#"{ "QuitApp": ["nonsense", "ctrl+x"], "BogusAction": ["ctrl+y"] }"#;
         let kb = KeyBindings::from_json(json).unwrap();
+        assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('x')));
+    }
+
+    #[test]
+    fn from_json_with_warnings_reports_skipped_entries() {
+        let json = r#"{ "QuitApp": ["nonsense", "ctrl+x"], "BogusAction": ["ctrl+y"] }"#;
+        let (_, warnings) = KeyBindings::from_json_with_warnings(json).unwrap();
+        assert!(
+            warnings.iter().any(|w| w.contains("BogusAction")),
+            "unknown action must be reported: {warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("nonsense")),
+            "invalid chord must be reported: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn from_json_with_warnings_reports_chord_conflicts() {
+        // Two global actions on the same chord: one nondeterministically wins.
+        let json = r#"{ "QuitApp": ["ctrl+x"], "NewSession": ["ctrl+x"] }"#;
+        let (_, warnings) = KeyBindings::from_json_with_warnings(json).unwrap();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("ctrl+x") && w.contains("bound to both")),
+            "conflict must be reported: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn from_json_with_warnings_is_quiet_for_valid_input() {
+        let json = r#"{ "QuitApp": ["ctrl+x"] }"#;
+        let (kb, warnings) = KeyBindings::from_json_with_warnings(json).unwrap();
+        assert!(warnings.is_empty(), "got: {warnings:?}");
         assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('x')));
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -2,6 +2,7 @@ pub mod agent_def;
 pub mod automation;
 pub mod host_def;
 pub mod keybindings;
+pub mod settings;
 pub mod task;
 pub mod theme_config;
 

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -1,0 +1,109 @@
+//! User-tunable scalar settings (`~/.config/thurbox/settings.toml`).
+//!
+//! Pure data + parsing, per the `session/` architecture rule; the file IO and
+//! seeding live in `crate::agent::settings_config`. Only knobs a user
+//! plausibly wants to change are exposed — timing/buffer internals stay
+//! hardcoded. The loaded value is published process-wide via [`init`] /
+//! [`global`] because the consumers span modules that must not know about each
+//! other (terminal wiring, layout, storage retention).
+
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+/// Scalar settings loaded from `settings.toml`. Every field has a default, so
+/// an absent file (the common case) behaves exactly like before the file
+/// existed. Unknown keys are tolerated but reported: the loader names every
+/// unrecognized key in a startup warning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Settings {
+    /// Config-format version, for future migrations. Currently `1`.
+    #[serde(default)]
+    pub config_version: Option<u32>,
+    /// Scrollback lines kept per session terminal (vt100 parser history).
+    #[serde(default = "default_scrollback_lines")]
+    pub scrollback_lines: usize,
+    /// Terminal width (columns) below which only the terminal pane renders.
+    #[serde(default = "default_two_panel_min_cols")]
+    pub two_panel_min_cols: u16,
+    /// Terminal width (columns) at which the optional third column (info /
+    /// tasks / file viewer) becomes available.
+    #[serde(default = "default_three_panel_min_cols")]
+    pub three_panel_min_cols: u16,
+    /// Days of audit-log history kept (pruned on startup).
+    #[serde(default = "default_audit_retention_days")]
+    pub audit_retention_days: u64,
+}
+
+fn default_scrollback_lines() -> usize {
+    1000
+}
+fn default_two_panel_min_cols() -> u16 {
+    80
+}
+fn default_three_panel_min_cols() -> u16 {
+    120
+}
+fn default_audit_retention_days() -> u64 {
+    90
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            config_version: None,
+            scrollback_lines: default_scrollback_lines(),
+            two_panel_min_cols: default_two_panel_min_cols(),
+            three_panel_min_cols: default_three_panel_min_cols(),
+            audit_retention_days: default_audit_retention_days(),
+        }
+    }
+}
+
+static GLOBAL: OnceLock<Settings> = OnceLock::new();
+
+/// Publish the loaded settings process-wide. Call once at startup, before the
+/// first [`global`] read; later calls are ignored (first writer wins).
+pub fn init(settings: Settings) {
+    let _ = GLOBAL.set(settings);
+}
+
+/// The process-wide settings; defaults when [`init`] was never called (tests,
+/// or library use outside the binaries).
+pub fn global() -> &'static Settings {
+    GLOBAL.get_or_init(Settings::default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_document_yields_defaults() {
+        let s: Settings = toml::from_str("").unwrap();
+        assert_eq!(s, Settings::default());
+        assert_eq!(s.scrollback_lines, 1000);
+        assert_eq!(s.two_panel_min_cols, 80);
+        assert_eq!(s.three_panel_min_cols, 120);
+        assert_eq!(s.audit_retention_days, 90);
+    }
+
+    #[test]
+    fn partial_override_keeps_other_defaults() {
+        let s: Settings = toml::from_str("scrollback_lines = 5000").unwrap();
+        assert_eq!(s.scrollback_lines, 5000);
+        assert_eq!(s.audit_retention_days, 90);
+    }
+
+    #[test]
+    fn type_mismatch_is_rejected() {
+        let err = toml::from_str::<Settings>("scrollback_lines = \"many\"").unwrap_err();
+        assert!(err.to_string().contains("scrollback_lines"));
+    }
+
+    #[test]
+    fn global_defaults_when_uninitialized() {
+        // Note: other tests may have init()'d already; both paths are default.
+        assert_eq!(global().two_panel_min_cols, 80);
+    }
+}

--- a/src/session/theme_config.rs
+++ b/src/session/theme_config.rs
@@ -180,6 +180,250 @@ impl ThemePreset {
     }
 }
 
+/// A selectable theme — a built-in preset or a user-defined custom theme —
+/// flattened to what the picker and the apply path need.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ThemeEntry {
+    /// Stable identifier persisted in `metadata.active_theme`.
+    pub name: String,
+    /// Human-readable label shown in the picker and status bar.
+    pub display_name: String,
+    pub palette: ThemePalette,
+    pub is_light: bool,
+}
+
+impl ThemeEntry {
+    pub fn from_preset(preset: ThemePreset) -> Self {
+        Self {
+            name: preset.as_str().to_string(),
+            display_name: preset.display_name().to_string(),
+            palette: preset.palette(),
+            is_light: preset.is_light(),
+        }
+    }
+}
+
+/// A user-defined theme from `themes.toml`: a base preset plus per-colour
+/// overrides. Colours accept anything ratatui parses — `#rrggbb`, ANSI names
+/// (`red`, `lightcyan`), indexed (`14`), or `reset`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CustomThemeDef {
+    /// Stable identifier (what `metadata.active_theme` stores). Must not
+    /// collide with a built-in preset name.
+    pub name: String,
+    /// Picker label; defaults to `name`.
+    #[serde(default)]
+    pub display_name: Option<String>,
+    /// Built-in preset the palette starts from; defaults to `default`.
+    #[serde(default)]
+    pub base: Option<String>,
+    /// Whether the theme targets light terminals; defaults to the base's.
+    #[serde(default)]
+    pub light: Option<bool>,
+    /// Nerd-font glyph opt-in; defaults to the base's.
+    #[serde(default)]
+    pub nerd_font: Option<bool>,
+    #[serde(default)]
+    pub accent: Option<String>,
+    #[serde(default)]
+    pub accent_bright: Option<String>,
+    #[serde(default)]
+    pub status_busy: Option<String>,
+    #[serde(default)]
+    pub status_waiting: Option<String>,
+    #[serde(default)]
+    pub status_idle: Option<String>,
+    #[serde(default)]
+    pub status_error: Option<String>,
+    #[serde(default)]
+    pub text_primary: Option<String>,
+    #[serde(default)]
+    pub text_secondary: Option<String>,
+    #[serde(default)]
+    pub text_muted: Option<String>,
+    #[serde(default)]
+    pub border_focused: Option<String>,
+    #[serde(default)]
+    pub border_unfocused: Option<String>,
+    #[serde(default)]
+    pub role_name: Option<String>,
+    #[serde(default)]
+    pub branch_name: Option<String>,
+    #[serde(default)]
+    pub search_bar: Option<String>,
+    #[serde(default)]
+    pub keybind_hint: Option<String>,
+    #[serde(default)]
+    pub tool_allowed: Option<String>,
+    #[serde(default)]
+    pub tool_disallowed: Option<String>,
+    #[serde(default)]
+    pub danger: Option<String>,
+    #[serde(default)]
+    pub selection_bg: Option<String>,
+    #[serde(default)]
+    pub selection_fg: Option<String>,
+    #[serde(default)]
+    pub modal_dim_bg: Option<String>,
+    #[serde(default)]
+    pub modal_bg: Option<String>,
+    #[serde(default)]
+    pub modal_border: Option<String>,
+    #[serde(default)]
+    pub inverted_fg: Option<String>,
+    #[serde(default)]
+    pub app_bg: Option<String>,
+}
+
+/// `themes.toml` document shape.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ThemesFile {
+    /// Config-format version, for future migrations. Currently `1`.
+    #[serde(default)]
+    pub config_version: Option<u32>,
+    #[serde(default)]
+    pub themes: Vec<CustomThemeDef>,
+}
+
+/// Apply one colour override, recording a warning instead of failing when the
+/// value doesn't parse (the base colour stays in effect).
+fn apply_color(
+    warnings: &mut Vec<String>,
+    theme: &str,
+    field: &str,
+    value: &Option<String>,
+    slot: &mut Color,
+) {
+    let Some(raw) = value else { return };
+    match raw.parse::<Color>() {
+        Ok(color) => *slot = color,
+        Err(_) => warnings.push(format!(
+            "theme \"{theme}\": invalid colour \"{raw}\" for {field} (kept base colour)"
+        )),
+    }
+}
+
+impl CustomThemeDef {
+    /// Materialise the theme: base preset palette + overrides. Unparsable
+    /// colours and an unknown base degrade to warnings, never to a hard
+    /// failure — a half-styled theme beats no theme.
+    pub fn resolve(&self) -> (ThemeEntry, Vec<String>) {
+        let mut warnings = Vec::new();
+        let base = match self.base.as_deref() {
+            None => ThemePreset::Default,
+            Some(name) => ThemePreset::from_str(name).unwrap_or_else(|| {
+                warnings.push(format!(
+                    "theme \"{}\": unknown base \"{name}\" (using default)",
+                    self.name
+                ));
+                ThemePreset::Default
+            }),
+        };
+        let mut palette = base.palette();
+        if let Some(nerd) = self.nerd_font {
+            palette.nerd_font_enabled = nerd;
+        }
+
+        let fields: [(&str, &Option<String>, &mut Color); 25] = [
+            ("accent", &self.accent, &mut palette.accent),
+            (
+                "accent_bright",
+                &self.accent_bright,
+                &mut palette.accent_bright,
+            ),
+            ("status_busy", &self.status_busy, &mut palette.status_busy),
+            (
+                "status_waiting",
+                &self.status_waiting,
+                &mut palette.status_waiting,
+            ),
+            ("status_idle", &self.status_idle, &mut palette.status_idle),
+            (
+                "status_error",
+                &self.status_error,
+                &mut palette.status_error,
+            ),
+            (
+                "text_primary",
+                &self.text_primary,
+                &mut palette.text_primary,
+            ),
+            (
+                "text_secondary",
+                &self.text_secondary,
+                &mut palette.text_secondary,
+            ),
+            ("text_muted", &self.text_muted, &mut palette.text_muted),
+            (
+                "border_focused",
+                &self.border_focused,
+                &mut palette.border_focused,
+            ),
+            (
+                "border_unfocused",
+                &self.border_unfocused,
+                &mut palette.border_unfocused,
+            ),
+            ("role_name", &self.role_name, &mut palette.role_name),
+            ("branch_name", &self.branch_name, &mut palette.branch_name),
+            ("search_bar", &self.search_bar, &mut palette.search_bar),
+            (
+                "keybind_hint",
+                &self.keybind_hint,
+                &mut palette.keybind_hint,
+            ),
+            (
+                "tool_allowed",
+                &self.tool_allowed,
+                &mut palette.tool_allowed,
+            ),
+            (
+                "tool_disallowed",
+                &self.tool_disallowed,
+                &mut palette.tool_disallowed,
+            ),
+            ("danger", &self.danger, &mut palette.danger),
+            (
+                "selection_bg",
+                &self.selection_bg,
+                &mut palette.selection_bg,
+            ),
+            (
+                "selection_fg",
+                &self.selection_fg,
+                &mut palette.selection_fg,
+            ),
+            (
+                "modal_dim_bg",
+                &self.modal_dim_bg,
+                &mut palette.modal_dim_bg,
+            ),
+            ("modal_bg", &self.modal_bg, &mut palette.modal_bg),
+            (
+                "modal_border",
+                &self.modal_border,
+                &mut palette.modal_border,
+            ),
+            ("inverted_fg", &self.inverted_fg, &mut palette.inverted_fg),
+            ("app_bg", &self.app_bg, &mut palette.app_bg),
+        ];
+        for (field, value, slot) in fields {
+            apply_color(&mut warnings, &self.name, field, value, slot);
+        }
+
+        let entry = ThemeEntry {
+            name: self.name.clone(),
+            display_name: self
+                .display_name
+                .clone()
+                .unwrap_or_else(|| self.name.clone()),
+            palette,
+            is_light: self.light.unwrap_or_else(|| base.is_light()),
+        };
+        (entry, warnings)
+    }
+}
+
 fn default_palette() -> ThemePalette {
     ThemePalette {
         accent: Color::Cyan,

--- a/src/storage/audit.rs
+++ b/src/storage/audit.rs
@@ -42,10 +42,6 @@ impl AuditAction {
     }
 }
 
-/// Audit entries older than this are pruned on `Database::open`. They are
-/// debugging breadcrumbs, not compliance data, so 90 days is plenty.
-pub const AUDIT_RETENTION_DAYS: u64 = 90;
-
 const MS_PER_DAY: u64 = 24 * 60 * 60 * 1000;
 
 /// A single audit log entry.
@@ -90,10 +86,13 @@ impl Database {
         Ok(())
     }
 
-    /// Delete audit entries older than [`AUDIT_RETENTION_DAYS`]. Returns the
-    /// number of rows removed. Cheap thanks to `idx_audit_log_timestamp`.
+    /// Delete audit entries older than the configured retention (settings.toml
+    /// `audit_retention_days`, default 90 — they are debugging breadcrumbs,
+    /// not compliance data). Returns the number of rows removed. Cheap thanks
+    /// to `idx_audit_log_timestamp`.
     pub fn prune_audit_log(&self) -> rusqlite::Result<usize> {
-        let cutoff = current_time_millis().saturating_sub(AUDIT_RETENTION_DAYS * MS_PER_DAY);
+        let retention_days = crate::session::settings::global().audit_retention_days;
+        let cutoff = current_time_millis().saturating_sub(retention_days * MS_PER_DAY);
         self.conn.execute(
             "DELETE FROM audit_log WHERE timestamp < ?1",
             params![cutoff as i64],
@@ -280,7 +279,8 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
 
         let now = current_time_millis();
-        let stale = now - (AUDIT_RETENTION_DAYS + 1) * MS_PER_DAY;
+        let retention_days = crate::session::settings::global().audit_retention_days;
+        let stale = now - (retention_days + 1) * MS_PER_DAY;
         let insert = |timestamp: u64, entity_id: &str| {
             db.conn_ref()
                 .execute(

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -99,7 +99,8 @@ pub fn compute_layout(
     let global_search = (search_height > 0).then_some(vertical[2]);
     let footer = vertical[3];
 
-    if area.width < 80 {
+    let settings = crate::session::settings::global();
+    if area.width < settings.two_panel_min_cols {
         return PanelAreas {
             header,
             left_panel: None,
@@ -113,9 +114,12 @@ pub fn compute_layout(
         };
     }
 
-    // At width ≥ 120, support optional info / tasks / file-viewer columns.
+    // At width ≥ three_panel_min_cols (default 120), support optional info /
+    // tasks / file-viewer columns.
     // Column order: list | info? | terminal | tasks? | file_viewer?.
-    if area.width >= 120 && (show_info_panel || show_tasks_panel || show_file_viewer) {
+    if area.width >= settings.three_panel_min_cols
+        && (show_info_panel || show_tasks_panel || show_file_viewer)
+    {
         let mut constraints: Vec<Constraint> = vec![Constraint::Percentage(18)]; // list
         if show_info_panel {
             constraints.push(Constraint::Percentage(15));

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -13,9 +13,52 @@ use std::sync::{OnceLock, RwLock};
 
 use ratatui::style::{Color, Modifier, Style};
 
+use crate::session::theme_config::ThemeEntry;
 use crate::session::{ThemePalette, ThemePreset};
 
 static ACTIVE_THEME: OnceLock<RwLock<ThemePalette>> = OnceLock::new();
+
+/// User-defined themes from `themes.toml`, published once at startup.
+static CUSTOM_THEMES: OnceLock<Vec<ThemeEntry>> = OnceLock::new();
+
+/// Publish the custom themes loaded from `themes.toml`. Call once at startup;
+/// later calls are ignored (first writer wins).
+pub fn set_custom_themes(themes: Vec<ThemeEntry>) {
+    let _ = CUSTOM_THEMES.set(themes);
+}
+
+/// The custom themes, empty when none were configured (or before startup).
+pub fn custom_themes() -> &'static [ThemeEntry] {
+    CUSTOM_THEMES.get().map(Vec::as_slice).unwrap_or(&[])
+}
+
+/// Every selectable theme: the built-in presets followed by the custom ones,
+/// in the order the picker shows them.
+pub fn all_theme_entries() -> Vec<ThemeEntry> {
+    ThemePreset::all()
+        .iter()
+        .map(|p| ThemeEntry::from_preset(*p))
+        .chain(custom_themes().iter().cloned())
+        .collect()
+}
+
+/// Look up a theme (built-in or custom) by its stable name.
+pub fn find_theme_entry(name: &str) -> Option<ThemeEntry> {
+    if let Some(preset) = ThemePreset::from_str(name) {
+        return Some(ThemeEntry::from_preset(preset));
+    }
+    custom_themes().iter().find(|t| t.name == name).cloned()
+}
+
+/// Activate a theme (built-in or custom) by name, falling back to the
+/// `Default` preset for unknown names. Returns the entry that was actually
+/// applied so callers can persist / display it.
+pub fn apply_theme_by_name(name: &str) -> ThemeEntry {
+    let entry =
+        find_theme_entry(name).unwrap_or_else(|| ThemeEntry::from_preset(ThemePreset::Default));
+    set_active(entry.palette.clone());
+    entry
+}
 
 /// Snapshot of the currently active palette.
 ///
@@ -38,15 +81,6 @@ pub fn set_active(palette: ThemePalette) {
 /// during a test from panicking on an uninitialised `OnceLock`.
 pub fn ensure_initialized() {
     ACTIVE_THEME.get_or_init(|| RwLock::new(ThemePalette::default()));
-}
-
-/// Convenience: load a built-in preset by name and activate it. Falls back
-/// to `Default` for unknown names. Returns the preset that was actually
-/// applied so callers can persist it back to storage.
-pub fn apply_preset_by_name(name: &str) -> ThemePreset {
-    let preset = ThemePreset::from_str(name).unwrap_or(ThemePreset::Default);
-    set_active(preset.palette());
-    preset
 }
 
 /// Centralised colour and style accessors for the Thurbox UI.
@@ -267,8 +301,27 @@ mod tests {
     }
 
     #[test]
-    fn apply_preset_falls_back_to_default_for_unknown_name() {
-        let applied = apply_preset_by_name("does-not-exist");
-        assert_eq!(applied, ThemePreset::Default);
+    fn apply_theme_falls_back_to_default_for_unknown_name() {
+        let applied = apply_theme_by_name("does-not-exist");
+        assert_eq!(applied.name, ThemePreset::Default.as_str());
+        // Restore default for any later test that depends on it.
+        set_active(ThemePalette::default());
+    }
+
+    #[test]
+    fn all_theme_entries_starts_with_builtins_in_order() {
+        let entries = all_theme_entries();
+        assert!(entries.len() >= ThemePreset::all().len());
+        for (entry, preset) in entries.iter().zip(ThemePreset::all()) {
+            assert_eq!(entry.name, preset.as_str());
+        }
+    }
+
+    #[test]
+    fn find_theme_entry_resolves_builtin_names() {
+        let entry = find_theme_entry("doom").expect("doom is built in");
+        assert_eq!(entry.display_name, "Doom");
+        assert!(!entry.is_light);
+        assert!(find_theme_entry("no-such-theme-xyz").is_none());
     }
 }

--- a/src/ui/theme_picker_modal.rs
+++ b/src/ui/theme_picker_modal.rs
@@ -1,4 +1,4 @@
-//! Modal that lets the user pick a built-in theme preset.
+//! Modal that lets the user pick a theme (built-in preset or custom).
 //!
 //! Renders the preset list on the left and a small live colour swatch for
 //! the highlighted preset on the right, so users can preview the palette
@@ -16,15 +16,15 @@ use super::{
     centered_fixed_height_rect, render_modal_frame, selector_list_item, selector_nav_footer,
     theme::Theme,
 };
-use crate::session::ThemePreset;
+use crate::session::theme_config::ThemeEntry;
 
 pub struct ThemePickerState<'a> {
-    pub presets: &'a [ThemePreset],
+    pub entries: &'a [ThemeEntry],
     pub selected_index: usize,
 }
 
 pub fn render_theme_picker_modal(frame: &mut Frame, state: &ThemePickerState<'_>) {
-    let height = (state.presets.len() as u16).max(4) + 6;
+    let height = (state.entries.len() as u16).max(4) + 6;
     let area = centered_fixed_height_rect(60, height, frame.area());
 
     let inner = render_modal_frame(frame, area, "Theme");
@@ -44,14 +44,14 @@ pub fn render_theme_picker_modal(frame: &mut Frame, state: &ThemePickerState<'_>
         .split(chunks[0]);
 
     let items: Vec<ListItem<'_>> = state
-        .presets
+        .entries
         .iter()
         .enumerate()
-        .map(|(i, preset)| {
-            let label = if preset.is_light() {
-                format!("{} (light)", preset.display_name())
+        .map(|(i, entry)| {
+            let label = if entry.is_light {
+                format!("{} (light)", entry.display_name)
             } else {
-                preset.display_name().to_string()
+                entry.display_name.clone()
             };
             selector_list_item(&label, i == state.selected_index)
         })
@@ -59,8 +59,8 @@ pub fn render_theme_picker_modal(frame: &mut Frame, state: &ThemePickerState<'_>
 
     frame.render_widget(List::new(items), columns[0]);
 
-    if let Some(preset) = state.presets.get(state.selected_index) {
-        let palette = preset.palette();
+    if let Some(entry) = state.entries.get(state.selected_index) {
+        let palette = &entry.palette;
         let swatch = vec![
             Line::from(vec![
                 Span::styled("  Accent      ", Style::default().fg(Theme::text_muted())),
@@ -95,7 +95,7 @@ pub fn render_theme_picker_modal(frame: &mut Frame, state: &ThemePickerState<'_>
         frame.render_widget(Paragraph::new(swatch), columns[1]);
 
         let id = Line::from(Span::styled(
-            format!("  preset id: {}", preset.as_str()),
+            format!("  theme id: {}", entry.name),
             Style::default().fg(Theme::text_muted()),
         ));
         frame.render_widget(Paragraph::new(id), chunks[1]);


### PR DESCRIPTION
## Summary

Implements the approved config improvements (follow-up to the config-surface review):

- **Config problems are no longer silent**: agents.toml / hosts.toml / settings.toml / keybindings.json load problems show as a status-bar toast at startup. Unknown TOML keys are tolerated but *named* (`serde_ignored`) — stale keys from older versions don't strand upgraders on built-ins. Both TOML seeds carry `config_version = 1`.
- **keybindings.json diagnostics**: unknown actions, invalid chords, and chords bound to two actions in overlapping contexts (nondeterministic winner) are reported. Also fixes a real parser bug: bare `"f"` entered the F-key branch, silently dropping hand-written `ctrl+f` bindings.
- **`settings.toml`**: scrollback_lines (was hardcoded 1000), the 80/120-column layout breakpoints, and audit_retention_days, seeded fully commented-out.
- **`thurbox-cli config validate`** (strict parse of every file, exit 1 on problems — a dotfiles CI gate; found 11 stale keys in my own real config) and **`config show`** (effective config with source attribution, e.g. which of editor_command/$VISUAL/$EDITOR won).
- **Custom themes** (`themes.toml`): base preset + per-colour overrides, shown in the Ctrl+Y picker after the nine built-ins, persisted by name like a preset.
- **Live reload**: agents.toml and keybindings.json apply on edit (~1 s mtime poll) with a toast; F1-editor self-writes don't re-toast. hosts/settings/themes stay restart-only, documented.

Design note (per discussion): files stay split by audience/lifecycle — hand-edited registries, machine-written keybindings, one settings.toml for scalars, shareable themes.toml — documented in `docs/CONFIG.md`.

## Test plan

- 1002 tests pass (`cargo test --all`), including new coverage for warning collection, lenient unknown-key parsing, chord-parser regression, settings defaults/overrides, theme resolution (base + overrides, collisions, bad colours), validate/show, and reload (external edit applies; self-write stays quiet)
- clippy `-D warnings` clean; architecture rules pass; rumdl clean
- Smoke-tested `config validate`/`show` and a custom theme end-to-end against the real dev environment