### PR TITLE
feat(cli): improve extension install UX, discovery, and JSON output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,8 +358,9 @@ create/list/show/edit/remove/run/runs/tick), `task` (alias `todo`:
 create/list/show/edit/remove/run), `editor`, `config`
 (validate/show — strict-parses every config file / prints the
 effective resolved config; see `docs/CONFIG.md`), `extension`
-(alias `ext`: install/uninstall/list/update/activate/deactivate/status —
-manage opt-in extensions; see below). Pass `--pretty` for indented JSON.
+(alias `ext`: install/uninstall/reinstall/list/available/update/activate/
+deactivate/status — manage opt-in extensions; see below). Pass `--pretty` for
+indented JSON.
 
 `session delete <uuid>` **soft-deletes** by default — only the DB
 row is marked deleted (the TUI tears down the tmux window/worktree
@@ -646,22 +647,36 @@ the symlinks, registers the agents (`ensure_agents_registered` appends to
 agents.toml, preserving existing entries), writes the home-resolved
 manifest to the discovery dir, and activates. A `substitute` file the user
 edited (its managed marker removed) is not clobbered on reinstall unless
-`--force`. `uninstall <name> [--purge]`
-(`session_ops::uninstall_extension`) reverses it: tear down session +
+`--force`. A **bare-name** install that can't fetch its manifest (a typo or an
+unknown extension) is turned into a discovery error
+(`agent::extension_config::unknown_extension_help`): it names the known official
+extensions (`OFFICIAL_EXTENSIONS`), offers a Levenshtein "did you mean?"
+suggestion, and points at `extension available`. `uninstall <name> [--purge]`
+(`session_ops::uninstall_extension`) reverses install: tear down session +
 automation, remove the extension's agents (`remove_agents_from_toml`,
 text-edit to preserve comments), delete the manifest, and with `--purge`
