### PR TITLE
feat(config): add [features] flags to disable TUI features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,8 +416,12 @@ keeper, and an OS timer never double-fire.
 
 In the TUI, automations also get a dedicated **Automations pane**
 beneath the session list (left column). It is always present
-(showing `none` when empty) and is treated as **part of the session
-pane**: it forms one continuous, **circular** vertical list with the
+(showing `none` when empty) — unless disabled via `[features]
+automations = false` in settings.toml, which hides the pane (the
+session list takes the whole column and `j`/`k` wrap within it),
+blocks `Ctrl+P`, stops the TUI firing schedules, and skips arming the
+heartbeat (the CLI surface stays fully functional) — and is treated
+as **part of the session pane**: it forms one continuous, **circular** vertical list with the
 session list. `j` past the last session drops focus into the pane and
 `k` at the top automation hands focus back to the last session; the
 ends wrap too — `j` past the last automation loops to the **top** of
@@ -464,7 +468,9 @@ the persistent `App::automation_editor` state (kept in sync by
 ## Tasks (todo list)
 
 Thurbox has a **task list**: todo items (title + markdown description +
-status). A task can be **acted on by a coding agent** via a **trigger-time
+status). The whole TUI surface is gated by `[features] tasks` in
+settings.toml (disabled: F5/Ctrl+W toasts, no task search results; the
+CLI stays functional). A task can be **acted on by a coding agent** via a **trigger-time
 picker** (`r`): you choose *Send → a running session* or *Spawn new session…*
 (the normal repo→agent flow) at the moment you act — the action is **not**
 authored into the task. Either way the agent is seeded with a **full context
@@ -574,7 +580,9 @@ A **non-modal bottom strip** (`Ctrl+A`, rebindable) searches **every scope at on
 matched), **automations** (name), and **files** (the active session's file
 tree). `Enter` jumps to the selected result and focuses its pane —
 switching to a session's terminal, the tasks panel, the automations pane,
-or the file viewer (revealing the path).
+or the file viewer (revealing the path). Gated by `[features]
+global_search` in settings.toml; scopes whose feature is disabled
+(tasks/automations/file viewer) contribute no results.
 
 - **Live in-place highlighting**: instead of reprinting results in the
   strip, matched characters highlight **in the panels themselves** (session

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -16,7 +16,7 @@ development checkout never touches your real setup.
 |------|--------|-----------|------|---------|
 | `~/.config/thurbox/agents.toml` | TOML | you | **live** (mtime poll) | coding-agent CLI definitions |
 | `~/.config/thurbox/hosts.toml` | TOML | you | startup | remote SSH hosts |
-| `~/.config/thurbox/settings.toml` | TOML | you | startup | scalar tuning knobs |
+| `~/.config/thurbox/settings.toml` | TOML | you | startup | tuning knobs + feature flags |
 | `~/.config/thurbox/themes.toml` | TOML | you | startup | custom theme palettes |
 | `~/.config/thurbox/keybindings.json` | JSON | F1 editor (or you) | **live** (mtime poll) | key chord overrides |
 | `~/.local/share/thurbox/thurbox.db` | SQLite | thurbox | live | sessions, automations, tasks, theme, editor command |
@@ -95,9 +95,9 @@ lifetime).
 
 ## settings.toml
 
-Scalar tuning knobs, seeded fully commented-out (defaults apply when
-absent). Only knobs a user plausibly wants are exposed; internals stay
-hardcoded.
+Scalar tuning knobs plus the `[features]` switches, seeded fully
+commented-out (defaults apply when absent). Only knobs a user plausibly
+wants are exposed; internals stay hardcoded.
 
 | Key | Default | Purpose |
 |-----|---------|---------|
@@ -105,6 +105,33 @@ hardcoded.
 | `two_panel_min_cols` | `80` | width below which only the terminal renders |
 | `three_panel_min_cols` | `120` | width unlocking the optional third column |
 | `audit_retention_days` | `90` | audit-log history kept (pruned on startup) |
+
+### `[features]` — whole-feature switches
+
+Turn major TUI features off entirely. All default to `true`; like the
+rest of settings.toml, changes need a restart. A disabled feature's
+pane never renders, its keybinding shows a status toast instead of
+acting, and its global-search scope returns no results. Data is never
+touched, so re-enabling a flag is lossless.
+
+| Key | Disables |
+|-----|----------|
+| `tasks` | tasks panel (`F5`/`Ctrl+W`) and task search results |
+| `automations` | automations pane, `Ctrl+P`, TUI schedule firing, heartbeat arming |
+| `file_viewer` | file viewer column (`F3`) and file search results |
+| `global_search` | global search strip (`Ctrl+A`) |
+| `info_panel` | info panel column (`F2`) |
+| `shell_pane` | per-session shell toggle (`Ctrl+T`) |
+
+`automations = false` is a full stop on the TUI side: the pane
+disappears (the session list takes the whole left column and `j`/`k`
+wrap within it), and the TUI neither fires due schedules nor arms the
+tmux heartbeat keeper on startup. Explicit `thurbox-cli automation`
+commands still work — and `automation create` still arms the
+heartbeat, so an already-armed keeper window (or an OS timer from
+`packaging/`) keeps firing schedules externally. Disabling
+`shell_pane` hides existing shell panes but never kills their
+processes.
 
 ## themes.toml
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -868,6 +868,31 @@ viewer's `/` is an unrelated in-file text search and is unchanged.
 
 ---
 
