### PR TITLE
fix: relay flow answers to workers by matching real session names

### DIFF
--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -55,8 +55,9 @@ new, unrelated work. See the ANSWER section.
 ./scripts/flow-snapshot.sh
 ```
 
-This prints the backlog grouped by status plus the live `task-*` / `flow`
-sessions. Also read `./repos.md` — the repo routing table (name → path →
+This prints the backlog grouped by status plus the live `flow` / worker
+(`… · #<id>`) sessions, each tagged with its `#<id>`. Also read `./repos.md` —
+the repo routing table (name → path →
 base branch → keywords). If a repo mentioned by the user is missing from
 the table, add a row when you learn its path.
 
@@ -151,7 +152,7 @@ and a worker's `result` message wakes you the moment it finishes — never wait
 for the cron tick to dispatch something that is eligible NOW.
 
 - Eligible: `status=todo` AND has a spawn action AND capacity OK
-  (**max 3** running `task-*` sessions).
+  (**max 3** running worker (`… · #<id>`) sessions).
 - Dispatch: `thurbox-cli task run <id>` — this spawns the worker session,
   seeds the full task prompt, and advances todo → in_progress. Re-running
   on a non-todo task is harmless (it only reuses the window), so never
@@ -208,7 +209,8 @@ When the user replies to questions or a plan you surfaced:
 
 1. Identify the waiting worker. Usually it's the one whose message you most
    recently surfaced; map its `#<id>` to the session uuid via `flow-snapshot.sh`
