### PR TITLE
chore(config): harden renovate against supply-chain attacks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    "security:openssf-scorecard",
+    "mergeConfidence:all-badges"
+  ],
   "labels": ["dependencies"],
   "automerge": true,
   "semanticCommitType": "fix",
   "semanticCommitScope": "deps",
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
@@ -13,6 +20,10 @@
     {
       "matchPackageNames": ["*"],
       "semanticCommitType": "fix"
+    },
+    {
+      "matchManagers": ["npm"],
+      "minimumReleaseAge": "14 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add a 7-day `minimumReleaseAge` cooldown (14 days for npm) so Renovate only proposes versions that survived the window in which registry malware is typically detected and yanked; vulnerability-fix PRs bypass the cooldown via Renovate's default `vulnerabilityAlerts` behavior
- Set `internalChecksFilter: strict` so Renovate proposes the newest version that already passed the cooldown instead of stalling on too-young releases
- Enable `osvVulnerabilityAlerts` (covers RustSec/crates.io) plus OpenSSF Scorecard and merge-confidence badges on update PRs

## Test plan

- CI checks pass
- `renovate-config-validator` passes locally