### PR TITLE
feat(ui): macOS-compatible shortcuts via Cmd chords + kitty protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -817,7 +817,9 @@ List contexts use plain `j`/`k`/`Enter` for navigation.
 In the focused session list, `Shift+J`/`Shift+K` move the selected
 session down/up (manual reordering; whole groups move past a group
 edge). Terminal forwards all non-Ctrl keys to the PTY.
-`Shift+arrows/PageUp/PageDown` for scrollback.
+`Shift+arrows/PageUp/PageDown` for scrollback; `Alt+PageUp/PageDown`
+also page (fallback for terminals that claim `Shift+Page` for their
+own scrollback, e.g. Terminal.app/iTerm2).
 
 These defaults can be overridden two ways, both writing the same
 `~/.config/thurbox/keybindings.json` (an `Action` name → one or more
@@ -841,8 +843,8 @@ chord strings, e.g. `{ "QuitApp": ["ctrl+x"] }`):
   `Action::rebindable_in_order()` — the flattened
   `keybindings::help_sections()`, the shared order used by
   `render_help_overlay`.
-- **By hand-editing** the JSON file (e.g. via `$EDITOR`); read once at
-  startup.
+- **By hand-editing** the JSON file (e.g. via `$EDITOR`); reloaded live
+  (mtime poll — see `docs/CONFIG.md`).
 
 **Context-scoped bindings.** Each `Action` has a `KeyContext` (`Global`,
 `SessionList`, `FileViewer`, `Terminal`). Global actions are active
@@ -862,6 +864,37 @@ A few stateful keys stay literal (the F1 panel lists them under
 **Fixed (not rebindable)**): modal selectors (j/k/Enter/Esc), the
 automations/tasks panes, the file-viewer **search sub-mode**, and the
 terminal's catch-all PTY forwarding.
+
+### macOS
+
+Ctrl chords work unchanged in macOS terminals (raw mode bypasses
+flow control; `Ctrl+Y`'s DSUSP quirk is why the `F4` alternate
+exists). On top of that:
+
+- **Cmd chords.** `main.rs` enables the kitty keyboard protocol
+  (`PushKeyboardEnhancementFlags(DISAMBIGUATE_ESCAPE_CODES)`, gated
+  on `supports_keyboard_enhancement()`, popped on shutdown and in
+  the panic hook) so the Command key can be bound like any modifier:
+  `cmd+j` in `keybindings.json` (`super`/`command`/`win` are parse
+  aliases; `cmd` is the canonical display form) or captured live in
+  the F1 editor. Delivered by iTerm2 3.5+, kitty, WezTerm, Ghostty;
+  **not** Terminal.app (no kitty protocol — everything else still
+  works there). The emulator's own Cmd shortcuts (`Cmd+Q/W/N/T/C/V`,
+  `Cmd+K` clears, `Cmd+H` hides, `Cmd+digits` switch tabs) are
+  consumed at the GUI level and can never reach the TUI — only bind
+  what the terminal leaves free.
+- **macOS-only default alternates** — appended after the Ctrl
+  primaries via `Action::default_chords_for(macos)` (the
+  `cfg!(target_os = "macos")` decision lives in `default_chords()`;
+  Linux defaults are byte-identical): `Cmd+J`/`Cmd+Shift+J` =
+  next/previous session, `Cmd+L`/`Cmd+Shift+L` = focus
+  next/previous pane.
+- **Unbound Cmd chords are swallowed**, never forwarded to the PTY
+  (`agent::input::key_to_bytes` returns `None` for SUPER).
+- **F-keys** (`F1`–`F5` alternates) need `Fn` on Mac laptops unless
+  "Use F1, F2, etc. keys as standard function keys" is enabled;
+  `Cmd+V` pastes via the terminal's native paste (bracketed paste),
+  no binding needed.
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -394,6 +394,12 @@ command = "codex"
 | `F2` | Toggle info panel | Next to F1 |
 | `F3` | Toggle file viewer | Next to F2 |
 
+**macOS:** in kitty-protocol terminals (iTerm2 3.5+, kitty, WezTerm,
+Ghostty) the Command key works as a modifier — `Cmd+J`/`Cmd+Shift+J`
+switch sessions and `Cmd+L`/`Cmd+Shift+L` cycle panes by default, and
+any action can be rebound to a `cmd+…` chord from the F1 editor.
+Terminal.app delivers no Cmd chords; everything else works there.
+
 ### List Navigation
 
 | Key | Action |
