### PR TITLE
refactor: cut cognitive complexity (SonarQube) + full readline editing in modal text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1134,6 +1134,18 @@ terminal. Navigation / app-control chords (`Ctrl+H/J/K/L` focus + session nav,
 escape route out of the terminal, so they must keep working there even though a
 few collide with readline.
 
+**Readline editing in modal text fields.** thurbox's own text inputs (session /
+branch name, repo-picker path & search, automation editor, task title /
+description) accept the standard emacs/readline line-editing chords, so the same
+muscle memory works there as in a terminal: `Ctrl+A`/`Ctrl+E` line start/end,
+`Ctrl+B`/`Ctrl+F` move by char, `Ctrl+H`/`Ctrl+D` delete the char before/under
+the cursor, `Ctrl+W` delete word, `Ctrl+U`/`Ctrl+K` kill to line start/end. The
+dispatch lives in one place — `modals::apply_ctrl_line_edit` over the `LineEdit`
+trait (implemented by both `TextInput` and `TextArea`) — and **every**
+`Ctrl`+letter is consumed (mapped or swallowed) so a bare control letter never
+leaks into the field. A `Ctrl` chord with a non-letter key (arrows, Home/End)
+falls through to normal cursor handling.
+
 A few stateful keys stay literal (the F1 panel lists them under
 **Fixed (not rebindable)**): modal selectors (j/k/Enter/Esc), the
 automations/tasks panes, the file-viewer **search sub-mode**, and the

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -53,21 +53,9 @@ impl App {
         }
 
         // Cmd/Super chords are commands, never text: only the keybinding
-        // lookup may consume them. The handlers below (modal inputs, the
-        // search query, in-pane editors, list hotkeys) predate the kitty
-        // keyboard protocol and match `Char` without checking SUPER, so a
-        // chord like Cmd+J would otherwise type a bare `j`. While a modal or
-        // the search strip owns input the chord is swallowed outright,
-        // mirroring how Ctrl chords are unavailable there. (The terminal
-        // pass-through swallows SUPER on its own — `agent::input::key_to_bytes`.)
+        // lookup may consume them (see `handle_super_chord`).
         if mods.contains(KeyModifiers::SUPER) {
-            if !self.modal.is_open() && !self.global_search.active {
-                self.text_selection = None;
-                let context = self.focus_key_context();
-                if let Some(action) = self.keybindings.lookup_in(context, code, mods) {
-                    self.dispatch_action(action);
-                }
-            }
+            self.handle_super_chord(code, mods);
             return;
         }
 
@@ -110,6 +98,31 @@ impl App {
             }
         }
 
