### PR TITLE
feat(ui): defer readline Ctrl chords to the PTY when terminal focused

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1092,6 +1092,25 @@ capture, lookup, and the JSON round-trip agree regardless of how the
 terminal encodes them. **Copy/Paste** are global rebindable actions handled
 early in `handle_priority_key` (so Paste reaches modal text inputs).
 
+**Terminal PTY passthrough.** thurbox's global chords share the
+`Ctrl+<letter>` namespace with readline / shell line editing (`Ctrl+A` =
+start-of-line, `Ctrl+E` = end-of-line, `Ctrl+W` = delete-word, `Ctrl+U` =
+kill-line, `Ctrl+R` = reverse-search, `Ctrl+D` = EOF, …). So when a session
+**terminal is focused**, the actions flagged by `Action::terminal_passthrough`
+(`GlobalSearch`/`ToggleInfoPanel`/`DeleteSession`/`ToggleFileViewer`/
+`ForkSession`/`OpenInEditor`/`OpenAutomations`/`RestartSession`/`StartSync`/
+`OpenRestoreSessions`/`FocusTasks`) **defer to the agent CLI** instead of
+running the thurbox command — `handle_key` skips `dispatch_action` and falls
+through to `handle_terminal_key`, which forwards the bytes to the PTY. The
+thurbox command stays reachable from the **session list** (and via its `F`-key
+alternate where one exists — `F2`/`F3`/`F5`). The deferral is gated on the
+bound chord still being a bare `Ctrl+<letter>` (`is_ctrl_letter_chord`), so
+rebinding a passthrough action to a non-conflicting key keeps it working in the
+terminal. Navigation / app-control chords (`Ctrl+H/J/K/L` focus + session nav,
+`Ctrl+Q` quit, `Ctrl+N` new, …) are **not** deferred — they are the keyboard
+escape route out of the terminal, so they must keep working there even though a
+few collide with readline.
+
 A few stateful keys stay literal (the F1 panel lists them under
 **Fixed (not rebindable)**): modal selectors (j/k/Enter/Esc), the
 automations/tasks panes, the file-viewer **search sub-mode**, and the

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -179,6 +179,17 @@ Maps `Action` names to one or more chord strings:
 - Unknown action names, invalid chords, and the same chord bound to two
   actions in overlapping contexts are reported at startup (the file
   still loads; bad entries fall back to defaults).
+- **Terminal passthrough.** When a session **terminal is focused**, the
+  readline / shell line-editing chords (`Ctrl+A` start-of-line, `Ctrl+E`
+  end-of-line, `Ctrl+W` delete-word, `Ctrl+U` kill-line, `Ctrl+R`
+  reverse-search, `Ctrl+D` EOF, plus `Ctrl+B/F/O/P/S`) are **forwarded to the
+  agent CLI** instead of triggering their thurbox command, so your terminal
+  muscle memory works inside a session. Those thurbox commands stay reachable
+  from the **session list** (focus it with `Ctrl+H`) and via their `F`-key
+  alternates (`F2` info panel, `F3` file viewer, `F5` tasks). Rebinding such an
+  action to a key that isn't a bare `Ctrl+<letter>` makes it work in the
+  terminal too. Navigation/quit chords (`Ctrl+H/J/K/L`, `Ctrl+Q`, `Ctrl+N`) are
+  **never** forwarded — they're how you leave the terminal.
 - Action names and defaults: see the table in CLAUDE.md / README, or
   `src/session/keybindings.rs`.
 

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -30,6 +30,15 @@ fn session_name_to_branch(name: &str) -> String {
     result.trim_matches('-').to_string()
 }
 