-delete the home dir. Flow's `install.sh` is now a thin shim over `install`.
+delete the home dir. `reinstall <name> [--purge]`
+(`session_ops::reinstall_extension`) is the clean-slate hammer — a full
+uninstall followed by a fresh `install --force` from the recorded source
+(rewriting even user-edited seed/`substitute` files; `--purge` also resets the
+home dir), heavier than `update --force` which only refreshes payload files in
+place. Flow's `install.sh` is a thin shim over `install`.
 
 `thurbox-cli extension` (alias `ext`) — `install` / `uninstall <name>
-[--purge]` / `list` / `update <name>|--all [--force]` / `activate <name>` /
-`deactivate <name> [--force] [--purge]` / `status [<name>]` — wraps
-`session_ops::extensions`: `ensure_extension` idempotently (re)creates any
-missing declared resource (reusing `spawn_session_headless` +
+[--purge]` / `reinstall <name> [--purge]` / `list` / `available [<query>]`
+(alias `search`) / `update [<name>] [--all] [--force]` (no name ⇒ all) /
+`activate <name>` / `deactivate <name> [--force] [--purge]` / `status [<name>]`
+— wraps `session_ops::extensions`: `ensure_extension` idempotently (re)creates
+any missing declared resource (reusing `spawn_session_headless` +
 `db.create_automation`, matching by name so existing ones are reused);
 `activate_extension` also records the name in the SQLite `metadata`
 `active_extensions` JSON set; `deactivate_extension` tears the resources
 down and clears the set. The CLI layer arms the tmux automation heartbeat
-on activate so a `Send` automation actually fires headlessly.
+on activate so a `Send` automation actually fires headlessly. `available`
+lists the official extensions (`OFFICIAL_EXTENSIONS`) for discovery — offline,
+with an `installed` flag and ready-to-run `install_command` per entry. Every
+mutating subcommand's JSON carries a human-readable `summary` line (and
+`list`/`status` surface each extension's `description`).
 
 **Versioning + update.** A manifest declares its own `version` and a
 `min_thurbox_version` (soft compat gate — install/activate/heal *warn*,

--- a/src/agent/extension_config.rs
+++ b/src/agent/extension_config.rs
@@ -51,6 +51,111 @@ pub fn official_base() -> String {
     format!("{OFFICIAL_REPO_RAW}/{}/extensions", official_ref())
 }
 
+/// One officially-distributed extension, surfaced for discovery
+/// (`thurbox-cli extension available`) and typo help on a failed bare-name
+/// install. Each installs by its bare `name` against [`official_base`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OfficialExtension {
+    /// Bare install name (`thurbox-cli extension install <name>`).
+    pub name: &'static str,
+    /// One-line human summary, mirrored from the extension's own manifest.
+    pub description: &'static str,
+}
+
+/// The official extensions shipped in `extensions/<name>/` of the thurbox repo.
+///
+/// **Source of truth for discovery + typo suggestions.** Keep in sync when an
+/// extension is added/removed under `extensions/` (descriptions mirror each
+/// `extension.toml`'s `description`). This is intentionally a small static list
+/// rather than a remote index so `extension available` works offline and a typo
+/// can be caught without a network round-trip.
+pub const OFFICIAL_EXTENSIONS: &[OfficialExtension] = &[
+    OfficialExtension {
+        name: "flow",
+        description: "Focus-protecting triage agent",
+    },
+    OfficialExtension {
+        name: "forge",
+        description: "Workflow analyst that proposes new automations",
+    },
+    OfficialExtension {
+        name: "ci-shepherd",
+        description: "Watches change requests (PR/MR) and dispatches CI/review fixers",
+    },
+    OfficialExtension {
+        name: "renovate",
+        description: "Keeps local repos on up-to-date dependencies via Renovate's local platform",
+    },
+];
+
+/// Whether an install `target` is a **bare name** (not a URL or path) — i.e. it
+/// resolves against the official source. Mirrors the branch in [`resolve_source`].
+pub fn is_bare_name(target: &str) -> bool {
+    let t = target.trim();
+    !(t.starts_with("https://")
+        || t.starts_with("http://")
+        || t.contains('/')
+        || t.starts_with('.')
+        || t.starts_with('~'))
+}
+
+/// Suggest the closest official extension name to `name` (for a "did you mean?"
+/// hint), within a small edit-distance budget so unrelated typos suggest nothing.
+pub fn suggest_extension(name: &str) -> Option<&'static str> {
+    let name = name.trim().to_lowercase();
+    // Budget scales a little with length: tolerate a couple of edits for short
+    // names (a transposition is 2), more for longer ones, but never so loose that
+    // everything matches.
+    let budget = (name.len() / 3).clamp(2, 3);
+    OFFICIAL_EXTENSIONS
+        .iter()
+        .map(|e| (e.name, levenshtein(&name, e.name)))
+        .filter(|(_, d)| *d <= budget)
+        .min_by_key(|(_, d)| *d)
+        .map(|(n, _)| n)
+}
+
+/// Build a helpful error for a failed **bare-name** install: surface the real
+/// fetch failure, list the known official extensions, and offer a "did you
+/// mean?" suggestion plus a pointer at `extension available`.
+pub fn unknown_extension_help(name: &str, cause: &str) -> String {
+    let mut msg = format!("could not install extension '{name}': {cause}\n");
+    if let Some(suggestion) = suggest_extension(name) {
+        msg.push_str(&format!("\nDid you mean '{suggestion}'?\n"));
+    }
+    msg.push_str("\nKnown official extensions:\n");
+    for ext in OFFICIAL_EXTENSIONS {
+        msg.push_str(&format!("  {:<12} {}\n", ext.name, ext.description));
+    }
+    msg.push_str(
+        "\nRun `thurbox-cli extension available` to list them, or pass a URL / local path.",
+    );
+    msg
+}
+
+/// Classic Levenshtein edit distance (two-row DP). Small inputs only.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
 /// The extension-manifest discovery directory:
 /// `~/.config/thurbox/extensions/` (sibling of `config.toml`).
 pub fn extensions_dir() -> Option<PathBuf> {
@@ -479,6 +584,49 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let _guard = crate::paths::TestPathGuard::new(temp.path());
         assert!(list_manifests().is_empty());
+    }
+
+    #[test]
+    fn is_bare_name_only_for_plain_names() {
+        assert!(is_bare_name("flow"));
+        assert!(is_bare_name("ci-shepherd"));
+        assert!(!is_bare_name("https://example.com/flow"));
+        assert!(!is_bare_name("./flow"));
+        assert!(!is_bare_name("~/flow"));
+        assert!(!is_bare_name("/abs/flow"));
+        assert!(!is_bare_name("a/b"));
+    }
+
+    #[test]
+    fn suggest_extension_catches_typos_but_not_noise() {
+        assert_eq!(suggest_extension("flwo"), Some("flow"));
+        assert_eq!(suggest_extension("forge"), Some("forge"));
+        assert_eq!(suggest_extension("renovat"), Some("renovate"));
+        assert_eq!(suggest_extension("ci-shepard"), Some("ci-shepherd"));
+        // Unrelated input shouldn't map to anything.
+        assert_eq!(suggest_extension("zzzzzzzzzz"), None);
+    }
+
+    #[test]
+    fn unknown_extension_help_lists_known_and_suggests() {
+        let msg = unknown_extension_help("flwo", "curl: HTTP 404");
+        assert!(msg.contains("could not install extension 'flwo'"));
+        assert!(msg.contains("curl: HTTP 404"));
+        assert!(msg.contains("Did you mean 'flow'?"));
+        // Every official extension is listed for discovery.
+        for ext in OFFICIAL_EXTENSIONS {
+            assert!(msg.contains(ext.name), "missing {}", ext.name);
+        }
+        assert!(msg.contains("extension available"));
+    }
+
+    #[test]
+    fn levenshtein_basics() {
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("flow", "flow"), 0);
+        assert_eq!(levenshtein("flwo", "flow"), 2);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
     }
 
     #[test]

--- a/src/cli/extensions.rs
+++ b/src/cli/extensions.rs
@@ -38,18 +38,38 @@ pub enum Action {
     },
     /// List installed extensions and whether each is active/healthy.
     List,
-    /// Update an installed extension by re-fetching it from its recorded source
-    /// (a bare name re-resolves to the running binary's release tag, so the
-    /// matching version is pulled). Preserves user-edited files unless --force.
+    /// List the official extensions available to install (name + description +
+    /// whether already installed), optionally filtered by a query.
+    #[command(alias = "search")]
+    Available {
+        /// Filter by a substring matched against name or description.
+        query: Option<String>,
+    },
+    /// Update installed extensions by re-fetching from their recorded source (a
+    /// bare name re-resolves to the running binary's release tag, so the matching
+    /// version is pulled). With no name, updates **all** installed extensions.
+    /// Preserves user-edited files unless --force.
     Update {
-        /// Extension name. Omit and pass --all to update every installed one.
+        /// Extension name. Omit to update every installed extension.
         name: Option<String>,
-        /// Update every installed extension instead of a single named one.
+        /// Update every installed extension (the default when no name is given).
         #[arg(long)]
         all: bool,
         /// Also overwrite user-edited `substitute` files and `if_absent` seeds.
         #[arg(long)]
         force: bool,
+    },
+    /// Clean-slate reinstall: uninstall the extension (tear down its resources,
+    /// remove its agents + manifest) then install it fresh from its recorded
+    /// source, overwriting user-edited seed/`substitute` files. Heavier than
+    /// `update --force`, which only refreshes payload files in place.
+    Reinstall {
+        /// Extension name.
+        name: String,
+        /// Also delete + recreate the install home directory (full reset,
+        /// discarding any user data under it).
+        #[arg(long)]
+        purge: bool,
     },
     /// Activate an extension: (re)create its sessions/automations and mark it
     /// active so thurbox self-heals them. Idempotent.
@@ -94,6 +114,8 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
         Action::Uninstall { name, purge } => {
             let report = crate::session_ops::uninstall_extension(db, &name, purge)?;
             Ok(json!({
+                "ok": true,
+                "summary": format!("Uninstalled extension '{}'", report.name),
                 "uninstalled": report.name,
                 "sessions_deleted": report.deactivate.sessions_deleted,
                 "automations_deleted": report.deactivate.automations_deleted,
@@ -112,30 +134,66 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             }
             Ok(Value::Array(out))
         }
-        Action::Update { name, all, force } => match (name, all) {
-            (Some(_), true) => Err("pass either a name or --all, not both".to_string()),
-            (None, false) => {
-                Err("specify an extension name, or --all to update every installed one".to_string())
-            }
-            (Some(name), false) => {
+        Action::Available { query } => Ok(available_to_json(query.as_deref())),
+        Action::Update { name, all, force } => match name {
+            // `--all` alongside a name is contradictory; otherwise a bare name
+            // updates one and *no* name updates them all (no flag required).
+            Some(_) if all => Err("pass either a name or --all, not both".to_string()),
+            Some(name) => {
                 let report = crate::session_ops::update_extension(db, &name, force)?;
                 // Arm the heartbeat so the refreshed automations keep firing headlessly.
                 arm_heartbeat();
                 Ok(update_report_to_json(&report))
             }
-            (None, true) => {
+            None => {
                 let results = crate::session_ops::update_all_extensions(db, force);
                 arm_heartbeat();
+                let total = results.len();
+                let mut changed = 0;
+                let mut failed = 0;
                 let out: Vec<Value> = results
                     .into_iter()
                     .map(|(name, result)| match result {
-                        Ok(report) => update_report_to_json(&report),
-                        Err(e) => json!({ "name": name, "error": e }),
+                        Ok(report) => {
+                            if report.changed {
+                                changed += 1;
+                            }
+                            update_report_to_json(&report)
+                        }
+                        Err(e) => {
+                            failed += 1;
+                            json!({ "name": name, "ok": false, "error": e })
+                        }
                     })
                     .collect();
-                Ok(Value::Array(out))
+                let summary = if total == 0 {
+                    "No extensions installed".to_string()
+                } else {
+                    format!("Updated {total} extension(s): {changed} changed, {failed} failed")
+                };
+                Ok(json!({ "ok": failed == 0, "summary": summary, "extensions": out }))
             }
         },
+        Action::Reinstall { name, purge } => {
+            let report = crate::session_ops::reinstall_extension(db, &name, purge)?;
+            arm_heartbeat();
+            let version = report.install.version.as_deref().unwrap_or("?");
+            Ok(json!({
+                "ok": true,
+                "summary": format!(
+                    "Reinstalled '{}' {} → {}",
+                    report.name, version, report.install.home
+                ),
+                "reinstalled": report.name,
+                "home_removed": report.uninstall.home_removed,
+                "home": report.install.home,
+                "version": report.install.version,
+                "files_written": report.install.files_written,
+                "agents_added": report.install.agents_added,
+                "sessions_created": report.install.ensure.sessions_created,
+                "automations_created": report.install.ensure.automations_created,
+            }))
+        }
         Action::Activate { name } => {
             let def = load_manifest(&name)?;
             let report = crate::session_ops::activate_extension(db, &def)?;
@@ -144,6 +202,13 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             // matching how `automation create` arms it.
             arm_heartbeat();
             Ok(json!({
+                "ok": true,
+                "summary": format!(
+                    "Activated '{}' ({} session(s), {} automation(s))",
+                    def.name,
+                    report.sessions_created.len(),
+                    report.automations_created.len(),
+                ),
                 "activated": def.name,
                 "sessions_created": report.sessions_created,
                 "automations_created": report.automations_created,
@@ -170,7 +235,14 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             } else {
                 false
             };
+            let summary = if report.was_active {
+                format!("Deactivated '{name}'")
+            } else {
+                format!("'{name}' was not active")
+            };
             Ok(json!({
+                "ok": true,
+                "summary": summary,
                 "deactivated": name,
                 "was_active": report.was_active,
                 "sessions_deleted": report.sessions_deleted,
@@ -209,9 +281,41 @@ fn arm_heartbeat() {
     }
 }
 
+/// Build the `extension available` result: every official extension with its
+/// description, whether it's already installed, and the install command.
+fn available_to_json(query: Option<&str>) -> Value {
+    let q = query.map(|s| s.trim().to_lowercase());
+    let installed: std::collections::HashSet<String> =
+        crate::agent::extension_config::list_manifests()
+            .into_iter()
+            .map(|d| d.name)
+            .collect();
+    let mut out = Vec::new();
+    for ext in crate::agent::extension_config::OFFICIAL_EXTENSIONS {
+        if let Some(q) = &q {
+            if !ext.name.to_lowercase().contains(q) && !ext.description.to_lowercase().contains(q) {
+                continue;
+            }
+        }
+        out.push(json!({
+            "name": ext.name,
+            "description": ext.description,
+            "installed": installed.contains(ext.name),
+            "install_command": format!("thurbox-cli extension install {}", ext.name),
+        }));
+    }
+    json!({
+        "ok": true,
+        "summary": format!("{} official extension(s) available", out.len()),
+        "available": out,
+    })
+}
+
 fn health_to_json(h: &crate::session_ops::ExtensionHealth) -> Value {
     json!({
         "name": h.name,
+        "description": h.description,
+        "summary": health_summary(h),
         "active": h.active,
         "healthy": h.is_healthy(),
         "version": h.version,
@@ -228,8 +332,41 @@ fn health_to_json(h: &crate::session_ops::ExtensionHealth) -> Value {
     })
 }
 
+/// A one-line human status for an extension's health (active/inactive, stale,
+/// missing resources), for the `summary` field of `list`/`status`.
+fn health_summary(h: &crate::session_ops::ExtensionHealth) -> String {
+    if !h.active {
+        return format!("'{}' is installed but not active", h.name);
+    }
+    if !h.is_healthy() {
+        return format!(
+            "'{}' is active but missing resources — run self-heal",
+            h.name
+        );
+    }
+    if h.stale {
+        return format!(
+            "'{}' is active but stale — run `thurbox-cli extension update {}`",
+            h.name, h.name
+        );
+    }
+    format!("'{}' is active and healthy", h.name)
+}
+
 fn install_report_to_json(report: &crate::session_ops::InstallReport) -> Value {
+    let version = report.version.as_deref().unwrap_or("?");
+    let summary = format!(
+        "Installed '{}' {} → {} ({} file(s), {} session(s), {} automation(s))",
+        report.name,
+        version,
+        report.home,
+        report.files_written.len(),
+        report.ensure.sessions_created.len(),
+        report.ensure.automations_created.len(),
+    );
     json!({
+        "ok": true,
+        "summary": summary,
         "installed": report.name,
         "home": report.home,
         "version": report.version,
@@ -246,7 +383,23 @@ fn install_report_to_json(report: &crate::session_ops::InstallReport) -> Value {
 }
 
 fn update_report_to_json(report: &crate::session_ops::UpdateReport) -> Value {
+    let summary = if report.changed {
+        format!(
+            "Updated '{}' {} → {}",
+            report.name,
+            report.install.previous_version.as_deref().unwrap_or("?"),
+            report.install.version.as_deref().unwrap_or("?"),
+        )
+    } else {
+        format!(
+            "'{}' already up to date ({})",
+            report.name,
+            report.install.version.as_deref().unwrap_or("?"),
+        )
+    };
     json!({
+        "ok": true,
+        "summary": summary,
         "updated": report.name,
         "changed": report.changed,
         "previous_version": report.install.previous_version,
@@ -256,4 +409,46 @@ fn update_report_to_json(report: &crate::session_ops::UpdateReport) -> Value {
         "files_skipped": report.install.files_skipped,
         "home": report.install.home,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn available_lists_official_extensions_with_install_commands() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let out = available_to_json(None);
+        assert_eq!(out["ok"], true);
+        let list = out["available"].as_array().unwrap();
+        // Every official extension shows up, none installed in a fresh dir.
+        let names: Vec<&str> = list.iter().map(|e| e["name"].as_str().unwrap()).collect();
+        for ext in crate::agent::extension_config::OFFICIAL_EXTENSIONS {
+            assert!(names.contains(&ext.name), "missing {}", ext.name);
+        }
+        let flow = list.iter().find(|e| e["name"] == "flow").unwrap();
+        assert_eq!(flow["installed"], false);
+        assert_eq!(
+            flow["install_command"],
+            "thurbox-cli extension install flow"
+        );
+    }
+
+    #[test]
+    fn available_query_filters_by_name_or_description() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        // Matches the renovate description ("dependencies").
+        let out = available_to_json(Some("dependencies"));
+        let list = out["available"].as_array().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0]["name"], "renovate");
+
+        // A query matching nothing yields an empty list (not an error).
+        let out = available_to_json(Some("nonexistent-xyz"));
+        assert!(out["available"].as_array().unwrap().is_empty());
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -445,6 +445,57 @@ mod tests {
     }
 
     #[test]
+    fn parse_extension_update_no_name_means_all() {
+        // No name and no --all is now valid: it updates every installed extension.
+        let cli = Cli::try_parse_from(["thurbox-cli", "extension", "update"]).unwrap();
+        let Command::Extension {
+            action: extensions::Action::Update { name, all, force },
+        } = cli.command
+        else {
+            panic!("expected Extension::Update");
+        };
+        assert!(name.is_none());
+        assert!(!all);
+        assert!(!force);
+    }
+
+    #[test]
+    fn parse_extension_reinstall() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "extension", "reinstall", "flow", "--purge"])
+            .unwrap();
+        let Command::Extension {
+            action: extensions::Action::Reinstall { name, purge },
+        } = cli.command
+        else {
+            panic!("expected Extension::Reinstall");
+        };
+        assert_eq!(name, "flow");
+        assert!(purge);
+    }
+
+    #[test]
+    fn parse_extension_available_and_search_alias() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "extension", "available"]).unwrap();
+        let Command::Extension {
+            action: extensions::Action::Available { query },
+        } = cli.command
+        else {
+            panic!("expected Extension::Available");
+        };
+        assert!(query.is_none());
+
+        // `search` is an alias and accepts a filter query.
+        let cli = Cli::try_parse_from(["thurbox-cli", "ext", "search", "deps"]).unwrap();
+        let Command::Extension {
+            action: extensions::Action::Available { query },
+        } = cli.command
+        else {
+            panic!("expected Extension::Available via search alias");
+        };
+        assert_eq!(query.as_deref(), Some("deps"));
+    }
+
+    #[test]
     fn extension_alias_ext_parses() {
         let cli = Cli::try_parse_from(["thurbox-cli", "ext", "list"]).unwrap();
         assert!(matches!(

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -60,6 +60,8 @@ pub struct DeactivateReport {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExtensionHealth {
     pub name: String,
+    /// The extension's own one-line description (`description` in its manifest).
+    pub description: Option<String>,
     pub active: bool,
     /// `(session_name, present)` for each declared session.
     pub sessions: Vec<(String, bool)>,
@@ -131,7 +133,17 @@ pub fn install_extension(
     // Agent-layer helpers are reached fully-qualified (no `use crate::agent`) per
     // the session_ops → agent path-only architecture rule.
     let source = crate::agent::extension_config::resolve_source(target);
-    let (def, warnings) = crate::agent::extension_config::load_manifest_from_source(&source)?;
+    let (def, warnings) = match crate::agent::extension_config::load_manifest_from_source(&source) {
+        Ok(v) => v,
+        // A bare name that can't be fetched is almost always a typo or an unknown
+        // extension — turn the raw curl/404 into discovery guidance.
+        Err(e) if crate::agent::extension_config::is_bare_name(target) => {
+            return Err(crate::agent::extension_config::unknown_extension_help(
+                target, &e,
+            ));
+        }
+        Err(e) => return Err(e),
+    };
     for w in &warnings {
         tracing::warn!("{w}");
     }
@@ -293,6 +305,53 @@ pub fn update_all_extensions(
             (name, result)
         })
         .collect()
+}
+
+/// What [`reinstall_extension`] did: the uninstall teardown followed by a fresh
+/// install from the recorded source.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReinstallReport {
+    pub name: String,
+    pub uninstall: UninstallReport,
+    pub install: InstallReport,
+}
+
+/// Clean-slate reinstall: fully [`uninstall_extension`] the extension (tearing
+/// down its session/automation, removing its agents, deleting its manifest, and
+/// — with `purge_home` — its home dir), then re-[`install_extension`] from the
+/// **recorded source** with `force` so even user-edited seed/`substitute` files
+/// are rewritten.
+///
+/// This is the heavier hammer than `update --force`: `update` refreshes payload
+/// files in place but never removes now-stale agents or runtime resources, while
+/// `reinstall` removes everything first and lays it down fresh. The extension's
+/// home is preserved unless `purge_home`. Errors if the extension isn't
+/// installed or its manifest recorded no source (older installs — uninstall +
+/// install by hand instead).
+pub fn reinstall_extension(
+    db: &Database,
+    name: &str,
+    purge_home: bool,
+) -> Result<ReinstallReport, String> {
+    let installed = crate::agent::extension_config::load_manifest(name)
+        .ok_or_else(|| format!("extension '{name}' is not installed (no manifest found)"))?;
+    let source = installed.source.clone().ok_or_else(|| {
+        format!(
+            "extension '{name}' has no recorded install source (installed by an older thurbox); \
+             reinstall it by hand: `thurbox-cli extension uninstall {name}` then \
+             `thurbox-cli extension install {name}`"
+        )
+    })?;
+    // Keep the extension in its existing home unless the caller purges it.
+    let home = installed.home.clone();
+
+    let uninstall = uninstall_extension(db, name, purge_home)?;
+    let install = install_extension(db, &source, home.as_deref(), true)?;
+    Ok(ReinstallReport {
+        name: name.to_string(),
+        uninstall,
+        install,
+    })
 }
 
 /// What [`uninstall_extension`] removed.
@@ -653,6 +712,7 @@ pub fn extension_health(db: &Database, def: &ExtensionDef) -> Result<ExtensionHe
     let current = crate::agent::extension_config::binary_version();
     Ok(ExtensionHealth {
         name: def.name.clone(),
+        description: def.description.clone(),
         active,
         sessions: def
             .sessions
@@ -1121,6 +1181,57 @@ prompt = "tick"
         })
         .unwrap();
         let err = update_extension(&db, "legacy", false).unwrap_err();
+        assert!(err.contains("no recorded install source"), "got: {err}");
+    }
+
+    #[test]
+    fn reinstall_tears_down_then_installs_fresh() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+        insert_session(&db, "flow");
+
+        let src = tempfile::TempDir::new().unwrap();
+        let home = temp.path().join("flowhome");
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                "name = \"flow\"\nversion = \"1.0.0\"\nhome = \"{}\"\n[[files]]\npath = \"seed.md\"\nif_absent = true\n[[sessions]]\nname = \"flow\"\nagent = \"flow\"\nrepo_path = \"{{home}}\"\n",
+                home.display()
+            ),
+        )
+        .unwrap();
+        std::fs::write(src.path().join("seed.md"), "pristine seed").unwrap();
+        let target = src.path().to_string_lossy().to_string();
+
+        install_extension(&db, &target, None, false).unwrap();
+        // User edits the if_absent seed — update without --force would keep it.
+        std::fs::write(home.join("seed.md"), "user edit").unwrap();
+
+        let report = reinstall_extension(&db, "flow", false).unwrap();
+        assert_eq!(report.name, "flow");
+        assert!(report.uninstall.manifest_removed);
+        assert_eq!(report.install.version.as_deref(), Some("1.0.0"));
+        // Reinstall forces even the if_absent seed back to pristine.
+        assert_eq!(
+            std::fs::read_to_string(home.join("seed.md")).unwrap(),
+            "pristine seed"
+        );
+        // The extension is installed + active again afterwards.
+        assert!(crate::agent::extension_config::load_manifest("flow").is_some());
+    }
+
+    #[test]
+    fn reinstall_errors_when_no_recorded_source() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+        crate::agent::extension_config::write_manifest(&ExtensionDef {
+            name: "legacy".into(),
+            ..Default::default()
+        })
+        .unwrap();
+        let err = reinstall_extension(&db, "legacy", false).unwrap_err();
         assert!(err.contains("no recorded install source"), "got: {err}");
     }
 

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -13,9 +13,9 @@ pub mod spawn;
 pub use delete::{delete_session_headless, ForceDeleteReport};
 pub use extensions::{
     activate_extension, deactivate_extension, ensure_extension, extension_health,
-    heal_active_extensions, install_extension, uninstall_extension, update_all_extensions,
-    update_extension, DeactivateReport, EnsureReport, ExtensionHealth, InstallReport,
-    UninstallReport, UpdateReport,
+    heal_active_extensions, install_extension, reinstall_extension, uninstall_extension,
+    update_all_extensions, update_extension, DeactivateReport, EnsureReport, ExtensionHealth,
+    InstallReport, ReinstallReport, UninstallReport, UpdateReport,
 };
 pub use restart::restart_session_headless;
 pub use spawn::{spawn_session_headless, SpawnRequest, SpawnResult};


### PR DESCRIPTION
## Summary

Improves the `thurbox-cli extension` CLI on three axes — **discovery**, **error messages**, and **JSON output** — plus two requested usability wins (easier `update`, a real `reinstall`).

## What changed

**Discovery**
- New `extension available` (alias `search [query]`) lists the official extensions **offline** — each with its description, an `installed` flag, and a ready-to-run `install_command`. Backed by a new `OFFICIAL_EXTENSIONS` registry (`flow`, `forge`, `ci-shepherd`, `renovate`).

**Better error messages**
- A failed **bare-name** install (typo or unknown extension) no longer dumps a raw `curl: 404`. It now lists the known extensions, offers a Levenshtein **"did you mean?"** suggestion, and points at `extension available`.

**Easier update**
- `extension update` with **no name** now updates **all** installed extensions (no `--all` required). `--all` is kept for back-compat; `name + --all` is still rejected as contradictory.

**Real reinstall** (`update --force` is only a refresh-in-place)
- New `extension reinstall <name> [--purge]`: a clean-slate **uninstall → fresh `install --force`** from the recorded source, rewriting even user-edited seed/`substitute` files (`--purge` also resets the home dir).

**Improved JSON**
- Every mutating subcommand emits a human-readable `summary` line and a consistent `ok` flag.
- `list`/`status` now surface each extension's `description` and a one-line health `summary`.

## Testing
- `cargo test --lib` — 1128 pass (new unit tests for the registry, `suggest_extension`, `unknown_extension_help`, `is_bare_name`, `levenshtein`, `available_to_json`, `reinstall_extension`, and CLI parsing for `available`/`reinstall`/no-arg `update`).
- `cargo clippy --all-targets --all-features -D warnings` clean; `cargo fmt`; architecture-rules + rumdl pass.

Closes thurbox task #31.