### PR TITLE
feat(core): stable session identity + identity-aware mailbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,14 +440,37 @@ conventions, not an enum), a `body`, and optional provenance (`from_session_id`,
   limits; `prune_messages` / `prune_old_messages` (read messages older than
   `DEFAULT_RETENTION_DAYS`) run at DB open and on every `automation tick`,
   mirroring audit-log pruning. The mailbox is **not** audited (high-churn).
-- **CLI** (`thurbox-cli message`, alias `msg`): `send --to <uuid|name> --kind
-  <k> [--task <id>] [--from <uuid|name>] --body <text> [--no-wake]` enqueues and,
-  unless `--no-wake`, types a short `inbox` token into the recipient's pane
-  (reusing `agent::tmux::send_prompt_now`) to nudge it to drain now; `inbox --for
-  <uuid|name> [--claim] [--all] [--limit N]` reads it (`--claim` = atomic drain);
-  `prune [--older-than-days N] [--read-only]`. `cli::messages` resolves a session
-  by UUID **or** name via `Database::get_session_by_name`. `PRAGMA data_version`
-  already surfaces writes to the TUI — no sync/`SharedState` change.
+- **Identity (the registry key, self-knowable).** A session's thurbox
+  `SessionId` is **stable for life** — `respawn_stale_session` reuses the
+  original id on re-adoption (no soft-delete + new-row churn), so a cached id or
+  queued message addressed to a session never goes stale. At spawn thurbox
+  injects `THURBOX_SESSION` (= the `SessionId`, threaded via
+  `SessionConfig.session_id` so it's known *before* launch and reused on
+  respawn) and, for task-spawned sessions, `THURBOX_TASK` (= the task id). These
+  are distinct from the pre-existing `THURBOX_SESSION_ID` (= `agent_session_id`,
+  read by the metrics statusline). A `thurbox-cli` call running *inside* a
+  session thus proves its own identity without scraping panes or names.
+- **CLI** (`thurbox-cli message`, alias `msg`) — identity-aware:
+  - `send --to <uuid|name> --kind <k> [--task <id>] [--from <uuid|name>] --body
+    <text> [--no-wake]` enqueues and, unless `--no-wake`, types a short `inbox`
+    token into the recipient's pane (`agent::tmux::send_prompt_now`) to nudge a
+    drain. **Provenance + task tag default to the caller's injected identity**
+    (`THURBOX_SESSION`/`THURBOX_TASK`) so an agent passes **no ids**; `--from`/
+    `--task` override.
+  - `reply <message_id> --body <text> [--kind k] [--from …] [--no-wake]` —
+    enqueues back to the *original message's sender* (looked up via
+    `get_message`) and wakes them, carrying the original `from_task_id`. The
+    replier handles only the opaque message id — never a peer's session id. This
+    is how flow relays the user's answer without name-scraping.
+  - `inbox [--for <uuid|name>] [--claim] [--all] [--limit N]` reads it (`--claim`
+    = atomic drain); **`--for` defaults to the calling session** so an agent
+    reads its own mail with no id.
+  - `prune [--older-than-days N] [--read-only]`.
+  - `cli::messages` resolves a session by UUID **or** name (`resolve_uuid_or_name`
+    → `Database::get_session_by_name`); a `send`/`reply` with a wake also arms the
+    automation heartbeat (`cli::automations::arm_heartbeat`) so a missed wake is
+    still drained headless. `PRAGMA data_version` already surfaces writes to the
+    TUI — no sync/`SharedState` change.
 
 Automations fire even when the TUI is closed: a tmux heartbeat
 keeper window (`automation-heartbeat`, armed on TUI startup and on
@@ -618,11 +641,16 @@ sync, but the TUI editor never sets it.)
   before it codes and stays in scope. Worker↔flow coordination is
   **event-driven over the [inter-session message queue](#inter-session-messages-mailbox-queue)**:
   a worker pushes `message send --to flow --kind questions|plan|result`
-  (which wakes flow); flow drains its inbox (`message inbox --for flow
-  --claim`), surfaces the questions/plan under "Needs you", and relays the
-  user's answer/approval back to the worker with `session send`. The
-  `flow-tick` automation is demoted to a janitor/safety-net (drain missed
-  wakes, reset stale tasks, dispatch). The behavior spec
+  (which wakes flow) — passing **no ids** (thurbox auto-stamps the sender + task
+  from the injected `THURBOX_SESSION`/`THURBOX_TASK`); flow drains its inbox
+  (`message inbox --claim`, `--for` defaults to itself), surfaces the
+  questions/plan under "Needs you", and relays the user's answer/approval back
+  with `message reply <message_id>` — thurbox routes it to that message's sender,
+  so flow never maps a task to a session id (the old `flow-snapshot.sh`
+  name-parsing is now human-board only). The worker drains its own inbox on the
+  resulting `inbox` wake. The `flow-tick` automation is demoted to a
+  janitor/safety-net (drain missed wakes, reset stale tasks, dispatch). The
+  behavior spec
   is `FLOW.md`, surfaced to whichever CLI runs it via context-file
   symlinks (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `FLOW.md`). Install with
   `thurbox-cli extension install flow` (its `install.sh` is a thin shim

--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -41,8 +41,11 @@ Pattern-match the incoming message:
 **Workers push, you don't scrape.** Each worker reports through the durable
 message queue: it runs `thurbox-cli message send --to flow --kind
 questions|plan|result …`, which enqueues the message **and** types `inbox` into
-your pane to wake you. You read it with `thurbox-cli message inbox --for flow
---claim --json` (DRAIN) — never by capturing the worker's terminal.
+your pane to wake you. You read it with `thurbox-cli message inbox --claim --json`
+(DRAIN) — never by capturing the worker's terminal. (`--for` defaults to *you*,
+the calling session, so you don't pass your own id.) Thurbox stamps each message
+with its sender, so you reply by message id alone — **you never look up or handle
+a worker's session id**.
 
 **ANSWER vs CAPTURE.** When you surfaced a worker's clarifying questions or plan,
 the user's next free-text message is almost always the **answers / approval**,
@@ -183,21 +186,22 @@ first step of every TICK, so a missed wake never strands a worker.
    same one twice):
 
    ```bash
-   thurbox-cli message inbox --for flow --claim --json
+   thurbox-cli message inbox --claim --json
    ```
 
-   Each item is JSON: `{ "kind", "body", "from_task_id", ... }`. (Pass `--json`
-   because you run inside a tmux pane — a TTY — where the CLI otherwise prints a
-   human-readable table.)
+   Each item is JSON: `{ "id", "kind", "body", "from_task_id", ... }`. (Pass
+   `--json` because you run inside a tmux pane — a TTY — where the CLI otherwise
+   prints a human-readable table. `--for` defaults to you.) **Keep each surfaced
+   message's `id`** — it's the handle you reply to in ANSWER.
 2. For each message, by `kind`:
    - **`questions`** → the worker is parked waiting on you with a **single**
      clarifying question (workers ask one at a time, not in a batch). List the
-     `body` **verbatim** under "Needs you", tagged `#<from_task_id> <title>`. The
-     user's answer lets the worker send its next question (another `questions`
-     message) or move on to the plan.
+     `body` **verbatim** under "Needs you", tagged `#<from_task_id> <title>` and
+     noting its message `id`. The user's answer lets the worker send its next
+     question (another `questions` message) or move on to the plan.
    - **`plan`** → the worker wants approval before it codes. Show the `body`
