### PR TITLE
feat(config): remove scheduled automation from flow extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -648,8 +648,9 @@ sync, but the TUI editor never sets it.)
   with `message reply <message_id>` — thurbox routes it to that message's sender,
   so flow never maps a task to a session id (the old `flow-snapshot.sh`
   name-parsing is now human-board only). The worker drains its own inbox on the
-  resulting `inbox` wake. The `flow-tick` automation is demoted to a
-  janitor/safety-net (drain missed wakes, reset stale tasks, dispatch). The
+  resulting `inbox` wake. Flow ships **no scheduled automation** — it is purely
+  event-driven; a **manual** `tick` is the janitor/safety-net (drain missed
+  wakes, reset stale tasks, dispatch) you type at the flow session. The
   behavior spec
   is `FLOW.md`, surfaced to whichever CLI runs it via context-file
   symlinks (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `FLOW.md`). Install with

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -227,8 +227,10 @@ name = "flow"
 agent = "flow"
 repo_path = "{home}"            # resolved to the absolute home at install
 
+# [[automations]] is an OPTIONAL runtime resource (flow itself ships none —
+# it is purely event-driven). An extension that wants a scheduled tick declares:
 [[automations]]
-name = "flow-tick"
+name = "example-tick"
 trigger = "cron:*/10 * * * *"   # same grammar as `automation create --trigger`
 session_ref = "flow"           # must match a [[sessions]] name above
 prompt = "tick"

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -775,11 +775,12 @@ Nothing in the extension names a vendor:
 ### Dispatch model
 
 Dispatch is **eager**: capture creates the task *and* spawns its
-worker in one atomic helper call (`create-task.sh`); workers send a
-`tick` back to the flow session when they finish so a freed capacity
-slot dispatches the next task immediately; a `flow-tick` cron
-automation (default every 10 min) is only the safety net that catches
-crashed workers and stale state. Workers always get a
+worker in one atomic helper call (`create-task.sh`); workers push a
+`result` message back to the flow session when they finish so a freed
+capacity slot dispatches the next task immediately. Flow is purely
+event-driven — there is no scheduled automation; a manual `tick`
+remains the safety net that catches crashed workers and stale state.
+Workers always get a
 `flow/<task-slug>` worktree branch on git repos, so they never dirty
 the main checkout and parallelize per repo. Completion is detected by
 task status (workers self-mark done) with an orchestrate-style
@@ -791,9 +792,9 @@ task status (workers self-mark done) with an orchestrate-style
 Flow installs with the generic extension installer —
 `thurbox-cli extension install flow` — which reads flow's
 `extension.toml` manifest: it lays down the flow home, registers the
-agents.toml aliases, creates the dedicated `flow` session + `flow-tick`
-automation, and marks the extension active so they **self-heal** if
-deleted. `extension uninstall flow [--purge]` reverses it. The
+agents.toml aliases, creates the dedicated `flow` session, and marks
+the extension active so it **self-heals** if deleted. `extension
+uninstall flow [--purge]` reverses it. The
 `extensions/flow/install.sh` curl one-liner is now a thin shim over the
 CLI. See the generic mechanism (manifest format, lifecycle commands,
 self-heal) in `docs/CONFIG.md` and `extensions/flow/README.md`.

--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -154,8 +154,8 @@ the table, add a row when you learn its path.
 ## DISPATCH (sub-step of CAPTURE and TICK)
 
 Dispatch is **eager**: it runs immediately at capture, on every DRAIN/tick,
-and a worker's `result` message wakes you the moment it finishes — never wait
-for the cron tick to dispatch something that is eligible NOW.
+and a worker's `result` message wakes you the moment it finishes — never defer
+dispatching something that is eligible NOW.
 
 - Eligible: `status=todo` AND has a spawn action AND capacity OK
   (**max 3** running worker (`… · #<id>`) sessions).
@@ -239,13 +239,13 @@ When the user replies to a question or a plan you surfaced:
 3. Confirm one line (`relayed → #<from_task_id>`) and end with the Output Contract
    footer. Create no task; an ANSWER is not a brain-dump.
 
-## TICK (from the automation — quiet janitor + safety net)
+## TICK (manual janitor + safety net)
 
