### PR TITLE
docs: restructure website nav and link home feature cards

### DIFF
--- a/website/_includes/sidebar.njk
+++ b/website/_includes/sidebar.njk
@@ -1,15 +1,19 @@
 {%- set sections = [
   { heading: "Getting Started", links: [
-    { slug: "installation", href: "installation.html", label: "Installation" },
-    { slug: "features", href: "features.html", label: "Features" },
-    { slug: "keybindings", href: "keybindings.html", label: "Keybindings" }
+    { slug: "installation", href: "installation.html", label: "Installation" }
   ]},
-  { heading: "Extensions", links: [
+  { heading: "Features", links: [
+    { slug: "features", href: "features.html", label: "Overview" },
+    { subheading: "Extensions" },
     { slug: "extensions", href: "extensions.html", label: "Overview" },
     { slug: "extension-flow", href: "extension-flow.html", label: "Flow" },
     { slug: "extension-forge", href: "extension-forge.html", label: "Forge" },
     { slug: "extension-ci-shepherd", href: "extension-ci-shepherd.html", label: "CI-shepherd" },
     { slug: "extension-renovate", href: "extension-renovate.html", label: "Renovate" }
+  ]},
+  { heading: "Configurations", links: [
+    { slug: "configuration", href: "configuration.html", label: "Configuration" },
+    { slug: "keybindings", href: "keybindings.html", label: "Keybindings" }
   ]},
   { heading: "Reference", links: [
     { slug: "architecture", href: "architecture.html", label: "Architecture" }
@@ -23,6 +27,9 @@
   <h4>{{ section.heading }}</h4>
   <ul>
     {%- for link in section.links %}
+    {%- if link.subheading %}
+    <li class="sidebar-subheading">{{ link.subheading }}</li>
+    {%- else %}
     <li>
       <a
         href="{{ link.href }}"
@@ -30,6 +37,7 @@
         >{{ link.label }}</a
       >
     </li>
+    {%- endif %}
     {%- endfor %}
   </ul>
   {%- endfor %}

--- a/website/css/docs.css
+++ b/website/css/docs.css
@@ -43,6 +43,15 @@
   margin: 0 0 var(--space-sm) 0;
 }
 
+.docs-sidebar .sidebar-subheading {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 0.35rem 0.75rem 0.1rem;
+}
+
 .docs-sidebar li {
   margin: 0;
 }

--- a/website/css/landing.css
+++ b/website/css/landing.css
@@ -135,6 +135,27 @@
   background: var(--bg-secondary);
 }
 
+.feature-link {
+  display: block;
+  text-decoration: none;
+}
+
+.feature-link .card {
+  height: 100%;
+}
+
+.feature-link .card h3 {
+  color: var(--text-primary);
+}
+
+.feature-link:hover .card {
+  border-color: var(--text-muted);
+}
+
+.feature-link:hover .card h3 {
+  color: var(--cyan);
+}
+
 .features .card-icon {
   display: inline-flex;
   align-items: center;

--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -1,0 +1,539 @@
+---
+layout: docs.njk
+title: 'Configuration — Thurbox Docs'
+description: 'Every config file and knob Thurbox reads: agents.toml, hosts.toml, settings.toml feature flags, themes.toml, keybindings.json, extension manifests, SQLite-backed state, and environment variables.'
+currentPage: 'configuration'
+breadcrumb: 'Configuration'
+onThisPage:
+  - { id: 'files', label: 'Files at a glance' }
+  - { id: 'agents-toml', label: 'agents.toml' }
+  - { id: 'hosts-toml', label: 'hosts.toml' }
+  - { id: 'settings-toml', label: 'settings.toml' }
+  - { id: 'themes-toml', label: 'themes.toml' }
+  - { id: 'keybindings-json', label: 'keybindings.json' }
+  - { id: 'extensions', label: 'Extensions' }
+  - { id: 'sqlite-settings', label: 'SQLite settings' }
+  - { id: 'environment', label: 'Environment variables' }
+  - { id: 'versioning', label: 'Versioning' }
+---
+<h1>Configuration</h1>
+
+          <p>
+            Every knob Thurbox reads, where it lives, and how it behaves. One file per
+            audience/lifecycle: hand-edited registries are TOML, the machine-written keybindings
+            are JSON, and concurrently-written runtime state lives in SQLite.
+          </p>
+          <div class="info-box">
+            <p>
+              <strong>Dev builds</strong>
+              (version
+              <code>0.0.0-dev</code>
+              ) use
+              <code>thurbox-dev</code>
+              in place of
+              <code>thurbox</code>
+              in every path below, plus a
+              <code>thurbox-dev</code>
+              tmux socket, so a development checkout never touches your real setup. All paths
+              respect
+              <code>$XDG_CONFIG_HOME</code>
+              /
+              <code>$XDG_DATA_HOME</code>
+              .
+            </p>
+          </div>
+
+          <h2 id="files">
+            Files at a glance
+            <a href="#files" class="heading-anchor">#</a>
+          </h2>
+          <table>
+            <thead>
+              <tr>
+                <th>File</th>
+                <th>Format</th>
+                <th>Edited by</th>
+                <th>Read</th>
+                <th>Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>~/.config/thurbox/agents.toml</code></td>
+                <td>TOML</td>
+                <td>you</td>
+                <td>live (mtime poll)</td>
+                <td>coding-agent CLI definitions</td>
+              </tr>
+              <tr>
+                <td><code>~/.config/thurbox/hosts.toml</code></td>
+                <td>TOML</td>
+                <td>you</td>
+                <td>startup</td>
+                <td>remote SSH hosts</td>
+              </tr>
+              <tr>
+                <td><code>~/.config/thurbox/settings.toml</code></td>
+                <td>TOML</td>
+                <td>you</td>
+                <td>startup</td>
+                <td>tuning knobs + feature flags</td>
+              </tr>
+              <tr>
+                <td><code>~/.config/thurbox/themes.toml</code></td>
+                <td>TOML</td>
+                <td>you</td>
+                <td>startup</td>
+                <td>custom theme palettes</td>
+              </tr>
+              <tr>
+                <td><code>~/.config/thurbox/keybindings.json</code></td>
+                <td>JSON</td>
+                <td>F1 editor (or you)</td>
+                <td>live (mtime poll)</td>
+                <td>key chord overrides</td>
+              </tr>
+              <tr>
+                <td><code>~/.config/thurbox/extensions/&lt;name&gt;.toml</code></td>
+                <td>TOML</td>
+                <td><code>extension install</code></td>
+                <td>startup + tick</td>
+                <td>extension manifests (self-healed resources)</td>
+              </tr>
+              <tr>
+                <td><code>~/.local/share/thurbox/thurbox.db</code></td>
+                <td>SQLite</td>
+                <td>thurbox</td>
+                <td>live</td>
+                <td>sessions, automations, tasks, theme, editor command</td>
+              </tr>
+              <tr>
+                <td><code>~/.local/share/thurbox/thurbox.log</code></td>
+                <td>text</td>
+                <td>thurbox</td>
+                <td>&mdash;</td>
+                <td>logs (incl. config warnings)</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            <code>agents.toml</code>
+            and
+            <code>keybindings.json</code>
+            reload
+            <strong>live</strong>
+            : the TUI polls their mtime (~1/s) and applies edits with a confirmation toast &mdash;
+            no restart.
+            <code>hosts.toml</code>
+            ,
+            <code>settings.toml</code>
+            , and
+            <code>themes.toml</code>
+            need a restart.
+          </p>
+          <p>
+            Config problems are
+            <strong>not silent</strong>
+            : parse errors, unknown fields, invalid chords, and chord conflicts surface as a
+            status-bar toast on startup (and in the log file). Unknown TOML keys are tolerated and
+            reported by name, while syntax/type errors fall back to built-ins (agents), zero hosts,
+            or defaults (settings). Check everything from the command line:
+          </p>
+          <pre><code>thurbox-cli config validate   # strict parse of every file; exit 1 on problems
+thurbox-cli config show       # effective config + where each value came from</code></pre>
+
+          <h2 id="agents-toml">
+            agents.toml
+            <a href="#agents-toml" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Declares the launchable coding agents. Seeded with the built-ins (
+            <code>claude</code>
+            ,
+            <code>codex</code>
+            ,
+            <code>gemini</code>
+            ,
+            <code>opencode</code>
+            ,
+            <code>aider</code>
+            ,
+            <code>vibe</code>
+            ) on first run; edit or add
+            <code>[[agents]]</code>
+            entries to support any CLI &mdash; no recompile. A malformed file falls back to the
+            built-ins and shows the error.
+          </p>
+          <pre><code>config_version = 1
+default = "claude"          # agent preselected in the picker / headless spawns
+
+[[agents]]
+name = "claude"             # display + lookup name (unique)
+command = "claude"          # executable
+args = []                   # always passed; bake a model here if you want one
+resume_args = ["--resume", "{id}"]            # emitted when resuming
+fork_args = ["--resume", "{id}", "--fork-session"]
+new_session_args = ["--session-id", "{id}"]   # emitted on a fresh spawn
+resume_latest = false       # true = id-less "resume last session in cwd"</code></pre>
+          <p>
+            <code>{id}</code>
+            is substituted with the thurbox-generated session UUID. Groups are emitted only when
+            their driving value exists; precedence is fork &gt; resume &gt; new-session.
+          </p>
+
+          <h2 id="hosts-toml">
+            hosts.toml
+            <a href="#hosts-toml" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Declares remote SSH hosts; each
+            <code>[[hosts]]</code>
+            entry registers a session backend named
+            <code>ssh:&lt;name&gt;</code>
+            . Seeded fully commented-out (fresh installs are local-only). A malformed file means
+            zero remote hosts and shows the error.
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Field</th>
+                <th>Required</th>
+                <th>Default</th>
+                <th>Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>name</code></td>
+                <td>yes</td>
+                <td>&mdash;</td>
+                <td>backend id <code>ssh:&lt;name&gt;</code>; what <code>--host</code> expects</td>
+              </tr>
+              <tr>
+                <td><code>destination</code></td>
+                <td>yes</td>
+                <td>&mdash;</td>
+                <td>ssh target (<code>user@host</code> or <code>~/.ssh/config</code> alias)</td>
+              </tr>
+              <tr>
+                <td><code>ssh_opts</code></td>
+                <td>no</td>
+                <td><code>[]</code></td>
+                <td>extra ssh flags, one token per element</td>
+              </tr>
+              <tr>
+                <td><code>socket</code></td>
+                <td>no</td>
+                <td><code>thurbox</code></td>
+                <td>remote <code>tmux -L</code> socket</td>
+              </tr>
+              <tr>
+                <td><code>session</code></td>
+                <td>no</td>
+                <td><code>thurbox</code></td>
+                <td>remote tmux session name</td>
+              </tr>
+              <tr>
+                <td><code>worktrees_dir</code></td>
+                <td>no</td>
+                <td>remote <code>$HOME/.local/share/thurbox/worktrees</code></td>
+                <td>absolute remote worktrees dir</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            Auth comes entirely from your
+            <code>~/.ssh/config</code>
+            ; thurbox never handles credentials. Host changes require a restart.
+          </p>
+
+          <h2 id="settings-toml">
+            settings.toml
+            <a href="#settings-toml" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Scalar tuning knobs plus the
+            <code>[features]</code>
+            switches, seeded fully commented-out (defaults apply when absent). Only knobs a user
+            plausibly wants are exposed; internals stay hardcoded.
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Key</th>
+                <th>Default</th>
+                <th>Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>scrollback_lines</code></td>
+                <td><code>1000</code></td>
+                <td>terminal scrollback kept per session</td>
+              </tr>
+              <tr>
+                <td><code>two_panel_min_cols</code></td>
+                <td><code>80</code></td>
+                <td>width below which only the terminal renders</td>
+              </tr>
+              <tr>
+                <td><code>three_panel_min_cols</code></td>
+                <td><code>120</code></td>
+                <td>width unlocking the optional third column</td>
+              </tr>
+              <tr>
+                <td><code>audit_retention_days</code></td>
+                <td><code>90</code></td>
+                <td>audit-log history kept (pruned on startup)</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h3><code>[features]</code> &mdash; whole-feature switches</h3>
+          <p>
+            Turn major TUI features off entirely. All default to
+            <code>true</code>
+            ; like the rest of settings.toml, changes need a restart. A disabled feature's pane
+            never renders, its keybinding shows a status toast instead of acting, and its
+            global-search scope returns no results. Data is never touched, so re-enabling a flag is
+            lossless.
+          </p>
+          <pre><code>[features]
+tasks = true          # F5/Ctrl+W tasks panel
+automations = true    # automations pane, Ctrl+P, schedule firing
+file_viewer = true    # F3/Ctrl+E file viewer
+global_search = true  # Ctrl+A search strip
+info_panel = true     # F2/Ctrl+B info panel
+shell_pane = true     # Ctrl+T per-session shell
+mouse = true          # mouse capture: clicks, wheel, drag-select, hover</code></pre>
+          <p>
+            <code>automations = false</code>
+            is the one flag with teeth beyond the UI: it also stops the TUI from firing due
+            schedules and arming the tmux heartbeat at startup (explicit
+            <code>thurbox-cli automation</code>
+            commands still work).
+            <code>mouse = false</code>
+            skips terminal mouse capture entirely, so the terminal keeps its native mouse behavior.
+          </p>
+
+          <h2 id="themes-toml">
+            themes.toml
+            <a href="#themes-toml" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            User-defined themes, offered in the
+            <code>Ctrl+Y</code>
+            picker alongside the nine built-in presets and persisted by
+            <code>name</code>
+            like any preset. Each
+            <code>[[themes]]</code>
+            entry starts from a built-in
+            <code>base</code>
+            and overrides only the colours it names:
+          </p>
+          <pre><code>[[themes]]
+name = "my-mocha"            # stable id; must not shadow a built-in
+display_name = "My Mocha"    # picker label (default: name)
+base = "catppuccin-mocha"    # starting palette (default: default)
+accent = "#fab387"
+app_bg = "reset"             # keep the terminal's native background</code></pre>
+          <p>
+            Colours accept anything ratatui parses:
+            <code>#rrggbb</code>
+            , ANSI names (
+            <code>red</code>
+            ,
+            <code>lightcyan</code>
+            ), indexed (
+            <code>14</code>
+            ), or
+            <code>reset</code>
+            . Bad colours and built-in name collisions degrade to startup warnings.
+          </p>
+
+          <h2 id="keybindings-json">
+            keybindings.json
+            <a href="#keybindings-json" class="heading-anchor">#</a>
+          </h2>
+          <p>Maps <code>Action</code> names to one or more chord strings:</p>
+          <pre><code>{ "QuitApp": ["ctrl+x"], "OpenThemePicker": ["ctrl+y", "f4"] }</code></pre>
+          <ul>
+            <li>
+              The preferred editing path is the
+              <strong>F1 panel</strong>
+              (live capture, conflict stealing, immediate persistence). Hand-edits are read at
+              startup and live via mtime poll.
+            </li>
+            <li>
+              Chord syntax:
+              <code>[ctrl+][alt+][shift+][cmd+]&lt;key&gt;</code>
+              where
+              <code>&lt;key&gt;</code>
+              is a letter,
+              <code>f1</code>
+              &ndash;
+              <code>f12</code>
+              , or a named key (
+              <code>enter</code>
+              ,
+              <code>esc</code>
+              ,
+              <code>tab</code>
+              , arrows,
+              <code>home</code>
+              ,
+              <code>end</code>
+              ,
+              <code>pageup</code>
+              ,
+              <code>pagedown</code>
+              ,
+              <code>backspace</code>
+              ,
+              <code>delete</code>
+              ,
+              <code>insert</code>
+              ). Case-insensitive.
+              <code>cmd</code>
+              (aliases
+              <code>super</code>
+              ,
+              <code>command</code>
+              ,
+              <code>win</code>
+              ) is the macOS Command key, delivered only by kitty-keyboard-protocol terminals.
+            </li>
+            <li>
+              Unknown action names, invalid chords, and the same chord bound to two actions in
+              overlapping contexts are reported at startup (the file still loads; bad entries fall
+              back to defaults).
+            </li>
+          </ul>
+          <p>
+            See the
+            <a href="keybindings.html">Keybindings</a>
+            page for the full default chord table.
+          </p>
+
+          <h2 id="extensions">
+            Extensions
+            <a href="#extensions" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Each opt-in extension is described by a single
+            <code>extension.toml</code>
+            manifest.
+            <code>thurbox-cli extension install</code>
+            writes the home-resolved copy to
+            <code>~/.config/thurbox/extensions/&lt;name&gt;.toml</code>
+            (thurbox never seeds this dir). The manifest has an
+            <strong>install</strong>
+            spec and a
+            <strong>runtime</strong>
+            spec; see the
+            <a href="extensions.html">Extensions</a>
+            page for the full manifest format, lifecycle commands, and versioning.
+          </p>
+          <pre><code>thurbox-cli extension install flow         # fetch + lay files + agents + activate
+thurbox-cli extension list                 # installed + active/healthy + version/stale
+thurbox-cli extension update --all         # re-fetch every installed extension
+thurbox-cli extension activate &lt;name&gt;      # (re)create resources + mark active
+thurbox-cli extension deactivate &lt;name&gt;    # tear down + stop self-heal
+thurbox-cli extension status [&lt;name&gt;]      # per-resource presence + version/stale</code></pre>
+
+          <h2 id="sqlite-settings">
+            SQLite-backed settings
+            <a href="#sqlite-settings" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Live in the
+            <code>metadata</code>
+            table and apply immediately (no restart):
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Key</th>
+                <th>Set via</th>
+                <th>Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>active_theme</code></td>
+                <td><code>Ctrl+Y</code> / <code>F4</code> picker</td>
+                <td>TUI palette (nine built-ins)</td>
+              </tr>
+              <tr>
+                <td><code>editor_command</code></td>
+                <td><code>thurbox-cli editor set "&lt;cmd&gt;"</code></td>
+                <td>what <code>Ctrl+O</code> runs</td>
+              </tr>
+              <tr>
+                <td><code>active_extensions</code></td>
+                <td><code>extension activate/deactivate</code></td>
+                <td>JSON array of active extensions to self-heal</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            These are in the DB rather than a file because they are written concurrently by
+            multiple thurbox processes (TUI, CLI, MCP) and picked up live via
+            <code>PRAGMA data_version</code>
+            polling.
+          </p>
+
+          <h2 id="environment">
+            Environment variables
+            <a href="#environment" class="heading-anchor">#</a>
+          </h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Variable</th>
+                <th>Used for</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>XDG_CONFIG_HOME</code>, <code>XDG_DATA_HOME</code></td>
+                <td>config/data roots</td>
+              </tr>
+              <tr>
+                <td><code>VISUAL</code>, then <code>EDITOR</code></td>
+                <td><code>Ctrl+O</code> editor when <code>editor_command</code> is unset</td>
+              </tr>
+              <tr>
+                <td><code>SHELL</code></td>
+                <td>the <code>Ctrl+T</code> companion shell pane (fallback <code>/bin/sh</code>)</td>
+              </tr>
+              <tr>
+                <td><code>RUST_LOG</code></td>
+                <td>log filter for <code>thurbox.log</code></td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            Editor resolution order: DB
+            <code>editor_command</code>
+            &rarr;
+            <code>$VISUAL</code>
+            &rarr;
+            <code>$EDITOR</code>
+            &rarr; error toast.
+          </p>
+
+          <h2 id="versioning">
+            Versioning
+            <a href="#versioning" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            The SQLite schema migrates automatically (
+            <code>schema_version</code>
+            in
+            <code>metadata</code>
+            ). The TOML files carry a
+            <code>config_version = 1</code>
+            marker so a future format change can migrate them too; current files are version 1 and
+            the field is optional.
+          </p>

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -9,7 +9,7 @@ onThisPage:
   - { id: 'agent-definitions', label: 'Agent Definitions' }
   - { id: 'automations', label: 'Automations' }
   - { id: 'tasks', label: 'Tasks' }
-  - { id: 'flow-extension', label: 'Flow Extension' }
+  - { id: 'extensions', label: 'Extensions' }
   - { id: 'git-worktrees', label: 'Git Worktrees' }
   - { id: 'remote-ssh-sessions', label: 'Remote SSH Sessions' }
   - { id: 'worktree-sync', label: 'Worktree Sync' }
@@ -293,74 +293,53 @@ onThisPage:
             </li>
           </ul>
 
-          <h2 id="flow-extension">
-            Flow Extension
-            <a href="#flow-extension" class="heading-anchor">#</a>
+          <h2 id="extensions">
+            Extensions
+            <a href="#extensions" class="heading-anchor">#</a>
           </h2>
           <div class="info-box warning">
             <p>
               <strong>Heads up:</strong>
-              The flow extension is a brand-new,
+              Extensions are
               <strong>experimental</strong>
-              feature under active testing &mdash; expect its behavior, spec, and installer to
+              and under active testing &mdash; expect their behavior, specs, and installers to
               change between releases.
             </p>
           </div>
           <p>
-            An opt-in,
+            Opt-in,
             <strong>agent-agnostic</strong>
-            add-on that composes tasks, sessions, worktrees, and automations into a focus-protecting
-            triage workflow: brain-dump at a dedicated cheap
-            <em>flow session</em>
-            and it captures everything into tasks, dispatches the dispatchable ones to worker
-            sessions, monitors them quietly, grooms the backlog, and ends every reply with the
-            single next thing to focus on.
+            add-ons that compose Thurbox through
+            <code>thurbox-cli</code>
+            &mdash; never the binary. Each ships a declarative manifest and installs in one command (
+            <code>thurbox-cli extension install &lt;name&gt;</code>
+            ); while active, Thurbox keeps the extension's sessions and automations
+            <strong>self-healed</strong>
+            , re-creating any you delete until you deactivate it.
           </p>
           <ul>
             <li>
-              The triager and workers are plain
+              Four extensions ship today (all experimental):
+              <strong>flow</strong>
+              (a focus-protecting triage agent),
+              <strong>forge</strong>
+              (a workflow analyst that proposes automations),
+              <strong>ci-shepherd</strong>
+              (watches change requests and dispatches CI/review fixers), and
+              <strong>renovate</strong>
+              (keeps local repos on up-to-date dependencies).
+            </li>
+            <li>
+              An extension registers its agents in
               <code>agents.toml</code>
-              aliases (
-              <code>flow</code>
-              ,
-              <code>flow-worker</code>
-              ,
-              <code>flow-worker-heavy</code>
-              ) &mdash; map them to claude, codex, gemini, opencode, vibe, or anything else. The
-              behavior is one markdown spec (
-              <code>FLOW.md</code>
-              ) surfaced to whichever CLI you pick via
-              <code>CLAUDE.md</code>
-              /
-              <code>AGENTS.md</code>
-              /
-              <code>GEMINI.md</code>
-              symlinks.
+              and lays down its payload from the manifest &mdash; map its worker agents to claude,
+              codex, gemini, opencode, vibe, or anything else.
             </li>
             <li>
-              Dispatch is eager: capture creates the task and spawns its worker in one atomic call,
-              each worker on its own
-              <code>flow/&lt;slug&gt;</code>
-              worktree branch. Every worker runs a
-              <strong>clarify &rarr; plan &rarr; build</strong>
-              contract: ask &ge;3 clarifying questions, then a written plan gated on your approval,
-              then implement.
-            </li>
-            <li>
-              Worker&harr;flow coordination is event-driven over the
-              <a href="#headless-cli">inter-session message queue</a>
-              (
-              <code>message send --kind questions|plan|result</code>
-              ): workers push clean structured payloads that wake flow, flow surfaces them under
-              &ldquo;Needs you,&rdquo; and your answer / approval is relayed back &mdash; no
-              terminal scraping. The cron tick is just a safety net.
-            </li>
-            <li>
-              One-command install:
-              <code>thurbox-cli extension install flow</code>
-              &mdash; see the
+              See the
               <a href="extensions.html">Extensions</a>
-              page for how install, self-heal, and the manifest work.
+              page for the full lifecycle (install, activate, update, self-heal), the manifest
+              format, and a guide to authoring your own.
             </li>
           </ul>
 

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -36,6 +36,17 @@ currentPage: 'index'
                 </p>
               </div>
             </a>
+            <a href="configuration.html" class="docs-hub-card">
+              <div class="card">
+                <div class="card-icon">&#x2699;</div>
+                <h3>Configuration</h3>
+                <p>
+                  Every config file and knob in one place:
+                  <code>agents.toml</code>
+                  , hosts, settings, feature flags, themes, keybindings, and env vars.
+                </p>
+              </div>
+            </a>
             <a href="keybindings.html" class="docs-hub-card">
               <div class="card">
                 <div class="card-icon">&#x2328;</div>

--- a/website/index.html
+++ b/website/index.html
@@ -62,129 +62,147 @@ footer: true
           <p>Everything you need to run coding agents at scale</p>
         </div>
         <div class="grid grid-3">
-          <div class="card">
-            <div class="card-icon">&#x1f5a5;</div>
-            <h3>Persistent Sessions</h3>
-            <p>
-              Run multiple coding-agent CLIs side-by-side, each in its own tmux pane. Sessions
-              persist across crashes, restarts, and multiple concurrent Thurbox instances.
-            </p>
-          </div>
-          <div class="card">
-            <div class="card-icon">&#x1f333;</div>
-            <h3>Git Worktrees &amp; Sync</h3>
-            <p>
-              Spawn sessions in isolated git worktrees for branch-level isolation. One-key sync (
-              <code>Ctrl+S</code>
-              ) rebases all worktrees from origin/main, with automatic conflict resolution and
-              worktree cleanup on session close.
-            </p>
-          </div>
-          <div class="card">
-            <div class="card-icon">&#x1f916;</div>
-            <h3>Any Coding Agent</h3>
-            <p>
-              A session runs one agent of your choice &mdash; Claude Code, Codex, Gemini CLI,
-              opencode, aider, Vibe, or any CLI you describe. Each agent runs with its own default
-              config. Mix different agents across the sidebar.
-            </p>
-          </div>
-          <div class="card">
-            <div class="card-icon">&#x1f6e1;</div>
-            <h3>Agent Definitions</h3>
-            <p>
-              Agents are declared as data in
-              <code>~/.config/thurbox/agents.toml</code>
-              , seeded with built-ins on first run. Add or tweak an agent &mdash; command and
-              argument templates &mdash; with no recompile.
-            </p>
-          </div>
-          <div class="card">
-            <div class="card-icon">&#x23f0;</div>
-            <h3>Automations</h3>
-            <p>
-              Named, scheduled agent runs &mdash; one-shot or recurring (cron, with
-              <code>daily</code>
-              /
-              <code>weekly</code>
-              presets). On schedule they
-              <strong>send</strong>
-              a prompt to a session or
-              <strong>spawn</strong>
-              a fresh one. Manage them from the always-on
-              <code>Ctrl+P</code>
-              pane (or the
-              <code>thurbox-cli</code>
-              headless binary); they fire even when the TUI is closed.
-            </p>
-          </div>
-          <div class="card">
-            <div class="card-icon">&#x2611;</div>
-            <h3>Tasks</h3>
-            <p>
-              A built-in todo list whose items
-              <strong>connect to a coding agent</strong>
-              &mdash;
-              <strong>send</strong>
-              the title to a session or
-              <strong>spawn</strong>
-              a fresh one. Toggle the panel with
-              <code>Ctrl+W</code>
-              ; edit in place, cycle status, and trigger the action with
-              <code>r</code>
-              .
-            </p>
-          </div>
-          <div class="card">
-            <div class="card-icon">&#x1f9e9;</div>
-            <h3>Extensions</h3>
-            <p>
-              Opt-in,
-              <strong>agent-agnostic</strong>
-              add-ons that compose Thurbox through
-              <code>thurbox-cli</code>
-              &mdash; never the binary. Install each from a declarative manifest in one command (
-              <code>thurbox-cli extension install &lt;name&gt;</code>
-              ), and Thurbox keeps its session and automation
-              <strong>self-healed</strong>
-              . Ships flow, forge, ci-shepherd, and renovate (all experimental) &mdash;
-              <a href="docs/extensions.html">browse the extensions</a>
-              .
-            </p>
-          </div>
-          <div class="card">
-            <div class="card-icon">&#x1f50d;</div>
-            <h3>Global Search</h3>
-            <p>
-              One key (
-              <code>Ctrl+A</code>
-              ) searches
-              <strong>every scope at once</strong>
-              &mdash; sessions (incl. live terminal content), tasks, automations, and files &mdash;
-              with matches highlighted live in the panels themselves.
-            </p>
-          </div>
-          <div class="card">
-            <div class="card-icon">&#x1f9e9;</div>
-            <h3>Persistent tmux Sessions</h3>
-            <p>
-              Every session runs in a dedicated
-              <code>tmux -L thurbox</code>
-              pane behind a single
-              <code>SessionBackend</code>
-              trait, so sessions survive crashes, restarts, and detaches.
-            </p>
-          </div>
-          <div class="card">
-            <div class="card-icon">&#x1f50c;</div>
-            <h3>Headless CLI</h3>
-            <p>
-              The
-              <code>thurbox-cli</code>
-              binary scripts everything from the terminal: create and drive sessions and schedule
-              commands, all sharing the TUI's SQLite database.
-            </p>
-          </div>
+          <a href="docs/features.html#session-orchestration" class="feature-link">
+            <div class="card">
+              <div class="card-icon">&#x1f5a5;</div>
+              <h3>Persistent Sessions</h3>
+              <p>
+                Run multiple coding-agent CLIs side-by-side, each in its own tmux pane. Sessions
+                persist across crashes, restarts, and multiple concurrent Thurbox instances.
+              </p>
+            </div>
+          </a>
+          <a href="docs/features.html#git-worktrees" class="feature-link">
+            <div class="card">
+              <div class="card-icon">&#x1f333;</div>
+              <h3>Git Worktrees &amp; Sync</h3>
+              <p>
+                Spawn sessions in isolated git worktrees for branch-level isolation. One-key sync (
+                <code>Ctrl+S</code>
+                ) rebases all worktrees from origin/main, with automatic conflict resolution and
+                worktree cleanup on session close.
+              </p>
+            </div>
+          </a>
+          <a href="docs/features.html#session-orchestration" class="feature-link">
+            <div class="card">
+              <div class="card-icon">&#x1f916;</div>
+              <h3>Any Coding Agent</h3>
+              <p>
+                A session runs one agent of your choice &mdash; Claude Code, Codex, Gemini CLI,
+                opencode, aider, Vibe, or any CLI you describe. Each agent runs with its own default
+                config. Mix different agents across the sidebar.
+              </p>
+            </div>
+          </a>
+          <a href="docs/features.html#agent-definitions" class="feature-link">
+            <div class="card">
+              <div class="card-icon">&#x1f6e1;</div>
+              <h3>Agent Definitions</h3>
+              <p>
+                Agents are declared as data in
+                <code>~/.config/thurbox/agents.toml</code>
+                , seeded with built-ins on first run. Add or tweak an agent &mdash; command and
+                argument templates &mdash; with no recompile.
+              </p>
+            </div>
+          </a>
+          <a href="docs/features.html#automations" class="feature-link">
+            <div class="card">
+              <div class="card-icon">&#x23f0;</div>
+              <h3>Automations</h3>
+              <p>
+                Named, scheduled agent runs &mdash; one-shot or recurring (cron, with
+                <code>daily</code>
+                /
+                <code>weekly</code>
+                presets). On schedule they
+                <strong>send</strong>
+                a prompt to a session or
+                <strong>spawn</strong>
+                a fresh one. Manage them from the always-on
+                <code>Ctrl+P</code>
+                pane (or the
+                <code>thurbox-cli</code>
+                headless binary); they fire even when the TUI is closed.
+              </p>
+            </div>
+          </a>
+          <a href="docs/features.html#tasks" class="feature-link">
+            <div class="card">
+              <div class="card-icon">&#x2611;</div>
+              <h3>Tasks</h3>
+              <p>
+                A built-in todo list whose items
+                <strong>connect to a coding agent</strong>
+                &mdash;
+                <strong>send</strong>
+                the title to a session or
+                <strong>spawn</strong>
+                a fresh one. Toggle the panel with
+                <code>Ctrl+W</code>
+                ; edit in place, cycle status, and trigger the action with
+                <code>r</code>
+                .
+              </p>
+            </div>
+          </a>
+          <a href="docs/extensions.html" class="feature-link">
+            <div class="card">
+              <div class="card-icon">&#x1f9e9;</div>
+              <h3>Extensions</h3>
+              <p>
+                Opt-in,
+                <strong>agent-agnostic</strong>
+                add-ons that compose Thurbox through
+                <code>thurbox-cli</code>
+                &mdash; never the binary. Install each from a declarative manifest in one command (
+                <code>thurbox-cli extension install &lt;name&gt;</code>
+                ), and Thurbox keeps its session and automation
+                <strong>self-healed</strong>
+                . Ships flow, forge, ci-shepherd, and renovate (all experimental).
+              </p>
+            </div>
+          </a>
+          <a href="docs/features.html#global-search" class="feature-link">
+            <div class="card">
+              <div class="card-icon">&#x1f50d;</div>
+              <h3>Global Search</h3>
+              <p>
+                One key (
+                <code>Ctrl+A</code>
+                ) searches
+                <strong>every scope at once</strong>
+                &mdash; sessions (incl. live terminal content), tasks, automations, and files
+                &mdash; with matches highlighted live in the panels themselves.
+              </p>
+            </div>
+          </a>
+          <a href="docs/features.html#session-persistence" class="feature-link">
+            <div class="card">
+              <div class="card-icon">&#x1f9e9;</div>
+              <h3>Persistent tmux Sessions</h3>
+              <p>
+                Every session runs in a dedicated
+                <code>tmux -L thurbox</code>
+                pane behind a single
+                <code>SessionBackend</code>
+                trait, so sessions survive crashes, restarts, and detaches.
+              </p>
+            </div>
+          </a>
+          <a href="docs/features.html#headless-cli" class="feature-link">
+            <div class="card">
+              <div class="card-icon">&#x1f50c;</div>
+              <h3>Headless CLI</h3>
+              <p>
+                The
+                <code>thurbox-cli</code>
+                binary scripts everything from the terminal: create and drive sessions and schedule
+                commands, all sharing the TUI's SQLite database.
+              </p>
+            </div>
+          </a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- Replace the Flow-specific feature section in the docs with a generic **Extensions** section linking to the Extensions page
- Make the home page feature cards **clickable**, each linking to its matching documentation anchor
- Reorganize the docs sidebar into **Getting Started / Features / Configurations / Reference / Developer**, nesting the extension pages as an "Extensions" subgroup under Features
- Add a new **Configuration** reference page built from `docs/CONFIG.md`

## Test plan

- `npm run lint:website` passes (Eleventy build + prettier + htmlhint + stylelint + eslint)
- CI checks pass