### PR TITLE
fix(config): quiet flow ticks and widen cadence to 10 min

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -229,7 +229,7 @@ repo_path = "{home}"            # resolved to the absolute home at install
 
 [[automations]]
 name = "flow-tick"
-trigger = "cron:*/5 * * * *"    # same grammar as `automation create --trigger`
+trigger = "cron:*/10 * * * *"   # same grammar as `automation create --trigger`
 session_ref = "flow"           # must match a [[sessions]] name above
 prompt = "tick"
 ```

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -778,7 +778,7 @@ Dispatch is **eager**: capture creates the task *and* spawns its
 worker in one atomic helper call (`create-task.sh`); workers send a
 `tick` back to the flow session when they finish so a freed capacity
 slot dispatches the next task immediately; a `flow-tick` cron
-automation (default every 5 min) is only the safety net that catches
+automation (default every 10 min) is only the safety net that catches
 crashed workers and stale state. Workers always get a
 `flow/<task-slug>` worktree branch on git repos, so they never dirty
 the main checkout and parallelize per repo. Completion is detected by

--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -235,35 +235,45 @@ When the user replies to a question or a plan you surfaced:
 
 ## TICK (from the automation — quiet janitor + safety net)
 
-The interactive loop is driven by worker pushes (DRAIN/ANSWER); the cron tick is
-the **safety net** — it drains anything a missed wake left queued and grooms
-stale state.
+The interactive loop is driven by worker pushes (DRAIN/ANSWER); the cron tick
+(every 10 min) is the **safety net** — it drains anything a missed wake left
+queued and grooms stale state. It runs **quietly**: a tick that finds nothing to
+report prints a single minimal line and nothing else, so routine ticks never
+interrupt the user. The board appears **only** when something actually needs
+attention.
 
-0. **Print the board.** Run `./scripts/flow-summary.sh` and put its output
-   (verbatim, fenced) at the **top** of your reply — a quick-glance table of
-   every live `flow` / worker (`… · #<id>`) session joined to its task (status /
-   age / title), plus any `detached` work. This is the one thing a tick always
-   shows, even when nothing needs you.
+Do the work first, track whether anything happened, then decide what to print.
 
 1. **Drain the queue** — run DRAIN (claim the inbox, surface questions/plans,
-   close out results). This catches any worker whose wake nudge was lost.
+   close out results). This catches any worker whose wake nudge was lost. Note
+   any surfaced questions/plans/results (incl. errors) as **events**.
 
 2. **Reconcile** each `in_progress` task:
-   - Status already flipped to `done` by the worker → note it; session
-     cleanup happens in CLEAN.
+   - Status already flipped to `done` by the worker → note it as an event;
+     session cleanup happens in CLEAN.
    - Worker session (name `… · #<id>`, or legacy `task-<id>-…`) missing from the
-     session list → stale: reset to todo (`task edit <id> --status todo`).
+     session list → stale: reset to todo (`task edit <id> --status todo`) — an
+     event.
    - Otherwise it's still working — leave it. (As a last-resort liveness check
      for a worker that died WITHOUT sending a `result`, you may
      `thurbox-cli session capture <uuid> --lines 40` and flag an obvious crash
      or user-addressed prompt under "Needs you"; the queue, not the pane, is the
      normal channel.)
 
-3. Run DISPATCH for next eligible todos (respect capacity).
-4. Output — the board (step 0) **always comes first**, then:
-   - nothing needs the user → one line `tick: all quiet (N running, M todo)`
-     under the board, nothing else;
-   - otherwise → the Needs-you bullets + footer under the board.
+3. Run DISPATCH for next eligible todos (respect capacity). A worker you
+   actually dispatch is an event.
+
+4. **Output — conditional on events.** An *event* is anything from steps 1–3
+   (a surfaced question/plan/result, a worker error/blocker, a stale reset, an
+   orphan session, or a fresh dispatch), or any pending Needs-you item.
+   - **No events, nothing needs you** → print **only** one minimal line
+     `tick: N running, M todo` (N = running workers, M = queued todos). No board,
+     no footer, nothing else.
+   - **Otherwise** → run `./scripts/flow-summary.sh` and put its output
+     (verbatim, fenced) at the **top** of your reply — a quick-glance table of
+     every live `flow` / worker (`… · #<id>`) session joined to its task (status
+     / age / title), plus any `detached` work — then the Needs-you bullets +
+     footer beneath it.
 
 ## REPORT
 

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -41,7 +41,7 @@ That single command is the installer — it reads flow's
    CLI/model);
 3. writes the manifest to `~/.config/thurbox/extensions/flow.toml` and
    activates it, creating the dedicated `flow` session and a `flow-tick`
