### PR TITLE
feat(cli): manage extensions with thurbox-cli (install + self-heal)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,8 +354,9 @@ send/capture), `automation` (alias `auto`:
 create/list/show/edit/remove/run/runs/tick), `task` (alias `todo`:
 create/list/show/edit/remove/run), `editor`, `config`
 (validate/show — strict-parses every config file / prints the
-effective resolved config; see `docs/CONFIG.md`). Pass
-`--pretty` for indented JSON.
+effective resolved config; see `docs/CONFIG.md`), `extension`
+(alias `ext`: install/uninstall/list/activate/deactivate/status — manage
+opt-in extensions; see below). Pass `--pretty` for indented JSON.
 
 `session delete <uuid>` **soft-deletes** by default — only the DB
 row is marked deleted (the TUI tears down the tmux window/worktree
@@ -569,8 +570,61 @@ curl-able `install.sh`.
   `flow` session monitors them via a `flow-tick` automation, and every
   reply ends with the single next thing to focus on. The behavior spec
   is `FLOW.md`, surfaced to whichever CLI runs it via context-file
-  symlinks (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `FLOW.md`). See
-  `extensions/flow/README.md`.
+  symlinks (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `FLOW.md`). Install with
+  `thurbox-cli extension install flow` (its `install.sh` is a thin shim
+  over that). See `extensions/flow/README.md`.
+
+### Extension manifests + self-heal (`thurbox-cli extension`)
+
+Extensions stay **data, not binary** (ADR-20): core thurbox knows a
+declarative **manifest format**, never a specific extension. Each
+extension ships an `extension.toml` (`session::ExtensionDef`, pure data in
+`session/extension_def.rs`; loaded by `agent::extension_config`). It has
+two halves: an **install** spec (`home`, `[[agents]]` to register in
+agents.toml, `[[files]]` payload, `[[symlinks]]`) and a **runtime** spec
+(`[[sessions]]` + `[[automations]]` to ensure/self-heal). The `{home}`
+token is substituted with the resolved home dir.
+
+`thurbox-cli extension install <name|url|dir> [--home <dir>] [--force]`
+(`session_ops::install_extension`) is the one-command installer: it
+resolves the source (`agent::extension_config::resolve_source` — a bare
+name → the official source `official_base()/<name>` over curl/wget,
+**pinned to the binary's release tag** (`main` for dev builds) so a
+fetched extension matches the binary; a path → a local dir), fetches + lays
+down the payload files (with `executable` / `if_absent` / `substitute`
+flags; paths are validated against traversal — no absolute/`..`), creates
+the symlinks, registers the agents (`ensure_agents_registered` appends to
+agents.toml, preserving existing entries), writes the home-resolved
+manifest to the discovery dir, and activates. A `substitute` file the user
+edited (its managed marker removed) is not clobbered on reinstall unless
+`--force`. `uninstall <name> [--purge]`
+(`session_ops::uninstall_extension`) reverses it: tear down session +
+automation, remove the extension's agents (`remove_agents_from_toml`,
+text-edit to preserve comments), delete the manifest, and with `--purge`
+delete the home dir. Flow's `install.sh` is now a thin shim over `install`.
+
+`thurbox-cli extension` (alias `ext`) — `install` / `uninstall <name>
+[--purge]` / `list` / `activate <name>` / `deactivate <name> [--force]
+[--purge]` / `status [<name>]` — wraps
+`session_ops::extensions`: `ensure_extension` idempotently (re)creates any
+missing declared resource (reusing `spawn_session_headless` +
+`db.create_automation`, matching by name so existing ones are reused);
+`activate_extension` also records the name in the SQLite `metadata`
+`active_extensions` JSON set; `deactivate_extension` tears the resources
+down and clears the set. The CLI layer arms the tmux automation heartbeat
+on activate so a `Send` automation actually fires headlessly.
+
+**Self-heal**: `session_ops::heal_active_extensions` re-ensures every
+active extension and is called at **TUI startup** (`main.rs`, before
+session restore so healed sessions are adopted normally) and at the top of
+the headless **`automation tick`** (`cli/automations.rs`, so healing works
+with the TUI closed via the heartbeat keeper). Consequence: while an
+extension is active, deleting its session/automation is a no-op — they're
+recreated (a startup status toast says so). `extension deactivate` is the
+real off-switch. Headless healing requires `[features] automations = true`
+(the heartbeat); with it off, healing happens only at TUI startup. The
+flow installer now delegates its bootstrap to `extension activate flow`
+(with an inline fallback for older thurbox).
 
 ## Global search (`Ctrl+A`)
 

--- a/README.md
+++ b/README.md
@@ -124,17 +124,23 @@ list:
   behavior is a plain context file (`FLOW.md`) surfaced to
   whichever CLI you pick via `CLAUDE.md`/`AGENTS.md`/`GEMINI.md`
   symlinks.
-- One-line install (idempotent):
+- One-command install (idempotent, self-healing):
 
   ```bash
-  curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/flow/install.sh | sh
+  thurbox-cli extension install flow
   ```
+
+  Uninstall just as easily with `thurbox-cli extension uninstall
+  flow` (add `--purge` to also delete `~/flow`).
 
 > **Note:** The flow extension is a brand-new, **experimental**
 > feature under active testing — expect its behavior, spec, and
-> installer to change between releases.
+> manifest to change between releases.
 