-     **verbatim** under "Needs you", tagged `#<from_task_id> <title>`, and make
-     clear it needs an **approve / change** decision.
+     **verbatim** under "Needs you", tagged `#<from_task_id> <title>` (noting its
+     message `id`), and make clear it needs an **approve / change** decision.
    - **`result`** → the worker finished. Parse the `body` JSON: if
      `"status":"ok"`, mark the task done (`task edit <from_task_id> --status
      done`) and note it; if `"status":"error"`, surface it under "Needs you".
@@ -218,22 +222,22 @@ pass it through.**
 
 When the user replies to a question or a plan you surfaced:
 
-1. Identify the waiting worker. Usually it's the one whose message you most
-   recently surfaced; map its `#<id>` to the session uuid via `flow-snapshot.sh`
-   (its `## sessions` block prints each worker's `#<id>` next to its uuid) or
-   `session list` (session name `… · #<id>`, or legacy `task-<id>-…`). If several
+1. Identify which surfaced message the reply answers — normally the one you most
+   recently surfaced. You need its **message `id`** (kept from DRAIN). If several
    workers are waiting and the reply doesn't make the target obvious, route by
    content — or ask ONE short routing question (`#<id> or #<id>?`).
-2. Relay the reply verbatim into that worker's session:
+2. Relay the reply verbatim with `message reply`, addressing the **message id**
+   (thurbox routes it back to that message's sender and wakes them — you never
+   touch a session id):
 
    ```bash
-   thurbox-cli session send <worker-uuid> "<the user's reply, verbatim>"
+   thurbox-cli message reply <message_id> --body "<the user's reply, verbatim>"
    ```
 
-   The worker resumes from there (plans after answers; builds after approval).
-   Your `send` is what wakes it.
-3. Confirm one line (`relayed → #<id>`) and end with the Output Contract footer.
-   Create no task; an ANSWER is not a brain-dump.
+   The worker drains its inbox on the wake and resumes (plans after answers;
+   builds after approval).
+3. Confirm one line (`relayed → #<from_task_id>`) and end with the Output Contract
+   footer. Create no task; an ANSWER is not a brain-dump.
 
 ## TICK (from the automation — quiet janitor + safety net)
 

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -119,12 +119,15 @@ tagged URL (`…/thurbox/v0.112.0/extensions/flow`) instead.
 - **Event-driven relay via a message queue**: workers hand the `flow` session
   clean, structured payloads through the durable `thurbox-cli message` queue —
   `--kind questions`, `--kind plan`, `--kind result` — instead of flow scraping
-  their terminals. Each push also wakes flow, so it surfaces the question or
+  their terminals. Workers pass **no ids**: thurbox injects each session's
+  identity (`THURBOX_SESSION`/`THURBOX_TASK`) at spawn and auto-stamps the
+  sender + task tag. Each push also wakes flow, so it surfaces the question or
   plan under "Needs you" immediately; you type your answer / approval naturally
-  and flow relays it straight back to the waiting worker (`session send`). Flow
-  is a pure pass-through: it never answers, invents, or approves — it just wires
-  the worker to you and back. Several workers can be mid-conversation at once,
-  each tagged by its `#<id>`.
+  and flow relays it back with `message reply <message_id>` — thurbox routes it
+  to that message's sender, so flow never handles a worker's session id. Flow is
+  a pure pass-through: it never answers, invents, or approves — it just wires the
+  worker to you and back. Several workers can be mid-conversation at once, each
+  tagged by its `#<id>`.
 - `status` for a one-screen report; `clean` to groom the backlog.
 - A tick prints the **board** — a quick-glance table of all live
   `flow` / worker (`… · #<id>`) sessions with status, age, and the task they're

--- a/extensions/flow/scripts/create-task.bats
+++ b/extensions/flow/scripts/create-task.bats
@@ -32,6 +32,12 @@ setup() {
   # The old batched phrasing (and its multi-question example body) must be gone.
   [[ "$output" != *"as ONE message"* ]]
   [[ "$output" != *"Q1 ..."* ]]
+  # The worker passes NO ids — thurbox injects identity + task tag. The old
+  # `--task <id>` / `--from` hand-typing must be gone, and the reply arrives in
+  # the worker's own inbox (drained on the `inbox` wake).
+  [[ "$output" != *"--task <id>"* ]]
+  [[ "$output" != *"--from"* ]]
+  [[ "$output" == *"message inbox --claim"* ]]
   [[ "$output" == *"message send --to flow --kind plan"* ]]
   [[ "$output" == *"## Problem"* ]]
   [[ "$output" == *"## Acceptance criteria"* ]]

--- a/extensions/flow/scripts/create-task.sh
+++ b/extensions/flow/scripts/create-task.sh
@@ -22,8 +22,10 @@
 # then (2) push a written plan via
 # `--kind plan` and WAIT for the user's approval (relayed by flow), then
 # (3) implement strictly against the approved plan. Worker → flow handoffs go
-# through the durable message queue (not pane scraping); flow → worker replies
-# arrive as normal session input. The flow agent no longer hand-types this
+# through the durable message queue (not pane scraping); the worker passes NO ids
+# (thurbox injects THURBOX_SESSION/THURBOX_TASK and auto-stamps provenance + the
+# task tag), and flow → worker replies arrive back in the worker's own inbox
+# (drained on the `inbox` wake). The flow agent no longer hand-types this
 # boilerplate; it passes the structured flags and the script keeps the contract
 # identical across every dispatch.
 #
@@ -83,31 +85,36 @@ build_description() {
 
 ## Planning phase — do this FIRST, before writing any code
 
-Clarify, then plan, then build — strictly in that order. You report back to the
-flow agent through the thurbox message queue (replace <id> with THIS task's id);
-flow surfaces each message to the user and relays the user's reply to you as a
-new message in this session.
+Clarify, then plan, then build — strictly in that order. You coordinate with the
+flow agent through the thurbox message queue. Thurbox already knows who you are
+and which task you're on, so you pass **no ids** — just `--to flow --kind … --body
+…`. When flow relays the user's reply, your pane is woken with the word `inbox`;
+the moment you see it, read the reply with:
+
+    thurbox-cli message inbox --claim
+
+(the answer/approval is the message body — `--for` defaults to you, no id needed).
 
 1. **Ask clarifying questions ONE AT A TIME.** Unless the task is genuinely
    trivial and unambiguous, ask clarifying questions about scope, edge cases, the
    acceptance bar, and anything underspecified — but send them **one at a time, in
    order, never batched**. Send a SINGLE question, then STOP:
 
-       thurbox-cli message send --to flow --kind questions --task <id> \
+       thurbox-cli message send --to flow --kind questions \
          --body 'Q: ...'
 
    End your turn and wait — do NOT send the next question, plan, or write code
-   yet. Flow relays that one question to the user and sends the answer back as a
-   new message here; resume only when it arrives, then send your next question
-   the same way (one message, then STOP). Ask **as many as you need** (typically
-   3+), but be adaptive: let each answer shape the next question, and once an
-   answer clarifies enough that the remaining questions are moot, drop them and
-   proceed straight to the plan.
+   yet. Flow relays that one question to the user; when the answer arrives you are
+   woken with `inbox` — drain it (above), then send your next question the same
+   way (one message, then STOP). Ask **as many as you need** (typically 3+), but
+   be adaptive: let each answer shape the next question, and once an answer
+   clarifies enough that the remaining questions are moot, drop them and proceed
+   straight to the plan.
 
 2. **Plan, then wait for approval.** With the answers in hand, write a structured
    plan and send it to flow for the user to approve — do NOT start coding yet:
 
-       thurbox-cli message send --to flow --kind plan --task <id> \
+       thurbox-cli message send --to flow --kind plan \
          --body '## Problem
        <1–2 sentences>
        ## Acceptance criteria
@@ -115,11 +122,11 @@ new message in this session.
        ## Approach
        <files you will touch, the design, risks / open questions>'
 
-   Then STOP and wait. Flow relays the plan to the user; resume only when the
-   reply arrives. If the user approves, implement. If they request changes,
-   revise the plan and send an updated `--kind plan` message, then wait again.
-   (Do not use an interactive plan mode / approval modal — nothing drives it in a
-   headless worker; the plan message IS the gate.)
+   Then STOP and wait. Flow relays the plan to the user; when you are woken with
+   `inbox`, drain it for the decision. If the user approves, implement. If they
+   request changes, revise the plan and send an updated `--kind plan` message,
+   then wait again. (Do not use an interactive plan mode / approval modal —
+   nothing drives it in a headless worker; the plan message IS the gate.)
 
 3. **Implement** strictly against the approved plan. If the work would drift
    outside it, stop and note the change rather than silently expanding scope.
@@ -130,11 +137,11 @@ PLAN_BLOCK
 
 You are working in a dedicated git worktree on branch ${branch}; commit
 your work there and open a PR when the accept criterion is met. When finished:
-mark this task done (thurbox-cli task edit <id> --status done), then report the
-result to the flow agent (replace <id> with THIS task's id) — this also wakes
-flow so the next task dispatches immediately:
+mark this task done (thurbox-cli task edit \$THURBOX_TASK --status done), then
+report the result to the flow agent — this also wakes flow so the next task
+dispatches immediately (no ids: thurbox tags the message with your task for you):
 
-    thurbox-cli message send --to flow --kind result --task <id> \\
+    thurbox-cli message send --to flow --kind result \\
       --body '{"status":"ok|error","artifact":"...","notes":"...","pr_url":"..."}'
 FOOTER
   fi

--- a/extensions/flow/scripts/flow-sessions.bats
+++ b/extensions/flow/scripts/flow-sessions.bats
@@ -1,10 +1,11 @@
 #!/usr/bin/env bats
 # Tests for the worker-session matching in flow-snapshot.sh / flow-summary.sh.
 # Worker sessions are named "<title> · #<id>" (current) or "task-<id>[-…]"
-# (legacy); both scripts must list them and map them to their task #<id> so the
-# flow agent can resolve a worker's session uuid for `session send`. A stub
-# `thurbox-cli` on PATH feeds canned `session list` / `task list` JSON, so these
-# run anywhere bats + jq are installed.
+# (legacy); both scripts must list them and tag them with their task #<id> for
+# the **human board** (routing now goes through `message reply <id>`, which
+# thurbox resolves — these scripts no longer drive it). A stub `thurbox-cli` on
+# PATH feeds canned `session list` / `task list` JSON, so these run anywhere
+# bats + jq are installed.
 
 setup() {
   SNAPSHOT="${BATS_TEST_DIRNAME}/flow-snapshot.sh"

--- a/extensions/flow/scripts/flow-snapshot.sh
+++ b/extensions/flow/scripts/flow-snapshot.sh
@@ -27,8 +27,10 @@ echo
 echo "## sessions (flow / workers)"
 # Worker sessions are named "<title> · #<id>" (current) or "task-<id>[-…]"
 # (legacy) — mirror Task::matches_spawn_session. The derived #<id> is printed
-# first so ANSWER can map a task id straight to the session uuid for
-# `session send`.
+# first purely for the **human board** (it tells you which task a worker is on).
+# Routing no longer relies on it: ANSWER replies by message id
+# (`message reply <id>`), and thurbox resolves the sender — flow never maps a
+# task id to a session uuid.
 if SESSIONS="$(thurbox-cli session list --json 2>/dev/null)"; then
   printf '%s' "$SESSIONS" | jq -r '
     .[]

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -331,6 +331,11 @@ impl Session {
         )?;
 
         let mut info = SessionInfo::new(name);
+        // Reuse the caller-supplied id when present (stable identity across a
+        // respawn; matches the `THURBOX_SESSION` env injected before launch).
+        if let Some(id) = config.session_id {
+            info.id = id;
+        }
         info.agent_session_id = config.agent_session_id.clone();
         info.cwd = config.cwd.clone();
         if !config.agent.is_empty() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2259,8 +2259,23 @@ impl App {
         if config.agent_session_id.is_none() {
             config.agent_session_id = Some(uuid::Uuid::new_v4().to_string());
         }
+        // Mint the thurbox SessionId up front (unless a respawn supplied one) so
+        // it can be injected as `THURBOX_SESSION` before launch and `Session::spawn`
+        // reuses it. Stable across restarts.
+        if config.session_id.is_none() {
+            config.session_id = Some(SessionId::default());
+        }
 
-        // Inject statusline env vars so the metrics script knows which session this is.
+        // Inject identity + statusline env vars (kept in sync with the headless
+        // `session_ops::inject_thurbox_env`). `THURBOX_SESSION` is the thurbox
+        // session key (read by the mailbox CLI); `THURBOX_SESSION_ID` is the
+        // agent's conversation id (read by the metrics script) — kept distinct.
+        // `THURBOX_TASK` is not set here: TUI task spawns track the task↔session
+        // link in-memory (`task_session_links`); only the headless `task run`
+        // path auto-tags messages with it.
+        if let Some(id) = config.session_id {
+            config.env.insert("THURBOX_SESSION".into(), id.to_string());
+        }
         if let Some(ref sid) = config.agent_session_id {
             config.env.insert("THURBOX_SESSION_ID".into(), sid.clone());
         }
@@ -3556,11 +3571,12 @@ impl App {
         agent_session_id: String,
         worktrees: Vec<WorktreeInfo>,
     ) {
-        if let Err(e) = self.db.soft_delete_session(shared.id) {
-            error!("Failed to soft-delete stale session {}: {e}", shared.id);
-        }
-
+        // Reuse the original SessionId so the session's identity is stable across
+        // restarts: `do_spawn_session` upserts in place (no soft-delete + new-row
+        // churn), and `THURBOX_SESSION` is re-injected with the same id. Any
+        // cached id / queued message addressed to this session stays valid.
         let mut config = SessionConfig {
+            session_id: Some(shared.id),
             resume_session_id: None,
             agent_session_id: Some(agent_session_id.clone()),
             cwd: shared.cwd,

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -457,6 +457,7 @@ fn fire_headless(
                 agent_session_id: None,
                 host: None,
                 parent_session_id: None,
+                task_id: None,
             };
             match crate::session_ops::spawn_session_headless(db, req) {
                 Ok(result) => {
@@ -559,7 +560,7 @@ fn automation_to_json(a: &Automation) -> Value {
 /// Best-effort: ensure the tmux heartbeat keeper is running so the automation
 /// fires even when no TUI is attached. Failures (e.g. tmux missing) are
 /// non-fatal — the automation still works while the TUI is up.
-fn arm_heartbeat() {
+pub(crate) fn arm_heartbeat() {
     let cli = crate::agent::tmux::resolve_cli_binary();
     if let Err(e) = crate::agent::tmux::ensure_automation_heartbeat(&cli) {
         eprintln!("warning: failed to arm automation heartbeat: {e}");

--- a/src/cli/messages.rs
+++ b/src/cli/messages.rs
@@ -34,21 +34,42 @@ pub enum Action {
         /// Message body.
         #[arg(long)]
         body: String,
-        /// Originating task id, when sending on behalf of a thurbox task.
+        /// Originating task id. Defaults to the caller's `THURBOX_TASK` when run
+        /// inside a task-spawned session; pass explicitly to override.
         #[arg(long)]
         task: Option<i64>,
-        /// Sender session (UUID or name), for provenance.
+        /// Sender session (UUID or name), for provenance. Defaults to the caller
+        /// (`THURBOX_SESSION`) when run inside a session; pass to override.
         #[arg(long)]
         from: Option<String>,
         /// Don't type a wake nudge into the recipient's pane (enqueue silently).
         #[arg(long = "no-wake")]
         no_wake: bool,
     },
+    /// Reply to a message: enqueue back to its original sender and wake them.
+    /// The replier only needs the message id (no peer UUID/name handling).
+    Reply {
+        /// The message id being answered (from an `inbox` read).
+        message_id: i64,
+        /// Reply body.
+        #[arg(long)]
+        body: String,
+        /// Reply kind tag (defaults to "reply").
+        #[arg(long, default_value = "reply")]
+        kind: String,
+        /// Sender session (UUID or name); defaults to the caller (`THURBOX_SESSION`).
+        #[arg(long)]
+        from: Option<String>,
+        /// Don't type a wake nudge into the recipient's pane.
+        #[arg(long = "no-wake")]
+        no_wake: bool,
+    },
     /// Read a session's inbox. Peeks unread by default; `--claim` drains them.
     Inbox {
-        /// Recipient session (UUID or name).
+        /// Recipient session (UUID or name). Defaults to the calling session
+        /// (`THURBOX_SESSION`) so an agent reads its own mail with no id.
         #[arg(long = "for")]
-        for_session: String,
+        for_session: Option<String>,
         /// Atomically mark the returned messages read (exactly-once drain).
         #[arg(long)]
         claim: bool,
@@ -81,48 +102,56 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             no_wake,
         } => {
             let recipient = resolve_uuid_or_name(db, &to)?;
+            // Provenance + task tag default to the calling session's injected
+            // identity (`THURBOX_SESSION` / `THURBOX_TASK`), so an agent never has
+            // to know or pass its own ids. Explicit flags override.
             let from_session_id = match from {
                 Some(ref f) => Some(resolve_uuid_or_name(db, f)?.id),
-                None => None,
+                None => calling_session_id(db),
             };
+            let from_task_id = task.or_else(calling_task_id);
             let new = NewMessage {
                 to_session_id: recipient.id,
                 from_session_id,
-                from_task_id: task,
+                from_task_id,
                 kind,
                 body,
             };
-            let id = db
-                .enqueue_message(&new)
-                .map_err(|e| format!("enqueue_message: {e}"))?;
-
-            let mut woke = false;
-            if !no_wake {
-                // Best-effort nudge: a missing/dead window must not fail the send
-                // (the message is already durably queued for the next drain).
-                match crate::agent::tmux::send_prompt_now(&recipient.name, WAKE_TOKEN) {
-                    Ok(()) => woke = true,
-                    Err(e) => tracing::debug!(
-                        "message send: wake nudge to {} failed: {e}",
-                        recipient.name
-                    ),
-                }
-            }
-            let human = format!(
-                "Enqueued message #{id} to '{}'{}.",
-                recipient.name,
-                if woke { " (woke it)" } else { "" }
-            );
-            Ok(CommandOutput::new(
-                json!({
-                    "enqueued": true,
-                    "message_id": id,
-                    "to_session_id": recipient.id.to_string(),
-                    "to_session_name": recipient.name,
-                    "woke": woke,
-                }),
-                human,
-            ))
+            enqueue_and_wake(db, &recipient, new, no_wake)
+        }
+        Action::Reply {
+            message_id,
+            body,
+            kind,
+            from,
+            no_wake,
+        } => {
+            let original = db
+                .get_message(message_id)
+                .map_err(|e| format!("get_message: {e}"))?
+                .ok_or_else(|| format!("Message not found: #{message_id}"))?;
+            let sender_id = original.from_session_id.ok_or_else(|| {
+                format!("Message #{message_id} has no known sender — cannot reply")
+            })?;
+            let recipient = db
+                .get_session_by_id(sender_id)
+                .map_err(|e| format!("get_session_by_id: {e}"))?
+                .ok_or_else(|| {
+                    format!("Sender of message #{message_id} ({sender_id}) no longer exists")
+                })?;
+            let from_session_id = match from {
+                Some(ref f) => Some(resolve_uuid_or_name(db, f)?.id),
+                None => calling_session_id(db),
+            };
+            // Carry the originating task tag through so the reply stays threaded.
+            let new = NewMessage {
+                to_session_id: recipient.id,
+                from_session_id,
+                from_task_id: original.from_task_id,
+                kind,
+                body,
+            };
+            enqueue_and_wake(db, &recipient, new, no_wake)
         }
         Action::Inbox {
             for_session,
@@ -130,7 +159,13 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             all,
             limit,
         } => {
-            let recipient = resolve_uuid_or_name(db, &for_session)?;
+            let recipient = match for_session {
+                Some(ref r) => resolve_uuid_or_name(db, r)?,
+                None => calling_session(db).ok_or_else(|| {
+                    "no --for given and THURBOX_SESSION is unset (not running inside a session)"
+                        .to_string()
+                })?,
+            };
             let messages = if claim {
                 db.claim_messages(recipient.id, limit)
                     .map_err(|e| format!("claim_messages: {e}"))?
@@ -205,6 +240,72 @@ fn first_line(body: &str) -> String {
     } else {
         line.to_string()
     }
+}
+
+/// Enqueue a message + best-effort wake nudge, then build the command output.
+/// Shared by `send` and `reply`. `new.to_session_id` must be `recipient.id`
+/// (the recipient is also needed by name for the wake nudge).
+fn enqueue_and_wake(
+    db: &Database,
+    recipient: &SharedSession,
+    new: NewMessage,
+    no_wake: bool,
+) -> Result<CommandOutput, String> {
+    let id = db
+        .enqueue_message(&new)
+        .map_err(|e| format!("enqueue_message: {e}"))?;
+
+    let mut woke = false;
+    if !no_wake {
+        // Best-effort nudge: a missing/dead window must not fail the send (the
+        // message is already durably queued for the next drain).
+        match crate::agent::tmux::send_prompt_now(&recipient.name, WAKE_TOKEN) {
+            Ok(()) => woke = true,
+            Err(e) => {
+                tracing::debug!("message: wake nudge to {} failed: {e}", recipient.name)
+            }
+        }
+        // Keep the headless janitor ticking so a missed wake is still drained in
+        // bounded time even when the TUI never started (durability is already
+        // guaranteed by the queue; this guarantees timeliness too). Tied to the
+        // wake path so silent (`--no-wake`) enqueues stay tmux-free.
+        crate::cli::automations::arm_heartbeat();
+    }
+
+    let human = format!(
+        "Enqueued message #{id} to '{}'{}.",
+        recipient.name,
+        if woke { " (woke it)" } else { "" }
+    );
+    Ok(CommandOutput::new(
+        json!({
+            "enqueued": true,
+            "message_id": id,
+            "to_session_id": recipient.id.to_string(),
+            "to_session_name": recipient.name,
+            "woke": woke,
+        }),
+        human,
+    ))
+}
+
+/// The calling session, resolved from the `THURBOX_SESSION` env var thurbox
+/// injects at spawn (the registry key). `None` when not running inside a thurbox
+/// session, or the id no longer maps to a live row.
+fn calling_session(db: &Database) -> Option<SharedSession> {
+    let raw = std::env::var("THURBOX_SESSION").ok()?;
+    let id: SessionId = raw.parse().ok()?;
+    db.get_session_by_id(id).ok().flatten()
+}
+
+/// The calling session's id from `THURBOX_SESSION` (used for provenance).
+fn calling_session_id(db: &Database) -> Option<SessionId> {
+    calling_session(db).map(|s| s.id)
+}
+
+/// The calling session's originating task id from the injected `THURBOX_TASK`.
+fn calling_task_id() -> Option<i64> {
+    std::env::var("THURBOX_TASK").ok()?.parse().ok()
 }
 
 /// Resolve a session reference that may be either a UUID or a session name.
@@ -288,7 +389,7 @@ mod tests {
         // Peek (unread) without consuming.
         let peek = run(
             Action::Inbox {
-                for_session: "flow".into(),
+                for_session: Some("flow".into()),
                 claim: false,
                 all: false,
                 limit: None,
@@ -303,7 +404,7 @@ mod tests {
         // Claim drains exactly once.
         let claimed = run(
             Action::Inbox {
-                for_session: "flow".into(),
+                for_session: Some("flow".into()),
                 claim: true,
                 all: false,
                 limit: None,
@@ -314,7 +415,7 @@ mod tests {
         assert_eq!(claimed.as_array().unwrap().len(), 1);
         let empty = run(
             Action::Inbox {
-                for_session: "flow".into(),
+                for_session: Some("flow".into()),
                 claim: true,
                 all: false,
                 limit: None,
@@ -344,7 +445,7 @@ mod tests {
         .unwrap();
         let peek = run(
             Action::Inbox {
-                for_session: "flow".into(),
+                for_session: Some("flow".into()),
                 claim: false,
                 all: false,
                 limit: None,
@@ -356,6 +457,126 @@ mod tests {
             peek[0]["from_session_id"].as_str(),
             Some(worker.to_string().as_str())
         );
+    }
+
+    #[test]
+    fn reply_routes_back_to_original_sender() {
+        let db = db();
+        add_session(&db, "flow");
+        let worker = add_session(&db, "worker");
+        // Worker → flow (provenance recorded via explicit --from, as the env is
+        // unset in tests).
+        let sent = run(
+            Action::Send {
+                to: "flow".into(),
+                kind: "questions".into(),
+                body: "Q1?".into(),
+                task: Some(7),
+                from: Some("worker".into()),
+                no_wake: true,
+            },
+            &db,
+        )
+        .unwrap();
+        let msg_id = sent["message_id"].as_i64().unwrap();
+
+        // Flow replies by message id — no peer id handling.
+        run(
+            Action::Reply {
+                message_id: msg_id,
+                body: "use the new API".into(),
+                kind: "reply".into(),
+                from: Some("flow".into()),
+                no_wake: true,
+            },
+            &db,
+        )
+        .unwrap();
+
+        // The reply lands in the worker's inbox, threaded on the original task.
+        let worker_inbox = run(
+            Action::Inbox {
+                for_session: Some("worker".into()),
+                claim: false,
+                all: false,
+                limit: None,
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(worker_inbox.as_array().unwrap().len(), 1);
+        assert_eq!(worker_inbox[0]["body"], "use the new API");
+        assert_eq!(worker_inbox[0]["from_task_id"], 7);
+        assert_eq!(
+            worker_inbox[0]["to_session_id"].as_str(),
+            Some(worker.to_string().as_str())
+        );
+    }
+
+    #[test]
+    fn reply_without_known_sender_errors() {
+        let db = db();
+        add_session(&db, "flow");
+        // A message with no provenance (from_session_id = None).
+        let sent = run(
+            Action::Send {
+                to: "flow".into(),
+                kind: "note".into(),
+                body: "anon".into(),
+                task: None,
+                from: None,
+                no_wake: true,
+            },
+            &db,
+        )
+        .unwrap();
+        let msg_id = sent["message_id"].as_i64().unwrap();
+        let err = run(
+            Action::Reply {
+                message_id: msg_id,
+                body: "hi".into(),
+                kind: "reply".into(),
+                from: None,
+                no_wake: true,
+            },
+            &db,
+        )
+        .unwrap_err();
+        assert!(err.contains("no known sender"), "got {err}");
+    }
+
+    #[test]
+    fn reply_to_missing_message_errors() {
+        let db = db();
+        let err = run(
+            Action::Reply {
+                message_id: 999,
+                body: "hi".into(),
+                kind: "reply".into(),
+                from: None,
+                no_wake: true,
+            },
+            &db,
+        )
+        .unwrap_err();
+        assert!(err.contains("Message not found"), "got {err}");
+    }
+
+    #[test]
+    fn inbox_without_for_and_no_env_errors() {
+        let db = db();
+        // No --for and (in tests) THURBOX_SESSION unset → a clear error.
+        let err = run(
+            Action::Inbox {
+                for_session: None,
+                claim: false,
+                all: false,
+                limit: None,
+            },
+            &db,
+        )
+        .unwrap_err();
+        assert!(err.contains("THURBOX_SESSION"), "got {err}");
     }
 
     #[test]
@@ -380,7 +601,7 @@ mod tests {
         // Claim it (marks read), then send a second unread one.
         run(
             Action::Inbox {
-                for_session: "flow".into(),
+                for_session: Some("flow".into()),
                 claim: true,
                 all: false,
                 limit: None,
@@ -393,7 +614,7 @@ mod tests {
         // Default peek shows only the unread one...
         let unread = run(
             Action::Inbox {
-                for_session: "flow".into(),
+                for_session: Some("flow".into()),
                 claim: false,
                 all: false,
                 limit: None,
@@ -407,7 +628,7 @@ mod tests {
         // ...--all shows both (read + unread).
         let all = run(
             Action::Inbox {
-                for_session: "flow".into(),
+                for_session: Some("flow".into()),
                 claim: false,
                 all: true,
                 limit: None,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -605,7 +605,7 @@ mod tests {
         else {
             panic!("expected Message::Inbox");
         };
-        assert_eq!(for_session, "flow");
+        assert_eq!(for_session.as_deref(), Some("flow"));
         assert!(claim);
         assert!(!all);
     }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -131,6 +131,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 agent_session_id: None,
                 host,
                 parent_session_id,
+                task_id: None,
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
             let human = format!(

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -297,6 +297,7 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
                 agent_session_id: None,
                 host: None,
                 parent_session_id: None,
+                task_id: Some(task.id),
             };
             crate::session_ops::spawn_session_headless(db, req)?;
             crate::agent::tmux::send_prompt_after_delay(&name, &prompt, BOOT_DELAY_SECS)

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -245,6 +245,12 @@ pub struct SessionCommand {
 
 #[derive(Debug, Clone, Default)]
 pub struct SessionConfig {
+    /// Desired thurbox [`SessionId`] for the spawned session. When set, the
+    /// spawn path uses this id instead of minting a fresh one — so the id is
+    /// known *before* launch (to inject it into the process env as
+    /// `THURBOX_SESSION`) and can be reused across a respawn so a session's
+    /// identity is stable for life. `None` mints a new id at spawn.
+    pub session_id: Option<SessionId>,
     /// Resume an existing agent session (process restart of a known session).
     pub resume_session_id: Option<String>,
     /// Pin a session id on a fresh spawn (agents that support it).

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -527,6 +527,7 @@ pub fn ensure_extension(db: &Database, def: &ExtensionDef) -> Result<EnsureRepor
                         agent_session_id: None,
                         host: None,
                         parent_session_id: None,
+                        task_id: None,
                     },
                 )?;
                 report.sessions_created.push(sess.name.clone());

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -106,15 +106,34 @@ fn build_agent_invocation(config: &SessionConfig) -> (String, Vec<String>) {
     (command, args)
 }
 
-/// Inject the standard thurbox env hints (`THURBOX_SESSION_ID`,
-/// `THURBOX_METRICS_DIR`) into a session config.
+/// Inject the standard thurbox env hints into a session config so a
+/// `thurbox-cli` call running *inside* the session can prove its own identity
+/// without scraping panes or names:
 ///
-/// Mirrors `App::do_spawn_session` so headless and TUI sessions look
-/// identical to the spawned process.
-fn inject_thurbox_env(config: &mut SessionConfig, agent_session_id: &str) {
+/// - `THURBOX_SESSION` — the thurbox [`SessionId`] (the registry key). Read by
+///   the mailbox CLI to auto-stamp provenance and default the inbox to "me".
+///   Requires `config.session_id` to be set before calling.
+/// - `THURBOX_SESSION_ID` — the *agent's* conversation id (`agent_session_id`),
+///   consumed by the metrics statusline. Distinct from `THURBOX_SESSION`.
+/// - `THURBOX_TASK` — the originating task id, when this session was spawned for
+///   a task (so messages auto-tag `from_task_id`). Headless `task run` only; the
+///   TUI task-spawn path tracks the link in-memory instead.
+/// - `THURBOX_METRICS_DIR` — metrics output dir.
+///
+/// Kept in sync with `App::build_spawn_inputs` so headless and TUI sessions look
+/// identical to the spawned process (modulo `THURBOX_TASK` as noted above).
+fn inject_thurbox_env(config: &mut SessionConfig, agent_session_id: &str, task_id: Option<i64>) {
     config
         .env
         .insert("THURBOX_SESSION_ID".into(), agent_session_id.into());
+    if let Some(id) = config.session_id {
+        config.env.insert("THURBOX_SESSION".into(), id.to_string());
+    }
+    if let Some(task_id) = task_id {
+        config
+            .env
+            .insert("THURBOX_TASK".into(), task_id.to_string());
+    }
     if let Some(dir) = crate::paths::metrics_directory() {
         config
             .env
@@ -125,6 +144,35 @@ fn inject_thurbox_env(config: &mut SessionConfig, agent_session_id: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::SessionId;
+
+    #[test]
+    fn inject_env_sets_identity_and_task() {
+        let sid = SessionId::default();
+        let mut config = SessionConfig {
+            session_id: Some(sid),
+            ..SessionConfig::default()
+        };
+        inject_thurbox_env(&mut config, "agent-conv-uuid", Some(42));
+        // The thurbox session key and the agent conversation id are distinct.
+        assert_eq!(config.env.get("THURBOX_SESSION"), Some(&sid.to_string()));
+        assert_eq!(
+            config.env.get("THURBOX_SESSION_ID"),
+            Some(&"agent-conv-uuid".to_string())
+        );
+        assert_eq!(config.env.get("THURBOX_TASK"), Some(&"42".to_string()));
+    }
+
+    #[test]
+    fn inject_env_omits_task_when_absent() {
+        let mut config = SessionConfig {
+            session_id: Some(SessionId::default()),
+            ..SessionConfig::default()
+        };
+        inject_thurbox_env(&mut config, "agent-conv-uuid", None);
+        assert!(config.env.contains_key("THURBOX_SESSION"));
+        assert!(!config.env.contains_key("THURBOX_TASK"));
+    }
 
     #[test]
     fn resume_id_is_none_when_no_transcript() {

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -25,12 +25,14 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
         .ok_or_else(|| format!("Cannot restart session {session_id} without agent_session_id"))?;
 
     let mut config = SessionConfig {
+        // Keep the same identity across a restart so `THURBOX_SESSION` is stable.
+        session_id: Some(session_id),
         agent_session_id: Some(agent_session_id.clone()),
         cwd: session.cwd.clone(),
         agent: session.agent.clone(),
         ..SessionConfig::default()
     };
-    super::inject_thurbox_env(&mut config, &agent_session_id);
+    super::inject_thurbox_env(&mut config, &agent_session_id, None);
     let def = super::resolve_agent_def(&config.agent);
     config.resume_session_id = super::resume_trigger_for(&def, &agent_session_id, &config.env);
 

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -37,6 +37,10 @@ pub struct SpawnRequest {
     /// Optional parent session (lead/worker relationship for orchestration).
     /// Must reference an existing active session.
     pub parent_session_id: Option<SessionId>,
+    /// Optional originating task id. When set it is injected as `THURBOX_TASK`
+    /// so the session's outgoing messages auto-tag `from_task_id` without the
+    /// agent passing any id by hand.
+    pub task_id: Option<i64>,
 }
 
 /// Result returned on successful headless spawn.
@@ -69,14 +73,19 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         .clone()
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
+    // Mint the thurbox SessionId up front so it can be injected into the
+    // process env (`THURBOX_SESSION`) before the agent launches.
+    let session_id = SessionId::default();
+
     let mut config = SessionConfig {
+        session_id: Some(session_id),
         agent_session_id: Some(agent_session_id.clone()),
         cwd: Some(cwd.clone()),
         agent: agent_name.clone(),
         backend: (backend_type != LOCAL_TMUX_BACKEND_TYPE).then(|| backend_type.clone()),
         ..SessionConfig::default()
     };
-    super::inject_thurbox_env(&mut config, &agent_session_id);
+    super::inject_thurbox_env(&mut config, &agent_session_id, req.task_id);
 
     let (command, args) = super::build_agent_invocation(&config);
 
@@ -99,7 +108,6 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         }
     };
 
-    let session_id = SessionId::default();
     let shared = SharedSession {
         id: session_id,
         name: req.name.clone(),
@@ -245,6 +253,7 @@ mod tests {
             agent_session_id: None,
             host: None,
             parent_session_id: None,
+            task_id: None,
         }
     }
 

--- a/src/storage/messages.rs
+++ b/src/storage/messages.rs
@@ -144,6 +144,15 @@ impl Database {
         rows.collect()
     }
 
+    /// Fetch a single message by id (read or unread), if it exists. Used by the
+    /// `reply` path to look up the original sender.
+    pub fn get_message(&self, id: i64) -> rusqlite::Result<Option<SessionMessage>> {
+        let sql = format!("SELECT {COLS} FROM session_messages WHERE id = ?1");
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut rows = stmt.query_map(params![id], map_message)?;
+        rows.next().transpose()
+    }
+
     /// Atomically claim (drain) up to `limit` unread messages for a recipient:
     /// mark the oldest unread read and return exactly those, in a **single**
     /// `UPDATE … RETURNING` statement. SQLite serializes writers, so the

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -535,6 +535,28 @@ mod tests {
     }
 
     #[test]
+    fn respawn_reuses_id_revives_one_active_row() {
+        // Models `respawn_stale_session`: re-upserting the SAME id after a
+        // soft-delete must revive the single row in place (clear deleted_at), not
+        // leave a tombstone behind — so a session's identity is stable for life.
+        let db = Database::open_in_memory().unwrap();
+        let mut session = make_session("worker");
+        let sid = session.id;
+        db.upsert_session(&session).unwrap();
+        db.soft_delete_session(sid).unwrap();
+        assert!(db.list_active_sessions().unwrap().is_empty());
+
+        // Respawn: same id, fresh backend_id (as the new tmux pane would have).
+        session.backend_id = "thurbox:@9".to_string();
+        db.upsert_session(&session).unwrap();
+
+        let active = db.list_active_sessions().unwrap();
+        assert_eq!(active.len(), 1, "exactly one active row");
+        assert_eq!(active[0].id, sid, "id is stable across the respawn");
+        assert_eq!(active[0].backend_id, "thurbox:@9");
+    }
+
+    #[test]
     fn restore_session() {
         let db = Database::open_in_memory().unwrap();
         let session = make_session("Session 1");


### PR DESCRIPTION
## Summary

- **Stable SessionId** across TUI re-adoption — `respawn_stale_session` reuses the original id instead of soft-deleting + minting a new row, so cached ids and queued messages never go stale.
- **Self-knowable identity** — thurbox injects `THURBOX_SESSION` (registry key) and `THURBOX_TASK` (task-spawned) at spawn, threaded via `SessionConfig.session_id`. Distinct from the existing `THURBOX_SESSION_ID` (agent conversation id).
- **Identity-aware mailbox** — `message send` auto-stamps provenance/task tag from the caller's env; `message inbox` defaults `--for` to the calling session; new `message reply <message_id>` routes back to a message's sender so the replier handles only an opaque message id. A waking send/reply arms the automation heartbeat for headless drain timeliness.
- **Flow as first consumer** — workers pass no ids and drain their own inbox on the wake; flow relays via `message reply`; `flow-snapshot.sh` name-parsing is demoted to the human board.

This makes thurbox own session identity end-to-end (extensions never parse names or manage UUIDs) and fixes the flow relay that depended on brittle name-scraping.

## Test plan

- New unit tests: `reply` routing + sender-less/missing-message errors, default-self inbox, stable-id round-trip, `inject_thurbox_env` injection.
- `cargo test --all`, `cargo clippy --all-targets`, 11/11 flow bats tests, rumdl — all green locally.
- CI checks pass.

> Note: existing in-flight flow workers must be re-dispatched to pick up the new injected env + id-free worker prompt.