### PR TITLE
feat(cli): orchestration primitives for headless session control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,10 @@ args = []                               # always passed; bake a model here if yo
 resume_args = ["--resume", "{id}"]      # emitted when resuming
 fork_args = ["--resume", "{id}", "--fork-session"]
 new_session_args = ["--session-id", "{id}"]  # emitted on a fresh spawn
+env = { FOO = "bar" }                   # optional: env for every session of this agent
+prompt_args = ["--append-system-prompt", "{prompt}"]
+                                        # optional: emitted when a system prompt is
+                                        # supplied (session create --system-prompt)
 
 [[agents]]
 name = "codex"
@@ -207,12 +211,17 @@ resume_latest = true
 ```
 
 Each `*_args` group is appended only when its driving value is
-present, with `{id}` substituted; `args` is always passed. No
-model is ever passed — each agent uses its own default config
-(put `["--model", "opus"]` in `args` if you want to pin one).
-Agents that omit `resume_args` simply start fresh on restart (the
-live tmux process is what carries state across TUI restarts). Add
-your own `[[agents]]` entry to support any CLI — no recompile.
+present, with `{id}`/`{prompt}` substituted; `args` is always
+passed. Emit order: session-selection group (fork > resume >
+new-session), `prompt_args`, `args`, then any per-spawn
+`--extra-arg` values (last, so they can override). `env` is the
+lowest env layer (per-spawn `--env`, then thurbox-internal
+`THURBOX_*` vars override it). No model is ever passed — each agent
+uses its own default config (put `["--model", "opus"]` in `args` if
+you want to pin one). Agents that omit `resume_args` simply start
+fresh on restart (the live tmux process is what carries state across
+TUI restarts). Add your own `[[agents]]` entry to support any CLI —
+no recompile.
 
 **Session id pinning vs. `resume_latest`.** thurbox generates the
 `agent_session_id` (a UUID) and only `claude` accepts it at creation
@@ -241,7 +250,11 @@ workspace, so `--last`/`--continue` finds no parent session (multi-repo
   `build_args(&SessionConfig)`). `App::provider_for(&config)`
   picks the provider for the session's agent.
 
-A session stores only its **agent name**; there are no
+A session stores only its **agent name** plus, for CLI-spawned
+sessions, an opaque per-spawn pass-through record (`--env` /
+`--extra-arg` / `--system-prompt`, in the `session_spawn_config`
+side table, `storage::SpawnConfigRecord`) that restart re-applies
+verbatim. Thurbox never interprets these values — there are no
 per-session model/permission/prompt/tool knobs.
 
 ### Multi-repo sessions (symlink workspace)
@@ -261,10 +274,13 @@ then sees each repo as a subdirectory — fully agent-neutral, no
 git context); the workspace is a spawn-time process-cwd detail,
 derived idempotently on every launch from the persisted members and
 never stored. `workspace::ensure_workspace` / `remove_workspace`
-(`src/workspace.rs`) build and tear it down; the member set is the
-single `App::session_member_dirs` list that also feeds the rendered
-repo names, and `App::resolve_process_cwd` picks workspace-vs-primary.
-Single-repo sessions are unchanged (`cwd` = the repo directly).
+(`src/workspace.rs`) build and tear it down, and
+`workspace::resolve_process_cwd` picks workspace-vs-primary from a
+labeled member list. The TUI feeds it the single
+`App::session_member_dirs` list that also feeds the rendered repo
+names; the headless paths (spawn with `--add-dir`, restart) feed it
+`session_ops::resolve_headless_process_cwd`. Single-repo sessions
+are unchanged (`cwd` = the repo directly).
 
 ## Remote SSH Sessions
 
@@ -342,20 +358,44 @@ thurbox-cli session create --name demo --repo-path /path \
 # Spawn on a remote host from hosts.toml (worktree + tmux live remotely):
 thurbox-cli session create --name demo --repo-path /srv/repo \
     --host devbox --worktree-branch feat/x
-# Spawn a worker under a lead session (parent must exist):
-thurbox-cli session create --name worker --repo-path /path \
-    --parent <lead-uuid>
-thurbox-cli session list | jq
+# Orchestration: spawn a fully-customized worker under a lead session,
+# wait for its sentinel, harvest the JSON result:
+thurbox-cli session create --name w1 --repo-path /path \
+    --parent <lead-uuid> \
+    --prompt 'do X; print ===RESULT=== {"status":"ok"}' \
+    --env WORKER=1 --extra-arg --permission-mode --extra-arg plan \
+    --add-dir ~/admin --label wave=1
+thurbox-cli session wait <uuid> --pattern '===RESULT===' --timeout 1800
+thurbox-cli session result <uuid> | jq .result
+thurbox-cli session list --label wave=1 | jq
 thurbox-cli session list --parent <lead-uuid> | jq  # direct children only
 ```
 
 Subcommands: `session` (create/list/get/delete/restore/restart/
-send/capture), `automation` (alias `auto`:
+send/capture/wait/result), `automation` (alias `auto`:
 create/list/show/edit/remove/run/runs/tick), `task` (alias `todo`:
 create/list/show/edit/remove/run), `editor`, `config`
 (validate/show — strict-parses every config file / prints the
 effective resolved config; see `docs/CONFIG.md`). Pass
 `--pretty` for indented JSON.
+
+**Orchestration primitives** (see `docs/FEATURES.md` → "Headless
+orchestration" for the full design): `session create` takes
+`--prompt` (one-shot, typed after a ~3 s boot delay; never re-sent
+on restart), `--system-prompt` (via the agent's `prompt_args`
+template; errors if undefined), repeatable `--env KEY=VALUE` /
+`--extra-arg` / `--add-dir` / `--label key=value`. Env/extra-args/
+system-prompt persist in the `session_spawn_config` table so both
+headless `session restart` and the TUI `Ctrl+R` reproduce them
+(`session_ops::restart::build_restart_invocation`); labels live in
+`session_labels` and surface in `list`/`get` JSON (`labels`,
+`alive`, `last_activity` from one batched tmux call; `alive: null`
+for remote sessions — `list` never SSHes). `session wait` polls the
+pane for a regex; `session result` extracts the last
+`===RESULT===`-marked JSON. Both use exit codes 3 (pending /
+window died) and 4 (timeout / malformed) on top of the standard
+0/1/2. `--prompt`/`--add-dir`/`wait`/`result` are local-only and
+error with `--host`.
 
 `session delete <uuid>` **soft-deletes** by default — only the DB
 row is marked deleted (the TUI tears down the tmux window/worktree

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -193,12 +193,22 @@ Each definition (`session::AgentDef`) carries:
 - `resume_latest` — when true, restart resumes the agent's most
   recent session in the launch directory via **id-less** flags
   (see below).
+- `env` — environment variables injected into every session of this
+  agent (lowest precedence: per-spawn `--env` and the
+  thurbox-internal `THURBOX_*` variables override them).
+- `prompt_args` — emitted only when a system prompt is supplied at
+  spawn time (`thurbox-cli session create --system-prompt …`), with
+  `{prompt}` substituted (e.g.
+  `["--append-system-prompt", "{prompt}"]` for claude). Agents
+  without this template reject `--system-prompt` with an error.
 
 `agent::GenericProvider` builds the launch arguments by appending
 each group **only when its driving value is present**, substituting
-`{id}` token-by-token. Selection precedence is fork > resume >
-new-session id; static `args` follow. A group with no value is
-simply omitted — no unresolved-placeholder heuristics.
+`{id}` token-by-token. Emit order: session-selection group (fork >
+resume > new-session id), then `prompt_args`, then static `args`,
+then any per-spawn `--extra-arg` values (last, so they can override
+baked-in flags). A group with no value is simply omitted — no
+unresolved-placeholder heuristics.
 
 Only `claude` accepts the thurbox-generated id at creation
 (`--session-id {id}`), so only it resumes/forks by that exact id.
@@ -427,6 +437,92 @@ UUIDs are collision-free without coordination, simple to generate,
 and usable as map keys. Sequential IDs would work too, but UUIDs
 prevent bugs where an old session ID accidentally refers to a new
 session after recycling.
+
+---
+
+## Headless orchestration (`thurbox-cli session`)
+
+`thurbox-cli` exposes the primitives a supervisor script needs to
+fan work out across worker sessions without the TUI: spawn fully
+customized, tag, wait, harvest a structured result, clean up.
+
+### Spawn-time customization
+
+`session create` accepts, beyond
+`--name/--repo-path/--agent/--worktree-branch/--base-branch/--host`:
+
+- `--prompt <text>` — initial prompt typed into the pane after a
+  ~3 s boot delay (the automation-spawn mechanism). **One-shot**: it
+  is not persisted, so a restart never re-sends it. Delivery is
+  fire-and-forget — `session wait` before sending follow-ups. If
+  scheduling fails the create still succeeds and reports a
+  `prompt_delivery_error` field.
+- `--system-prompt <text>` — rendered through the agent's
+  `prompt_args` template (errors when the agent defines none).
+  Persisted; re-emitted on restart.
+- `--env KEY=VALUE` (repeatable) — process env overrides, layered
+  agent `env` < `--env` < thurbox-internal. Persisted.
+- `--extra-arg <arg>` (repeatable, hyphen-safe) — appended after all
+  configured arg groups so it can override them (e.g.
+  `--extra-arg --permission-mode --extra-arg plan` for claude).
+  Persisted.
+- `--add-dir <path>` (repeatable) — the session launches in the
+  multi-repo **symlink workspace** gathering the repo plus each
+  added dir (same machinery as the TUI's multi-repo picker;
+  `session_ops::resolve_headless_process_cwd`).
+- `--label key=value` (repeatable) — free-form tags stored in the
+  `session_labels` table.
+
+Per-spawn env/extra-args/system-prompt persist in the
+`session_spawn_config` side table (one row per session, written at
+spawn) so **both** the headless `session restart` and the TUI's
+`Ctrl+R` reproduce the exact invocation
+(`session_ops::restart::build_restart_invocation`). Side tables —
+not `sessions` columns — because the TUI's whole-row session upsert
+would wipe new columns on every `save_state()`.
+
+`--prompt`, `--add-dir`, `wait`, and `result` are **local-only** in
+v1; combining them with `--host` errors instead of silently
+degrading.
+
+### Polling primitives
+
+- `session wait <uuid> [--pattern <regex>] [--timeout 600]
+  [--interval 2000] [--lines 2000]` — blocks until the captured pane
+  text matches the regex (without `--pattern`: until the window
+  exits). Capture uses `-J`, so wrapped lines are joined before
+  matching.
+- `session result <uuid> [--marker '===RESULT==='] [--lines 2000]`
+  — finds the **last** marker in the pane (reruns overwrite) and
+  parses the JSON document after it. A truncated document (clean
+  EOF) counts as *pending* — the agent is still printing — not
+  *malformed*.
+
+Exit codes (0/1/2 keep their existing meanings — success, CLI
+error, init error):
+
+| Code | `session wait` | `session result` |
+|------|----------------|------------------|
+| 0 | pattern matched (no `--pattern`: window exited) | marker found, JSON valid (emitted as `result`) |
+| 1 | usage/DB error (bad uuid/regex, remote session) | same |
+| 3 | window died before the pattern matched | pending — no marker yet, or JSON still streaming |
+| 4 | timeout expired | malformed JSON after the marker |
+
+Match unique sentinels, not screen layout: agent TUIs redraw and
+clear panes, and `--lines` bounds the scan window, so a result older
+than the scanned scrollback is invisible.
+
+### Liveness + labels in `list`/`get`
+
+Every session JSON now carries `labels` (object), `alive`, and
+`last_activity` (tmux `#{window_activity}`, epoch seconds). Liveness
+comes from **one** batched `tmux list-windows` call per invocation;
+remote (`ssh:*`) sessions report `alive: null` — `session list`
+never opens an SSH connection, so a down host can't hang a
+supervisor. `session list --label k=v` filters (repeatable = AND).
+
+Future work: `session label --set/--unset` mutation, quiet-time
+heuristics on `window_activity`, remote `wait`/`result`.
 
 ---
 

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -30,6 +30,15 @@ pub const BUILTIN_AGENTS_TOML: &str = r#"# Thurbox coding-agent definitions.
 #
 # Unknown keys are reported on startup (and fail `thurbox-cli config
 # validate`) but don't break the load — your agents stay in effect.
+#
+# Optional per-agent keys:
+#   env         — table of environment variables injected into every session
+#                 of this agent (per-spawn `--env` overrides them), e.g.
+#                 env = { FOO = "bar" }
+#   prompt_args — emitted when a system prompt is supplied at spawn time
+#                 (`thurbox-cli session create --system-prompt …`), with
+#                 {prompt} substituted, e.g. for claude:
+#                 prompt_args = ["--append-system-prompt", "{prompt}"]
 
 config_version = 1
 default = "claude"
@@ -328,5 +337,31 @@ mod tests {
         let reg = load_or_seed();
         assert_eq!(reg.default, "mine");
         assert_eq!(reg.get("mine").unwrap().command, "my-agent");
+    }
+
+    #[test]
+    fn load_or_seed_reads_agent_env_and_prompt_args() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = agents_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            concat!(
+                "default = \"mine\"\n",
+                "[[agents]]\n",
+                "name = \"mine\"\n",
+                "command = \"my-agent\"\n",
+                "prompt_args = [\"--system\", \"{prompt}\"]\n",
+                "env = { FOO = \"bar\" }\n",
+            ),
+        )
+        .unwrap();
+
+        let reg = load_or_seed();
+        let def = reg.get("mine").unwrap();
+        assert_eq!(def.env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(def.prompt_args, vec!["--system", "{prompt}"]);
     }
 }

--- a/src/agent/generic.rs
+++ b/src/agent/generic.rs
@@ -4,7 +4,7 @@
 //! `agents.toml` is launched through this single provider, which maps the
 //! session's resume/fork/session ids onto the definition's argument templates.
 
