### PR TITLE
feat: add renovate extension for local dependency updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -598,6 +598,19 @@ sync, but the TUI editor never sets it.)
   add -b` (which fails on an existing branch), `dispatch-fix.sh` adopts the
   request branch itself (git-universal) into a shepherd-owned worktree. Spec:
   `SHEPHERD.md`.
+- **`extensions/renovate/`** *(experimental)* — keeps local repos on up-to-date
+  dependencies. A `renovate` session sweeps a `repos.md` watch list on a weekly
+  `renovate-tick` automation and dispatches a `renovate-worker` per eligible
+  repo; the worker runs **Renovate's `local` platform only**
+  (`scripts/renovate-run.sh` hard-codes `--platform=local` — no hosted bot, no
+  token, no Renovate-opened PR), tests the result, commits to a fresh
+  `renovate/updates-<ts>` branch, and opens a review PR. Updaters are thurbox
+  **tasks** (`update <repo> deps …`) that self-report with the same
+  `===RESULT===` sentinel as flow. Unlike ci-shepherd it starts a *new* branch,
+  so `scripts/dispatch-update.sh` uses thurbox's native `--worktree` (no branch
+  adoption). Version strategy is per-repo (`strategy` column: `patch`/`minor`/
+  `major`/`all`, layered as a `RENOVATE_CONFIG` overlay) plus a global
+  `renovate-config.json`. Spec: `RENOVATE.md`.
 
 ### Extension manifests + self-heal (`thurbox-cli extension`)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -809,6 +809,12 @@ Two more ship in `extensions/`, both built the same agent-agnostic way
   agent at runtime) and dispatches a `shepherd-worker` fixer for each with
   **failing CI** or a **changes-requested review**.
   `thurbox-cli extension install ci-shepherd`.
+- **`renovate`** — keeps local repos on up-to-date dependencies. A weekly
+  `renovate-tick` dispatches a `renovate-worker` per watched repo that runs
+  **Renovate's local platform only** (`--platform=local`, no bot/token/PR),
+  tests the bumps, commits to a fresh `renovate/updates-<ts>` branch, and
+  opens a review PR. Per-repo `strategy` (patch/minor/major/all) layers onto a
+  global `renovate-config.json`. `thurbox-cli extension install renovate`.
 
 ---
 

--- a/extensions/renovate/README.md
+++ b/extensions/renovate/README.md
@@ -1,0 +1,124 @@
+# Renovate — keep your local repos on up-to-date dependencies
+
+> **Status: experimental.** Renovate (the thurbox extension) is new and under
+> active testing — expect the behavior spec, scripts, and installer to change
+> between releases.
+
+This extension keeps the dependencies in your local repos current with minimal
+fuss. A quiet `renovate` session sweeps a watch list on a schedule and, for each
+repo that isn't already mid-update, dispatches a worker that runs
+[Renovate](https://github.com/renovatebot/renovate) on its **local platform**,
+runs your project's tests, commits the bumps to a fresh branch, and opens a
+review PR — then pings the monitor so the next repo dispatches. Dependency
+upkeep becomes background work you only look at when a PR is ready or a major
+upgrade needs a decision.
+
+```text
+---
+Needs you: example — major bump of `serde` 1→2 needs your call (tests pass)
+🎯 Next: review the open PR for myrepo (12 patch/minor bumps, CI green)
+```
+
+## Renovate runs only locally
+
+The worker always invokes Renovate with `--platform=local`: **no hosted bot, no
+token, no Renovate-opened PRs.** Renovate simply rewrites the dependency
+manifests + lockfiles in an isolated worktree; the thurbox worker owns the rest
+(test, commit, push, open a PR). That keeps it forge-agnostic *and*
+agent-agnostic, like thurbox itself — only **git** is baked in. The monitor and
+worker are plain `agents.toml` aliases (`renovate`, `renovate-worker`), so each
+can be claude, codex, gemini, opencode, vibe, … The behavior lives in
+[RENOVATE.md](RENOVATE.md), surfaced to whatever CLI you pick via context-file
+symlinks (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `RENOVATE.md`).
+
+## Update strategy
+
+Two layers control how far versions move:
+
+- **Per repo** — the `strategy` column in `repos.md`: `patch`, `minor`
+  (patch + minor, the default), `major`, or `all`.
+- **Global** — `renovate-config.json`, Renovate's own config (grouping, version
+  ranges, ignored deps, lockfile maintenance). The worker passes it via
+  `RENOVATE_CONFIG_FILE`; the per-repo strategy is layered on top.
+
+## Requirements
+
+- `git`, `jq`, and `thurbox-cli` on `PATH`.
+- **Node ≥ 20** — Renovate runs via `npx --yes renovate` (a global `renovate`
+  install is used if present). Set `GITHUB_COM_TOKEN` to raise GitHub API limits
+  / fetch changelogs (optional, read-only).
+- For the worker to open a review PR: the forge client authenticated
+  (`gh auth login` / `glab auth login`). Without one the worker leaves the
+  branch committed locally and says so.
+
+## Install
+
+Renovate is a thurbox **extension** (a declarative `extension.toml` manifest):
+
+```bash
+thurbox-cli extension install renovate
+```
+
+or from a checkout: `thurbox-cli extension install ./extensions/renovate` (the
+`install.sh` / curl one-liner is a thin shim over this). Override the home with
+`--home <dir>`. Installing:
+
+1. lays down the renovate home (`~/renovate`): the `RENOVATE.md` spec, helper
+   scripts, context-file symlinks, claude permission settings, a `repos.md`
+   watch list, and a `renovate-config.json` (both seeded once, then user-owned);
+2. registers the `renovate` / `renovate-worker` agents in
+   `~/.config/thurbox/agents.toml` (defaults: claude on haiku for the monitor,
+   opus for the worker — edit the entries to change the model/CLI);
+3. activates the dedicated `renovate` session and a `renovate-tick` automation
+   (weekly, Monday 09:00) — both **self-healed** by thurbox at startup and on
+   every tick, so deleting them is a no-op until you `deactivate`.
+
+Re-running `extension install` refreshes the installer-owned files. `thurbox-cli
+extension list` / `status renovate` show what's active.
+
+## Use
+
+- Add the repos to keep current to `~/renovate/repos.md` (one row each;
+  `strategy` defaults to `minor`, `provider` to `auto`).
+- The monitor sweeps on its schedule; trigger one now by sending `tick` to the
+  renovate session (or open it in the TUI).
+- `status` for a one-screen report; `clean` to prune merged update worktrees.
+- An updater is a thurbox **task** named `update <repo> deps …`; its worker runs
+  in an isolated worktree on a fresh `renovate/updates-<ts>` branch and
+  self-reports via a `===RESULT===` sentinel, pinging the monitor when it
+  finishes.
+
+## How the worker gets its branch
+
+A renovate run starts a **brand-new** branch, so — unlike ci-shepherd — there's
+no branch to adopt: `dispatch-update.sh` uses thurbox's native `--worktree`,
+which runs `git worktree add -b renovate/updates-<ts> origin/main`. The worker
+runs Renovate locally there, tests, commits, and pushes that branch for review.
+`clean` removes the worktree once the PR has merged (refusing if it has
+uncommitted work).
+
+## Files
+
+| Path | Purpose |
+|------|---------|
+| `RENOVATE.md` | The agent behavior spec (modes, eligibility rules, output contract) |
+| `renovate-config.json` | Renovate's own config (global update strategy), passed via `RENOVATE_CONFIG_FILE` |
+| `repos.md` | Watch list: repos + per-repo strategy/provider |
+| `scripts/renovate-snapshot.sh` | One-call local view: watched repos + in-flight branches/tasks/sessions |
+| `scripts/dispatch-update.sh` | Create a fresh update worktree + create and run the updater task |
+| `scripts/renovate-run.sh` | Run Renovate (`--platform=local` only); maps strategy → config overlay |
+| `scripts/parse-result.sh` | Extract the worker `===RESULT===` sentinel |
+| `extension.toml` | Declarative install + runtime manifest (`thurbox-cli extension install` reads this) |
+| `claude-settings.json` | Pre-approved permissions template (laid down as `.claude/settings.json`) |
+| `install.sh` | Thin curl/sh shim over `thurbox-cli extension install` |
+
+## Uninstall
+
+```bash
+thurbox-cli extension deactivate renovate   # off-switch: tears down session + automation
+thurbox-cli extension uninstall renovate    # also removes the agents + manifest
+thurbox-cli extension uninstall renovate --purge  # ...and deletes ~/renovate
+```
+
+> Remove any leftover update worktrees first (`git -C <repo> worktree remove …`)
+> if you `--purge` while updates are mid-flight.

--- a/extensions/renovate/RENOVATE.md
+++ b/extensions/renovate/RENOVATE.md
@@ -1,0 +1,137 @@
+# Renovate agent
+
+You are the **renovate agent** — a quiet monitor that keeps the user's local
+repos on up-to-date dependencies. Each tick you dispatch a worker per watched
+repo that isn't already being updated; the worker runs **Renovate's local
+platform** inside an isolated worktree, tests the result, commits, and opens a
+review PR.
+
+**You never update dependencies yourself.** You are a dispatcher: never run
+Renovate, edit a manifest, or push — that is the worker's job. You read state,
+decide what's eligible, dispatch a worker, monitor it, and surface only what
+needs the user. The only files you ever touch are in this renovate home.
+
+**Renovate runs only locally.** Every worker invokes Renovate with
+`--platform=local` (via `./scripts/renovate-run.sh`): no hosted bot, no token,
+no Renovate-opened PRs. Renovate just rewrites the dependency files in the
+worktree; the worker owns git + the review PR. Never suggest the hosted Renovate
+app or a `RENOVATE_TOKEN` platform mode.
+
+Be terse. No preamble, no praise. Every user-facing reply ends with the Output
+Contract footer.
+
+You run inside a thurbox session whose working directory is the renovate home
+(this directory). Update workers are thurbox **tasks** named `update <repo>
+deps …` whose worker session is `task-<id>-…`. The watch list is `./repos.md`.
+
+## Update strategy (per repo)
+
+The `strategy` column in `repos.md` decides how far each repo's versions bump:
+
+| strategy | bumps |
+|---|---|
+| `patch` | patch only |
+| `minor` | patch + minor (default) |
+| `major` / `all` | everything |
+
+`dispatch-update.sh --strategy <s>` passes it through to `renovate-run.sh`, which
+layers it onto `renovate-config.json` (the user's global Renovate config:
+grouping, ranges, ignored deps, lockfile maintenance). You don't tune config —
+you pass the repo's strategy and let the worker run it.
+
+## Mode detection
+
+| Message starts with | Mode |
+|---|---|
+| `tick` | TICK (from the automation — dispatch + monitor, silent) |
+| `status` / `report` | REPORT |
+| `clean` | CLEAN |
+| anything else | ASK (ad-hoc, e.g. "update myrepo now") |
+
+## Shared context (run FIRST in every mode, one call)
+
+```bash
+./scripts/renovate-snapshot.sh
+```
+
+It reads `./repos.md` and, per repo, prints its strategy/provider and any live
+`renovate/*` branches (a branch present means a worker is updating it or a
+finished update awaits review). Then it lists the live `update …` tasks and the
+`renovate`/`task-*` sessions. It is entirely local — fast, no forge calls.
+
+## TICK (be silent unless action is needed)
+
+1. **Dispatch** an updater for every watched repo that is **eligible**:
+   - **Eligible**: the path exists AND it has no live `renovate/*` branch AND no
+     non-`done` `update <repo>` task. (A live branch or task means work is
+     already in flight or awaiting your review — skip it.)
+   - **Capacity**: at most **3** running update sessions total. Over capacity →
+     leave the rest for the next tick.
+   - Dispatch — one call, passing the repo's strategy from `repos.md`:
+
+     ```bash
+     ./scripts/dispatch-update.sh --repo <abs-repo-path> --strategy <s> \
+       --provider <p> --agent renovate-worker
+     ```
+
+     It creates the fresh `renovate/updates-<ts>` worktree, seeds the worker with
+     the full context, and runs it.
+
+2. **Monitor** each in-flight update task (`in_progress`):
+   - Worker marked the task `done` → note it (the branch/PR is the artifact;
+     CLEAN prunes the worktree once it's merged).
+   - Worker session missing from the session list → stale: reset the task to
+     todo (`thurbox-cli task edit <id> --status todo`).
+   - Otherwise capture recent output and parse the worker's sentinel:
+
+     ```bash
+     thurbox-cli session capture <uuid> --lines 40 | jq -r .output \
+       | ./scripts/parse-result.sh
+     ```
+
+     - Exit 0 → sentinel found. `"status":"ok"` → mark the task done if it isn't
+       (a `pr_url` is the artifact; `"no updates available"` is a clean no-op).
+       `"status":"error"` (or the JSON has a `question`) → "Needs you".
+     - Exit 1 → still working; but if the visible output shows an error, a
+       permission prompt, or a question addressed to the user → "Needs you".
+     - Exit 2 → malformed; treat as still working, flag if it repeats.
+
+3. Output: if nothing needs the user, reply EXACTLY
+   `tick: all quiet (N updating, M eligible)` — nothing else. Otherwise emit
+   ONLY the Needs-you bullets + footer.
+
+## REPORT
+
+One screen max:
+
+- **Updating**: `#task <repo> [worker] (age)`
+- **Awaiting review**: a repo with a finished `renovate/*` branch + its PR url
+- **Eligible, unstarted**: repos with no branch and no task
+- **Needs you**: true blockers only (a worker's question, a major bump awaiting a
+  decision, a repo whose tests keep failing after updates)
+- Footer.
+
+## CLEAN
+
+- Update task `done` AND its `renovate/*` branch is merged/closed (the PR landed)
+  → `thurbox-cli task remove <id>`, then remove its worktree:
+  `git -C <repo> worktree remove --force <worktree-path>`. Never remove a
+  worktree with uncommitted work — if `git -C <wt> status --porcelain` is
+  non-empty, leave it and flag under "Needs you".
+- Update task `in_progress` with no session → reset to todo.
+- Orphan `task-*` sessions whose task is removed →
+  `thurbox-cli session delete <uuid> --force`.
+
+## ASK (anything else)
+
+Usually a one-off "update <repo> now": resolve the repo from `./repos.md` (use
+its strategy, or one the user names), and dispatch via `dispatch-update.sh`.
+Otherwise answer the question from the snapshot in a few lines. Footer.
+
+## Output Contract (every non-tick reply ends with)
+
+```text
+---
+Needs you: ≤3 bullets, only true decisions/blockers (omit the line if none)
+🎯 Next: <the ONE thing — usually the update closest to merging>
+```

--- a/extensions/renovate/claude-settings.json
+++ b/extensions/renovate/claude-settings.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Installed by thurbox `extension install renovate` (template: claude-settings.json). Re-installing overwrites this file; remove this line to keep your own edits.",
+  "permissions": {
+    "allow": [
+      "Bash(thurbox-cli:*)",
+      "Bash({home}/scripts/renovate-snapshot.sh:*)",
+      "Bash({home}/scripts/dispatch-update.sh:*)",
+      "Bash({home}/scripts/renovate-run.sh:*)",
+      "Bash({home}/scripts/parse-result.sh:*)",
+      "Bash(./scripts/renovate-snapshot.sh:*)",
+      "Bash(./scripts/dispatch-update.sh:*)",
+      "Bash(./scripts/renovate-run.sh:*)",
+      "Bash(./scripts/parse-result.sh:*)",
+      "Bash(npx:*)",
+      "Bash(renovate:*)",
+      "Bash(gh:*)",
+      "Bash(glab:*)",
+      "Bash(git:*)",
+      "Bash(jq:*)",
+      "Read(/{home}/**)",
+      "Edit(/{home}/**)",
+      "Write(/{home}/**)"
+    ]
+  }
+}

--- a/extensions/renovate/extension.toml
+++ b/extensions/renovate/extension.toml
@@ -1,0 +1,98 @@
+# Renovate extension manifest.
+#
+# Single source of truth for installing + running renovate. Install it with
+# `thurbox-cli extension install renovate` (or point at this directory:
+# `thurbox-cli extension install ./extensions/renovate`). thurbox fetches this
+# file, lays down the [[files]] / [[symlinks]] under `home`, registers the
+# [[agents]] in agents.toml, then activates the [[sessions]] + [[automations]]
+# and self-heals them if deleted. `{home}` is replaced with the resolved home
+# dir. Turn it off with `thurbox-cli extension deactivate renovate`.
+
+name = "renovate"
+description = "Keeps local repos on up-to-date dependencies via Renovate's local platform"
+config_version = 1
+home = "~/renovate"
+
+# --- agents registered in agents.toml (override the model by editing it) ------
+
+[[agents]]
+name = "renovate"
+command = "claude"
+args = ["--model", "claude-haiku-4-5"]
+resume_args = ["--resume", "{id}"]
+fork_args = ["--resume", "{id}", "--fork-session"]
+new_session_args = ["--session-id", "{id}"]
+
+[[agents]]
+name = "renovate-worker"
+command = "claude"
+args = ["--model", "claude-opus-4-8"]
+resume_args = ["--resume", "{id}"]
+fork_args = ["--resume", "{id}", "--fork-session"]
+new_session_args = ["--session-id", "{id}"]
+
+# --- payload files laid down under home ---------------------------------------
+
+[[files]]
+path = "RENOVATE.md"
+
+[[files]]
+path = "scripts/renovate-snapshot.sh"
+executable = true
+
+[[files]]
+path = "scripts/dispatch-update.sh"
+executable = true
+
+[[files]]
+path = "scripts/renovate-run.sh"
+executable = true
+
+[[files]]
+path = "scripts/parse-result.sh"
+executable = true
+
+# Watch list — seeded once, then user-owned (never clobbered on reinstall).
+[[files]]
+path = "repos.md"
+if_absent = true
+
+# Renovate's own config the workers pass via RENOVATE_CONFIG_FILE — seeded once,
+# then user-owned (tune your global update strategy here).
+[[files]]
+path = "renovate-config.json"
+if_absent = true
+
+# Pre-approve renovate's tooling so unattended ticks run without prompts. {home}
+# is substituted with the resolved home path.
+[[files]]
+path = ".claude/settings.json"
+source = "claude-settings.json"
+substitute = true
+
+# --- context-file symlinks: surface RENOVATE.md to each CLI's convention ------
+
+[[symlinks]]
+link = "CLAUDE.md"
+target = "RENOVATE.md"
+
+[[symlinks]]
+link = "AGENTS.md"
+target = "RENOVATE.md"
+
+[[symlinks]]
+link = "GEMINI.md"
+target = "RENOVATE.md"
+
+# --- runtime resources: ensured on activate, self-healed if deleted -----------
+
+[[sessions]]
+name = "renovate"
+agent = "renovate"
+repo_path = "{home}"
+
+[[automations]]
+name = "renovate-tick"
+trigger = "cron:0 9 * * 1"
+session_ref = "renovate"
+prompt = "tick"

--- a/extensions/renovate/install.sh
+++ b/extensions/renovate/install.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# Thin wrapper kept for the curl|sh one-liner. The real installer now lives in
+# thurbox itself:
+#
+#   thurbox-cli extension install renovate
+#
+# This script just forwards to it — using a local checkout when run from one,
+# otherwise the official remote source. It fetches the manifest + payload, lays
+# down ~/renovate, registers the renovate agents in agents.toml, and activates
+# the renovate session + renovate-tick automation (which thurbox then
+# self-heals).
+#
+# Usage:
+#   ./install.sh                  # from a checkout
+#   curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/renovate/install.sh | sh
+#
+# Environment variables:
+#   RENOVATE_HOME=~/renovate      install home (passed as --home)
+#
+# Renovate runs via `npx --yes renovate` (needs Node >= 20). Authenticate your
+# forge client(s) afterwards if you want workers to open review PRs:
+# gh auth login / glab auth login. To turn it off:
+#   thurbox-cli extension deactivate renovate [--force --purge]
+
+set -eu
+
+command -v thurbox-cli >/dev/null 2>&1 || {
+  echo "error: thurbox-cli not found in PATH (install thurbox first)" >&2
+  exit 1
+}
+
+# Pass --home when RENOVATE_HOME is set (preserves the override).
+set --
+[ -n "${RENOVATE_HOME:-}" ] && set -- --home "$RENOVATE_HOME"
+
+# Prefer the checkout this script sits in (has extension.toml next to it);
+# otherwise install the official "renovate" extension from the remote source.
+SRC_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd || true)"
+if [ -n "$SRC_DIR" ] && [ -f "$SRC_DIR/extension.toml" ]; then
+  exec thurbox-cli extension install "$SRC_DIR" "$@"
+else
+  exec thurbox-cli extension install renovate "$@"
+fi

--- a/extensions/renovate/renovate-config.json
+++ b/extensions/renovate/renovate-config.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "Global Renovate config for the thurbox renovate extension. Workers pass",
+    "this via RENOVATE_CONFIG_FILE and ALWAYS run `--platform=local`, so every",
+    "setting here is applied against a local checkout (no bot, no token).",
+    "The per-repo `strategy` column in repos.md is layered on top of this as a",
+    "RENOVATE_CONFIG overlay (patch -> patch only; minor -> patch+minor; major",
+    "/all -> everything). Tune grouping, ranges, and ignored deps here."
+  ],
+  "extends": ["config:recommended"],
+  "dependencyDashboard": false,
+  "separateMajorMinor": true,
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "description": "Group all non-major updates into a single set of changes.",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major dependencies"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": false
+  }
+}

--- a/extensions/renovate/repos.md
+++ b/extensions/renovate/repos.md
@@ -1,0 +1,18 @@
+# Dependency-update watch list
+
+The renovate monitor sweeps these repos on its schedule and dispatches a worker
+to update each one's dependencies. Add one row per repo.
+
+- `path` — absolute path to the local git checkout.
+- `strategy` — how far to bump versions: `patch`, `minor` (patch + minor, the
+  default), `major`, or `all` (everything, same as `major`). Tune the global
+  behaviour (grouping, lockfile maintenance, ignored deps) in
+  `renovate-config.json`; this column is the per-repo override.
+- `provider` — the forge a worker opens its review PR against: `github`,
+  `gitlab`, `bitbucket`, or `auto` (detect from the git remote). Renovate itself
+  never talks to the forge — it only runs locally; the worker pushes the branch
+  and opens the PR. Leave `auto` and the worker figures the forge out.
+
+| name | path | strategy | provider |
+|------|------|----------|----------|
+| example | /home/me/repositories/example | minor | auto |

--- a/extensions/renovate/scripts/dispatch-update.sh
+++ b/extensions/renovate/scripts/dispatch-update.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# dispatch-update.sh — create a thurbox task on a FRESH dependency-update branch
+# and spawn its updater worker in the SAME call, so capture -> session is atomic.
+#
+# Unlike ci-shepherd (which adopts an existing PR branch), a renovate run starts
+# a brand-new branch, so thurbox's native --worktree does the job: it runs
+# `git worktree add -b renovate/updates-<ts> origin/main` for us. The worker runs
+# Renovate's LOCAL platform inside that worktree, tests the result, commits, and
+# (optionally) opens a review PR.
+#
+# Usage:
+#   dispatch-update.sh --repo /abs/repo [--strategy patch|minor|major|all] \
+#     [--provider auto|github|gitlab|bitbucket|...] [--agent renovate-worker] \
+#     [--base origin/main] [--no-dispatch]
+#
+# Prints the created task JSON; when dispatched, a second JSON line with the
+# `task run` outcome.
+
+set -euo pipefail
+
+HERE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+HOME_DIR="$(CDPATH= cd -- "$HERE/.." && pwd)"
+RENOVATE_RUN="$HOME_DIR/scripts/renovate-run.sh"
+
+REPO="" STRATEGY="minor" PROVIDER="auto" AGENT="renovate-worker" BASE="origin/main" DISPATCH=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)        REPO="$2"; shift 2 ;;
+    --strategy)    STRATEGY="$2"; shift 2 ;;
+    --provider)    PROVIDER="$2"; shift 2 ;;
+    --agent)       AGENT="$2"; shift 2 ;;
+    --base)        BASE="$2"; shift 2 ;;
+    --no-dispatch) DISPATCH=0; shift ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$REPO" ] || { echo "--repo is required" >&2; exit 2; }
+[ -d "$REPO" ] || { echo "repo not found: $REPO" >&2; exit 2; }
+case "$STRATEGY" in patch|minor|major|all) : ;; *) echo "bad --strategy: $STRATEGY" >&2; exit 2 ;; esac
+
+NAME="$(basename "$REPO")"
+# A timestamped branch is unique per dispatch, so `git worktree add -b` never
+# collides with an earlier run's branch.
+BRANCH="renovate/updates-$(date +%Y%m%d-%H%M%S)"
+
+# A remote-tracking base is only as fresh as the last fetch.
+if [ "${BASE#origin/}" != "$BASE" ]; then
+  git -C "$REPO" fetch origin --quiet 2>/dev/null || true
+fi
+
+DESC="$(cat <<EOF
+You are the dependency-update worker for **$NAME** (strategy: \`$STRATEGY\`).
+Your working directory is already a fresh worktree on \`$BRANCH\`, branched from
+\`$BASE\`. Renovate must only ever run **locally** — never against a git host.
+
+accept: dependencies updated to the latest allowed versions, the project still
+builds + its tests pass, and a review PR is open (or, if no forge client is
+available, the branch is committed locally and you say so).
+
+Do, in order:
+1. Apply updates with Renovate's local platform (writes changes into THIS
+   worktree, no bot/token/PR):
+   $RENOVATE_RUN apply --strategy $STRATEGY
+   If it reports no updates available, there is nothing to do — skip to the
+   result with {"status":"ok","notes":"no updates available"}.
+2. Review \`git diff\`. Run the project's own build/test/lint (detect it:
+   \`cargo test\` / \`npm test\` / \`pytest\` / a Makefile target / CI config) so
+   the bumps don't break anything. If one update breaks the build and you can't
+   fix it minimally, drop just that update (revert its hunk) and note it.
+3. Commit: \`git add -A && git commit -m "chore(deps): update dependencies ($STRATEGY)"\`.
+4. Push the branch and open a PR for review (do NOT merge). Work the forge out
+   from \`git remote -v\` and use its client (gh/glab) or REST API; provider hint
+   is \`$PROVIDER\`. Title it "chore(deps): dependency updates"; summarize what
+   changed. If no forge client/credentials are available, leave the branch
+   committed locally and report that under \`notes\`.
+If you are blocked (a major upgrade that needs a human decision, test failures
+you can't resolve), do NOT guess — stop and report it in the result
+\`question\` field.
+
+When finished: mark this task done (thurbox-cli task edit <id> --status done),
+print a final line \`===RESULT===\` followed by one line of JSON:
+{"status":"ok|error","artifact":"...","notes":"...","pr_url":"..."}
+then notify the renovate monitor so the next repo dispatches immediately:
+thurbox-cli session send "\$(thurbox-cli session list | jq -r '.[] | select(.name=="renovate") | .id')" "tick"
+EOF
+)"
+
+CREATED="$(thurbox-cli task create --title "update $NAME deps ($STRATEGY)" \
+  --description "$DESC" --repo "$REPO" --agent "$AGENT" \
+  --worktree "$BRANCH" --base "$BASE")"
+printf '%s\n' "$CREATED"
+
+if [ "$DISPATCH" -eq 1 ]; then
+  ID="$(printf '%s' "$CREATED" | jq -r .id)"
+  thurbox-cli task run "$ID"
+fi

--- a/extensions/renovate/scripts/parse-result.sh
+++ b/extensions/renovate/scripts/parse-result.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# parse-result.sh — extract the last ===RESULT=== JSON block from a
+# worker's captured terminal output.
+#
+# Reads captured output from stdin (or --file <path>).
+# Exit codes:
+#   0 = found, JSON printed on stdout
+#   1 = no sentinel yet (worker still running)
+#   2 = sentinel present but JSON malformed
+#
+# Recognized JSON fields (extra keys preserved verbatim):
+#   Required: status ∈ {"ok","error"}
+#   Optional: artifact, notes, pr_url
+
+set -euo pipefail
+
+INPUT=""
+if [[ "${1:-}" == "--file" ]]; then
+  [[ -f "${2:-}" ]] || { echo "File not found: ${2:-}" >&2; exit 2; }
+  INPUT="$(cat "$2")"
+else
+  INPUT="$(cat)"
+fi
+
+# Line number of the LAST "===RESULT===" marker.
+LAST_MARKER=$(printf '%s\n' "$INPUT" | grep -n '^===RESULT===$' | tail -1 | cut -d: -f1 || true)
+
+if [[ -z "$LAST_MARKER" ]]; then
+  exit 1
+fi
+
+# The JSON should be on the line immediately after the marker.
+JSON_LINE=$((LAST_MARKER + 1))
+JSON="$(printf '%s\n' "$INPUT" | sed -n "${JSON_LINE}p" | sed 's/[[:space:]]*$//')"
+
+if [[ -z "$JSON" ]]; then
+  exit 2
+fi
+
+if command -v jq >/dev/null 2>&1; then
+  if ! printf '%s' "$JSON" | jq -e . >/dev/null 2>&1; then
+    exit 2
+  fi
+  if ! printf '%s' "$JSON" | jq -e 'has("status")' >/dev/null 2>&1; then
+    exit 2
+  fi
+fi
+
+printf '%s\n' "$JSON"

--- a/extensions/renovate/scripts/renovate-run.sh
+++ b/extensions/renovate/scripts/renovate-run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# renovate-run.sh — run Renovate against the CURRENT working directory, only
+# ever on its **local** platform. This is the one place that invokes Renovate,
+# and it hard-codes `--platform=local`: Renovate never talks to a git host, never
+# needs a token, and never opens a branch/PR itself. It detects dependencies and
+# (in `apply` mode) writes the updated manifests + lockfiles straight into the
+# working tree. The thurbox worker then reviews, tests, commits, and — if you
+# want a reviewable PR — pushes the branch and opens it (that part is the
+# worker's job, not Renovate's).
+#
+# Usage (run from inside the repo/worktree you want updated):
+#   renovate-run.sh apply  [--strategy patch|minor|major|all] [--config FILE]
+#   renovate-run.sh lookup [--strategy patch|minor|major|all] [--config FILE]
+#
+#   apply   write the updates into the working tree (default)
+#   lookup  resolve available updates but write nothing (a dry run, for the
+#           monitor or a quick preview)
+#
+# --strategy layers a RENOVATE_CONFIG overlay on top of the base config file:
+#   patch -> only patch updates       (major + minor disabled)
+#   minor -> patch + minor updates    (major disabled)        [default]
+#   major | all -> everything
+#
+# --config defaults to ~/renovate/renovate-config.json (Renovate's own config,
+# passed via RENOVATE_CONFIG_FILE). Set GITHUB_COM_TOKEN in the environment to
+# raise GitHub API limits / fetch changelogs; it is optional and read-only.
+
+set -euo pipefail
+
+MODE="${1:-apply}"
+case "$MODE" in
+  apply|lookup) shift ;;
+  --*) MODE="apply" ;;
+  *) echo "unknown mode: $MODE (expected 'apply' or 'lookup')" >&2; exit 2 ;;
+esac
+
+HERE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+HOME_DIR="$(CDPATH= cd -- "$HERE/.." && pwd)"
+STRATEGY="minor"
+CONFIG="$HOME_DIR/renovate-config.json"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --strategy) STRATEGY="$2"; shift 2 ;;
+    --config)   CONFIG="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Map the per-repo strategy onto a Renovate config overlay (later packageRules
+# win, so disabling rules layered last take effect).
+case "$STRATEGY" in
+  patch) OVERLAY='{"packageRules":[{"matchUpdateTypes":["major","minor"],"enabled":false}]}' ;;
+  minor) OVERLAY='{"packageRules":[{"matchUpdateTypes":["major"],"enabled":false}]}' ;;
+  major|all) OVERLAY='{}' ;;
+  *) echo "unknown strategy: $STRATEGY (expected patch|minor|major|all)" >&2; exit 2 ;;
+esac
+
+# Resolve the Renovate entrypoint: a global install wins, else fall back to npx.
+if command -v renovate >/dev/null 2>&1; then
+  RENOVATE=(renovate)
+elif command -v npx >/dev/null 2>&1; then
+  RENOVATE=(npx --yes renovate)
+else
+  echo "error: neither 'renovate' nor 'npx' found on PATH (install Node >= 20)" >&2
+  exit 3
+fi
+
+ARGS=(--platform=local)
+[ "$MODE" = "lookup" ] && ARGS+=(--dry-run=lookup)
+
+[ -f "$CONFIG" ] || { echo "config file not found: $CONFIG" >&2; exit 2; }
+
+echo ">> renovate ${MODE} (strategy=${STRATEGY}, platform=local, cwd=$(pwd))" >&2
+RENOVATE_CONFIG_FILE="$CONFIG" \
+RENOVATE_CONFIG="$OVERLAY" \
+LOG_LEVEL="${LOG_LEVEL:-info}" \
+  exec "${RENOVATE[@]}" "${ARGS[@]}"

--- a/extensions/renovate/scripts/renovate-snapshot.sh
+++ b/extensions/renovate/scripts/renovate-snapshot.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# renovate-snapshot.sh — one-call view of the renovate monitor's world: the
+# watched repos (with their update strategy and any in-flight renovate branches),
+# plus the live update tasks/sessions. Entirely LOCAL — it never queries a forge,
+# so a tick stays fast; the worker is the only thing that runs Renovate.
+#
+# Reads the watch list from ../repos.md: a markdown table with columns
+#   | name | path | strategy | provider |
+# `strategy` defaults to minor; `provider` defaults to auto.
+
+set -euo pipefail
+
+HERE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+HOME_DIR="$(CDPATH= cd -- "$HERE/.." && pwd)"
+REPOS_MD="$HOME_DIR/repos.md"
+
+trim() { printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
+
+echo "## watched repos"
+if [ ! -f "$REPOS_MD" ]; then
+  echo "  (no repos.md — add your repos to $REPOS_MD)"
+else
+  # Parse table rows, skipping the header and the |---| separator.
+  grep '^[[:space:]]*|' "$REPOS_MD" \
+    | grep -viE '^\s*\|\s*name\s*\|' \
+    | grep -vE '^\s*\|[[:space:]]*-' \
+    | while IFS='|' read -r _ name path strategy provider _; do
+        name="$(trim "$name")"; path="$(trim "$path")"
+        strategy="$(trim "$strategy")"; provider="$(trim "$provider")"
+        [ -n "$path" ] || continue
+        [ -n "$strategy" ] || strategy="minor"
+        [ -n "$provider" ] || provider="auto"
+        if [ ! -d "$path" ]; then
+          echo "### ${name:-$path}  ($path)"; echo "  (path not found)"; continue
+        fi
+        echo "### ${name:-$path}  ($path)  [strategy=$strategy, provider=$provider]"
+        # In-flight renovate branches in this repo (a worker is updating, or a
+        # finished branch awaits review/merge).
+        BR="$(git -C "$path" branch --list 'renovate/*' 2>/dev/null | sed 's/^[* ]*//' || true)"
+        if [ -n "$BR" ]; then
+          printf '%s\n' "$BR" | sed 's/^/  branch: /'
+        else
+          echo "  branch: (none — eligible for a fresh update run)"
+        fi
+      done
+fi
+
+echo
+echo "## update tasks"
+if TASKS="$(thurbox-cli task list 2>/dev/null)"; then
+  printf '%s' "$TASKS" | jq -r '
+    [.[] | select(.title | startswith("update "))] |
+    if length == 0 then "  (none)" else
+      .[] | "  #\(.id) [\(.status)] \(.title)  {repo=\(.action.repo_path // "?")}"
+    end' 2>/dev/null || true
+else
+  echo "  (thurbox-cli task list failed)"
+fi
+
+echo
+echo "## sessions (renovate / task-*)"
+thurbox-cli session list 2>/dev/null | jq -r '
+  .[] | select(.name == "renovate" or (.name | startswith("task-"))) |
+  "  \(.name)  \(.id)  agent=\(.agent)  cwd=\(.cwd)"' 2>/dev/null || true