-The interactive loop is driven by worker pushes (DRAIN/ANSWER); the cron tick
-(every 10 min) is the **safety net** — it drains anything a missed wake left
-queued and grooms stale state. It runs **quietly**: a tick that finds nothing to
-report prints a single minimal line and nothing else, so routine ticks never
-interrupt the user. The board appears **only** when something actually needs
+The interactive loop is driven by worker pushes (DRAIN/ANSWER); there is no
+scheduled automation. `tick` is a **manual** safety net you can type at the flow
+session — it drains anything a missed wake left queued and grooms stale state. It
+runs **quietly**: a tick that finds nothing to report prints a single minimal
+line and nothing else. The board appears **only** when something actually needs
 attention.
 
 Do the work first, track whether anything happened, then decide what to print.

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -40,9 +40,9 @@ That single command is the installer — it reads flow's
    triager, opus for workers — edit agents.toml to change the
    CLI/model);
 3. writes the manifest to `~/.config/thurbox/extensions/flow.toml` and
-   activates it, creating the dedicated `flow` session and a `flow-tick`
-   automation (every 10 minutes) that keeps it monitoring workers even
-   while the TUI is closed.
+   activates it, creating the dedicated `flow` session. Flow is event-driven:
+   worker sessions push messages over the mailbox queue to wake it — there is
+   no scheduled automation.
 
 It's idempotent — re-run it any time to pull the latest spec/scripts,
 while leaving your own data (`repos.md`, edited agents) untouched.
@@ -65,11 +65,10 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/extensions/fl
 
 ### Self-healing
 
-The flow session and `flow-tick` automation are **managed**: thurbox
-re-creates them automatically if they're ever deleted (on TUI startup and
-on every automation tick), so flow can't be half-removed by accident.
-Deleting the flow session/automation by hand is therefore a no-op — they
-come back. To turn flow off for good, run:
+The flow session is **managed**: thurbox re-creates it automatically if it's
+ever deleted (on TUI startup and on every automation tick), so flow can't be
+half-removed by accident. Deleting the flow session by hand is therefore a
+no-op — it comes back. To turn flow off for good, run:
 
 ```bash
 thurbox-cli extension deactivate flow         # tear down + stop self-heal
@@ -129,37 +128,37 @@ tagged URL (`…/thurbox/v0.112.0/extensions/flow`) instead.
   worker to you and back. Several workers can be mid-conversation at once, each
   tagged by its `#<id>`.
 - `status` for a one-screen report; `clean` to groom the backlog.
-- A tick prints the **board** — a quick-glance table of all live
+- Flow is **event-driven**: worker pushes over the mailbox queue
+  (`message send --to flow`) wake the flow session and drive the interactive
+  loop — there is no scheduled (cron) automation.
+- A manual `tick` prints the **board** — a quick-glance table of all live
   `flow` / worker (`… · #<id>`) sessions with status, age, and the task they're
   working (`scripts/flow-summary.sh`) — **only when something needs attention**
   (a surfaced question/plan/result, an error/blocker, a stale reset, an orphan
   session, or a fresh dispatch). A quiet tick prints just one minimal line
-  (`tick: N running, M todo`), so routine ticks don't interrupt you. The
-  `flow-tick` automation is a **safety net** that fires every 10 minutes: worker
-  pushes drive the interactive loop; the cron tick just drains anything a missed
-  wake left queued and grooms stale state.
+  (`tick: N running, M todo`), so a manual groom pass doesn't interrupt you. Type
+  `tick` at the flow session whenever you want to force a drain/dispatch/groom.
 - Workers self-report: they mark their task done and send a `--kind result`
-  message, which wakes flow so the next task dispatches without waiting for the
-  cron tick.
+  message, which wakes flow so the next task dispatches immediately.
 
 ## Files
 
 | Path | Purpose |
 |------|---------|
-| `extension.toml` | Manifest: agents, payload files, symlinks, session + automation (the installer) |
+| `extension.toml` | Manifest: agents, payload files, symlinks, session (the installer) |
 | `FLOW.md` | The agent behavior spec (modes, dispatch rules, output contract) |
 | `claude-settings.json` | Permission template (`{home}`-substituted into `.claude/settings.json`) |
 | `repos.md` | Routing-table seed (installed once, then user-owned) |
 | `scripts/create-task.sh` | Atomic task create + dispatch; composes the plan-first worker prompt (`--dry-run` to preview) |
 | `scripts/flow-snapshot.sh` | One-call backlog + sessions view |
