### PR TITLE
feat(cli): version-aware extension updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,8 +358,8 @@ create/list/show/edit/remove/run/runs/tick), `task` (alias `todo`:
 create/list/show/edit/remove/run), `editor`, `config`
 (validate/show — strict-parses every config file / prints the
 effective resolved config; see `docs/CONFIG.md`), `extension`
-(alias `ext`: install/uninstall/list/activate/deactivate/status — manage
-opt-in extensions; see below). Pass `--pretty` for indented JSON.
+(alias `ext`: install/uninstall/list/update/activate/deactivate/status —
+manage opt-in extensions; see below). Pass `--pretty` for indented JSON.
 
 `session delete <uuid>` **soft-deletes** by default — only the DB
 row is marked deleted (the TUI tears down the tmux window/worktree
@@ -640,8 +640,8 @@ text-edit to preserve comments), delete the manifest, and with `--purge`
 delete the home dir. Flow's `install.sh` is now a thin shim over `install`.
 
 `thurbox-cli extension` (alias `ext`) — `install` / `uninstall <name>
-[--purge]` / `list` / `activate <name>` / `deactivate <name> [--force]
-[--purge]` / `status [<name>]` — wraps
+[--purge]` / `list` / `update <name>|--all [--force]` / `activate <name>` /
+`deactivate <name> [--force] [--purge]` / `status [<name>]` — wraps
 `session_ops::extensions`: `ensure_extension` idempotently (re)creates any
 missing declared resource (reusing `spawn_session_headless` +
 `db.create_automation`, matching by name so existing ones are reused);
@@ -649,6 +649,23 @@ missing declared resource (reusing `spawn_session_headless` +
 `active_extensions` JSON set; `deactivate_extension` tears the resources
 down and clears the set. The CLI layer arms the tmux automation heartbeat
 on activate so a `Send` automation actually fires headlessly.
+
+**Versioning + update.** A manifest declares its own `version` and a
+`min_thurbox_version` (soft compat gate — install/activate/heal *warn*,
+never block, if the binary is older). The installer stamps two provenance
+fields into the discovery-dir copy: `installed_with` (the thurbox version
+that installed it) and `source` (the resolved install target). After a
+thurbox upgrade the on-disk copy is older than the binary, so
+`ExtensionDef::is_stale` flags it (`extension list`/`status`, and a
+self-heal nudge). `update_extension` re-runs `install_extension` from the
+recorded `source` — a bare name re-resolves against the *new* binary's
+release tag, so the matching extension version is pulled — preserving
+user-edited files unless `--force`; `update_all_extensions` does every
+installed one. Version helpers (`compare_versions`, `is_dev_version`,
+`is_stale`, `compat_warning`) are pure functions in
+`session::extension_def`; dev builds (`0.0.0-dev`) skip staleness/compat
+since their version doesn't order against tags. No version-snapshot store:
+rollback = pin a tagged install URL or downgrade the binary + `update`.
 
 **Self-heal**: `session_ops::heal_active_extensions` re-ensures every
 active extension and is called at **TUI startup** (`main.rs`, before

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -193,7 +193,9 @@ and a **runtime** spec:
 ```toml
 name = "flow"
 description = "Focus-protecting triage agent"
-config_version = 1
+config_version = 1              # manifest *format* version (for migrations)
+version = "1.0.0"              # the extension's own version (bumped by its author)
+min_thurbox_version = "0.113.0" # minimum thurbox; older binaries get a warning
 home = "~/flow"                 # install home; {home} is substituted everywhere
 
 # install spec ---------------------------------------------------------------
@@ -240,11 +242,14 @@ thurbox-cli extension install ./extensions/flow   # from a local dir
 thurbox-cli extension install <url> --home ~/x    # from a URL, custom home
 thurbox-cli extension uninstall <name>     # reverse install (keep home dir)
 thurbox-cli extension uninstall <name> --purge    # also delete the home dir
-thurbox-cli extension list                 # installed + active/healthy state
+thurbox-cli extension list                 # installed + active/healthy + version/stale
+thurbox-cli extension update <name>        # re-fetch from recorded source (refresh)
+thurbox-cli extension update --all         # update every installed extension
+thurbox-cli extension update <name> --force # also overwrite user-edited seed files
 thurbox-cli extension activate <name>      # (re)create resources + mark active
 thurbox-cli extension deactivate <name>    # tear down + stop self-heal
 thurbox-cli extension deactivate <name> --force --purge  # also kill tmux + drop manifest
