### PR TITLE
feat: detect and handle PRs needing rebase in ci-shepherd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -591,8 +591,12 @@ sync, but the TUI editor never sets it.)
   with `thurbox-cli`. Spec: `FORGE.md`.
 - **`extensions/ci-shepherd/`** *(experimental)* — watches your open change
   requests (GitHub PRs / GitLab MRs / Bitbucket PRs; repos in `repos.md`) and
-  dispatches a `shepherd-worker` fixer for each one with **failing CI** or a
-  **changes-requested review**. A `shepherd` session monitors via a
+  dispatches a `shepherd-worker` fixer for each one with **failing CI**, a
+  **changes-requested review**, or a branch that is **behind its target**
+  (needs rebase — the normalized `rebase` signal from `provider.sh`, surfaced
+  as the `REBASE` action flag by `scripts/classify.sh`; `dispatch-fix.sh
+  --rebase` makes the worker rebase onto the base and force-push before
+  fixing). A `shepherd` session monitors via a
   `shepherd-tick` automation; fixers are thurbox **tasks** (`fix #<n>: …`) that
   self-report with the same `===RESULT===` sentinel as flow. It is
   **forge-agnostic**: the only thing baked in is **git**; *how* to talk to a

--- a/extensions/ci-shepherd/README.md
+++ b/extensions/ci-shepherd/README.md
@@ -4,11 +4,13 @@
 > expect the behavior spec, scripts, and installer to change between releases.
 
 CI-shepherd watches your open **change requests** — GitHub PRs, GitLab MRs,
-Bitbucket PRs — and whenever one picks up **failing CI** or a
-**changes-requested review**, dispatches a worker session to address it: the
-worker checks out the request branch, fixes the feedback, pushes to the same
-branch (so the request updates), and leaves a comment — then pings the shepherd
-so the next one dispatches. It turns review round-trips into background work.
+Bitbucket PRs — and whenever one picks up **failing CI**, a
+**changes-requested review**, or falls **behind its target branch** (a rebase
+branch-protection requires before merge), dispatches a worker session to address
+it: the worker checks out the request branch, rebases it onto the target if it's
+behind, fixes the feedback, pushes to the same branch (so the request updates),
+and leaves a comment — then pings the shepherd so the next one dispatches. It
+turns review round-trips into background work.
 
 ```text
 ---
@@ -107,7 +109,8 @@ branch; `clean` removes the worktree once the request is no longer actionable
 | Path | Purpose |
 |------|---------|
 | `SHEPHERD.md` | The agent behavior spec (modes, actionability rules, output contract) |
-| `scripts/provider.sh` | The forge adapter layer — normalizes GitHub/GitLab/Bitbucket onto one contract |
+| `scripts/provider.sh` | The forge adapter layer — normalizes GitHub/GitLab/Bitbucket onto one contract (incl. the `rebase` behind/conflict signal) |
+| `scripts/classify.sh` | Pure request → action-flag classifier (`CHANGES-REQ`/`CI-FAIL`/`REBASE`/…); unit-tested by `classify.bats` |
 | `scripts/shepherd-snapshot.sh` | One-call view: watched requests (with action flags) + fixer tasks/sessions/worktrees |
 | `scripts/dispatch-fix.sh` | Prepare a request-branch worktree + create and run the fixer task |
 | `scripts/parse-result.sh` | Extract the worker `===RESULT===` sentinel |

--- a/extensions/ci-shepherd/SHEPHERD.md
+++ b/extensions/ci-shepherd/SHEPHERD.md
@@ -65,19 +65,28 @@ installed, surface it under "Needs you" rather than guessing.
 ```
 
 It reads `./repos.md` (the watch list) and, for each repo with a **built-in**
