### PR TITLE
feat(core): first-class parent session ids for lead/worker orchestration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,7 +386,7 @@ keeps its own position with a `↳` mark instead), and the info panel
 `ui::project_list::compute_session_order` (`SessionOrder::depths`),
 so `Ctrl+J`/`Ctrl+K` navigation follows the tree automatically.
 Storage: nullable `sessions.parent_session_id` column (schema v30;
-v28/v29 are reserved by an in-flight branch).
+v29 is reserved by an in-flight branch).
 
 Automations fire even when the TUI is closed: a tmux heartbeat
 keeper window (`automation-heartbeat`, armed on TUI startup and on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,11 @@ thurbox-cli session create --name demo --repo-path /path \
 # Spawn on a remote host from hosts.toml (worktree + tmux live remotely):
 thurbox-cli session create --name demo --repo-path /srv/repo \
     --host devbox --worktree-branch feat/x
+# Spawn a worker under a lead session (parent must exist):
+thurbox-cli session create --name worker --repo-path /path \
+    --parent <lead-uuid>
 thurbox-cli session list | jq
+thurbox-cli session list --parent <lead-uuid> | jq  # direct children only
 ```
 
 Subcommands: `session` (create/list/get/delete/restore/restart/
@@ -362,6 +366,27 @@ window, remove worktrees + the symlink workspace, and disable
 when no TUI is running. Teardown is best-effort (failures land in
 the JSON report); the row is always soft-deleted last, so even a
 forced delete stays restorable.
+
+### Parent sessions (lead/worker)
+
+Sessions carry an optional **`parent_session_id`** so orchestration
+scripts can model lead → worker relationships. `session create
+--parent <uuid>` sets it (the parent must be an existing active
+session — validated before any side effects); `session list`/`get`
+emit it in the JSON (`null` for top-level sessions) and `session
+list --parent <uuid>` filters to direct children. The link is
+**purely informational**: deleting a parent never cascades to
+children (orphans simply render as top-level), and the parent is
+only validated at creation. In the TUI, **`Ctrl+F` fork** records
+the source session as the fork's parent; the session list nests
+children under their parent **within the same repo group** (muted
+`└` tree prefix; a child whose parent renders in another group
+keeps its own position with a `↳` mark instead), and the info panel
+(F2) shows a `Parent:` row. The nesting lives in
+`ui::project_list::compute_session_order` (`SessionOrder::depths`),
+so `Ctrl+J`/`Ctrl+K` navigation follows the tree automatically.
+Storage: nullable `sessions.parent_session_id` column (schema v30;
+v28/v29 are reserved by an in-flight branch).
 
 Automations fire even when the TUI is closed: a tmux heartbeat
 keeper window (`automation-heartbeat`, armed on TUI startup and on

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1002,6 +1002,44 @@ there is no primary/secondary distinction.
 
 ---
 
+## Parent Sessions (Lead/Worker)
+
+Sessions carry an optional `parent_session_id` (nullable column on
+`sessions`, schema v30) so orchestration scripts can model a lead
+session that spawns workers: `thurbox-cli session create --parent
+<uuid>` sets it, `session list`/`get` expose it, and `session list
+--parent <uuid>` lists direct children. In the TUI, `Ctrl+F` fork
+records the source session as the fork's parent.
+
+### Why informational-only (no cascade)
+
+The link is metadata, not a lifecycle contract. Deleting a parent
+does **not** delete or orphan-block its children — workers routinely
+outlive the lead that spawned them (the lead finishes orchestrating
+while workers keep coding). A dangling parent id is harmless: the
+child simply renders as a top-level session again. The parent is
+validated once, at creation (it must be an existing active session),
+and never re-validated.
+
+### Why nesting stays inside repo groups
+
+The session list's primary grouping is the repo set
+(`compute_session_order`), and that stays authoritative: children
+nest under their parent **within** a repo group (muted `└` prefix,
+depth tracked in `SessionOrder::depths`), because a lead and its
+workers usually share a repo. A child whose parent renders in a
+different group keeps its natural position and gets a `↳` mark
+instead — reordering across repo groups would break the "one header
+per repo" invariant and make rows jump between groups. Group
+bubbling is unchanged: an `Attention` child still pulls its whole
+repo group to the top. Navigation (`Ctrl+J`/`Ctrl+K`) shares the
+same ordering function, so it walks the tree exactly as rendered.
+Parent cycles can't be produced by current writers (the parent must
+exist before the child, and the link is immutable), but the ordering
+is still defensive: cycle members render flat rather than vanish.
+
+---
+
 ## Terminal Scrollback
 
 ### Scrollback buffer

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -943,6 +943,7 @@ impl App {
                     self.new_session.spawn_config = None;
                     self.new_session.spawn_worktrees.clear();
                     self.new_session.fork = false;
+                    self.new_session.parent_session_id = None;
                 }
             }
             KeyCode::Enter => {
@@ -1329,9 +1330,10 @@ impl App {
         ) {
             self.new_automation_in_pane();
         } else {
-            // A manual new-session must not inherit a task prompt left over from
-            // a cancelled task-spawn.
+            // A manual new-session must not inherit a task prompt or fork
+            // parenthood left over from a cancelled task-spawn / fork.
             self.task_ui.pending_task_prompt = None;
+            self.new_session.parent_session_id = None;
             self.start_new_session();
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2874,6 +2874,7 @@ impl App {
             spawned.info.id = shared_session.id;
             spawned.info.worktrees = worktree_infos;
             spawned.info.additional_dirs = shared_session.additional_dirs.clone();
+            spawned.info.parent_session_id = shared_session.parent_session_id;
             self.sessions.push(spawned);
             self.save_state();
             tracing::debug!(
@@ -7107,6 +7108,35 @@ mod tests {
         let wt = &shared.worktrees[0];
         assert_eq!(wt.branch, "feat");
         assert_eq!(wt.repo_path, PathBuf::from("/repo"));
+    }
+
+    #[test]
+    fn session_to_shared_maps_parent_session_id() {
+        // Regression guard: `save_state` upserts every session via
+        // `session_to_shared`, so dropping the parent here would wipe a
+        // CLI-set lead/worker link from the DB on the TUI's next save.
+        let backend_arc = stub_backend_arc();
+        let provider = stub_provider();
+        let mut app = App::new(
+            24,
+            120,
+            BackendRegistry::new(backend_arc.clone()),
+            stub_agents(),
+            test_db(),
+        );
+
+        let parent_id = SessionId::default();
+        let mut session = Session::stub("worker", &backend_arc, &provider);
+        session.info.parent_session_id = Some(parent_id);
+        app.sessions.push(session);
+
+        let shared = app.session_to_shared(&app.sessions[0]);
+        assert_eq!(shared.parent_session_id, Some(parent_id));
+
+        // And the metadata copy applies it back on adoption/update.
+        let mut adopted = Session::stub("worker", &backend_arc, &provider);
+        App::apply_shared_session_metadata(&mut adopted, &shared);
+        assert_eq!(adopted.info.parent_session_id, Some(parent_id));
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -92,6 +92,9 @@ struct PendingSessionSpawn {
     primary_cwd: Option<PathBuf>,
     worktrees: Vec<WorktreeInfo>,
     additional_dirs: Vec<PathBuf>,
+    /// Parent session (lead/worker linkage), captured at kickoff like the
+    /// other wizard state so an overlapping flow can't steal it.
+    parent_session_id: Option<SessionId>,
     /// A task-initiated spawn's `(task_id, title)`, captured at kickoff so the
     /// prompt is delivered + the task advanced when the session comes up.
     task_prompt: Option<(i64, String)>,
@@ -1105,6 +1108,7 @@ impl App {
         self.new_session.spawn_config = Some(config);
         self.new_session.spawn_worktrees = worktrees;
         self.new_session.fork = true;
+        self.new_session.parent_session_id = Some(session.info.id);
 
         let mut sn = modals::SessionNameModal::default();
         sn.name.set(&format!("{source_name}-fork"));
@@ -1282,6 +1286,7 @@ impl App {
             Ok(mut session) => {
                 session.info.id = deleted.id;
                 session.info.worktrees = worktree_infos;
+                session.info.parent_session_id = deleted.parent_session_id;
                 resolve_repo_display_names(&mut session.info);
                 self.sessions.push(session);
                 self.active_index = self.sessions.len() - 1;
@@ -1307,6 +1312,7 @@ impl App {
         session.info.additional_dirs = shared.additional_dirs.clone();
         session.info.agent_session_id = shared.agent_session_id.clone();
         session.info.worktrees = shared.worktrees.iter().cloned().map(Into::into).collect();
+        session.info.parent_session_id = shared.parent_session_id;
         resolve_repo_display_names(&mut session.info);
     }
 
@@ -1980,11 +1986,13 @@ impl App {
         primary_cwd: Option<PathBuf>,
         worktrees: Vec<WorktreeInfo>,
         additional_dirs: Vec<PathBuf>,
+        parent_session_id: Option<SessionId>,
         task_prompt: Option<(i64, String)>,
     ) {
         session.info.cwd = primary_cwd;
         session.info.worktrees = worktrees;
         session.info.additional_dirs = additional_dirs;
+        session.info.parent_session_id = parent_session_id;
 
         resolve_repo_display_names(&mut session.info);
         self.sessions.push(session);
@@ -2028,6 +2036,7 @@ impl App {
         worktrees: Vec<WorktreeInfo>,
     ) {
         let additional_dirs = std::mem::take(&mut self.new_session.additional_dirs);
+        let parent_session_id = self.new_session.parent_session_id.take();
         let Some(inputs) = self.build_spawn_inputs(config, &worktrees, &additional_dirs) else {
             return;
         };
@@ -2047,6 +2056,7 @@ impl App {
                     inputs.primary_cwd,
                     worktrees,
                     additional_dirs,
+                    parent_session_id,
                     task_prompt,
                 );
             }
@@ -2074,6 +2084,7 @@ impl App {
         }
 
         let additional_dirs = std::mem::take(&mut self.new_session.additional_dirs);
+        let parent_session_id = self.new_session.parent_session_id.take();
         let Some(inputs) = self.build_spawn_inputs(config, &worktrees, &additional_dirs) else {
             return;
         };
@@ -2093,6 +2104,7 @@ impl App {
             primary_cwd,
             worktrees,
             additional_dirs,
+            parent_session_id,
             task_prompt,
         });
         self.set_status(StatusLevel::Info, format!("Spawning {name}…"));
@@ -2125,6 +2137,7 @@ impl App {
                 pending.primary_cwd,
                 pending.worktrees,
                 pending.additional_dirs,
+                pending.parent_session_id,
                 pending.task_prompt,
             ),
             Err(e) => {
@@ -2957,6 +2970,7 @@ impl App {
                 .map(Into::into)
                 .collect(),
             shell_backend_id: session.info.shell_backend_id.clone(),
+            parent_session_id: session.info.parent_session_id,
             tombstone: false,
             tombstone_at: None,
         }
@@ -3131,6 +3145,7 @@ impl App {
         session.info.additional_dirs = shared.additional_dirs.clone();
         session.info.agent = agent;
         session.info.worktrees = worktrees;
+        session.info.parent_session_id = shared.parent_session_id;
         resolve_repo_display_names(&mut session.info);
 
         // Re-adopt shell pane if one was persisted
@@ -3193,6 +3208,7 @@ impl App {
         config.resume_session_id =
             crate::session_ops::resume_trigger_for(&def, &agent_session_id, &config.env);
         self.new_session.additional_dirs = shared.additional_dirs;
+        self.new_session.parent_session_id = shared.parent_session_id;
         self.do_spawn_session(name, &config, worktrees);
     }
 
@@ -7680,6 +7696,7 @@ mod tests {
             primary_cwd: None,
             worktrees: vec![],
             additional_dirs: vec![],
+            parent_session_id: None,
             task_prompt: None,
         });
 
@@ -7701,6 +7718,7 @@ mod tests {
             primary_cwd: None,
             worktrees: vec![],
             additional_dirs: vec![],
+            parent_session_id: None,
             task_prompt: None,
         });
 
@@ -7957,6 +7975,7 @@ mod tests {
             additional_dirs: Vec::new(),
             worktrees: Vec::new(),
             shell_backend_id: None,
+            parent_session_id: None,
             tombstone: false,
             tombstone_at: None,
         }

--- a/src/app/new_session_state.rs
+++ b/src/app/new_session_state.rs
@@ -8,7 +8,7 @@
 
 use std::path::PathBuf;
 
-use crate::session::{SessionConfig, WorktreeInfo};
+use crate::session::{SessionConfig, SessionId, WorktreeInfo};
 
 /// State accumulated across the multi-step new-session flow. Also reused by
 /// the fork (`Ctrl+F`) and restart (`Ctrl+R`) flows, which pre-seed parts of
@@ -31,6 +31,10 @@ pub(crate) struct NewSessionWizardState {
     /// attach to the spawned session's `SessionInfo`. Consumed by
     /// `do_spawn_session`.
     pub(crate) additional_dirs: Vec<PathBuf>,
+    /// Parent session for the spawned session (lead/worker linkage). Set by
+    /// fork (`Ctrl+F`, the forked-from session) and stale-session respawn;
+    /// consumed by `do_spawn_session`/`do_spawn_session_async`.
+    pub(crate) parent_session_id: Option<SessionId>,
     pub(crate) fork: bool,
     pub(crate) restart: bool,
     pub(crate) spawn_name: Option<String>,

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -157,6 +157,7 @@ impl App {
                 session_match_positions: &ordered.match_positions,
                 session_search_active,
                 headers: &ordered.headers,
+                depths: &ordered.depths,
             },
         );
     }
@@ -234,6 +235,18 @@ impl App {
                 }
             })
             .collect();
+        // Resolve the parent session's name for child sessions; fall back to
+        // the short uuid when the parent is no longer in the list.
+        let parent_name = info.parent_session_id.map(|pid| {
+            self.sessions
+                .iter()
+                .find(|s| s.info.id == pid)
+                .map(|s| s.info.name.clone())
+                .unwrap_or_else(|| {
+                    let id = pid.to_string();
+                    id.chars().take(8).collect()
+                })
+        });
         info_panel::render_info_panel(
             frame,
             info_area,
@@ -241,6 +254,7 @@ impl App {
             Some(&self.metrics.system_metrics),
             &automation_entries,
             agent_usage,
+            parent_name.as_deref(),
         );
     }
 

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -343,6 +343,7 @@ fn fire_headless(
                 agent: agent.clone(),
                 agent_session_id: None,
                 host: None,
+                parent_session_id: None,
             };
             match crate::session_ops::spawn_session_headless(db, req) {
                 Ok(result) => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -90,7 +90,7 @@ mod tests {
         assert!(matches!(
             cli.command,
             Command::Session {
-                action: sessions::Action::List
+                action: sessions::Action::List { parent: None }
             }
         ));
     }
@@ -132,6 +132,54 @@ mod tests {
         assert_eq!(repo_path.to_string_lossy(), "/tmp/repo");
         assert_eq!(worktree_branch.as_deref(), Some("feat/x"));
         assert_eq!(agent.as_deref(), Some("codex"));
+    }
+
+    #[test]
+    fn parse_session_create_accepts_parent() {
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "session",
+            "create",
+            "--name",
+            "worker",
+            "--repo-path",
+            "/tmp/repo",
+            "--parent",
+            "0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a",
+        ])
+        .unwrap();
+        let Command::Session {
+            action: sessions::Action::Create { parent, .. },
+        } = cli.command
+        else {
+            panic!("expected Session::Create");
+        };
+        assert_eq!(
+            parent.as_deref(),
+            Some("0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a")
+        );
+    }
+
+    #[test]
+    fn parse_session_list_accepts_parent_filter() {
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "session",
+            "list",
+            "--parent",
+            "0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a",
+        ])
+        .unwrap();
+        let Command::Session {
+            action: sessions::Action::List { parent },
+        } = cli.command
+        else {
+            panic!("expected Session::List");
+        };
+        assert_eq!(
+            parent.as_deref(),
+            Some("0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a")
+        );
     }
 
     #[test]

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -12,7 +12,11 @@ use crate::sync::SharedSession;
 #[derive(Subcommand, Debug)]
 pub enum Action {
     /// List all active sessions.
-    List,
+    List {
+        /// Only list children of this parent session UUID.
+        #[arg(long)]
+        parent: Option<String>,
+    },
     /// Get a session by UUID.
     Get {
         /// Session UUID.
@@ -40,6 +44,10 @@ pub enum Action {
         /// worktree and tmux window are created on that host over SSH.
         #[arg(long)]
         host: Option<String>,
+        /// Parent session UUID (lead/worker relationship for orchestration).
+        /// Must reference an existing active session.
+        #[arg(long)]
+        parent: Option<String>,
     },
     /// Soft-delete a session.
     ///
@@ -85,12 +93,17 @@ pub enum Action {
 
 pub fn run(action: Action, db: &Database) -> Result<Value, String> {
     match action {
-        Action::List => {
+        Action::List { parent } => {
+            let parent_id = parent.as_deref().map(parse_session_id).transpose()?;
             let sessions = db
                 .list_active_sessions()
                 .map_err(|e| format!("list_active_sessions: {e}"))?;
             Ok(Value::Array(
-                sessions.iter().map(shared_session_to_json).collect(),
+                sessions
+                    .iter()
+                    .filter(|s| parent_id.is_none() || s.parent_session_id == parent_id)
+                    .map(shared_session_to_json)
+                    .collect(),
             ))
         }
         Action::Get { uuid } => {
@@ -104,7 +117,9 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             worktree_branch,
             base_branch,
             host,
+            parent,
         } => {
+            let parent_session_id = parent.as_deref().map(parse_session_id).transpose()?;
             let req = crate::session_ops::SpawnRequest {
                 name,
                 repo_path,
@@ -113,6 +128,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 agent,
                 agent_session_id: None,
                 host,
+                parent_session_id,
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
             Ok(json!({
@@ -121,6 +137,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 "agent": res.agent,
                 "agent_session_id": res.agent_session_id,
                 "cwd": res.cwd.display().to_string(),
+                "parent_session_id": res.parent_session_id.map(|id| id.to_string()),
             }))
         }
         Action::Delete { uuid, force } => {
@@ -189,10 +206,13 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
     }
 }
 
+fn parse_session_id(uuid: &str) -> Result<SessionId, String> {
+    uuid.parse()
+        .map_err(|_| format!("Invalid session UUID: {uuid}"))
+}
+
 fn resolve(db: &Database, uuid: &str) -> Result<SharedSession, String> {
-    let id: SessionId = uuid
-        .parse()
-        .map_err(|_| format!("Invalid session UUID: {uuid}"))?;
+    let id = parse_session_id(uuid)?;
     db.get_session_by_id(id)
         .map_err(|e| format!("get_session_by_id: {e}"))?
         .ok_or_else(|| format!("Session not found: {uuid}"))
@@ -206,6 +226,7 @@ fn shared_session_to_json(s: &SharedSession) -> Value {
         "backend_type": s.backend_type,
         "agent_session_id": s.agent_session_id,
         "cwd": s.cwd.as_ref().map(|p| p.display().to_string()),
+        "parent_session_id": s.parent_session_id.map(|id| id.to_string()),
         "worktrees": s.worktrees.iter().map(|w| json!({
             "repo_path": w.repo_path.display().to_string(),
             "worktree_path": w.worktree_path.display().to_string(),
@@ -225,7 +246,7 @@ mod tests {
     #[test]
     fn list_empty_returns_array() {
         let db = db();
-        let v = run(Action::List, &db).unwrap();
+        let v = run(Action::List { parent: None }, &db).unwrap();
         assert!(v.is_array(), "got {v}");
         assert_eq!(v.as_array().unwrap().len(), 0);
     }
@@ -245,12 +266,13 @@ mod tests {
             additional_dirs: Vec::new(),
             worktrees: Vec::new(),
             shell_backend_id: None,
+            parent_session_id: None,
             tombstone: false,
             tombstone_at: None,
         };
         db.upsert_session(&shared).unwrap();
 
-        let v = run(Action::List, &db).unwrap();
+        let v = run(Action::List { parent: None }, &db).unwrap();
         let arr = v.as_array().unwrap();
         assert_eq!(arr.len(), 1);
         let s = &arr[0];
@@ -260,7 +282,67 @@ mod tests {
         assert_eq!(s["backend_type"].as_str(), Some("local-tmux"));
         assert_eq!(s["agent_session_id"].as_str(), Some("agent-1"));
         assert_eq!(s["cwd"].as_str(), Some("/tmp/repo"));
+        assert!(s["parent_session_id"].is_null());
         assert!(s["worktrees"].is_array());
+    }
+
+    #[test]
+    fn list_emits_parent_session_id_and_filters_by_parent() {
+        let db = db();
+        let parent_id = SessionId::default();
+        let parent = SharedSession {
+            id: parent_id,
+            name: "lead".into(),
+            agent: "dev".into(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        db.upsert_session(&parent).unwrap();
+        let mut child = parent.clone();
+        child.id = SessionId::default();
+        child.name = "worker".into();
+        child.parent_session_id = Some(parent_id);
+        db.upsert_session(&child).unwrap();
+
+        // Unfiltered list carries the field on both rows.
+        let v = run(Action::List { parent: None }, &db).unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        let worker = arr.iter().find(|s| s["name"] == "worker").unwrap();
+        assert_eq!(
+            worker["parent_session_id"].as_str(),
+            Some(parent_id.to_string().as_str())
+        );
+
+        // --parent filters to direct children only.
+        let v = run(
+            Action::List {
+                parent: Some(parent_id.to_string()),
+            },
+            &db,
+        )
+        .unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"].as_str(), Some("worker"));
+
+        // Malformed --parent uuid errors.
+        let err = run(
+            Action::List {
+                parent: Some("not-a-uuid".into()),
+            },
+            &db,
+        )
+        .unwrap_err();
+        assert!(err.contains("Invalid session UUID"), "got {err}");
     }
 
     #[test]
@@ -291,6 +373,7 @@ mod tests {
             additional_dirs: Vec::new(),
             worktrees: Vec::new(),
             shell_backend_id: None,
+            parent_session_id: None,
             tombstone: false,
             tombstone_at: None,
         };
@@ -324,6 +407,7 @@ mod tests {
             additional_dirs: Vec::new(),
             worktrees: Vec::new(),
             shell_backend_id: None,
+            parent_session_id: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -192,6 +192,7 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
                 agent: agent.clone(),
                 agent_session_id: None,
                 host: None,
+                parent_session_id: None,
             };
             crate::session_ops::spawn_session_headless(db, req)?;
             crate::agent::tmux::send_prompt_after_delay(&name, &prompt, BOOT_DELAY_SECS)

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -191,6 +191,9 @@ pub struct SessionInfo {
     /// Order: worktree repos first, then non-worktree additional dirs.
     /// Populated by the app layer at spawn/restore time.
     pub repo_display_names: Vec<String>,
+    /// Parent session (lead/worker relationship for orchestration).
+    /// `None` for top-level sessions. Purely informational.
+    pub parent_session_id: Option<SessionId>,
 }
 
 impl SessionInfo {
@@ -212,6 +215,7 @@ impl SessionInfo {
             notification: None,
             git_stats: None,
             repo_display_names: Vec::new(),
+            parent_session_id: None,
         }
     }
 }

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -90,6 +90,7 @@ mod tests {
             additional_dirs: Vec::new(),
             worktrees: Vec::new(),
             shell_backend_id: None,
+            parent_session_id: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -53,9 +53,9 @@ pub struct SpawnResult {
 
 /// Spawn a new session inside `tmux -L thurbox`, persisting its state to the
 /// shared SQLite database.
-pub fn spawn_session_headless(_db: &Database, req: SpawnRequest) -> Result<SpawnResult, String> {
+pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnResult, String> {
     validate_session_name(&req.name)?;
-    validate_parent_session(_db, req.parent_session_id)?;
+    validate_parent_session(db, req.parent_session_id)?;
 
     let agent_name = resolve_agent_name(req.agent.as_deref());
 
@@ -119,7 +119,7 @@ pub fn spawn_session_headless(_db: &Database, req: SpawnRequest) -> Result<Spawn
     // for the TUI to adopt and the window would be orphaned — untrackable and
     // unkillable from the UI. Best-effort tear it down before surfacing the
     // error so we don't leak a window.
-    if let Err(e) = _db.upsert_session(&shared) {
+    if let Err(e) = db.upsert_session(&shared) {
         tracing::error!(
             "spawn race: DB upsert failed after the tmux window for '{}' spawned; \
              tearing down the orphaned window: {e}",

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -34,6 +34,9 @@ pub struct SpawnRequest {
     /// Optional remote host name (from `hosts.toml`). When set, the session is
     /// created on that host over SSH (worktree + tmux window live remotely).
     pub host: Option<String>,
+    /// Optional parent session (lead/worker relationship for orchestration).
+    /// Must reference an existing active session.
+    pub parent_session_id: Option<SessionId>,
 }
 
 /// Result returned on successful headless spawn.
@@ -45,12 +48,14 @@ pub struct SpawnResult {
     pub agent_session_id: String,
     pub cwd: PathBuf,
     pub worktrees: Vec<SharedWorktree>,
+    pub parent_session_id: Option<SessionId>,
 }
 
 /// Spawn a new session inside `tmux -L thurbox`, persisting its state to the
 /// shared SQLite database.
 pub fn spawn_session_headless(_db: &Database, req: SpawnRequest) -> Result<SpawnResult, String> {
     validate_session_name(&req.name)?;
+    validate_parent_session(_db, req.parent_session_id)?;
 
     let agent_name = resolve_agent_name(req.agent.as_deref());
 
@@ -106,6 +111,7 @@ pub fn spawn_session_headless(_db: &Database, req: SpawnRequest) -> Result<Spawn
         additional_dirs: Vec::new(),
         worktrees: worktrees.clone(),
         shell_backend_id: None,
+        parent_session_id: req.parent_session_id,
         tombstone: false,
         tombstone_at: None,
     };
@@ -139,12 +145,26 @@ pub fn spawn_session_headless(_db: &Database, req: SpawnRequest) -> Result<Spawn
         agent_session_id,
         cwd,
         worktrees,
+        parent_session_id: req.parent_session_id,
     })
 }
 
 /// Validate a session name. Delegates to the shared `paths::validate_safe_name`.
 fn validate_session_name(name: &str) -> Result<(), String> {
     crate::paths::validate_safe_name(name)
+}
+
+/// Validate that the requested parent session, if any, exists and is active.
+/// Runs before any side effects (worktree creation, tmux spawn).
+fn validate_parent_session(db: &Database, parent: Option<SessionId>) -> Result<(), String> {
+    let Some(parent) = parent else {
+        return Ok(());
+    };
+    match db.get_session_by_id(parent) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err(format!("Parent session not found: {parent}")),
+        Err(e) => Err(format!("get_session_by_id: {e}")),
+    }
 }
 
 /// Resolve the agent name: explicit request wins, otherwise the registry's
@@ -223,6 +243,7 @@ mod tests {
             agent: None,
             agent_session_id: None,
             host: None,
+            parent_session_id: None,
         }
     }
 
@@ -242,6 +263,39 @@ mod tests {
                 "should reject {bad}"
             );
         }
+    }
+
+    #[test]
+    fn unknown_parent_session_is_rejected_before_spawn() {
+        let db = empty_db();
+        let mut r = req("worker");
+        r.parent_session_id = Some(SessionId::default());
+        let err = spawn_session_headless(&db, r).unwrap_err();
+        assert!(err.contains("Parent session not found"), "got {err}");
+    }
+
+    #[test]
+    fn validate_parent_session_accepts_existing_and_none() {
+        let db = empty_db();
+        assert!(validate_parent_session(&db, None).is_ok());
+
+        let parent = crate::sync::SharedSession {
+            id: SessionId::default(),
+            name: "lead".into(),
+            agent: "dev".into(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        db.upsert_session(&parent).unwrap();
+        assert!(validate_parent_session(&db, Some(parent.id)).is_ok());
     }
 
     #[test]

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1,7 +1,11 @@
 use rusqlite::Connection;
 
 /// Current schema version. Incremented when schema changes.
-pub const SCHEMA_VERSION: u32 = 28;
+///
+/// v29 is reserved by the in-flight `improve-agent-thurbox-cli` branch
+/// (`session_labels` + `session_spawn_config`); this branch takes v30.
+/// Gaps in the step table are fine (there is no v18 step either).
+pub const SCHEMA_VERSION: u32 = 30;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -35,6 +39,7 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             cwd               TEXT,
             additional_dirs   TEXT NOT NULL DEFAULT '',
             shell_backend_id  TEXT,
+            parent_session_id TEXT,
             created_at        INTEGER NOT NULL,
             updated_at        INTEGER NOT NULL,
             deleted_at        INTEGER
@@ -190,6 +195,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (26, migrate_v26_task_description),
         (27, migrate_v27_repo_parent_bookmarks),
         (28, migrate_v28_run_related_session),
+        (30, migrate_v30_parent_session_id),
     ];
 
     for &(target, step) in steps {
@@ -843,6 +849,17 @@ fn migrate_v28_run_related_session(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
+/// v29 → v30: add a nullable `parent_session_id` column to `sessions`
+/// (lead/worker linkage for orchestration; v29 belongs to another branch).
+///
+/// Fresh v30 databases already have the column from `initialize` and skip this
+/// step; existing databases get it via the ALTER. `let _` swallows the
+/// "duplicate column" error so a re-run is a no-op.
+fn migrate_v30_parent_session_id(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN parent_session_id TEXT", []);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1067,6 +1084,59 @@ mod tests {
             has_column,
             "related_session_id column should be added at v28"
         );
+
+        let version: String = conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn migrate_from_v27_adds_parent_session_id_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Minimal v27 state: a sessions table without the parent_session_id column.
+        conn.execute_batch(
+            "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO metadata (key, value) VALUES ('schema_version', '27');
+             CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, name TEXT NOT NULL,
+                agent TEXT NOT NULL DEFAULT 'claude',
+                backend_id TEXT NOT NULL DEFAULT '',
+                backend_type TEXT NOT NULL DEFAULT 'tmux',
+                agent_session_id TEXT, cwd TEXT,
+                additional_dirs TEXT NOT NULL DEFAULT '',
+                shell_backend_id TEXT, created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL, deleted_at INTEGER);
+             INSERT INTO sessions (id, name, created_at, updated_at)
+                VALUES ('s1', 'demo', 0, 0);",
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        let has_parent: bool = conn
+            .prepare("SELECT 1 FROM pragma_table_info('sessions') WHERE name='parent_session_id'")
+            .unwrap()
+            .exists([])
+            .unwrap();
+        assert!(
+            has_parent,
+            "parent_session_id column should be added at v30"
+        );
+
+        // Existing rows survive with a NULL parent.
+        let parent: Option<String> = conn
+            .query_row(
+                "SELECT parent_session_id FROM sessions WHERE id = 's1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(parent.is_none());
 
         let version: String = conn
             .query_row(

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -16,6 +16,7 @@ pub struct DeletedSessionInfo {
     pub agent: String,
     pub agent_session_id: Option<String>,
     pub cwd: Option<PathBuf>,
+    pub parent_session_id: Option<SessionId>,
     pub deleted_at: u64,
     pub worktrees: Vec<SharedWorktree>,
 }
@@ -47,8 +48,8 @@ impl Database {
                 "UPDATE sessions SET name = ?1, agent = ?2, \
                  backend_id = ?3, backend_type = ?4, agent_session_id = ?5, \
                  cwd = ?6, additional_dirs = ?7, shell_backend_id = ?8, \
-                 updated_at = ?9, deleted_at = NULL \
-                 WHERE id = ?10",
+                 parent_session_id = ?9, updated_at = ?10, deleted_at = NULL \
+                 WHERE id = ?11",
                 params![
                     session.name,
                     session.agent,
@@ -58,6 +59,7 @@ impl Database {
                     session.cwd.as_ref().map(|p| p.display().to_string()),
                     additional_dirs_str,
                     session.shell_backend_id,
+                    session.parent_session_id.map(|id| id.to_string()),
                     now,
                     id_str,
                 ],
@@ -75,8 +77,8 @@ impl Database {
             self.conn.execute(
                 "INSERT INTO sessions (id, name, agent, backend_id, backend_type, \
                  agent_session_id, cwd, additional_dirs, shell_backend_id, \
-                 created_at, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                 parent_session_id, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
                 params![
                     id_str,
                     session.name,
@@ -87,6 +89,7 @@ impl Database {
                     session.cwd.as_ref().map(|p| p.display().to_string()),
                     additional_dirs_str,
                     session.shell_backend_id,
+                    session.parent_session_id.map(|id| id.to_string()),
                     now,
                     now,
                 ],
@@ -170,6 +173,7 @@ impl Database {
         let sql = format!(
             "SELECT s.id, s.name, s.agent, s.backend_id, s.backend_type, \
              s.agent_session_id, s.cwd, s.additional_dirs, s.shell_backend_id, \
+             s.parent_session_id, \
              w.repo_path, w.worktree_path, w.branch \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id AND w.deleted_at IS NULL \
@@ -278,7 +282,7 @@ impl Database {
     ) -> rusqlite::Result<Vec<DeletedSessionInfo>> {
         let sql = format!(
             "SELECT s.id, s.name, s.agent, s.agent_session_id, \
-             s.cwd, s.deleted_at, \
+             s.cwd, s.parent_session_id, s.deleted_at, \
              w.repo_path, w.worktree_path, w.branch \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id \
@@ -290,10 +294,11 @@ impl Database {
         let rows = stmt.query_map(params, |row| {
             let id_str: String = row.get(0)?;
             let cwd: Option<String> = row.get(4)?;
-            let deleted_at: i64 = row.get(5)?;
-            let wt_repo: Option<String> = row.get(6)?;
-            let wt_path: Option<String> = row.get(7)?;
-            let wt_branch: Option<String> = row.get(8)?;
+            let parent_str: Option<String> = row.get(5)?;
+            let deleted_at: i64 = row.get(6)?;
+            let wt_repo: Option<String> = row.get(7)?;
+            let wt_path: Option<String> = row.get(8)?;
+            let wt_branch: Option<String> = row.get(9)?;
 
             let worktree = worktree_from_cols(wt_repo, wt_path, wt_branch);
 
@@ -304,6 +309,7 @@ impl Database {
                     agent: row.get(2)?,
                     agent_session_id: row.get(3)?,
                     cwd: cwd.map(PathBuf::from),
+                    parent_session_id: parent_str.and_then(|s| s.parse().ok()),
                     deleted_at: deleted_at as u64,
                     worktrees: Vec::new(),
                 },
@@ -359,9 +365,10 @@ fn row_to_shared_session(
     let cwd: Option<String> = row.get(6)?;
     let dirs_str: String = row.get(7)?;
     let shell_backend_id: Option<String> = row.get(8)?;
-    let wt_repo: Option<String> = row.get(9)?;
-    let wt_path: Option<String> = row.get(10)?;
-    let wt_branch: Option<String> = row.get(11)?;
+    let parent_str: Option<String> = row.get(9)?;
+    let wt_repo: Option<String> = row.get(10)?;
+    let wt_path: Option<String> = row.get(11)?;
+    let wt_branch: Option<String> = row.get(12)?;
 
     let additional_dirs: Vec<PathBuf> = if dirs_str.is_empty() {
         Vec::new()
@@ -383,6 +390,7 @@ fn row_to_shared_session(
             additional_dirs,
             worktrees: Vec::new(),
             shell_backend_id,
+            parent_session_id: parent_str.and_then(|s| s.parse().ok()),
             tombstone: false,
             tombstone_at: None,
         },
@@ -406,6 +414,7 @@ mod tests {
             additional_dirs: Vec::new(),
             worktrees: Vec::new(),
             shell_backend_id: None,
+            parent_session_id: None,
             tombstone: false,
             tombstone_at: None,
         }
@@ -622,6 +631,30 @@ mod tests {
             sessions[0].agent_session_id,
             Some("claude-abc-123".to_string())
         );
+    }
+
+    #[test]
+    fn session_parent_session_id_roundtrips() {
+        let db = Database::open_in_memory().unwrap();
+        let parent = make_session("Lead");
+        let mut child = make_session("Worker");
+        child.parent_session_id = Some(parent.id);
+
+        db.upsert_session(&parent).unwrap();
+        db.upsert_session(&child).unwrap();
+
+        let found = db.get_session_by_id(child.id).unwrap().unwrap();
+        assert_eq!(found.parent_session_id, Some(parent.id));
+        let lead = db.get_session_by_id(parent.id).unwrap().unwrap();
+        assert_eq!(lead.parent_session_id, None);
+
+        // An update keeps the parent linkage.
+        let mut renamed = child.clone();
+        renamed.name = "Worker 2".into();
+        db.upsert_session(&renamed).unwrap();
+        let found = db.get_session_by_id(child.id).unwrap().unwrap();
+        assert_eq!(found.name, "Worker 2");
+        assert_eq!(found.parent_session_id, Some(parent.id));
     }
 
     #[test]

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -658,6 +658,25 @@ mod tests {
     }
 
     #[test]
+    fn deleted_session_preserves_parent_session_id() {
+        let db = Database::open_in_memory().unwrap();
+        let parent = make_session("Lead");
+        let mut child = make_session("Worker");
+        child.parent_session_id = Some(parent.id);
+        db.upsert_session(&parent).unwrap();
+        db.upsert_session(&child).unwrap();
+
+        db.soft_delete_session(child.id).unwrap();
+        let deleted = db.get_deleted_session_by_id(child.id).unwrap().unwrap();
+        assert_eq!(deleted.parent_session_id, Some(parent.id));
+
+        // Restore keeps the linkage in the active row.
+        db.restore_session(child.id).unwrap();
+        let restored = db.get_session_by_id(child.id).unwrap().unwrap();
+        assert_eq!(restored.parent_session_id, Some(parent.id));
+    }
+
+    #[test]
     fn list_deleted_sessions() {
         let db = Database::open_in_memory().unwrap();
         let s1 = make_session("S1");

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -56,6 +56,7 @@ mod tests {
             additional_dirs: Vec::new(),
             worktrees: Vec::new(),
             shell_backend_id: None,
+            parent_session_id: None,
             tombstone: false,
             tombstone_at: None,
         }

--- a/src/storage/worktrees.rs
+++ b/src/storage/worktrees.rs
@@ -132,6 +132,7 @@ mod tests {
             additional_dirs: Vec::new(),
             worktrees: Vec::new(),
             shell_backend_id: None,
+            parent_session_id: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/sync/delta.rs
+++ b/src/sync/delta.rs
@@ -95,6 +95,7 @@ fn session_changed(old: &SharedSession, new: &SharedSession) -> bool {
         || old.cwd != new.cwd
         || old.additional_dirs != new.additional_dirs
         || old.worktrees != new.worktrees
+        || old.parent_session_id != new.parent_session_id
 }
 
 #[cfg(test)]
@@ -114,6 +115,7 @@ mod tests {
             additional_dirs: Vec::new(),
             worktrees: Vec::new(),
             shell_backend_id: None,
+            parent_session_id: None,
             tombstone: false,
             tombstone_at: None,
         }

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -80,6 +80,11 @@ pub struct SharedSession {
     /// Backend ID of the companion shell pane (if spawned).
     pub shell_backend_id: Option<String>,
 
+    /// Parent session (lead/worker relationship for orchestration).
+    /// `None` for top-level sessions. Purely informational: deleting the
+    /// parent does not cascade to children.
+    pub parent_session_id: Option<SessionId>,
+
     /// Tombstone flag: true if this session was soft-deleted.
     /// Soft-deleted sessions are excluded from active listings.
     pub tombstone: bool,

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -36,6 +36,7 @@ pub fn render_info_panel(
     metrics: Option<&SystemMetrics>,
     automations: &[AutomationEntry],
     usage: Option<&crate::session::AgentUsage>,
+    parent_name: Option<&str>,
 ) {
     let block = Block::default()
         .title(" Info ")
@@ -69,6 +70,16 @@ pub fn render_info_panel(
                 .add_modifier(Modifier::BOLD),
         ),
     ]));
+    // Parent session (lead/worker linkage); omitted for top-level sessions.
+    if let Some(parent) = parent_name {
+        lines.push(Line::from(vec![
+            Span::styled("Parent: ", Theme::label()),
+            Span::styled(
+                parent.to_string(),
+                Style::default().fg(Theme::text_secondary()),
+            ),
+        ]));
+    }
     // Remote host (ssh:<host>); omitted entirely for local sessions.
     if let Some(host) = info.remote_host.as_deref() {
         lines.push(Line::from(vec![

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -136,6 +136,11 @@ pub struct SessionOrder {
     pub order: Vec<usize>,
     /// Parallel to `order`: `Some(label)` on each group's first row, else `None`.
     pub headers: Vec<Option<String>>,
+    /// Parallel to `order`: tree depth within the repo group (0 = root, 1+ =
+    /// child nested under its parent via `parent_session_id`). Children nest
+    /// only when their parent is in the same group; a child whose parent lives
+    /// in another group (or is gone) stays at depth 0 in its own group.
+    pub depths: Vec<u8>,
 }
 
 pub fn compute_session_order(sessions: &[&SessionInfo]) -> SessionOrder {
@@ -183,14 +188,84 @@ pub fn compute_session_order(sessions: &[&SessionInfo]) -> SessionOrder {
 
     let mut order = Vec::with_capacity(sessions.len());
     let mut headers = Vec::with_capacity(sessions.len());
+    let mut depths = Vec::with_capacity(sessions.len());
     for g in &groups {
-        for (j, &i) in g.members.iter().enumerate() {
+        // Nest children directly under their parent (parent-first, preserving
+        // the status-then-index order among siblings and among roots).
+        for (j, (i, depth)) in nest_group_members(sessions, &g.members)
+            .into_iter()
+            .enumerate()
+        {
             order.push(i);
             headers.push(if j == 0 { g.label.clone() } else { None });
+            depths.push(depth);
         }
     }
 
-    SessionOrder { order, headers }
+    SessionOrder {
+        order,
+        headers,
+        depths,
+    }
+}
+
+/// Reorder a group's (already status-sorted) members into parent-first DFS
+/// order: every member whose `parent_session_id` is also a member of this group
+/// nests directly under that parent; everyone else (no parent, parent in
+/// another group, or parent gone) is a root. Returns `(session index, depth)`
+/// pairs covering every member exactly once — a visited set plus a flat-emit
+/// fallback guard against parent cycles, which current writers can't produce
+/// but must not make sessions vanish from the list.
+fn nest_group_members(sessions: &[&SessionInfo], members: &[usize]) -> Vec<(usize, u8)> {
+    use std::collections::{HashMap, HashSet};
+
+    let id_to_member: HashMap<crate::session::SessionId, usize> =
+        members.iter().map(|&i| (sessions[i].id, i)).collect();
+
+    let mut roots: Vec<usize> = Vec::new();
+    let mut children: HashMap<usize, Vec<usize>> = HashMap::new();
+    for &i in members {
+        let parent = sessions[i]
+            .parent_session_id
+            .and_then(|p| id_to_member.get(&p))
+            .copied()
+            .filter(|&p| p != i);
+        match parent {
+            Some(p) => children.entry(p).or_default().push(i),
+            None => roots.push(i),
+        }
+    }
+
+    fn emit(
+        i: usize,
+        depth: u8,
+        children: &HashMap<usize, Vec<usize>>,
+        visited: &mut HashSet<usize>,
+        out: &mut Vec<(usize, u8)>,
+    ) {
+        if !visited.insert(i) {
+            return;
+        }
+        out.push((i, depth));
+        if let Some(kids) = children.get(&i) {
+            for &k in kids {
+                emit(k, depth.saturating_add(1), children, visited, out);
+            }
+        }
+    }
+
+    let mut out = Vec::with_capacity(members.len());
+    let mut visited = HashSet::new();
+    for &r in &roots {
+        emit(r, 0, &children, &mut visited, &mut out);
+    }
+    // Members unreachable from any root (a parent cycle): emit flat.
+    for &i in members {
+        if visited.insert(i) {
+            out.push((i, 0));
+        }
+    }
+    out
 }
 
 /// Display-ordered view of the session list. All fields are parallel arrays
@@ -203,6 +278,9 @@ pub struct OrderedSessions<'a> {
     /// Parallel to `sessions`: `Some(label)` on each repo group's first row,
     /// used to render a subtle header above it. `None` elsewhere.
     pub headers: Vec<Option<String>>,
+    /// Parallel to `sessions`: tree depth within the repo group
+    /// (see [`SessionOrder::depths`]).
+    pub depths: Vec<u8>,
 }
 
 impl<'a> OrderedSessions<'a> {
@@ -216,7 +294,11 @@ impl<'a> OrderedSessions<'a> {
     ) -> Self {
         // Ordering depends only on status + stable index, never on `elapsed_ms`
         // (which is still used below for the per-row elapsed display).
-        let SessionOrder { order, headers } = compute_session_order(sessions);
+        let SessionOrder {
+            order,
+            headers,
+            depths,
+        } = compute_session_order(sessions);
 
         let ordered_sessions = order.iter().map(|&i| sessions[i]).collect();
         let ordered_elapsed = order.iter().map(|&i| elapsed_ms[i]).collect();
@@ -232,6 +314,7 @@ impl<'a> OrderedSessions<'a> {
             match_positions: ordered_matches,
             active_index: new_active,
             headers,
+            depths,
         }
     }
 }
@@ -256,6 +339,9 @@ pub struct LeftPanelState<'a> {
     /// Parallel to `sessions`: `Some(label)` on each repo group's first row,
     /// rendered as a subtle header above that row. `None` elsewhere.
     pub headers: &'a [Option<String>],
+    /// Parallel to `sessions`: tree depth within the repo group
+    /// (see [`SessionOrder::depths`]). Children render indented.
+    pub depths: &'a [u8],
 }
 
 pub fn render_left_panel(frame: &mut Frame, area: Rect, state: &mut LeftPanelState<'_>) {
@@ -273,6 +359,7 @@ pub fn render_left_panel(frame: &mut Frame, area: Rect, state: &mut LeftPanelSta
         state.session_match_positions,
         state.session_search_active,
         state.headers,
+        state.depths,
     );
 }
 
@@ -377,6 +464,7 @@ fn render_session_section(
     match_positions: &[Option<SessionMatch>],
     search_active: bool,
     headers: &[Option<String>],
+    depths: &[u8],
 ) {
     let mut block = focus_block(" Sessions ", level);
 
@@ -410,6 +498,11 @@ fn render_session_section(
 
     let mut item_heights: Vec<u16> = Vec::with_capacity(sessions.len());
 
+    // Session ids on screen, for the cross-group child mark (a child whose
+    // parent lives in another repo group gets `↳` instead of indentation).
+    let visible_ids: std::collections::HashSet<crate::session::SessionId> =
+        sessions.iter().map(|s| s.id).collect();
+
     let items: Vec<ListItem> = sessions
         .iter()
         .enumerate()
@@ -417,10 +510,22 @@ fn render_session_section(
             let is_active = i == active_index && show_selection;
             let session_match = match_positions.get(i).and_then(|m| m.as_ref());
             let is_dimmed = search_active && session_match.is_none();
+            let depth = depths.get(i).copied().unwrap_or(0);
+            let cross_group_child = depth == 0
+                && info
+                    .parent_session_id
+                    .is_some_and(|p| p != info.id && visible_ids.contains(&p));
 
             let mut item_lines = vec![
-                build_session_line1(info, session_match, is_active, is_dimmed),
-                build_session_line2(info, is_dimmed, elapsed_ms.get(i).copied()),
+                build_session_line1(
+                    info,
+                    session_match,
+                    is_active,
+                    is_dimmed,
+                    depth,
+                    cross_group_child,
+                ),
+                build_session_line2(info, is_dimmed, elapsed_ms.get(i).copied(), depth),
             ];
 
             // Prepend a subtle repo-group header above the first session of
@@ -522,17 +627,21 @@ fn session_status_text(info: &SessionInfo, elapsed: Option<u64>) -> String {
         .unwrap_or_else(|| format_status_with_elapsed(info.status, elapsed))
 }
 
-/// Build line 1 of a session entry: `<status-dot> [☁] [⑂] <name>`.
+/// Build line 1 of a session entry: `<status-dot> [└] [↳] [☁] [⑂] <name>`.
 ///
 /// The active row is signalled by the list's highlight background, so no extra
-/// pointer glyph is needed. Remote (`ssh:<host>`) sessions get a `☁` mark and
-/// sessions running in a git worktree get a `⑂` mark, both between the status
-/// dot and the name. The live status itself lives on line 2.
+/// pointer glyph is needed. A child session nested under its parent (`depth >
+/// 0`) gets a muted `└` tree prefix; a child whose parent renders in another
+/// repo group gets a `↳` mark instead. Remote (`ssh:<host>`) sessions get a
+/// `☁` mark and sessions running in a git worktree get a `⑂` mark, all between
+/// the status dot and the name. The live status itself lives on line 2.
 fn build_session_line1<'a>(
     info: &'a SessionInfo,
     session_match: Option<&SessionMatch>,
     is_active: bool,
     is_dimmed: bool,
+    depth: u8,
+    cross_group_child: bool,
 ) -> Line<'a> {
     let name_style = if is_dimmed {
         Style::default().fg(Theme::text_muted())
@@ -551,6 +660,16 @@ fn build_session_line1<'a>(
         format!(" {} ", info.status.icon()),
         status_style,
     )];
