### PR TITLE
feat(ui): task feature improvement menu + live work dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,8 +548,14 @@ sync, but the TUI editor never sets it.)
   `ui/tasks_panel.rs` (checkbox glyphs ☐/◐/☑) with the shared
   `ui::focus_block` for the highlighted title + accent border, matching the
   session list / file viewer. `InputFocus::TaskList` is the panel focus. Rows
-  whose task has an **open related session** get a trailing accent `⇄` marker
-  (`TaskPaneEntry::linked`).
+  whose task has an **open related session** get a trailing **live-status icon**
+  — the same shape+colour glyph the session list uses (`SessionStatus::icon()` /
+  `ui::status_color`: ●busy ◆waiting ○idle ✗error ▲attention) — so the dispatched
+  worker's live state is glanceable (`TaskPaneEntry::session_status`, fed by
+  `App::task_linked_status`, which picks the **most urgent** status when a task
+  drives several sessions). The status is read live from in-memory session state
+  each frame — no new fetch, cache, or schema. The task detail pane mirrors it,
+  showing `<icon> <name> — <Status>` per related session.
 - **Full-screen preview / edit toggle** — the central pane is a clean toggle
   (`view::render_task_workspace`): while the tasks panel is focused
   (`InputFocus::TaskList`) it shows the selected task's **full-screen,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4181,6 +4181,38 @@ impl App {
         out
     }
 
+    /// The live [`SessionStatus`](crate::session::SessionStatus) to surface for a
+    /// task in the dashboard view — the status of its related open session(s),
+    /// or `None` when no related session is open.
+    ///
+    /// When a task drives more than one open session the most *urgent* status
+    /// wins (a worker that needs you outranks one quietly working), so a
+    /// "needs attention" signal is never hidden behind a busy sibling. The status
+    /// is read live from in-memory session state (refreshed each tick from the
+    /// PTY) — there is no separate fetch, cache, or schema; the dashboard is a
+    /// pure view over existing model state.
+    pub(crate) fn task_linked_status(
+        &self,
+        task: &crate::session::Task,
+    ) -> Option<crate::session::SessionStatus> {
+        use crate::session::SessionStatus;
+        // Rank a status by how much it wants the user's eyes; the highest-ranked
+        // among a task's sessions is the one shown.
+        fn urgency(s: SessionStatus) -> u8 {
+            match s {
+                SessionStatus::Attention => 4,
+                SessionStatus::Error => 3,
+                SessionStatus::Busy => 2,
+                SessionStatus::Waiting => 1,
+                SessionStatus::Idle => 0,
+            }
+        }
+        self.task_related_session_indices(task)
+            .iter()
+            .filter_map(|&i| self.sessions.get(i).map(|s| s.info.status))
+            .max_by_key(|s| urgency(*s))
+    }
+
     /// Jump to the task's related session terminal (the first open one). Bound
     /// to `o` in the focused tasks panel; mirrors `open_run_related_session`.
     pub(crate) fn open_task_related_session(&mut self) {
@@ -6546,6 +6578,35 @@ mod tests {
         let sid = app.sessions[0].info.id;
         app.task_ui.task_session_links.insert(id, sid);
         assert_eq!(app.task_related_session_indices(&task), vec![0]);
+    }
+
+    #[test]
+    fn task_linked_status_reflects_related_session_and_picks_most_urgent() {
+        use crate::session::SessionStatus;
+        let mut app = app_with_sessions(2);
+        let id = app
+            .db
+            .create_task(&crate::storage::tasks::NewTask::local("t"))
+            .unwrap();
+        app.refresh_tasks();
+        let task = app.db.get_task(id).unwrap().unwrap();
+
+        // No related session → no dashboard status.
+        assert_eq!(app.task_linked_status(&task), None);
+
+        // One related busy session → its status surfaces.
+        app.sessions[1].info.name = task.spawn_session_name();
+        app.sessions[1].info.status = SessionStatus::Busy;
+        assert_eq!(app.task_linked_status(&task), Some(SessionStatus::Busy));
+
+        // A second related session that needs attention outranks the busy one.
+        let sid0 = app.sessions[0].info.id;
+        app.task_ui.task_session_links.insert(id, sid0);
+        app.sessions[0].info.status = SessionStatus::Attention;
+        assert_eq!(
+            app.task_linked_status(&task),
+            Some(SessionStatus::Attention)
+        );
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -322,7 +322,7 @@ impl App {
                     status: t.status,
                     match_positions: m.as_ref().map(|m| m.positions.clone()).unwrap_or_default(),
                     dimmed: search.is_some() && m.is_none(),
-                    linked: !self.task_related_session_indices(t).is_empty(),
+                    session_status: self.task_linked_status(t),
                 }
             })
             .collect();