-forge, lists its open requests with a derived **action flag** (`CI-FAIL`,
-`CHANGES-REQ`, `ok`, `draft`); for any **other** forge it instead prints the
-`describe` block and an `ACTION:` line telling you to list that repo yourself
+forge, lists its open requests with a derived **action flag** (`CHANGES-REQ`,
+`CI-FAIL`, `REBASE`, `ok`, `draft`); for any **other** forge it instead prints
+the `describe` block and an `ACTION:` line telling you to list that repo yourself
 (see *Forge handling*). Then it shows the live `fix-*` / `task-*` tasks and
 sessions. The relevant forge client must be authenticated (`gh auth status` /
 `glab auth status` / Bitbucket `BB_TOKEN`); if a repo shows a provider error,
 surface it once under "Needs you" and move on.
 
+**Action flags** (precedence, highest first): `draft` (skip) → `CHANGES-REQ` →
+`CI-FAIL` → `REBASE` → `ok`. **`REBASE`** means the request is **behind its
+target branch** (`rebase=NEEDED`) or has **diverged into conflict**
+(`rebase=CONFLICT`) — branch protection ("require branches up to date") blocks
+the merge until it's rebased. CI-FAIL outranks REBASE on purpose: clear red
+checks first, since the rebase re-runs CI and is the last gate before a clean
+request can merge. The per-request line shows `rebase=NEEDED|CONFLICT|none`.
+
 ## TICK (be silent unless action is needed)
 
 1. **Dispatch** a fixer for every request that is actionable AND has no live
    fixer:
-   - **Actionable**: flag is `CI-FAIL` or `CHANGES-REQ`, and not `draft`.
+   - **Actionable**: flag is `CI-FAIL`, `CHANGES-REQ`, or `REBASE`, and not
+     `draft`.
    - **Already handled**: a `fix #<n>` task exists for that repo+number that is
      not `done` → skip (a worker is on it). If the task is `done` but the
      request is STILL actionable, the previous fix didn't land it →
@@ -91,10 +100,20 @@ surface it once under "Needs you" and move on.
        --agent shepherd-worker
      ```
 
+     **REBASE flag** — add `--rebase` so the worker rebases the branch onto its
+     target before anything else and force-pushes (the base is filled from the
+     provider meta; override with `--base <branch>` if needed):
+
+     ```bash
+     ./scripts/dispatch-fix.sh --repo <abs-repo-path> --number <n> \
+       --agent shepherd-worker --rebase
+     ```
+
      **Any other forge** — follow *Forge handling* above: list it yourself and
      pass the `--branch`/`--checkout-cmd`/`--feedback-cmd`/`--comment-cmd` you
-     chose. Either way `dispatch-fix.sh` prepares an isolated worktree on the
-     request's branch, seeds the fixer task with the full context, and runs it.
+     chose (add `--rebase --base <target>` if it's behind). Either way
+     `dispatch-fix.sh` prepares an isolated worktree on the request's branch,
+     seeds the fixer task with the full context, and runs it.
 
 2. **Monitor** each in-flight fixer task (`in_progress`):
    - Worker marked the task `done` → note it; the request re-checks next tick
@@ -123,7 +142,7 @@ surface it once under "Needs you" and move on.
 One screen max:
 
 - **Fixing**: `#task #n <repo> [worker] (age)`
-- **Actionable, unassigned**: `#n <repo> — CI-FAIL|CHANGES-REQ`
+- **Actionable, unassigned**: `#n <repo> — CI-FAIL|CHANGES-REQ|REBASE`
 - **Needs you**: true blockers only (a worker's question, a request that keeps
   failing after a fix, a provider auth error)
 - Footer.

--- a/extensions/ci-shepherd/extension.toml
+++ b/extensions/ci-shepherd/extension.toml
@@ -49,6 +49,10 @@ path = "scripts/provider.sh"
 executable = true
 
 [[files]]
+path = "scripts/classify.sh"
+executable = true
+
+[[files]]
 path = "scripts/parse-result.sh"
 executable = true
 

