### PR TITLE
feat: send flow worker clarifying questions one at a time

### DIFF
--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -89,8 +89,9 @@ the table, add a row when you learn its path.
    `--description` (the user's words) plus the `--accept` / `--priority` /
    `--repo` / `--worktree` flags it composes the full description — the
    `priority/repo/accept` header, the user's words, a mandatory **Planning
-   phase** (clarify → plan → build: ask ≥3 clarifying questions and wait,
-   then send a written plan and wait for approval, then implement), and the
+   phase** (clarify → plan → build: ask clarifying questions one at a time,
+   waiting for each answer before the next, then send a written plan and wait for
+   approval, then implement), and the
    result/notify footer. So
    **never hand-type that header, planning block, or footer** — pass the
    structured flags and the helper keeps the contract byte-identical on every
@@ -120,8 +121,10 @@ the table, add a row when you learn its path.
    ```
 
 4. **The planning phase happens inside the worker, not in this session.**
-   The composed prompt makes every worker, in order: (a) ask **≥3 clarifying
-   questions** (pushed via `message send --kind questions`) and WAIT, (b) send a
+   The composed prompt makes every worker, in order: (a) ask clarifying questions
+   **one at a time** — a single question pushed via `message send --kind
+   questions`, then WAIT for its answer before the next, adaptively dropping later
+   questions once an answer clarifies enough — then (b) send a
    written plan (`--kind plan`) — problem, concrete acceptance criteria (refined
    from your `accept:` line), and approach — and WAIT for the user's approval,
    then (c) build strictly against the approved plan and report (`--kind
@@ -185,8 +188,11 @@ first step of every TICK, so a missed wake never strands a worker.
 
    Each item is JSON: `{ "kind", "body", "from_task_id", ... }`.
 2. For each message, by `kind`:
-   - **`questions`** → the worker is parked waiting on you. List the `body`
-     **verbatim** under "Needs you", tagged `#<from_task_id> <title>`.
+   - **`questions`** → the worker is parked waiting on you with a **single**
+     clarifying question (workers ask one at a time, not in a batch). List the
+     `body` **verbatim** under "Needs you", tagged `#<from_task_id> <title>`. The
+     user's answer lets the worker send its next question (another `questions`
+     message) or move on to the plan.
    - **`plan`** → the worker wants approval before it codes. Show the `body`
      **verbatim** under "Needs you", tagged `#<from_task_id> <title>`, and make
      clear it needs an **approve / change** decision.
@@ -199,13 +205,16 @@ first step of every TICK, so a missed wake never strands a worker.
 
 ## ANSWER (relay the user's reply to a waiting worker)
 
-A worker asks **≥3 clarifying questions**, then later sends a **plan**, WAITING
-after each — building nothing until it hears back. You surfaced those (in DRAIN)
-and now relay the user's reply (answers, or **approve / change** on a plan).
+A worker asks clarifying questions **one at a time** (a single question, then it
+WAITS for the answer before sending the next), then later sends a **plan**,
+WAITING after each — building nothing until it hears back. You surfaced those (in
+DRAIN) and now relay the user's reply (the answer to the current question, or
+**approve / change** on a plan). The worker uses each answer to send its next
+question or to move on; you just keep relaying.
 **You are a pure wire: never answer, reword, expand, or approve on your own —
 pass it through.**
 
-When the user replies to questions or a plan you surfaced:
+When the user replies to a question or a plan you surfaced:
 
 1. Identify the waiting worker. Usually it's the one whose message you most
    recently surfaced; map its `#<id>` to the session uuid via `flow-snapshot.sh`

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -107,7 +107,9 @@ tagged URL (`…/thurbox/v0.112.0/extensions/flow`) instead.
   the repo is git).
 - **Plan-first dispatch**: every worker prompt carries a mandatory
   planning phase — clarify, then plan, then build. Before writing any code
-  the worker (1) asks **at least 3 clarifying questions** and waits, (2)
+  the worker (1) asks clarifying questions **one at a time** — a single question,
+  then it waits for your answer before sending the next, adaptively (often 3+,
+  but fewer if an early answer makes later ones moot) — (2)
   writes a structured plan — problem, concrete acceptance criteria, approach —
   and waits for your **approval**, then (3) builds strictly against the
   approved plan, so dispatched work stays scoped to what you asked for. The flow
@@ -117,7 +119,7 @@ tagged URL (`…/thurbox/v0.112.0/extensions/flow`) instead.
 - **Event-driven relay via a message queue**: workers hand the `flow` session
   clean, structured payloads through the durable `thurbox-cli message` queue —
   `--kind questions`, `--kind plan`, `--kind result` — instead of flow scraping
-  their terminals. Each push also wakes flow, so it surfaces the questions or
+  their terminals. Each push also wakes flow, so it surfaces the question or
   plan under "Needs you" immediately; you type your answer / approval naturally
   and flow relays it straight back to the waiting worker (`session send`). Flow
   is a pure pass-through: it never answers, invents, or approves — it just wires

