### PR TITLE
feat(core): add task lifecycle cleanup (retention sweep + clear-done)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -527,7 +527,8 @@ sync, but the TUI editor never sets it.)
   `Space` cycle status, `r` open the **trigger-time action picker**, `o` **open
   the task's related session** (`App::open_task_related_session` — jumps to the
   spawned `task-<id>-<slug>` window or a Send target, else a status hint), `d`/`Ctrl+D`
-  delete, `Esc` back to the session list. In the editor: field nav +
+  delete, `C` **clear all done tasks** (`App::clear_done_tasks`, guided lifecycle
+  cleanup), `Esc` back to the session list. In the editor: field nav +
   `Enter`/`Ctrl+S` save (→ back to panel), `Esc` discard; the editor captures
   its keys before global bindings (so `e`/`d` edit text) via
   `handle_automation_pane_capture`.
@@ -542,12 +543,21 @@ sync, but the TUI editor never sets it.)
   cleared on a manual `Ctrl+N` so a cancelled task-spawn can't leak into it.
   Both paths call `App::advance_task_to_in_progress`.
 - **CLI**: `thurbox-cli task` (alias `todo`) —
-  `create`/`list`/`show`/`edit`/`remove`/`run`. `create`/`edit` take an
+  `create`/`list`/`show`/`edit`/`remove`/`run`/`cleanup`. `create`/`edit` take an
   optional `--description` (markdown; `edit --description ""` clears it), and
   `task_to_json` emits a `description` field. `create` with neither
   `--session` nor `--repo` is a plain local todo; `run` triggers the
-  Send/Spawn action headlessly. Tasks do **not** participate in sync
+  Send/Spawn action headlessly. `cleanup` soft-deletes done tasks (all of them,
+  or `--older-than-days N` for the retention sweep), returning `{cleared: N}`.
+  Tasks do **not** participate in sync
   (`SharedState`) and have no run-history table (audited via `audit_log`).
+- **Lifecycle / cleanup** — done tasks don't accumulate without bound. On every
+  DB open (`storage::Database::open`) `prune_done_tasks` soft-deletes done tasks
+  last updated more than `task_retention_days` ago (`settings.toml`, default 30;
+  `0` disables the sweep). On-demand cleanup is `clear_done_tasks` (all done
+  tasks regardless of age), exposed as the tasks panel's **`C`** key
+  (`App::clear_done_tasks`) and `thurbox-cli task cleanup`. Both are soft-deletes
+  audited per row, so cleared tasks stay restorable.
 
 ## Extensions
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -105,6 +105,7 @@ hardcoded.
 | `two_panel_min_cols` | `80` | width below which only the terminal renders |
 | `three_panel_min_cols` | `120` | width unlocking the optional third column |
 | `audit_retention_days` | `90` | audit-log history kept (pruned on startup) |
+| `task_retention_days` | `30` | days a done task is kept before auto-removal (soft-deleted on startup; `0` disables) |
 
 ## themes.toml
 

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -33,6 +33,12 @@ config_version = 1
 
 # Days of audit-log history kept (pruned on startup).
 # audit_retention_days = 90
+
+# Days a done task is kept before auto-removal (soft-deleted on startup).
+# Counted from the task's last update. Set to 0 to disable the automatic
+# sweep (done tasks then only clear via `thurbox-cli task cleanup` or the
+# tasks panel's clear-done key).
+# task_retention_days = 30
 "#;
 
 /// Path to the settings file: `~/.config/thurbox/settings.toml`.