-| `scripts/flow-summary.sh` | At-a-glance board table (printed atop every tick) |
+| `scripts/flow-summary.sh` | At-a-glance board table (printed atop a `tick`) |
 | `scripts/parse-result.sh` | Fallback-only: extract a `===RESULT===` sentinel from a worker that died without sending a `result` message |
 | `install.sh` | Thin shim → `thurbox-cli extension install` (curl\|sh bootstrap) |
 
 ## Uninstall
 
-`uninstall` reverses `install` — it tears down the session + automation,
-removes the `flow*` agents from `agents.toml`, and deletes the manifest:
+`uninstall` reverses `install` — it tears down the session, removes the
+`flow*` agents from `agents.toml`, and deletes the manifest:
 
 ```bash
 thurbox-cli extension uninstall flow            # keeps ~/flow (your repos.md etc.)
@@ -172,6 +171,6 @@ To only switch flow off (keeping it installed for a later `activate`):
 thurbox-cli extension deactivate flow           # stop self-heal, keep files
 ```
 
-> Note: a plain `session delete` / `automation remove` is **not** enough on
-> its own — while flow is active, thurbox self-heals those resources.
-> `deactivate` (or `uninstall`) is what stops the self-heal.
+> Note: a plain `session delete` is **not** enough on its own — while flow is
+> active, thurbox self-heals the session. `deactivate` (or `uninstall`) is what
+> stops the self-heal.

--- a/extensions/flow/extension.toml
+++ b/extensions/flow/extension.toml
@@ -4,14 +4,14 @@
 # with `thurbox-cli extension install flow` (or point at this directory:
 # `thurbox-cli extension install ./extensions/flow`). thurbox fetches this file,
 # lays down the [[files]] / [[symlinks]] under `home`, registers the [[agents]]
-# in agents.toml, then activates the [[sessions]] + [[automations]] and
-# self-heals them if they're ever deleted. `{home}` is replaced with the
+# in agents.toml, then activates the [[sessions]] and self-heals them if
+# they're ever deleted. `{home}` is replaced with the
 # resolved home dir. Turn flow off with `thurbox-cli extension deactivate flow`.
 
 name = "flow"
 description = "Focus-protecting triage agent"
 config_version = 1
-version = "1.2.0"                 # this extension's own version; bump on changes
+version = "1.3.0"                 # this extension's own version; bump on changes
 min_thurbox_version = "0.120.0"  # needs the `thurbox-cli message` mailbox queue
 home = "~/flow"
 
@@ -89,14 +89,14 @@ link = "GEMINI.md"
 target = "FLOW.md"
 
 # --- runtime resources: ensured on activate, self-healed if deleted -----------
+#
+# Flow is purely event-driven: worker sessions push messages over the
+# inter-session mailbox queue (`message send --to flow`), which wakes the flow
+# session to drain its inbox. There is no scheduled (cron) automation — `tick`
+# remains a manual janitor command you can type at the flow session when you
+# want to force a drain/dispatch/groom pass.
 
 [[sessions]]
 name = "flow"
 agent = "flow"
 repo_path = "{home}"
-
-[[automations]]
-name = "flow-tick"
-trigger = "cron:*/10 * * * *"
-session_ref = "flow"
-prompt = "tick"

--- a/extensions/flow/install.sh
+++ b/extensions/flow/install.sh
@@ -7,7 +7,8 @@
 # This script just forwards to it — using a local checkout when run from one,
 # otherwise the official remote source. It fetches the manifest + payload, lays
 # down ~/flow, registers the flow agents in agents.toml, and activates the flow
-# session + flow-tick automation (which thurbox then self-heals).
+# session (which thurbox then self-heals). Flow is event-driven — worker pushes
+# over the mailbox queue wake it; there is no scheduled automation.
 #
 # Usage:
 #   ./install.sh                  # from a checkout