+
+    // Tree prefix for children nested under their parent in the same repo
+    // group; `↳` for children whose parent renders elsewhere in the list.
+    let tree_style = Style::default().fg(Theme::text_muted());
+    if depth > 0 {
+        let indent = "  ".repeat(depth as usize - 1);
+        line1_spans.push(Span::styled(format!("{indent}\u{2514} "), tree_style));
+    } else if cross_group_child {
+        line1_spans.push(Span::styled("\u{21b3} ", tree_style));
+    }
 
     // Remote (ssh:<host>) sessions get a cloud mark so it's clear at a glance
     // the agent runs on another machine. Sits right after the status dot.
@@ -585,8 +704,14 @@ fn build_session_line1<'a>(
 
 /// Build line 2 of a session entry: the dedicated status line `   <status-text>`
 /// (e.g. `   Waiting 2m`). No status glyph here — the colored dot on line 1
-/// already conveys the state, so repeating it would be redundant.
-fn build_session_line2(info: &SessionInfo, is_dimmed: bool, elapsed: Option<u64>) -> Line<'static> {
+/// already conveys the state, so repeating it would be redundant. The indent
+/// grows with `depth` so the status stays aligned under a nested child's name.
+fn build_session_line2(
+    info: &SessionInfo,
+    is_dimmed: bool,
+    elapsed: Option<u64>,
+    depth: u8,
+) -> Line<'static> {
     let text_style = if is_dimmed {
         Style::default().fg(Theme::text_muted())
     } else {
@@ -594,8 +719,9 @@ fn build_session_line2(info: &SessionInfo, is_dimmed: bool, elapsed: Option<u64>
     };
 
     let status_text = session_status_text(info, elapsed);
+    let indent = "  ".repeat(depth as usize);
     Line::from(vec![
-        Span::raw("   "),
+        Span::raw(format!("   {indent}")),
         Span::styled(status_text, text_style),
     ])
 }
