### PR TITLE
feat: add at-a-glance session board to flow ticks

### DIFF
--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -150,7 +150,13 @@ the cron tick to dispatch something that is eligible NOW.
 - **Never dispatch**: decisions, questions for the user, anything needing
   credentials you don't have → leave todo, surface under "Needs you".
 
-## TICK (from the automation — be silent unless action is needed)
+## TICK (from the automation — quiet, but always show the board)
+
+0. **Print the board.** Run `./scripts/flow-summary.sh` and put its output
+   (verbatim, fenced) at the **top** of your reply — a quick-glance table of
+   every live `flow`/`task-*` session joined to its task (status / age /
+   title), plus any `detached` work. This is the one thing a tick always
+   shows, even when nothing needs you.
 
 1. For each `in_progress` task:
    - Status already flipped to `done` by the worker → note it; session
@@ -174,9 +180,10 @@ the cron tick to dispatch something that is eligible NOW.
        under "Needs you" if it repeats.
 
 2. Run DISPATCH for next eligible todos (respect capacity).
-3. Output: if nothing needs the user, reply EXACTLY
-   `tick: all quiet (N running, M todo)` — nothing else.
-   Otherwise emit ONLY the Needs-you bullets + footer.
+3. Output — the board (step 0) **always comes first**, then:
+   - nothing needs the user → one line `tick: all quiet (N running, M todo)`
+     under the board, nothing else;
+   - otherwise → the Needs-you bullets + footer under the board.
 
 ## REPORT
 

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -95,6 +95,9 @@ active and healthy.
   rest. (Pass `--no-plan` to `create-task.sh` for trivial mechanical
   changes where a plan is overkill.)
 - `status` for a one-screen report; `clean` to groom the backlog.
+- Every tick prints a **board** — a quick-glance table of all live
+  `flow`/`task-*` sessions with status, age, and the task they're working
+  (`scripts/flow-summary.sh`) — so you can see the whole picture at once.
 - Workers self-report: they mark their task done, print a
   `===RESULT===` JSON line, and ping the flow session so the next task
   dispatches without waiting for the cron tick.
@@ -109,6 +112,7 @@ active and healthy.
 | `repos.md` | Routing-table seed (installed once, then user-owned) |
 | `scripts/create-task.sh` | Atomic task create + dispatch; composes the plan-first worker prompt (`--dry-run` to preview) |
 | `scripts/flow-snapshot.sh` | One-call backlog + sessions view |
+| `scripts/flow-summary.sh` | At-a-glance board table (printed atop every tick) |
 | `scripts/parse-result.sh` | Extract the worker `===RESULT===` sentinel |
 | `install.sh` | Thin shim → `thurbox-cli extension install` (curl\|sh bootstrap) |
 

--- a/extensions/flow/extension.toml
+++ b/extensions/flow/extension.toml
@@ -53,6 +53,10 @@ path = "scripts/flow-snapshot.sh"
 executable = true
 
 [[files]]
+path = "scripts/flow-summary.sh"
+executable = true
+
+[[files]]
 path = "scripts/parse-result.sh"
 executable = true
 

