### PR TITLE
feat: agent-agnostic flow extension + readable task session names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,7 +508,7 @@ sync, but the TUI editor never sets it.)
   scroll the preview, `n` new, `e`/`Enter` open the central-pane editor,
   `Space` cycle status, `r` open the **trigger-time action picker**, `o` **open
   the task's related session** (`App::open_task_related_session` — jumps to the
-  spawned `task-<id>` window or a Send target, else a status hint), `d`/`Ctrl+D`
+  spawned `task-<id>-<slug>` window or a Send target, else a status hint), `d`/`Ctrl+D`
   delete, `Esc` back to the session list. In the editor: field nav +
   `Enter`/`Ctrl+S` save (→ back to panel), `Esc` discard; the editor captures
   its keys before global bindings (so `e`/`d` edit text) via
@@ -530,6 +530,23 @@ sync, but the TUI editor never sets it.)
   `--session` nor `--repo` is a plain local todo; `run` triggers the
   Send/Spawn action headlessly. Tasks do **not** participate in sync
   (`SharedState`) and have no run-history table (audited via `audit_log`).
+
+## Extensions
+
+`extensions/` holds opt-in, **agent-agnostic** add-ons that build on
+`thurbox-cli` without touching the core binary. Each ships its own
+curl-able `install.sh`.
+
+- **`extensions/flow/`** *(experimental — new and under active
+  testing)* — a focus-protecting triage agent: brain-dumps
+  become thurbox tasks, dispatchable ones spawn worker sessions (on
+  `flow/<slug>` worktree branches, agents `flow-worker` /
+  `flow-worker-heavy` mapped in `agents.toml` to any CLI), a dedicated
+  `flow` session monitors them via a `flow-tick` automation, and every
+  reply ends with the single next thing to focus on. The behavior spec
+  is `FLOW.md`, surfaced to whichever CLI runs it via context-file
+  symlinks (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `FLOW.md`). See
+  `extensions/flow/README.md`.
 
 ## Global search (`Ctrl+A`)
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,33 @@ list:
 
 ![Tasks demo](./docs/media/tasks-demo.gif)
 