@@ -860,14 +986,14 @@ mod tests {
             worktree_path: std::path::PathBuf::from("/tmp/wt/feat"),
             branch: "feat".to_string(),
         });
-        let line = build_session_line1(&s, None, false, false);
+        let line = build_session_line1(&s, None, false, false, 0, false);
         assert!(line_text(&line).contains('\u{2442}'));
     }
 
     #[test]
     fn line1_no_worktree_glyph_for_plain_session() {
         let s = info("plain");
-        let line = build_session_line1(&s, None, false, false);
+        let line = build_session_line1(&s, None, false, false, 0, false);
         assert!(!line_text(&line).contains('\u{2442}'));
     }
 
@@ -875,22 +1001,48 @@ mod tests {
     fn line1_shows_remote_glyph_when_remote_host_present() {
         let mut s = info("remote");
         s.remote_host = Some("devbox".to_string());
-        let line = build_session_line1(&s, None, false, false);
+        let line = build_session_line1(&s, None, false, false, 0, false);
         assert!(line_text(&line).contains('\u{2601}'));
     }
 
     #[test]
     fn line1_no_remote_glyph_for_local_session() {
         let s = info("local");
-        let line = build_session_line1(&s, None, false, false);
+        let line = build_session_line1(&s, None, false, false, 0, false);
         assert!(!line_text(&line).contains('\u{2601}'));
+    }
+
+    #[test]
+    fn line1_shows_tree_prefix_for_nested_child() {
+        let s = info("worker");
+        let line = build_session_line1(&s, None, false, false, 1, false);
+        assert!(line_text(&line).contains('\u{2514}')); // └
+    }
+
+    #[test]
+    fn line1_shows_arrow_for_cross_group_child() {
+        let s = info("worker");
+        let line = build_session_line1(&s, None, false, false, 0, true);
+        let text = line_text(&line);
+        assert!(text.contains('\u{21b3}')); // ↳
+        assert!(!text.contains('\u{2514}'));
+    }
+
+    #[test]
+    fn line2_indent_grows_with_depth() {
+        let mut s = info("worker");
+        s.status = SessionStatus::Busy;
+        let root = line_text(&build_session_line2(&s, false, None, 0));
+        let child = line_text(&build_session_line2(&s, false, None, 1));
+        assert_eq!(child.len(), root.len() + 2);
+        assert!(child.starts_with("     ")); // 3 base + 2 per depth level
     }
 
     #[test]
     fn line2_shows_status_text_without_glyph() {
         let mut s = info("busy");
         s.status = SessionStatus::Busy;
-        let line = build_session_line2(&s, false, None);
+        let line = build_session_line2(&s, false, None, 0);
         let text = line_text(&line);
         assert!(text.contains("Busy"));
         // The status dot lives on line 1 only; line 2 must not repeat it.
@@ -902,7 +1054,7 @@ mod tests {
         let mut s = info("attn");
         s.status = SessionStatus::Attention;
         s.notification = Some("Review this diff".to_string());
-        let line = build_session_line2(&s, false, None);
+        let line = build_session_line2(&s, false, None, 0);
         assert!(line_text(&line).contains("Review this diff"));
     }
 
@@ -924,6 +1076,28 @@ mod tests {
             .order
             .into_iter()
             .map(|i| sessions[i].name.as_str())
+            .collect()
+    }
+
+    /// A child of `parent` in the given repo (same helper shape as `info_repo`).
+    fn info_child(
+        name: &str,
+        repo: &str,
+        status: SessionStatus,
+        parent: &SessionInfo,
+    ) -> SessionInfo {
+        let mut s = info_repo(name, repo, status);
+        s.parent_session_id = Some(parent.id);
+        s
+    }
+
+    /// `(name, depth)` pairs in render order.
+    fn order_names_depths<'a>(sessions: &[&'a SessionInfo]) -> Vec<(&'a str, u8)> {
+        let SessionOrder { order, depths, .. } = compute_session_order(sessions);
+        order
+            .into_iter()
+            .zip(depths)
+            .map(|(i, d)| (sessions[i].name.as_str(), d))
             .collect()
     }
 
