### PR TITLE
fix(ci-shepherd): detect behind-base PRs via git-local rebase check

### DIFF
--- a/extensions/ci-shepherd/README.md
+++ b/extensions/ci-shepherd/README.md
@@ -109,7 +109,8 @@ branch; `clean` removes the worktree once the request is no longer actionable
 | Path | Purpose |
 |------|---------|
 | `SHEPHERD.md` | The agent behavior spec (modes, actionability rules, output contract) |
-| `scripts/provider.sh` | The forge adapter layer — normalizes GitHub/GitLab/Bitbucket onto one contract (incl. the `rebase` behind/conflict signal) |
+| `scripts/provider.sh` | The forge adapter layer — normalizes GitHub/GitLab/Bitbucket onto one contract (incl. the `rebase` behind/conflict signal, overridden by a git-local check) |
+| `scripts/rebase-check.sh` | Authoritative git-local behind/conflict check (`none`/`NEEDED`/`CONFLICT`) — fetched `origin/<base>` vs `origin/<head>`; unit-tested by `rebase-check.bats` |
 | `scripts/classify.sh` | Pure request → action-flag classifier (`CHANGES-REQ`/`CI-FAIL`/`REBASE`/…); unit-tested by `classify.bats` |
 | `scripts/shepherd-snapshot.sh` | One-call view: watched requests (with action flags) + fixer tasks/sessions/worktrees |
 | `scripts/dispatch-fix.sh` | Prepare a request-branch worktree + create and run the fixer task |

--- a/extensions/ci-shepherd/SHEPHERD.md
+++ b/extensions/ci-shepherd/SHEPHERD.md
@@ -81,6 +81,13 @@ the merge until it's rebased. CI-FAIL outranks REBASE on purpose: clear red
 checks first, since the rebase re-runs CI and is the last gate before a clean
 request can merge. The per-request line shows `rebase=NEEDED|CONFLICT|none`.
 
+The `rebase` signal is **git-local and authoritative**: the snapshot fetches
+`origin` and tests each request's head against its base directly
+(`rebase-check.sh`), rather than trusting the forge's lazily-computed merge state
+(which is frequently stale, so a behind branch would otherwise read as `none`).
+The forge's own value is kept only as a fallback for heads that aren't on
+`origin` (fork PRs).
+
 ## TICK (be silent unless action is needed)
 
 1. **Dispatch** a fixer for every request that is actionable AND has no live

--- a/extensions/ci-shepherd/extension.toml
+++ b/extensions/ci-shepherd/extension.toml
@@ -55,6 +55,10 @@ path = "scripts/classify.sh"
 executable = true
 
 [[files]]
+path = "scripts/rebase-check.sh"
+executable = true
+
+[[files]]
 path = "scripts/parse-result.sh"
 executable = true
 

--- a/extensions/ci-shepherd/scripts/provider.sh
+++ b/extensions/ci-shepherd/scripts/provider.sh
@@ -30,8 +30,18 @@
 # base (branch-protection "require branches to be up to date" will block the
 # merge); CONFLICT = it has diverged so far it no longer merges cleanly (a rebase
 # with conflict resolution is required). Providers that can't tell map to "none".
+#
+# The forges compute this lazily/asynchronously, so an API read is often stale.
+# The `list` verb therefore OVERRIDES each request's `rebase` with an authoritative
+# git-local check (augment_rebase): it fetches origin once, then runs
+# rebase-check.sh against origin/<base> vs origin/<head>. The forge's own value is
+# only kept as a fallback when the head can't be resolved locally (a fork PR).
+# Each `*_list` emits an extra `base` field for this; augment_rebase strips it so
+# the normalized output shape above is unchanged.
 
 set -euo pipefail
+
+HERE="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
 VERB="${1:-}"; REPO="${2:-}"; shift 2 || true
 [ -n "$VERB" ] && [ -n "$REPO" ] || { echo "usage: provider.sh <verb> <repo> [args]" >&2; exit 2; }