-thurbox-cli extension status [<name>]      # per-resource presence
+thurbox-cli extension status [<name>]      # per-resource presence + version/stale
 ```
 
 A bare name installs from the official source
@@ -264,6 +269,42 @@ a no-op (they come back); `extension deactivate` is the real off-switch.
 Self-heal while the TUI is closed depends on the automation heartbeat
 (`[features] automations = true`); with automations off, healing happens
 at the next TUI startup only.
+
+### Versioning + the update lifecycle
+
+Extensions carry two version markers, and the installer stamps two more
+into the discovery-dir copy so staleness can be detected:
+
+| Field | Where set | Purpose |
+|-------|-----------|---------|
+| `version` | source manifest | the extension's own semver (author-bumped) |
+| `min_thurbox_version` | source manifest | minimum thurbox; older binaries warn |
+| `installed_with` | stamped on install | the thurbox version that installed it |
+| `source` | stamped on install | the target it was installed from |
+
+A **bare-name** install (`extension install flow`) fetches from the
+official source **pinned to the running binary's release tag**, so the
+extension you get always matches your thurbox. When you later **upgrade
+thurbox**, the on-disk copy is now older than the binary — thurbox
+flags it as `stale` (in `extension list`/`status`, and as a one-line
+nudge from self-heal at startup). Run `extension update <name>` (or
+`--all`) to re-fetch from the recorded `source`; because a bare name
+re-resolves against the *new* binary's tag, this pulls the version that
+matches your upgraded thurbox. Updates honour the same file rules as
+install — user-edited `substitute` files and `if_absent` seeds are
+preserved unless you pass `--force`.
+
+`min_thurbox_version` is a **soft** gate: an extension authored for a
+newer thurbox still installs on an older binary, but install/activate and
+self-heal emit a compatibility warning so the mismatch is visible.
+**Dev builds** (`0.0.0-dev`) skip both the staleness and compatibility
+checks — their version doesn't order against release tags.
+
+**Rollback.** There's no version snapshot store: to roll an extension
+back, pin a specific thurbox tag — `extension install
+https://raw.githubusercontent.com/Thurbeen/thurbox/v0.112.0/extensions/flow`
+— or downgrade the binary and run `extension update`, which re-resolves
+the bare name to that older tag.
 
 ## SQLite-backed settings
 

--- a/extensions/ci-shepherd/extension.toml
+++ b/extensions/ci-shepherd/extension.toml
@@ -11,6 +11,8 @@
 name = "ci-shepherd"
 description = "Watches change requests (PR/MR) and dispatches CI/review fixers"
 config_version = 1
+version = "1.0.0"                 # this extension's own version; bump on changes
+min_thurbox_version = "0.113.0"  # needs the `extension install`/self-heal machinery
 home = "~/ci-shepherd"
 
 # --- agents registered in agents.toml (override the model by editing it) ------

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -80,6 +80,24 @@ Re-enable any time with `thurbox-cli extension activate flow` (no full
 reinstall needed). `thurbox-cli extension list` shows whether flow is
 active and healthy.
 
+### Updating
+
+Flow is **pinned to your thurbox version**: a bare-name install fetches
+the copy that matches your binary's release tag. After you upgrade
+thurbox, `extension list`/`status` mark flow `stale` (and self-heal prints
+a one-line nudge at startup) because the on-disk copy predates the new
+binary. Refresh it with:
+
+```bash
+thurbox-cli extension update flow      # re-fetch the version matching your thurbox
+thurbox-cli extension update --all     # update every installed extension
+```
+
+`update` re-lays flow's payload from its recorded source but keeps files
+you've edited — `repos.md` and a customised `.claude/settings.json` are
+preserved unless you pass `--force`. To pin an older flow, install from a
+tagged URL (`…/thurbox/v0.112.0/extensions/flow`) instead.
+
 ## Use
 
 - Open the `flow` session in the thurbox TUI and type at it — anything

--- a/extensions/flow/extension.toml
+++ b/extensions/flow/extension.toml
@@ -11,6 +11,8 @@
 name = "flow"
 description = "Focus-protecting triage agent"
 config_version = 1
+version = "1.0.0"                 # this extension's own version; bump on changes
+min_thurbox_version = "0.113.0"  # needs the `extension install`/self-heal machinery
 home = "~/flow"
 
 # --- agents registered in agents.toml (override the model by editing it) ------

--- a/extensions/forge/extension.toml
+++ b/extensions/forge/extension.toml
@@ -11,6 +11,8 @@
 name = "forge"
 description = "Workflow analyst that proposes new automations"
 config_version = 1
+version = "1.0.0"                 # this extension's own version; bump on changes
+min_thurbox_version = "0.113.0"  # needs the `extension install`/self-heal machinery
 home = "~/forge"
 
 # --- agents registered in agents.toml (override the model by editing it) ------

--- a/src/agent/extension_config.rs
+++ b/src/agent/extension_config.rs
@@ -20,15 +20,27 @@ use crate::session::{AgentDef, ExtensionDef};
 /// Raw-content root of the thurbox repo (no git ref).
 const OFFICIAL_REPO_RAW: &str = "https://raw.githubusercontent.com/Thurbeen/thurbox";
 
