### PR TITLE
docs: redesign the homepage (hero, install tabs, agent logos, feature showcase)

### DIFF
--- a/website/_includes/base.njk
+++ b/website/_includes/base.njk
@@ -4,6 +4,7 @@ extraCss: []
 footer: false
 navScrolled: false
 activeNav: ''
+hasOwnMain: false
 ---
 <!doctype html>
 <html lang="en">
@@ -28,6 +29,7 @@ activeNav: ''
     {%- endfor %}
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
     <nav class="nav{% if navScrolled %} scrolled{% endif %}" id="nav">
       <!-- prettier-ignore -->
       <a href="{{ root }}/index.html" class="nav-brand">thur<span>box</span></a>
@@ -67,7 +69,11 @@ activeNav: ''
       </ul>
     </nav>
 
+    {%- if hasOwnMain %}
     {{ content | safe }}
+    {%- else %}
+    <main id="main-content">{{ content | safe }}</main>
+    {%- endif %}
 
     {%- if footer %}
     <footer class="footer">

--- a/website/_includes/docs.njk
+++ b/website/_includes/docs.njk
@@ -4,6 +4,7 @@ root: '..'
 extraCss: ['docs.css']
 navScrolled: true
 activeNav: 'docs'
+hasOwnMain: true
 ---
 <div class="docs-page">
   <div class="docs-layout">
@@ -13,7 +14,7 @@ activeNav: 'docs'
       &#9776;
     </button>
 
-    <main class="docs-content">
+    <main class="docs-content" id="main-content">
       <div class="breadcrumbs">
         <a href="{{ root }}/index.html">Home</a>
         <span class="separator">/</span>

--- a/website/css/base.css
+++ b/website/css/base.css
@@ -171,3 +171,26 @@ hr {
   background: rgb(255, 92, 84, 0.4);
   color: #fff;
 }
+
+/* Keyboard focus — visible ring on every interactive element */
+:focus-visible {
+  outline: 2px solid var(--green);
+  outline-offset: 2px;
+}
+
+/* Skip to main content (visible only when focused) */
+.skip-link {
+  position: fixed;
+  top: var(--space-sm);
+  left: -9999px;
+  z-index: 200;
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  background: var(--green);
+  color: #0a2e0a;
+}
+
+.skip-link:focus {
+  left: var(--space-sm);
+}

--- a/website/css/components.css
+++ b/website/css/components.css
@@ -55,6 +55,11 @@
   color: var(--text-primary);
 }
 
+.nav-links a.active {
+  color: var(--cyan);
+  text-shadow: var(--glow-red);
+}
+
 .nav-links .github-link {
   display: flex;
   align-items: center;

--- a/website/css/landing.css
+++ b/website/css/landing.css
@@ -48,6 +48,16 @@
   }
 }
 
+.hero-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--green);
+  margin-bottom: var(--space-md);
+}
+
 .hero .subtitle {
   font-size: 1.15rem;
   max-width: 600px;
@@ -70,7 +80,10 @@
 }
 
 .agent-support span {
-  padding: 0.15rem 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.6rem;
   border: 1px solid var(--border);
   border-radius: var(--border-radius-sm);
   font-family: var(--font-mono);
@@ -78,6 +91,20 @@
   text-transform: none;
   letter-spacing: 0;
   color: var(--text-primary);
+  transition:
+    color var(--transition),
+    border-color var(--transition);
+}
+
+.agent-support span:hover {
+  border-color: var(--text-secondary);
+}
+
+.agent-logo {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  fill: currentColor;
 }
 
 .agent-support .agent-support-any {
@@ -130,6 +157,70 @@
   color: var(--text-secondary);
 }
 
+/* ---- Feature showcase (alternating media + text) ---- */
+.feature-showcase {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xl);
+  max-width: 1040px;
+  margin: 0 auto;
+}
+
+.feature-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.feature-row-text,
+.feature-row-media {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.feature-row-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  color: var(--green);
+  margin-bottom: var(--space-sm);
+}
+
+.feature-row-text h3 {
+  margin-bottom: var(--space-sm);
+}
+
+.feature-row-link {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+.feature-row-media .terminal-frame {
+  box-shadow: 0 16px 44px rgb(0, 0, 0, 0.5);
+}
+
+.feature-row-media video {
+  display: block;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .feature-row {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-2xl);
+  }
+
+  .feature-row:nth-child(even) {
+    flex-direction: row-reverse;
+  }
+
+  .feature-row-media {
+    flex: 1.15 1 0;
+  }
+}
+
 /* ---- Features grid ---- */
 .features {
   background: var(--bg-secondary);
@@ -142,18 +233,28 @@
 
 .feature-link .card {
   height: 100%;
+  transition:
+    border-color var(--transition),
+    box-shadow var(--transition),
+    transform var(--transition);
 }
 
 .feature-link .card h3 {
   color: var(--text-primary);
+  transition: color var(--transition);
 }
 
 .feature-link:hover .card {
-  border-color: var(--text-muted);
+  transform: translateY(-3px);
+  border-color: var(--green);
+  box-shadow:
+    0 8px 24px rgb(0, 0, 0, 0.45),
+    0 0 0 1px rgb(110, 255, 110, 0.15);
 }
 
 .feature-link:hover .card h3 {
-  color: var(--cyan);
+  color: var(--green);
+  text-shadow: var(--glow-green);
 }
 
 .features .card-icon {
@@ -164,6 +265,16 @@
   height: 40px;
   border-radius: var(--border-radius-sm);
   font-size: 1.25rem;
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  transition:
+    border-color var(--transition),
+    box-shadow var(--transition);
+}
+
+.feature-link:hover .card-icon {
+  border-color: var(--green);
+  box-shadow: var(--glow-green);
 }
 
 /* ---- How it works ---- */
@@ -213,40 +324,84 @@
   text-align: left;
 }
 
