### PR TITLE
feat(cli): human-readable thurbox-cli output by default, JSON via --json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,8 +348,9 @@ thurbox-cli session create --name demo --repo-path /srv/repo \
 # Spawn a worker under a lead session (parent must exist):
 thurbox-cli session create --name worker --repo-path /path \
     --parent <lead-uuid>
-thurbox-cli session list | jq
-thurbox-cli session list --parent <lead-uuid> | jq  # direct children only
+thurbox-cli session list                       # human-readable table
+thurbox-cli session list --json | jq           # machine output for scripts
+thurbox-cli session list --parent <lead-uuid> --json | jq  # direct children only
 ```
 
 Subcommands: `session` (create/list/get/delete/restore/restart/
@@ -360,8 +361,10 @@ send/inbox/prune — the inter-session mailbox queue; see below), `editor`, `con
 (validate/show — strict-parses every config file / prints the
 effective resolved config; see `docs/CONFIG.md`), `extension`
 (alias `ext`: install/uninstall/reinstall/list/available/update/activate/
-deactivate/status — manage opt-in extensions; see below). Pass `--pretty` for
-indented JSON.
+deactivate/status — manage opt-in extensions; see below). Output is
+**human-readable by default** and switches to JSON automatically when stdout is
+piped (so `… | jq` keeps working); force a format with `--json` (compact),
+`--pretty` (indented JSON), or `--text` (human even when piped).
 
 `session delete <uuid>` **soft-deletes** by default — only the DB
 row is marked deleted (the TUI tears down the tmux window/worktree

--- a/extensions/ci-shepherd/SHEPHERD.md
+++ b/extensions/ci-shepherd/SHEPHERD.md
@@ -130,7 +130,7 @@ The forge's own value is kept only as a fallback for heads that aren't on
    - Otherwise capture recent output and parse the worker's sentinel:
 
      ```bash
-     thurbox-cli session capture <uuid> --lines 40 | jq -r .output \
+     thurbox-cli session capture <uuid> --lines 40 --json | jq -r .output \
        | ./scripts/parse-result.sh
      ```
 

--- a/extensions/ci-shepherd/scripts/dispatch-fix.sh
+++ b/extensions/ci-shepherd/scripts/dispatch-fix.sh
@@ -166,7 +166,7 @@ When finished: mark this task done (thurbox-cli task edit <id> --status done),
 print a final line \`===RESULT===\` followed by one line of JSON:
 {"status":"ok|error","url":"...","notes":"...","question":"..."}
 then notify the shepherd so the next request dispatches immediately:
-thurbox-cli session send "\$(thurbox-cli session list | jq -r '.[] | select(.name=="shepherd") | .id')" "tick"
+thurbox-cli session send "\$(thurbox-cli session list --json | jq -r '.[] | select(.name=="shepherd") | .id')" "tick"
 EOF
 )"
 

--- a/extensions/ci-shepherd/scripts/shepherd-snapshot.sh
+++ b/extensions/ci-shepherd/scripts/shepherd-snapshot.sh
@@ -67,7 +67,7 @@ fi
 
 echo
 echo "## sessions (shepherd / task-*)"
-thurbox-cli session list 2>/dev/null | jq -r '
+thurbox-cli session list --json 2>/dev/null | jq -r '
   .[] | select(.name == "shepherd" or (.name | startswith("task-"))) |
   "  \(.name)  \(.id)  agent=\(.agent)  cwd=\(.cwd)"' 2>/dev/null || true
 

--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -42,7 +42,7 @@ Pattern-match the incoming message:
 message queue: it runs `thurbox-cli message send --to flow --kind
 questions|plan|result …`, which enqueues the message **and** types `inbox` into
 your pane to wake you. You read it with `thurbox-cli message inbox --for flow
---claim` (DRAIN) — never by capturing the worker's terminal.
+--claim --json` (DRAIN) — never by capturing the worker's terminal.
 
 **ANSWER vs CAPTURE.** When you surfaced a worker's clarifying questions or plan,
 the user's next free-text message is almost always the **answers / approval**,
@@ -183,10 +183,12 @@ first step of every TICK, so a missed wake never strands a worker.
    same one twice):
 
    ```bash
-   thurbox-cli message inbox --for flow --claim
+   thurbox-cli message inbox --for flow --claim --json
    ```
 
-   Each item is JSON: `{ "kind", "body", "from_task_id", ... }`.
+   Each item is JSON: `{ "kind", "body", "from_task_id", ... }`. (Pass `--json`
+   because you run inside a tmux pane — a TTY — where the CLI otherwise prints a
+   human-readable table.)
 2. For each message, by `kind`:
    - **`questions`** → the worker is parked waiting on you with a **single**
      clarifying question (workers ask one at a time, not in a batch). List the

--- a/extensions/flow/scripts/flow-snapshot.sh
+++ b/extensions/flow/scripts/flow-snapshot.sh
@@ -29,7 +29,7 @@ echo "## sessions (flow / workers)"
 # (legacy) — mirror Task::matches_spawn_session. The derived #<id> is printed
 # first so ANSWER can map a task id straight to the session uuid for
 # `session send`.
-if SESSIONS="$(thurbox-cli session list 2>/dev/null)"; then
+if SESSIONS="$(thurbox-cli session list --json 2>/dev/null)"; then
   printf '%s' "$SESSIONS" | jq -r '
     .[]
     # extract <id> from "<title> · #<id>" (current) or "task-<id>[-…]" (legacy);

--- a/extensions/flow/scripts/flow-summary.sh
+++ b/extensions/flow/scripts/flow-summary.sh
@@ -17,8 +17,8 @@
 
 set -euo pipefail
 
-SESSIONS="$(thurbox-cli session list 2>/dev/null || echo '[]')"
-TASKS="$(thurbox-cli task list 2>/dev/null || echo '[]')"
+SESSIONS="$(thurbox-cli session list --json 2>/dev/null || echo '[]')"
+TASKS="$(thurbox-cli task list --json 2>/dev/null || echo '[]')"
 
 ROWS="$(printf '%s' "$SESSIONS" | jq -r --argjson tasks "$TASKS" '
   # tasks indexed by id (string keys)

--- a/extensions/renovate/RENOVATE.md
+++ b/extensions/renovate/RENOVATE.md
@@ -85,7 +85,7 @@ finished update awaits review). Then it lists the live `update …` tasks and th
    - Otherwise capture recent output and parse the worker's sentinel:
 
      ```bash
-     thurbox-cli session capture <uuid> --lines 40 | jq -r .output \
+     thurbox-cli session capture <uuid> --lines 40 --json | jq -r .output \
        | ./scripts/parse-result.sh
      ```
 