+/// The running binary's version string (e.g. `0.113.0`, or `0.0.0-dev` for a
+/// development build), injected at compile time by `build.rs`. The reference
+/// point for extension staleness + compatibility checks.
+pub fn binary_version() -> &'static str {
+    env!("THURBOX_VERSION")
+}
+
+/// Whether this is an unstable development build (its version doesn't order
+/// against release tags, so version checks are skipped for it).
+pub fn is_dev_build() -> bool {
+    cfg!(dev_build) || crate::session::extension_def::is_dev_version(binary_version())
+}
+
 /// The git ref to fetch official extensions from: the running binary's release
 /// tag (`v0.7.0`), so a fetched extension matches the binary that reads it. Dev
 /// builds track `main`.
 fn official_ref() -> String {
-    let version = env!("THURBOX_VERSION");
-    if cfg!(dev_build) || version.contains("-dev") {
+    if is_dev_build() {
         "main".to_string()
     } else {
-        format!("v{version}")
+        format!("v{}", binary_version())
     }
 }
 

--- a/src/cli/extensions.rs
+++ b/src/cli/extensions.rs
@@ -38,6 +38,19 @@ pub enum Action {
     },
     /// List installed extensions and whether each is active/healthy.
     List,
+    /// Update an installed extension by re-fetching it from its recorded source
+    /// (a bare name re-resolves to the running binary's release tag, so the
+    /// matching version is pulled). Preserves user-edited files unless --force.
+    Update {
+        /// Extension name. Omit and pass --all to update every installed one.
+        name: Option<String>,
+        /// Update every installed extension instead of a single named one.
+        #[arg(long)]
+        all: bool,
+        /// Also overwrite user-edited `substitute` files and `if_absent` seeds.
+        #[arg(long)]
+        force: bool,
+    },
     /// Activate an extension: (re)create its sessions/automations and mark it
     /// active so thurbox self-heals them. Idempotent.
     Activate {
@@ -76,17 +89,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 crate::session_ops::install_extension(db, &target, home.as_deref(), force)?;
             // Arm the heartbeat so the extension's automations fire headlessly.
             arm_heartbeat();
-            Ok(json!({
-                "installed": report.name,
-                "home": report.home,
-                "files_written": report.files_written,
-                "files_skipped": report.files_skipped,
-                "symlinks_created": report.symlinks_created,
-                "symlinks_skipped": report.symlinks_skipped,
-                "agents_added": report.agents_added,
-                "sessions_created": report.ensure.sessions_created,
-                "automations_created": report.ensure.automations_created,
-            }))
+            Ok(install_report_to_json(&report))
         }
         Action::Uninstall { name, purge } => {
             let report = crate::session_ops::uninstall_extension(db, &name, purge)?;
@@ -109,6 +112,30 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             }
             Ok(Value::Array(out))
         }