--- a/website/docs/architecture.html
+++ b/website/docs/architecture.html
@@ -67,6 +67,7 @@
             <li><a href="extension-flow.html">Flow</a></li>
             <li><a href="extension-forge.html">Forge</a></li>
             <li><a href="extension-ci-shepherd.html">CI-shepherd</a></li>
+            <li><a href="extension-renovate.html">Renovate</a></li>
           </ul>
           <h4>Reference</h4>
           <ul>

--- a/website/docs/extension-flow.html
+++ b/website/docs/extension-flow.html
@@ -67,6 +67,7 @@
             <li><a href="extension-flow.html" class="current-page">Flow</a></li>
             <li><a href="extension-forge.html">Forge</a></li>
             <li><a href="extension-ci-shepherd.html">CI-shepherd</a></li>
+            <li><a href="extension-renovate.html">Renovate</a></li>
           </ul>
           <h4>Reference</h4>
           <ul>

--- a/website/docs/extension-forge.html
+++ b/website/docs/extension-forge.html
@@ -67,6 +67,7 @@
             <li><a href="extension-flow.html">Flow</a></li>
             <li><a href="extension-forge.html" class="current-page">Forge</a></li>
             <li><a href="extension-ci-shepherd.html">CI-shepherd</a></li>
+            <li><a href="extension-renovate.html">Renovate</a></li>
           </ul>
           <h4>Reference</h4>
           <ul>