-See [`extensions/flow/README.md`](./extensions/flow/README.md).
+Flow is the reference **extension**: opt-in, agent-agnostic add-ons
+managed by `thurbox-cli extension install/uninstall/activate/
+deactivate`. See the [Extensions guide](https://thurbeen.github.io/thurbox/docs/extensions.html)
+and [`extensions/flow/README.md`](./extensions/flow/README.md).
 
 ### Global search
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -678,3 +678,41 @@ load-bearing contract.
 - *A separate repository* — the extension scripts against
   `thurbox-cli`'s JSON surface and should version and CI alongside
   it.
+
+## ADR-21: Declarative extension manifests + first-class lifecycle
+
+**Choice**: Extend ADR-20 by teaching the core a single declarative
+**manifest format** (`extension.toml`, `session::ExtensionDef`) and a
+first-class lifecycle on the public surface:
+`thurbox-cli extension install/uninstall/activate/deactivate/list/status`
+(`session_ops::*`, `agent::extension_config`). The manifest has an
+*install* half (`home`, `[[agents]]`, `[[files]]`, `[[symlinks]]`) and a
+*runtime* half (`[[sessions]]`, `[[automations]]`). `install` resolves a
+source (a bare name → the official repo pinned to the binary's release
+tag; a path; or an `http(s)://` base — fetched via `curl`/`wget`), lays
+down the payload, registers agents (append-only, comment-preserving),
+writes the home-resolved manifest to the discovery dir, and activates.
+Active extensions are recorded in SQLite `metadata` and **self-healed**
+(missing sessions/automations recreated) at TUI startup and on every
+`automation tick`. The core still knows the *format*, never a specific
+extension; flow's `install.sh` becomes a thin shim over the CLI.
+
+**Why**: ADR-20 left each extension to reimplement bootstrap in bespoke
+shell, and gave no way to recover from a half-removed extension. Folding
+the mechanics behind one data-driven command makes install reproducible
+and uninstall symmetric, and self-heal makes an active extension robust
+against accidental deletion — all while staying extension-neutral
+(reusing `spawn_session_headless`, `db.create_automation`, `AgentDef`).
+Pinning the fetch to the binary's release tag keeps a fetched extension
+in sync with the binary that reads it.
+
+**Rejected**:
+
+- *Embedding extension assets in the binary* (the option ADR-20
+  rejected) — still rejected; `install` fetches **data** at runtime, it
+  does not bake assets in, so the agent-neutral core is preserved.
+- *Adding an HTTP client dependency* — `curl`/`wget` shell-out matches
+  the existing installer and keeps the dependency tree small.
+- *Re-serializing `agents.toml` to add/remove agents* — would drop user
+  comments/formatting; the installer edits text (append on install,
+  block-removal by name on uninstall) instead.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,6 +19,7 @@ development checkout never touches your real setup.
 | `~/.config/thurbox/settings.toml` | TOML | you | startup | tuning knobs + feature flags |
 | `~/.config/thurbox/themes.toml` | TOML | you | startup | custom theme palettes |
 | `~/.config/thurbox/keybindings.json` | JSON | F1 editor (or you) | **live** (mtime poll) | key chord overrides |
+| `~/.config/thurbox/extensions/<name>.toml` | TOML | `thurbox-cli extension install` | startup + tick | extension manifests (self-healed resources) |
 | `~/.local/share/thurbox/thurbox.db` | SQLite | thurbox | live | sessions, automations, tasks, theme, editor command |
 | `~/.local/share/thurbox/thurbox.log` | text | thurbox | — | logs (incl. config warnings) |
 
@@ -181,6 +182,89 @@ Maps `Action` names to one or more chord strings:
 - Action names and defaults: see the table in CLAUDE.md / README, or
   `src/session/keybindings.rs`.
 
+## extensions/
+
+Each opt-in extension (see `extensions/<name>/`) is described by a single
+`extension.toml` manifest. `thurbox-cli extension install` writes the
+home-resolved copy to `~/.config/thurbox/extensions/<name>.toml` (thurbox
+never seeds this dir). The manifest has two halves — an **install** spec
+and a **runtime** spec:
+
+```toml
+name = "flow"
+description = "Focus-protecting triage agent"
+config_version = 1
+home = "~/flow"                 # install home; {home} is substituted everywhere
+
+# install spec ---------------------------------------------------------------
+[[agents]]                      # registered in agents.toml (existing kept)
+name = "flow"
+command = "claude"
+args = ["--model", "claude-haiku-4-5"]
+
+[[files]]                       # fetched from the source, written under home
+path = "FLOW.md"
+[[files]]
+path = "scripts/create-task.sh"
+executable = true               # chmod +x
+[[files]]
+path = "repos.md"
+if_absent = true                # seed once; never clobbered on reinstall
+[[files]]
+path = ".claude/settings.json"
+source = "claude-settings.json" # source path differs from dest
+substitute = true               # replace {home} in the content
+
+[[symlinks]]                    # never clobbers a real file at `link`
+link = "CLAUDE.md"
+target = "FLOW.md"
+
+# runtime spec (ensured on activate, self-healed if deleted) -----------------
+[[sessions]]
+name = "flow"
+agent = "flow"
+repo_path = "{home}"            # resolved to the absolute home at install
+
+[[automations]]
+name = "flow-tick"
+trigger = "cron:*/5 * * * *"    # same grammar as `automation create --trigger`
+session_ref = "flow"           # must match a [[sessions]] name above
+prompt = "tick"
+```
+
+Manage extensions with the CLI:
+
+```bash
+thurbox-cli extension install flow         # fetch + lay files + agents + activate
+thurbox-cli extension install ./extensions/flow   # from a local dir
+thurbox-cli extension install <url> --home ~/x    # from a URL, custom home
+thurbox-cli extension uninstall <name>     # reverse install (keep home dir)
+thurbox-cli extension uninstall <name> --purge    # also delete the home dir
+thurbox-cli extension list                 # installed + active/healthy state
+thurbox-cli extension activate <name>      # (re)create resources + mark active
+thurbox-cli extension deactivate <name>    # tear down + stop self-heal
+thurbox-cli extension deactivate <name> --force --purge  # also kill tmux + drop manifest
+thurbox-cli extension status [<name>]      # per-resource presence
+```
+
+A bare name installs from the official source
+(`raw.githubusercontent.com/Thurbeen/thurbox/<ref>/extensions/<name>`,
+fetched via curl/wget) — `<ref>` is the running binary's release tag
+(`main` for dev builds), so a fetched extension matches your binary. A
+path or `http(s)://` URL installs from there instead. Payload paths are
+validated against traversal (no absolute paths or `..`), and a
+`substitute` file you've edited isn't overwritten on reinstall (use
+`--force`). Payload files are fetched as **text** (specs/scripts/JSON),
+not binaries.
+
+While an extension is **active**, thurbox **self-heals** its declared
+resources: on TUI startup and on every `automation tick` it re-creates
+any session/automation that has been deleted. So deleting them by hand is
+a no-op (they come back); `extension deactivate` is the real off-switch.
+Self-heal while the TUI is closed depends on the automation heartbeat
+(`[features] automations = true`); with automations off, healing happens
+at the next TUI startup only.
+
 ## SQLite-backed settings
 
 Live in the `metadata` table and apply immediately (no restart):
@@ -189,6 +273,7 @@ Live in the `metadata` table and apply immediately (no restart):
 |-----|---------|---------|
 | `active_theme` | `Ctrl+Y` / `F4` picker | TUI palette (nine built-ins) |
 | `editor_command` | `thurbox-cli editor set "<cmd>"` | what `Ctrl+O` runs |
+| `active_extensions` | `thurbox-cli extension activate/deactivate` | JSON array of active extensions to self-heal |
 
 These are in the DB rather than a file because they are written
 concurrently by multiple thurbox processes (TUI, CLI, MCP) and picked

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -784,11 +784,15 @@ task status (workers self-mark done) with an orchestrate-style
 
 ### Install
 
-`extensions/flow/install.sh` (curl-able, idempotent, POSIX sh) sets up
-the flow home, appends missing agents.toml aliases (overridable via
-`FLOW_CMD`/`WORKER_CMD`/`WORKER_HEAVY_CMD` + `*_ARGS` env vars),
-creates the dedicated `flow` session and the `flow-tick` automation.
-See `extensions/flow/README.md`.
+Flow installs with the generic extension installer —
+`thurbox-cli extension install flow` — which reads flow's
+`extension.toml` manifest: it lays down the flow home, registers the
+agents.toml aliases, creates the dedicated `flow` session + `flow-tick`
+automation, and marks the extension active so they **self-heal** if
+deleted. `extension uninstall flow [--purge]` reverses it. The
+`extensions/flow/install.sh` curl one-liner is now a thin shim over the
+CLI. See the generic mechanism (manifest format, lifecycle commands,
+self-heal) in `docs/CONFIG.md` and `extensions/flow/README.md`.
 
 ---
 

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -26,25 +26,59 @@ surfaced to whatever CLI you pick via symlinks (`CLAUDE.md`, `AGENTS.md`,
 ## Install
 
 ```bash
+thurbox-cli extension install flow
+```
+
+That single command is the installer — it reads flow's
+[`extension.toml`](extension.toml) manifest and:
+
+1. sets up the flow home (`~/flow`, override with `--home`): `FLOW.md`
+   spec, helper scripts, context-file symlinks, claude permission
+   settings, and a `repos.md` routing table (edit it!);
+2. registers the `flow` / `flow-worker` / `flow-worker-heavy` entries in
+   `~/.config/thurbox/agents.toml` (defaults: claude on haiku for the
+   triager, opus / fable for workers — edit agents.toml to change the
+   CLI/model);
+3. writes the manifest to `~/.config/thurbox/extensions/flow.toml` and
+   activates it, creating the dedicated `flow` session and a `flow-tick`
+   automation (every 5 minutes) that keeps it monitoring workers even
+   while the TUI is closed.
+
+It's idempotent — re-run it any time to pull the latest spec/scripts,
+while leaving your own data (`repos.md`, edited agents) untouched.
+
+`install flow` fetches from the official source; you can also install
+from a local checkout or any URL:
+
+```bash
+thurbox-cli extension install ./extensions/flow        # local directory
+thurbox-cli extension install https://example.com/ext/flow   # custom source
+```
+
+A `curl … install.sh | sh` one-liner still works (it's now a thin shim
+that calls `thurbox-cli extension install`), needed only to bootstrap on
+a box where you'd rather pipe a script:
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/flow/install.sh | sh
 ```
 
-or from a checkout: `extensions/flow/install.sh`. The installer is
-idempotent **and self-updating** — re-run it any time to pull the latest
-`FLOW.md` spec, helper scripts, context-file symlinks, and claude
-permission settings (the files it owns), while leaving your own data
-(`repos.md`, `agents.toml` entries, the flow session, the `flow-tick`
-automation) untouched. It
+### Self-healing
 
-1. sets up the flow home (`~/flow`): `FLOW.md` spec, helper scripts,
-   context-file symlinks, and a `repos.md` routing table (edit it!);
-2. adds the `flow` / `flow-worker` / `flow-worker-heavy` entries to
-   `~/.config/thurbox/agents.toml` (defaults: claude on haiku for the
-   triager, opus / fable for workers — override with `FLOW_CMD`,
-   `WORKER_CMD`, `WORKER_HEAVY_CMD` + matching `*_ARGS` env vars);
-3. creates the dedicated `flow` session and a `flow-tick` automation
-   (every 5 minutes by default, `TICK_CRON` to change) that keeps it
-   monitoring workers even while the TUI is closed.
+The flow session and `flow-tick` automation are **managed**: thurbox
+re-creates them automatically if they're ever deleted (on TUI startup and
+on every automation tick), so flow can't be half-removed by accident.
+Deleting the flow session/automation by hand is therefore a no-op — they
+come back. To turn flow off for good, run:
+
+```bash
+thurbox-cli extension deactivate flow         # tear down + stop self-heal
+thurbox-cli extension deactivate flow --purge # also remove the manifest
+```
+
+Re-enable any time with `thurbox-cli extension activate flow` (no full
+reinstall needed). `thurbox-cli extension list` shows whether flow is
+active and healthy.
 
 ## Use
 
@@ -61,18 +95,31 @@ automation) untouched. It
 
 | Path | Purpose |
 |------|---------|
+| `extension.toml` | Manifest: agents, payload files, symlinks, session + automation (the installer) |
 | `FLOW.md` | The agent behavior spec (modes, dispatch rules, output contract) |
+| `claude-settings.json` | Permission template (`{home}`-substituted into `.claude/settings.json`) |
+| `repos.md` | Routing-table seed (installed once, then user-owned) |
 | `scripts/create-task.sh` | Atomic task create + dispatch |
 | `scripts/flow-snapshot.sh` | One-call backlog + sessions view |
 | `scripts/parse-result.sh` | Extract the worker `===RESULT===` sentinel |
-| `install.sh` | Idempotent, self-updating installer/bootstrapper |
+| `install.sh` | Thin shim → `thurbox-cli extension install` (curl\|sh bootstrap) |
 
 ## Uninstall
 
+`uninstall` reverses `install` — it tears down the session + automation,
+removes the `flow*` agents from `agents.toml`, and deletes the manifest:
+
 ```bash
-thurbox-cli automation list | jq -r '.[] | select(.name=="flow-tick") | .id' \
-  | xargs -r -n1 thurbox-cli automation remove
-thurbox-cli session list | jq -r '.[] | select(.name=="flow") | .id' \
-  | xargs -r -n1 thurbox-cli session delete --force
-rm -rf ~/flow   # and remove the flow* entries from agents.toml
+thurbox-cli extension uninstall flow            # keeps ~/flow (your repos.md etc.)
+thurbox-cli extension uninstall flow --purge    # also deletes ~/flow
 ```
+
+To only switch flow off (keeping it installed for a later `activate`):
+
+```bash
+thurbox-cli extension deactivate flow           # stop self-heal, keep files
+```
+
+> Note: a plain `session delete` / `automation remove` is **not** enough on
+> its own — while flow is active, thurbox self-heals those resources.
+> `deactivate` (or `uninstall`) is what stops the self-heal.

--- a/extensions/flow/claude-settings.json
+++ b/extensions/flow/claude-settings.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Installed by thurbox `extension install flow` (template: claude-settings.json). Re-installing overwrites this file; remove this line to keep your own edits.",
+  "permissions": {
+    "allow": [
+      "Bash(thurbox-cli:*)",
+      "Bash({home}/scripts/create-task.sh:*)",
+      "Bash({home}/scripts/flow-snapshot.sh:*)",
+      "Bash({home}/scripts/parse-result.sh:*)",
+      "Bash(./scripts/create-task.sh:*)",
+      "Bash(./scripts/flow-snapshot.sh:*)",
+      "Bash(./scripts/parse-result.sh:*)",
+      "Bash(jq:*)",
+      "Read(/{home}/**)",
+      "Edit(/{home}/**)",
+      "Write(/{home}/**)"
+    ]
+  }
+}

--- a/extensions/flow/extension.toml
+++ b/extensions/flow/extension.toml
@@ -1,0 +1,96 @@
+# Flow extension manifest.
+#
+# This is the single source of truth for installing + running flow. Install it
+# with `thurbox-cli extension install flow` (or point at this directory:
+# `thurbox-cli extension install ./extensions/flow`). thurbox fetches this file,
+# lays down the [[files]] / [[symlinks]] under `home`, registers the [[agents]]
+# in agents.toml, then activates the [[sessions]] + [[automations]] and
+# self-heals them if they're ever deleted. `{home}` is replaced with the
+# resolved home dir. Turn flow off with `thurbox-cli extension deactivate flow`.
+
+name = "flow"
+description = "Focus-protecting triage agent"
+config_version = 1
+home = "~/flow"
+
+# --- agents registered in agents.toml (override the model by editing it) ------
+
+[[agents]]
+name = "flow"
+command = "claude"
+args = ["--model", "claude-haiku-4-5"]
+resume_args = ["--resume", "{id}"]
+fork_args = ["--resume", "{id}", "--fork-session"]
+new_session_args = ["--session-id", "{id}"]
+
+[[agents]]
+name = "flow-worker"
+command = "claude"
+args = ["--model", "claude-opus-4-8"]
+resume_args = ["--resume", "{id}"]
+fork_args = ["--resume", "{id}", "--fork-session"]
+new_session_args = ["--session-id", "{id}"]
+
+[[agents]]
+name = "flow-worker-heavy"
+command = "claude"
+args = ["--model", "claude-fable-5"]
+resume_args = ["--resume", "{id}"]
+fork_args = ["--resume", "{id}", "--fork-session"]
+new_session_args = ["--session-id", "{id}"]
+
+# --- payload files laid down under home ---------------------------------------
+
+[[files]]
+path = "FLOW.md"
+
+[[files]]
+path = "scripts/create-task.sh"
+executable = true
+
+[[files]]
+path = "scripts/flow-snapshot.sh"
+executable = true
+
+[[files]]
+path = "scripts/parse-result.sh"
+executable = true
+
+# Routing table — seeded once, then user-owned (never clobbered on reinstall).
+[[files]]
+path = "repos.md"
+if_absent = true
+
+# Pre-approve flow's tooling so unattended ticks run without prompts. {home} is
+# substituted with the resolved home path.
+[[files]]
+path = ".claude/settings.json"
+source = "claude-settings.json"
+substitute = true
+
+# --- context-file symlinks: surface FLOW.md to each CLI's convention ----------
+
+[[symlinks]]
+link = "CLAUDE.md"
+target = "FLOW.md"
+
+[[symlinks]]
+link = "AGENTS.md"
+target = "FLOW.md"
+
+[[symlinks]]
+link = "GEMINI.md"
+target = "FLOW.md"
+
+# --- runtime resources: ensured on activate, self-healed if deleted -----------
+
+[[sessions]]
+name = "flow"
+agent = "flow"
+repo_path = "{home}"
+
+[[automations]]
+name = "flow-tick"
+trigger = "cron:*/5 * * * *"
+session_ref = "flow"
+prompt = "tick"

--- a/extensions/flow/install.sh
+++ b/extensions/flow/install.sh
@@ -1,242 +1,39 @@
 #!/usr/bin/env sh
-# Install the thurbox "flow" extension: an agent-agnostic triage agent that
-# captures brain-dumps into thurbox tasks, dispatches workers, and protects
-# your focus. See FLOW.md for the behavior spec.
+# Thin wrapper kept for the curl|sh one-liner. The real installer now lives in
+# thurbox itself:
+#
+#   thurbox-cli extension install flow
+#
+# This script just forwards to it — using a local checkout when run from one,
+# otherwise the official remote source. It fetches the manifest + payload, lays
+# down ~/flow, registers the flow agents in agents.toml, and activates the flow
+# session + flow-tick automation (which thurbox then self-heals).
 #
 # Usage:
 #   ./install.sh                  # from a checkout
 #   curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/flow/install.sh | sh
 #
 # Environment variables:
-#   FLOW_HOME=~/flow              flow agent home directory
-#   FLOW_CMD=claude               CLI for the triager (any agents.toml-able CLI)
-#   FLOW_ARGS="--model claude-haiku-4-5"        extra args for the triager
-#   WORKER_CMD=claude             CLI for the default worker
-#   WORKER_ARGS="--model claude-opus-4-8"       extra args for the worker
-#   WORKER_HEAVY_CMD=claude       CLI for the heavy worker
-#   WORKER_HEAVY_ARGS="--model claude-fable-5"  extra args for the heavy worker
-#   TICK_CRON="*/5 * * * *"       tick automation schedule
+#   FLOW_HOME=~/flow              install home (passed as --home)
 #
-# Idempotent and self-updating: re-running refreshes the files the installer
-# owns (FLOW.md, the helper scripts, the context-file symlinks, and the claude
-# permission settings) to the current version, while leaving your own data
-# untouched — agents.toml entries, repos.md, the flow session, and the
-# flow-tick automation are created once and never overwritten.
+# To turn flow off:  thurbox-cli extension deactivate flow [--force --purge]
 
 set -eu
 
-FLOW_HOME="${FLOW_HOME:-$HOME/flow}"
-FLOW_CMD="${FLOW_CMD:-claude}"
-FLOW_ARGS="${FLOW_ARGS:---model claude-haiku-4-5}"
-WORKER_CMD="${WORKER_CMD:-claude}"
-WORKER_ARGS="${WORKER_ARGS:---model claude-opus-4-8}"
-WORKER_HEAVY_CMD="${WORKER_HEAVY_CMD:-claude}"
-WORKER_HEAVY_ARGS="${WORKER_HEAVY_ARGS:---model claude-fable-5}"
-TICK_CRON="${TICK_CRON:-*/5 * * * *}"
-CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/thurbox"
-AGENTS_TOML="$CONFIG_DIR/agents.toml"
-RAW_BASE="https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/flow"
+command -v thurbox-cli >/dev/null 2>&1 || {
+  echo "error: thurbox-cli not found in PATH (install thurbox first)" >&2
+  exit 1
+}
 
-say()  { printf '%s\n' "$*"; }
-die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+# Pass --home when FLOW_HOME is set (preserves the old override).
+set --
+[ -n "${FLOW_HOME:-}" ] && set -- --home "$FLOW_HOME"
 
-command -v thurbox-cli >/dev/null 2>&1 || die "thurbox-cli not found in PATH (install thurbox first)"
-command -v jq >/dev/null 2>&1 || die "jq is required"
-
-# --- flow home: spec, scripts, context-file symlinks, routing table --------
-
-mkdir -p "$FLOW_HOME/scripts"
-
-# Source files: prefer the checkout next to this script, fall back to GitHub
-# (pipe-to-shell install).
+# Prefer the checkout this script sits in (has extension.toml next to it);
+# otherwise install the official "flow" extension from the remote source.
 SRC_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd || true)"
-fetch() { # fetch <relpath> <dest>
-  if [ -n "$SRC_DIR" ] && [ -f "$SRC_DIR/$1" ]; then
-    cp "$SRC_DIR/$1" "$2"
-  elif command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$RAW_BASE/$1" -o "$2"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q "$RAW_BASE/$1" -O "$2"
-  else
-    die "cannot fetch $1 (no local checkout, curl, or wget)"
-  fi
-}
-
-# These are installer-owned: always refreshed to the current version so a
-# re-run picks up spec/script changes (the update path).
-[ -e "$FLOW_HOME/FLOW.md" ] && verb="updated" || verb="installed"
-fetch FLOW.md "$FLOW_HOME/FLOW.md"
-for s in create-task.sh flow-snapshot.sh parse-result.sh; do
-  fetch "scripts/$s" "$FLOW_HOME/scripts/$s"
-  chmod +x "$FLOW_HOME/scripts/$s"
-done
-say "$verb spec + scripts in $FLOW_HOME"
-
-# Surface FLOW.md to every CLI's context-file convention. Skip anything that
-# is already a regular file (never clobber user content).
-for ctx in CLAUDE.md AGENTS.md GEMINI.md; do
-  if [ -f "$FLOW_HOME/$ctx" ] && [ ! -L "$FLOW_HOME/$ctx" ]; then
-    say "skip: $FLOW_HOME/$ctx exists (not a symlink), leaving it alone"
-  else
-    ln -sf FLOW.md "$FLOW_HOME/$ctx"
-  fi
-done
-
-if [ ! -f "$FLOW_HOME/repos.md" ]; then
-  cat > "$FLOW_HOME/repos.md" <<'EOF'
-# Repo routing table
-
-Used by the flow agent to map brain-dump keywords to repositories.
-Add one row per repo you work on; the flow agent appends rows as it
-learns new paths.
-
-| name | path | base | keywords |
-|------|------|------|----------|
-| example | /home/me/repositories/example | main | example, sample |
-EOF
-  say "seeded $FLOW_HOME/repos.md (edit it!)"
-fi
-
-# --- agents.toml: flow / flow-worker / flow-worker-heavy aliases -----------
-
-toml_args() { # "$@"-style words -> "a", "b" list
-  out=""
-  for w in $1; do
-    out="$out\"$w\", "
-  done
-  printf '%s' "${out%, }"
-}
-
-append_agent() { # append_agent <name> <cmd> <args>
-  name="$1" cmd="$2" args="$3"
-  if grep -q "name = \"$name\"" "$AGENTS_TOML" 2>/dev/null; then
-    say "agents.toml: '$name' already present, skipping"
-    return
-  fi
-  {
-    printf '\n[[agents]]\n'
-    printf 'name = "%s"\n' "$name"
-    printf 'command = "%s"\n' "$cmd"
-    [ -n "$args" ] && printf 'args = [%s]\n' "$(toml_args "$args")"
-    # Session pinning/resume flags are claude's; other CLIs resume the last
-    # session in cwd themselves (see the agents.toml seed for examples).
-    if [ "$cmd" = "claude" ]; then
-      printf 'resume_args = ["--resume", "{id}"]\n'
-      printf 'fork_args = ["--resume", "{id}", "--fork-session"]\n'
-      printf 'new_session_args = ["--session-id", "{id}"]\n'
-    fi
-  } >> "$AGENTS_TOML"
-  say "agents.toml: added '$name' ($cmd $args)"
-}
-
-mkdir -p "$CONFIG_DIR"
-if [ ! -f "$AGENTS_TOML" ]; then
-  # Same content thurbox seeds on first run, so later runs read it unchanged.
-  cat > "$AGENTS_TOML" <<'EOF'
-# Thurbox coding-agent definitions (seeded by the flow extension installer).
-
-default = "claude"
-
-[[agents]]
-name = "claude"
-command = "claude"
-resume_args = ["--resume", "{id}"]
-fork_args = ["--resume", "{id}", "--fork-session"]
-new_session_args = ["--session-id", "{id}"]
-
-[[agents]]
-name = "codex"
-command = "codex"
-
-[[agents]]
-name = "gemini"
-command = "gemini"
-
-[[agents]]
-name = "opencode"
-command = "opencode"
-
-[[agents]]
-name = "aider"
-command = "aider"
-
-[[agents]]
-name = "vibe"
-command = "vibe"
-EOF
-  say "seeded $AGENTS_TOML"
-fi
-
-append_agent flow "$FLOW_CMD" "$FLOW_ARGS"
-append_agent flow-worker "$WORKER_CMD" "$WORKER_ARGS"
-append_agent flow-worker-heavy "$WORKER_HEAVY_CMD" "$WORKER_HEAVY_ARGS"
-
-# --- claude nicety: pre-approve the flow tooling so ticks run unattended ---
-#
-# Regenerated on every run so new scripts/permissions land on update, but only
-# for a file we generated ourselves: a settings.json without our marker is
-# assumed user-owned and left alone.
-
-SETTINGS="$FLOW_HOME/.claude/settings.json"
-SETTINGS_MARKER="generated by the thurbox flow installer"
-if [ "$FLOW_CMD" = "claude" ]; then
-  if [ -f "$SETTINGS" ] && ! grep -q "$SETTINGS_MARKER" "$SETTINGS" 2>/dev/null; then
-    say "skip: $SETTINGS exists and isn't installer-generated, leaving it alone"
-  else
-    existed=false
-    [ -f "$SETTINGS" ] && existed=true
-    mkdir -p "$FLOW_HOME/.claude"
-    cat > "$SETTINGS" <<EOF
-{
-  "_comment": "$SETTINGS_MARKER — re-running install.sh overwrites this file; remove this line to keep your own edits",
-  "permissions": {
-    "allow": [
-      "Bash(thurbox-cli:*)",
-      "Bash($FLOW_HOME/scripts/create-task.sh:*)",
-      "Bash($FLOW_HOME/scripts/flow-snapshot.sh:*)",
-      "Bash($FLOW_HOME/scripts/parse-result.sh:*)",
-      "Bash(./scripts/create-task.sh:*)",
-      "Bash(./scripts/flow-snapshot.sh:*)",
-      "Bash(./scripts/parse-result.sh:*)",
-      "Bash(jq:*)",
-      "Read(//${FLOW_HOME#/}/**)",
-      "Edit(//${FLOW_HOME#/}/**)",
-      "Write(//${FLOW_HOME#/}/**)"
-    ]
-  }
-}
-EOF
-    if [ "$existed" = true ]; then
-      say "updated $SETTINGS (unattended tick permissions)"
-    else
-      say "wrote $SETTINGS (unattended tick permissions)"
-    fi
-  fi
-fi
-
-# --- bootstrap: dedicated session + tick automation ------------------------
-
-FLOW_UUID="$(thurbox-cli session list 2>/dev/null | jq -r '.[] | select(.name == "flow") | .id' | head -1)"
-if [ -n "$FLOW_UUID" ]; then
-  say "session 'flow' already exists ($FLOW_UUID)"
+if [ -n "$SRC_DIR" ] && [ -f "$SRC_DIR/extension.toml" ]; then
+  exec thurbox-cli extension install "$SRC_DIR" "$@"
 else
-  FLOW_UUID="$(thurbox-cli session create --name flow --agent flow --repo-path "$FLOW_HOME" | jq -r .id)"
-  say "created session 'flow' ($FLOW_UUID)"
+  exec thurbox-cli extension install flow "$@"
 fi
-
-if thurbox-cli automation list 2>/dev/null | jq -e '.[] | select(.name == "flow-tick")' >/dev/null; then
-  say "automation 'flow-tick' already exists"
-else
-  thurbox-cli automation create --name flow-tick \
-    --trigger "cron:$TICK_CRON" \
-    --session "$FLOW_UUID" \
-    --prompt "tick" >/dev/null
-  say "created automation 'flow-tick' ($TICK_CRON)"
-fi
-
-say ""
-say "flow extension $verb."
-say "  1. Edit $FLOW_HOME/repos.md with your repos."
-say "  2. Open the 'flow' session in thurbox and brain-dump at it,"
-say "     or: thurbox-cli session send $FLOW_UUID \"your dump\""
-say "  3. Map flow-worker / flow-worker-heavy in $AGENTS_TOML to any CLI."

--- a/extensions/flow/repos.md
+++ b/extensions/flow/repos.md
@@ -1,0 +1,9 @@
+# Repo routing table
+
+Used by the flow agent to map brain-dump keywords to repositories.
+Add one row per repo you work on; the flow agent appends rows as it
+learns new paths.
+
+| name | path | base | keywords |
+|------|------|------|----------|
+| example | /home/me/repositories/example | main | example, sample |

--- a/src/agent/extension_config.rs
+++ b/src/agent/extension_config.rs
@@ -1,0 +1,606 @@
+//! Loading of extension manifests from the discovery directory.
+//!
+//! Opt-in extensions (see `extensions/<name>/`) drop an `extension.toml`
+//! manifest into `~/.config/thurbox/extensions/<name>.toml` from their own
+//! installer. thurbox core reads any manifest there without knowing the
+//! extension by name (ADR-20: extensions are data + scripts, never embedded).
+//!
+//! Unlike `agents.toml`/`hosts.toml` this file is **never seeded** — a fresh
+//! install has no extensions, and the directory only appears once a user runs an
+//! extension's installer. Read/parse errors degrade gracefully (a bad manifest
+//! is skipped with a warning, never aborting startup).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde::Serialize;
+
+use crate::session::{AgentDef, ExtensionDef};
+
+/// Raw-content root of the thurbox repo (no git ref).
+const OFFICIAL_REPO_RAW: &str = "https://raw.githubusercontent.com/Thurbeen/thurbox";
+
+/// The git ref to fetch official extensions from: the running binary's release
+/// tag (`v0.7.0`), so a fetched extension matches the binary that reads it. Dev
+/// builds track `main`.
+fn official_ref() -> String {
+    let version = env!("THURBOX_VERSION");
+    if cfg!(dev_build) || version.contains("-dev") {
+        "main".to_string()
+    } else {
+        format!("v{version}")
+    }
+}
+
+/// Base URL for the official extensions shipped in the thurbox repo, pinned to
+/// this binary's version. A bare `thurbox-cli extension install <name>` resolves
+/// to `<official_base()>/<name>`.
+pub fn official_base() -> String {
+    format!("{OFFICIAL_REPO_RAW}/{}/extensions", official_ref())
+}
+
+/// The extension-manifest discovery directory:
+/// `~/.config/thurbox/extensions/` (sibling of `config.toml`).
+pub fn extensions_dir() -> Option<PathBuf> {
+    crate::paths::config_file().map(|p| p.with_file_name("extensions"))
+}
+
+/// Path to a single extension's manifest: `<extensions_dir>/<name>.toml`.
+pub fn manifest_path(name: &str) -> Option<PathBuf> {
+    extensions_dir().map(|d| d.join(format!("{name}.toml")))
+}
+
+/// Load one extension manifest by name. Returns `None` when the file is absent,
+/// unreadable, or malformed (with a logged warning) — callers treat a missing
+/// manifest as "this extension isn't installed".
+pub fn load_manifest(name: &str) -> Option<ExtensionDef> {
+    let (def, warnings) = load_manifest_with_warnings(name);
+    for w in &warnings {
+        tracing::warn!("{w}");
+    }
+    def
+}
+
+/// [`load_manifest`], also returning user-facing warnings (unknown fields,
+/// parse errors) so the TUI/CLI can surface them.
+pub fn load_manifest_with_warnings(name: &str) -> (Option<ExtensionDef>, Vec<String>) {
+    let Some(path) = manifest_path(name) else {
+        return (None, vec!["Could not resolve extensions directory".into()]);
+    };
+    if !path.exists() {
+        return (None, Vec::new());
+    }
+    let label = format!("{name}.toml");
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            match super::agent_config::parse_toml_reporting_unknown::<ExtensionDef>(
+                &contents, &label,
+            ) {
+                Ok((def, warnings)) => (Some(def), warnings),
+                Err(e) => (
+                    None,
+                    vec![format!(
+                        "{label}: {}; extension skipped",
+                        super::agent_config::compact_toml_error(&e.to_string())
+                    )],
+                ),
+            }
+        }
+        Err(e) => (None, vec![format!("Failed to read {label}: {e}")]),
+    }
+}
+
+/// Load every installed extension manifest, in filename order. Malformed
+/// manifests are skipped (their warnings logged), never aborting the scan.
+pub fn list_manifests() -> Vec<ExtensionDef> {
+    let (defs, warnings) = list_manifests_with_warnings();
+    for w in &warnings {
+        tracing::warn!("{w}");
+    }
+    defs
+}
+
+/// [`list_manifests`], also returning accumulated warnings.
+pub fn list_manifests_with_warnings() -> (Vec<ExtensionDef>, Vec<String>) {
+    let Some(dir) = extensions_dir() else {
+        return (
+            Vec::new(),
+            vec!["Could not resolve extensions directory".into()],
+        );
+    };
+    if !dir.exists() {
+        return (Vec::new(), Vec::new());
+    }
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) => {
+            return (
+                Vec::new(),
+                vec![format!("Failed to read extensions dir: {e}")],
+            )
+        }
+    };
+    // Collect + sort filenames so the scan order is deterministic across runs.
+    let mut stems: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("toml"))
+        .filter_map(|p| p.file_stem().and_then(|s| s.to_str()).map(String::from))
+        .collect();
+    stems.sort();
+
+    let mut defs = Vec::new();
+    let mut warnings = Vec::new();
+    for stem in stems {
+        let (def, mut warns) = load_manifest_with_warnings(&stem);
+        warnings.append(&mut warns);
+        if let Some(def) = def {
+            defs.push(def);
+        }
+    }
+    (defs, warnings)
+}
+
+// --- install: source resolution, fetching, agents.toml + manifest writes ----
+
+/// Where an extension's files come from during install.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExtensionSource {
+    /// A base URL (no trailing slash); files fetched via `<base>/<rel>`.
+    Remote(String),
+    /// A local directory containing `extension.toml` + payload files.
+    Local(PathBuf),
+}
+
+/// Resolve an install target into a source:
+/// - `http(s)://…` → that base URL,
+/// - a path-like target (`/abs`, `./rel`, `~/x`, anything with a `/`) → local dir,
+/// - a bare name (`flow`) → the official remote `<official_base()>/<name>`.
+pub fn resolve_source(target: &str) -> ExtensionSource {
+    let t = target.trim();
+    if let Some(rest) = t
+        .strip_prefix("https://")
+        .or_else(|| t.strip_prefix("http://"))
+    {
+        let scheme = if t.starts_with("https://") {
+            "https://"
+        } else {
+            "http://"
+        };
+        return ExtensionSource::Remote(format!("{scheme}{}", rest.trim_end_matches('/')));
+    }
+    if t.contains('/') || t.starts_with('.') || t.starts_with('~') {
+        return ExtensionSource::Local(expand_tilde(t));
+    }
+    ExtensionSource::Remote(format!("{}/{t}", official_base()))
+}
+
+/// Expand a leading `~/` (or bare `~`) to the user's home directory. Shared by
+/// the source resolver and the installer so both agree on home expansion.
+pub fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    } else if path == "~" {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home);
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// Fetch one file's text content from a source (`<source>/<rel>`).
+pub fn fetch_file(source: &ExtensionSource, rel: &str) -> Result<String, String> {
+    match source {
+        ExtensionSource::Local(dir) => {
+            let p = dir.join(rel);
+            std::fs::read_to_string(&p).map_err(|e| format!("read {}: {e}", p.display()))
+        }
+        ExtensionSource::Remote(base) => http_get(&format!("{base}/{rel}")),
+    }
+}
+
+/// HTTP GET to stdout via `curl` (falling back to `wget`) — same dependency-free
+/// approach as the shell installer. Both run with a timeout. On failure the
+/// real cause is surfaced: a missing tool is distinguished from a tool that ran
+/// but failed (e.g. HTTP 404 for a misspelled extension name), whose stderr is
+/// included so the user sees the actual status.
+///
+/// Note: the body is decoded as UTF-8 (lossy); extension payloads are expected
+/// to be text files (specs, scripts, JSON), not binaries.
+fn http_get(url: &str) -> Result<String, String> {
+    let attempts: [(&str, Vec<&str>); 2] = [
+        ("curl", vec!["-fsSL", "--max-time", "30", url]),
+        ("wget", vec!["--timeout=30", "-O", "-", url]),
+    ];
+    let mut errors = Vec::new();
+    for (bin, args) in attempts {
+        match Command::new(bin).args(&args).output() {
+            Ok(out) if out.status.success() => {
+                return Ok(String::from_utf8_lossy(&out.stdout).into_owned());
+            }
+            Ok(out) => {
+                // The tool ran but failed (404, DNS, refused…) — keep its stderr.
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let detail = stderr.trim();
+                let detail = if detail.is_empty() {
+                    format!("exit {}", out.status)
+                } else {
+                    detail.lines().last().unwrap_or(detail).to_string()
+                };
+                errors.push(format!("{bin}: {detail}"));
+            }
+            Err(_) => errors.push(format!("{bin}: not found")),
+        }
+    }
+    Err(format!("failed to fetch {url} ({})", errors.join("; ")))
+}
+
+/// Fetch + parse the `extension.toml` manifest from a source.
+pub fn load_manifest_from_source(
+    source: &ExtensionSource,
+) -> Result<(ExtensionDef, Vec<String>), String> {
+    let contents = fetch_file(source, "extension.toml")?;
+    super::agent_config::parse_toml_reporting_unknown::<ExtensionDef>(&contents, "extension.toml")
+        .map_err(|e| {
+            format!(
+                "extension.toml: {}",
+                super::agent_config::compact_toml_error(&e.to_string())
+            )
+        })
+}
+
+/// Register agents in `agents.toml`, appending only the ones whose names aren't
+/// already present (so user edits and existing agents are preserved — the file's
+/// comments/formatting stay intact because we append text rather than rewrite).
+/// Returns the names actually added.
+pub fn ensure_agents_registered(agents: &[AgentDef]) -> Result<Vec<String>, String> {
+    if agents.is_empty() {
+        return Ok(Vec::new());
+    }
+    // load_or_seed writes the built-in file if absent, so the path then exists.
+    let existing_reg = super::agent_config::load_or_seed();
+    let Some(path) = super::agent_config::agents_config_path() else {
+        return Err("could not resolve agents.toml path".into());
+    };
+    let mut text =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+
+    let missing: Vec<&AgentDef> = agents
+        .iter()
+        .filter(|a| existing_reg.get(&a.name).is_none())
+        .collect();
+    if missing.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    #[derive(Serialize)]
+    struct AgentsDoc<'a> {
+        agents: Vec<&'a AgentDef>,
+    }
+    let block = toml::to_string(&AgentsDoc {
+        agents: missing.clone(),
+    })
+    .map_err(|e| format!("serialize agents: {e}"))?;
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text.push('\n');
+    text.push_str(&block);
+    std::fs::write(&path, text).map_err(|e| format!("write {}: {e}", path.display()))?;
+
+    Ok(missing.iter().map(|a| a.name.clone()).collect())
+}
+
+/// Remove `[[agents]]` entries from `agents.toml` by name, preserving the rest
+/// of the file (other agents, comments, top-level keys) by editing text rather
+/// than re-serializing. The reverse of [`ensure_agents_registered`], used by
+/// extension uninstall. Returns the names actually removed.
+///
+/// Caveat: removal is by name, so an agent a user re-pointed at a different CLI
+/// but kept the name is still removed. Names are namespaced per extension
+/// (`flow`, `flow-worker`, …) to make collisions unlikely.
+pub fn remove_agents_from_toml(names: &[String]) -> Result<Vec<String>, String> {
+    if names.is_empty() {
+        return Ok(Vec::new());
+    }
+    let Some(path) = super::agent_config::agents_config_path() else {
+        return Err("could not resolve agents.toml path".into());
+    };
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let text =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+
+    let lines: Vec<&str> = text.lines().collect();
+    let mut out: Vec<&str> = Vec::with_capacity(lines.len());
+    let mut removed = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if trimmed.starts_with("[[agents]]") {
+            // Collect this block: from the header to just before the next
+            // top-level table header (`[` at the start of a trimmed line) or EOF.
+            let start = i;
+            let mut j = i + 1;
+            while j < lines.len() && !lines[j].trim_start().starts_with('[') {
+                j += 1;
+            }
+            let block = &lines[start..j];
+            let target = block.iter().find_map(|l| parse_agent_name(l));
+            match target {
+                Some(name) if names.iter().any(|n| n == &name) => {
+                    removed.push(name);
+                    // Drop the block and a single trailing blank separator line.
+                    i = j;
+                    if i < lines.len() && lines[i].trim().is_empty() {
+                        i += 1;
+                    }
+                    continue;
+                }
+                _ => {
+                    out.extend_from_slice(block);
+                    i = j;
+                    continue;
+                }
+            }
+        }
+        out.push(lines[i]);
+        i += 1;
+    }
+
+    if removed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut new_text = out.join("\n");
+    if text.ends_with('\n') {
+        new_text.push('\n');
+    }
+    std::fs::write(&path, new_text).map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(removed)
+}
+
+/// Parse `name = "x"` out of a TOML line, returning the value.
+fn parse_agent_name(line: &str) -> Option<String> {
+    let rest = line.trim_start().strip_prefix("name")?.trim_start();
+    let rest = rest.strip_prefix('=')?.trim();
+    let inner = rest.strip_prefix('"')?;
+    let end = inner.find('"')?;
+    Some(inner[..end].to_string())
+}
+
+/// Write a manifest to the discovery dir (`<extensions_dir>/<name>.toml`),
+/// creating the directory if needed. Returns the path written.
+pub fn write_manifest(def: &ExtensionDef) -> Result<PathBuf, String> {
+    let Some(path) = manifest_path(&def.name) else {
+        return Err("could not resolve extensions directory".into());
+    };
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    let text = toml::to_string(def).map_err(|e| format!("serialize manifest: {e}"))?;
+    std::fs::write(&path, text).map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(path)
+}
+
+/// Remove an extension's manifest from the discovery dir. Returns whether a file
+/// was actually removed.
+pub fn remove_manifest_file(name: &str) -> Result<bool, String> {
+    let Some(path) = manifest_path(name) else {
+        return Err("could not resolve extensions directory".into());
+    };
+    if !path.exists() {
+        return Ok(false);
+    }
+    std::fs::remove_file(&path).map_err(|e| format!("remove {}: {e}", path.display()))?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_manifest_file(name: &str, contents: &str) {
+        let path = manifest_path(name).unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, contents).unwrap();
+    }
+
+    #[test]
+    fn missing_manifest_is_none_without_warning() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let (def, warnings) = load_manifest_with_warnings("flow");
+        assert!(def.is_none());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn loads_a_valid_manifest() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        write_manifest_file(
+            "flow",
+            "name = \"flow\"\n[[sessions]]\nname = \"flow\"\nagent = \"flow\"\nrepo_path = \"/home/me/flow\"\n",
+        );
+        let def = load_manifest("flow").unwrap();
+        assert_eq!(def.name, "flow");
+        assert_eq!(def.sessions.len(), 1);
+    }
+
+    #[test]
+    fn malformed_manifest_is_skipped_with_warning() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        write_manifest_file("flow", "this is not = valid toml {{{");
+        let (def, warnings) = load_manifest_with_warnings("flow");
+        assert!(def.is_none());
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("flow.toml"));
+    }
+
+    #[test]
+    fn unknown_field_warns_but_keeps_manifest() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        write_manifest_file("flow", "name = \"flow\"\nbogus = 1\n");
+        let (def, warnings) = load_manifest_with_warnings("flow");
+        assert_eq!(def.unwrap().name, "flow");
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("bogus"));
+    }
+
+    #[test]
+    fn lists_manifests_in_sorted_order() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        write_manifest_file("zed", "name = \"zed\"\n");
+        write_manifest_file("flow", "name = \"flow\"\n");
+        let names: Vec<String> = list_manifests().into_iter().map(|d| d.name).collect();
+        assert_eq!(names, ["flow", "zed"]);
+    }
+
+    #[test]
+    fn lists_nothing_when_dir_absent() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        assert!(list_manifests().is_empty());
+    }
+
+    #[test]
+    fn resolve_source_distinguishes_name_url_and_path() {
+        assert_eq!(
+            resolve_source("flow"),
+            ExtensionSource::Remote(format!("{}/flow", official_base()))
+        );
+        // Official base is pinned to a concrete ref (a tag or main), never bare.
+        assert!(official_base().starts_with(OFFICIAL_REPO_RAW));
+        assert!(official_base().ends_with("/extensions"));
+        assert_eq!(
+            resolve_source("https://example.com/ext/foo/"),
+            ExtensionSource::Remote("https://example.com/ext/foo".into())
+        );
+        assert_eq!(
+            resolve_source("./extensions/flow"),
+            ExtensionSource::Local(PathBuf::from("./extensions/flow"))
+        );
+        assert_eq!(
+            resolve_source("/abs/flow"),
+            ExtensionSource::Local(PathBuf::from("/abs/flow"))
+        );
+    }
+
+    #[test]
+    fn fetch_and_load_manifest_from_local_source() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("extension.toml"),
+            "name = \"flow\"\nhome = \"~/flow\"\n[[files]]\npath = \"FLOW.md\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("FLOW.md"), "spec body").unwrap();
+
+        let src = ExtensionSource::Local(dir.path().to_path_buf());
+        assert_eq!(fetch_file(&src, "FLOW.md").unwrap(), "spec body");
+        let (def, warnings) = load_manifest_from_source(&src).unwrap();
+        assert_eq!(def.name, "flow");
+        assert_eq!(def.home.as_deref(), Some("~/flow"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn ensure_agents_registered_appends_only_missing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let flow = AgentDef {
+            name: "flow".into(),
+            command: "claude".into(),
+            args: vec!["--model".into(), "haiku".into()],
+            resume_args: vec![],
+            fork_args: vec![],
+            new_session_args: vec![],
+            resume_latest: false,
+        };
+        // claude already exists in the seeded built-ins → not re-added.
+        let claude = AgentDef {
+            name: "claude".into(),
+            command: "claude".into(),
+            ..flow.clone()
+        };
+
+        let added = ensure_agents_registered(&[flow.clone(), claude]).unwrap();
+        assert_eq!(added, ["flow"]);
+
+        let reg = super::super::agent_config::load_or_seed();
+        assert_eq!(reg.get("flow").unwrap().command, "claude");
+        assert_eq!(reg.get("flow").unwrap().args, ["--model", "haiku"]);
+
+        // Idempotent: a second call adds nothing.
+        assert!(ensure_agents_registered(&[flow]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn remove_agents_preserves_other_entries_and_comments() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let flow = AgentDef {
+            name: "flow".into(),
+            command: "claude".into(),
+            args: vec![],
+            resume_args: vec![],
+            fork_args: vec![],
+            new_session_args: vec![],
+            resume_latest: false,
+        };
+        ensure_agents_registered(&[flow]).unwrap();
+        // Sanity: flow + the seeded built-ins are present.
+        assert!(super::super::agent_config::load_or_seed()
+            .get("flow")
+            .is_some());
+
+        let removed = remove_agents_from_toml(&["flow".to_string()]).unwrap();
+        assert_eq!(removed, ["flow"]);
+
+        let reg = super::super::agent_config::load_or_seed();
+        assert!(reg.get("flow").is_none(), "flow removed");
+        // Built-ins (and the seed file's header comment) survive.
+        assert!(reg.get("claude").is_some(), "other agents preserved");
+        let text =
+            std::fs::read_to_string(super::super::agent_config::agents_config_path().unwrap())
+                .unwrap();
+        assert!(text.contains('#'), "header comments preserved");
+
+        // Removing a non-existent agent is a no-op.
+        assert!(remove_agents_from_toml(&["ghost".to_string()])
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn parse_agent_name_extracts_value() {
+        assert_eq!(parse_agent_name("name = \"flow\"").as_deref(), Some("flow"));
+        assert_eq!(
+            parse_agent_name("  name=\"flow-worker\"  ").as_deref(),
+            Some("flow-worker")
+        );
+        assert_eq!(parse_agent_name("command = \"claude\""), None);
+    }
+
+    #[test]
+    fn write_manifest_round_trips_to_discovery_dir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let def = ExtensionDef {
+            name: "flow".into(),
+            ..Default::default()
+        };
+        let path = write_manifest(&def).unwrap();
+        assert!(path.exists());
+        assert_eq!(load_manifest("flow").unwrap().name, "flow");
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_config;
 pub mod backend;
 pub mod control_mode;
+pub mod extension_config;
 pub mod generic;
 pub mod host_config;
 pub mod input;

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -240,6 +240,14 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
 /// Fire every due automation headlessly: claim (atomic CAS, so this is safe to
 /// run alongside the TUI and other tickers), perform the action, record the run.
 fn tick(db: &Database) -> Result<Value, String> {
+    // Self-heal active extensions before firing: this runs from the tmux
+    // heartbeat keeper every 60s, so a deleted flow session/automation is
+    // recreated even with the TUI closed. Best-effort — heal messages are
+    // reported but never abort the due-automation pass below.
+    let healed = crate::session_ops::heal_active_extensions(db);
+    for m in &healed {
+        tracing::info!("{m}");
+    }
     let now = current_time_millis();
     let due = db
         .due_automations(now)
@@ -269,7 +277,7 @@ fn tick(db: &Database) -> Result<Value, String> {
             "detail": detail,
         }));
     }
-    Ok(json!({ "fired": fired, "skipped": skipped }))
+    Ok(json!({ "fired": fired, "skipped": skipped, "healed": healed }))
 }
 
 /// Execute one automation's action without a TUI, returning the run outcome.

--- a/src/cli/extensions.rs
+++ b/src/cli/extensions.rs
@@ -1,0 +1,197 @@
+//! Extension activate/deactivate subcommands for `thurbox-cli`.
+//!
+//! Extensions declare the sessions/automations they need in an `extension.toml`
+//! manifest under `~/.config/thurbox/extensions/`. `activate` (re)creates those
+//! resources and marks the extension active so thurbox self-heals them if
+//! deleted; `deactivate` tears them down and is the real off-switch. See
+//! [`crate::session_ops::extensions`].
+
+use clap::Subcommand;
+use serde_json::{json, Value};
+
+use crate::session::ExtensionDef;
+use crate::storage::Database;
+
+#[derive(Subcommand, Debug)]
+pub enum Action {
+    /// Install an extension from a name, URL, or local directory: fetch it, lay
+    /// down its files, register its agents, and activate it. Idempotent.
+    Install {
+        /// What to install: a bare name (`flow`, from the official source), an
+        /// `http(s)://` base URL, or a path to a local extension directory.
+        target: String,
+        /// Override the install home directory (default: the manifest's `home`).
+        #[arg(long)]
+        home: Option<String>,
+        /// Re-write even `if_absent` seed files (e.g. reset `repos.md`).
+        #[arg(long)]
+        force: bool,
+    },
+    /// Uninstall an extension: tear down its session/automation, remove its
+    /// agents from agents.toml, and delete its manifest (the reverse of install).
+    Uninstall {
+        /// Extension name.
+        name: String,
+        /// Also delete the install home directory (payload + any data under it).
+        #[arg(long)]
+        purge: bool,
+    },
+    /// List installed extensions and whether each is active/healthy.
+    List,
+    /// Activate an extension: (re)create its sessions/automations and mark it
+    /// active so thurbox self-heals them. Idempotent.
+    Activate {
+        /// Extension name (matches `<name>.toml` in the extensions dir).
+        name: String,
+    },
+    /// Deactivate an extension: tear down its resources and stop self-healing.
+    Deactivate {
+        /// Extension name.
+        name: String,
+        /// Also tear down each session's tmux window + worktrees (not just a
+        /// soft delete).
+        #[arg(long)]
+        force: bool,
+        /// Also remove the extension's manifest from the discovery dir, so it no
+        /// longer appears in `extension list`. Leaves the extension's own files
+        /// (e.g. its home dir) alone — use the extension's uninstall for those.
+        #[arg(long)]
+        purge: bool,
+    },
+    /// Show one extension's resource health (or all when no name is given).
+    Status {
+        /// Extension name; omit to report on every installed extension.
+        name: Option<String>,
+    },
+}
+
+pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+    match action {
+        Action::Install {
+            target,
+            home,
+            force,
+        } => {
+            let report =
+                crate::session_ops::install_extension(db, &target, home.as_deref(), force)?;
+            // Arm the heartbeat so the extension's automations fire headlessly.
+            arm_heartbeat();
+            Ok(json!({
+                "installed": report.name,
+                "home": report.home,
+                "files_written": report.files_written,
+                "files_skipped": report.files_skipped,
+                "symlinks_created": report.symlinks_created,
+                "symlinks_skipped": report.symlinks_skipped,
+                "agents_added": report.agents_added,
+                "sessions_created": report.ensure.sessions_created,
+                "automations_created": report.ensure.automations_created,
+            }))
+        }
+        Action::Uninstall { name, purge } => {
+            let report = crate::session_ops::uninstall_extension(db, &name, purge)?;
+            Ok(json!({
+                "uninstalled": report.name,
+                "sessions_deleted": report.deactivate.sessions_deleted,
+                "automations_deleted": report.deactivate.automations_deleted,
+                "agents_removed": report.agents_removed,
+                "manifest_removed": report.manifest_removed,
+                "home_removed": report.home_removed,
+            }))
+        }
+        Action::List => {
+            let defs = crate::agent::extension_config::list_manifests();
+            let mut out = Vec::with_capacity(defs.len());
+            for def in &defs {
+                out.push(health_to_json(&crate::session_ops::extension_health(
+                    db, def,
+                )?));
+            }
+            Ok(Value::Array(out))
+        }
+        Action::Activate { name } => {
+            let def = load_manifest(&name)?;
+            let report = crate::session_ops::activate_extension(db, &def)?;
+            // A `Send` automation only fires while something ticks it. Arm the
+            // heartbeat keeper so the extension works headlessly (TUI closed),
+            // matching how `automation create` arms it.
+            arm_heartbeat();
+            Ok(json!({
+                "activated": def.name,
+                "sessions_created": report.sessions_created,
+                "automations_created": report.automations_created,
+                "health": health_to_json(&crate::session_ops::extension_health(db, &def)?),
+            }))
+        }
+        Action::Deactivate { name, force, purge } => {
+            // Tear down whatever the manifest declares. If the manifest is gone
+            // we can't know the resources, but still clear the active-set entry.
+            let report = match crate::agent::extension_config::load_manifest(&name) {
+                Some(def) => crate::session_ops::deactivate_extension(db, &def, force)?,
+                None => {
+                    let was_active = db
+                        .remove_active_extension(&name)
+                        .map_err(|e| format!("remove_active_extension: {e}"))?;
+                    crate::session_ops::DeactivateReport {
+                        was_active,
+                        ..Default::default()
+                    }
+                }
+            };
+            let manifest_removed = if purge {
+                crate::agent::extension_config::remove_manifest_file(&name)?
+            } else {
+                false
+            };
+            Ok(json!({
+                "deactivated": name,
+                "was_active": report.was_active,
+                "sessions_deleted": report.sessions_deleted,
+                "automations_deleted": report.automations_deleted,
+                "manifest_removed": manifest_removed,
+            }))
+        }
+        Action::Status { name } => match name {
+            Some(name) => {
+                let def = load_manifest(&name)?;
+                Ok(health_to_json(&crate::session_ops::extension_health(
+                    db, &def,
+                )?))
+            }
+            None => run(Action::List, db),
+        },
+    }
+}
+
+/// Load a manifest by name or error with guidance.
+fn load_manifest(name: &str) -> Result<ExtensionDef, String> {
+    crate::agent::extension_config::load_manifest(name).ok_or_else(|| {
+        format!(
+            "No extension manifest '{name}' found. Install the extension first \
+             (it writes ~/.config/thurbox/extensions/{name}.toml)."
+        )
+    })
+}
+
+/// Best-effort: ensure the tmux heartbeat keeper runs so the extension's
+/// automations fire even when no TUI is attached. Non-fatal on failure.
+fn arm_heartbeat() {
+    let cli = crate::agent::tmux::resolve_cli_binary();
+    if let Err(e) = crate::agent::tmux::ensure_automation_heartbeat(&cli) {
+        eprintln!("warning: failed to arm automation heartbeat: {e}");
+    }
+}
+
+fn health_to_json(h: &crate::session_ops::ExtensionHealth) -> Value {
+    json!({
+        "name": h.name,
+        "active": h.active,
+        "healthy": h.is_healthy(),
+        "sessions": h.sessions.iter()
+            .map(|(n, present)| json!({ "name": n, "present": present }))
+            .collect::<Vec<_>>(),
+        "automations": h.automations.iter()
+            .map(|(n, present)| json!({ "name": n, "present": present }))
+            .collect::<Vec<_>>(),
+    })
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,6 +13,7 @@ use crate::storage::Database;
 pub mod automations;
 pub mod config;
 pub mod editor;
+pub mod extensions;
 pub mod sessions;
 pub mod tasks;
 
@@ -57,6 +58,12 @@ pub enum Command {
         #[command(subcommand)]
         action: config::Action,
     },
+    /// Activate/deactivate opt-in extensions (e.g. flow).
+    #[command(alias = "ext")]
+    Extension {
+        #[command(subcommand)]
+        action: extensions::Action,
+    },
 }
 
 /// Run a parsed CLI invocation against `db` and write JSON to stdout.
@@ -67,6 +74,7 @@ pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
         Command::Automation { action } => automations::run(action, db),
         Command::Task { action } => tasks::run(action, db),
         Command::Config { action } => config::run(action, db),
+        Command::Extension { action } => extensions::run(action, db),
     }?;
 
     let text = if cli.pretty {
@@ -330,6 +338,93 @@ mod tests {
             cli.command,
             Command::Task {
                 action: tasks::Action::List
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_extension_install() {
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "extension",
+            "install",
+            "flow",
+            "--home",
+            "/home/me/flow",
+            "--force",
+        ])
+        .unwrap();
+        let Command::Extension {
+            action:
+                extensions::Action::Install {
+                    target,
+                    home,
+                    force,
+                },
+        } = cli.command
+        else {
+            panic!("expected Extension::Install");
+        };
+        assert_eq!(target, "flow");
+        assert_eq!(home.as_deref(), Some("/home/me/flow"));
+        assert!(force);
+    }
+
+    #[test]
+    fn parse_extension_uninstall() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "extension", "uninstall", "flow", "--purge"])
+            .unwrap();
+        let Command::Extension {
+            action: extensions::Action::Uninstall { name, purge },
+        } = cli.command
+        else {
+            panic!("expected Extension::Uninstall");
+        };
+        assert_eq!(name, "flow");
+        assert!(purge);
+    }
+
+    #[test]
+    fn parse_extension_activate() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "extension", "activate", "flow"]).unwrap();
+        let Command::Extension {
+            action: extensions::Action::Activate { name },
+        } = cli.command
+        else {
+            panic!("expected Extension::Activate");
+        };
+        assert_eq!(name, "flow");
+    }
+
+    #[test]
+    fn parse_extension_deactivate_with_flags() {
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "extension",
+            "deactivate",
+            "flow",
+            "--force",
+            "--purge",
+        ])
+        .unwrap();
+        let Command::Extension {
+            action: extensions::Action::Deactivate { name, force, purge },
+        } = cli.command
+        else {
+            panic!("expected Extension::Deactivate");
+        };
+        assert_eq!(name, "flow");
+        assert!(force);
+        assert!(purge);
+    }
+
+    #[test]
+    fn extension_alias_ext_parses() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "ext", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Extension {
+                action: extensions::Action::List
             }
         ));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,18 @@ async fn main() -> Result<()> {
         thurbox::ui::theme::ensure_initialized();
     }
 