@@ -122,6 +128,7 @@ mod tests {
             "two_panel_min_cols",
             "three_panel_min_cols",
             "audit_retention_days",
+            "task_retention_days",
         ] {
             assert!(
                 SEED_SETTINGS_TOML.contains(field),

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -658,7 +658,34 @@ impl App {
             // `task-<id>-<slug>` window, or a persisted Send target).
             KeyCode::Char('o') => self.open_task_related_session(),
             KeyCode::Char('d') => self.delete_selected_task(),
+            // Clear every completed task at once (guided cleanup), so the list
+            // doesn't accumulate done items between automatic retention sweeps.
+            KeyCode::Char('C') => self.clear_done_tasks(),
             _ => {}
+        }
+    }
+
+    /// Soft-delete every done task on demand (the `C` key), then clamp the
+    /// selection and report the count.
+    fn clear_done_tasks(&mut self) {
+        match self.db.clear_done_tasks() {
+            Ok(0) => self.set_status(super::StatusLevel::Info, "No done tasks to clear"),
+            Ok(n) => {
+                self.refresh_tasks();
+                let new_count = self.task_ui.filtered_task_indices.len();
+                if new_count > 0 && self.task_ui.task_panel_index >= new_count {
+                    self.task_ui.task_panel_index = new_count - 1;
+                }
+                self.refresh_task_view();
+                self.set_status(
+                    super::StatusLevel::Success,
+                    format!("Cleared {n} done task{}", if n == 1 { "" } else { "s" }),
+                );
+            }
+            Err(e) => {
+                error!("Failed to clear done tasks: {e}");
+                self.set_status(super::StatusLevel::Error, "Failed to clear done tasks");
+            }
         }
     }
 

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -783,7 +783,8 @@ impl App {
                 ("r", " run  "),
                 ("Space", " status  "),
                 ("n", " new  "),
-                ("d", " del"),
+                ("d", " del  "),
+                ("C", " clear done"),
             ]
         } else {
             &[
@@ -792,7 +793,8 @@ impl App {
                 ("o", " open  "),
                 ("Space", " status  "),
                 ("n", " new  "),
-                ("d", " del"),
+                ("d", " del  "),
+                ("C", " clear done"),
             ]
         };
         crate::ui::task_detail::render_task_detail(

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -75,6 +75,16 @@ pub enum Action {
         /// Task id.
         id: i64,
     },
+    /// Clean up completed tasks so the list doesn't grow without bound.
+    ///
+    /// By default removes **all** done tasks (soft delete). Pass
+    /// `--older-than-days N` to only remove done tasks last updated more than N
+    /// days ago — the same retention sweep that runs automatically on startup.
+    Cleanup {
+        /// Only remove done tasks last updated more than N days ago.
+        #[arg(long)]
+        older_than_days: Option<u64>,
+    },
 }
 
 pub fn run(action: Action, db: &Database) -> Result<Value, String> {
@@ -142,6 +152,17 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
         Action::Run { id } => {
             let task = load(db, id)?;
             run_task(db, &task)
+        }
+        Action::Cleanup { older_than_days } => {
+            let cleared = match older_than_days {
+                Some(days) => db
+                    .prune_done_tasks(days)
+                    .map_err(|e| format!("prune_done_tasks: {e}"))?,
+                None => db
+                    .clear_done_tasks()
+                    .map_err(|e| format!("clear_done_tasks: {e}"))?,
+            };
+            Ok(json!({ "cleared": cleared }))
         }
     }
 }
