### PR TITLE
test: add TUI acceptance (e2e) test harness and smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,18 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --test architecture_rules
 
+  tui-smoke:
+    name: TUI Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Install tmux
+        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: Black-box TUI smoke test
+        run: scripts/dev/tui-smoke-test.sh
+
   deny:
     name: Cargo Deny
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,26 @@ cargo test test_name                 # Run single test via cargo test
 bats scripts/install.bats            # Test install script (requires bats-core)
 ```
 
+### TUI acceptance (e2e) tests
+
+The TUI has two layers of end-to-end coverage:
+
+- **In-process driver + snapshots** (`src/app/acceptance.rs`, a `#[cfg(test)]`
+  module). A `Harness` builds a real `App` on a no-op `StubBackend` +
+  `Database::open_in_memory()` + a `TestPathGuard` tempdir (fully hermetic),
+  feeds `AppMessage::KeyPress` events exactly as `main.rs`'s loop does, and
+  renders to a headless ratatui `TestBackend`. Stable screens (welcome state,
+  F1 help, theme picker) are pinned with **`insta`** snapshots
+  (`src/app/snapshots/`); dynamic flows (navigation, modals, panel toggles,
+  quit) assert on `App` state instead, so live metrics/clock never make them
+  flaky. Runs in the normal `cargo nextest --all` — no tmux/TTY needed. Update
+  snapshots with `INSTA_UPDATE=always cargo test` (or `cargo insta review`).
+- **Black-box smoke test** (`scripts/dev/tui-smoke-test.sh`). Launches the real
+  `thurbox` binary inside a throwaway tmux pane (isolated `HOME`/XDG/
+  `TMUX_TMPDIR`, mirroring `scripts/demo/record.sh`), drives it with
+  `tmux send-keys`, and asserts on captured frames (boot → F1 → theme → quit).
+  Gated behind the `tui-smoke` CI job (needs tmux).
+
 ## Installation Script
 
 **Location:** `scripts/install.sh`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1922,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,6 +2173,7 @@ dependencies = [
  "clap",
  "cron",
  "crossterm",
+ "insta",
  "pulldown-cmark",
  "ratatui",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,3 +101,8 @@ strip = true
 inherits = "release"
 debug = true
 strip = false
+
+[dev-dependencies]
+# Snapshot assertions for the TUI acceptance tests (src/app/acceptance.rs).
+# default-features off keeps the dep tree minimal (just `similar`).
+insta = { version = "1.48.0", default-features = false }

--- a/scripts/dev/tui-smoke-test.sh
+++ b/scripts/dev/tui-smoke-test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Black-box smoke test for the thurbox TUI: launch the *real* `thurbox` binary
+# inside a throwaway tmux pane, drive it with keystrokes, and assert on the
+# frames it actually paints — the one thing the in-process acceptance tests
+# (src/app/acceptance.rs) can't cover, since they never touch a terminal.
+#
+# Everything is isolated from your real environment, mirroring scripts/demo/
+# record.sh: a temp HOME + XDG dirs, and a private TMUX_TMPDIR so both the outer
+# "driver" tmux (socket `tui-smoke`) and thurbox's own dev socket
+# (`thurbox-dev`) live in — and are torn down from — the temp dir. It never
+# touches your real ~/.config/thurbox or any tmux server you have running.
+#
+# Usage:
+#   scripts/dev/tui-smoke-test.sh           # build (debug) + run the smoke test
+#   THURBOX_BIN=/path/to/thurbox \
+#     scripts/dev/tui-smoke-test.sh         # test a prebuilt binary (skip build)
+#
+# Requires: tmux >= 3.2, cargo (unless THURBOX_BIN is set).
+# Exit status: 0 = all assertions passed, non-zero = a failure (printed).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SOCKET="tui-smoke"
+SESSION="thurbox-smoke"
+COLS=120
+ROWS=40
+
+log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+ok() { printf '\033[1;32m  ok\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v tmux >/dev/null || die "tmux not found (need >= 3.2)"
+
+# --- isolated environment -----------------------------------------------------
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/thurbox-smoke.XXXXXX")"
+export HOME="$WORKDIR/home"
+export XDG_CONFIG_HOME="$WORKDIR/config"
+export XDG_DATA_HOME="$WORKDIR/data"
+export XDG_STATE_HOME="$WORKDIR/state"
+export XDG_CACHE_HOME="$WORKDIR/cache"
+export TMUX_TMPDIR="$WORKDIR/tmux"
+mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME" \
+  "$XDG_CACHE_HOME" "$TMUX_TMPDIR"
+
+# shellcheck disable=SC2317 # body runs via the `trap` below; not unreachable
+cleanup() {
+  tmux -L "$SOCKET" kill-server >/dev/null 2>&1 || true
+  # thurbox's own dev socket lives under our private TMUX_TMPDIR too.
+  tmux -L thurbox-dev kill-server >/dev/null 2>&1 || true
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT INT TERM
+
+# --- build (unless a binary was provided) ------------------------------------
+if [ -n "${THURBOX_BIN:-}" ]; then
+  BIN="$THURBOX_BIN"
+  [ -x "$BIN" ] || die "THURBOX_BIN=$BIN is not executable"
+else
+  log "building thurbox (debug)"
+  ( cd "$REPO_ROOT" && cargo build --bin thurbox >&2 )
+  BIN="$REPO_ROOT/target/debug/thurbox"
+fi
+[ -x "$BIN" ] || die "thurbox binary not found at $BIN"
+
+# --- launch the TUI in an isolated tmux pane ---------------------------------
+log "launching TUI in tmux ($COLS x $ROWS)"
+tmux -L "$SOCKET" new-session -d -s "$SESSION" -x "$COLS" -y "$ROWS" "$BIN"
+
+# Capture the current pane as plain text.
+capture() { tmux -L "$SOCKET" capture-pane -p -t "$SESSION"; }
+
+# Poll until `capture` contains $1 (or time out). tmux send-keys is fire-and-
+# forget, so we wait on the rendered result rather than sleeping a fixed time.
+wait_for() {
+  local needle="$1" tries="${2:-50}"
+  for _ in $(seq 1 "$tries"); do
+    if capture | grep -qF "$needle"; then return 0; fi
+    sleep 0.1
+  done
+  printf '\n--- final frame ---\n%s\n-------------------\n' "$(capture)" >&2
+  die "timed out waiting for: $needle"
+}
+
+send() { tmux -L "$SOCKET" send-keys -t "$SESSION" "$@"; }
+
+# --- assertions --------------------------------------------------------------
+# 1. It boots and paints its chrome.
+wait_for "thurbox"
+ok "TUI booted and rendered its header"
+wait_for "No sessions yet"
+ok "empty-state hint is shown"
+
+# 2. F1 opens the keybindings help overlay.
+send F1
+wait_for "Quit"
+ok "F1 opened the help overlay"
+send Escape
+
+# 3. Ctrl+Y opens the theme picker, listing built-in palettes.
+send C-y
+wait_for "Catppuccin Mocha"
+ok "Ctrl+Y opened the theme picker"
+send Escape
+
+# 4. Ctrl+Q exits cleanly (the tmux session ends when thurbox returns).
+send C-q
+for _ in $(seq 1 50); do
+  if ! tmux -L "$SOCKET" has-session -t "$SESSION" 2>/dev/null; then
+    ok "Ctrl+Q quit and the process exited"
+    log "all smoke assertions passed"
+    exit 0
+  fi
+  sleep 0.1
+done
+die "TUI did not exit after Ctrl+Q"

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -1,0 +1,322 @@
+//! In-process acceptance ("end-to-end") tests for the thurbox TUI.
+//!
+//! Where the focused unit tests in [`super::tests`] poke individual methods,
+//! these drive a *real* [`App`] the way `main.rs`'s loop does — feeding
+//! `update(AppMessage)` events and rendering `view(Frame)` to a headless
+//! ratatui [`TestBackend`]. (The loop's third step, `tick()`, is deliberately
+//! skipped: it spawns Tokio tasks and so needs a runtime these synchronous
+//! tests don't have; nothing under test here depends on it.) No TTY, tmux
+//! server, or agent process is involved:
+//!
+//! * sessions are inert [`Session::stub`]s on a no-op [`StubBackend`],
+//! * the database is `Database::open_in_memory()`,
+//! * every config/data path is redirected to a throwaway tempdir via
+//!   [`crate::paths::TestPathGuard`], so the suite never touches the
+//!   developer's real `~/.config/thurbox`.
+//!
+//! Stable, deterministic screens (the empty welcome state, the keybindings
+//! help overlay, the theme picker) are pinned with `insta` snapshots so a UI
+//! change surfaces as a reviewable diff (`cargo insta review` /
+//! `INSTA_UPDATE=always cargo test`). Flows whose output depends on live
+//! metrics or wall-clock time are asserted on `App` *state* instead (modal
+//! kind, selection index, panel visibility, quit flag) to stay robust.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+
+use super::*;
+use crate::agent::AgentProvider;
+
+/// Wide layout (≥120 cols) used by the behavioral tests — exercises the full
+/// multi-panel TUI the way a real terminal would.
+const STD_COLS: u16 = 120;
+const STD_ROWS: u16 = 40;
+
+/// Smaller, sessionless size for the pinned snapshot screens, kept compact so
+/// the `.snap` files stay readable.
+const SNAP_COLS: u16 = 100;
+const SNAP_ROWS: u16 = 30;
+
+/// Inert [`SessionBackend`] for the harness — every method is a no-op or an
+/// error. Sessions rendered on top of it have a real vt100 parser (so the
+/// session list draws) but never spawn or talk to tmux.
+#[derive(Default)]
+struct StubBackend;
+
+impl SessionBackend for StubBackend {
+    fn name(&self) -> &str {
+        "stub"
+    }
+    fn check_available(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn ensure_ready(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn spawn(
+        &self,
+        _: &str,
+        _: &str,
+        _: &[String],
+        _: Option<&Path>,
+        _: &std::collections::HashMap<String, String>,
+        _: u16,
+        _: u16,
+    ) -> anyhow::Result<crate::agent::backend::SpawnedSession> {
+        anyhow::bail!("stub backend does not spawn")
+    }
+    fn adopt(
+        &self,
+        _: &str,
+        _: u16,
+        _: u16,
+    ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
+        anyhow::bail!("stub backend does not adopt")
+    }
+    fn discover(&self) -> anyhow::Result<Vec<crate::agent::backend::DiscoveredSession>> {
+        Ok(vec![])
+    }
+    fn resize(&self, _: &str, _: u16, _: u16) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn is_dead(&self, _: &str) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+    fn kill(&self, _: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn detach(&self, _: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn pane_pid(&self, _: &str) -> anyhow::Result<Option<u32>> {
+        Ok(None)
+    }
+}
+
+/// A driveable TUI under test: a real [`App`] paired with a headless terminal,
+/// plus the tempdir + path guard that keep it hermetic for the harness's life.
+struct Harness {
+    app: App,
+    terminal: Terminal<TestBackend>,
+    // Held for their `Drop` side effects (restore XDG paths / delete tempdir);
+    // ordering matters — the guard resets path resolution before the dir goes.
+    _guard: crate::paths::TestPathGuard,
+    _tmp: tempfile::TempDir,
+}
+
+impl Harness {
+    /// Build an `App` of `cols`×`rows` seeded with `session_count` stub
+    /// sessions, wired to an in-memory DB and a headless `TestBackend`.
+    fn new(cols: u16, rows: u16, session_count: usize) -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let guard = crate::paths::TestPathGuard::new(tmp.path());
+
+        let backend: Arc<dyn SessionBackend> = Arc::new(StubBackend);
+        let provider: Arc<dyn AgentProvider> = Arc::new(GenericProvider::new(
+            crate::agent::agent_config::builtin_registry()
+                .default_agent()
+                .unwrap()
+                .clone(),
+        ));
+
+        let mut app = App::new(
+            rows,
+            cols,
+            BackendRegistry::new(Arc::clone(&backend)),
+            crate::agent::agent_config::builtin_registry(),
+            Database::open_in_memory().unwrap(),
+        );
+        for i in 0..session_count {
+            app.sessions
+                .push(Session::stub(&format!("session-{i}"), &backend, &provider));
+        }
+        if session_count > 0 {
+            app.active_index = 0;
+        }
+
+        let terminal = Terminal::new(TestBackend::new(cols, rows)).unwrap();
+        Self {
+            app,
+            terminal,
+            _guard: guard,
+            _tmp: tmp,
+        }
+    }
+
+    /// Standard wide harness ([`STD_COLS`]×[`STD_ROWS`]) seeded with
+    /// `session_count` stub sessions — the default for behavioral tests.
+    fn standard(session_count: usize) -> Self {
+        Self::new(STD_COLS, STD_ROWS, session_count)
+    }
+
+    /// Snapshot-sized, sessionless harness for the pinned-screen tests.
+    fn snapshot() -> Self {
+        Self::new(SNAP_COLS, SNAP_ROWS, 0)
+    }
+
+    /// Feed one key event, exactly as the real event loop converts a crossterm
+    /// `KeyPress` into an [`AppMessage`].
+    fn key(&mut self, code: KeyCode, mods: KeyModifiers) -> &mut Self {
+        self.app.update(AppMessage::KeyPress(code, mods));
+        self
+    }
+
+    /// A `Ctrl+<c>` chord (the form most global thurbox bindings take).
+    fn ctrl(&mut self, c: char) -> &mut Self {
+        self.key(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    /// A bare function key (`F1`…`F5`).
+    fn func(&mut self, n: u8) -> &mut Self {
+        self.key(KeyCode::F(n), KeyModifiers::NONE)
+    }
+
+    /// Draw the current state to the headless backend and return the visible
+    /// glyphs as newline-separated rows (one string per terminal line), the
+    /// shape both `insta` snapshots and substring assertions read.
+    fn render(&mut self) -> String {
+        let app = &mut self.app;
+        self.terminal.draw(|f| app.view(f)).unwrap();
+        let buffer = self.terminal.backend().buffer();
+        let area = *buffer.area();
+        let mut out = String::new();
+        for y in 0..area.height {
+            let mut line = String::new();
+            for x in 0..area.width {
+                line.push_str(buffer[(x, y)].symbol());
+            }
+            // Drop trailing blanks so snapshots aren't a wall of spaces.
+            out.push_str(line.trim_end());
+            out.push('\n');
+        }
+        out
+    }
+}
+
+// ── Snapshot tests: stable, deterministic screens ────────────────────────────
+
+#[test]
+fn empty_welcome_screen_renders() {
+    let mut h = Harness::snapshot();
+    insta::assert_snapshot!(h.render());
+}
+
+#[test]
+fn help_overlay_lists_keybindings() {
+    let mut h = Harness::snapshot();
+    h.func(1); // F1 → ToggleHelp
+    assert!(
+        matches!(h.app.modal, modals::Modal::Help(_)),
+        "F1 should open the help modal"
+    );
+    insta::assert_snapshot!(h.render());
+}
+
+#[test]
+fn theme_picker_lists_palettes() {
+    let mut h = Harness::snapshot();
+    h.ctrl('y'); // Ctrl+Y → OpenThemePicker
+    assert!(
+        matches!(h.app.modal, modals::Modal::ThemePicker(_)),
+        "Ctrl+Y should open the theme picker"
+    );
+    insta::assert_snapshot!(h.render());
+}
+
+// ── Behavioral tests: drive keys, assert on App state ────────────────────────
+
+#[test]
+fn ctrl_n_opens_repo_picker() {
+    let mut h = Harness::standard(0);
+    h.render(); // first frame
+    h.ctrl('n'); // Ctrl+N → NewSession
+    assert!(
+        matches!(h.app.modal, modals::Modal::RepoPicker(_)),
+        "Ctrl+N should open the repo picker (no hosts configured)"
+    );
+    // Esc closes it again.
+    h.key(KeyCode::Esc, KeyModifiers::NONE);
+    assert!(!h.app.modal.is_open(), "Esc should dismiss the modal");
+}
+
+#[test]
+fn ctrl_j_and_k_cycle_session_selection() {
+    let mut h = Harness::standard(3);
+    assert_eq!(h.app.active_index, 0);
+
+    h.ctrl('j'); // NextSession
+    assert_eq!(h.app.active_index, 1, "Ctrl+J moves to the next session");
+    h.ctrl('j');
+    assert_eq!(h.app.active_index, 2);
+
+    h.ctrl('k'); // PreviousSession
+    assert_eq!(h.app.active_index, 1, "Ctrl+K moves back up");
+}
+
+#[test]
+fn ctrl_w_toggles_tasks_panel() {
+    let mut h = Harness::standard(0);
+    assert!(!h.app.show_tasks_panel);
+
+    h.ctrl('w'); // FocusTasks
+    assert!(h.app.show_tasks_panel, "Ctrl+W reveals the tasks panel");
+    h.ctrl('w');
+    assert!(!h.app.show_tasks_panel, "Ctrl+W again hides it");
+}
+
+#[test]
+fn f5_toggles_tasks_panel_like_ctrl_w() {
+    // F5 is the documented alternate chord for FocusTasks (Ctrl+W); both must
+    // drive the same toggle.
+    let mut h = Harness::standard(0);
+    assert!(!h.app.show_tasks_panel);
+
+    h.func(5);
+    assert!(h.app.show_tasks_panel, "F5 reveals the tasks panel");
+    h.func(5);
+    assert!(!h.app.show_tasks_panel, "F5 again hides it");
+}
+
+#[test]
+fn ctrl_a_opens_global_search_strip() {
+    let mut h = Harness::standard(2);
+    assert!(!h.app.global_search.active);
+
+    h.ctrl('a'); // GlobalSearch
+    assert!(h.app.global_search.active, "Ctrl+A opens the search strip");
+
+    // The strip captures typing before global keybindings, so a plain letter
+    // edits the query rather than triggering a binding.
+    h.key(KeyCode::Char('s'), KeyModifiers::NONE);
+    assert_eq!(h.app.global_search.query.value(), "s");
+
+    // Esc restores the prior state.
+    h.key(KeyCode::Esc, KeyModifiers::NONE);
+    assert!(!h.app.global_search.active, "Esc closes the search strip");
+}
+
+#[test]
+fn ctrl_q_requests_quit() {
+    let mut h = Harness::standard(1);
+    assert!(!h.app.should_quit());
+    h.ctrl('q'); // QuitApp
+    assert!(h.app.should_quit(), "Ctrl+Q should request shutdown");
+}
+
+#[test]
+fn session_list_renders_seeded_sessions() {
+    // Not a snapshot (status dots/metrics drift); assert the names appear.
+    let mut h = Harness::standard(2);
+    let frame = h.render();
+    assert!(
+        frame.contains("session-0"),
+        "first session name should render"
+    );
+    assert!(
+        frame.contains("session-1"),
+        "second session name should render"
+    );
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5177,6 +5177,9 @@ fn session_process_cwd(info: &SessionInfo) -> Option<PathBuf> {
 }
 
 #[cfg(test)]
+mod acceptance;
+
+#[cfg(test)]
 mod tests {
     use std::path::Path;
     use std::sync::Arc;

--- a/src/app/snapshots/thurbox__app__acceptance__empty_welcome_screen_renders.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__empty_welcome_screen_renders.snap
@@ -1,0 +1,34 @@
+---
+source: src/app/acceptance.rs
+expression: h.render()
+---
+ thurbox  Multi-Session Agent Orchestrator  v0.0.0-dev                                    ◐ Default
+╭ Sessions ─────────────╮┌ No Session ─────────────────────────────────────────────────────────────┐
+│                       ││                                                                         │
+│    No sessions yet    ││                                                                         │
+│Press Ctrl+N to create ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                    ┌───────────────────────────────┐                    │
+│                       ││                    │No active sessions             │                    │
+│                       ││                    │                               │                    │
+│                       ││                    │  Ctrl+N  New session          │                    │
+│                       ││                    │  F1      Help                 │                    │
+│                       ││                    └───────────────────────────────┘                    │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+╰───────────────────────╯│                                                                         │
+┌ Automations ──────────┐│                                                                         │
+│none                   ││                                                                         │
+└───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
+ Sessions  0 session(s)  ^H/^L Focus  F1 Help  ^Q Quit

--- a/src/app/snapshots/thurbox__app__acceptance__help_overlay_lists_keybindings.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__help_overlay_lists_keybindings.snap
@@ -1,0 +1,34 @@
+---
+source: src/app/acceptance.rs
+expression: h.render()
+---
+ thurbox  Multi-Session Agent Orchestrator  v0.0.0-dev                                    ◐ Default
+╭ Sessions ─────────────╮┌ No Session ─────────────────────────────────────────────────────────────┐
+│                       ││                                                                         │
+│    No sessions yet    ││                                                                         │
+│Press Ctrl+N to create ││                                                                         │
+│                   ╭ Keybindings ─────────────────────────────────────────────╮                   │
+│                   │Navigation                                               ▲│                   │
+│                   │› ctrl+h          Focus previous pane                    █│                   │
+│                   │  ctrl+l          Focus next pane                        █│                   │
+│                   │  ctrl+j          Next session                           █│                   │
+│                   │  ctrl+k          Previous session                       █│                   │
+│                   │                                                         ║│                   │
+│                   │Sessions                                                 ║│                   │
+│                   │  ctrl+n          New session                            ║│                   │
+│                   │  ctrl+d          Delete session                         ║│                   │
+│                   │  ctrl+r          Restart session                        ║│                   │
+│                   │  ctrl+f          Fork session                           ║│                   │
+│                   │  ctrl+p          Automations                            ║│                   │
+│                   │  ctrl+w / f5     Tasks                                  ║│                   │
+│                   │  ctrl+z          Undo delete                            ║│                   │
+│                   │  ctrl+u          Restore deleted sessions               ║│                   │
+│                   │                                                         ║│                   │
+│                   │Project                                                  ║│                   │
+│                   │  ctrl+o          Open in editor                         ▼│                   │
+│                   │j/k move · Enter/r rebind · d reset · shift+D reset all · │                   │
+╰───────────────────╰──────────────────────────────────────────────────────────╯                   │
+┌ Automations ──────────┐│                                                                         │
+│none                   ││                                                                         │
+└───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
+ Sessions  0 session(s)  ^H/^L Focus  F1 Help  ^Q Quit

--- a/src/app/snapshots/thurbox__app__acceptance__theme_picker_lists_palettes.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__theme_picker_lists_palettes.snap
@@ -1,0 +1,34 @@
+---
+source: src/app/acceptance.rs
+expression: h.render()
+---
+ thurbox  Multi-Session Agent Orchestrator  v0.0.0-dev                                    ◐ Default
+╭ Sessions ─────────────╮┌ No Session ─────────────────────────────────────────────────────────────┐
+│                       ││                                                                         │
+│    No sessions yet    ││                                                                         │
+│Press Ctrl+N to create ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                   ╭ Theme ───────────────────────────────────────────────────╮                   │
+│                   │▸ Default                   Accent      █████ █████       │                   │
+│                   │  Catppuccin Mocha          Status      ● ◆ ○ ✗           │                   │
+│                   │  Tokyo Night               Border      ╭─────╮           │                   │
+│                   │  Gruvbox Dark              Modal bg                      │                   │
+│                   │  Catppuccin Latte (light)                                │                   │
+│                   │  Tokyo Night Day (light)                                 │                   │
+│                   │  Gruvbox Light (light)                                   │                   │
+│                   │  Solarized Light (light)                                 │                   │
+│                   │  Doom                                                    │                   │
+│                   │                                                          │                   │
+│                   │                                                          │                   │
+│                   │  theme id: default                                       │                   │
+│                   │j/k navigate  Enter select  Esc cancel                    │                   │
+│                   ╰──────────────────────────────────────────────────────────╯                   │
+│                       ││                                                                         │
+│                       ││                                                                         │
+╰───────────────────────╯│                                                                         │
+┌ Automations ──────────┐│                                                                         │
+│none                   ││                                                                         │
+└───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
+ Sessions  0 session(s)  ^H/^L Focus  F1 Help  ^Q Quit


### PR DESCRIPTION
## Summary

Adds two complementary layers of end-to-end coverage for the TUI, neither of which existed before.

- **In-process driver + snapshots** (`src/app/acceptance.rs`, a `#[cfg(test)]` module). A hermetic `Harness` builds a real `App` on a no-op `StubBackend` + `Database::open_in_memory()` + a `TestPathGuard` tempdir, feeds `AppMessage::KeyPress` events exactly as `main.rs`'s loop does, and renders `view()` to a headless ratatui `TestBackend`. Stable screens (welcome, F1 help, theme picker) are pinned with **`insta`** snapshots (`src/app/snapshots/`); dynamic flows (Ctrl+N repo picker, Ctrl+J/K nav, Ctrl+W/F5 tasks, Ctrl+A search, Ctrl+Q quit, session-list render) assert on `App` state so live metrics/clock can't make them flaky. Runs in the normal `cargo nextest --all` — no tmux/TTY.
- **Black-box smoke test** (`scripts/dev/tui-smoke-test.sh`). Launches the real `thurbox` binary in a throwaway tmux pane (isolated `HOME`/XDG/`TMUX_TMPDIR`, mirroring `scripts/demo/record.sh`), drives it with `tmux send-keys`, and asserts on captured frames (boot → F1 → theme → clean Ctrl+Q exit). Wired into a new `tui-smoke` CI job.

Also adds `insta` as a `--no-default-features` dev-dependency (only pulls `similar`) and documents both layers in `CLAUDE.md`.

## Test plan

- `cargo nextest run --all` / `cargo test --lib app::acceptance` — 10 acceptance tests pass; snapshots committed.
- `cargo test --test architecture_rules` — passes (new file lives under the existing `app` module allowlist).
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `scripts/dev/tui-smoke-test.sh` — run locally, all assertions pass; also runs in the new `tui-smoke` CI job.


---
_Generated by [Claude Code](https://claude.ai/code/session_011y7em69Q4A6qkbbRni2eVy)_