--- a/website/docs/extension-flow.html
+++ b/website/docs/extension-flow.html
@@ -78,13 +78,12 @@ onThisPage:
             <code>--home</code>
             ), registers the agents, and activates the dedicated
             <code>flow</code>
-            session plus a
-            <code>flow-tick</code>
-            automation &mdash; both
+            session &mdash;
             <strong>self-healed</strong>
-            by Thurbox, so deleting them is a no-op until you
+            by Thurbox, so deleting it is a no-op until you
             <code>deactivate</code>
-            .
+            . Flow is event-driven (worker pushes over the mailbox queue wake
+            it); there is no scheduled automation.
           </p>
 
           <h2 id="use">
@@ -131,8 +130,7 @@ onThisPage:
             <li>
               Workers self-report: they mark their task done and send a
               <code>--kind result</code>
-              message, which wakes the flow session so the next task dispatches without waiting for
-              the cron tick.
+              message, which wakes the flow session so the next task dispatches immediately.
             </li>
           </ul>
 
@@ -157,10 +155,12 @@ onThisPage:
             <code>result</code>
             message (which also wakes flow), and flow drains its inbox with
             <code>message inbox --for flow --claim</code>
-            &mdash; clean JSON, never scraped from a rendered terminal. The
-            <code>flow-tick</code>
-            cron automation (default every 5&nbsp;min) is demoted to a safety net: it drains
-            anything a missed wake left queued, catches crashed workers, and grooms stale state.
+            &mdash; clean JSON, never scraped from a rendered terminal. Flow ships
+            <strong>no scheduled automation</strong>
+            &mdash; a manual
+            <code>tick</code>
+            is the safety net you type at the flow session: it drains anything a missed wake left
+            queued, catches crashed workers, and grooms stale state.
           </p>
 
           <h2 id="files">

--- a/website/docs/extensions.html
+++ b/website/docs/extensions.html
@@ -301,9 +301,11 @@ name = "flow"
 agent = "flow"
 repo_path = "{home}"            # resolved to the absolute home at install
 
+# [[automations]] is an OPTIONAL runtime resource (flow itself ships none —
+# it is purely event-driven). An extension that wants a scheduled tick declares:
 [[automations]]
-name = "flow-tick"
-trigger = "cron:*/5 * * * *"    # same grammar as `automation create --trigger`
+name = "example-tick"
+trigger = "cron:*/10 * * * *"   # same grammar as `automation create --trigger`
 session_ref = "flow"            # must match a [[sessions]] name above
 prompt = "tick"</code></pre>
           <table>


### PR DESCRIPTION
## Summary

- Drop the `[[automations]]` block (`flow-tick`, `cron:*/10 * * * *`) from `extensions/flow/extension.toml` so the flow extension ships **no scheduled automation**.
- Flow's worker↔triager coordination is already fully event-driven over the inter-session mailbox queue (worker pushes wake the flow session), so the cron tick was only a janitor/safety-net. The `tick` command stays available as a **manual** drain/dispatch/groom pass typed at the flow session.
- Bump the extension version `1.2.0 → 1.3.0`.
- Sync docs to match: `extensions/flow/README.md`, `FLOW.md`, `install.sh`, `CLAUDE.md`, `docs/FEATURES.md`, and the website docs (`extension-flow.html`).
- `docs/CONFIG.md` / `extensions.html` document the manifest *format*, so they keep an illustrative (clearly optional) `[[automations]]` example rather than dropping it — the format still supports automations.

## Trade-off

Without the cron tick, a worker wake-nudge lost while the TUI is closed won't be auto-drained until flow is next opened or `tick` is run manually. That's the intended consequence of removing the scheduled safety-net.

## Test plan

- `extension.toml` parses with no `[[automations]]` and `version = "1.3.0"`.
- No Rust tests reference the real flow manifest (the `flow-tick` strings in `src/` are inline test fixtures for the generic manifest machinery and are intentionally left unchanged).
- CI: fmt / clippy / nextest / architecture / markdown + website linters.

https://claude.ai/code/session_018CNcCENJsAKcqUJKGcqQxH

---
_Generated by [Claude Code](https://claude.ai/code/session_018CNcCENJsAKcqUJKGcqQxH)_