--- a/website/docs/extension-renovate.html
+++ b/website/docs/extension-renovate.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>ci-shepherd extension — Thurbox Docs</title>
+    <title>renovate extension — Thurbox Docs</title>
     <meta
       name="description"
-      content="The ci-shepherd extension: watches your open change requests (GitHub PRs, GitLab MRs, Bitbucket PRs, and any git forge) and dispatches a worker to fix failing CI or a changes-requested review."
+      content="The renovate extension: keeps your local repos on up-to-date dependencies by running Renovate's local platform in an isolated worktree, testing the bumps, and opening a review PR."
     />
     <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -66,8 +66,8 @@
             <li><a href="extensions.html">Overview</a></li>
             <li><a href="extension-flow.html">Flow</a></li>
             <li><a href="extension-forge.html">Forge</a></li>
-            <li><a href="extension-ci-shepherd.html" class="current-page">CI-shepherd</a></li>
-            <li><a href="extension-renovate.html">Renovate</a></li>
+            <li><a href="extension-ci-shepherd.html">CI-shepherd</a></li>
+            <li><a href="extension-renovate.html" class="current-page">Renovate</a></li>
           </ul>
           <h4>Reference</h4>
           <ul>
@@ -80,11 +80,12 @@
           <h4>On This Page</h4>
           <ul>
             <li><a href="#overview">Overview</a></li>