@@ -885,10 +885,20 @@ impl App {
         let sessions = if related.is_empty() {
             "none open".to_string()
         } else {
+            // Enrich each related session with its live status icon + label so the
+            // detail pane mirrors the dashboard row (e.g. `● Wire up SSH · #7 —
+            // Busy`). Agent-neutral: status is read live from session state.
             related
                 .iter()
                 .filter_map(|&i| self.sessions.get(i))
-                .map(|s| s.info.name.clone())
+                .map(|s| {
+                    format!(
+                        "{} {} — {}",
+                        s.info.status.icon(),
+                        s.info.name,
+                        s.info.status
+                    )
+                })
                 .collect::<Vec<_>>()
                 .join(", ")
         };

--- a/src/ui/tasks_panel.rs
+++ b/src/ui/tasks_panel.rs
@@ -12,7 +12,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::session::TaskStatus;
+use crate::session::{SessionStatus, TaskStatus};
 
 use super::theme::Theme;
 use super::{focus_block, truncate_ellipsis, FocusLevel};
@@ -26,14 +26,14 @@ pub struct TaskPaneEntry {
     pub match_positions: Vec<usize>,
     /// When a global search is active, rows that don't match are dimmed.
     pub dimmed: bool,
-    /// The task has at least one currently-open related session (a spawned
-    /// `<title> · #<id>` window or a Send target). Drawn as a trailing `⇄`
-    /// marker so a live task is glanceable in the list; press `o` to jump to it.
-    pub linked: bool,
+    /// Live status of the task's related open session(s) — a spawned
+    /// `<title> · #<id>` window or a Send target — or `None` when none is open.
+    /// `Some(_)` is drawn as a trailing status icon (the same glyph + colour the
+    /// session list uses) so the live state of the dispatched work is glanceable;
+    /// press `o` to jump to it. The most urgent status wins when a task drives
+    /// several sessions (see `App::task_linked_status`).
+    pub session_status: Option<SessionStatus>,
 }
-
-/// Trailing marker shown on rows whose task has an open related session.
-const LINKED_MARKER: &str = " ⇄";
 
 pub struct TaskPaneState<'a> {
     pub entries: &'a [TaskPaneEntry],
@@ -117,17 +117,13 @@ fn render_task_list(frame: &mut Frame, area: Rect, state: &TaskPaneState<'_>) {
 }
 
 /// Build one task row: `<glyph> <title>` with global-search highlighting, plus a
-/// trailing `⇄` marker when the task has a live related session.
+/// trailing live-status icon when the task has a related open session.
 fn task_row_line(e: &TaskPaneEntry, selected: bool, width: usize) -> Line<'_> {
     let glyph = status_glyph(e.status);
     // The glyph is its own span; the title follows so highlight byte offsets
-    // (which index `title`) line up. Reserve room for the trailing link marker
-    // so it never pushes the title off-row.
-    let reserved = if e.linked {
-        2 + LINKED_MARKER.chars().count()
-    } else {
-        2
-    };
+    // (which index `title`) line up. Reserve room for the trailing status marker
+    // (a leading space + one-cell icon) so it never pushes the title off-row.
+    let reserved = if e.session_status.is_some() { 4 } else { 2 };
     let title = truncate_ellipsis(&e.title, width.saturating_sub(reserved));
 
     // Matched characters are layered *on top* of this base (see `row_base_style`),
@@ -145,15 +141,18 @@ fn task_row_line(e: &TaskPaneEntry, selected: bool, width: usize) -> Line<'_> {
     spans.extend(super::highlight::highlighted_spans_owned(
         &title, positions, base,
     ));
-    // Trailing accent marker for tasks with a live session. Dimmed rows
-    // (non-matches during a search) keep the dim tone for consistency.
-    if e.linked {
+    // Trailing live-status icon for tasks with a related open session, using the
+    // same glyph + colour the session list shows so the two never drift. Dimmed
+    // rows (non-matches during a search) keep the dim tone for consistency.
+    if let Some(status) = e.session_status {
         let marker_style = if e.dimmed {
             base
         } else {
-            Style::default().fg(Theme::accent())
+            // `super::status_color` (session status) — distinct from the local
+            // `status_color(TaskStatus)` used for the row glyph above.
+            Style::default().fg(super::status_color(status))
         };
-        spans.push(Span::styled(LINKED_MARKER, marker_style));
+        spans.push(Span::styled(format!(" {}", status.icon()), marker_style));
     }
     Line::from(spans)
 }
@@ -185,7 +184,65 @@ mod tests {
             status: TaskStatus::Todo,
             match_positions: vec![],
             dimmed: false,
-            linked: false,
+            session_status: None,
+        }
+    }
+
+    /// Render a single entry into a fresh buffer and return its first row text.
+    fn render_row(entry: TaskPaneEntry) -> String {
+        let backend = TestBackend::new(20, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                render_tasks_panel(
+                    f,
+                    Rect::new(0, 0, 20, 3),
+                    &TaskPaneState {
+                        entries: &[entry],
+                        selected: 0,
+                        focus: FocusLevel::Inactive,
+                        preview_selected: false,
+                    },
+                );
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        (0..buf.area.width)
+            .map(|x| buf[(x, 1)].symbol())
+            .collect::<String>()
+    }
+
+    #[test]
+    fn row_shows_linked_session_status_icon() {
+        // A task with a busy related session shows the session-list busy glyph;
+        // attention shows the triangle; no session shows no trailing icon.
+        let busy = render_row(TaskPaneEntry {
+            session_status: Some(SessionStatus::Busy),
+            ..entry("build")
+        });
+        assert!(busy.contains(SessionStatus::Busy.icon()), "got {busy:?}");
+
+        let attn = render_row(TaskPaneEntry {
+            session_status: Some(SessionStatus::Attention),
+            ..entry("build")
+        });
+        assert!(
+            attn.contains(SessionStatus::Attention.icon()),
+            "got {attn:?}"
+        );
+
+        let unlinked = render_row(entry("build"));
+        for s in [
+            SessionStatus::Busy,
+            SessionStatus::Waiting,
+            SessionStatus::Idle,
+            SessionStatus::Error,
+            SessionStatus::Attention,
+        ] {
+            assert!(
+                !unlinked.contains(s.icon()),
+                "unexpected icon in {unlinked:?}"
+            );
         }
     }
 


### PR DESCRIPTION
## Context

Task #42 — *Explore: task feature improvements and new ideas*. Audited the current task feature (data model, storage v26, CLI, state machine, TUI), produced a prioritized menu of improvements (Integrations + UI/UX, constitution-compliant), and built the recommended top pick.

The full menu was delivered to the user via the flow message queue (per the revised acceptance criterion — no separate doc). Summary:

| # | Idea | Kind | Effort | Priority |
|---|------|------|--------|----------|
| 1 ★ | **Live work dashboard** (this PR) | Integration+UI | S/M | P0 |
| 2 | Auto-complete tasks from worker `result` messages | Integration | M | P1 |
| 3 | Capture worker result (summary + PR url) onto the task | Integration | M | P2 |
| 4 | Activate dormant external-sync (GitHub issues import) | Integration | L | P3 |
| 5 | Collapse/hide Done + `task list --status` filter | UI/UX | S | P1 |
| 6 | Manual task ordering (`Shift+J/K`) = priority-without-a-knob | UI/UX | S/M | P2 |
| 7 | Quick-add task (single-keystroke title-only create) | UI/UX | S | P2 |

## What this PR builds — #1 Live work dashboard

Turns the passive todo list into a live view of the agent work it dispatched. Each task with an open related session now shows that session's **live status icon** (`●busy ◆waiting ○idle ✗error ▲attention`) on its row, using the same glyph + colour the session list uses — replacing the static `⇄` marker. The detail pane mirrors it as `<icon> <name> — <Status>` per related session.

### Design
- **No new data path.** `SessionStatus` is already live on `self.sessions[i].info.status`, refreshed each tick by the existing vt100/PTY reader. The dashboard just reads it at render time — **no DB, no cache, no schema, no per-task knob**.
- New `App::task_linked_status(task) -> Option<SessionStatus>`: maps the existing `task_related_session_indices` to their live statuses and picks the **most urgent** (Attention > Error > Busy > Waiting > Idle) so a "needs you" worker is never hidden behind a busy sibling.
- `ui/tasks_panel.rs`: `TaskPaneEntry.linked: bool` → `session_status: Option<SessionStatus>`; trailing marker is the status icon via the shared `ui::status_color` (so the panel and session list never drift).
- `app/view.rs`: builds the entry from `task_linked_status`, and enriches the detail-pane session row.

### Constitution compliance
- **Agent-neutral**: status derives from PTY signals, never an agent API.
- **Minimal knobs**: zero new task fields/columns/config — pure derived view state.
- **TEA**: view-only, no side effects, no migration.

## Tests
- `ui::tasks_panel`: a busy entry renders `●`, attention renders `▲`, an unlinked entry renders no trailing icon (TestBackend buffer assertions).
- `app`: `task_linked_status` returns the related session's status, `None` when none is open, and picks Attention over Busy across multiple sessions.

All 1150 lib tests + architecture rules pass; `cargo fmt`/`clippy -D warnings`/`rumdl` clean. CLAUDE.md updated.