-use crate::session::{AgentDef, SessionConfig};
+use crate::session::{AgentDef, LaunchArgs, SessionConfig};
 
 use super::provider::AgentProvider;
 
@@ -31,11 +31,13 @@ impl AgentProvider for GenericProvider {
     }
 
     fn build_args(&self, config: &SessionConfig) -> Vec<String> {
-        self.def.build_args(
-            config.resume_session_id.as_deref(),
-            config.fork_session_id.as_deref(),
-            config.agent_session_id.as_deref(),
-        )
+        self.def.build_args(&LaunchArgs {
+            resume_id: config.resume_session_id.as_deref(),
+            fork_id: config.fork_session_id.as_deref(),
+            new_session_id: config.agent_session_id.as_deref(),
+            system_prompt: config.system_prompt.as_deref(),
+            extra_args: &config.extra_args,
+        })
     }
 }
 
@@ -70,5 +72,31 @@ mod tests {
         };
         let args = provider.build_args(&config);
         assert_eq!(args, vec!["--session-id", "new-id"]);
+    }
+
+    #[test]
+    fn provider_threads_system_prompt_and_extra_args() {
+        let mut def = builtin_registry().get("claude").unwrap().clone();
+        def.prompt_args = vec!["--append-system-prompt".into(), "{prompt}".into()];
+        let provider = GenericProvider::new(def);
+
+        let config = SessionConfig {
+            agent_session_id: Some("id-9".into()),
+            system_prompt: Some("be brief".into()),
+            extra_args: vec!["--permission-mode".into(), "plan".into()],
+            ..SessionConfig::default()
+        };
+        let args = provider.build_args(&config);
+        assert_eq!(
+            args,
+            vec![
+                "--session-id",
+                "id-9",
+                "--append-system-prompt",
+                "be brief",
+                "--permission-mode",
+                "plan"
+            ]
+        );
     }
 }

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -1079,6 +1079,37 @@ pub fn window_exists(session_name: &str) -> bool {
     list_window_names().contains(&want)
 }
 
