### PR TITLE
feat(core): name task sessions after the task title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -536,7 +536,7 @@ sync, but the TUI editor never sets it.)
   scroll the preview, `n` new, `e`/`Enter` open the central-pane editor,
   `Space` cycle status, `r` open the **trigger-time action picker**, `o` **open
   the task's related session** (`App::open_task_related_session` — jumps to the
-  spawned `task-<id>-<slug>` window or a Send target, else a status hint), `d`/`Ctrl+D`
+  spawned `<title> · #<id>` window or a Send target, else a status hint), `d`/`Ctrl+D`
   delete, `Esc` back to the session list. In the editor: field nav +
   `Enter`/`Ctrl+S` save (→ back to panel), `Esc` discard; the editor captures
   its keys before global bindings (so `e`/`d` edit text) via

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -735,9 +735,13 @@ migration. No fetch logic ships yet.
 `create`/`list`/`show`/`edit`/`remove`/`run`. `create` with neither
 `--session` nor `--repo` is a plain local todo; `run` triggers the
 task's Send/Spawn action headlessly (spawned sessions are named
-`task-<id>-<title-slug>` via `Task::spawn_session_name`, adopted by the
-TUI on next startup; `Task::matches_spawn_session` also recognizes the
-legacy bare `task-<id>` form and spawns from a since-edited title).
+`<title> · #<id>` via `Task::spawn_session_name` — the human title reads
+straight in the session list while the trailing `· #<id>` tag keeps the
+tmux window name unique and lets the task relink to its session — adopted
+by the TUI on next startup; `Task::matches_spawn_session` recovers the
+owning task from that tag and also recognizes the legacy
+`task-<id>-<slug>` / bare `task-<id>` forms, so a since-edited title still
+relinks).
 
 ---
 

--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -19,7 +19,8 @@ instead. The only files you ever touch are in this flow home.
 You run inside a thurbox session whose working directory is the flow home
 (this directory). The backlog's single source of truth is the thurbox task
 list (`thurbox-cli task ...`). Worker sessions are thurbox sessions named
-`task-<id>-<title-slug>`. Never act on a message without following this
+after the task title, tagged with its id (`<title> · #<id>`). Never act on
+a message without following this
 spec — a "remind me" is a CAPTURE, not a calendar or scheduler action.
 
 ## Mode detection

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -84,8 +84,9 @@ active and healthy.
 
 - Open the `flow` session in the thurbox TUI and type at it — anything
   that isn't `tick`/`status`/`clean` is treated as a brain-dump.
-- Dispatchable items spawn a worker immediately (`task-<id>-<slug>`
-  session, on a `flow/<slug>` worktree branch whenever the repo is git).
+- Dispatchable items spawn a worker immediately (a session named after the
+  task title, `<title> · #<id>`, on a `flow/<slug>` worktree branch whenever
+  the repo is git).
 - **Plan-first dispatch**: every worker prompt carries a mandatory
   planning phase. Before writing any code the worker posts a short PLAN —
   problem statement, concrete acceptance criteria, and an implementation

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -677,7 +677,7 @@ impl App {
                 }
             }
             // Jump to the task's related session terminal (the spawned