@@ -316,4 +337,64 @@ fn task_to_json(t: &Task) -> Value {
         "created_at": t.created_at,
         "updated_at": t.updated_at,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a task at a given status via the CLI handler.
+    fn make(db: &Database, title: &str, status: &str) -> i64 {
+        let out = run(
+            Action::Create {
+                title: title.into(),
+                description: None,
+                status: Some(status.into()),
+                session: None,
+                repo: None,
+                worktree: None,
+                base: None,
+                agent: None,
+            },
+            db,
+        )
+        .unwrap();
+        out["id"].as_i64().unwrap()
+    }
+
+    #[test]
+    fn cleanup_clears_all_done_tasks() {
+        let db = Database::open_in_memory().unwrap();
+        make(&db, "open", "todo");
+        let done = make(&db, "finished", "done");
+
+        let out = run(
+            Action::Cleanup {
+                older_than_days: None,
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(out["cleared"], 1);
+        // The done task is gone; the todo survives.
+        assert!(db.get_task(done).unwrap().is_none());
+        assert_eq!(db.list_tasks().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn cleanup_with_age_keeps_recent_done_tasks() {
+        let db = Database::open_in_memory().unwrap();
+        // A freshly-created done task is within any positive retention window,
+        // so an age-bounded cleanup removes nothing.
+        make(&db, "just finished", "done");
+        let out = run(
+            Action::Cleanup {
+                older_than_days: Some(7),
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(out["cleared"], 0);
+        assert_eq!(db.list_tasks().unwrap().len(), 1);
+    }
 }

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -33,6 +33,13 @@ pub struct Settings {
     /// Days of audit-log history kept (pruned on startup).
     #[serde(default = "default_audit_retention_days")]
     pub audit_retention_days: u64,
+    /// Days a **done** task is kept before being auto-removed (soft-deleted on
+    /// startup, so the task list doesn't grow without bound). Counted from the
+    /// task's last update. `0` disables the automatic sweep — done tasks then
+    /// only go away via manual cleanup (`thurbox-cli task cleanup` / the tasks
+    /// panel's clear-done key).
+    #[serde(default = "default_task_retention_days")]
+    pub task_retention_days: u64,
 }
 
 fn default_scrollback_lines() -> usize {
@@ -47,6 +54,9 @@ fn default_three_panel_min_cols() -> u16 {
 fn default_audit_retention_days() -> u64 {
     90
 }
+fn default_task_retention_days() -> u64 {
+    30
+}
 
 impl Default for Settings {
     fn default() -> Self {
@@ -56,6 +66,7 @@ impl Default for Settings {
             two_panel_min_cols: default_two_panel_min_cols(),
             three_panel_min_cols: default_three_panel_min_cols(),
             audit_retention_days: default_audit_retention_days(),
+            task_retention_days: default_task_retention_days(),
         }
     }
 }
@@ -86,6 +97,7 @@ mod tests {
         assert_eq!(s.two_panel_min_cols, 80);
         assert_eq!(s.three_panel_min_cols, 120);
         assert_eq!(s.audit_retention_days, 90);
+        assert_eq!(s.task_retention_days, 30);
     }
 
     #[test]
@@ -93,6 +105,7 @@ mod tests {
         let s: Settings = toml::from_str("scrollback_lines = 5000").unwrap();
         assert_eq!(s.scrollback_lines, 5000);
         assert_eq!(s.audit_retention_days, 90);
+        assert_eq!(s.task_retention_days, 30);
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -56,6 +56,14 @@ impl Database {
         if let Err(e) = db.prune_audit_log() {
             tracing::warn!("Failed to prune audit log: {e}");
         }
+        // Auto-remove long-completed tasks so the todo list doesn't grow without
+        // bound (settings.toml `task_retention_days`, default 30; 0 disables).
+        let task_retention = crate::session::settings::global().task_retention_days;
+        match db.prune_done_tasks(task_retention) {
+            Ok(n) if n > 0 => tracing::info!("Pruned {n} done task(s) past retention"),
+            Ok(_) => {}
+            Err(e) => tracing::warn!("Failed to prune done tasks: {e}"),
+        }
         Ok(db)
     }
 

--- a/src/storage/tasks.rs
+++ b/src/storage/tasks.rs
@@ -164,6 +164,64 @@ impl Database {
         Ok(updated > 0)
     }
 
+    /// Soft-delete every **done** task, regardless of age. Drives the on-demand
+    /// "clear done" cleanup (the tasks panel's clear-done key and `thurbox-cli
+    /// task cleanup`). Returns the number of tasks removed. Audited per row so
+    /// the deletions stay traceable, matching [`soft_delete_task`].
+    ///
+    /// [`soft_delete_task`]: Self::soft_delete_task
+    pub fn clear_done_tasks(&self) -> rusqlite::Result<usize> {
+        self.soft_delete_done_tasks(None)
+    }
+
+    /// Soft-delete **done** tasks older than `retention_days` (counted from the
+    /// task's last update). `0` disables the sweep (returns `Ok(0)`). Run on
+    /// startup so completed tasks don't accumulate without bound. Returns the
+    /// number of tasks removed.
+    pub fn prune_done_tasks(&self, retention_days: u64) -> rusqlite::Result<usize> {
+        if retention_days == 0 {
+            return Ok(0);
+        }
+        let cutoff = current_time_millis().saturating_sub(retention_days * MS_PER_DAY);
+        self.soft_delete_done_tasks(Some(cutoff as i64))
+    }
+
+    /// Shared body of [`clear_done_tasks`]/[`prune_done_tasks`]: soft-delete the
+    /// active `done` tasks (optionally only those last updated before `cutoff`),
+    /// auditing each removed row. Returns how many were removed.
+    ///
+    /// [`clear_done_tasks`]: Self::clear_done_tasks
+    /// [`prune_done_tasks`]: Self::prune_done_tasks
+    fn soft_delete_done_tasks(&self, cutoff: Option<i64>) -> rusqlite::Result<usize> {
+        let done = TaskStatus::Done.as_str();
+        // Collect the ids first so each deletion can be audited individually.
+        let ids: Vec<i64> = {
+            let mut stmt = self.conn.prepare(
+                "SELECT id FROM tasks
+                 WHERE status = ?1 AND deleted_at IS NULL
+                   AND (?2 IS NULL OR updated_at < ?2)",
+            )?;
+            let rows = stmt.query_map(params![done, cutoff], |row| row.get(0))?;
+            rows.collect::<rusqlite::Result<_>>()?
+        };
+        let now = current_time_millis() as i64;
+        for id in &ids {
+            self.conn.execute(
+                "UPDATE tasks SET deleted_at = ?2 WHERE id = ?1 AND deleted_at IS NULL",
+                params![id, now],
+            )?;
+            self.log_audit(
+                EntityType::Task,
+                &id.to_string(),
+                AuditAction::Deleted,
+                None,
+                None,
+                None,
+            )?;
+        }
+        Ok(ids.len())
+    }
+
     /// Soft-delete a task (mark `deleted_at`). Returns whether a row changed.
     pub fn soft_delete_task(&self, id: i64) -> rusqlite::Result<bool> {
         let now = current_time_millis() as i64;
@@ -184,6 +242,9 @@ impl Database {
         Ok(updated > 0)
     }
 }
+
+/// Milliseconds in a day, for [`Database::prune_done_tasks`] retention math.
+const MS_PER_DAY: u64 = 24 * 60 * 60 * 1000;
 
 /// Column list for task SELECTs (keep in sync with [`map_task`]).
 const COLS: &str = "id, title, status, action_kind, target_session, repo_path, \
@@ -419,6 +480,84 @@ mod tests {
         got.description = None;
         db.update_task(&got).unwrap();
         assert_eq!(db.get_task(id).unwrap().unwrap().description, None);
+    }
+
+    /// Force a task's `updated_at` to an arbitrary timestamp, bypassing the
+    /// auto-stamping in `set_task_status`/`update_task` (so retention math can be
+    /// tested without sleeping).
+    fn backdate(db: &Database, id: i64, updated_at: i64) {
+        db.conn
+            .execute(
+                "UPDATE tasks SET updated_at = ?2 WHERE id = ?1",
+                params![id, updated_at],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn clear_done_removes_only_done_tasks() {
+        let db = Database::open_in_memory().unwrap();
+        let todo = db.create_task(&NewTask::local("todo")).unwrap();
+        let in_prog = db.create_task(&NewTask::local("in progress")).unwrap();
+        let done_a = db.create_task(&NewTask::local("done a")).unwrap();
+        let done_b = db.create_task(&NewTask::local("done b")).unwrap();
+        db.set_task_status(in_prog, TaskStatus::InProgress).unwrap();
+        db.set_task_status(done_a, TaskStatus::Done).unwrap();
+        db.set_task_status(done_b, TaskStatus::Done).unwrap();
+
+        assert_eq!(db.clear_done_tasks().unwrap(), 2);
+        // The done tasks are gone; the others survive.
+        let remaining: Vec<i64> = db.list_tasks().unwrap().into_iter().map(|t| t.id).collect();
+        assert_eq!(remaining, vec![in_prog, todo]); // newest-first
+        assert!(db.get_task(done_a).unwrap().is_none());
+        assert!(db.get_task(done_b).unwrap().is_none());
+        // Idempotent: a second sweep removes nothing.
+        assert_eq!(db.clear_done_tasks().unwrap(), 0);
+    }
+
+    #[test]
+    fn prune_done_respects_retention_window() {
+        let db = Database::open_in_memory().unwrap();
+        let now = current_time_millis() as i64;
+        let day = MS_PER_DAY as i64;
+
+        let fresh = db.create_task(&NewTask::local("fresh done")).unwrap();
+        let stale = db.create_task(&NewTask::local("stale done")).unwrap();
+        let stale_todo = db.create_task(&NewTask::local("stale todo")).unwrap();
+        db.set_task_status(fresh, TaskStatus::Done).unwrap();
+        db.set_task_status(stale, TaskStatus::Done).unwrap();
+        // Backdate the "stale" tasks well past a 7-day window.
+        backdate(&db, fresh, now - day); // 1 day old, within window
+        backdate(&db, stale, now - 10 * day);
+        backdate(&db, stale_todo, now - 10 * day);
+
+        // Only the old *done* task is pruned; old todos and recent done stay.
+        assert_eq!(db.prune_done_tasks(7).unwrap(), 1);
+        assert!(db.get_task(stale).unwrap().is_none());
+        assert!(db.get_task(fresh).unwrap().is_some());
+        assert!(db.get_task(stale_todo).unwrap().is_some());
+    }
+
+    #[test]
+    fn prune_done_zero_retention_disables_sweep() {
+        let db = Database::open_in_memory().unwrap();
+        let id = db.create_task(&NewTask::local("ancient")).unwrap();
+        db.set_task_status(id, TaskStatus::Done).unwrap();
+        backdate(&db, id, 0); // epoch — as stale as possible
+        assert_eq!(db.prune_done_tasks(0).unwrap(), 0);
+        assert!(db.get_task(id).unwrap().is_some());
+    }
+
+    #[test]
+    fn clear_done_logs_audit_per_task() {
+        let db = Database::open_in_memory().unwrap();
+        let id = db.create_task(&NewTask::local("done")).unwrap();
+        db.set_task_status(id, TaskStatus::Done).unwrap();
+        assert_eq!(db.clear_done_tasks().unwrap(), 1);
+        let entries = db
+            .get_audit_log(Some(EntityType::Task), Some(&id.to_string()), 10)
+            .unwrap();
+        assert!(entries.iter().any(|e| e.action == "deleted"));
     }
 
     #[test]

--- a/src/ui/tasks_panel.rs
+++ b/src/ui/tasks_panel.rs
@@ -61,11 +61,13 @@ pub fn render_tasks_panel(frame: &mut Frame, area: Rect, state: &TaskPaneState<'
     if matches!(state.focus, FocusLevel::Focused) && inner.height > 2 {
         let hint_area = Rect::new(inner.x, inner.y + inner.height - 1, inner.width, 1);
         frame.render_widget(
-            // Same relative order as the central preview footer (e · r · n).
+            // Same relative order as the central preview footer (e · r · n),
+            // plus `C` to clear completed tasks (guided lifecycle cleanup).
             Paragraph::new(super::key_hint_line(&[
                 ("e", " edit "),
                 ("r", " run "),
                 ("n", " new "),
+                ("C", " clear done "),
             ])),
             hint_area,
         );


### PR DESCRIPTION
## What

Completed tasks previously accumulated without bound — there was no way to close out / clean up the todo list. This adds two complementary cleanup mechanisms, mirroring the existing `audit_retention_days` retention pattern.

### Automatic (retention sweep)
- New `task_retention_days` setting in `settings.toml` (default **30**; `0` disables).
- `Database::prune_done_tasks(days)` soft-deletes **done** tasks last updated past the cutoff.
- Runs best-effort on every DB open (`storage::Database::open`), alongside the existing audit-log prune.

### Guided (on-demand)
- `Database::clear_done_tasks()` removes **all** done tasks regardless of age.
- TUI: tasks panel **`C`** key (`App::clear_done_tasks`) with a status toast + footer hint.
- CLI: `thurbox-cli task cleanup` (all done) / `--older-than-days N` (bounded sweep), returning `{cleared: N}`.

Both paths are **soft-deletes, audited per row**, so cleared tasks stay restorable.

## Accept criterion
> Task lifecycle improved with automatic or guided cleanup — completed tasks don't accumulate indefinitely.

Met by both an automatic retention sweep and a guided manual flow (CLI + TUI key).

## Tests
- `storage::tasks`: retention window, zero-retention disable, clear-done scope, per-row audit.
- `cli::tasks`: `cleanup` all vs `--older-than-days`.
- `session::settings` + `settings_config`: new field defaults / seed / docs-every-field.
- Full suite: **1063 passing**, clippy clean, arch rules 11/11, rustdoc clean, rumdl clean.

## Docs
- `docs/CONFIG.md` settings table
- `CLAUDE.md` Tasks section (CLI + lifecycle + key)