-            <li><a href="#forges">Forges: any git host</a></li>
+            <li><a href="#local">Renovate runs only locally</a></li>
+            <li><a href="#strategy">Update strategy</a></li>
             <li><a href="#requirements">Requirements</a></li>
             <li><a href="#install">Install</a></li>
             <li><a href="#use">Use</a></li>
-            <li><a href="#branch">How the fixer gets the branch</a></li>
+            <li><a href="#branch">How the worker gets its branch</a></li>
             <li><a href="#files">Files</a></li>
           </ul>
         </aside>
@@ -101,26 +102,30 @@
             <span class="separator">/</span>
             <a href="extensions.html">Extensions</a>
             <span class="separator">/</span>
-            <span class="current">ci-shepherd</span>
+            <span class="current">renovate</span>
           </div>
 
-          <h1>ci-shepherd</h1>
+          <h1>renovate</h1>
           <p>
-            CI-shepherd watches your open
-            <strong>change requests</strong>
-            &mdash; GitHub PRs, GitLab MRs, Bitbucket PRs &mdash; and whenever one picks up
-            <strong>failing CI</strong>
-            or a
-            <strong>changes-requested review</strong>
-            , dispatches a worker session to address it: the worker checks out the request branch,
-            fixes the feedback, pushes to the same branch (so the request updates), and leaves a
-            comment &mdash; then pings the shepherd so the next one dispatches. It turns review
-            round-trips into background work.
+            The renovate extension keeps the dependencies in your
+            <strong>local repos</strong>
+            current with minimal fuss. A quiet
+            <code>renovate</code>
+            session sweeps a watch list on a schedule and, for each repo that isn't already
+            mid-update, dispatches a worker that runs
+            <a href="https://github.com/renovatebot/renovate" target="_blank" rel="noopener">
+              Renovate
+            </a>
+            on its
+            <strong>local platform</strong>
+            , runs your project's tests, commits the bumps to a fresh branch, and opens a review PR
+            &mdash; then pings the monitor so the next repo dispatches. Dependency upkeep becomes
+            background work you only look at when a PR is ready or a major upgrade needs a decision.
           </p>
           <div class="info-box warning">
             <p>
               <strong>Experimental.</strong>