+## Feature Flags (`[features]` in settings.toml)
+
+Whole features can be switched off declaratively: `tasks`,
+`automations`, `file_viewer`, `global_search`, `info_panel`,
+`shell_pane` — all default `true` (see `docs/CONFIG.md`).
+
+**Decision: flags are UI-level gates, not data switches.** A disabled
+feature hides its pane, consumes its keybinding with an explanatory
+status toast (the chord never reaches the PTY), and contributes no
+global-search results — but its data and the `thurbox-cli` surface
+stay fully functional, so flipping a flag back on is lossless. The one
+deliberate exception is `automations = false`, which also stops the
+TUI firing due schedules and arming the tmux heartbeat at startup —
+"disable automations" should actually stop scheduled work, not just
+hide a list. Explicit CLI automation commands (and an already-armed
+keeper window) keep working, because typing a command is unambiguous
+intent.
+
+The F1 help panel intentionally keeps disabled actions listed: hiding
+rows would break the selection-index contract with
+`Action::rebindable_in_order()`, and the toast already explains why a
+chord did nothing.
+
+---
+
 ## Error Handling UX
 
 ### Rule: never crash, never modal

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -1,7 +1,7 @@
-//! Loading and seeding of the scalar-settings config file.
+//! Loading and seeding of the settings config file.
 //!
-//! `~/.config/thurbox/settings.toml` holds the few user-tunable scalars (see
-//! [`crate::session::settings::Settings`]). On first run the file is seeded
+//! `~/.config/thurbox/settings.toml` holds the user-tunable scalars and
+//! feature flags (see [`crate::session::settings::Settings`]). On first run the file is seeded
 //! fully commented-out, so a fresh install runs on the built-in defaults. A
 //! malformed file degrades to the defaults with a startup warning.
 
@@ -33,6 +33,19 @@ config_version = 1
 
 # Days of audit-log history kept (pruned on startup).
 # audit_retention_days = 90
+
+# Feature flags: turn whole TUI features off. All default to true.
+# Disabling `automations` also stops the TUI firing schedules and arming
+# the tmux heartbeat on startup; explicit `thurbox-cli automation`
+# commands (and an already-armed heartbeat window) keep working. Data is
+# never touched, so re-enabling a flag is lossless.
+# [features]
+# tasks = true            # F5/Ctrl+W tasks panel
+# automations = true      # automations pane, Ctrl+P, schedule firing
+# file_viewer = true      # F3 file viewer column
+# global_search = true    # Ctrl+A search strip
+# info_panel = true       # F2 info panel
+# shell_pane = true       # Ctrl+T per-session shell
 "#;
 
 /// Path to the settings file: `~/.config/thurbox/settings.toml`.
@@ -122,6 +135,13 @@ mod tests {
             "two_panel_min_cols",
             "three_panel_min_cols",
             "audit_retention_days",
+            "[features]",
+            "tasks",
+            "automations",
+            "file_viewer",
+            "global_search",
+            "info_panel",
+            "shell_pane",
         ] {
             assert!(
                 SEED_SETTINGS_TOML.contains(field),
@@ -173,5 +193,20 @@ mod tests {
         assert_eq!(s.scrollback_lines, 4000);
         assert_eq!(s.audit_retention_days, 7);
         assert_eq!(s.two_panel_min_cols, 80);
+    }
+
+    #[test]
+    fn load_or_seed_reads_feature_overrides() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let path = settings_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "[features]\nautomations = false\n").unwrap();
+
+        let (s, warnings) = load_or_seed_with_warnings();
+        assert!(warnings.is_empty(), "got: {warnings:?}");
+        assert!(!s.features.automations);
+        assert!(s.features.tasks, "untouched flags stay enabled");
     }
 }

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1165,6 +1165,16 @@ impl App {
         }
     }
 
