### PR TITLE
feat: add plan-first dispatch to flow extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -572,7 +572,11 @@ sync, but the TUI editor never sets it.)
   `flow/<slug>` worktree branches, agents `flow-worker` /
   `flow-worker-heavy` mapped in `agents.toml` to any CLI), a dedicated
   `flow` session monitors them via a `flow-tick` automation, and every
-  reply ends with the single next thing to focus on. The behavior spec
+  reply ends with the single next thing to focus on. Dispatch is
+  **plan-first**: `scripts/create-task.sh` owns the worker prompt and
+  injects a mandatory planning phase (problem → acceptance criteria →
+  approach, seeded from `--accept`) so each worker plans before it codes
+  and stays in scope. The behavior spec
   is `FLOW.md`, surfaced to whichever CLI runs it via context-file
   symlinks (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `FLOW.md`). Install with
   `thurbox-cli extension install flow` (its `install.sh` is a thin shim

--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -50,16 +50,34 @@ the table, add a row when you learn its path.
 2. For each task decide NOW (cheap heuristics, no deliberation):
    - **priority**: high / normal / low.
    - **repo**: guess from keywords via `./repos.md`.
+   - **accept**: a one-line, checkable done-criterion. Phrase it as a
+     condition that is either true or false ("requests over the limit get
+     429", "README documents the new flag"), never a vague aim. This is
+     the seed of the worker's planning phase — spend a moment to make it
+     concrete, but do **not** explore the repo to write it (you are a
+     dispatcher; the worker plans the rest).
    - **worker**: apply the Worker rubric (below).
 3. Create the task — ALWAYS via the helper (it creates AND dispatches in
    one atomic call; the user expects the worker session to exist
    immediately):
 
    ```bash
-   ./scripts/create-task.sh --title "<title>" --description "<desc>" \
+   ./scripts/create-task.sh --title "<title>" --description "<user words>" \
+     --accept "<one-line done criterion>" --priority <high|normal|low> \
      --repo <abs-path> --agent <flow-worker|flow-worker-heavy> \
      --worktree flow/<task-slug> --base origin/<base-from-repos.md>
    ```
+
+   **Plan-first dispatch.** The helper OWNS the worker prompt: from
+   `--description` (the user's words) plus the `--accept` / `--priority` /
+   `--repo` / `--worktree` flags it composes the full description — the
+   `priority/repo/accept` header, the user's words, a mandatory **Planning
+   phase** (Problem → Acceptance criteria → Approach), and the
+   result/notify footer. So **never hand-type that header, planning block,
+   or footer** — pass the structured flags and the helper keeps the
+   contract byte-identical on every dispatch. Always pass `--accept`
+   whenever you dispatch a worker; preview the composed prompt any time
+   with `--dry-run`.
 
    Pass `--repo`/`--agent` whenever the repo is confident — NEVER create a
    dispatchable task without them. **Always pass `--worktree
@@ -70,37 +88,41 @@ the table, add a row when you learn its path.
    default branch** — `origin/<base>` with the base column from
    `./repos.md` (e.g. `origin/main`), never a local branch; the helper
    fetches origin first so the base is current. If the repo is not
-   confident → omit `--repo`/`--agent` (plain todo); triage later or ask
-   ONE question. Over capacity → add `--no-dispatch`. Description template
-   (first lines, then the user's words):
+   confident → omit `--repo`/`--agent`/`--accept` (plain todo: the
+   `--description` is then used verbatim, with no planning block); triage
+   later or ask ONE question. Over capacity → add `--no-dispatch`. For a
+   trivial mechanical change where a plan is overkill, add `--no-plan`
+   (the header + footer stay; only the planning phase is dropped).
 
-   ```text
-   priority: <high|normal|low>
-   repo: <abs path or unknown>
-   accept: <one-line done criterion>
-
-   <original user words>
-
-   You are working in a dedicated git worktree on branch flow/<task-slug>;
-   commit your work there and open a PR when the accept criterion is met.
-   When finished: mark this task done (thurbox-cli task edit <id> --status done),
-   print a final line `===RESULT===` followed by one line of JSON:
-   {"status":"ok|error","artifact":"...","notes":"...","pr_url":"..."}
-   then notify the flow agent so the next task dispatches immediately:
-   thurbox-cli session send "$(thurbox-cli session list | jq -r '.[] | select(.name=="flow") | .id')" "tick"
+   ```bash
+   # Preview the exact worker prompt the helper composes — creates nothing:
+   ./scripts/create-task.sh --title "<title>" --description "<user words>" \
+     --accept "<criterion>" --repo <abs-path> --agent flow-worker \
+     --worktree flow/<task-slug> --dry-run
    ```
 
-4. Planning / investigation / design requests ("plan an improvement to
-   X", "investigate why Y is slow", "design Z") are **dispatchable
-   tasks like any other** — never plan or investigate yourself. Title
-   them verb-first (`Plan: …`, `Investigate: …`), carry the user's full
-   context into the description, set `accept:` to the expected artifact
-   (e.g. "written plan as PR/markdown"), and dispatch — usually to
-   `flow-worker-heavy`, since these are exploratory.
-5. Trivial items (a lookup, a question you can answer): answer inline in
+4. **The planning phase happens inside the worker, not in this session.**
+   The composed prompt makes every worker post a short PLAN — problem
+   statement, concrete acceptance criteria (refined from your `accept:`
+   line), and an implementation approach/architecture — as its first move,
+   then build strictly against it. That is what keeps dispatched work from
+   drifting: the plan is captured in the worker's own session and visible
+   on the next `tick`. You still never plan, explore, or design here.
+5. Heavyweight planning / investigation / design requests ("plan an
+   improvement to X", "investigate why Y is slow", "design Z") are
+   **dispatchable tasks like any other** — never plan or investigate
+   yourself. Title them verb-first (`Plan: …`, `Investigate: …`), carry
+   the user's full context into the description, set `--accept` to the
+   expected artifact (e.g. "written plan as PR/markdown"), and dispatch —
+   usually to `flow-worker-heavy`, since these are exploratory. (The
+   per-worker planning phase in step 4 is the lightweight default for
+   ordinary tasks; a dedicated `Plan:` task is for work whose *whole
+   point* is the plan, or when the approach must be reviewed before any
+   code is written.)
+6. Trivial items (a lookup, a question you can answer): answer inline in
    one line, create no task.
-6. Confirm one line per task: `#<id> <title> [worker|heavy|todo]`.
-7. End with the Output Contract footer.
+7. Confirm one line per task: `#<id> <title> [worker|heavy|todo]`.
+8. End with the Output Contract footer.
 
 ## DISPATCH (sub-step of CAPTURE and TICK)
 
@@ -116,8 +138,10 @@ the cron tick to dispatch something that is eligible NOW.
   worry about double-dispatch.
 - A plain todo that became ready (repo now known): `task edit` cannot
   attach an action — **remove + recreate** it via `create-task.sh`,
-  carrying the title and description over VERBATIM (the id changes;
-  that's fine).
+  carrying the title and the user's words over VERBATIM as
+  `--description`, and now adding `--repo`/`--agent`/`--accept` (+
+  `--worktree`) so the recreate composes the planning phase + footer (the
+  id changes; that's fine).
 - **Worker rubric** (pick one, default `flow-worker`):
   - `flow-worker-heavy` IF: multi-repo or large refactor; >~1 h expected;
     ambiguous spec needing real exploration; "overnight"/"deep" keywords;

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -86,6 +86,14 @@ active and healthy.
   that isn't `tick`/`status`/`clean` is treated as a brain-dump.
 - Dispatchable items spawn a worker immediately (`task-<id>-<slug>`
   session, on a `flow/<slug>` worktree branch whenever the repo is git).
+- **Plan-first dispatch**: every worker prompt carries a mandatory
+  planning phase. Before writing any code the worker posts a short PLAN —
+  problem statement, concrete acceptance criteria, and an implementation
+  approach/architecture — then builds strictly against it, so dispatched
+  work stays scoped to what you asked for. The flow agent seeds the
+  acceptance criterion (`--accept`) at capture; the worker fills in the
+  rest. (Pass `--no-plan` to `create-task.sh` for trivial mechanical
+  changes where a plan is overkill.)
 - `status` for a one-screen report; `clean` to groom the backlog.
 - Workers self-report: they mark their task done, print a
   `===RESULT===` JSON line, and ping the flow session so the next task
@@ -99,7 +107,7 @@ active and healthy.
 | `FLOW.md` | The agent behavior spec (modes, dispatch rules, output contract) |
 | `claude-settings.json` | Permission template (`{home}`-substituted into `.claude/settings.json`) |
 | `repos.md` | Routing-table seed (installed once, then user-owned) |
-| `scripts/create-task.sh` | Atomic task create + dispatch |
+| `scripts/create-task.sh` | Atomic task create + dispatch; composes the plan-first worker prompt (`--dry-run` to preview) |
 | `scripts/flow-snapshot.sh` | One-call backlog + sessions view |
 | `scripts/parse-result.sh` | Extract the worker `===RESULT===` sentinel |
 | `install.sh` | Thin shim → `thurbox-cli extension install` (curl\|sh bootstrap) |

--- a/extensions/flow/scripts/create-task.bats
+++ b/extensions/flow/scripts/create-task.bats
@@ -41,6 +41,18 @@ setup() {
   [[ "$output" == *"===RESULT==="* ]]
 }
 
+@test "--accept without a repo composes the header only (no planning, no footer)" {
+  run "$SCRIPT" --title "Idea" --description "some notes" \
+    --accept "decided one way or the other" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"priority: normal"* ]]   # default priority
+  [[ "$output" == *"repo: unknown"* ]]       # default repo
+  [[ "$output" == *"accept: decided one way or the other"* ]]
+  [[ "$output" == *"some notes"* ]]
+  [[ "$output" != *"## Planning phase"* ]]   # gated on a worker dispatch
+  [[ "$output" != *"===RESULT==="* ]]        # footer is worker-only
+}
+
 @test "plain todo without --accept keeps the description verbatim" {
   run "$SCRIPT" --title "Revisit caching" \
     --description "low priority idea" --dry-run

--- a/extensions/flow/scripts/create-task.bats
+++ b/extensions/flow/scripts/create-task.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# Tests for create-task.sh's plan-first prompt composition. These exercise the
+# pure `--dry-run` path (no thurbox-cli, no side effects), so they run anywhere
+# bats is installed: `bats extensions/flow/scripts/create-task.bats`.
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/create-task.sh"
+}
+
+@test "syntax is valid" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "worker dispatch composes header, planning phase, and footer" {
+  run "$SCRIPT" --title "Add rate limiting" \
+    --description "Throttle the API." \
+    --repo /tmp/repo --agent flow-worker \
+    --accept "requests over the limit get 429" --priority high \
+    --worktree flow/add-rate-limiting --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"priority: high"* ]]
+  [[ "$output" == *"repo: /tmp/repo"* ]]
+  [[ "$output" == *"accept: requests over the limit get 429"* ]]
+  [[ "$output" == *"Throttle the API."* ]]
+  [[ "$output" == *"## Planning phase"* ]]
+  [[ "$output" == *"**Problem**"* ]]
+  [[ "$output" == *"**Acceptance criteria**"* ]]
+  [[ "$output" == *"**Approach**"* ]]
+  [[ "$output" == *"branch flow/add-rate-limiting"* ]]
+  [[ "$output" == *"===RESULT==="* ]]
+}
+
+@test "--no-plan drops only the planning phase, keeps header and footer" {
+  run "$SCRIPT" --title "Fix typo" --description "readme typo" \
+    --repo /tmp/repo --agent flow-worker --accept "typo fixed" \
+    --worktree flow/fix-typo --no-plan --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"accept: typo fixed"* ]]
+  [[ "$output" != *"## Planning phase"* ]]
+  [[ "$output" == *"===RESULT==="* ]]
+}
+
+@test "plain todo without --accept keeps the description verbatim" {
+  run "$SCRIPT" --title "Revisit caching" \
+    --description "low priority idea" --dry-run
+  [ "$status" -eq 0 ]
+  [ "$output" = "low priority idea" ]
+}
+
+@test "--title is required" {
+  run "$SCRIPT" --description "no title" --dry-run
+  [ "$status" -eq 2 ]
+}

--- a/extensions/flow/scripts/create-task.sh
+++ b/extensions/flow/scripts/create-task.sh
@@ -6,18 +6,37 @@
 #   create-task.sh --title T --description D            # plain todo
 #   create-task.sh --title T --description D \
 #     --repo /abs/path --agent flow-worker \
-#     [--worktree BRANCH] [--base origin/main] [--no-dispatch]
+#     [--accept "done when ..."] [--priority high|normal|low] \
+#     [--worktree BRANCH] [--base origin/main] [--no-plan] [--no-dispatch]
+#   create-task.sh ... --dry-run        # print the composed description, create nothing
 #
-# Worktrees are always based on the REMOTE default branch: with --worktree
-# and no --base, origin/main is assumed. When the base is a remote-tracking
-# ref (origin/...), the repo is fetched first so the base is current.
+# Plan-first dispatch: when an acceptance criterion is supplied (--accept) the
+# script OWNS the worker prompt. It composes a standardized description —
+#   priority/repo/accept header → the user's words → a mandatory **Planning
+#   phase** → the result/notify footer — so every worker runs a planning step
+# (problem → acceptance criteria → approach) BEFORE touching code, and the plan
+# is fed straight into the worker prompt to keep it from drifting. The flow
+# agent no longer hand-types this boilerplate; it passes the structured flags
+# and the script keeps the contract identical across every dispatch.
+#
+# Without --accept the legacy behavior is preserved: --description is used
+# verbatim, with no header/planning/footer composition (plain todos, or any
+# direct caller that builds its own body).
+#
+# --no-plan drops only the planning section (still composes header + footer) for
+# trivial mechanical work where a plan is overkill.
+#
+# Worktrees are always based on the REMOTE default branch: with --worktree and
+# no --base, origin/main is assumed. When the base is a remote-tracking ref
+# (origin/...), the repo is fetched first so the base is current.
 #
 # Prints the created task JSON; when dispatched, a second JSON line with the
 # `task run` outcome ({"spawned": "..."} / {"reused": "..."}).
 
 set -euo pipefail
 
-TITLE="" DESC="" REPO="" AGENT="" WORKTREE="" BASE="" DISPATCH=1
+TITLE="" DESC="" REPO="" AGENT="" WORKTREE="" BASE="" ACCEPT="" PRIORITY=""
+DISPATCH=1 PLAN=1 DRYRUN=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --title)       TITLE="$2"; shift 2 ;;
@@ -26,11 +45,70 @@ while [[ $# -gt 0 ]]; do
     --agent)       AGENT="$2"; shift 2 ;;
     --worktree)    WORKTREE="$2"; shift 2 ;;
     --base)        BASE="$2"; shift 2 ;;