--- a/extensions/ci-shepherd/scripts/classify.bats
+++ b/extensions/ci-shepherd/scripts/classify.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Tests for classify.sh — the pure request → action-flag classifier. These feed
+# crafted normalized-request JSON on stdin (the provider.sh `list` shape), so
+# they run anywhere bats + jq are installed, with no live forge:
+#   bats extensions/ci-shepherd/scripts/classify.bats
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/classify.sh"
+}
+
+# Build a one-element request array, overriding base fields via key=value args.
+req() {
+  jq -nc --args '
+    [ { number: 1, title: "t", branch: "feat/x", draft: false,
+        review: "none", ci: "OK", rebase: "none" }
+      + ( $ARGS.positional | map(split("=") | {(.[0]): (.[1]
+            | if . == "true" then true elif . == "false" then false else . end)})
+          | add // {} ) ]' "$@"
+}
+
+# Classify a crafted request (key=value overrides) — the function `run` invokes.
+classify() { req "$@" | "$SCRIPT"; }
+
+@test "syntax is valid" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "behind target branch surfaces REBASE" {
+  run classify rebase=NEEDED
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[REBASE]"* ]]
+  [[ "$output" == *"rebase=NEEDED"* ]]
+}
+
+@test "merge conflict (diverged) surfaces REBASE" {
+  run classify rebase=CONFLICT
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[REBASE]"* ]]
+  [[ "$output" == *"rebase=CONFLICT"* ]]
+}
+
+@test "a clean, up-to-date request is ok" {
+  run classify
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[ok]"* ]]
+}
+
+@test "CI-FAIL outranks REBASE" {
+  run classify ci=FAIL rebase=NEEDED
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[CI-FAIL]"* ]]
+  [[ "$output" != *"[REBASE]"* ]]
+}
+
+@test "changes-requested outranks rebase" {
+  run classify review=CHANGES_REQUESTED rebase=NEEDED
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[CHANGES-REQ]"* ]]
+}
+
+@test "draft is never actionable even when behind" {
+  run classify draft=true rebase=NEEDED
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[draft]"* ]]
+}
+
+@test "a missing rebase field defaults to none (ok)" {
+  run bash -c "jq -nc '[{number:2,title:\"t\",branch:\"b\",draft:false,review:\"none\",ci:\"OK\"}]' | '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[ok]"* ]]
+  [[ "$output" == *"rebase=none"* ]]
+}
+
+@test "empty array prints the no-requests placeholder" {
+  run bash -c "echo '[]' | '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"(no open requests)"* ]]
+}

--- a/extensions/ci-shepherd/scripts/classify.sh
+++ b/extensions/ci-shepherd/scripts/classify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# classify.sh — pure request → action-flag classifier for ci-shepherd.
+#
+# Reads a normalized request JSON array (the provider.sh `list` shape) on stdin
+# and prints one formatted line per request with its derived action flag. Kept
+# separate from shepherd-snapshot.sh so the flag precedence is unit-testable
+# (`bats classify.bats`) without a live forge.
+#
+# Flag precedence (highest first):
+#   draft        — work in progress, never actionable
+#   CHANGES-REQ  — a reviewer asked for changes
+#   CI-FAIL      — checks are red
+#   REBASE       — behind the target branch / diverged (rebase.NEEDED|CONFLICT);
+#                  branch protection blocks the merge until it's brought up to date
+#   ok           — nothing to do
+#
+# CI-FAIL outranks REBASE on purpose: fix the red checks first; a rebase re-runs
+# CI anyway, so it's the last gate before a clean PR can merge.
+
+set -euo pipefail
+
+jq -r '
+  if length == 0 then "  (no open requests)" else
+  .[] |
+  ((.rebase // "none")) as $rb |
+  (if .draft then "draft"
+   elif .review == "CHANGES_REQUESTED" then "CHANGES-REQ"
+   elif .ci == "FAIL" then "CI-FAIL"
+   elif $rb == "NEEDED" or $rb == "CONFLICT" then "REBASE"
+   else "ok" end) as $flag |
+  "  #\(.number)  [\($flag)]  \(.title)  (head=\(.branch), CI=\(.ci), review=\(.review), rebase=\($rb))"
+  end'

--- a/extensions/ci-shepherd/scripts/dispatch-fix.sh
+++ b/extensions/ci-shepherd/scripts/dispatch-fix.sh
@@ -12,6 +12,7 @@
 #   dispatch-fix.sh --repo /abs/repo --number 42 [--agent shepherd-worker] \
 #     [--title T] [--branch B] [--checkout-cmd CMD] \
 #     [--feedback-cmd CMD] [--comment-cmd CMD] \
+#     [--rebase] [--base BRANCH] \
 #     [--provider auto|github|gitlab|bitbucket|...] [--no-dispatch]
 #
 # Agent-supplied forge flags (each optional; falls back to the provider fast
@@ -21,6 +22,10 @@
 #                   (default: git fetch origin <branch> && git checkout -B …)
 #   --feedback-cmd  shell the worker runs to READ review feedback + CI
 #   --comment-cmd   shell TEMPLATE the worker runs to post a summary (body appended)
+#   --rebase        the request is behind/diverged from its target branch: prepend
+#                   a rebase-onto-base step and tell the worker to force-push.
+#   --base          the target branch to rebase onto (default: filled from the
+#                   provider meta for built-in forges, else the repo's default).
 #
 # thurbox's own --worktree always passes `git worktree add -b` and so FAILS on a
 # branch that already exists — which a request branch always does. So we adopt
@@ -36,6 +41,7 @@ PROVIDER_SH="$HERE/provider.sh"
 
 REPO="" NUMBER="" AGENT="shepherd-worker" PROVIDER="auto" DISPATCH=1
 TITLE="" BRANCH="" CHECKOUT_CMD="" FEEDBACK_CMD="" COMMENT_CMD=""
+REBASE=0 BASE=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --repo)         REPO="$2"; shift 2 ;;
@@ -47,6 +53,8 @@ while [ $# -gt 0 ]; do
     --checkout-cmd) CHECKOUT_CMD="$2"; shift 2 ;;
     --feedback-cmd) FEEDBACK_CMD="$2"; shift 2 ;;
     --comment-cmd)  COMMENT_CMD="$2"; shift 2 ;;
