### PR TITLE
feat(ui): add manual session list reordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,6 +388,24 @@ so `Ctrl+J`/`Ctrl+K` navigation follows the tree automatically.
 Storage: nullable `sessions.parent_session_id` column (schema v30;
 v29 is reserved by an in-flight branch).
 
+### Manual session ordering
+
+The session list is **manually orderable**: `Shift+J`/`Shift+K`
+(while the session list is focused; rebindable
+`SessionListMoveDown`/`SessionListMoveUp` actions) move the selected
+session one row down/up. Manual order **wins** — status changes only
+recolor the dot, never move a row. A move swaps two adjacent
+*blocks* (a row plus its nested children, so a parent drags its
+subtree): root rows swap within their repo group, the **whole
+group** swaps past a group edge, and nested children move among
+their siblings only (`ui::project_list::move_in_order`, pure;
+`App::move_active_session` applies it). On every move all sessions
+are densely renumbered `0..n` and persisted, so the order survives
+restarts and syncs across instances via the existing
+`data_version` polling. Storage: nullable `sessions.display_order`
+column (schema v31); `None` = never moved, renders after ordered
+sessions in creation order (new sessions append to their group).
+
 Automations fire even when the TUI is closed: a tmux heartbeat
 keeper window (`automation-heartbeat`, armed on TUI startup and on
 `automation create`) loops `automation tick` every 60 s and keeps
@@ -707,9 +725,11 @@ backend dependency stays visible at each call site.
   panel areas (responsive: <80 = terminal only, >=80 = 2-panel,
   >=120 = optional 3-panel). Widgets: `project_list` (session
   list with repo/branch display; `compute_session_order` is the
-  single comparator that orders sessions by activity/status and
-  groups them by repo under headers — shared with `App`'s
-  `Ctrl+J/K` navigation so the two never drift),
+  single comparator that orders sessions by manual order
+  (`display_order`, never by status) and groups them by repo
+  under headers — shared with `App`'s `Ctrl+J/K` navigation so
+  the two never drift; `move_in_order` is the pure reorder step
+  behind `Shift+J`/`Shift+K`),
   `terminal_view`, `info_panel`,
   `status_bar`, `repo_picker_modal` (repo selection with
   worktree toggle). `selection.rs` handles mouse-drag text
@@ -794,7 +814,9 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `F5` | Toggle tasks panel (visible at width >= 120) | Next to F4 |
 
 List contexts use plain `j`/`k`/`Enter` for navigation.
-Terminal forwards all non-Ctrl keys to the PTY.
+In the focused session list, `Shift+J`/`Shift+K` move the selected
+session down/up (manual reordering; whole groups move past a group
+edge). Terminal forwards all non-Ctrl keys to the PTY.
 `Shift+arrows/PageUp/PageDown` for scrollback.
 
 These defaults can be overridden two ways, both writing the same

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1257,6 +1257,14 @@ impl App {
                 self.focus = InputFocus::Terminal;
                 true
             }
+            Action::SessionListMoveDown => {
+                self.move_active_session(true);
+                true
+            }
+            Action::SessionListMoveUp => {
+                self.move_active_session(false);
+                true
+            }
 
             // ── File viewer (scoped) ────────────────────────────────────
             Action::FileViewerDown => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1289,6 +1289,8 @@ impl App {
                 session.info.id = deleted.id;
                 session.info.worktrees = worktree_infos;
                 session.info.parent_session_id = deleted.parent_session_id;
+                // `DeletedSessionInfo` doesn't carry display_order: a restored
+                // session simply re-appends at the end of its repo group.
                 resolve_repo_display_names(&mut session.info);
                 self.sessions.push(session);
                 self.active_index = self.sessions.len() - 1;
@@ -1315,6 +1317,7 @@ impl App {
         session.info.agent_session_id = shared.agent_session_id.clone();
         session.info.worktrees = shared.worktrees.iter().cloned().map(Into::into).collect();
         session.info.parent_session_id = shared.parent_session_id;
+        session.info.display_order = shared.display_order;
         resolve_repo_display_names(&mut session.info);
     }
 
@@ -2163,15 +2166,43 @@ impl App {
         }
     }
 
