### PR TITLE
feat(ui): full mouse navigation with per-frame click registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -742,6 +742,17 @@ backend dependency stays visible at each call site.
   `status_bar`, `repo_picker_modal` (repo selection with
   worktree toggle). `selection.rs` handles mouse-drag text
   selection, `links.rs` detects clickable URLs for Ctrl+Click.
+  Mouse clicks are routed through a per-frame registry
+  (`App::click_targets`, mirroring `scrollbar_hits`): list/modal
+  renderers return `ui::RowHitbox`es, `App::view` records them as
+  `ClickAction`s, and `handle_mouse_click` hit-tests them (rows
+  select/confirm, panes focus, modals swallow everything else; the
+  hovered row is underlined via mouse-move events). With a modal
+  open, the wheel steps its selection and overflowing picker lists
+  render a draggable scrollbar (`ScrollTarget::Modal`, drag replayed
+  as Up/Down through the modal's key handler). All of it is gated by
+  `[features] mouse` in settings.toml — disabled, mouse capture is
+  never enabled and the terminal keeps native mouse behavior.
   `agent_picker_modal` drives the new-session flow.
 - **`cli/`** — `thurbox-cli` subcommand dispatch (headless
   session ops + scheduling + editor command).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -122,6 +122,7 @@ touched, so re-enabling a flag is lossless.
 | `global_search` | global search strip (`Ctrl+A`) |
 | `info_panel` | info panel column (`F2`) |
 | `shell_pane` | per-session shell toggle (`Ctrl+T`) |
+| `mouse` | mouse capture: clicks, wheel, drag-select, hover, scrollbars |
 
 `automations = false` is a full stop on the TUI side: the pane
 disappears (the session list takes the whole left column and `j`/`k`
@@ -131,7 +132,9 @@ commands still work — and `automation create` still arms the
 heartbeat, so an already-armed keeper window (or an OS timer from
 `packaging/`) keeps firing schedules externally. Disabling
 `shell_pane` hides existing shell panes but never kills their
-processes.
+processes. `mouse = false` skips terminal mouse capture entirely, so
+the terminal keeps its native mouse behavior (its own text selection,
+URL handling, etc.) and no click/wheel/hover handling runs in the TUI.
 
 ## themes.toml
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -358,6 +358,10 @@ applicable: `h/j/k/l` for navigation, semantic letters for actions
 | `Shift+PageUp` / `Alt+PageUp` | Focused terminal | Scroll up half page | |
 | `Shift+PageDown` / `Alt+PageDown` | Focused terminal | Scroll down half page | |
 | Mouse wheel | Focused terminal | Scroll up/down 3 lines | |
+| Click | Session/task/automation/file row | Select the row and focus its pane | |
+| Click | Any pane | Focus the pane under the cursor | |
+| Click | Picker modal row | Select and confirm (Enter; repo picker: Space toggle) | |
+| Hover | Clickable rows | Underline the row a click would hit | |
 | All other keys | Focused terminal | Forwarded to PTY (snaps to bottom if scrolled) | |
 
 ### Customizing shortcuts
@@ -872,7 +876,7 @@ viewer's `/` is an unrelated in-file text search and is unchanged.
 
 Whole features can be switched off declaratively: `tasks`,
 `automations`, `file_viewer`, `global_search`, `info_panel`,
-`shell_pane` — all default `true` (see `docs/CONFIG.md`).
+`shell_pane`, `mouse` — all default `true` (see `docs/CONFIG.md`).
 
 **Decision: flags are UI-level gates, not data switches.** A disabled
 feature hides its pane, consumes its keybinding with an explanatory
@@ -884,7 +888,10 @@ TUI firing due schedules and arming the tmux heartbeat at startup —
 "disable automations" should actually stop scheduled work, not just
 hide a list. Explicit CLI automation commands (and an already-armed
 keeper window) keep working, because typing a command is unambiguous
-intent.
+intent. `mouse = false` is similarly a hard gate at the boundary:
+terminal mouse capture is never enabled (so the terminal keeps its
+native selection/URL handling) and any stray mouse event is dropped
+before dispatch.
 
 The F1 help panel intentionally keeps disabled actions listed: hiding
 rows would break the selection-index contract with
@@ -1304,6 +1311,53 @@ confined to the active pane bounds.
 Selection is highlighted in the terminal render buffer using
 inverted colors. The clipboard handle is kept alive for the app
 lifetime to avoid Linux-specific "dropped too quickly" issues.
+
+---
+
+## Mouse Navigation
+
+The whole TUI is clickable. Every list renderer reports the screen
+rect of each row it draws; `App::view` records them per frame in a
+click registry (`App::click_targets`, mirroring `scrollbar_hits`)
+that the mouse handler hit-tests — first match wins, with rows
+recorded before their pane's whole-rect focus fallback.
+
+- **Click a row** (session list, tasks panel, automations pane,
+  file viewer): selects it and focuses that pane. A session-list
+  group header selects that group's first session. File rows also
+  activate (toggle a directory, open a file in the editor).
+  Clicking into another pane while an in-pane editor has unsaved
+  edits discards them, exactly like `Esc`/`Ctrl+H`.
+- **Click a pane**: focuses it; terminal and session-list clicks
+  still arm drag-selection on the same press.
+- **Click a picker row** (theme, agent, host, branch, task-action,
+  automations list, restore, F1 editor): selects and confirms it in
+  one click (Enter-equivalent — F1 starts chord capture). The repo
+  picker is the exception: a row click toggles/folds (Space), since
+  Enter there confirms the whole modal.
+- **Clicks are swallowed by modals**: anywhere else on (or outside)
+  an open modal does nothing — a stray click can never discard
+  typed input or fall through to the panes beneath. Clicks are also
+  ignored while the F1 editor is capturing a chord and while the
+  global-search strip is open.
+- **Hover**: the clickable row under the pointer is underlined
+  (driven by mouse-move events; applied post-render from the same
+  click registry).
+- **Modal scrolling**: while a modal is open the wheel steps its
+  selection (one row per tick, like `j`/`k`); overflowing picker
+  lists window around the selection and draw a draggable scrollbar
+  (`ScrollTarget::Modal`) in their rightmost column. Drag replays
+  Up/Down through the modal's own key handler, so clamping and side
+  effects (e.g. theme live preview) match keyboard navigation. Pane
+  scrollbars beneath an overlay are never grabbable.
+
+Dispatch order on click: modal (scrollbar grab → row act → swallow)
+→ `Ctrl+Click` URL → pane scrollbar grab → global-search swallow →
+click targets → text selection arming.
+
+The whole subsystem is gated by `[features] mouse` in settings.toml
+(default `true`): when disabled, mouse capture is never enabled, so
+the terminal keeps its native mouse behavior.
 
 ---
 

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -46,6 +46,7 @@ config_version = 1
 # global_search = true    # Ctrl+A search strip
 # info_panel = true       # F2 info panel
 # shell_pane = true       # Ctrl+T per-session shell
+# mouse = true            # mouse capture: clicks, wheel, drag-select, hover
 "#;
 
 /// Path to the settings file: `~/.config/thurbox/settings.toml`.

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -170,7 +170,7 @@ impl App {
     ///
     /// Capture mode: the next keypress (any chord, including `ctrl+q` or `f1`)
     /// becomes the action's sole binding; `Esc` cancels without rebinding.
-    fn handle_help_key(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
+    pub(super) fn handle_help_key(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
         use crate::session::{Action, KeyChord};
 
         let actions = Action::rebindable_in_order();
@@ -254,7 +254,7 @@ impl App {
 
     /// Route the key to the open modal's handler, if any. Returns `true` if a
     /// modal was open and consumed the key.
-    fn handle_modal_key_if_open(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
+    pub(super) fn handle_modal_key_if_open(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
         use super::modals::Modal;
         match self.modal {
             Modal::RestoreSessions(_) => self.handle_restore_sessions_key(code),
@@ -420,7 +420,7 @@ impl App {
     /// Shared bookkeeping after a focus change via the `Ctrl+L`/`Ctrl+H` cycle:
     /// keep the in-pane editor + run history in sync, and start the run-history
     /// selection at the top (newest run) when entering that panel.
-    fn on_focus_changed(&mut self) {
+    pub(super) fn on_focus_changed(&mut self) {
         if self.focus == InputFocus::AutomationRunHistory {
             self.automation_ui.automation_run_index = 0;
         }
@@ -1475,7 +1475,7 @@ impl App {
 
     /// Expand the selected file-viewer node, opening it in the editor when it's
     /// a file (dirs just toggle). Shared by the `FileViewerExpand` action.
-    fn file_viewer_expand(&mut self) {
+    pub(super) fn file_viewer_expand(&mut self) {
         use crate::ui::file_viewer::Activation;
         // Capture root+file before activate() (activate only opens files, not dirs).
         let file_with_root = self.file_viewer.selected_file_with_root();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -324,6 +324,11 @@ pub enum AppMessage {
         x: u16,
         y: u16,
     },
+    /// Pointer moved with no button held — tracked for hover highlighting.
+    MouseMove {
+        x: u16,
+        y: u16,
+    },
     Resize(u16, u16),
     ExternalStateChange(StateDelta),
 }
@@ -344,6 +349,8 @@ pub(crate) enum ScrollTarget {
     TaskPreview,
     FileViewer,
     RunHistory,
+    /// The active modal's list scrollbar — position is the selection index.
+    Modal,
 }
 
 /// One scrollbar rendered this frame: its geometry plus the scroll state it
@@ -351,6 +358,35 @@ pub(crate) enum ScrollTarget {
 pub(crate) struct ScrollbarHit {
     pub(crate) geom: ScrollbarGeom,
     pub(crate) target: ScrollTarget,
+}
+
+/// What a left click on a recorded screen region does. Recorded per-frame in
+/// [`App::click_targets`] (mirroring [`App::scrollbar_hits`]) so the mouse
+/// handler can route clicks to rows and panes without re-deriving the layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClickAction {
+    /// Select the session at this display-order index (resolved through
+    /// `render_order_indices()` at click time, like `Ctrl+J`/`Ctrl+K`).
+    SelectSession(usize),
+    /// Select the task at this index in the filtered tasks panel.
+    SelectTask(usize),
+    /// Select the automation at this index in the automations pane.
+    SelectAutomation(usize),
+    /// Select + activate the file-viewer row at this flattened tree index
+    /// (expand/collapse a directory, open a file).
+    SelectFileRow(usize),
+    /// Focus the pane — the whole-rect fallback recorded after row targets.
+    FocusPane(InputFocus),
+    /// Select + activate the row in the active modal's list.
+    ModalRow(usize),
+}
+
+/// One clickable region rendered this frame: its rect plus what a click on it
+/// does. First recorded match wins, so rows are pushed before their pane's
+/// whole-rect `FocusPane` fallback.
+pub(crate) struct ClickTarget {
+    pub(crate) rect: Rect,
+    pub(crate) action: ClickAction,
 }
 
 /// A scrollable pane identified by hit-testing the cursor against the layout,
@@ -487,6 +523,13 @@ pub struct App {
     /// The scrollbar currently being dragged, if any. Set when a click lands on
     /// a track, cleared on mouse-up, so drags keep driving the same pane.
     pub(crate) dragging_scrollbar: Option<ScrollTarget>,
+    /// Clickable regions rendered this frame (list rows, pane focus areas,
+    /// modal rows). Cleared and rebuilt every [`App::view`]; hit-tested by
+    /// [`App::handle_mouse_click`]. First match wins.
+    pub(crate) click_targets: Vec<ClickTarget>,
+    /// Last pointer position from a motion event, used to highlight the
+    /// hovered row in list panes and selector modals.
+    pub(crate) mouse_hover: Option<(u16, u16)>,
     /// Cached text extracted from the frame buffer for the current selection.
     selected_text_cache: Option<String>,
     /// Persistent clipboard handle to avoid "dropped too quickly" warnings on Linux.
@@ -624,6 +667,8 @@ impl App {
             text_selection: None,
             scrollbar_hits: Vec::new(),
             dragging_scrollbar: None,
+            click_targets: Vec::new(),
+            mouse_hover: None,
             selected_text_cache: None,
             clipboard: arboard::Clipboard::new().ok(),
             session_list_state: ratatui::widgets::ListState::default(),
@@ -1327,6 +1372,22 @@ impl App {
     }
 
     pub fn update(&mut self, msg: AppMessage) {
+        // `[features] mouse = false`: capture is never enabled, so mouse
+        // events shouldn't arrive — drop any that do (defense in depth, and
+        // it makes the flag authoritative in tests).
+        if !self.features.mouse
+            && matches!(
+                msg,
+                AppMessage::MouseScrollUp { .. }
+                    | AppMessage::MouseScrollDown { .. }
+                    | AppMessage::MouseClick { .. }
+                    | AppMessage::MouseDrag { .. }
+                    | AppMessage::MouseUp { .. }
+                    | AppMessage::MouseMove { .. }
+            )
+        {
+            return;
+        }
         match msg {
             AppMessage::KeyPress(code, mods) => self.handle_key(code, mods),
             AppMessage::Paste(text) => self.handle_paste(text),
@@ -1335,6 +1396,7 @@ impl App {
             AppMessage::MouseClick { x, y, modifiers } => self.handle_mouse_click(x, y, modifiers),
             AppMessage::MouseDrag { x, y } => self.handle_mouse_drag(x, y),
             AppMessage::MouseUp { x, y } => self.handle_mouse_up(x, y),
+            AppMessage::MouseMove { x, y } => self.mouse_hover = Some((x, y)),
             AppMessage::Resize(cols, rows) => self.handle_resize(cols, rows),
             AppMessage::ExternalStateChange(delta) => self.handle_external_state_change(delta),
         }
@@ -1433,6 +1495,14 @@ impl App {
     fn handle_mouse_click(&mut self, x: u16, y: u16, modifiers: KeyModifiers) {
         use crate::ui::links;
 
+        // A modal captures every click: a hit on one of its rows acts on it,
+        // anything else is swallowed — clicks never reach the scrollbars,
+        // panes, or selection beneath an overlay.
+        if !matches!(self.modal, modals::Modal::None) {
+            self.handle_modal_click(x, y);
+            return;
+        }
+
         let areas = self.screen_layout();
         let border_block = Block::default().borders(Borders::ALL);
 
@@ -1457,18 +1527,34 @@ impl App {
 
         // Grab a scrollbar thumb: a click on any rendered track starts a drag of
         // that pane's scroll state (and never starts a text selection).
-        if let Some(hit) = self.scrollbar_hits.iter().find(|h| h.geom.contains(x, y)) {
-            let target = hit.target;
-            let pos = hit.geom.position_for_y(y);
-            let content_len = hit.geom.content_len;
-            self.text_selection = None;
-            self.dragging_scrollbar = Some(target);
-            self.apply_scrollbar_position(target, pos, content_len);
+        if self.try_grab_scrollbar(x, y, None) {
             return;
         }
 
-        // Find which pane was clicked; use inner area (excluding borders).
+        // While the global-search strip is open it owns all input (it is
+        // entered/left only via its keybinding / Esc / Enter), so plain
+        // clicks are swallowed rather than stealing focus from it.
+        if self.global_search.active {
+            return;
+        }
+
+        // Row / pane targets recorded by the last view() (first match wins:
+        // rows are recorded before their pane's whole-rect fallback). A
+        // consumed click stops here; session-list and terminal clicks fall
+        // through so the same press still arms text selection.
         let pos = Position::new(x, y);
+        if let Some(action) = self
+            .click_targets
+            .iter()
+            .find(|t| t.rect.contains(pos))
+            .map(|t| t.action)
+        {
+            if self.activate_click_target(action) {
+                return;
+            }
+        }
+
+        // Find which pane was clicked; use inner area (excluding borders).
         let pane_rects = [Some(areas.terminal), areas.left_panel, areas.info_panel];
         let pane_inner = pane_rects
             .into_iter()
@@ -1487,6 +1573,178 @@ impl App {
             col: x as usize,
         };
         self.text_selection = Some(Selection::new(anchor, pane));
+    }
+
+    /// Route a click while a modal is open: a hit on a recorded row selects
+    /// it and immediately activates it with the row's primary key (replayed
+    /// through the modal's own key handler so side effects match the keyboard
+    /// path). Every other click — inside or outside the overlay — is
+    /// swallowed, so a stray click can never discard typed input or fall
+    /// through to the panes beneath.
+    fn handle_modal_click(&mut self, x: u16, y: u16) {
+        // The F1 editor consumes the next *keypress* while capturing; clicks
+        // are ignored so they can't be mistaken for a chord.
+        if self.help_is_capturing() {
+            return;
+        }
+        // The modal's own scrollbar is grabbable (recorded under
+        // `ScrollTarget::Modal`); the pane scrollbars beneath the overlay are
+        // not.
+        if self.try_grab_scrollbar(x, y, Some(ScrollTarget::Modal)) {
+            return;
+        }
+
+        // Only `ModalRow` targets count here: the registry also holds the
+        // pane targets recorded beneath the overlay (panes render first), and
+        // a plain first-match lookup would hit those instead and swallow the
+        // click.
+        let pos = Position::new(x, y);
+        let Some(row) = self.click_targets.iter().find_map(|t| match t.action {
+            ClickAction::ModalRow(row) if t.rect.contains(pos) => Some(row),
+            _ => None,
+        }) else {
+            return;
+        };
+        let Some(confirm) = self.select_modal_row(row) else {
+            return;
+        };
+        if matches!(self.modal, modals::Modal::Help(_)) {
+            self.handle_help_key(confirm, KeyModifiers::NONE);
+        } else {
+            self.handle_modal_key_if_open(confirm, KeyModifiers::NONE);
+        }
+    }
+
+    /// Move the open modal's selection to `row` (a row index recorded by this
+    /// frame's renderer, so it is always in bounds) and return the key that
+    /// activates a row there: `Enter` for the selectors and the F1 editor,
+    /// `Space` for the repo picker — where a row's action is toggle/fold and
+    /// `Enter` would confirm the whole modal on a misclick.
+    fn select_modal_row(&mut self, row: usize) -> Option<KeyCode> {
+        match &mut self.modal {
+            modals::Modal::Help(h) => {
+                h.selected = row;
+                Some(KeyCode::Enter)
+            }
+            modals::Modal::ThemePicker(tp) => {
+                tp.index = row;
+                Some(KeyCode::Enter)
+            }
+            modals::Modal::AgentPicker(ap) => {
+                ap.selected_index = row;
+                Some(KeyCode::Enter)
+            }
+            modals::Modal::HostPicker(hp) => {
+                hp.selected_index = row;
+                Some(KeyCode::Enter)
+            }
+            modals::Modal::BranchSelector(bs) => {
+                bs.index = row;
+                Some(KeyCode::Enter)
+            }
+            modals::Modal::TaskActionPicker(p) => {
+                p.selected = row;
+                Some(KeyCode::Enter)
+            }
+            modals::Modal::AutomationsList(al) => {
+                al.index = row;
+                Some(KeyCode::Enter)
+            }
+            modals::Modal::RestoreSessions(rs) => {
+                rs.index = row;
+                Some(KeyCode::Enter)
+            }
+            modals::Modal::RepoPicker(rp) => {
+                rp.focus = modals::RepoPickerFocus::List;
+                rp.list_index = row;
+                Some(KeyCode::Char(' '))
+            }
+            _ => None,
+        }
+    }
+
+    /// Act on a clicked target. Returns `true` when the click is fully
+    /// consumed; `false` lets the caller continue to text-selection arming
+    /// (terminal / session-list / info panes keep their drag-select).
+    fn activate_click_target(&mut self, action: ClickAction) -> bool {
+        match action {
+            ClickAction::SelectSession(display_idx) => {
+                if let Some(&idx) = self.render_order_indices().get(display_idx) {
+                    self.active_index = idx;
+                }
+                self.focus = InputFocus::SessionList;
+                self.on_focus_changed();
+                false
+            }
+            ClickAction::SelectTask(i) => {
+                self.focus = InputFocus::TaskList;
+                let len = self.task_ui.filtered_task_indices.len();
+                if len > 0 {
+                    self.task_ui.task_panel_index = i.min(len - 1);
+                }
+                // Same bookkeeping as entering the panel via the focus cycle
+                // (refresh list + in-pane preview). Leaving an in-pane editor
+                // this way discards unsaved edits, exactly like Esc/Ctrl+H.
+                self.on_focus_changed();
+                true
+            }
+            ClickAction::SelectAutomation(i) => {
+                self.focus = InputFocus::Automations;
+                let len = self.automation_ui.cached_automations.len();
+                if len > 0 {
+                    self.automation_ui.automation_panel_index = i.min(len - 1);
+                }
+                self.refresh_automation_view();
+                true
+            }
+            ClickAction::SelectFileRow(i) => {
+                self.focus = InputFocus::FileViewer;
+                self.file_viewer.select_index(i);
+                // Single click activates, like Enter: toggle a directory,
+                // open a file in the editor.
+                self.file_viewer_expand();
+                true
+            }
+            ClickAction::FocusPane(focus) => {
+                let changed = self.focus != focus;
+                self.focus = focus;
+                if changed {
+                    self.on_focus_changed();
+                }
+                // Terminal and session-list clicks keep arming drag-select.
+                !matches!(focus, InputFocus::Terminal | InputFocus::SessionList)
+            }
+            // Modal rows are dispatched by `handle_modal_click` before pane
+            // targets are even considered.
+            ClickAction::ModalRow(_) => true,
+        }
+    }
+
+    /// Whether the F1 editor is mid chord-capture — any key (including a
+    /// synthesized one) would become the new binding, so mouse handlers must
+    /// stay silent.
+    fn help_is_capturing(&self) -> bool {
+        matches!(self.modal, modals::Modal::Help(ref h) if h.capturing)
+    }
+
+    /// Grab the scrollbar track under the cursor and start dragging it.
+    /// `only` restricts which target may be grabbed: modals grab only their
+    /// own bar, panes grab any. Returns whether a track was hit.
+    fn try_grab_scrollbar(&mut self, x: u16, y: u16, only: Option<ScrollTarget>) -> bool {
+        let Some(hit) = self
+            .scrollbar_hits
+            .iter()
+            .find(|h| only.map_or(true, |t| h.target == t) && h.geom.contains(x, y))
+        else {
+            return false;
+        };
+        let target = hit.target;
+        let pos = hit.geom.position_for_y(y);
+        let content_len = hit.geom.content_len;
+        self.text_selection = None;
+        self.dragging_scrollbar = Some(target);
+        self.apply_scrollbar_position(target, pos, content_len);
+        true
     }
 
     fn handle_mouse_drag(&mut self, x: u16, y: u16) {
@@ -1558,6 +1816,66 @@ impl App {
                     .saturating_sub(1);
                 self.automation_ui.automation_run_index = pos.min(max);
             }
+            ScrollTarget::Modal => self.step_modal_selection_to(pos),
+        }
+    }
+
+    /// Move the open modal's selection to `target` by replaying Up/Down
+    /// through its own key handler — keeps each modal's clamping and side
+    /// effects (e.g. the theme picker's live preview) identical to keyboard
+    /// navigation. Stops as soon as a step no longer makes progress.
+    fn step_modal_selection_to(&mut self, target: usize) {
+        // While the F1 editor is capturing, any key would be taken as the new
+        // chord — never synthesize navigation there.
+        if self.help_is_capturing() {
+            return;
+        }
+        // The repo picker routes keys by its internal focus; a scrollbar drag
+        // always means the list.
+        if let modals::Modal::RepoPicker(ref mut rp) = self.modal {
+            rp.focus = modals::RepoPickerFocus::List;
+        }
+        loop {
+            let Some(current) = self.modal_selected_index() else {
+                return;
+            };
+            if current == target {
+                return;
+            }
+            let key = if target > current {
+                KeyCode::Down
+            } else {
+                KeyCode::Up
+            };
+            self.synthesize_modal_nav(key);
+            if self.modal_selected_index() == Some(current) {
+                return; // clamped — can't get closer
+            }
+        }
+    }
+
+    /// Replay a navigation key through the open modal's key handler.
+    fn synthesize_modal_nav(&mut self, code: KeyCode) {
+        if matches!(self.modal, modals::Modal::Help(_)) {
+            self.handle_help_key(code, KeyModifiers::NONE);
+        } else {
+            self.handle_modal_key_if_open(code, KeyModifiers::NONE);
+        }
+    }
+
+    /// The open modal's current selection index, when it has a selectable list.
+    fn modal_selected_index(&self) -> Option<usize> {
+        match &self.modal {
+            modals::Modal::Help(h) => Some(h.selected),
+            modals::Modal::ThemePicker(tp) => Some(tp.index),
+            modals::Modal::AgentPicker(ap) => Some(ap.selected_index),
+            modals::Modal::HostPicker(hp) => Some(hp.selected_index),
+            modals::Modal::BranchSelector(bs) => Some(bs.index),
+            modals::Modal::TaskActionPicker(p) => Some(p.selected),
+            modals::Modal::AutomationsList(al) => Some(al.index),
+            modals::Modal::RestoreSessions(rs) => Some(rs.index),
+            modals::Modal::RepoPicker(rp) => Some(rp.list_index),
+            _ => None,
         }
     }
 
@@ -1565,6 +1883,16 @@ impl App {
     /// wheel scrolls the hovered pane (terminal, task preview, file viewer, run
     /// history, or a list pane) rather than always the terminal.
     fn handle_mouse_scroll(&mut self, x: u16, y: u16, up: bool) {
+        // An open modal owns the wheel: one selection step per tick (like
+        // j/k), never the panes beneath. Capture mode would treat the
+        // synthesized key as the new chord, so it stays untouched.
+        if !matches!(self.modal, modals::Modal::None) {
+            if !self.help_is_capturing() {
+                self.synthesize_modal_nav(if up { KeyCode::Up } else { KeyCode::Down });
+            }
+            return;
+        }
+
         let step: i32 = if up { -1 } else { 1 };
         match self.pane_at(x, y) {
             Some(ScrollPane::Terminal) | None => {
@@ -5820,6 +6148,7 @@ mod tests {
             global_search: false,
             info_panel: false,
             shell_pane: false,
+            mouse: true,
         };
 
         app.handle_key(KeyCode::F(5), KeyModifiers::NONE);
@@ -6388,6 +6717,385 @@ mod tests {
         app.handle_mouse_click(10, 10, KeyModifiers::NONE);
         assert!(app.dragging_scrollbar.is_none());
         assert!(app.text_selection.is_some());
+    }
+
+    // --- Mouse click targets (click-to-select/focus + modal rows) ---
+
+    #[test]
+    fn click_session_row_selects_and_focuses_list() {
+        let mut app = app_with_sessions(3);
+        app.focus = InputFocus::Terminal;
+        // As recorded by view(): a row hitbox inside the left panel.
+        app.click_targets.push(ClickTarget {
+            rect: Rect::new(1, 3, 20, 1),
+            action: ClickAction::SelectSession(2),
+        });
+
+        app.handle_mouse_click(5, 3, KeyModifiers::NONE);
+
+        let order = app.render_order_indices();
+        assert_eq!(app.active_index, order[2]);
+        assert_eq!(app.focus, InputFocus::SessionList);
+        // The same press still arms drag-select inside the left panel.
+        assert!(app.text_selection.is_some());
+    }
+
+    #[test]
+    fn click_terminal_pane_focuses_terminal_and_arms_selection() {
+        let mut app = app_with_sessions(1);
+        app.focus = InputFocus::SessionList;
+        let areas = app.screen_layout();
+        app.click_targets.push(ClickTarget {
+            rect: areas.terminal,
+            action: ClickAction::FocusPane(InputFocus::Terminal),
+        });
+        let cx = areas.terminal.x + areas.terminal.width / 2;
+        let cy = areas.terminal.y + areas.terminal.height / 2;
+
+        app.handle_mouse_click(cx, cy, KeyModifiers::NONE);
+
+        assert_eq!(app.focus, InputFocus::Terminal);
+        assert!(app.text_selection.is_some());
+    }
+
+    #[test]
+    fn click_with_modal_open_is_swallowed() {
+        let mut app = app_with_sessions(1);
+        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index: 0 });
+        // A scrollbar track and a pane target beneath the overlay must both
+        // be unreachable while the modal is open.
+        app.scrollbar_hits.push(ScrollbarHit {
+            geom: ScrollbarGeom {
+                track: Rect::new(40, 5, 1, 10),
+                content_len: 100,
+                viewport: 10,
+            },
+            target: ScrollTarget::Terminal,
+        });
+        app.click_targets.push(ClickTarget {
+            rect: Rect::new(0, 0, 120, 24),
+            action: ClickAction::FocusPane(InputFocus::Terminal),
+        });
+
+        app.handle_mouse_click(40, 7, KeyModifiers::NONE);
+
+        assert!(app.dragging_scrollbar.is_none());
+        assert!(app.text_selection.is_none());
+        assert!(matches!(app.modal, modals::Modal::ThemePicker(_)));
+    }
+
+    #[test]
+    fn click_theme_picker_row_confirms_theme() {
+        let mut app = app_with_sessions(1);
+        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index: 2 });
+        // As in a real frame: the pane targets beneath the overlay are
+        // recorded first and overlap the modal — the modal row must still
+        // win while a modal is open.
+        app.click_targets.push(ClickTarget {
+            rect: Rect::new(0, 0, 120, 24),
+            action: ClickAction::FocusPane(InputFocus::Terminal),
+        });
+        app.click_targets.push(ClickTarget {
+            rect: Rect::new(30, 8, 20, 1),
+            action: ClickAction::ModalRow(0),
+        });
+
+        // Single click selects the row and confirms it (Enter-equivalent).
+        app.handle_mouse_click(35, 8, KeyModifiers::NONE);
+
+        assert!(matches!(app.modal, modals::Modal::None));
+        assert_eq!(
+            app.active_theme.name,
+            crate::ui::theme::all_theme_entries()[0].name
+        );
+    }
+
+    #[test]
+    fn click_repo_picker_row_toggles_not_confirms() {
+        let mut app = app_with_sessions(0);
+        app.start_new_session(); // no hosts → opens the repo picker
+        let modals::Modal::RepoPicker(ref mut rp) = app.modal else {
+            panic!("expected repo picker");
+        };
+        // Seed two plain bookmarks (no headers/children).
+        rp.bookmarks = vec!["/tmp/a".into(), "/tmp/b".into()];
+        rp.selected = vec![false, false];
+        rp.worktree = vec![false, false];
+        rp.is_header = vec![false, false];
+        rp.is_child = vec![false, false];
+        rp.filtered_indices = vec![0, 1];
+        app.click_targets.push(ClickTarget {
+            rect: Rect::new(30, 9, 40, 1),
+            action: ClickAction::ModalRow(1),
+        });
+
+        app.handle_mouse_click(35, 9, KeyModifiers::NONE);
+
+        // The click toggled the row's checkbox (Space), not Enter: the
+        // modal stays open and nothing was spawned.
+        let modals::Modal::RepoPicker(ref rp) = app.modal else {
+            panic!("repo picker must stay open after a row click");
+        };
+        assert_eq!(rp.list_index, 1);
+        assert!(rp.selected[1]);
+    }
+
+    #[test]
+    fn help_capture_ignores_clicks() {
+        let mut app = app_with_sessions(1);
+        app.modal = modals::Modal::Help(modals::HelpModal {
+            selected: 0,
+            capturing: true,
+        });
+        app.click_targets.push(ClickTarget {
+            rect: Rect::new(30, 8, 20, 1),
+            action: ClickAction::ModalRow(3),
+        });
+
+        app.handle_mouse_click(35, 8, KeyModifiers::NONE);
+
+        // Still capturing, selection untouched.
+        let modals::Modal::Help(ref h) = app.modal else {
+            panic!("help must stay open");
+        };
+        assert!(h.capturing);
+        assert_eq!(h.selected, 0);
+    }
+
+    #[test]
+    fn click_while_global_search_open_is_swallowed() {
+        let mut app = app_with_sessions(1);
+        app.focus = InputFocus::SessionList;
+        app.handle_key(KeyCode::Char('a'), KeyModifiers::CONTROL);
+        assert!(app.global_search.active);
+        app.click_targets.push(ClickTarget {
+            rect: Rect::new(1, 3, 20, 1),
+            action: ClickAction::SelectSession(0),
+        });
+
+        app.handle_mouse_click(5, 3, KeyModifiers::NONE);
+
+        // The strip keeps focus; no selection armed, no target activated.
+        assert!(app.global_search.active);
+        assert_eq!(app.focus, InputFocus::GlobalSearch);
+        assert!(app.text_selection.is_none());
+    }
+
+    #[test]
+    fn view_records_session_row_click_targets() {
+        let mut app = app_with_sessions(2);
+        let backend = ratatui::backend::TestBackend::new(120, 30);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.view(f)).unwrap();
+
+        let rows: Vec<Rect> = app
+            .click_targets
+            .iter()
+            .filter_map(|t| match t.action {
+                ClickAction::SelectSession(_) => Some(t.rect),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(rows.len(), 2, "one hitbox per rendered session row");
+
+        // Click the second rendered row end-to-end through the registry.
+        let target = app
+            .click_targets
+            .iter()
+            .find(|t| t.action == ClickAction::SelectSession(1))
+            .map(|t| t.rect)
+            .unwrap();
+        app.handle_mouse_click(target.x, target.y, KeyModifiers::NONE);
+        let order = app.render_order_indices();
+        assert_eq!(app.active_index, order[1]);
+        assert_eq!(app.focus, InputFocus::SessionList);
+    }
+
+    #[test]
+    fn view_drawn_modal_row_click_confirms() {
+        // End-to-end through a real frame: the registry holds the pane
+        // targets *and* the theme-picker rows; clicking a rendered row must
+        // reach the modal, not the pane beneath it.
+        let mut app = app_with_sessions(1);
+        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index: 1 });
+        let backend = ratatui::backend::TestBackend::new(120, 30);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.view(f)).unwrap();
+
+        let row = app
+            .click_targets
+            .iter()
+            .find(|t| t.action == ClickAction::ModalRow(0))
+            .map(|t| t.rect)
+            .expect("theme picker rows must be recorded");
+        app.handle_mouse_click(row.x + 1, row.y, KeyModifiers::NONE);
+
+        assert!(matches!(app.modal, modals::Modal::None));
+        assert_eq!(
+            app.active_theme.name,
+            crate::ui::theme::all_theme_entries()[0].name
+        );
+    }
+
+    #[test]
+    fn mouse_move_updates_hover() {
+        let mut app = app_with_sessions(1);
+        app.update(AppMessage::MouseMove { x: 7, y: 9 });
+        assert_eq!(app.mouse_hover, Some((7, 9)));
+    }
+
+    /// `[features] mouse = false` drops every mouse message before dispatch.
+    #[test]
+    fn mouse_feature_flag_disables_all_mouse_handling() {
+        let mut app = app_with_sessions(2);
+        app.features.mouse = false;
+        app.click_targets.push(ClickTarget {
+            rect: Rect::new(1, 3, 20, 1),
+            action: ClickAction::SelectSession(1),
+        });
+
+        app.update(AppMessage::MouseMove { x: 5, y: 3 });
+        app.update(AppMessage::MouseClick {
+            x: 5,
+            y: 3,
+            modifiers: KeyModifiers::NONE,
+        });
+        app.update(AppMessage::MouseScrollUp { x: 5, y: 3 });
+
+        assert_eq!(app.mouse_hover, None);
+        assert_eq!(app.active_index, 0);
+        assert!(app.text_selection.is_none());
+        assert_eq!(app.focus, InputFocus::SessionList);
+    }
+
+    fn automations_list_modal(count: usize) -> modals::Modal {
+        modals::Modal::AutomationsList(modals::AutomationsListModal {
+            index: 0,
+            entries: (0..count)
+                .map(|i| modals::AutomationListEntry {
+                    id: i as i64,
+                    name: format!("auto-{i}"),
+                    summary: "daily".into(),
+                    enabled: true,
+                })
+                .collect(),
+        })
+    }
+
+    /// The wheel steps an open modal's selection (one row per tick, like j/k)
+    /// instead of scrolling the panes beneath.
+    #[test]
+    fn wheel_in_modal_steps_selection() {
+        let mut app = app_with_sessions(1);
+        app.modal = automations_list_modal(5);
+
+        app.handle_mouse_scroll(0, 0, false);
+        app.handle_mouse_scroll(0, 0, false);
+        let modals::Modal::AutomationsList(ref al) = app.modal else {
+            panic!("modal must stay open");
+        };
+        assert_eq!(al.index, 2);
+
+        app.handle_mouse_scroll(0, 0, true);
+        let modals::Modal::AutomationsList(ref al) = app.modal else {
+            panic!("modal must stay open");
+        };
+        assert_eq!(al.index, 1);
+    }
+
+    /// Clicking + dragging the modal's own scrollbar moves its selection;
+    /// the clamp guard stops at the list end.
+    #[test]
+    fn modal_scrollbar_drag_moves_selection() {
+        let mut app = app_with_sessions(1);
+        app.modal = automations_list_modal(20);
+        let track = Rect::new(70, 5, 1, 10);
+        app.scrollbar_hits.push(ScrollbarHit {
+            geom: ScrollbarGeom {
+                track,
+                content_len: 20,
+                viewport: 10,
+            },
+            target: ScrollTarget::Modal,
+        });
+
+        // Grab the bottom of the track → selection jumps to the last row.
+        app.handle_mouse_click(70, 14, KeyModifiers::NONE);
+        assert_eq!(app.dragging_scrollbar, Some(ScrollTarget::Modal));
+        let modals::Modal::AutomationsList(ref al) = app.modal else {
+            panic!("modal must stay open");
+        };
+        assert_eq!(al.index, 19);
+
+        // Drag back to the top.
+        app.handle_mouse_drag(70, 5);
+        let modals::Modal::AutomationsList(ref al) = app.modal else {
+            panic!("modal must stay open");
+        };
+        assert_eq!(al.index, 0);
+
+        app.handle_mouse_up(70, 5);
+        assert!(app.dragging_scrollbar.is_none());
+    }
+
+    /// While a modal is open, the wheel never reaches the panes beneath it.
+    #[test]
+    fn wheel_in_modal_does_not_scroll_panes() {
+        let mut app = app_with_sessions(2);
+        app.modal = automations_list_modal(2);
+        let before = app.active_index;
+        // Coordinates over the session list, which would normally switch
+        // sessions on wheel.
+        app.handle_mouse_scroll(2, 3, false);
+        assert_eq!(app.active_index, before);
+    }
+
+    /// While the F1 editor captures a chord, the wheel must not synthesize a
+    /// key (it would become the new binding).
+    #[test]
+    fn wheel_during_help_capture_is_ignored() {
+        let mut app = app_with_sessions(1);
+        app.modal = modals::Modal::Help(modals::HelpModal {
+            selected: 3,
+            capturing: true,
+        });
+        app.handle_mouse_scroll(0, 0, false);
+        let modals::Modal::Help(ref h) = app.modal else {
+            panic!("help must stay open");
+        };
+        assert!(h.capturing, "capture must survive a wheel tick");
+        assert_eq!(h.selected, 3);
+    }
+
+    /// The hovered clickable row is underlined in the rendered frame.
+    #[test]
+    fn hovered_session_row_is_underlined() {
+        let mut app = app_with_sessions(2);
+        let backend = ratatui::backend::TestBackend::new(120, 30);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        // First draw records the row hitboxes; hover over the first row and
+        // draw again so the highlight applies.
+        terminal.draw(|f| app.view(f)).unwrap();
+        let row = app
+            .click_targets
+            .iter()
+            .find(|t| matches!(t.action, ClickAction::SelectSession(0)))
+            .map(|t| t.rect)
+            .unwrap();
+        app.update(AppMessage::MouseMove { x: row.x, y: row.y });
+        terminal.draw(|f| app.view(f)).unwrap();
+
+        let buffer = terminal.backend().buffer();
+        assert!(
+            buffer[(row.x, row.y)]
+                .modifier
+                .contains(ratatui::style::Modifier::UNDERLINED),
+            "hovered row cell must be underlined"
+        );
+        // A cell outside any clickable row stays plain.
+        assert!(!buffer[(0, 0)]
+            .modifier
+            .contains(ratatui::style::Modifier::UNDERLINED));
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -5,7 +5,7 @@
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::Style,
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
     Frame,
@@ -21,14 +21,16 @@ use crate::ui::{
     terminal_view, theme_picker_modal, worktree_name_modal,
 };
 
-use super::{App, InputFocus, ScrollTarget, ScrollbarHit, TerminalView};
+use super::{App, ClickAction, ClickTarget, InputFocus, ScrollTarget, ScrollbarHit, TerminalView};
 use crate::ui::scrollbar::ScrollbarGeom;
 
 impl App {
     pub fn view(&mut self, frame: &mut Frame) {
-        // Rebuilt fresh each frame: every scrollbar drawn below records its
-        // geometry + drag target here for the mouse handlers to hit-test.
+        // Rebuilt fresh each frame: every scrollbar and clickable row drawn
+        // below records its geometry + target here for the mouse handlers to
+        // hit-test.
         self.scrollbar_hits.clear();
+        self.click_targets.clear();
 
         let areas = self.layout_for(frame.area());
 
@@ -55,7 +57,51 @@ impl App {
         self.render_footer(frame, areas.footer);
         self.render_modals(frame);
         self.repaint_theme_background(frame);
+        self.apply_hover_highlight(frame);
         self.apply_selection_highlight(frame);
+    }
+
+    /// Underline the clickable row under the mouse pointer (list panes and
+    /// selector-modal rows) so what a click would hit is visible before
+    /// clicking. Runs on the recorded click targets, after all rendering;
+    /// the selection highlight is applied later and wins on overlap.
+    fn apply_hover_highlight(&self, frame: &mut Frame) {
+        let Some((hx, hy)) = self.mouse_hover else {
+            return;
+        };
+        let modal_open = !matches!(self.modal, super::modals::Modal::None);
+        // While the global-search strip is open clicks are swallowed (it owns
+        // all input), so don't underline rows as if they were clickable.
+        if self.global_search.active && !modal_open {
+            return;
+        }
+        let pos = ratatui::layout::Position::new(hx, hy);
+        let hovered = self.click_targets.iter().find(|t| {
+            // While a modal is open, only its rows react — the pane targets
+            // recorded beneath the overlay are unreachable for clicks too.
+            (!modal_open || matches!(t.action, ClickAction::ModalRow(_)))
+                && matches!(
+                    t.action,
+                    ClickAction::SelectSession(_)
+                        | ClickAction::SelectTask(_)
+                        | ClickAction::SelectAutomation(_)
+                        | ClickAction::SelectFileRow(_)
+                        | ClickAction::ModalRow(_)
+                )
+                && t.rect.contains(pos)
+        });
+        let Some(target) = hovered else {
+            return;
+        };
+        let buf = frame.buffer_mut();
+        let rect = target.rect;
+        for y in rect.y..rect.y + rect.height {
+            for x in rect.x..rect.x + rect.width {
+                if let Some(cell) = buf.cell_mut(ratatui::layout::Position::new(x, y)) {
+                    cell.modifier |= Modifier::UNDERLINED;
+                }
+            }
+        }
     }
 
     /// Render the top status-bar header with the active-session/theme badge.
@@ -130,7 +176,7 @@ impl App {
         // A (global) search is active iff there's a query — non-matching rows dim.
         let session_search_active = global_query.is_some();
 
-        project_list::render_left_panel(
+        let rows = project_list::render_left_panel(
             frame,
             left_area,
             &mut project_list::LeftPanelState {
@@ -145,10 +191,16 @@ impl App {
                 depths: &ordered.depths,
             },
         );
+        self.record_row_clicks(
+            rows,
+            ClickAction::SelectSession,
+            left_area,
+            InputFocus::SessionList,
+        );
     }
 
     /// Render the automations pane beneath the session list (when present).
-    fn render_automations_pane(&self, frame: &mut Frame, auto_area: Option<Rect>) {
+    fn render_automations_pane(&mut self, frame: &mut Frame, auto_area: Option<Rect>) {
         let Some(auto_area) = auto_area else {
             return;
         };
@@ -185,7 +237,7 @@ impl App {
             .min(entries.len().saturating_sub(1));
         let preview_selected =
             self.global_search_preview_kind() == Some(crate::app::search::SearchKind::Automation);
-        automations_panel::render_automations_pane(
+        let rows = automations_panel::render_automations_pane(
             frame,
             auto_area,
             &automations_panel::AutomationsPaneState {
@@ -194,6 +246,12 @@ impl App {
                 focus,
                 preview_selected,
             },
+        );
+        self.record_row_clicks(
+            rows,
+            ClickAction::SelectAutomation,
+            auto_area,
+            InputFocus::Automations,
         );
     }
 
@@ -244,7 +302,7 @@ impl App {
     }
 
     /// Render the tasks panel column (when present).
-    fn render_tasks_panel(&self, frame: &mut Frame, area: Option<Rect>) {
+    fn render_tasks_panel(&mut self, frame: &mut Frame, area: Option<Rect>) {
         let Some(area) = area else {
             return;
         };
@@ -277,7 +335,7 @@ impl App {
         };
         let preview_selected =
             self.global_search_preview_kind() == Some(crate::app::search::SearchKind::Task);
-        tasks_panel::render_tasks_panel(
+        let rows = tasks_panel::render_tasks_panel(
             frame,
             area,
             &tasks_panel::TaskPaneState {
@@ -287,6 +345,7 @@ impl App {
                 preview_selected,
             },
         );
+        self.record_row_clicks(rows, ClickAction::SelectTask, area, InputFocus::TaskList);
     }
 
     /// Record a scrollbar drawn this frame as a drag target, if one was drawn.
@@ -294,6 +353,27 @@ impl App {
         if let Some(geom) = geom {
             self.scrollbar_hits.push(ScrollbarHit { geom, target });
         }
+    }
+
+    /// Record one clickable region drawn this frame. Recording order is
+    /// priority order (first hit wins), so push row targets before their
+    /// pane's whole-rect `FocusPane` fallback.
+    fn record_click(&mut self, rect: Rect, action: ClickAction) {
+        self.click_targets.push(ClickTarget { rect, action });
+    }
+
+    /// Record a row hitbox per entry plus the pane's whole-rect fallback.
+    fn record_row_clicks(
+        &mut self,
+        rows: Vec<crate::ui::RowHitbox>,
+        to_action: fn(usize) -> ClickAction,
+        pane: Rect,
+        pane_focus: InputFocus,
+    ) {
+        for row in rows {
+            self.record_click(row.rect, to_action(row.index));
+        }
+        self.record_click(pane, ClickAction::FocusPane(pane_focus));
     }
 
     /// Render the file viewer in the right column (when present).
@@ -312,8 +392,15 @@ impl App {
             InputFocus::FileViewer => crate::ui::FocusLevel::Focused,
             _ => crate::ui::FocusLevel::Inactive,
         };
-        let geom = file_viewer::render_file_viewer(frame, fv_area, &self.file_viewer, fv_focus);
+        let (geom, rows) =
+            file_viewer::render_file_viewer(frame, fv_area, &self.file_viewer, fv_focus);
         self.record_scrollbar(geom, ScrollTarget::FileViewer);
+        self.record_row_clicks(
+            rows,
+            ClickAction::SelectFileRow,
+            fv_area,
+            InputFocus::FileViewer,
+        );
     }
 
     /// Render the central pane. In the automations context (the pane or its
@@ -368,6 +455,11 @@ impl App {
             | InputFocus::FileViewer => crate::ui::FocusLevel::Active,
         };
         let is_shell_view = self.active_terminal_view() == TerminalView::Shell;
+
+        // A click anywhere in the central pane focuses the terminal (row
+        // targets in other panes were recorded first and win on overlap —
+        // there is none — and the scrollbar check runs before click targets).
+        self.record_click(terminal, ClickAction::FocusPane(InputFocus::Terminal));
 
         // Scope the immutable `session` borrow so it ends before the
         // `&mut self` record_scrollbar call below.
@@ -438,16 +530,22 @@ impl App {
         );
     }
 
-    /// Render any active modal overlay on top of everything else.
-    fn render_modals(&self, frame: &mut Frame) {
+    /// Render any active modal overlay on top of everything else. Selector
+    /// modals report their row hitboxes, recorded as `ModalRow` click
+    /// targets; text-input modals report none, so every click on them is
+    /// swallowed.
+    fn render_modals(&mut self, frame: &mut Frame) {
+        let mut modal_hits: crate::ui::SelectorHits = (Vec::new(), None);
+
         // Help overlay (rendered last, on top of everything)
         if let super::modals::Modal::Help(ref help) = self.modal {
-            render_help_overlay(frame, &self.keybindings, help);
+            modal_hits = render_help_overlay(frame, &self.keybindings, help);
         }
 
         // Task trigger-time action picker
         if let super::modals::Modal::TaskActionPicker(ref p) = self.modal {
-            crate::ui::task_action_picker_modal::render_task_action_picker_modal(frame, p);
+            modal_hits =
+                crate::ui::task_action_picker_modal::render_task_action_picker_modal(frame, p);
         }
 
         // Worktree name modal
@@ -476,7 +574,7 @@ impl App {
 
         // Branch selector modal
         if let super::modals::Modal::BranchSelector(ref bs) = self.modal {
-            branch_selector_modal::render_branch_selector_modal(
+            modal_hits = branch_selector_modal::render_branch_selector_modal(
                 frame,
                 &branch_selector_modal::BranchSelectorState {
                     branches: &bs.branches,
@@ -487,17 +585,17 @@ impl App {
 
         // Agent picker modal
         if let super::modals::Modal::AgentPicker(ref ap) = self.modal {
-            agent_picker_modal::render_agent_picker_modal(frame, ap);
+            modal_hits = agent_picker_modal::render_agent_picker_modal(frame, ap);
         }
 
         // Host picker modal
         if let super::modals::Modal::HostPicker(ref hp) = self.modal {
-            crate::ui::host_picker_modal::render_host_picker_modal(frame, hp);
+            modal_hits = crate::ui::host_picker_modal::render_host_picker_modal(frame, hp);
         }
 
         // Theme picker modal
         if let super::modals::Modal::ThemePicker(ref tp) = self.modal {
-            theme_picker_modal::render_theme_picker_modal(
+            modal_hits = theme_picker_modal::render_theme_picker_modal(
                 frame,
                 &theme_picker_modal::ThemePickerState {
                     entries: &crate::ui::theme::all_theme_entries(),
@@ -518,7 +616,7 @@ impl App {
                     has_worktrees: !d.worktrees.is_empty(),
                 })
                 .collect();
-            restore_sessions_modal::render_restore_sessions_modal(
+            modal_hits = restore_sessions_modal::render_restore_sessions_modal(
                 frame,
                 &restore_sessions_modal::RestoreSessionsModalState {
                     entries: &entries,
@@ -550,7 +648,7 @@ impl App {
                     enabled: e.enabled,
                 })
                 .collect();
-            automations_list_modal::render_automations_list_modal(
+            modal_hits = automations_list_modal::render_automations_list_modal(
                 frame,
                 &automations_list_modal::AutomationsListState {
                     entries: &entries,
@@ -561,7 +659,7 @@ impl App {
 
         // Repo picker modal
         if let super::modals::Modal::RepoPicker(ref rp) = self.modal {
-            crate::ui::repo_picker_modal::render_repo_picker_modal(
+            modal_hits = crate::ui::repo_picker_modal::render_repo_picker_modal(
                 frame,
                 &crate::ui::repo_picker_modal::RepoPickerState {
                     bookmarks: &rp.bookmarks,
@@ -583,6 +681,15 @@ impl App {
                 },
             );
         }
+
+        let (modal_rows, modal_geom) = modal_hits;
+        for row in modal_rows {
+            self.record_click(row.rect, ClickAction::ModalRow(row.index));
+        }
+        // The modal's own scrollbar: grabbable while the modal is open
+        // (pane scrollbars beneath the overlay are not — see
+        // `handle_modal_click`).
+        self.record_scrollbar(modal_geom, ScrollTarget::Modal);
     }
 
     /// Repaint cells that fell back to terminal-default colours with the
@@ -634,7 +741,11 @@ impl App {
     /// scoped automation (a preview while the list is focused, editable once the
     /// editor is focused), with the automation's run history beneath it. Shows a
     /// discoverability hint when there's nothing to edit.
-    fn render_automation_workspace(&self, frame: &mut Frame, area: Rect) -> Option<ScrollbarGeom> {
+    fn render_automation_workspace(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+    ) -> Option<ScrollbarGeom> {
         let editing = self.focus == InputFocus::AutomationEditor;
 
         let Some(m) = self.automation_ui.automation_editor.as_ref() else {
@@ -688,7 +799,19 @@ impl App {
             &automation_editor_modal::AutomationEditorState::from_modal(m, &preview, editing),
         );
 
+        // Clicks focus the in-pane editor / run-history panels. Direct field
+        // pushes (not `record_click`): `runs` above still borrows
+        // `self.automation_ui`, so no `&mut self` method can be called here.
+        self.click_targets.push(ClickTarget {
+            rect: editor_area,
+            action: ClickAction::FocusPane(InputFocus::AutomationEditor),
+        });
+
         if let Some(history_area) = history_area {
+            self.click_targets.push(ClickTarget {
+                rect: history_area,
+                action: ClickAction::FocusPane(InputFocus::AutomationRunHistory),
+            });
             let history_focus = if self.focus == InputFocus::AutomationRunHistory {
                 crate::ui::FocusLevel::Focused
             } else {
@@ -913,7 +1036,7 @@ fn render_help_overlay(
     frame: &mut Frame,
     keybindings: &KeyBindings,
     help: &super::modals::HelpModal,
-) {
+) -> crate::ui::SelectorHits {
     let area = centered_rect(60, 70, frame.area());
 
     let inner = crate::ui::render_modal_frame(frame, area, "Keybindings");
@@ -927,6 +1050,8 @@ fn render_help_overlay(
     // Line index of the selected action row, so the body can scroll to keep it
     // visible on short terminals.
     let mut selected_line = 0usize;
+    // (line index, action index) per rebindable row, for click hitboxes.
+    let mut action_rows: Vec<(usize, usize)> = Vec::new();
     for (title, actions) in crate::session::keybindings::help_sections() {
         help_lines.push(help_section(title));
         for action in actions {
@@ -939,6 +1064,7 @@ fn render_help_overlay(
             if selected {
                 selected_line = help_lines.len();
             }
+            action_rows.push((help_lines.len(), idx));
             help_lines.push(help_row(key, action.label(), selected));
             idx += 1;
         }
@@ -979,6 +1105,14 @@ fn render_help_overlay(
         "Terminal: scroll three lines",
     ));
     help_lines.push(help_line("Click+drag".into(), "Select text"));
+    help_lines.push(help_line(
+        "Click".into(),
+        "Select row / focus pane; pickers: confirm row",
+    ));
+    help_lines.push(help_line(
+        "Hover".into(),
+        "Underline the clickable row under the pointer",
+    ));
     help_lines.push(help_line(
         "*".into(),
         "Terminal: all other keys forwarded to session",
@@ -1023,6 +1157,33 @@ fn render_help_overlay(
         ))),
         footer,
     );
+
+    // Hitboxes for the rebindable action rows visible after scrolling;
+    // section headers and the fixed-keys reference are not clickable.
+    let total_actions = action_rows.len();
+    let hitboxes: Vec<crate::ui::RowHitbox> = action_rows
+        .into_iter()
+        .filter_map(|(line, idx)| {
+            let on_screen = line.checked_sub(scroll)?;
+            if on_screen >= body_h {
+                return None;
+            }
+            Some(crate::ui::RowHitbox {
+                rect: Rect::new(body.x, body.y + on_screen as u16, body.width, 1),
+                index: idx,
+            })
+        })
+        .collect();
+
+    // Scrollbar (action-index space, so a drag maps straight to a selection)
+    // when the body overflows the modal height.
+    let geom = if total > body_h {
+        let viewport = hitboxes.len().max(1);
+        crate::ui::scrollbar::render_into(frame, body, total_actions, viewport, help.selected)
+    } else {
+        None
+    };
+    (hitboxes, geom)
 }
 
 /// Format a slice of chords as the F1-help key column, e.g.

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,13 @@ async fn main() -> Result<()> {
     }
 
     let mut terminal = ratatui::init();
-    execute!(std::io::stdout(), EnableMouseCapture, EnableBracketedPaste)?;
+    // Mouse capture is opt-out (`[features] mouse = false` in settings.toml):
+    // without it the terminal keeps its native mouse behavior and no mouse
+    // events ever reach the app.
+    if thurbox::session::settings::global().features.mouse {
+        execute!(std::io::stdout(), EnableMouseCapture)?;
+    }
+    execute!(std::io::stdout(), EnableBracketedPaste)?;
     push_keyboard_enhancement();
     let size = terminal.size()?;
 
@@ -205,6 +211,10 @@ async fn run_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Res
                         y: m.row,
                     }),
                     MouseEventKind::Up(MouseButton::Left) => Some(AppMessage::MouseUp {
+                        x: m.column,
+                        y: m.row,
+                    }),
+                    MouseEventKind::Moved => Some(AppMessage::MouseMove {
                         x: m.column,
                         y: m.row,
                     }),

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -65,6 +65,12 @@ pub struct FeatureFlags {
     /// Per-session shell pane toggle (Ctrl+T).
     #[serde(default = "default_true")]
     pub shell_pane: bool,
+    /// Mouse support: terminal mouse capture plus all click/scroll/hover
+    /// handling (click-to-select, drag selection, Ctrl+Click URLs,
+    /// scrollbars). Disable to keep the terminal's native mouse behavior
+    /// (e.g. its own text selection).
+    #[serde(default = "default_true")]
+    pub mouse: bool,
 }
 
 fn default_true() -> bool {
@@ -80,6 +86,7 @@ impl Default for FeatureFlags {
             global_search: true,
             info_panel: true,
             shell_pane: true,
+            mouse: true,
         }
     }
 }
@@ -173,6 +180,14 @@ mod tests {
         assert!(s.features.global_search);
         assert!(s.features.info_panel);
         assert!(s.features.shell_pane);
+        assert!(s.features.mouse);
+    }
+
+    #[test]
+    fn mouse_feature_flag_parses() {
+        let s: Settings = toml::from_str("[features]\nmouse = false").unwrap();
+        assert!(!s.features.mouse);
+        assert!(s.features.tasks, "untouched flags stay enabled");
     }
 
     #[test]

--- a/src/ui/agent_picker_modal.rs
+++ b/src/ui/agent_picker_modal.rs
@@ -1,11 +1,13 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    widgets::{List, ListItem, Paragraph},
+    text::Line,
+    widgets::Paragraph,
     Frame,
 };
 
 use super::{
-    centered_fixed_height_rect, render_modal_frame, selector_list_item, selector_nav_footer,
+    centered_fixed_height_rect, render_modal_frame, render_selector_rows, selector_line,
+    selector_nav_footer,
 };
 
 /// One selectable agent row: display name + the CLI command it launches.
@@ -21,7 +23,10 @@ pub struct AgentPickerState {
     pub selected_index: usize,
 }
 
-pub fn render_agent_picker_modal(frame: &mut Frame, state: &AgentPickerState) {
+pub fn render_agent_picker_modal(
+    frame: &mut Frame,
+    state: &AgentPickerState,
+) -> super::SelectorHits {
     let height = (state.choices.len() as u16) + 3;
     let area = centered_fixed_height_rect(50, height, frame.area());
 
@@ -32,7 +37,7 @@ pub fn render_agent_picker_modal(frame: &mut Frame, state: &AgentPickerState) {
         .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(inner);
 
-    let items: Vec<ListItem<'_>> = state
+    let lines: Vec<Line<'_>> = state
         .choices
         .iter()
         .enumerate()
@@ -42,10 +47,10 @@ pub fn render_agent_picker_modal(frame: &mut Frame, state: &AgentPickerState) {
             } else {
                 format!("{}  ({})", c.name, c.command)
             };
-            selector_list_item(&label, i == state.selected_index)
+            selector_line(&label, i == state.selected_index)
         })
         .collect();
 
-    frame.render_widget(List::new(items), chunks[0]);
     frame.render_widget(Paragraph::new(selector_nav_footer()), chunks[1]);
+    render_selector_rows(frame, chunks[0], lines, state.selected_index)
 }

--- a/src/ui/automations_list_modal.rs
+++ b/src/ui/automations_list_modal.rs
@@ -20,7 +20,10 @@ pub struct AutomationsListState<'a> {
     pub selected_index: usize,
 }
 
-pub fn render_automations_list_modal(frame: &mut Frame, state: &AutomationsListState<'_>) {
+pub fn render_automations_list_modal(
+    frame: &mut Frame,
+    state: &AutomationsListState<'_>,
+) -> super::SelectorHits {
     let empty_footer = Line::from(vec![
         Span::styled("n", Theme::keybind()),
         Span::styled(" new  ", Theme::keybind_desc()),
@@ -36,7 +39,7 @@ pub fn render_automations_list_modal(frame: &mut Frame, state: &AutomationsListS
         Some("No automations — press n to create one"),
         Some(empty_footer),
     ) else {
-        return;
+        return (Vec::new(), None);
     };
 
     let inner_width = list_area.width as usize;
@@ -65,7 +68,7 @@ pub fn render_automations_list_modal(frame: &mut Frame, state: &AutomationsListS
         })
         .collect();
 
-    frame.render_widget(Paragraph::new(lines), list_area);
+    let hits = super::render_selector_rows(frame, list_area, lines, state.selected_index);
 
     let help = Line::from(vec![
         Span::styled("n", Theme::keybind()),
@@ -82,6 +85,7 @@ pub fn render_automations_list_modal(frame: &mut Frame, state: &AutomationsListS
         Span::styled(" close", Theme::keybind_desc()),
     ]);
     frame.render_widget(Paragraph::new(help), footer_area);
+    hits
 }
 
 fn truncate(s: &str, max: usize) -> String {

--- a/src/ui/automations_panel.rs
+++ b/src/ui/automations_panel.rs
@@ -35,7 +35,11 @@ pub struct AutomationsPaneState<'a> {
     pub preview_selected: bool,
 }
 
-pub fn render_automations_pane(frame: &mut Frame, area: Rect, state: &AutomationsPaneState<'_>) {
+pub fn render_automations_pane(
+    frame: &mut Frame,
+    area: Rect,
+    state: &AutomationsPaneState<'_>,
+) -> Vec<super::RowHitbox> {
     let border_color = match state.focus {
         FocusLevel::Focused => Theme::border_focused(),
         _ => Theme::border_unfocused(),
@@ -58,7 +62,7 @@ pub fn render_automations_pane(frame: &mut Frame, area: Rect, state: &Automation
             Style::default().fg(Theme::text_muted()),
         )));
         frame.render_widget(hint, inner);
-        return;
+        return Vec::new();
     }
 
     let width = inner.width as usize;
@@ -99,4 +103,5 @@ pub fn render_automations_pane(frame: &mut Frame, area: Rect, state: &Automation
         .collect();
 
     frame.render_widget(Paragraph::new(lines), inner);
+    super::single_line_row_hitboxes(inner, state.entries.len())
 }

--- a/src/ui/branch_selector_modal.rs
+++ b/src/ui/branch_selector_modal.rs
@@ -1,21 +1,24 @@
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout},
     text::{Line, Span},
-    widgets::{List, ListItem, ListState, Paragraph},
+    widgets::Paragraph,
     Frame,
 };
 
 use super::centered_fixed_height_rect;
-use super::project_list::render_scroll_indicators;
 use super::render_modal_frame;
 use super::theme::Theme;
+use super::{render_selector_rows, selector_line};
 
 pub struct BranchSelectorState<'a> {
     pub branches: &'a [String],
     pub selected_index: usize,
 }
 
-pub fn render_branch_selector_modal(frame: &mut Frame, state: &BranchSelectorState<'_>) {
+pub fn render_branch_selector_modal(
+    frame: &mut Frame,
+    state: &BranchSelectorState<'_>,
+) -> super::SelectorHits {
     let height = (state.branches.len().min(15) + 4) as u16;
     let area = centered_fixed_height_rect(50, height, frame.area());
 
@@ -29,34 +32,14 @@ pub fn render_branch_selector_modal(frame: &mut Frame, state: &BranchSelectorSta
         ])
         .split(inner);
 
-    let items: Vec<ListItem<'_>> = state
+    // Windowed around the selection with a scrollbar when more branches than
+    // fit (the modal caps at 15 visible).
+    let lines: Vec<Line<'_>> = state
         .branches
         .iter()
-        .map(|branch| {
-            ListItem::new(Line::from(Span::styled(
-                branch.as_str(),
-                Theme::normal_item(),
-            )))
-        })
+        .enumerate()
+        .map(|(i, branch)| selector_line(branch, i == state.selected_index))
         .collect();
-
-    let list = List::new(items)
-        .highlight_symbol("▸ ")
-        .highlight_style(Theme::selected_item());
-
-    let mut list_state = ListState::default();
-    list_state.select(Some(state.selected_index));
-    frame.render_stateful_widget(list, chunks[0], &mut list_state);
-
-    // Compute a block-like rect around the list area for scroll indicators.
-    // Expand by 1 on each side to cover the outer block's border lines.
-    let indicator_area = Rect::new(
-        chunks[0].x.saturating_sub(1),
-        chunks[0].y.saturating_sub(1),
-        chunks[0].width + 2,
-        chunks[0].height + 2,
-    );
-    render_scroll_indicators(frame, indicator_area, state.branches.len(), &list_state, 1);
 
     let footer = Line::from(vec![
         Span::styled("j/k", Theme::keybind()),
@@ -67,6 +50,7 @@ pub fn render_branch_selector_modal(frame: &mut Frame, state: &BranchSelectorSta
         Span::styled(" cancel", Theme::keybind_desc()),
     ]);
     frame.render_widget(Paragraph::new(footer), chunks[1]);
+    render_selector_rows(frame, chunks[0], lines, state.selected_index)
 }
 
 #[cfg(test)]

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -591,7 +591,7 @@ pub fn render_file_viewer(
     area: Rect,
     state: &FileViewerState,
     focus: FocusLevel,
-) -> Option<ScrollbarGeom> {
+) -> (Option<ScrollbarGeom>, Vec<super::RowHitbox>) {
     use ratatui::layout::{Constraint, Direction, Layout};
 
     let search_visible = state.search_active || !state.search_query.is_empty();
@@ -628,7 +628,7 @@ pub fn render_file_viewer(
     }
 
     if inner.height == 0 || inner.width == 0 {
-        return None;
+        return (None, Vec::new());
     }
 
     let list_area = inner;
@@ -639,13 +639,13 @@ pub fn render_file_viewer(
             Style::default().fg(Theme::text_muted()),
         )));
         frame.render_widget(p, list_area);
-        return None;
+        return (None, Vec::new());
     }
 
     let rows = state.flatten();
     let height = list_area.height as usize;
     if height == 0 {
-        return None;
+        return (None, Vec::new());
     }
 
     let query_lc = if state.search_active && !state.search_query.is_empty() {
@@ -666,7 +666,19 @@ pub fn render_file_viewer(
         .collect();
     frame.render_widget(Paragraph::new(lines), rows_area);
 
-    track.and_then(|track| scrollbar::render_into(frame, track, rows.len(), height, state.selected))
+    // One hitbox per visible tree row; `rows_area` already excludes the
+    // reserved scrollbar column, so row clicks never overlap the track.
+    let hitboxes = (start..end)
+        .enumerate()
+        .map(|(line, i)| super::RowHitbox {
+            rect: Rect::new(rows_area.x, rows_area.y + line as u16, rows_area.width, 1),
+            index: i,
+        })
+        .collect();
+
+    let geom = track
+        .and_then(|track| scrollbar::render_into(frame, track, rows.len(), height, state.selected));
+    (geom, hitboxes)
 }
 
 fn row_marker(row: &FlatRow) -> &'static str {

--- a/src/ui/host_picker_modal.rs
+++ b/src/ui/host_picker_modal.rs
@@ -1,11 +1,13 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    widgets::{List, ListItem, Paragraph},
+    text::Line,
+    widgets::Paragraph,
     Frame,
 };
 
 use super::{
-    centered_fixed_height_rect, render_modal_frame, selector_list_item, selector_nav_footer,
+    centered_fixed_height_rect, render_modal_frame, render_selector_rows, selector_line,
+    selector_nav_footer,
 };
 
 /// One selectable host row: display label + the backend name it maps to
@@ -24,7 +26,7 @@ pub struct HostPickerState {
     pub selected_index: usize,
 }
 
-pub fn render_host_picker_modal(frame: &mut Frame, state: &HostPickerState) {
+pub fn render_host_picker_modal(frame: &mut Frame, state: &HostPickerState) -> super::SelectorHits {
     let height = (state.choices.len() as u16) + 3;
     let area = centered_fixed_height_rect(50, height, frame.area());
 
@@ -35,13 +37,13 @@ pub fn render_host_picker_modal(frame: &mut Frame, state: &HostPickerState) {
         .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(inner);
 
-    let items: Vec<ListItem<'_>> = state
+    let lines: Vec<Line<'_>> = state
         .choices
         .iter()
         .enumerate()
-        .map(|(i, c)| selector_list_item(&c.label, i == state.selected_index))
+        .map(|(i, c)| selector_line(&c.label, i == state.selected_index))
         .collect();
 
-    frame.render_widget(List::new(items), chunks[0]);
     frame.render_widget(Paragraph::new(selector_nav_footer()), chunks[1]);
+    render_selector_rows(frame, chunks[0], lines, state.selected_index)
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -39,6 +39,65 @@ use ratatui::{
 use crate::session::SessionStatus;
 use theme::Theme;
 
+/// One clickable row rendered this frame: its rect (full row width) plus the
+/// row's index in whatever list the renderer drew. Pure geometry — the app
+/// layer decides what the index means (mirrors how `ScrollbarGeom` is wrapped
+/// into `ScrollTarget` hits).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RowHitbox {
+    pub rect: Rect,
+    pub index: usize,
+}
+
+/// Build one `RowHitbox` per single-line entry of a vertically packed list
+/// starting at `area`'s top row — the common shape for the tasks/automations
+/// panes and every selector modal. Rows that would fall below `area` are
+/// clipped.
+pub fn single_line_row_hitboxes(area: Rect, count: usize) -> Vec<RowHitbox> {
+    (0..count.min(area.height as usize))
+        .map(|i| RowHitbox {
+            rect: Rect::new(area.x, area.y + i as u16, area.width, 1),
+            index: i,
+        })
+        .collect()
+}
+
+/// Row hitboxes + optional scrollbar geometry returned by the selector-modal
+/// renderers (and the F1 help overlay).
+pub type SelectorHits = (Vec<RowHitbox>, Option<scrollbar::ScrollbarGeom>);
+
+/// Render a single-line-per-row selector list into `area`. When the entries
+/// overflow, the list windows around `selected` (like the file viewer) and a
+/// scrollbar is drawn in the reserved rightmost column. Returns the visible
+/// rows' hitboxes (indexed in entry space) plus the scrollbar geometry
+/// (`None` when everything fits).
+pub fn render_selector_rows(
+    frame: &mut Frame,
+    area: Rect,
+    lines: Vec<Line<'_>>,
+    selected: usize,
+) -> SelectorHits {
+    let total = lines.len();
+    let height = area.height as usize;
+    if total == 0 || height == 0 || area.width == 0 {
+        return (Vec::new(), None);
+    }
+    let selected = selected.min(total - 1);
+    let (rows_area, track) = scrollbar::reserve_track(area, total, height);
+    let (start, end) = file_viewer::visible_window(total, selected, height);
+    let visible: Vec<Line<'_>> = lines.into_iter().skip(start).take(end - start).collect();
+    frame.render_widget(Paragraph::new(visible), rows_area);
+    let hitboxes = (start..end)
+        .enumerate()
+        .map(|(line, i)| RowHitbox {
+            rect: Rect::new(rows_area.x, rows_area.y + line as u16, rows_area.width, 1),
+            index: i,
+        })
+        .collect();
+    let geom = track.and_then(|t| scrollbar::render_into(frame, t, total, height, selected));
+    (hitboxes, geom)
+}
+
 pub fn status_color(status: SessionStatus) -> Color {
     match status {
         SessionStatus::Busy => Theme::status_busy(),
@@ -336,16 +395,22 @@ pub fn selector_nav_footer() -> Line<'static> {
     ])
 }
 
-/// Build a selector list item with the standard "▸ " selected prefix and
+/// Build a selector row line with the standard "▸ " selected prefix and
 /// selected/normal theme styles.
-pub fn selector_list_item<'a>(label: &str, selected: bool) -> ratatui::widgets::ListItem<'a> {
+pub fn selector_line<'a>(label: &str, selected: bool) -> Line<'a> {
     let style = if selected {
         Theme::selected_item()
     } else {
         Theme::normal_item()
     };
     let prefix = if selected { "▸ " } else { "  " };
-    ratatui::widgets::ListItem::new(Line::from(Span::styled(format!("{prefix}{label}"), style)))
+    Line::from(Span::styled(format!("{prefix}{label}"), style))
+}
+
+/// Build a selector list item with the standard "▸ " selected prefix and
+/// selected/normal theme styles.
+pub fn selector_list_item<'a>(label: &str, selected: bool) -> ratatui::widgets::ListItem<'a> {
+    ratatui::widgets::ListItem::new(selector_line(label, selected))
 }
 
 /// Render a labeled text input field with cursor visualization and horizontal
@@ -574,6 +639,51 @@ mod tests {
 
     fn area(width: u16, height: u16) -> Rect {
         Rect::new(0, 0, width, height)
+    }
+
+    #[test]
+    fn single_line_row_hitboxes_clip_to_area() {
+        let rows = single_line_row_hitboxes(Rect::new(2, 5, 10, 3), 5);
+        assert_eq!(rows.len(), 3, "rows below the area are clipped");
+        assert_eq!(rows[0].rect, Rect::new(2, 5, 10, 1));
+        assert_eq!(rows[2].rect, Rect::new(2, 7, 10, 1));
+        assert_eq!(rows[2].index, 2);
+        assert!(single_line_row_hitboxes(Rect::new(0, 0, 10, 5), 0).is_empty());
+    }
+
+    #[test]
+    fn render_selector_rows_windows_overflow_with_scrollbar() {
+        let backend = ratatui::backend::TestBackend::new(40, 12);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = Rect::new(5, 2, 20, 4);
+
+                // Fits: all rows hit, full width, no scrollbar.
+                let lines: Vec<Line> = (0..3)
+                    .map(|i| selector_line(&format!("r{i}"), false))
+                    .collect();
+                let (rows, geom) = render_selector_rows(f, area, lines, 0);
+                assert_eq!(rows.len(), 3);
+                assert_eq!(rows[0].rect, Rect::new(5, 2, 20, 1));
+                assert!(geom.is_none());
+
+                // Overflows: windowed around the selection, scrollbar in the
+                // reserved rightmost column, indices in entry space.
+                let lines: Vec<Line> = (0..10)
+                    .map(|i| selector_line(&format!("r{i}"), i == 8))
+                    .collect();
+                let (rows, geom) = render_selector_rows(f, area, lines, 8);
+                assert_eq!(rows.len(), 4, "only the visible window is clickable");
+                assert!(rows.iter().any(|r| r.index == 8), "selection stays visible");
+                let geom = geom.expect("overflowing list draws a scrollbar");
+                assert_eq!(geom.track, Rect::new(24, 2, 1, 4));
+                assert!(
+                    rows.iter().all(|r| r.rect.width == 19),
+                    "rows exclude the track column"
+                );
+            })
+            .unwrap();
     }
 
     #[test]

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -419,7 +419,11 @@ pub struct LeftPanelState<'a> {
     pub depths: &'a [u8],
 }
 
-pub fn render_left_panel(frame: &mut Frame, area: Rect, state: &mut LeftPanelState<'_>) {
+pub fn render_left_panel(
+    frame: &mut Frame,
+    area: Rect,
+    state: &mut LeftPanelState<'_>,
+) -> Vec<super::RowHitbox> {
     // The session list fills the whole left panel — search lives in the global
     // `Ctrl+A` strip now, so there's no in-list search bar.
     render_session_section(
@@ -434,34 +438,13 @@ pub fn render_left_panel(frame: &mut Frame, area: Rect, state: &mut LeftPanelSta
         state.session_search_active,
         state.headers,
         state.depths,
-    );
+    )
 }
 
 /// Overlay scroll indicators ("^" N" / "v N") on the block borders when items
-/// are clipped above or below. Renders right-aligned on the top/bottom border
-/// lines, consuming no content space.
-pub(super) fn render_scroll_indicators(
-    frame: &mut Frame,
-    block_area: Rect,
-    total_items: usize,
-    list_state: &ListState,
-    item_height: u16,
-) {
-    let offset = list_state.offset();
-    // Inner height = block_area.height - 2 (top + bottom border)
-    let inner_height = block_area.height.saturating_sub(2);
-    let visible_count = inner_height
-        .checked_div(item_height)
-        .map(|n| n as usize)
-        .unwrap_or(0);
-
-    let items_above = offset;
-    let items_below = total_items.saturating_sub(offset + visible_count);
-
-    draw_scroll_indicators(frame, block_area, items_above, items_below);
-}
-
-/// Variable-height variant: uses per-item heights to compute the visible range.
+/// are clipped above or below, using per-item heights to compute the visible
+/// range. Renders right-aligned on the top/bottom border lines, consuming no
+/// content space.
 fn render_scroll_indicators_variable(
     frame: &mut Frame,
     block_area: Rect,
@@ -538,7 +521,7 @@ fn render_session_section(
     search_active: bool,
     headers: &[Option<String>],
     depths: &[u8],
-) {
+) -> Vec<super::RowHitbox> {
     let mut block = focus_block(" Sessions ", level);
 
     if !sessions.is_empty() {
@@ -556,7 +539,7 @@ fn render_session_section(
 
     if sessions.is_empty() {
         render_empty_sessions(frame, area, block);
-        return;
+        return Vec::new();
     }
 
     // Available width inside the block (subtract 2 for borders)
@@ -623,6 +606,32 @@ fn render_session_section(
     frame.render_stateful_widget(list, area, list_state);
 
     render_scroll_indicators_variable(frame, area, list_state, &item_heights);
+
+    // Hitboxes for the rows actually on screen, computed *after* the stateful
+    // render so `list_state.offset()` is the offset ratatui really used. A
+    // 2-line item (group header + session row) gets one hitbox spanning both
+    // lines, so clicking a group header selects that group's first session.
+    let inner = Rect::new(
+        area.x + 1,
+        area.y + 1,
+        area.width.saturating_sub(2),
+        area.height.saturating_sub(2),
+    );
+    let bottom = inner.y + inner.height;
+    let mut hitboxes = Vec::new();
+    let mut y = inner.y;
+    for (i, &h) in item_heights.iter().enumerate().skip(list_state.offset()) {
+        if y >= bottom || h == 0 {
+            break;
+        }
+        let height = h.min(bottom - y);
+        hitboxes.push(super::RowHitbox {
+            rect: Rect::new(inner.x, y, inner.width, height),
+            index: i,
+        });
+        y += h;
+    }
+    hitboxes
 }
 
 /// Render the centered "no sessions yet" placeholder inside the given block.
@@ -1050,6 +1059,44 @@ mod tests {
         let ordered = OrderedSessions::new(&sessions, &[None, None], 0);
         // Single "(no repo)" group: header on row 0, none after.
         assert_eq!(ordered.headers, vec![Some("(no repo)".to_string()), None]);
+    }
+
+    #[test]
+    fn session_section_hitboxes_span_group_headers() {
+        // Two sessions in one "(no repo)" group: the first item is 2 lines
+        // tall (header + row) and its hitbox spans both; the second is 1.
+        let n1 = info("n1");
+        let n2 = info("n2");
+        let backend = ratatui::backend::TestBackend::new(30, 12);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        let mut list_state = ListState::default();
+        let mut hitboxes = Vec::new();
+        terminal
+            .draw(|f| {
+                let sessions = vec![&n1, &n2];
+                let ordered = OrderedSessions::new(&sessions, &[None, None], 0);
+                hitboxes = render_left_panel(
+                    f,
+                    Rect::new(0, 0, 30, 12),
+                    &mut LeftPanelState {
+                        sessions: &ordered.sessions,
+                        active_session: ordered.active_index,
+                        show_selection: true,
+                        session_focus: FocusLevel::Focused,
+                        session_list_state: &mut list_state,
+                        session_match_positions: &ordered.match_positions,
+                        session_search_active: false,
+                        headers: &ordered.headers,
+                        depths: &ordered.depths,
+                    },
+                );
+            })
+            .unwrap();
+        assert_eq!(hitboxes.len(), 2);
+        assert_eq!(hitboxes[0].rect, Rect::new(1, 1, 28, 2));
+        assert_eq!(hitboxes[0].index, 0);
+        assert_eq!(hitboxes[1].rect, Rect::new(1, 3, 28, 1));
+        assert_eq!(hitboxes[1].index, 1);
     }
 
     #[test]

--- a/src/ui/repo_picker_modal.rs
+++ b/src/ui/repo_picker_modal.rs
@@ -35,7 +35,10 @@ pub struct RepoPickerState<'a> {
     pub filtered_indices: &'a [usize],
 }
 
-pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) {
+pub fn render_repo_picker_modal(
+    frame: &mut Frame,
+    state: &RepoPickerState<'_>,
+) -> super::SelectorHits {
     let visible_count = if state.filtered_indices.is_empty() {
         1
     } else {
@@ -78,7 +81,7 @@ pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) 
     }
 
     // Bookmark list with checkboxes
-    render_bookmark_list(frame, list_area, state);
+    let hitboxes = render_bookmark_list(frame, list_area, state);
 
     // Path input
     render_text_field_with_suggestion(
@@ -93,6 +96,7 @@ pub fn render_repo_picker_modal(frame: &mut Frame, state: &RepoPickerState<'_>) 
 
     // Footer
     frame.render_widget(Paragraph::new(footer_line(state)), footer_area);
+    hitboxes
 }
 
 /// Render the search bar at the top of the modal (only shown when search is active).
@@ -117,7 +121,7 @@ fn render_bookmark_list(
     frame: &mut Frame,
     list_area: ratatui::layout::Rect,
     state: &RepoPickerState<'_>,
-) {
+) -> super::SelectorHits {
     let list_focused = state.focus == RepoPickerFocus::List;
     let border_color = if list_focused {
         Theme::border_focused()
@@ -146,15 +150,19 @@ fn render_bookmark_list(
             Style::default().fg(Theme::text_muted()),
         )));
         frame.render_widget(placeholder, list_inner_area);
-        return;
+        return (Vec::new(), None);
     }
 
+    let total = state.filtered_indices.len();
     let visible_count = list_inner_area.height as usize;
     let scroll_offset = if state.list_index >= visible_count {
         state.list_index - visible_count + 1
     } else {
         0
     };
+
+    // Reserve the rightmost column for a scrollbar when the list overflows.
+    let (rows_area, track) = super::scrollbar::reserve_track(list_inner_area, total, visible_count);
 
     let items: Vec<ListItem<'_>> = state
         .filtered_indices
@@ -165,7 +173,27 @@ fn render_bookmark_list(
         .map(|(vi, &real_idx)| bookmark_item(state, vi, real_idx, list_focused))
         .collect();
 
-    frame.render_widget(List::new(items), list_inner_area);
+    frame.render_widget(List::new(items), rows_area);
+
+    // One hitbox per visible row, indexed by position in `filtered_indices`
+    // (the same space as `list_index`).
+    let hitboxes = (scroll_offset..total.min(scroll_offset + visible_count))
+        .enumerate()
+        .map(|(line, vi)| super::RowHitbox {
+            rect: ratatui::layout::Rect::new(
+                rows_area.x,
+                rows_area.y + line as u16,
+                rows_area.width,
+                1,
+            ),
+            index: vi,
+        })
+        .collect();
+
+    let geom = track.and_then(|t| {
+        super::scrollbar::render_into(frame, t, total, visible_count, state.list_index)
+    });
+    (hitboxes, geom)
 }
 
 /// Build a single bookmark list item (checkbox + path + optional `[wt]` marker).

--- a/src/ui/restore_sessions_modal.rs
+++ b/src/ui/restore_sessions_modal.rs
@@ -6,7 +6,6 @@ use ratatui::{
 };
 
 use super::render_list_modal_frame;
-use super::scrollbar;
 use super::theme::Theme;
 
 /// View-only entry for the restore sessions modal.
@@ -22,7 +21,10 @@ pub struct RestoreSessionsModalState<'a> {
     pub selected_index: usize,
 }
 
-pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsModalState<'_>) {
+pub fn render_restore_sessions_modal(
+    frame: &mut Frame,
+    state: &RestoreSessionsModalState<'_>,
+) -> super::SelectorHits {
     let empty_footer = Line::from(vec![
         Span::styled("Esc", Theme::keybind()),
         Span::raw(" close"),
@@ -36,24 +38,18 @@ pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsM
         Some("No deleted sessions"),
         Some(empty_footer),
     ) else {
-        return;
+        return (Vec::new(), None);
     };
 
-    // Session list — window the entries so the selected row stays visible,
-    // reserving the rightmost column for a scrollbar when the list overflows.
-    let height = list_area.height as usize;
-    let (rows_area, track) = scrollbar::reserve_track(list_area, state.entries.len(), height);
-    let (start, end) = super::file_viewer::visible_window(
-        state.entries.len(),
-        state.selected_index,
-        height.max(1),
-    );
-
-    let lines: Vec<Line<'_>> = state.entries[start..end]
+    // Session list — `render_selector_rows` windows the entries around the
+    // selection and reserves the rightmost column for a scrollbar when the
+    // list overflows.
+    let lines: Vec<Line<'_>> = state
+        .entries
         .iter()
         .enumerate()
-        .map(|(offset, entry)| {
-            let selected = start + offset == state.selected_index;
+        .map(|(i, entry)| {
+            let selected = i == state.selected_index;
             let wt_indicator = if entry.has_worktrees { " [wt]" } else { "" };
             let text = format!(
                 " {} ({}) {}{} ",
@@ -70,17 +66,7 @@ pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsM
         })
         .collect();
 
-    frame.render_widget(Paragraph::new(lines), rows_area);
-
-    if let Some(track) = track {
-        scrollbar::render_into(
-            frame,
-            track,
-            state.entries.len(),
-            height,
-            state.selected_index,
-        );
-    }
+    let hits = super::render_selector_rows(frame, list_area, lines, state.selected_index);
 
     // Footer
     let help = Line::from(vec![
@@ -90,6 +76,7 @@ pub fn render_restore_sessions_modal(frame: &mut Frame, state: &RestoreSessionsM
         Span::raw(" close"),
     ]);
     frame.render_widget(Paragraph::new(help), footer_area);
+    hits
 }
 
 #[cfg(test)]
@@ -144,6 +131,32 @@ mod tests {
         assert!(
             !text.contains("session-0 "),
             "first entry should have scrolled out of view:\n{text}"
+        );
+    }
+
+    #[test]
+    fn overflowing_list_reports_windowed_hitboxes_and_scrollbar() {
+        let list = entries(40);
+        let backend = ratatui::backend::TestBackend::new(80, 24);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        let mut hits: super::super::SelectorHits = (Vec::new(), None);
+        terminal
+            .draw(|frame| {
+                hits = render_restore_sessions_modal(
+                    frame,
+                    &RestoreSessionsModalState {
+                        entries: &list,
+                        selected_index: 39,
+                    },
+                );
+            })
+            .unwrap();
+        let (rows, geom) = hits;
+        assert!(geom.is_some(), "overflowing list draws a scrollbar");
+        assert!(rows.len() < 40, "only the visible window is clickable");
+        assert!(
+            rows.iter().any(|r| r.index == 39),
+            "the selected row stays clickable"
         );
     }
 

--- a/src/ui/task_action_picker_modal.rs
+++ b/src/ui/task_action_picker_modal.rs
@@ -8,17 +8,20 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::Style,
     text::{Line, Span},
-    widgets::{List, ListItem, Paragraph},
+    widgets::Paragraph,
     Frame,
 };
 
 use super::{
-    centered_fixed_height_rect, render_modal_frame, selector_list_item, selector_nav_footer,
-    theme::Theme, truncate_ellipsis,
+    centered_fixed_height_rect, render_modal_frame, render_selector_rows, selector_line,
+    selector_nav_footer, theme::Theme, truncate_ellipsis,
 };
 use crate::app::modals::TaskActionPickerModal;
 
-pub fn render_task_action_picker_modal(frame: &mut Frame, state: &TaskActionPickerModal) {
+pub fn render_task_action_picker_modal(
+    frame: &mut Frame,
+    state: &TaskActionPickerModal,
+) -> super::SelectorHits {
     let height = (state.choices.len() as u16).max(2) + 6;
     let area = centered_fixed_height_rect(60, height, frame.area());
     let inner = render_modal_frame(frame, area, "Run task");
@@ -44,13 +47,13 @@ pub fn render_task_action_picker_modal(frame: &mut Frame, state: &TaskActionPick
         chunks[0],
     );
 
-    let items: Vec<ListItem<'_>> = state
+    let lines: Vec<Line<'_>> = state
         .choices
         .iter()
         .enumerate()
-        .map(|(i, choice)| selector_list_item(&choice.label(), i == state.selected))
+        .map(|(i, choice)| selector_line(&choice.label(), i == state.selected))
         .collect();
-    frame.render_widget(List::new(items), chunks[1]);
 
     frame.render_widget(Paragraph::new(selector_nav_footer()), chunks[2]);
+    render_selector_rows(frame, chunks[1], lines, state.selected)
 }

--- a/src/ui/tasks_panel.rs
+++ b/src/ui/tasks_panel.rs
@@ -44,7 +44,11 @@ pub struct TaskPaneState<'a> {
     pub preview_selected: bool,
 }
 
-pub fn render_tasks_panel(frame: &mut Frame, area: Rect, state: &TaskPaneState<'_>) {
+pub fn render_tasks_panel(
+    frame: &mut Frame,
+    area: Rect,
+    state: &TaskPaneState<'_>,
+) -> Vec<super::RowHitbox> {
     // Shared focus block: highlighted title + accent/rounded border when focused,
     // matching the session list and file viewer panes.
     let block = focus_block(" Tasks ", state.focus);
@@ -52,7 +56,7 @@ pub fn render_tasks_panel(frame: &mut Frame, area: Rect, state: &TaskPaneState<'
     frame.render_widget(block, area);
 
     if inner.height == 0 {
-        return;
+        return Vec::new();
     }
 
     // While focused, reserve the bottom row for a compact action footer that
@@ -73,6 +77,9 @@ pub fn render_tasks_panel(frame: &mut Frame, area: Rect, state: &TaskPaneState<'
     }
 
     render_task_list(frame, inner, state);
+    // One single-line hitbox per visible row (the hint footer, when present,
+    // was already subtracted from `inner`).
+    super::single_line_row_hitboxes(inner, state.entries.len())
 }
 
 fn render_task_list(frame: &mut Frame, area: Rect, state: &TaskPaneState<'_>) {
@@ -164,5 +171,61 @@ fn status_color(status: TaskStatus) -> ratatui::style::Color {
         TaskStatus::Todo => Theme::text_primary(),
         TaskStatus::InProgress => Theme::accent(),
         TaskStatus::Done => Theme::text_muted(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn entry(title: &str) -> TaskPaneEntry {
+        TaskPaneEntry {
+            title: title.into(),
+            status: TaskStatus::Todo,
+            match_positions: vec![],
+            dimmed: false,
+            linked: false,
+        }
+    }
+
+    fn hitboxes(focus: FocusLevel, count: usize) -> Vec<super::super::RowHitbox> {
+        let backend = TestBackend::new(20, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let entries: Vec<TaskPaneEntry> = (0..count).map(|i| entry(&format!("t{i}"))).collect();
+        let mut rows = Vec::new();
+        terminal
+            .draw(|f| {
+                rows = render_tasks_panel(
+                    f,
+                    Rect::new(0, 0, 20, 6),
+                    &TaskPaneState {
+                        entries: &entries,
+                        selected: 0,
+                        focus,
+                        preview_selected: false,
+                    },
+                );
+            })
+            .unwrap();
+        rows
+    }
+
+    #[test]
+    fn row_hitboxes_start_below_border() {
+        let rows = hitboxes(FocusLevel::Inactive, 2);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].rect, Rect::new(1, 1, 18, 1));
+        assert_eq!(rows[1].rect, Rect::new(1, 2, 18, 1));
+        assert_eq!(rows[1].index, 1);
+    }
+
+    #[test]
+    fn focused_panel_hitboxes_exclude_hint_footer() {
+        // 6 outer rows → 4 inner; while focused the bottom inner row is the
+        // action footer, so only 3 rows are clickable.
+        let rows = hitboxes(FocusLevel::Focused, 10);
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows.last().unwrap().rect.y, 3);
     }
 }

--- a/src/ui/theme_picker_modal.rs
+++ b/src/ui/theme_picker_modal.rs
@@ -8,13 +8,13 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::Style,
     text::{Line, Span},
-    widgets::{List, ListItem, Paragraph},
+    widgets::Paragraph,
     Frame,
 };
 
 use super::{
-    centered_fixed_height_rect, render_modal_frame, selector_list_item, selector_nav_footer,
-    theme::Theme,
+    centered_fixed_height_rect, render_modal_frame, render_selector_rows, selector_line,
+    selector_nav_footer, theme::Theme,
 };
 use crate::session::theme_config::ThemeEntry;
 
@@ -23,7 +23,10 @@ pub struct ThemePickerState<'a> {
     pub selected_index: usize,
 }
 
-pub fn render_theme_picker_modal(frame: &mut Frame, state: &ThemePickerState<'_>) {
+pub fn render_theme_picker_modal(
+    frame: &mut Frame,
+    state: &ThemePickerState<'_>,
+) -> super::SelectorHits {
     let height = (state.entries.len() as u16).max(4) + 6;
     let area = centered_fixed_height_rect(60, height, frame.area());
 
@@ -43,7 +46,7 @@ pub fn render_theme_picker_modal(frame: &mut Frame, state: &ThemePickerState<'_>
         .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
         .split(chunks[0]);
 
-    let items: Vec<ListItem<'_>> = state
+    let lines: Vec<Line<'_>> = state
         .entries
         .iter()
         .enumerate()
@@ -53,11 +56,11 @@ pub fn render_theme_picker_modal(frame: &mut Frame, state: &ThemePickerState<'_>
             } else {
                 entry.display_name.clone()
             };
-            selector_list_item(&label, i == state.selected_index)
+            selector_line(&label, i == state.selected_index)
         })
         .collect();
 
-    frame.render_widget(List::new(items), columns[0]);
+    let hits = render_selector_rows(frame, columns[0], lines, state.selected_index);
 
     if let Some(entry) = state.entries.get(state.selected_index) {
         let palette = &entry.palette;
@@ -102,4 +105,6 @@ pub fn render_theme_picker_modal(frame: &mut Frame, state: &ThemePickerState<'_>
     }
 
     frame.render_widget(Paragraph::new(selector_nav_footer()), chunks[2]);
+    // Rows live in the left column only; the swatch column isn't clickable.
+    hits
 }


### PR DESCRIPTION
## Summary

- Whole-TUI mouse navigation: clicking a row in the session list, tasks panel, automations pane, or file viewer selects it and focuses its pane; a single click confirms picker-modal rows (repo picker toggles); all other clicks on modals are swallowed.
- Modals are fully mouse compatible: the wheel steps an open modal's selection, and overflowing picker lists window around the selection with a draggable scrollbar; the hovered clickable row is underlined.
- Everything is gated by a new `[features] mouse` flag in settings.toml (default `true`) — disabled, mouse capture is never enabled and the terminal keeps native mouse behavior. Existing drag-select, Ctrl+Click URLs, and pane scrollbar drag are preserved.

## Test plan

- CI checks pass
- 30+ new unit/integration tests: click dispatch per pane, modal confirm/swallow/toggle, wheel + scrollbar-drag in modals, hover underline, flag gating, hitbox geometry (windowing, group headers, footer exclusion)