-   / `session list` (session name `task-<id>-…` / `… · #<id>`). If several
+   (its `## sessions` block prints each worker's `#<id>` next to its uuid) or
+   `session list` (session name `… · #<id>`, or legacy `task-<id>-…`). If several
    workers are waiting and the reply doesn't make the target obvious, route by
    content — or ask ONE short routing question (`#<id> or #<id>?`).
 2. Relay the reply verbatim into that worker's session:
@@ -230,8 +232,8 @@ stale state.
 
 0. **Print the board.** Run `./scripts/flow-summary.sh` and put its output
    (verbatim, fenced) at the **top** of your reply — a quick-glance table of
-   every live `flow`/`task-*` session joined to its task (status / age /
-   title), plus any `detached` work. This is the one thing a tick always
+   every live `flow` / worker (`… · #<id>`) session joined to its task (status /
+   age / title), plus any `detached` work. This is the one thing a tick always
    shows, even when nothing needs you.
 
 1. **Drain the queue** — run DRAIN (claim the inbox, surface questions/plans,
@@ -240,8 +242,8 @@ stale state.
 2. **Reconcile** each `in_progress` task:
    - Status already flipped to `done` by the worker → note it; session
      cleanup happens in CLEAN.
-   - Worker session (name `task-<id>-…` / `… · #<id>`) missing from the session
-     list → stale: reset to todo (`task edit <id> --status todo`).
+   - Worker session (name `… · #<id>`, or legacy `task-<id>-…`) missing from the
+     session list → stale: reset to todo (`task edit <id> --status todo`).
    - Otherwise it's still working — leave it. (As a last-resort liveness check
      for a worker that died WITHOUT sending a `result`, you may
      `thurbox-cli session capture <uuid> --lines 40` and flag an obvious crash
@@ -269,7 +271,7 @@ One screen max:
 - Duplicate titles → keep oldest, remove the rest (list what was
   removed).
 - `in_progress` with no session → reset to todo.
-- Orphan `task-*` sessions whose task is done/removed →
+- Orphan worker (`… · #<id>`) sessions whose task is done/removed →
   `thurbox-cli session delete <uuid> --force`.
 - **Never** remove a todo without listing it first and getting a yes.
 

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -13,7 +13,7 @@ focus on:
 ```text
 ---
 Needs you: PR #42 has a failing migration — approve the schema change?
-🎯 Next: review task-7-add-rate-limiting (worker finished, PR open)
+🎯 Next: review "Add rate limiting · #7" (worker finished, PR open)
 ```
 
 Flow is **agent-agnostic**, like thurbox itself: the triager and the
@@ -125,8 +125,8 @@ tagged URL (`…/thurbox/v0.112.0/extensions/flow`) instead.
   each tagged by its `#<id>`.
 - `status` for a one-screen report; `clean` to groom the backlog.
 - Every tick prints a **board** — a quick-glance table of all live
-  `flow`/`task-*` sessions with status, age, and the task they're working
-  (`scripts/flow-summary.sh`) — so you can see the whole picture at once. The
+  `flow` / worker (`… · #<id>`) sessions with status, age, and the task they're
+  working (`scripts/flow-summary.sh`) — so you can see the whole picture at once. The
   `flow-tick` automation is now a **safety net**: worker pushes drive the
   interactive loop; the cron tick just drains anything a missed wake left queued
   and grooms stale state.

--- a/extensions/flow/scripts/flow-sessions.bats
+++ b/extensions/flow/scripts/flow-sessions.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# Tests for the worker-session matching in flow-snapshot.sh / flow-summary.sh.
+# Worker sessions are named "<title> · #<id>" (current) or "task-<id>[-…]"
+# (legacy); both scripts must list them and map them to their task #<id> so the
+# flow agent can resolve a worker's session uuid for `session send`. A stub
+# `thurbox-cli` on PATH feeds canned `session list` / `task list` JSON, so these
+# run anywhere bats + jq are installed.
+
+setup() {
+  SNAPSHOT="${BATS_TEST_DIRNAME}/flow-snapshot.sh"
+  SUMMARY="${BATS_TEST_DIRNAME}/flow-summary.sh"
+
+  STUBDIR="$(mktemp -d)"
+  # A worker per naming convention, the flow monitor, and a non-worker shell.
+  cat >"${STUBDIR}/sessions.json" <<'JSON'
+[
+  {"name":"flow","id":"uuid-flow","agent":"flow","cwd":"/home/me/flow"},
+  {"name":"Wire up SSH backend · #42","id":"uuid-42","agent":"flow-worker","cwd":"/repo"},
+  {"name":"task-7-add-rate-limiting","id":"uuid-7","agent":"flow-worker","cwd":"/repo"},
+  {"name":"task-9","id":"uuid-9","agent":"flow-worker","cwd":"/repo"},
+  {"name":"Some random shell","id":"uuid-x","agent":"shell","cwd":"/x"}
+]
+JSON
+  # #42 and #7 have live sessions; #4 is in_progress with NO session (detached);
+  # #9 is done. #4 exercises the #4-vs-#42 boundary in the footer.
+  cat >"${STUBDIR}/tasks.json" <<'JSON'
+[
+  {"id":42,"title":"Wire up SSH backend","status":"in_progress","created_at":1700000000000},
+  {"id":7,"title":"Add rate limiting","status":"in_progress","created_at":1700000000000},
+  {"id":4,"title":"Edit README","status":"in_progress","created_at":1700000000000},
+  {"id":9,"title":"Done thing","status":"done","created_at":1700000000000}
+]
+JSON
+
+  mkdir -p "${STUBDIR}/bin"
+  cat >"${STUBDIR}/bin/thurbox-cli" <<EOF
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "task list")    cat "${STUBDIR}/tasks.json" ;;
+  "session list") cat "${STUBDIR}/sessions.json" ;;
+  *) echo "[]" ;;
+esac
+EOF
+  chmod +x "${STUBDIR}/bin/thurbox-cli"
+  PATH="${STUBDIR}/bin:${PATH}"
+}
+
+teardown() {
+  rm -rf "${STUBDIR}"
+}
+
+@test "snapshot syntax is valid" {
+  run bash -n "$SNAPSHOT"
+  [ "$status" -eq 0 ]
+}
+
+@test "summary syntax is valid" {
+  run bash -n "$SUMMARY"
+  [ "$status" -eq 0 ]
+}
+
+@test "snapshot lists current and legacy worker sessions, tagged with #<id>" {
+  run "$SNAPSHOT"
+  [ "$status" -eq 0 ]
+  # Current "<title> · #<id>" worker — the case the bug used to drop.
+  [[ "$output" == *"#42  Wire up SSH backend · #42  uuid-42"* ]]
+  # Legacy "task-<id>-…" and bare "task-<id>" still resolve.
+  [[ "$output" == *"#7  task-7-add-rate-limiting  uuid-7"* ]]
+  [[ "$output" == *"#9  task-9  uuid-9"* ]]
+  # The flow monitor is listed (untagged).
+  [[ "$output" == *"—  flow  uuid-flow"* ]]
+  # A non-worker session is excluded.
+  [[ "$output" != *"Some random shell"* ]]
+}
+
+@test "summary board joins workers to their tasks" {
+  run "$SUMMARY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"#42"* ]]
+  [[ "$output" == *"Wire up SSH backend"* ]]
+  [[ "$output" == *"#7"* ]]
+  [[ "$output" == *"Add rate limiting"* ]]
+  [[ "$output" == *"monitor"* ]]          # the flow row
+  [[ "$output" != *"Some random shell"* ]]
+}
+
+@test "summary footer flags only the detached task, honoring the #4 vs #42 boundary" {
+  run "$SUMMARY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"## detached"* ]]
+  # Footer lines start with two spaces ("  #<id> <title>"), board rows start at
+  # column 0 — so the two-space prefix targets the footer regardless of whether
+  # `column` is installed (the no-column path collapses tabs to single spaces).
+  # #4 has no session (the "· #42" session must NOT match id 4).
+  [[ "$output" == *"  #4 Edit README"* ]]
+  # #42 and #7 have live sessions; #9 is done — none are detached.
+  [[ "$output" != *"  #42 Wire up SSH backend"* ]]
+  [[ "$output" != *"  #7 Add rate limiting"* ]]
+  [[ "$output" != *"  #9 Done thing"* ]]
+}