@@ -411,6 +417,7 @@ Session search matches against name, agent, and branch.
 |-----|--------|
 | `Shift+Up` / `Shift+Down` | Scroll 1 line |
 | `Shift+PageUp` / `Shift+PageDown` | Scroll half page |
+| `Alt+PageUp` / `Alt+PageDown` | Scroll half page (fallback where the terminal claims `Shift+Page`, e.g. Terminal.app/iTerm2) |
 | Mouse wheel | Scroll 3 lines |
 | Mouse drag | Select text |
 | Any other key | Snap to bottom + forward to PTY |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -137,10 +137,14 @@ Maps `Action` names to one or more chord strings:
 
 - Preferred editing path is the **F1 panel** (live capture, conflict
   stealing, immediate persistence). Hand-edits are read at startup.
-- Chord syntax: `[ctrl+][alt+][shift+]<key>` where `<key>` is a letter,
-  `f1`–`f12`, or a named key (`enter`, `esc`, `tab`, arrows, `home`,
-  `end`, `pageup`, `pagedown`, `backspace`, `delete`, `insert`).
-  Case-insensitive.
+- Chord syntax: `[ctrl+][alt+][shift+][cmd+]<key>` where `<key>` is a
+  letter, `f1`–`f12`, or a named key (`enter`, `esc`, `tab`, arrows,
+  `home`, `end`, `pageup`, `pagedown`, `backspace`, `delete`,
+  `insert`). Case-insensitive. `cmd` (aliases `super`, `command`,
+  `win`) is the macOS Command key — delivered only by
+  kitty-keyboard-protocol terminals (iTerm2 3.5+, kitty, WezTerm,
+  Ghostty; not Terminal.app), and only for chords the emulator
+  doesn't claim itself.
 - Unknown action names, invalid chords, and the same chord bound to two
   actions in overlapping contexts are reported at startup (the file
   still loads; bad entries fall back to defaults).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -291,7 +291,8 @@ Headless: `thurbox-cli session create --host devbox --repo-path
 
 When the terminal panel is focused, **all keys are forwarded to the
 PTY** except those with a `Ctrl` modifier (intercepted as global
-commands) and `Shift+arrow/page` keys (intercepted for scrollback).
+commands) and `Shift+arrow/page` / `Alt+page` keys (intercepted for
+scrollback).
 
 **Why Ctrl, not Alt?**
 
@@ -354,8 +355,8 @@ applicable: `h/j/k/l` for navigation, semantic letters for actions
 | `Esc` | Repo picker | Cancel | |
 | `Shift+Up` | Focused terminal | Scroll up 1 line | |
 | `Shift+Down` | Focused terminal | Scroll down 1 line | |
-| `Shift+PageUp` | Focused terminal | Scroll up half page | |
-| `Shift+PageDown` | Focused terminal | Scroll down half page | |
+| `Shift+PageUp` / `Alt+PageUp` | Focused terminal | Scroll up half page | |
+| `Shift+PageDown` / `Alt+PageDown` | Focused terminal | Scroll down half page | |
 | Mouse wheel | Focused terminal | Scroll up/down 3 lines | |
 | All other keys | Focused terminal | Forwarded to PTY (snaps to bottom if scrolled) | |
 
@@ -382,6 +383,34 @@ actions whose scopes overlap. A handful of stateful keys stay fixed (shown in
 the F1 panel under *Fixed (not rebindable)*): modal selectors
 (`j`/`k`/`Enter`/`Esc`), the automations/tasks panes, the file-viewer search
 sub-mode, and the terminal's catch-all PTY forwarding.
+
+### macOS
+
+Ctrl chords pass through macOS terminals unchanged (raw mode disables
+flow control; the `Ctrl+Y` DSUSP quirk is why the `F4` alternate
+exists). Beyond that:
+
+- **Cmd as a modifier.** Thurbox enables the kitty keyboard protocol
+  when the terminal supports it, so the Command key is a first-class
+  modifier: write `cmd+j` in `keybindings.json` (`super`, `command`,
+  and `win` parse as aliases; `cmd` is canonical) or capture a Cmd
+  chord live in the F1 editor. Supported by iTerm2 3.5+, kitty,
+  WezTerm, and Ghostty; Terminal.app lacks the protocol, so Cmd
+  chords never arrive there (everything else degrades gracefully).
+  Note the emulator consumes its own Cmd shortcuts (`Cmd+Q/W/N/T/C/V`,
+  `Cmd+K` clear, `Cmd+H` hide, `Cmd+digit` tabs) before Thurbox can
+  see them — only unclaimed chords are bindable.
+- **macOS default alternates.** On macOS builds four Cmd chords are
+  appended after the Ctrl primaries (Linux defaults are identical):
+  `Cmd+J` / `Cmd+Shift+J` select the next/previous session and
+  `Cmd+L` / `Cmd+Shift+L` cycle pane focus forward/backward. The
+  pattern is "Cmd mirrors the Ctrl primary, Shift reverses" —
+  `Cmd+K` and `Cmd+H` themselves are unusable (see above).
+- **Unbound Cmd chords are swallowed**, never forwarded to the PTY:
+  injecting the bare letter into the agent would corrupt its input.
+- **F-keys** (`F1`–`F5` alternates) require `Fn` on Mac laptops
+  unless function keys are set to standard; `Cmd+V` already pastes
+  through the terminal's native paste → bracketed paste path.
 
 ---
 
@@ -1108,8 +1137,12 @@ the offset is 0, new output naturally stays at the bottom.
 
 ### Scroll keybindings
 
-`Shift+Up/Down` scrolls one line, `Shift+PageUp/PageDown` scrolls
-half a page, and the mouse wheel scrolls three lines per tick.
+`Shift+Up/Down` scrolls one line, `Shift+PageUp/PageDown` (or
+`Alt+PageUp/PageDown`) scrolls half a page, and the mouse wheel
+scrolls three lines per tick. The `Alt+Page` pair exists because
+Terminal.app and iTerm2 claim `Shift+Page` for their own scrollback,
+so on macOS those chords never reach Thurbox (`Fn+Option+Up/Down`
+on a Mac laptop).
 Any other keypress while scrolled up snaps back to the bottom
 before forwarding to the PTY. This matches the mental model of
 "I'm reading history, and when I start typing I'm back in the

--- a/src/agent/input.rs
+++ b/src/agent/input.rs
@@ -3,6 +3,12 @@ use crossterm::event::{KeyCode, KeyModifiers};
 /// Translate a crossterm key event into the ANSI byte sequence that should be
 /// sent to the PTY. Follows xterm-style modifier encoding conventions.
 pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
+    // Cmd/Super-modified keys have no legacy PTY encoding and the inner app
+    // never negotiated the kitty protocol — swallow rather than inject the
+    // bare key into the agent.
+    if modifiers.contains(KeyModifiers::SUPER) {
+        return None;
+    }
     let shift = modifiers.contains(KeyModifiers::SHIFT);
     let alt = modifiers.contains(KeyModifiers::ALT);
     let ctrl = modifiers.contains(KeyModifiers::CONTROL);
@@ -456,5 +462,19 @@ mod tests {
             key_to_bytes(KeyCode::Char('z'), KeyModifiers::CONTROL),
             Some(vec![0x1a])
         );
+    }
+
+    #[test]
+    fn super_modified_keys_are_swallowed() {
+        // An unbound Cmd+letter must not inject the bare key into the agent.
+        assert_eq!(key_to_bytes(KeyCode::Char('j'), KeyModifiers::SUPER), None);
+        assert_eq!(
+            key_to_bytes(
+                KeyCode::Char('j'),
+                KeyModifiers::SUPER | KeyModifiers::CONTROL
+            ),
+            None
+        );
+        assert_eq!(key_to_bytes(KeyCode::Enter, KeyModifiers::SUPER), None);
     }
 }

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -43,6 +43,25 @@ impl App {
             return;
         }
 
+        // Cmd/Super chords are commands, never text: only the keybinding
+        // lookup may consume them. The handlers below (modal inputs, the
+        // search query, in-pane editors, list hotkeys) predate the kitty
+        // keyboard protocol and match `Char` without checking SUPER, so a
+        // chord like Cmd+J would otherwise type a bare `j`. While a modal or
+        // the search strip owns input the chord is swallowed outright,
+        // mirroring how Ctrl chords are unavailable there. (The terminal
+        // pass-through swallows SUPER on its own — `agent::input::key_to_bytes`.)
+        if mods.contains(KeyModifiers::SUPER) {
+            if !self.modal.is_open() && !self.global_search.active {
+                self.text_selection = None;
+                let context = self.focus_key_context();
+                if let Some(action) = self.keybindings.lookup_in(context, code, mods) {
+                    self.dispatch_action(action);
+                }
+            }
+            return;
+        }
+
         // An open modal captures all input.
         if self.handle_modal_key_if_open(code, mods) {
             return;
@@ -164,7 +183,10 @@ impl App {
                 help.capturing = false;
                 return true;
             }
-            let chord = KeyChord { mods, code };
+            // Normalize so the toast below shows the stored chord (masked
+            // modifiers, canonical Shift+letter) — `rebind` normalizes again
+            // for storage.
+            let chord = KeyChord::normalized(mods, code);
             let selected = help.selected.min(actions.len().saturating_sub(1));
             help.capturing = false;
             let action = actions[selected];

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5458,6 +5458,45 @@ mod tests {
         assert!(app.text_selection.is_none());
     }
 
+    // --- Cmd/Super chord routing (kitty keyboard protocol) ---
+
+    #[test]
+    fn super_chord_dispatches_bound_global_action() {
+        let mut app = app_with_sessions(1);
+        app.keybindings.rebind(
+            crate::session::Action::ToggleFileViewer,
+            crate::session::KeyChord::cmd('e'),
+        );
+        assert!(!app.show_file_viewer);
+        app.handle_key(KeyCode::Char('e'), KeyModifiers::SUPER);
+        assert!(app.show_file_viewer, "bound Cmd chord must dispatch");
+    }
+
+    #[test]
+    fn super_chord_never_types_into_modal_text_input() {
+        let mut app = app_with_sessions(1);
+        app.modal = modals::Modal::SessionName(modals::SessionNameModal::default());
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::SUPER);
+        let modals::Modal::SessionName(ref sn) = app.modal else {
+            panic!("modal must stay open");
+        };
+        assert_eq!(
+            sn.name.value(),
+            "",
+            "Cmd+J must not insert a bare 'j' into the text input"
+        );
+    }
+
+    #[test]
+    fn unbound_super_chord_skips_focus_letter_hotkeys() {
+        let mut app = app_with_sessions(1);
+        app.focus = InputFocus::TaskList;
+        // Cmd+N is unbound: it must be swallowed, not treated as the task
+        // list's plain `n` (new task) hotkey.
+        app.handle_key(KeyCode::Char('n'), KeyModifiers::SUPER);
+        assert_eq!(app.focus, InputFocus::TaskList, "no editor must open");
+    }
+
     #[test]
     fn scroll_clears_selection() {
         let mut app = app_with_sessions(1);

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -1127,6 +1127,10 @@ impl Modal {
     pub fn close(&mut self) {
         *self = Modal::None;
     }
+
+    pub fn is_open(&self) -> bool {
+        !matches!(self, Modal::None)
+    }
 }
 
 // ── TaskActionPickerModal ────────────────────────────────────────────────

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -986,6 +986,18 @@ fn render_help_overlay(
         "Terminal: all other keys forwarded to session",
     ));
 
+    // Cmd chords only arrive through the kitty keyboard protocol — worth a
+    // note on the platform whose defaults include them.
+    #[cfg(target_os = "macos")]
+    {
+        help_lines.push(Line::from(""));
+        help_lines.push(help_section("macOS"));
+        help_lines.push(help_line(
+            "cmd+…".into(),
+            "Needs a kitty-protocol terminal (iTerm2 3.5+, kitty, WezTerm, Ghostty) — not Terminal.app",
+        ));
+    }
+
     // Reserve the bottom row for the controls footer so it stays visible even
     // when the body overflows the modal height (the body scrolls, the footer
     // never does).

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
 use crossterm::event::{
     self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-    Event, KeyEventKind, MouseButton, MouseEventKind,
+    Event, KeyEventKind, KeyboardEnhancementFlags, MouseButton, MouseEventKind,
+    PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
 
@@ -13,11 +15,46 @@ use thurbox::agent::{BackendRegistry, SessionBackend};
 use thurbox::app::{App, AppMessage};
 use thurbox::storage::Database;
 
+/// Whether we pushed kitty keyboard-protocol flags onto the terminal. The
+/// panic hook is installed before the push happens, so it reads this to know
+/// whether a matching pop is needed.
+static KEYBOARD_ENHANCEMENT_PUSHED: AtomicBool = AtomicBool::new(false);
+
+/// Enable the kitty keyboard protocol where the terminal supports it: with
+/// DISAMBIGUATE_ESCAPE_CODES, Cmd/Super-modified keys are reported at all
+/// (otherwise the terminal never delivers them), while plain keys keep their
+/// legacy encodings and no Release/Repeat events arrive — the
+/// `KeyEventKind::Press` filter in `run_loop` stays correct. The support
+/// query needs raw mode, so call this only after `ratatui::init()`.
+fn push_keyboard_enhancement() {
+    if matches!(
+        crossterm::terminal::supports_keyboard_enhancement(),
+        Ok(true)
+    ) && execute!(
+        std::io::stdout(),
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+    )
+    .is_ok()
+    {
+        KEYBOARD_ENHANCEMENT_PUSHED.store(true, Ordering::SeqCst);
+    }
+}
+
+/// Pop the kitty flags if (and only if) we pushed them — `ratatui::restore()`
+/// does not, so both the shutdown path and the panic hook call this before
+/// leaving raw mode.
+fn pop_keyboard_enhancement() {
+    if KEYBOARD_ENHANCEMENT_PUSHED.load(Ordering::SeqCst) {
+        let _ = execute!(std::io::stdout(), PopKeyboardEnhancementFlags);
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Set up panic hook that restores terminal before printing the panic
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
+        pop_keyboard_enhancement();
         let _ = execute!(
             std::io::stdout(),
             DisableBracketedPaste,
@@ -101,6 +138,7 @@ async fn main() -> Result<()> {
 
     let mut terminal = ratatui::init();
     execute!(std::io::stdout(), EnableMouseCapture, EnableBracketedPaste)?;
+    push_keyboard_enhancement();
     let size = terminal.size()?;
 
     let mut app = App::new(size.height, size.width, backends, agents, db);
@@ -126,6 +164,7 @@ async fn main() -> Result<()> {
     let res = run_loop(&mut terminal, &mut app).await;
 
     app.shutdown();
+    pop_keyboard_enhancement();
     execute!(
         std::io::stdout(),
         DisableBracketedPaste,

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -208,11 +208,28 @@ impl Action {
         }
     }
 
+    /// Default key chord(s) bound to this action for the platform we were
+    /// compiled for. `cfg!(target_os)` is decided at exactly this one
+    /// callsite; everything else goes through [`Action::default_chords_for`]
+    /// so Linux CI can test both platform sets.
+    pub fn default_chords(self) -> Vec<KeyChord> {
+        self.default_chords_for(cfg!(target_os = "macos"))
+    }
+
     /// Default key chord(s) bound to this action. Exhaustive match —
     /// adding a new `Action` variant without a default chord here is a
     /// compile error.
-    pub fn default_chords(self) -> Vec<KeyChord> {
-        match self {
+    ///
+    /// With `macos` set, a few Cmd alternates are **appended** after the
+    /// cross-platform chords (the primaries — and so the rendered hints —
+    /// are identical on every platform). The Cmd set is deliberately tiny:
+    /// macOS terminals claim most of the Cmd namespace at the GUI level
+    /// (Cmd+Q/W/N/T/C/V/F, Cmd+K clears, Cmd+H hides, Cmd+digits switch
+    /// tabs), and only kitty-protocol terminals deliver Cmd at all — so we
+    /// add one coherent pattern (Cmd mirrors the Ctrl primary, Shift
+    /// reverses) on letters no major terminal claims.
+    pub fn default_chords_for(self, macos: bool) -> Vec<KeyChord> {
+        let mut chords = match self {
             Action::QuitApp => vec![KeyChord::ctrl('q')],
             Action::NewSession => vec![KeyChord::ctrl('n')],
             Action::DeleteSession => vec![KeyChord::ctrl('d')],
@@ -266,9 +283,35 @@ impl Action {
             }
             Action::TerminalScrollUp => vec![KeyChord::shift(KeyCode::Up)],
             Action::TerminalScrollDown => vec![KeyChord::shift(KeyCode::Down)],
-            Action::TerminalPageUp => vec![KeyChord::shift(KeyCode::PageUp)],
-            Action::TerminalPageDown => vec![KeyChord::shift(KeyCode::PageDown)],
+            // Alt+Page fallbacks: Terminal.app/iTerm2 intercept Shift+PageUp/
+            // PageDown for their own scrollback, and Mac laptops reach PageUp
+            // only via Fn — Alt+PageUp (Fn+Option+Up) is unclaimed everywhere.
+            Action::TerminalPageUp => {
+                vec![
+                    KeyChord::shift(KeyCode::PageUp),
+                    KeyChord::alt(KeyCode::PageUp),
+                ]
+            }
+            Action::TerminalPageDown => {
+                vec![
+                    KeyChord::shift(KeyCode::PageDown),
+                    KeyChord::alt(KeyCode::PageDown),
+                ]
+            }
+        };
+        if macos {
+            match self {
+                Action::NextSession => chords.push(KeyChord::cmd('j')),
+                // Cmd+K is "clear buffer" in Terminal.app/iTerm2/kitty/Ghostty
+                // — Shift reverses the pair instead.
+                Action::PreviousSession => chords.push(KeyChord::cmd_shift('j')),
+                Action::FocusForward => chords.push(KeyChord::cmd('l')),
+                // Cmd+H is OS-level Hide — Shift-reverse again.
+                Action::FocusBackward => chords.push(KeyChord::cmd_shift('l')),
+                _ => {}
+            }
         }
+        chords
     }
 
     /// Rebindable actions in F1 help render order — the flattened
@@ -393,12 +436,36 @@ impl KeyChord {
         Self::normalized(KeyModifiers::SHIFT, code)
     }
 
+    /// An `Alt`+key chord (e.g. `Alt+PageUp`).
+    pub fn alt(code: KeyCode) -> Self {
+        Self::normalized(KeyModifiers::ALT, code)
+    }
+
+    /// A `Cmd`+char chord (macOS Command key — crossterm's SUPER modifier).
+    /// Only deliverable by kitty-keyboard-protocol terminals.
+    pub fn cmd(c: char) -> Self {
+        Self::normalized(KeyModifiers::SUPER, KeyCode::Char(c))
+    }
+
+    /// A `Cmd+Shift`+char chord.
+    pub fn cmd_shift(c: char) -> Self {
+        Self::normalized(KeyModifiers::SUPER | KeyModifiers::SHIFT, KeyCode::Char(c))
+    }
+
     /// Build a chord, normalizing the Shift+letter encoding ambiguity:
     /// terminals deliver e.g. Shift+n as `Char('N')` (sometimes with the SHIFT
     /// modifier, sometimes without), and `KeyChord::parse` lowercases letters.
     /// We canonicalize every uppercase `Char` to `Shift` + the lowercase letter
-    /// so capture, lookup, and the JSON round-trip all agree.
+    /// so capture, lookup, and the JSON round-trip all agree. Modifiers are
+    /// also masked to the supported set (Ctrl/Alt/Shift/Super): under the kitty
+    /// keyboard protocol terminals may report extra bits (HYPER, META,
+    /// KEYPAD, …) that would otherwise make lookups silently fail.
     pub fn normalized(mods: KeyModifiers, code: KeyCode) -> Self {
+        let mods = mods
+            & (KeyModifiers::CONTROL
+                | KeyModifiers::ALT
+                | KeyModifiers::SHIFT
+                | KeyModifiers::SUPER);
         if let KeyCode::Char(c) = code {
             if c.is_ascii_uppercase() {
                 return Self {
@@ -421,6 +488,9 @@ impl KeyChord {
         }
         if self.mods.contains(KeyModifiers::SHIFT) {
             parts.push("shift");
+        }
+        if self.mods.contains(KeyModifiers::SUPER) {
+            parts.push("cmd");
         }
         let key = match self.code {
             KeyCode::Char(c) => c.to_string(),
@@ -446,7 +516,9 @@ impl KeyChord {
         parts.join("+")
     }
 
-    /// Parse `"ctrl+n"`, `"f1"`, `"shift+pageup"`. Case-insensitive.
+    /// Parse `"ctrl+n"`, `"f1"`, `"shift+pageup"`, `"cmd+j"`. Case-insensitive.
+    /// `cmd`/`super`/`command`/`win` all mean the SUPER modifier (`cmd` is the
+    /// canonical display form).
     pub fn parse(s: &str) -> Option<Self> {
         let lc = s.trim().to_ascii_lowercase();
         if lc.is_empty() {
@@ -461,6 +533,7 @@ impl KeyChord {
                 "ctrl" | "control" => mods |= KeyModifiers::CONTROL,
                 "alt" | "meta" => mods |= KeyModifiers::ALT,
                 "shift" => mods |= KeyModifiers::SHIFT,
+                "cmd" | "super" | "command" | "win" => mods |= KeyModifiers::SUPER,
                 _ => return None,
             }
         }
@@ -1071,6 +1144,112 @@ mod tests {
             kb.rebind(Action::FileViewerDown, KeyChord::ctrl('q')),
             Some(Action::QuitApp)
         );
+    }
+
+    #[test]
+    fn cmd_chord_parse_aliases_and_canonical_display() {
+        for s in ["cmd+j", "super+j", "command+j", "win+j"] {
+            assert_eq!(KeyChord::parse(s), Some(KeyChord::cmd('j')), "{s}");
+        }
+        assert_eq!(KeyChord::cmd('j').display(), "cmd+j");
+        assert_eq!(KeyChord::cmd_shift('j').display(), "shift+cmd+j");
+        // Both forms round-trip through display/parse.
+        for chord in [KeyChord::cmd('j'), KeyChord::cmd_shift('j')] {
+            assert_eq!(KeyChord::parse(&chord.display()), Some(chord));
+        }
+    }
+
+    #[test]
+    fn normalized_masks_unsupported_modifier_bits() {
+        // Kitty-protocol terminals can report HYPER/META/KEYPAD bits the app
+        // never binds — they must not make lookups fail.
+        let chord = KeyChord::normalized(
+            KeyModifiers::CONTROL | KeyModifiers::HYPER | KeyModifiers::META,
+            KeyCode::Char('q'),
+        );
+        assert_eq!(chord, KeyChord::ctrl('q'));
+        let kb = KeyBindings::default();
+        assert_eq!(
+            kb.lookup(
+                KeyCode::Char('q'),
+                KeyModifiers::CONTROL | KeyModifiers::HYPER
+            ),
+            Some(Action::QuitApp)
+        );
+    }
+
+    #[test]
+    fn macos_defaults_are_additive_superset() {
+        // The Linux chord list must be a prefix of the macOS one for every
+        // action: primaries (and so rendered hints) identical on both
+        // platforms, Cmd alternates strictly appended.
+        for action in Action::all() {
+            let linux = action.default_chords_for(false);
+            let macos = action.default_chords_for(true);
+            assert!(
+                macos.len() >= linux.len() && macos[..linux.len()] == linux[..],
+                "{action:?}: {linux:?} is not a prefix of {macos:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn macos_default_set_has_no_conflicts() {
+        let map = Action::all()
+            .iter()
+            .map(|a| (*a, a.default_chords_for(true)))
+            .collect();
+        let kb = KeyBindings { map };
+        let warnings = kb.conflict_warnings();
+        assert!(warnings.is_empty(), "macOS defaults conflict: {warnings:?}");
+    }
+
+    #[test]
+    fn rebind_steals_cmd_chord_across_overlapping_contexts() {
+        let map = Action::all()
+            .iter()
+            .map(|a| (*a, a.default_chords_for(true)))
+            .collect();
+        let mut kb = KeyBindings { map };
+        // cmd+j belongs to the global NextSession; a scoped action grabbing it
+        // steals it like any other chord.
+        assert_eq!(
+            kb.rebind(Action::FileViewerDown, KeyChord::cmd('j')),
+            Some(Action::NextSession)
+        );
+        assert!(!kb
+            .chords_for(Action::NextSession)
+            .contains(&KeyChord::cmd('j')));
+    }
+
+    #[test]
+    fn cmd_chord_json_round_trip() {
+        let mut kb = KeyBindings::default();
+        kb.rebind(Action::NextSession, KeyChord::cmd('j'));
+        let parsed = KeyBindings::from_json(&kb.to_json().unwrap()).unwrap();
+        assert_eq!(
+            parsed.chords_for(Action::NextSession),
+            &[KeyChord::cmd('j')]
+        );
+    }
+
+    #[test]
+    fn terminal_paging_has_alt_fallback() {
+        // Shift+PageUp/PageDown is intercepted by Terminal.app/iTerm2
+        // scrollback, so the Alt variants must resolve too — on every platform.
+        let kb = KeyBindings::default();
+        for (code, action) in [
+            (KeyCode::PageUp, Action::TerminalPageUp),
+            (KeyCode::PageDown, Action::TerminalPageDown),
+        ] {
+            for mods in [KeyModifiers::SHIFT, KeyModifiers::ALT] {
+                assert_eq!(
+                    kb.lookup_in(KeyContext::Terminal, code, mods),
+                    Some(action),
+                    "{action:?} via {mods:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -108,6 +108,8 @@
             <code>Ctrl</code>
             modifier (intercepted as global commands) and
             <code>Shift+arrow/page</code>
+            /
+            <code>Alt+page</code>
             keys (for scrollback).
           </p>
           <div class="info-box">
@@ -322,6 +324,30 @@
             </tbody>
           </table>
 
+          <div class="info-box">
+            <p>
+              <strong>macOS:</strong>
+              in kitty-protocol terminals (iTerm2 3.5+, kitty, WezTerm, Ghostty) the Command key
+              works as a modifier:
+              <code>Cmd+J</code>
+              /
+              <code>Cmd+Shift+J</code>
+              switch sessions,
+              <code>Cmd+L</code>
+              /
+              <code>Cmd+Shift+L</code>
+              cycle panes, and any action can be rebound to a
+              <code>cmd+&hellip;</code>
+              chord (aliases:
+              <code>super</code>
+              ,
+              <code>command</code>
+              ). Terminal.app delivers no Cmd chords; everything else works there. F1&ndash;F5 need
+              <code>Fn</code>
+              on Mac laptops unless function keys are set to standard.
+            </p>
+          </div>
+
           <h2 id="list-navigation">
             List Navigation
             <a href="#list-navigation" class="heading-anchor">#</a>
@@ -422,6 +448,17 @@
                   <code>Shift+PageDown</code>
                 </td>
                 <td>Scroll half page</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>Alt+PageUp</code>
+                  /
+                  <code>Alt+PageDown</code>
+                </td>
+                <td>
+                  Scroll half page (fallback where the terminal claims Shift+Page, e.g.
+                  Terminal.app/iTerm2)
+                </td>
               </tr>
               <tr>
                 <td>Mouse wheel</td>


### PR DESCRIPTION
## Summary

- Enable the kitty keyboard protocol (`DISAMBIGUATE_ESCAPE_CODES`, gated on `supports_keyboard_enhancement()`, popped on shutdown/panic) so macOS users on iTerm2 3.5+/kitty/WezTerm/Ghostty can bind the Command key: `cmd+j` syntax in `keybindings.json` (aliases `super`/`command`/`win`) and live capture in the F1 editor. SUPER chords resolve only through the keybinding lookup — never typed into modal/search text inputs, never forwarded bare to the PTY.
- macOS-only default alternates appended after the Ctrl primaries (`Action::default_chords_for(macos)`; Linux defaults byte-identical): `Cmd+J`/`Cmd+Shift+J` next/previous session, `Cmd+L`/`Cmd+Shift+L` pane focus. Pattern: Cmd mirrors the Ctrl primary, Shift reverses (`Cmd+K` clears / `Cmd+H` hides are terminal/OS-claimed).
- `Alt+PageUp/PageDown` terminal-paging fallback on all platforms — Terminal.app/iTerm2 claim `Shift+Page` for their own scrollback. macOS guidance added to CLAUDE.md, docs/FEATURES.md, docs/CONFIG.md, README, and the website keybindings page.

## Test plan

- 12 new tests: cmd parse/display round-trip, modifier-bit masking, macOS-set additive-superset + no-conflict invariants, SUPER swallowing in PTY forwarding, and App-level routing (dispatch/modal/hotkey guards)
- CI checks pass
- Manual gate on real macOS terminals: verify the four Cmd defaults aren't claimed by iTerm2/kitty/WezTerm/Ghostty (set is a one-line swap in `default_chords_for` if so)