### PR TITLE
fix(config): remove unavailable fable model from flow extension

### DIFF
--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -37,7 +37,7 @@ That single command is the installer — it reads flow's
    settings, and a `repos.md` routing table (edit it!);
 2. registers the `flow` / `flow-worker` / `flow-worker-heavy` entries in
    `~/.config/thurbox/agents.toml` (defaults: claude on haiku for the
-   triager, opus / fable for workers — edit agents.toml to change the
+   triager, opus for workers — edit agents.toml to change the
    CLI/model);
 3. writes the manifest to `~/.config/thurbox/extensions/flow.toml` and
    activates it, creating the dedicated `flow` session and a `flow-tick`

--- a/extensions/flow/extension.toml
+++ b/extensions/flow/extension.toml
@@ -36,7 +36,7 @@ new_session_args = ["--session-id", "{id}"]
 [[agents]]
 name = "flow-worker-heavy"
 command = "claude"
-args = ["--model", "claude-fable-5"]
+args = ["--model", "claude-opus-4-8"]
 resume_args = ["--resume", "{id}"]
 fork_args = ["--resume", "{id}", "--fork-session"]
 new_session_args = ["--session-id", "{id}"]


### PR DESCRIPTION
## Problem

The flow extension's `flow-worker-heavy` agent was pinned to `claude-fable-5`, which is no longer available. The README also documented fable as a worker model.

## Changes

- `extensions/flow/extension.toml`: `flow-worker-heavy` now uses `claude-opus-4-8` (current top-tier model) instead of `claude-fable-5`.
- `extensions/flow/README.md`: updated worker model docs from "opus / fable" to "opus".

## Acceptance

`grep -rni fable extensions/flow/` returns nothing.

Closes thurbox task #32.