### PR TITLE
fix(ui): scroll the restore-sessions modal to keep the selection visible

### DIFF
--- a/src/ui/restore_sessions_modal.rs
+++ b/src/ui/restore_sessions_modal.rs
@@ -6,6 +6,7 @@ use ratatui::{
 };
 
 use super::render_list_modal_frame;
+use super::scrollbar;
 use super::theme::Theme;
 
 /// View-only entry for the restore sessions modal.
@@ -38,13 +39,21 @@ pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsM
         return;
     };
 
-    // Session list
-    let lines: Vec<Line<'_>> = state
-        .entries
+    // Session list — window the entries so the selected row stays visible,
+    // reserving the rightmost column for a scrollbar when the list overflows.
+    let height = list_area.height as usize;
+    let (rows_area, track) = scrollbar::reserve_track(list_area, state.entries.len(), height);
+    let (start, end) = super::file_viewer::visible_window(
+        state.entries.len(),
+        state.selected_index,
+        height.max(1),
+    );
+
+    let lines: Vec<Line<'_>> = state.entries[start..end]
         .iter()
         .enumerate()
-        .map(|(i, entry)| {
-            let selected = i == state.selected_index;
+        .map(|(offset, entry)| {
+            let selected = start + offset == state.selected_index;
             let wt_indicator = if entry.has_worktrees { " [wt]" } else { "" };
             let text = format!(
                 " {} ({}) {}{} ",
@@ -61,7 +70,17 @@ pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsM
         })
         .collect();
 
-    frame.render_widget(Paragraph::new(lines), list_area);
+    frame.render_widget(Paragraph::new(lines), rows_area);
+
+    if let Some(track) = track {
+        scrollbar::render_into(
+            frame,
+            track,
+            state.entries.len(),
+            height,
+            state.selected_index,
+        );
+    }
 
     // Footer
     let help = Line::from(vec![
@@ -71,4 +90,73 @@ pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsM
         Span::raw(" close"),
     ]);
     frame.render_widget(Paragraph::new(help), footer_area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entries(n: usize) -> Vec<DeletedSessionEntry> {
+        (0..n)
+            .map(|i| DeletedSessionEntry {
+                name: format!("session-{i}"),
+                agent: "claude".into(),
+                deleted_ago: "1m ago".into(),
+                has_worktrees: false,
+            })
+            .collect()
+    }
+
+    fn rendered_text(entries: &[DeletedSessionEntry], selected_index: usize) -> String {
+        let backend = ratatui::backend::TestBackend::new(80, 24);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_restore_sessions_modal(
+                    frame,
+                    &RestoreSessionsModalState {
+                        entries,
+                        selected_index,
+                    },
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        let area = *buffer.area();
+        let mut text = String::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                text.push_str(buffer[(x, y)].symbol());
+            }
+            text.push('\n');
+        }
+        text
+    }
+
+    #[test]
+    fn selection_beyond_first_page_is_scrolled_into_view() {
+        let list = entries(40);
+        let text = rendered_text(&list, 39);
+        assert!(
+            text.contains("session-39"),
+            "selected entry should be visible after scrolling:\n{text}"
+        );
+        assert!(
+            !text.contains("session-0 "),
+            "first entry should have scrolled out of view:\n{text}"
+        );
+    }
+
+    #[test]
+    fn short_list_renders_fully_without_scrolling() {
+        let list = entries(3);
+        let text = rendered_text(&list, 0);
+        for entry in &list {
+            assert!(
+                text.contains(&entry.name),
+                "missing {}:\n{text}",
+                entry.name
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- The restore (Ctrl+U undo) modal rendered all deleted sessions in one flat `Paragraph` while the modal frame caps its height at 20 rows — lists longer than the viewport were clipped and `j`/`k` could move the selection onto invisible rows.
- Window the entries around the selected row via the shared `visible_window` helper so the selection always stays in view.
- Draw the standard right-edge scrollbar (`scrollbar::reserve_track`/`render_into`) when the list overflows, matching the file tree and automation run history.
- Short lists render exactly as before (no scrollbar, no behavior change).

## Test plan
- New `TestBackend` regression tests in `src/ui/restore_sessions_modal.rs`: `selection_beyond_first_page_is_scrolled_into_view` (40 entries, last selected, asserts visibility) and `short_list_renders_fully_without_scrolling`.
- `cargo nextest run --all`: 1038/1038 pass; clippy clean with `-D warnings`.