@@ -55,15 +65,17 @@ resolve_provider() {
 github_list() { # <author>
   have gh || { echo "gh (GitHub CLI) not installed" >&2; return 3; }
   ( cd "$REPO" && gh pr list --author "$1" --state open \
-      --json number,title,headRefName,isDraft,reviewDecision,statusCheckRollup,mergeStateStatus,mergeable,url ) \
+      --json number,title,headRefName,baseRefName,isDraft,reviewDecision,statusCheckRollup,mergeStateStatus,mergeable,url ) \
   | jq '[ .[] | {
-      number, title, branch: .headRefName, draft: .isDraft, url,
+      number, title, branch: .headRefName, base: .baseRefName, draft: .isDraft, url,
       review: ((.reviewDecision // "") | if . == "" then "none" else . end),
       ci: ((.statusCheckRollup // []) | map(.conclusion // .state // "")
            | if length == 0 then "none"
              elif any(. == "FAILURE" or . == "ERROR" or . == "TIMED_OUT") then "FAIL"
              elif any(. == "PENDING" or . == "IN_PROGRESS" or . == "QUEUED") then "PENDING"
              else "OK" end),
+      # Fallback only (augment_rebase overrides this with a git-local check, which
+      # is authoritative for same-repo PRs and avoids the lazy forge merge state).
       # mergeStateStatus BEHIND = out of date with base (branch protection blocks);
       # DIRTY / mergeable CONFLICTING = diverged, a conflict-resolving rebase needed.
       rebase: ((.mergeStateStatus // "") as $m | (.mergeable // "") as $g
@@ -88,7 +100,7 @@ gitlab_list() { # <author>
   # glab proxies the raw GitLab MR API, whose field names we normalize here.
   ( cd "$REPO" && glab mr list --state opened ${author:+--author "$author"} --output json ) \
   | jq '[ .[] | {
-      number: .iid, title, branch: .source_branch,
+      number: .iid, title, branch: .source_branch, base: .target_branch,
       draft: (.draft // .work_in_progress // false),
       url: .web_url,
       review: (if (.blocking_discussions_resolved == false) then "CHANGES_REQUESTED" else "none" end),
@@ -135,13 +147,13 @@ bitbucket_list() { # <author> (filtered client-side; Bitbucket has no review-dec
   bb_curl GET "pullrequests?state=OPEN&pagelen=50" \
   | jq --arg author "$author" '[ .values[]
       | select($author == "@me" or $author == "*" or (.author.nickname // "") == $author)
-      | { number: .id, title, branch: .source.branch.name,
+      | { number: .id, title, branch: .source.branch.name, base: .destination.branch.name,
           draft: (.draft // false), url: .links.html.href,
           review: ([.participants[]? | select(.state == "changes_requested")] | if length>0 then "CHANGES_REQUESTED" else "none" end),
           ci: "none",
-          # Bitbucket list payload exposes neither ahead/behind nor merge state,
-          # so we cannot tell from here; the shepherd agent can inspect a
-          # specific PR if needed.
+          # The Bitbucket list payload exposes neither ahead/behind nor merge
+          # state, so the forge value is always "none"; augment_rebase fills it
+          # from the git-local check for same-repo PRs.
           rebase: "none" } ]'
 }
 bitbucket_meta() { # <number>
@@ -154,6 +166,31 @@ bitbucket_checkout() { # <worktree> <number>
 }
 bitbucket_feedback_cmd() { printf 'provider.sh _bb-comments %q %s' "$REPO" "$1"; }
 bitbucket_comment_cmd()  { printf 'provider.sh _bb-comment %q %s' "$REPO" "$1"; }
+
+# Override each request's `rebase` with an authoritative git-local check, since
+# the forges compute their merge state lazily and often hand back a stale value.
+# Reads a normalized JSON array (each element carrying a helper `base` field) on
+# stdin, fetches origin once, and for every request whose head+base resolve
+# locally replaces `rebase` with rebase-check.sh's verdict (origin/<base> vs
+# origin/<head>). Unresolvable heads (fork PRs) keep the forge's value. The helper
+# `base` field is stripped so the emitted shape matches the normalized contract.
+augment_rebase() {
+  raw="$(cat)"
+  [ -n "$raw" ] || { echo '[]'; return; }
+  [ "$(printf '%s' "$raw" | jq 'length')" -gt 0 ] || { printf '%s\n' "$raw"; return; }
+  # One fetch brings every request's base + same-repo head up to date locally.
+  git -C "$REPO" fetch --quiet origin 2>/dev/null || true
+  printf '%s' "$raw" | jq -c '.[]' | while IFS= read -r el; do
+    head="$(printf '%s' "$el" | jq -r '.branch // empty')"
+    base="$(printf '%s' "$el" | jq -r '.base // empty')"
+    rb="$(printf '%s' "$el" | jq -r '.rebase // "none"')"
+    if [ -n "$head" ] && [ -n "$base" ]; then
+      local_rb="$("$HERE/rebase-check.sh" "$REPO" "origin/$base" "origin/$head" 2>/dev/null || echo unknown)"
+      case "$local_rb" in none|NEEDED|CONFLICT) rb="$local_rb" ;; esac
+    fi
+    printf '%s' "$el" | jq -c --arg rb "$rb" '.rebase = $rb | del(.base)'
+  done | jq -s '.'
+}
 
 # What the agent reads to DECIDE how to handle this repo's forge each time:
 # the remote, the best forge guess, and which clients are installed. For a
@@ -182,7 +219,7 @@ PROV="$(resolve_provider)"
 case "$VERB" in
   provider-of)   echo "$PROV" ;;
   describe)      describe ;;
-  list)          "${PROV}_list" "${1:?author}" ;;
+  list)          "${PROV}_list" "${1:?author}" | augment_rebase ;;
   meta)          "${PROV}_meta" "${1:?number}" ;;
   checkout)      "${PROV}_checkout" "${1:?worktree}" "${2:?number}" ;;
   feedback-cmd)  "${PROV}_feedback_cmd" "${1:?number}" ;;

--- a/extensions/ci-shepherd/scripts/rebase-check.bats
+++ b/extensions/ci-shepherd/scripts/rebase-check.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Tests for rebase-check.sh — the git-local "is this head behind its base?" check.
+# Each test builds a throwaway repo with a known base/head topology, so they run
+# anywhere git is installed with no live forge:
+#   bats extensions/ci-shepherd/scripts/rebase-check.bats
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/rebase-check.sh"
+  REPO="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$REPO"
+  git -C "$REPO" init -q -b main
+  git -C "$REPO" config user.email t@t.t
+  git -C "$REPO" config user.name t
+  # Seed: a base branch `main` with one commit, and a `feat` branch off it.
+  printf 'base\n' > "$REPO/file.txt"
+  git -C "$REPO" add file.txt
+  git -C "$REPO" commit -qm "base commit"
+  git -C "$REPO" branch feat
+}
+
+# Advance main by one commit (so feat falls behind). $1 = the file content added.
+advance_main() {
+  printf '%s\n' "$1" >> "$REPO/file.txt"
+  git -C "$REPO" add file.txt
+  git -C "$REPO" commit -qm "advance main"
+}
+
+@test "syntax is valid" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "up to date (base is an ancestor of head) is none" {
+  run "$SCRIPT" "$REPO" main feat
+  [ "$status" -eq 0 ]
+  [ "$output" = "none" ]
+}
+
+@test "head behind base with a clean rebase is NEEDED" {
+  # main moves ahead on a NEW line; feat is untouched -> behind but no conflict.
+  printf 'base\nmore\n' > "$REPO/file.txt"
+  git -C "$REPO" add file.txt
+  git -C "$REPO" commit -qm "advance main cleanly"
+  run "$SCRIPT" "$REPO" main feat
+  [ "$status" -eq 0 ]
+  [ "$output" = "NEEDED" ]
+}
+
+@test "head diverged from base into a conflict is CONFLICT" {
+  # Both branches edit the SAME line differently -> a merge/rebase conflicts.
+  git -C "$REPO" checkout -q feat
+  printf 'feat-change\n' > "$REPO/file.txt"
+  git -C "$REPO" add file.txt
+  git -C "$REPO" commit -qm "feat edits the line"
+  git -C "$REPO" checkout -q main
+  printf 'main-change\n' > "$REPO/file.txt"
+  git -C "$REPO" add file.txt
+  git -C "$REPO" commit -qm "main edits the same line"
+  run "$SCRIPT" "$REPO" main feat
+  [ "$status" -eq 0 ]
+  [ "$output" = "CONFLICT" ]
+}
+
+@test "an unresolvable head ref is unknown (exit 3)" {
+  run "$SCRIPT" "$REPO" main does-not-exist
+  [ "$status" -eq 3 ]
+  [ "$output" = "unknown" ]
+}
+
+@test "an unresolvable base ref is unknown (exit 3)" {
+  run "$SCRIPT" "$REPO" origin/missing feat
+  [ "$status" -eq 3 ]
+  [ "$output" = "unknown" ]
+}
+
+@test "missing arguments is a usage error (exit 2)" {
+  run "$SCRIPT" "$REPO" main
+  [ "$status" -eq 2 ]
+}

--- a/extensions/ci-shepherd/scripts/rebase-check.sh
+++ b/extensions/ci-shepherd/scripts/rebase-check.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# rebase-check.sh — authoritative, git-local "is this head behind its base?" check.
+#
+# The forges compute their merge state lazily and asynchronously (GitHub's
+# mergeStateStatus, GitLab's diverged_commits_count), so an API read frequently
+# returns a stale/UNKNOWN value and a genuinely behind branch never gets flagged.
+# This script answers the same question from git directly: given two already-
+# resolvable refs (typically remote-tracking refs the caller just fetched), it
+# tells whether <head> needs to be brought up to date with <base>.
+#
+# Usage:  rebase-check.sh <repo> <base-ref> <head-ref>
+#
+# Prints exactly one of:
+#   none      — <base> is already contained in <head>; up to date, nothing to do
+#   NEEDED    — <head> is behind <base> and a rebase would apply cleanly
+#   CONFLICT  — <head> has diverged from <base> so far it no longer merges cleanly
+#   unknown   — a ref could not be resolved (e.g. a fork head not on origin);
+#               the caller should fall back to the forge's own value (exit 3)
+#
+# It is pure and side-effect-free over the two refs (no fetch, no working-tree
+# mutation), so it unit-tests against a throwaway repo with no live forge.
+
+set -euo pipefail
+
+REPO="${1:-}"; BASE="${2:-}"; HEAD="${3:-}"
+[ -n "$REPO" ] && [ -n "$BASE" ] && [ -n "$HEAD" ] \
+  || { echo "usage: rebase-check.sh <repo> <base-ref> <head-ref>" >&2; exit 2; }
+[ -d "$REPO" ] || { echo "repo not found: $REPO" >&2; exit 2; }
+
+git_q() { git -C "$REPO" "$@"; }
+
+# Both refs must resolve locally; an unresolvable head (cross-repo/fork PR whose
+# branch was never pushed to origin) is reported as `unknown` so the caller keeps
+# whatever the forge said rather than mis-classifying it.
+git_q rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null 2>&1 \
+  || { echo unknown; exit 3; }
+git_q rev-parse --verify --quiet "${HEAD}^{commit}" >/dev/null 2>&1 \
+  || { echo unknown; exit 3; }
+
+# Up to date: base is already an ancestor of head, so head has every base commit.
+if git_q merge-base --is-ancestor "$BASE" "$HEAD"; then
+  echo none
+  exit 0
+fi
+
+# Behind base. Decide NEEDED vs CONFLICT by test-merging base into head without
+# touching the working tree. `merge-tree --write-tree` (git >= 2.38) exits 0 on a
+# clean merge, 1 on conflicts, >1 on usage error (older git). A merge conflict is
+# a close proxy for a rebase conflict; on older git we can still report NEEDED
+# since we already know the branch is behind.
+set +e
+git_q merge-tree --write-tree "$HEAD" "$BASE" >/dev/null 2>&1
+rc=$?
+set -e
+case "$rc" in
+  0) echo NEEDED ;;
+  1) echo CONFLICT ;;
+  *) echo NEEDED ;;
+esac


