### PR TITLE
feat: doom-font ASCII banner + colorized install output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
 
 **Features:**
 
+- Thurbox ASCII-art banner (doom font) + colorized output (auto-disabled
+  when stderr is not a TTY, `NO_COLOR` is set, or `TERM=dumb`)
 - Platform detection (Linux/macOS, x86_64/aarch64)
 - Automatic version fetching with API rate limit fallback (scrapes releases page)
 - SHA256 checksum verification
@@ -66,7 +68,8 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
 **Testing:**
 
 - Comprehensive test suite in `scripts/install.bats` using bats-core framework
-- 25 tests covering platform detection, checksum verification, binary extraction, and error handling
+- 28 tests covering platform detection, checksum verification, binary extraction,
+  error handling, the ASCII banner, and `NO_COLOR` handling
 - Run tests locally: `bats scripts/install.bats`
 - CI runs tests automatically on every commit
 

--- a/scripts/install.bats
+++ b/scripts/install.bats
@@ -64,8 +64,23 @@
   grep -q "trap cleanup" "${BATS_TEST_DIRNAME}/install.sh"
 }
 
-@test "script is under 210 lines" {
-  [ $(wc -l < "${BATS_TEST_DIRNAME}/install.sh") -lt 210 ]
+@test "script is under 250 lines" {
+  [ $(wc -l < "${BATS_TEST_DIRNAME}/install.sh") -lt 250 ]
+}
+
+@test "script contains banner function" {
+  grep -q "^banner()" "${BATS_TEST_DIRNAME}/install.sh"
+}
+
+@test "banner renders ASCII art to stderr" {
+  run sh -c "TEST_TMPDIR=1 . '${BATS_TEST_DIRNAME}/install.sh'; banner" 2>&1
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+@test "colors disabled when NO_COLOR is set" {
+  run sh -c "TEST_TMPDIR=1 NO_COLOR=1 . '${BATS_TEST_DIRNAME}/install.sh'; printf '%s' \"\$C_RED\""
+  [ -z "$output" ]
 }
 
 @test "script has logging functions" {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,15 @@ INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${VERSION:-}"
 TEMP_DIR=""
 
+# Colors (auto-disabled when stderr is not a terminal, NO_COLOR is set, or TERM=dumb)
+C_RESET=''; C_BOLD=''; C_DIM=''; C_RED=''; C_GREEN=''; C_YELLOW=''; C_CYAN=''; C_MAGENTA=''
+if [ -t 2 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+  ESC=$(printf '\033')
+  C_RESET="${ESC}[0m"; C_BOLD="${ESC}[1m"; C_DIM="${ESC}[2m"
+  C_RED="${ESC}[31m"; C_GREEN="${ESC}[32m"; C_YELLOW="${ESC}[33m"
+  C_CYAN="${ESC}[36m"; C_MAGENTA="${ESC}[35m"
+fi
+
 # Cleanup
 cleanup() {
   [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ] && rm -rf "$TEMP_DIR" || true
@@ -16,9 +25,24 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # Logging
-info() { echo "→ $*" >&2; }
-error() { echo "✗ Error: $*" >&2; }
-success() { echo "✓ $*" >&2; }
+info() { printf '%b\n' "${C_CYAN}▸${C_RESET} $*" >&2; }
+error() { printf '%b\n' "${C_RED}${C_BOLD}✗ Error:${C_RESET}${C_RED} $*${C_RESET}" >&2; }
+success() { printf '%b\n' "${C_GREEN}✓${C_RESET} $*" >&2; }
+warn() { printf '%b\n' "${C_YELLOW}⚠${C_RESET} $*" >&2; }
+step() { printf '%b\n' "  ${C_DIM}$*${C_RESET}" >&2; }
+
+# Thurbox ASCII art banner (doom font)
+banner() {
+  printf '%b' "$C_BOLD$C_MAGENTA" >&2
+  printf '%s\n' \
+'   _____ _   _ _   _____________  _______   __' \
+'  |_   _| | | | | | | ___ \ ___ \|  _  \ \ / /' \
+'    | | | |_| | | | | |_/ / |_/ /| | | |\ V / ' \
+'    | | |  _  | | | |    /| ___ \| | | |/   \ ' \
+'    | | | | | | |_| | |\ \| |_/ /\ \_/ / /^\ \' \
+'    \_/ \_| |_/\___/\_| \_\____/  \___/\/   \/' >&2
+  printf '%b\n\n' "$C_RESET  ${C_DIM}multi-session coding-agent orchestrator${C_RESET}" >&2
+}
 
 # Detect platform
 detect_platform() {
@@ -158,42 +182,44 @@ do_install() {
 
 # Show success message
 show_success() {
-  success "Thurbox installed to $1/thurbox"
+  printf '\n' >&2
+  success "Thurbox installed to ${C_BOLD}$1/thurbox${C_RESET}"
 
   if ! echo "$PATH" | grep -q "$1"; then
-    echo "⚠ Add to PATH: export PATH=\"$1:\$PATH\""
+    warn "Add to PATH: ${C_BOLD}export PATH=\"$1:\$PATH\"${C_RESET}"
   fi
 
-  echo "Setup:"
-  echo "  • Install tmux >= 3.2"
-  echo "  • Install a coding-agent CLI (claude, codex, gemini, opencode, aider, …)"
-  echo "  • Run: thurbox"
-  echo "  • Scriptable CLI: thurbox-cli"
+  printf '\n%b\n' "${C_BOLD}${C_MAGENTA}Next steps${C_RESET}" >&2
+  step "• Install tmux >= 3.2"
+  step "• Install a coding-agent CLI (claude, codex, gemini, opencode, aider, …)"
+  step "• Launch the TUI:    ${C_CYAN}thurbox${C_RESET}"
+  step "• Scriptable CLI:    ${C_CYAN}thurbox-cli${C_RESET}"
 }
 
 # Main
 main() {
-  info "Thurbox Installer"
+  banner
 
   local platform target version binary
 
   platform=$(detect_platform) || return 1
-  info "Platform: $platform"
+  info "Platform: ${C_BOLD}$platform${C_RESET}"
 
   target=$(get_target "$platform") || return 1
-  info "Target: $target"
+  info "Target:   ${C_BOLD}$target${C_RESET}"
 
   TEMP_DIR=$(mktemp -d) || { error "Failed to create temp dir"; return 1; }
 
   version=$(get_version) || return 1
-  info "Version: $version"
+  info "Version:  ${C_BOLD}$version${C_RESET}"
 
   binary=$(get_binary "$version" "$target" "$TEMP_DIR") || return 1
 
   do_install "$binary" "$INSTALL_DIR"
 
   show_success "$INSTALL_DIR"
-  success "Installation complete!"
+  printf '\n' >&2
+  success "${C_BOLD}Installation complete!${C_RESET} Happy hacking ${C_MAGENTA}❯_${C_RESET}"
 }
 
 if [ -z "$TEST_TMPDIR" ]; then main "$@"; fi


### PR DESCRIPTION
## Summary
Makes `scripts/install.sh` more visually appealing and polished.

- **THURBOX ASCII-art banner** in the **doom** figlet font, shown at the top of the install run.
- **Colorized, TTY-aware output**: magenta banner, cyan steps, green success, red errors, yellow warnings. Colors auto-disable when stderr is not a terminal, `NO_COLOR` is set, or `TERM=dumb` — so piped/CI output stays clean.
- New `banner` + `step` helpers; logging functions switched to `printf '%b'` for portable ANSI.
- Refreshed **Next steps** section with highlighted commands.

## Banner preview
```
   _____ _   _ _   _____________  _______   __
  |_   _| | | | | | | ___ \ ___ \|  _  \ \ / /
    | | | |_| | | | | |_/ / |_/ /| | | |\ V /
    | | |  _  | | | |    /| ___ \| | | |/   \
    | | | | | | |_| | |\ \| |_/ /\ \_/ / /^\ \
    \_/ \_| |_/\___/\_| \_\____/  \___/\/   \/
  multi-session coding-agent orchestrator
```

## Tests
- Adds 3 bats tests (`banner` function present, banner renders to stderr, `NO_COLOR` disables colors); bumps the line-count guard 210 → 250.
- All existing `scripts/install.bats` checks verified locally (function greps, target maps, `do_install` extraction).
- `sh -n` syntax check passes; POSIX-shell compatible.
- Updated `CLAUDE.md` install-script docs (feature list + test count).