--- a/extensions/flow/scripts/flow-snapshot.sh
+++ b/extensions/flow/scripts/flow-snapshot.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # flow-snapshot.sh — one-call compact view of the flow agent's world:
-# the task backlog grouped by status + the live flow / task-* sessions.
+# the task backlog grouped by status + the live flow / worker sessions.
 # Keeps the triager to a single shell call per mode.
 
 set -euo pipefail
@@ -24,11 +24,22 @@ else
 fi
 
 echo
-echo "## sessions (flow / task-*)"
+echo "## sessions (flow / workers)"
+# Worker sessions are named "<title> · #<id>" (current) or "task-<id>[-…]"
+# (legacy) — mirror Task::matches_spawn_session. The derived #<id> is printed
+# first so ANSWER can map a task id straight to the session uuid for
+# `session send`.
 if SESSIONS="$(thurbox-cli session list 2>/dev/null)"; then
   printf '%s' "$SESSIONS" | jq -r '
-    .[] | select(.name == "flow" or (.name | startswith("task-"))) |
-    "  \(.name)  \(.id)  agent=\(.agent)  cwd=\(.cwd)"
+    .[]
+    # extract <id> from "<title> · #<id>" (current) or "task-<id>[-…]" (legacy);
+    # null for the flow session and any non-worker session
+    | (.name
+       | (([scan(" · #([0-9]+)$")] | (first // [])[0])
+          // ([scan("^task-([0-9]+)(?:-|$)")] | (first // [])[0]))) as $tid
+    | select(.name == "flow" or $tid != null)
+    | (if $tid then "#\($tid)" else "—" end) as $idtag
+    | "  \($idtag)  \(.name)  \(.id)  agent=\(.agent)  cwd=\(.cwd)"
   ' 2>/dev/null || true
 else
   echo "  (thurbox-cli session list failed)"

--- a/extensions/flow/scripts/flow-summary.sh
+++ b/extensions/flow/scripts/flow-summary.sh
@@ -3,10 +3,11 @@
 # their tasks (status / age / title). Printed at the top of every TICK so the
 # user can see the whole board without parsing verbose worker output.
 #
-# Each row is one live `flow` / `task-*` session. `task-<id>-…` sessions are
-# joined to task #<id> for status, age (from created_at) and title; a session
-# whose task is gone shows "orphan", and tasks whose worker session is missing
-# are listed under a "detached" footer line (so stale work isn't silently lost).
+# Each row is one live `flow` / worker session. Worker sessions are named
+# "<title> · #<id>" (current) or "task-<id>[-…]" (legacy); they are joined to
+# task #<id> for status, age (from created_at) and title; a session whose task
+# is gone shows "orphan", and tasks whose worker session is missing are listed
+# under a "detached" footer line (so stale work isn't silently lost).
 #
 # Columns: ID  SESSION  AGENT  STATUS  AGE  TITLE
 # Status glyphs: ◆ monitor (flow) · ● running · ○ queued · ✔ done · ⚠ orphan
@@ -38,9 +39,12 @@ ROWS="$(printf '%s' "$SESSIONS" | jq -r --argjson tasks "$TASKS" '
     else $st end;
 
   [ .[]
-    | select(.name == "flow" or (.name | startswith("task-")))
-    # extract <id> from a task-<id>-… session name (null for the flow session)
-    | (.name | [scan("^task-([0-9]+)-")] | (first // [])[0]) as $tid
+    # extract <id> from "<title> · #<id>" (current) or "task-<id>[-…]" (legacy);
+    # null for the flow session and any non-worker session
+    | (.name
+       | (([scan(" · #([0-9]+)$")] | (first // [])[0])
+          // ([scan("^task-([0-9]+)(?:-|$)")] | (first // [])[0]))) as $tid
+    | select(.name == "flow" or $tid != null)
     | (if $tid then $byid[$tid] else null end) as $task
     | {
         id:      (if $tid then "#\($tid)" else "—" end),
@@ -76,12 +80,21 @@ else
   printf '%s\n' "$ROWS" | tr '\t' ' '
 fi
 
-# Footer: tasks that are in_progress but whose worker session is gone (detached)
+# Footer: tasks that are in_progress but whose worker session is gone (detached).
+# A session belongs to task <id> when its name ends with " · #<id>" (current) or
+# equals "task-<id>" / starts with "task-<id>-" (legacy) — mirrors
+# Task::matches_spawn_session.
 DETACHED="$(printf '%s' "$TASKS" | jq -r --argjson sessions "$SESSIONS" '
   ($sessions | map(.name)) as $names |
+  # does session name $n belong to task $id?
+  def belongs($n; $id):
+    ($n | endswith(" · #\($id)"))
+    or ($n == "task-\($id)")
+    or ($n | startswith("task-\($id)-"));
   .[]
   | select(.status == "in_progress")
-  | select( [ $names[] | startswith("task-\(.id|tostring)-") ] | any | not )
+  | (.id|tostring) as $id
+  | select( [ $names[] | belongs(.; $id) ] | any | not )
   | "  #\(.id) \(.title)"
 ' 2>/dev/null || true)"
 


### PR DESCRIPTION
## Summary

- Fixes the flow extension's broken flow→worker answer relay: worker sessions are named `<title> · #<id>` (`Task::spawn_session_name`), but `flow-snapshot.sh`/`flow-summary.sh` still filtered/parsed by the obsolete `task-<id>-…` pattern, so workers were invisible to flow and the user's answers never reached them via `session send`.
- Both scripts now match the current `<title> · #<id>` naming (keeping legacy `task-<id>[-…]` support), mirroring `Task::matches_spawn_session`; `flow-snapshot.sh` also prints each worker's derived `#<id>` next to its uuid so ANSWER routing is direct.
- Fixes `flow-summary.sh`'s row filter, id extraction, and detached-footer check (live workers were being mislabeled "detached").
- Aligns FLOW.md/README.md wording to lead with the current naming.

## Test plan

- New `extensions/flow/scripts/flow-sessions.bats`: current/legacy worker listing, non-worker exclusion, task joins, and the `#4`-vs-`#42` detached-footer boundary.
- `shellcheck` + `rumdl` clean; Rust naming-contract tests (`spawn_session_name`, `matches_spawn_session`) still pass.
- CI checks pass.