### PR TITLE
feat(core): name task-spawned sessions after the task title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -526,7 +526,7 @@ sync, but the TUI editor never sets it.)
   scroll the preview, `n` new, `e`/`Enter` open the central-pane editor,
   `Space` cycle status, `r` open the **trigger-time action picker**, `o` **open
   the task's related session** (`App::open_task_related_session` — jumps to the
-  spawned `task-<id>-<slug>` window or a Send target, else a status hint), `d`/`Ctrl+D`
+  session spawned for the task or a Send target, else a status hint), `d`/`Ctrl+D`
   delete, `Esc` back to the session list. In the editor: field nav +
   `Enter`/`Ctrl+S` save (→ back to panel), `Esc` discard; the editor captures
   its keys before global bindings (so `e`/`d` edit text) via
@@ -541,6 +541,18 @@ sync, but the TUI editor never sets it.)
   `AGENT_BOOT_DELAY_TICKS`) and advances the task. The pending prompt is
   cleared on a manual `Ctrl+N` so a cancelled task-spawn can't leak into it.
   Both paths call `App::advance_task_to_in_progress`.
+- **Spawned-session naming** — a task-spawned session is named after the task
+  **title** (`Task::spawn_session_name`: title verbatim, whitespace collapsed,
+  path separators/`..`/leading-`.` sanitized away and capped to 64 bytes so it
+  satisfies `paths::validate_safe_name`), e.g. `Wire up SSH backend` rather than
+  the old `task-<id>-<title-slug>`. The durable task↔session link is the
+  persisted **`spawn_task_id`** column (schema v32) on `sessions` — set by the
+  headless `task run` Spawn path (`SpawnRequest.spawn_task_id`) and by the TUI
+  spawn tail (`finalize_spawned_session` sets `SessionInfo.spawn_task_id` from
+  the `pending_task_prompt`). Recovery (`App::task_related_session_indices`, the
+  headless re-trigger reuse) matches on `spawn_task_id` first, with the legacy
+  `Task::matches_spawn_session` name convention (`task-<id>[-slug]`) kept only as
+  a fallback for sessions created before the column existed.
 - **CLI**: `thurbox-cli task` (alias `todo`) —
   `create`/`list`/`show`/`edit`/`remove`/`run`. `create`/`edit` take an
   optional `--description` (markdown; `edit --description ""` clears it), and

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -654,8 +654,8 @@ impl App {
                     self.open_task_action_picker(&task);
                 }
             }
-            // Jump to the task's related session terminal (the spawned
-            // `task-<id>-<slug>` window, or a persisted Send target).
+            // Jump to the task's related session terminal (the session spawned
+            // for this task, or a persisted Send target).
             KeyCode::Char('o') => self.open_task_related_session(),
             KeyCode::Char('d') => self.delete_selected_task(),
             _ => {}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1318,6 +1318,7 @@ impl App {
         session.info.worktrees = shared.worktrees.iter().cloned().map(Into::into).collect();
         session.info.parent_session_id = shared.parent_session_id;
         session.info.display_order = shared.display_order;
+        session.info.spawn_task_id = shared.spawn_task_id;
         resolve_repo_display_names(&mut session.info);
     }
 