--- a/extensions/flow/scripts/create-task.bats
+++ b/extensions/flow/scripts/create-task.bats
@@ -24,8 +24,14 @@ setup() {
   [[ "$output" == *"accept: requests over the limit get 429"* ]]
   [[ "$output" == *"Throttle the API."* ]]
   [[ "$output" == *"## Planning phase"* ]]
-  [[ "$output" == *"at least 3"* ]]
+  # Clarifying questions go out ONE AT A TIME, not batched into a single message.
+  [[ "$output" == *"ONE AT A TIME"* ]]
+  [[ "$output" == *"never batched"* ]]
+  [[ "$output" == *"Send a SINGLE question"* ]]
   [[ "$output" == *"message send --to flow --kind questions"* ]]
+  # The old batched phrasing (and its multi-question example body) must be gone.
+  [[ "$output" != *"as ONE message"* ]]
+  [[ "$output" != *"Q1 ..."* ]]
   [[ "$output" == *"message send --to flow --kind plan"* ]]
   [[ "$output" == *"## Problem"* ]]
   [[ "$output" == *"## Acceptance criteria"* ]]

--- a/extensions/flow/scripts/create-task.sh
+++ b/extensions/flow/scripts/create-task.sh
@@ -15,9 +15,11 @@
 #   priority/repo/accept header → the user's words → a mandatory **Planning
 #   phase** → the result/notify footer — so every worker follows the same
 # clarify → plan → build contract BEFORE touching code. The planning phase makes
-# the worker (1) ask >=3 clarifying questions and push them to the flow session
-# via `thurbox-cli message send --kind questions` and WAIT (flow relays them to
-# the user and sends the answers back), then (2) push a written plan via
+# the worker (1) ask clarifying questions ONE AT A TIME — push a single question
+# via `thurbox-cli message send --kind questions` and WAIT for its answer before
+# sending the next (flow relays each question to the user and sends the answer
+# back), adaptively, dropping later questions once an answer clarifies enough —
+# then (2) push a written plan via
 # `--kind plan` and WAIT for the user's approval (relayed by flow), then
 # (3) implement strictly against the approved plan. Worker → flow handoffs go
 # through the durable message queue (not pane scraping); flow → worker replies
@@ -86,19 +88,21 @@ flow agent through the thurbox message queue (replace <id> with THIS task's id);
 flow surfaces each message to the user and relays the user's reply to you as a
 new message in this session.
 
-1. **Ask clarifying questions first.** Unless the task is genuinely trivial and
-   unambiguous, ask **at least 3** clarifying questions (more if it needs them)
-   about scope, edge cases, the acceptance bar, and anything underspecified.
-   Send them to flow as ONE message, then STOP:
+1. **Ask clarifying questions ONE AT A TIME.** Unless the task is genuinely
+   trivial and unambiguous, ask clarifying questions about scope, edge cases, the
+   acceptance bar, and anything underspecified — but send them **one at a time, in
+   order, never batched**. Send a SINGLE question, then STOP:
 
        thurbox-cli message send --to flow --kind questions --task <id> \
-         --body 'Q1 ...
-       Q2 ...
-       Q3 ...'
+         --body 'Q: ...'
 
-   End your turn and wait — do NOT plan or write code yet. Flow relays your
-   questions to the user and sends the answers back as a new message here;
-   resume only when they arrive.
+   End your turn and wait — do NOT send the next question, plan, or write code
+   yet. Flow relays that one question to the user and sends the answer back as a
+   new message here; resume only when it arrives, then send your next question
+   the same way (one message, then STOP). Ask **as many as you need** (typically
+   3+), but be adaptive: let each answer shape the next question, and once an
+   answer clarifies enough that the remaining questions are moot, drop them and
+   proceed straight to the plan.
 
 2. **Plan, then wait for approval.** With the answers in hand, write a structured
    plan and send it to flow for the user to approve — do NOT start coding yet:


### PR DESCRIPTION
## Problem

The flow extension instructed each dispatched worker to ask **"at least 3 clarifying questions" batched into a single** `--kind questions` message. Batching all questions up front makes for a worse flow↔worker↔user interaction — the user answers a wall of questions at once, and the worker can't let an early answer reshape a later question.

## Change

Switch to an **adaptive, one-question-at-a-time** loop in the worker's planning phase:

- The worker sends a **single** question (`--kind questions`), then STOPS and waits for the answer.
- Flow relays that one question, gets the answer, relays it back; the worker then sends its next question — shaped by the previous answer.
- It is **adaptive**: ask as many as needed (often 3+), but drop remaining questions once an answer clarifies enough to proceed straight to the plan.

This is a **prompt/docs-only** change — no Rust/CLI changes were required. The `thurbox-cli message` queue already sends one message per `message send` call, and flow's DRAIN/ANSWER already round-trip each message independently, so the sequential loop works with existing primitives.

## Files touched (`extensions/flow/`)

- **`scripts/create-task.sh`** — rewrote the composed worker prompt (Planning phase step 1) to the one-at-a-time adaptive loop, plus the header doc-comment describing it.
- **`FLOW.md`** — aligned the CAPTURE (step 4 + plan-first dispatch note), DRAIN (`questions` handling), and ANSWER sections to the sequential protocol.
- **`README.md`** — updated the plan-first dispatch description.
- **`scripts/create-task.bats`** — updated assertions: prompt now instructs one-at-a-time (`ONE AT A TIME`, `never batched`, `Send a SINGLE question`) and no longer contains the batched `as ONE message` / `Q1 ...` phrasing.

## Verification

- `shellcheck scripts/create-task.sh` — clean.
- `rumdl check FLOW.md README.md` — clean.
- `create-task.bats` assertions re-emulated against live `--dry-run` output (all positive/negative checks pass). `bats` is not installed locally; CI runs the suite.

Resolves Thurbox task #44.