### PR DESCRIPTION
## Problem

ci-shepherd's "needs rebase / behind target" detection relied on the forge's
merge state (GitHub `mergeStateStatus`, GitLab `diverged_commits_count`), which
forges compute **lazily and asynchronously**. On API reads it's frequently
`UNKNOWN`/stale, so PRs genuinely behind their target branch never got flagged
`REBASE` and were silently left out of date.

## Fix

Detect behind-base/diverged state **locally from git** by fetching `origin` and
testing the head against its base — the extension's "only git is baked in"
principle.

- **New `scripts/rebase-check.sh <repo> <base-ref> <head-ref>`** — pure,
  side-effect-free git check over two refs → prints `none` / `NEEDED` /
  `CONFLICT` (via `git merge-base --is-ancestor` + `git merge-tree --write-tree`),
  or `unknown` (exit 3) when a ref can't be resolved.
- **`scripts/provider.sh`** — each `*_list` now emits a helper `base` field; the
  `list` verb fetches `origin` once and runs `augment_rebase`, which overrides
  every request's `rebase` with the authoritative `rebase-check.sh` verdict
  (`origin/<base>` vs `origin/<head>`). The forge value is kept only as a
  fallback for fork heads not on `origin`. The helper `base` field is stripped,
  so the normalized output shape — and `classify.sh` — is unchanged.
- **`scripts/rebase-check.bats`** — temp-repo fixtures: up-to-date / behind-clean
  / diverged-conflict / unresolvable-ref / usage-error.
- Docs (`SHEPHERD.md`, `README.md`) updated to note the git-local detection.

## Verification

- `shellcheck` clean on all scripts; `rumdl` clean on the docs.
- `rebase-check.sh` manually exercised: up-to-date→`none`, behind→`NEEDED`,
  diverged→`CONFLICT`, missing head→`unknown`/exit 3.
- `augment_rebase` against a repo with `origin` refs: a behind PR the forge
  reported as `none` is now correctly surfaced as `NEEDED`.

Closes the detection gap in Thurbox task #35.