+        self.handle_focused_pane_key(code, mods);
+    }
+
+    /// Cmd/Super chords are commands, never text: only the keybinding lookup
+    /// may consume them. The focus-based handlers (modal inputs, the search
+    /// query, in-pane editors, list hotkeys) predate the kitty keyboard
+    /// protocol and match `Char` without checking SUPER, so a chord like Cmd+J
+    /// would otherwise type a bare `j`. While a modal or the search strip owns
+    /// input the chord is swallowed outright, mirroring how Ctrl chords are
+    /// unavailable there. (The terminal pass-through swallows SUPER on its own —
+    /// `agent::input::key_to_bytes`.)
+    fn handle_super_chord(&mut self, code: KeyCode, mods: KeyModifiers) {
+        if self.modal.is_open() || self.global_search.active {
+            return;
+        }
+        self.text_selection = None;
+        let context = self.focus_key_context();
+        if let Some(action) = self.keybindings.lookup_in(context, code, mods) {
+            self.dispatch_action(action);
+        }
+    }
+
+    /// Route a key (already cleared of priority/modal/global handling) to the
+    /// handler for the currently focused pane.
+    fn handle_focused_pane_key(&mut self, code: KeyCode, mods: KeyModifiers) {
         match self.focus {
             InputFocus::SessionList => self.handle_session_list_key(code),
             InputFocus::Automations => self.handle_automations_pane_key(code),
@@ -455,37 +468,39 @@ impl App {
     /// create is handled globally in `dispatch_action`, so it works here too,
     /// including on an empty pane.)
     pub(crate) fn handle_automations_pane_key(&mut self, code: KeyCode) {
-        // Creating works regardless of whether the pane has entries.
-        if matches!(code, KeyCode::Char('n')) {
-            self.new_automation_in_pane();
-            return;
-        }
         let count = self.automation_ui.cached_automations.len();
-        // `k`/Up at the top row (or empty pane) flows focus back up into the
-        // session list; `j`/Down past the last loops to the top of it — so the
-        // left column behaves as one circular vertical list.
-        if matches!(code, KeyCode::Char('k') | KeyCode::Up) {
-            self.automations_pane_move_up(count);
-            return;
+        match code {
+            // Creating works regardless of whether the pane has entries.
+            KeyCode::Char('n') => self.new_automation_in_pane(),
+            // `k`/Up at the top row (or empty pane) flows focus back up into the
+            // session list; `j`/Down past the last loops to the top of it — so
+            // the left column behaves as one circular vertical list.
+            KeyCode::Char('k') | KeyCode::Up => self.automations_pane_move_up(count),
+            KeyCode::Char('j') | KeyCode::Down => self.automations_pane_move_down(count),
+            // `Enter`/`e` focuses the central-pane editor (like `Enter` on a
+            // session focuses its terminal); on an empty pane it starts a new
+            // automation.
+            KeyCode::Enter | KeyCode::Char('e') => self.enter_automation_editor_in_pane(count),
+            // Remaining nav/actions are no-ops on an empty pane.
+            _ if count > 0 => self.dispatch_automation_pane_action(code, count),
+            _ => {}
         }
-        if matches!(code, KeyCode::Char('j') | KeyCode::Down) {
-            self.automations_pane_move_down(count);
-            return;
-        }
-        // `Enter`/`e` focuses the central-pane editor (like `Enter` on a session
-        // focuses its terminal); on an empty pane it starts a new automation.
-        if matches!(code, KeyCode::Enter | KeyCode::Char('e')) {
-            if count == 0 {
-                self.new_automation_in_pane();
-            } else {
-                self.enter_automation_editor();
-            }
-            self.refresh_selected_automation_runs();
-            return;
-        }
+    }
+
+    /// `Enter`/`e` in the automations pane: open the editor for the selection,
+    /// or start a new automation on an empty pane.
+    fn enter_automation_editor_in_pane(&mut self, count: usize) {
         if count == 0 {
-            return; // empty pane: remaining nav/actions are no-ops
+            self.new_automation_in_pane();
+        } else {
+            self.enter_automation_editor();
         }
+        self.refresh_selected_automation_runs();
+    }
+
+    /// Clamp the selection and run the toggle/run/delete action for the row
+    /// under the cursor (caller guarantees a non-empty pane).
+    fn dispatch_automation_pane_action(&mut self, code: KeyCode, count: usize) {
         if self.automation_ui.automation_panel_index >= count {
             self.automation_ui.automation_panel_index = count - 1;
         }
@@ -1322,56 +1337,54 @@ impl App {
                 true
             }
 
-            // ── File viewer (scoped) ────────────────────────────────────
-            Action::FileViewerDown => {
-                self.file_viewer.move_selection(1);
-                true
-            }
-            Action::FileViewerUp => {
-                self.file_viewer.move_selection(-1);
-                true
-            }
-            Action::FileViewerCollapse => {
-                self.file_viewer.collapse();
-                true
-            }
-            Action::FileViewerExpand => {
-                self.file_viewer_expand();
-                true
-            }
-            Action::FileViewerSearch => {
-                self.file_viewer.start_search();
-                true
-            }
-            Action::FileViewerNextMatch => {
-                self.file_viewer.next_match();
-                true
-            }
-            Action::FileViewerPrevMatch => {
-                self.file_viewer.prev_match();
-                true
-            }
+            // ── File viewer + terminal scroll (scoped) ──────────────────
+            Action::FileViewerDown
+            | Action::FileViewerUp
+            | Action::FileViewerCollapse
+            | Action::FileViewerExpand
+            | Action::FileViewerSearch
+            | Action::FileViewerNextMatch
+            | Action::FileViewerPrevMatch => self.dispatch_file_viewer_action(action),
+            Action::TerminalScrollUp
+            | Action::TerminalScrollDown
+            | Action::TerminalPageUp
+            | Action::TerminalPageDown => self.dispatch_terminal_scroll_action(action),
+        }
+    }
 
-            // ── Terminal scroll (scoped) ────────────────────────────────
-            Action::TerminalScrollUp => {
-                self.scroll_terminal_up(1);
-                true
-            }
-            Action::TerminalScrollDown => {
-                self.scroll_terminal_down(1);
-                true
-            }
+    /// Run a `FileViewer`-scoped action. Always consumes the key (`true`).
+    fn dispatch_file_viewer_action(&mut self, action: crate::session::Action) -> bool {
+        use crate::session::Action;
+        match action {
+            Action::FileViewerDown => self.file_viewer.move_selection(1),
+            Action::FileViewerUp => self.file_viewer.move_selection(-1),
+            Action::FileViewerCollapse => self.file_viewer.collapse(),
+            Action::FileViewerExpand => self.file_viewer_expand(),
+            Action::FileViewerSearch => self.file_viewer.start_search(),
+            Action::FileViewerNextMatch => self.file_viewer.next_match(),
+            Action::FileViewerPrevMatch => self.file_viewer.prev_match(),
+            _ => {}
+        }
+        true
+    }
+
+    /// Run a terminal-scroll action. Always consumes the key (`true`).
+    fn dispatch_terminal_scroll_action(&mut self, action: crate::session::Action) -> bool {
+        use crate::session::Action;
+        match action {
+            Action::TerminalScrollUp => self.scroll_terminal_up(1),
+            Action::TerminalScrollDown => self.scroll_terminal_down(1),
             Action::TerminalPageUp => {
                 let amount = self.page_scroll_amount();
                 self.scroll_terminal_up(amount);
-                true
             }
             Action::TerminalPageDown => {
                 let amount = self.page_scroll_amount();
                 self.scroll_terminal_down(amount);
-                true
             }
+            _ => {}
         }
+        true
     }
 
     /// `Ctrl+N`: in the automations context create an automation (mirrors `n`),

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1195,6 +1195,16 @@ impl App {
         enabled
     }
 
+    /// Run a feature-gated action when its switch is enabled (toasting the
+    /// switch name otherwise), and always consume the key (`true`) so a
+    /// disabled chord never falls through to the PTY.
+    fn gated(&mut self, enabled: bool, what: &str, act: impl FnOnce(&mut Self)) -> bool {
+        if self.feature_gate(enabled, what) {
+            act(self);
+        }
+        true
+    }
+
     fn dispatch_action(&mut self, action: crate::session::Action) -> bool {
         use crate::session::Action;
         match action {
@@ -1211,22 +1221,20 @@ impl App {
                 self.open_active_in_editor();
                 true
             }
-            Action::OpenAutomations => {
-                if self.feature_gate(self.features.automations, "Automations") {
-                    self.open_automations_list();
-                }
-                true
-            }
+            Action::OpenAutomations => self.gated(
+                self.features.automations,
+                "Automations",
+                Self::open_automations_list,
+            ),
             Action::StartSync => {
                 self.start_sync();
                 true
             }
-            Action::ToggleShell => {
-                if self.feature_gate(self.features.shell_pane, "Shell pane") {
-                    self.toggle_shell_view();
-                }
-                true
-            }
+            Action::ToggleShell => self.gated(
+                self.features.shell_pane,
+                "Shell pane",
+                Self::toggle_shell_view,
+            ),
             Action::ForkSession => {
                 self.fork_active_session();
                 true
@@ -1271,31 +1279,23 @@ impl App {
                 self.modal = super::modals::Modal::Help(super::modals::HelpModal::default());
                 true
             }
-            Action::ToggleInfoPanel => {
-                if self.feature_gate(self.features.info_panel, "Info panel") {
-                    self.show_info_panel = !self.show_info_panel;
-                    self.resize_sessions_to_content_area();
-                }
-                true
-            }
+            Action::ToggleInfoPanel => self.gated(self.features.info_panel, "Info panel", |s| {
+                s.show_info_panel = !s.show_info_panel;
+                s.resize_sessions_to_content_area();
+            }),
             Action::FocusTasks => {
-                if self.feature_gate(self.features.tasks, "Tasks panel") {
-                    self.act_toggle_tasks();
-                }
-                true
+                self.gated(self.features.tasks, "Tasks panel", Self::act_toggle_tasks)
             }
-            Action::ToggleFileViewer => {
-                if self.feature_gate(self.features.file_viewer, "File viewer") {
-                    self.act_toggle_file_viewer();
-                }
-                true
-            }
-            Action::GlobalSearch => {
-                if self.feature_gate(self.features.global_search, "Global search") {
-                    self.open_global_search();
-                }
-                true
-            }
+            Action::ToggleFileViewer => self.gated(
+                self.features.file_viewer,
+                "File viewer",
+                Self::act_toggle_file_viewer,
+            ),
+            Action::GlobalSearch => self.gated(
+                self.features.global_search,
+                "Global search",
+                Self::open_global_search,
+            ),
 
             // ── Clipboard (global) ──────────────────────────────────────
             // Copy only consumes the key when there's a selection; otherwise

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3464,43 +3464,7 @@ impl App {
             .filter(|s| s.agent_session_id.is_some())
             .collect();
 
-        // Discover existing windows per backend. Each distinct backend_type is
-        // readied + discovered at most once (a remote backend needs its
-        // control-mode connection up before adopt()).
-        let mut discovered_by_backend: HashMap<
-            String,
-            Vec<crate::agent::backend::DiscoveredSession>,
-        > = HashMap::new();
-        for shared in &resumable {
-            if discovered_by_backend.contains_key(&shared.backend_type) {
-                continue;
-            }
-            // Skip discovery for backends this instance can't manage (unknown
-            // remote hosts); their sessions are left un-adopted rather than
-            // misadopted on local.
-            let Some(backend) = self.resolve_persisted_backend(&shared.backend_type) else {
-                discovered_by_backend.insert(shared.backend_type.clone(), Vec::new());
-                continue;
-            };
-
-            let disc = match backend.ensure_ready() {
-                Ok(()) => backend.discover().unwrap_or_else(|e| {
-                    warn!(
-                        backend = backend.name(),
-                        "Failed to discover sessions from backend: {e}"
-                    );
-                    Vec::new()
-                }),
-                Err(e) => {
-                    warn!(
-                        backend = backend.name(),
-                        "Backend not ready during restore; skipping its sessions: {e}"
-                    );
-                    Vec::new()
-                }
-            };
-            discovered_by_backend.insert(shared.backend_type.clone(), disc);
-        }
+        let discovered_by_backend = self.discover_windows_by_backend(&resumable);
 
         for shared in resumable {
             let discovered = discovered_by_backend
@@ -3512,6 +3476,59 @@ impl App {
 
         // Claim ownership of restored sessions in the shared state
         self.save_state();
+    }
+
+    /// Discover existing backend windows once per distinct `backend_type`.
+    ///
+    /// Each backend is readied + discovered at most once (a remote backend
+    /// needs its control-mode connection up before `adopt()`). Backends this
+    /// instance can't manage (unknown remote hosts) map to an empty list so
+    /// their sessions are left un-adopted rather than misadopted on local.
+    fn discover_windows_by_backend(
+        &self,
+        resumable: &[sync::SharedSession],
+    ) -> HashMap<String, Vec<crate::agent::backend::DiscoveredSession>> {
+        let mut discovered_by_backend: HashMap<
+            String,
+            Vec<crate::agent::backend::DiscoveredSession>,
+        > = HashMap::new();
+        for shared in resumable {
+            if discovered_by_backend.contains_key(&shared.backend_type) {
+                continue;
+            }
+            let disc = self.discover_windows_for_backend(&shared.backend_type);
+            discovered_by_backend.insert(shared.backend_type.clone(), disc);
+        }
+        discovered_by_backend
+    }
+
+    /// Ready + discover a single backend's windows, degrading to an empty list
+    /// when the backend is unknown or not reachable (logged, never fatal).
+    fn discover_windows_for_backend(
+        &self,
+        backend_type: &str,
+    ) -> Vec<crate::agent::backend::DiscoveredSession> {
+        // Skip discovery for backends this instance can't manage (unknown
+        // remote hosts); their sessions are left un-adopted.
+        let Some(backend) = self.resolve_persisted_backend(backend_type) else {
+            return Vec::new();
+        };
+
+        if let Err(e) = backend.ensure_ready() {
+            warn!(
+                backend = backend.name(),
+                "Backend not ready during restore; skipping its sessions: {e}"
+            );
+            return Vec::new();
+        }
+
+        backend.discover().unwrap_or_else(|e| {
+            warn!(
+                backend = backend.name(),
+                "Failed to discover sessions from backend: {e}"
+            );
+            Vec::new()
+        })
     }
 
     /// Restore a single session synchronously (used during startup). The

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -275,6 +275,17 @@ fn remove_before_cursor(buffer: &mut String, cursor: &mut usize, start: usize) {
     *cursor = start;
 }
 
+/// Delete the chars in `[cursor, end)` (char indices) from `buffer`, leaving
+/// `cursor` in place. A no-op when `end <= cursor`. Backs the forward line-edit
+/// (`Ctrl+K` kill to line end) of both text widgets.
+fn remove_after_cursor(buffer: &mut String, cursor: usize, end: usize) {
+    if end <= cursor {
+        return;
+    }
+    let (s, e) = (byte_index(buffer, cursor), byte_index(buffer, end));
+    buffer.replace_range(s..e, "");
+}
+
 /// Char index of the start of the word ending at `cursor`: skip any trailing
 /// whitespace, then the run of non-whitespace before it. Backs the `Ctrl+W`
 /// handlers of both text widgets (newlines count as whitespace).
@@ -290,56 +301,131 @@ fn word_start_before(chars: &[char], cursor: usize) -> usize {
 }
 
 /// Readline-style line editing shared by the single-line [`TextInput`] and the
-/// multi-line [`TextArea`], so the Ctrl-chord dispatch lives in one place.
+/// multi-line [`TextArea`], so the Ctrl-chord dispatch lives in one place. The
+/// cursor-move and single-char delete chords delegate to each widget's existing
+/// inherent methods; only the word/line kills carry their own logic.
 trait LineEdit {
     /// Delete the word before the cursor (readline `Ctrl+W`).
     fn delete_word_before(&mut self);
     /// Delete from the cursor to the start of the current line (readline `Ctrl+U`).
     fn kill_to_line_start(&mut self);
+    /// Delete from the cursor to the end of the current line (readline `Ctrl+K`).
+    fn kill_to_line_end(&mut self);
+    /// Move the cursor to the start of the current line (readline `Ctrl+A`).
+    fn line_start(&mut self);
+    /// Move the cursor to the end of the current line (readline `Ctrl+E`).
+    fn line_end(&mut self);
+    /// Move the cursor one char left (readline `Ctrl+B`).
+    fn cursor_left(&mut self);
+    /// Move the cursor one char right (readline `Ctrl+F`).
+    fn cursor_right(&mut self);
+    /// Delete the char under the cursor (readline `Ctrl+D`).
+    fn delete_forward(&mut self);
+    /// Delete the char before the cursor (readline `Ctrl+H`, like Backspace).
+    fn delete_backward(&mut self);
+}
+
+/// The `LineEdit` methods identical for both text widgets: the word kill plus
+/// the cursor-move / single-char deletes that delegate to each widget's
+/// inherent methods. Defined once here so the single-line and multi-line impls
+/// share one copy (the line kills, which differ per widget, stay inline). Both
+/// widgets expose the `buffer`/`cursor` fields and inherent methods this needs.
+macro_rules! line_edit_shared {
+    () => {
+        fn delete_word_before(&mut self) {
+            let chars: Vec<char> = self.buffer.chars().collect();
+            let start = word_start_before(&chars, self.cursor);
+            remove_before_cursor(&mut self.buffer, &mut self.cursor, start);
+        }
+        fn line_start(&mut self) {
+            self.home();
+        }
+        fn line_end(&mut self) {
+            self.end();
+        }
+        fn cursor_left(&mut self) {
+            self.move_left();
+        }
+        fn cursor_right(&mut self) {
+            self.move_right();
+        }
+        fn delete_forward(&mut self) {
+            self.delete();
+        }
+        fn delete_backward(&mut self) {
+            self.backspace();
+        }
+    };
 }
 
 impl LineEdit for TextInput {
-    fn delete_word_before(&mut self) {
-        let chars: Vec<char> = self.buffer.chars().collect();
-        let start = word_start_before(&chars, self.cursor);
-        remove_before_cursor(&mut self.buffer, &mut self.cursor, start);
-    }
+    line_edit_shared!();
 
     /// For a single-line input this clears everything before the cursor.
     fn kill_to_line_start(&mut self) {
         remove_before_cursor(&mut self.buffer, &mut self.cursor, 0);
     }
+
+    /// For a single-line input this clears everything from the cursor onward.
+    fn kill_to_line_end(&mut self) {
+        let end = self.buffer.chars().count();
+        remove_after_cursor(&mut self.buffer, self.cursor, end);
+    }
 }
 
 impl LineEdit for TextArea {
-    fn delete_word_before(&mut self) {
-        let chars: Vec<char> = self.buffer.chars().collect();
-        let start = word_start_before(&chars, self.cursor);
-        remove_before_cursor(&mut self.buffer, &mut self.cursor, start);
-    }
+    line_edit_shared!();
 
     fn kill_to_line_start(&mut self) {
         let (line, _) = self.cursor_line_col();
         let line_start = self.cursor_at(line, 0);
         remove_before_cursor(&mut self.buffer, &mut self.cursor, line_start);
     }
+
+    /// Kill to the end of the current line; at the line end (with text below)
+    /// this consumes the trailing newline, joining the next line — matching
+    /// readline/emacs `Ctrl+K`.
+    fn kill_to_line_end(&mut self) {
+        let (line, _) = self.cursor_line_col();
+        let mut end = self.cursor_at(line, usize::MAX);
+        if end == self.cursor && self.cursor < self.char_count() {
+            end = self.cursor + 1;
+        }
+        remove_after_cursor(&mut self.buffer, self.cursor, end);
+    }
 }
 
-/// Apply a readline `Ctrl`+letter line-edit chord to `field` (`Ctrl+W` delete
-/// word, `Ctrl+U` kill to line start). Returns `true` when `code` is a
-/// `Ctrl`+letter chord — handled (W/U) or swallowed (any other letter) — so the
-/// caller treats it as consumed and never inserts the bare letter as text.
-/// `Ctrl` with a non-letter key (arrows, Home/End) returns `false` so normal
-/// cursor handling still applies, keeping every text field consistent.
+/// Apply a readline `Ctrl`+letter line-edit chord to `field`, giving modal text
+/// fields the same emacs-style editing as a terminal:
+///
+/// - `Ctrl+A` / `Ctrl+E` — move to line start / end
+/// - `Ctrl+B` / `Ctrl+F` — move one char left / right
+/// - `Ctrl+H` / `Ctrl+D` — delete the char before / under the cursor
+/// - `Ctrl+W` — delete the word before the cursor
+/// - `Ctrl+U` / `Ctrl+K` — kill to line start / end
+///
+/// Returns `true` when `code` is a `Ctrl`+letter chord — handled or swallowed
+/// (any unmapped letter) — so the caller treats it as consumed and never
+/// inserts the bare letter as text. `Ctrl` with a non-letter key (arrows,
+/// Home/End) returns `false` so normal cursor handling still applies.
 fn apply_ctrl_line_edit(field: &mut impl LineEdit, code: KeyCode, mods: KeyModifiers) -> bool {
     if !mods.contains(KeyModifiers::CONTROL) {
         return false;
     }
-    match code {
-        KeyCode::Char('w') | KeyCode::Char('W') => field.delete_word_before(),
-        KeyCode::Char('u') | KeyCode::Char('U') => field.kill_to_line_start(),
-        KeyCode::Char(_) => {} // other Ctrl+letter: swallow (never insert)
-        _ => return false,     // Ctrl+<non-letter>: defer to normal handling
+    let KeyCode::Char(c) = code else {
+        return false; // Ctrl+<non-letter>: defer to normal handling
+    };
+    match c.to_ascii_lowercase() {
+        'a' => field.line_start(),
+        'e' => field.line_end(),
+        'b' => field.cursor_left(),
+        'f' => field.cursor_right(),
+        'h' => field.delete_backward(),
+        'd' => field.delete_forward(),
+        'w' => field.delete_word_before(),
+        'u' => field.kill_to_line_start(),
+        'k' => field.kill_to_line_end(),
+        _ => {} // other Ctrl+letter: swallow (never insert)
     }
     true
 }
@@ -1461,6 +1547,102 @@ mod tests {
         area.home(); // start of "second"
         area.delete_word_before();
         assert_eq!(area.value(), "second");
+    }
+
+    #[test]
+    fn ctrl_chords_move_cursor_like_a_terminal() {
+        // Ctrl+A/E to line ends, Ctrl+B/F by one char — emacs/readline moves
+        // that must edit the cursor without ever inserting the bare letter.
+        let ctrl = KeyModifiers::CONTROL;
+        let mut input = TextInput::new();
+        input.set("abcd"); // cursor at end (4)
+
+        assert!(apply_text_input_key(
+            Some(&mut input),
+            KeyCode::Char('a'),
+            ctrl
+        ));
+        assert_eq!(input.cursor_pos(), 0);
+        assert!(apply_text_input_key(
+            Some(&mut input),
+            KeyCode::Char('e'),
+            ctrl
+        ));
+        assert_eq!(input.cursor_pos(), 4);
+        assert!(apply_text_input_key(
+            Some(&mut input),
+            KeyCode::Char('b'),
+            ctrl
+        ));
+        assert_eq!(input.cursor_pos(), 3);
+        assert!(apply_text_input_key(
+            Some(&mut input),
+            KeyCode::Char('f'),
+            ctrl
+        ));
+        assert_eq!(input.cursor_pos(), 4);
+        // Uppercase (Shift+Ctrl) maps the same way.
+        assert!(apply_text_input_key(
+            Some(&mut input),
+            KeyCode::Char('A'),
+            ctrl
+        ));
+        assert_eq!(input.cursor_pos(), 0);
+        assert_eq!(input.value(), "abcd", "cursor chords must not change text");
+    }
+
+    #[test]
+    fn ctrl_chords_delete_chars_and_kill_to_line_end() {
+        let ctrl = KeyModifiers::CONTROL;
+        let mut input = TextInput::new();
+
+        // Ctrl+H deletes the char before the cursor (like Backspace).
+        input.set("abc"); // cursor at end
+        assert!(apply_text_input_key(
+            Some(&mut input),
+            KeyCode::Char('h'),
+            ctrl
+        ));
+        assert_eq!(input.value(), "ab");
+
+        // Ctrl+D deletes the char under the cursor.
+        input.set("abc");
+        input.home(); // cursor before 'a'
+        assert!(apply_text_input_key(
+            Some(&mut input),
+            KeyCode::Char('d'),
+            ctrl
+        ));
+        assert_eq!(input.value(), "bc");
+
+        // Ctrl+K kills from the cursor to the end of the line.
+        input.set("hello world");
+        input.home();
+        input.move_right(); // after 'h'
+        input.kill_to_line_end();
+        assert_eq!(input.value(), "h");
+    }
+
+    #[test]
+    fn text_area_kill_to_line_end_respects_lines() {
+        let mut area = TextArea::new();
+        // Ctrl+K mid-line kills only the rest of the current line.
+        area.set("first line\nsecond");
+        area.home(); // start of line 1 ("second")
+        area.move_up(); // start of line 0 ("first line")
+        for _ in 0..5 {
+            area.move_right(); // park after "first"
+        }
+        area.kill_to_line_end();
+        assert_eq!(area.value(), "first\nsecond");
+
+        // At the end of a line (text below), Ctrl+K joins the next line.
+        area.set("first\nsecond");
+        area.home(); // start of line 1 ("second")
+        area.move_up(); // line 0
+        area.end(); // end of "first", before the newline
+        area.kill_to_line_end();
+        assert_eq!(area.value(), "firstsecond");
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -1032,25 +1032,25 @@ fn editor_preview(m: &super::modals::AutomationEditorModal, now: u64) -> String 
     }
 }
 
-fn render_help_overlay(
-    frame: &mut Frame,
+/// The rebindable section of the F1 help body: the rendered lines, the line
+/// index of the selected action row (for centering the scroll), and the
+/// `(line index, action index)` pairs used to build click hitboxes.
+struct RebindableRows {
+    help_lines: Vec<Line<'static>>,
+    selected_line: usize,
+    action_rows: Vec<(usize, usize)>,
+}
+
+/// Build the editable keybinding section of the help overlay (one section
+/// header + one row per rebindable action), driven by `help_sections()` so the
+/// row index matches `help.selected`.
+fn build_rebindable_rows(
     keybindings: &KeyBindings,
     help: &super::modals::HelpModal,
-) -> crate::ui::SelectorHits {
-    let area = centered_rect(60, 70, frame.area());
-
-    let inner = crate::ui::render_modal_frame(frame, area, "Keybindings");
-
+) -> RebindableRows {
     let mut help_lines: Vec<Line<'static>> = Vec::new();
-
-    // Editable sections — driven by `keybindings::help_sections()`, the same
-    // ordering as `Action::rebindable_in_order()`, so `idx` lines up with
-    // `help.selected` from the interactive editor. EVERY row here is rebindable.
     let mut idx = 0usize;
-    // Line index of the selected action row, so the body can scroll to keep it
-    // visible on short terminals.
     let mut selected_line = 0usize;
-    // (line index, action index) per rebindable row, for click hitboxes.
     let mut action_rows: Vec<(usize, usize)> = Vec::new();
     for (title, actions) in crate::session::keybindings::help_sections() {
         help_lines.push(help_section(title));
@@ -1070,6 +1070,64 @@ fn render_help_overlay(
         }
         help_lines.push(Line::from(""));
     }
+    RebindableRows {
+        help_lines,
+        selected_line,
+        action_rows,
+    }
+}
+
+/// Scroll offset for the help body so the selected action row stays visible
+/// (roughly centered), clamped to the real content range. `0` when everything
+/// fits.
+fn help_body_scroll(total: usize, body_h: usize, selected_line: usize) -> usize {
+    if total <= body_h {
+        return 0;
+    }
+    let max_scroll = total - body_h;
+    selected_line.saturating_sub(body_h / 2).min(max_scroll)
+}
+
+/// Hitboxes for the rebindable action rows currently on screen after scrolling.
+fn help_action_hitboxes(
+    action_rows: &[(usize, usize)],
+    scroll: usize,
+    body_h: usize,
+    body: Rect,
+) -> Vec<crate::ui::RowHitbox> {
+    action_rows
+        .iter()
+        .filter_map(|&(line, idx)| {
+            let on_screen = line.checked_sub(scroll)?;
+            if on_screen >= body_h {
+                return None;
+            }
+            Some(crate::ui::RowHitbox {
+                rect: Rect::new(body.x, body.y + on_screen as u16, body.width, 1),
+                index: idx,
+            })
+        })
+        .collect()
+}
+
+fn render_help_overlay(
+    frame: &mut Frame,
+    keybindings: &KeyBindings,
+    help: &super::modals::HelpModal,
+) -> crate::ui::SelectorHits {
+    let area = centered_rect(60, 70, frame.area());
+
+    let inner = crate::ui::render_modal_frame(frame, area, "Keybindings");
+
+    // Editable sections — driven by `keybindings::help_sections()`, the same
+    // ordering as `Action::rebindable_in_order()`, so the row index lines up
+    // with `help.selected` from the interactive editor. EVERY row here is
+    // rebindable.
+    let RebindableRows {
+        mut help_lines,
+        selected_line,
+        action_rows,
+    } = build_rebindable_rows(keybindings, help);
 
     // Fixed keys that are NOT rebindable: stateful sub-modes (file-viewer
     // search, modal selectors) and terminal pass-through. Shown for reference,
@@ -1142,12 +1200,7 @@ fn render_help_overlay(
     // row stays visible (roughly centered), clamped to the real content range.
     let total = help_lines.len();
     let body_h = body.height as usize;
-    let scroll = if total <= body_h {
-        0
-    } else {
-        let max_scroll = total - body_h;
-        selected_line.saturating_sub(body_h / 2).min(max_scroll)
-    };
+    let scroll = help_body_scroll(total, body_h, selected_line);
 
     frame.render_widget(Paragraph::new(help_lines).scroll((scroll as u16, 0)), body);
     frame.render_widget(
@@ -1161,19 +1214,7 @@ fn render_help_overlay(
     // Hitboxes for the rebindable action rows visible after scrolling;
     // section headers and the fixed-keys reference are not clickable.
     let total_actions = action_rows.len();
-    let hitboxes: Vec<crate::ui::RowHitbox> = action_rows
-        .into_iter()
-        .filter_map(|(line, idx)| {
-            let on_screen = line.checked_sub(scroll)?;
-            if on_screen >= body_h {
-                return None;
-            }
-            Some(crate::ui::RowHitbox {
-                rect: Rect::new(body.x, body.y + on_screen as u16, body.width, 1),
-                index: idx,
-            })
-        })
-        .collect();
+    let hitboxes = help_action_hitboxes(&action_rows, scroll, body_h, body);
 
     // Scrollbar (action-index space, so a drag maps straight to a selection)
     // when the body overflows the modal height.

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -272,61 +272,105 @@ pub fn move_in_order(
     active_input_idx: usize,
     down: bool,
 ) -> Option<Vec<usize>> {
-    let n = ord.order.len();
     let pos = ord.order.iter().position(|&i| i == active_input_idx)?;
-    let depth = ord.depths[pos];
 
-    // End of the block rooted at `start`: first following row at <= its depth.
-    let block_end = |start: usize| {
-        let mut end = start + 1;
-        while end < n && ord.depths[end] > ord.depths[start] {
-            end += 1;
-        }
-        end
-    };
-    // Start of the group containing `p` / end of the group starting at `start`
-    // (group starts are the rows carrying a header label).
-    let group_start = |p: usize| (0..=p).rev().find(|&q| ord.headers[q].is_some());
-    let group_end = |start: usize| {
-        (start + 1..n)
-            .find(|&q| ord.headers[q].is_some())
-            .unwrap_or(n)
+    // The two adjacent ranges to swap: `a` directly precedes `b`. A root block
+    // (depth 0) swaps within / across its repo group; a nested child swaps with
+    // a same-depth sibling only.
+    let (a, b) = if ord.depths[pos] == 0 {
+        move_root_block_range(ord, pos, down)?
+    } else {
+        move_child_block_range(ord, pos, down)?
     };
 
-    let end = block_end(pos);
-    let gs = group_start(pos)?;
-    let ge = group_end(gs);
+    debug_assert_eq!(a.end, b.start);
+    let mut new_order = Vec::with_capacity(ord.order.len());
+    new_order.extend_from_slice(&ord.order[..a.start]);
+    new_order.extend_from_slice(&ord.order[b.start..b.end]);
+    new_order.extend_from_slice(&ord.order[a.start..a.end]);
+    new_order.extend_from_slice(&ord.order[b.end..]);
+    Some(new_order)
+}
 
-    // The two adjacent ranges to swap: `a` directly precedes `b`.
-    let (a, b) = if depth == 0 {
-        if down {
-            if end < ge {
-                // Swap with the next root block in the group.
-                (pos..end, end..block_end(end))
-            } else if ge < n {
-                // Last root block: the whole group swaps with the next group.
-                (gs..ge, ge..group_end(ge))
-            } else {
-                return None; // bottom of the list
-            }
-        } else if pos > gs {
-            // Swap with the previous root block in the group.
-            let prev = (gs..pos).rev().find(|&q| ord.depths[q] == 0)?;
-            (prev..pos, pos..end)
-        } else if gs > 0 {
-            // First root block: the whole group swaps with the previous group.
-            let pgs = group_start(gs - 1)?;
-            (pgs..gs, gs..ge)
+/// End of the block rooted at `start`: the first following row at a depth `<=`
+/// `start`'s (i.e. the row past `start`'s whole rendered subtree).
+fn block_end(ord: &SessionOrder, start: usize) -> usize {
+    let n = ord.order.len();
+    let mut end = start + 1;
+    while end < n && ord.depths[end] > ord.depths[start] {
+        end += 1;
+    }
+    end
+}
+
+/// Start of the group containing `p` (the nearest header row at or above `p`).
+fn group_start(ord: &SessionOrder, p: usize) -> Option<usize> {
+    (0..=p).rev().find(|&q| ord.headers[q].is_some())
+}
+
+/// End of the group starting at `start`: the next header row, or the list end.
+fn group_end(ord: &SessionOrder, start: usize) -> usize {
+    let n = ord.order.len();
+    (start + 1..n)
+        .find(|&q| ord.headers[q].is_some())
+        .unwrap_or(n)
+}
+
+/// Adjacent ranges to swap when moving a **root** block (depth 0): with the
+/// neighbouring root block in the same group, or — at a group edge — the whole
+/// group with its neighbouring group. `None` at the top/bottom of the list.
+fn move_root_block_range(
+    ord: &SessionOrder,
+    pos: usize,
+    down: bool,
+) -> Option<(std::ops::Range<usize>, std::ops::Range<usize>)> {
+    let n = ord.order.len();
+    let end = block_end(ord, pos);
+    let gs = group_start(ord, pos)?;
+    let ge = group_end(ord, gs);
+
+    if down {
+        if end < ge {
+            // Swap with the next root block in the group.
+            Some((pos..end, end..block_end(ord, end)))
+        } else if ge < n {
+            // Last root block: the whole group swaps with the next group.
+            Some((gs..ge, ge..group_end(ord, ge)))
         } else {
-            return None; // top of the list
+            None // bottom of the list
         }
-    } else if down {
+    } else if pos > gs {
+        // Swap with the previous root block in the group.
+        let prev = (gs..pos).rev().find(|&q| ord.depths[q] == 0)?;
+        Some((prev..pos, pos..end))
+    } else if gs > 0 {
+        // First root block: the whole group swaps with the previous group.
+        let pgs = group_start(ord, gs - 1)?;
+        Some((pgs..gs, gs..ge))
+    } else {
+        None // top of the list
+    }
+}
+
+/// Adjacent ranges to swap when moving a **nested child**: with the adjacent
+/// same-depth sibling only (never leaving its parent). `None` at the first/last
+/// sibling.
+fn move_child_block_range(
+    ord: &SessionOrder,
+    pos: usize,
+    down: bool,
+) -> Option<(std::ops::Range<usize>, std::ops::Range<usize>)> {
+    let n = ord.order.len();
+    let depth = ord.depths[pos];
+    let end = block_end(ord, pos);
+
+    if down {
         // Next sibling starts right after our block, at the same depth; a
         // shallower row there means the parent's subtree (or group) ended.
         if end < n && ord.depths[end] == depth {
-            (pos..end, end..block_end(end))
+            Some((pos..end, end..block_end(ord, end)))
         } else {
-            return None; // last sibling
+            None // last sibling
         }
     } else {
         // Scan back over deeper rows (the previous sibling's subtree); a
@@ -336,19 +380,11 @@ pub fn move_in_order(
             p -= 1;
         }
         if ord.depths[p] == depth {
-            (p..pos, pos..end)
+            Some((p..pos, pos..end))
         } else {
-            return None; // first sibling
+            None // first sibling
         }
-    };
-
-    debug_assert_eq!(a.end, b.start);
-    let mut new_order = Vec::with_capacity(n);
-    new_order.extend_from_slice(&ord.order[..a.start]);
-    new_order.extend_from_slice(&ord.order[b.start..b.end]);
-    new_order.extend_from_slice(&ord.order[a.start..a.end]);
-    new_order.extend_from_slice(&ord.order[b.end..]);
-    Some(new_order)
+    }
 }
 
 /// Display-ordered view of the session list. All fields are parallel arrays


### PR DESCRIPTION
## Summary

- **SonarQube cleanup** — reduced cognitive complexity (rule `rust:S3776`) of the
  functions that were genuinely over threshold in current code, by extracting
  private helpers and flattening nesting (no public signatures or behavior
  changed): `key_handlers::handle_key` (~58→~12), `dispatch_action` (split + new
  `gated()` helper), `handle_automations_pane_key` (~31→~9),
  `app::mod::restore_sessions`, `view::render_help_overlay`,
  `project_list::move_in_order`. Most of the 35 stale Sonar issues (last scan
  2026-04-14, 6 flagged files since removed) were already fixed in current code
  and will clear on the next scan.
- **Readline editing in modal text fields** — thurbox's own text inputs
  (session/branch name, repo-picker path & search, automation/task editors) now
  accept the full standard emacs/readline chords, matching terminal muscle
  memory: `Ctrl+A`/`E` line start/end, `Ctrl+B`/`F` move char, `Ctrl+H`/`D`
  delete char, `Ctrl+K` kill to line end — extending the existing `Ctrl+W`/`U`.
  Centralised in `modals::apply_ctrl_line_edit` over the `LineEdit` trait.

## Test plan

- `cargo check` / `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all` — 1220 pass; the 4 remaining failures pre-exist on `main`
  (verified on `f4bcc02`) and are sandbox-environmental, unrelated to this change
- New unit tests cover every added readline chord on both `TextInput` and `TextArea`
- CI checks pass