+    // Self-heal active extensions: re-create any session/automation a managed
+    // extension declares but that has since been deleted. Runs before the
+    // session restore below (so healed sessions are adopted like any other) and
+    // before the TUI takes over the terminal (so tmux spawn output can't corrupt
+    // it). Deleting an active extension's resources is therefore a no-op — they
+    // come back; `thurbox-cli extension deactivate <name>` is the real off-switch.
+    let heal_messages = thurbox::session_ops::heal_active_extensions(&db);
+    for m in &heal_messages {
+        tracing::info!("{m}");
+    }
+    config_warnings.extend(heal_messages);
+
     let mut terminal = ratatui::init();
     // Mouse capture is opt-out (`[features] mouse = false` in settings.toml):
     // without it the terminal keeps its native mouse behavior and no mouse

--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -1,0 +1,283 @@
+//! Extension manifests — pure data describing the thurbox resources an opt-in
+//! extension needs to function (a dedicated session, a tick automation, …).
+//!
+//! Extensions (see `extensions/<name>/`) are agent-agnostic add-ons built on
+//! `thurbox-cli`; per ADR-20 they live as data + shell scripts, never embedded
+//! in the binary. An extension ships an `extension.toml` manifest; its installer
+//! copies it into the discovery dir (`~/.config/thurbox/extensions/<name>.toml`),
+//! and thurbox core reads *any* manifest without knowing the extension by name.
+//!
+//! The manifest is the declarative contract behind `thurbox-cli extension
+//! activate/deactivate` and the startup/tick self-heal: it names the
+//! sessions/automations to (re)create idempotently. Kept here in `session` (the
+//! dependency sink) so both `agent` (the loader) and `session_ops` (the
+//! orchestration) can depend on the same type without crossing module-isolation
+//! rules — exactly like [`crate::session::HostDef`].
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::AgentDef;
+
+/// Token replaced with the resolved (absolute) extension home directory wherever
+/// it appears in a manifest (session `repo_path`, file contents marked
+/// `substitute`). The only template token the installer understands.
+pub const HOME_TOKEN: &str = "{home}";
+
+/// A file the installer lays down under the extension home directory. The
+/// content comes from the install source (`<source>/<source_path>`); only
+/// `path` is required.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionFile {
+    /// Destination path, relative to the extension home dir.
+    pub path: String,
+    /// Source path relative to the install source, when it differs from `path`
+    /// (e.g. a `claude-settings.json` template installed as `.claude/settings.json`).
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Mark the written file executable (`chmod +x`). For helper scripts.
+    #[serde(default)]
+    pub executable: bool,
+    /// Only write when the destination is absent (seed files like `repos.md`
+    /// the user then edits — never clobbered on reinstall).
+    #[serde(default)]
+    pub if_absent: bool,
+    /// Replace the [`HOME_TOKEN`] in the content with the resolved home path
+    /// before writing (e.g. claude permission paths).
+    #[serde(default)]
+    pub substitute: bool,
+}
+
+impl ExtensionFile {
+    /// Source-relative path to fetch this file's content from.
+    pub fn source_path(&self) -> &str {
+        self.source.as_deref().unwrap_or(&self.path)
+    }
+}
+
+/// A symlink the installer creates under the extension home directory. Used to
+/// surface a spec file under each agent CLI's context-file name
+/// (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `FLOW.md`). An existing *regular* file
+/// at `link` is never clobbered.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionSymlink {
+    /// Link path, relative to the extension home dir.
+    pub link: String,
+    /// Link target (relative to the link's directory).
+    pub target: String,
+}
+
+/// A session an extension wants kept alive. Identified by `name`, so an existing
+/// active session of that name is reused rather than duplicated.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionSession {
+    /// Session name (also the tmux window `tb-<name>`). Used to find/reuse it.
+    pub name: String,
+    /// Agent name to launch (an `agents.toml` entry the installer registers).
+    pub agent: String,
+    /// Directory the agent runs in (absolute; the installer resolves any `~`).
+    pub repo_path: PathBuf,
+}
+
+/// An automation an extension wants kept alive. Identified by `name`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionAutomation {
+    /// Automation name. Used to find/reuse it.
+    pub name: String,
+    /// Trigger spec, same grammar as `thurbox-cli automation create --trigger`
+    /// (`hourly` | `daily` | `weekdays` | `weekly` | `cron:<expr>` | `at:<ms>`).
+    pub trigger: String,
+    /// Name of the extension session this automation sends its prompt to. Must
+    /// match one of the manifest's `[[sessions]]` entries.
+    pub session_ref: String,
+    /// Prompt text delivered on each fire (e.g. `tick`).
+    pub prompt: String,
+}
+
+/// A full extension manifest: the resources to ensure when the extension is
+/// active. One manifest per `extension.toml` file.
+///
+/// Unknown fields are tolerated but reported by the loader as a warning, so a
+/// newer manifest doesn't strand an older thurbox on defaults.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionDef {
+    /// Unique extension name (matches the discovery file stem and what
+    /// `thurbox-cli extension activate <name>` expects).
+    pub name: String,
+    /// Optional human-readable summary, shown in `extension list`.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Manifest-format version, for future migrations. Currently `1`.
+    #[serde(default)]
+    pub config_version: Option<u32>,
+    /// Default install home directory (may use `~`), where payload files land
+    /// and the session runs. The `--home` flag overrides it. Required to
+    /// install; unused once installed.
+    #[serde(default)]
+    pub home: Option<String>,
+    /// Agents to register in `agents.toml` on install (idempotent — existing
+    /// names are left untouched). Install-time only.
+    #[serde(default)]
+    pub agents: Vec<AgentDef>,
+    /// Payload files the installer lays down under the home dir. Install-time only.
+    #[serde(default)]
+    pub files: Vec<ExtensionFile>,
+    /// Symlinks the installer creates under the home dir. Install-time only.
+    #[serde(default)]
+    pub symlinks: Vec<ExtensionSymlink>,
+    /// Sessions to ensure exist while the extension is active.
+    #[serde(default)]
+    pub sessions: Vec<ExtensionSession>,
+    /// Automations to ensure exist while the extension is active.
+    #[serde(default)]
+    pub automations: Vec<ExtensionAutomation>,
+}
+
+impl ExtensionDef {
+    /// Whether the manifest declares no runtime resources (nothing to ensure).
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty() && self.automations.is_empty()
+    }
+
+    /// Return a copy with the [`HOME_TOKEN`] resolved to `home` in every session
+    /// `repo_path`, and with `home` itself stored as the resolved absolute path.
+    /// This is what gets written to the discovery dir at install time, so
+    /// `activate`/self-heal read absolute paths (they don't expand tokens
+    /// themselves) and uninstall knows the real home directory.
+    pub fn resolved_for_home(&self, home: &str) -> ExtensionDef {
+        let mut out = self.clone();
+        out.home = Some(home.to_string());
+        for s in &mut out.sessions {
+            let p = s.repo_path.to_string_lossy().replace(HOME_TOKEN, home);
+            s.repo_path = PathBuf::from(p);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_full_manifest() {
+        let toml = r#"
+name = "flow"
+description = "Focus-protecting triage agent"
+config_version = 1
+
+[[sessions]]
+name = "flow"
+agent = "flow"
+repo_path = "/home/me/flow"
+
+[[automations]]
+name = "flow-tick"
+trigger = "cron:*/5 * * * *"
+session_ref = "flow"
+prompt = "tick"
+"#;
+        let def: ExtensionDef = toml::from_str(toml).unwrap();
+        assert_eq!(def.name, "flow");
+        assert_eq!(
+            def.description.as_deref(),
+            Some("Focus-protecting triage agent")
+        );
+        assert_eq!(def.sessions.len(), 1);
+        assert_eq!(def.sessions[0].agent, "flow");
+        assert_eq!(def.sessions[0].repo_path, PathBuf::from("/home/me/flow"));
+        assert_eq!(def.automations.len(), 1);
+        assert_eq!(def.automations[0].session_ref, "flow");
+        assert_eq!(def.automations[0].prompt, "tick");
+        assert!(!def.is_empty());
+    }
+
+    #[test]
+    fn round_trips_through_toml() {
+        let def = ExtensionDef {
+            name: "flow".into(),
+            description: None,
+            config_version: Some(1),
+            home: Some("~/flow".into()),
+            agents: vec![AgentDef {
+                name: "flow".into(),
+                command: "claude".into(),
+                args: vec!["--model".into(), "claude-haiku-4-5".into()],
+                resume_args: vec![],
+                fork_args: vec![],
+                new_session_args: vec![],
+                resume_latest: false,
+            }],
+            files: vec![ExtensionFile {
+                path: "FLOW.md".into(),
+                source: None,
+                executable: false,
+                if_absent: false,
+                substitute: false,
+            }],
+            symlinks: vec![ExtensionSymlink {
+                link: "CLAUDE.md".into(),
+                target: "FLOW.md".into(),
+            }],
+            sessions: vec![ExtensionSession {
+                name: "flow".into(),
+                agent: "flow".into(),
+                repo_path: PathBuf::from("{home}"),
+            }],
+            automations: vec![ExtensionAutomation {
+                name: "flow-tick".into(),
+                trigger: "cron:*/5 * * * *".into(),
+                session_ref: "flow".into(),
+                prompt: "tick".into(),
+            }],
+        };
+        let text = toml::to_string(&def).unwrap();
+        let back: ExtensionDef = toml::from_str(&text).unwrap();
+        assert_eq!(def, back);
+    }
+
+    #[test]
+    fn minimal_manifest_has_no_resources() {
+        let def: ExtensionDef = toml::from_str("name = \"bare\"\n").unwrap();
+        assert_eq!(def.name, "bare");
+        assert!(def.is_empty());
+        assert!(def.agents.is_empty());
+        assert!(def.files.is_empty());
+    }
+
+    #[test]
+    fn resolved_for_home_substitutes_session_repo_path() {
+        let def: ExtensionDef = toml::from_str(
+            "name = \"flow\"\n[[sessions]]\nname = \"flow\"\nagent = \"flow\"\nrepo_path = \"{home}\"\n",
+        )
+        .unwrap();
+        let resolved = def.resolved_for_home("/home/me/flow");
+        assert_eq!(
+            resolved.sessions[0].repo_path,
+            PathBuf::from("/home/me/flow")
+        );
+        // Original is untouched.
+        assert_eq!(def.sessions[0].repo_path, PathBuf::from("{home}"));
+    }
+
+    #[test]
+    fn file_source_path_falls_back_to_path() {
+        let f = ExtensionFile {
+            path: ".claude/settings.json".into(),
+            source: Some("claude-settings.json".into()),
+            executable: false,
+            if_absent: false,
+            substitute: true,
+        };
+        assert_eq!(f.source_path(), "claude-settings.json");
+        let g = ExtensionFile {
+            path: "FLOW.md".into(),
+            source: None,
+            executable: false,
+            if_absent: false,
+            substitute: false,
+        };
+        assert_eq!(g.source_path(), "FLOW.md");
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_def;
 pub mod automation;
+pub mod extension_def;
 pub mod host_def;
 pub mod keybindings;
 pub mod settings;
@@ -10,6 +11,9 @@ pub use agent_def::{AgentDef, AgentRegistry};
 pub use automation::{
     parse_hhmm, preset_to_cron, Automation, AutomationAction, AutomationRun, AutomationRunStatus,
     AutomationSchedule, SchedulePreset,
+};
+pub use extension_def::{
+    ExtensionAutomation, ExtensionDef, ExtensionFile, ExtensionSession, ExtensionSymlink,
 };
 pub use host_def::{is_ssh_backend, HostDef, HostRegistry, SSH_BACKEND_PREFIX};
 pub use keybindings::{Action, KeyBindings, KeyChord, KeyContext};

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -1,0 +1,963 @@
+//! Headless extension activation, deactivation, and self-healing.
+//!
+//! An extension manifest ([`ExtensionDef`]) declares the sessions/automations an
+//! opt-in extension needs. These helpers make that declaration real and keep it
+//! real:
+//!
+//! - [`ensure_extension`] idempotently (re)creates any missing declared
+//!   resources — the self-heal primitive run at TUI startup and on every
+//!   headless `automation tick`.
+//! - [`activate_extension`] = `ensure` + record the extension in the active set
+//!   (SQLite `metadata`), so self-heal will resurrect its resources if deleted.
+//! - [`deactivate_extension`] tears the resources down and clears the active-set
+//!   entry, so self-heal stops resurrecting it. This is the real off-switch.
+//!
+//! Deleting an extension's session/automation by hand (TUI `Ctrl+D`, `clean`,
+//! `thurbox-cli session/automation delete`) is therefore a no-op while the
+//! extension is active: the next ensure pass recreates it. `deactivate` is how a
+//! user turns an extension off for good.
+//!
+//! This module reaches no `agent::` symbols — spawn/delete go through the
+//! sibling `session_ops` helpers and everything else is `storage`/`session`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::session::automation::parse_trigger;
+use crate::session::extension_def::HOME_TOKEN;
+use crate::session::{AutomationAction, ExtensionDef, SessionId};
+use crate::storage::automations::NewAutomation;
+use crate::storage::Database;
+use crate::sync::current_time_millis;
+
+/// What [`ensure_extension`] actually created this pass (empty = everything was
+/// already present). Lets callers toast only on a real (re)creation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EnsureReport {
+    /// Names of sessions newly spawned this pass.
+    pub sessions_created: Vec<String>,
+    /// Names of automations newly created this pass.
+    pub automations_created: Vec<String>,
+}
+
+impl EnsureReport {
+    /// Whether anything was (re)created.
+    pub fn created_anything(&self) -> bool {
+        !self.sessions_created.is_empty() || !self.automations_created.is_empty()
+    }
+}
+
+/// What [`deactivate_extension`] tore down.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DeactivateReport {
+    pub sessions_deleted: Vec<String>,
+    pub automations_deleted: Vec<String>,
+    /// Whether the extension was in the active set before this call.
+    pub was_active: bool,
+}
+
+/// Per-resource presence snapshot for `extension status` / `extension list`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionHealth {
+    pub name: String,
+    pub active: bool,
+    /// `(session_name, present)` for each declared session.
+    pub sessions: Vec<(String, bool)>,
+    /// `(automation_name, present)` for each declared automation.
+    pub automations: Vec<(String, bool)>,
+}
+
+impl ExtensionHealth {
+    /// Healthy = active and every declared resource currently exists.
+    pub fn is_healthy(&self) -> bool {
+        self.active
+            && self.sessions.iter().all(|(_, p)| *p)
+            && self.automations.iter().all(|(_, p)| *p)
+    }
+}
+
+/// What [`install_extension`] did.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InstallReport {
+    pub name: String,
+    /// Resolved (absolute) home directory the payload landed in.
+    pub home: String,
+    pub files_written: Vec<String>,
+    /// Files skipped because they already existed and are `if_absent`.
+    pub files_skipped: Vec<String>,
+    pub symlinks_created: Vec<String>,
+    /// Symlinks skipped because a regular file already occupies the link path.
+    pub symlinks_skipped: Vec<String>,
+    pub agents_added: Vec<String>,
+    /// The activate result (sessions/automations created).
+    pub ensure: EnsureReport,
+}
+
+/// Install an extension end-to-end from a `target` (a bare name resolved against
+/// the official source, a `http(s)://` base, or a local directory): fetch the
+/// manifest, lay down its payload files + symlinks under the home dir, register
+/// its agents in `agents.toml`, write the (home-resolved) manifest to the
+/// discovery dir, then activate it (ensure session/automation + self-heal).
+///
+/// Idempotent: re-running refreshes payload files (except `if_absent` ones,
+/// unless `force`), adds only missing agents, and reuses existing
+/// sessions/automations.
+pub fn install_extension(
+    db: &Database,
+    target: &str,
+    home_override: Option<&str>,
+    force: bool,
+) -> Result<InstallReport, String> {
+    // Agent-layer helpers are reached fully-qualified (no `use crate::agent`) per
+    // the session_ops → agent path-only architecture rule.
+    let source = crate::agent::extension_config::resolve_source(target);
+    let (def, warnings) = crate::agent::extension_config::load_manifest_from_source(&source)?;
+    for w in &warnings {
+        tracing::warn!("{w}");
+    }
+
+    let home_raw = home_override
+        .map(str::to_string)
+        .or_else(|| def.home.clone())
+        .ok_or_else(|| {
+            format!(
+                "extension '{}' has no `home` in its manifest; pass --home <dir>",
+                def.name
+            )
+        })?;
+    let home = crate::agent::extension_config::expand_tilde(&home_raw);
+    let home_str = home.to_string_lossy().to_string();
+
+    let mut report = InstallReport {
+        name: def.name.clone(),
+        home: home_str.clone(),
+        ..Default::default()
+    };
+
+    // 1. Payload files.
+    for f in &def.files {
+        // Reject absolute / `..` destinations and sources so a manifest can't
+        // write or read outside the home / source dir (path-traversal guard).
+        let dest = safe_join(&home, &f.path)?;
+        ensure_safe_relative(f.source_path())?;
+        if f.if_absent && dest.exists() && !force {
+            report.files_skipped.push(f.path.clone());
+            continue;
+        }
+        // Don't clobber a `substitute` file (e.g. .claude/settings.json) the
+        // user has edited: we only overwrite ours, identified by the installer
+        // marker we write into it. `--force` overrides.
+        if f.substitute && !force && is_user_modified(&dest) {
+            report.files_skipped.push(f.path.clone());
+            continue;
+        }
+        let mut content = crate::agent::extension_config::fetch_file(&source, f.source_path())?;
+        if f.substitute {
+            content = content.replace(HOME_TOKEN, &home_str);
+        }
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create {}: {e}", parent.display()))?;
+        }
+        std::fs::write(&dest, content).map_err(|e| format!("write {}: {e}", dest.display()))?;
+        if f.executable {
+            set_executable(&dest)?;
+        }
+        report.files_written.push(f.path.clone());
+    }
+
+    // 2. Symlinks (never clobber a regular file the user owns).
+    for s in &def.symlinks {
+        // Validate both ends before touching the filesystem, so a bad target
+        // can't leave a removed symlink behind.
+        let link = safe_join(&home, &s.link)?;
+        ensure_safe_relative(&s.target)?;
+        match std::fs::symlink_metadata(&link) {
+            Ok(m) if m.file_type().is_symlink() => {
+                std::fs::remove_file(&link)
+                    .map_err(|e| format!("replace symlink {}: {e}", link.display()))?;
+            }
+            Ok(_) => {
+                report.symlinks_skipped.push(s.link.clone());
+                continue;
+            }
+            Err(_) => {}
+        }
+        if let Some(parent) = link.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create {}: {e}", parent.display()))?;
+        }
+        make_symlink(&s.target, &link)?;
+        report.symlinks_created.push(s.link.clone());
+    }
+
+    // 3. Agents → agents.toml (idempotent).
+    report.agents_added = crate::agent::extension_config::ensure_agents_registered(&def.agents)?;
+
+    // 4. Persist the home-resolved manifest to the discovery dir, then activate.
+    let resolved = def.resolved_for_home(&home_str);
+    crate::agent::extension_config::write_manifest(&resolved)?;
+    report.ensure = activate_extension(db, &resolved)?;
+
+    Ok(report)
+}
+
+/// What [`uninstall_extension`] removed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UninstallReport {
+    pub name: String,
+    /// The teardown of runtime resources (session/automation) + active set.
+    pub deactivate: DeactivateReport,
+    pub agents_removed: Vec<String>,
+    pub manifest_removed: bool,
+    /// The home dir, if it was removed (`purge_home`).
+    pub home_removed: Option<String>,
+}
+
+/// Fully reverse an install: tear down the session/automation (force), remove
+/// the extension's agents from `agents.toml`, and delete the discovery manifest.
+/// With `purge_home`, also delete the install home directory (the payload +
+/// any user data under it). The inverse of [`install_extension`].
+pub fn uninstall_extension(
+    db: &Database,
+    name: &str,
+    purge_home: bool,
+) -> Result<UninstallReport, String> {
+    let def = crate::agent::extension_config::load_manifest(name)
+        .ok_or_else(|| format!("extension '{name}' is not installed (no manifest found)"))?;
+
+    let mut report = UninstallReport {
+        name: name.to_string(),
+        ..Default::default()
+    };
+
+    // Tear down runtime resources + clear the active set (force kills tmux/worktrees).
+    report.deactivate = deactivate_extension(db, &def, true)?;
+
+    // Remove the agents this extension registered.
+    let agent_names: Vec<String> = def.agents.iter().map(|a| a.name.clone()).collect();
+    report.agents_removed = crate::agent::extension_config::remove_agents_from_toml(&agent_names)?;
+
+    // Optionally delete the install home (payload + user data).
+    if purge_home {
+        if let Some(home) = &def.home {
+            let path = crate::agent::extension_config::expand_tilde(home);
+            guard_removable_dir(&path)?;
+            if path.is_dir() {
+                std::fs::remove_dir_all(&path)
+                    .map_err(|e| format!("remove {}: {e}", path.display()))?;
+                report.home_removed = Some(path.to_string_lossy().into_owned());
+            }
+        }
+    }
+
+    // Drop the discovery manifest last, so a failure above leaves it recoverable.
+    report.manifest_removed = crate::agent::extension_config::remove_manifest_file(name)?;
+
+    Ok(report)
+}
+
+/// Refuse to recursively delete obviously-dangerous paths (root, `$HOME`
+/// itself, or a shallow path) — a guard before `remove_dir_all` on a
+/// manifest-supplied home.
+fn guard_removable_dir(path: &Path) -> Result<(), String> {
+    let depth = path
+        .components()
+        .filter(|c| matches!(c, std::path::Component::Normal(_)))
+        .count();
+    if depth < 2 {
+        return Err(format!(
+            "refusing to remove '{}' (too shallow); remove it by hand",
+            path.display()
+        ));
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        if path == Path::new(&home) {
+            return Err("refusing to remove $HOME".into());
+        }
+    }
+    Ok(())
+}
+
+/// Validate that a manifest-supplied path is a safe relative path (no absolute
+/// root, no `..` components) — the path-traversal guard for install payloads.
+fn ensure_safe_relative(rel: &str) -> Result<(), String> {
+    let p = Path::new(rel);
+    if p.is_absolute() {
+        return Err(format!(
+            "manifest path '{rel}' must be relative, not absolute"
+        ));
+    }
+    for c in p.components() {
+        match c {
+            std::path::Component::Normal(_) | std::path::Component::CurDir => {}
+            _ => {
+                return Err(format!(
+                    "manifest path '{rel}' must not contain '..' or a root component"
+                ))
+            }
+        }
+    }
+    Ok(())
+}
+
+/// [`ensure_safe_relative`] + join under `home`.
+fn safe_join(home: &Path, rel: &str) -> Result<PathBuf, String> {
+    ensure_safe_relative(rel)?;
+    Ok(home.join(rel))
+}
+
+/// Marker an installer-managed `substitute` file carries (in the template
+/// content) so reinstall can overwrite *its own* file but not one the user has
+/// edited (or whose marker they removed).
+const MANAGED_MARKER: &str = "thurbox `extension install`";
+
+/// Whether `dest` is a `substitute` file the user has taken ownership of: it
+/// exists but no longer carries the managed marker. A missing file (fresh
+/// install) or one still carrying the marker is ours to (over)write.
+fn is_user_modified(dest: &Path) -> bool {
+    match std::fs::read_to_string(dest) {
+        Ok(content) => !content.contains(MANAGED_MARKER),
+        Err(_) => false,
+    }
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)
+        .map_err(|e| format!("stat {}: {e}", path.display()))?
+        .permissions();
+    perms.set_mode(perms.mode() | 0o755);
+    std::fs::set_permissions(path, perms).map_err(|e| format!("chmod {}: {e}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn make_symlink(target: &str, link: &Path) -> Result<(), String> {
+    std::os::unix::fs::symlink(target, link)
+        .map_err(|e| format!("symlink {} -> {target}: {e}", link.display()))
+}
+
+#[cfg(not(unix))]
+fn make_symlink(_target: &str, _link: &Path) -> Result<(), String> {
+    Err("symlinks are only supported on unix".into())
+}
+
+/// Idempotently ensure every resource a manifest declares exists. Existing
+/// sessions/automations are matched by name and reused; only the missing ones
+/// are created. Safe to call repeatedly (this is the self-heal primitive).
+pub fn ensure_extension(db: &Database, def: &ExtensionDef) -> Result<EnsureReport, String> {
+    let mut report = EnsureReport::default();
+    let mut session_ids: HashMap<String, SessionId> = HashMap::new();
+
+    for sess in &def.sessions {
+        let existing = db
+            .list_active_sessions()
+            .map_err(|e| format!("list_active_sessions: {e}"))?
+            .into_iter()
+            .find(|row| row.name == sess.name);
+        let id = match existing {
+            Some(row) => row.id,
+            None => {
+                let result = super::spawn_session_headless(
+                    db,
+                    super::SpawnRequest {
+                        name: sess.name.clone(),
+                        repo_path: sess.repo_path.clone(),
+                        worktree_branch: None,
+                        base_branch: None,
+                        agent: Some(sess.agent.clone()),
+                        agent_session_id: None,
+                        host: None,
+                        parent_session_id: None,
+                    },
+                )?;
+                report.sessions_created.push(sess.name.clone());
+                result.session_id
+            }
+        };
+        session_ids.insert(sess.name.clone(), id);
+    }
+
+    for auto in &def.automations {
+        let exists = db
+            .list_automations()
+            .map_err(|e| format!("list_automations: {e}"))?
+            .iter()
+            .any(|row| row.name == auto.name);
+        if exists {
+            continue;
+        }
+        let target = *session_ids.get(&auto.session_ref).ok_or_else(|| {
+            format!(
+                "automation '{}' references unknown session '{}'",
+                auto.name, auto.session_ref
+            )
+        })?;
+        let schedule = parse_trigger(&auto.trigger, None, None)?;
+        let next_run_at = schedule.next_after(current_time_millis(), None);
+        let new = NewAutomation {
+            name: auto.name.clone(),
+            enabled: true,
+            schedule,
+            timezone: None,
+            action: AutomationAction::Send { session_id: target },
+            prompt: auto.prompt.clone(),
+            next_run_at,
+        };
+        db.create_automation(&new)
+            .map_err(|e| format!("create_automation: {e}"))?;
+        report.automations_created.push(auto.name.clone());
+    }
+
+    Ok(report)
+}
+
+/// Activate an extension: ensure its resources exist, then record it in the
+/// active set so self-heal keeps them alive. Idempotent.
+///
+/// Note: this does NOT arm the tmux automation heartbeat — the CLI layer does
+/// that (it owns the `agent::tmux` dependency). A `Send` automation only fires
+/// while something ticks it (TUI tick loop, or the heartbeat keeper window).
+pub fn activate_extension(db: &Database, def: &ExtensionDef) -> Result<EnsureReport, String> {
+    let report = ensure_extension(db, def)?;
+    db.add_active_extension(&def.name)
+        .map_err(|e| format!("add_active_extension: {e}"))?;
+    Ok(report)
+}
+
+/// Deactivate an extension: delete its declared automations and sessions, then
+/// drop it from the active set so self-heal won't resurrect it. `force` also
+/// tears down each session's tmux window/worktrees (otherwise a soft delete).
+/// Idempotent — missing resources are simply skipped.
+pub fn deactivate_extension(
+    db: &Database,
+    def: &ExtensionDef,
+    force: bool,
+) -> Result<DeactivateReport, String> {
+    let mut report = DeactivateReport::default();
+
+    for auto in &def.automations {
+        let id = db
+            .list_automations()
+            .map_err(|e| format!("list_automations: {e}"))?
+            .into_iter()
+            .find(|row| row.name == auto.name)
+            .map(|row| row.id);
+        if let Some(id) = id {
+            db.delete_automation(id)
+                .map_err(|e| format!("delete_automation: {e}"))?;
+            report.automations_deleted.push(auto.name.clone());
+        }
+    }
+
+    for sess in &def.sessions {
+        let id = db
+            .list_active_sessions()
+            .map_err(|e| format!("list_active_sessions: {e}"))?
+            .into_iter()
+            .find(|row| row.name == sess.name)
+            .map(|row| row.id);
+        if let Some(id) = id {
+            super::delete_session_headless(db, id, force)?;
+            report.sessions_deleted.push(sess.name.clone());
+        }
+    }
+
+    report.was_active = db
+        .remove_active_extension(&def.name)
+        .map_err(|e| format!("remove_active_extension: {e}"))?;
+
+    Ok(report)
+}
+
+/// Re-ensure every active extension's declared resources, returning user-facing
+/// messages for anything that was recreated, has a missing manifest, or failed.
+/// This is the self-heal entry point shared by TUI startup and the headless
+/// `automation tick`. Never errors out: per-extension problems become messages,
+/// so one bad extension can't block the others (or, in tick, the firing pass).
+///
+/// The active set is read from SQLite `metadata`; `activate_extension` /
+/// `deactivate_extension` (i.e. `thurbox-cli extension …`) manage membership.
+pub fn heal_active_extensions(db: &Database) -> Vec<String> {
+    let active = db.get_active_extensions().unwrap_or_default();
+    let mut messages = Vec::new();
+    for name in active {
+        // Fully-qualified agent reference (no `use`) per the session_ops →
+        // agent path-only architecture rule.
+        let Some(def) = crate::agent::extension_config::load_manifest(&name) else {
+            messages.push(format!(
+                "extension '{name}' is active but its manifest is missing; reinstall it \
+                 or run `thurbox-cli extension deactivate {name}`"
+            ));
+            continue;
+        };
+        match ensure_extension(db, &def) {
+            Ok(report) if report.created_anything() => {
+                let mut parts = Vec::new();
+                if !report.sessions_created.is_empty() {
+                    parts.push(format!("session(s) {}", report.sessions_created.join(", ")));
+                }
+                if !report.automations_created.is_empty() {
+                    parts.push(format!(
+                        "automation(s) {}",
+                        report.automations_created.join(", ")
+                    ));
+                }
+                messages.push(format!(
+                    "Recreated {} for managed extension '{name}' \
+                     (`thurbox-cli extension deactivate {name}` to turn it off)",
+                    parts.join(" + ")
+                ));
+            }
+            Ok(_) => {}
+            Err(e) => messages.push(format!("extension '{name}' self-heal failed: {e}")),
+        }
+    }
+    messages
+}
+
+/// Snapshot which of a manifest's declared resources currently exist and whether
+/// the extension is in the active set.
+pub fn extension_health(db: &Database, def: &ExtensionDef) -> Result<ExtensionHealth, String> {
+    let session_names: Vec<String> = db
+        .list_active_sessions()
+        .map_err(|e| format!("list_active_sessions: {e}"))?
+        .into_iter()
+        .map(|row| row.name)
+        .collect();
+    let automation_names: Vec<String> = db
+        .list_automations()
+        .map_err(|e| format!("list_automations: {e}"))?
+        .into_iter()
+        .map(|row| row.name)
+        .collect();
+    let active = db
+        .get_active_extensions()
+        .map_err(|e| format!("get_active_extensions: {e}"))?
+        .iter()
+        .any(|n| n == &def.name);
+
+    Ok(ExtensionHealth {
+        name: def.name.clone(),
+        active,
+        sessions: def
+            .sessions
+            .iter()
+            .map(|s| (s.name.clone(), session_names.contains(&s.name)))
+            .collect(),
+        automations: def
+            .automations
+            .iter()
+            .map(|a| (a.name.clone(), automation_names.contains(&a.name)))
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::{ExtensionAutomation, ExtensionSession};
+    use crate::sync::SharedSession;
+
+    fn insert_session(db: &Database, name: &str) -> SessionId {
+        let id = SessionId::default();
+        let shared = SharedSession {
+            id,
+            name: name.into(),
+            agent: "flow".into(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: Some(uuid::Uuid::new_v4().to_string()),
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        db.upsert_session(&shared).unwrap();
+        id
+    }
+
+    /// A manifest whose single session already exists, so ensure never has to
+    /// spawn (which would need tmux) — only the automation is created.
+    fn flow_def() -> ExtensionDef {
+        ExtensionDef {
+            name: "flow".into(),
+            description: None,
+            config_version: Some(1),
+            home: None,
+            agents: Vec::new(),
+            files: Vec::new(),
+            symlinks: Vec::new(),
+            sessions: vec![ExtensionSession {
+                name: "flow".into(),
+                agent: "flow".into(),
+                repo_path: "/tmp/flow".into(),
+            }],
+            automations: vec![ExtensionAutomation {
+                name: "flow-tick".into(),
+                trigger: "cron:*/5 * * * *".into(),
+                session_ref: "flow".into(),
+                prompt: "tick".into(),
+            }],
+        }
+    }
+
+    #[test]
+    fn ensure_reuses_existing_session_and_creates_automation() {
+        let db = Database::open_in_memory().unwrap();
+        insert_session(&db, "flow");
+
+        let report = ensure_extension(&db, &flow_def()).unwrap();
+        assert!(report.sessions_created.is_empty(), "session was reused");
+        assert_eq!(report.automations_created, ["flow-tick"]);
+
+        let autos = db.list_automations().unwrap();
+        assert_eq!(autos.len(), 1);
+        assert_eq!(autos[0].name, "flow-tick");
+        assert!(matches!(autos[0].action, AutomationAction::Send { .. }));
+    }
+
+    #[test]
+    fn ensure_is_idempotent() {
+        let db = Database::open_in_memory().unwrap();
+        insert_session(&db, "flow");
+        let def = flow_def();
+
+        ensure_extension(&db, &def).unwrap();
+        let second = ensure_extension(&db, &def).unwrap();
+        assert!(!second.created_anything(), "second pass creates nothing");
+        assert_eq!(db.list_automations().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn unknown_session_ref_errors() {
+        let db = Database::open_in_memory().unwrap();
+        insert_session(&db, "flow");
+        let mut def = flow_def();
+        def.automations[0].session_ref = "ghost".into();
+        let err = ensure_extension(&db, &def).unwrap_err();
+        assert!(err.contains("ghost"), "got: {err}");
+    }
+
+    #[test]
+    fn activate_records_active_set() {
+        let db = Database::open_in_memory().unwrap();
+        insert_session(&db, "flow");
+        activate_extension(&db, &flow_def()).unwrap();
+        assert_eq!(db.get_active_extensions().unwrap(), ["flow"]);
+    }
+
+    #[test]
+    fn deactivate_tears_down_and_clears_active_set() {
+        let db = Database::open_in_memory().unwrap();
+        insert_session(&db, "flow");
+        let def = flow_def();
+        activate_extension(&db, &def).unwrap();
+
+        let report = deactivate_extension(&db, &def, false).unwrap();
+        assert!(report.was_active);
+        assert_eq!(report.automations_deleted, ["flow-tick"]);
+        assert_eq!(report.sessions_deleted, ["flow"]);
+        assert!(db.list_automations().unwrap().is_empty());
+        assert!(
+            db.get_active_extensions().unwrap().is_empty(),
+            "self-heal must not resurrect a deactivated extension"
+        );
+    }
+
+    #[test]
+    fn deactivate_is_idempotent() {
+        let db = Database::open_in_memory().unwrap();
+        let def = flow_def();
+        // Nothing exists / not active — deactivate is a clean no-op.
+        let report = deactivate_extension(&db, &def, false).unwrap();
+        assert!(!report.was_active);
+        assert!(report.automations_deleted.is_empty());
+        assert!(report.sessions_deleted.is_empty());
+    }
+
+    #[test]
+    fn install_lays_files_registers_agents_and_activates() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+        // Pre-create the session so activate reuses it (no tmux spawn in tests).
+        insert_session(&db, "flow");
+
+        // A local source dir with a manifest + payload.
+        let src = tempfile::TempDir::new().unwrap();
+        let home = temp.path().join("flowhome");
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                r#"name = "flow"
+home = "{}"
+
+[[agents]]
+name = "flow"
+command = "claude"
+args = ["--model", "haiku"]
+
+[[files]]
+path = "FLOW.md"
+
+[[files]]
+path = "scripts/do.sh"
+executable = true
+
+[[files]]
+path = "repos.md"
+if_absent = true
+
+[[files]]
+path = ".claude/settings.json"
+source = "settings.tmpl"
+substitute = true
+
+[[symlinks]]
+link = "CLAUDE.md"
+target = "FLOW.md"
+
+[[sessions]]
+name = "flow"
+agent = "flow"
+repo_path = "{{home}}"
+
+[[automations]]
+name = "flow-tick"
+trigger = "cron:*/5 * * * *"
+session_ref = "flow"
+prompt = "tick"
+"#,
+                home.display()
+            ),
+        )
+        .unwrap();
+        std::fs::write(src.path().join("FLOW.md"), "spec").unwrap();
+        std::fs::create_dir_all(src.path().join("scripts")).unwrap();
+        std::fs::write(src.path().join("scripts/do.sh"), "#!/bin/sh\n").unwrap();
+        std::fs::write(src.path().join("repos.md"), "seed table").unwrap();
+        std::fs::write(src.path().join("settings.tmpl"), "perm {home}/x").unwrap();
+
+        let target = src.path().to_string_lossy().to_string();
+        let report = install_extension(&db, &target, None, false).unwrap();
+
+        // Files laid down under home.
+        assert!(home.join("FLOW.md").exists());
+        assert!(home.join("scripts/do.sh").exists());
+        assert!(home.join("repos.md").exists());
+        // {home} substituted in the settings template.
+        let settings = std::fs::read_to_string(home.join(".claude/settings.json")).unwrap();
+        assert_eq!(settings, format!("perm {}/x", home.display()));
+        // Symlink created.
+        assert!(std::fs::symlink_metadata(home.join("CLAUDE.md"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        // executable bit set.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(home.join("scripts/do.sh"))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o100, 0o100, "do.sh should be executable");
+        }
+
+        // Agent registered, manifest written + active, automation created.
+        assert_eq!(report.agents_added, ["flow"]);
+        let reg = crate::agent::agent_config::load_or_seed();
+        assert_eq!(reg.get("flow").unwrap().args, ["--model", "haiku"]);
+        assert_eq!(db.get_active_extensions().unwrap(), ["flow"]);
+        let stored = crate::agent::extension_config::load_manifest("flow").unwrap();
+        // repo_path was resolved from {home} to the absolute home.
+        assert_eq!(stored.sessions[0].repo_path, home);
+        assert_eq!(report.ensure.automations_created, ["flow-tick"]);
+
+        // Re-install is idempotent: repos.md kept (if_absent), no new agents.
+        std::fs::write(home.join("repos.md"), "user edited").unwrap();
+        let again = install_extension(&db, &target, None, false).unwrap();
+        assert!(again.files_skipped.contains(&"repos.md".to_string()));
+        assert_eq!(
+            std::fs::read_to_string(home.join("repos.md")).unwrap(),
+            "user edited",
+            "if_absent file must not be clobbered on reinstall"
+        );
+        assert!(again.agents_added.is_empty());
+    }
+
+    #[test]
+    fn ensure_safe_relative_rejects_traversal_and_absolute() {
+        assert!(ensure_safe_relative("FLOW.md").is_ok());
+        assert!(ensure_safe_relative("scripts/do.sh").is_ok());
+        assert!(ensure_safe_relative("./a/b").is_ok());
+        assert!(ensure_safe_relative("/etc/passwd").is_err());
+        assert!(ensure_safe_relative("../escape").is_err());
+        assert!(ensure_safe_relative("a/../../b").is_err());
+    }
+
+    #[test]
+    fn install_rejects_path_traversal_in_manifest() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                "name = \"evil\"\nhome = \"{}\"\n[[files]]\npath = \"../../pwned\"\n",
+                temp.path().join("h").display()
+            ),
+        )
+        .unwrap();
+        std::fs::write(src.path().join("../../pwned"), "x").ok();
+
+        let target = src.path().to_string_lossy().to_string();
+        let err = install_extension(&db, &target, None, false).unwrap_err();
+        assert!(err.contains("must not contain '..'"), "got: {err}");
+    }
+
+    #[test]
+    fn install_skips_user_modified_substitute_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+        insert_session(&db, "flow");
+
+        let src = tempfile::TempDir::new().unwrap();
+        let home = temp.path().join("h");
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                "name = \"flow\"\nhome = \"{}\"\n[[files]]\npath = \"settings.json\"\nsubstitute = true\n[[sessions]]\nname = \"flow\"\nagent = \"flow\"\nrepo_path = \"{{home}}\"\n",
+                home.display()
+            ),
+        )
+        .unwrap();
+        // Template carries the managed marker so a fresh install owns it.
+        std::fs::write(
+            src.path().join("settings.json"),
+            "thurbox `extension install` managed {home}",
+        )
+        .unwrap();
+        let target = src.path().to_string_lossy().to_string();
+
+        // First install writes it.
+        let r1 = install_extension(&db, &target, None, false).unwrap();
+        assert!(r1.files_written.contains(&"settings.json".to_string()));
+
+        // User edits it (drops the marker) → reinstall must not clobber it.
+        std::fs::write(home.join("settings.json"), "MY CUSTOM PERMS").unwrap();
+        let r2 = install_extension(&db, &target, None, false).unwrap();
+        assert!(r2.files_skipped.contains(&"settings.json".to_string()));
+        assert_eq!(
+            std::fs::read_to_string(home.join("settings.json")).unwrap(),
+            "MY CUSTOM PERMS"
+        );
+
+        // --force overrides and rewrites from the template.
+        let r3 = install_extension(&db, &target, None, true).unwrap();
+        assert!(r3.files_written.contains(&"settings.json".to_string()));
+    }
+
+    #[test]
+    fn uninstall_reverses_install() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+        insert_session(&db, "flow");
+
+        let src = tempfile::TempDir::new().unwrap();
+        let home = temp.path().join("flowhome");
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                r#"name = "flow"
+home = "{}"
+[[agents]]
+name = "flow"
+command = "claude"
+[[files]]
+path = "FLOW.md"
+[[sessions]]
+name = "flow"
+agent = "flow"
+repo_path = "{{home}}"
+[[automations]]
+name = "flow-tick"
+trigger = "cron:*/5 * * * *"
+session_ref = "flow"
+prompt = "tick"
+"#,
+                home.display()
+            ),
+        )
+        .unwrap();
+        std::fs::write(src.path().join("FLOW.md"), "spec").unwrap();
+        let target = src.path().to_string_lossy().to_string();
+
+        install_extension(&db, &target, None, false).unwrap();
+        assert!(home.join("FLOW.md").exists());
+        assert!(crate::agent::agent_config::load_or_seed()
+            .get("flow")
+            .is_some());
+        assert_eq!(db.get_active_extensions().unwrap(), ["flow"]);
+
+        // Uninstall without --purge keeps the home dir but removes everything else.
+        let report = uninstall_extension(&db, "flow", false).unwrap();
+        assert_eq!(report.agents_removed, ["flow"]);
+        assert!(report.manifest_removed);
+        assert!(report.home_removed.is_none());
+        assert!(crate::agent::agent_config::load_or_seed()
+            .get("flow")
+            .is_none());
+        assert!(db.get_active_extensions().unwrap().is_empty());
+        assert!(crate::agent::extension_config::load_manifest("flow").is_none());
+        assert!(home.join("FLOW.md").exists(), "home kept without --purge");
+
+        // Reinstall, then uninstall --purge removes the home dir too.
+        install_extension(&db, &target, None, false).unwrap();
+        let report = uninstall_extension(&db, "flow", true).unwrap();
+        assert_eq!(
+            report.home_removed.as_deref(),
+            Some(home.to_string_lossy().as_ref())
+        );
+        assert!(!home.exists(), "home removed with --purge");
+    }
+
+    #[test]
+    fn guard_refuses_shallow_dirs() {
+        assert!(guard_removable_dir(Path::new("/x")).is_err());
+        assert!(guard_removable_dir(Path::new("/home/me/flow")).is_ok());
+    }
+
+    #[test]
+    fn health_reports_presence_and_active_flag() {
+        let db = Database::open_in_memory().unwrap();
+        let def = flow_def();
+
+        let before = extension_health(&db, &def).unwrap();
+        assert!(!before.active);
+        assert_eq!(before.sessions, [("flow".to_string(), false)]);
+        assert_eq!(before.automations, [("flow-tick".to_string(), false)]);
+        assert!(!before.is_healthy());
+
+        insert_session(&db, "flow");
+        activate_extension(&db, &def).unwrap();
+        let after = extension_health(&db, &def).unwrap();
+        assert!(after.active);
+        assert!(after.is_healthy());
+    }
+}

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -6,10 +6,16 @@
 //! thurbox` server.
 
 pub mod delete;