--- a/extensions/renovate/scripts/dispatch-update.sh
+++ b/extensions/renovate/scripts/dispatch-update.sh
@@ -81,7 +81,7 @@ When finished: mark this task done (thurbox-cli task edit <id> --status done),
 print a final line \`===RESULT===\` followed by one line of JSON:
 {"status":"ok|error","artifact":"...","notes":"...","pr_url":"..."}
 then notify the renovate monitor so the next repo dispatches immediately:
-thurbox-cli session send "\$(thurbox-cli session list | jq -r '.[] | select(.name=="renovate") | .id')" "tick"
+thurbox-cli session send "\$(thurbox-cli session list --json | jq -r '.[] | select(.name=="renovate") | .id')" "tick"
 EOF
 )"
 

--- a/extensions/renovate/scripts/renovate-snapshot.sh
+++ b/extensions/renovate/scripts/renovate-snapshot.sh
@@ -59,6 +59,6 @@ fi
 
 echo
 echo "## sessions (renovate / task-*)"
-thurbox-cli session list 2>/dev/null | jq -r '
+thurbox-cli session list --json 2>/dev/null | jq -r '
   .[] | select(.name == "renovate" or (.name | startswith("task-"))) |
   "  \(.name)  \(.id)  agent=\(.agent)  cwd=\(.cwd)"' 2>/dev/null || true

--- a/scripts/dev/remote-ssh-test.sh
+++ b/scripts/dev/remote-ssh-test.sh
@@ -141,7 +141,7 @@ EOF
   local out
   out="$(cd "$REPO_ROOT" && \
     XDG_CONFIG_HOME="$xdg/config" XDG_DATA_HOME="$xdg/data" \
-    cargo run -q --bin thurbox-cli -- session create \
+    cargo run -q --bin thurbox-cli -- --json session create \
       --name e2e --host podman --repo-path "$REMOTE_REPO" \
       --agent shell --worktree-branch test/e2e --base-branch main 2>/dev/null)"
 
@@ -150,7 +150,7 @@ EOF
     || die "session create failed: $out"
   backend_type="$(cd "$REPO_ROOT" && \
     XDG_CONFIG_HOME="$xdg/config" XDG_DATA_HOME="$xdg/data" \
-    cargo run -q --bin thurbox-cli -- session get "$id" 2>/dev/null \
+    cargo run -q --bin thurbox-cli -- --json session get "$id" 2>/dev/null \
     | python3 -c 'import sys,json;print(json.load(sys.stdin).get("backend_type",""))')"
 
   # Confirm the artifacts really live on the remote.

--- a/src/bin/thurbox-cli.rs
+++ b/src/bin/thurbox-cli.rs
@@ -40,8 +40,7 @@ fn main() {
     };
 
     if let Err(e) = thurbox::cli::run(cli, &db) {
-        let msg = serde_json::json!({ "error": e }).to_string();
-        eprintln!("{msg}");
+        eprintln!("error: {e}");
         std::process::exit(1);
     }
 }

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -7,6 +7,7 @@
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use crate::cli::output::{self, CommandOutput};
 use crate::session::automation::parse_trigger;
 use crate::session::{Automation, AutomationAction, AutomationRun, AutomationRunStatus, SessionId};
 use crate::session_ops::SpawnRequest;
@@ -113,7 +114,7 @@ pub enum Action {
     Tick,
 }
 
-pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
     match action {
         Action::Create {
             name,
@@ -158,17 +159,28 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 .get_automation(id)
                 .map_err(|e| format!("get_automation: {e}"))?
                 .ok_or("automation vanished after insert")?;
-            Ok(automation_to_json(&auto))
+            let human = format!(
+                "Created automation #{} '{}' ({}){}",
+                auto.id,
+                auto.name,
+                auto.schedule.kind(),
+                if auto.enabled { "" } else { " — disabled" }
+            );
+            Ok(CommandOutput::new(automation_to_json(&auto), human))
         }
         Action::List => {
             let autos = db
                 .list_automations()
                 .map_err(|e| format!("list_automations: {e}"))?;
-            Ok(Value::Array(autos.iter().map(automation_to_json).collect()))
+            let json = Value::Array(autos.iter().map(automation_to_json).collect());
+            Ok(CommandOutput::new(json, render_automation_list(&autos)))
         }
         Action::Show { id } => {
             let auto = load(db, id)?;
-            Ok(automation_to_json(&auto))
+            Ok(CommandOutput::new(
+                automation_to_json(&auto),
+                render_automation_detail(&auto),
+            ))
         }
         Action::Edit {
             id,
@@ -215,15 +227,25 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             if auto.enabled {
                 arm_heartbeat();
             }
-            Ok(automation_to_json(&load(db, id)?))
+            let auto = load(db, id)?;
+            Ok(CommandOutput::new(
+                automation_to_json(&auto),
+                render_automation_detail(&auto),
+            ))
         }
         Action::Remove { id } => match db.delete_automation(id) {
-            Ok(true) => Ok(json!({ "removed": true, "id": id })),
+            Ok(true) => Ok(CommandOutput::new(
+                json!({ "removed": true, "id": id }),
+                format!("Removed automation #{id}."),
+            )),
             Ok(false) => Err(format!("Automation not found: {id}")),
             Err(e) => Err(format!("delete_automation: {e}")),
         },
         Action::Run { id } => match db.trigger_automation_now(id) {
-            Ok(true) => Ok(json!({ "triggered": true, "id": id })),
+            Ok(true) => Ok(CommandOutput::new(
+                json!({ "triggered": true, "id": id }),
+                format!("Triggered automation #{id} (fires on the next tick)."),
+            )),
             Ok(false) => Err(format!("Automation not found: {id}")),
             Err(e) => Err(format!("trigger_automation_now: {e}")),
         },
@@ -231,9 +253,86 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             let runs = db
                 .list_automation_runs(id, limit.unwrap_or(20))
                 .map_err(|e| format!("list_automation_runs: {e}"))?;
-            Ok(Value::Array(runs.iter().map(run_to_json).collect()))
+            let json = Value::Array(runs.iter().map(run_to_json).collect());
+            Ok(CommandOutput::new(json, render_run_history(id, &runs)))
         }
-        Action::Tick => tick(db),
+        Action::Tick => {
+            let json = tick(db)?;
+            let human = render_tick(&json);
+            Ok(CommandOutput::new(json, human))
+        }
+    }
+}
+
+/// Render the automation list as an aligned table (or a friendly empty line).
+fn render_automation_list(autos: &[Automation]) -> String {
+    if autos.is_empty() {
+        return "No automations.".to_string();
+    }
+    let rows: Vec<Vec<String>> = autos
+        .iter()
+        .map(|a| {
+            vec![
+                a.id.to_string(),
+                if a.enabled { "on" } else { "off" }.to_string(),
+                a.name.clone(),
+                a.schedule.kind().to_string(),
+                automation_action_label(&a.action),
+            ]
+        })
+        .collect();
+    output::table(&["ID", "STATE", "NAME", "SCHEDULE", "ACTION"], &rows)
+}
+
+/// Render a single automation as an aligned key/value block.
+fn render_automation_detail(a: &Automation) -> String {
+    let pairs: Vec<(&str, String)> = vec![
+        ("id", a.id.to_string()),
+        ("name", a.name.clone()),
+        ("enabled", a.enabled.to_string()),
+        (
+            "schedule",
+            format!("{} ({})", a.schedule.kind(), a.schedule.spec()),
+        ),
+        ("timezone", output::dash(a.timezone.as_deref())),
+        ("action", automation_action_label(&a.action)),
+        ("prompt", a.prompt.clone()),
+    ];
+    output::kv(&pairs)
+}
+
+/// Render an automation's run history as a table.
+fn render_run_history(id: i64, runs: &[AutomationRun]) -> String {
+    if runs.is_empty() {
+        return format!("No run history for automation #{id}.");
+    }
+    let rows: Vec<Vec<String>> = runs
+        .iter()
+        .map(|r| {
+            vec![
+                r.id.to_string(),
+                r.status.as_str().to_string(),
+                r.detail.clone(),
+            ]
+        })
+        .collect();
+    output::table(&["RUN", "STATUS", "DETAIL"], &rows)
+}
+
+/// One-line human summary of an `automation tick`.
+fn render_tick(v: &Value) -> String {
+    let count = |key: &str| v.get(key).and_then(Value::as_array).map_or(0, Vec::len);
+    let fired = count("fired");
+    let skipped = count("skipped");
+    let healed = count("healed");
+    format!("Tick: {fired} fired, {skipped} skipped, {healed} extension(s) healed.")
+}
+
+/// Human label for an automation's send/spawn action.
+fn automation_action_label(action: &AutomationAction) -> String {
+    match action {
+        AutomationAction::Send { .. } => "send".to_string(),
+        AutomationAction::Spawn { .. } => "spawn".to_string(),
     }
 }
 

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -590,6 +590,43 @@ mod tests {
     }
 
     #[test]
+    fn render_tick_counts_fired_skipped_and_healed() {
+        let v = json!({
+            "fired": [{ "id": 1 }, { "id": 2 }],
+            "skipped": [{ "id": 3 }],
+            "healed": [],
+        });
+        assert_eq!(
+            render_tick(&v),
+            "Tick: 2 fired, 1 skipped, 0 extension(s) healed."
+        );
+    }
+
+    #[test]
+    fn render_automation_list_empty_is_friendly() {
+        assert_eq!(render_automation_list(&[]), "No automations.");
+    }
+
+    #[test]
+    fn action_label_distinguishes_send_and_spawn() {
+        assert_eq!(
+            automation_action_label(&AutomationAction::Send {
+                session_id: SessionId::default(),
+            }),
+            "send"
+        );
+        assert_eq!(
+            automation_action_label(&AutomationAction::Spawn {
+                repo_path: "/x".into(),
+                worktree_branch: None,
+                base_branch: None,
+                agent: None,
+            }),
+            "spawn"
+        );
+    }
+
+    #[test]
     fn run_to_json_emits_related_session_id() {
         let sid = SessionId::default();
         let run = AutomationRun {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -160,19 +160,11 @@ fn render_validate(report: &Value, failed: &[String]) -> String {
         let entry = &report[key];
         let exists = entry["exists"].as_bool().unwrap_or(false);
         let valid = entry["valid"].as_bool().unwrap_or(false);
-        let mark = if !exists {
-            "·" // absent files are valid (defaults apply)
-        } else if valid {
-            "✓"
-        } else {
-            "✗"
-        };
-        let status = if !exists {
-            "absent"
-        } else if valid {
-            "ok"
-        } else {
-            "invalid"
+        // Absent files are valid (defaults/seeding apply), so flag them apart.
+        let (mark, status) = match (exists, valid) {
+            (false, _) => ("·", "absent"),
+            (true, true) => ("✓", "ok"),
+            (true, false) => ("✗", "invalid"),
         };
         lines.push(format!("{mark} {label}  {status}"));
         if let Some(problems) = entry["problems"].as_array() {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -11,6 +11,7 @@
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use crate::cli::output::{self, CommandOutput};
 use crate::storage::Database;
 
 #[derive(Subcommand, Debug)]
@@ -21,10 +22,28 @@ pub enum Action {
     Show,
 }
 
-pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
     match action {
-        Action::Validate => validate(),
-        Action::Show => show(db),
+        Action::Validate => {
+            let (report, failed) = validate();
+            let human = render_validate(&report, &failed);
+            if failed.is_empty() {
+                Ok(CommandOutput::new(report, human))
+            } else {
+                // Print the full report (human or JSON), then exit non-zero so
+                // this is usable as a dotfiles CI gate.
+                Ok(CommandOutput::failed(
+                    report,
+                    human,
+                    format!("config invalid: {}", failed.join(", ")),
+                ))
+            }
+        }
+        Action::Show => {
+            let report = show(db)?;
+            let human = render_show(&report);
+            Ok(CommandOutput::new(report, human))
+        }
     }
 }
 
@@ -83,7 +102,9 @@ fn validate_keybindings() -> (Value, bool) {
     }
 }
 
-fn validate() -> Result<Value, String> {
+/// Validate every config file. Returns the full report plus the list of files
+/// that failed (empty = all valid).
+fn validate() -> (Value, Vec<String>) {
     let (agents, agents_ok) = validate_toml::<crate::session::AgentRegistry>(
         crate::agent::agent_config::agents_config_path(),
         "agents.toml",
@@ -102,7 +123,7 @@ fn validate() -> Result<Value, String> {
     );
     let (keybindings, kb_ok) = validate_keybindings();
 
-    let failed: Vec<&str> = [
+    let failed: Vec<String> = [
         ("agents.toml", agents_ok),
         ("hosts.toml", hosts_ok),
         ("settings.toml", settings_ok),
@@ -111,7 +132,7 @@ fn validate() -> Result<Value, String> {
     ]
     .iter()
     .filter(|(_, ok)| !ok)
-    .map(|(name, _)| *name)
+    .map(|(name, _)| (*name).to_string())
     .collect();
 
     let report = json!({
@@ -122,18 +143,99 @@ fn validate() -> Result<Value, String> {
         "themes_toml": themes,
         "keybindings_json": keybindings,
     });
-    if failed.is_empty() {
-        Ok(report)
-    } else {
-        // Print the full report on stdout (like the Ok path would), then fail
-        // with a one-line error so the process exits non-zero — usable as a
-        // dotfiles CI gate.
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&report).unwrap_or_else(|_| report.to_string())
-        );
-        Err(format!("config invalid: {}", failed.join(", ")))
+    (report, failed)
+}
+
+/// Render `config validate` as a per-file status list.
+fn render_validate(report: &Value, failed: &[String]) -> String {
+    let files = [
+        ("agents.toml", "agents_toml"),
+        ("hosts.toml", "hosts_toml"),
+        ("settings.toml", "settings_toml"),
+        ("themes.toml", "themes_toml"),
+        ("keybindings.json", "keybindings_json"),
+    ];
+    let mut lines = Vec::new();
+    for (label, key) in files {
+        let entry = &report[key];
+        let exists = entry["exists"].as_bool().unwrap_or(false);
+        let valid = entry["valid"].as_bool().unwrap_or(false);
+        let mark = if !exists {
+            "·" // absent files are valid (defaults apply)
+        } else if valid {
+            "✓"
+        } else {
+            "✗"
+        };
+        let status = if !exists {
+            "absent"
+        } else if valid {
+            "ok"
+        } else {
+            "invalid"
+        };
+        lines.push(format!("{mark} {label}  {status}"));
+        if let Some(problems) = entry["problems"].as_array() {
+            for p in problems {
+                if let Some(p) = p.as_str() {
+                    lines.push(format!("    - {p}"));
+                }
+            }
+        }
     }
+    if failed.is_empty() {
+        lines.push("All config files valid.".to_string());
+    } else {
+        lines.push(format!("Invalid: {}", failed.join(", ")));
+    }
+    lines.join("\n")
+}
+
+/// Render `config show` as grouped key/value blocks.
+fn render_show(report: &Value) -> String {
+    let mut sections: Vec<String> = Vec::new();
+
+    if let Some(paths) = report["paths"].as_object() {
+        let pairs: Vec<(&str, String)> = paths
+            .iter()
+            .map(|(k, v)| (k.as_str(), output::dash(v.as_str())))
+            .collect();
+        sections.push(format!("Paths\n{}", output::kv(&pairs)));
+    }
+
+    let agents = &report["agents"];
+    let names = agents["names"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    sections.push(format!(
+        "Agents\n{}",
+        output::kv(&[
+            ("default", output::dash(agents["default"].as_str())),
+            ("names", names),
+        ])
+    ));
+
+    let editor = &report["editor"];
+    sections.push(format!(
+        "Editor\n{}",
+        output::kv(&[
+            ("command", output::dash(editor["command"].as_str())),
+            ("source", output::dash(editor["source"].as_str())),
+        ])
+    ));
+
+    sections.push(format!(
+        "Theme\n{}",
+        output::kv(&[("active", output::dash(report["theme"].as_str()))])
+    ));
+
+    sections.join("\n\n")
 }
 
 fn show(db: &Database) -> Result<Value, String> {
@@ -202,7 +304,8 @@ mod tests {
     fn validate_passes_on_fresh_environment() {
         let tmp = tempfile::tempdir().unwrap();
         let _g = TestPathGuard::new(tmp.path());
-        let v = validate().unwrap();
+        let (v, failed) = validate();
+        assert!(failed.is_empty(), "got failures: {failed:?}");
         assert_eq!(v["valid"], json!(true));
     }
 
@@ -214,8 +317,8 @@ mod tests {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, "not toml {{{").unwrap();
 
-        let err = validate().unwrap_err();
-        assert!(err.contains("agents.toml"), "got: {err}");
+        let (_, failed) = validate();
+        assert!(failed.iter().any(|f| f == "agents.toml"), "got: {failed:?}");
     }
 
     #[test]
@@ -227,8 +330,11 @@ mod tests {
         )
         .unwrap();
 
-        let err = validate().unwrap_err();
-        assert!(err.contains("keybindings.json"), "got: {err}");
+        let (_, failed) = validate();
+        assert!(
+            failed.iter().any(|f| f == "keybindings.json"),
+            "got: {failed:?}"
+        );
     }
 
     /// `serde_ignored` reports nested unknown keys, so a typo inside
@@ -241,8 +347,11 @@ mod tests {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, "[features]\nbogus = true\n").unwrap();
 
-        let err = validate().unwrap_err();
-        assert!(err.contains("settings.toml"), "got: {err}");
+        let (_, failed) = validate();
+        assert!(
+            failed.iter().any(|f| f == "settings.toml"),
+            "got: {failed:?}"
+        );
     }
 
     #[test]

--- a/src/cli/editor.rs
+++ b/src/cli/editor.rs
@@ -1,6 +1,7 @@
 //! Editor command get/set subcommands.
 
 use clap::Subcommand;
+use serde_json::json;
 
 use crate::cli::output::CommandOutput;
 use crate::storage::Database;
@@ -26,10 +27,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 Some(c) if !c.is_empty() => format!("Editor: {c}"),
                 _ => "Editor: (not set)".to_string(),
             };
-            Ok(CommandOutput::new(
-                serde_json::json!({ "command": cmd }),
-                human,
-            ))
+            Ok(CommandOutput::new(json!({ "command": cmd }), human))
         }
         Action::Set { command } => {
             db.set_editor_command(&command)
@@ -40,7 +38,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 format!("Editor set to: {command}")
             };
             Ok(CommandOutput::new(
-                serde_json::json!({
+                json!({
                     "command": if command.is_empty() { None } else { Some(command) }
                 }),
                 human,

--- a/src/cli/editor.rs
+++ b/src/cli/editor.rs
@@ -1,8 +1,8 @@
 //! Editor command get/set subcommands.
 
 use clap::Subcommand;
-use serde_json::Value;
 
+use crate::cli::output::CommandOutput;
 use crate::storage::Database;
 
 #[derive(Subcommand, Debug)]
@@ -16,20 +16,35 @@ pub enum Action {
     },
 }
 
-pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
     match action {
         Action::Get => {
             let cmd = db
                 .get_editor_command()
                 .map_err(|e| format!("get_editor_command: {e}"))?;
-            Ok(serde_json::json!({ "command": cmd }))
+            let human = match &cmd {
+                Some(c) if !c.is_empty() => format!("Editor: {c}"),
+                _ => "Editor: (not set)".to_string(),
+            };
+            Ok(CommandOutput::new(
+                serde_json::json!({ "command": cmd }),
+                human,
+            ))
         }
         Action::Set { command } => {
             db.set_editor_command(&command)
                 .map_err(|e| format!("set_editor_command: {e}"))?;
-            Ok(serde_json::json!({
-                "command": if command.is_empty() { None } else { Some(command) }
-            }))
+            let human = if command.is_empty() {
+                "Editor cleared.".to_string()
+            } else {
+                format!("Editor set to: {command}")
+            };
+            Ok(CommandOutput::new(
+                serde_json::json!({
+                    "command": if command.is_empty() { None } else { Some(command) }
+                }),
+                human,
+            ))
         }
     }
 }

--- a/src/cli/extensions.rs
+++ b/src/cli/extensions.rs
@@ -9,6 +9,7 @@
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use crate::cli::output::{self, CommandOutput};
 use crate::session::ExtensionDef;
 use crate::storage::Database;
 
@@ -98,7 +99,7 @@ pub enum Action {
     },
 }
 
-pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
     match action {
         Action::Install {
             target,
@@ -109,11 +110,11 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 crate::session_ops::install_extension(db, &target, home.as_deref(), force)?;
             // Arm the heartbeat so the extension's automations fire headlessly.
             arm_heartbeat();
-            Ok(install_report_to_json(&report))
+            Ok(CommandOutput::from_summary(install_report_to_json(&report)))
         }
         Action::Uninstall { name, purge } => {
             let report = crate::session_ops::uninstall_extension(db, &name, purge)?;
-            Ok(json!({
+            Ok(CommandOutput::from_summary(json!({
                 "ok": true,
                 "summary": format!("Uninstalled extension '{}'", report.name),
                 "uninstalled": report.name,
@@ -122,19 +123,18 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 "agents_removed": report.agents_removed,
                 "manifest_removed": report.manifest_removed,
                 "home_removed": report.home_removed,
-            }))
+            })))
         }
         Action::List => {
             let defs = crate::agent::extension_config::list_manifests();
-            let mut out = Vec::with_capacity(defs.len());
+            let mut healths = Vec::with_capacity(defs.len());
             for def in &defs {
-                out.push(health_to_json(&crate::session_ops::extension_health(
-                    db, def,
-                )?));
+                healths.push(crate::session_ops::extension_health(db, def)?);
             }
-            Ok(Value::Array(out))
+            let json = Value::Array(healths.iter().map(health_to_json).collect());
+            Ok(CommandOutput::new(json, render_extension_list(&healths)))
         }
-        Action::Available { query } => Ok(available_to_json(query.as_deref())),
+        Action::Available { query } => Ok(available_output(query.as_deref())),
         Action::Update { name, all, force } => match name {
             // `--all` alongside a name is contradictory; otherwise a bare name
             // updates one and *no* name updates them all (no flag required).
@@ -143,7 +143,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 let report = crate::session_ops::update_extension(db, &name, force)?;
                 // Arm the heartbeat so the refreshed automations keep firing headlessly.
                 arm_heartbeat();
-                Ok(update_report_to_json(&report))
+                Ok(CommandOutput::from_summary(update_report_to_json(&report)))
             }
             None => {
                 let results = crate::session_ops::update_all_extensions(db, force);
@@ -171,14 +171,16 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 } else {
                     format!("Updated {total} extension(s): {changed} changed, {failed} failed")
                 };
-                Ok(json!({ "ok": failed == 0, "summary": summary, "extensions": out }))
+                Ok(CommandOutput::from_summary(
+                    json!({ "ok": failed == 0, "summary": summary, "extensions": out }),
+                ))
             }
         },
         Action::Reinstall { name, purge } => {
             let report = crate::session_ops::reinstall_extension(db, &name, purge)?;
             arm_heartbeat();
             let version = report.install.version.as_deref().unwrap_or("?");
-            Ok(json!({
+            Ok(CommandOutput::from_summary(json!({
                 "ok": true,
                 "summary": format!(
                     "Reinstalled '{}' {} → {}",
@@ -192,7 +194,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 "agents_added": report.install.agents_added,
                 "sessions_created": report.install.ensure.sessions_created,
                 "automations_created": report.install.ensure.automations_created,
-            }))
+            })))
         }
         Action::Activate { name } => {
             let def = load_manifest(&name)?;
@@ -201,7 +203,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             // heartbeat keeper so the extension works headlessly (TUI closed),
             // matching how `automation create` arms it.
             arm_heartbeat();
-            Ok(json!({
+            Ok(CommandOutput::from_summary(json!({
                 "ok": true,
                 "summary": format!(
                     "Activated '{}' ({} session(s), {} automation(s))",
@@ -213,7 +215,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 "sessions_created": report.sessions_created,
                 "automations_created": report.automations_created,
                 "health": health_to_json(&crate::session_ops::extension_health(db, &def)?),
-            }))
+            })))
         }
         Action::Deactivate { name, force, purge } => {
             // Tear down whatever the manifest declares. If the manifest is gone
@@ -240,7 +242,7 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             } else {
                 format!("'{name}' was not active")
             };
-            Ok(json!({
+            Ok(CommandOutput::from_summary(json!({
                 "ok": true,
                 "summary": summary,
                 "deactivated": name,
@@ -248,18 +250,70 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 "sessions_deleted": report.sessions_deleted,
                 "automations_deleted": report.automations_deleted,
                 "manifest_removed": manifest_removed,
-            }))
+            })))
         }
         Action::Status { name } => match name {
             Some(name) => {
                 let def = load_manifest(&name)?;
-                Ok(health_to_json(&crate::session_ops::extension_health(
-                    db, &def,
-                )?))
+                let health = crate::session_ops::extension_health(db, &def)?;
+                Ok(CommandOutput::new(
+                    health_to_json(&health),
+                    render_extension_detail(&health),
+                ))
             }
             None => run(Action::List, db),
         },
     }
+}
+
+/// Render the installed-extension list as an aligned table.
+fn render_extension_list(healths: &[crate::session_ops::ExtensionHealth]) -> String {
+    if healths.is_empty() {
+        return "No extensions installed.".to_string();
+    }
+    let rows: Vec<Vec<String>> = healths
+        .iter()
+        .map(|h| {
+            vec![
+                h.name.clone(),
+                if h.active { "active" } else { "inactive" }.to_string(),
+                if h.is_healthy() { "ok" } else { "degraded" }.to_string(),
+                if h.stale { "yes" } else { "no" }.to_string(),
+                output::dash(h.version.as_deref()),
+            ]
+        })
+        .collect();
+    output::table(&["NAME", "STATE", "HEALTH", "STALE", "VERSION"], &rows)
+}
+
+/// Render a single extension's health as a key/value block + resource lines.
+fn render_extension_detail(h: &crate::session_ops::ExtensionHealth) -> String {
+    let mut pairs: Vec<(&str, String)> = vec![
+        ("name", h.name.clone()),
+        ("status", health_summary(h)),
+        ("active", h.active.to_string()),
+        ("healthy", h.is_healthy().to_string()),
+        ("version", output::dash(h.version.as_deref())),
+        ("stale", h.stale.to_string()),
+    ];
+    if let Some(w) = &h.compat_warning {
+        pairs.push(("compat_warning", w.clone()));
+    }
+    let mut block = output::kv(&pairs);
+    let resources = |label: &str, items: &[(String, bool)]| -> String {
+        if items.is_empty() {
+            return String::new();
+        }
+        let listed = items
+            .iter()
+            .map(|(n, present)| format!("{} {n}", if *present { "✓" } else { "✗" }))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("\n{label}:  {listed}")
+    };
+    block.push_str(&resources("sessions", &h.sessions));
+    block.push_str(&resources("automations", &h.automations));
+    block
 }
 
 /// Load a manifest by name or error with guidance.
@@ -309,6 +363,35 @@ fn available_to_json(query: Option<&str>) -> Value {
         "summary": format!("{} official extension(s) available", out.len()),
         "available": out,
     })
+}
+
+/// `extension available`: the JSON above plus a human table (NAME / INSTALLED /
+/// DESCRIPTION) built from the same `available` entries.
+fn available_output(query: Option<&str>) -> CommandOutput {
+    let json = available_to_json(query);
+    let entries = json.get("available").and_then(Value::as_array);
+    let human = match entries {
+        Some(list) if !list.is_empty() => {
+            let rows: Vec<Vec<String>> = list
+                .iter()
+                .map(|e| {
+                    vec![
+                        e["name"].as_str().unwrap_or("").to_string(),
+                        if e["installed"].as_bool().unwrap_or(false) {
+                            "yes"
+                        } else {
+                            "no"
+                        }
+                        .to_string(),
+                        e["description"].as_str().unwrap_or("").to_string(),
+                    ]
+                })
+                .collect();
+            output::table(&["NAME", "INSTALLED", "DESCRIPTION"], &rows)
+        }
+        _ => "No matching extensions.".to_string(),
+    };
+    CommandOutput::new(json, human)
 }
 
 fn health_to_json(h: &crate::session_ops::ExtensionHealth) -> Value {

--- a/src/cli/messages.rs
+++ b/src/cli/messages.rs
@@ -7,6 +7,7 @@
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use crate::cli::output::{self, CommandOutput};
 use crate::session::{SessionId, SessionMessage};
 use crate::storage::messages::{NewMessage, DEFAULT_RETENTION_DAYS};
 use crate::storage::Database;
@@ -69,7 +70,7 @@ pub enum Action {
     },
 }
 
-pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
     match action {
         Action::Send {
             to,
@@ -107,13 +108,21 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                     ),
                 }
             }
-            Ok(json!({
-                "enqueued": true,
-                "message_id": id,
-                "to_session_id": recipient.id.to_string(),
-                "to_session_name": recipient.name,
-                "woke": woke,
-            }))
+            let human = format!(
+                "Enqueued message #{id} to '{}'{}.",
+                recipient.name,
+                if woke { " (woke it)" } else { "" }
+            );
+            Ok(CommandOutput::new(
+                json!({
+                    "enqueued": true,
+                    "message_id": id,
+                    "to_session_id": recipient.id.to_string(),
+                    "to_session_name": recipient.name,
+                    "woke": woke,
+                }),
+                human,
+            ))
         }
         Action::Inbox {
             for_session,
@@ -129,7 +138,11 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 db.list_messages(recipient.id, !all, limit)
                     .map_err(|e| format!("list_messages: {e}"))?
             };
-            Ok(Value::Array(messages.iter().map(message_to_json).collect()))
+            let json = Value::Array(messages.iter().map(message_to_json).collect());
+            Ok(CommandOutput::new(
+                json,
+                render_inbox(&recipient.name, &messages, claim),
+            ))
         }
         Action::Prune {
             older_than_days,
@@ -140,8 +153,53 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             let pruned = db
                 .prune_messages(cutoff, read_only)
                 .map_err(|e| format!("prune_messages: {e}"))?;
-            Ok(json!({ "pruned": pruned, "older_than_days": days, "read_only": read_only }))
+            let human = format!(
+                "Pruned {pruned} {}message(s) older than {days} day(s).",
+                if read_only { "read " } else { "" }
+            );
+            Ok(CommandOutput::new(
+                json!({ "pruned": pruned, "older_than_days": days, "read_only": read_only }),
+                human,
+            ))
         }
+    }
+}
+
+/// Render an inbox read as a table of messages (or a friendly empty line).
+fn render_inbox(recipient: &str, messages: &[SessionMessage], claimed: bool) -> String {
+    if messages.is_empty() {
+        return format!(
+            "No {}messages for '{recipient}'.",
+            if claimed { "unread " } else { "" }
+        );
+    }
+    let rows: Vec<Vec<String>> = messages
+        .iter()
+        .map(|m| {
+            vec![
+                m.id.to_string(),
+                m.kind.clone(),
+                output::dash(m.from_task_id.map(|t| t.to_string()).as_deref()),
+                first_line(&m.body),
+            ]
+        })
+        .collect();
+    let verb = if claimed { "Claimed" } else { "Inbox for" };
+    let header = format!("{verb} '{recipient}' — {} message(s):", messages.len());
+    format!(
+        "{header}\n{}",
+        output::table(&["ID", "KIND", "TASK", "BODY"], &rows)
+    )
+}
+
+/// First line of a body, truncated for table display.
+fn first_line(body: &str) -> String {
+    let line = body.lines().next().unwrap_or("");
+    if line.chars().count() > 60 {
+        let truncated: String = line.chars().take(57).collect();
+        format!("{truncated}…")
+    } else {
+        line.to_string()
     }
 }
 

--- a/src/cli/messages.rs
+++ b/src/cli/messages.rs
@@ -192,11 +192,15 @@ fn render_inbox(recipient: &str, messages: &[SessionMessage], claimed: bool) -> 
     )
 }
 
-/// First line of a body, truncated for table display.
+/// Max display width of a message-body preview in the inbox table.
+const BODY_PREVIEW_MAX: usize = 60;
+
+/// First line of a body, truncated to [`BODY_PREVIEW_MAX`] (ellipsis included)
+/// for table display.
 fn first_line(body: &str) -> String {
     let line = body.lines().next().unwrap_or("");
-    if line.chars().count() > 60 {
-        let truncated: String = line.chars().take(57).collect();
+    if line.chars().count() > BODY_PREVIEW_MAX {
+        let truncated: String = line.chars().take(BODY_PREVIEW_MAX - 1).collect();
         format!("{truncated}…")
     } else {
         line.to_string()
@@ -465,5 +469,30 @@ mod tests {
         assert_eq!(v["pruned"], 0);
         assert_eq!(v["older_than_days"], 7);
         assert_eq!(v["read_only"], true);
+    }
+
+    #[test]
+    fn first_line_keeps_short_and_first_line_only() {
+        assert_eq!(first_line("hello"), "hello");
+        assert_eq!(first_line("line one\nline two"), "line one");
+        assert_eq!(first_line(""), "");
+    }
+
+    #[test]
+    fn first_line_truncates_to_preview_max_with_ellipsis() {
+        let long = "x".repeat(BODY_PREVIEW_MAX + 10);
+        let rendered = first_line(&long);
+        // Result is exactly BODY_PREVIEW_MAX wide: (MAX-1) chars + the ellipsis.
+        assert_eq!(rendered.chars().count(), BODY_PREVIEW_MAX);
+        assert!(rendered.ends_with('…'));
+    }
+
+    #[test]
+    fn render_inbox_reports_empty_and_claimed_wording() {
+        assert_eq!(render_inbox("flow", &[], false), "No messages for 'flow'.");
+        assert_eq!(
+            render_inbox("flow", &[], true),
+            "No unread messages for 'flow'."
+        );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,9 @@
 //! Command-line interface dispatcher for the `thurbox-cli` binary.
 //!
-//! Output is JSON; pass `--pretty` to pretty-print.
+//! Output is human-readable by default and switches to JSON automatically when
+//! stdout is a pipe (so `thurbox-cli … | jq` keeps working). Force a format with
+//! `--json` (compact), `--pretty` (indented JSON), or `--text` (human). See
+//! [`output::Format`].
 //!
 //! The CLI is intentionally thin: it parses arguments, calls into
 //! `storage::Database`, `session_ops`, or the tmux helpers in
@@ -15,16 +18,27 @@ pub mod config;
 pub mod editor;
 pub mod extensions;
 pub mod messages;
+pub mod output;
 pub mod sessions;
 pub mod tasks;
+
+use output::{CommandOutput, Format};
 
 /// Thurbox CLI — manage sessions, scheduled commands, and more.
 #[derive(Parser, Debug)]
 #[command(name = "thurbox-cli", version, about)]
 pub struct Cli {
-    /// Pretty-print JSON output.
+    /// Output JSON instead of the human-readable default.
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    /// Pretty-print JSON output (implies --json).
     #[arg(long, global = true)]
     pub pretty: bool,
+
+    /// Force human-readable output even when piped.
+    #[arg(long, global = true)]
+    pub text: bool,
 
     #[command(subcommand)]
     pub command: Command,
@@ -73,9 +87,11 @@ pub enum Command {
     },
 }
 
-/// Run a parsed CLI invocation against `db` and write JSON to stdout.
+/// Run a parsed CLI invocation against `db`, rendering the result in the
+/// resolved [`Format`] (human by default, JSON when piped or forced).
 pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
-    let value = match cli.command {
+    let format = Format::resolve(cli.json, cli.text, cli.pretty);
+    let output: CommandOutput = match cli.command {
         Command::Editor { action } => editor::run(action, db),
         Command::Session { action } => sessions::run(action, db),
         Command::Automation { action } => automations::run(action, db),
@@ -85,13 +101,13 @@ pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
         Command::Extension { action } => extensions::run(action, db),
     }?;
 
-    let text = if cli.pretty {
-        serde_json::to_string_pretty(&value).unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
-    } else {
-        serde_json::to_string(&value).unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
-    };
-    println!("{text}");
-    Ok(())
+    println!("{}", format.render(&output));
+    // A command can render normally yet still request a non-zero exit (e.g.
+    // `config validate` on an invalid file).
+    match output.failure {
+        Some(msg) => Err(msg),
+        None => Ok(()),
+    }
 }
 
 #[cfg(test)]
@@ -109,6 +125,16 @@ mod tests {
                 action: sessions::Action::List { parent: None }
             }
         ));
+    }
+
+    #[test]
+    fn json_and_text_flags_are_global() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "task", "list", "--json"]).unwrap();
+        assert!(cli.json);
+        assert!(!cli.text);
+        let cli = Cli::try_parse_from(["thurbox-cli", "--text", "task", "list"]).unwrap();
+        assert!(cli.text);
+        assert!(!cli.json);
     }
 
     #[test]

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,0 +1,265 @@
+//! Output rendering for `thurbox-cli`.
+//!
+//! Every subcommand builds a [`CommandOutput`] carrying *both* a machine-
+//! readable JSON `Value` and a pre-rendered human string. [`mod@crate::cli`]'s
+//! dispatcher picks which to print based on the resolved [`Format`]:
+//!
+//! - `--json` forces JSON (compact); `--pretty` forces pretty-printed JSON.
+//! - `--text` forces the human rendering.
+//! - With no flag we auto-detect: a TTY gets human output, a pipe gets JSON, so
+//!   existing `thurbox-cli … | jq` pipelines keep working untouched.
+//!
+//! Subcommands build the human string where they already hold the typed data
+//! (no fragile re-parsing of `Value` in a central renderer). The small
+//! [`table`]/[`kv`] helpers keep that rendering aligned and consistent.
+
+use std::io::IsTerminal;
+
+use serde_json::Value;
+
+/// A command result carrying both a JSON `Value` (machine output) and a
+/// pre-rendered human string. Optionally flags a non-zero exit (e.g. `config
+/// validate` on an invalid file still prints its report, then exits 1).
+#[derive(Debug)]
+pub struct CommandOutput {
+    /// Machine-readable representation, printed under `--json` / `--pretty` (and
+    /// when stdout is not a TTY).
+    pub json: Value,
+    /// Human-readable representation, printed by default in a terminal.
+    pub human: String,
+    /// When `Some`, the dispatcher prints the output normally, then returns this
+    /// message as an error so the process exits non-zero.
+    pub failure: Option<String>,
+}
+
+impl CommandOutput {
+    /// Build an output with an explicit human rendering.
+    pub fn new(json: Value, human: impl Into<String>) -> Self {
+        Self {
+            json,
+            human: human.into(),
+            failure: None,
+        }
+    }
+
+    /// Build an output whose human rendering is the JSON's `summary` string, when
+    /// present (most mutating commands set one); otherwise fall back to compact
+    /// JSON. Handy for create/delete/install-style confirmations.
+    pub fn from_summary(json: Value) -> Self {
+        let human = json
+            .get("summary")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| json.to_string());
+        Self::new(json, human)
+    }
+
+    /// Build an output that prints normally but then exits non-zero with `msg`.
+    pub fn failed(json: Value, human: impl Into<String>, msg: impl Into<String>) -> Self {
+        Self {
+            json,
+            human: human.into(),
+            failure: Some(msg.into()),
+        }
+    }
+}
+
+// Deref to the inner `Value` so `run(...)` call sites in unit tests keep
+// indexing/method access (`out["id"]`, `out.as_array()`) unchanged.
+impl std::ops::Deref for CommandOutput {
+    type Target = Value;
+
+    fn deref(&self) -> &Self::Target {
+        &self.json
+    }
+}
+
+// Display the JSON form, so `format!("{out}")` in tests/diagnostics works.
+impl std::fmt::Display for CommandOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.json)
+    }
+}
+
+/// Which representation to print.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Format {
+    /// Human-readable text (tables / key-value blocks / confirmation lines).
+    Human,
+    /// Compact single-line JSON.
+    Json,
+    /// Indented JSON.
+    JsonPretty,
+}
+
+impl Format {
+    /// Resolve the effective format from the global flags, falling back to TTY
+    /// auto-detection. Precedence: `--pretty` > `--json` > `--text` > auto.
+    pub fn resolve(json: bool, text: bool, pretty: bool) -> Self {
+        Self::resolve_with(json, text, pretty, std::io::stdout().is_terminal())
+    }
+
+    /// Resolution core, parameterized on whether stdout is a TTY (testable).
+    pub fn resolve_with(json: bool, text: bool, pretty: bool, stdout_is_tty: bool) -> Self {
+        if pretty {
+            Format::JsonPretty
+        } else if json {
+            Format::Json
+        } else if text || stdout_is_tty {
+            // Explicit --text, or auto-detected interactive terminal.
+            Format::Human
+        } else {
+            // Piped/redirected with no flag: stay machine-readable.
+            Format::Json
+        }
+    }
+
+    /// Render an output to a string in this format.
+    pub fn render(self, out: &CommandOutput) -> String {
+        match self {
+            Format::Human => out.human.clone(),
+            Format::Json => serde_json::to_string(&out.json)
+                .unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}")),
+            Format::JsonPretty => serde_json::to_string_pretty(&out.json)
+                .unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}")),
+        }
+    }
+}
+
+/// Render an aligned, left-justified text table: a header row followed by data
+/// rows, columns padded to the widest cell, two-space gutters, no trailing
+/// whitespace. Returns headers only when `rows` is empty (callers usually print
+/// an explicit "none" line instead).
+pub fn table(headers: &[&str], rows: &[Vec<String>]) -> String {
+    let mut widths: Vec<usize> = headers.iter().map(|h| h.chars().count()).collect();
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            if i < widths.len() {
+                widths[i] = widths[i].max(cell.chars().count());
+            }
+        }
+    }
+    let header: Vec<String> = headers.iter().map(|h| (*h).to_string()).collect();
+    let mut lines = vec![fmt_row(&header, &widths)];
+    for row in rows {
+        lines.push(fmt_row(row, &widths));
+    }
+    lines.join("\n")
+}
+
+/// Format one table row: each cell but the last is right-padded to its column
+/// width with a two-space gutter; the last cell is emitted bare (no trailing
+/// pad).
+fn fmt_row(cells: &[String], widths: &[usize]) -> String {
+    let mut s = String::new();
+    let last = cells.len().saturating_sub(1);
+    for (i, cell) in cells.iter().enumerate() {
+        if i == last {
+            s.push_str(cell.trim_end());
+        } else {
+            let width = widths.get(i).copied().unwrap_or(0);
+            let pad = width.saturating_sub(cell.chars().count());
+            s.push_str(cell);
+            for _ in 0..pad {
+                s.push(' ');
+            }
+            s.push_str("  ");
+        }
+    }
+    s.trim_end().to_string()
+}
+
+/// Render an aligned key/value block: `key:` columns padded to the widest key,
+/// values following after two spaces. Multi-line values keep their newlines (no
+/// re-indentation), so a trailing free-form blob renders naturally.
+pub fn kv(pairs: &[(&str, String)]) -> String {
+    let width = pairs
+        .iter()
+        .map(|(k, _)| k.chars().count() + 1) // +1 for the colon
+        .max()
+        .unwrap_or(0);
+    pairs
+        .iter()
+        .map(|(k, v)| {
+            let key = format!("{k}:");
+            let pad = width.saturating_sub(key.chars().count());
+            format!("{key}{}  {v}", " ".repeat(pad))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Render an optional string, mapping `None`/empty to a muted dash.
+pub fn dash(s: Option<&str>) -> String {
+    match s {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => "-".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn format_resolution_precedence() {
+        // --pretty wins over everything.
+        assert_eq!(
+            Format::resolve_with(true, true, true, false),
+            Format::JsonPretty
+        );
+        // --json beats --text.
+        assert_eq!(Format::resolve_with(true, true, false, true), Format::Json);
+        // --text forces human even when piped.
+        assert_eq!(
+            Format::resolve_with(false, true, false, false),
+            Format::Human
+        );
+        // Auto: TTY = human, pipe = json.
+        assert_eq!(
+            Format::resolve_with(false, false, false, true),
+            Format::Human
+        );
+        assert_eq!(
+            Format::resolve_with(false, false, false, false),
+            Format::Json
+        );
+    }
+
+    #[test]
+    fn table_aligns_columns() {
+        let rendered = table(
+            &["NAME", "AGENT"],
+            &[
+                vec!["flow".into(), "claude".into()],
+                vec!["worker-long".into(), "codex".into()],
+            ],
+        );
+        let lines: Vec<&str> = rendered.lines().collect();
+        assert_eq!(lines[0], "NAME         AGENT");
+        assert_eq!(lines[1], "flow         claude");
+        assert_eq!(lines[2], "worker-long  codex");
+    }
+
+    #[test]
+    fn kv_aligns_keys_and_keeps_multiline_values() {
+        let rendered = kv(&[
+            ("id", "5".into()),
+            ("status", "todo".into()),
+            ("description", "line1\nline2".into()),
+        ]);
+        assert_eq!(
+            rendered,
+            "id:           5\nstatus:       todo\ndescription:  line1\nline2"
+        );
+    }
+
+    #[test]
+    fn from_summary_uses_summary_field() {
+        let out = CommandOutput::from_summary(json!({ "ok": true, "summary": "Done it" }));
+        assert_eq!(out.human, "Done it");
+        // Deref still exposes the JSON for callers/tests.
+        assert_eq!(out["ok"], true);
+    }
+}

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -262,4 +262,43 @@ mod tests {
         // Deref still exposes the JSON for callers/tests.
         assert_eq!(out["ok"], true);
     }
+
+    #[test]
+    fn from_summary_falls_back_to_compact_json() {
+        let out = CommandOutput::from_summary(json!({ "ok": true }));
+        assert_eq!(out.human, "{\"ok\":true}");
+    }
+
+    #[test]
+    fn table_with_no_rows_is_header_only() {
+        assert_eq!(table(&["A", "B"], &[]), "A  B");
+    }
+
+    #[test]
+    fn kv_with_no_pairs_is_empty() {
+        assert_eq!(kv(&[]), "");
+    }
+
+    #[test]
+    fn dash_maps_none_and_empty_to_dash() {
+        assert_eq!(dash(None), "-");
+        assert_eq!(dash(Some("")), "-");
+        assert_eq!(dash(Some("x")), "x");
+    }
+
+    #[test]
+    fn render_picks_the_matching_representation() {
+        let out = CommandOutput::new(json!({ "k": 1 }), "human line");
+        assert_eq!(Format::Human.render(&out), "human line");
+        assert_eq!(Format::Json.render(&out), "{\"k\":1}");
+        assert_eq!(Format::JsonPretty.render(&out), "{\n  \"k\": 1\n}");
+    }
+
+    #[test]
+    fn failed_carries_the_exit_message() {
+        let out = CommandOutput::failed(json!({}), "report", "boom");
+        assert_eq!(out.failure.as_deref(), Some("boom"));
+        // Output still renders normally before the caller acts on `failure`.
+        assert_eq!(Format::Human.render(&out), "report");
+    }
 }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use crate::cli::output::{self, CommandOutput};
 use crate::session::SessionId;
 use crate::storage::Database;
 use crate::sync::SharedSession;
@@ -91,24 +92,25 @@ pub enum Action {
     },
 }
 
-pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
     match action {
         Action::List { parent } => {
             let parent_id = parent.as_deref().map(parse_session_id).transpose()?;
-            let sessions = db
+            let sessions: Vec<SharedSession> = db
                 .list_active_sessions()
-                .map_err(|e| format!("list_active_sessions: {e}"))?;
-            Ok(Value::Array(
-                sessions
-                    .iter()
-                    .filter(|s| parent_id.is_none() || s.parent_session_id == parent_id)
-                    .map(shared_session_to_json)
-                    .collect(),
-            ))
+                .map_err(|e| format!("list_active_sessions: {e}"))?
+                .into_iter()
+                .filter(|s| parent_id.is_none() || s.parent_session_id == parent_id)
+                .collect();
+            let json = Value::Array(sessions.iter().map(shared_session_to_json).collect());
+            Ok(CommandOutput::new(json, render_session_list(&sessions)))
         }
         Action::Get { uuid } => {
             let session = resolve(db, &uuid)?;
-            Ok(shared_session_to_json(&session))
+            Ok(CommandOutput::new(
+                shared_session_to_json(&session),
+                render_session_detail(&session),
+            ))
         }
         Action::Create {
             name,
@@ -131,28 +133,56 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 parent_session_id,
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
-            Ok(json!({
-                "id": res.session_id.to_string(),
-                "name": res.name,
-                "agent": res.agent,
-                "agent_session_id": res.agent_session_id,
-                "cwd": res.cwd.display().to_string(),
-                "parent_session_id": res.parent_session_id.map(|id| id.to_string()),
-            }))
+            let human = format!(
+                "Created session '{}' ({}) — {}\ncwd: {}",
+                res.name,
+                res.agent,
+                res.session_id,
+                res.cwd.display()
+            );
+            Ok(CommandOutput::new(
+                json!({
+                    "id": res.session_id.to_string(),
+                    "name": res.name,
+                    "agent": res.agent,
+                    "agent_session_id": res.agent_session_id,
+                    "cwd": res.cwd.display().to_string(),
+                    "parent_session_id": res.parent_session_id.map(|id| id.to_string()),
+                }),
+                human,
+            ))
         }
         Action::Delete { uuid, force } => {
             let session = resolve(db, &uuid)?;
             let report = crate::session_ops::delete_session_headless(db, session.id, force)?;
-            Ok(json!({
-                "deleted": true,
-                "id": session.id.to_string(),
-                "name": session.name,
-                "forced": force,
-                "killed_window": report.killed_window,
-                "removed_worktrees": report.removed_worktrees,
-                "worktree_errors": report.worktree_errors,
-                "disabled_automations": report.disabled_automations,
-            }))
+            let mut human = format!("Deleted session '{}' ({})", session.name, session.id);
+            if force {
+                human.push_str(&format!(
+                    "\n  killed window:       {}\n  removed worktrees:   {}\n  disabled automations: {}",
+                    report.killed_window,
+                    report.removed_worktrees.len(),
+                    report.disabled_automations
+                ));
+                if !report.worktree_errors.is_empty() {
+                    human.push_str(&format!(
+                        "\n  worktree errors:     {}",
+                        report.worktree_errors.join("; ")
+                    ));
+                }
+            }
+            Ok(CommandOutput::new(
+                json!({
+                    "deleted": true,
+                    "id": session.id.to_string(),
+                    "name": session.name,
+                    "forced": force,
+                    "killed_window": report.killed_window,
+                    "removed_worktrees": report.removed_worktrees,
+                    "worktree_errors": report.worktree_errors,
+                    "disabled_automations": report.disabled_automations,
+                }),
+                human,
+            ))
         }
         Action::Restore { uuid } => {
             let id: SessionId = uuid
@@ -164,20 +194,26 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
                 .ok_or_else(|| format!("Deleted session not found: {uuid}"))?;
             db.restore_session(deleted.id)
                 .map_err(|e| format!("restore_session: {e}"))?;
-            Ok(json!({
-                "restored": true,
-                "id": deleted.id.to_string(),
-                "name": deleted.name,
-            }))
+            Ok(CommandOutput::new(
+                json!({
+                    "restored": true,
+                    "id": deleted.id.to_string(),
+                    "name": deleted.name,
+                }),
+                format!("Restored session '{}' ({})", deleted.name, deleted.id),
+            ))
         }
         Action::Restart { uuid } => {
             let session = resolve(db, &uuid)?;
             crate::session_ops::restart_session_headless(db, session.id)?;
-            Ok(json!({
-                "restarted": true,
-                "session_id": session.id.to_string(),
-                "session_name": session.name,
-            }))
+            Ok(CommandOutput::new(
+                json!({
+                    "restarted": true,
+                    "session_id": session.id.to_string(),
+                    "session_name": session.name,
+                }),
+                format!("Restarted session '{}' ({})", session.name, session.id),
+            ))
         }
         Action::Send { uuid, text } => {
             let session = resolve(db, &uuid)?;
@@ -186,24 +222,94 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             }
             crate::agent::tmux::send_prompt_now(&session.name, &text)
                 .map_err(|e| format!("send_prompt_now: {e}"))?;
-            Ok(json!({
-                "sent": true,
-                "session_id": session.id.to_string(),
-                "session_name": session.name,
-            }))
+            Ok(CommandOutput::new(
+                json!({
+                    "sent": true,
+                    "session_id": session.id.to_string(),
+                    "session_name": session.name,
+                }),
+                format!("Sent to '{}'.", session.name),
+            ))
         }
         Action::Capture { uuid, lines } => {
             let session = resolve(db, &uuid)?;
             let output = crate::agent::tmux::capture_pane_text(&session.name, lines)
                 .map_err(|e| format!("capture_pane_text: {e}"))?;
-            Ok(json!({
-                "session_id": session.id.to_string(),
-                "session_name": session.name,
-                "lines": lines,
-                "output": output,
-            }))
+            // The pane text itself is the useful human payload.
+            let human = output.clone();
+            Ok(CommandOutput::new(
+                json!({
+                    "session_id": session.id.to_string(),
+                    "session_name": session.name,
+                    "lines": lines,
+                    "output": output,
+                }),
+                human,
+            ))
         }
     }
+}
+
+/// Render the session list as an aligned table (or a friendly empty line).
+fn render_session_list(sessions: &[SharedSession]) -> String {
+    if sessions.is_empty() {
+        return "No active sessions.".to_string();
+    }
+    let rows: Vec<Vec<String>> = sessions
+        .iter()
+        .map(|s| {
+            let branch = s
+                .worktrees
+                .first()
+                .map(|w| w.branch.clone())
+                .unwrap_or_default();
+            vec![
+                s.name.clone(),
+                s.agent.clone(),
+                s.backend_type.clone(),
+                output::dash(if branch.is_empty() {
+                    None
+                } else {
+                    Some(&branch)
+                }),
+                output::dash(s.cwd.as_ref().map(|p| p.display().to_string()).as_deref()),
+                s.id.to_string(),
+            ]
+        })
+        .collect();
+    output::table(&["NAME", "AGENT", "BACKEND", "BRANCH", "CWD", "ID"], &rows)
+}
+
+/// Render a single session as an aligned key/value block.
+fn render_session_detail(s: &SharedSession) -> String {
+    let mut pairs: Vec<(&str, String)> = vec![
+        ("name", s.name.clone()),
+        ("id", s.id.to_string()),
+        ("agent", s.agent.clone()),
+        ("backend", s.backend_type.clone()),
+        (
+            "agent_session_id",
+            output::dash(s.agent_session_id.as_deref()),
+        ),
+        (
+            "cwd",
+            output::dash(s.cwd.as_ref().map(|p| p.display().to_string()).as_deref()),
+        ),
+        (
+            "parent",
+            output::dash(s.parent_session_id.map(|id| id.to_string()).as_deref()),
+        ),
+    ];
+    if !s.worktrees.is_empty() {
+        let wt = s
+            .worktrees
+            .iter()
+            .map(|w| format!("{} @ {}", w.branch, w.worktree_path.display()))
+            .collect::<Vec<_>>()
+            .join("\n              ");
+        pairs.push(("worktrees", wt));
+    }
+    output::kv(&pairs)
 }
 
 fn parse_session_id(uuid: &str) -> Result<SessionId, String> {

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -157,17 +157,23 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             let report = crate::session_ops::delete_session_headless(db, session.id, force)?;
             let mut human = format!("Deleted session '{}' ({})", session.name, session.id);
             if force {
-                human.push_str(&format!(
-                    "\n  killed window:       {}\n  removed worktrees:   {}\n  disabled automations: {}",
-                    report.killed_window,
-                    report.removed_worktrees.len(),
-                    report.disabled_automations
-                ));
+                // Aligned, two-space-indented detail under the header line.
+                let mut detail: Vec<(&str, String)> = vec![
+                    ("killed window", report.killed_window.to_string()),
+                    (
+                        "removed worktrees",
+                        report.removed_worktrees.len().to_string(),
+                    ),
+                    (
+                        "disabled automations",
+                        report.disabled_automations.to_string(),
+                    ),
+                ];
                 if !report.worktree_errors.is_empty() {
-                    human.push_str(&format!(
-                        "\n  worktree errors:     {}",
-                        report.worktree_errors.join("; ")
-                    ));
+                    detail.push(("worktree errors", report.worktree_errors.join("; ")));
+                }
+                for line in output::kv(&detail).lines() {
+                    human.push_str(&format!("\n  {line}"));
                 }
             }
             Ok(CommandOutput::new(
@@ -258,20 +264,13 @@ fn render_session_list(sessions: &[SharedSession]) -> String {
     let rows: Vec<Vec<String>> = sessions
         .iter()
         .map(|s| {
-            let branch = s
-                .worktrees
-                .first()
-                .map(|w| w.branch.clone())
-                .unwrap_or_default();
+            // `dash` already maps an empty branch (no worktree) to "-".
+            let branch = s.worktrees.first().map(|w| w.branch.as_str());
             vec![
                 s.name.clone(),
                 s.agent.clone(),
                 s.backend_type.clone(),
-                output::dash(if branch.is_empty() {
-                    None
-                } else {
-                    Some(&branch)
-                }),
+                output::dash(branch),
                 output::dash(s.cwd.as_ref().map(|p| p.display().to_string()).as_deref()),
                 s.id.to_string(),
             ]
@@ -280,9 +279,10 @@ fn render_session_list(sessions: &[SharedSession]) -> String {
     output::table(&["NAME", "AGENT", "BACKEND", "BRANCH", "CWD", "ID"], &rows)
 }
 
-/// Render a single session as an aligned key/value block.
+/// Render a single session as an aligned key/value block, with any worktrees
+/// listed one per line beneath it.
 fn render_session_detail(s: &SharedSession) -> String {
-    let mut pairs: Vec<(&str, String)> = vec![
+    let pairs: Vec<(&str, String)> = vec![
         ("name", s.name.clone()),
         ("id", s.id.to_string()),
         ("agent", s.agent.clone()),
@@ -300,16 +300,15 @@ fn render_session_detail(s: &SharedSession) -> String {
             output::dash(s.parent_session_id.map(|id| id.to_string()).as_deref()),
         ),
     ];
-    if !s.worktrees.is_empty() {
-        let wt = s
-            .worktrees
-            .iter()
-            .map(|w| format!("{} @ {}", w.branch, w.worktree_path.display()))
-            .collect::<Vec<_>>()
-            .join("\n              ");
-        pairs.push(("worktrees", wt));
+    let mut block = output::kv(&pairs);
+    for w in &s.worktrees {
+        block.push_str(&format!(
+            "\nworktree:  {} @ {}",
+            w.branch,
+            w.worktree_path.display()
+        ));
     }
-    output::kv(&pairs)
+    block
 }
 
 fn parse_session_id(uuid: &str) -> Result<SessionId, String> {
@@ -356,6 +355,34 @@ mod tests {
         let v = run(Action::List { parent: None }, &db).unwrap();
         assert!(v.is_array(), "got {v}");
         assert_eq!(v.as_array().unwrap().len(), 0);
+        // The human rendering for an empty list is a friendly line, not a table.
+        assert_eq!(v.human, "No active sessions.");
+    }
+
+    #[test]
+    fn render_session_list_tabulates_rows() {
+        let s = SharedSession {
+            id: SessionId::default(),
+            name: "demo".into(),
+            agent: "dev".into(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: Some(std::path::PathBuf::from("/tmp/repo")),
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        };
+        let rendered = render_session_list(std::slice::from_ref(&s));
+        assert!(rendered.contains("NAME"));
+        assert!(rendered.contains("demo"));
+        assert!(rendered.contains("local-tmux"));
+        // No worktree → branch column shows a dash.
+        assert!(rendered.contains('-'));
     }
 
     #[test]

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -412,3 +412,91 @@ fn task_to_json(t: &Task) -> Value {
         "updated_at": t.updated_at,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal local task for render tests.
+    fn task(id: i64, title: &str, status: TaskStatus, action: Option<AutomationAction>) -> Task {
+        Task {
+            id,
+            title: title.to_string(),
+            description: None,
+            status,
+            action,
+            source: SOURCE_LOCAL.to_string(),
+            external_id: None,
+            external_url: None,
+            created_at: 0,
+            updated_at: 0,
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn status_glyph_covers_every_status() {
+        assert_eq!(status_glyph(TaskStatus::Todo), "☐ todo");
+        assert_eq!(status_glyph(TaskStatus::InProgress), "◐ in-progress");
+        assert_eq!(status_glyph(TaskStatus::Done), "☑ done");
+    }
+
+    #[test]
+    fn action_label_distinguishes_send_spawn_and_none() {
+        assert_eq!(task_action_label(&None), "-");
+        assert_eq!(
+            task_action_label(&Some(AutomationAction::Send {
+                session_id: SessionId::default(),
+            })),
+            "send"
+        );
+        assert_eq!(
+            task_action_label(&Some(AutomationAction::Spawn {
+                repo_path: "/x".into(),
+                worktree_branch: None,
+                base_branch: None,
+                agent: None,
+            })),
+            "spawn"
+        );
+    }
+
+    #[test]
+    fn render_task_list_empty_and_rows() {
+        assert_eq!(render_task_list(&[]), "No tasks.");
+        let rendered = render_task_list(&[task(1, "Write docs", TaskStatus::Todo, None)]);
+        assert!(rendered.contains("ID"));
+        assert!(rendered.contains("Write docs"));
+        assert!(rendered.contains("☐ todo"));
+    }
+
+    #[test]
+    fn render_task_detail_appends_description() {
+        let mut t = task(7, "Title", TaskStatus::InProgress, None);
+        t.description = Some("notes here".to_string());
+        let rendered = render_task_detail(&t);
+        assert!(rendered.contains("id:"));
+        assert!(rendered.contains("Title"));
+        assert!(rendered.ends_with("notes here"));
+    }
+
+    #[test]
+    fn render_task_run_summarizes_each_outcome() {
+        assert_eq!(
+            render_task_run(&json!({ "spawned": "demo", "id": 1 })),
+            "Spawned session 'demo' for the task."
+        );
+        assert_eq!(
+            render_task_run(&json!({ "reused": "demo", "id": 1 })),
+            "Re-sent the task to existing session 'demo'."
+        );
+        assert_eq!(
+            render_task_run(&json!({ "sent": true, "id": 1 })),
+            "Sent the task to its session."
+        );
+        assert_eq!(
+            render_task_run(&json!({ "skipped": "no agent", "id": 1 })),
+            "Skipped: no agent"
+        );
+    }
+}

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -8,6 +8,7 @@
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use crate::cli::output::{self, CommandOutput};
 use crate::session::{AutomationAction, SessionId, Task, TaskStatus, SOURCE_LOCAL};
 use crate::session_ops::SpawnRequest;
 use crate::storage::tasks::NewTask;
@@ -77,7 +78,7 @@ pub enum Action {
     },
 }
 
-pub fn run(action: Action, db: &Database) -> Result<Value, String> {
+pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
     match action {
         Action::Create {
             title,
@@ -106,13 +107,24 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             let id = db
                 .create_task(&new)
                 .map_err(|e| format!("create_task: {e}"))?;
-            Ok(task_to_json(&load(db, id)?))
+            let task = load(db, id)?;
+            Ok(CommandOutput::new(
+                task_to_json(&task),
+                format!("Created task #{}: {}", task.id, task.title),
+            ))
         }
         Action::List => {
             let tasks = db.list_tasks().map_err(|e| format!("list_tasks: {e}"))?;
-            Ok(Value::Array(tasks.iter().map(task_to_json).collect()))
+            let json = Value::Array(tasks.iter().map(task_to_json).collect());
+            Ok(CommandOutput::new(json, render_task_list(&tasks)))
         }
-        Action::Show { id } => Ok(task_to_json(&load(db, id)?)),
+        Action::Show { id } => {
+            let task = load(db, id)?;
+            Ok(CommandOutput::new(
+                task_to_json(&task),
+                render_task_detail(&task),
+            ))
+        }
         Action::Edit {
             id,
             title,
@@ -132,17 +144,100 @@ pub fn run(action: Action, db: &Database) -> Result<Value, String> {
             }
             db.update_task(&task)
                 .map_err(|e| format!("update_task: {e}"))?;
-            Ok(task_to_json(&load(db, id)?))
+            let task = load(db, id)?;
+            Ok(CommandOutput::new(
+                task_to_json(&task),
+                render_task_detail(&task),
+            ))
         }
         Action::Remove { id } => match db.soft_delete_task(id) {
-            Ok(true) => Ok(json!({ "removed": true, "id": id })),
+            Ok(true) => Ok(CommandOutput::new(
+                json!({ "removed": true, "id": id }),
+                format!("Removed task #{id}."),
+            )),
             Ok(false) => Err(format!("Task not found: {id}")),
             Err(e) => Err(format!("soft_delete_task: {e}")),
         },
         Action::Run { id } => {
             let task = load(db, id)?;
-            run_task(db, &task)
+            let json = run_task(db, &task)?;
+            let human = render_task_run(&json);
+            Ok(CommandOutput::new(json, human))
         }
+    }
+}
+
+/// Render the task list as an aligned table (or a friendly empty line).
+fn render_task_list(tasks: &[Task]) -> String {
+    if tasks.is_empty() {
+        return "No tasks.".to_string();
+    }
+    let rows: Vec<Vec<String>> = tasks
+        .iter()
+        .map(|t| {
+            vec![
+                t.id.to_string(),
+                status_glyph(t.status),
+                t.title.clone(),
+                task_action_label(&t.action),
+            ]
+        })
+        .collect();
+    output::table(&["ID", "STATUS", "TITLE", "ACTION"], &rows)
+}
+
+/// Render a single task as a key/value block, with the markdown body trailing.
+fn render_task_detail(t: &Task) -> String {
+    let mut pairs: Vec<(&str, String)> = vec![
+        ("id", t.id.to_string()),
+        ("title", t.title.clone()),
+        ("status", t.status.as_str().to_string()),
+        ("action", task_action_label(&t.action)),
+        ("source", t.source.clone()),
+    ];
+    if let Some(url) = &t.external_url {
+        pairs.push(("url", url.clone()));
+    }
+    let mut block = output::kv(&pairs);
+    if let Some(desc) = &t.description {
+        if !desc.is_empty() {
+            block.push_str("\n\n");
+            block.push_str(desc);
+        }
+    }
+    block
+}
+
+/// One-line human summary of a headless `task run` outcome.
+fn render_task_run(v: &Value) -> String {
+    if let Some(name) = v.get("spawned").and_then(Value::as_str) {
+        format!("Spawned session '{name}' for the task.")
+    } else if let Some(name) = v.get("reused").and_then(Value::as_str) {
+        format!("Re-sent the task to existing session '{name}'.")
+    } else if v.get("sent").and_then(Value::as_bool) == Some(true) {
+        "Sent the task to its session.".to_string()
+    } else if let Some(reason) = v.get("skipped").and_then(Value::as_str) {
+        format!("Skipped: {reason}")
+    } else {
+        v.to_string()
+    }
+}
+
+/// Short status glyph + word for the list table.
+fn status_glyph(status: TaskStatus) -> String {
+    match status {
+        TaskStatus::Todo => "☐ todo".to_string(),
+        TaskStatus::InProgress => "◐ in-progress".to_string(),
+        TaskStatus::Done => "☑ done".to_string(),
+    }
+}
+
+/// Human label for a task's optional agent action.
+fn task_action_label(action: &Option<AutomationAction>) -> String {
+    match action {
+        None => "-".to_string(),
+        Some(AutomationAction::Send { .. }) => "send".to_string(),
+        Some(AutomationAction::Spawn { .. }) => "spawn".to_string(),
     }
 }
 


### PR DESCRIPTION
## Problem
`thurbox-cli` printed JSON for every subcommand, which is unfriendly for humans running commands like `extension install` interactively.

## What changed
- **Human-readable by default**, with automatic JSON when stdout is piped (so `… | jq` keeps working untouched). Force a format with `--json` (compact), `--pretty` (indented JSON), or `--text` (human even when piped).
- Output: aligned **tables** for list/inbox/run-history, **key/value blocks** for get/show/detail, concise **confirmation lines** for mutations. `session capture` now prints the raw pane text.
- Architecture: every subcommand returns a `CommandOutput` carrying both the JSON `Value` and a pre-rendered human string, built where the typed data is in hand (no fragile re-parsing). New `src/cli/output.rs` holds format resolution + `table`/`kv` helpers. `config validate` can print its report yet still exit non-zero.
- Errors now print `error: <msg>` to stderr (plain) instead of a JSON blob.

## Compatibility (important)
Agents run **inside tmux panes (a TTY)**, so auto-detect would hand them human output. Every internal consumer that parses output now passes `--json` explicitly: the flow/shepherd/renovate snapshot + dispatch scripts, the remote-ssh dev test, and the agent-facing specs (FLOW/SHEPHERD/RENOVATE.md) + CLAUDE.md examples.

## Tests
- New unit tests for `output.rs` (format precedence, table/kv alignment). All existing CLI tests kept green via a `Deref<Target=Value>` on `CommandOutput`.
- `cargo test` (1153 passing), `cargo clippy -D warnings`, `cargo fmt --check`, architecture-rules, shellcheck, rumdl all pass locally.

Closes thurbox task #45.