+    --rebase)       REBASE=1; shift ;;
+    --base)         BASE="$2"; shift 2 ;;
     --no-dispatch)  DISPATCH=0; shift ;;
     *) echo "unknown flag: $1" >&2; exit 2 ;;
   esac
@@ -62,17 +70,23 @@ case "$prov" in github|gitlab|bitbucket) builtin=1 ;; esac
 # Fill any forge details the agent didn't supply, using the fast path when the
 # forge is built-in. Anything still missing for a non-built-in forge is an error.
 if [ "$builtin" -eq 1 ]; then
-  if [ -z "$TITLE" ] || [ -z "$BRANCH" ]; then
+  if [ -z "$TITLE" ] || [ -z "$BRANCH" ] || { [ "$REBASE" -eq 1 ] && [ -z "$BASE" ]; }; then
     META="$(PROVIDER="$PROVIDER" "$PROVIDER_SH" meta "$REPO" "$NUMBER" 2>&1)" \
       || { echo "provider meta failed: $META" >&2; exit 2; }
     [ -n "$TITLE" ]  || TITLE="$(printf '%s' "$META" | jq -r '.title')"
     [ -n "$BRANCH" ] || BRANCH="$(printf '%s' "$META" | jq -r '.branch')"
+    [ -n "$BASE" ]   || BASE="$(printf '%s' "$META" | jq -r '.base // empty')"
   fi
   [ -n "$FEEDBACK_CMD" ] || FEEDBACK_CMD="$(PROVIDER="$PROVIDER" "$PROVIDER_SH" feedback-cmd "$REPO" "$NUMBER")"
   [ -n "$COMMENT_CMD" ]  || COMMENT_CMD="$(PROVIDER="$PROVIDER" "$PROVIDER_SH" comment-cmd "$REPO" "$NUMBER")"
 fi
 [ -n "$BRANCH" ] || { echo "forge '$prov' is not built-in: pass --branch (and --checkout-cmd/--feedback-cmd/--comment-cmd)" >&2; exit 2; }
 [ -n "$TITLE" ]  || TITLE="request #$NUMBER"