-            // `task-<id>-<slug>` window, or a persisted Send target).
+            // `<title> · #<id>` window, or a persisted Send target).
             KeyCode::Char('o') => self.open_task_related_session(),
             KeyCode::Char('d') => self.delete_selected_task(),
             _ => {}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2333,7 +2333,7 @@ impl App {
         if let Some((task_id, title)) = task_prompt {
             let new_id = self.sessions[self.active_index].info.id;
             // Record the link now — the session was named by the user, so the
-            // `task-<id>-<slug>` convention can't recover it later.
+            // `<title> · #<id>` convention can't recover it later.
             self.task_ui.task_session_links.insert(task_id, new_id);
             let prompt = self.task_agent_prompt(task_id, &title);
             self.send_prompt_to_session(new_id, &prompt, AGENT_BOOT_DELAY_TICKS);
@@ -3778,7 +3778,7 @@ impl App {
     /// queue `prompt` into it. The session is named `name`; a recurring caller
     /// reuses that session on later invocations (and after a TUI restart, where
     /// it is restored from the database by name). Shared by automations
-    /// (`auto-<id>`) and tasks (`task-<id>-<title-slug>`).
+    /// (`auto-<id>`) and tasks (`<title> · #<id>`).
     fn spawn_and_prompt(
         &mut self,
         name: String,
@@ -4150,8 +4150,8 @@ impl App {
     /// Indices into `self.sessions` of the **currently-open** sessions a task is
     /// related to, in display order:
     ///
-    /// - the session named by the spawn convention (`task-<id>-<title-slug>`,
-    ///   or the legacy bare `task-<id>`) — used by the headless `task run`
+    /// - the session named by the spawn convention (`<title> · #<id>`, or the
+    ///   legacy `task-<id>-<slug>` / bare `task-<id>`) — used by the headless `task run`
     ///   (and what survives a restart; see [`Task::matches_spawn_session`]);
     /// - the target of a persisted `Send` action (`task.action`), when one is
     ///   set via the CLI; and

--- a/src/app/task_state.rs
+++ b/src/app/task_state.rs
@@ -34,7 +34,7 @@ pub(crate) struct TaskUiState {
     pub(crate) pending_task_prompt: Option<(i64, String)>,
     /// Live `task id → session id` links recorded when a task is triggered from
     /// the TUI (Spawn-new or Send). TUI spawns get a user-chosen session name
-    /// rather than the `task-<id>-<slug>` convention, so the name alone can't
+    /// rather than the `<title> · #<id>` convention, so the name alone can't
     /// recover the link — this map does. Consulted by
     /// `task_related_session_indices` alongside the name convention and any
     /// persisted `Send` action. In-memory only (the spawn-name convention is

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -880,7 +880,7 @@ impl App {
         area: Rect,
         task: &crate::session::Task,
     ) -> Option<ScrollbarGeom> {
-        // Related running sessions (spawned `task-<id>-<slug>` and/or a Send target).
+        // Related running sessions (spawned `<title> · #<id>` and/or a Send target).
         let related = self.task_related_session_indices(task);
         let sessions = if related.is_empty() {
             "none open".to_string()

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -2,7 +2,7 @@
 //!
 //! Tasks are persisted to the shared database; the TUI's right-side panel reads
 //! them. `run` triggers a task's agent action headlessly (Send into a live tmux
-//! window, or Spawn a fresh session named `task-<id>-<title-slug>` seeded with
+//! window, or Spawn a fresh session named `<title> · #<id>` seeded with
 //! the title).
 
 use clap::Subcommand;
@@ -179,8 +179,8 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
         }) => {
             let name = task.spawn_session_name();
             // Reuse an existing session window (re-trigger / restored session).
-            // Match by convention rather than exact name so legacy `task-<id>`
-            // sessions and spawns from a since-edited title are found too.
+            // Match by the `· #<id>` tag rather than the exact name so a
+            // since-edited title (and legacy `task-<id>` sessions) are found too.
             let existing = db
                 .list_active_sessions()
                 .map_err(|e| format!("list_active_sessions: {e}"))?

--- a/src/session/task.rs
+++ b/src/session/task.rs
@@ -127,39 +127,36 @@ impl Task {
     }
 
     /// Session name used when this task is dispatched via a `Spawn` action:
-    /// `task-<id>-<title-slug>` (e.g. `task-42-wire-up-ssh-backend`), capped at
-    /// [`SPAWN_SESSION_NAME_MAX`] chars. Falls back to plain `task-<id>` when
-    /// the title yields no slug. Shared by the headless `task run` path; use
-    /// [`matches_spawn_session`](Self::matches_spawn_session) to recognize the
-    /// session later (it also accepts the legacy bare `task-<id>` form).
+    /// the human task title with a compact id tag, e.g.
+    /// `Wire up SSH backend · #42`. The title is kept verbatim (author casing
+    /// and spacing) so the session list reads like the task itself; the trailing
+    /// [`TASK_ID_TAG`]`<id>` keeps the name unique (the tmux window name is
+    /// derived from it) and lets [`matches_spawn_session`](Self::matches_spawn_session)
+    /// recover the owning task. The whole name is bounded by
+    /// [`SPAWN_SESSION_NAME_MAX`], truncating the title at a word boundary.
+    /// Falls back to the bare `task-<id>` form when the title is empty. Shared by
+    /// the headless `task run` path.
     pub fn spawn_session_name(&self) -> String {
-        let prefix = format!("task-{}", self.id);
-        let budget = SPAWN_SESSION_NAME_MAX.saturating_sub(prefix.len() + 1);
-        let mut slug = String::new();
-        for c in self.title.chars() {
-            if c.is_ascii_alphanumeric() {
-                slug.push(c.to_ascii_lowercase());
-            } else if !slug.is_empty() && !slug.ends_with('-') {
-                slug.push('-');
-            }
-            if slug.len() >= budget {
-                break;
-            }
-        }
-        slug.truncate(budget);
-        let slug = slug.trim_end_matches('-');
-        if slug.is_empty() {
-            prefix
+        let suffix = format!("{TASK_ID_TAG}{}", self.id);
+        let budget = SPAWN_SESSION_NAME_MAX.saturating_sub(suffix.len());
+        let title = truncate_title(&self.title, budget);
+        if title.is_empty() {
+            format!("task-{}", self.id)
         } else {
-            format!("{prefix}-{slug}")
+            format!("{title}{suffix}")
         }
     }
 
-    /// Whether `name` is this task's spawned session: the current
-    /// `task-<id>-<slug>` convention or the legacy bare `task-<id>` (which
-    /// pre-slug sessions still carry; the title may also have been edited
-    /// since the spawn, so only the `task-<id>` part is significant).
+    /// Whether `name` is this task's spawned session. Recognizes the current
+    /// `… · #<id>` convention (matched on the exact tag-and-id suffix, whose
+    /// ` · #` boundary keeps `#4` from matching `…#14`) as well as the legacy
+    /// `task-<id>-<slug>` and bare `task-<id>` forms still carried by sessions
+    /// spawned before this naming change (the title may also have been edited
+    /// since the spawn, so only the id is significant).
     pub fn matches_spawn_session(&self, name: &str) -> bool {
+        if name.ends_with(&format!("{TASK_ID_TAG}{}", self.id)) {
+            return true;
+        }
         let prefix = format!("task-{}", self.id);
         name == prefix
             || name
@@ -168,9 +165,36 @@ impl Task {
     }
 }
 
-/// Cap for [`Task::spawn_session_name`], matching the session-name limit used
-/// elsewhere (tmux window names stay readable in the TUI session list).
+/// Upper bound on a spawned session name (bytes), matching `validate_safe_name`.
+/// tmux window names stay readable in the TUI session list well under this.
 pub const SPAWN_SESSION_NAME_MAX: usize = 64;
+
+/// Separator + marker that tags a spawned session name with its task id, e.g.
+/// the ` · #` in `Wire up SSH backend · #42`. The surrounding spaces and `#`
+/// make the trailing-id match in [`Task::matches_spawn_session`] unambiguous.
+pub const TASK_ID_TAG: &str = " · #";
+
+/// The task title trimmed and whitespace-collapsed to a single line, truncated
+/// at a word boundary so its byte length does not exceed `budget` (never
+/// splitting a multi-byte char or leaving trailing whitespace).
+fn truncate_title(title: &str, budget: usize) -> String {
+    let collapsed = title.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.len() <= budget {
+        return collapsed;
+    }
+    // Cut at the last char boundary within budget, then back off to the last
+    // whole word so we never dangle a half word.
+    let mut end = budget;
+    while end > 0 && !collapsed.is_char_boundary(end) {
+        end -= 1;
+    }
+    let head = &collapsed[..end];
+    let trimmed = match head.rsplit_once(' ') {
+        Some((words, _partial)) => words,
+        None => head,
+    };
+    trimmed.trim_end().to_string()
+}
 
 #[cfg(test)]
 mod tests {
@@ -231,43 +255,64 @@ mod tests {
     }
 
     #[test]
-    fn spawn_session_name_slugs_the_title() {
+    fn spawn_session_name_keeps_the_title_verbatim() {
+        // The human title is preserved (casing + spacing), tagged with the id.
         assert_eq!(
             sample_task(None).spawn_session_name(),
-            "task-42-wire-up-ssh-backend"
+            "Wire up SSH backend · #42"
         );
     }
 
     #[test]
-    fn spawn_session_name_collapses_symbols_and_caps_length() {
+    fn spawn_session_name_collapses_whitespace() {
         let mut task = sample_task(None);
-        task.title = "Fix: TUI crash!! (on concurrent CLI commands)".to_string();
-        assert_eq!(
-            task.spawn_session_name(),
-            "task-42-fix-tui-crash-on-concurrent-cli-commands"
+        task.title = "  Fix   TUI\tcrash  ".to_string();
+        // Internal runs collapse to single spaces; ends are trimmed.
+        assert_eq!(task.spawn_session_name(), "Fix TUI crash · #42");
+    }
+
+    #[test]
+    fn spawn_session_name_truncates_long_titles_at_a_word_boundary() {
+        let mut task = sample_task(None);
+        task.title = "Improve task session naming with simpler shorter human readable identifiers"
+            .to_string();
+        let name = task.spawn_session_name();
+        assert!(name.len() <= SPAWN_SESSION_NAME_MAX);
+        assert!(name.ends_with(" · #42"));
+        // The kept title portion is whole words (no dangling partial word).
+        let title = name.strip_suffix(" · #42").unwrap();
+        assert!(!title.ends_with(' '));
+        assert!(
+            "Improve task session naming with simpler shorter human readable identifiers"
+                .starts_with(title)
         );
+        // A single pathological word is hard-capped, still within budget.
         task.title = "x".repeat(200);
         let name = task.spawn_session_name();
         assert!(name.len() <= SPAWN_SESSION_NAME_MAX);
-        assert!(name.starts_with("task-42-x"));
-        // Truncation never leaves a dangling hyphen.
-        assert!(!name.ends_with('-'));
+        assert!(name.ends_with(" · #42"));
     }
 
     #[test]
-    fn spawn_session_name_falls_back_to_bare_id() {
+    fn spawn_session_name_falls_back_to_bare_id_for_blank_title() {
         let mut task = sample_task(None);
-        task.title = "??? !!!".to_string();
+        task.title = "   ".to_string();
         assert_eq!(task.spawn_session_name(), "task-42");
     }
 
     #[test]
     fn matches_spawn_session_accepts_current_and_legacy_names() {
         let task = sample_task(None);
+        // Current convention: trailing " · #<id>" tag.
+        assert!(task.matches_spawn_session("Wire up SSH backend · #42"));
+        assert!(task.matches_spawn_session("Some since-edited title · #42"));
+        // Legacy forms still relink after a restart.
         assert!(task.matches_spawn_session("task-42-wire-up-ssh-backend"));
-        assert!(task.matches_spawn_session("task-42-some-older-title")); // title edited
-        assert!(task.matches_spawn_session("task-42")); // legacy convention
-        assert!(!task.matches_spawn_session("task-421")); // different task id
+        assert!(task.matches_spawn_session("task-42")); // legacy bare convention
+                                                        // Different task ids never match — including the tricky #4 vs #42 boundary.
+        assert!(!task.matches_spawn_session("Wire up SSH backend · #421"));
+        assert!(!task.matches_spawn_session("Wire up SSH backend · #4"));
+        assert!(!task.matches_spawn_session("task-421"));
         assert!(!task.matches_spawn_session("task-4"));
         assert!(!task.matches_spawn_session("my-task-42"));
     }

--- a/src/ui/tasks_panel.rs
+++ b/src/ui/tasks_panel.rs
@@ -27,7 +27,7 @@ pub struct TaskPaneEntry {
     /// When a global search is active, rows that don't match are dimmed.
     pub dimmed: bool,
     /// The task has at least one currently-open related session (a spawned
-    /// `task-<id>-<slug>` window or a Send target). Drawn as a trailing `⇄`
+    /// `<title> · #<id>` window or a Send target). Drawn as a trailing `⇄`
     /// marker so a live task is glanceable in the list; press `o` to jump to it.
     pub linked: bool,
 }


### PR DESCRIPTION
## What

Spawned task sessions were named `task-<id>-<kebab-slug>` (e.g. `task-23-improve-session-naming`), which reads like a machine id rather than the task itself. This renames them after the **human title** with a compact id tag:

```
Improve session naming · #23
```

Closes thurbox task #24.

## Why it keeps the id

For local sessions the session name *is* the tmux addressing key, and the id was doing two real jobs beyond looks:

1. **Uniqueness** — two same-titled tasks would otherwise produce colliding tmux window names and break `send-keys`/capture targeting.
2. **Task↔session linking** — `Task::matches_spawn_session` recovers which task owns a session purely from the name (used by headless re-dispatch dedup in `cli/tasks.rs` and the TUI's `⇄` related-session marker / `o`-to-open, both of which must survive a restart — there is no persistent session→task DB link today).

Leading with the title and keeping a trailing `· #<id>` tag preserves both with **no schema migration**. The session-list display uses the raw name, so it reads nicely even though the internal tmux window name gets sanitized.

## Details

- `Task::spawn_session_name` → `"<title> · #<id>"`. Title kept verbatim (author casing/spacing), whitespace-collapsed, truncated at a word boundary within the 64-char cap. Empty titles fall back to the legacy bare `task-<id>`.
- `Task::matches_spawn_session` recognizes the new `· #<id>` suffix (false-positive-safe — the ` · #` boundary keeps `#4` from matching `…#14`) **plus** the legacy `task-<id>-<slug>` / bare `task-<id>` forms, so pre-existing sessions still relink after a restart.
- No call-site changes: re-dispatch dedup and the TUI related-session lookup already go through the matcher.
- Docs + convention comments updated (FEATURES.md, flow FLOW.md/README.md, CLAUDE.md, inline).

The flow worktree branch naming (`flow/<slug>`) is unchanged.

## Test

- `cargo test --lib session::task` — new format + matcher (incl. truncation + `#4` vs `#42` boundary).
- `cargo test --lib task` — TUI related-session tests pass with both name shapes (69 passed).
- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo test --test architecture_rules` green.