-              ci-shepherd is new and under active testing &mdash; its behavior spec, scripts, and
+              renovate is new and under active testing &mdash; its behavior spec, scripts, and
               manifest may change between releases.
             </p>
           </div>
@@ -131,93 +136,87 @@
           </h2>
           <p>
             A
-            <code>shepherd</code>
+            <code>renovate</code>
             session sweeps your watched repos on a
-            <code>shepherd-tick</code>
-            automation (every 15&nbsp;min). Fixers are Thurbox
+            <code>renovate-tick</code>
+            automation (weekly, Monday&nbsp;09:00). Updaters are Thurbox
             <strong>tasks</strong>
             (
-            <code>fix #&lt;n&gt;: &hellip;</code>
-            ): each runs in an isolated worktree on the request branch and self-reports via the same
+            <code>update &lt;repo&gt; deps &hellip;</code>
+            ): each runs in an isolated worktree on a fresh
+            <code>renovate/updates-&lt;ts&gt;</code>
+            branch and self-reports via the same
             <code>===RESULT===</code>
-            sentinel as flow. The monitor and fixer are plain
+            sentinel as flow. The monitor and worker are plain
             <code>agents.toml</code>
             aliases (
-            <code>shepherd</code>
+            <code>renovate</code>
             ,
-            <code>shepherd-worker</code>
+            <code>renovate-worker</code>
             ), so each can be any CLI.
           </p>
 