-   automation (every 5 minutes) that keeps it monitoring workers even
+   automation (every 10 minutes) that keeps it monitoring workers even
    while the TUI is closed.
 
 It's idempotent — re-run it any time to pull the latest spec/scripts,
@@ -126,12 +126,15 @@ tagged URL (`…/thurbox/v0.112.0/extensions/flow`) instead.
   the worker to you and back. Several workers can be mid-conversation at once,
   each tagged by its `#<id>`.
 - `status` for a one-screen report; `clean` to groom the backlog.
-- Every tick prints a **board** — a quick-glance table of all live
+- A tick prints the **board** — a quick-glance table of all live
   `flow` / worker (`… · #<id>`) sessions with status, age, and the task they're
-  working (`scripts/flow-summary.sh`) — so you can see the whole picture at once. The
-  `flow-tick` automation is now a **safety net**: worker pushes drive the
-  interactive loop; the cron tick just drains anything a missed wake left queued
-  and grooms stale state.
+  working (`scripts/flow-summary.sh`) — **only when something needs attention**
+  (a surfaced question/plan/result, an error/blocker, a stale reset, an orphan
+  session, or a fresh dispatch). A quiet tick prints just one minimal line
+  (`tick: N running, M todo`), so routine ticks don't interrupt you. The
+  `flow-tick` automation is a **safety net** that fires every 10 minutes: worker
+  pushes drive the interactive loop; the cron tick just drains anything a missed
+  wake left queued and grooms stale state.
 - Workers self-report: they mark their task done and send a `--kind result`
   message, which wakes flow so the next task dispatches without waiting for the
   cron tick.

--- a/extensions/flow/extension.toml
+++ b/extensions/flow/extension.toml
@@ -11,7 +11,7 @@
 name = "flow"
 description = "Focus-protecting triage agent"
 config_version = 1
-version = "1.1.0"                 # this extension's own version; bump on changes
+version = "1.2.0"                 # this extension's own version; bump on changes
 min_thurbox_version = "0.120.0"  # needs the `thurbox-cli message` mailbox queue
 home = "~/flow"
 
@@ -97,6 +97,6 @@ repo_path = "{home}"
 
 [[automations]]
 name = "flow-tick"
-trigger = "cron:*/5 * * * *"
+trigger = "cron:*/10 * * * *"
 session_ref = "flow"
 prompt = "tick"


### PR DESCRIPTION
Closes flow task #46.

## Problem
The flow-tick cron fired every 5 min and the TICK spec in `FLOW.md` *always* printed the full board plus an `all quiet` line — interrupting the user even when nothing changed.

## Changes
- **`extensions/flow/extension.toml`**: automation trigger `cron:*/5` → `cron:*/10`; bump extension `version` 1.1.0 → 1.2.0.
- **`extensions/flow/FLOW.md`**: rewrite the TICK section. Do the drain/reconcile/dispatch work first, tracking whether anything happened. Output is now conditional:
  - **No events / nothing needs you** → print only one minimal line `tick: N running, M todo`.
  - **Otherwise** (queued question/plan/result, error/blocker, stale reset, orphan session, or fresh dispatch) → print the board + Needs-you bullets as before.
  - No snapshot/state file — the decision is purely "are there events this tick?".
- **`extensions/flow/README.md`**, **`docs/CONFIG.md`**, **`docs/FEATURES.md`**: match the 10-min cadence + conditional-board behavior.

## Acceptance
- [x] flow-tick runs every 10 min.
- [x] Quiet tick → one minimal line, no board.
- [x] Eventful tick → board + Needs-you, unchanged.
- [x] No state file.
- [x] Docs updated.

No Rust/code changes; extension data + spec only. (Existing `#[cfg(test)]` fixtures in `src/` that happen to use `*/5` are arbitrary parser test data, left untouched.)