@@ -2001,6 +2002,9 @@ impl App {
         session.info.worktrees = worktrees;
         session.info.additional_dirs = additional_dirs;
         session.info.parent_session_id = parent_session_id;
+        // Persist the task link on the session itself (durable across restarts),
+        // so a task-spawned session can carry a friendly, id-free name.
+        session.info.spawn_task_id = task_prompt.as_ref().map(|(id, _)| *id);
 
         resolve_repo_display_names(&mut session.info);
         self.sessions.push(session);
@@ -2015,8 +2019,8 @@ impl App {
         // task to in progress.
         if let Some((task_id, title)) = task_prompt {
             let new_id = self.sessions[self.active_index].info.id;
-            // Record the link now — the session was named by the user, so the
-            // `task-<id>-<slug>` convention can't recover it later.
+            // Also keep the in-memory link for this run (cheap lookup; the
+            // persisted `spawn_task_id` is the source of truth across restarts).
             self.task_ui.task_session_links.insert(task_id, new_id);
             let prompt = self.task_agent_prompt(task_id, &title);
             self.send_prompt_to_session(new_id, &prompt, AGENT_BOOT_DELAY_TICKS);
@@ -2919,6 +2923,7 @@ impl App {
             spawned.info.additional_dirs = shared_session.additional_dirs.clone();
             spawned.info.parent_session_id = shared_session.parent_session_id;
             spawned.info.display_order = shared_session.display_order;
+            spawned.info.spawn_task_id = shared_session.spawn_task_id;
             self.sessions.push(spawned);
             self.save_state();
             tracing::debug!(
@@ -3017,6 +3022,7 @@ impl App {
             shell_backend_id: session.info.shell_backend_id.clone(),
             parent_session_id: session.info.parent_session_id,
             display_order: session.info.display_order,
+            spawn_task_id: session.info.spawn_task_id,
             tombstone: false,
             tombstone_at: None,
         }
@@ -3193,6 +3199,7 @@ impl App {
         session.info.worktrees = worktrees;
         session.info.parent_session_id = shared.parent_session_id;
         session.info.display_order = shared.display_order;
+        session.info.spawn_task_id = shared.spawn_task_id;
         resolve_repo_display_names(&mut session.info);
 
         // Re-adopt shell pane if one was persisted
@@ -3456,7 +3463,8 @@ impl App {
     /// queue `prompt` into it. The session is named `name`; a recurring caller
     /// reuses that session on later invocations (and after a TUI restart, where
     /// it is restored from the database by name). Shared by automations
-    /// (`auto-<id>`) and tasks (`task-<id>-<title-slug>`).
+    /// (`auto-<id>`) and tasks (named after the task title, linked back via
+    /// `spawn_task_id`).
     fn spawn_and_prompt(
         &mut self,
         name: String,
@@ -3828,9 +3836,11 @@ impl App {
     /// Indices into `self.sessions` of the **currently-open** sessions a task is
     /// related to, in display order:
     ///
-    /// - the session named by the spawn convention (`task-<id>-<title-slug>`,
-    ///   or the legacy bare `task-<id>`) — used by the headless `task run`
-    ///   (and what survives a restart; see [`Task::matches_spawn_session`]);
+    /// - the session whose persisted `spawn_task_id` is this task (the durable
+    ///   link that survives a restart), or, for legacy sessions predating that
+    ///   column, one matching the old name convention
+    ///   (`task-<id>-<title-slug>` / bare `task-<id>`; see
+    ///   [`Task::matches_spawn_session`]);
     /// - the target of a persisted `Send` action (`task.action`), when one is
     ///   set via the CLI; and
     /// - the in-memory `task_session_links` entry recorded when the task was
@@ -3849,7 +3859,8 @@ impl App {
         let linked = self.task_ui.task_session_links.get(&task.id).copied();
         let mut out = Vec::new();
         for (i, s) in self.sessions.iter().enumerate() {
-            let related = task.matches_spawn_session(&s.info.name)
+            let related = s.info.spawn_task_id == Some(task.id)
+                || task.matches_spawn_session(&s.info.name)
                 || send_target.is_some_and(|t| t == s.info.id)
                 || linked.is_some_and(|t| t == s.info.id);
             if related && !out.contains(&i) {
@@ -6042,7 +6053,7 @@ mod tests {
     }
 
     #[test]
-    fn task_related_sessions_match_spawn_name_and_send_target() {
+    fn task_related_sessions_match_spawn_task_id_and_legacy_name() {
         let mut app = app_with_sessions(2);
         let id = app
             .db
@@ -6050,13 +6061,22 @@ mod tests {
             .unwrap();
         app.refresh_tasks();
 
-        // No related session yet (generic stub names).
+        // No related session yet (generic stub names, no link).
         let task = app.db.get_task(id).unwrap().unwrap();
         assert!(app.task_related_session_indices(&task).is_empty());
 
-        // Rename session 1 to the spawn convention → it's related. Both the
-        // current slugged form and the legacy bare `task-<id>` must match.
+        // The durable link: a session carrying this task's `spawn_task_id` is
+        // related regardless of its (friendly) name.
+        app.sessions[1].info.spawn_task_id = Some(id);
+        assert_eq!(app.task_related_session_indices(&task), vec![1]);
+
+        // Legacy fallback: a pre-`spawn_task_id` session named by the old
+        // `task-<id>` convention is still recognized.
+        app.sessions[1].info.spawn_task_id = None;
         app.sessions[1].info.name = task.spawn_session_name();
+        // The friendly title ("t") is no longer a recovery anchor by itself.
+        assert!(app.task_related_session_indices(&task).is_empty());
+        app.sessions[1].info.name = format!("task-{id}-t");
         assert_eq!(app.task_related_session_indices(&task), vec![1]);
         app.sessions[1].info.name = format!("task-{id}");
         assert_eq!(app.task_related_session_indices(&task), vec![1]);
@@ -8203,6 +8223,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         }

--- a/src/app/task_state.rs
+++ b/src/app/task_state.rs
@@ -33,12 +33,11 @@ pub(crate) struct TaskUiState {
     /// spawn flow's success tail to deliver the prompt + advance the task.
     pub(crate) pending_task_prompt: Option<(i64, String)>,
     /// Live `task id → session id` links recorded when a task is triggered from
-    /// the TUI (Spawn-new or Send). TUI spawns get a user-chosen session name
-    /// rather than the `task-<id>-<slug>` convention, so the name alone can't
-    /// recover the link — this map does. Consulted by
-    /// `task_related_session_indices` alongside the name convention and any
-    /// persisted `Send` action. In-memory only (the spawn-name convention is
-    /// what survives a restart); stale entries are harmless since lookups
-    /// filter to currently-open sessions.
+    /// the TUI (Spawn-new or Send). A convenience cache for this run; the
+    /// durable link is the session's persisted `spawn_task_id` (what survives a
+    /// restart). Consulted by `task_related_session_indices` alongside
+    /// `spawn_task_id`, the legacy name convention, and any persisted `Send`
+    /// action. In-memory only; stale entries are harmless since lookups filter
+    /// to currently-open sessions.
     pub(crate) task_session_links: HashMap<i64, SessionId>,
 }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -759,7 +759,7 @@ impl App {
         area: Rect,
         task: &crate::session::Task,
     ) -> Option<ScrollbarGeom> {
-        // Related running sessions (spawned `task-<id>-<slug>` and/or a Send target).
+        // Related running sessions (spawned for this task and/or a Send target).
         let related = self.task_related_session_indices(task);
         let sessions = if related.is_empty() {
             "none open".to_string()

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -344,6 +344,7 @@ fn fire_headless(
                 agent_session_id: None,
                 host: None,
                 parent_session_id: None,
+                spawn_task_id: None,
             };
             match crate::session_ops::spawn_session_headless(db, req) {
                 Ok(result) => {

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -129,6 +129,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 agent_session_id: None,
                 host,
                 parent_session_id,
+                spawn_task_id: None,
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
             Ok(json!({
@@ -269,6 +270,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         };
@@ -306,6 +308,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         };
@@ -379,6 +382,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         };
@@ -414,6 +418,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -2,8 +2,9 @@
 //!
 //! Tasks are persisted to the shared database; the TUI's right-side panel reads
 //! them. `run` triggers a task's agent action headlessly (Send into a live tmux
-//! window, or Spawn a fresh session named `task-<id>-<title-slug>` seeded with
-//! the title).
+//! window, or Spawn a fresh session named after the task title, e.g.
+//! `Wire up SSH backend`, seeded with the title and linked back to the task via
+//! the session's `spawn_task_id`).
 
 use clap::Subcommand;
 use serde_json::{json, Value};
@@ -179,14 +180,17 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
         }) => {
             let name = task.spawn_session_name();
             // Reuse an existing session window (re-trigger / restored session).
-            // Match by convention rather than exact name so legacy `task-<id>`
-            // sessions and spawns from a since-edited title are found too.
+            // Prefer the durable `spawn_task_id` link; fall back to the legacy
+            // name convention so pre-`spawn_task_id` `task-<id>` sessions and
+            // spawns from a since-edited title are still found. The tmux window
+            // is keyed by the session name, so check `window_exists(name)`.
             let existing = db
                 .list_active_sessions()
                 .map_err(|e| format!("list_active_sessions: {e}"))?
                 .into_iter()
+                .filter(|s| s.spawn_task_id == Some(task.id) || task.matches_spawn_session(&s.name))
                 .map(|s| s.name)
-                .find(|n| task.matches_spawn_session(n) && crate::agent::tmux::window_exists(n));
+                .find(|n| crate::agent::tmux::window_exists(n));
             if let Some(name) = existing {
                 crate::agent::tmux::send_prompt_now(&name, &prompt)
                     .map_err(|e| format!("send_prompt_now: {e}"))?;
@@ -202,6 +206,7 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
                 agent_session_id: None,
                 host: None,
                 parent_session_id: None,
+                spawn_task_id: Some(task.id),
             };
             crate::session_ops::spawn_session_headless(db, req)?;
             crate::agent::tmux::send_prompt_after_delay(&name, &prompt, BOOT_DELAY_SECS)

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -197,6 +197,11 @@ pub struct SessionInfo {
     /// Manual position in the session list. `None` = never moved: renders
     /// after all ordered sessions, in creation order.
     pub display_order: Option<i64>,
+    /// Task id this session was spawned for (`Spawn` action), if any. The
+    /// durable task↔session link, recovered from the persisted session so the
+    /// task panel can find its session by id rather than name convention.
+    /// `None` for sessions not spawned from a task.
+    pub spawn_task_id: Option<i64>,
 }
 
 impl SessionInfo {
@@ -220,6 +225,7 @@ impl SessionInfo {
             repo_display_names: Vec::new(),
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
         }
     }
 }

--- a/src/session/task.rs
+++ b/src/session/task.rs
@@ -126,39 +126,65 @@ impl Task {
         prompt
     }
 
-    /// Session name used when this task is dispatched via a `Spawn` action:
-    /// `task-<id>-<title-slug>` (e.g. `task-42-wire-up-ssh-backend`), capped at
-    /// [`SPAWN_SESSION_NAME_MAX`] chars. Falls back to plain `task-<id>` when
-    /// the title yields no slug. Shared by the headless `task run` path; use
-    /// [`matches_spawn_session`](Self::matches_spawn_session) to recognize the
-    /// session later (it also accepts the legacy bare `task-<id>` form).
+    /// Session name used when this task is dispatched via a `Spawn` action: the
+    /// task title made human-readable (case, spaces and accents preserved, e.g.
+    /// `Wire up SSH backend`). Runs of whitespace collapse to one space, and the
+    /// result is sanitized to satisfy [`crate::paths::validate_safe_name`] (which
+    /// the headless spawn enforces) and to round-trip cleanly as a tmux window
+    /// name: path separators become spaces, runs of `.` collapse to one, no
+    /// leading `.`, and the whole thing is capped to
+    /// [`SPAWN_SESSION_NAME_MAX`] **bytes** (never splitting a multi-byte glyph).
+    /// Falls back to `task-<id>` when the title yields nothing usable.
+    ///
+    /// The session no longer carries the task id in its name; the durable
+    /// task↔session link is the persisted `spawn_task_id` column instead (see
+    /// [`matches_spawn_session`](Self::matches_spawn_session) for the legacy
+    /// name-based fallback used only for pre-existing sessions).
     pub fn spawn_session_name(&self) -> String {
-        let prefix = format!("task-{}", self.id);
-        let budget = SPAWN_SESSION_NAME_MAX.saturating_sub(prefix.len() + 1);
-        let mut slug = String::new();
+        let mut name = String::with_capacity(self.title.len());
+        let mut pending_space = false;
         for c in self.title.chars() {
-            if c.is_ascii_alphanumeric() {
-                slug.push(c.to_ascii_lowercase());
-            } else if !slug.is_empty() && !slug.ends_with('-') {
-                slug.push('-');
+            // Path separators and whitespace both become a single space — the
+            // validator rejects `/`/`\\`, and tmux sanitizes them away anyway.
+            if c.is_whitespace() || c == '/' || c == '\\' {
+                pending_space = !name.is_empty();
+                continue;
             }
-            if slug.len() >= budget {
-                break;
+            if pending_space {
+                name.push(' ');
+                pending_space = false;
             }
+            // Collapse runs of `.` to a single one so `..` (rejected by the
+            // validator) can never appear, and drop a leading `.`.
+            if c == '.' && (name.is_empty() || name.ends_with('.')) {
+                continue;
+            }
+            name.push(c);
         }
-        slug.truncate(budget);
-        let slug = slug.trim_end_matches('-');
-        if slug.is_empty() {
-            prefix
+        // Cap by byte length to match the validator's 64-byte limit, stopping on
+        // a char boundary so a multi-byte glyph is never split.
+        if name.len() > SPAWN_SESSION_NAME_MAX {
+            let cut = (0..=SPAWN_SESSION_NAME_MAX)
+                .rev()
+                .find(|&i| name.is_char_boundary(i))
+                .unwrap_or(0);
+            name.truncate(cut);
+        }
+        let name = name.trim_end_matches([' ', '.']).to_string();
+        if name.is_empty() {
+            format!("task-{}", self.id)
         } else {
-            format!("{prefix}-{slug}")
+            name
         }
     }
 
-    /// Whether `name` is this task's spawned session: the current
-    /// `task-<id>-<slug>` convention or the legacy bare `task-<id>` (which
-    /// pre-slug sessions still carry; the title may also have been edited
-    /// since the spawn, so only the `task-<id>` part is significant).
+    /// Whether `name` is this task's spawned session by **name convention**.
+    ///
+    /// Spawned sessions are now linked durably by `spawn_task_id`, so this is
+    /// only a fallback for legacy sessions created before that column existed:
+    /// it accepts the old `task-<id>-<slug>` form and the bare `task-<id>`
+    /// (the `task-<id>` prefix is the only significant part, since the title
+    /// may have been edited since the spawn).
     pub fn matches_spawn_session(&self, name: &str) -> bool {
         let prefix = format!("task-{}", self.id);
         name == prefix
@@ -231,33 +257,96 @@ mod tests {
     }
 
     #[test]
-    fn spawn_session_name_slugs_the_title() {
+    fn spawn_session_name_is_the_title_verbatim() {
         assert_eq!(
             sample_task(None).spawn_session_name(),
-            "task-42-wire-up-ssh-backend"
+            "Wire up SSH backend"
         );
     }
 
     #[test]
-    fn spawn_session_name_collapses_symbols_and_caps_length() {
+    fn spawn_session_name_preserves_punctuation_and_accents() {
         let mut task = sample_task(None);
         task.title = "Fix: TUI crash!! (on concurrent CLI commands)".to_string();
         assert_eq!(
             task.spawn_session_name(),
-            "task-42-fix-tui-crash-on-concurrent-cli-commands"
+            "Fix: TUI crash!! (on concurrent CLI commands)"
         );
-        task.title = "x".repeat(200);
-        let name = task.spawn_session_name();
-        assert!(name.len() <= SPAWN_SESSION_NAME_MAX);
-        assert!(name.starts_with("task-42-x"));
-        // Truncation never leaves a dangling hyphen.
-        assert!(!name.ends_with('-'));
+        // Accents survive (the accept criterion's "Blabla Blablä" case).
+        task.title = "Blabla Blablä".to_string();
+        assert_eq!(task.spawn_session_name(), "Blabla Blablä");
     }
 
     #[test]
-    fn spawn_session_name_falls_back_to_bare_id() {
+    fn spawn_session_name_collapses_whitespace_and_caps_length() {
         let mut task = sample_task(None);
-        task.title = "??? !!!".to_string();
+        task.title = "  Wire   up\tSSH\n backend  ".to_string();
+        assert_eq!(task.spawn_session_name(), "Wire up SSH backend");
+        // Length is capped by byte count, and any trailing space is trimmed.
+        task.title = "x".repeat(200);
+        let name = task.spawn_session_name();
+        assert!(name.len() <= SPAWN_SESSION_NAME_MAX);
+        assert!(name.starts_with('x'));
+        // A multi-byte title is capped by bytes without splitting a glyph.
+        task.title = "é".repeat(200);
+        let name = task.spawn_session_name();
+        assert!(name.len() <= SPAWN_SESSION_NAME_MAX);
+        assert!(name.chars().all(|c| c == 'é'));
+    }
+
+    /// Mirror of `crate::paths::validate_safe_name`'s rules. Duplicated here
+    /// rather than imported because `session` may not reference other crate
+    /// modules (architecture rule); the headless spawn enforces the real one.
+    fn is_safe_name(name: &str) -> bool {
+        !name.is_empty()
+            && name.len() <= 64
+            && !name.starts_with('.')
+            && !name.contains('/')
+            && !name.contains('\\')
+            && !name.contains("..")
+    }
+
+    #[test]
+    fn spawn_session_name_always_passes_validate_safe_name() {
+        // Titles with the characters the validator rejects (`/`, `\`, `..`,
+        // leading `.`) and over-long multi-byte titles must still produce a
+        // name the headless spawn accepts.
+        let mut task = sample_task(None);
+        for title in [
+            "feat/foo: wire it up",
+            "path\\to\\thing",
+            "weird.. name.. here",
+            "...leading dots",
+            &"é".repeat(200),
+            &"a/".repeat(100),
+        ] {
+            task.title = title.to_string();
+            let name = task.spawn_session_name();
+            assert!(
+                is_safe_name(&name),
+                "name {name:?} from title {title:?} is not a safe name"
+            );
+        }
+    }
+
+    #[test]
+    fn spawn_session_name_sanitizes_separators_and_dot_runs() {
+        let mut task = sample_task(None);
+        task.title = "feat/foo".to_string();
+        assert_eq!(task.spawn_session_name(), "feat foo");
+        task.title = "weird.. name".to_string();
+        assert_eq!(task.spawn_session_name(), "weird. name");
+        task.title = "...leading".to_string();
+        assert_eq!(task.spawn_session_name(), "leading");
+    }
+
+    #[test]
+    fn spawn_session_name_falls_back_to_bare_id_when_blank() {
+        let mut task = sample_task(None);
+        task.title = "   ".to_string();
+        assert_eq!(task.spawn_session_name(), "task-42");
+        // A title of only separators/dots also collapses to nothing usable.
+        task.title = "/// ...".to_string();
         assert_eq!(task.spawn_session_name(), "task-42");
     }
 

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -92,6 +92,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -37,6 +37,10 @@ pub struct SpawnRequest {
     /// Optional parent session (lead/worker relationship for orchestration).
     /// Must reference an existing active session.
     pub parent_session_id: Option<SessionId>,
+    /// Task id this session is being spawned for (`Spawn` action), if any. The
+    /// durable task↔session link, persisted so the session keeps a friendly,
+    /// id-free name while still being recoverable after a restart.
+    pub spawn_task_id: Option<i64>,
 }
 
 /// Result returned on successful headless spawn.
@@ -113,6 +117,7 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         shell_backend_id: None,
         parent_session_id: req.parent_session_id,
         display_order: None,
+        spawn_task_id: req.spawn_task_id,
         tombstone: false,
         tombstone_at: None,
     };
@@ -245,6 +250,7 @@ mod tests {
             agent_session_id: None,
             host: None,
             parent_session_id: None,
+            spawn_task_id: None,
         }
     }
 
@@ -293,6 +299,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -4,9 +4,9 @@ use rusqlite::Connection;
 ///
 /// v29 is reserved by the in-flight `improve-agent-thurbox-cli` branch
 /// (`session_labels` + `session_spawn_config`); v30 added
-/// `parent_session_id`, v31 adds `display_order`.
+/// `parent_session_id`, v31 added `display_order`, v32 adds `spawn_task_id`.
 /// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 31;
+pub const SCHEMA_VERSION: u32 = 32;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -42,6 +42,7 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             shell_backend_id  TEXT,
             parent_session_id TEXT,
             display_order     INTEGER,
+            spawn_task_id     INTEGER,
             created_at        INTEGER NOT NULL,
             updated_at        INTEGER NOT NULL,
             deleted_at        INTEGER
@@ -199,6 +200,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (28, migrate_v28_run_related_session),
         (30, migrate_v30_parent_session_id),
         (31, migrate_v31_display_order),
+        (32, migrate_v32_spawn_task_id),
     ];
 
     for &(target, step) in steps {
@@ -872,6 +874,21 @@ fn migrate_v30_parent_session_id(conn: &Connection) -> rusqlite::Result<()> {
 /// "duplicate column" error so a re-run is a no-op.
 fn migrate_v31_display_order(conn: &Connection) -> rusqlite::Result<()> {
     let _ = conn.execute("ALTER TABLE sessions ADD COLUMN display_order INTEGER", []);
+    Ok(())
+}
+
+/// v31 → v32: add a nullable `spawn_task_id` column to `sessions` — the durable
+/// link from a session to the task that spawned it. Replaces parsing the task id
+/// out of the session name, so spawned sessions can display the friendly task
+/// title verbatim. `NULL` = not spawned from a task. No backfill on purpose:
+/// legacy `task-<id>` sessions are still recovered by name convention
+/// ([`crate::session::Task::matches_spawn_session`]).
+///
+/// Fresh v32 databases already have the column from `initialize` and skip this
+/// step; existing databases get it via the ALTER. `let _` swallows the
+/// "duplicate column" error so a re-run is a no-op.
+fn migrate_v32_spawn_task_id(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN spawn_task_id INTEGER", []);
     Ok(())
 }
 

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -48,9 +48,9 @@ impl Database {
                 "UPDATE sessions SET name = ?1, agent = ?2, \
                  backend_id = ?3, backend_type = ?4, agent_session_id = ?5, \
                  cwd = ?6, additional_dirs = ?7, shell_backend_id = ?8, \
-                 parent_session_id = ?9, display_order = ?10, updated_at = ?11, \
-                 deleted_at = NULL \
-                 WHERE id = ?12",
+                 parent_session_id = ?9, display_order = ?10, spawn_task_id = ?11, \
+                 updated_at = ?12, deleted_at = NULL \
+                 WHERE id = ?13",
                 params![
                     session.name,
                     session.agent,
@@ -62,6 +62,7 @@ impl Database {
                     session.shell_backend_id,
                     session.parent_session_id.map(|id| id.to_string()),
                     session.display_order,
+                    session.spawn_task_id,
                     now,
                     id_str,
                 ],
@@ -79,8 +80,8 @@ impl Database {
             self.conn.execute(
                 "INSERT INTO sessions (id, name, agent, backend_id, backend_type, \
                  agent_session_id, cwd, additional_dirs, shell_backend_id, \
-                 parent_session_id, display_order, created_at, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                 parent_session_id, display_order, spawn_task_id, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                 params![
                     id_str,
                     session.name,
@@ -93,6 +94,7 @@ impl Database {
                     session.shell_backend_id,
                     session.parent_session_id.map(|id| id.to_string()),
                     session.display_order,
+                    session.spawn_task_id,
                     now,
                     now,
                 ],
@@ -176,7 +178,7 @@ impl Database {
         let sql = format!(
             "SELECT s.id, s.name, s.agent, s.backend_id, s.backend_type, \
              s.agent_session_id, s.cwd, s.additional_dirs, s.shell_backend_id, \
-             s.parent_session_id, s.display_order, \
+             s.parent_session_id, s.display_order, s.spawn_task_id, \
              w.repo_path, w.worktree_path, w.branch \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id AND w.deleted_at IS NULL \
@@ -370,9 +372,10 @@ fn row_to_shared_session(
     let shell_backend_id: Option<String> = row.get(8)?;
     let parent_str: Option<String> = row.get(9)?;
     let display_order: Option<i64> = row.get(10)?;
-    let wt_repo: Option<String> = row.get(11)?;
-    let wt_path: Option<String> = row.get(12)?;
-    let wt_branch: Option<String> = row.get(13)?;
+    let spawn_task_id: Option<i64> = row.get(11)?;
+    let wt_repo: Option<String> = row.get(12)?;
+    let wt_path: Option<String> = row.get(13)?;
+    let wt_branch: Option<String> = row.get(14)?;
 
     let additional_dirs: Vec<PathBuf> = if dirs_str.is_empty() {
         Vec::new()
@@ -396,6 +399,7 @@ fn row_to_shared_session(
             shell_backend_id,
             parent_session_id: parent_str.and_then(|s| s.parse().ok()),
             display_order,
+            spawn_task_id,
             tombstone: false,
             tombstone_at: None,
         },
@@ -421,6 +425,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         }
@@ -700,6 +705,32 @@ mod tests {
         let found = db.get_session_by_id(child.id).unwrap().unwrap();
         assert_eq!(found.name, "Worker 2");
         assert_eq!(found.parent_session_id, Some(parent.id));
+    }
+
+    #[test]
+    fn session_spawn_task_id_roundtrips() {
+        let db = Database::open_in_memory().unwrap();
+        let mut session = make_session("Wire up SSH backend");
+        session.spawn_task_id = Some(42);
+        db.upsert_session(&session).unwrap();
+
+        let found = db.get_session_by_id(session.id).unwrap().unwrap();
+        assert_eq!(found.spawn_task_id, Some(42));
+        // The friendly name persists verbatim alongside the durable link.
+        assert_eq!(found.name, "Wire up SSH backend");
+
+        // A non-task session keeps a NULL link.
+        let plain = make_session("manual");
+        db.upsert_session(&plain).unwrap();
+        let found = db.get_session_by_id(plain.id).unwrap().unwrap();
+        assert_eq!(found.spawn_task_id, None);
+
+        // An update preserves the link.
+        let mut renamed = session.clone();
+        renamed.name = "Renamed".into();
+        db.upsert_session(&renamed).unwrap();
+        let found = db.get_session_by_id(session.id).unwrap().unwrap();
+        assert_eq!(found.spawn_task_id, Some(42));
     }
 
     #[test]

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -58,6 +58,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         }

--- a/src/storage/worktrees.rs
+++ b/src/storage/worktrees.rs
@@ -134,6 +134,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         };

--- a/src/sync/delta.rs
+++ b/src/sync/delta.rs
@@ -97,6 +97,7 @@ fn session_changed(old: &SharedSession, new: &SharedSession) -> bool {
         || old.worktrees != new.worktrees
         || old.parent_session_id != new.parent_session_id
         || old.display_order != new.display_order
+        || old.spawn_task_id != new.spawn_task_id
 }
 
 #[cfg(test)]
@@ -118,6 +119,7 @@ mod tests {
             shell_backend_id: None,
             parent_session_id: None,
             display_order: None,
+            spawn_task_id: None,
             tombstone: false,
             tombstone_at: None,
         }

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -89,6 +89,12 @@ pub struct SharedSession {
     /// after all ordered sessions, in creation order.
     pub display_order: Option<i64>,
 
+    /// Task id this session was spawned for (`Spawn` action), if any. The
+    /// durable task↔session link: lets a spawned session display the friendly
+    /// task title while still being recoverable after a restart. `None` for
+    /// sessions not spawned from a task.
+    pub spawn_task_id: Option<i64>,
+
     /// Tombstone flag: true if this session was soft-deleted.
     /// Soft-deleted sessions are excluded from active listings.
     pub tombstone: bool,

--- a/src/ui/tasks_panel.rs
+++ b/src/ui/tasks_panel.rs
@@ -26,8 +26,8 @@ pub struct TaskPaneEntry {
     pub match_positions: Vec<usize>,
     /// When a global search is active, rows that don't match are dimmed.
     pub dimmed: bool,
-    /// The task has at least one currently-open related session (a spawned
-    /// `task-<id>-<slug>` window or a Send target). Drawn as a trailing `⇄`
+    /// The task has at least one currently-open related session (a session
+    /// spawned for this task or a Send target). Drawn as a trailing `⇄`
     /// marker so a live task is glanceable in the list; press `o` to jump to it.
     pub linked: bool,
 }

--- a/tests/sync_integration.rs
+++ b/tests/sync_integration.rs
@@ -23,6 +23,7 @@ fn make_session(id: SessionId, name: &str) -> SharedSession {
         shell_backend_id: None,
         parent_session_id: None,
         display_order: None,
+        spawn_task_id: None,
         tombstone: false,
         tombstone_at: None,
     }
@@ -370,6 +371,7 @@ fn db_session_metadata_preserved_across_instances() {
         shell_backend_id: None,
         parent_session_id: None,
         display_order: None,
+        spawn_task_id: None,
         tombstone: false,
         tombstone_at: None,
     };


### PR DESCRIPTION
## What

Task-spawned sessions (the headless `thurbox-cli task run` Spawn path) used a verbose, unnatural `task-<id>-<title-slug>` name — e.g. `task-5-improve-spawned-session-naming`. They now display the **task title verbatim** (case, spaces and accents preserved), e.g. `Improve spawned session naming` — or `Blabla Blablä` for a title with accents.

## Why this needed a schema change

The session name doubled as the task↔session **recovery key** (the tmux window name and the `matches_spawn_session` parse target). To show a friendly, id-free name we decouple display from recovery:

- New nullable **`spawn_task_id`** column on `sessions` (**schema v32**, migration `migrate_v32_spawn_task_id`) — the durable task↔session link, surviving restarts.
- Set by the headless Spawn path (`SpawnRequest.spawn_task_id`) and the TUI spawn tail (`finalize_spawned_session` copies it from `pending_task_prompt` onto `SessionInfo.spawn_task_id`).
- Recovery (`App::task_related_session_indices`, headless re-trigger reuse in `cli/tasks.rs`) matches on `spawn_task_id` **first**; the legacy `task-<id>[-slug]` name convention (`Task::matches_spawn_session`) is kept **only as a fallback** for sessions created before the column existed. No backfill.

## Naming safety

`Task::spawn_session_name` sanitizes the title so it always passes `paths::validate_safe_name` (which the headless spawn enforces) and round-trips as a tmux window name: whitespace collapses to one space, path separators (`/`, `\\`) become spaces, runs of `.` collapse (no `..`, no leading `.`), and the result is capped to 64 **bytes** on a char boundary. Blank titles fall back to `task-<id>`.

## Scope note

Automation sessions keep their short `auto-<id>` name — that's not the verbose slug form this task targets, and giving them friendly names would need the same `spawn_*_id` decoupling (a separate column). Left as a deliberate follow-up.

## Tests

- New: `spawn_session_name_*` (verbatim title, accent preservation, whitespace collapse, byte-cap, separator/`..`/leading-`.` sanitization, `validate_safe_name` safety, blank fallback); `session_spawn_task_id_roundtrips`; `session_changed` delta covers the new field.
- Updated: `task_related_sessions_match_spawn_task_id_and_legacy_name` exercises both the durable link and the legacy name fallback.
- Full suite green: 1061 passed, 11/11 arch rules, 0 clippy warnings, rustdoc clean, rumdl clean.

Docs: CLAUDE.md Tasks section + inline doc comments updated for the new naming/`spawn_task_id` model.