+/// Whether a pressed chord is a bare `Ctrl+<letter>` — the namespace thurbox
+/// shares with readline / shell line-editing chords. Used to gate
+/// [`crate::session::Action::terminal_passthrough`] so the PTY-deferral only
+/// fires for the conflicting chords; a non-`Ctrl+letter` rebind of a
+/// passthrough action keeps working in the terminal.
+fn is_ctrl_letter_chord(code: KeyCode, mods: KeyModifiers) -> bool {
+    mods == KeyModifiers::CONTROL && matches!(code, KeyCode::Char(c) if c.is_ascii_alphabetic())
+}
+
 impl App {
     /// Main key handler dispatcher.
     ///
@@ -85,12 +94,18 @@ impl App {
 
         // Keybinding lookup, scoped to the focused pane: global actions plus
         // any scoped to the current context (file viewer, session list,
-        // terminal). Some actions intentionally yield to the PTY when the
-        // terminal is focused (e.g. Ctrl+R = bash reverse-search) — those are
-        // handled inside `dispatch_action`.
+        // terminal). Some readline/shell chords (Ctrl+A/E/W/U/R/D/…) defer to
+        // the PTY when the terminal is focused so the inner agent CLI's
+        // line editing keeps working — see `Action::terminal_passthrough`.
+        // The deferral is gated on the bound chord still being a bare
+        // `Ctrl+<letter>`, so a rebind to a non-conflicting key keeps the
+        // thurbox command working even in the terminal.
         let context = self.focus_key_context();
         if let Some(action) = self.keybindings.lookup_in(context, code, mods) {
-            if self.dispatch_action(action) {
+            let defer_to_pty = self.focus == InputFocus::Terminal
+                && action.terminal_passthrough()
+                && is_ctrl_letter_chord(code, mods);
+            if !defer_to_pty && self.dispatch_action(action) {
                 return;
             }
         }
@@ -1187,9 +1202,10 @@ impl App {
                 true
             }
             Action::DeleteSession => self.act_delete_session(),
-            // Forward to the PTY in the terminal (shell editor / search chords),
-            // else run the action.
-            Action::OpenInEditor => self.act_unless_terminal(Self::open_active_in_editor),
+            Action::OpenInEditor => {
+                self.open_active_in_editor();
+                true
+            }
             Action::OpenAutomations => {
                 if self.feature_gate(self.features.automations, "Automations") {
                     self.open_automations_list();
@@ -1206,8 +1222,14 @@ impl App {
                 }
                 true
             }
-            Action::ForkSession => self.act_unless_terminal(Self::fork_active_session),
-            Action::RestartSession => self.act_unless_terminal(Self::restart_active_session),
+            Action::ForkSession => {
+                self.fork_active_session();
+                true
+            }
+            Action::RestartSession => {
+                self.restart_active_session();
+                true
+            }
             Action::UndoDelete => {
                 if self.pending_delete.is_some() {
                     self.undo_delete();
@@ -1360,17 +1382,6 @@ impl App {
                 true
             }
         }
-    }
-
-    /// Run `act` unless the terminal is focused (where the chord must forward to
-    /// the PTY — e.g. shell history search). Returns whether the key was
-    /// consumed. Backs the `OpenInEditor`/`ForkSession`/`RestartSession` actions.
-    fn act_unless_terminal(&mut self, act: impl FnOnce(&mut Self)) -> bool {
-        if self.focus == InputFocus::Terminal {
-            return false; // forward to PTY
-        }
-        act(self);
-        true
     }
 
     /// `Ctrl+N`: in the automations context create an automation (mirrors `n`),
@@ -1991,7 +2002,37 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::session_name_to_branch;
+    use super::{is_ctrl_letter_chord, session_name_to_branch};
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    #[test]
+    fn ctrl_letter_chord_detects_readline_namespace() {
+        // Bare Ctrl+letter — the readline-conflicting namespace.
+        assert!(is_ctrl_letter_chord(
+            KeyCode::Char('a'),
+            KeyModifiers::CONTROL
+        ));
+        assert!(is_ctrl_letter_chord(
+            KeyCode::Char('r'),
+            KeyModifiers::CONTROL
+        ));
+        // Plain letters, F-keys, and Ctrl+<non-letter> are not in the namespace,
+        // so a passthrough action bound to them keeps working in the terminal.
+        assert!(!is_ctrl_letter_chord(
+            KeyCode::Char('a'),
+            KeyModifiers::NONE
+        ));
+        assert!(!is_ctrl_letter_chord(KeyCode::F(3), KeyModifiers::NONE));
+        assert!(!is_ctrl_letter_chord(
+            KeyCode::Char('1'),
+            KeyModifiers::CONTROL
+        ));
+        // Extra modifiers take it out of the bare-Ctrl namespace.
+        assert!(!is_ctrl_letter_chord(
+            KeyCode::Char('a'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT
+        ));
+    }
 
     #[test]
     fn basic_conversion() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6224,6 +6224,55 @@ mod tests {
         assert_eq!(app.focus, InputFocus::SessionList);
     }
 
+    /// When the terminal is focused, readline/shell `Ctrl+<letter>` chords
+    /// (here `Ctrl+W` = delete-word) defer to the PTY instead of running their
+    /// thurbox command — but the same chord still works from the session list,
+    /// and the `F`-key alternate works everywhere.
+    #[test]
+    fn terminal_focus_defers_readline_ctrl_chords_to_pty() {
+        let mut app = app_with_sessions(1);
+        app.update(AppMessage::Resize(160, 40));
+
+        // From the session list, Ctrl+W (FocusTasks) toggles the tasks panel.
+        app.focus = InputFocus::SessionList;
+        app.handle_key(KeyCode::Char('w'), KeyModifiers::CONTROL);
+        assert!(app.show_tasks_panel, "Ctrl+W toggles tasks from the list");
+
+        // Reset, then focus the terminal: Ctrl+W now forwards to the PTY, so
+        // the tasks panel is left untouched.
+        app.show_tasks_panel = false;
+        app.focus = InputFocus::Terminal;
+        app.handle_key(KeyCode::Char('w'), KeyModifiers::CONTROL);
+        assert!(
+            !app.show_tasks_panel,
+            "Ctrl+W should defer to the PTY when the terminal is focused"
+        );
+        assert_eq!(app.focus, InputFocus::Terminal);
+
+        // The F5 alternate is not a Ctrl+letter chord, so it still toggles.
+        app.handle_key(KeyCode::F(5), KeyModifiers::NONE);
+        assert!(
+            app.show_tasks_panel,
+            "F5 keeps toggling tasks even in the terminal"
+        );
+    }
+
+    /// Navigation chords are the keyboard escape route, so they keep working in
+    /// the terminal even though `Ctrl+H` collides with readline's backspace.
+    #[test]
+    fn terminal_focus_keeps_navigation_chords_active() {
+        let mut app = app_with_sessions(1);
+        app.update(AppMessage::Resize(160, 40));
+        app.focus = InputFocus::Terminal;
+
+        app.handle_key(KeyCode::Char('h'), KeyModifiers::CONTROL);
+        assert_ne!(
+            app.focus,
+            InputFocus::Terminal,
+            "Ctrl+H (FocusBackward) must still leave the terminal"
+        );
+    }
+
     /// Every `[features]` flag blocks its keybinding with a toast: state stays
     /// untouched and the chord is consumed (never forwarded to the PTY).
     #[test]

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -208,6 +208,42 @@ impl Action {
         }
     }
 
+    /// Whether this action should **defer to the agent CLI** when a session
+    /// terminal is focused, instead of running as a thurbox command.
+    ///
+    /// thurbox's global chords share the `Ctrl+<letter>` namespace with the
+    /// readline / shell line-editing chords users have in muscle memory
+    /// (`Ctrl+A` = start-of-line, `Ctrl+E` = end-of-line, `Ctrl+W` =
+    /// delete-word, `Ctrl+U` = kill-line, `Ctrl+R` = reverse-search, `Ctrl+D`
+    /// = EOF, …). For the actions below we let those keystrokes pass through to
+    /// the PTY while the terminal is focused, so the inner agent CLI behaves
+    /// normally; the thurbox command stays reachable from the session list (and
+    /// via its `F`-key alternate, where one exists). The deferral is gated on
+    /// the *bound chord* still being a bare `Ctrl+<letter>` (applied in
+    /// `App::handle_key`), so rebinding an action to a non-conflicting key keeps
+    /// it working in the terminal.
+    ///
+    /// Navigation / app-control chords (`Ctrl+H/J/K/L` focus + session nav,
+    /// `Ctrl+Q` quit, `Ctrl+N` new, …) are deliberately **not** deferred: they
+    /// are the keyboard escape route out of the terminal, so they must keep
+    /// working there even though some collide with readline.
+    pub fn terminal_passthrough(self) -> bool {
+        matches!(
+            self,
+            Action::GlobalSearch        // Ctrl+A — beginning of line
+                | Action::ToggleInfoPanel   // Ctrl+B — backward char   (F2 alt)
+                | Action::DeleteSession     // Ctrl+D — EOF / delete char
+                | Action::ToggleFileViewer  // Ctrl+E — end of line      (F3 alt)
+                | Action::ForkSession       // Ctrl+F — forward char
+                | Action::OpenInEditor      // Ctrl+O — operate-and-get-next
+                | Action::OpenAutomations   // Ctrl+P — previous history
+                | Action::RestartSession    // Ctrl+R — reverse search
+                | Action::StartSync         // Ctrl+S — forward search / XOFF
+                | Action::OpenRestoreSessions // Ctrl+U — kill line
+                | Action::FocusTasks // Ctrl+W — delete word    (F5 alt)
+        )
+    }
+
     /// Default key chord(s) bound to this action for the platform we were
     /// compiled for. `cfg!(target_os)` is decided at exactly this one
     /// callsite; everything else goes through [`Action::default_chords_for`]
@@ -808,6 +844,50 @@ mod tests {
         assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('q')));
         assert_eq!(kb.chord_for(Action::NewSession), Some(&KeyChord::ctrl('n')));
         assert_eq!(kb.chord_for(Action::ToggleHelp), Some(&KeyChord::ctrl('g')));
+    }
+
+    #[test]
+    fn terminal_passthrough_covers_readline_chords_not_navigation() {
+        // The readline / shell line-editing chords defer to the PTY when the
+        // terminal is focused…
+        for action in [
+            Action::GlobalSearch,        // Ctrl+A
+            Action::ToggleInfoPanel,     // Ctrl+B
+            Action::DeleteSession,       // Ctrl+D
+            Action::ToggleFileViewer,    // Ctrl+E
+            Action::ForkSession,         // Ctrl+F
+            Action::OpenInEditor,        // Ctrl+O
+            Action::OpenAutomations,     // Ctrl+P
+            Action::RestartSession,      // Ctrl+R
+            Action::StartSync,           // Ctrl+S
+            Action::OpenRestoreSessions, // Ctrl+U
+            Action::FocusTasks,          // Ctrl+W
+        ] {
+            assert!(
+                action.terminal_passthrough(),
+                "{action:?} should defer to the PTY in the terminal"
+            );
+        }
+
+        // …but the keyboard escape route (focus / session nav) and quit must
+        // keep working in the terminal, so they never defer.
+        for action in [
+            Action::QuitApp,
+            Action::NewSession,
+            Action::FocusBackward,
+            Action::FocusForward,
+            Action::NextSession,
+            Action::PreviousSession,
+            Action::ToggleShell,
+            Action::UndoDelete,
+            Action::Copy,
+            Action::Paste,
+        ] {
+            assert!(
+                !action.terminal_passthrough(),
+                "{action:?} must stay active in the terminal"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- thurbox's global chords share the `Ctrl+<letter>` namespace with the readline/shell line-editing chords users have in muscle memory (`Ctrl+A` start-of-line, `Ctrl+E` end-of-line, `Ctrl+W` delete-word, `Ctrl+U` kill-line, `Ctrl+R` reverse-search, `Ctrl+D` EOF, …). Previously thurbox always intercepted these, so they never reached the agent CLI running inside a session.
- Adds a data-driven `Action::terminal_passthrough()` classifier plus a central guard in `handle_key`: when a session **terminal is focused** and the matched action is a readline-conflicting one bound to a bare `Ctrl+<letter>` chord, the keystroke **forwards to the PTY** instead of running the thurbox command.
- The thurbox command stays reachable from the **session list** and via **F-key alternates** (`F2`/`F3`/`F5`). Because the gate checks the *bound chord*, rebinding a passthrough action to a non-`Ctrl+letter` key keeps it working in the terminal too.
- **Navigation/quit chords** (`Ctrl+H/J/K/L`, `Ctrl+Q`, `Ctrl+N`) are never deferred — they remain the keyboard escape route out of the terminal.
- Generalizes the former ad-hoc `act_unless_terminal` helper (which only covered `OpenInEditor`/`ForkSession`/`RestartSession`) into one classifier; documents the behavior in `CLAUDE.md` and `docs/CONFIG.md`.

## Test plan

- `cargo test --lib` — added unit tests for the `terminal_passthrough()` classification, the `is_ctrl_letter_chord` predicate, and two end-to-end `handle_key` tests (Ctrl+W deferred to PTY in the terminal but works from the session list / via F5; Ctrl+H still escapes the terminal).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all` + `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` — clean.

https://claude.ai/code/session_01EegnoG6Zs8YdYQhqkiu5Rq

---
_Generated by [Claude Code](https://claude.ai/code/session_01EegnoG6Zs8YdYQhqkiu5Rq)_