+    --accept)      ACCEPT="$2"; shift 2 ;;
+    --priority)    PRIORITY="$2"; shift 2 ;;
+    --no-plan)     PLAN=0; shift ;;
     --no-dispatch) DISPATCH=0; shift ;;
+    --dry-run)     DRYRUN=1; shift ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
 done
 [[ -n "$TITLE" ]] || { echo "--title is required" >&2; exit 2; }
+
+# A worker is dispatched when we know both the repo and the agent.
+WORKER=0
+[[ -n "$REPO" && -n "$AGENT" ]] && WORKER=1
+
+# --- compose the worker prompt body ------------------------------------------
+# With --accept we own the full description; the planning phase + footer make
+# the plan-first contract identical on every dispatch.
+build_description() {
+  local branch="${WORKTREE:-flow/<task-slug>}"
+  printf 'priority: %s\n' "${PRIORITY:-normal}"
+  printf 'repo: %s\n' "${REPO:-unknown}"
+  printf 'accept: %s\n' "$ACCEPT"
+  if [[ -n "$DESC" ]]; then
+    printf '\n%s\n' "$DESC"
+  fi
+  if [[ "$WORKER" -eq 1 && "$PLAN" -eq 1 ]]; then
+    cat <<'PLAN_BLOCK'
+
+## Planning phase — do this FIRST, before writing any code
+
+Post a short PLAN as your opening message, then build strictly against it:
+
+1. **Problem** — restate the problem in 1–2 sentences.
+2. **Acceptance criteria** — the concrete, checkable conditions for "done".
+   Start from the `accept:` line above and make each item testable.
+3. **Approach** — the implementation approach / architecture: the files you'll
+   touch, the design, and any risks or open questions.
+
+Implement against that plan. If the work would drift outside it, stop and note
+the change rather than silently expanding scope.
+PLAN_BLOCK
+  fi
+  if [[ "$WORKER" -eq 1 ]]; then
+    cat <<FOOTER
+
+You are working in a dedicated git worktree on branch ${branch}; commit your
+work there and open a PR when the accept criterion is met. When finished: mark
+this task done (thurbox-cli task edit <id> --status done), print a final line
+\`===RESULT===\` followed by one line of JSON:
+{"status":"ok|error","artifact":"...","notes":"...","pr_url":"..."}
+then notify the flow agent so the next task dispatches immediately:
+thurbox-cli session send "\$(thurbox-cli session list | jq -r '.[] | select(.name=="flow") | .id')" "tick"
+FOOTER
+  fi
+}
+
+if [[ -n "$ACCEPT" ]]; then
+  DESC="$(build_description)"
+fi
+
+if [[ "$DRYRUN" -eq 1 ]]; then
+  printf '%s\n' "$DESC"
+  exit 0
+fi
 
 ARGS=(task create --title "$TITLE")
 [[ -n "$DESC" ]] && ARGS+=(--description "$DESC")


### PR DESCRIPTION
## What

Adds a **planning phase** to the flow extension's task-dispatch process, so every dispatched worker defines the problem, acceptance criteria, and implementation approach **before** writing code.

## Why

Task #25: workers were spawned straight from a brain-dump description, with the accept/footer boilerplate hand-typed by the flow triager each time. That left requirements loose and invited scope drift / rework.

## How

`scripts/create-task.sh` now **owns the worker prompt**. From the user's words plus `--accept` / `--priority` / `--repo` / `--worktree`, it composes a standardized description:

1. `priority:` / `repo:` / `accept:` header
2. the user's own words
3. a mandatory **Planning phase** — *Problem → Acceptance criteria → Approach* — that the worker posts as its first message and builds strictly against
4. the existing `===RESULT===` / notify footer

The plan is fed straight into the worker prompt, keeping dispatched work scoped to what was asked. The flow agent no longer hand-types the template — it passes structured flags and the helper keeps the contract byte-identical across dispatches.

Flags:
- `--accept` — seeds the acceptance criterion (the planning phase refines it)
- `--no-plan` — drops only the planning section (trivial mechanical work)
- `--dry-run` — prints the composed prompt, creates nothing (used by tests)
- no `--accept` → legacy verbatim-description behavior preserved (plain todos / direct callers)

## Docs & tests

- `FLOW.md` CAPTURE/DISPATCH sections rewritten for plan-first dispatch
- `README.md` + `CLAUDE.md` document the planning phase
- `scripts/create-task.bats` covers composition, `--no-plan`, legacy, and arg validation via the pure `--dry-run` path

## Verification

- `bash -n` clean; `shellcheck` clean
- All bats assertions pass (run as plain bash — bats not installed locally)
- `rumdl check` clean on all changed markdown