+pub mod extensions;
 pub mod restart;
 pub mod spawn;
 
 pub use delete::{delete_session_headless, ForceDeleteReport};
+pub use extensions::{
+    activate_extension, deactivate_extension, ensure_extension, extension_health,
+    heal_active_extensions, install_extension, uninstall_extension, DeactivateReport, EnsureReport,
+    ExtensionHealth, InstallReport, UninstallReport,
+};
 pub use restart::restart_session_headless;
 pub use spawn::{spawn_session_headless, SpawnRequest, SpawnResult};
 

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -6,6 +6,7 @@ use super::Database;
 
 const EDITOR_COMMAND_KEY: &str = "editor_command";
 const THEME_KEY: &str = "active_theme";
+const ACTIVE_EXTENSIONS_KEY: &str = "active_extensions";
 
 impl Database {
     /// Get the configured editor command (e.g. `code`, `nvim --remote-tab`).
@@ -61,6 +62,68 @@ impl Database {
         }
         Ok(())
     }
+
+    /// The set of currently-active extension names (e.g. `["flow"]`), stored as
+    /// a JSON array under the `active_extensions` metadata key. Drives self-heal:
+    /// thurbox re-ensures each active extension's resources on startup and tick.
+    /// A malformed/missing value reads as an empty set rather than erroring.
+    pub fn get_active_extensions(&self) -> rusqlite::Result<Vec<String>> {
+        let raw: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![ACTIVE_EXTENSIONS_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(raw
+            .and_then(|s| serde_json::from_str::<Vec<String>>(&s).ok())
+            .unwrap_or_default())
+    }
+
+    /// Persist the active-extension set as a JSON array. An empty set deletes the
+    /// key (mirrors the editor/theme reset-on-empty convention).
+    fn set_active_extensions(&self, names: &[String]) -> rusqlite::Result<()> {
+        if names.is_empty() {
+            self.conn.execute(
+                "DELETE FROM metadata WHERE key = ?1",
+                params![ACTIVE_EXTENSIONS_KEY],
+            )?;
+        } else {
+            let json = serde_json::to_string(names).unwrap_or_else(|_| "[]".into());
+            self.conn.execute(
+                "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![ACTIVE_EXTENSIONS_KEY, json],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Mark an extension active (idempotent). Returns `true` if it was newly
+    /// added, `false` if already active.
+    pub fn add_active_extension(&self, name: &str) -> rusqlite::Result<bool> {
+        let mut names = self.get_active_extensions()?;
+        if names.iter().any(|n| n == name) {
+            return Ok(false);
+        }
+        names.push(name.to_string());
+        self.set_active_extensions(&names)?;
+        Ok(true)
+    }
+
+    /// Mark an extension inactive (idempotent). Returns `true` if it was removed,
+    /// `false` if it wasn't active. Self-heal will no longer resurrect it.
+    pub fn remove_active_extension(&self, name: &str) -> rusqlite::Result<bool> {
+        let mut names = self.get_active_extensions()?;
+        let before = names.len();
+        names.retain(|n| n != name);
+        if names.len() == before {
+            return Ok(false);
+        }
+        self.set_active_extensions(&names)?;
+        Ok(true)
+    }
 }
 
 #[cfg(test)]
@@ -104,5 +167,36 @@ mod tests {
 
         db.set_active_theme("").unwrap();
         assert_eq!(db.get_active_theme().unwrap(), None);
+    }
+
+    #[test]
+    fn active_extensions_round_trip() {
+        let db = Database::open_in_memory().unwrap();
+        assert!(db.get_active_extensions().unwrap().is_empty());
+
+        // Add is idempotent and preserves order.
+        assert!(db.add_active_extension("flow").unwrap());
+        assert!(!db.add_active_extension("flow").unwrap());
+        assert!(db.add_active_extension("other").unwrap());
+        assert_eq!(db.get_active_extensions().unwrap(), ["flow", "other"]);
+
+        // Remove is idempotent; removing the last entry clears the key.
+        assert!(db.remove_active_extension("flow").unwrap());
+        assert!(!db.remove_active_extension("flow").unwrap());
+        assert_eq!(db.get_active_extensions().unwrap(), ["other"]);
+        assert!(db.remove_active_extension("other").unwrap());
+        assert!(db.get_active_extensions().unwrap().is_empty());
+    }
+
+    #[test]
+    fn malformed_active_extensions_reads_as_empty() {
+        let db = Database::open_in_memory().unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO metadata (key, value) VALUES ('active_extensions', 'not json')",
+                [],
+            )
+            .unwrap();
+        assert!(db.get_active_extensions().unwrap().is_empty());
     }
 }

--- a/website/docs/architecture.html
+++ b/website/docs/architecture.html
@@ -59,6 +59,7 @@
           <ul>
             <li><a href="installation.html">Installation</a></li>
             <li><a href="features.html">Features</a></li>
+            <li><a href="extensions.html">Extensions</a></li>
             <li><a href="keybindings.html">Keybindings</a></li>
           </ul>
           <h4>Reference</h4>

--- a/website/docs/extensions.html
+++ b/website/docs/extensions.html
@@ -1,0 +1,528 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Extensions — Thurbox Docs</title>
+    <meta
+      name="description"
+      content="Thurbox extensions: install, activate, deactivate, and self-heal opt-in, agent-agnostic add-ons with thurbox-cli, plus the extension.toml manifest format and how to author one."
+    />
+    <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600;700&family=Press+Start+2P&display=swap"
+    />
+    <link rel="stylesheet" href="../css/variables.css" />
+    <link rel="stylesheet" href="../css/base.css" />
+    <link rel="stylesheet" href="../css/layout.css" />
+    <link rel="stylesheet" href="../css/components.css" />
+    <link rel="stylesheet" href="../css/docs.css" />
+  </head>
+  <body>
+    <nav class="nav scrolled" id="nav">
+      <!-- prettier-ignore -->
+      <a href="../index.html" class="nav-brand">thur<span>box</span></a>
+      <button class="hamburger" id="hamburger" aria-label="Toggle menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <ul class="nav-links" id="nav-links">
+        <li><a href="../index.html#features">Features</a></li>
+        <li><a href="../index.html#installation">Install</a></li>
+        <li><a href="index.html" style="color: var(--text-primary)">Docs</a></li>
+        <li>
+          <a
+            href="https://github.com/Thurbeen/thurbox"
+            class="github-link"
+            target="_blank"
+            rel="noopener"
+          >
+            <svg class="icon-github" viewBox="0 0 16 16">
+              <path
+                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+              />
+            </svg>
+            GitHub
+          </a>
+        </li>
+      </ul>
+    </nav>
+
+    <div class="docs-page">
+      <div class="docs-layout">
+        <aside class="docs-sidebar" id="docs-sidebar">
+          <h4>Getting Started</h4>
+          <ul>
+            <li><a href="installation.html">Installation</a></li>
+            <li><a href="features.html">Features</a></li>
+            <li><a href="extensions.html" class="current-page">Extensions</a></li>
+            <li><a href="keybindings.html">Keybindings</a></li>
+          </ul>
+          <h4>Reference</h4>
+          <ul>
+            <li><a href="architecture.html">Architecture</a></li>
+          </ul>
+          <h4>Developer</h4>
+          <ul>
+            <li><a href="ui-review.html">UI/UX Review</a></li>
+          </ul>
+          <h4>On This Page</h4>
+          <ul>
+            <li><a href="#overview">Overview</a></li>
+            <li><a href="#install">Install</a></li>
+            <li><a href="#lifecycle">Lifecycle commands</a></li>
+            <li><a href="#sources">Sources &amp; versioning</a></li>
+            <li><a href="#self-heal">Self-healing</a></li>
+            <li><a href="#manifest">The manifest</a></li>
+            <li><a href="#authoring">Authoring an extension</a></li>
+            <li><a href="#flow">The flow extension</a></li>
+          </ul>
+        </aside>
+
+        <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle sidebar">
+          &#9776;
+        </button>
+
+        <main class="docs-content">
+          <div class="breadcrumbs">
+            <a href="../index.html">Home</a>
+            <span class="separator">/</span>
+            <a href="index.html">Docs</a>
+            <span class="separator">/</span>
+            <span class="current">Extensions</span>
+          </div>
+
+          <h1>Extensions</h1>
+          <p>
+            Extensions are opt-in,
+            <strong>agent-agnostic</strong>
+            add-ons that
+            <em>compose</em>
+            Thurbox through the public
+            <code>thurbox-cli</code>
+            surface &mdash; they never extend the binary. The core knows a declarative
+            <strong>manifest format</strong>
+            , never any specific extension, so the same machinery installs and manages any of them.
+          </p>
+
+          <h2 id="overview">
+            Overview
+            <a href="#overview" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            An extension is a directory with a single
+            <code>extension.toml</code>
+            manifest plus the files it ships (specs, scripts, config templates). One command
+            installs it:
+            <code>thurbox-cli</code>
+            fetches the manifest, lays the files down under a home directory, registers any agents
+            the extension needs in
+            <code>agents.toml</code>
+            , then creates &mdash; and keeps alive &mdash; the sessions and automations the
+            extension declares.
+          </p>
+          <ul>
+            <li>
+              <strong>Data, not binary.</strong>
+              Nothing about an extension is compiled in; the core reads a manifest and acts on it.
+            </li>
+            <li>
+              <strong>Agent-neutral.</strong>
+              Extensions reach coding agents only through
+              <code>agents.toml</code>
+              aliases you remap to any CLI (claude, codex, gemini, opencode, vibe, &hellip;).
+            </li>
+            <li>
+              <strong>Self-healing.</strong>
+              While an extension is active, deleting its session or automation is a no-op &mdash;
+              Thurbox recreates it. Deactivating is the real off-switch.
+            </li>
+          </ul>
+          <div class="info-box">
+            <p>
+              <strong>
+                The only built-in extension today is
+                <a href="#flow">flow</a>
+                .
+              </strong>
+              The examples below use it, but every command and manifest field is generic.
+            </p>
+          </div>
+
+          <h2 id="install">
+            Install
+            <a href="#install" class="heading-anchor">#</a>
+          </h2>
+          <p>Install an extension by name from the official source:</p>
+          <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> extension install flow</code></pre>
+          <p>
+            That single command is the whole installer. It resolves the source, fetches the manifest
+            and payload, writes them under the extension home (
+            <code>~/flow</code>
+            by default;
+            <code>--home &lt;dir&gt;</code>
+            to override), registers the extension's agents, writes the resolved manifest to
+            <code>~/.config/thurbox/extensions/&lt;name&gt;.toml</code>
+            , and activates it. It is idempotent &mdash; re-running refreshes shipped files while
+            keeping your own data (seeded files you've edited, agent tweaks).
+          </p>
+          <div class="info-box warning">
+            <p>
+              <strong>Heads up:</strong>
+              The flow extension is
+              <strong>experimental</strong>
+              and under active testing &mdash; its behavior, spec, and manifest may change between
+              releases.
+            </p>
+          </div>
+
+          <h2 id="lifecycle">
+            Lifecycle commands
+            <a href="#lifecycle" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            All extension management lives under
+            <code>thurbox-cli extension</code>
+            (alias
+            <code>ext</code>
+            ):
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Command</th>
+                <th>What it does</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>install &lt;name|url|dir&gt;</code></td>
+                <td>Fetch + lay down files, register agents, write manifest, and activate.</td>
+              </tr>
+              <tr>
+                <td><code>uninstall &lt;name&gt;</code></td>
+                <td>
+                  Reverse an install: tear down the session/automation, remove the extension's
+                  agents, and delete the manifest. Add
+                  <code>--purge</code>
+                  to also delete the home dir.
+                </td>
+              </tr>
+              <tr>
+                <td><code>activate &lt;name&gt;</code></td>
+                <td>(Re)create the declared sessions/automations and mark the extension active.</td>
+              </tr>
+              <tr>
+                <td><code>deactivate &lt;name&gt;</code></td>
+                <td>
+                  Tear down resources and stop self-heal (the off-switch). Add
+                  <code>--force</code>
+                  to kill tmux/worktrees,
+                  <code>--purge</code>
+                  to also drop the manifest.
+                </td>
+              </tr>
+              <tr>
+                <td><code>list</code></td>
+                <td>Show installed extensions with their active / healthy state.</td>
+              </tr>
+              <tr>
+                <td><code>status [&lt;name&gt;]</code></td>
+                <td>Per-resource presence for one extension (or all).</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <strong>Install vs. activate.</strong>
+            <code>install</code>
+            also lays down files and registers agents;
+            <code>activate</code>
+            only (re)creates the runtime resources from an already-installed manifest. Use
+            <code>deactivate</code>
+            to switch an extension off but keep it installed for a later
+            <code>activate</code>
+            .
+          </p>
+
+          <h2 id="sources">
+            Sources &amp; versioning
+            <a href="#sources" class="heading-anchor">#</a>
+          </h2>
+          <p>The install target can be three things:</p>
+          <ul>
+            <li>
+              <strong>A bare name</strong>
+              (
+              <code>flow</code>
+              ) &mdash; fetched from the official source over
+              <code>curl</code>
+              /
+              <code>wget</code>
+              , pinned to your binary's release tag (dev builds track
+              <code>main</code>
+              ), so a fetched extension always matches the binary reading it.
+            </li>
+            <li>
+              <strong>A local directory</strong>
+              (
+              <code>./extensions/flow</code>
+              ) &mdash; installs from a checkout.
+            </li>
+            <li>
+              <strong>
+                An
+                <code>http(s)://</code>
+                base URL
+              </strong>
+              &mdash; installs from your own source.
+            </li>
+          </ul>
+          <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> extension install ./extensions/flow
+<span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> extension install https://example.com/ext/flow --home ~/work/flow</code></pre>
+          <div class="info-box">
+            <p>
+              <strong>Safety:</strong>
+              payload paths are validated against traversal (no absolute paths or
+              <code>..</code>
+              ), a config template you've edited isn't overwritten on reinstall (use
+              <code>--force</code>
+              ), and payload files are fetched as text (specs, scripts, JSON) &mdash; not binaries.
+            </p>
+          </div>
+
+          <h2 id="self-heal">
+            Self-healing
+            <a href="#self-heal" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            An installed extension is recorded in an
+            <strong>active set</strong>
+            . On TUI startup and on every automation tick, Thurbox re-ensures each active
+            extension's declared sessions and automations exist &mdash; so deleting them by hand
+            (TUI
+            <code>Ctrl+D</code>
+            , a
+            <code>clean</code>
+            , or
+            <code>thurbox-cli session/automation delete</code>
+            ) is a no-op: they come back. This is what makes an extension hard to half-remove by
+            accident.
+          </p>
+          <ul>
+            <li>
+              <code>deactivate &lt;name&gt;</code>
+              removes the extension from the active set, so self-heal stops resurrecting it &mdash;
+              the real off-switch.
+            </li>
+            <li>
+              Headless self-heal (while the TUI is closed) rides the automation heartbeat, so it
+              needs
+              <code>[features] automations = true</code>
+              ; with automations off, healing happens at the next TUI startup only.
+            </li>
+          </ul>
+
+          <h2 id="manifest">
+            The manifest
+            <a href="#manifest" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            An extension is fully described by its
+            <code>extension.toml</code>
+            . It has two halves: an
+            <strong>install</strong>
+            spec (what to lay down) and a
+            <strong>runtime</strong>
+            spec (what to keep alive). The
+            <code>{home}</code>
+            token is substituted with the resolved home directory.
+          </p>
+          <pre><code>name = "flow"
+description = "Focus-protecting triage agent"
+config_version = 1
+home = "~/flow"                 # install home; {home} is substituted everywhere
+
+# install spec ---------------------------------------------------------------
+[[agents]]                      # registered in agents.toml (existing kept)
+name = "flow"
+command = "claude"
+args = ["--model", "claude-haiku-4-5"]
+
+[[files]]                       # fetched from the source, written under home
+path = "FLOW.md"
+[[files]]
+path = "scripts/create-task.sh"
+executable = true               # chmod +x
+[[files]]
+path = "repos.md"
+if_absent = true                # seed once; never clobbered on reinstall
+[[files]]
+path = ".claude/settings.json"
+source = "claude-settings.json" # source path differs from dest
+substitute = true               # replace {home} in the content
+
+[[symlinks]]                    # never clobbers a real file at `link`
+link = "CLAUDE.md"
+target = "FLOW.md"
+
+# runtime spec (ensured on activate, self-healed if deleted) -----------------
+[[sessions]]
+name = "flow"
+agent = "flow"
+repo_path = "{home}"            # resolved to the absolute home at install
+
+[[automations]]
+name = "flow-tick"
+trigger = "cron:*/5 * * * *"    # same grammar as `automation create --trigger`
+session_ref = "flow"            # must match a [[sessions]] name above
+prompt = "tick"</code></pre>
+          <table>
+            <thead>
+              <tr>
+                <th>Section</th>
+                <th>Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>home</code></td>
+                <td>
+                  Default install directory; overridable with
+                  <code>--home</code>
+                  .
+                </td>
+              </tr>
+              <tr>
+                <td><code>[[agents]]</code></td>
+                <td>
+                  Agent definitions appended to
+                  <code>agents.toml</code>
+                  (existing names are kept).
+                </td>
+              </tr>
+              <tr>
+                <td><code>[[files]]</code></td>
+                <td>
+                  Payload files written under
+                  <code>home</code>
+                  . Flags:
+                  <code>executable</code>
+                  ,
+                  <code>if_absent</code>
+                  (seed once),
+                  <code>substitute</code>
+                  (
+                  <code>{home}</code>
+                  in content), and
+                  <code>source</code>
+                  (when the source path differs from the destination).
+                </td>
+              </tr>
+              <tr>
+                <td><code>[[symlinks]]</code></td>
+                <td>
+                  Symlinks created under
+                  <code>home</code>
+                  (never clobber a real file).
+                </td>
+              </tr>
+              <tr>
+                <td><code>[[sessions]]</code></td>
+                <td>Sessions ensured on activate and self-healed if deleted.</td>
+              </tr>
+              <tr>
+                <td><code>[[automations]]</code></td>
+                <td>
+                  Automations ensured on activate;
+                  <code>session_ref</code>
+                  names a session above.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h2 id="authoring">
+            Authoring an extension
+            <a href="#authoring" class="heading-anchor">#</a>
+          </h2>
+          <ol>
+            <li>
+              Create a directory with an
+              <code>extension.toml</code>
+              and the files it references (
+              <code>[[files]]</code>
+              paths are relative to both the source and the home dir).
+            </li>
+            <li>
+              Build the behavior on the
+              <code>thurbox-cli</code>
+              surface (
+              <code>session</code>
+              ,
+              <code>task</code>
+              ,
+              <code>automation</code>
+              ) plus standard tools &mdash; no core changes, no vendor lock-in.
+            </li>
+            <li>
+              Test locally with
+              <code>thurbox-cli extension install ./your-ext</code>
+              , then publish the directory (e.g. under
+              <code>extensions/&lt;name&gt;/</code>
+              ) so
+              <code>install &lt;name&gt;</code>
+              can fetch it.
+            </li>
+          </ol>
+          <p>
+            For the exact config-file locations and the metadata key that tracks active extensions,
+            see the
+            <a
+              href="https://github.com/Thurbeen/thurbox/blob/main/docs/CONFIG.md"
+              target="_blank"
+              rel="noopener"
+            >
+              configuration reference
+            </a>
+            .
+          </p>
+
+          <h2 id="flow">
+            The flow extension
+            <a href="#flow" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            <a href="features.html#flow-extension">Flow</a>
+            is the reference extension: a focus-protecting triage agent. You brain-dump at a cheap,
+            dedicated
+            <em>flow session</em>
+            ; it captures everything into the task list, dispatches real work to worker sessions
+            (each on its own
+            <code>flow/&lt;slug&gt;</code>
+            worktree branch), monitors them quietly, and ends every reply with the single next thing
+            to focus on.
+          </p>
+          <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> extension install flow      <span class="syn-comment"># set it up</span>
+<span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> extension uninstall flow    <span class="syn-comment"># reverse it (--purge also deletes ~/flow)</span></code></pre>
+          <p>
+            See
+            <a
+              href="https://github.com/Thurbeen/thurbox/tree/main/extensions/flow"
+              target="_blank"
+              rel="noopener"
+            >
+              extensions/flow
+            </a>
+            for the behavior spec and helper scripts.
+          </p>
+        </main>
+      </div>
+    </div>
+
+    <script src="../js/main.js"></script>
+  </body>
+</html>

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -59,6 +59,7 @@
           <ul>
             <li><a href="installation.html">Installation</a></li>
             <li><a href="features.html" class="current-page">Features</a></li>
+            <li><a href="extensions.html">Extensions</a></li>
             <li><a href="keybindings.html">Keybindings</a></li>
           </ul>
           <h4>Reference</h4>
@@ -426,15 +427,11 @@
               cron tick as the safety net.
             </li>
             <li>
-              One-line install (idempotent):
-              <code>
-                curl -fsSL
-                https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/flow/install.sh |
-                sh
-              </code>
-              &mdash; see
-              <code>extensions/flow/README.md</code>
-              .
+              One-command install:
+              <code>thurbox-cli extension install flow</code>
+              &mdash; see the
+              <a href="extensions.html">Extensions</a>
+              page for how install, self-heal, and the manifest work.
             </li>
           </ul>
 

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -59,6 +59,7 @@
           <ul>
             <li><a href="installation.html">Installation</a></li>
             <li><a href="features.html">Features</a></li>
+            <li><a href="extensions.html">Extensions</a></li>
             <li><a href="keybindings.html">Keybindings</a></li>
           </ul>
           <h4>Reference</h4>
@@ -101,6 +102,17 @@
                 <div class="card-icon">&#x2728;</div>
                 <h3>Features</h3>
                 <p>Per-session coding agents, worktrees, automations, and the responsive UI.</p>
+              </div>
+            </a>
+            <a href="extensions.html" class="docs-hub-card">
+              <div class="card">
+                <div class="card-icon">&#x1f9e9;</div>
+                <h3>Extensions</h3>
+                <p>
+                  Install, activate, and self-heal opt-in agent-agnostic add-ons with
+                  <code>thurbox-cli</code>
+                  , plus the manifest format and how to author one.
+                </p>
               </div>
             </a>
             <a href="keybindings.html" class="docs-hub-card">

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -59,6 +59,7 @@
           <ul>
             <li><a href="installation.html" class="current-page">Installation</a></li>
             <li><a href="features.html">Features</a></li>
+            <li><a href="extensions.html">Extensions</a></li>
             <li><a href="keybindings.html">Keybindings</a></li>
           </ul>
           <h4>Reference</h4>

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -59,6 +59,7 @@
           <ul>
             <li><a href="installation.html">Installation</a></li>
             <li><a href="features.html">Features</a></li>
+            <li><a href="extensions.html">Extensions</a></li>
             <li><a href="keybindings.html" class="current-page">Keybindings</a></li>
           </ul>
           <h4>Reference</h4>

--- a/website/docs/ui-review.html
+++ b/website/docs/ui-review.html
@@ -168,6 +168,7 @@
           <ul>
             <li><a href="installation.html">Installation</a></li>
             <li><a href="features.html">Features</a></li>
+            <li><a href="extensions.html">Extensions</a></li>
             <li><a href="keybindings.html">Keybindings</a></li>
           </ul>
           <h4>Reference</h4>

--- a/website/index.html
+++ b/website/index.html
@@ -193,6 +193,8 @@
               add-on: brain-dump at a dedicated flow session and it captures tasks, dispatches
               workers on isolated worktrees, and always ends with
               <strong>the one next thing to focus on</strong>
+              . Install it in one command &mdash;
+              <code>thurbox-cli extension install flow</code>
               . New and under active testing.
             </p>
           </div>


### PR DESCRIPTION
## Summary

- First-class, agent-neutral **extension system**: a declarative `extension.toml` manifest driven by `thurbox-cli extension install/uninstall/activate/deactivate/list/status`.
- **Self-heal**: active extensions' session/automation are recreated at TUI startup and on every automation tick; `deactivate` is the off-switch.
- **Install** fetches by name (pinned to the release tag), URL, or local dir; lays down traversal-guarded payload files, registers agents, activates. **Uninstall** reverses it (`--purge` also removes the home dir).
- Flow extension migrated to a manifest; its `install.sh` is now a thin shim. Docs (CONFIG/FEATURES/ARCHITECTURE ADR-21) + a dedicated website Extensions page.

## Test plan

- `cargo nextest run --all`, clippy `-D warnings`, architecture rules, markdown + website linters
- Headless E2E: install -> delete -> tick self-heals -> deactivate -> uninstall
- CI checks pass