+### Flow extension
+
+- An opt-in, **agent-agnostic** add-on (`extensions/flow/`) that
+  turns the task list into a focus-protecting workflow: brain-dump
+  at a dedicated cheap **flow session** and it captures everything
+  into tasks, dispatches the dispatchable ones to worker sessions
+  (each on its own `flow/<slug>` worktree branch), monitors them
+  via a tick automation, and ends every reply with the single next
+  thing to focus on.
+- The triager and the workers are plain `agents.toml` aliases
+  (`flow`, `flow-worker`, `flow-worker-heavy`) — map them to
+  claude, codex, gemini, opencode, vibe, or anything else. The
+  behavior is a plain context file (`FLOW.md`) surfaced to
+  whichever CLI you pick via `CLAUDE.md`/`AGENTS.md`/`GEMINI.md`
+  symlinks.
+- One-line install (idempotent):
+
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/flow/install.sh | sh
+  ```
+
+> **Note:** The flow extension is a brand-new, **experimental**
+> feature under active testing — expect its behavior, spec, and
+> installer to change between releases.
+
+See [`extensions/flow/README.md`](./extensions/flow/README.md).
+
 ### Global search
 
 - One key (`Ctrl+A`) opens a **non-modal search strip** that

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -644,3 +644,37 @@ database.
   across agents; a session now configures only its agent.
 - *Agent definitions in SQLite* — overkill for read-mostly,
   user-authored config; TOML keeps them inspectable and diffable.
+
+## ADR-20: Agent-agnostic extensions in `extensions/`
+
+**Choice**: Opt-in workflows that *compose* thurbox (rather than
+extend the binary) live in `extensions/<name>/` as data + shell:
+a plain-markdown behavior spec, portable scripts built on
+`thurbox-cli` + `jq`, and a curl-able, idempotent `install.sh` —
+the same distribution model as `scripts/install.sh` and
+`packaging/`. The first extension is **flow** (an experimental
+focus-protecting triage agent; see FEATURES.md). Extensions reach
+agents only through `agents.toml` **aliases** (e.g. `flow-worker`)
+that the user maps to any CLI, and surface their spec through
+context-file symlinks (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → the
+spec), so no vendor is named anywhere.
+
+**Why**: ADR-19's pivot made thurbox agent-neutral; an opinionated
+LLM workflow (prompts, triage rubrics, tick cadences) would undo
+that if baked into core, and it iterates on a much faster cadence
+than the binary (editing a markdown spec vs. cutting a release).
+Keeping extensions as data over the public surface (`thurbox-cli`
+plus `agents.toml`) also makes that surface's stability a tested,
+load-bearing contract.
+
+**Rejected**:
+
+- *Vendor plugin formats* (e.g. a Claude Code plugin) — couples
+  the workflow to one agent's ecosystem; the same agent brain must
+  be runnable by codex, gemini, opencode, vibe, ….
+- *A `thurbox-cli flow init` subcommand with embedded assets* —
+  puts one opinionated workflow inside the agent-neutral core and
+  ties spec iteration to the release cycle.
+- *A separate repository* — the extension scripts against
+  `thurbox-cli`'s JSON surface and should version and CI alongside
+  it.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -702,7 +702,60 @@ migration. No fetch logic ships yet.
 `create`/`list`/`show`/`edit`/`remove`/`run`. `create` with neither
 `--session` nor `--repo` is a plain local todo; `run` triggers the
 task's Send/Spawn action headlessly (spawned sessions are named
-`task-<id>`, adopted by the TUI on next startup).
+`task-<id>-<title-slug>` via `Task::spawn_session_name`, adopted by the
+TUI on next startup; `Task::matches_spawn_session` also recognizes the
+legacy bare `task-<id>` form and spawns from a since-edited title).
+
+---
+
+## Flow Extension (experimental)
+
+> **Status:** brand-new and under active testing — the spec, scripts,
+> and installer are all expected to change between releases.
+
+An opt-in add-on (`extensions/flow/`) that composes the task list,
+sessions, worktrees, and automations into a **focus-protecting triage
+workflow**: a dedicated cheap *flow session* captures brain-dumps into
+tasks, dispatches the dispatchable ones to worker sessions, monitors
+them, grooms the backlog, and ends every reply with the single next
+thing to focus on (`🎯 Next: …`).
+
+### Agent-agnostic by construction
+
+Nothing in the extension names a vendor:
+
+- The behavior is a plain context file, `FLOW.md`, installed into the
+  flow home (`~/flow`) and surfaced to whichever CLI runs the session
+  via symlinks to each CLI's context convention
+  (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `FLOW.md`).
+- The triager and workers are **agents.toml aliases** — `flow`,
+  `flow-worker` (default), `flow-worker-heavy` (long/hard work) — that
+  the installer seeds with defaults and the user remaps freely.
+- All orchestration goes through `thurbox-cli` (`task create/run`,
+  `session capture/send`, `automation create`) plus `jq`; the core
+  binary has no flow-specific code.
+
+### Dispatch model
+
+Dispatch is **eager**: capture creates the task *and* spawns its
+worker in one atomic helper call (`create-task.sh`); workers send a
+`tick` back to the flow session when they finish so a freed capacity
+slot dispatches the next task immediately; a `flow-tick` cron
+automation (default every 5 min) is only the safety net that catches
+crashed workers and stale state. Workers always get a
+`flow/<task-slug>` worktree branch on git repos, so they never dirty
+the main checkout and parallelize per repo. Completion is detected by
+task status (workers self-mark done) with an orchestrate-style
+`===RESULT===` JSON sentinel as the fallback, parsed from
+`session capture` output.
+
+### Install
+
+`extensions/flow/install.sh` (curl-able, idempotent, POSIX sh) sets up
+the flow home, appends missing agents.toml aliases (overridable via
+`FLOW_CMD`/`WORKER_CMD`/`WORKER_HEAVY_CMD` + `*_ARGS` env vars),
+creates the dedicated `flow` session and the `flow-tick` automation.
+See `extensions/flow/README.md`.
 
 ---
 

--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -1,0 +1,165 @@
+# Flow agent
+
+You are the **flow agent** — a cheap, fast triage agent. **Prime directive:
+protect the user's focus.** Never explain, never editorialize, no preamble,
+no praise. Every user-facing reply ends with the Output Contract footer.
+Ask at most ONE clarifying question per interaction, and only when a task
+is undispatchable without the answer.
+
+You run inside a thurbox session whose working directory is the flow home
+(this directory). The backlog's single source of truth is the thurbox task
+list (`thurbox-cli task ...`). Worker sessions are thurbox sessions named
+`task-<id>-<title-slug>`. Never act on a message without following this
+spec — a "remind me" is a CAPTURE, not a calendar or scheduler action.
+
+## Mode detection
+
+Pattern-match the incoming message:
+
+| Message starts with | Mode |
+|---|---|
+| `tick` | TICK (silent monitoring) |
+| `status` / `report` | REPORT |
+| `clean` | CLEAN |
+| anything else | CAPTURE (it's a brain-dump) |
+
+## Shared context (run FIRST in every mode, one call)
+
+```bash
+./scripts/flow-snapshot.sh
+```
+
+This prints the backlog grouped by status plus the live `task-*` / `flow`
+sessions. Also read `./repos.md` — the repo routing table (name → path →
+base branch → keywords). If a repo mentioned by the user is missing from
+the table, add a row when you learn its path.
+
+## CAPTURE
+
+1. Split the dump into atomic tasks: verb-first titles, ≤64 chars.
+2. For each task decide NOW (cheap heuristics, no deliberation):
+   - **priority**: high / normal / low.
+   - **repo**: guess from keywords via `./repos.md`.
+   - **worker**: apply the Worker rubric (below).
+3. Create the task — ALWAYS via the helper (it creates AND dispatches in
+   one atomic call; the user expects the worker session to exist
+   immediately):
+
+   ```bash
+   ./scripts/create-task.sh --title "<title>" --description "<desc>" \
+     --repo <abs-path> --agent <flow-worker|flow-worker-heavy> \
+     --worktree flow/<task-slug>
+   ```
+
+   Pass `--repo`/`--agent` whenever the repo is confident — NEVER create a
+   dispatchable task without them. **Always pass `--worktree
+   flow/<task-slug>` when the repo is a git repository** (derive the slug
+   from the title): workers get an isolated worktree, never dirty the main
+   checkout, and several can work the same repo in parallel. Omit it only
+   for non-git directories. If the repo is not confident → omit
+   `--repo`/`--agent` (plain todo); triage later or ask ONE question. Over
+   capacity → add `--no-dispatch`. Description template (first lines, then
+   the user's words):
+
+   ```text
+   priority: <high|normal|low>
+   repo: <abs path or unknown>
+   accept: <one-line done criterion>
+
+   <original user words>
+
+   You are working in a dedicated git worktree on branch flow/<task-slug>;
+   commit your work there and open a PR when the accept criterion is met.
+   When finished: mark this task done (thurbox-cli task edit <id> --status done),
+   print a final line `===RESULT===` followed by one line of JSON:
+   {"status":"ok|error","artifact":"...","notes":"...","pr_url":"..."}
+   then notify the flow agent so the next task dispatches immediately:
+   thurbox-cli session send "$(thurbox-cli session list | jq -r '.[] | select(.name=="flow") | .id')" "tick"
+   ```
+
+4. Trivial items (a lookup, a question you can answer): answer inline in
+   one line, create no task.
+5. Confirm one line per task: `#<id> <title> [worker|heavy|todo]`.
+6. End with the Output Contract footer.
+
+## DISPATCH (sub-step of CAPTURE and TICK)
+
+Dispatch is **eager**: it runs immediately at capture, again on every
+tick, and workers send a `tick` the moment they finish — never wait for
+the cron tick to dispatch something that is eligible NOW.
+
+- Eligible: `status=todo` AND has a spawn action AND capacity OK
+  (**max 3** running `task-*` sessions).
+- Dispatch: `thurbox-cli task run <id>` — this spawns the worker session,
+  seeds the full task prompt, and advances todo → in_progress. Re-running
+  on a non-todo task is harmless (it only reuses the window), so never
+  worry about double-dispatch.
+- A plain todo that became ready (repo now known): `task edit` cannot
+  attach an action — **remove + recreate** it via `create-task.sh`,
+  carrying the title and description over VERBATIM (the id changes;
+  that's fine).
+- **Worker rubric** (pick one, default `flow-worker`):
+  - `flow-worker-heavy` IF: multi-repo or large refactor; >~1 h expected;
+    ambiguous spec needing real exploration; "overnight"/"deep" keywords;
+    priority high AND genuinely hard.
+  - `flow-worker` OTHERWISE — all normal coding / docs / test work.
+- **Never dispatch**: decisions, questions for the user, anything needing
+  credentials you don't have → leave todo, surface under "Needs you".
+
+## TICK (from the automation — be silent unless action is needed)
+
+1. For each `in_progress` task:
+   - Status already flipped to `done` by the worker → note it; session
+     cleanup happens in CLEAN.
+   - Worker session (name starting `task-<id>`) missing from the session
+     list → stale: reset to todo (`task edit <id> --status todo`).
+   - Otherwise capture recent output:
+
+     ```bash
+     thurbox-cli session capture <uuid> --lines 40 | jq -r .output \
+       | ./scripts/parse-result.sh
+     ```
+
+     - Exit 0 → sentinel found: if the task isn't marked done, mark it
+       (`task edit <id> --status done`). If `"status":"error"` →
+       "Needs you".
+     - Exit 1 → still working; but if the visible output shows an error,
+       a permission prompt, or a question addressed to the user →
+       "Needs you".
+     - Exit 2 → malformed result; treat as still working, and flag it
+       under "Needs you" if it repeats.
+
+2. Run DISPATCH for next eligible todos (respect capacity).
+3. Output: if nothing needs the user, reply EXACTLY
+   `tick: all quiet (N running, M todo)` — nothing else.
+   Otherwise emit ONLY the Needs-you bullets + footer.
+
+## REPORT
+
+One screen max:
+
+- **Running**: `#id title [worker] (age)`
+- **Needs you**: true blockers only
+- **Top 3 todo** (by priority line)
+- Footer.
+
+## CLEAN
+
+- `done` tasks older than 7 days → `thurbox-cli task remove <id>`.
+- Duplicate titles → keep oldest, remove the rest (list what was
+  removed).
+- `in_progress` with no session → reset to todo.
+- Orphan `task-*` sessions whose task is done/removed →
+  `thurbox-cli session delete <uuid> --force`.
+- **Never** remove a todo without listing it first and getting a yes.
+
+## Output Contract (every non-tick reply ends with)
+
+```text
+---
+Needs you: ≤3 bullets, only true decisions/blockers (omit the line if none)
+🎯 Next: <the ONE thing>
+```
+
+For `🎯 Next`, an in-flight decision beats a new todo beats
+"nothing — stay on what you're doing".

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -1,0 +1,74 @@
+# Flow — a focus-protecting triage agent for thurbox
+
+> **Status: experimental.** Flow is a brand-new feature under active
+> testing — expect the behavior spec, scripts, and installer to change
+> between releases.
+
+Flow keeps you in flow state. You brain-dump tasks at a cheap, fast triage
+agent; it captures everything into the thurbox task list, dispatches real
+work to worker sessions (each in its own git worktree), monitors them
+quietly, cleans the backlog, and always ends with the single next thing to
+focus on:
+
+```text
+---
+Needs you: PR #42 has a failing migration — approve the schema change?
+🎯 Next: review task-7-add-rate-limiting (worker finished, PR open)
+```
+
+Flow is **agent-agnostic**, like thurbox itself: the triager and the
+workers are plain `agents.toml` entries (`flow`, `flow-worker`,
+`flow-worker-heavy`), so each can be claude, codex, gemini, opencode,
+vibe, … The behavior lives in [FLOW.md](FLOW.md), a plain context file
+surfaced to whatever CLI you pick via symlinks (`CLAUDE.md`, `AGENTS.md`,
+`GEMINI.md` → `FLOW.md`).
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/flow/install.sh | sh
+```
+
+or from a checkout: `extensions/flow/install.sh`. The installer is
+idempotent; it
+
+1. sets up the flow home (`~/flow`): `FLOW.md` spec, helper scripts,
+   context-file symlinks, and a `repos.md` routing table (edit it!);
+2. adds the `flow` / `flow-worker` / `flow-worker-heavy` entries to
+   `~/.config/thurbox/agents.toml` (defaults: claude on haiku for the
+   triager, opus / fable for workers — override with `FLOW_CMD`,
+   `WORKER_CMD`, `WORKER_HEAVY_CMD` + matching `*_ARGS` env vars);
+3. creates the dedicated `flow` session and a `flow-tick` automation
+   (every 5 minutes by default, `TICK_CRON` to change) that keeps it
+   monitoring workers even while the TUI is closed.
+
+## Use
+
+- Open the `flow` session in the thurbox TUI and type at it — anything
+  that isn't `tick`/`status`/`clean` is treated as a brain-dump.
+- Dispatchable items spawn a worker immediately (`task-<id>-<slug>`
+  session, on a `flow/<slug>` worktree branch whenever the repo is git).
+- `status` for a one-screen report; `clean` to groom the backlog.
+- Workers self-report: they mark their task done, print a
+  `===RESULT===` JSON line, and ping the flow session so the next task
+  dispatches without waiting for the cron tick.
+
+## Files
+
+| Path | Purpose |
+|------|---------|
+| `FLOW.md` | The agent behavior spec (modes, dispatch rules, output contract) |
+| `scripts/create-task.sh` | Atomic task create + dispatch |
+| `scripts/flow-snapshot.sh` | One-call backlog + sessions view |
+| `scripts/parse-result.sh` | Extract the worker `===RESULT===` sentinel |
+| `install.sh` | Idempotent installer/bootstrapper |
+
+## Uninstall
+
+```bash
+thurbox-cli automation list | jq -r '.[] | select(.name=="flow-tick") | .id' \
+  | xargs -r -n1 thurbox-cli automation remove
+thurbox-cli session list | jq -r '.[] | select(.name=="flow") | .id' \
+  | xargs -r -n1 thurbox-cli session delete --force
+rm -rf ~/flow   # and remove the flow* entries from agents.toml
+```

--- a/extensions/flow/install.sh
+++ b/extensions/flow/install.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env sh
+# Install the thurbox "flow" extension: an agent-agnostic triage agent that
+# captures brain-dumps into thurbox tasks, dispatches workers, and protects
+# your focus. See FLOW.md for the behavior spec.
+#
+# Usage:
+#   ./install.sh                  # from a checkout
+#   curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/flow/install.sh | sh
+#
+# Environment variables:
+#   FLOW_HOME=~/flow              flow agent home directory
+#   FLOW_CMD=claude               CLI for the triager (any agents.toml-able CLI)
+#   FLOW_ARGS="--model claude-haiku-4-5"        extra args for the triager
+#   WORKER_CMD=claude             CLI for the default worker
+#   WORKER_ARGS="--model claude-opus-4-8"       extra args for the worker
+#   WORKER_HEAVY_CMD=claude       CLI for the heavy worker
+#   WORKER_HEAVY_ARGS="--model claude-fable-5"  extra args for the heavy worker
+#   TICK_CRON="*/5 * * * *"       tick automation schedule
+#
+# Idempotent: existing agents.toml entries, the flow session, and the
+# flow-tick automation are left untouched on re-run.
+
+set -eu
+
+FLOW_HOME="${FLOW_HOME:-$HOME/flow}"
+FLOW_CMD="${FLOW_CMD:-claude}"
+FLOW_ARGS="${FLOW_ARGS:---model claude-haiku-4-5}"
+WORKER_CMD="${WORKER_CMD:-claude}"
+WORKER_ARGS="${WORKER_ARGS:---model claude-opus-4-8}"
+WORKER_HEAVY_CMD="${WORKER_HEAVY_CMD:-claude}"
+WORKER_HEAVY_ARGS="${WORKER_HEAVY_ARGS:---model claude-fable-5}"
+TICK_CRON="${TICK_CRON:-*/5 * * * *}"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/thurbox"
+AGENTS_TOML="$CONFIG_DIR/agents.toml"
+RAW_BASE="https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/flow"
+
+say()  { printf '%s\n' "$*"; }
+die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+command -v thurbox-cli >/dev/null 2>&1 || die "thurbox-cli not found in PATH (install thurbox first)"
+command -v jq >/dev/null 2>&1 || die "jq is required"
+
+# --- flow home: spec, scripts, context-file symlinks, routing table --------
+
+mkdir -p "$FLOW_HOME/scripts"
+
+# Source files: prefer the checkout next to this script, fall back to GitHub
+# (pipe-to-shell install).
+SRC_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd || true)"
+fetch() { # fetch <relpath> <dest>
+  if [ -n "$SRC_DIR" ] && [ -f "$SRC_DIR/$1" ]; then
+    cp "$SRC_DIR/$1" "$2"
+  elif command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$RAW_BASE/$1" -o "$2"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$RAW_BASE/$1" -O "$2"
+  else
+    die "cannot fetch $1 (no local checkout, curl, or wget)"
+  fi
+}
+
+fetch FLOW.md "$FLOW_HOME/FLOW.md"
+for s in create-task.sh flow-snapshot.sh parse-result.sh; do
+  fetch "scripts/$s" "$FLOW_HOME/scripts/$s"
+  chmod +x "$FLOW_HOME/scripts/$s"
+done
+say "installed spec + scripts into $FLOW_HOME"
+
+# Surface FLOW.md to every CLI's context-file convention. Skip anything that
+# is already a regular file (never clobber user content).
+for ctx in CLAUDE.md AGENTS.md GEMINI.md; do
+  if [ -f "$FLOW_HOME/$ctx" ] && [ ! -L "$FLOW_HOME/$ctx" ]; then
+    say "skip: $FLOW_HOME/$ctx exists (not a symlink), leaving it alone"
+  else
+    ln -sf FLOW.md "$FLOW_HOME/$ctx"
+  fi
+done
+
+if [ ! -f "$FLOW_HOME/repos.md" ]; then
+  cat > "$FLOW_HOME/repos.md" <<'EOF'
+# Repo routing table
+
+Used by the flow agent to map brain-dump keywords to repositories.
+Add one row per repo you work on; the flow agent appends rows as it
+learns new paths.
+
+| name | path | base | keywords |
+|------|------|------|----------|
+| example | /home/me/repositories/example | main | example, sample |
+EOF
+  say "seeded $FLOW_HOME/repos.md (edit it!)"
+fi
+
+# --- agents.toml: flow / flow-worker / flow-worker-heavy aliases -----------
+
+toml_args() { # "$@"-style words -> "a", "b" list
+  out=""
+  for w in $1; do
+    out="$out\"$w\", "
+  done
+  printf '%s' "${out%, }"
+}
+
+append_agent() { # append_agent <name> <cmd> <args>
+  name="$1" cmd="$2" args="$3"
+  if grep -q "name = \"$name\"" "$AGENTS_TOML" 2>/dev/null; then
+    say "agents.toml: '$name' already present, skipping"
+    return
+  fi
+  {
+    printf '\n[[agents]]\n'
+    printf 'name = "%s"\n' "$name"
+    printf 'command = "%s"\n' "$cmd"
+    [ -n "$args" ] && printf 'args = [%s]\n' "$(toml_args "$args")"
+    # Session pinning/resume flags are claude's; other CLIs resume the last
+    # session in cwd themselves (see the agents.toml seed for examples).
+    if [ "$cmd" = "claude" ]; then
+      printf 'resume_args = ["--resume", "{id}"]\n'
+      printf 'fork_args = ["--resume", "{id}", "--fork-session"]\n'
+      printf 'new_session_args = ["--session-id", "{id}"]\n'
+    fi
+  } >> "$AGENTS_TOML"
+  say "agents.toml: added '$name' ($cmd $args)"
+}
+
+mkdir -p "$CONFIG_DIR"
+if [ ! -f "$AGENTS_TOML" ]; then
+  # Same content thurbox seeds on first run, so later runs read it unchanged.
+  cat > "$AGENTS_TOML" <<'EOF'
+# Thurbox coding-agent definitions (seeded by the flow extension installer).
+
+default = "claude"
+
+[[agents]]
+name = "claude"
+command = "claude"
+resume_args = ["--resume", "{id}"]
+fork_args = ["--resume", "{id}", "--fork-session"]
+new_session_args = ["--session-id", "{id}"]
+
+[[agents]]
+name = "codex"
+command = "codex"
+
+[[agents]]
+name = "gemini"
+command = "gemini"
+
+[[agents]]
+name = "opencode"
+command = "opencode"
+
+[[agents]]
+name = "aider"
+command = "aider"
+
+[[agents]]
+name = "vibe"
+command = "vibe"
+EOF
+  say "seeded $AGENTS_TOML"
+fi
+
+append_agent flow "$FLOW_CMD" "$FLOW_ARGS"
+append_agent flow-worker "$WORKER_CMD" "$WORKER_ARGS"
+append_agent flow-worker-heavy "$WORKER_HEAVY_CMD" "$WORKER_HEAVY_ARGS"
+
+# --- claude nicety: pre-approve the flow tooling so ticks run unattended ---
+
+if [ "$FLOW_CMD" = "claude" ] && [ ! -f "$FLOW_HOME/.claude/settings.json" ]; then
+  mkdir -p "$FLOW_HOME/.claude"
+  cat > "$FLOW_HOME/.claude/settings.json" <<EOF
+{
+  "permissions": {
+    "allow": [
+      "Bash(thurbox-cli:*)",
+      "Bash($FLOW_HOME/scripts/create-task.sh:*)",
+      "Bash($FLOW_HOME/scripts/flow-snapshot.sh:*)",
+      "Bash($FLOW_HOME/scripts/parse-result.sh:*)",
+      "Bash(./scripts/create-task.sh:*)",
+      "Bash(./scripts/flow-snapshot.sh:*)",
+      "Bash(./scripts/parse-result.sh:*)",
+      "Bash(jq:*)",
+      "Read(//${FLOW_HOME#/}/**)",
+      "Edit(//${FLOW_HOME#/}/**)",
+      "Write(//${FLOW_HOME#/}/**)"
+    ]
+  }
+}
+EOF
+  say "wrote $FLOW_HOME/.claude/settings.json (unattended tick permissions)"
+fi
+
+# --- bootstrap: dedicated session + tick automation ------------------------
+
+FLOW_UUID="$(thurbox-cli session list 2>/dev/null | jq -r '.[] | select(.name == "flow") | .id' | head -1)"
+if [ -n "$FLOW_UUID" ]; then
+  say "session 'flow' already exists ($FLOW_UUID)"
+else
+  FLOW_UUID="$(thurbox-cli session create --name flow --agent flow --repo-path "$FLOW_HOME" | jq -r .id)"
+  say "created session 'flow' ($FLOW_UUID)"
+fi
+
+if thurbox-cli automation list 2>/dev/null | jq -e '.[] | select(.name == "flow-tick")' >/dev/null; then
+  say "automation 'flow-tick' already exists"
+else
+  thurbox-cli automation create --name flow-tick \
+    --trigger "cron:$TICK_CRON" \
+    --session "$FLOW_UUID" \
+    --prompt "tick" >/dev/null
+  say "created automation 'flow-tick' ($TICK_CRON)"
+fi
+
+say ""
+say "flow extension installed."
+say "  1. Edit $FLOW_HOME/repos.md with your repos."
+say "  2. Open the 'flow' session in thurbox and brain-dump at it,"
+say "     or: thurbox-cli session send $FLOW_UUID \"your dump\""
+say "  3. Map flow-worker / flow-worker-heavy in $AGENTS_TOML to any CLI."

--- a/extensions/flow/scripts/create-task.sh
+++ b/extensions/flow/scripts/create-task.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# create-task.sh — create a thurbox task and (when dispatchable) spawn its
+# worker in the SAME call, so capture → session is atomic and immediate.
+#
+# Usage:
+#   create-task.sh --title T --description D            # plain todo
+#   create-task.sh --title T --description D \
+#     --repo /abs/path --agent flow-worker [--worktree BRANCH] [--no-dispatch]
+#
+# Prints the created task JSON; when dispatched, a second JSON line with the
+# `task run` outcome ({"spawned": "..."} / {"reused": "..."}).
+
+set -euo pipefail
+
+TITLE="" DESC="" REPO="" AGENT="" WORKTREE="" DISPATCH=1
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)       TITLE="$2"; shift 2 ;;
+    --description) DESC="$2"; shift 2 ;;
+    --repo)        REPO="$2"; shift 2 ;;
+    --agent)       AGENT="$2"; shift 2 ;;
+    --worktree)    WORKTREE="$2"; shift 2 ;;
+    --no-dispatch) DISPATCH=0; shift ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -n "$TITLE" ]] || { echo "--title is required" >&2; exit 2; }
+
+ARGS=(task create --title "$TITLE")
+[[ -n "$DESC" ]] && ARGS+=(--description "$DESC")
+if [[ -n "$REPO" ]]; then
+  [[ -n "$AGENT" ]] || { echo "--repo requires --agent" >&2; exit 2; }
+  ARGS+=(--repo "$REPO" --agent "$AGENT")
+  [[ -n "$WORKTREE" ]] && ARGS+=(--worktree "$WORKTREE")
+fi
+
+CREATED="$(thurbox-cli "${ARGS[@]}")"
+printf '%s\n' "$CREATED"
+
+if [[ -n "$REPO" && "$DISPATCH" -eq 1 ]]; then
+  ID="$(printf '%s' "$CREATED" | jq -r .id)"
+  thurbox-cli task run "$ID"
+fi

--- a/extensions/flow/scripts/flow-snapshot.sh
+++ b/extensions/flow/scripts/flow-snapshot.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# flow-snapshot.sh — one-call compact view of the flow agent's world:
+# the task backlog grouped by status + the live flow / task-* sessions.
+# Keeps the triager to a single shell call per mode.
+
+set -euo pipefail
+
+echo "## tasks"
+if TASKS="$(thurbox-cli task list 2>/dev/null)"; then
+  printf '%s' "$TASKS" | jq -r '
+    group_by(.status) | .[] |
+    "### \(.[0].status) (\(length))",
+    (.[] | "  #\(.id) \(.title)"
+      + (if .action.kind == "spawn" then " [spawn:\(.action.agent // "default")]"
+         elif .action.kind == "send" then " [send]"
+         else " [todo-only]" end)
+      + (if .description then
+           ((.description | split("\n")[0]) as $p |
+            if $p | startswith("priority:") then " {\($p)}" else "" end)
+         else "" end))
+  ' 2>/dev/null || printf '%s\n' "$TASKS"
+else
+  echo "  (thurbox-cli task list failed)"
+fi
+
+echo
+echo "## sessions (flow / task-*)"
+if SESSIONS="$(thurbox-cli session list 2>/dev/null)"; then
+  printf '%s' "$SESSIONS" | jq -r '
+    .[] | select(.name == "flow" or (.name | startswith("task-"))) |
+    "  \(.name)  \(.id)  agent=\(.agent)  cwd=\(.cwd)"
+  ' 2>/dev/null || true
+else
+  echo "  (thurbox-cli session list failed)"
+fi

--- a/extensions/flow/scripts/parse-result.sh
+++ b/extensions/flow/scripts/parse-result.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# parse-result.sh — extract the last ===RESULT=== JSON block from a
+# worker's captured terminal output.
+#
+# Reads captured output from stdin (or --file <path>).
+# Exit codes:
+#   0 = found, JSON printed on stdout
+#   1 = no sentinel yet (worker still running)
+#   2 = sentinel present but JSON malformed
+#
+# Recognized JSON fields (extra keys preserved verbatim):
+#   Required: status ∈ {"ok","error"}
+#   Optional: artifact, notes, pr_url
+
+set -euo pipefail
+
+INPUT=""
+if [[ "${1:-}" == "--file" ]]; then
+  [[ -f "${2:-}" ]] || { echo "File not found: ${2:-}" >&2; exit 2; }
+  INPUT="$(cat "$2")"
+else
+  INPUT="$(cat)"
+fi
+
+# Line number of the LAST "===RESULT===" marker.
+LAST_MARKER=$(printf '%s\n' "$INPUT" | grep -n '^===RESULT===$' | tail -1 | cut -d: -f1 || true)
+
+if [[ -z "$LAST_MARKER" ]]; then
+  exit 1
+fi
+
+# The JSON should be on the line immediately after the marker.
+JSON_LINE=$((LAST_MARKER + 1))
+JSON="$(printf '%s\n' "$INPUT" | sed -n "${JSON_LINE}p" | sed 's/[[:space:]]*$//')"
+
+if [[ -z "$JSON" ]]; then
+  exit 2
+fi
+
+if command -v jq >/dev/null 2>&1; then
+  if ! printf '%s' "$JSON" | jq -e . >/dev/null 2>&1; then
+    exit 2
+  fi
+  if ! printf '%s' "$JSON" | jq -e 'has("status")' >/dev/null 2>&1; then
+    exit 2
+  fi
+fi
+
+printf '%s\n' "$JSON"

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -655,7 +655,7 @@ impl App {
                 }
             }
             // Jump to the task's related session terminal (the spawned
-            // `task-<id>` window, or a persisted Send target).
+            // `task-<id>-<slug>` window, or a persisted Send target).
             KeyCode::Char('o') => self.open_task_related_session(),
             KeyCode::Char('d') => self.delete_selected_task(),
             _ => {}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2013,7 +2013,7 @@ impl App {
         if let Some((task_id, title)) = task_prompt {
             let new_id = self.sessions[self.active_index].info.id;
             // Record the link now — the session was named by the user, so the
-            // `task-<id>` convention can't recover it later.
+            // `task-<id>-<slug>` convention can't recover it later.
             self.task_ui.task_session_links.insert(task_id, new_id);
             let prompt = self.task_agent_prompt(task_id, &title);
             self.send_prompt_to_session(new_id, &prompt, AGENT_BOOT_DELAY_TICKS);
@@ -3410,7 +3410,7 @@ impl App {
     /// queue `prompt` into it. The session is named `name`; a recurring caller
     /// reuses that session on later invocations (and after a TUI restart, where
     /// it is restored from the database by name). Shared by automations
-    /// (`auto-<id>`) and tasks (`task-<id>`).
+    /// (`auto-<id>`) and tasks (`task-<id>-<title-slug>`).
     fn spawn_and_prompt(
         &mut self,
         name: String,
@@ -3782,18 +3782,18 @@ impl App {
     /// Indices into `self.sessions` of the **currently-open** sessions a task is
     /// related to, in display order:
     ///
-    /// - the session named `task-<id>` — the spawn convention used by the
-    ///   headless `task run` (and what survives a restart);
+    /// - the session named by the spawn convention (`task-<id>-<title-slug>`,
+    ///   or the legacy bare `task-<id>`) — used by the headless `task run`
+    ///   (and what survives a restart; see [`Task::matches_spawn_session`]);
     /// - the target of a persisted `Send` action (`task.action`), when one is
     ///   set via the CLI; and
     /// - the in-memory `task_session_links` entry recorded when the task was
-    ///   triggered from the TUI this run (TUI spawns get a user-chosen name, not
-    ///   `task-<id>`, so this is how that link is recovered).
+    ///   triggered from the TUI this run (TUI spawns get a user-chosen name,
+    ///   not the spawn convention, so this is how that link is recovered).
     ///
     /// Deduplicated. Empty when nothing related is open right now. This is the
     /// single source of truth for both the details panel and the *open* key.
     pub(crate) fn task_related_session_indices(&self, task: &crate::session::Task) -> Vec<usize> {
-        let spawn_name = format!("task-{}", task.id);
         // Persisted `Send` action target (CLI-authored), plus the in-memory link
         // recorded when this task was triggered from the TUI this run.
         let send_target = match &task.action {
@@ -3803,7 +3803,7 @@ impl App {
         let linked = self.task_ui.task_session_links.get(&task.id).copied();
         let mut out = Vec::new();
         for (i, s) in self.sessions.iter().enumerate() {
-            let related = s.info.name == spawn_name
+            let related = task.matches_spawn_session(&s.info.name)
                 || send_target.is_some_and(|t| t == s.info.id)
                 || linked.is_some_and(|t| t == s.info.id);
             if related && !out.contains(&i) {
@@ -6008,7 +6008,10 @@ mod tests {
         let task = app.db.get_task(id).unwrap().unwrap();
         assert!(app.task_related_session_indices(&task).is_empty());
 
-        // Rename session 1 to the spawn convention `task-<id>` → it's related.
+        // Rename session 1 to the spawn convention → it's related. Both the
+        // current slugged form and the legacy bare `task-<id>` must match.
+        app.sessions[1].info.name = task.spawn_session_name();
+        assert_eq!(app.task_related_session_indices(&task), vec![1]);
         app.sessions[1].info.name = format!("task-{id}");
         assert_eq!(app.task_related_session_indices(&task), vec![1]);
     }

--- a/src/app/task_state.rs
+++ b/src/app/task_state.rs
@@ -34,10 +34,11 @@ pub(crate) struct TaskUiState {
     pub(crate) pending_task_prompt: Option<(i64, String)>,
     /// Live `task id → session id` links recorded when a task is triggered from
     /// the TUI (Spawn-new or Send). TUI spawns get a user-chosen session name
-    /// rather than the `task-<id>` convention, so the name alone can't recover
-    /// the link — this map does. Consulted by `task_related_session_indices`
-    /// alongside the name convention and any persisted `Send` action. In-memory
-    /// only (the `task-<id>` convention is what survives a restart); stale
-    /// entries are harmless since lookups filter to currently-open sessions.
+    /// rather than the `task-<id>-<slug>` convention, so the name alone can't
+    /// recover the link — this map does. Consulted by
+    /// `task_related_session_indices` alongside the name convention and any
+    /// persisted `Send` action. In-memory only (the spawn-name convention is
+    /// what survives a restart); stale entries are harmless since lookups
+    /// filter to currently-open sessions.
     pub(crate) task_session_links: HashMap<i64, SessionId>,
 }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -759,7 +759,7 @@ impl App {
         area: Rect,
         task: &crate::session::Task,
     ) -> Option<ScrollbarGeom> {
-        // Related running sessions (spawned `task-<id>` and/or a Send target).
+        // Related running sessions (spawned `task-<id>-<slug>` and/or a Send target).
         let related = self.task_related_session_indices(task);
         let sessions = if related.is_empty() {
             "none open".to_string()

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -2,7 +2,8 @@
 //!
 //! Tasks are persisted to the shared database; the TUI's right-side panel reads
 //! them. `run` triggers a task's agent action headlessly (Send into a live tmux
-//! window, or Spawn a fresh session named `task-<id>` seeded with the title).
+//! window, or Spawn a fresh session named `task-<id>-<title-slug>` seeded with
+//! the title).
 
 use clap::Subcommand;
 use serde_json::{json, Value};
@@ -176,9 +177,17 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
             base_branch,
             agent,
         }) => {
-            let name = format!("task-{}", task.id);
+            let name = task.spawn_session_name();
             // Reuse an existing session window (re-trigger / restored session).
-            if crate::agent::tmux::window_exists(&name) {
+            // Match by convention rather than exact name so legacy `task-<id>`
+            // sessions and spawns from a since-edited title are found too.
+            let existing = db
+                .list_active_sessions()
+                .map_err(|e| format!("list_active_sessions: {e}"))?
+                .into_iter()
+                .map(|s| s.name)
+                .find(|n| task.matches_spawn_session(n) && crate::agent::tmux::window_exists(n));
+            if let Some(name) = existing {
                 crate::agent::tmux::send_prompt_now(&name, &prompt)
                     .map_err(|e| format!("send_prompt_now: {e}"))?;
                 mark_in_progress(db, task)?;

--- a/src/session/task.rs
+++ b/src/session/task.rs
@@ -125,7 +125,52 @@ impl Task {
         ));
         prompt
     }
+
+    /// Session name used when this task is dispatched via a `Spawn` action:
+    /// `task-<id>-<title-slug>` (e.g. `task-42-wire-up-ssh-backend`), capped at
+    /// [`SPAWN_SESSION_NAME_MAX`] chars. Falls back to plain `task-<id>` when
+    /// the title yields no slug. Shared by the headless `task run` path; use
+    /// [`matches_spawn_session`](Self::matches_spawn_session) to recognize the
+    /// session later (it also accepts the legacy bare `task-<id>` form).
+    pub fn spawn_session_name(&self) -> String {
+        let prefix = format!("task-{}", self.id);
+        let budget = SPAWN_SESSION_NAME_MAX.saturating_sub(prefix.len() + 1);
+        let mut slug = String::new();
+        for c in self.title.chars() {
+            if c.is_ascii_alphanumeric() {
+                slug.push(c.to_ascii_lowercase());
+            } else if !slug.is_empty() && !slug.ends_with('-') {
+                slug.push('-');
+            }
+            if slug.len() >= budget {
+                break;
+            }
+        }
+        slug.truncate(budget);
+        let slug = slug.trim_end_matches('-');
+        if slug.is_empty() {
+            prefix
+        } else {
+            format!("{prefix}-{slug}")
+        }
+    }
+
+    /// Whether `name` is this task's spawned session: the current
+    /// `task-<id>-<slug>` convention or the legacy bare `task-<id>` (which
+    /// pre-slug sessions still carry; the title may also have been edited
+    /// since the spawn, so only the `task-<id>` part is significant).
+    pub fn matches_spawn_session(&self, name: &str) -> bool {
+        let prefix = format!("task-{}", self.id);
+        name == prefix
+            || name
+                .strip_prefix(&prefix)
+                .is_some_and(|r| r.starts_with('-'))
+    }
 }
+
+/// Cap for [`Task::spawn_session_name`], matching the session-name limit used
+/// elsewhere (tmux window names stay readable in the TUI session list).
+pub const SPAWN_SESSION_NAME_MAX: usize = 64;
 
 #[cfg(test)]
 mod tests {
@@ -183,6 +228,48 @@ mod tests {
         // Self-service context: how to read more and how to close it out.
         assert!(prompt.contains("thurbox-cli task show 42"));
         assert!(prompt.contains("thurbox-cli task edit 42 --status done"));
+    }
+
+    #[test]
+    fn spawn_session_name_slugs_the_title() {
+        assert_eq!(
+            sample_task(None).spawn_session_name(),
+            "task-42-wire-up-ssh-backend"
+        );
+    }
+
+    #[test]
+    fn spawn_session_name_collapses_symbols_and_caps_length() {
+        let mut task = sample_task(None);
+        task.title = "Fix: TUI crash!! (on concurrent CLI commands)".to_string();
+        assert_eq!(
+            task.spawn_session_name(),
+            "task-42-fix-tui-crash-on-concurrent-cli-commands"
+        );
+        task.title = "x".repeat(200);
+        let name = task.spawn_session_name();
+        assert!(name.len() <= SPAWN_SESSION_NAME_MAX);
+        assert!(name.starts_with("task-42-x"));
+        // Truncation never leaves a dangling hyphen.
+        assert!(!name.ends_with('-'));
+    }
+
+    #[test]
+    fn spawn_session_name_falls_back_to_bare_id() {
+        let mut task = sample_task(None);
+        task.title = "??? !!!".to_string();
+        assert_eq!(task.spawn_session_name(), "task-42");
+    }
+
+    #[test]
+    fn matches_spawn_session_accepts_current_and_legacy_names() {
+        let task = sample_task(None);
+        assert!(task.matches_spawn_session("task-42-wire-up-ssh-backend"));
+        assert!(task.matches_spawn_session("task-42-some-older-title")); // title edited
+        assert!(task.matches_spawn_session("task-42")); // legacy convention
+        assert!(!task.matches_spawn_session("task-421")); // different task id
+        assert!(!task.matches_spawn_session("task-4"));
+        assert!(!task.matches_spawn_session("my-task-42"));
     }
 
     #[test]

--- a/src/ui/tasks_panel.rs
+++ b/src/ui/tasks_panel.rs
@@ -27,8 +27,8 @@ pub struct TaskPaneEntry {
     /// When a global search is active, rows that don't match are dimmed.
     pub dimmed: bool,
     /// The task has at least one currently-open related session (a spawned
-    /// `task-<id>` window or a Send target). Drawn as a trailing `⇄` marker so a
-    /// live task is glanceable in the list; press `o` to jump to it.
+    /// `task-<id>-<slug>` window or a Send target). Drawn as a trailing `⇄`
+    /// marker so a live task is glanceable in the list; press `o` to jump to it.
     pub linked: bool,
 }
 

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -75,6 +75,7 @@
             <li><a href="#agent-definitions">Agent Definitions</a></li>
             <li><a href="#automations">Automations</a></li>
             <li><a href="#tasks">Tasks</a></li>
+            <li><a href="#flow-extension">Flow Extension</a></li>
             <li><a href="#git-worktrees">Git Worktrees</a></li>
             <li><a href="#remote-ssh-sessions">Remote SSH Sessions</a></li>
             <li><a href="#worktree-sync">Worktree Sync</a></li>
@@ -368,6 +369,70 @@
               ):
               <code>create/list/show/edit/remove/run</code>
               . External issue-tracker sync (Jira, GitHub Issues) is scaffolded for a later release.
+            </li>
+          </ul>
+
+          <h2 id="flow-extension">
+            Flow Extension
+            <a href="#flow-extension" class="heading-anchor">#</a>
+          </h2>
+          <div class="info-box warning">
+            <p>
+              <strong>Heads up:</strong>
+              The flow extension is a brand-new,
+              <strong>experimental</strong>
+              feature under active testing &mdash; expect its behavior, spec, and installer to
+              change between releases.
+            </p>
+          </div>
+          <p>
+            An opt-in,
+            <strong>agent-agnostic</strong>
+            add-on that composes tasks, sessions, worktrees, and automations into a focus-protecting
+            triage workflow: brain-dump at a dedicated cheap
+            <em>flow session</em>
+            and it captures everything into tasks, dispatches the dispatchable ones to worker
+            sessions, monitors them quietly, grooms the backlog, and ends every reply with the
+            single next thing to focus on.
+          </p>
+          <ul>
+            <li>
+              The triager and workers are plain
+              <code>agents.toml</code>
+              aliases (
+              <code>flow</code>
+              ,
+              <code>flow-worker</code>
+              ,
+              <code>flow-worker-heavy</code>
+              ) &mdash; map them to claude, codex, gemini, opencode, vibe, or anything else. The
+              behavior is one markdown spec (
+              <code>FLOW.md</code>
+              ) surfaced to whichever CLI you pick via
+              <code>CLAUDE.md</code>
+              /
+              <code>AGENTS.md</code>
+              /
+              <code>GEMINI.md</code>
+              symlinks.
+            </li>
+            <li>
+              Dispatch is eager: capture creates the task and spawns its worker in one atomic call,
+              each worker on its own
+              <code>flow/&lt;slug&gt;</code>
+              worktree branch; workers report back so the next task dispatches immediately, with a
+              cron tick as the safety net.
+            </li>
+            <li>
+              One-line install (idempotent):
+              <code>
+                curl -fsSL
+                https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/flow/install.sh |
+                sh
+              </code>
+              &mdash; see
+              <code>extensions/flow/README.md</code>
+              .
             </li>
           </ul>
 

--- a/website/index.html
+++ b/website/index.html
@@ -185,6 +185,18 @@
             </p>
           </div>
           <div class="card">
+            <div class="card-icon">&#x1f3af;</div>
+            <h3>Flow Extension (experimental)</h3>
+            <p>
+              An opt-in,
+              <strong>agent-agnostic</strong>
+              add-on: brain-dump at a dedicated flow session and it captures tasks, dispatches
+              workers on isolated worktrees, and always ends with
+              <strong>the one next thing to focus on</strong>
+              . New and under active testing.
+            </p>
+          </div>
+          <div class="card">
             <div class="card-icon">&#x1f50d;</div>
             <h3>Global Search</h3>
             <p>


### PR DESCRIPTION
## Summary

- **`extensions/flow/`** (new, experimental): an opt-in, agent-agnostic focus-protecting triage agent built entirely on `thurbox-cli` + `agents.toml` aliases — brain-dumps become tasks, dispatchable tasks spawn workers on `flow/<slug>` worktrees, a `flow-tick` automation monitors them, and every reply ends with the single next thing to focus on. The behavior spec (`FLOW.md`) is surfaced to any CLI (claude, codex, gemini, opencode, vibe, …) via `CLAUDE.md`/`AGENTS.md`/`GEMINI.md` symlinks; `install.sh` is curl-able and idempotent. Recorded as **ADR-20**.
- **Readable task session names**: `task run` spawns sessions named `task-<id>-<title-slug>` (`Task::spawn_session_name`); `Task::matches_spawn_session` keeps the TUI linkage (`o` key, ⇄ marker) and CLI reuse working for legacy bare `task-<id>` names and titles edited after the spawn.
- Docs updated everywhere (README, FEATURES, ARCHITECTURE, CLAUDE.md, website features page + landing card), all marking flow as a new feature under active testing.

## Test plan

- `cargo nextest run --all` — 1040/1040 pass (new unit tests for slug generation, length cap, fallback, and legacy-name matching)
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, architecture rules 11/11
- `rumdl check .` and `npm run lint:website` clean
- `extensions/flow/install.sh` exercised end-to-end locally: idempotent re-run, agents.toml seeding/skipping, session + automation bootstrap, and a live capture→dispatch→tick cycle against a real flow session