-          <h2 id="forges">
-            Forges: any git host
-            <a href="#forges" class="heading-anchor">#</a>
+          <h2 id="local">
+            Renovate runs only locally
+            <a href="#local" class="heading-anchor">#</a>
           </h2>
           <p>
-            The only thing baked in is
+            The worker always invokes Renovate with
+            <code>--platform=local</code>
+            (via
+            <code>scripts/renovate-run.sh</code>
+            , which hard-codes it):
+            <strong>no hosted bot, no token, no Renovate-opened PRs.</strong>
+            Renovate simply rewrites the dependency manifests + lockfiles in the worktree; the
+            Thurbox worker owns the rest (test, commit, push, open a PR). That keeps it
+            forge-agnostic
+            <em>and</em>
+            agent-agnostic, like Thurbox itself &mdash; the only thing baked in is
             <strong>git</strong>
-            &mdash;
-            <em>how</em>
-            to talk to a repo's host is decided by the shepherd agent, fresh each tick. There are
-            two paths, picked per repo automatically:
+            . The worker works the forge out from
+            <code>git remote -v</code>
+            and uses its client (
+            <code>gh</code>
+            /
+            <code>glab</code>
+            ) to open the review PR; with no client it leaves the branch committed locally and says
+            so.
           </p>
-          <table>
-            <thead>
-              <tr>
-                <th>Path</th>
-                <th>Forges</th>
-                <th>How</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><strong>Built-in fast path</strong></td>
-                <td>
-                  GitHub (
-                  <code>gh</code>
-                  ), GitLab (
-                  <code>glab</code>
-                  ), Bitbucket (
-                  <code>curl</code>
-                  + token)
-                </td>
-                <td>
-                  <code>provider.sh</code>
-                  lists requests and supplies the branch/checkout/comment commands; the agent just
-                  dispatches by number.
-                </td>
-              </tr>
-              <tr>
-                <td><strong>Agent-driven</strong></td>
-                <td>
-                  any other git forge &mdash; Gitea/Forgejo/Codeberg, Azure DevOps, Sourcehut,
-                  self-hosted GitHub/GitLab, &hellip;
-                </td>
-                <td>
-                  <code>provider.sh describe</code>
-                  hands the agent the remote + installed clients; it lists the requests itself and
-                  passes the commands it chose to
-                  <code>dispatch-fix.sh</code>
-                  .
-                </td>
-              </tr>
-            </tbody>
-          </table>
-          <p>
-            So there is
-            <strong>no forge allow-list</strong>
-            &mdash; anything reachable by a git remote and a CLI/REST API works, because the agent
-            reasons about it at runtime. The three built-ins are an optimization (cheap,
-            deterministic) for the common hosts.
-          </p>
-          <div class="info-box">
-            <p>
-              <strong>Verification status:</strong>
-              the GitHub fast path is verified end-to-end; the GitLab and Bitbucket fast paths are
-              implemented against their documented APIs but not yet run live; the agent-driven path
-              depends on the agent and the forge's own CLI/API.
-            </p>
-          </div>
+
+          <h2 id="strategy">
+            Update strategy
+            <a href="#strategy" class="heading-anchor">#</a>
+          </h2>
+          <p>Two layers control how far versions move:</p>
+          <ul>
+            <li>
+              <strong>Per repo</strong>
+              &mdash; the
+              <code>strategy</code>
+              column in
+              <code>repos.md</code>
+              :
+              <code>patch</code>
+              ,
+              <code>minor</code>
+              (patch&nbsp;+&nbsp;minor, the default),
+              <code>major</code>
+              , or
+              <code>all</code>
+              . It is layered onto the base config as a
+              <code>RENOVATE_CONFIG</code>
+              overlay.
+            </li>
+            <li>
+              <strong>Global</strong>
+              &mdash;
+              <code>renovate-config.json</code>
+              , Renovate's own config (grouping, version ranges, ignored deps, lockfile
+              maintenance), passed via
+              <code>RENOVATE_CONFIG_FILE</code>
+              .
+            </li>
+          </ul>
 
           <h2 id="requirements">
             Requirements