-.install-methods {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-xl);
-  max-width: 1000px;
-  margin: 0 auto;
+/* ---- Install method tabs ---- */
+.install-tabs {
+  max-width: 780px;
+  margin: 0 auto var(--space-xl);
+  text-align: left;
 }
 
-@media (min-width: 900px) {
-  .install-methods {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-.install-method {
+.install-tablist {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-lg);
 }
 
-.install-method h3 {
-  display: flex;
+.install-tab {
+  display: inline-flex;
   align-items: center;
   gap: var(--space-sm);
-  margin-bottom: var(--space-sm);
+  padding: 0.65rem 1.1rem;
+  margin-bottom: -1px;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-bottom: none;
+  cursor: pointer;
+  transition:
+    color var(--transition),
+    background var(--transition),
+    border-color var(--transition);
 }
 
-.install-method > p {
+.install-tab:hover {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.install-tab[aria-selected='true'] {
+  color: var(--green);
+  background: var(--bg-card);
+  border-color: var(--border);
+  border-bottom-color: var(--bg-card);
+  text-shadow: var(--glow-green);
+}
+
+.install-tab .badge {
+  padding: 0.1rem 0.5rem;
+  font-size: 0.65rem;
+}
+
+.install-panel > p {
   font-size: 0.9rem;
   margin-bottom: var(--space-md);
 }
 
-.install-method .terminal-frame {
-  margin-top: auto;
+.install-panel .terminal-frame {
   box-shadow: none;
+}
+
+@keyframes install-fade {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .install-panel:not([hidden]) {
+    animation: install-fade 200ms ease;
+  }
 }
 
 .install-alt {
@@ -298,4 +453,51 @@
 .prereqs li .optional {
   color: var(--text-muted);
   font-size: 0.8rem;
+}
+
+/* ---- Back to top ---- */
+.back-to-top {
+  position: fixed;
+  bottom: var(--space-lg);
+  right: var(--space-lg);
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  background: var(--bg-nav);
+  color: var(--cyan);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(8px);
+  backdrop-filter: blur(12px);
+  transition:
+    opacity var(--transition),
+    visibility var(--transition),
+    transform var(--transition),
+    border-color var(--transition),
+    box-shadow var(--transition);
+  z-index: 90;
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.back-to-top:hover {
+  color: var(--text-primary);
+  border-color: var(--cyan);
+  box-shadow: var(--glow-red);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .back-to-top {
+    transition: opacity var(--transition);
+    transform: none;
+  }
 }

--- a/website/index.html
+++ b/website/index.html
@@ -9,28 +9,217 @@ footer: true
 <!-- Hero -->
     <section class="hero section">
       <div class="container">
+        <p class="hero-eyebrow">Multi-session coding-agent orchestrator</p>
         <h1>
           <span class="accent">TUI</span>
           Agentic IDE
         </h1>
         <p class="subtitle">
-          A multi-session orchestrator for your terminal. Run any coding-agent CLI — Claude Code,
-          Codex, Gemini CLI, opencode, aider, Vibe, or your own — in parallel, persistent tmux panes
-          that survive crashes and restarts.
+          Run Claude Code, Codex, Gemini CLI, opencode, aider, Vibe — or any CLI you define — side by
+          side in persistent tmux panes that survive crashes and restarts.
         </p>
         <p class="agent-support">
           Built-in agent support for
-          <span>Claude Code</span>
-          <span>Codex</span>
-          <span>Gemini CLI</span>
-          <span>opencode</span>
-          <span>aider</span>
-          <span>Vibe</span>
+          <span>
+            <!-- prettier-ignore -->
+            <svg class="agent-logo" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z"/></svg>
+            Claude Code
+          </span>
+          <span>
+            <!-- prettier-ignore -->
+            <svg class="agent-logo" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z"/></svg>
+            Codex
+          </span>
+          <span>
+            <!-- prettier-ignore -->
+            <svg class="agent-logo" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81"/></svg>
+            Gemini CLI
+          </span>
+          <span>
+            <!-- prettier-ignore -->
+            <svg class="agent-logo" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M22 24H2V0h20zM17 4.8H7v14.4h10z"/></svg>
+            opencode
+          </span>
+          <span>
+            <!-- prettier-ignore -->
+            <svg class="agent-logo" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M3 5.8 4.8 4 12.3 11.5 4.8 19 3 17.2 8.7 11.5Z M11 17h9v2.4h-9z"/></svg>
+            aider
+          </span>
+          <span>
+            <!-- prettier-ignore -->
+            <svg class="agent-logo" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M17.143 3.429v3.428h-3.429v3.429h-3.428V6.857H6.857V3.43H3.43v13.714H0v3.428h10.286v-3.428H6.857v-3.429h3.429v3.429h3.429v-3.429h3.428v3.429h-3.428v3.428H24v-3.428h-3.43V3.429z"/></svg>
+            Vibe
+          </span>
           <span class="agent-support-any">plus any CLI agent</span>
         </p>
         <div class="hero-ctas">
           <a href="#installation" class="btn btn-primary">Get Started</a>
           <a href="docs/index.html" class="btn btn-secondary">View Docs</a>
+        </div>
+        <div class="install-tabs" id="installation">
+          <div class="install-tablist" role="tablist" aria-label="Installation methods">
+            <button
+              class="install-tab"
+              id="tab-script"
+              role="tab"
+              aria-controls="panel-script"
+              aria-selected="true"
+            >
+              Install Script
+              <span class="badge badge-green">Recommended</span>
+            </button>
+            <button
+              class="install-tab"
+              id="tab-brew"
+              role="tab"
+              aria-controls="panel-brew"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              Homebrew
+            </button>
+            <button
+              class="install-tab"
+              id="tab-aur"
+              role="tab"
+              aria-controls="panel-aur"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              Arch (AUR)
+            </button>
+            <button
+              class="install-tab"
+              id="tab-source"
+              role="tab"
+              aria-controls="panel-source"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              From Source
+            </button>
+          </div>
+
+          <div class="install-panel" role="tabpanel" id="panel-script" aria-labelledby="tab-script">
+            <p>
+              Linux &amp; macOS. Auto-detects your platform, verifies checksums, and installs the
+              latest release to
+              <code>~/.local/bin</code>
+              .
+            </p>
+            <div class="terminal-frame">
+              <div class="terminal-header">
+                <div class="terminal-dot red"></div>
+                <div class="terminal-dot yellow"></div>
+                <div class="terminal-dot green"></div>
+                <span class="terminal-title">bash</span>
+              </div>
+              <div class="terminal-body">
+                <button
+                  class="copy-btn"
+                  data-code="curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh"
+                >
+                  Copy
+                </button>
+                <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">curl</span> <span class="syn-flag">-fsSL</span> <span class="syn-url">https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh</span> | <span class="syn-cmd">sh</span></code></pre>
+              </div>
+            </div>
+          </div>
+
+          <div class="install-panel" role="tabpanel" id="panel-brew" aria-labelledby="tab-brew" hidden>
+            <p>
+              macOS (Apple Silicon) &amp; Linux x86_64. Prebuilt binaries from the
+              <a href="https://github.com/Thurbeen/homebrew-thurbox" target="_blank" rel="noopener">
+                thurbox tap
+              </a>
+              ; pulls in
+              <code>tmux</code>
+              and
+              <code>git</code>
+              automatically.
+            </p>
+            <div class="terminal-frame">
+              <div class="terminal-header">
+                <div class="terminal-dot red"></div>
+                <div class="terminal-dot yellow"></div>
+                <div class="terminal-dot green"></div>
+                <span class="terminal-title">bash</span>
+              </div>
+              <div class="terminal-body">
+                <button class="copy-btn" data-code="brew install thurbeen/thurbox/thurbox">
+                  Copy
+                </button>
+                <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">brew</span> install thurbeen/thurbox/thurbox</code></pre>
+              </div>
+            </div>
+          </div>
+
+          <div class="install-panel" role="tabpanel" id="panel-aur" aria-labelledby="tab-aur" hidden>
+            <p>
+              <a
+                href="https://aur.archlinux.org/packages/thurbox-bin"
+                target="_blank"
+                rel="noopener"
+              >
+                <code>thurbox-bin</code>
+              </a>
+              (prebuilt binary) or
+              <a href="https://aur.archlinux.org/packages/thurbox" target="_blank" rel="noopener">
+                <code>thurbox</code>
+              </a>
+              (builds from source) &mdash; use
+              <code>paru</code>
+              ,
+              <code>yay</code>
+              , or your preferred AUR helper.
+            </p>
+            <div class="terminal-frame">
+              <div class="terminal-header">
+                <div class="terminal-dot red"></div>
+                <div class="terminal-dot yellow"></div>
+                <div class="terminal-dot green"></div>
+                <span class="terminal-title">bash</span>
+              </div>
+              <div class="terminal-body">
+                <button class="copy-btn" data-code="paru -S thurbox-bin">Copy</button>
+                <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">paru</span> <span class="syn-flag">-S</span> thurbox-bin   <span class="syn-comment"># prebuilt (fastest)</span>
+<span class="syn-prompt">$</span> <span class="syn-cmd">paru</span> <span class="syn-flag">-S</span> thurbox       <span class="syn-comment"># build from source</span></code></pre>
+              </div>
+            </div>
+          </div>
+
+          <div class="install-panel" role="tabpanel" id="panel-source" aria-labelledby="tab-source" hidden>
+            <p>
+              Any platform with Rust 1.75+. Builds both the
+              <code>thurbox</code>
+              TUI and the
+              <code>thurbox-cli</code>
+              headless binary into
+              <code>target/release/</code>
+              .
+            </p>
+            <div class="terminal-frame">
+              <div class="terminal-header">
+                <div class="terminal-dot red"></div>
+                <div class="terminal-dot yellow"></div>
+                <div class="terminal-dot green"></div>
+                <span class="terminal-title">bash</span>
+              </div>
+              <div class="terminal-body">
+                <button
+                  class="copy-btn"
+                  data-code="git clone https://github.com/Thurbeen/thurbox.git
+cd thurbox
+cargo build --release"
+                >
+                  Copy
+                </button>
+                <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">git</span> clone <span class="syn-url">https://github.com/Thurbeen/thurbox.git</span>
+<span class="syn-prompt">$</span> <span class="syn-cmd">cd</span> thurbox
+<span class="syn-prompt">$</span> <span class="syn-cmd">cargo</span> build <span class="syn-flag">--release</span></code></pre>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="hero-badges">
           <span class="badge badge-yellow">MIT License</span>
@@ -212,36 +401,11 @@ footer: true
       <div class="container">
         <div class="section-title">
           <h2>How It Works</h2>
-          <p>Four steps from install to coding</p>
+          <p>Three steps from launch to coding</p>
         </div>
         <div class="how-it-works-steps">
           <div class="step">
             <span class="step-number">1</span>
-            <div class="step-content">
-              <h3>Install</h3>
-              <p>One command to download and install the latest release.</p>
-              <div class="terminal-frame">
-                <div class="terminal-header">
-                  <div class="terminal-dot red"></div>
-                  <div class="terminal-dot yellow"></div>
-                  <div class="terminal-dot green"></div>
-                  <span class="terminal-title">bash</span>
-                </div>
-                <div class="terminal-body">
-                  <button
-                    class="copy-btn"
-                    data-code="curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh"
-                  >
-                    Copy
-                  </button>
-                  <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">curl</span> <span class="syn-flag">-fsSL</span> <span class="syn-url">https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh</span> | <span class="syn-cmd">sh</span></code></pre>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="step">
-            <span class="step-number">2</span>
             <div class="step-content">
               <h3>Launch</h3>
               <p>Start Thurbox. The session sidebar and terminal panel appear.</p>
@@ -261,7 +425,7 @@ footer: true
           </div>
 
           <div class="step">
-            <span class="step-number">3</span>
+            <span class="step-number">2</span>
             <div class="step-content">
               <h3>Create a Session</h3>
               <p>
@@ -286,7 +450,7 @@ footer: true
           </div>
 
           <div class="step">
-            <span class="step-number">4</span>
+            <span class="step-number">3</span>
             <div class="step-content">
               <h3>Start Coding</h3>
               <p>
@@ -324,332 +488,214 @@ footer: true
           <h2>Feature walkthrough</h2>
           <p>See the TUI in action &mdash; recorded from the real app</p>
         </div>
-        <div class="grid grid-2">
-          <figure class="video-card">
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">Automations</span>
-              </div>
-              <div class="terminal-body">
-                <video
-                  src="assets/automations-demo.mp4"
-                  autoplay
-                  loop
-                  muted
-                  playsinline
-                  preload="none"
-                >
-                  Creating and running a scheduled automation from the Ctrl+P pane
-                </video>
+        <div class="feature-showcase">
+          <div class="feature-row">
+            <div class="feature-row-text">
+              <p class="feature-row-eyebrow">Ctrl+P</p>
+              <h3>Automations</h3>
+              <p>
+                Named, scheduled agent runs &mdash; one-shot or recurring cron. Each fires on its own
+                schedule to send a prompt to a session or spawn a fresh one, even when the TUI is
+                closed.
+              </p>
+              <a class="feature-row-link" href="docs/features.html#automations">Learn more &rarr;</a>
+            </div>
+            <div class="feature-row-media">
+              <div class="terminal-frame">
+                <div class="terminal-header">
+                  <div class="terminal-dot red"></div>
+                  <div class="terminal-dot yellow"></div>
+                  <div class="terminal-dot green"></div>
+                  <span class="terminal-title">Automations</span>
+                </div>
+                <div class="terminal-body">
+                  <!-- prettier-ignore -->
+                  <video src="assets/automations-demo.mp4" autoplay loop muted playsinline preload="none">
+                    Creating and running a scheduled automation from the Ctrl+P pane
+                  </video>
+                </div>
               </div>
             </div>
-            <figcaption>
-              <strong>Automations</strong>
-              &mdash;
-              <code>Ctrl+P</code>
-              schedules agent runs that fire even when the TUI is closed.
-            </figcaption>
-          </figure>
-          <figure class="video-card">
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">Tasks</span>
-              </div>
-              <div class="terminal-body">
-                <video src="assets/tasks-demo.mp4" autoplay loop muted playsinline preload="none">
-                  Creating tasks and connecting them to a coding agent in the tasks panel
-                </video>
+          </div>
+
+          <div class="feature-row">
+            <div class="feature-row-text">
+              <p class="feature-row-eyebrow">Ctrl+W</p>
+              <h3>Tasks</h3>
+              <p>
+                A built-in todo list whose items connect to a coding agent: send the title to a
+                running session or spawn a new one, edit in place, and cycle status as work moves.
+              </p>
+              <a class="feature-row-link" href="docs/features.html#tasks">Learn more &rarr;</a>
+            </div>
+            <div class="feature-row-media">
+              <div class="terminal-frame">
+                <div class="terminal-header">
+                  <div class="terminal-dot red"></div>
+                  <div class="terminal-dot yellow"></div>
+                  <div class="terminal-dot green"></div>
+                  <span class="terminal-title">Tasks</span>
+                </div>
+                <div class="terminal-body">
+                  <video src="assets/tasks-demo.mp4" autoplay loop muted playsinline preload="none">
+                    Creating tasks and connecting them to a coding agent in the tasks panel
+                  </video>
+                </div>
               </div>
             </div>
-            <figcaption>
-              <strong>Tasks</strong>
-              &mdash;
-              <code>Ctrl+W</code>
-              a todo list whose items hand their text off to an agent.
-            </figcaption>
-          </figure>
-          <figure class="video-card">
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">Global search</span>
-              </div>
-              <div class="terminal-body">
-                <video src="assets/search-demo.mp4" autoplay loop muted playsinline preload="none">
-                  Searching sessions, tasks, automations and files at once with live in-panel
-                  highlighting
-                </video>
+          </div>
+
+          <div class="feature-row">
+            <div class="feature-row-text">
+              <p class="feature-row-eyebrow">Ctrl+A</p>
+              <h3>Global search</h3>
+              <p>
+                One strip searches every scope at once &mdash; sessions (including live terminal
+                content), tasks, automations, and files &mdash; with matches highlighted live in the
+                panels themselves.
+              </p>
+              <a class="feature-row-link" href="docs/features.html#global-search">Learn more &rarr;</a>
+            </div>
+            <div class="feature-row-media">
+              <div class="terminal-frame">
+                <div class="terminal-header">
+                  <div class="terminal-dot red"></div>
+                  <div class="terminal-dot yellow"></div>
+                  <div class="terminal-dot green"></div>
+                  <span class="terminal-title">Global search</span>
+                </div>
+                <div class="terminal-body">
+                  <video src="assets/search-demo.mp4" autoplay loop muted playsinline preload="none">
+                    Searching sessions, tasks, automations and files at once with live in-panel
+                    highlighting
+                  </video>
+                </div>
               </div>
             </div>
-            <figcaption>
-              <strong>Global search</strong>
-              &mdash;
-              <code>Ctrl+A</code>
-              searches sessions, tasks, automations and files at once.
-            </figcaption>
-          </figure>
-          <figure class="video-card">
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">Session creation</span>
-              </div>
-              <div class="terminal-body">
-                <video
-                  src="assets/thurbox-session-creation.mp4"
-                  autoplay
-                  loop
-                  muted
-                  playsinline
-                  preload="none"
-                >
-                  Creating a new session: repo picker, name, agent picker
-                </video>
+          </div>
+
+          <div class="feature-row">
+            <div class="feature-row-text">
+              <p class="feature-row-eyebrow">Ctrl+N</p>
+              <h3>Session creation</h3>
+              <p>
+                Spin up a session in a few keystrokes: pick one or more repos, name it, and choose an
+                agent &mdash; optionally on a fresh git worktree for branch isolation.
+              </p>
+              <a class="feature-row-link" href="docs/features.html#session-orchestration">
+                Learn more &rarr;
+              </a>
+            </div>
+            <div class="feature-row-media">
+              <div class="terminal-frame">
+                <div class="terminal-header">
+                  <div class="terminal-dot red"></div>
+                  <div class="terminal-dot yellow"></div>
+                  <div class="terminal-dot green"></div>
+                  <span class="terminal-title">Session creation</span>
+                </div>
+                <div class="terminal-body">
+                  <!-- prettier-ignore -->
+                  <video src="assets/thurbox-session-creation.mp4" autoplay loop muted playsinline preload="none">
+                    Creating a new session: repo picker, name, agent picker
+                  </video>
+                </div>
               </div>
             </div>
-            <figcaption>
-              <strong>Session creation</strong>
-              &mdash;
-              <code>Ctrl+N</code>
-              walks you through repo, name, and agent.
-            </figcaption>
-          </figure>
-          <figure class="video-card">
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">File viewer</span>
-              </div>
-              <div class="terminal-body">
-                <video
-                  src="assets/thurbox-file-manager.mp4"
-                  autoplay
-                  loop
-                  muted
-                  playsinline
-                  preload="none"
-                >
-                  Browsing the worktree file tree with the file viewer
-                </video>
+          </div>
+
+          <div class="feature-row">
+            <div class="feature-row-text">
+              <p class="feature-row-eyebrow">Ctrl+E</p>
+              <h3>File viewer</h3>
+              <p>
+                Browse the worktree's file tree right beside the agent, with fuzzy search to jump
+                straight to any file.
+              </p>
+              <a class="feature-row-link" href="docs/features.html#responsive-ui">Learn more &rarr;</a>
+            </div>
+            <div class="feature-row-media">
+              <div class="terminal-frame">
+                <div class="terminal-header">
+                  <div class="terminal-dot red"></div>
+                  <div class="terminal-dot yellow"></div>
+                  <div class="terminal-dot green"></div>
+                  <span class="terminal-title">File viewer</span>
+                </div>
+                <div class="terminal-body">
+                  <!-- prettier-ignore -->
+                  <video src="assets/thurbox-file-manager.mp4" autoplay loop muted playsinline preload="none">
+                    Browsing the worktree file tree with the file viewer
+                  </video>
+                </div>
               </div>
             </div>
-            <figcaption>
-              <strong>File viewer</strong>
-              &mdash;
-              <code>Ctrl+E</code>
-              browses the worktree tree with fuzzy search.
-            </figcaption>
-          </figure>
-          <figure class="video-card">
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">Info panel</span>
-              </div>
-              <div class="terminal-body">
-                <video
-                  src="assets/thurbox-info-panel.mp4"
-                  autoplay
-                  loop
-                  muted
-                  playsinline
-                  preload="none"
-                >
-                  Info panel showing session details and live metrics
-                </video>
+          </div>
+
+          <div class="feature-row">
+            <div class="feature-row-text">
+              <p class="feature-row-eyebrow">Ctrl+B</p>
+              <h3>Info panel</h3>
+              <p>
+                Keep an eye on each session: live details plus CPU/RAM and agent activity metrics, in
+                a panel beside the terminal.
+              </p>
+              <a class="feature-row-link" href="docs/features.html#responsive-ui">Learn more &rarr;</a>
+            </div>
+            <div class="feature-row-media">
+              <div class="terminal-frame">
+                <div class="terminal-header">
+                  <div class="terminal-dot red"></div>
+                  <div class="terminal-dot yellow"></div>
+                  <div class="terminal-dot green"></div>
+                  <span class="terminal-title">Info panel</span>
+                </div>
+                <div class="terminal-body">
+                  <!-- prettier-ignore -->
+                  <video src="assets/thurbox-info-panel.mp4" autoplay loop muted playsinline preload="none">
+                    Info panel showing session details and live metrics
+                  </video>
+                </div>
               </div>
             </div>
-            <figcaption>
-              <strong>Info panel</strong>
-              &mdash;
-              <code>Ctrl+B</code>
-              shows session details and live CPU/RAM and agent metrics.
-            </figcaption>
-          </figure>
-          <figure class="video-card">
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">Themes</span>
-              </div>
-              <div class="terminal-body">
-                <video
-                  src="assets/thurbox-theme.mp4"
-                  autoplay
-                  loop
-                  muted
-                  playsinline
-                  preload="none"
-                >
-                  Switching between light and dark themes live
-                </video>
+          </div>
+
+          <div class="feature-row">
+            <div class="feature-row-text">
+              <p class="feature-row-eyebrow">Ctrl+Y</p>
+              <h3>Themes</h3>
+              <p>
+                Nine built-in palettes &mdash; five dark, four light &mdash; switch live with a
+                keystroke and persist across restarts. Bring your own in themes.toml.
+              </p>
+              <a class="feature-row-link" href="docs/features.html#themes">Learn more &rarr;</a>
+            </div>
+            <div class="feature-row-media">
+              <div class="terminal-frame">
+                <div class="terminal-header">
+                  <div class="terminal-dot red"></div>
+                  <div class="terminal-dot yellow"></div>
+                  <div class="terminal-dot green"></div>
+                  <span class="terminal-title">Themes</span>
+                </div>
+                <div class="terminal-body">
+                  <video src="assets/thurbox-theme.mp4" autoplay loop muted playsinline preload="none">
+                    Switching between light and dark themes live
+                  </video>
+                </div>
               </div>
             </div>
-            <figcaption>
-              <strong>Themes</strong>
-              &mdash;
-              <code>Ctrl+Y</code>
-              switches nine light and dark palettes live.
-            </figcaption>
-          </figure>
+          </div>
         </div>
       </div>
     </section>
 
-    <!-- Installation -->
-    <section class="install section" id="installation">
+    <!-- Prerequisites -->
+    <section class="install section" id="prerequisites">
       <div class="container">
         <div class="section-title">
-          <h2>Installation</h2>
-          <p>
-            Pick the method that fits your platform &mdash; every channel ships the same release
-          </p>
-        </div>
-
-        <div class="install-methods">
-          <div class="install-method">
-            <h3>
-              Install Script
-              <span class="badge badge-green">Recommended</span>
-            </h3>
-            <p>
-              Linux &amp; macOS. Auto-detects your platform, verifies checksums, and installs the
-              latest release to
-              <code>~/.local/bin</code>
-              .
-            </p>
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">bash</span>
-              </div>
-              <div class="terminal-body">
-                <button
-                  class="copy-btn"
-                  data-code="curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh"
-                >
-                  Copy
-                </button>
-                <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">curl</span> <span class="syn-flag">-fsSL</span> <span class="syn-url">https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh</span> | <span class="syn-cmd">sh</span></code></pre>
-              </div>
-            </div>
-          </div>
-
-          <div class="install-method">
-            <h3>Homebrew</h3>
-            <p>
-              macOS (Apple Silicon) &amp; Linux x86_64. Prebuilt binaries from the
-              <a href="https://github.com/Thurbeen/homebrew-thurbox" target="_blank" rel="noopener">
-                thurbox tap
-              </a>
-              ; pulls in
-              <code>tmux</code>
-              and
-              <code>git</code>
-              automatically.
-            </p>
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">bash</span>
-              </div>
-              <div class="terminal-body">
-                <button class="copy-btn" data-code="brew install thurbeen/thurbox/thurbox">
-                  Copy
-                </button>
-                <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">brew</span> install thurbeen/thurbox/thurbox</code></pre>
-              </div>
-            </div>
-          </div>
-
-          <div class="install-method">
-            <h3>Arch Linux (AUR)</h3>
-            <p>
-              <a
-                href="https://aur.archlinux.org/packages/thurbox-bin"
-                target="_blank"
-                rel="noopener"
-              >
-                <code>thurbox-bin</code>
-              </a>
-              (prebuilt binary) or
-              <a href="https://aur.archlinux.org/packages/thurbox" target="_blank" rel="noopener">
-                <code>thurbox</code>
-              </a>
-              (builds from source) &mdash; use
-              <code>paru</code>
-              ,
-              <code>yay</code>
-              , or your preferred AUR helper.
-            </p>
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">bash</span>
-              </div>
-              <div class="terminal-body">
-                <button class="copy-btn" data-code="paru -S thurbox-bin">Copy</button>
-                <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">paru</span> <span class="syn-flag">-S</span> thurbox-bin   <span class="syn-comment"># prebuilt (fastest)</span>
-<span class="syn-prompt">$</span> <span class="syn-cmd">paru</span> <span class="syn-flag">-S</span> thurbox       <span class="syn-comment"># build from source</span></code></pre>
-              </div>
-            </div>
-          </div>
-
-          <div class="install-method">
-            <h3>From Source</h3>
-            <p>
-              Any platform with Rust 1.75+. Builds both the
-              <code>thurbox</code>
-              TUI and the
-              <code>thurbox-cli</code>
-              headless binary into
-              <code>target/release/</code>
-              .
-            </p>
-            <div class="terminal-frame">
-              <div class="terminal-header">
-                <div class="terminal-dot red"></div>
-                <div class="terminal-dot yellow"></div>
-                <div class="terminal-dot green"></div>
-                <span class="terminal-title">bash</span>
-              </div>
-              <div class="terminal-body">
-                <button
-                  class="copy-btn"
-                  data-code="git clone https://github.com/Thurbeen/thurbox.git
-cd thurbox
-cargo build --release"
-                >
-                  Copy
-                </button>
-                <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">git</span> clone <span class="syn-url">https://github.com/Thurbeen/thurbox.git</span>
-<span class="syn-prompt">$</span> <span class="syn-cmd">cd</span> thurbox
-<span class="syn-prompt">$</span> <span class="syn-cmd">cargo</span> build <span class="syn-flag">--release</span></code></pre>
-              </div>
-            </div>
-          </div>
+          <h2>Prerequisites</h2>
+          <p>What you need before running Thurbox &mdash; plus extra install options</p>
         </div>
 
         <div class="install-main">
@@ -697,3 +743,8 @@ cargo build --release"
         </div>
       </div>
     </section>
+
+    <!-- Back to top -->
+    <button class="back-to-top" id="back-to-top" aria-label="Back to top" title="Back to top">
+      <span aria-hidden="true">&uarr;</span>
+    </button>

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -110,6 +110,123 @@
     }
   }
 
+  // ---- Active top-nav link (landing page scroll-spy) ----
+  var navSpyLinks = [];
+  document.querySelectorAll('.nav-links a[href*="#"]').forEach(function (link) {
+    var hash = link.getAttribute('href').split('#')[1];
+    var section = hash ? document.getElementById(hash) : null;
+    if (section) navSpyLinks.push({ el: section, link: link });
+  });
+
+  if (navSpyLinks.length > 0 && 'IntersectionObserver' in window) {
+    var navObserver = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            navSpyLinks.forEach(function (s) {
+              s.link.classList.remove('active');
+              s.link.removeAttribute('aria-current');
+            });
+            var match = navSpyLinks.find(function (s) {
+              return s.el === entry.target;
+            });
+            if (match) {
+              match.link.classList.add('active');
+              match.link.setAttribute('aria-current', 'true');
+            }
+          }
+        });
+      },
+      { rootMargin: '-80px 0px -70% 0px', threshold: 0 },
+    );
+    navSpyLinks.forEach(function (s) {
+      navObserver.observe(s.el);
+    });
+  }
+
+  // ---- Back to top button ----
+  var backToTop = document.getElementById('back-to-top');
+  if (backToTop) {
+    window.addEventListener(
+      'scroll',
+      function () {
+        backToTop.classList.toggle('visible', window.scrollY > 600);
+      },
+      { passive: true },
+    );
+    backToTop.addEventListener('click', function () {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+
+  // ---- Install method tabs (ARIA tabs pattern) ----
+  var installTablist = document.querySelector('.install-tablist');
+  if (installTablist) {
+    var installTabs = Array.prototype.slice.call(installTablist.querySelectorAll('[role="tab"]'));
+    var selectInstallTab = function (tab) {
+      installTabs.forEach(function (t) {
+        var isSelected = t === tab;
+        t.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+        t.tabIndex = isSelected ? 0 : -1;
+        var panel = document.getElementById(t.getAttribute('aria-controls'));
+        if (panel) panel.hidden = !isSelected;
+      });
+    };
+    installTabs.forEach(function (tab, i) {
+      tab.addEventListener('click', function () {
+        selectInstallTab(tab);
+      });
+      tab.addEventListener('keydown', function (e) {
+        var next = null;
+        if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (i + 1) % installTabs.length;
+        else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp')
+          next = (i - 1 + installTabs.length) % installTabs.length;
+        else if (e.key === 'Home') next = 0;
+        else if (e.key === 'End') next = installTabs.length - 1;
+        if (next !== null) {
+          e.preventDefault();
+          selectInstallTab(installTabs[next]);
+          installTabs[next].focus();
+        }
+      });
+    });
+  }
+
+  // ---- Videos: play only when in view; honor reduced motion ----
+  var videos = document.querySelectorAll('video');
+  var reduceMotion =
+    window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (videos.length > 0) {
+    if (reduceMotion) {
+      // No autoplay: pause everything and let the user opt in via controls.
+      videos.forEach(function (v) {
+        v.autoplay = false;
+        v.removeAttribute('autoplay');
+        v.setAttribute('controls', '');
+        v.pause();
+      });
+    } else if ('IntersectionObserver' in window) {
+      var videoObserver = new IntersectionObserver(
+        function (entries) {
+          entries.forEach(function (entry) {
+            var v = entry.target;
+            if (entry.isIntersecting) {
+              var played = v.play();
+              if (played && played.catch) played.catch(function () {});
+            } else {
+              v.pause();
+            }
+          });
+        },
+        { threshold: 0.25 },
+      );
+      videos.forEach(function (v) {
+        videoObserver.observe(v);
+      });
+    }
+  }
+
   // ---- Mobile sidebar toggle (docs pages) ----
   var sidebarToggle = document.getElementById('sidebar-toggle');
   var sidebar = document.querySelector('.docs-sidebar');


### PR DESCRIPTION
## Summary

- **Hero**: eyebrow kicker, restored **TUI Agentic IDE** title, and the install-method **tabs** (Install Script / Homebrew / AUR / From Source) in place of the one-liner — no duplicate install UI lower down
- **Agent logos**: built-in agent list now shows brand marks (Claude, Codex/OpenAI, Gemini, opencode, aider, Mistral for Vibe) as inline `currentColor` SVGs
- **Feature showcase**: the walkthrough is now an Orca-style **alternating media + text** layout — keybind eyebrow, explanation, and "Learn more" link per row
- **UX/a11y**: top-nav scroll-spy, back-to-top button, play-videos-only-in-view + `prefers-reduced-motion`, `:focus-visible` rings, skip-to-content `<main>` landmark
- Removed the redundant **Install** step from "How It Works" (now 3 steps)

## Test plan

- `npm run lint:website` passes (Eleventy build + prettier + htmlhint + stylelint + eslint)
- Verified no dead CSS, all "Learn more" anchors resolve, section ids unique, JS hooks present