-    /// Indices into `self.sessions` in the order they are rendered.
-    ///
-    /// Delegates to the same `ui::project_list::compute_session_order` the
-    /// rendering widget uses, so `Ctrl+J`/`Ctrl+K` step through the list in the
-    /// exact order the user sees (repo groups ordered by activity/status).
-    fn render_order_indices(&self) -> Vec<usize> {
+    /// The rendered order of `self.sessions`, from the same
+    /// `ui::project_list::compute_session_order` the rendering widget uses, so
+    /// navigation and reordering operate on the exact order the user sees.
+    fn session_order(&self) -> crate::ui::project_list::SessionOrder {
         let infos: Vec<&crate::session::SessionInfo> =
             self.sessions.iter().map(|s| &s.info).collect();
-        crate::ui::project_list::compute_session_order(&infos).order
+        crate::ui::project_list::compute_session_order(&infos)
+    }
+
+    /// Indices into `self.sessions` in the order they are rendered — the order
+    /// `Ctrl+J`/`Ctrl+K` step through (repo groups in manual order).
+    fn render_order_indices(&self) -> Vec<usize> {
+        self.session_order().order
+    }
+
+    /// Move the active session one step up or down in the rendered order
+    /// (`Shift+J`/`Shift+K` in the session list): root blocks swap within their
+    /// repo group, whole groups swap past the group edge, nested children move
+    /// among their siblings (see `ui::project_list::move_in_order`).
+    ///
+    /// On success every session is renumbered densely along the new order and
+    /// persisted, so the order survives restarts and reaches other instances
+    /// via the DB poll. The selection follows the moved row automatically
+    /// (`active_index` is an input index, which the move never changes).
+    pub(crate) fn move_active_session(&mut self, down: bool) {
+        if self.sessions.is_empty() {
+            return;
+        }
+        let ord = self.session_order();
+        let Some(new_order) = crate::ui::project_list::move_in_order(&ord, self.active_index, down)
+        else {
+            return;
+        };
+        for (pos, &idx) in new_order.iter().enumerate() {
+            self.sessions[idx].info.display_order = Some(pos as i64);
+        }
+        self.save_state();
     }
 
     /// Whether the active session is the first row in render order (top of the
@@ -2887,6 +2918,7 @@ impl App {
             spawned.info.worktrees = worktree_infos;
             spawned.info.additional_dirs = shared_session.additional_dirs.clone();
             spawned.info.parent_session_id = shared_session.parent_session_id;
+            spawned.info.display_order = shared_session.display_order;
             self.sessions.push(spawned);
             self.save_state();
             tracing::debug!(
@@ -2984,6 +3016,7 @@ impl App {
                 .collect(),
             shell_backend_id: session.info.shell_backend_id.clone(),
             parent_session_id: session.info.parent_session_id,
+            display_order: session.info.display_order,
             tombstone: false,
             tombstone_at: None,
         }
@@ -3159,6 +3192,7 @@ impl App {
         session.info.agent = agent;
         session.info.worktrees = worktrees;
         session.info.parent_session_id = shared.parent_session_id;
+        session.info.display_order = shared.display_order;
         resolve_repo_display_names(&mut session.info);
 
         // Re-adopt shell pane if one was persisted
@@ -3222,7 +3256,19 @@ impl App {
             crate::session_ops::resume_trigger_for(&def, &agent_session_id, &config.env);
         self.new_session.additional_dirs = shared.additional_dirs;
         self.new_session.parent_session_id = shared.parent_session_id;
+        // After a reboot every session takes this path (the tmux server died),
+        // so the manual list position must survive the respawn or one restart
+        // would scramble the whole order. `do_spawn_session` pushes + persists
+        // the fresh session; stamp the inherited order on it afterwards.
+        let display_order = shared.display_order;
+        let before = self.sessions.len();
         self.do_spawn_session(name, &config, worktrees);
+        if self.sessions.len() > before && display_order.is_some() {
+            if let Some(session) = self.sessions.last_mut() {
+                session.info.display_order = display_order;
+            }
+            self.save_state();
+        }
     }
 
     /// Find a discovered backend session matching a shared session.
@@ -7220,6 +7266,76 @@ mod tests {
     }
 
     #[test]
+    fn session_to_shared_maps_display_order() {
+        // Regression guard: `save_state` upserts every session via
+        // `session_to_shared`, so dropping the field here would wipe the
+        // manual list order from the DB on the TUI's next save.
+        let backend_arc = stub_backend_arc();
+        let provider = stub_provider();
+        let mut app = App::new(
+            24,
+            120,
+            BackendRegistry::new(backend_arc.clone()),
+            stub_agents(),
+            test_db(),
+        );
+
+        let mut session = Session::stub("ordered", &backend_arc, &provider);
+        session.info.display_order = Some(7);
+        app.sessions.push(session);
+
+        let shared = app.session_to_shared(&app.sessions[0]);
+        assert_eq!(shared.display_order, Some(7));
+
+        // And the metadata copy applies it back on adoption/update.
+        let mut adopted = Session::stub("ordered", &backend_arc, &provider);
+        App::apply_shared_session_metadata(&mut adopted, &shared);
+        assert_eq!(adopted.info.display_order, Some(7));
+    }
+
+    #[test]
+    fn move_active_session_renumbers_and_persists() {
+        let mut app = app_with_sessions(3);
+        for (i, s) in app.sessions.iter_mut().enumerate() {
+            s.info.name = format!("s{i}");
+        }
+        app.active_index = 0;
+
+        app.move_active_session(true);
+
+        // Render order is now [s1, s0, s2], densely renumbered 0..n.
+        assert_eq!(app.render_order_indices(), vec![1, 0, 2]);
+        assert_eq!(app.sessions[1].info.display_order, Some(0));
+        assert_eq!(app.sessions[0].info.display_order, Some(1));
+        assert_eq!(app.sessions[2].info.display_order, Some(2));
+        // The selection follows the moved row (input index unchanged).
+        assert_eq!(app.active_index, 0);
+
+        // Persisted: the DB lists sessions in the new order.
+        let names: Vec<String> = app
+            .db
+            .list_active_sessions()
+            .unwrap()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(names, ["s1", "s0", "s2"]);
+
+        // A status change never moves a row.
+        app.sessions[2].info.status = SessionStatus::Attention;
+        assert_eq!(app.render_order_indices(), vec![1, 0, 2]);
+    }
+
+    #[test]
+    fn move_active_session_at_edge_is_noop() {
+        let mut app = app_with_sessions(2);
+        app.active_index = 0;
+        app.move_active_session(false); // already at the top
+        assert_eq!(app.render_order_indices(), vec![0, 1]);
+        assert!(app.sessions.iter().all(|s| s.info.display_order.is_none()));
+    }
+
+    #[test]
     fn ctrl_r_no_op_without_agent_session_id() {
         let mut app = app_with_sessions(1);
         // App::new may toast warnings from the developer's real keybindings
@@ -8086,6 +8202,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -227,6 +227,7 @@ fn shared_session_to_json(s: &SharedSession) -> Value {
         "agent_session_id": s.agent_session_id,
         "cwd": s.cwd.as_ref().map(|p| p.display().to_string()),
         "parent_session_id": s.parent_session_id.map(|id| id.to_string()),
+        "display_order": s.display_order,
         "worktrees": s.worktrees.iter().map(|w| json!({
             "repo_path": w.repo_path.display().to_string(),
             "worktree_path": w.worktree_path.display().to_string(),
@@ -267,6 +268,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         };
@@ -283,6 +285,7 @@ mod tests {
         assert_eq!(s["agent_session_id"].as_str(), Some("agent-1"));
         assert_eq!(s["cwd"].as_str(), Some("/tmp/repo"));
         assert!(s["parent_session_id"].is_null());
+        assert!(s["display_order"].is_null());
         assert!(s["worktrees"].is_array());
     }
 
@@ -302,6 +305,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         };
@@ -374,6 +378,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         };
@@ -408,6 +413,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -58,6 +58,10 @@ pub enum Action {
     SessionListNext,
     SessionListPrev,
     SessionListOpen,
+    /// Move the selected session one row down (manual reordering).
+    SessionListMoveDown,
+    /// Move the selected session one row up (manual reordering).
+    SessionListMoveUp,
     // ── File viewer (scoped) ────────────────────────────────────────────
     FileViewerDown,
     FileViewerUp,
@@ -115,6 +119,8 @@ impl Action {
             Action::SessionListNext,
             Action::SessionListPrev,
             Action::SessionListOpen,
+            Action::SessionListMoveDown,
+            Action::SessionListMoveUp,
             Action::FileViewerDown,
             Action::FileViewerUp,
             Action::FileViewerCollapse,
@@ -158,6 +164,8 @@ impl Action {
             Action::SessionListNext => "Next item",
             Action::SessionListPrev => "Previous item",
             Action::SessionListOpen => "Focus terminal",
+            Action::SessionListMoveDown => "Move session down",
+            Action::SessionListMoveUp => "Move session up",
             Action::FileViewerDown => "Move down",
             Action::FileViewerUp => "Move up",
             Action::FileViewerCollapse => "Collapse / parent",
@@ -179,9 +187,11 @@ impl Action {
     /// [`KeyBindings::rebind`].
     pub fn context(self) -> KeyContext {
         match self {
-            Action::SessionListNext | Action::SessionListPrev | Action::SessionListOpen => {
-                KeyContext::SessionList
-            }
+            Action::SessionListNext
+            | Action::SessionListPrev
+            | Action::SessionListOpen
+            | Action::SessionListMoveDown
+            | Action::SessionListMoveUp => KeyContext::SessionList,
             Action::FileViewerDown
             | Action::FileViewerUp
             | Action::FileViewerCollapse
@@ -233,6 +243,13 @@ impl Action {
             Action::SessionListNext => vec![KeyChord::plain('j'), KeyChord::key(KeyCode::Down)],
             Action::SessionListPrev => vec![KeyChord::plain('k'), KeyChord::key(KeyCode::Up)],
             Action::SessionListOpen => vec![KeyChord::key(KeyCode::Enter)],
+            // Shift+J / Shift+K — normalized like FileViewerPrevMatch's Shift+N.
+            Action::SessionListMoveDown => {
+                vec![KeyChord::normalized(KeyModifiers::NONE, KeyCode::Char('J'))]
+            }
+            Action::SessionListMoveUp => {
+                vec![KeyChord::normalized(KeyModifiers::NONE, KeyCode::Char('K'))]
+            }
             Action::FileViewerDown => vec![KeyChord::plain('j'), KeyChord::key(KeyCode::Down)],
             Action::FileViewerUp => vec![KeyChord::plain('k'), KeyChord::key(KeyCode::Up)],
             Action::FileViewerCollapse => vec![KeyChord::plain('h'), KeyChord::key(KeyCode::Left)],
@@ -307,7 +324,13 @@ pub fn help_sections() -> Vec<(&'static str, Vec<Action>)> {
         ("Clipboard", vec![Copy, Paste]),
         (
             "Session list (when focused)",
-            vec![SessionListNext, SessionListPrev, SessionListOpen],
+            vec![
+                SessionListNext,
+                SessionListPrev,
+                SessionListOpen,
+                SessionListMoveDown,
+                SessionListMoveUp,
+            ],
         ),
         (
             "File viewer (when focused)",
@@ -880,6 +903,8 @@ mod tests {
                 Action::SessionListNext => 0,
                 Action::SessionListPrev => 0,
                 Action::SessionListOpen => 0,
+                Action::SessionListMoveDown => 0,
+                Action::SessionListMoveUp => 0,
                 Action::FileViewerDown => 0,
                 Action::FileViewerUp => 0,
                 Action::FileViewerCollapse => 0,
@@ -893,9 +918,9 @@ mod tests {
                 Action::TerminalPageDown => 0,
             }
         }
-        // 37 listed variants must equal Action::all().len(). If you add
+        // 39 listed variants must equal Action::all().len(). If you add
         // a variant, update both `Action::all()` and the match above.
-        const EXPECTED: usize = 37;
+        const EXPECTED: usize = 39;
         assert_eq!(Action::all().len(), EXPECTED);
         for a in Action::all() {
             classify(*a);

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -194,6 +194,9 @@ pub struct SessionInfo {
     /// Parent session (lead/worker relationship for orchestration).
     /// `None` for top-level sessions. Purely informational.
     pub parent_session_id: Option<SessionId>,
+    /// Manual position in the session list. `None` = never moved: renders
+    /// after all ordered sessions, in creation order.
+    pub display_order: Option<i64>,
 }
 
 impl SessionInfo {
@@ -216,6 +219,7 @@ impl SessionInfo {
             git_stats: None,
             repo_display_names: Vec::new(),
             parent_session_id: None,
+            display_order: None,
         }
     }
 }

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -91,6 +91,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -112,6 +112,7 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         worktrees: worktrees.clone(),
         shell_backend_id: None,
         parent_session_id: req.parent_session_id,
+        display_order: None,
         tombstone: false,
         tombstone_at: None,
     };
@@ -291,6 +292,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -3,9 +3,10 @@ use rusqlite::Connection;
 /// Current schema version. Incremented when schema changes.
 ///
 /// v29 is reserved by the in-flight `improve-agent-thurbox-cli` branch
-/// (`session_labels` + `session_spawn_config`); this branch takes v30.
+/// (`session_labels` + `session_spawn_config`); v30 added
+/// `parent_session_id`, v31 adds `display_order`.
 /// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 30;
+pub const SCHEMA_VERSION: u32 = 31;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -40,6 +41,7 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             additional_dirs   TEXT NOT NULL DEFAULT '',
             shell_backend_id  TEXT,
             parent_session_id TEXT,
+            display_order     INTEGER,
             created_at        INTEGER NOT NULL,
             updated_at        INTEGER NOT NULL,
             deleted_at        INTEGER
@@ -196,6 +198,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (27, migrate_v27_repo_parent_bookmarks),
         (28, migrate_v28_run_related_session),
         (30, migrate_v30_parent_session_id),
+        (31, migrate_v31_display_order),
     ];
 
     for &(target, step) in steps {
@@ -857,6 +860,18 @@ fn migrate_v28_run_related_session(conn: &Connection) -> rusqlite::Result<()> {
 /// "duplicate column" error so a re-run is a no-op.
 fn migrate_v30_parent_session_id(conn: &Connection) -> rusqlite::Result<()> {
     let _ = conn.execute("ALTER TABLE sessions ADD COLUMN parent_session_id TEXT", []);
+    Ok(())
+}
+
+/// v30 → v31: add a nullable `display_order` column to `sessions` (manual
+/// position in the session list; `NULL` = never moved, renders after ordered
+/// sessions in creation order). No backfill on purpose.
+///
+/// Fresh v31 databases already have the column from `initialize` and skip this
+/// step; existing databases get it via the ALTER. `let _` swallows the
+/// "duplicate column" error so a re-run is a no-op.
+fn migrate_v31_display_order(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN display_order INTEGER", []);
     Ok(())
 }
 

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -48,8 +48,9 @@ impl Database {
                 "UPDATE sessions SET name = ?1, agent = ?2, \
                  backend_id = ?3, backend_type = ?4, agent_session_id = ?5, \
                  cwd = ?6, additional_dirs = ?7, shell_backend_id = ?8, \
-                 parent_session_id = ?9, updated_at = ?10, deleted_at = NULL \
-                 WHERE id = ?11",
+                 parent_session_id = ?9, display_order = ?10, updated_at = ?11, \
+                 deleted_at = NULL \
+                 WHERE id = ?12",
                 params![
                     session.name,
                     session.agent,
@@ -60,6 +61,7 @@ impl Database {
                     additional_dirs_str,
                     session.shell_backend_id,
                     session.parent_session_id.map(|id| id.to_string()),
+                    session.display_order,
                     now,
                     id_str,
                 ],
@@ -77,8 +79,8 @@ impl Database {
             self.conn.execute(
                 "INSERT INTO sessions (id, name, agent, backend_id, backend_type, \
                  agent_session_id, cwd, additional_dirs, shell_backend_id, \
-                 parent_session_id, created_at, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                 parent_session_id, display_order, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
                 params![
                     id_str,
                     session.name,
@@ -90,6 +92,7 @@ impl Database {
                     additional_dirs_str,
                     session.shell_backend_id,
                     session.parent_session_id.map(|id| id.to_string()),
+                    session.display_order,
                     now,
                     now,
                 ],
@@ -173,12 +176,12 @@ impl Database {
         let sql = format!(
             "SELECT s.id, s.name, s.agent, s.backend_id, s.backend_type, \
              s.agent_session_id, s.cwd, s.additional_dirs, s.shell_backend_id, \
-             s.parent_session_id, \
+             s.parent_session_id, s.display_order, \
              w.repo_path, w.worktree_path, w.branch \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id AND w.deleted_at IS NULL \
              WHERE {condition} \
-             ORDER BY s.created_at, w.created_at"
+             ORDER BY s.display_order IS NULL, s.display_order, s.created_at, w.created_at"
         );
 
         let mut stmt = self.conn.prepare(&sql)?;
@@ -366,9 +369,10 @@ fn row_to_shared_session(
     let dirs_str: String = row.get(7)?;
     let shell_backend_id: Option<String> = row.get(8)?;
     let parent_str: Option<String> = row.get(9)?;
-    let wt_repo: Option<String> = row.get(10)?;
-    let wt_path: Option<String> = row.get(11)?;
-    let wt_branch: Option<String> = row.get(12)?;
+    let display_order: Option<i64> = row.get(10)?;
+    let wt_repo: Option<String> = row.get(11)?;
+    let wt_path: Option<String> = row.get(12)?;
+    let wt_branch: Option<String> = row.get(13)?;
 
     let additional_dirs: Vec<PathBuf> = if dirs_str.is_empty() {
         Vec::new()
@@ -391,6 +395,7 @@ fn row_to_shared_session(
             worktrees: Vec::new(),
             shell_backend_id,
             parent_session_id: parent_str.and_then(|s| s.parse().ok()),
+            display_order,
             tombstone: false,
             tombstone_at: None,
         },
@@ -415,6 +420,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         }
@@ -431,6 +437,45 @@ mod tests {
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].name, "Session 1");
         assert_eq!(sessions[0].agent, "claude");
+    }
+
+    #[test]
+    fn display_order_roundtrips() {
+        let db = Database::open_in_memory().unwrap();
+        let mut session = make_session("Session 1");
+        session.display_order = Some(3);
+
+        db.upsert_session(&session).unwrap();
+        let sessions = db.list_active_sessions().unwrap();
+        assert_eq!(sessions[0].display_order, Some(3));
+
+        session.display_order = Some(1);
+        db.upsert_session(&session).unwrap();
+        let sessions = db.list_active_sessions().unwrap();
+        assert_eq!(sessions[0].display_order, Some(1));
+    }
+
+    #[test]
+    fn list_orders_by_display_order_with_none_last() {
+        let db = Database::open_in_memory().unwrap();
+        let mut ordered_late = make_session("ordered-late");
+        ordered_late.display_order = Some(5);
+        let unordered = make_session("unordered");
+        let mut ordered_early = make_session("ordered-early");
+        ordered_early.display_order = Some(2);
+
+        // Insert in an order that disagrees with display_order on purpose.
+        db.upsert_session(&ordered_late).unwrap();
+        db.upsert_session(&unordered).unwrap();
+        db.upsert_session(&ordered_early).unwrap();
+
+        let names: Vec<String> = db
+            .list_active_sessions()
+            .unwrap()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(names, ["ordered-early", "ordered-late", "unordered"]);
     }
 
     #[test]

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -57,6 +57,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         }

--- a/src/storage/worktrees.rs
+++ b/src/storage/worktrees.rs
@@ -133,6 +133,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/sync/delta.rs
+++ b/src/sync/delta.rs
@@ -96,6 +96,7 @@ fn session_changed(old: &SharedSession, new: &SharedSession) -> bool {
         || old.additional_dirs != new.additional_dirs
         || old.worktrees != new.worktrees
         || old.parent_session_id != new.parent_session_id
+        || old.display_order != new.display_order
 }
 
 #[cfg(test)]
@@ -116,6 +117,7 @@ mod tests {
             worktrees: Vec::new(),
             shell_backend_id: None,
             parent_session_id: None,
+            display_order: None,
             tombstone: false,
             tombstone_at: None,
         }
@@ -253,6 +255,26 @@ mod tests {
         let delta = StateDelta::compute(&old_state, &new_state);
 
         assert_eq!(delta.updated_sessions.len(), 1);
+    }
+
+    #[test]
+    fn session_changed_detects_display_order_change() {
+        let session_id = SessionId::default();
+
+        let mut old_state = SharedState::new();
+        let mut s1 = make_session(session_id, "Session");
+        s1.display_order = Some(0);
+        old_state.sessions.push(s1);
+
+        let mut new_state = SharedState::new();
+        let mut s2 = make_session(session_id, "Session");
+        s2.display_order = Some(2);
+        new_state.sessions.push(s2);
+
+        let delta = StateDelta::compute(&old_state, &new_state);
+
+        assert_eq!(delta.updated_sessions.len(), 1);
+        assert_eq!(delta.updated_sessions[0].display_order, Some(2));
     }
 
     #[test]

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -85,6 +85,10 @@ pub struct SharedSession {
     /// parent does not cascade to children.
     pub parent_session_id: Option<SessionId>,
 
+    /// Manual position in the session list. `None` = never moved: renders
+    /// after all ordered sessions, in creation order.
+    pub display_order: Option<i64>,
+
     /// Tombstone flag: true if this session was soft-deleted.
     /// Soft-deleted sessions are excluded from active listings.
     pub tombstone: bool,

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -58,24 +58,6 @@ impl SessionMatch {
     }
 }
 
-/// Rank a session status for ordering. Lower ranks sort closer to the top:
-/// sessions that need you first, then running, then exited, then errored.
-///
-/// `Busy` and `Waiting` share one **running** rank on purpose. A live agent
-/// flickers across the ~1s "recent output" boundary every tick (`Busy` while
-/// emitting, `Waiting` in the gaps), so ranking them apart would make active
-/// sessions churn up and down the list endlessly. The status *dot* still shows
-/// the distinction; only the ordering ignores it.
-fn status_rank(status: crate::session::SessionStatus) -> u8 {
-    use crate::session::SessionStatus::{Attention, Busy, Error, Idle, Waiting};
-    match status {
-        Attention => 0,
-        Busy | Waiting => 1,
-        Idle => 2,
-        Error => 3,
-    }
-}
-
 /// Fallback label/key for a session that spans no repos.
 const NO_REPO_GROUP: &str = "(no repo)";
 
@@ -120,17 +102,16 @@ fn group_display(info: &SessionInfo) -> String {
 /// the two never drift.
 ///
 /// Ordering (top → bottom):
-///   1. Repo groups, each ordered by its most-urgent member (and then by name),
-///      so a repo holding an `Attention` session bubbles above a merely-running
-///      one. Each group's first row carries the repo header label.
-///   2. Within a group: by status rank, then original index for stability.
+///   1. Repo groups, each ordered by its lowest member `display_order` (and
+///      then by name). Each group's first row carries the repo header label.
+///   2. Within a group: by `display_order`, then original index for stability.
+///      Sessions never manually moved (`display_order == None`) sort after all
+///      ordered ones, in insertion (= creation) order.
 ///
-/// The order is intentionally a pure function of *status* and *stable insertion
-/// order* — never of live recency. Recency (`millis_since_last_output`) changes
-/// every tick for active sessions, so using it as a sort key made `Busy`
-/// sessions reorder endlessly. Status changes are discrete and meaningful
-/// (→`Attention`, →`Idle`), so the list only re-sorts when something real
-/// happens. See `status_rank` for why `Busy`/`Waiting` are not split.
+/// The order is intentionally a pure function of *manual order*
+/// (`display_order`, set by the user via move up/down) and *stable insertion
+/// order* — never of status or live recency. A status change (→`Attention`,
+/// →`Idle`) only recolors the dot; rows stay exactly where the user put them.
 pub struct SessionOrder {
     /// Input indices in render order.
     pub order: Vec<usize>,
@@ -165,23 +146,25 @@ pub fn compute_session_order(sessions: &[&SessionInfo]) -> SessionOrder {
         groups[gi].members.push(i);
     }
 
-    // Within each group: status rank, then original index (stable — no recency).
+    // Within each group: manual order, then original index (stable — never
+    // moved sessions sort after ordered ones, in insertion order).
+    let sort_key = |i: usize| (sessions[i].display_order.unwrap_or(i64::MAX), i);
     for g in &mut groups {
-        g.members
-            .sort_by_key(|&i| (status_rank(sessions[i].status), i));
+        g.members.sort_by_key(|&i| sort_key(i));
     }
 
-    // Groups: by most-urgent member (min status rank), then label for
-    // determinism. No recency term, so active groups don't churn.
+    // Groups: by lowest member manual order, then label for determinism.
+    // Moves renumber all sessions densely in render order, so a group's
+    // minimum reproduces the group order the user last saw.
     groups.sort_by(|a, b| {
         let key = |g: &Group| {
-            let rank = g
+            let order = g
                 .members
                 .iter()
-                .map(|&i| status_rank(sessions[i].status))
+                .map(|&i| sort_key(i).0)
                 .min()
-                .unwrap_or(u8::MAX);
-            (rank, g.label.clone().unwrap_or_default())
+                .unwrap_or(i64::MAX);
+            (order, g.label.clone().unwrap_or_default())
         };
         key(a).cmp(&key(b))
     });
@@ -191,7 +174,7 @@ pub fn compute_session_order(sessions: &[&SessionInfo]) -> SessionOrder {
     let mut depths = Vec::with_capacity(sessions.len());
     for g in &groups {
         // Nest children directly under their parent (parent-first, preserving
-        // the status-then-index order among siblings and among roots).
+        // the manual-order-then-index order among siblings and among roots).
         for (j, (i, depth)) in nest_group_members(sessions, &g.members)
             .into_iter()
             .enumerate()
@@ -209,7 +192,7 @@ pub fn compute_session_order(sessions: &[&SessionInfo]) -> SessionOrder {
     }
 }
 
-/// Reorder a group's (already status-sorted) members into parent-first DFS
+/// Reorder a group's (already manually-sorted) members into parent-first DFS
 /// order: every member whose `parent_session_id` is also a member of this group
 /// nests directly under that parent; everyone else (no parent, parent in
 /// another group, or parent gone) is a root. Returns `(session index, depth)`
@@ -266,6 +249,106 @@ fn nest_group_members(sessions: &[&SessionInfo], members: &[usize]) -> Vec<(usiz
         }
     }
     out
+}
+
+/// Move the session `active_input_idx` one step up or down in the rendered
+/// order, returning the new flat order of **input indices** — or `None` when
+/// the move is a no-op (active session missing, or already at an edge it
+/// can't cross).
+///
+/// Every move swaps two adjacent **blocks** (a row plus its rendered subtree,
+/// so a parent always drags its nested children):
+///   - a root block (depth 0) swaps with the adjacent root block in its repo
+///     group; at the group edge the *whole group* swaps with the adjacent
+///     group; at the very top/bottom of the list it stays put;
+///   - a nested child swaps with its adjacent same-depth sibling and never
+///     leaves its parent.
+///
+/// The caller is expected to renumber `display_order` densely (`0..n`) along
+/// the returned order; [`compute_session_order`] then reproduces it exactly
+/// (groups stay contiguous runs, DFS nesting preserves block order).
+pub fn move_in_order(
+    ord: &SessionOrder,
+    active_input_idx: usize,
+    down: bool,
+) -> Option<Vec<usize>> {
+    let n = ord.order.len();
+    let pos = ord.order.iter().position(|&i| i == active_input_idx)?;
+    let depth = ord.depths[pos];
+
+    // End of the block rooted at `start`: first following row at <= its depth.
+    let block_end = |start: usize| {
+        let mut end = start + 1;
+        while end < n && ord.depths[end] > ord.depths[start] {
+            end += 1;
+        }
+        end
+    };
+    // Start of the group containing `p` / end of the group starting at `start`
+    // (group starts are the rows carrying a header label).
+    let group_start = |p: usize| (0..=p).rev().find(|&q| ord.headers[q].is_some());
+    let group_end = |start: usize| {
+        (start + 1..n)
+            .find(|&q| ord.headers[q].is_some())
+            .unwrap_or(n)
+    };
+
+    let end = block_end(pos);
+    let gs = group_start(pos)?;
+    let ge = group_end(gs);
+
+    // The two adjacent ranges to swap: `a` directly precedes `b`.
+    let (a, b) = if depth == 0 {
+        if down {
+            if end < ge {
+                // Swap with the next root block in the group.
+                (pos..end, end..block_end(end))
+            } else if ge < n {
+                // Last root block: the whole group swaps with the next group.
+                (gs..ge, ge..group_end(ge))
+            } else {
+                return None; // bottom of the list
+            }
+        } else if pos > gs {
+            // Swap with the previous root block in the group.
+            let prev = (gs..pos).rev().find(|&q| ord.depths[q] == 0)?;
+            (prev..pos, pos..end)
+        } else if gs > 0 {
+            // First root block: the whole group swaps with the previous group.
+            let pgs = group_start(gs - 1)?;
+            (pgs..gs, gs..ge)
+        } else {
+            return None; // top of the list
+        }
+    } else if down {
+        // Next sibling starts right after our block, at the same depth; a
+        // shallower row there means the parent's subtree (or group) ended.
+        if end < n && ord.depths[end] == depth {
+            (pos..end, end..block_end(end))
+        } else {
+            return None; // last sibling
+        }
+    } else {
+        // Scan back over deeper rows (the previous sibling's subtree); a
+        // same-depth row is that sibling, a shallower one is our parent.
+        let mut p = pos - 1;
+        while ord.depths[p] > depth {
+            p -= 1;
+        }
+        if ord.depths[p] == depth {
+            (p..pos, pos..end)
+        } else {
+            return None; // first sibling
+        }
+    };
+
+    debug_assert_eq!(a.end, b.start);
+    let mut new_order = Vec::with_capacity(n);
+    new_order.extend_from_slice(&ord.order[..a.start]);
+    new_order.extend_from_slice(&ord.order[b.start..b.end]);
+    new_order.extend_from_slice(&ord.order[a.start..a.end]);
+    new_order.extend_from_slice(&ord.order[b.end..]);
+    Some(new_order)
 }
 
 /// Display-ordered view of the session list. All fields are parallel arrays
@@ -735,21 +818,20 @@ mod tests {
     use crate::session::SessionStatus;
 
     #[test]
-    fn attention_sessions_sort_above_normal_ones() {
+    fn manually_ordered_sessions_sort_first_and_active_index_follows() {
         use crate::session::SessionInfo;
 
-        let mut busy = SessionInfo::new("busy".into());
-        busy.status = SessionStatus::Busy;
-        let mut attn = SessionInfo::new("attn".into());
-        attn.status = SessionStatus::Attention;
+        let first = SessionInfo::new("first".into());
+        let mut moved = SessionInfo::new("moved".into());
+        moved.display_order = Some(0);
 
-        let sessions = vec![&busy, &attn];
+        let sessions = vec![&first, &moved];
         let matches: Vec<Option<SessionMatch>> = vec![None, None];
-        // active_index points at the busy session; the attention one still
-        // floats to the top and active_index is remapped to follow it.
+        // active_index points at the first input session; the manually ordered
+        // one renders above it and active_index is remapped to follow it.
         let ordered = OrderedSessions::new(&sessions, &matches, 0);
-        assert_eq!(ordered.sessions[0].name, "attn");
-        assert_eq!(ordered.sessions[1].name, "busy");
+        assert_eq!(ordered.sessions[0].name, "moved");
+        assert_eq!(ordered.sessions[1].name, "first");
         assert_eq!(ordered.active_index, 1);
     }
 
@@ -1105,7 +1187,7 @@ mod tests {
         assert!(text.trim_end().ends_with("a-rather-long-session-name"));
     }
 
-    // --- compute_session_order (grouping + activity) ---
+    // --- compute_session_order (grouping + manual order) ---
 
     fn info_repo(name: &str, repo: &str, status: SessionStatus) -> SessionInfo {
         info_repos(name, &[repo], status)
@@ -1161,31 +1243,42 @@ mod tests {
     }
 
     #[test]
-    fn group_with_more_urgent_member_bubbles_up() {
-        // "infra" only has a Waiting session; "webapp" has an Attention one, so
-        // the webapp group sorts above infra even though infra sorts first by name.
+    fn status_never_reorders_groups() {
+        // Manual order wins: an Attention session recolors its dot but never
+        // bubbles its group. Groups stay in label order ("infra" < "webapp").
         let waiting = info_repo("infra-1", "infra", SessionStatus::Waiting);
         let attn = info_repo("web-attn", "webapp", SessionStatus::Attention);
         let busy = info_repo("web-busy", "webapp", SessionStatus::Busy);
         let sessions = vec![&waiting, &attn, &busy];
-        let names = order_names(&sessions);
-        // webapp group first (has Attention), ordered Attention then running within.
-        assert_eq!(names, vec!["web-attn", "web-busy", "infra-1"]);
+        assert_eq!(
+            order_names(&sessions),
+            vec!["infra-1", "web-attn", "web-busy"]
+        );
+
+        // Flip every status: the order is identical.
+        let waiting2 = info_repo("infra-1", "infra", SessionStatus::Attention);
+        let attn2 = info_repo("web-attn", "webapp", SessionStatus::Idle);
+        let busy2 = info_repo("web-busy", "webapp", SessionStatus::Error);
+        let flipped = vec![&waiting2, &attn2, &busy2];
+        assert_eq!(
+            order_names(&flipped),
+            vec!["infra-1", "web-attn", "web-busy"]
+        );
     }
 
     #[test]
-    fn busy_and_waiting_share_a_rank_and_keep_stable_order() {
-        // A live agent flickers Busy↔Waiting every tick; that must not reorder
-        // the list. Both rank as "running", so order stays the insertion order.
+    fn status_changes_never_reorder_within_a_group() {
+        // A live agent flickers Busy↔Waiting every tick, and sessions go
+        // Idle/Attention; none of it may move a row.
         let a = info_repo("a", "webapp", SessionStatus::Busy);
         let b = info_repo("b", "webapp", SessionStatus::Waiting);
         let c = info_repo("c", "webapp", SessionStatus::Busy);
         let sessions = vec![&a, &b, &c];
         assert_eq!(order_names(&sessions), vec!["a", "b", "c"]);
 
-        // Flip a's status Busy→Waiting and b's Waiting→Busy: order is unchanged.
-        let a2 = info_repo("a", "webapp", SessionStatus::Waiting);
-        let b2 = info_repo("b", "webapp", SessionStatus::Busy);
+        // Flip a→Attention and b→Idle: order is unchanged.
+        let a2 = info_repo("a", "webapp", SessionStatus::Attention);
+        let b2 = info_repo("b", "webapp", SessionStatus::Idle);
         let flipped = vec![&a2, &b2, &c];
         assert_eq!(order_names(&flipped), vec!["a", "b", "c"]);
     }
@@ -1202,7 +1295,7 @@ mod tests {
             .zip(headers.iter())
             .map(|(&i, h)| (sessions[i].name.as_str(), h.clone()))
             .collect();
-        // infra (Attention) group first with its header, then webapp group.
+        // Groups in label order ("infra" < "webapp"), header on first row only.
         assert_eq!(
             labelled,
             vec![
@@ -1249,6 +1342,155 @@ mod tests {
         );
     }
 
+    #[test]
+    fn display_order_overrides_insertion_within_group() {
+        let mut a = info_repo("a", "webapp", SessionStatus::Idle);
+        let mut b = info_repo("b", "webapp", SessionStatus::Idle);
+        a.display_order = Some(1);
+        b.display_order = Some(0);
+        let sessions = vec![&a, &b];
+        assert_eq!(order_names(&sessions), vec!["b", "a"]);
+    }
+
+    #[test]
+    fn group_order_follows_min_member_display_order() {
+        // "webapp" sorts after "infra" by label, but holds the lowest
+        // display_order, so the webapp group renders first.
+        let mut w1 = info_repo("w1", "webapp", SessionStatus::Idle);
+        let mut w2 = info_repo("w2", "webapp", SessionStatus::Idle);
+        let mut i1 = info_repo("i1", "infra", SessionStatus::Idle);
+        w1.display_order = Some(0);
+        w2.display_order = Some(1);
+        i1.display_order = Some(2);
+        let sessions = vec![&i1, &w1, &w2];
+        assert_eq!(order_names(&sessions), vec!["w1", "w2", "i1"]);
+    }
+
+    #[test]
+    fn unordered_sessions_append_after_ordered_in_insertion_order() {
+        let mut moved = info_repo("moved", "webapp", SessionStatus::Idle);
+        moved.display_order = Some(0);
+        let new1 = info_repo("new1", "webapp", SessionStatus::Idle);
+        let new2 = info_repo("new2", "webapp", SessionStatus::Idle);
+        // Unordered sessions (`None`) land after the ordered one, keeping
+        // their insertion order.
+        let sessions = vec![&new1, &moved, &new2];
+        assert_eq!(order_names(&sessions), vec!["moved", "new1", "new2"]);
+    }
+
+    // --- move_in_order ---
+
+    /// Apply `move_in_order` and return the resulting names, or `None` on no-op.
+    fn move_names<'a>(
+        sessions: &[&'a SessionInfo],
+        active: &str,
+        down: bool,
+    ) -> Option<Vec<&'a str>> {
+        let ord = compute_session_order(sessions);
+        let active_idx = sessions.iter().position(|s| s.name == active).unwrap();
+        move_in_order(&ord, active_idx, down).map(|order| {
+            order
+                .into_iter()
+                .map(|i| sessions[i].name.as_str())
+                .collect()
+        })
+    }
+
+    #[test]
+    fn move_swaps_adjacent_root_blocks_within_group() {
+        let a = info_repo("a", "webapp", SessionStatus::Idle);
+        let b = info_repo("b", "webapp", SessionStatus::Idle);
+        let c = info_repo("c", "webapp", SessionStatus::Idle);
+        let sessions = vec![&a, &b, &c];
+        assert_eq!(move_names(&sessions, "a", true), Some(vec!["b", "a", "c"]));
+        assert_eq!(move_names(&sessions, "c", false), Some(vec!["a", "c", "b"]));
+    }
+
+    #[test]
+    fn move_past_group_edge_moves_whole_group() {
+        let i1 = info_repo("i1", "infra", SessionStatus::Idle);
+        let i2 = info_repo("i2", "infra", SessionStatus::Idle);
+        let w1 = info_repo("w1", "webapp", SessionStatus::Idle);
+        let w2 = info_repo("w2", "webapp", SessionStatus::Idle);
+        let sessions = vec![&i1, &i2, &w1, &w2];
+        // Render order: [i1, i2, w1, w2] ("infra" < "webapp").
+        // i2 is the last root block of infra: down moves the whole infra
+        // group below webapp.
+        assert_eq!(
+            move_names(&sessions, "i2", true),
+            Some(vec!["w1", "w2", "i1", "i2"])
+        );
+        // w1 is the first root block of webapp: up moves the whole webapp
+        // group above infra.
+        assert_eq!(
+            move_names(&sessions, "w1", false),
+            Some(vec!["w1", "w2", "i1", "i2"])
+        );
+    }
+
+    #[test]
+    fn move_at_list_edges_is_noop() {
+        let i1 = info_repo("i1", "infra", SessionStatus::Idle);
+        let w1 = info_repo("w1", "webapp", SessionStatus::Idle);
+        let sessions = vec![&i1, &w1];
+        // i1's group is at the top, w1's at the bottom.
+        assert_eq!(move_names(&sessions, "i1", false), None);
+        assert_eq!(move_names(&sessions, "w1", true), None);
+    }
+
+    #[test]
+    fn moving_parent_drags_nested_children() {
+        let lead = info_repo("lead", "webapp", SessionStatus::Idle);
+        let w1 = info_child("w1", "webapp", SessionStatus::Idle, &lead);
+        let other = info_repo("other", "webapp", SessionStatus::Idle);
+        let sessions = vec![&lead, &w1, &other];
+        // Render order: [lead, w1, other]; moving lead down carries w1 along.
+        assert_eq!(
+            move_names(&sessions, "lead", true),
+            Some(vec!["other", "lead", "w1"])
+        );
+    }
+
+    #[test]
+    fn child_moves_among_siblings_only() {
+        let lead = info_repo("lead", "webapp", SessionStatus::Idle);
+        let w1 = info_child("w1", "webapp", SessionStatus::Idle, &lead);
+        let w2 = info_child("w2", "webapp", SessionStatus::Idle, &lead);
+        let other = info_repo("other", "webapp", SessionStatus::Idle);
+        let sessions = vec![&lead, &w1, &w2, &other];
+        // Render order: [lead, w1, w2, other].
+        assert_eq!(
+            move_names(&sessions, "w1", true),
+            Some(vec!["lead", "w2", "w1", "other"])
+        );
+        // First/last sibling can't leave the parent.
+        assert_eq!(move_names(&sessions, "w1", false), None);
+        assert_eq!(move_names(&sessions, "w2", true), None);
+    }
+
+    #[test]
+    fn renumbering_along_moved_order_reproduces_it() {
+        // The app renumbers display_order densely along the returned order;
+        // compute_session_order must then reproduce that order exactly.
+        let i1 = info_repo("i1", "infra", SessionStatus::Idle);
+        let i2 = info_repo("i2", "infra", SessionStatus::Idle);
+        let lead = info_repo("lead", "webapp", SessionStatus::Idle);
+        let w1 = info_child("w1", "webapp", SessionStatus::Idle, &lead);
+        let mut sessions_owned = [i1, i2, lead, w1];
+
+        let sessions: Vec<&SessionInfo> = sessions_owned.iter().collect();
+        let ord = compute_session_order(&sessions);
+        // Move i2 (last root of the top group) down: whole infra group drops.
+        let active = sessions.iter().position(|s| s.name == "i2").unwrap();
+        let new_order = move_in_order(&ord, active, true).unwrap();
+
+        for (pos, &idx) in new_order.iter().enumerate() {
+            sessions_owned[idx].display_order = Some(pos as i64);
+        }
+        let sessions: Vec<&SessionInfo> = sessions_owned.iter().collect();
+        assert_eq!(order_names(&sessions), vec!["lead", "w1", "i1", "i2"]);
+    }
+
     // --- compute_session_order (parent/child nesting) ---
 
     #[test]
@@ -1279,17 +1521,16 @@ mod tests {
     }
 
     #[test]
-    fn attention_child_still_bubbles_its_group_up() {
+    fn attention_child_does_not_move_its_group() {
         let lead = info_repo("lead", "webapp", SessionStatus::Idle);
         let worker = info_child("worker", "webapp", SessionStatus::Attention, &lead);
         let busy = info_repo("busy", "infra", SessionStatus::Busy);
         let sessions = vec![&busy, &lead, &worker];
-        // The webapp group holds the Attention session (min rank 0), so it
-        // sorts above the merely-running infra group even though the parent
-        // itself is Idle; within the group the child stays nested.
+        // The child's Attention status doesn't bubble its group: groups stay
+        // in label order ("infra" < "webapp"); the child stays nested.
         assert_eq!(
             order_names_depths(&sessions),
-            vec![("lead", 0), ("worker", 1), ("busy", 0)]
+            vec![("busy", 0), ("lead", 0), ("worker", 1)]
         );
     }
 

--- a/tests/sync_integration.rs
+++ b/tests/sync_integration.rs
@@ -22,6 +22,7 @@ fn make_session(id: SessionId, name: &str) -> SharedSession {
         worktrees: Vec::new(),
         shell_backend_id: None,
         parent_session_id: None,
+        display_order: None,
         tombstone: false,
         tombstone_at: None,
     }
@@ -368,6 +369,7 @@ fn db_session_metadata_preserved_across_instances() {
         worktrees: Vec::new(),
         shell_backend_id: None,
         parent_session_id: None,
+        display_order: None,
         tombstone: false,
         tombstone_at: None,
     };


### PR DESCRIPTION
## Summary
- `Shift+J`/`Shift+K` (focused session list; rebindable `SessionListMoveDown`/`SessionListMoveUp` actions, listed in the F1 editor) move the selected session one row down/up
- Manual order wins: status changes only recolor the dot and never move a row — the status-based sort is removed from `compute_session_order`
- Moves swap adjacent blocks: a parent drags its nested children, root rows swap within their repo group, the whole group swaps past a group edge, children reorder among siblings only (pure `ui::project_list::move_in_order` + `App::move_active_session`)
- Order persists in a new nullable `sessions.display_order` column (schema v31), renumbered densely per move; survives restarts (incl. the respawn-after-reboot path) and syncs across instances via the existing `data_version` polling
- `NULL` = never moved → renders after ordered sessions in creation order, so new sessions append to their group; restored soft-deleted sessions re-append
- `thurbox-cli session list` follows the manual order and emits `display_order` in the JSON

## Test plan
- `cargo nextest run --all` — 1057/1057 pass (≈15 new tests: move semantics incl. group-edge/parent-drag/sibling/no-op cases, renumber-reproduces-order, DB roundtrip + NULL-last ordering, sync-delta detection, status-never-reorders, active-index follow)
- `cargo clippy --all-targets --all-features -- -D warnings` clean; architecture rules 11/11; rustdoc + rumdl clean
- Manual: move rows/groups with Shift+J/K, restart TUI → order persists; status flips don't move rows