@@ -975,7 +1149,7 @@ mod tests {
         let b = info_repo("b", "webapp", SessionStatus::Busy);
         let c = info_repo("c", "infra", SessionStatus::Attention);
         let sessions = vec![&a, &b, &c];
-        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        let SessionOrder { order, headers, .. } = compute_session_order(&sessions);
         let labelled: Vec<(&str, Option<String>)> = order
             .iter()
             .zip(headers.iter())
@@ -997,7 +1171,7 @@ mod tests {
         let a = info("a");
         let b = info("b");
         let sessions = vec![&a, &b];
-        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        let SessionOrder { order, headers, .. } = compute_session_order(&sessions);
         assert_eq!(order, vec![0, 1]);
         assert_eq!(headers, vec![Some("(no repo)".to_string()), None]);
     }
@@ -1011,7 +1185,7 @@ mod tests {
         let c = info_repo("c", "infra", SessionStatus::Waiting);
         let sessions = vec![&a, &b, &c];
 
-        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        let SessionOrder { order, headers, .. } = compute_session_order(&sessions);
         let labelled: Vec<(&str, Option<String>)> = order
             .iter()
             .zip(headers.iter())
@@ -1028,6 +1202,98 @@ mod tests {
         );
     }
 
+    // --- compute_session_order (parent/child nesting) ---
+
+    #[test]
+    fn children_nest_directly_under_their_parent() {
+        let lead = info_repo("lead", "webapp", SessionStatus::Idle);
+        let other = info_repo("other", "webapp", SessionStatus::Idle);
+        let w1 = info_child("w1", "webapp", SessionStatus::Idle, &lead);
+        let w2 = info_child("w2", "webapp", SessionStatus::Idle, &lead);
+        // Input interleaves the children with an unrelated session; they still
+        // nest directly under their parent, in stable order.
+        let sessions = vec![&lead, &other, &w1, &w2];
+        assert_eq!(
+            order_names_depths(&sessions),
+            vec![("lead", 0), ("w1", 1), ("w2", 1), ("other", 0)]
+        );
+    }
+
+    #[test]
+    fn grandchildren_nest_one_level_deeper() {
+        let lead = info_repo("lead", "webapp", SessionStatus::Idle);
+        let worker = info_child("worker", "webapp", SessionStatus::Idle, &lead);
+        let sub = info_child("sub", "webapp", SessionStatus::Idle, &worker);
+        let sessions = vec![&sub, &worker, &lead];
+        assert_eq!(
+            order_names_depths(&sessions),
+            vec![("lead", 0), ("worker", 1), ("sub", 2)]
+        );
+    }
+
+    #[test]
+    fn attention_child_still_bubbles_its_group_up() {
+        let lead = info_repo("lead", "webapp", SessionStatus::Idle);
+        let worker = info_child("worker", "webapp", SessionStatus::Attention, &lead);
+        let busy = info_repo("busy", "infra", SessionStatus::Busy);
+        let sessions = vec![&busy, &lead, &worker];
+        // The webapp group holds the Attention session (min rank 0), so it
+        // sorts above the merely-running infra group even though the parent
+        // itself is Idle; within the group the child stays nested.
+        assert_eq!(
+            order_names_depths(&sessions),
+            vec![("lead", 0), ("worker", 1), ("busy", 0)]
+        );
+    }
+
+    #[test]
+    fn cross_group_child_stays_in_its_own_group_at_depth_zero() {
+        let lead = info_repo("lead", "webapp", SessionStatus::Idle);
+        let worker = info_child("worker", "infra", SessionStatus::Idle, &lead);
+        let sessions = vec![&lead, &worker];
+        // Parent lives in another repo group: no reordering, no indentation.
+        assert_eq!(
+            order_names_depths(&sessions),
+            vec![("worker", 0), ("lead", 0)] // "infra" < "webapp"
+        );
+    }
+
+    #[test]
+    fn dangling_parent_renders_child_as_root() {
+        let gone = info_repo("gone", "webapp", SessionStatus::Idle);
+        let orphan = info_child("orphan", "webapp", SessionStatus::Idle, &gone);
+        let sessions = vec![&orphan]; // parent not in the list
+        assert_eq!(order_names_depths(&sessions), vec![("orphan", 0)]);
+    }
+
+    #[test]
+    fn parent_cycle_emits_all_members_flat() {
+        // Cycles can't be produced by current writers; corrupted data must
+        // still render every session.
+        let mut a = info_repo("a", "webapp", SessionStatus::Idle);
+        let mut b = info_repo("b", "webapp", SessionStatus::Idle);
+        a.parent_session_id = Some(b.id);
+        b.parent_session_id = Some(a.id);
+        let sessions = vec![&a, &b];
+        assert_eq!(order_names_depths(&sessions), vec![("a", 0), ("b", 0)]);
+    }
+
+    #[test]
+    fn depths_are_parallel_to_order_and_headers() {
+        let lead = info_repo("lead", "webapp", SessionStatus::Idle);
+        let worker = info_child("worker", "webapp", SessionStatus::Idle, &lead);
+        let other = info_repo("other", "infra", SessionStatus::Idle);
+        let sessions = vec![&lead, &worker, &other];
+        let SessionOrder {
+            order,
+            headers,
+            depths,
+        } = compute_session_order(&sessions);
+        assert_eq!(order.len(), 3);
+        assert_eq!(headers.len(), 3);
+        assert_eq!(depths.len(), 3);
+    }
+
     #[test]
     fn duplicate_repos_collapse_to_one_group() {
         // A repo set with the same repo twice (e.g. two worktrees of one repo)
@@ -1036,7 +1302,7 @@ mod tests {
         let single = info_repo("single", "webapp", SessionStatus::Waiting);
         let sessions = vec![&multi, &single];
 
-        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        let SessionOrder { order, headers, .. } = compute_session_order(&sessions);
         // Same canonical key → one group; header is the de-duplicated display.
         assert_eq!(order, vec![0, 1]);
         assert_eq!(headers, vec![Some("webapp".to_string()), None]);
@@ -1050,7 +1316,7 @@ mod tests {
         let d = info_repos("d", &["infra", "webapp"], SessionStatus::Waiting);
         let sessions = vec![&b, &d];
 
-        let SessionOrder { order, headers } = compute_session_order(&sessions);
+        let SessionOrder { order, headers, .. } = compute_session_order(&sessions);
         assert_eq!(
             order
                 .iter()

--- a/tests/sync_integration.rs
+++ b/tests/sync_integration.rs
@@ -21,6 +21,7 @@ fn make_session(id: SessionId, name: &str) -> SharedSession {
         additional_dirs: Vec::new(),
         worktrees: Vec::new(),
         shell_backend_id: None,
+        parent_session_id: None,
         tombstone: false,
         tombstone_at: None,
     }
@@ -366,6 +367,7 @@ fn db_session_metadata_preserved_across_instances() {
         additional_dirs: Vec::new(),
         worktrees: Vec::new(),
         shell_backend_id: None,
+        parent_session_id: None,
         tombstone: false,
         tombstone_at: None,
     };


### PR DESCRIPTION
## Summary

- Sessions gain a nullable `parent_session_id` (schema v30; v29 stays reserved for `improve-agent-thurbox-cli`), threaded through `SharedSession`/`SessionInfo`, storage, sync deltas, and all TUI adoption/respawn/restore paths, so orchestration scripts can model lead → worker relationships. The link is informational only — deleting a parent never cascades.
- `thurbox-cli session create --parent <uuid>` (validated against an existing active session before any side effects), `session list --parent <uuid>` filters to direct children, and `parent_session_id` appears in `list`/`get`/`create` JSON.
- TUI: children tree-nest under their parent inside their repo group (`└` prefix, `↳` for cross-group children), `Ctrl+J/K` follows the tree, `Ctrl+F` fork records the source as parent, and the info panel shows a `Parent:` row.

## Test plan

- New tests: v27→v30 migration, storage + deleted-session roundtrips, spawn parent validation, clap parses, list JSON shape + `--parent` filter, 7 ordering cases (nesting, grandchildren, attention bubbling, cross-group, dangling parent, cycles), line-builder glyphs, `session_to_shared` mapping regression.
- Verified locally: `cargo test` (1021 passed, 0 failed), `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt`, architecture rules.
- CI on this PR will be monitored after creation.