+# For a rebase we need a target branch; fall back to the repo's default branch.
+if [ "$REBASE" -eq 1 ] && [ -z "$BASE" ]; then
+  BASE="$(git -C "$REPO" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+  [ -n "$BASE" ] || BASE="main"
+fi
 
 # Prepare the worktree (git-universal), then land the branch.
 mkdir -p "$WT_ROOT"
@@ -106,18 +120,42 @@ else
   COMMENT_STEP="Post a summary comment on the request using this forge's CLI/API."
 fi
 
+# When the request is behind/diverged from its base, prepend a rebase step and
+# force-push (history is rewritten) instead of a plain push.
+if [ "$REBASE" -eq 1 ]; then
+  REBASE_STEP="$(cat <<EOF
+0. This request is **behind its target branch \`$BASE\`** and must be brought up
+   to date before it can merge (branch protection blocks an out-of-date branch).
+   Rebase it onto the latest base first:
+     git fetch origin $BASE
+     git rebase origin/$BASE
+   If the rebase stops on a conflict, resolve each conflict minimally and
+   correctly — preserve THIS request's intent, take base for unrelated churn —
+   then \`git rebase --continue\`. If the conflicts are genuinely ambiguous, abort
+   (\`git rebase --abort\`) and stop with a \`question\` rather than guessing.
+EOF
+)"
+  PUSH_STEP="Commit any fixes, then push the rebased branch with \`git push --force-with-lease\` (the rebase rewrote history) so the request updates."
+  ACCEPT_LINE="accept: the branch is rebased onto \`$BASE\` (no longer behind), CI is green, and every changes-requested review thread is addressed."
+else
+  REBASE_STEP=""
+  PUSH_STEP="Commit and push to the SAME branch (\`git push\`) so the request updates."
+  ACCEPT_LINE="accept: CI is green and every changes-requested review thread is addressed."
+fi
+
 DESC="$(cat <<EOF
 You are the fixer for **#$NUMBER** ("$TITLE") on the $prov branch \`$BRANCH\`.
 Your working directory is already a worktree checked out on that branch.
 
-accept: CI is green and every changes-requested review thread is addressed.
+$ACCEPT_LINE
 
 Do, in order:
-1. Read the review feedback and CI state:
+${REBASE_STEP:+$REBASE_STEP
+}1. Read the review feedback and CI state:
    $READ_STEP
 2. Address the failing checks and/or the changes-requested comments. Make the
    minimal correct change.
-3. Commit and push to the SAME branch (\`git push\`) so the request updates.
+3. $PUSH_STEP
 4. Post a summary so reviewers know it's handled (do NOT merge):
    $COMMENT_STEP
 If you are blocked (a decision only the user can make, missing credentials, an

--- a/extensions/ci-shepherd/scripts/provider.sh
+++ b/extensions/ci-shepherd/scripts/provider.sh
@@ -12,7 +12,7 @@
 # Verbs (the adapter contract):
 #   provider-of <repo>                  -> prints the resolved provider name
 #   list <repo> <author>                -> normalized JSON array (see shape below)
-#   meta <repo> <number>                -> {"title":..,"branch":..,"url":..}
+#   meta <repo> <number>                -> {"title":..,"branch":..,"base":..,"url":..}
 #   checkout <repo> <worktree> <number> -> checks the PR/MR branch out into <worktree>
 #   feedback-cmd <repo> <number>        -> prints the shell command the WORKER runs
 #                                          to read review feedback
@@ -22,7 +22,14 @@
 # Normalized `list` element (all providers map their API onto this):
 #   {"number":42,"title":"..","branch":"feat/x","draft":false,
 #    "review":"CHANGES_REQUESTED|APPROVED|REVIEW_REQUIRED|none",
-#    "ci":"FAIL|PENDING|OK|none","url":".."}
+#    "ci":"FAIL|PENDING|OK|none",
+#    "rebase":"NEEDED|CONFLICT|none","url":".."}
+#
+# `rebase` tells the shepherd a request can't merge as-is and must be brought up
+# to date with its target branch first: NEEDED = the head branch is *behind* the
+# base (branch-protection "require branches to be up to date" will block the
+# merge); CONFLICT = it has diverged so far it no longer merges cleanly (a rebase
+# with conflict resolution is required). Providers that can't tell map to "none".
 
 set -euo pipefail
 
@@ -48,7 +55,7 @@ resolve_provider() {
 github_list() { # <author>
   have gh || { echo "gh (GitHub CLI) not installed" >&2; return 3; }
   ( cd "$REPO" && gh pr list --author "$1" --state open \
-      --json number,title,headRefName,isDraft,reviewDecision,statusCheckRollup,url ) \
+      --json number,title,headRefName,isDraft,reviewDecision,statusCheckRollup,mergeStateStatus,mergeable,url ) \
   | jq '[ .[] | {
       number, title, branch: .headRefName, draft: .isDraft, url,
       review: ((.reviewDecision // "") | if . == "" then "none" else . end),
@@ -56,11 +63,17 @@ github_list() { # <author>
            | if length == 0 then "none"
              elif any(. == "FAILURE" or . == "ERROR" or . == "TIMED_OUT") then "FAIL"
              elif any(. == "PENDING" or . == "IN_PROGRESS" or . == "QUEUED") then "PENDING"
-             else "OK" end) } ]'
+             else "OK" end),
+      # mergeStateStatus BEHIND = out of date with base (branch protection blocks);
+      # DIRTY / mergeable CONFLICTING = diverged, a conflict-resolving rebase needed.
+      rebase: ((.mergeStateStatus // "") as $m | (.mergeable // "") as $g
+           | if $m == "BEHIND" then "NEEDED"
+             elif $m == "DIRTY" or $g == "CONFLICTING" then "CONFLICT"
+             else "none" end) } ]'
 }
 github_meta() { # <number>
-  ( cd "$REPO" && gh pr view "$1" --json title,headRefName,url ) \
-  | jq '{title, branch: .headRefName, url}'
+  ( cd "$REPO" && gh pr view "$1" --json title,headRefName,baseRefName,url ) \
+  | jq '{title, branch: .headRefName, base: .baseRefName, url}'
 }
 github_checkout() { ( cd "$2" && gh pr checkout "$3" ); }   # <worktree> <number>
 github_feedback_cmd() { printf 'gh pr view %s --comments; gh api "repos/{owner}/{repo}/pulls/%s/comments"' "$1" "$1"; }
@@ -82,11 +95,16 @@ gitlab_list() { # <author>
       ci: ((.pipeline.status // (.head_pipeline.status) // "none") as $s
            | if $s == "failed" or $s == "canceled" then "FAIL"
              elif $s == "running" or $s == "pending" or $s == "created" then "PENDING"
-             elif $s == "success" then "OK" else "none" end) } ]'
+             elif $s == "success" then "OK" else "none" end),
+      # cannot_be_merged = a real merge conflict; diverged_commits_count>0 = behind
+      # the target (fast-forward-only projects need a rebase to merge).
+      rebase: (if (.merge_status // "") == "cannot_be_merged" then "CONFLICT"
+               elif ((.diverged_commits_count // 0) > 0) then "NEEDED"
+               else "none" end) } ]'
 }
 gitlab_meta() { # <number>
   ( cd "$REPO" && glab mr view "$1" --output json ) \
-  | jq '{title, branch: .source_branch, url: .web_url}'
+  | jq '{title, branch: .source_branch, base: .target_branch, url: .web_url}'
 }
 gitlab_checkout() { ( cd "$2" && glab mr checkout "$3" ); }   # <worktree> <number>
 gitlab_feedback_cmd() { printf 'glab mr view %s --comments' "$1"; }
@@ -120,11 +138,15 @@ bitbucket_list() { # <author> (filtered client-side; Bitbucket has no review-dec
       | { number: .id, title, branch: .source.branch.name,
           draft: (.draft // false), url: .links.html.href,
           review: ([.participants[]? | select(.state == "changes_requested")] | if length>0 then "CHANGES_REQUESTED" else "none" end),
-          ci: "none" } ]'
+          ci: "none",
+          # Bitbucket list payload exposes neither ahead/behind nor merge state,
+          # so we cannot tell from here; the shepherd agent can inspect a
+          # specific PR if needed.
+          rebase: "none" } ]'
 }
 bitbucket_meta() { # <number>
   bb_curl GET "pullrequests/$1" \
-  | jq '{title, branch: .source.branch.name, url: .links.html.href}'
+  | jq '{title, branch: .source.branch.name, base: .destination.branch.name, url: .links.html.href}'
 }
 bitbucket_checkout() { # <worktree> <number>
   branch="$(bitbucket_meta "$2" | jq -r '.branch')"

--- a/extensions/ci-shepherd/scripts/shepherd-snapshot.sh
+++ b/extensions/ci-shepherd/scripts/shepherd-snapshot.sh
@@ -48,15 +48,8 @@ else
         esac
         CRS="$(PROVIDER="$provider" "$HERE/provider.sh" list "$path" "$author" 2>&1)" \
           || { echo "  (provider error: $(printf '%s' "$CRS" | head -1))"; continue; }
-        printf '%s' "$CRS" | jq -r '
-          if length == 0 then "  (no open requests)" else
-          .[] |
-          (if .draft then "draft"
-           elif .review == "CHANGES_REQUESTED" then "CHANGES-REQ"
-           elif .ci == "FAIL" then "CI-FAIL"
-           else "ok" end) as $flag |
-          "  #\(.number)  [\($flag)]  \(.title)  (head=\(.branch), CI=\(.ci), review=\(.review))"
-          end' 2>/dev/null || echo "  (could not parse provider output)"
+        printf '%s' "$CRS" | "$HERE/classify.sh" 2>/dev/null \
+          || echo "  (could not parse provider output)"
       done
 fi
 


### PR DESCRIPTION
## What

ci-shepherd now detects change requests that are **behind their target branch** and must be rebased before they can merge (branch protection's "require branches up to date"), and dispatches a worker to rebase them. Previously it only acted on failing CI or changes-requested reviews, so an otherwise-green, approved PR that was merely out of date would sit forever.

## Changes

- **`provider.sh`**: new normalized `rebase` field (`NEEDED|CONFLICT|none`) on the `list` shape.
  - GitHub: `mergeStateStatus == BEHIND → NEEDED`; `DIRTY` / `mergeable == CONFLICTING → CONFLICT`.
  - GitLab: `merge_status == cannot_be_merged → CONFLICT`; `diverged_commits_count > 0 → NEEDED`.
  - Bitbucket: list payload can't tell → `none`.
  - `meta` also reports the target `base` branch (`baseRefName`/`target_branch`/`destination`).
- **`classify.sh`** (new): pure request→action-flag classifier extracted from the snapshot, adding the `REBASE` flag. Precedence: `draft → CHANGES-REQ → CI-FAIL → REBASE → ok` (CI-FAIL outranks REBASE — clear red checks first; a rebase re-runs CI anyway). Unit-tested by `classify.bats` (9 cases).
- **`shepherd-snapshot.sh`**: delegates flag derivation to `classify.sh`; the per-request line now shows `rebase=NEEDED|CONFLICT|none`.
- **`dispatch-fix.sh`**: `--rebase` / `--base` flags. With `--rebase`, the worker prompt gets a rebase-onto-base step (fetch base, `git rebase origin/<base>`, minimal conflict resolution or stop-with-question), and pushes with `--force-with-lease`. Base is filled from provider `meta` (or the repo default branch).
- **Docs**: `SHEPHERD.md` (flag table, actionability, `--rebase` dispatch), `README.md`, `CLAUDE.md`.

## Testing

- `classify.bats` — 9 cases covering each flag and precedence (REBASE surfaced for NEEDED/CONFLICT, CI-FAIL/CHANGES-REQ/draft outrank it, missing field defaults to `none`). Manually verified all 9 pass (bats not installed locally; follows the `create-task.bats` precedent of an extension-local manual suite).
- `shellcheck` clean on all shepherd scripts; `bash -n` clean; `rumdl` clean on changed markdown.
- Offline jq smoke test of the GitHub `list` mapping (BEHIND → `rebase: NEEDED`).