--- a/extensions/flow/scripts/flow-summary.sh
+++ b/extensions/flow/scripts/flow-summary.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# flow-summary.sh — at-a-glance table of the flow + worker sessions, joined to
+# their tasks (status / age / title). Printed at the top of every TICK so the
+# user can see the whole board without parsing verbose worker output.
+#
+# Each row is one live `flow` / `task-*` session. `task-<id>-…` sessions are
+# joined to task #<id> for status, age (from created_at) and title; a session
+# whose task is gone shows "orphan", and tasks whose worker session is missing
+# are listed under a "detached" footer line (so stale work isn't silently lost).
+#
+# Columns: ID  SESSION  AGENT  STATUS  AGE  TITLE
+# Status glyphs: ◆ monitor (flow) · ● running · ○ queued · ✔ done · ⚠ orphan
+#
+# No arguments. Reads `thurbox-cli session list` + `task list`; degrades to a
+# one-line notice if either call fails or there are no sessions to show.
+
+set -euo pipefail
+
+SESSIONS="$(thurbox-cli session list 2>/dev/null || echo '[]')"
+TASKS="$(thurbox-cli task list 2>/dev/null || echo '[]')"
+
+ROWS="$(printf '%s' "$SESSIONS" | jq -r --argjson tasks "$TASKS" '
+  # tasks indexed by id (string keys)
+  ($tasks | map({ key: (.id|tostring), value: . }) | from_entries) as $byid |
+
+  def trunc($n): if (.|length) > $n then (.[0:$n-1] + "…") else . end;
+  def humanage($ms):
+    ((now - ($ms / 1000)) | floor) as $s |
+    if   $s < 0       then "—"
+    elif $s < 90      then "\($s)s"
+    elif $s < 5400    then "\(($s / 60)    | floor)m"
+    elif $s < 172800  then "\(($s / 3600)  | floor)h"
+    else                   "\(($s / 86400) | floor)d" end;
+  def statusglyph($st):
+    if   $st == "done"        then "✔ done"
+    elif $st == "in_progress" then "● running"
+    elif $st == "todo"        then "○ queued"
+    else $st end;
+
+  [ .[]
+    | select(.name == "flow" or (.name | startswith("task-")))
+    # extract <id> from a task-<id>-… session name (null for the flow session)
+    | (.name | [scan("^task-([0-9]+)-")] | (first // [])[0]) as $tid
+    | (if $tid then $byid[$tid] else null end) as $task
+    | {
+        id:      (if $tid then "#\($tid)" else "—" end),
+        session: (.name | trunc(22)),
+        agent:   (.agent // "—"),
+        status:  (
+          if .name == "flow"      then "◆ monitor"
+          elif $task             then statusglyph($task.status)
+          else "⚠ orphan" end),
+        age:     (if $task then humanage($task.created_at) else "—" end),
+        title:   (if .name == "flow" then "(triage monitor)"
+                  elif $task         then ($task.title | trunc(40))
+                  else "(no task)" end),
+      }
+  ]
+  # flow first, then worker sessions by id
+  | sort_by((.id == "—" | not), .id)
+  | select(length > 0)
+  | (["ID","SESSION","AGENT","STATUS","AGE","TITLE"]),
+    (.[] | [.id, .session, .agent, .status, .age, .title])
+  | @tsv
+' 2>/dev/null || true)"
+
+if [[ -z "$ROWS" ]]; then
+  echo "## flow board — (no flow/worker sessions)"
+  exit 0
+fi
+
+echo "## flow board"
+if command -v column >/dev/null 2>&1; then
+  printf '%s\n' "$ROWS" | column -t -s $'\t'
+else
+  printf '%s\n' "$ROWS" | tr '\t' ' '
+fi
+
+# Footer: tasks that are in_progress but whose worker session is gone (detached)
+DETACHED="$(printf '%s' "$TASKS" | jq -r --argjson sessions "$SESSIONS" '
+  ($sessions | map(.name)) as $names |
+  .[]
+  | select(.status == "in_progress")
+  | select( [ $names[] | startswith("task-\(.id|tostring)-") ] | any | not )
+  | "  #\(.id) \(.title)"
+' 2>/dev/null || true)"
+
+if [[ -n "$DETACHED" ]]; then
+  echo
+  echo "## detached (in_progress, no worker session)"
+  printf '%s\n' "$DETACHED"
+fi


### PR DESCRIPTION
## What

Adds a quick visual summary table that the flow triage agent prints at the top of **every tick**, so the user can see the whole board at a glance without parsing verbose worker output.

## How

- **`scripts/flow-summary.sh`** (new) — one-call board that joins every live `flow`/`task-*` session to its task and renders an aligned table:

  ```
  ## flow board
  ID   SESSION                 AGENT              STATUS     AGE  TITLE
  —    flow                    flow               ◆ monitor  —    (triage monitor)
  #27  task-27-add-renovate-…  flow-worker-heavy  ● running  6m   Add renovate extension for local sessio…
  #28  task-28-add-quick-sum…  flow-worker        ● running  4m   Add quick summary table to flow session…
  ```

  Columns: **ID · SESSION · AGENT · STATUS · AGE · TITLE**. Status glyphs: `◆ monitor` (flow) · `● running` · `○ queued` · `✔ done` · `⚠ orphan`. Age is humanized from the task's `created_at`. A footer lists `detached` work — `in_progress` tasks whose worker session has vanished. Degrades gracefully (empty/failed `thurbox-cli` calls → a one-line notice) and falls back to `tr` when `column` is absent.

- **`FLOW.md`** — TICK now runs the script and prints the board verbatim at the top of every reply, before the quiet line / Needs-you bullets.
- **`extension.toml`** — ships the new script as an executable payload file.
- **`README.md`** — documents the board in the Use section + file table.

## Test

- `shellcheck` clean; `rumdl check` clean on FLOW.md/README.md.
- Ran against live state: correct join, ages, glyphs, alignment; empty-state path verified.

Accept criterion: flow displays a formatted summary table on each tick showing all active sessions with status/age/key metrics.