### PR TITLE
docs: enumerate features in the docs sidebar and split out extensions

### DIFF
--- a/website/_includes/sidebar.njk
+++ b/website/_includes/sidebar.njk
@@ -3,8 +3,23 @@
     { slug: "installation", href: "installation.html", label: "Installation" }
   ]},
   { heading: "Features", links: [
-    { slug: "features", href: "features.html", label: "Overview" },
-    { subheading: "Extensions" },
+    { href: "features.html#session-orchestration", label: "Sessions" },
+    { href: "features.html#agent-definitions", label: "Agent Definitions" },
+    { href: "features.html#automations", label: "Automations" },
+    { href: "features.html#tasks", label: "Tasks" },
+    { href: "features.html#git-worktrees", label: "Git Worktrees" },
+    { href: "features.html#remote-ssh-sessions", label: "Remote SSH Sessions" },
+    { href: "features.html#worktree-sync", label: "Worktree Sync" },
+    { href: "features.html#session-forking", label: "Session Forking" },
+    { href: "features.html#global-search", label: "Global Search" },
+    { href: "features.html#responsive-ui", label: "Responsive UI" },
+    { href: "features.html#themes", label: "Themes" },
+    { href: "features.html#mouse-navigation", label: "Mouse Navigation" },
+    { href: "features.html#feature-flags", label: "Feature Flags" },
+    { href: "features.html#session-persistence", label: "Session Persistence" },
+    { href: "features.html#headless-cli", label: "Headless CLI" }
+  ]},
+  { heading: "Extensions", links: [
     { slug: "extensions", href: "extensions.html", label: "Overview" },
     { slug: "extension-flow", href: "extension-flow.html", label: "Flow" },
     { slug: "extension-forge", href: "extension-forge.html", label: "Forge" },
@@ -27,9 +42,6 @@
   <h4>{{ section.heading }}</h4>
   <ul>
     {%- for link in section.links %}
-    {%- if link.subheading %}
-    <li class="sidebar-subheading">{{ link.subheading }}</li>
-    {%- else %}
     <li>
       <a
         href="{{ link.href }}"
@@ -37,7 +49,6 @@
         >{{ link.label }}</a
       >
     </li>
-    {%- endif %}
     {%- endfor %}
   </ul>
   {%- endfor %}

--- a/website/css/docs.css
+++ b/website/css/docs.css
@@ -43,15 +43,6 @@
   margin: 0 0 var(--space-sm) 0;
 }
 
-.docs-sidebar .sidebar-subheading {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-muted);
-  padding: 0.35rem 0.75rem 0.1rem;
-}
-
 .docs-sidebar li {
   margin: 0;
 }

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -4,23 +4,6 @@ title: 'Features — Thurbox Docs'
 description: 'Thurbox features: persistent coding-agent sessions, agent definitions, git worktrees, remote SSH sessions, automations, a responsive UI, and a headless CLI.'
 currentPage: 'features'
 breadcrumb: 'Features'
-onThisPage:
-  - { id: 'session-orchestration', label: 'Sessions' }
-  - { id: 'agent-definitions', label: 'Agent Definitions' }
-  - { id: 'automations', label: 'Automations' }
-  - { id: 'tasks', label: 'Tasks' }
-  - { id: 'extensions', label: 'Extensions' }
-  - { id: 'git-worktrees', label: 'Git Worktrees' }
-  - { id: 'remote-ssh-sessions', label: 'Remote SSH Sessions' }
-  - { id: 'worktree-sync', label: 'Worktree Sync' }
-  - { id: 'session-forking', label: 'Session Forking' }
-  - { id: 'global-search', label: 'Global Search' }
-  - { id: 'responsive-ui', label: 'Responsive UI' }
-  - { id: 'themes', label: 'Themes' }
-  - { id: 'mouse-navigation', label: 'Mouse Navigation' }
-  - { id: 'feature-flags', label: 'Feature Flags' }
-  - { id: 'session-persistence', label: 'Session Persistence' }
-  - { id: 'headless-cli', label: 'Headless CLI' }
 ---
 <h1>Features</h1>
 
@@ -290,56 +273,6 @@ onThisPage:
               ):
               <code>create/list/show/edit/remove/run</code>
               . External issue-tracker sync (Jira, GitHub Issues) is scaffolded for a later release.
-            </li>
-          </ul>
-
-          <h2 id="extensions">
-            Extensions
-            <a href="#extensions" class="heading-anchor">#</a>
-          </h2>
-          <div class="info-box warning">
-            <p>
-              <strong>Heads up:</strong>
-              Extensions are
-              <strong>experimental</strong>
-              and under active testing &mdash; expect their behavior, specs, and installers to
-              change between releases.
-            </p>
-          </div>
-          <p>
-            Opt-in,
-            <strong>agent-agnostic</strong>
-            add-ons that compose Thurbox through
-            <code>thurbox-cli</code>
-            &mdash; never the binary. Each ships a declarative manifest and installs in one command (
-            <code>thurbox-cli extension install &lt;name&gt;</code>
-            ); while active, Thurbox keeps the extension's sessions and automations
-            <strong>self-healed</strong>
-            , re-creating any you delete until you deactivate it.
-          </p>
-          <ul>
-            <li>
-              Four extensions ship today (all experimental):
-              <strong>flow</strong>
-              (a focus-protecting triage agent),
-              <strong>forge</strong>
-              (a workflow analyst that proposes automations),
-              <strong>ci-shepherd</strong>
-              (watches change requests and dispatches CI/review fixers), and
-              <strong>renovate</strong>
-              (keeps local repos on up-to-date dependencies).
-            </li>
-            <li>
-              An extension registers its agents in
-              <code>agents.toml</code>
-              and lays down its payload from the manifest &mdash; map its worker agents to claude,
-              codex, gemini, opencode, vibe, or anything else.
-            </li>
-            <li>
-              See the
-              <a href="extensions.html">Extensions</a>
-              page for the full lifecycle (install, activate, update, self-heal), the manifest
-              format, and a guide to authoring your own.
             </li>
           </ul>
 

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -73,12 +73,14 @@
   });
 
   // ---- Active sidebar link (docs pages) ----
-  var sidebarLinks = document.querySelectorAll('.docs-sidebar a[href^="#"]');
+  // Matches both in-page anchors (#id) and same-page section links
+  // (page.html#id) so the section-enumerating sidebar highlights on scroll.
+  var sidebarLinks = document.querySelectorAll('.docs-sidebar a[href*="#"]');
   if (sidebarLinks.length > 0) {
     var headings = [];
     sidebarLinks.forEach(function (link) {
-      var id = link.getAttribute('href').slice(1);
-      var heading = document.getElementById(id);
+      var id = link.getAttribute('href').split('#')[1];
+      var heading = id ? document.getElementById(id) : null;
       if (heading) headings.push({ el: heading, link: link });
     });
 


### PR DESCRIPTION
## Summary

- List each feature under the sidebar **Features** section (anchor links into `features.html`) so it mirrors how **Extensions** enumerates its pages — fixes the asymmetry where Features showed only a single "Overview" link
- Promote **Extensions** to its own top-level sidebar section, peer to Features and Configurations
- Generalize the sidebar scroll-spy (`main.js`) to highlight same-page section links (`page.html#id`), not just bare `#id` anchors
- Drop the now-redundant "On This Page" rail and the inline Extensions teaser section from the features page

## Test plan

- `npm run lint:website` passes (Eleventy build + prettier + htmlhint + stylelint + eslint)
- Verified bidirectional coherence: every sidebar feature link resolves to a `features.html` heading id, and no feature heading is orphaned