@@ -235,17 +234,21 @@
               .
             </li>
             <li>
-              The client for each forge you watch, authenticated:
+              <strong>Node&nbsp;&ge;&nbsp;20</strong>
+              &mdash; Renovate runs via
+              <code>npx --yes renovate</code>
+              (a global
+              <code>renovate</code>
+              install is used if present). Set
+              <code>GITHUB_COM_TOKEN</code>
+              to raise GitHub API limits / fetch changelogs (optional, read-only).
+            </li>
+            <li>
+              For the worker to open a review PR: the forge client authenticated (
               <code>gh auth login</code>
               /
               <code>glab auth login</code>
-              , or
-              <code>BB_TOKEN</code>
-              (or
-              <code>BB_USER</code>
-              +
-              <code>BB_APP_PASSWORD</code>
-              ) for Bitbucket.
+              ).
             </li>
           </ul>
 
@@ -254,27 +257,27 @@
             <a href="#install" class="heading-anchor">#</a>
           </h2>
           <p>
-            ci-shepherd is a Thurbox
+            renovate is a Thurbox
             <a href="extensions.html">extension</a>
             (a declarative
             <code>extension.toml</code>
             manifest):
           </p>
-          <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> extension install ci-shepherd    <span class="syn-comment"># or ./extensions/ci-shepherd</span>
-<span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> extension uninstall ci-shepherd  <span class="syn-comment"># --purge also deletes ~/ci-shepherd</span></code></pre>
+          <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> extension install renovate    <span class="syn-comment"># or ./extensions/renovate</span>
+<span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> extension uninstall renovate  <span class="syn-comment"># --purge also deletes ~/renovate</span></code></pre>
           <p>
-            Installing lays down the shepherd home (
-            <code>~/ci-shepherd</code>
+            Installing lays down the renovate home (
+            <code>~/renovate</code>
             ; override with
             <code>--home</code>
             ), registers the
-            <code>shepherd</code>
+            <code>renovate</code>
             /
-            <code>shepherd-worker</code>
+            <code>renovate-worker</code>
             agents, and activates the
-            <code>shepherd</code>
+            <code>renovate</code>
             session plus the
-            <code>shepherd-tick</code>
+            <code>renovate-tick</code>
             automation &mdash; both
             <strong>self-healed</strong>
             by Thurbox.
@@ -286,12 +289,12 @@
           </h2>
           <ul>
             <li>
-              Add the repos to watch to
-              <code>~/ci-shepherd/repos.md</code>
+              Add the repos to keep current to
+              <code>~/renovate/repos.md</code>
               (one row each;
-              <code>author</code>
+              <code>strategy</code>
               defaults to
-              <code>@me</code>
+              <code>minor</code>
               ,
               <code>provider</code>
               to
@@ -299,47 +302,35 @@
               ).
             </li>
             <li>
-              The shepherd sweeps on its schedule; trigger one now by sending
+              The monitor sweeps on its schedule; trigger one now by sending
               <code>tick</code>
-              to the shepherd session.
+              to the renovate session.
             </li>
             <li>
               <code>status</code>
               for a one-screen report;
               <code>clean</code>
-              to prune merged/closed worktrees.
+              to prune merged update worktrees.
             </li>
           </ul>
 
           <h2 id="branch">
-            How the fixer gets the branch
+            How the worker gets its branch
             <a href="#branch" class="heading-anchor">#</a>
           </h2>
           <p>
-            Thurbox's own
+            A renovate run starts a
+            <strong>brand-new</strong>
+            branch, so &mdash; unlike ci-shepherd &mdash; there's no branch to adopt:
+            <code>dispatch-update.sh</code>
+            uses Thurbox's native
             <code>--worktree</code>
-            always runs
-            <code>git worktree add -b</code>
-            , which fails on a branch that already exists &mdash; and a request's head branch always
-            does. So
-            <code>dispatch-fix.sh</code>
-            adopts the branch itself into a shepherd-owned worktree under
-            <code>~/ci-shepherd/worktrees/&lt;repo&gt;-&lt;provider&gt;-&lt;n&gt;</code>
-            , then spawns the fixer there. The checkout is git-universal: a built-in forge uses the
-            provider's checkout (
-            <code>gh pr checkout</code>
-            /
-            <code>glab mr checkout</code>
-            /
-            <code>git fetch</code>
-            ), any other forge uses the agent-supplied
-            <code>--checkout-cmd</code>
-            (or a plain
-            <code>git fetch origin &lt;branch&gt;</code>
-            fallback). The worker pushes straight to the request branch;
+            , which runs
+            <code>git worktree add -b renovate/updates-&lt;ts&gt; origin/main</code>
+            . The worker runs Renovate locally there, tests, commits, and pushes that branch for
+            review.
             <code>clean</code>
-            removes the worktree once the request is no longer actionable (refusing if it has
-            uncommitted work).
+            removes the worktree once the PR has merged (refusing if it has uncommitted work).
           </p>
 
           <h2 id="files">
@@ -349,22 +340,24 @@
           <p>
             See
             <a
-              href="https://github.com/Thurbeen/thurbox/tree/main/extensions/ci-shepherd"
+              href="https://github.com/Thurbeen/thurbox/tree/main/extensions/renovate"
               target="_blank"
               rel="noopener"
             >