+    /// Gate a feature-flagged action: returns whether the feature is enabled,
+    /// surfacing a toast naming the switch when it isn't. Callers still
+    /// consume the key either way (a disabled chord must not reach the PTY).
+    fn feature_gate(&mut self, enabled: bool, what: &str) -> bool {
+        if !enabled {
+            self.set_info(format!("{what} is disabled ([features] in settings.toml)"));
+        }
+        enabled
+    }
+
     fn dispatch_action(&mut self, action: crate::session::Action) -> bool {
         use crate::session::Action;
         match action {
@@ -1181,7 +1191,9 @@ impl App {
             // else run the action.
             Action::OpenInEditor => self.act_unless_terminal(Self::open_active_in_editor),
             Action::OpenAutomations => {
-                self.open_automations_list();
+                if self.feature_gate(self.features.automations, "Automations") {
+                    self.open_automations_list();
+                }
                 true
             }
             Action::StartSync => {
@@ -1189,7 +1201,9 @@ impl App {
                 true
             }
             Action::ToggleShell => {
-                self.toggle_shell_view();
+                if self.feature_gate(self.features.shell_pane, "Shell pane") {
+                    self.toggle_shell_view();
+                }
                 true
             }
             Action::ForkSession => self.act_unless_terminal(Self::fork_active_session),
@@ -1231,20 +1245,28 @@ impl App {
                 true
             }
             Action::ToggleInfoPanel => {
-                self.show_info_panel = !self.show_info_panel;
-                self.resize_sessions_to_content_area();
+                if self.feature_gate(self.features.info_panel, "Info panel") {
+                    self.show_info_panel = !self.show_info_panel;
+                    self.resize_sessions_to_content_area();
+                }
                 true
             }
             Action::FocusTasks => {
-                self.act_toggle_tasks();
+                if self.feature_gate(self.features.tasks, "Tasks panel") {
+                    self.act_toggle_tasks();
+                }
                 true
             }
             Action::ToggleFileViewer => {
-                self.act_toggle_file_viewer();
+                if self.feature_gate(self.features.file_viewer, "File viewer") {
+                    self.act_toggle_file_viewer();
+                }
                 true
             }
             Action::GlobalSearch => {
-                self.open_global_search();
+                if self.feature_gate(self.features.global_search, "Global search") {
+                    self.open_global_search();
+                }
                 true
             }
 
@@ -1423,8 +1445,10 @@ impl App {
 
     /// Session-list `Ctrl+J`: step to the next session, or flow into the
     /// automations pane past the last so the left column reads as one list.
+    /// With automations disabled there is no pane to flow into, so the list
+    /// wraps onto itself.
     fn act_session_list_next(&mut self) {
-        if self.active_is_last_in_order() {
+        if self.features.automations && self.active_is_last_in_order() {
             self.focus = InputFocus::Automations;
             self.automation_ui.automation_panel_index = 0;
             self.refresh_automation_view();
@@ -1436,7 +1460,7 @@ impl App {
     /// Session-list `Ctrl+K`: step to the previous session, or flow into the
     /// automations pane (last row) above the first.
     fn act_session_list_prev(&mut self) {
-        if self.active_is_first_in_order() {
+        if self.features.automations && self.active_is_first_in_order() {
             self.focus = InputFocus::Automations;
             self.automation_ui.automation_panel_index = self
                 .automation_ui

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -432,6 +432,10 @@ pub struct App {
     terminal_rows: u16,
     pub(crate) terminal_cols: u16,
     session_counter: usize,
+    /// Whole-feature switches (`[features]` in settings.toml), copied out of
+    /// the process-wide settings at construction so tests can flip flags
+    /// without touching the first-writer-wins global.
+    pub(crate) features: crate::session::settings::FeatureFlags,
     pub(crate) show_info_panel: bool,
     /// Whether the tasks panel column is shown (toggled like the file viewer).
     pub(crate) show_tasks_panel: bool,
@@ -598,6 +602,7 @@ impl App {
             terminal_rows: rows,
             terminal_cols: cols,
             session_counter,
+            features: crate::session::settings::global().features,
             show_info_panel: false,
             show_tasks_panel: false,
             show_file_viewer: false,
@@ -1428,15 +1433,7 @@ impl App {
     fn handle_mouse_click(&mut self, x: u16, y: u16, modifiers: KeyModifiers) {
         use crate::ui::links;
 
-        let area = Rect::new(0, 0, self.terminal_cols, self.terminal_rows);
-        let areas = layout::compute_layout(
-            area,
-            self.show_info_panel,
-            self.show_tasks_panel,
-            self.show_file_viewer,
-            self.global_search.active,
-            self.automation_ui.cached_automations.len(),
-        );
+        let areas = self.screen_layout();
         let border_block = Block::default().borders(Borders::ALL);
 
         // Ctrl+Click: URL opening (terminal-relative, existing behavior)
@@ -1641,15 +1638,7 @@ impl App {
     /// Hit-test `(x, y)` against the current layout to find the scrollable pane
     /// under the cursor (used for pane-aware wheel scrolling).
     fn pane_at(&self, x: u16, y: u16) -> Option<ScrollPane> {
-        let area = Rect::new(0, 0, self.terminal_cols, self.terminal_rows);
-        let areas = layout::compute_layout(
-            area,
-            self.show_info_panel,
-            self.show_tasks_panel,
-            self.show_file_viewer,
-            self.global_search.active,
-            self.automation_ui.cached_automations.len(),
-        );
+        let areas = self.screen_layout();
         let pos = Position::new(x, y);
         let hit = |r: Option<Rect>| r.map(|r| r.contains(pos)).unwrap_or(false);
 
@@ -3304,6 +3293,11 @@ impl App {
     /// Fire any due automations. Called once per ~second from `tick()`; pass
     /// `force = true` for the one-shot startup catch-up pass (ignores cadence).
     fn process_automations(&mut self, force: bool) {
+        // Automations fully off: the TUI neither fires schedules nor catches
+        // up at startup (explicit `thurbox-cli automation` use still works).
+        if !self.features.automations {
+            return;
+        }
         if !force && self.metrics.tick_count % 100 != 0 {
             return;
         }
@@ -4169,11 +4163,19 @@ impl App {
             return Vec::new();
         }
         let query_lc = query.to_lowercase();
-        // Group order: Sessions → Tasks → Automations → Files.
+        // Group order: Sessions → Tasks → Automations → Files. Disabled
+        // features contribute no results, so a selection can never preview or
+        // jump into a pane the feature flags hide.
         let mut out = self.search_sessions(query, &query_lc, with_content);
-        out.extend(self.search_tasks(query, &query_lc));
-        out.extend(self.search_automations(query));
-        out.extend(self.search_files(&query_lc));
+        if self.features.tasks {
+            out.extend(self.search_tasks(query, &query_lc));
+        }
+        if self.features.automations {
+            out.extend(self.search_automations(query));
+        }
+        if self.features.file_viewer {
+            out.extend(self.search_files(&query_lc));
+        }
         out
     }
 
@@ -4606,17 +4608,28 @@ impl App {
         }
     }
 
-    pub(crate) fn content_area_size(&self) -> (u16, u16) {
-        let area = Rect::new(0, 0, self.terminal_cols, self.terminal_rows);
-        let terminal = layout::compute_layout(
+    /// Compute the panel layout for `area` from the current panel visibility
+    /// and feature flags — the single funnel into `layout::compute_layout`,
+    /// so the view, mouse routing, and content sizing can never disagree.
+    pub(crate) fn layout_for(&self, area: Rect) -> layout::PanelAreas {
+        layout::compute_layout(
             area,
             self.show_info_panel,
             self.show_tasks_panel,
             self.show_file_viewer,
             self.global_search.active,
+            self.features.automations,
             self.automation_ui.cached_automations.len(),
         )
-        .terminal;
+    }
+
+    /// The layout for the whole terminal screen (mouse hit-testing, sizing).
+    pub(crate) fn screen_layout(&self) -> layout::PanelAreas {
+        self.layout_for(Rect::new(0, 0, self.terminal_cols, self.terminal_rows))
+    }
+
+    pub(crate) fn content_area_size(&self) -> (u16, u16) {
+        let terminal = self.screen_layout().terminal;
         let inner = Block::default().borders(Borders::ALL).inner(terminal);
         (inner.height, inner.width)
     }
@@ -5794,6 +5807,86 @@ mod tests {
         assert_eq!(app.focus, InputFocus::SessionList);
     }
 
+    /// Every `[features]` flag blocks its keybinding with a toast: state stays
+    /// untouched and the chord is consumed (never forwarded to the PTY).
+    #[test]
+    fn disabled_features_block_actions_with_a_toast() {
+        let mut app = app_with_sessions(1);
+        app.update(AppMessage::Resize(160, 40));
+        app.features = crate::session::settings::FeatureFlags {
+            tasks: false,
+            automations: false,
+            file_viewer: false,
+            global_search: false,
+            info_panel: false,
+            shell_pane: false,
+        };
+
+        app.handle_key(KeyCode::F(5), KeyModifiers::NONE);
+        assert!(!app.show_tasks_panel);
+        assert_eq!(app.focus, InputFocus::SessionList);
+        assert!(app.status_message.take().unwrap().text.contains("disabled"));
+
+        app.handle_key(KeyCode::F(3), KeyModifiers::NONE);
+        assert!(!app.show_file_viewer);
+        assert!(app.status_message.take().unwrap().text.contains("disabled"));
+
+        app.handle_key(KeyCode::F(2), KeyModifiers::NONE);
+        assert!(!app.show_info_panel);
+        assert!(app.status_message.take().unwrap().text.contains("disabled"));
+
+        app.handle_key(KeyCode::Char('a'), KeyModifiers::CONTROL);
+        assert!(!app.global_search.active);
+        assert!(app.status_message.take().unwrap().text.contains("disabled"));
+
+        app.handle_key(KeyCode::Char('p'), KeyModifiers::CONTROL);
+        assert!(matches!(app.modal, modals::Modal::None));
+        assert_eq!(app.focus, InputFocus::SessionList);
+        assert!(app.status_message.take().unwrap().text.contains("disabled"));
+
+        app.handle_key(KeyCode::Char('t'), KeyModifiers::CONTROL);
+        assert_eq!(app.active_terminal_view(), TerminalView::Claude);
+        assert!(app.status_message.take().unwrap().text.contains("disabled"));
+    }
+
+    /// The automations flag flows through `screen_layout` (the shared layout
+    /// funnel): disabling it removes the pane and gives the session list the
+    /// whole left column.
+    #[test]
+    fn screen_layout_drops_automations_pane_when_disabled() {
+        let mut app = app_with_sessions(1);
+        app.update(AppMessage::Resize(100, 30));
+        let with = app.screen_layout();
+        assert!(with.automations_panel.is_some());
+
+        app.features.automations = false;
+        let without = app.screen_layout();
+        assert!(without.automations_panel.is_none());
+        assert_eq!(
+            without.left_panel.unwrap().height,
+            with.left_panel.unwrap().height + with.automations_panel.unwrap().height,
+            "session list absorbs the pane's rows"
+        );
+    }
+
+    /// With automations disabled there is no pane beneath the session list, so
+    /// `j`/`k` wrap within the list instead of flowing into the pane.
+    #[test]
+    fn session_list_wraps_when_automations_disabled() {
+        let mut app = app_with_sessions(2);
+        app.features.automations = false;
+        app.focus = InputFocus::SessionList;
+        app.active_index = 1; // last session in render order
+
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE);
+        assert_eq!(app.focus, InputFocus::SessionList, "no pane to flow into");
+        assert_eq!(app.active_index, 0, "j past the last wraps to the first");
+
+        app.handle_key(KeyCode::Char('k'), KeyModifiers::NONE);
+        assert_eq!(app.focus, InputFocus::SessionList);
+        assert_eq!(app.active_index, 1, "k above the first wraps to the last");
+    }
+
     #[test]
     fn opening_tasks_panel_populates_central_preview() {
         // Focusing the tasks panel (F5/Ctrl+W) must build the central-pane
@@ -6263,14 +6356,7 @@ mod tests {
     fn pane_at_central_pane_follows_focus() {
         let mut app = app_with_sessions(1);
         // Pick a point guaranteed to be inside the central (terminal) pane.
-        let areas = layout::compute_layout(
-            Rect::new(0, 0, app.terminal_cols, app.terminal_rows),
-            app.show_info_panel,
-            app.show_tasks_panel,
-            app.show_file_viewer,
-            app.global_search.active,
-            app.automation_ui.cached_automations.len(),
-        );
+        let areas = app.screen_layout();
         let cx = areas.terminal.x + areas.terminal.width / 2;
         let cy = areas.terminal.y + areas.terminal.height / 2;
 
@@ -6426,6 +6512,70 @@ mod tests {
             .results
             .iter()
             .any(|r| r.target == search::SearchTarget::Automation { id: aid }));
+    }
+
+    /// Disabled features contribute no search results, so a selection can
+    /// never preview or jump into a pane the feature flags hide.
+    #[test]
+    fn global_search_omits_disabled_scopes() {
+        let mut app = app_with_sessions(1);
+        app.features.tasks = false;
+        app.features.automations = false;
+        app.db
+            .create_task(&crate::storage::tasks::NewTask::local("fix the widget"))
+            .unwrap();
+        app.refresh_tasks();
+        let new = crate::storage::automations::NewAutomation {
+            name: "widget-nightly".into(),
+            enabled: true,
+            schedule: crate::session::AutomationSchedule::Once { at: 0 },
+            timezone: None,
+            action: crate::session::AutomationAction::Send {
+                session_id: SessionId::default(),
+            },
+            prompt: "go".into(),
+            next_run_at: None,
+        };
+        app.db.create_automation(&new).unwrap();
+        app.refresh_automations();
+
+        app.open_global_search();
+        for c in "widget".chars() {
+            app.handle_key(KeyCode::Char(c), KeyModifiers::NONE);
+        }
+        assert!(app.global_search.results.iter().all(|r| !matches!(
+            r.kind,
+            search::SearchKind::Task | search::SearchKind::Automation
+        )));
+    }
+
+    /// Automations fully off: the TUI must not claim/fire due automations on
+    /// tick or at startup catch-up (the CLI surface stays in charge).
+    #[test]
+    fn process_automations_noops_when_feature_disabled() {
+        let mut app = app_with_sessions(1);
+        app.features.automations = false;
+        let new = crate::storage::automations::NewAutomation {
+            name: "nightly".into(),
+            enabled: true,
+            schedule: crate::session::AutomationSchedule::Once { at: 1 },
+            timezone: None,
+            action: crate::session::AutomationAction::Send {
+                session_id: SessionId::default(),
+            },
+            prompt: "go".into(),
+            next_run_at: Some(1),
+        };
+        app.db.create_automation(&new).unwrap();
+        let now = crate::sync::current_time_millis();
+        assert_eq!(app.db.due_automations(now).unwrap().len(), 1);
+
+        app.process_automations(true);
+        assert_eq!(
+            app.db.due_automations(now).unwrap().len(),
+            1,
+            "a due automation must stay unclaimed while the feature is off"
+        );
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -16,7 +16,7 @@ use crate::ui::selection;
 use crate::ui::theme::Theme;
 use crate::ui::{
     agent_picker_modal, automation_editor_modal, automations_list_modal, automations_panel,
-    branch_selector_modal, file_viewer, global_search, info_panel, layout, project_list,
+    branch_selector_modal, file_viewer, global_search, info_panel, project_list,
     restore_sessions_modal, session_name_modal, status_bar, task_editor_modal, tasks_panel,
     terminal_view, theme_picker_modal, worktree_name_modal,
 };
@@ -30,14 +30,7 @@ impl App {
         // geometry + drag target here for the mouse handlers to hit-test.
         self.scrollbar_hits.clear();
 
-        let areas = layout::compute_layout(
-            frame.area(),
-            self.show_info_panel,
-            self.show_tasks_panel,
-            self.show_file_viewer,
-            self.global_search.active,
-            self.automation_ui.cached_automations.len(),
-        );
+        let areas = self.layout_for(frame.area());
 
         self.render_header(frame, areas.header);
         self.render_left_panel(frame, areas.left_panel);
@@ -429,12 +422,17 @@ impl App {
                 focus_label,
                 sync_in_progress: self.worktree_sync.in_progress,
                 tick_count: self.metrics.tick_count,
-                automation_count: self
-                    .automation_ui
-                    .cached_automations
-                    .iter()
-                    .filter(|a| a.enabled)
-                    .count(),
+                // With automations disabled the badge would advertise a
+                // feature the TUI won't fire — report 0 so it stays hidden.
+                automation_count: if self.features.automations {
+                    self.automation_ui
+                        .cached_automations
+                        .iter()
+                        .filter(|a| a.enabled)
+                        .count()
+                } else {
+                    0
+                },
                 file_viewer_open: self.show_file_viewer,
             },
         );

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -231,6 +231,20 @@ mod tests {
         assert!(err.contains("keybindings.json"), "got: {err}");
     }
 
+    /// `serde_ignored` reports nested unknown keys, so a typo inside
+    /// `[features]` must fail strict validation just like a top-level one.
+    #[test]
+    fn validate_fails_on_unknown_feature_flag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let path = crate::agent::settings_config::settings_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "[features]\nbogus = true\n").unwrap();
+
+        let err = validate().unwrap_err();
+        assert!(err.contains("settings.toml"), "got: {err}");
+    }
+
     #[test]
     fn show_reports_effective_settings_and_editor_source() {
         let tmp = tempfile::tempdir().unwrap();
@@ -242,6 +256,7 @@ mod tests {
         assert_eq!(v["editor"]["command"], json!("code --wait"));
         assert_eq!(v["editor"]["source"], json!("database (editor_command)"));
         assert!(v["settings"]["scrollback_lines"].is_number());
+        assert_eq!(v["settings"]["features"]["tasks"], json!(true));
         assert_eq!(v["agents"]["default"], json!("claude"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
     // (~/.config/thurbox/hosts.toml). These are registered lazily: a down or
     // slow host must not block TUI startup, so check_available()/ensure_ready()
     // are deferred to first spawn/restore (see App::backend_for).
-    // Load (or seed) the scalar settings and publish them process-wide before
+    // Load (or seed) the settings and publish them process-wide before
     // anything reads them (Database::open prunes the audit log; layout and
     // terminal wiring read breakpoints/scrollback).
     let (settings, mut config_warnings) =
@@ -154,7 +154,9 @@ async fn main() -> Result<()> {
 
     // Arm the tmux heartbeat keeper so automations keep firing after the TUI is
     // closed (best-effort: a missing/old tmux just means TUI-only firing).
-    {
+    // Skipped when the `automations` feature flag is off — `thurbox-cli
+    // automation create` still arms it, since that's explicit user intent.
+    if thurbox::session::settings::global().features.automations {
         let cli = thurbox::agent::tmux::resolve_cli_binary();
         if let Err(e) = thurbox::agent::tmux::ensure_automation_heartbeat(&cli) {
             tracing::warn!("Failed to arm automation heartbeat: {e}");

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -1,4 +1,5 @@
-//! User-tunable scalar settings (`~/.config/thurbox/settings.toml`).
+//! User-tunable settings (`~/.config/thurbox/settings.toml`): scalar knobs
+//! plus the `[features]` whole-feature switches.
 //!
 //! Pure data + parsing, per the `session/` architecture rule; the file IO and
 //! seeding live in `crate::agent::settings_config`. Only knobs a user
@@ -11,7 +12,7 @@ use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 
-/// Scalar settings loaded from `settings.toml`. Every field has a default, so
+/// Settings loaded from `settings.toml`. Every field has a default, so
 /// an absent file (the common case) behaves exactly like before the file
 /// existed. Unknown keys are tolerated but reported: the loader names every
 /// unrecognized key in a startup warning.
@@ -33,6 +34,54 @@ pub struct Settings {
     /// Days of audit-log history kept (pruned on startup).
     #[serde(default = "default_audit_retention_days")]
     pub audit_retention_days: u64,
+    /// Per-feature on/off switches (`[features]` table). Absent table = all
+    /// enabled.
+    #[serde(default)]
+    pub features: FeatureFlags,
+}
+
+/// Whole-feature switches (`[features]` in settings.toml). Each flag hides the
+/// feature's UI and blocks its keybinding; disabling `automations` also stops
+/// the TUI firing schedules and arming the tmux heartbeat. Data and
+/// `thurbox-cli` surfaces stay fully functional regardless, so re-enabling a
+/// flag is lossless.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FeatureFlags {
+    /// Tasks panel (F5/Ctrl+W) and task search results.
+    #[serde(default = "default_true")]
+    pub tasks: bool,
+    /// Automations pane, Ctrl+P editor, TUI schedule firing, heartbeat arming.
+    #[serde(default = "default_true")]
+    pub automations: bool,
+    /// File viewer column (F3) and file search results.
+    #[serde(default = "default_true")]
+    pub file_viewer: bool,
+    /// Global search strip (Ctrl+A).
+    #[serde(default = "default_true")]
+    pub global_search: bool,
+    /// Info panel column (F2).
+    #[serde(default = "default_true")]
+    pub info_panel: bool,
+    /// Per-session shell pane toggle (Ctrl+T).
+    #[serde(default = "default_true")]
+    pub shell_pane: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for FeatureFlags {
+    fn default() -> Self {
+        Self {
+            tasks: true,
+            automations: true,
+            file_viewer: true,
+            global_search: true,
+            info_panel: true,
+            shell_pane: true,
+        }
+    }
 }
 
 fn default_scrollback_lines() -> usize {
@@ -56,6 +105,7 @@ impl Default for Settings {
             two_panel_min_cols: default_two_panel_min_cols(),
             three_panel_min_cols: default_three_panel_min_cols(),
             audit_retention_days: default_audit_retention_days(),
+            features: FeatureFlags::default(),
         }
     }
 }
@@ -99,6 +149,36 @@ mod tests {
     fn type_mismatch_is_rejected() {
         let err = toml::from_str::<Settings>("scrollback_lines = \"many\"").unwrap_err();
         assert!(err.to_string().contains("scrollback_lines"));
+    }
+
+    #[test]
+    fn absent_features_table_enables_everything() {
+        let s: Settings = toml::from_str("").unwrap();
+        assert_eq!(s.features, FeatureFlags::default());
+        assert!(s.features.tasks && s.features.automations);
+    }
+
+    #[test]
+    fn empty_features_table_enables_everything() {
+        let s: Settings = toml::from_str("[features]").unwrap();
+        assert_eq!(s.features, FeatureFlags::default());
+    }
+
+    #[test]
+    fn partial_features_override_keeps_other_flags_enabled() {
+        let s: Settings = toml::from_str("[features]\ntasks = false").unwrap();
+        assert!(!s.features.tasks);
+        assert!(s.features.automations);
+        assert!(s.features.file_viewer);
+        assert!(s.features.global_search);
+        assert!(s.features.info_panel);
+        assert!(s.features.shell_pane);
+    }
+
+    #[test]
+    fn feature_flag_type_mismatch_is_rejected() {
+        let err = toml::from_str::<Settings>("[features]\ntasks = \"no\"").unwrap_err();
+        assert!(err.to_string().contains("tasks"));
     }
 
     #[test]

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -4,9 +4,10 @@ pub struct PanelAreas {
     pub header: Rect,
     /// Session list area (top of the left column).
     pub left_panel: Option<Rect>,
-    /// Automations pane, below the session list in the left column. Always
-    /// present (even with zero automations) as long as the column is tall
-    /// enough to fit both lists; its height grows with the automation count.
+    /// Automations pane, below the session list in the left column. Present
+    /// (even with zero automations) as long as the automations feature is
+    /// enabled and the column is tall enough to fit both lists; its height
+    /// grows with the automation count.
     pub automations_panel: Option<Rect>,
     pub info_panel: Option<Rect>,
     /// Tasks panel — a toggleable column on the right, between the terminal and
@@ -60,8 +61,9 @@ fn split_left_column(col: Rect, automation_count: usize) -> (Rect, Option<Rect>)
 /// `list | info? | terminal | tasks? | file_viewer?` with info (15%), tasks
 /// (20%), and file_viewer (20%) appearing only when requested. The tasks panel
 /// sits between the terminal and the file viewer (both right-side columns). The
-/// left column is further split into a session list and an always-present
-/// automations pane beneath it (whenever the column is tall enough);
+/// left column is further split into a session list and an automations pane
+/// beneath it (whenever the column is tall enough and `show_automations_pane`
+/// is set — false when the `automations` feature flag is off);
 /// `automation_count` only sizes that pane.
 pub fn compute_layout(
     area: Rect,
@@ -69,6 +71,7 @@ pub fn compute_layout(
     show_tasks_panel: bool,
     show_file_viewer: bool,
     show_global_search: bool,
+    show_automations_pane: bool,
     automation_count: usize,
 ) -> PanelAreas {
     // Compact mode: when the terminal is shorter than 20 rows, drop the
@@ -161,7 +164,11 @@ pub fn compute_layout(
             None
         };
 
-        let (left_panel, automations_panel) = split_left_column(horizontal[0], automation_count);
+        let (left_panel, automations_panel) = if show_automations_pane {
+            split_left_column(horizontal[0], automation_count)
+        } else {
+            (horizontal[0], None)
+        };
         return PanelAreas {
             header,
             left_panel: Some(left_panel),
@@ -181,7 +188,11 @@ pub fn compute_layout(
         .constraints([Constraint::Percentage(25), Constraint::Percentage(75)])
         .split(content);
 
-    let (left_panel, automations_panel) = split_left_column(horizontal[0], automation_count);
+    let (left_panel, automations_panel) = if show_automations_pane {
+        split_left_column(horizontal[0], automation_count)
+    } else {
+        (horizontal[0], None)
+    };
     PanelAreas {
         header,
         left_panel: Some(left_panel),
@@ -205,7 +216,7 @@ mod tests {
 
     #[test]
     fn narrow_terminal_hides_left_panel() {
-        let areas = compute_layout(area(79, 24), false, false, false, false, 0);
+        let areas = compute_layout(area(79, 24), false, false, false, false, true, 0);
         assert!(areas.left_panel.is_none());
         assert!(areas.info_panel.is_none());
         assert!(areas.file_viewer.is_none());
@@ -213,7 +224,7 @@ mod tests {
 
     #[test]
     fn normal_width_shows_two_panels() {
-        let areas = compute_layout(area(100, 24), false, false, false, false, 0);
+        let areas = compute_layout(area(100, 24), false, false, false, false, true, 0);
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_none());
         assert!(areas.file_viewer.is_none());
@@ -221,7 +232,7 @@ mod tests {
 
     #[test]
     fn wide_terminal_with_info_panel_shows_three_panels() {
-        let areas = compute_layout(area(120, 24), true, false, false, false, 0);
+        let areas = compute_layout(area(120, 24), true, false, false, false, true, 0);
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_some());
         assert!(areas.file_viewer.is_none());
@@ -229,7 +240,7 @@ mod tests {
 
     #[test]
     fn wide_terminal_without_info_panel_shows_two_panels() {
-        let areas = compute_layout(area(120, 24), false, false, false, false, 0);
+        let areas = compute_layout(area(120, 24), false, false, false, false, true, 0);
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_none());
         assert!(areas.file_viewer.is_none());
@@ -237,7 +248,7 @@ mod tests {
 
     #[test]
     fn wide_terminal_with_file_viewer_only() {
-        let areas = compute_layout(area(160, 24), false, false, true, false, 0);
+        let areas = compute_layout(area(160, 24), false, false, true, false, true, 0);
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_none());
         assert!(areas.file_viewer.is_some());
@@ -245,7 +256,7 @@ mod tests {
 
     #[test]
     fn wide_terminal_with_info_and_file_viewer() {
-        let areas = compute_layout(area(160, 24), true, false, true, false, 0);
+        let areas = compute_layout(area(160, 24), true, false, true, false, true, 0);
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_some());
         assert!(areas.file_viewer.is_some());
@@ -257,7 +268,7 @@ mod tests {
 
     #[test]
     fn wide_terminal_with_tasks_panel_only() {
-        let areas = compute_layout(area(160, 24), false, true, false, false, 0);
+        let areas = compute_layout(area(160, 24), false, true, false, false, true, 0);
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_none());
         assert!(areas.tasks_panel.is_some());
@@ -270,7 +281,7 @@ mod tests {
 
     #[test]
     fn tasks_panel_sits_left_of_file_viewer() {
-        let areas = compute_layout(area(180, 24), false, true, true, false, 0);
+        let areas = compute_layout(area(180, 24), false, true, true, false, true, 0);
         let term = areas.terminal;
         let tp = areas.tasks_panel.expect("tasks panel shown");
         let fv = areas.file_viewer.expect("file viewer shown");
@@ -281,19 +292,19 @@ mod tests {
 
     #[test]
     fn tasks_panel_ignored_below_120_cols() {
-        let areas = compute_layout(area(119, 24), false, true, false, false, 0);
+        let areas = compute_layout(area(119, 24), false, true, false, false, true, 0);
         assert!(areas.tasks_panel.is_none());
     }
 
     #[test]
     fn global_search_strip_absent_by_default() {
-        let areas = compute_layout(area(120, 40), false, false, false, false, 0);
+        let areas = compute_layout(area(120, 40), false, false, false, false, true, 0);
         assert!(areas.global_search.is_none());
     }
 
     #[test]
     fn global_search_strip_present_when_active() {
-        let areas = compute_layout(area(120, 40), false, false, false, true, 0);
+        let areas = compute_layout(area(120, 40), false, false, false, true, true, 0);
         let strip = areas.global_search.expect("strip shown when active");
         // Full width, carved directly above the footer.
         assert_eq!(strip.width, 120);
@@ -304,22 +315,22 @@ mod tests {
 
     #[test]
     fn global_search_strip_shrinks_content() {
-        let without = compute_layout(area(120, 40), false, false, false, false, 0).terminal;
-        let with = compute_layout(area(120, 40), false, false, false, true, 0).terminal;
+        let without = compute_layout(area(120, 40), false, false, false, false, true, 0).terminal;
+        let with = compute_layout(area(120, 40), false, false, false, true, true, 0).terminal;
         // The terminal (content) region loses the strip's rows.
         assert_eq!(without.height - with.height, GLOBAL_SEARCH_HEIGHT);
     }
 
     #[test]
     fn header_and_footer_are_one_line() {
-        let areas = compute_layout(area(100, 24), false, false, false, false, 0);
+        let areas = compute_layout(area(100, 24), false, false, false, false, true, 0);
         assert_eq!(areas.header.height, 1);
         assert_eq!(areas.footer.height, 1);
     }
 
     #[test]
     fn compact_mode_hides_header_below_20_rows() {
-        let areas = compute_layout(area(100, 19), false, false, false, false, 0);
+        let areas = compute_layout(area(100, 19), false, false, false, false, true, 0);
         assert_eq!(areas.header.height, 0);
         assert_eq!(areas.footer.height, 1);
         assert!(areas.left_panel.is_some());
@@ -327,26 +338,26 @@ mod tests {
 
     #[test]
     fn header_returns_at_20_rows() {
-        let areas = compute_layout(area(100, 20), false, false, false, false, 0);
+        let areas = compute_layout(area(100, 20), false, false, false, false, true, 0);
         assert_eq!(areas.header.height, 1);
     }
 
     #[test]
     fn info_panel_ignored_below_120_cols() {
-        let areas = compute_layout(area(119, 24), true, false, false, false, 0);
+        let areas = compute_layout(area(119, 24), true, false, false, false, true, 0);
         assert!(areas.info_panel.is_none());
     }
 
     #[test]
     fn file_viewer_ignored_below_120_cols() {
-        let areas = compute_layout(area(119, 24), false, false, true, false, 0);
+        let areas = compute_layout(area(119, 24), false, false, true, false, true, 0);
         assert!(areas.file_viewer.is_none());
     }
 
     fn terminal_inner(width: u16, height: u16, show_info: bool) -> (u16, u16) {
         use ratatui::widgets::{Block, Borders};
         let terminal =
-            compute_layout(area(width, height), show_info, false, false, false, 0).terminal;
+            compute_layout(area(width, height), show_info, false, false, false, true, 0).terminal;
         let inner = Block::default().borders(Borders::ALL).inner(terminal);
         (inner.height, inner.width)
     }
@@ -383,7 +394,7 @@ mod tests {
     #[test]
     fn automations_pane_present_even_when_empty() {
         // Zero automations still get a minimum-height pane (so it's discoverable).
-        let areas = compute_layout(area(100, 24), false, false, false, false, 0);
+        let areas = compute_layout(area(100, 24), false, false, false, false, true, 0);
         assert!(areas.left_panel.is_some());
         let autos = areas.automations_panel.expect("empty pane still shown");
         assert_eq!(autos.height, AUTOMATIONS_PANE_MIN_ROWS);
@@ -391,7 +402,7 @@ mod tests {
 
     #[test]
     fn automations_pane_appears_below_sessions() {
-        let areas = compute_layout(area(100, 30), false, false, false, false, 2);
+        let areas = compute_layout(area(100, 30), false, false, false, false, true, 2);
         let sessions = areas.left_panel.unwrap();
         let autos = areas.automations_panel.expect("automations pane shown");
         // Same column, automations stacked beneath the session list.
@@ -405,7 +416,7 @@ mod tests {
 
     #[test]
     fn automations_pane_height_is_capped() {
-        let areas = compute_layout(area(100, 60), false, false, false, false, 50);
+        let areas = compute_layout(area(100, 60), false, false, false, false, true, 50);
         assert_eq!(
             areas.automations_panel.unwrap().height,
             AUTOMATIONS_PANE_MAX_ROWS
@@ -413,9 +424,23 @@ mod tests {
     }
 
     #[test]
+    fn automations_pane_hidden_when_feature_disabled() {
+        let with = compute_layout(area(100, 30), false, false, false, false, true, 2);
+        let without = compute_layout(area(100, 30), false, false, false, false, false, 2);
+        assert!(without.automations_panel.is_none());
+        // The session list absorbs the whole left column.
+        let full = without.left_panel.unwrap();
+        let split = with.left_panel.unwrap();
+        assert_eq!(
+            full.height,
+            split.height + with.automations_panel.unwrap().height
+        );
+    }
+
+    #[test]
     fn automations_pane_hidden_when_column_too_short() {
         // Content height ≈ 4 rows leaves no room for both lists.
-        let areas = compute_layout(area(100, 6), false, false, false, false, 3);
+        let areas = compute_layout(area(100, 6), false, false, false, false, true, 3);
         assert!(areas.left_panel.is_some());
         assert!(areas.automations_panel.is_none());
     }


### PR DESCRIPTION
## Summary

- New `[features]` table in `~/.config/thurbox/settings.toml` with six switches (`tasks`, `automations`, `file_viewer`, `global_search`, `info_panel`, `shell_pane`), all defaulting to enabled — absent file/table behaves exactly as before.
- A disabled feature hides its pane, consumes its keybinding with a status toast, and contributes no global-search results; disabling `automations` also stops the TUI firing schedules and arming the tmux heartbeat (the `thurbox-cli` surface stays fully functional, so re-enabling is lossless).
- Rides the existing settings machinery: seeded commented-out, startup warnings, strict `thurbox-cli config validate` (rejects unknown nested keys) and `config show` for free; docs updated (CONFIG.md, FEATURES.md, CLAUDE.md).

## Test plan

- 15 new tests: serde defaults/overrides/type-mismatch, seed documentation, dispatch gating + toast for all six flags, j/k wrap without the automations pane, layout funnel, search-scope filtering, no-fire guarantee, CLI validate/show
- CI checks pass