### PR TITLE
docs: harden the flow extension spec (dispatcher-only + remote worktree bases)

### DIFF
--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -58,7 +58,7 @@ the table, add a row when you learn its path.
    ```bash
    ./scripts/create-task.sh --title "<title>" --description "<desc>" \
      --repo <abs-path> --agent <flow-worker|flow-worker-heavy> \
-     --worktree flow/<task-slug>
+     --worktree flow/<task-slug> --base origin/<base-from-repos.md>
    ```
 
    Pass `--repo`/`--agent` whenever the repo is confident — NEVER create a
@@ -66,10 +66,13 @@ the table, add a row when you learn its path.
    flow/<task-slug>` when the repo is a git repository** (derive the slug
    from the title): workers get an isolated worktree, never dirty the main
    checkout, and several can work the same repo in parallel. Omit it only
-   for non-git directories. If the repo is not confident → omit
-   `--repo`/`--agent` (plain todo); triage later or ask ONE question. Over
-   capacity → add `--no-dispatch`. Description template (first lines, then
-   the user's words):
+   for non-git directories. **The worktree base is always the REMOTE
+   default branch** — `origin/<base>` with the base column from
+   `./repos.md` (e.g. `origin/main`), never a local branch; the helper
+   fetches origin first so the base is current. If the repo is not
+   confident → omit `--repo`/`--agent` (plain todo); triage later or ask
+   ONE question. Over capacity → add `--no-dispatch`. Description template
+   (first lines, then the user's words):
 
    ```text
    priority: <high|normal|low>

--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -6,6 +6,16 @@ no praise. Every user-facing reply ends with the Output Contract footer.
 Ask at most ONE clarifying question per interaction, and only when a task
 is undispatchable without the answer.
 
+**You never do the work yourself.** You are a dispatcher, not a worker:
+never enter plan mode, never explore a repository, never write code,
+docs, designs, or plans — no matter how the message is phrased. Verbs
+like "plan", "improve", "fix", "investigate", "design", "refactor"
+describe the **task's** job, not yours: CAPTURE them and dispatch a
+worker (planning and investigation are real work — the worker session
+does them). If you catch yourself about to open project files, enter
+plan mode, or produce a plan or analysis, stop and create a task
+instead. The only files you ever touch are in this flow home.
+
 You run inside a thurbox session whose working directory is the flow home
 (this directory). The backlog's single source of truth is the thurbox task
 list (`thurbox-cli task ...`). Worker sessions are thurbox sessions named
@@ -77,10 +87,17 @@ the table, add a row when you learn its path.
    thurbox-cli session send "$(thurbox-cli session list | jq -r '.[] | select(.name=="flow") | .id')" "tick"
    ```
 
-4. Trivial items (a lookup, a question you can answer): answer inline in
+4. Planning / investigation / design requests ("plan an improvement to
+   X", "investigate why Y is slow", "design Z") are **dispatchable
+   tasks like any other** — never plan or investigate yourself. Title
+   them verb-first (`Plan: …`, `Investigate: …`), carry the user's full
+   context into the description, set `accept:` to the expected artifact
+   (e.g. "written plan as PR/markdown"), and dispatch — usually to
+   `flow-worker-heavy`, since these are exploratory.
+5. Trivial items (a lookup, a question you can answer): answer inline in
    one line, create no task.
-5. Confirm one line per task: `#<id> <title> [worker|heavy|todo]`.
-6. End with the Output Contract footer.
+6. Confirm one line per task: `#<id> <title> [worker|heavy|todo]`.
+7. End with the Output Contract footer.
 
 ## DISPATCH (sub-step of CAPTURE and TICK)
 

--- a/extensions/flow/scripts/create-task.sh
+++ b/extensions/flow/scripts/create-task.sh
@@ -5,14 +5,19 @@
 # Usage:
 #   create-task.sh --title T --description D            # plain todo
 #   create-task.sh --title T --description D \
-#     --repo /abs/path --agent flow-worker [--worktree BRANCH] [--no-dispatch]
+#     --repo /abs/path --agent flow-worker \
+#     [--worktree BRANCH] [--base origin/main] [--no-dispatch]
+#
+# Worktrees are always based on the REMOTE default branch: with --worktree
+# and no --base, origin/main is assumed. When the base is a remote-tracking
+# ref (origin/...), the repo is fetched first so the base is current.
 #
 # Prints the created task JSON; when dispatched, a second JSON line with the
 # `task run` outcome ({"spawned": "..."} / {"reused": "..."}).
 
 set -euo pipefail
 
-TITLE="" DESC="" REPO="" AGENT="" WORKTREE="" DISPATCH=1
+TITLE="" DESC="" REPO="" AGENT="" WORKTREE="" BASE="" DISPATCH=1
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --title)       TITLE="$2"; shift 2 ;;
@@ -20,6 +25,7 @@ while [[ $# -gt 0 ]]; do
     --repo)        REPO="$2"; shift 2 ;;
     --agent)       AGENT="$2"; shift 2 ;;
     --worktree)    WORKTREE="$2"; shift 2 ;;
+    --base)        BASE="$2"; shift 2 ;;
     --no-dispatch) DISPATCH=0; shift ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
@@ -31,7 +37,14 @@ ARGS=(task create --title "$TITLE")
 if [[ -n "$REPO" ]]; then
   [[ -n "$AGENT" ]] || { echo "--repo requires --agent" >&2; exit 2; }
   ARGS+=(--repo "$REPO" --agent "$AGENT")
-  [[ -n "$WORKTREE" ]] && ARGS+=(--worktree "$WORKTREE")
+  if [[ -n "$WORKTREE" ]]; then
+    [[ -n "$BASE" ]] || BASE="origin/main"
+    ARGS+=(--worktree "$WORKTREE" --base "$BASE")
+    # A remote-tracking base is only as fresh as the last fetch.
+    if [[ "$BASE" == origin/* ]]; then
+      git -C "$REPO" fetch origin --quiet 2>/dev/null || true
+    fi
+  fi
 fi
 
 CREATED="$(thurbox-cli "${ARGS[@]}")"


### PR DESCRIPTION
## Summary

Two flow-extension hardenings from real usage:

- **The flow agent never does the work itself.** A "Plan an improvement" brain-dump made it enter plan mode and start exploring the repo instead of capturing a task. The spec now states the flow agent is a **dispatcher, never a worker** — work verbs ("plan", "investigate", "design", "improve") describe the task's job; planning/investigation requests are captured and dispatched (typically to `flow-worker-heavy`) with the expected artifact as the accept criterion.
- **Worktrees always base on the remote default branch.** Dispatch passes `--base origin/<base>` (per-repo via `repos.md`, `origin/main` by default) instead of a possibly-stale local branch; `create-task.sh` gains `--base` (defaulting to `origin/main` when `--worktree` is set) and fetches origin first so the remote-tracking ref is current.

## Test plan

- `rumdl check` clean, `bash -n` on the changed script
- Live: spec + script synced to a running flow session; dispatcher rule regression-prompted against the original failing phrasing