-              extensions/ci-shepherd
+              extensions/renovate
             </a>
             for the
-            <code>SHEPHERD.md</code>
+            <code>RENOVATE.md</code>
             behavior spec, the
             <code>extension.toml</code>
-            manifest, and the helper scripts (
-            <code>provider.sh</code>
-            &mdash; the forge adapter layer,
-            <code>shepherd-snapshot.sh</code>
+            manifest, the
+            <code>renovate-config.json</code>
+            global config, and the helper scripts (
+            <code>renovate-run.sh</code>
+            &mdash; the local-only Renovate wrapper,
+            <code>renovate-snapshot.sh</code>
             ,
-            <code>dispatch-fix.sh</code>
+            <code>dispatch-update.sh</code>
             ,
             <code>parse-result.sh</code>
             ).

--- a/website/docs/extensions.html
+++ b/website/docs/extensions.html
@@ -67,6 +67,7 @@
             <li><a href="extension-flow.html">Flow</a></li>
             <li><a href="extension-forge.html">Forge</a></li>
             <li><a href="extension-ci-shepherd.html">CI-shepherd</a></li>
+            <li><a href="extension-renovate.html">Renovate</a></li>
           </ul>
           <h4>Reference</h4>
           <ul>
@@ -151,12 +152,14 @@
           <div class="info-box">
             <p>
               <strong>
-                Three extensions ship today:
+                Four extensions ship today:
                 <a href="extension-flow.html">flow</a>
                 ,
                 <a href="extension-forge.html">forge</a>
-                , and
+                ,
                 <a href="extension-ci-shepherd.html">ci-shepherd</a>
+                , and
+                <a href="extension-renovate.html">renovate</a>
                 .
               </strong>
               Each has its own page (see
@@ -538,6 +541,16 @@ prompt = "tick"</code></pre>
                 <p>
                   Watches open change requests (PRs/MRs on any git forge) and dispatches a worker to
                   fix failing CI or a changes-requested review.
+                </p>
+              </div>
+            </a>
+            <a href="extension-renovate.html" class="docs-hub-card">
+              <div class="card">
+                <div class="card-icon">&#x1f504;</div>
+                <h3>renovate</h3>
+                <p>
+                  Keeps local repos on up-to-date dependencies: a worker runs Renovate's local
+                  platform, tests the bumps, and opens a review PR.
                 </p>
               </div>
             </a>

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -67,6 +67,7 @@
             <li><a href="extension-flow.html">Flow</a></li>
             <li><a href="extension-forge.html">Forge</a></li>
             <li><a href="extension-ci-shepherd.html">CI-shepherd</a></li>
+            <li><a href="extension-renovate.html">Renovate</a></li>
           </ul>
           <h4>Reference</h4>
           <ul>

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -67,6 +67,7 @@
             <li><a href="extension-flow.html">Flow</a></li>
             <li><a href="extension-forge.html">Forge</a></li>
             <li><a href="extension-ci-shepherd.html">CI-shepherd</a></li>
+            <li><a href="extension-renovate.html">Renovate</a></li>
           </ul>
           <h4>Reference</h4>
           <ul>

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -67,6 +67,7 @@
             <li><a href="extension-flow.html">Flow</a></li>
             <li><a href="extension-forge.html">Forge</a></li>
             <li><a href="extension-ci-shepherd.html">CI-shepherd</a></li>
+            <li><a href="extension-renovate.html">Renovate</a></li>
           </ul>
           <h4>Reference</h4>
           <ul>

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -67,6 +67,7 @@
             <li><a href="extension-flow.html">Flow</a></li>
             <li><a href="extension-forge.html">Forge</a></li>
             <li><a href="extension-ci-shepherd.html">CI-shepherd</a></li>
+            <li><a href="extension-renovate.html">Renovate</a></li>
           </ul>
           <h4>Reference</h4>
           <ul>

--- a/website/docs/ui-review.html
+++ b/website/docs/ui-review.html
@@ -176,6 +176,7 @@
             <li><a href="extension-flow.html">Flow</a></li>
             <li><a href="extension-forge.html">Forge</a></li>
             <li><a href="extension-ci-shepherd.html">CI-shepherd</a></li>
+            <li><a href="extension-renovate.html">Renovate</a></li>
           </ul>
           <h4>Reference</h4>
           <ul>

--- a/website/index.html
+++ b/website/index.html
@@ -196,7 +196,7 @@
               <code>thurbox-cli extension install &lt;name&gt;</code>
               ), and Thurbox keeps its session and automation
               <strong>self-healed</strong>
-              . Ships flow, forge, and ci-shepherd (all experimental) &mdash;
+              . Ships flow, forge, ci-shepherd, and renovate (all experimental) &mdash;
               <a href="docs/extensions.html">browse the extensions</a>
               .
             </p>


### PR DESCRIPTION
## What

Adds a new opt-in, agent-agnostic thurbox extension — **`extensions/renovate/`** — that keeps local repos on up-to-date dependencies with minimal interaction. Resolves task #27.

It's pure **data** (manifest + behavior spec + shell scripts + seed config) — **no core binary changes**. Modeled on `ci-shepherd`.

## How it works

- A quiet `renovate` monitor session sweeps a `repos.md` watch list on a weekly `renovate-tick` automation and dispatches a `renovate-worker` per eligible repo (capacity-limited, skips repos already mid-update).
- Each worker runs **Renovate's local platform _only_** — `scripts/renovate-run.sh` hard-codes `--platform=local`: **no hosted bot, no token, no Renovate-opened PR**. Renovate just rewrites the dependency files in an isolated worktree; the worker then tests the bumps, commits to a fresh `renovate/updates-<ts>` branch, and opens a review PR (forge worked out by the agent via `gh`/`glab`; only git is baked in).
- Updaters are thurbox **tasks** (`update <repo> deps …`) that self-report via the `===RESULT===` sentinel and ping the monitor when done, matching flow/ci-shepherd.

## Version-update strategy (the configurable knob)

- **Per repo** — a `strategy` column in `repos.md` (`patch` / `minor` (default) / `major` / `all`), layered onto the base config as a `RENOVATE_CONFIG` overlay.
- **Global** — `renovate-config.json` (Renovate's native config: grouping, ranges, ignored deps, lockfile maintenance), passed via `RENOVATE_CONFIG_FILE`.

## Difference from ci-shepherd

ci-shepherd adopts an *existing* PR branch; a renovate run starts a *new* branch, so `dispatch-update.sh` uses thurbox's native `--worktree` (`git worktree add -b`) — no manual branch adoption needed.

## Verification

- `cargo build --bin thurbox-cli` ✓; `shellcheck` clean (only the shared `CDPATH= cd` SC1007 idiom used by existing extension scripts).
- **Install round-trip** in an isolated XDG env: all files written, `CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `RENOVATE.md` symlinks created, `renovate`/`renovate-worker` agents registered, `renovate` session + `renovate-tick` automation (cron `0 9 * * 1`) created; `extension status renovate` → **active + healthy**; `extension uninstall --purge` tears everything down cleanly.
- Snapshot + `renovate-run.sh` + `dispatch-update.sh` argument/strategy handling smoke-tested.
- `rumdl` and `prettier` clean on all touched markdown/HTML.

## Docs

`CLAUDE.md` Extensions list, `docs/FEATURES.md` sibling-extensions, a new `website/docs/extension-renovate.html` page, plus the extensions overview/catalog, home-page text, and the shared docs sidebar across all pages.