+        Action::Update { name, all, force } => match (name, all) {
+            (Some(_), true) => Err("pass either a name or --all, not both".to_string()),
+            (None, false) => {
+                Err("specify an extension name, or --all to update every installed one".to_string())
+            }
+            (Some(name), false) => {
+                let report = crate::session_ops::update_extension(db, &name, force)?;
+                // Arm the heartbeat so the refreshed automations keep firing headlessly.
+                arm_heartbeat();
+                Ok(update_report_to_json(&report))
+            }
+            (None, true) => {
+                let results = crate::session_ops::update_all_extensions(db, force);
+                arm_heartbeat();
+                let out: Vec<Value> = results
+                    .into_iter()
+                    .map(|(name, result)| match result {
+                        Ok(report) => update_report_to_json(&report),
+                        Err(e) => json!({ "name": name, "error": e }),
+                    })
+                    .collect();
+                Ok(Value::Array(out))
+            }
+        },
         Action::Activate { name } => {
             let def = load_manifest(&name)?;
             let report = crate::session_ops::activate_extension(db, &def)?;
@@ -187,11 +214,46 @@ fn health_to_json(h: &crate::session_ops::ExtensionHealth) -> Value {
         "name": h.name,
         "active": h.active,
         "healthy": h.is_healthy(),
+        "version": h.version,
+        "installed_with": h.installed_with,
+        "current_binary": h.current_binary,
+        "stale": h.stale,
+        "compat_warning": h.compat_warning,
         "sessions": h.sessions.iter()
             .map(|(n, present)| json!({ "name": n, "present": present }))
             .collect::<Vec<_>>(),
         "automations": h.automations.iter()
             .map(|(n, present)| json!({ "name": n, "present": present }))
             .collect::<Vec<_>>(),
+    })
+}
+
+fn install_report_to_json(report: &crate::session_ops::InstallReport) -> Value {
+    json!({
+        "installed": report.name,
+        "home": report.home,
+        "version": report.version,
+        "previous_version": report.previous_version,
+        "compat_warning": report.compat_warning,
+        "files_written": report.files_written,
+        "files_skipped": report.files_skipped,
+        "symlinks_created": report.symlinks_created,
+        "symlinks_skipped": report.symlinks_skipped,
+        "agents_added": report.agents_added,
+        "sessions_created": report.ensure.sessions_created,
+        "automations_created": report.ensure.automations_created,
+    })
+}
+
+fn update_report_to_json(report: &crate::session_ops::UpdateReport) -> Value {
+    json!({
+        "updated": report.name,
+        "changed": report.changed,
+        "previous_version": report.install.previous_version,
+        "version": report.install.version,
+        "compat_warning": report.install.compat_warning,
+        "files_written": report.install.files_written,
+        "files_skipped": report.install.files_skipped,
+        "home": report.install.home,
     })
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -419,6 +419,32 @@ mod tests {
     }
 
     #[test]
+    fn parse_extension_update() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "extension", "update", "flow"]).unwrap();
+        let Command::Extension {
+            action: extensions::Action::Update { name, all, force },
+        } = cli.command
+        else {
+            panic!("expected Extension::Update");
+        };
+        assert_eq!(name.as_deref(), Some("flow"));
+        assert!(!all);
+        assert!(!force);
+
+        let all_cli =
+            Cli::try_parse_from(["thurbox-cli", "ext", "update", "--all", "--force"]).unwrap();
+        let Command::Extension {
+            action: extensions::Action::Update { name, all, force },
+        } = all_cli.command
+        else {
+            panic!("expected Extension::Update");
+        };
+        assert!(name.is_none());
+        assert!(all);
+        assert!(force);
+    }
+
+    #[test]
     fn extension_alias_ext_parses() {
         let cli = Cli::try_parse_from(["thurbox-cli", "ext", "list"]).unwrap();
         assert!(matches!(

--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -111,6 +111,28 @@ pub struct ExtensionDef {
     /// Manifest-format version, for future migrations. Currently `1`.
     #[serde(default)]
     pub config_version: Option<u32>,
+    /// The extension's own semantic version (e.g. `"1.2.0"`), authored in the
+    /// source `extension.toml` and bumped by the extension's maintainer. Lets
+    /// `extension update` report what moved and surfaces in `extension list`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Minimum thurbox version this extension needs (e.g. `"0.113.0"`). Install
+    /// and activate emit a compatibility **warning** (never a hard block, to
+    /// stay graceful) when the running binary is older. Dev builds skip it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_thurbox_version: Option<String>,
+    /// The thurbox version that performed the install. **Stamped** into the
+    /// discovery-dir copy by the installer (never authored in source); compared
+    /// against the running binary to flag a stale extension after a thurbox
+    /// upgrade. `None` in a source manifest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub installed_with: Option<String>,
+    /// The resolved install target (a bare name, `http(s)://` URL, or local
+    /// path) the extension was installed from. **Stamped** into the discovery
+    /// copy so `extension update` can re-fetch from the same place. `None` in a
+    /// source manifest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
     /// Default install home directory (may use `~`), where payload files land
     /// and the session runs. The `--home` flag overrides it. Required to
     /// install; unused once installed.
@@ -154,6 +176,84 @@ impl ExtensionDef {
         }
         out
     }
+
+    /// Stamp install provenance onto the (resolved) manifest before it's written
+    /// to the discovery dir: which thurbox version installed it and where it came
+    /// from, so staleness can be detected and `update` can re-fetch. Returns
+    /// `self` for chaining off [`resolved_for_home`].
+    pub fn with_provenance(mut self, installed_with: &str, source: &str) -> ExtensionDef {
+        self.installed_with = Some(installed_with.to_string());
+        self.source = Some(source.to_string());
+        self
+    }
+
+    /// Whether this extension was installed under a thurbox version different
+    /// from `current` — i.e. an upgrade has happened since and re-running
+    /// `extension update` would refresh it. Always `false` for a dev build
+    /// (`current` is unstable) or a manifest with no recorded install version.
+    pub fn is_stale(&self, current: &str) -> bool {
+        if is_dev_version(current) {
+            return false;
+        }
+        match &self.installed_with {
+            Some(installed) => installed != current,
+            None => false,
+        }
+    }
+
+    /// A compatibility warning if this extension declares a `min_thurbox_version`
+    /// the running `current` binary doesn't satisfy, else `None`. Dev builds are
+    /// treated as compatible with everything (their version is unstable).
+    pub fn compat_warning(&self, current: &str) -> Option<String> {
+        if is_dev_version(current) {
+            return None;
+        }
+        let min = self.min_thurbox_version.as_deref()?;
+        if compare_versions(current, min) == std::cmp::Ordering::Less {
+            Some(format!(
+                "extension '{}' wants thurbox >= {min} but this binary is {current}; \
+                 some features may not work — upgrade thurbox",
+                self.name
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+/// Whether a version string denotes an unstable dev build (`0.0.0-dev`, or any
+/// version carrying a `-dev`/pre-release suffix). Such builds skip staleness and
+/// compatibility checks because their version doesn't order against releases.
+pub fn is_dev_version(v: &str) -> bool {
+    v.contains("-dev") || v.trim_start_matches('v').starts_with("0.0.0")
+}
+
+/// Compare two dotted version strings (`a.b.c`, optional leading `v`, any
+/// `-suffix` ignored) numerically, component by component. Missing trailing
+/// components count as `0` (so `1.2` == `1.2.0`). Non-numeric components sort as
+/// `0`. A dependency-free stand-in for the `semver` crate, sufficient for the
+/// `major.minor.patch` tags thurbox ships.
+pub fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    let parts = |s: &str| -> Vec<u64> {
+        s.trim_start_matches('v')
+            .split('-')
+            .next()
+            .unwrap_or("")
+            .split('.')
+            .map(|p| p.parse::<u64>().unwrap_or(0))
+            .collect()
+    };
+    let (pa, pb) = (parts(a), parts(b));
+    let n = pa.len().max(pb.len());
+    for i in 0..n {
+        let x = pa.get(i).copied().unwrap_or(0);
+        let y = pb.get(i).copied().unwrap_or(0);
+        match x.cmp(&y) {
+            std::cmp::Ordering::Equal => {}
+            other => return other,
+        }
+    }
+    std::cmp::Ordering::Equal
 }
 
 #[cfg(test)]
@@ -199,6 +299,10 @@ prompt = "tick"
             name: "flow".into(),
             description: None,
             config_version: Some(1),
+            version: Some("1.0.0".into()),
+            min_thurbox_version: Some("0.113.0".into()),
+            installed_with: Some("0.113.0".into()),
+            source: Some("flow".into()),
             home: Some("~/flow".into()),
             agents: vec![AgentDef {
                 name: "flow".into(),
@@ -259,6 +363,80 @@ prompt = "tick"
         );
         // Original is untouched.
         assert_eq!(def.sessions[0].repo_path, PathBuf::from("{home}"));
+    }
+
+    #[test]
+    fn compare_versions_orders_numerically() {
+        use std::cmp::Ordering;
+        assert_eq!(compare_versions("0.113.0", "0.113.0"), Ordering::Equal);
+        assert_eq!(compare_versions("0.114.0", "0.113.0"), Ordering::Greater);
+        assert_eq!(compare_versions("0.113.0", "0.114.0"), Ordering::Less);
+        // Numeric, not lexical: 0.20 > 0.9.
+        assert_eq!(compare_versions("0.20.0", "0.9.0"), Ordering::Greater);
+        // Leading `v` and missing trailing components are tolerated.
+        assert_eq!(compare_versions("v1.2", "1.2.0"), Ordering::Equal);
+        assert_eq!(compare_versions("2.0.0", "1.99.99"), Ordering::Greater);
+        // Pre-release suffix is ignored for ordering.
+        assert_eq!(compare_versions("0.113.0-rc1", "0.113.0"), Ordering::Equal);
+    }
+
+    #[test]
+    fn is_dev_version_detects_unstable_builds() {
+        assert!(is_dev_version("0.0.0-dev"));
+        assert!(is_dev_version("0.113.0-dev"));
+        assert!(is_dev_version("0.0.0"));
+        assert!(!is_dev_version("0.113.0"));
+        assert!(!is_dev_version("v1.2.3"));
+    }
+
+    #[test]
+    fn is_stale_compares_install_version_to_current() {
+        let mut def = ExtensionDef {
+            name: "flow".into(),
+            installed_with: Some("0.113.0".into()),
+            ..Default::default()
+        };
+        assert!(def.is_stale("0.114.0"), "binary upgraded → stale");
+        assert!(!def.is_stale("0.113.0"), "same version → fresh");
+        // Dev binary never flags staleness (its version is unstable).
+        assert!(!def.is_stale("0.0.0-dev"));
+        // No recorded install version → can't be stale.
+        def.installed_with = None;
+        assert!(!def.is_stale("0.114.0"));
+    }
+
+    #[test]
+    fn compat_warning_fires_only_when_binary_too_old() {
+        let def = ExtensionDef {
+            name: "flow".into(),
+            min_thurbox_version: Some("0.113.0".into()),
+            ..Default::default()
+        };
+        assert!(
+            def.compat_warning("0.112.0").is_some(),
+            "older binary warns"
+        );
+        assert!(def.compat_warning("0.113.0").is_none(), "exact match ok");
+        assert!(def.compat_warning("0.200.0").is_none(), "newer binary ok");
+        // Dev builds are treated as compatible with everything.
+        assert!(def.compat_warning("0.0.0-dev").is_none());
+        // No declared minimum → never warns.
+        let bare = ExtensionDef {
+            name: "x".into(),
+            ..Default::default()
+        };
+        assert!(bare.compat_warning("0.1.0").is_none());
+    }
+
+    #[test]
+    fn with_provenance_stamps_install_metadata() {
+        let def = ExtensionDef {
+            name: "flow".into(),
+            ..Default::default()
+        }
+        .with_provenance("0.113.0", "flow");
+        assert_eq!(def.installed_with.as_deref(), Some("0.113.0"));
+        assert_eq!(def.source.as_deref(), Some("flow"));
     }
 
     #[test]

--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -180,7 +180,7 @@ impl ExtensionDef {
     /// Stamp install provenance onto the (resolved) manifest before it's written
     /// to the discovery dir: which thurbox version installed it and where it came
     /// from, so staleness can be detected and `update` can re-fetch. Returns
-    /// `self` for chaining off [`resolved_for_home`].
+    /// `self` for chaining off [`Self::resolved_for_home`].
     pub fn with_provenance(mut self, installed_with: &str, source: &str) -> ExtensionDef {
         self.installed_with = Some(installed_with.to_string());
         self.source = Some(source.to_string());

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -65,6 +65,18 @@ pub struct ExtensionHealth {
     pub sessions: Vec<(String, bool)>,
     /// `(automation_name, present)` for each declared automation.
     pub automations: Vec<(String, bool)>,
+    /// The extension's own declared version (`version` in its manifest), if any.
+    pub version: Option<String>,
+    /// The thurbox version that installed it (`installed_with`), if recorded.
+    pub installed_with: Option<String>,
+    /// The running binary's version (the staleness reference point).
+    pub current_binary: String,
+    /// `true` when the binary upgraded since install — `extension update` would
+    /// refresh it. Always `false` on a dev build.
+    pub stale: bool,
+    /// A compatibility warning when the binary is older than the extension's
+    /// declared `min_thurbox_version`, else `None`.
+    pub compat_warning: Option<String>,
 }
 
 impl ExtensionHealth {
@@ -91,6 +103,14 @@ pub struct InstallReport {
     pub agents_added: Vec<String>,
     /// The activate result (sessions/automations created).
     pub ensure: EnsureReport,
+    /// The newly-installed extension's declared `version` (if any).
+    pub version: Option<String>,
+    /// The version that was installed before this run (for `update` to report a
+    /// `0.9.0 → 1.0.0` move). `None` on a first install.
+    pub previous_version: Option<String>,
+    /// A compatibility warning if the running binary is older than the
+    /// extension's declared `min_thurbox_version`.
+    pub compat_warning: Option<String>,
 }
 
 /// Install an extension end-to-end from a `target` (a bare name resolved against
@@ -116,6 +136,11 @@ pub fn install_extension(
         tracing::warn!("{w}");
     }
 
+    // Record the previously-installed version (if any) before we overwrite the
+    // discovery manifest, so an install-over-existing / update can report a move.
+    let previous_version =
+        crate::agent::extension_config::load_manifest(&def.name).and_then(|prev| prev.version);
+
     let home_raw = home_override
         .map(str::to_string)
         .or_else(|| def.home.clone())
@@ -128,11 +153,18 @@ pub fn install_extension(
     let home = crate::agent::extension_config::expand_tilde(&home_raw);
     let home_str = home.to_string_lossy().to_string();
 
+    let current = crate::agent::extension_config::binary_version();
     let mut report = InstallReport {
         name: def.name.clone(),
         home: home_str.clone(),
+        version: def.version.clone(),
+        previous_version,
+        compat_warning: def.compat_warning(current),
         ..Default::default()
     };
+    if let Some(w) = &report.compat_warning {
+        tracing::warn!("{w}");
+    }
 
     // 1. Payload files.
     for f in &def.files {
@@ -194,12 +226,73 @@ pub fn install_extension(
     // 3. Agents → agents.toml (idempotent).
     report.agents_added = crate::agent::extension_config::ensure_agents_registered(&def.agents)?;
 
-    // 4. Persist the home-resolved manifest to the discovery dir, then activate.
-    let resolved = def.resolved_for_home(&home_str);
+    // 4. Persist the home-resolved manifest (stamped with install provenance —
+    //    which binary installed it + where from) to the discovery dir, then
+    //    activate. `target` is recorded verbatim so `update` re-fetches the same
+    //    source (a bare name re-resolves against the *current* binary's tag).
+    let resolved = def
+        .resolved_for_home(&home_str)
+        .with_provenance(current, target);
     crate::agent::extension_config::write_manifest(&resolved)?;
     report.ensure = activate_extension(db, &resolved)?;
 
     Ok(report)
+}
+
+/// What [`update_extension`] did to one extension.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UpdateReport {
+    pub name: String,
+    /// `true` when the declared `version` changed (a real upgrade/downgrade).
+    pub changed: bool,
+    /// The underlying re-install report (files refreshed, version move, …).
+    pub install: InstallReport,
+}
+
+/// Re-install an already-installed extension from its **recorded source**,
+/// refreshing its payload + manifest to match the running binary. This is the
+/// mechanism that keeps extensions in sync after a thurbox upgrade: a bare-name
+/// source re-resolves against the new binary's release tag, so the matching
+/// extension version is fetched.
+///
+/// User-edited `substitute` files and `if_absent` seed files are preserved
+/// (same rules as install; pass `force` to overwrite them). Errors if the
+/// extension isn't installed or its manifest recorded no source.
+pub fn update_extension(db: &Database, name: &str, force: bool) -> Result<UpdateReport, String> {
+    let installed = crate::agent::extension_config::load_manifest(name)
+        .ok_or_else(|| format!("extension '{name}' is not installed (no manifest found)"))?;
+    let source = installed.source.clone().ok_or_else(|| {
+        format!(
+            "extension '{name}' has no recorded install source (installed by an older thurbox); \
+             reinstall it with `thurbox-cli extension install {name}`"
+        )
+    })?;
+    // Keep it in its existing home, regardless of what the new manifest defaults to.
+    let home = installed.home.clone();
+    let install = install_extension(db, &source, home.as_deref(), force)?;
+    let changed = install.previous_version != install.version;
+    Ok(UpdateReport {
+        name: name.to_string(),
+        changed,
+        install,
+    })
+}
+
+/// Update every installed extension (see [`update_extension`]), returning a
+/// per-extension result so one failure doesn't abort the rest. The names come
+/// from the discovery dir, in sorted order.
+pub fn update_all_extensions(
+    db: &Database,
+    force: bool,
+) -> Vec<(String, Result<UpdateReport, String>)> {
+    crate::agent::extension_config::list_manifests()
+        .into_iter()
+        .map(|def| {
+            let name = def.name.clone();
+            let result = update_extension(db, &name, force);
+            (name, result)
+        })
+        .collect()
 }
 
 /// What [`uninstall_extension`] removed.
@@ -497,6 +590,20 @@ pub fn heal_active_extensions(db: &Database) -> Vec<String> {
             ));
             continue;
         };
+        // Nudge once-per-pass when the binary upgraded since install, or when the
+        // extension wants a newer thurbox than this one. Both clear after the
+        // user acts (`extension update` / a thurbox upgrade), so they don't
+        // persist as noise.
+        let current = crate::agent::extension_config::binary_version();
+        if let Some(w) = def.compat_warning(current) {
+            messages.push(w);
+        } else if def.is_stale(current) {
+            messages.push(format!(
+                "extension '{name}' was installed under thurbox {} but this binary is {current}; \
+                 run `thurbox-cli extension update {name}` to refresh it",
+                def.installed_with.as_deref().unwrap_or("an older version")
+            ));
+        }
         match ensure_extension(db, &def) {
             Ok(report) if report.created_anything() => {
                 let mut parts = Vec::new();
@@ -543,6 +650,7 @@ pub fn extension_health(db: &Database, def: &ExtensionDef) -> Result<ExtensionHe
         .iter()
         .any(|n| n == &def.name);
 
+    let current = crate::agent::extension_config::binary_version();
     Ok(ExtensionHealth {
         name: def.name.clone(),
         active,
@@ -556,6 +664,11 @@ pub fn extension_health(db: &Database, def: &ExtensionDef) -> Result<ExtensionHe
             .iter()
             .map(|a| (a.name.clone(), automation_names.contains(&a.name)))
             .collect(),
+        version: def.version.clone(),
+        installed_with: def.installed_with.clone(),
+        current_binary: current.to_string(),
+        stale: def.is_stale(current),
+        compat_warning: def.compat_warning(current),
     })
 }
 
@@ -594,6 +707,10 @@ mod tests {
             name: "flow".into(),
             description: None,
             config_version: Some(1),
+            version: None,
+            min_thurbox_version: None,
+            installed_with: None,
+            source: None,
             home: None,
             agents: Vec::new(),
             files: Vec::new(),
@@ -783,6 +900,12 @@ prompt = "tick"
         let stored = crate::agent::extension_config::load_manifest("flow").unwrap();
         // repo_path was resolved from {home} to the absolute home.
         assert_eq!(stored.sessions[0].repo_path, home);
+        // Install provenance is stamped into the discovery manifest.
+        assert_eq!(
+            stored.installed_with.as_deref(),
+            Some(crate::agent::extension_config::binary_version())
+        );
+        assert_eq!(stored.source.as_deref(), Some(target.as_str()));
         assert_eq!(report.ensure.automations_created, ["flow-tick"]);
 
         // Re-install is idempotent: repos.md kept (if_absent), no new agents.
@@ -935,6 +1058,70 @@ prompt = "tick"
             Some(home.to_string_lossy().as_ref())
         );
         assert!(!home.exists(), "home removed with --purge");
+    }
+
+    #[test]
+    fn update_refetches_from_recorded_source_and_reports_version_move() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+        insert_session(&db, "flow");
+
+        let src = tempfile::TempDir::new().unwrap();
+        let home = temp.path().join("flowhome");
+        let manifest = |version: &str| {
+            format!(
+                "name = \"flow\"\nversion = \"{version}\"\nhome = \"{}\"\n[[files]]\npath = \"FLOW.md\"\n[[sessions]]\nname = \"flow\"\nagent = \"flow\"\nrepo_path = \"{{home}}\"\n",
+                home.display()
+            )
+        };
+        std::fs::write(src.path().join("extension.toml"), manifest("1.0.0")).unwrap();
+        std::fs::write(src.path().join("FLOW.md"), "v1 spec").unwrap();
+        let target = src.path().to_string_lossy().to_string();
+
+        install_extension(&db, &target, None, false).unwrap();
+        let stored = crate::agent::extension_config::load_manifest("flow").unwrap();
+        assert_eq!(stored.version.as_deref(), Some("1.0.0"));
+        assert_eq!(stored.source.as_deref(), Some(target.as_str()));
+
+        // Author publishes a new version at the same source; update pulls it.
+        std::fs::write(src.path().join("extension.toml"), manifest("2.0.0")).unwrap();
+        std::fs::write(src.path().join("FLOW.md"), "v2 spec").unwrap();
+
+        let report = update_extension(&db, "flow", false).unwrap();
+        assert!(report.changed, "version moved 1.0.0 -> 2.0.0");
+        assert_eq!(report.install.previous_version.as_deref(), Some("1.0.0"));
+        assert_eq!(report.install.version.as_deref(), Some("2.0.0"));
+        assert_eq!(
+            std::fs::read_to_string(home.join("FLOW.md")).unwrap(),
+            "v2 spec"
+        );
+        assert_eq!(
+            crate::agent::extension_config::load_manifest("flow")
+                .unwrap()
+                .version
+                .as_deref(),
+            Some("2.0.0")
+        );
+
+        // A no-op update (same source, unchanged) reports changed = false.
+        let again = update_extension(&db, "flow", false).unwrap();
+        assert!(!again.changed);
+    }
+
+    #[test]
+    fn update_errors_when_no_recorded_source() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+        // A manifest installed by an older thurbox carries no `source`.
+        crate::agent::extension_config::write_manifest(&ExtensionDef {
+            name: "legacy".into(),
+            ..Default::default()
+        })
+        .unwrap();
+        let err = update_extension(&db, "legacy", false).unwrap_err();
+        assert!(err.contains("no recorded install source"), "got: {err}");
     }
 
     #[test]

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -13,8 +13,9 @@ pub mod spawn;
 pub use delete::{delete_session_headless, ForceDeleteReport};
 pub use extensions::{
     activate_extension, deactivate_extension, ensure_extension, extension_health,
-    heal_active_extensions, install_extension, uninstall_extension, DeactivateReport, EnsureReport,
-    ExtensionHealth, InstallReport, UninstallReport,
+    heal_active_extensions, install_extension, uninstall_extension, update_all_extensions,
+    update_extension, DeactivateReport, EnsureReport, ExtensionHealth, InstallReport,
+    UninstallReport, UpdateReport,
 };
 pub use restart::restart_session_headless;
 pub use spawn::{spawn_session_headless, SpawnRequest, SpawnResult};


### PR DESCRIPTION
## Problem

Extensions had no versioning or update path. Once installed, an extension's manifest sat frozen in `~/.config/thurbox/extensions/<name>.toml` while thurbox upgraded around it — with no way to detect the drift or refresh it. The install URL was pinned to the binary's release tag, but nothing ever re-fetched after an upgrade.

## What this adds — a versioning + update lifecycle

**Manifest versioning + compatibility**
- `version` — the extension's own semver (author-bumped).
- `min_thurbox_version` — a **soft** compat gate: install / activate / self-heal emit a *warning* (never a hard block) when the running binary is older.

**Install provenance (stamped into the discovery copy, not authored)**
- `installed_with` — the thurbox version that performed the install.
- `source` — the resolved install target, so `update` can re-fetch from the same place.

**Staleness detection**
- After a thurbox upgrade the on-disk copy predates the binary → `ExtensionDef::is_stale` flags it in `extension list`/`status`, and self-heal prints a one-line nudge at startup. A dependency-free `compare_versions` backs the checks; **dev builds skip** staleness/compat (their version doesn't order against tags).

**`thurbox-cli extension update <name>|--all [--force]`**
- Re-installs from the recorded `source`. A bare name re-resolves against the *current* binary's release tag, so the matching extension version is pulled. User-edited `substitute` files and `if_absent` seeds are preserved unless `--force`.

**Surfacing**
- `list`/`status` JSON now includes `version`, `installed_with`, `current_binary`, `stale`, `compat_warning`.

The three shipped extensions (flow/forge/ci-shepherd) are bumped to `version = 1.0.0`, `min_thurbox_version = 0.113.0`.

## Rollback

No version-snapshot store; documented path is to pin a tagged install URL (`…/thurbox/v0.112.0/extensions/flow`) or downgrade the binary and `update` (the bare name re-resolves to that tag).

## Tests
- Pure helpers: `compare_versions`, `is_dev_version`, `is_stale`, `compat_warning`, `with_provenance`.
- `session_ops`: install stamps provenance; `update_extension` re-fetches + reports a version move; error when no recorded source.
- CLI: `extension update` parse (name / --all / --force).
- Full lib suite (1116) + architecture rules green; verified end-to-end with an isolated install→bump→update→`--all` smoke run.

## Docs
- `docs/CONFIG.md`: new manifest fields + a *Versioning + the update lifecycle* section.
- `extensions/flow/README.md`: an *Updating* section.
- `CLAUDE.md`: extension manifest/self-heal section updated.