+/// Window name → `#{window_activity}` (epoch seconds of last pane activity)
+/// for every window in the local thurbox tmux session, in one round-trip.
+/// Empty when the server is not running. Used by `thurbox-cli session
+/// list/get` to report liveness without a per-session tmux call.
+pub fn list_window_activity() -> std::collections::HashMap<String, u64> {
+    let Ok(out) = Command::new("tmux")
+        .args([
+            "-L",
+            TMUX_SOCKET,
+            "list-windows",
+            "-t",
+            TMUX_SESSION,
+            "-F",
+            "#{window_name}|#{window_activity}",
+        ])
+        .output()
+    else {
+        return std::collections::HashMap::new();
+    };
+    if !out.status.success() {
+        return std::collections::HashMap::new();
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (name, activity) = line.split_once('|')?;
+            Some((name.to_string(), activity.parse().ok()?))
+        })
+        .collect()
+}
+
 /// Schedule a one-shot prompt delivery into a session's window after
 /// `delay_secs`, via a detached `tmux run-shell` timer.
 ///

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -977,15 +977,27 @@ impl App {
         // or the (idempotently rebuilt) symlink workspace for a multi-repo one.
         let cwd = session_process_cwd(&session.info);
 
+        // CLI-spawned sessions may carry per-spawn customizations
+        // (`--env`/`--extra-arg`/`--system-prompt`); restarting from the TUI
+        // must not drop them. TUI-created sessions have no row.
+        let spawn_cfg = self
+            .db
+            .get_session_spawn_config(session.info.id)
+            .unwrap_or_default()
+            .unwrap_or_default();
+
         let mut config = SessionConfig {
             resume_session_id: None,
             agent_session_id: Some(agent_session_id.clone()),
             cwd,
             agent,
             fork_session_id: None,
+            extra_args: spawn_cfg.extra_args.clone(),
+            system_prompt: spawn_cfg.system_prompt.clone(),
             ..SessionConfig::default()
         };
         let def = self.agent_def_for(&config.agent);
+        crate::session_ops::merge_spawn_env(&mut config, &def, &spawn_cfg.env, &agent_session_id);
         config.resume_session_id =
             crate::session_ops::resume_trigger_for(&def, &agent_session_id, &config.env);
 
@@ -1933,6 +1945,14 @@ impl App {
         }
         if config.agent_session_id.is_none() {
             config.agent_session_id = Some(uuid::Uuid::new_v4().to_string());
+        }
+
+        // Agent-level env defaults from agents.toml; anything already set on
+        // the config (per-spawn values) wins over them.
+        if let Some(def) = self.agents.get(&config.agent) {
+            for (k, v) in &def.env {
+                config.env.entry(k.clone()).or_insert_with(|| v.clone());
+            }
         }
 
         // Inject statusline env vars so the metrics script knows which session this is.
@@ -4635,13 +4655,10 @@ fn session_member_dirs(
     members
 }
 
-/// The directory the agent process should launch in.
-///
-/// For a single-member session that's the member itself (`primary_cwd`). For a
-/// multi-member session it is a per-session **symlink workspace** (built
-/// idempotently from the members) so the agent sees every repo as a
-/// subdirectory — agent-neutral, needing no per-CLI flag. On any failure it
-/// falls back to `primary_cwd`.
+/// The directory the agent process should launch in: the multi-repo symlink
+/// workspace, or `primary_cwd` when single-member. Thin adapter over
+/// [`crate::workspace::resolve_process_cwd`] feeding it the canonical
+/// [`session_member_dirs`] member set (repo display names included).
 fn resolve_process_cwd(
     agent_session_id: Option<&str>,
     primary_cwd: Option<PathBuf>,
@@ -4649,30 +4666,7 @@ fn resolve_process_cwd(
     additional_dirs: &[PathBuf],
 ) -> Option<PathBuf> {
     let members = session_member_dirs(primary_cwd.as_deref(), worktrees, additional_dirs);
-    if members.len() < 2 {
-        return primary_cwd;
-    }
-    let Some(id) = agent_session_id else {
-        return primary_cwd;
-    };
-
-    let pairs: Vec<(String, PathBuf)> = members
-        .into_iter()
-        .map(|(name, dir)| {
-            let label = name
-                .or_else(|| dir.file_name().and_then(|s| s.to_str()).map(String::from))
-                .unwrap_or_else(|| "repo".to_string());
-            (label, dir)
-        })
-        .collect();
-
-    match crate::workspace::ensure_workspace(id, &pairs) {
-        Ok(ws) => Some(ws),
-        Err(e) => {
-            error!("Failed to build multi-repo workspace: {e}");
-            primary_cwd
-        }
-    }
+    crate::workspace::resolve_process_cwd(agent_session_id, primary_cwd, &members)
 }
 
 /// The launch cwd for an *existing* session, derived from its persisted

--- a/src/bin/thurbox-cli.rs
+++ b/src/bin/thurbox-cli.rs
@@ -39,9 +39,12 @@ fn main() {
         }
     };
 
-    if let Err(e) = thurbox::cli::run(cli, &db) {
-        let msg = serde_json::json!({ "error": e }).to_string();
-        eprintln!("{msg}");
-        std::process::exit(1);
+    match thurbox::cli::run(cli, &db) {
+        Ok(code) => std::process::exit(code),
+        Err(e) => {
+            let msg = serde_json::json!({ "error": e }).to_string();
+            eprintln!("{msg}");
+            std::process::exit(1);
+        }
     }
 }

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -14,10 +14,6 @@ use crate::storage::automations::NewAutomation;
 use crate::storage::Database;
 use crate::sync::current_time_millis;
 
-/// Seconds to wait after a headless spawn before delivering the automation's
-/// prompt, giving the agent CLI time to start.
-const BOOT_DELAY_SECS: u64 = 3;
-
 #[derive(Subcommand, Debug)]
 pub enum Action {
     /// Create an automation.
@@ -341,9 +337,7 @@ fn fire_headless(
                 worktree_branch: worktree_branch.clone(),
                 base_branch: base_branch.clone(),
                 agent: agent.clone(),
-                agent_session_id: None,
-                host: None,
-                parent_session_id: None,
+                ..SpawnRequest::default()
             };
             match crate::session_ops::spawn_session_headless(db, req) {
                 Ok(result) => {
@@ -351,7 +345,7 @@ fn fire_headless(
                     match crate::agent::tmux::send_prompt_after_delay(
                         &name,
                         &auto.prompt,
-                        BOOT_DELAY_SECS,
+                        crate::session_ops::AGENT_BOOT_DELAY_SECS,
                     ) {
                         Ok(()) => (
                             AutomationRunStatus::Success,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@
 //! `agent::tmux`, and prints the result. No TUI, no event loop.
 
 use clap::{Parser, Subcommand};
+use serde_json::Value;
 
 use crate::storage::Database;
 
@@ -15,6 +16,22 @@ pub mod config;
 pub mod editor;
 pub mod sessions;
 pub mod tasks;
+
+/// Result of a subcommand: the JSON document to print plus the process
+/// exit code. Most commands exit 0 on success; polling-oriented commands
+/// (`session wait`, `session result`) use distinct non-zero codes to let
+/// scripts branch without parsing JSON.
+#[derive(Debug)]
+pub struct Outcome {
+    pub value: Value,
+    pub code: i32,
+}
+
+impl From<Value> for Outcome {
+    fn from(value: Value) -> Self {
+        Self { value, code: 0 }
+    }
+}
 
 /// Thurbox CLI — manage sessions, scheduled commands, and more.
 #[derive(Parser, Debug)]
@@ -59,23 +76,25 @@ pub enum Command {
     },
 }
 
-/// Run a parsed CLI invocation against `db` and write JSON to stdout.
-pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
-    let value = match cli.command {
-        Command::Editor { action } => editor::run(action, db),
+/// Run a parsed CLI invocation against `db`, write JSON to stdout, and
+/// return the process exit code.
+pub fn run(cli: Cli, db: &Database) -> Result<i32, String> {
+    let outcome = match cli.command {
+        Command::Editor { action } => editor::run(action, db).map(Outcome::from),
         Command::Session { action } => sessions::run(action, db),
-        Command::Automation { action } => automations::run(action, db),
-        Command::Task { action } => tasks::run(action, db),
-        Command::Config { action } => config::run(action, db),
+        Command::Automation { action } => automations::run(action, db).map(Outcome::from),
+        Command::Task { action } => tasks::run(action, db).map(Outcome::from),
+        Command::Config { action } => config::run(action, db).map(Outcome::from),
     }?;
 
     let text = if cli.pretty {
-        serde_json::to_string_pretty(&value).unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
+        serde_json::to_string_pretty(&outcome.value)
+            .unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
     } else {
-        serde_json::to_string(&value).unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
+        serde_json::to_string(&outcome.value).unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
     };
     println!("{text}");
-    Ok(())
+    Ok(outcome.code)
 }
 
 #[cfg(test)]
@@ -90,7 +109,7 @@ mod tests {
         assert!(matches!(
             cli.command,
             Command::Session {
-                action: sessions::Action::List { parent: None }
+                action: sessions::Action::List { .. }
             }
         ));
     }
@@ -171,7 +190,7 @@ mod tests {
         ])
         .unwrap();
         let Command::Session {
-            action: sessions::Action::List { parent },
+            action: sessions::Action::List { parent, .. },
         } = cli.command
         else {
             panic!("expected Session::List");
@@ -180,6 +199,58 @@ mod tests {
             parent.as_deref(),
             Some("0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a")
         );
+    }
+
+    #[test]
+    fn parse_session_create_orchestration_flags() {
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "session",
+            "create",
+            "--name",
+            "w1",
+            "--repo-path",
+            "/tmp/repo",
+            "--prompt",
+            "do the thing",
+            "--system-prompt",
+            "be terse",
+            "--env",
+            "WORKER=1",
+            "--env",
+            "MODE=ci",
+            "--extra-arg",
+            "--permission-mode",
+            "--extra-arg",
+            "plan",
+            "--add-dir",
+            "/srv/admin",
+            "--label",
+            "wave=1",
+        ])
+        .unwrap();
+        let Command::Session {
+            action:
+                sessions::Action::Create {
+                    prompt,
+                    system_prompt,
+                    env,
+                    extra_args,
+                    add_dirs,
+                    labels,
+                    ..
+                },
+        } = cli.command
+        else {
+            panic!("expected Session::Create");
+        };
+        assert_eq!(prompt.as_deref(), Some("do the thing"));
+        assert_eq!(system_prompt.as_deref(), Some("be terse"));
+        assert_eq!(env, vec!["WORKER=1", "MODE=ci"]);
+        // Hyphen-leading values reach --extra-arg verbatim.
+        assert_eq!(extra_args, vec!["--permission-mode", "plan"]);
+        assert_eq!(add_dirs, vec![std::path::PathBuf::from("/srv/admin")]);
+        assert_eq!(labels, vec!["wave=1"]);
     }
 
     #[test]

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -5,10 +5,14 @@ use std::path::PathBuf;
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use super::Outcome;
 use crate::session::SessionId;
 use crate::storage::Database;
 use crate::sync::SharedSession;
 
+// `Create` carries a dozen flag fields; a parsed Action is short-lived and
+// never stored in bulk, so the size spread between variants is irrelevant.
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug)]
 pub enum Action {
     /// List all active sessions.
@@ -16,6 +20,10 @@ pub enum Action {
         /// Only list children of this parent session UUID.
         #[arg(long)]
         parent: Option<String>,
+        /// Only sessions carrying this label, as key=value. Repeatable
+        /// (all given labels must match).
+        #[arg(long = "label", value_name = "KEY=VALUE")]
+        labels: Vec<String>,
     },
     /// Get a session by UUID.
     Get {
@@ -48,6 +56,34 @@ pub enum Action {
         /// Must reference an existing active session.
         #[arg(long)]
         parent: Option<String>,
+        /// Initial prompt typed into the agent's pane after a short boot
+        /// delay. One-shot (not re-sent on restart). Local sessions only.
+        #[arg(long)]
+        prompt: Option<String>,
+        /// System prompt passed via the agent's `prompt_args` template from
+        /// `agents.toml` (errors if the agent defines none). Persisted and
+        /// re-emitted on restart.
+        #[arg(long)]
+        system_prompt: Option<String>,
+        /// Environment variable for the agent process, as KEY=VALUE.
+        /// Repeatable. Overrides the agent's `env` defaults; persisted and
+        /// reproduced on restart.
+        #[arg(long = "env", value_name = "KEY=VALUE")]
+        env: Vec<String>,
+        /// Extra CLI argument appended to the agent invocation (after all
+        /// configured args, so it can override them). Repeatable; persisted
+        /// and reproduced on restart.
+        #[arg(long = "extra-arg", value_name = "ARG", allow_hyphen_values = true)]
+        extra_args: Vec<String>,
+        /// Additional member directory: the session launches in a symlink
+        /// workspace gathering the repo plus each added dir. Repeatable.
+        /// Local sessions only.
+        #[arg(long = "add-dir", value_name = "PATH")]
+        add_dirs: Vec<PathBuf>,
+        /// Free-form label attached to the session, as key=value. Repeatable;
+        /// shown in `session list`/`get` and filterable via `list --label`.
+        #[arg(long = "label", value_name = "KEY=VALUE")]
+        labels: Vec<String>,
     },
     /// Soft-delete a session.
     ///
@@ -89,26 +125,287 @@ pub enum Action {
         #[arg(long, default_value_t = 200)]
         lines: u32,
     },
+    /// Block until the session's pane output matches a pattern, the window
+    /// exits, or the timeout expires. Local sessions only.
+    ///
+    /// Exit codes: 0 = pattern matched (or, without --pattern, window
+    /// exited); 3 = window died before the pattern matched; 4 = timeout.
+    Wait {
+        /// Session UUID.
+        uuid: String,
+        /// Regex matched against the captured pane text. When omitted, waits
+        /// for the window to exit instead.
+        #[arg(long)]
+        pattern: Option<String>,
+        /// Give up after this many seconds.
+        #[arg(long, default_value_t = 600)]
+        timeout: u64,
+        /// Poll cadence in milliseconds.
+        #[arg(long, default_value_t = 2000)]
+        interval: u64,
+        /// Scrollback lines scanned per poll (max 10000).
+        #[arg(long, default_value_t = 2000)]
+        lines: u32,
+    },
+    /// Extract the sentinel-terminated JSON result from a session's pane.
+    ///
+    /// Scans the captured pane text for the last occurrence of the marker
+    /// and parses the JSON document that follows it. Local sessions only.
+    ///
+    /// Exit codes: 0 = found and valid (emitted as `result`); 3 = pending
+    /// (no marker yet, or the JSON is still streaming); 4 = malformed JSON
+    /// after the marker.
+    Result {
+        /// Session UUID.
+        uuid: String,
+        /// Sentinel marker preceding the JSON document.
+        #[arg(long, default_value = "===RESULT===")]
+        marker: String,
+        /// Scrollback lines scanned (max 10000).
+        #[arg(long, default_value_t = 2000)]
+        lines: u32,
+    },
 }
 
-pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+/// Exit code for "keep polling" outcomes (`wait`: window died before match;
+/// `result`: sentinel not there yet).
+const EXIT_PENDING: i32 = 3;
+/// Exit code for terminal failures (`wait`: timeout; `result`: malformed JSON).
+const EXIT_FAILED: i32 = 4;
+/// Floor for `session wait --interval` so a zero value can't busy-loop tmux.
+const MIN_WAIT_INTERVAL_MS: u64 = 50;
+
+pub fn run(action: Action, db: &Database) -> Result<Outcome, String> {
     match action {
-        Action::List { parent } => {
+        Action::Wait {
+            uuid,
+            pattern,
+            timeout,
+            interval,
+            lines,
+        } => run_wait(db, &uuid, pattern.as_deref(), timeout, interval, lines),
+        Action::Result {
+            uuid,
+            marker,
+            lines,
+        } => run_result(db, &uuid, &marker, lines),
+        other => run_value(other, db).map(Outcome::from),
+    }
+}
+
+/// Extract and validate the sentinel JSON from the session's pane (see
+/// [`Action::Result`] for the exit-code contract).
+fn run_result(db: &Database, uuid: &str, marker: &str, lines: u32) -> Result<Outcome, String> {
+    if marker.is_empty() {
+        return Err("--marker must not be empty".into());
+    }
+    let session = resolve(db, uuid)?;
+    ensure_local(&session, "result")?;
+    let text = crate::agent::tmux::capture_pane_text(&session.name, lines)
+        .map_err(|e| format!("capture_pane_text: {e}"))?;
+
+    let sid = session.id.to_string();
+    Ok(match extract_result(&text, marker) {
+        ResultPayload::Found(result) => Outcome {
+            value: json!({ "status": "ok", "session_id": sid, "result": result }),
+            code: 0,
+        },
+        ResultPayload::Pending => Outcome {
+            value: json!({ "status": "pending", "session_id": sid }),
+            code: EXIT_PENDING,
+        },
+        ResultPayload::Malformed(error) => Outcome {
+            value: json!({ "status": "malformed", "session_id": sid, "error": error }),
+            code: EXIT_FAILED,
+        },
+    })
+}
+
+/// Outcome of scanning pane text for a sentinel-terminated JSON document.
+#[derive(Debug, PartialEq)]
+enum ResultPayload {
+    Found(Value),
+    /// Marker absent, or the JSON after it is truncated (still streaming).
+    Pending,
+    /// The text after the marker is not (a prefix of) valid JSON.
+    Malformed(String),
+}
+
+/// Find the **last** marker (reruns overwrite earlier results) and parse the
+/// first JSON document after it. A clean-EOF parse error means the agent is
+/// still printing — that's `Pending`, not `Malformed`.
+fn extract_result(text: &str, marker: &str) -> ResultPayload {
+    let Some(pos) = text.rfind(marker) else {
+        return ResultPayload::Pending;
+    };
+    let rest = &text[pos + marker.len()..];
+    if rest.trim().is_empty() {
+        return ResultPayload::Pending;
+    }
+    let mut stream = serde_json::Deserializer::from_str(rest).into_iter::<Value>();
+    match stream.next() {
+        Some(Ok(value)) => ResultPayload::Found(value),
+        Some(Err(e)) if e.is_eof() => ResultPayload::Pending,
+        Some(Err(e)) => ResultPayload::Malformed(e.to_string()),
+        None => ResultPayload::Pending,
+    }
+}
+
+/// Poll the session's pane until the wait condition resolves (see
+/// [`Action::Wait`] for the exit-code contract).
+fn run_wait(
+    db: &Database,
+    uuid: &str,
+    pattern: Option<&str>,
+    timeout_secs: u64,
+    interval_ms: u64,
+    lines: u32,
+) -> Result<Outcome, String> {
+    let session = resolve(db, uuid)?;
+    ensure_local(&session, "wait")?;
+    let regex = pattern
+        .map(regex::Regex::new)
+        .transpose()
+        .map_err(|e| format!("Invalid --pattern regex: {e}"))?;
+
+    let start = std::time::Instant::now();
+    let deadline = start + std::time::Duration::from_secs(timeout_secs);
+    loop {
+        let alive = crate::agent::tmux::window_exists(&session.name);
+        let text = if alive && regex.is_some() {
+            Some(
+                crate::agent::tmux::capture_pane_text(&session.name, lines)
+                    .map_err(|e| format!("capture_pane_text: {e}"))?,
+            )
+        } else {
+            None
+        };
+
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        match evaluate_wait_poll(alive, text.as_deref(), regex.as_ref()) {
+            WaitPoll::Matched(matched) => {
+                return Ok(Outcome {
+                    value: json!({
+                        "status": "matched",
+                        "match": matched,
+                        "session_id": session.id.to_string(),
+                        "elapsed_ms": elapsed_ms,
+                    }),
+                    code: 0,
+                });
+            }
+            WaitPoll::WindowExited => {
+                return Ok(Outcome {
+                    value: json!({
+                        "status": "exited",
+                        "session_id": session.id.to_string(),
+                        "elapsed_ms": elapsed_ms,
+                    }),
+                    code: 0,
+                });
+            }
+            WaitPoll::WindowDied => {
+                return Ok(Outcome {
+                    value: json!({
+                        "status": "window-died",
+                        "session_id": session.id.to_string(),
+                        "elapsed_ms": elapsed_ms,
+                    }),
+                    code: EXIT_PENDING,
+                });
+            }
+            WaitPoll::KeepWaiting => {}
+        }
+
+        let now = std::time::Instant::now();
+        if now >= deadline {
+            return Ok(Outcome {
+                value: json!({
+                    "status": "timeout",
+                    "session_id": session.id.to_string(),
+                    "elapsed_ms": start.elapsed().as_millis() as u64,
+                }),
+                code: EXIT_FAILED,
+            });
+        }
+        let sleep = std::time::Duration::from_millis(interval_ms.max(MIN_WAIT_INTERVAL_MS))
+            .min(deadline - now);
+        std::thread::sleep(sleep);
+    }
+}
+
+/// One poll-cycle decision for `session wait`, pure for unit testing.
+#[derive(Debug, PartialEq)]
+enum WaitPoll {
+    /// Pattern found in the pane text (the matched fragment).
+    Matched(String),
+    /// No pattern was requested and the window is gone — success.
+    WindowExited,
+    /// A pattern was requested but the window died before it matched.
+    WindowDied,
+    KeepWaiting,
+}
+
+fn evaluate_wait_poll(alive: bool, text: Option<&str>, regex: Option<&regex::Regex>) -> WaitPoll {
+    match (alive, regex) {
+        (false, None) => WaitPoll::WindowExited,
+        (false, Some(_)) => WaitPoll::WindowDied,
+        (true, None) => WaitPoll::KeepWaiting,
+        (true, Some(re)) => match text.and_then(|t| re.find(t)) {
+            Some(m) => WaitPoll::Matched(m.as_str().to_string()),
+            None => WaitPoll::KeepWaiting,
+        },
+    }
+}
+
+/// Reject remote sessions for pane-polling commands: they are local-tmux
+/// mechanisms in v1, and probing a possibly-down SSH host could hang.
+fn ensure_local(session: &SharedSession, command: &str) -> Result<(), String> {
+    if session.backend_type == crate::session::LOCAL_TMUX_BACKEND_TYPE {
+        Ok(())
+    } else {
+        Err(format!(
+            "session {command} is local-only; session '{}' runs on backend '{}'",
+            session.name, session.backend_type
+        ))
+    }
+}
+
+fn run_value(action: Action, db: &Database) -> Result<Value, String> {
+    match action {
+        Action::List { parent, labels } => {
             let parent_id = parent.as_deref().map(parse_session_id).transpose()?;
+            let filters = parse_kv_pairs(&labels, "--label")?;
             let sessions = db
                 .list_active_sessions()
                 .map_err(|e| format!("list_active_sessions: {e}"))?;
+            let all_labels = db
+                .labels_for_all_sessions()
+                .map_err(|e| format!("labels_for_all_sessions: {e}"))?;
+            let activity = crate::agent::tmux::list_window_activity();
+
+            let none: Vec<(String, String)> = Vec::new();
             Ok(Value::Array(
                 sessions
                     .iter()
                     .filter(|s| parent_id.is_none() || s.parent_session_id == parent_id)
-                    .map(shared_session_to_json)
+                    .filter_map(|s| {
+                        let labels = all_labels.get(&s.id.to_string()).unwrap_or(&none);
+                        filters
+                            .iter()
+                            .all(|f| labels.contains(f))
+                            .then(|| decorate_session_json(s, labels, &activity))
+                    })
                     .collect(),
             ))
         }
         Action::Get { uuid } => {
             let session = resolve(db, &uuid)?;
-            Ok(shared_session_to_json(&session))
+            let labels = db
+                .get_session_labels(session.id)
+                .map_err(|e| format!("get_session_labels: {e}"))?;
+            let activity = crate::agent::tmux::list_window_activity();
+            Ok(decorate_session_json(&session, &labels, &activity))
         }
         Action::Create {
             name,
@@ -118,8 +415,16 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             base_branch,
             host,
             parent,
+            prompt,
+            system_prompt,
+            env,
+            extra_args,
+            add_dirs,
+            labels,
         } => {
             let parent_session_id = parent.as_deref().map(parse_session_id).transpose()?;
+            let env = parse_kv_pairs(&env, "--env")?;
+            let labels = parse_kv_pairs(&labels, "--label")?;
             let req = crate::session_ops::SpawnRequest {
                 name,
                 repo_path,
@@ -129,16 +434,27 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 agent_session_id: None,
                 host,
                 parent_session_id,
+                prompt,
+                system_prompt,
+                env,
+                extra_args,
+                additional_dirs: add_dirs,
+                labels,
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
-            Ok(json!({
+            let mut out = json!({
                 "id": res.session_id.to_string(),
                 "name": res.name,
                 "agent": res.agent,
                 "agent_session_id": res.agent_session_id,
                 "cwd": res.cwd.display().to_string(),
                 "parent_session_id": res.parent_session_id.map(|id| id.to_string()),
-            }))
+                "labels": labels_to_json(&res.labels),
+            });
+            if let Some(err) = res.prompt_delivery_error {
+                out["prompt_delivery_error"] = Value::String(err);
+            }
+            Ok(out)
         }
         Action::Delete { uuid, force } => {
             let session = resolve(db, &uuid)?;
@@ -192,6 +508,10 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 "session_name": session.name,
             }))
         }
+        // Routed to dedicated handlers in `run` (they need non-zero exit codes).
+        Action::Wait { .. } | Action::Result { .. } => {
+            unreachable!("Wait/Result are dispatched in run()")
+        }
         Action::Capture { uuid, lines } => {
             let session = resolve(db, &uuid)?;
             let output = crate::agent::tmux::capture_pane_text(&session.name, lines)
@@ -206,6 +526,37 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
     }
 }
 
+/// Parse repeatable `KEY=VALUE` flag values, splitting on the first `=`.
+///
+/// Values may contain further `=` signs; newlines are rejected because the
+/// remote tmux control-mode transport is line-oriented.
+fn parse_kv_pairs(raw: &[String], flag: &str) -> Result<Vec<(String, String)>, String> {
+    raw.iter()
+        .map(|s| {
+            let (key, value) = s
+                .split_once('=')
+                .ok_or_else(|| format!("{flag} expects KEY=VALUE, got '{s}'"))?;
+            if key.is_empty() {
+                return Err(format!("{flag} expects a non-empty key, got '{s}'"));
+            }
+            if s.contains('\n') {
+                return Err(format!("{flag} values must not contain newlines"));
+            }
+            Ok((key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+/// Render `(key, value)` label pairs as a JSON object.
+fn labels_to_json(labels: &[(String, String)]) -> Value {
+    Value::Object(
+        labels
+            .iter()
+            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+            .collect(),
+    )
+}
+
 fn parse_session_id(uuid: &str) -> Result<SessionId, String> {
     uuid.parse()
         .map_err(|_| format!("Invalid session UUID: {uuid}"))
@@ -216,6 +567,30 @@ fn resolve(db: &Database, uuid: &str) -> Result<SharedSession, String> {
     db.get_session_by_id(id)
         .map_err(|e| format!("get_session_by_id: {e}"))?
         .ok_or_else(|| format!("Session not found: {uuid}"))
+}
+
+/// [`shared_session_to_json`] plus the orchestration fields: `labels`,
+/// `alive` (window present; `null` for remote sessions — `list` never opens
+/// an SSH connection), and `last_activity` (epoch seconds, or `null`).
+fn decorate_session_json(
+    s: &SharedSession,
+    labels: &[(String, String)],
+    activity: &std::collections::HashMap<String, u64>,
+) -> Value {
+    let mut v = shared_session_to_json(s);
+    v["labels"] = labels_to_json(labels);
+    let (alive, last_activity) = if s.backend_type == crate::session::LOCAL_TMUX_BACKEND_TYPE {
+        let window = crate::agent::tmux::agent_window_name(&s.name);
+        match activity.get(&window) {
+            Some(ts) => (Value::Bool(true), json!(ts)),
+            None => (Value::Bool(false), Value::Null),
+        }
+    } else {
+        (Value::Null, Value::Null)
+    };
+    v["alive"] = alive;
+    v["last_activity"] = last_activity;
+    v
 }
 
 fn shared_session_to_json(s: &SharedSession) -> Value {
@@ -246,7 +621,14 @@ mod tests {
     #[test]
     fn list_empty_returns_array() {
         let db = db();
-        let v = run(Action::List { parent: None }, &db).unwrap();
+        let v = run_value(
+            Action::List {
+                parent: None,
+                labels: vec![],
+            },
+            &db,
+        )
+        .unwrap();
         assert!(v.is_array(), "got {v}");
         assert_eq!(v.as_array().unwrap().len(), 0);
     }
@@ -272,7 +654,14 @@ mod tests {
         };
         db.upsert_session(&shared).unwrap();
 
-        let v = run(Action::List { parent: None }, &db).unwrap();
+        let v = run_value(
+            Action::List {
+                parent: None,
+                labels: vec![],
+            },
+            &db,
+        )
+        .unwrap();
         let arr = v.as_array().unwrap();
         assert_eq!(arr.len(), 1);
         let s = &arr[0];
@@ -282,8 +671,85 @@ mod tests {
         assert_eq!(s["backend_type"].as_str(), Some("local-tmux"));
         assert_eq!(s["agent_session_id"].as_str(), Some("agent-1"));
         assert_eq!(s["cwd"].as_str(), Some("/tmp/repo"));
-        assert!(s["parent_session_id"].is_null());
         assert!(s["worktrees"].is_array());
+        // Orchestration decoration: labels object; no tmux server running in
+        // tests, so the local window is reported dead with no activity.
+        assert!(s["labels"].is_object());
+        assert_eq!(s["alive"], false);
+        assert!(s["last_activity"].is_null());
+    }
+
+    #[test]
+    fn list_label_filter_is_and_and_remote_alive_is_null() {
+        let db = db();
+        let mk = |name: &str, backend_type: &str| SharedSession {
+            id: SessionId::default(),
+            name: name.into(),
+            agent: "dev".into(),
+            backend_id: String::new(),
+            backend_type: backend_type.into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        let worker = mk("worker", "local-tmux");
+        let remote = mk("remote", "ssh:devbox");
+        db.upsert_session(&worker).unwrap();
+        db.upsert_session(&remote).unwrap();
+        db.set_session_labels(
+            worker.id,
+            &[("wave".into(), "1".into()), ("task".into(), "demo".into())],
+        )
+        .unwrap();
+        db.set_session_labels(remote.id, &[("wave".into(), "1".into())])
+            .unwrap();
+
+        // Single label matches both; two labels (AND) narrow to the worker.
+        let both = run_value(
+            Action::List {
+                parent: None,
+                labels: vec!["wave=1".into()],
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(both.as_array().unwrap().len(), 2);
+
+        let narrowed = run_value(
+            Action::List {
+                parent: None,
+                labels: vec!["wave=1".into(), "task=demo".into()],
+            },
+            &db,
+        )
+        .unwrap();
+        let arr = narrowed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"], "worker");
+        assert_eq!(arr[0]["labels"]["wave"], "1");
+
+        // Remote sessions never get a liveness probe.
+        let all = run_value(
+            Action::List {
+                parent: None,
+                labels: vec![],
+            },
+            &db,
+        )
+        .unwrap();
+        let remote_json = all
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["name"] == "remote")
+            .unwrap();
+        assert!(remote_json["alive"].is_null());
+        assert!(remote_json["last_activity"].is_null());
     }
 
     #[test]
@@ -312,8 +778,14 @@ mod tests {
         child.parent_session_id = Some(parent_id);
         db.upsert_session(&child).unwrap();
 
-        // Unfiltered list carries the field on both rows.
-        let v = run(Action::List { parent: None }, &db).unwrap();
+        let v = run_value(
+            Action::List {
+                parent: None,
+                labels: vec![],
+            },
+            &db,
+        )
+        .unwrap();
         let arr = v.as_array().unwrap();
         assert_eq!(arr.len(), 2);
         let worker = arr.iter().find(|s| s["name"] == "worker").unwrap();
@@ -323,21 +795,25 @@ mod tests {
         );
 
         // --parent filters to direct children only.
-        let v = run(
+        let v = run_value(
             Action::List {
                 parent: Some(parent_id.to_string()),
+                labels: vec![],
             },
             &db,
         )
         .unwrap();
         let arr = v.as_array().unwrap();
         assert_eq!(arr.len(), 1);
-        assert_eq!(arr[0]["name"].as_str(), Some("worker"));
+        assert_eq!(arr[0]["name"], "worker");
+    }
 
-        // Malformed --parent uuid errors.
-        let err = run(
-            Action::List {
-                parent: Some("not-a-uuid".into()),
+    #[test]
+    fn get_unknown_uuid_errors() {
+        let db = db();
+        let err = run_value(
+            Action::Get {
+                uuid: "not-a-uuid".into(),
             },
             &db,
         )
@@ -346,16 +822,117 @@ mod tests {
     }
 
     #[test]
-    fn get_unknown_uuid_errors() {
+    fn wait_poll_decisions() {
+        let re = regex::Regex::new("===RESULT===").unwrap();
+        // Window gone: success without a pattern, pending-failure with one.
+        assert_eq!(
+            evaluate_wait_poll(false, None, None),
+            WaitPoll::WindowExited
+        );
+        assert_eq!(
+            evaluate_wait_poll(false, None, Some(&re)),
+            WaitPoll::WindowDied
+        );
+        // Alive without a pattern: keep waiting for exit.
+        assert_eq!(evaluate_wait_poll(true, None, None), WaitPoll::KeepWaiting);
+        // Alive with a pattern: match decides.
+        assert_eq!(
+            evaluate_wait_poll(true, Some("...===RESULT=== {}"), Some(&re)),
+            WaitPoll::Matched("===RESULT===".into())
+        );
+        assert_eq!(
+            evaluate_wait_poll(true, Some("still working"), Some(&re)),
+            WaitPoll::KeepWaiting
+        );
+    }
+
+    #[test]
+    fn wait_rejects_remote_sessions_and_bad_regex() {
         let db = db();
-        let err = run(
-            Action::Get {
-                uuid: "not-a-uuid".into(),
-            },
-            &db,
-        )
-        .unwrap_err();
-        assert!(err.contains("Invalid session UUID"), "got {err}");
+        let id = SessionId::default();
+        let shared = SharedSession {
+            id,
+            name: "remote".into(),
+            agent: "dev".into(),
+            backend_id: "%1".into(),
+            backend_type: "ssh:devbox".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        db.upsert_session(&shared).unwrap();
+
+        let err = run_wait(&db, &id.to_string(), None, 1, 100, 200).unwrap_err();
+        assert!(err.contains("local-only"), "got {err}");
+    }
+
+    #[test]
+    fn extract_result_finds_valid_json() {
+        let text = "agent chatter\n===RESULT=== {\"status\":\"ok\",\"pr_url\":\"x\"}\n";
+        let ResultPayload::Found(v) = extract_result(text, "===RESULT===") else {
+            panic!("expected Found");
+        };
+        assert_eq!(v["status"], "ok");
+    }
+
+    #[test]
+    fn extract_result_last_marker_wins() {
+        let text = "===RESULT=== {\"run\":1}\nretrying…\n===RESULT=== {\"run\":2}";
+        let ResultPayload::Found(v) = extract_result(text, "===RESULT===") else {
+            panic!("expected Found");
+        };
+        assert_eq!(v["run"], 2);
+    }
+
+    #[test]
+    fn extract_result_pending_when_no_marker_or_truncated() {
+        // No marker yet.
+        assert_eq!(
+            extract_result("still working…", "===RESULT==="),
+            ResultPayload::Pending
+        );
+        // Marker present but nothing after it yet.
+        assert_eq!(
+            extract_result("===RESULT===  \n", "===RESULT==="),
+            ResultPayload::Pending
+        );
+        // JSON truncated mid-stream (clean EOF) — agent is still printing.
+        assert_eq!(
+            extract_result("===RESULT=== {\"status\":\"ok\",", "===RESULT==="),
+            ResultPayload::Pending
+        );
+    }
+
+    #[test]
+    fn extract_result_malformed_on_invalid_json() {
+        let got = extract_result("===RESULT=== not-json-at-all", "===RESULT===");
+        assert!(
+            matches!(got, ResultPayload::Malformed(_)),
+            "expected Malformed, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn parse_kv_pairs_splits_on_first_equals() {
+        let pairs = parse_kv_pairs(&["A=1".into(), "B=x=y".into()], "--env").unwrap();
+        assert_eq!(
+            pairs,
+            vec![("A".into(), "1".into()), ("B".into(), "x=y".into())]
+        );
+        assert!(parse_kv_pairs(&[], "--env").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_kv_pairs_rejects_bad_input() {
+        for bad in ["no-equals", "=novalue-key", "A=line\nbreak"] {
+            let err = parse_kv_pairs(&[bad.into()], "--label").unwrap_err();
+            assert!(err.contains("--label"), "got {err}");
+        }
     }
 
     #[test]
@@ -378,7 +955,7 @@ mod tests {
             tombstone_at: None,
         };
         db.upsert_session(&shared).unwrap();
-        let err = run(
+        let err = run_value(
             Action::Send {
                 uuid: id.to_string(),
                 text: String::new(),
@@ -424,7 +1001,7 @@ mod tests {
             })
             .unwrap();
 
-        let v = run(
+        let v = run_value(
             Action::Delete {
                 uuid: id.to_string(),
                 force: false,
@@ -439,7 +1016,7 @@ mod tests {
         // Row is soft-deleted but recoverable; the automation is untouched.
         assert!(db.get_session_by_id(id).unwrap().is_none());
         assert!(db.get_automation(auto).unwrap().unwrap().enabled);
-        let restored = run(
+        let restored = run_value(
             Action::Restore {
                 uuid: id.to_string(),
             },

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -12,10 +12,6 @@ use crate::session_ops::SpawnRequest;
 use crate::storage::tasks::NewTask;
 use crate::storage::Database;
 
-/// Seconds to wait after a headless spawn before delivering the task's title,
-/// giving the agent CLI time to start.
-const BOOT_DELAY_SECS: u64 = 3;
-
 #[derive(Subcommand, Debug)]
 pub enum Action {
     /// Create a task. With no `--session`/`--repo` it is a plain local todo.
@@ -190,13 +186,15 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
                 worktree_branch: worktree_branch.clone(),
                 base_branch: base_branch.clone(),
                 agent: agent.clone(),
-                agent_session_id: None,
-                host: None,
-                parent_session_id: None,
+                ..SpawnRequest::default()
             };
             crate::session_ops::spawn_session_headless(db, req)?;
-            crate::agent::tmux::send_prompt_after_delay(&name, &prompt, BOOT_DELAY_SECS)
-                .map_err(|e| format!("spawned {name} but prompt delivery failed: {e}"))?;
+            crate::agent::tmux::send_prompt_after_delay(
+                &name,
+                &prompt,
+                crate::session_ops::AGENT_BOOT_DELAY_SECS,
+            )
+            .map_err(|e| format!("spawned {name} but prompt delivery failed: {e}"))?;
             mark_in_progress(db, task)?;
             Ok(json!({ "spawned": name, "id": task.id }))
         }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -866,6 +866,9 @@ mod tests {
         git(&["init", "-q"]);
         git(&["config", "user.email", "t@example.com"]);
         git(&["config", "user.name", "t"]);
+        // Don't inherit host-level commit signing: the signing agent may be
+        // unavailable in test environments, failing every commit.
+        git(&["config", "commit.gpgsign", "false"]);
         std::fs::write(repo.join("file.txt"), "hi").unwrap();
         git(&["add", "."]);
         git(&["commit", "-qm", "init"]);

--- a/src/session/agent_def.rs
+++ b/src/session/agent_def.rs
@@ -11,18 +11,24 @@
 //! beyond serde/std) to satisfy the `session/` architecture rule. The TOML
 //! loading and the `AgentProvider` bridge live in `crate::agent`.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 /// Placeholder substituted with a session id in resume/fork/new-session groups.
 const ID_PLACEHOLDER: &str = "{id}";
 
+/// Placeholder substituted with the system prompt in `prompt_args`.
+const PROMPT_PLACEHOLDER: &str = "{prompt}";
+
 /// One coding-agent CLI definition.
 ///
 /// Each `*_args` group is appended to the final argument list **only** when its
-/// driving value is present (a model is selected, the session is being resumed,
-/// etc.), with `{model}` / `{id}` substituted token-by-token. This avoids any
-/// "unresolved placeholder" heuristics: a group with no value is simply omitted.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// driving value is present (the session is being resumed, a system prompt was
+/// supplied, etc.), with `{id}` / `{prompt}` substituted token-by-token. This
+/// avoids any "unresolved placeholder" heuristics: a group with no value is
+/// simply omitted.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentDef {
     /// Display + lookup name (e.g. `"claude"`). Unique within a registry.
     pub name: String,
@@ -49,32 +55,63 @@ pub struct AgentDef {
     /// (claude) leave this `false` and resume by a thurbox-known id instead.
     #[serde(default)]
     pub resume_latest: bool,
+    /// Environment variables injected into every session of this agent.
+    /// Lowest precedence: per-spawn `--env` and thurbox-internal variables
+    /// (`THURBOX_SESSION_ID`, …) override these on key collision.
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    /// Emitted when a system prompt is supplied for the launch; `{prompt}`
+    /// is substituted (e.g. `["--append-system-prompt", "{prompt}"]`).
+    /// Agents without this template reject `--system-prompt` at spawn time.
+    #[serde(default)]
+    pub prompt_args: Vec<String>,
+}
+
+/// Per-launch inputs to [`AgentDef::build_args`].
+///
+/// Bundles the session-selection ids with the per-spawn customizations so
+/// new launch knobs don't ripple through every call site.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LaunchArgs<'a> {
+    /// Resume an existing session by thurbox-known id.
+    pub resume_id: Option<&'a str>,
+    /// Fork from a parent conversation by id (wins over `resume_id`).
+    pub fork_id: Option<&'a str>,
+    /// Pin a fresh session id on first spawn.
+    pub new_session_id: Option<&'a str>,
+    /// System prompt substituted into the agent's `prompt_args` template.
+    pub system_prompt: Option<&'a str>,
+    /// Per-spawn arguments appended after every templated group, so they
+    /// can override anything baked into the definition.
+    pub extra_args: &'a [String],
 }
 
 impl AgentDef {
     /// Build the CLI argument list for one launch.
     ///
     /// Session-selection precedence mirrors the historical Claude behaviour:
-    /// fork wins over resume, which wins over a fresh `new_session` id. After
-    /// the selection group come the static `args`. No model is ever passed —
-    /// the agent uses its own default config (bake one into `args` if needed).
-    pub fn build_args(
-        &self,
-        resume_id: Option<&str>,
-        fork_id: Option<&str>,
-        new_session_id: Option<&str>,
-    ) -> Vec<String> {
+    /// fork wins over resume, which wins over a fresh `new_session` id. Then
+    /// come `prompt_args` (when a system prompt is supplied), the static
+    /// `args`, and finally any per-spawn `extra_args` (last, so they can
+    /// override baked-in flags). No model is ever passed — the agent uses its
+    /// own default config (bake one into `args` if needed).
+    pub fn build_args(&self, launch: &LaunchArgs<'_>) -> Vec<String> {
         let mut out: Vec<String> = Vec::new();
 
-        if let Some(id) = fork_id {
+        if let Some(id) = launch.fork_id {
             out.extend(subst(&self.fork_args, ID_PLACEHOLDER, id));
-        } else if let Some(id) = resume_id {
+        } else if let Some(id) = launch.resume_id {
             out.extend(subst(&self.resume_args, ID_PLACEHOLDER, id));
-        } else if let Some(id) = new_session_id {
+        } else if let Some(id) = launch.new_session_id {
             out.extend(subst(&self.new_session_args, ID_PLACEHOLDER, id));
         }
 
+        if let Some(prompt) = launch.system_prompt {
+            out.extend(subst(&self.prompt_args, PROMPT_PLACEHOLDER, prompt));
+        }
+
         out.extend(self.args.iter().cloned());
+        out.extend(launch.extra_args.iter().cloned());
 
         out
     }
@@ -147,18 +184,20 @@ mod tests {
         AgentDef {
             name: "claude".into(),
             command: "claude".into(),
-            args: vec![],
             resume_args: vec!["--resume".into(), "{id}".into()],
             fork_args: vec!["--resume".into(), "{id}".into(), "--fork-session".into()],
             new_session_args: vec!["--session-id".into(), "{id}".into()],
-            resume_latest: false,
+            ..AgentDef::default()
         }
     }
 
     #[test]
     fn fresh_session_pins_id() {
         let d = claude();
-        let args = d.build_args(None, None, Some("new-id"));
+        let args = d.build_args(&LaunchArgs {
+            new_session_id: Some("new-id"),
+            ..LaunchArgs::default()
+        });
         assert_eq!(args, vec!["--session-id", "new-id"]);
         // No model is ever passed.
         assert!(!args.iter().any(|a| a == "--model"));
@@ -167,14 +206,23 @@ mod tests {
     #[test]
     fn resume_takes_precedence_over_new() {
         let d = claude();
-        let args = d.build_args(Some("resume-id"), None, Some("new-id"));
+        let args = d.build_args(&LaunchArgs {
+            resume_id: Some("resume-id"),
+            new_session_id: Some("new-id"),
+            ..LaunchArgs::default()
+        });
         assert_eq!(args, vec!["--resume", "resume-id"]);
     }
 
     #[test]
     fn fork_takes_precedence_over_resume() {
         let d = claude();
-        let args = d.build_args(Some("resume-id"), Some("fork-id"), Some("new-id"));
+        let args = d.build_args(&LaunchArgs {
+            resume_id: Some("resume-id"),
+            fork_id: Some("fork-id"),
+            new_session_id: Some("new-id"),
+            ..LaunchArgs::default()
+        });
         assert_eq!(args, vec!["--resume", "fork-id", "--fork-session"]);
     }
 
@@ -184,12 +232,12 @@ mod tests {
             name: "codex".into(),
             command: "codex".into(),
             args: vec!["--quiet".into()],
-            resume_args: vec![],
-            fork_args: vec![],
-            new_session_args: vec![],
-            resume_latest: false,
+            ..AgentDef::default()
         };
-        let args = d.build_args(None, None, Some("ignored"));
+        let args = d.build_args(&LaunchArgs {
+            new_session_id: Some("ignored"),
+            ..LaunchArgs::default()
+        });
         assert_eq!(args, vec!["--quiet"]);
     }
 
@@ -200,23 +248,109 @@ mod tests {
         let d = AgentDef {
             name: "codex".into(),
             command: "codex".into(),
-            args: vec![],
             resume_args: vec!["resume".into(), "--last".into()],
             fork_args: vec!["fork".into(), "--last".into()],
-            new_session_args: vec![],
             resume_latest: true,
+            ..AgentDef::default()
         };
         // resume id present, but no {id} token -> tokens unchanged.
         assert_eq!(
-            d.build_args(Some("ignored-uuid"), None, None),
+            d.build_args(&LaunchArgs {
+                resume_id: Some("ignored-uuid"),
+                ..LaunchArgs::default()
+            }),
             vec!["resume", "--last"]
         );
         // fork wins over resume, still id-less.
         assert_eq!(
-            d.build_args(Some("ignored-uuid"), Some("also-ignored"), None),
+            d.build_args(&LaunchArgs {
+                resume_id: Some("ignored-uuid"),
+                fork_id: Some("also-ignored"),
+                ..LaunchArgs::default()
+            }),
             vec!["fork", "--last"]
         );
         assert!(d.resumes_latest());
+    }
+
+    #[test]
+    fn prompt_args_substituted_when_system_prompt_present() {
+        let d = AgentDef {
+            prompt_args: vec!["--append-system-prompt".into(), "{prompt}".into()],
+            args: vec!["--quiet".into()],
+            ..claude()
+        };
+        let args = d.build_args(&LaunchArgs {
+            new_session_id: Some("id-1"),
+            system_prompt: Some("be terse"),
+            ..LaunchArgs::default()
+        });
+        // Emit order: session-selection group, prompt_args, static args.
+        assert_eq!(
+            args,
+            vec![
+                "--session-id",
+                "id-1",
+                "--append-system-prompt",
+                "be terse",
+                "--quiet"
+            ]
+        );
+    }
+
+    #[test]
+    fn prompt_args_omitted_without_system_prompt() {
+        let d = AgentDef {
+            prompt_args: vec!["--append-system-prompt".into(), "{prompt}".into()],
+            ..claude()
+        };
+        let args = d.build_args(&LaunchArgs {
+            new_session_id: Some("id-1"),
+            ..LaunchArgs::default()
+        });
+        assert_eq!(args, vec!["--session-id", "id-1"]);
+    }
+
+    #[test]
+    fn extra_args_appended_last() {
+        let d = AgentDef {
+            args: vec!["--quiet".into()],
+            ..claude()
+        };
+        let extra = vec!["--permission-mode".to_string(), "plan".to_string()];
+        let args = d.build_args(&LaunchArgs {
+            new_session_id: Some("id-1"),
+            extra_args: &extra,
+            ..LaunchArgs::default()
+        });
+        assert_eq!(
+            args,
+            vec![
+                "--session-id",
+                "id-1",
+                "--quiet",
+                "--permission-mode",
+                "plan"
+            ]
+        );
+    }
+
+    #[test]
+    fn env_and_prompt_args_roundtrip_toml() {
+        let toml = r#"
+            name = "custom"
+            command = "custom"
+            prompt_args = ["--system", "{prompt}"]
+            [env]
+            FOO = "bar"
+        "#;
+        let d: AgentDef = toml::from_str(toml).unwrap();
+        assert_eq!(d.env.get("FOO").map(String::as_str), Some("bar"));
+        assert_eq!(d.prompt_args, vec!["--system", "{prompt}"]);
+        // Fields default to empty when absent.
+        let bare: AgentDef = toml::from_str("name = \"x\"\ncommand = \"x\"").unwrap();
+        assert!(bare.env.is_empty());
+        assert!(bare.prompt_args.is_empty());
     }
 
     #[test]
@@ -224,11 +358,8 @@ mod tests {
         let mut d = AgentDef {
             name: "x".into(),
             command: "x".into(),
-            args: vec![],
-            resume_args: vec![],
-            fork_args: vec![],
-            new_session_args: vec![],
             resume_latest: true,
+            ..AgentDef::default()
         };
         // Flag set but no resume_args -> nothing to emit, so not "resumes latest".
         assert!(!d.resumes_latest());
@@ -248,11 +379,7 @@ mod tests {
                 AgentDef {
                     name: "codex".into(),
                     command: "codex".into(),
-                    args: vec![],
-                    resume_args: vec![],
-                    fork_args: vec![],
-                    new_session_args: vec![],
-                    resume_latest: false,
+                    ..AgentDef::default()
                 },
             ],
         };

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -13,6 +13,10 @@ use serde::{Deserialize, Serialize};
 /// (and persisted in `backend_type`) as `ssh:devbox`.
 pub const SSH_BACKEND_PREFIX: &str = "ssh:";
 
+/// Backend name/type of the default local-tmux backend — the one non-SSH
+/// value `backend_type` can hold.
+pub const LOCAL_TMUX_BACKEND_TYPE: &str = "local-tmux";
+
 /// Whether a backend name refers to a remote SSH host (`ssh:<name>`).
 pub fn is_ssh_backend(backend_name: &str) -> bool {
     backend_name.starts_with(SSH_BACKEND_PREFIX)

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -6,12 +6,14 @@ pub mod settings;
 pub mod task;
 pub mod theme_config;
 
-pub use agent_def::{AgentDef, AgentRegistry};
+pub use agent_def::{AgentDef, AgentRegistry, LaunchArgs};
 pub use automation::{
     parse_hhmm, preset_to_cron, Automation, AutomationAction, AutomationRun, AutomationRunStatus,
     AutomationSchedule, SchedulePreset,
 };
-pub use host_def::{is_ssh_backend, HostDef, HostRegistry, SSH_BACKEND_PREFIX};
+pub use host_def::{
+    is_ssh_backend, HostDef, HostRegistry, LOCAL_TMUX_BACKEND_TYPE, SSH_BACKEND_PREFIX,
+};
 pub use keybindings::{Action, KeyBindings, KeyChord, KeyContext};
 pub use task::{Task, TaskStatus, SOURCE_LOCAL};
 pub use theme_config::{ThemePalette, ThemePreset};
@@ -244,8 +246,14 @@ pub struct SessionConfig {
     /// Fork from an existing session's conversation (agents that support it).
     pub fork_session_id: Option<String>,
     /// Environment variables injected into the spawned session process
-    /// (thurbox-internal: session id, metrics dir, etc.).
+    /// (agent-level defaults, per-spawn overrides, and thurbox-internal
+    /// variables, merged in that precedence order).
     pub env: HashMap<String, String>,
+    /// Per-spawn arguments appended after every templated group from the
+    /// agent definition, so they can override baked-in flags.
+    pub extra_args: Vec<String>,
+    /// System prompt substituted into the agent's `prompt_args` template.
+    pub system_prompt: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -17,6 +17,11 @@ use std::collections::HashMap;
 
 use crate::session::SessionConfig;
 
+/// Seconds to let a freshly spawned agent CLI boot before an initial prompt
+/// is typed into its pane. Shared by `session create --prompt` and the
+/// automation/task spawn paths so all headless deliveries behave the same.
+pub(crate) const AGENT_BOOT_DELAY_SECS: u64 = 3;
+
 /// Decide whether to pass the agent's resume group vs starting fresh when
 /// (re)spawning. Returns `Some(id.clone())` only when a Claude transcript for
 /// that id already exists on disk under `CLAUDE_CONFIG_DIR`/`~/.claude`.
@@ -115,9 +120,116 @@ fn inject_thurbox_env(config: &mut SessionConfig, agent_session_id: &str) {
     }
 }
 
+/// Merge the three environment layers into `config.env`, lowest precedence
+/// first: agent-level defaults from `agents.toml`, then per-spawn `--env`
+/// overrides, then the thurbox-internal variables (which stay authoritative).
+///
+/// Shared by headless spawn and restart so both produce the same process env.
+pub(crate) fn merge_spawn_env(
+    config: &mut SessionConfig,
+    def: &crate::session::AgentDef,
+    spawn_env: &[(String, String)],
+    agent_session_id: &str,
+) {
+    for (k, v) in &def.env {
+        // `or_insert`: values already on the config (e.g. set by a TUI flow)
+        // outrank agent-level defaults, same as `App::build_spawn_inputs`.
+        config.env.entry(k.clone()).or_insert_with(|| v.clone());
+    }
+    for (k, v) in spawn_env {
+        config.env.insert(k.clone(), v.clone());
+    }
+    inject_thurbox_env(config, agent_session_id);
+}
+
+/// The directory a headless session's agent process launches in: the primary
+/// cwd directly, or the multi-repo symlink workspace when the session spans
+/// several member dirs (worktree checkouts first, then non-duplicate
+/// additional dirs — mirroring the TUI's `session_member_dirs` ordering).
+///
+/// Shared by headless spawn and restart so both land in the same workspace.
+pub(crate) fn resolve_headless_process_cwd(
+    agent_session_id: &str,
+    primary_cwd: Option<std::path::PathBuf>,
+    worktrees: &[crate::sync::SharedWorktree],
+    additional_dirs: &[std::path::PathBuf],
+) -> Option<std::path::PathBuf> {
+    let mut members: Vec<(Option<String>, std::path::PathBuf)> = Vec::new();
+    if worktrees.is_empty() {
+        if let Some(cwd) = &primary_cwd {
+            members.push((crate::git::repo_display_name(cwd), cwd.clone()));
+        }
+    } else {
+        for wt in worktrees {
+            members.push((
+                crate::git::repo_display_name(&wt.repo_path),
+                wt.worktree_path.clone(),
+            ));
+        }
+    }
+    for dir in additional_dirs {
+        if !members.iter().any(|(_, d)| d == dir) {
+            members.push((crate::git::repo_display_name(dir), dir.clone()));
+        }
+    }
+    crate::workspace::resolve_process_cwd(Some(agent_session_id), primary_cwd, &members)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn merge_spawn_env_layers_def_then_spawn_then_thurbox() {
+        let def = crate::session::AgentDef {
+            name: "x".into(),
+            command: "x".into(),
+            env: [
+                ("FROM_DEF".to_string(), "def".to_string()),
+                ("SHARED".to_string(), "def".to_string()),
+                ("THURBOX_SESSION_ID".to_string(), "spoofed".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            ..crate::session::AgentDef::default()
+        };
+        let spawn_env = vec![("SHARED".to_string(), "spawn".to_string())];
+
+        let mut config = SessionConfig::default();
+        config.env.insert("PRESET".into(), "config".into());
+        merge_spawn_env(&mut config, &def, &spawn_env, "sid-1");
+
+        // Agent defaults fill gaps but never override pre-existing values…
+        assert_eq!(config.env.get("FROM_DEF").map(String::as_str), Some("def"));
+        assert_eq!(config.env.get("PRESET").map(String::as_str), Some("config"));
+        // …per-spawn values beat agent defaults…
+        assert_eq!(config.env.get("SHARED").map(String::as_str), Some("spawn"));
+        // …and thurbox internals beat everything.
+        assert_eq!(
+            config.env.get("THURBOX_SESSION_ID").map(String::as_str),
+            Some("sid-1")
+        );
+    }
+
+    #[test]
+    fn headless_process_cwd_dedups_members_and_keeps_primary_for_single() {
+        use std::path::PathBuf;
+        let wt = crate::sync::SharedWorktree {
+            repo_path: PathBuf::from("/src/repo"),
+            worktree_path: PathBuf::from("/src/repo/worktrees/feat"),
+            branch: "feat".into(),
+        };
+        // The additional dir duplicates the worktree checkout: after dedup
+        // only one member remains, so the primary cwd is used directly (no
+        // workspace is built, no filesystem touched).
+        let out = resolve_headless_process_cwd(
+            "sid-1",
+            Some(wt.worktree_path.clone()),
+            std::slice::from_ref(&wt),
+            std::slice::from_ref(&wt.worktree_path),
+        );
+        assert_eq!(out, Some(wt.worktree_path));
+    }
 
     #[test]
     fn resume_id_is_none_when_no_transcript() {

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -4,6 +4,7 @@
 
 use crate::session::{SessionConfig, SessionId};
 use crate::storage::Database;
+use crate::sync::SharedSession;
 
 /// Restart an existing session in-place — kills its tmux window and
 /// re-spawns the agent CLI.
@@ -13,28 +14,18 @@ use crate::storage::Database;
 /// For `resume_latest` agents (codex, opencode, gemini, aider) it resumes the
 /// latest session in the (unchanged) launch directory. Other agents degrade to
 /// "start fresh" (the live tmux process is what carries state across restarts).
+///
+/// Per-spawn customizations (`--env`/`--extra-arg`/`--system-prompt`) are read
+/// back from the session's persisted spawn config so the relaunched process
+/// matches the original, and multi-dir sessions land back in their symlink
+/// workspace.
 pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<(), String> {
     let session = db
         .get_session_by_id(session_id)
         .map_err(|e| format!("Failed to load session: {e}"))?
         .ok_or_else(|| format!("Session not found: {session_id}"))?;
 
-    let agent_session_id = session
-        .agent_session_id
-        .clone()
-        .ok_or_else(|| format!("Cannot restart session {session_id} without agent_session_id"))?;
-
-    let mut config = SessionConfig {
-        agent_session_id: Some(agent_session_id.clone()),
-        cwd: session.cwd.clone(),
-        agent: session.agent.clone(),
-        ..SessionConfig::default()
-    };
-    super::inject_thurbox_env(&mut config, &agent_session_id);
-    let def = super::resolve_agent_def(&config.agent);
-    config.resume_session_id = super::resume_trigger_for(&def, &agent_session_id, &config.env);
-
-    let (command, args) = super::build_agent_invocation(&config);
+    let (config, command, args) = build_restart_invocation(db, &session)?;
 
     crate::agent::tmux::kill_window(&session.name)
         .map_err(|e| format!("Failed to kill tmux window: {e}"))?;
@@ -48,4 +39,161 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
     .map_err(|e| format!("Failed to re-spawn tmux window: {e}"))?;
 
     Ok(())
+}
+
+/// Rebuild the full launch invocation for an existing session: persisted
+/// spawn config (env/extra args/system prompt), the resume decision, and the
+/// process cwd (symlink workspace for multi-dir sessions). Split from
+/// [`restart_session_headless`] so it is testable without tmux.
+pub(crate) fn build_restart_invocation(
+    db: &Database,
+    session: &SharedSession,
+) -> Result<(SessionConfig, String, Vec<String>), String> {
+    let agent_session_id = session.agent_session_id.clone().ok_or_else(|| {
+        format!(
+            "Cannot restart session {} without agent_session_id",
+            session.id
+        )
+    })?;
+
+    let spawn_cfg = db
+        .get_session_spawn_config(session.id)
+        .map_err(|e| format!("Failed to load spawn config: {e}"))?
+        .unwrap_or_default();
+
+    let cwd = super::resolve_headless_process_cwd(
+        &agent_session_id,
+        session.cwd.clone(),
+        &session.worktrees,
+        &session.additional_dirs,
+    );
+
+    let mut config = SessionConfig {
+        agent_session_id: Some(agent_session_id.clone()),
+        cwd,
+        agent: session.agent.clone(),
+        extra_args: spawn_cfg.extra_args,
+        system_prompt: spawn_cfg.system_prompt,
+        ..SessionConfig::default()
+    };
+    let def = super::resolve_agent_def(&config.agent);
+    super::merge_spawn_env(&mut config, &def, &spawn_cfg.env, &agent_session_id);
+    config.resume_session_id = super::resume_trigger_for(&def, &agent_session_id, &config.env);
+
+    let (command, args) = super::build_agent_invocation(&config);
+    Ok((config, command, args))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::SpawnConfigRecord;
+
+    fn session_with_spawn_config(db: &Database) -> SharedSession {
+        let session = SharedSession {
+            id: SessionId::default(),
+            name: "w1".into(),
+            agent: "claude".into(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: Some("11111111-2222-3333-4444-555555555555".into()),
+            cwd: Some(std::path::PathBuf::from("/src/repo")),
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        db.upsert_session(&session).unwrap();
+        db.set_session_spawn_config(
+            session.id,
+            &SpawnConfigRecord {
+                env: vec![("WORKER".into(), "1".into())],
+                extra_args: vec!["--permission-mode".into(), "plan".into()],
+                system_prompt: None,
+            },
+        )
+        .unwrap();
+        session
+    }
+
+    #[test]
+    fn restart_reproduces_persisted_spawn_config() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+        let session = session_with_spawn_config(&db);
+
+        let (config, command, args) = build_restart_invocation(&db, &session).unwrap();
+
+        assert_eq!(command, "claude");
+        // Per-spawn extra args come back, appended after the arg groups.
+        assert_eq!(
+            &args[args.len() - 2..],
+            &["--permission-mode".to_string(), "plan".to_string()]
+        );
+        // Per-spawn env comes back, with thurbox internals layered on top.
+        assert_eq!(config.env.get("WORKER").map(String::as_str), Some("1"));
+        assert_eq!(
+            config.env.get("THURBOX_SESSION_ID").map(String::as_str),
+            session.agent_session_id.as_deref()
+        );
+        // Single-dir session restarts in its primary cwd.
+        assert_eq!(config.cwd, session.cwd);
+    }
+
+    #[test]
+    fn restart_without_spawn_config_row_is_clean() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+        let session = SharedSession {
+            id: SessionId::default(),
+            name: "plain".into(),
+            agent: "claude".into(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: Some("66666666-7777-8888-9999-aaaaaaaaaaaa".into()),
+            cwd: Some(std::path::PathBuf::from("/src/repo")),
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        db.upsert_session(&session).unwrap();
+
+        let (config, _, args) = build_restart_invocation(&db, &session).unwrap();
+        assert!(config.extra_args.is_empty());
+        assert!(config.system_prompt.is_none());
+        // No transcript on disk -> fresh start pinning the same id.
+        assert_eq!(
+            args,
+            vec!["--session-id", "66666666-7777-8888-9999-aaaaaaaaaaaa"]
+        );
+    }
+
+    #[test]
+    fn restart_without_agent_session_id_errors() {
+        let db = Database::open_in_memory().unwrap();
+        let session = SharedSession {
+            id: SessionId::default(),
+            name: "x".into(),
+            agent: "claude".into(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        let err = build_restart_invocation(&db, &session).unwrap_err();
+        assert!(err.contains("agent_session_id"), "got {err}");
+    }
 }

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -3,18 +3,17 @@
 
 use std::path::PathBuf;
 
-use crate::session::{HostDef, SessionConfig, SessionId, DEFAULT_AGENT_NAME};
+use crate::session::{
+    HostDef, SessionConfig, SessionId, DEFAULT_AGENT_NAME, LOCAL_TMUX_BACKEND_TYPE,
+};
 use crate::storage::Database;
 use crate::sync::{SharedSession, SharedWorktree};
 
 /// Default base branch for `--worktree-branch` when none is given.
 const DEFAULT_BASE_BRANCH: &str = "main";
 
-/// Backend identifier for the local-tmux backend (matches `LocalTmuxBackend`).
-const LOCAL_TMUX_BACKEND_TYPE: &str = "local-tmux";
-
 /// Request to create a new headless session.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SpawnRequest {
     /// Session name (used for the tmux window `tb-<name>`).
     pub name: String,
@@ -37,6 +36,24 @@ pub struct SpawnRequest {
     /// Optional parent session (lead/worker relationship for orchestration).
     /// Must reference an existing active session.
     pub parent_session_id: Option<SessionId>,
+    /// Initial prompt typed into the pane after a short boot delay. One-shot
+    /// (not persisted — restart must not re-send it). Local sessions only.
+    pub prompt: Option<String>,
+    /// System prompt substituted into the agent's `prompt_args` template.
+    /// Rejected when the agent defines no `prompt_args`. Persisted so restart
+    /// re-emits it.
+    pub system_prompt: Option<String>,
+    /// Per-spawn env overrides (`--env KEY=VAL`), applied over the agent's
+    /// `env` defaults. Persisted so restart reproduces them.
+    pub env: Vec<(String, String)>,
+    /// Per-spawn arguments appended after every templated arg group, so they
+    /// can override baked-in flags. Persisted so restart reproduces them.
+    pub extra_args: Vec<String>,
+    /// Extra member directories. The session launches in a multi-repo symlink
+    /// workspace gathering the primary dir plus these. Local sessions only.
+    pub additional_dirs: Vec<PathBuf>,
+    /// Free-form `key=value` labels persisted with the session.
+    pub labels: Vec<(String, String)>,
 }
 
 /// Result returned on successful headless spawn.
@@ -49,6 +66,10 @@ pub struct SpawnResult {
     pub cwd: PathBuf,
     pub worktrees: Vec<SharedWorktree>,
     pub parent_session_id: Option<SessionId>,
+    pub labels: Vec<(String, String)>,
+    /// Set when the spawn succeeded but the initial `--prompt` could not be
+    /// scheduled (the window is live and tracked either way).
+    pub prompt_delivery_error: Option<String>,
 }
 
 /// Spawn a new session inside `tmux -L thurbox`, persisting its state to the
@@ -58,6 +79,25 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     validate_parent_session(db, req.parent_session_id)?;
 
     let agent_name = resolve_agent_name(req.agent.as_deref());
+    let def = super::resolve_agent_def(&agent_name);
+
+    // `--system-prompt` needs an arg template to land in; failing fast beats
+    // silently launching an agent that never saw its instructions.
+    if req.system_prompt.is_some() && def.prompt_args.is_empty() {
+        return Err(format!(
+            "Agent '{agent_name}' defines no prompt_args in agents.toml; \
+             --system-prompt is not supported for it"
+        ));
+    }
+    // Prompt delivery and the symlink workspace are local-tmux mechanisms.
+    if req.host.is_some() {
+        if req.prompt.is_some() {
+            return Err("--prompt is local-only; use `session send` for remote sessions".into());
+        }
+        if !req.additional_dirs.is_empty() {
+            return Err("--add-dir is local-only (the symlink workspace is built locally)".into());
+        }
+    }
 
     // Resolve the optional remote host. `backend_type` is `local-tmux` or
     // `ssh:<host>`; `host` is the matching HostDef for remote git/tmux ops.
@@ -69,14 +109,30 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         .clone()
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
+    // Multi-dir sessions launch in a symlink workspace gathering every member;
+    // `cwd` (the primary dir) is what gets persisted and displayed.
+    let process_cwd = if req.additional_dirs.is_empty() {
+        cwd.clone()
+    } else {
+        super::resolve_headless_process_cwd(
+            &agent_session_id,
+            Some(cwd.clone()),
+            &worktrees,
+            &req.additional_dirs,
+        )
+        .unwrap_or_else(|| cwd.clone())
+    };
+
     let mut config = SessionConfig {
         agent_session_id: Some(agent_session_id.clone()),
-        cwd: Some(cwd.clone()),
+        cwd: Some(process_cwd.clone()),
         agent: agent_name.clone(),
         backend: (backend_type != LOCAL_TMUX_BACKEND_TYPE).then(|| backend_type.clone()),
+        extra_args: req.extra_args.clone(),
+        system_prompt: req.system_prompt.clone(),
         ..SessionConfig::default()
     };
-    super::inject_thurbox_env(&mut config, &agent_session_id);
+    super::merge_spawn_env(&mut config, &def, &req.env, &agent_session_id);
 
     let (command, args) = super::build_agent_invocation(&config);
 
@@ -88,13 +144,19 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
             &req.name,
             &command,
             &args,
-            Some(&cwd),
+            Some(&process_cwd),
             &config.env,
         )
         .map_err(|e| format!("Failed to spawn remote tmux window: {e:#}"))?,
         None => {
-            crate::agent::tmux::spawn_window(&req.name, &command, &args, Some(&cwd), &config.env)
-                .map_err(|e| format!("Failed to spawn tmux window: {e}"))?;
+            crate::agent::tmux::spawn_window(
+                &req.name,
+                &command,
+                &args,
+                Some(&process_cwd),
+                &config.env,
+            )
+            .map_err(|e| format!("Failed to spawn tmux window: {e}"))?;
             String::new()
         }
     };
@@ -108,7 +170,7 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         backend_type,
         agent_session_id: Some(agent_session_id.clone()),
         cwd: Some(cwd.clone()),
-        additional_dirs: Vec::new(),
+        additional_dirs: req.additional_dirs.clone(),
         worktrees: worktrees.clone(),
         shell_backend_id: None,
         parent_session_id: req.parent_session_id,
@@ -138,6 +200,38 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         return Err(format!("Failed to persist session: {e}"));
     }
 
+    // Best-effort side-table persistence: the session row exists and the
+    // window is live, so losing these must not fail the spawn — but it does
+    // degrade restart fidelity / list filtering, hence the loud log.
+    let spawn_cfg = crate::storage::SpawnConfigRecord {
+        env: req.env.clone(),
+        extra_args: req.extra_args.clone(),
+        system_prompt: req.system_prompt.clone(),
+    };
+    if !spawn_cfg.is_empty() {
+        if let Err(e) = db.set_session_spawn_config(session_id, &spawn_cfg) {
+            tracing::error!("failed to persist spawn config for '{}': {e}", req.name);
+        }
+    }
+    if !req.labels.is_empty() {
+        if let Err(e) = db.set_session_labels(session_id, &req.labels) {
+            tracing::error!("failed to persist labels for '{}': {e}", req.name);
+        }
+    }
+
+    // Schedule the one-shot initial prompt last, so it can't fire against a
+    // window we might still tear down above.
+    let mut prompt_delivery_error = None;
+    if let Some(prompt) = req.prompt.as_deref() {
+        if let Err(e) = crate::agent::tmux::send_prompt_after_delay(
+            &req.name,
+            prompt,
+            super::AGENT_BOOT_DELAY_SECS,
+        ) {
+            prompt_delivery_error = Some(format!("{e:#}"));
+        }
+    }
+
     Ok(SpawnResult {
         session_id,
         name: req.name,
@@ -146,6 +240,8 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         cwd,
         worktrees,
         parent_session_id: req.parent_session_id,
+        labels: req.labels,
+        prompt_delivery_error,
     })
 }
 
@@ -238,12 +334,7 @@ mod tests {
         SpawnRequest {
             name: name.into(),
             repo_path: PathBuf::from("/tmp"),
-            worktree_branch: None,
-            base_branch: None,
-            agent: None,
-            agent_session_id: None,
-            host: None,
-            parent_session_id: None,
+            ..SpawnRequest::default()
         }
     }
 
@@ -302,6 +393,52 @@ mod tests {
     fn resolve_agent_name_uses_explicit() {
         assert_eq!(resolve_agent_name(Some("codex")), "codex");
         assert_eq!(resolve_agent_name(Some("")), DEFAULT_AGENT_NAME);
+    }
+
+    #[test]
+    fn system_prompt_without_prompt_args_is_rejected() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = empty_db();
+        // The seeded built-in claude has no prompt_args template.
+        let err = spawn_session_headless(
+            &db,
+            SpawnRequest {
+                system_prompt: Some("be terse".into()),
+                ..req("demo")
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("prompt_args"), "got {err}");
+        assert!(err.contains("--system-prompt"), "got {err}");
+    }
+
+    #[test]
+    fn prompt_and_add_dir_are_local_only() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = empty_db();
+        let err = spawn_session_headless(
+            &db,
+            SpawnRequest {
+                host: Some("devbox".into()),
+                prompt: Some("hi".into()),
+                ..req("demo")
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("local-only"), "got {err}");
+
+        let err = spawn_session_headless(
+            &db,
+            SpawnRequest {
+                host: Some("devbox".into()),
+                additional_dirs: vec![PathBuf::from("/srv/other")],
+                ..req("demo")
+            },
+        )
+        .unwrap_err();
+        assert!(err.contains("local-only"), "got {err}");
     }
 
     #[test]

--- a/src/storage/labels.rs
+++ b/src/storage/labels.rs
@@ -1,0 +1,181 @@
+//! Free-form `key=value` labels attached to sessions.
+//!
+//! Labels let orchestration scripts tag worker sessions (wave, task id,
+//! parent reference, …) without overloading the session name. They live in
+//! their own table keyed by `(session_id, key)`, so soft-deleting/restoring
+//! the session row leaves them untouched.
+
+use std::collections::HashMap;
+
+use rusqlite::params;
+
+use crate::session::SessionId;
+use crate::sync::current_time_millis;
+
+use super::audit::{AuditAction, EntityType};
+use super::Database;
+
+impl Database {
+    /// Replace all labels for a session.
+    pub fn set_session_labels(
+        &self,
+        session_id: SessionId,
+        labels: &[(String, String)],
+    ) -> rusqlite::Result<()> {
+        let now = current_time_millis() as i64;
+        let sid = session_id.to_string();
+
+        self.conn.execute(
+            "DELETE FROM session_labels WHERE session_id = ?1",
+            params![sid],
+        )?;
+        for (key, value) in labels {
+            self.conn.execute(
+                "INSERT INTO session_labels (session_id, key, value, created_at) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![sid, key, value, now],
+            )?;
+        }
+
+        if !labels.is_empty() {
+            self.log_audit(
+                EntityType::Session,
+                &sid,
+                AuditAction::Updated,
+                Some("labels"),
+                None,
+                Some(&labels.len().to_string()),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// All labels for one session, sorted by key.
+    pub fn get_session_labels(
+        &self,
+        session_id: SessionId,
+    ) -> rusqlite::Result<Vec<(String, String)>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT key, value FROM session_labels WHERE session_id = ?1 ORDER BY key")?;
+        let rows = stmt.query_map(params![session_id.to_string()], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+        rows.collect()
+    }
+
+    /// Labels for every session in one query: session id (text) → sorted
+    /// `(key, value)` pairs. Used to decorate/filter `session list` without
+    /// a per-session round-trip.
+    pub fn labels_for_all_sessions(
+        &self,
+    ) -> rusqlite::Result<HashMap<String, Vec<(String, String)>>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT session_id, key, value FROM session_labels ORDER BY key")?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?;
+
+        let mut out: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        for row in rows {
+            let (sid, key, value) = row?;
+            out.entry(sid).or_default().push((key, value));
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::SharedSession;
+
+    fn setup_db_with_session() -> (Database, SessionId) {
+        let db = Database::open_in_memory().unwrap();
+        let session = SharedSession {
+            id: SessionId::default(),
+            name: "S1".to_string(),
+            agent: "dev".to_string(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".to_string(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        let sid = session.id;
+        db.upsert_session(&session).unwrap();
+        (db, sid)
+    }
+
+    fn labels(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn set_and_get_roundtrip_sorted_by_key() {
+        let (db, sid) = setup_db_with_session();
+        db.set_session_labels(sid, &labels(&[("wave", "1"), ("task", "demo")]))
+            .unwrap();
+        assert_eq!(
+            db.get_session_labels(sid).unwrap(),
+            labels(&[("task", "demo"), ("wave", "1")])
+        );
+    }
+
+    #[test]
+    fn set_replaces_existing_labels() {
+        let (db, sid) = setup_db_with_session();
+        db.set_session_labels(sid, &labels(&[("wave", "1")]))
+            .unwrap();
+        db.set_session_labels(sid, &labels(&[("wave", "2")]))
+            .unwrap();
+        assert_eq!(
+            db.get_session_labels(sid).unwrap(),
+            labels(&[("wave", "2")])
+        );
+    }
+
+    #[test]
+    fn labels_for_all_sessions_batches() {
+        let (db, sid) = setup_db_with_session();
+        db.set_session_labels(sid, &labels(&[("wave", "1")]))
+            .unwrap();
+        let all = db.labels_for_all_sessions().unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[&sid.to_string()], labels(&[("wave", "1")]));
+    }
+
+    #[test]
+    fn labels_survive_soft_delete_and_restore() {
+        let (db, sid) = setup_db_with_session();
+        db.set_session_labels(sid, &labels(&[("wave", "1")]))
+            .unwrap();
+        db.soft_delete_session(sid).unwrap();
+        db.restore_session(sid).unwrap();
+        assert_eq!(
+            db.get_session_labels(sid).unwrap(),
+            labels(&[("wave", "1")])
+        );
+    }
+
+    #[test]
+    fn no_labels_returns_empty() {
+        let (db, sid) = setup_db_with_session();
+        assert!(db.get_session_labels(sid).unwrap().is_empty());
+        assert!(db.labels_for_all_sessions().unwrap().is_empty());
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -13,11 +13,14 @@
 pub mod audit;
 pub mod automations;
 pub mod keybindings;
+mod labels;
 pub mod repo_bookmarks;
 mod schema;
 mod sessions;
 mod settings;
+mod spawn_config;
 pub use sessions::DeletedSessionInfo;
+pub use spawn_config::SpawnConfigRecord;
 pub mod sync;
 pub mod tasks;
 mod worktrees;

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -2,10 +2,8 @@ use rusqlite::Connection;
 
 /// Current schema version. Incremented when schema changes.
 ///
-/// v29 is reserved by the in-flight `improve-agent-thurbox-cli` branch
-/// (`session_labels` + `session_spawn_config`); this branch takes v30.
-/// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 30;
+/// (Gaps in the step table are fine — there is no v18 or v29 step.)
+pub const SCHEMA_VERSION: u32 = 31;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -136,6 +134,23 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
         );
         CREATE INDEX IF NOT EXISTS idx_tasks_status
             ON tasks(status) WHERE deleted_at IS NULL;
+
+        CREATE TABLE IF NOT EXISTS session_labels (
+            session_id TEXT NOT NULL REFERENCES sessions(id),
+            key        TEXT NOT NULL,
+            value      TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY (session_id, key)
+        );
+
+        CREATE TABLE IF NOT EXISTS session_spawn_config (
+            session_id    TEXT PRIMARY KEY REFERENCES sessions(id),
+            env           TEXT NOT NULL DEFAULT '',
+            extra_args    TEXT NOT NULL DEFAULT '',
+            system_prompt TEXT,
+            created_at    INTEGER NOT NULL,
+            updated_at    INTEGER NOT NULL
+        );
         ",
     )?;
 
@@ -196,6 +211,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (27, migrate_v27_repo_parent_bookmarks),
         (28, migrate_v28_run_related_session),
         (30, migrate_v30_parent_session_id),
+        (31, migrate_v31_orchestration),
     ];
 
     for &(target, step) in steps {
@@ -850,14 +866,40 @@ fn migrate_v28_run_related_session(conn: &Connection) -> rusqlite::Result<()> {
 }
 
 /// v29 → v30: add a nullable `parent_session_id` column to `sessions`
-/// (lead/worker linkage for orchestration; v29 belongs to another branch).
+/// (lead/worker linkage for orchestration; v29 was reserved by a branch
+/// that ultimately landed as v31).
 ///
-/// Fresh v30 databases already have the column from `initialize` and skip this
+/// Fresh databases already have the column from `initialize` and skip this
 /// step; existing databases get it via the ALTER. `let _` swallows the
 /// "duplicate column" error so a re-run is a no-op.
 fn migrate_v30_parent_session_id(conn: &Connection) -> rusqlite::Result<()> {
     let _ = conn.execute("ALTER TABLE sessions ADD COLUMN parent_session_id TEXT", []);
     Ok(())
+}
+
+/// v30 → v31: orchestration support — free-form session labels plus the
+/// per-spawn config (env / extra args / system prompt) that restart must
+/// reproduce. Side tables rather than `sessions` columns so the TUI's
+/// whole-row session upsert can't wipe them.
+fn migrate_v31_orchestration(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS session_labels (
+            session_id TEXT NOT NULL REFERENCES sessions(id),
+            key        TEXT NOT NULL,
+            value      TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY (session_id, key)
+        );
+
+        CREATE TABLE IF NOT EXISTS session_spawn_config (
+            session_id    TEXT PRIMARY KEY REFERENCES sessions(id),
+            env           TEXT NOT NULL DEFAULT '',
+            extra_args    TEXT NOT NULL DEFAULT '',
+            system_prompt TEXT,
+            created_at    INTEGER NOT NULL,
+            updated_at    INTEGER NOT NULL
+        );",
+    )
 }
 
 #[cfg(test)]
@@ -1137,6 +1179,41 @@ mod tests {
             )
             .unwrap();
         assert!(parent.is_none());
+
+        let version: String = conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn migrate_from_v30_adds_orchestration_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Minimal v30 state: metadata only; the v31 step creates both tables.
+        conn.execute_batch(
+            "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO metadata (key, value) VALUES ('schema_version', '30');
+             CREATE TABLE sessions (id TEXT PRIMARY KEY);",
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        for table in ["session_labels", "session_spawn_config"] {
+            let exists: bool = conn
+                .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1")
+                .unwrap()
+                .exists([table])
+                .unwrap();
+            assert!(exists, "{table} table should be created at v31");
+        }
+
+        // Re-running is idempotent (CREATE TABLE IF NOT EXISTS).
+        migrate_v31_orchestration(&conn).unwrap();
 
         let version: String = conn
             .query_row(

--- a/src/storage/spawn_config.rs
+++ b/src/storage/spawn_config.rs
@@ -1,0 +1,174 @@
+//! Per-session spawn configuration persisted for restart fidelity.
+//!
+//! `session create --env/--extra-arg/--system-prompt` customizations must
+//! survive a restart, which rebuilds the agent invocation from scratch. They
+//! live in a side table (not `sessions` columns) so the TUI's whole-row
+//! session upsert can never wipe them. Written once at headless spawn; read
+//! by both the headless and TUI restart paths. Sessions without a row simply
+//! restart with no per-spawn customization (the TUI-created default).
+
+use rusqlite::{params, OptionalExtension};
+
+use crate::session::SessionId;
+use crate::sync::current_time_millis;
+
+use super::Database;
+
+/// The per-spawn customizations of one session.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SpawnConfigRecord {
+    /// Per-spawn environment overrides (`--env`), in insertion order.
+    pub env: Vec<(String, String)>,
+    /// Per-spawn arguments appended to the agent invocation (`--extra-arg`).
+    pub extra_args: Vec<String>,
+    /// System prompt substituted into the agent's `prompt_args` template.
+    pub system_prompt: Option<String>,
+}
+
+impl SpawnConfigRecord {
+    /// True when there is nothing to persist.
+    pub fn is_empty(&self) -> bool {
+        self.env.is_empty() && self.extra_args.is_empty() && self.system_prompt.is_none()
+    }
+}
+
+impl Database {
+    /// Insert or replace the spawn config for a session.
+    pub fn set_session_spawn_config(
+        &self,
+        session_id: SessionId,
+        cfg: &SpawnConfigRecord,
+    ) -> rusqlite::Result<()> {
+        let now = current_time_millis() as i64;
+        let env = serde_json::to_string(&cfg.env).unwrap_or_else(|_| "[]".into());
+        let extra_args = serde_json::to_string(&cfg.extra_args).unwrap_or_else(|_| "[]".into());
+
+        self.conn.execute(
+            "INSERT INTO session_spawn_config \
+                 (session_id, env, extra_args, system_prompt, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?5) \
+             ON CONFLICT(session_id) DO UPDATE SET \
+                 env = ?2, extra_args = ?3, system_prompt = ?4, updated_at = ?5",
+            params![
+                session_id.to_string(),
+                env,
+                extra_args,
+                cfg.system_prompt,
+                now
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// The spawn config for a session, or `None` when it never had one.
+    pub fn get_session_spawn_config(
+        &self,
+        session_id: SessionId,
+    ) -> rusqlite::Result<Option<SpawnConfigRecord>> {
+        self.conn
+            .query_row(
+                "SELECT env, extra_args, system_prompt FROM session_spawn_config \
+                 WHERE session_id = ?1",
+                params![session_id.to_string()],
+                |row| {
+                    let env: String = row.get(0)?;
+                    let extra_args: String = row.get(1)?;
+                    let system_prompt: Option<String> = row.get(2)?;
+                    Ok(SpawnConfigRecord {
+                        env: serde_json::from_str(&env).unwrap_or_default(),
+                        extra_args: serde_json::from_str(&extra_args).unwrap_or_default(),
+                        system_prompt,
+                    })
+                },
+            )
+            .optional()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::SharedSession;
+
+    fn setup_db_with_session() -> (Database, SessionId) {
+        let db = Database::open_in_memory().unwrap();
+        let session = SharedSession {
+            id: SessionId::default(),
+            name: "S1".to_string(),
+            agent: "dev".to_string(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".to_string(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        let sid = session.id;
+        db.upsert_session(&session).unwrap();
+        (db, sid)
+    }
+
+    #[test]
+    fn roundtrip_preserves_env_order_args_and_prompt() {
+        let (db, sid) = setup_db_with_session();
+        let cfg = SpawnConfigRecord {
+            env: vec![
+                ("ZED".into(), "last".into()),
+                ("ALPHA".into(), "first".into()),
+            ],
+            extra_args: vec!["--permission-mode".into(), "plan".into()],
+            system_prompt: Some("be terse".into()),
+        };
+        db.set_session_spawn_config(sid, &cfg).unwrap();
+        assert_eq!(db.get_session_spawn_config(sid).unwrap(), Some(cfg));
+    }
+
+    #[test]
+    fn missing_row_returns_none() {
+        let (db, sid) = setup_db_with_session();
+        assert_eq!(db.get_session_spawn_config(sid).unwrap(), None);
+    }
+
+    #[test]
+    fn set_replaces_existing_config() {
+        let (db, sid) = setup_db_with_session();
+        db.set_session_spawn_config(
+            sid,
+            &SpawnConfigRecord {
+                system_prompt: Some("v1".into()),
+                ..SpawnConfigRecord::default()
+            },
+        )
+        .unwrap();
+        db.set_session_spawn_config(
+            sid,
+            &SpawnConfigRecord {
+                system_prompt: Some("v2".into()),
+                ..SpawnConfigRecord::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            db.get_session_spawn_config(sid)
+                .unwrap()
+                .unwrap()
+                .system_prompt
+                .as_deref(),
+            Some("v2")
+        );
+    }
+
+    #[test]
+    fn is_empty_detects_default() {
+        assert!(SpawnConfigRecord::default().is_empty());
+        assert!(!SpawnConfigRecord {
+            extra_args: vec!["--x".into()],
+            ..SpawnConfigRecord::default()
+        }
+        .is_empty());
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -43,6 +43,47 @@ fn workspace_dir(id: &str) -> io::Result<PathBuf> {
     Ok(base.join(segment))
 }
 
+/// The directory the agent process should launch in.
+///
+/// For a single-member session that's the member itself (`primary_cwd`). For
+/// a multi-member session it is the per-session **symlink workspace** (built
+/// idempotently from the members via [`ensure_workspace`]) so the agent sees
+/// every repo as a subdirectory — agent-neutral, needing no per-CLI flag.
+/// Member labels fall back to the directory's file name (then `"repo"`).
+/// Without an `agent_session_id` there is no stable workspace name, and on
+/// any build failure, it falls back to `primary_cwd`.
+pub fn resolve_process_cwd(
+    agent_session_id: Option<&str>,
+    primary_cwd: Option<PathBuf>,
+    members: &[(Option<String>, PathBuf)],
+) -> Option<PathBuf> {
+    if members.len() < 2 {
+        return primary_cwd;
+    }
+    let Some(id) = agent_session_id else {
+        return primary_cwd;
+    };
+
+    let pairs: Vec<(String, PathBuf)> = members
+        .iter()
+        .map(|(name, dir)| {
+            let label = name
+                .clone()
+                .or_else(|| dir.file_name().and_then(|s| s.to_str()).map(String::from))
+                .unwrap_or_else(|| "repo".to_string());
+            (label, dir.clone())
+        })
+        .collect();
+
+    match ensure_workspace(id, &pairs) {
+        Ok(ws) => Some(ws),
+        Err(e) => {
+            tracing::error!("Failed to build multi-repo workspace: {e}");
+            primary_cwd
+        }
+    }
+}
+
 /// (Re)build the symlink workspace for `id` from `members` and return its path.
 ///
 /// Idempotent: any existing workspace dir is removed first (it holds only
@@ -235,5 +276,47 @@ mod tests {
         assert_eq!(sanitize_segment("a/b\\c:d"), "a-b-c-d");
         assert_eq!(sanitize_segment("  .git  "), "git");
         assert_eq!(sanitize_segment("my repo"), "my-repo");
+    }
+
+    #[test]
+    fn resolve_single_member_is_primary() {
+        let cwd = PathBuf::from("/src/only");
+        let members = vec![(None, cwd.clone())];
+        assert_eq!(
+            resolve_process_cwd(Some("id-1"), Some(cwd.clone()), &members),
+            Some(cwd)
+        );
+    }
+
+    #[test]
+    fn resolve_multi_member_without_id_falls_back_to_primary() {
+        let primary = PathBuf::from("/src/a");
+        let members = vec![(None, primary.clone()), (None, PathBuf::from("/src/b"))];
+        assert_eq!(
+            resolve_process_cwd(None, Some(primary.clone()), &members),
+            Some(primary)
+        );
+    }
+
+    #[test]
+    fn resolve_multi_member_builds_workspace_with_file_name_labels() {
+        let base = temp_base();
+        let _g = TestPathGuard::new(&base);
+        let primary = base.join("repo-a");
+        let other = base.join("repo-b");
+        std::fs::create_dir_all(&primary).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+
+        let members = vec![
+            (Some("named".to_string()), primary.clone()),
+            (None, other.clone()),
+        ];
+        let out = resolve_process_cwd(Some("sess-y"), Some(primary.clone()), &members).unwrap();
+
+        let ws_root = crate::paths::workspaces_directory().unwrap();
+        assert!(out.starts_with(&ws_root), "{out:?} not under {ws_root:?}");
+        assert_eq!(std::fs::read_link(out.join("named")).unwrap(), primary);
+        // Unnamed member labeled by its directory file name.
+        assert_eq!(std::fs::read_link(out.join("repo-b")).unwrap(), other);
     }
 }


### PR DESCRIPTION
## Summary

- `session create` gains agent-neutral pass-through flags: `--prompt` (one-shot, typed after a 3 s boot delay), `--system-prompt` (via the agent's new `prompt_args` template), repeatable `--env` / `--extra-arg` / `--add-dir` / `--label`
- New polling primitives for orchestration scripts: `session wait` (regex on pane output / window exit, exit codes 3=pending 4=timeout) and `session result` (extracts the last `===RESULT===`-terminated JSON document; EOF-truncated counts as pending)
- `session list`/`get` now report `labels`, `alive`, and `last_activity` from one batched tmux call (`alive: null` for remote hosts — list never SSHes); `list --label k=v` filters (AND)
- `agents.toml` entries take `env` (lowest-precedence env layer) and `prompt_args` (`{prompt}` substituted); per-spawn env/extra-args/system-prompt persist in the new `session_spawn_config` table (schema v29, with `session_labels`) so both headless restart and the TUI `Ctrl+R` reproduce the exact invocation
- Restart also rebuilds multi-dir symlink workspaces headlessly and no longer drops `THURBOX_*` env in the TUI path

## Test plan

- 981 unit tests + architecture rules green; clippy `-D warnings` and rustdoc clean
- Live smoke test against an isolated dev build (fake agent) verified arg emit order, env precedence, prompt delivery, label filter, workspace symlinks, restart fidelity, and the 0/3/4 exit codes
- CI checks pass