### PR TITLE
refactor: reduce cognitive complexity below SonarQube S3776 threshold

### DIFF
--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -120,44 +120,54 @@ pub fn load_or_seed_with_warnings() -> (AgentRegistry, Vec<String>) {
     };
 
     if !path.exists() {
-        if let Some(parent) = path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                return (
-                    builtin_registry(),
-                    vec![format!("Failed to create config dir for agents.toml: {e}")],
-                );
-            }
-        }
-        if let Err(e) = std::fs::write(&path, BUILTIN_AGENTS_TOML) {
-            return (
-                builtin_registry(),
-                vec![format!("Failed to seed agents.toml: {e}")],
-            );
-        }
-        tracing::info!(path = %path.display(), "Seeded agents.toml with built-in agents");
-        return (builtin_registry(), Vec::new());
+        return seed_agents_toml(&path);
     }
 
     match std::fs::read_to_string(&path) {
-        Ok(contents) => {
-            match parse_toml_reporting_unknown::<AgentRegistry>(&contents, "agents.toml") {
-                Ok((reg, warnings)) if !reg.agents.is_empty() => (reg, warnings),
-                Ok(_) => (
-                    builtin_registry(),
-                    vec!["agents.toml has no agents; using built-in agents".into()],
-                ),
-                Err(e) => (
-                    builtin_registry(),
-                    vec![format!(
-                        "agents.toml: {}; using built-in agents",
-                        compact_toml_error(&e.to_string())
-                    )],
-                ),
-            }
-        }
+        Ok(contents) => parse_agents_toml(&contents),
         Err(e) => (
             builtin_registry(),
             vec![format!("Failed to read agents.toml: {e}")],
+        ),
+    }
+}
+
+/// Write the bundled agents.toml on first run, degrading to the built-in
+/// registry (with a warning) if the dir or file can't be created.
+fn seed_agents_toml(path: &std::path::Path) -> (AgentRegistry, Vec<String>) {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return (
+                builtin_registry(),
+                vec![format!("Failed to create config dir for agents.toml: {e}")],
+            );
+        }
+    }
+    if let Err(e) = std::fs::write(path, BUILTIN_AGENTS_TOML) {
+        return (
+            builtin_registry(),
+            vec![format!("Failed to seed agents.toml: {e}")],
+        );
+    }
+    tracing::info!(path = %path.display(), "Seeded agents.toml with built-in agents");
+    (builtin_registry(), Vec::new())
+}
+
+/// Parse agents.toml contents, falling back to the built-in registry (with a
+/// warning) on parse error or an empty agent list.
+fn parse_agents_toml(contents: &str) -> (AgentRegistry, Vec<String>) {
+    match parse_toml_reporting_unknown::<AgentRegistry>(contents, "agents.toml") {
+        Ok((reg, warnings)) if !reg.agents.is_empty() => (reg, warnings),
+        Ok(_) => (
+            builtin_registry(),
+            vec!["agents.toml has no agents; using built-in agents".into()],
+        ),
+        Err(e) => (
+            builtin_registry(),
+            vec![format!(
+                "agents.toml: {}; using built-in agents",
+                compact_toml_error(&e.to_string())
+            )],
         ),
     }
 }

--- a/src/agent/extension_config.rs
+++ b/src/agent/extension_config.rs
@@ -432,41 +432,7 @@ pub fn remove_agents_from_toml(names: &[String]) -> Result<Vec<String>, String> 
         std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
 
     let lines: Vec<&str> = text.lines().collect();
-    let mut out: Vec<&str> = Vec::with_capacity(lines.len());
-    let mut removed = Vec::new();
-    let mut i = 0;
-    while i < lines.len() {
-        let trimmed = lines[i].trim_start();
-        if trimmed.starts_with("[[agents]]") {
-            // Collect this block: from the header to just before the next
-            // top-level table header (`[` at the start of a trimmed line) or EOF.
-            let start = i;
-            let mut j = i + 1;
-            while j < lines.len() && !lines[j].trim_start().starts_with('[') {
-                j += 1;
-            }
-            let block = &lines[start..j];
-            let target = block.iter().find_map(|l| parse_agent_name(l));
-            match target {
-                Some(name) if names.iter().any(|n| n == &name) => {
-                    removed.push(name);
-                    // Drop the block and a single trailing blank separator line.
-                    i = j;
-                    if i < lines.len() && lines[i].trim().is_empty() {
-                        i += 1;
-                    }
-                    continue;
-                }
-                _ => {
-                    out.extend_from_slice(block);
-                    i = j;
-                    continue;
-                }
-            }
-        }
-        out.push(lines[i]);
-        i += 1;
-    }
+    let (out, removed) = strip_agent_blocks(&lines, names);
 
     if removed.is_empty() {
         return Ok(Vec::new());
@@ -477,6 +443,65 @@ pub fn remove_agents_from_toml(names: &[String]) -> Result<Vec<String>, String> 
     }
     std::fs::write(&path, new_text).map_err(|e| format!("write {}: {e}", path.display()))?;
     Ok(removed)
+}
+
+/// Walk `lines`, dropping every `[[agents]]` block whose `name` is in `names`
+/// (with a single trailing blank separator). Returns the kept lines and the
+/// names actually removed.
+fn strip_agent_blocks<'a>(lines: &[&'a str], names: &[String]) -> (Vec<&'a str>, Vec<String>) {
+    let mut out: Vec<&str> = Vec::with_capacity(lines.len());
+    let mut removed = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if !lines[i].trim_start().starts_with("[[agents]]") {
+            out.push(lines[i]);
+            i += 1;
+            continue;
+        }
+        i = take_agent_block(lines, i, names, &mut out, &mut removed);
+    }
+    (out, removed)
+}
+
+/// Handle a single `[[agents]]` block starting at `start`: either keep it
+/// (append to `out`) or drop it (record the name in `removed`). Returns the
+/// index to resume scanning from.
+fn take_agent_block<'a>(
+    lines: &[&'a str],
+    start: usize,
+    names: &[String],
+    out: &mut Vec<&'a str>,
+    removed: &mut Vec<String>,
+) -> usize {
+    // Collect this block: from the header to just before the next
+    // top-level table header (`[` at the start of a trimmed line) or EOF.
+    let end = agent_block_end(lines, start);
+    let block = &lines[start..end];
+    let target = block
+        .iter()
+        .find_map(|l| parse_agent_name(l))
+        .filter(|name| names.iter().any(|n| n == name));
+    let Some(name) = target else {
+        out.extend_from_slice(block);
+        return end;
+    };
+    removed.push(name);
+    // Drop the block and a single trailing blank separator line.
+    if end < lines.len() && lines[end].trim().is_empty() {
+        end + 1
+    } else {
+        end
+    }
+}
+
+/// Index just past the `[[agents]]` block starting at `start` — the next line
+/// whose trimmed form begins a top-level table header (`[`), or EOF.
+fn agent_block_end(lines: &[&str], start: usize) -> usize {
+    let mut j = start + 1;
+    while j < lines.len() && !lines[j].trim_start().starts_with('[') {
+        j += 1;
+    }
+    j
 }
 
 /// Parse `name = "x"` out of a TOML line, returning the value.

--- a/src/agent/input.rs
+++ b/src/agent/input.rs
@@ -14,28 +14,11 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
     let ctrl = modifiers.contains(KeyModifiers::CONTROL);
     let modifier_param = xterm_modifier(shift, alt, ctrl);
 
-    // Ctrl+letter → control character (0x01..=0x1A), optionally wrapped with ESC for Alt
-    if let Some(bytes) = ctrl_letter_bytes(code, shift, alt, ctrl) {
+    if let Some(bytes) = ctrl_or_shift_special_bytes(code, shift, alt, ctrl) {
         return Some(bytes);
     }
 
-    // Shift+Enter → ESC [ 13;2u (xterm modifyOtherKeys / kitty protocol)
-    if shift && code == KeyCode::Enter {
-        return Some(b"\x1b[13;2u".to_vec());
-    }
-
-    // BackTab / Shift+Tab → reverse tab (CSI Z)
-    if matches!(code, KeyCode::BackTab) || (shift && code == KeyCode::Tab) {
-        return Some(b"\x1b[Z".to_vec());
-    }
-
-    // Cursor keys & navigation with modifiers: CSI 1;<mod> X
-    if let Some(bytes) = cursor_key_bytes(code, modifier_param) {
-        return Some(bytes);
-    }
-
-    // Extended keys with modifiers: CSI <num>;<mod> ~
-    if let Some(bytes) = extended_key_bytes(code, modifier_param) {
+    if let Some(bytes) = csi_key_bytes(code, modifier_param) {
         return Some(bytes);
     }
 
@@ -57,6 +40,43 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
     }
 
     unmodified_key(code)
+}
+
+/// Ctrl+letter and the Shift-special keys (Shift+Enter, reverse-tab) that have
+/// dedicated encodings handled before the generic CSI/Alt paths.
+fn ctrl_or_shift_special_bytes(
+    code: KeyCode,
+    shift: bool,
+    alt: bool,
+    ctrl: bool,
+) -> Option<Vec<u8>> {
+    // Ctrl+letter → control character (0x01..=0x1A), optionally wrapped with ESC for Alt
+    if let Some(bytes) = ctrl_letter_bytes(code, shift, alt, ctrl) {
+        return Some(bytes);
+    }
+
+    // Shift+Enter → ESC [ 13;2u (xterm modifyOtherKeys / kitty protocol)
+    if shift && code == KeyCode::Enter {
+        return Some(b"\x1b[13;2u".to_vec());
+    }
+
+    // BackTab / Shift+Tab → reverse tab (CSI Z)
+    if matches!(code, KeyCode::BackTab) || (shift && code == KeyCode::Tab) {
+        return Some(b"\x1b[Z".to_vec());
+    }
+
+    None
+}
+
+/// Cursor/navigation and extended keys that share the CSI `1;<mod>` family.
+fn csi_key_bytes(code: KeyCode, modifier_param: u8) -> Option<Vec<u8>> {
+    // Cursor keys & navigation with modifiers: CSI 1;<mod> X
+    if let Some(bytes) = cursor_key_bytes(code, modifier_param) {
+        return Some(bytes);
+    }
+
+    // Extended keys with modifiers: CSI <num>;<mod> ~
+    extended_key_bytes(code, modifier_param)
 }
 
 /// Encode a `char` as its UTF-8 bytes.

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -934,11 +934,7 @@ impl App {
         match code {
             KeyCode::Esc => {
                 self.modal.close();
-                self.new_session.base_branch = None;
-                self.new_session.repo_path = None;
-                self.new_session.all_repos = None;
-                self.new_session.normal_repos.clear();
-                self.new_session.session_name = None;
+                self.cancel_worktree_name();
             }
             KeyCode::Enter => {
                 let new_branch = wn.name.value().trim().to_string();
@@ -947,29 +943,39 @@ impl App {
                     return;
                 }
                 self.modal.close();
-                if let Some(base_branch) = self.new_session.base_branch.take() {
-                    // Use all repos for multi-repo projects, single repo otherwise
-                    let repo_paths = if let Some(all_repos) = self.new_session.all_repos.take() {
-                        self.new_session.repo_path = None;
-                        all_repos
-                    } else if let Some(repo_path) = self.new_session.repo_path.take() {
-                        vec![repo_path]
-                    } else {
-                        return;
-                    };
-                    let session_name = self.new_session.session_name.take();
-                    self.spawn_worktree_session(
-                        &repo_paths,
-                        &new_branch,
-                        &base_branch,
-                        session_name,
-                    );
-                }
+                self.confirm_worktree_name(&new_branch);
             }
             other => {
                 super::modals::apply_text_input_key(Some(&mut wn.name), other, mods);
             }
         }
+    }
+
+    /// Clear the worktree-flow pending state when the branch-name modal is cancelled.
+    fn cancel_worktree_name(&mut self) {
+        self.new_session.base_branch = None;
+        self.new_session.repo_path = None;
+        self.new_session.all_repos = None;
+        self.new_session.normal_repos.clear();
+        self.new_session.session_name = None;
+    }
+
+    /// Spawn the worktree session for the confirmed branch name.
+    fn confirm_worktree_name(&mut self, new_branch: &str) {
+        let Some(base_branch) = self.new_session.base_branch.take() else {
+            return;
+        };
+        // Use all repos for multi-repo projects, single repo otherwise
+        let repo_paths = if let Some(all_repos) = self.new_session.all_repos.take() {
+            self.new_session.repo_path = None;
+            all_repos
+        } else if let Some(repo_path) = self.new_session.repo_path.take() {
+            vec![repo_path]
+        } else {
+            return;
+        };
+        let session_name = self.new_session.session_name.take();
+        self.spawn_worktree_session(&repo_paths, new_branch, &base_branch, session_name);
     }
 
     fn handle_session_name_key(&mut self, code: KeyCode, mods: KeyModifiers) {
@@ -979,19 +985,7 @@ impl App {
         match code {
             KeyCode::Esc => {
                 self.modal.close();
-                if self.new_session.base_branch.is_some() {
-                    // Worktree flow — clean up worktree-specific pending state.
-                    self.new_session.base_branch = None;
-                    self.new_session.repo_path = None;
-                    self.new_session.all_repos = None;
-                    self.new_session.normal_repos.clear();
-                } else {
-                    // Normal flow — clean up spawn state.
-                    self.new_session.spawn_config = None;
-                    self.new_session.spawn_worktrees.clear();
-                    self.new_session.fork = false;
-                    self.new_session.parent_session_id = None;
-                }
+                self.cancel_session_name();
             }
             KeyCode::Enter => {
                 let name = sn.name.value().trim().to_string();
@@ -1000,27 +994,49 @@ impl App {
                     return;
                 }
                 self.modal.close();
-                if self.new_session.base_branch.is_some() {
-                    // Worktree flow — proceed to branch name input.
-                    let branch = session_name_to_branch(&name);
-                    self.new_session.session_name = Some(name);
-                    let mut modal = super::modals::WorktreeNameModal::default();
-                    modal.name.set(&branch);
-                    self.modal = super::modals::Modal::WorktreeName(modal);
-                } else if let Some(config) = self.new_session.spawn_config.take() {
-                    let worktrees = std::mem::take(&mut self.new_session.spawn_worktrees);
-                    if self.new_session.fork {
-                        // Fork flow — role already set, spawn directly.
-                        self.new_session.fork = false;
-                        self.do_spawn_session_async(name, &config, worktrees);
-                    } else {
-                        // Normal flow — proceed to role selection / spawn.
-                        self.finish_prepare_spawn(name, config, worktrees);
-                    }
-                }
+                self.confirm_session_name(name);
             }
             other => {
                 super::modals::apply_text_input_key(Some(&mut sn.name), other, mods);
+            }
+        }
+    }
+
+    /// Clear pending state when the session-name modal is cancelled.
+    fn cancel_session_name(&mut self) {
+        if self.new_session.base_branch.is_some() {
+            // Worktree flow — clean up worktree-specific pending state.
+            self.new_session.base_branch = None;
+            self.new_session.repo_path = None;
+            self.new_session.all_repos = None;
+            self.new_session.normal_repos.clear();
+        } else {
+            // Normal flow — clean up spawn state.
+            self.new_session.spawn_config = None;
+            self.new_session.spawn_worktrees.clear();
+            self.new_session.fork = false;
+            self.new_session.parent_session_id = None;
+        }
+    }
+
+    /// Advance from the confirmed session name to the next step of the flow.
+    fn confirm_session_name(&mut self, name: String) {
+        if self.new_session.base_branch.is_some() {
+            // Worktree flow — proceed to branch name input.
+            let branch = session_name_to_branch(&name);
+            self.new_session.session_name = Some(name);
+            let mut modal = super::modals::WorktreeNameModal::default();
+            modal.name.set(&branch);
+            self.modal = super::modals::Modal::WorktreeName(modal);
+        } else if let Some(config) = self.new_session.spawn_config.take() {
+            let worktrees = std::mem::take(&mut self.new_session.spawn_worktrees);
+            if self.new_session.fork {
+                // Fork flow — role already set, spawn directly.
+                self.new_session.fork = false;
+                self.do_spawn_session_async(name, &config, worktrees);
+            } else {
+                // Normal flow — proceed to role selection / spawn.
+                self.finish_prepare_spawn(name, config, worktrees);
             }
         }
     }
@@ -1040,26 +1056,35 @@ impl App {
     }
 
     fn handle_automations_list_key(&mut self, code: KeyCode) {
-        if let super::modals::Modal::AutomationsList(ref mut al) = self.modal {
-            match code {
-                KeyCode::Esc => {
-                    self.modal.close();
-                    return;
-                }
-                KeyCode::Char('j') | KeyCode::Down => {
-                    if al.index + 1 < al.entries.len() {
-                        al.index += 1;
-                    }
-                    return;
-                }
-                KeyCode::Char('k') | KeyCode::Up => {
-                    al.index = al.index.saturating_sub(1);
-                    return;
-                }
-                _ => {}
-            }
+        if self.handle_automations_list_nav(code) {
+            return;
         }
+        self.handle_automations_list_action(code);
+    }
 
+    /// Close/select navigation for the automations list modal. Returns `true`
+    /// when the key was consumed as navigation.
+    fn handle_automations_list_nav(&mut self, code: KeyCode) -> bool {
+        let super::modals::Modal::AutomationsList(ref mut al) = self.modal else {
+            return false;
+        };
+        match code {
+            KeyCode::Esc => self.modal.close(),
+            KeyCode::Char('j') | KeyCode::Down => {
+                if al.index + 1 < al.entries.len() {
+                    al.index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                al.index = al.index.saturating_sub(1);
+            }
+            _ => return false,
+        }
+        true
+    }
+
+    /// Action keys (new/edit/toggle/run/delete) for the automations list modal.
+    fn handle_automations_list_action(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('n') => {
                 self.modal.close();
@@ -1942,37 +1967,53 @@ impl App {
         self.modal.close();
 
         if worktree_repos.is_empty() && normal_repos.is_empty() {
-            // No repos selected — spawn with HOME as cwd. For a remote target,
-            // leave cwd unset so the remote session starts in its own default
-            // directory (local $HOME is meaningless there).
-            let mut config = SessionConfig::default();
-            if self.new_session.backend.is_none() {
-                if let Some(home) = std::env::var_os("HOME") {
-                    config.cwd = Some(std::path::PathBuf::from(home));
-                }
-            }
-            self.spawn_session_with_config(&config);
+            self.spawn_repo_picker_no_repos();
         } else if !worktree_repos.is_empty() {
-            // Has worktree repos — go to branch selection.
-            // Store normal repos for inclusion after worktree creation.
-            self.new_session.repo_path = Some(worktree_repos[0].clone());
-            self.new_session.all_repos = if worktree_repos.len() > 1 {
-                Some(worktree_repos)
-            } else {
-                None
-            };
-            self.new_session.normal_repos = normal_repos;
-            self.start_branch_selection();
+            self.spawn_repo_picker_worktrees(worktree_repos, normal_repos);
         } else {
-            // All normal repos — spawn directly (local-tmux), going straight
-            // to the agent picker chain.
-            self.new_session.additional_dirs = normal_repos[1..].to_vec();
-            let config = SessionConfig {
-                cwd: Some(normal_repos[0].clone()),
-                ..SessionConfig::default()
-            };
-            self.spawn_session_with_config(&config);
+            self.spawn_repo_picker_normal(normal_repos);
         }
+    }
+
+    /// No repos selected — spawn with HOME as cwd. For a remote target,
+    /// leave cwd unset so the remote session starts in its own default
+    /// directory (local $HOME is meaningless there).
+    fn spawn_repo_picker_no_repos(&mut self) {
+        let mut config = SessionConfig::default();
+        if self.new_session.backend.is_none() {
+            if let Some(home) = std::env::var_os("HOME") {
+                config.cwd = Some(std::path::PathBuf::from(home));
+            }
+        }
+        self.spawn_session_with_config(&config);
+    }
+
+    /// Has worktree repos — go to branch selection.
+    /// Store normal repos for inclusion after worktree creation.
+    fn spawn_repo_picker_worktrees(
+        &mut self,
+        worktree_repos: Vec<std::path::PathBuf>,
+        normal_repos: Vec<std::path::PathBuf>,
+    ) {
+        self.new_session.repo_path = Some(worktree_repos[0].clone());
+        self.new_session.all_repos = if worktree_repos.len() > 1 {
+            Some(worktree_repos)
+        } else {
+            None
+        };
+        self.new_session.normal_repos = normal_repos;
+        self.start_branch_selection();
+    }
+
+    /// All normal repos — spawn directly (local-tmux), going straight
+    /// to the agent picker chain.
+    fn spawn_repo_picker_normal(&mut self, normal_repos: Vec<std::path::PathBuf>) {
+        self.new_session.additional_dirs = normal_repos[1..].to_vec();
+        let config = SessionConfig {
+            cwd: Some(normal_repos[0].clone()),
+            ..SessionConfig::default()
+        };
+        self.spawn_session_with_config(&config);
     }
 
     /// Split the selected bookmarks into (worktree repos, normal repos).

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -709,60 +709,72 @@ impl App {
     /// time, so they don't re-toast here.
     fn poll_config_reload(&mut self) {
         if config_reload::agents_mtime() != self.config_reload.agents_mtime {
-            let (registry, warnings) = crate::agent::agent_config::load_or_seed_with_warnings();
-            self.agents = registry;
-            // Re-stat after the load: a missing file gets re-seeded by it.
-            self.config_reload.agents_mtime = config_reload::agents_mtime();
-            if warnings.is_empty() {
-                self.set_status(StatusLevel::Info, "agents.toml reloaded");
-            } else {
-                self.set_status(
-                    StatusLevel::Error,
-                    format!("Config: {}", warnings.join(" · ")),
-                );
-            }
-            for w in &warnings {
-                warn!("{w}");
-            }
+            self.reload_agents_config();
         }
 
         let kb_mtime = config_reload::keybindings_mtime();
         if kb_mtime != self.config_reload.keybindings_mtime {
             self.config_reload.keybindings_mtime = kb_mtime;
-            let (bindings, warnings) = match crate::storage::keybindings::load_keybindings_json() {
-                Ok(Some(json)) => {
-                    match crate::session::KeyBindings::from_json_with_warnings(&json) {
-                        Ok((bindings, warnings)) => (
-                            bindings,
-                            warnings
-                                .into_iter()
-                                .map(|w| format!("keybindings.json: {w}"))
-                                .collect(),
-                        ),
-                        Err(e) => (
-                            crate::session::KeyBindings::default(),
-                            vec![format!("keybindings.json: {e}; using default keybindings")],
-                        ),
-                    }
-                }
-                Ok(None) => (crate::session::KeyBindings::default(), Vec::new()),
+            self.reload_keybindings_config();
+        }
+    }
+
+    /// Reload `agents.toml` and toast the result. Caller has already detected an
+    /// mtime change; this re-stats afterwards so a re-seeded file is recorded.
+    fn reload_agents_config(&mut self) {
+        let (registry, warnings) = crate::agent::agent_config::load_or_seed_with_warnings();
+        self.agents = registry;
+        // Re-stat after the load: a missing file gets re-seeded by it.
+        self.config_reload.agents_mtime = config_reload::agents_mtime();
+        self.toast_config_reload("agents.toml reloaded", &warnings);
+    }
+
+    /// Reload `keybindings.json` and toast the result. Caller has already
+    /// recorded the new mtime.
+    fn reload_keybindings_config(&mut self) {
+        let (bindings, warnings) = Self::load_keybindings_with_warnings();
+        self.keybindings = bindings;
+        self.toast_config_reload("keybindings.json reloaded", &warnings);
+    }
+
+    /// Load the on-disk keybindings, falling back to defaults (with a warning)
+    /// on any read/parse error.
+    fn load_keybindings_with_warnings() -> (crate::session::KeyBindings, Vec<String>) {
+        match crate::storage::keybindings::load_keybindings_json() {
+            Ok(Some(json)) => match crate::session::KeyBindings::from_json_with_warnings(&json) {
+                Ok((bindings, warnings)) => (
+                    bindings,
+                    warnings
+                        .into_iter()
+                        .map(|w| format!("keybindings.json: {w}"))
+                        .collect(),
+                ),
                 Err(e) => (
                     crate::session::KeyBindings::default(),
                     vec![format!("keybindings.json: {e}; using default keybindings")],
                 ),
-            };
-            self.keybindings = bindings;
-            if warnings.is_empty() {
-                self.set_status(StatusLevel::Info, "keybindings.json reloaded");
-            } else {
-                self.set_status(
-                    StatusLevel::Error,
-                    format!("Config: {}", warnings.join(" · ")),
-                );
-            }
-            for w in &warnings {
-                warn!("{w}");
-            }
+            },
+            Ok(None) => (crate::session::KeyBindings::default(), Vec::new()),
+            Err(e) => (
+                crate::session::KeyBindings::default(),
+                vec![format!("keybindings.json: {e}; using default keybindings")],
+            ),
+        }
+    }
+
+    /// Toast the outcome of a live config reload: an info `ok` line when clean,
+    /// otherwise the joined warnings (also logged).
+    fn toast_config_reload(&mut self, ok: &str, warnings: &[String]) {
+        if warnings.is_empty() {
+            self.set_status(StatusLevel::Info, ok);
+        } else {
+            self.set_status(
+                StatusLevel::Error,
+                format!("Config: {}", warnings.join(" · ")),
+            );
+        }
+        for w in warnings {
+            warn!("{w}");
         }
     }
 
@@ -1893,8 +1905,14 @@ impl App {
             return;
         }
 
+        self.scroll_pane(self.pane_at(x, y), up);
+    }
+
+    /// Apply a wheel tick (`up`) to a specific scrollable pane (the terminal
+    /// when `pane` is `None`/`Terminal`).
+    fn scroll_pane(&mut self, pane: Option<ScrollPane>, up: bool) {
         let step: i32 = if up { -1 } else { 1 };
-        match self.pane_at(x, y) {
+        match pane {
             Some(ScrollPane::Terminal) | None => {
                 if up {
                     self.scroll_terminal_up(MOUSE_SCROLL_LINES);
@@ -2697,22 +2715,7 @@ impl App {
     pub fn tick(&mut self) {
         self.metrics.tick_count = self.metrics.tick_count.wrapping_add(1);
 
-        // Run the debounced global-search content scan once the query has been
-        // settled for the debounce window (Instant-based, since tick cadence is
-        // event-load-dependent).
-        if self.global_search.active && self.global_search.content_dirty {
-            let settled = self
-                .global_search
-                .query_changed_at
-                .map(|t| {
-                    t.elapsed() >= std::time::Duration::from_millis(search::CONTENT_DEBOUNCE_MS)
-                })
-                .unwrap_or(false);
-            if settled {
-                self.recompute_global_search_content();
-                self.global_search.content_dirty = false;
-            }
-        }
+        self.tick_global_search_content();
 
         self.refresh_session_statuses();
 
@@ -2727,19 +2730,7 @@ impl App {
         // Send deferred inputs whose delay has elapsed
         self.drain_deferred_inputs();
 
-        // Finalize pending delete after undo timeout
-        if let Some(ref pending) = self.pending_delete {
-            if pending.created_at.elapsed() >= UNDO_TIMEOUT {
-                self.finalize_pending_delete();
-            }
-        }
-
-        // Auto-expire status messages so default project/session counts reappear
-        if let Some(ref msg) = self.status_message {
-            if msg.created_at.elapsed() >= STATUS_MESSAGE_TIMEOUT {
-                self.status_message = None;
-            }
-        }
+        self.tick_expire_timers();
 
         self.poll_external_changes();
 
@@ -2755,10 +2746,50 @@ impl App {
             self.refresh_tasks();
         }
 
-        // Apply completed background metric/git-stat refreshes, then kick off
-        // the next one on its cadence. Both run off the UI thread (sysinfo +
-        // statusline file reads / `git` shell-outs) so a slow read never stalls
-        // rendering — mirrors the worktree-sync poll above.
+        self.tick_background_refreshes();
+    }
+
+    /// Run the debounced global-search content scan once the query has been
+    /// settled for the debounce window (Instant-based, since tick cadence is
+    /// event-load-dependent).
+    fn tick_global_search_content(&mut self) {
+        if !(self.global_search.active && self.global_search.content_dirty) {
+            return;
+        }
+        let settled = self
+            .global_search
+            .query_changed_at
+            .map(|t| t.elapsed() >= std::time::Duration::from_millis(search::CONTENT_DEBOUNCE_MS))
+            .unwrap_or(false);
+        if settled {
+            self.recompute_global_search_content();
+            self.global_search.content_dirty = false;
+        }
+    }
+
+    /// Expire the undo window for a pending delete and auto-clear stale status
+    /// messages so default project/session counts reappear.
+    fn tick_expire_timers(&mut self) {
+        // Finalize pending delete after undo timeout
+        if let Some(ref pending) = self.pending_delete {
+            if pending.created_at.elapsed() >= UNDO_TIMEOUT {
+                self.finalize_pending_delete();
+            }
+        }
+
+        // Auto-expire status messages so default project/session counts reappear
+        if let Some(ref msg) = self.status_message {
+            if msg.created_at.elapsed() >= STATUS_MESSAGE_TIMEOUT {
+                self.status_message = None;
+            }
+        }
+    }
+
+    /// Apply completed background metric/git-stat/usage refreshes and kick off
+    /// the next ones on their cadences. All run off the UI thread (sysinfo +
+    /// statusline file reads / `git` shell-outs) so a slow read never stalls
+    /// rendering — mirrors the worktree-sync poll.
+    fn tick_background_refreshes(&mut self) {
         self.poll_metrics_refresh();
         self.poll_git_stats();
 
@@ -4139,31 +4170,8 @@ impl App {
 
         let timezone = m.timezone();
 
-        let action = match m.action {
-            modals::AutomationActionKind::Send => {
-                let Some(session_id) = m.selected_target().map(|(id, _)| *id) else {
-                    self.set_error("No target session — start a session first");
-                    return false;
-                };
-                AutomationAction::Send { session_id }
-            }
-            modals::AutomationActionKind::Spawn => {
-                let repo = m.repo.value().trim();
-                if repo.is_empty() {
-                    self.set_error("Repo path required for spawn action");
-                    return false;
-                }
-                let worktree = m.worktree.value().trim();
-                let agent = m.agent.value().trim();
-                AutomationAction::Spawn {
-                    // Expand `~` so the stored path is absolute (git and the
-                    // session cwd don't expand it themselves).
-                    repo_path: crate::paths::expand_tilde(repo),
-                    worktree_branch: (!worktree.is_empty()).then(|| worktree.to_string()),
-                    base_branch: None,
-                    agent: (!agent.is_empty()).then(|| agent.to_string()),
-                }
-            }
+        let Some(action) = self.build_automation_action(m) else {
+            return false;
         };
 
         let next_run_at = m
@@ -4171,36 +4179,17 @@ impl App {
             .then(|| schedule.next_after(now, timezone.as_deref()))
             .flatten();
 
-        let result = match m.editing_id {
-            Some(id) => match self.db.get_automation(id) {
-                Ok(Some(mut auto)) => {
-                    auto.name = name;
-                    auto.prompt = prompt;
-                    auto.schedule = schedule;
-                    auto.timezone = timezone;
-                    auto.action = action;
-                    auto.enabled = m.enabled;
-                    auto.next_run_at = next_run_at;
-                    self.db.update_automation(&auto)
-                }
-                Ok(None) => {
-                    self.set_error("Automation no longer exists");
-                    return false;
-                }
-                Err(e) => Err(e),
-            },
-            None => {
-                let new = crate::storage::automations::NewAutomation {
-                    name,
-                    enabled: m.enabled,
-                    schedule,
-                    timezone,
-                    action,
-                    prompt,
-                    next_run_at,
-                };
-                self.db.create_automation(&new).map(|_| ())
-            }
+        let new = crate::storage::automations::NewAutomation {
+            name,
+            enabled: m.enabled,
+            schedule,
+            timezone,
+            action,
+            prompt,
+            next_run_at,
+        };
+        let Some(result) = self.persist_automation(m.editing_id, new) else {
+            return false;
         };
 
         if let Err(e) = result {
@@ -4211,6 +4200,70 @@ impl App {
         self.refresh_automations();
         self.set_status(StatusLevel::Success, "Automation saved");
         true
+    }
+
+    /// Build the [`AutomationAction`] from the editor's action fields. Returns
+    /// `None` (after setting an error status) when a required field is missing.
+    fn build_automation_action(
+        &mut self,
+        m: &modals::AutomationEditorModal,
+    ) -> Option<AutomationAction> {
+        match m.action {
+            modals::AutomationActionKind::Send => {
+                let Some(session_id) = m.selected_target().map(|(id, _)| *id) else {
+                    self.set_error("No target session — start a session first");
+                    return None;
+                };
+                Some(AutomationAction::Send { session_id })
+            }
+            modals::AutomationActionKind::Spawn => {
+                let repo = m.repo.value().trim();
+                if repo.is_empty() {
+                    self.set_error("Repo path required for spawn action");
+                    return None;
+                }
+                let worktree = m.worktree.value().trim();
+                let agent = m.agent.value().trim();
+                Some(AutomationAction::Spawn {
+                    // Expand `~` so the stored path is absolute (git and the
+                    // session cwd don't expand it themselves).
+                    repo_path: crate::paths::expand_tilde(repo),
+                    worktree_branch: (!worktree.is_empty()).then(|| worktree.to_string()),
+                    base_branch: None,
+                    agent: (!agent.is_empty()).then(|| agent.to_string()),
+                })
+            }
+        }
+    }
+
+    /// Persist the automation: update the existing row (`editing_id`) or create
+    /// a new one. Returns the DB result, or `None` (after an error status) when
+    /// editing a row that no longer exists.
+    fn persist_automation(
+        &mut self,
+        editing_id: Option<i64>,
+        new: crate::storage::automations::NewAutomation,
+    ) -> Option<rusqlite::Result<()>> {
+        match editing_id {
+            Some(id) => match self.db.get_automation(id) {
+                Ok(Some(mut auto)) => {
+                    auto.name = new.name;
+                    auto.prompt = new.prompt;
+                    auto.schedule = new.schedule;
+                    auto.timezone = new.timezone;
+                    auto.action = new.action;
+                    auto.enabled = new.enabled;
+                    auto.next_run_at = new.next_run_at;
+                    Some(self.db.update_automation(&auto))
+                }
+                Ok(None) => {
+                    self.set_error("Automation no longer exists");
+                    None
+                }
+                Err(e) => Some(Err(e)),
+            },
+            None => Some(self.db.create_automation(&new).map(|_| ())),
+        }
     }
 
     // ---- Tasks (right-side panel) ----------------------------------------

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -451,45 +451,43 @@ pub(super) fn apply_text_input_key(
         }
         // Ctrl+<non-letter> (arrows, Home/End): fall through to normal handling.
     }
-    match code {
-        KeyCode::Char(c) => {
-            if let Some(f) = field {
-                f.insert(c);
-            }
-        }
-        KeyCode::Backspace => {
-            if let Some(f) = field {
-                f.backspace();
-            }
-        }
-        KeyCode::Delete => {
-            if let Some(f) = field {
-                f.delete();
-            }
-        }
-        KeyCode::Left => {
-            if let Some(f) = field {
-                f.move_left();
-            }
-        }
-        KeyCode::Right => {
-            if let Some(f) = field {
-                f.move_right();
-            }
-        }
-        KeyCode::Home => {
-            if let Some(f) = field {
-                f.home();
-            }
-        }
-        KeyCode::End => {
-            if let Some(f) = field {
-                f.end();
-            }
-        }
-        _ => return false,
+    if !is_text_input_key(code) {
+        return false;
+    }
+    if let Some(f) = field {
+        apply_text_edit_op(f, code);
     }
     true
+}
+
+/// Whether `code` is a text-editing key handled by [`apply_text_input_key`]
+/// (insert/backspace/delete/cursor move).
+fn is_text_input_key(code: KeyCode) -> bool {
+    matches!(
+        code,
+        KeyCode::Char(_)
+            | KeyCode::Backspace
+            | KeyCode::Delete
+            | KeyCode::Left
+            | KeyCode::Right
+            | KeyCode::Home
+            | KeyCode::End
+    )
+}
+
+/// Apply a single text-editing key to a focused field. `code` must be a key for
+/// which [`is_text_input_key`] returns `true`; anything else is a no-op.
+fn apply_text_edit_op(f: &mut TextInput, code: KeyCode) {
+    match code {
+        KeyCode::Char(c) => f.insert(c),
+        KeyCode::Backspace => f.backspace(),
+        KeyCode::Delete => f.delete(),
+        KeyCode::Left => f.move_left(),
+        KeyCode::Right => f.move_right(),
+        KeyCode::Home => f.home(),
+        KeyCode::End => f.end(),
+        _ => {}
+    }
 }
 
 // ── Modal State Structs ────────────────────────────────────────────────────

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -535,19 +535,28 @@ impl App {
     /// targets; text-input modals report none, so every click on them is
     /// swallowed.
     fn render_modals(&mut self, frame: &mut Frame) {
-        let mut modal_hits: crate::ui::SelectorHits = (Vec::new(), None);
+        // Text-input modals report no hitboxes (every click is swallowed).
+        self.render_text_input_modals(frame);
 
-        // Help overlay (rendered last, on top of everything)
-        if let super::modals::Modal::Help(ref help) = self.modal {
-            modal_hits = render_help_overlay(frame, &self.keybindings, help);
+        // Selector modals report row hitboxes for click routing. Exactly one
+        // modal is active at a time, so the first match wins.
+        let modal_hits = self
+            .render_selector_modal(frame)
+            .unwrap_or((Vec::new(), None));
+
+        let (modal_rows, modal_geom) = modal_hits;
+        for row in modal_rows {
+            self.record_click(row.rect, ClickAction::ModalRow(row.index));
         }
+        // The modal's own scrollbar: grabbable while the modal is open
+        // (pane scrollbars beneath the overlay are not — see
+        // `handle_modal_click`).
+        self.record_scrollbar(modal_geom, ScrollTarget::Modal);
+    }
 
-        // Task trigger-time action picker
-        if let super::modals::Modal::TaskActionPicker(ref p) = self.modal {
-            modal_hits =
-                crate::ui::task_action_picker_modal::render_task_action_picker_modal(frame, p);
-        }
-
+    /// Render the text-input modals (worktree / session name). These report no
+    /// click hitboxes, so they are rendered separately from selector modals.
+    fn render_text_input_modals(&self, frame: &mut Frame) {
         // Worktree name modal
         if let super::modals::Modal::WorktreeName(ref wn) = self.modal {
             let base = self.new_session.base_branch.as_deref().unwrap_or("");
@@ -571,58 +580,60 @@ impl App {
                 },
             );
         }
+    }
+
+    /// Render whichever selector-style modal is active, returning its row
+    /// hitboxes + scrollbar geometry (`None` when no selector modal is open).
+    fn render_selector_modal(&self, frame: &mut Frame) -> Option<crate::ui::SelectorHits> {
+        // Help overlay (rendered last, on top of everything)
+        if let super::modals::Modal::Help(ref help) = self.modal {
+            return Some(render_help_overlay(frame, &self.keybindings, help));
+        }
+
+        // Task trigger-time action picker
+        if let super::modals::Modal::TaskActionPicker(ref p) = self.modal {
+            return Some(
+                crate::ui::task_action_picker_modal::render_task_action_picker_modal(frame, p),
+            );
+        }
 
         // Branch selector modal
         if let super::modals::Modal::BranchSelector(ref bs) = self.modal {
-            modal_hits = branch_selector_modal::render_branch_selector_modal(
+            return Some(branch_selector_modal::render_branch_selector_modal(
                 frame,
                 &branch_selector_modal::BranchSelectorState {
                     branches: &bs.branches,
                     selected_index: bs.index,
                 },
-            );
+            ));
         }
 
         // Agent picker modal
         if let super::modals::Modal::AgentPicker(ref ap) = self.modal {
-            modal_hits = agent_picker_modal::render_agent_picker_modal(frame, ap);
+            return Some(agent_picker_modal::render_agent_picker_modal(frame, ap));
         }
 
         // Host picker modal
         if let super::modals::Modal::HostPicker(ref hp) = self.modal {
-            modal_hits = crate::ui::host_picker_modal::render_host_picker_modal(frame, hp);
+            return Some(crate::ui::host_picker_modal::render_host_picker_modal(
+                frame, hp,
+            ));
         }
 
         // Theme picker modal
         if let super::modals::Modal::ThemePicker(ref tp) = self.modal {
-            modal_hits = theme_picker_modal::render_theme_picker_modal(
+            return Some(theme_picker_modal::render_theme_picker_modal(
                 frame,
                 &theme_picker_modal::ThemePickerState {
                     entries: &crate::ui::theme::all_theme_entries(),
                     selected_index: tp.index,
                 },
-            );
+            ));
         }
 
         // Restore sessions modal
         if let super::modals::Modal::RestoreSessions(ref rsm) = self.modal {
-            let entries: Vec<restore_sessions_modal::DeletedSessionEntry> = rsm
-                .list
-                .iter()
-                .map(|d| restore_sessions_modal::DeletedSessionEntry {
-                    name: d.name.clone(),
-                    agent: d.agent.clone(),
-                    deleted_ago: format_time_ago(d.deleted_at),
-                    has_worktrees: !d.worktrees.is_empty(),
-                })
-                .collect();
-            modal_hits = restore_sessions_modal::render_restore_sessions_modal(
-                frame,
-                &restore_sessions_modal::RestoreSessionsModalState {
-                    entries: &entries,
-                    selected_index: rsm.index,
-                },
-            );
+            return Some(self.render_restore_sessions_modal(frame, rsm));
         }
 
         // Automation editor modal (centered overlay — the Ctrl+P list path).
@@ -635,61 +646,95 @@ impl App {
                 frame,
                 &automation_editor_modal::AutomationEditorState::from_modal(m, &preview, true),
             );
+            return Some((Vec::new(), None));
         }
 
         // Automations list modal
         if let super::modals::Modal::AutomationsList(ref al) = self.modal {
-            let entries: Vec<automations_list_modal::AutomationsListEntry> = al
-                .entries
-                .iter()
-                .map(|e| automations_list_modal::AutomationsListEntry {
-                    name: e.name.clone(),
-                    summary: e.summary.clone(),
-                    enabled: e.enabled,
-                })
-                .collect();
-            modal_hits = automations_list_modal::render_automations_list_modal(
-                frame,
-                &automations_list_modal::AutomationsListState {
-                    entries: &entries,
-                    selected_index: al.index,
-                },
-            );
+            return Some(self.render_automations_list_modal(frame, al));
         }
 
         // Repo picker modal
         if let super::modals::Modal::RepoPicker(ref rp) = self.modal {
-            modal_hits = crate::ui::repo_picker_modal::render_repo_picker_modal(
-                frame,
-                &crate::ui::repo_picker_modal::RepoPickerState {
-                    bookmarks: &rp.bookmarks,
-                    selected: &rp.selected,
-                    worktree: &rp.worktree,
-                    is_header: &rp.is_header,
-                    is_child: &rp.is_child,
-                    collapsed: &rp.collapsed,
-                    list_index: rp.list_index,
-                    path_input: rp.path_input.value(),
-                    path_cursor: rp.path_input.cursor_pos(),
-                    path_suggestion: rp.path_suggestion.as_deref(),
-                    focus: rp.focus,
-                    search_query: rp.search_input.value(),
-                    search_cursor: rp.search_input.cursor_pos(),
-                    search_active: rp.focus == super::modals::RepoPickerFocus::Search
-                        || !rp.search_input.value().is_empty(),
-                    filtered_indices: &rp.filtered_indices,
-                },
-            );
+            return Some(self.render_repo_picker_modal(frame, rp));
         }
 
-        let (modal_rows, modal_geom) = modal_hits;
-        for row in modal_rows {
-            self.record_click(row.rect, ClickAction::ModalRow(row.index));
-        }
-        // The modal's own scrollbar: grabbable while the modal is open
-        // (pane scrollbars beneath the overlay are not — see
-        // `handle_modal_click`).
-        self.record_scrollbar(modal_geom, ScrollTarget::Modal);
+        None
+    }
+
+    fn render_restore_sessions_modal(
+        &self,
+        frame: &mut Frame,
+        rsm: &super::modals::RestoreSessionsModal,
+    ) -> crate::ui::SelectorHits {
+        let entries: Vec<restore_sessions_modal::DeletedSessionEntry> = rsm
+            .list
+            .iter()
+            .map(|d| restore_sessions_modal::DeletedSessionEntry {
+                name: d.name.clone(),
+                agent: d.agent.clone(),
+                deleted_ago: format_time_ago(d.deleted_at),
+                has_worktrees: !d.worktrees.is_empty(),
+            })
+            .collect();
+        restore_sessions_modal::render_restore_sessions_modal(
+            frame,
+            &restore_sessions_modal::RestoreSessionsModalState {
+                entries: &entries,
+                selected_index: rsm.index,
+            },
+        )
+    }
+
+    fn render_automations_list_modal(
+        &self,
+        frame: &mut Frame,
+        al: &super::modals::AutomationsListModal,
+    ) -> crate::ui::SelectorHits {
+        let entries: Vec<automations_list_modal::AutomationsListEntry> = al
+            .entries
+            .iter()
+            .map(|e| automations_list_modal::AutomationsListEntry {
+                name: e.name.clone(),
+                summary: e.summary.clone(),
+                enabled: e.enabled,
+            })
+            .collect();
+        automations_list_modal::render_automations_list_modal(
+            frame,
+            &automations_list_modal::AutomationsListState {
+                entries: &entries,
+                selected_index: al.index,
+            },
+        )
+    }
+
+    fn render_repo_picker_modal(
+        &self,
+        frame: &mut Frame,
+        rp: &super::modals::RepoPickerModal,
+    ) -> crate::ui::SelectorHits {
+        crate::ui::repo_picker_modal::render_repo_picker_modal(
+            frame,
+            &crate::ui::repo_picker_modal::RepoPickerState {
+                bookmarks: &rp.bookmarks,
+                selected: &rp.selected,
+                worktree: &rp.worktree,
+                is_header: &rp.is_header,
+                is_child: &rp.is_child,
+                collapsed: &rp.collapsed,
+                list_index: rp.list_index,
+                path_input: rp.path_input.value(),
+                path_cursor: rp.path_input.cursor_pos(),
+                path_suggestion: rp.path_suggestion.as_deref(),
+                focus: rp.focus,
+                search_query: rp.search_input.value(),
+                search_cursor: rp.search_input.cursor_pos(),
+                search_active: rp.focus == super::modals::RepoPickerFocus::Search
+                    || !rp.search_input.value().is_empty(),
+                filtered_indices: &rp.filtered_indices,
+            },
+        )
     }
 
     /// Repaint cells that fell back to terminal-default colours with the
@@ -708,12 +753,7 @@ impl App {
             for x in area.x..area.x + area.width {
                 let pos = ratatui::layout::Position::new(x, y);
                 if let Some(cell) = buf.cell_mut(pos) {
-                    if cell.bg == ratatui::style::Color::Reset {
-                        cell.bg = app_bg;
-                    }
-                    if cell.fg == ratatui::style::Color::Reset {
-                        cell.fg = text_primary;
-                    }
+                    repaint_reset_cell(cell, app_bg, text_primary);
                 }
             }
         }
@@ -1286,6 +1326,22 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(vertical[1])[1]
+}
+
+/// Replace a cell's terminal-default (`Color::Reset`) background/foreground
+/// with the active theme's `app_bg` / `text_primary`. Cells with an explicit
+/// colour are left untouched.
+fn repaint_reset_cell(
+    cell: &mut ratatui::buffer::Cell,
+    app_bg: ratatui::style::Color,
+    text_primary: ratatui::style::Color,
+) {
+    if cell.bg == ratatui::style::Color::Reset {
+        cell.bg = app_bg;
+    }
+    if cell.fg == ratatui::style::Color::Reset {
+        cell.fg = text_primary;
+    }
 }
 
 /// Format a millisecond timestamp as an absolute local clock time

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -129,52 +129,11 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             base,
             agent,
             disabled,
-        } => {
-            if prompt.is_empty() {
-                return Err("prompt must not be empty".into());
-            }
-            let schedule = parse_trigger(&trigger, time.as_deref(), weekday)?;
-            let action = resolve_action(session, repo, worktree, base, agent, db)?;
-            let next_run_at = if disabled {
-                None
-            } else {
-                schedule.next_after(current_time_millis(), timezone.as_deref())
-            };
-            let new = NewAutomation {
-                name,
-                enabled: !disabled,
-                schedule,
-                timezone,
-                action,
-                prompt,
-                next_run_at,
-            };
-            let id = db
-                .create_automation(&new)
-                .map_err(|e| format!("create_automation: {e}"))?;
-            if !disabled {
-                arm_heartbeat();
-            }
-            let auto = db
-                .get_automation(id)
-                .map_err(|e| format!("get_automation: {e}"))?
-                .ok_or("automation vanished after insert")?;
-            let human = format!(
-                "Created automation #{} '{}' ({}){}",
-                auto.id,
-                auto.name,
-                auto.schedule.kind(),
-                if auto.enabled { "" } else { " — disabled" }
-            );
-            Ok(CommandOutput::new(automation_to_json(&auto), human))
-        }
-        Action::List => {
-            let autos = db
-                .list_automations()
-                .map_err(|e| format!("list_automations: {e}"))?;
-            let json = Value::Array(autos.iter().map(automation_to_json).collect());
-            Ok(CommandOutput::new(json, render_automation_list(&autos)))
-        }
+        } => create_automation(
+            db, name, trigger, time, weekday, timezone, prompt, session, repo, worktree, base,
+            agent, disabled,
+        ),
+        Action::List => list_automations(db),
         Action::Show { id } => {
             let auto = load(db, id)?;
             Ok(CommandOutput::new(
@@ -192,63 +151,11 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             prompt,
             enabled,
             disabled,
-        } => {
-            if enabled && disabled {
-                return Err("--enabled and --disabled are mutually exclusive".into());
-            }
-            let mut auto = load(db, id)?;
-            if let Some(n) = name {
-                auto.name = n;
-            }
-            if let Some(p) = prompt {
-                auto.prompt = p;
-            }
-            if let Some(tz) = timezone {
-                auto.timezone = if tz.is_empty() { None } else { Some(tz) };
-            }
-            if let Some(t) = trigger {
-                auto.schedule = parse_trigger(&t, time.as_deref(), weekday)?;
-            }
-            if disabled {
-                auto.enabled = false;
-            }
-            if enabled {
-                auto.enabled = true;
-            }
-            // Recompute next fire after any schedule/timezone/enabled change.
-            auto.next_run_at = if auto.enabled {
-                auto.schedule
-                    .next_after(current_time_millis(), auto.timezone.as_deref())
-            } else {
-                None
-            };
-            db.update_automation(&auto)
-                .map_err(|e| format!("update_automation: {e}"))?;
-            if auto.enabled {
-                arm_heartbeat();
-            }
-            let auto = load(db, id)?;
-            Ok(CommandOutput::new(
-                automation_to_json(&auto),
-                render_automation_detail(&auto),
-            ))
-        }
-        Action::Remove { id } => match db.delete_automation(id) {
-            Ok(true) => Ok(CommandOutput::new(
-                json!({ "removed": true, "id": id }),
-                format!("Removed automation #{id}."),
-            )),
-            Ok(false) => Err(format!("Automation not found: {id}")),
-            Err(e) => Err(format!("delete_automation: {e}")),
-        },
-        Action::Run { id } => match db.trigger_automation_now(id) {
-            Ok(true) => Ok(CommandOutput::new(
-                json!({ "triggered": true, "id": id }),
-                format!("Triggered automation #{id} (fires on the next tick)."),
-            )),
-            Ok(false) => Err(format!("Automation not found: {id}")),
-            Err(e) => Err(format!("trigger_automation_now: {e}")),
-        },
+        } => edit_automation(
+            db, id, name, trigger, time, weekday, timezone, prompt, enabled, disabled,
+        ),
+        Action::Remove { id } => remove_automation(db, id),
+        Action::Run { id } => trigger_automation(db, id),
         Action::Runs { id, limit } => {
             let runs = db
                 .list_automation_runs(id, limit.unwrap_or(20))
@@ -261,6 +168,164 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             let human = render_tick(&json);
             Ok(CommandOutput::new(json, human))
         }
+    }
+}
+
+/// Handle `automation create`: validate, persist, and arm the heartbeat.
+#[allow(clippy::too_many_arguments)]
+fn create_automation(
+    db: &Database,
+    name: String,
+    trigger: String,
+    time: Option<String>,
+    weekday: Option<u32>,
+    timezone: Option<String>,
+    prompt: String,
+    session: Option<String>,
+    repo: Option<String>,
+    worktree: Option<String>,
+    base: Option<String>,
+    agent: Option<String>,
+    disabled: bool,
+) -> Result<CommandOutput, String> {
+    if prompt.is_empty() {
+        return Err("prompt must not be empty".into());
+    }
+    let schedule = parse_trigger(&trigger, time.as_deref(), weekday)?;
+    let action = resolve_action(session, repo, worktree, base, agent, db)?;
+    let next_run_at = if disabled {
+        None
+    } else {
+        schedule.next_after(current_time_millis(), timezone.as_deref())
+    };
+    let new = NewAutomation {
+        name,
+        enabled: !disabled,
+        schedule,
+        timezone,
+        action,
+        prompt,
+        next_run_at,
+    };
+    let id = db
+        .create_automation(&new)
+        .map_err(|e| format!("create_automation: {e}"))?;
+    if !disabled {
+        arm_heartbeat();
+    }
+    let auto = db
+        .get_automation(id)
+        .map_err(|e| format!("get_automation: {e}"))?
+        .ok_or("automation vanished after insert")?;
+    let human = format!(
+        "Created automation #{} '{}' ({}){}",
+        auto.id,
+        auto.name,
+        auto.schedule.kind(),
+        if auto.enabled { "" } else { " — disabled" }
+    );
+    Ok(CommandOutput::new(automation_to_json(&auto), human))
+}
+
+/// Handle `automation list`.
+fn list_automations(db: &Database) -> Result<CommandOutput, String> {
+    let autos = db
+        .list_automations()
+        .map_err(|e| format!("list_automations: {e}"))?;
+    let json = Value::Array(autos.iter().map(automation_to_json).collect());
+    Ok(CommandOutput::new(json, render_automation_list(&autos)))
+}
+
+/// Handle `automation edit`: apply the supplied field overrides and persist.
+#[allow(clippy::too_many_arguments)]
+fn edit_automation(
+    db: &Database,
+    id: i64,
+    name: Option<String>,
+    trigger: Option<String>,
+    time: Option<String>,
+    weekday: Option<u32>,
+    timezone: Option<String>,
+    prompt: Option<String>,
+    enabled: bool,
+    disabled: bool,
+) -> Result<CommandOutput, String> {
+    if enabled && disabled {
+        return Err("--enabled and --disabled are mutually exclusive".into());
+    }
+    let mut auto = load(db, id)?;
+    apply_edit_overrides(&mut auto, name, trigger, time, weekday, timezone, prompt)?;
+    if disabled {
+        auto.enabled = false;
+    }
+    if enabled {
+        auto.enabled = true;
+    }
+    // Recompute next fire after any schedule/timezone/enabled change.
+    auto.next_run_at = if auto.enabled {
+        auto.schedule
+            .next_after(current_time_millis(), auto.timezone.as_deref())
+    } else {
+        None
+    };
+    db.update_automation(&auto)
+        .map_err(|e| format!("update_automation: {e}"))?;
+    if auto.enabled {
+        arm_heartbeat();
+    }
+    let auto = load(db, id)?;
+    Ok(CommandOutput::new(
+        automation_to_json(&auto),
+        render_automation_detail(&auto),
+    ))
+}
+
+/// Apply the name/prompt/timezone/schedule overrides supplied to `edit`.
+fn apply_edit_overrides(
+    auto: &mut Automation,
+    name: Option<String>,
+    trigger: Option<String>,
+    time: Option<String>,
+    weekday: Option<u32>,
+    timezone: Option<String>,
+    prompt: Option<String>,
+) -> Result<(), String> {
+    if let Some(n) = name {
+        auto.name = n;
+    }
+    if let Some(p) = prompt {
+        auto.prompt = p;
+    }
+    if let Some(tz) = timezone {
+        auto.timezone = if tz.is_empty() { None } else { Some(tz) };
+    }
+    if let Some(t) = trigger {
+        auto.schedule = parse_trigger(&t, time.as_deref(), weekday)?;
+    }
+    Ok(())
+}
+
+/// Handle `automation remove`.
+fn remove_automation(db: &Database, id: i64) -> Result<CommandOutput, String> {
+    match db.delete_automation(id) {
+        Ok(true) => Ok(CommandOutput::new(
+            json!({ "removed": true, "id": id }),
+            format!("Removed automation #{id}."),
+        )),
+        Ok(false) => Err(format!("Automation not found: {id}")),
+        Err(e) => Err(format!("delete_automation: {e}")),
+    }
+}
+
+/// Handle `automation run`: mark the automation due for the next tick.
+fn trigger_automation(db: &Database, id: i64) -> Result<CommandOutput, String> {
+    match db.trigger_automation_now(id) {
+        Ok(true) => Ok(CommandOutput::new(
+            json!({ "triggered": true, "id": id }),
+            format!("Triggered automation #{id} (fires on the next tick)."),
+        )),
+        Ok(false) => Err(format!("Automation not found: {id}")),
+        Err(e) => Err(format!("trigger_automation_now: {e}")),
     }
 }
 
@@ -399,89 +464,105 @@ fn fire_headless(
     // to keep the cli module free of an `agent` import — see
     // tests/architecture_rules.rs::cli_module_isolation.
     match &auto.action {
-        AutomationAction::Send { session_id } => {
-            let name = match db.get_session_name(*session_id) {
-                Ok(Some(name)) => name,
-                Ok(None) => {
-                    return (
-                        AutomationRunStatus::Skipped,
-                        "target session not found".into(),
-                        None,
-                    )
-                }
-                Err(e) => {
-                    return (
-                        AutomationRunStatus::Error,
-                        format!("get_session_name: {e}"),
-                        None,
-                    )
-                }
-            };
-            if !crate::agent::tmux::window_exists(&name) {
-                return (
-                    AutomationRunStatus::Skipped,
-                    "target session not running".into(),
-                    None,
-                );
-            }
-            match crate::agent::tmux::send_prompt_now(&name, &auto.prompt) {
-                Ok(()) => (
-                    AutomationRunStatus::Success,
-                    format!("sent to {session_id}"),
-                    Some(*session_id),
-                ),
-                Err(e) => (AutomationRunStatus::Error, e.to_string(), None),
-            }
-        }
+        AutomationAction::Send { session_id } => fire_send(db, auto, *session_id),
         AutomationAction::Spawn {
             repo_path,
             worktree_branch,
             base_branch,
             agent,
-        } => {
-            let name = format!("auto-{}", auto.id);
-            // Reuse an existing session window (later fires / restored sessions).
-            if crate::agent::tmux::window_exists(&name) {
-                // The reused window's session id has no cheap lookup here.
-                return match crate::agent::tmux::send_prompt_now(&name, &auto.prompt) {
-                    Ok(()) => (AutomationRunStatus::Success, format!("reused {name}"), None),
-                    Err(e) => (AutomationRunStatus::Error, e.to_string(), None),
-                };
-            }
-            let req = SpawnRequest {
-                name: name.clone(),
-                repo_path: repo_path.clone(),
-                worktree_branch: worktree_branch.clone(),
-                base_branch: base_branch.clone(),
-                agent: agent.clone(),
-                agent_session_id: None,
-                host: None,
-                parent_session_id: None,
-                task_id: None,
-            };
-            match crate::session_ops::spawn_session_headless(db, req) {
-                Ok(result) => {
-                    let session_id = Some(result.session_id);
-                    match crate::agent::tmux::send_prompt_after_delay(
-                        &name,
-                        &auto.prompt,
-                        BOOT_DELAY_SECS,
-                    ) {
-                        Ok(()) => (
-                            AutomationRunStatus::Success,
-                            format!("spawned {name}"),
-                            session_id,
-                        ),
-                        Err(e) => (
-                            AutomationRunStatus::Error,
-                            format!("spawned {name} but prompt delivery failed: {e}"),
-                            session_id,
-                        ),
-                    }
-                }
-                Err(e) => (AutomationRunStatus::Error, e, None),
+        } => fire_spawn(db, auto, repo_path, worktree_branch, base_branch, agent),
+    }
+}
+
+/// Execute a `send` automation: type the prompt into the target session's
+/// still-alive tmux window.
+fn fire_send(
+    db: &Database,
+    auto: &Automation,
+    session_id: SessionId,
+) -> (AutomationRunStatus, String, Option<SessionId>) {
+    let name = match db.get_session_name(session_id) {
+        Ok(Some(name)) => name,
+        Ok(None) => {
+            return (
+                AutomationRunStatus::Skipped,
+                "target session not found".into(),
+                None,
+            )
+        }
+        Err(e) => {
+            return (
+                AutomationRunStatus::Error,
+                format!("get_session_name: {e}"),
+                None,
+            )
+        }
+    };
+    if !crate::agent::tmux::window_exists(&name) {
+        return (
+            AutomationRunStatus::Skipped,
+            "target session not running".into(),
+            None,
+        );
+    }
+    match crate::agent::tmux::send_prompt_now(&name, &auto.prompt) {
+        Ok(()) => (
+            AutomationRunStatus::Success,
+            format!("sent to {session_id}"),
+            Some(session_id),
+        ),
+        Err(e) => (AutomationRunStatus::Error, e.to_string(), None),
+    }
+}
+
+/// Execute a `spawn` automation: reuse an existing window or spawn a new
+/// headless session, then deliver the prompt once the agent boots.
+fn fire_spawn(
+    db: &Database,
+    auto: &Automation,
+    repo_path: &std::path::Path,
+    worktree_branch: &Option<String>,
+    base_branch: &Option<String>,
+    agent: &Option<String>,
+) -> (AutomationRunStatus, String, Option<SessionId>) {
+    let name = format!("auto-{}", auto.id);
+    // Reuse an existing session window (later fires / restored sessions).
+    if crate::agent::tmux::window_exists(&name) {
+        // The reused window's session id has no cheap lookup here.
+        return match crate::agent::tmux::send_prompt_now(&name, &auto.prompt) {
+            Ok(()) => (AutomationRunStatus::Success, format!("reused {name}"), None),
+            Err(e) => (AutomationRunStatus::Error, e.to_string(), None),
+        };
+    }
+    let req = SpawnRequest {
+        name: name.clone(),
+        repo_path: repo_path.to_path_buf(),
+        worktree_branch: worktree_branch.clone(),
+        base_branch: base_branch.clone(),
+        agent: agent.clone(),
+        agent_session_id: None,
+        host: None,
+        parent_session_id: None,
+        task_id: None,
+    };
+    match crate::session_ops::spawn_session_headless(db, req) {
+        Ok(result) => {
+            let session_id = Some(result.session_id);
+            match crate::agent::tmux::send_prompt_after_delay(&name, &auto.prompt, BOOT_DELAY_SECS)
+            {
+                Ok(()) => (
+                    AutomationRunStatus::Success,
+                    format!("spawned {name}"),
+                    session_id,
+                ),
+                Err(e) => (
+                    AutomationRunStatus::Error,
+                    format!("spawned {name} but prompt delivery failed: {e}"),
+                    session_id,
+                ),
             }
         }
+        Err(e) => (AutomationRunStatus::Error, e, None),
     }
 }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -157,23 +157,7 @@ fn render_validate(report: &Value, failed: &[String]) -> String {
     ];
     let mut lines = Vec::new();
     for (label, key) in files {
-        let entry = &report[key];
-        let exists = entry["exists"].as_bool().unwrap_or(false);
-        let valid = entry["valid"].as_bool().unwrap_or(false);
-        // Absent files are valid (defaults/seeding apply), so flag them apart.
-        let (mark, status) = match (exists, valid) {
-            (false, _) => ("·", "absent"),
-            (true, true) => ("✓", "ok"),
-            (true, false) => ("✗", "invalid"),
-        };
-        lines.push(format!("{mark} {label}  {status}"));
-        if let Some(problems) = entry["problems"].as_array() {
-            for p in problems {
-                if let Some(p) = p.as_str() {
-                    lines.push(format!("    - {p}"));
-                }
-            }
-        }
+        push_validate_file_lines(&mut lines, label, &report[key]);
     }
     if failed.is_empty() {
         lines.push("All config files valid.".to_string());
@@ -181,6 +165,26 @@ fn render_validate(report: &Value, failed: &[String]) -> String {
         lines.push(format!("Invalid: {}", failed.join(", ")));
     }
     lines.join("\n")
+}
+
+/// Append one config file's status line (and any problem lines) to `lines`.
+fn push_validate_file_lines(lines: &mut Vec<String>, label: &str, entry: &Value) {
+    let exists = entry["exists"].as_bool().unwrap_or(false);
+    let valid = entry["valid"].as_bool().unwrap_or(false);
+    // Absent files are valid (defaults/seeding apply), so flag them apart.
+    let (mark, status) = match (exists, valid) {
+        (false, _) => ("·", "absent"),
+        (true, true) => ("✓", "ok"),
+        (true, false) => ("✗", "invalid"),
+    };
+    lines.push(format!("{mark} {label}  {status}"));
+    if let Some(problems) = entry["problems"].as_array() {
+        for p in problems {
+            if let Some(p) = p.as_str() {
+                lines.push(format!("    - {p}"));
+            }
+        }
+    }
 }
 
 /// Render `config show` as grouped key/value blocks.
@@ -237,31 +241,8 @@ fn show(db: &Database) -> Result<Value, String> {
     let (custom_themes, _) = crate::agent::themes_config::load_or_seed_with_warnings();
 
     // Editor resolution mirrors the TUI's Ctrl+O chain: DB → $VISUAL → $EDITOR.
-    let db_editor = db.get_editor_command().ok().flatten();
-    let (editor, editor_source) = match db_editor {
-        Some(cmd) if !cmd.is_empty() => (Some(cmd), "database (editor_command)"),
-        _ => match std::env::var("VISUAL") {
-            Ok(v) if !v.is_empty() => (Some(v), "$VISUAL"),
-            _ => match std::env::var("EDITOR") {
-                Ok(v) if !v.is_empty() => (Some(v), "$EDITOR"),
-                _ => (None, "unset"),
-            },
-        },
-    };
-
-    let overridden_actions: Vec<String> = match crate::storage::keybindings::load_keybindings_json()
-    {
-        Ok(Some(jsonbody)) => {
-            serde_json::from_str::<std::collections::HashMap<String, Vec<String>>>(&jsonbody)
-                .map(|m| {
-                    let mut keys: Vec<String> = m.into_keys().collect();
-                    keys.sort();
-                    keys
-                })
-                .unwrap_or_default()
-        }
-        _ => Vec::new(),
-    };
+    let (editor, editor_source) = resolve_editor(db);
+    let overridden_actions = overridden_action_names();
 
     Ok(json!({
         "paths": {
@@ -285,6 +266,43 @@ fn show(db: &Database) -> Result<Value, String> {
         "theme": db.get_active_theme().ok().flatten(),
         "custom_themes": custom_themes.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
     }))
+}
+
+/// Resolve the effective editor command + its source, mirroring the TUI's
+/// Ctrl+O chain: DB (editor_command) → $VISUAL → $EDITOR → unset.
+fn resolve_editor(db: &Database) -> (Option<String>, &'static str) {
+    let db_editor = db.get_editor_command().ok().flatten();
+    if let Some(cmd) = db_editor.filter(|c| !c.is_empty()) {
+        return (Some(cmd), "database (editor_command)");
+    }
+    if let Some(v) = nonempty_env("VISUAL") {
+        return (Some(v), "$VISUAL");
+    }
+    if let Some(v) = nonempty_env("EDITOR") {
+        return (Some(v), "$EDITOR");
+    }
+    (None, "unset")
+}
+
+/// A non-empty environment variable value, or `None` when unset/empty.
+fn nonempty_env(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+/// The sorted action names overridden in keybindings.json (empty when none).
+fn overridden_action_names() -> Vec<String> {
+    match crate::storage::keybindings::load_keybindings_json() {
+        Ok(Some(jsonbody)) => {
+            serde_json::from_str::<std::collections::HashMap<String, Vec<String>>>(&jsonbody)
+                .map(|m| {
+                    let mut keys: Vec<String> = m.into_keys().collect();
+                    keys.sort();
+                    keys
+                })
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/extensions.rs
+++ b/src/cli/extensions.rs
@@ -105,164 +105,208 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             target,
             home,
             force,
-        } => {
-            let report =
-                crate::session_ops::install_extension(db, &target, home.as_deref(), force)?;
-            // Arm the heartbeat so the extension's automations fire headlessly.
-            arm_heartbeat();
-            Ok(CommandOutput::from_summary(install_report_to_json(&report)))
-        }
-        Action::Uninstall { name, purge } => {
-            let report = crate::session_ops::uninstall_extension(db, &name, purge)?;
-            Ok(CommandOutput::from_summary(json!({
-                "ok": true,
-                "summary": format!("Uninstalled extension '{}'", report.name),
-                "uninstalled": report.name,
-                "sessions_deleted": report.deactivate.sessions_deleted,
-                "automations_deleted": report.deactivate.automations_deleted,
-                "agents_removed": report.agents_removed,
-                "manifest_removed": report.manifest_removed,
-                "home_removed": report.home_removed,
-            })))
-        }
-        Action::List => {
-            let defs = crate::agent::extension_config::list_manifests();
-            let mut healths = Vec::with_capacity(defs.len());
-            for def in &defs {
-                healths.push(crate::session_ops::extension_health(db, def)?);
-            }
-            let json = Value::Array(healths.iter().map(health_to_json).collect());
-            Ok(CommandOutput::new(json, render_extension_list(&healths)))
-        }
+        } => install_extension(db, target, home, force),
+        Action::Uninstall { name, purge } => uninstall_extension(db, name, purge),
+        Action::List => list_extensions(db),
         Action::Available { query } => Ok(available_output(query.as_deref())),
-        Action::Update { name, all, force } => match name {
-            // `--all` alongside a name is contradictory; otherwise a bare name
-            // updates one and *no* name updates them all (no flag required).
-            Some(_) if all => Err("pass either a name or --all, not both".to_string()),
-            Some(name) => {
-                let report = crate::session_ops::update_extension(db, &name, force)?;
-                // Arm the heartbeat so the refreshed automations keep firing headlessly.
-                arm_heartbeat();
-                Ok(CommandOutput::from_summary(update_report_to_json(&report)))
-            }
-            None => {
-                let results = crate::session_ops::update_all_extensions(db, force);
-                arm_heartbeat();
-                let total = results.len();
-                let mut changed = 0;
-                let mut failed = 0;
-                let out: Vec<Value> = results
-                    .into_iter()
-                    .map(|(name, result)| match result {
-                        Ok(report) => {
-                            if report.changed {
-                                changed += 1;
-                            }
-                            update_report_to_json(&report)
-                        }
-                        Err(e) => {
-                            failed += 1;
-                            json!({ "name": name, "ok": false, "error": e })
-                        }
-                    })
-                    .collect();
-                let summary = if total == 0 {
-                    "No extensions installed".to_string()
-                } else {
-                    format!("Updated {total} extension(s): {changed} changed, {failed} failed")
-                };
-                Ok(CommandOutput::from_summary(
-                    json!({ "ok": failed == 0, "summary": summary, "extensions": out }),
-                ))
-            }
-        },
-        Action::Reinstall { name, purge } => {
-            let report = crate::session_ops::reinstall_extension(db, &name, purge)?;
+        Action::Update { name, all, force } => update_extensions(db, name, all, force),
+        Action::Reinstall { name, purge } => reinstall_extension(db, name, purge),
+        Action::Activate { name } => activate_extension(db, name),
+        Action::Deactivate { name, force, purge } => deactivate_extension(db, name, force, purge),
+        Action::Status { name } => status_extension(db, name),
+    }
+}
+
+/// Handle `extension install`.
+fn install_extension(
+    db: &Database,
+    target: String,
+    home: Option<String>,
+    force: bool,
+) -> Result<CommandOutput, String> {
+    let report = crate::session_ops::install_extension(db, &target, home.as_deref(), force)?;
+    // Arm the heartbeat so the extension's automations fire headlessly.
+    arm_heartbeat();
+    Ok(CommandOutput::from_summary(install_report_to_json(&report)))
+}
+
+/// Handle `extension uninstall`.
+fn uninstall_extension(db: &Database, name: String, purge: bool) -> Result<CommandOutput, String> {
+    let report = crate::session_ops::uninstall_extension(db, &name, purge)?;
+    Ok(CommandOutput::from_summary(json!({
+        "ok": true,
+        "summary": format!("Uninstalled extension '{}'", report.name),
+        "uninstalled": report.name,
+        "sessions_deleted": report.deactivate.sessions_deleted,
+        "automations_deleted": report.deactivate.automations_deleted,
+        "agents_removed": report.agents_removed,
+        "manifest_removed": report.manifest_removed,
+        "home_removed": report.home_removed,
+    })))
+}
+
+/// Handle `extension list`.
+fn list_extensions(db: &Database) -> Result<CommandOutput, String> {
+    let defs = crate::agent::extension_config::list_manifests();
+    let mut healths = Vec::with_capacity(defs.len());
+    for def in &defs {
+        healths.push(crate::session_ops::extension_health(db, def)?);
+    }
+    let json = Value::Array(healths.iter().map(health_to_json).collect());
+    Ok(CommandOutput::new(json, render_extension_list(&healths)))
+}
+
+/// Handle `extension update` for a single named extension or all of them.
+fn update_extensions(
+    db: &Database,
+    name: Option<String>,
+    all: bool,
+    force: bool,
+) -> Result<CommandOutput, String> {
+    match name {
+        // `--all` alongside a name is contradictory; otherwise a bare name
+        // updates one and *no* name updates them all (no flag required).
+        Some(_) if all => Err("pass either a name or --all, not both".to_string()),
+        Some(name) => {
+            let report = crate::session_ops::update_extension(db, &name, force)?;
+            // Arm the heartbeat so the refreshed automations keep firing headlessly.
             arm_heartbeat();
-            let version = report.install.version.as_deref().unwrap_or("?");
-            Ok(CommandOutput::from_summary(json!({
-                "ok": true,
-                "summary": format!(
-                    "Reinstalled '{}' {} → {}",
-                    report.name, version, report.install.home
-                ),
-                "reinstalled": report.name,
-                "home_removed": report.uninstall.home_removed,
-                "home": report.install.home,
-                "version": report.install.version,
-                "files_written": report.install.files_written,
-                "agents_added": report.install.agents_added,
-                "sessions_created": report.install.ensure.sessions_created,
-                "automations_created": report.install.ensure.automations_created,
-            })))
+            Ok(CommandOutput::from_summary(update_report_to_json(&report)))
         }
-        Action::Activate { name } => {
-            let def = load_manifest(&name)?;
-            let report = crate::session_ops::activate_extension(db, &def)?;
-            // A `Send` automation only fires while something ticks it. Arm the
-            // heartbeat keeper so the extension works headlessly (TUI closed),
-            // matching how `automation create` arms it.
-            arm_heartbeat();
-            Ok(CommandOutput::from_summary(json!({
-                "ok": true,
-                "summary": format!(
-                    "Activated '{}' ({} session(s), {} automation(s))",
-                    def.name,
-                    report.sessions_created.len(),
-                    report.automations_created.len(),
-                ),
-                "activated": def.name,
-                "sessions_created": report.sessions_created,
-                "automations_created": report.automations_created,
-                "health": health_to_json(&crate::session_ops::extension_health(db, &def)?),
-            })))
-        }
-        Action::Deactivate { name, force, purge } => {
-            // Tear down whatever the manifest declares. If the manifest is gone
-            // we can't know the resources, but still clear the active-set entry.
-            let report = match crate::agent::extension_config::load_manifest(&name) {
-                Some(def) => crate::session_ops::deactivate_extension(db, &def, force)?,
-                None => {
-                    let was_active = db
-                        .remove_active_extension(&name)
-                        .map_err(|e| format!("remove_active_extension: {e}"))?;
-                    crate::session_ops::DeactivateReport {
-                        was_active,
-                        ..Default::default()
-                    }
+        None => Ok(update_all_extensions(db, force)),
+    }
+}
+
+/// `extension update` with no name: refresh every installed extension and
+/// aggregate the per-extension reports.
+fn update_all_extensions(db: &Database, force: bool) -> CommandOutput {
+    let results = crate::session_ops::update_all_extensions(db, force);
+    arm_heartbeat();
+    let total = results.len();
+    let mut changed = 0;
+    let mut failed = 0;
+    let out: Vec<Value> = results
+        .into_iter()
+        .map(|(name, result)| match result {
+            Ok(report) => {
+                if report.changed {
+                    changed += 1;
                 }
-            };
-            let manifest_removed = if purge {
-                crate::agent::extension_config::remove_manifest_file(&name)?
-            } else {
-                false
-            };
-            let summary = if report.was_active {
-                format!("Deactivated '{name}'")
-            } else {
-                format!("'{name}' was not active")
-            };
-            Ok(CommandOutput::from_summary(json!({
-                "ok": true,
-                "summary": summary,
-                "deactivated": name,
-                "was_active": report.was_active,
-                "sessions_deleted": report.sessions_deleted,
-                "automations_deleted": report.automations_deleted,
-                "manifest_removed": manifest_removed,
-            })))
-        }
-        Action::Status { name } => match name {
-            Some(name) => {
-                let def = load_manifest(&name)?;
-                let health = crate::session_ops::extension_health(db, &def)?;
-                Ok(CommandOutput::new(
-                    health_to_json(&health),
-                    render_extension_detail(&health),
-                ))
+                update_report_to_json(&report)
             }
-            None => run(Action::List, db),
-        },
+            Err(e) => {
+                failed += 1;
+                json!({ "name": name, "ok": false, "error": e })
+            }
+        })
+        .collect();
+    let summary = if total == 0 {
+        "No extensions installed".to_string()
+    } else {
+        format!("Updated {total} extension(s): {changed} changed, {failed} failed")
+    };
+    CommandOutput::from_summary(json!({ "ok": failed == 0, "summary": summary, "extensions": out }))
+}
+
+/// Handle `extension reinstall`.
+fn reinstall_extension(db: &Database, name: String, purge: bool) -> Result<CommandOutput, String> {
+    let report = crate::session_ops::reinstall_extension(db, &name, purge)?;
+    arm_heartbeat();
+    let version = report.install.version.as_deref().unwrap_or("?");
+    Ok(CommandOutput::from_summary(json!({
+        "ok": true,
+        "summary": format!(
+            "Reinstalled '{}' {} → {}",
+            report.name, version, report.install.home
+        ),
+        "reinstalled": report.name,
+        "home_removed": report.uninstall.home_removed,
+        "home": report.install.home,
+        "version": report.install.version,
+        "files_written": report.install.files_written,
+        "agents_added": report.install.agents_added,
+        "sessions_created": report.install.ensure.sessions_created,
+        "automations_created": report.install.ensure.automations_created,
+    })))
+}
+
+/// Handle `extension activate`.
+fn activate_extension(db: &Database, name: String) -> Result<CommandOutput, String> {
+    let def = load_manifest(&name)?;
+    let report = crate::session_ops::activate_extension(db, &def)?;
+    // A `Send` automation only fires while something ticks it. Arm the
+    // heartbeat keeper so the extension works headlessly (TUI closed),
+    // matching how `automation create` arms it.
+    arm_heartbeat();
+    Ok(CommandOutput::from_summary(json!({
+        "ok": true,
+        "summary": format!(
+            "Activated '{}' ({} session(s), {} automation(s))",
+            def.name,
+            report.sessions_created.len(),
+            report.automations_created.len(),
+        ),
+        "activated": def.name,
+        "sessions_created": report.sessions_created,
+        "automations_created": report.automations_created,
+        "health": health_to_json(&crate::session_ops::extension_health(db, &def)?),
+    })))
+}
+
+/// Handle `extension deactivate`.
+fn deactivate_extension(
+    db: &Database,
+    name: String,
+    force: bool,
+    purge: bool,
+) -> Result<CommandOutput, String> {
+    // Tear down whatever the manifest declares. If the manifest is gone
+    // we can't know the resources, but still clear the active-set entry.
+    let report = match crate::agent::extension_config::load_manifest(&name) {
+        Some(def) => crate::session_ops::deactivate_extension(db, &def, force)?,
+        None => {
+            let was_active = db
+                .remove_active_extension(&name)
+                .map_err(|e| format!("remove_active_extension: {e}"))?;
+            crate::session_ops::DeactivateReport {
+                was_active,
+                ..Default::default()
+            }
+        }
+    };
+    let manifest_removed = if purge {
+        crate::agent::extension_config::remove_manifest_file(&name)?
+    } else {
+        false
+    };
+    let summary = if report.was_active {
+        format!("Deactivated '{name}'")
+    } else {
+        format!("'{name}' was not active")
+    };
+    Ok(CommandOutput::from_summary(json!({
+        "ok": true,
+        "summary": summary,
+        "deactivated": name,
+        "was_active": report.was_active,
+        "sessions_deleted": report.sessions_deleted,
+        "automations_deleted": report.automations_deleted,
+        "manifest_removed": manifest_removed,
+    })))
+}
+
+/// Handle `extension status` (one extension, or all when no name is given).
+fn status_extension(db: &Database, name: Option<String>) -> Result<CommandOutput, String> {
+    match name {
+        Some(name) => {
+            let def = load_manifest(&name)?;
+            let health = crate::session_ops::extension_health(db, &def)?;
+            Ok(CommandOutput::new(
+                health_to_json(&health),
+                render_extension_detail(&health),
+            ))
+        }
+        None => run(Action::List, db),
     }
 }
 

--- a/src/cli/messages.rs
+++ b/src/cli/messages.rs
@@ -100,104 +100,141 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             task,
             from,
             no_wake,
-        } => {
-            let recipient = resolve_uuid_or_name(db, &to)?;
-            // Provenance + task tag default to the calling session's injected
-            // identity (`THURBOX_SESSION` / `THURBOX_TASK`), so an agent never has
-            // to know or pass its own ids. Explicit flags override.
-            let from_session_id = match from {
-                Some(ref f) => Some(resolve_uuid_or_name(db, f)?.id),
-                None => calling_session_id(db),
-            };
-            let from_task_id = task.or_else(calling_task_id);
-            let new = NewMessage {
-                to_session_id: recipient.id,
-                from_session_id,
-                from_task_id,
-                kind,
-                body,
-            };
-            enqueue_and_wake(db, &recipient, new, no_wake)
-        }
+        } => send_message(db, to, kind, body, task, from, no_wake),
         Action::Reply {
             message_id,
             body,
             kind,
             from,
             no_wake,
-        } => {
-            let original = db
-                .get_message(message_id)
-                .map_err(|e| format!("get_message: {e}"))?
-                .ok_or_else(|| format!("Message not found: #{message_id}"))?;
-            let sender_id = original.from_session_id.ok_or_else(|| {
-                format!("Message #{message_id} has no known sender — cannot reply")
-            })?;
-            let recipient = db
-                .get_session_by_id(sender_id)
-                .map_err(|e| format!("get_session_by_id: {e}"))?
-                .ok_or_else(|| {
-                    format!("Sender of message #{message_id} ({sender_id}) no longer exists")
-                })?;
-            let from_session_id = match from {
-                Some(ref f) => Some(resolve_uuid_or_name(db, f)?.id),
-                None => calling_session_id(db),
-            };
-            // Carry the originating task tag through so the reply stays threaded.
-            let new = NewMessage {
-                to_session_id: recipient.id,
-                from_session_id,
-                from_task_id: original.from_task_id,
-                kind,
-                body,
-            };
-            enqueue_and_wake(db, &recipient, new, no_wake)
-        }
+        } => reply_message(db, message_id, body, kind, from, no_wake),
         Action::Inbox {
             for_session,
             claim,
             all,
             limit,
-        } => {
-            let recipient = match for_session {
-                Some(ref r) => resolve_uuid_or_name(db, r)?,
-                None => calling_session(db).ok_or_else(|| {
-                    "no --for given and THURBOX_SESSION is unset (not running inside a session)"
-                        .to_string()
-                })?,
-            };
-            let messages = if claim {
-                db.claim_messages(recipient.id, limit)
-                    .map_err(|e| format!("claim_messages: {e}"))?
-            } else {
-                db.list_messages(recipient.id, !all, limit)
-                    .map_err(|e| format!("list_messages: {e}"))?
-            };
-            let json = Value::Array(messages.iter().map(message_to_json).collect());
-            Ok(CommandOutput::new(
-                json,
-                render_inbox(&recipient.name, &messages, claim),
-            ))
-        }
+        } => read_inbox(db, for_session, claim, all, limit),
         Action::Prune {
             older_than_days,
             read_only,
-        } => {
-            let days = older_than_days.unwrap_or(DEFAULT_RETENTION_DAYS);
-            let cutoff = current_time_millis().saturating_sub(days * MS_PER_DAY);
-            let pruned = db
-                .prune_messages(cutoff, read_only)
-                .map_err(|e| format!("prune_messages: {e}"))?;
-            let human = format!(
-                "Pruned {pruned} {}message(s) older than {days} day(s).",
-                if read_only { "read " } else { "" }
-            );
-            Ok(CommandOutput::new(
-                json!({ "pruned": pruned, "older_than_days": days, "read_only": read_only }),
-                human,
-            ))
-        }
+        } => prune_messages(db, older_than_days, read_only),
     }
+}
+
+/// Handle `message send`: enqueue a message addressed to a session.
+fn send_message(
+    db: &Database,
+    to: String,
+    kind: String,
+    body: String,
+    task: Option<i64>,
+    from: Option<String>,
+    no_wake: bool,
+) -> Result<CommandOutput, String> {
+    let recipient = resolve_uuid_or_name(db, &to)?;
+    // Provenance + task tag default to the calling session's injected
+    // identity (`THURBOX_SESSION` / `THURBOX_TASK`), so an agent never has
+    // to know or pass its own ids. Explicit flags override.
+    let from_session_id = resolve_from(db, from.as_deref())?;
+    let from_task_id = task.or_else(calling_task_id);
+    let new = NewMessage {
+        to_session_id: recipient.id,
+        from_session_id,
+        from_task_id,
+        kind,
+        body,
+    };
+    enqueue_and_wake(db, &recipient, new, no_wake)
+}
+
+/// Handle `message reply`: enqueue back to the original message's sender.
+fn reply_message(
+    db: &Database,
+    message_id: i64,
+    body: String,
+    kind: String,
+    from: Option<String>,
+    no_wake: bool,
+) -> Result<CommandOutput, String> {
+    let original = db
+        .get_message(message_id)
+        .map_err(|e| format!("get_message: {e}"))?
+        .ok_or_else(|| format!("Message not found: #{message_id}"))?;
+    let sender_id = original
+        .from_session_id
+        .ok_or_else(|| format!("Message #{message_id} has no known sender — cannot reply"))?;
+    let recipient = db
+        .get_session_by_id(sender_id)
+        .map_err(|e| format!("get_session_by_id: {e}"))?
+        .ok_or_else(|| format!("Sender of message #{message_id} ({sender_id}) no longer exists"))?;
+    let from_session_id = resolve_from(db, from.as_deref())?;
+    // Carry the originating task tag through so the reply stays threaded.
+    let new = NewMessage {
+        to_session_id: recipient.id,
+        from_session_id,
+        from_task_id: original.from_task_id,
+        kind,
+        body,
+    };
+    enqueue_and_wake(db, &recipient, new, no_wake)
+}
+
+/// Resolve the `--from` provenance: an explicit reference, else the calling
+/// session's injected id (`THURBOX_SESSION`).
+fn resolve_from(db: &Database, from: Option<&str>) -> Result<Option<SessionId>, String> {
+    match from {
+        Some(f) => Ok(Some(resolve_uuid_or_name(db, f)?.id)),
+        None => Ok(calling_session_id(db)),
+    }
+}
+
+/// Handle `message inbox`: peek or claim a session's messages.
+fn read_inbox(
+    db: &Database,
+    for_session: Option<String>,
+    claim: bool,
+    all: bool,
+    limit: Option<usize>,
+) -> Result<CommandOutput, String> {
+    let recipient = match for_session {
+        Some(ref r) => resolve_uuid_or_name(db, r)?,
+        None => calling_session(db).ok_or_else(|| {
+            "no --for given and THURBOX_SESSION is unset (not running inside a session)".to_string()
+        })?,
+    };
+    let messages = if claim {
+        db.claim_messages(recipient.id, limit)
+            .map_err(|e| format!("claim_messages: {e}"))?
+    } else {
+        db.list_messages(recipient.id, !all, limit)
+            .map_err(|e| format!("list_messages: {e}"))?
+    };
+    let json = Value::Array(messages.iter().map(message_to_json).collect());
+    Ok(CommandOutput::new(
+        json,
+        render_inbox(&recipient.name, &messages, claim),
+    ))
+}
+
+/// Handle `message prune`: retention sweep of old messages.
+fn prune_messages(
+    db: &Database,
+    older_than_days: Option<u64>,
+    read_only: bool,
+) -> Result<CommandOutput, String> {
+    let days = older_than_days.unwrap_or(DEFAULT_RETENTION_DAYS);
+    let cutoff = current_time_millis().saturating_sub(days * MS_PER_DAY);
+    let pruned = db
+        .prune_messages(cutoff, read_only)
+        .map_err(|e| format!("prune_messages: {e}"))?;
+    let human = format!(
+        "Pruned {pruned} {}message(s) older than {days} day(s).",
+        if read_only { "read " } else { "" }
+    );
+    Ok(CommandOutput::new(
+        json!({ "pruned": pruned, "older_than_days": days, "read_only": read_only }),
+        human,
+    ))
 }
 
 /// Render an inbox read as a table of messages (or a friendly empty line).

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,16 +77,72 @@ async fn main() -> Result<()> {
         .with_ansi(false)
         .init();
 
+    // Initialize session backends, load every config file, and open the DB.
+    let (backends, agents, hosts, mut config_warnings) = init_backends_and_config()?;
+    let db = open_database();
+    activate_persisted_theme(&db);
+
+    // Self-heal active extensions: re-create any session/automation a managed
+    // extension declares but that has since been deleted. Runs before the
+    // session restore below (so healed sessions are adopted like any other) and
+    // before the TUI takes over the terminal (so tmux spawn output can't corrupt
+    // it). Deleting an active extension's resources is therefore a no-op — they
+    // come back; `thurbox-cli extension deactivate <name>` is the real off-switch.
+    let heal_messages = thurbox::session_ops::heal_active_extensions(&db);
+    for m in &heal_messages {
+        tracing::info!("{m}");
+    }
+    config_warnings.extend(heal_messages);
+
+    let mut terminal = ratatui::init();
+    enable_terminal_features()?;
+    push_keyboard_enhancement();
+    let size = terminal.size()?;
+
+    let mut app = App::new(size.height, size.width, backends, agents, db);
+    app.set_hosts(hosts);
+    // Surface agents.toml/hosts.toml load problems in the status bar — the
+    // tracing::warn above only reaches the log file the TUI hides.
+    app.report_config_warnings(config_warnings);
+
+    // Load session state from DB and restore
+    if let Some((sessions, counter)) = app.load_persisted_state_from_db() {
+        app.restore_sessions(sessions, counter);
+    }
+
+    arm_automation_heartbeat();
+
+    let res = run_loop(&mut terminal, &mut app).await;
+
+    app.shutdown();
+    pop_keyboard_enhancement();
+    execute!(
+        std::io::stdout(),
+        DisableBracketedPaste,
+        DisableMouseCapture
+    )?;
+    ratatui::restore();
+
+    res
+}
+
+/// Bring up the session backends and load every config file (settings, hosts,
+/// agents, custom themes), publishing the process-wide state each reader needs.
+/// Returns the backend registry, the agent registry, the host registry, and the
+/// accumulated load warnings (logged here and later surfaced in the status bar).
+#[allow(clippy::type_complexity)]
+fn init_backends_and_config() -> Result<(
+    BackendRegistry,
+    thurbox::session::AgentRegistry,
+    thurbox::session::HostRegistry,
+    Vec<String>,
+)> {
     // Initialize session backends and agent provider.
     let local_tmux: Arc<dyn SessionBackend> = Arc::new(LocalTmuxBackend::new());
     local_tmux.check_available()?;
     local_tmux.ensure_ready()?;
     let mut backends = BackendRegistry::new(local_tmux);
 
-    // Register one SSH backend per configured remote host
-    // (~/.config/thurbox/hosts.toml). These are registered lazily: a down or
-    // slow host must not block TUI startup, so check_available()/ensure_ready()
-    // are deferred to first spawn/restore (see App::backend_for).
     // Load (or seed) the settings and publish them process-wide before
     // anything reads them (Database::open prunes the audit log; layout and
     // terminal wiring read breakpoints/scrollback).
@@ -94,6 +150,10 @@ async fn main() -> Result<()> {
         thurbox::agent::settings_config::load_or_seed_with_warnings();
     thurbox::session::settings::init(settings);
 
+    // Register one SSH backend per configured remote host
+    // (~/.config/thurbox/hosts.toml). These are registered lazily: a down or
+    // slow host must not block TUI startup, so check_available()/ensure_ready()
+    // are deferred to first spawn/restore (see App::backend_for).
     let (hosts, host_warnings) = thurbox::agent::host_config::load_or_seed_with_warnings();
     config_warnings.extend(host_warnings);
     for host in &hosts.hosts {
@@ -116,7 +176,12 @@ async fn main() -> Result<()> {
         tracing::warn!("{w}");
     }
 
-    // Open SQLite database for persistent state
+    Ok((backends, agents, hosts, config_warnings))
+}
+
+/// Open the SQLite database for persistent state, falling back to the default
+/// XDG location (dev vs. prod build) when the path can't be resolved.
+fn open_database() -> Database {
     let db_path = thurbox::paths::database_file().unwrap_or_else(|| {
         let mut p = std::path::PathBuf::from(std::env::var_os("HOME").unwrap_or_default());
         p.push(if cfg!(dev_build) {
@@ -126,73 +191,41 @@ async fn main() -> Result<()> {
         });
         p
     });
-    let db = Database::open(&db_path).expect("Failed to open database");
+    Database::open(&db_path).expect("Failed to open database")
+}
 
-    // Activate the persisted theme — built-in or custom — falling back to
-    // default when unset/unknown.
+/// Activate the persisted theme — built-in or custom — falling back to the
+/// default when unset or unknown.
+fn activate_persisted_theme(db: &Database) {
     if let Ok(Some(name)) = db.get_active_theme() {
         thurbox::ui::theme::apply_theme_by_name(&name);
     } else {
         thurbox::ui::theme::ensure_initialized();
     }
+}
 
-    // Self-heal active extensions: re-create any session/automation a managed
-    // extension declares but that has since been deleted. Runs before the
-    // session restore below (so healed sessions are adopted like any other) and
-    // before the TUI takes over the terminal (so tmux spawn output can't corrupt
-    // it). Deleting an active extension's resources is therefore a no-op — they
-    // come back; `thurbox-cli extension deactivate <name>` is the real off-switch.
-    let heal_messages = thurbox::session_ops::heal_active_extensions(&db);
-    for m in &heal_messages {
-        tracing::info!("{m}");
-    }
-    config_warnings.extend(heal_messages);
-
-    let mut terminal = ratatui::init();
-    // Mouse capture is opt-out (`[features] mouse = false` in settings.toml):
-    // without it the terminal keeps its native mouse behavior and no mouse
-    // events ever reach the app.
+/// Enable bracketed paste and (opt-in via `[features] mouse`) mouse capture on
+/// the terminal. Without mouse capture the terminal keeps its native mouse
+/// behavior and no mouse events ever reach the app.
+fn enable_terminal_features() -> Result<()> {
     if thurbox::session::settings::global().features.mouse {
         execute!(std::io::stdout(), EnableMouseCapture)?;
     }
     execute!(std::io::stdout(), EnableBracketedPaste)?;
-    push_keyboard_enhancement();
-    let size = terminal.size()?;
+    Ok(())
+}
 
-    let mut app = App::new(size.height, size.width, backends, agents, db);
-    app.set_hosts(hosts);
-    // Surface agents.toml/hosts.toml load problems in the status bar — the
-    // tracing::warn above only reaches the log file the TUI hides.
-    app.report_config_warnings(config_warnings);
-
-    // Load session state from DB and restore
-    if let Some((sessions, counter)) = app.load_persisted_state_from_db() {
-        app.restore_sessions(sessions, counter);
-    }
-
-    // Arm the tmux heartbeat keeper so automations keep firing after the TUI is
-    // closed (best-effort: a missing/old tmux just means TUI-only firing).
-    // Skipped when the `automations` feature flag is off — `thurbox-cli
-    // automation create` still arms it, since that's explicit user intent.
+/// Arm the tmux heartbeat keeper so automations keep firing after the TUI is
+/// closed (best-effort: a missing/old tmux just means TUI-only firing). Skipped
+/// when the `automations` feature flag is off — `thurbox-cli automation create`
+/// still arms it, since that's explicit user intent.
+fn arm_automation_heartbeat() {
     if thurbox::session::settings::global().features.automations {
         let cli = thurbox::agent::tmux::resolve_cli_binary();
         if let Err(e) = thurbox::agent::tmux::ensure_automation_heartbeat(&cli) {
             tracing::warn!("Failed to arm automation heartbeat: {e}");
         }
     }
-
-    let res = run_loop(&mut terminal, &mut app).await;
-
-    app.shutdown();
-    pop_keyboard_enhancement();
-    execute!(
-        std::io::stdout(),
-        DisableBracketedPaste,
-        DisableMouseCapture
-    )?;
-    ratatui::restore();
-
-    res
 }
 
 async fn run_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Result<()> {
@@ -200,43 +233,7 @@ async fn run_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Res
         terminal.draw(|f| app.view(f))?;
 
         if event::poll(Duration::from_millis(10))? {
-            let msg = match event::read()? {
-                Event::Key(k) if k.kind == KeyEventKind::Press => {
-                    Some(AppMessage::KeyPress(k.code, k.modifiers))
-                }
-                Event::Mouse(m) => match m.kind {
-                    MouseEventKind::ScrollUp => Some(AppMessage::MouseScrollUp {
-                        x: m.column,
-                        y: m.row,
-                    }),
-                    MouseEventKind::ScrollDown => Some(AppMessage::MouseScrollDown {
-                        x: m.column,
-                        y: m.row,
-                    }),
-                    MouseEventKind::Down(MouseButton::Left) => Some(AppMessage::MouseClick {
-                        x: m.column,
-                        y: m.row,
-                        modifiers: m.modifiers,
-                    }),
-                    MouseEventKind::Drag(MouseButton::Left) => Some(AppMessage::MouseDrag {
-                        x: m.column,
-                        y: m.row,
-                    }),
-                    MouseEventKind::Up(MouseButton::Left) => Some(AppMessage::MouseUp {
-                        x: m.column,
-                        y: m.row,
-                    }),
-                    MouseEventKind::Moved => Some(AppMessage::MouseMove {
-                        x: m.column,
-                        y: m.row,
-                    }),
-                    _ => None,
-                },
-                Event::Paste(text) => Some(AppMessage::Paste(text)),
-                Event::Resize(cols, rows) => Some(AppMessage::Resize(cols, rows)),
-                _ => None,
-            };
-            if let Some(msg) = msg {
+            if let Some(msg) = event_to_message(event::read()?) {
                 app.update(msg);
             }
         }
@@ -249,4 +246,51 @@ async fn run_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Res
     }
 
     Ok(())
+}
+
+/// Translate a crossterm `Event` into the matching `AppMessage`, or `None` for
+/// events the app ignores (key release/repeat, unhandled mouse kinds, …).
+fn event_to_message(event: Event) -> Option<AppMessage> {
+    match event {
+        Event::Key(k) if k.kind == KeyEventKind::Press => {
+            Some(AppMessage::KeyPress(k.code, k.modifiers))
+        }
+        Event::Mouse(m) => mouse_to_message(m),
+        Event::Paste(text) => Some(AppMessage::Paste(text)),
+        Event::Resize(cols, rows) => Some(AppMessage::Resize(cols, rows)),
+        _ => None,
+    }
+}
+
+/// Translate a crossterm mouse event into the matching `AppMessage`, or `None`
+/// for mouse kinds the app does not handle.
+fn mouse_to_message(m: event::MouseEvent) -> Option<AppMessage> {
+    match m.kind {
+        MouseEventKind::ScrollUp => Some(AppMessage::MouseScrollUp {
+            x: m.column,
+            y: m.row,
+        }),
+        MouseEventKind::ScrollDown => Some(AppMessage::MouseScrollDown {
+            x: m.column,
+            y: m.row,
+        }),
+        MouseEventKind::Down(MouseButton::Left) => Some(AppMessage::MouseClick {
+            x: m.column,
+            y: m.row,
+            modifiers: m.modifiers,
+        }),
+        MouseEventKind::Drag(MouseButton::Left) => Some(AppMessage::MouseDrag {
+            x: m.column,
+            y: m.row,
+        }),
+        MouseEventKind::Up(MouseButton::Left) => Some(AppMessage::MouseUp {
+            x: m.column,
+            y: m.row,
+        }),
+        MouseEventKind::Moved => Some(AppMessage::MouseMove {
+            x: m.column,
+            y: m.row,
+        }),
+        _ => None,
+    }
 }

--- a/src/session/automation.rs
+++ b/src/session/automation.rs
@@ -263,22 +263,9 @@ pub fn parse_duration(s: &str) -> Option<u64> {
     for ch in s.chars() {
         if ch.is_ascii_digit() {
             num.push(ch);
-        } else if ch.is_whitespace() {
-            continue;
-        } else {
-            if num.is_empty() {
-                return None; // unit with no preceding number
-            }
-            let n: u64 = num.parse().ok()?;
+        } else if !ch.is_whitespace() {
+            total = total.checked_add(duration_token_ms(&num, ch)?)?;
             num.clear();
-            let unit_ms: u64 = match ch.to_ascii_lowercase() {
-                's' => 1_000,
-                'm' => 60_000,
-                'h' => 3_600_000,
-                'd' => 86_400_000,
-                _ => return None,
-            };
-            total = total.checked_add(n.checked_mul(unit_ms)?)?;
             any = true;
         }
     }
@@ -287,6 +274,25 @@ pub fn parse_duration(s: &str) -> Option<u64> {
         return None;
     }
     any.then_some(total)
+}
+
+/// Convert one `<digits><unit>` token into milliseconds. `digits` is the number
+/// accumulated so far (must be non-empty) and `unit` the unit char (`s`/`m`/
+/// `h`/`d`, case-insensitive). Returns `None` on a missing number, unknown
+/// unit, or arithmetic overflow.
+fn duration_token_ms(digits: &str, unit: char) -> Option<u64> {
+    if digits.is_empty() {
+        return None; // unit with no preceding number
+    }
+    let n: u64 = digits.parse().ok()?;
+    let unit_ms: u64 = match unit.to_ascii_lowercase() {
+        's' => 1_000,
+        'm' => 60_000,
+        'h' => 3_600_000,
+        'd' => 86_400_000,
+        _ => return None,
+    };
+    n.checked_mul(unit_ms)
 }
 
 /// Parse an `HH:MM` string into `(hour, minute)`. Returns `None` if malformed

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -36,39 +36,59 @@ pub fn delete_session_headless(
     let mut report = ForceDeleteReport::default();
 
     if force {
-        match crate::agent::tmux::kill_window(&session.name) {
-            Ok(()) => report.killed_window = true,
-            Err(e) => tracing::warn!("kill_window({}) failed: {e}", session.name),
-        }
-
-        for wt in &session.worktrees {
-            match crate::git::remove_worktree(&wt.repo_path, &wt.worktree_path) {
-                Ok(()) => report
-                    .removed_worktrees
-                    .push(wt.worktree_path.display().to_string()),
-                Err(e) => report
-                    .worktree_errors
-                    .push(format!("{}: {e}", wt.worktree_path.display())),
-            }
-        }
-
-        // Tear down the multi-repo symlink workspace (if any). Only the symlinks
-        // are removed — the underlying repos are untouched.
-        if let Some(asid) = &session.agent_session_id {
-            if let Err(e) = crate::workspace::remove_workspace(asid) {
-                tracing::warn!("remove_workspace({asid}) failed: {e}");
-            }
-        }
-
-        report.disabled_automations = db
-            .disable_send_automations_for_session(session_id)
-            .map_err(|e| format!("disable_send_automations_for_session: {e}"))?;
+        force_teardown(db, session_id, &session, &mut report)?;
     }
 
     db.soft_delete_session(session_id)
         .map_err(|e| format!("soft_delete_session: {e}"))?;
 
     Ok(report)
+}
+
+/// Tear down a session's runtime resources for a force-delete: kill the tmux
+/// window, remove worktrees + the symlink workspace, and disable any pending
+/// `Send` automations. Best-effort cleanup is recorded in `report`; only the
+/// automation-disable failure (a DB error) aborts.
+fn force_teardown(
+    db: &Database,
+    session_id: SessionId,
+    session: &crate::sync::SharedSession,
+    report: &mut ForceDeleteReport,
+) -> Result<(), String> {
+    match crate::agent::tmux::kill_window(&session.name) {
+        Ok(()) => report.killed_window = true,
+        Err(e) => tracing::warn!("kill_window({}) failed: {e}", session.name),
+    }
+
+    for wt in &session.worktrees {
+        remove_worktree_into(wt, report);
+    }
+
+    // Tear down the multi-repo symlink workspace (if any). Only the symlinks
+    // are removed — the underlying repos are untouched.
+    if let Some(asid) = &session.agent_session_id {
+        if let Err(e) = crate::workspace::remove_workspace(asid) {
+            tracing::warn!("remove_workspace({asid}) failed: {e}");
+        }
+    }
+
+    report.disabled_automations = db
+        .disable_send_automations_for_session(session_id)
+        .map_err(|e| format!("disable_send_automations_for_session: {e}"))?;
+
+    Ok(())
+}
+
+/// Best-effort worktree removal, recording success/failure into `report`.
+fn remove_worktree_into(wt: &crate::sync::SharedWorktree, report: &mut ForceDeleteReport) {
+    match crate::git::remove_worktree(&wt.repo_path, &wt.worktree_path) {
+        Ok(()) => report
+            .removed_worktrees
+            .push(wt.worktree_path.display().to_string()),
+        Err(e) => report
+            .worktree_errors
+            .push(format!("{}: {e}", wt.worktree_path.display())),
+    }
 }
 
 #[cfg(test)]

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -138,17 +138,7 @@ pub fn install_extension(
     // Agent-layer helpers are reached fully-qualified (no `use crate::agent`) per
     // the session_ops → agent path-only architecture rule.
     let source = crate::agent::extension_config::resolve_source(target);
-    let (def, warnings) = match crate::agent::extension_config::load_manifest_from_source(&source) {
-        Ok(v) => v,
-        // A bare name that can't be fetched is almost always a typo or an unknown
-        // extension — turn the raw curl/404 into discovery guidance.
-        Err(e) if crate::agent::extension_config::is_bare_name(target) => {
-            return Err(crate::agent::extension_config::unknown_extension_help(
-                target, &e,
-            ));
-        }
-        Err(e) => return Err(e),
-    };
+    let (def, warnings) = load_manifest_for_install(target, &source)?;
     for w in &warnings {
         tracing::warn!("{w}");
     }
@@ -185,59 +175,12 @@ pub fn install_extension(
 
     // 1. Payload files.
     for f in &def.files {
-        // Reject absolute / `..` destinations and sources so a manifest can't
-        // write or read outside the home / source dir (path-traversal guard).
-        let dest = safe_join(&home, &f.path)?;
-        ensure_safe_relative(f.source_path())?;
-        if f.if_absent && dest.exists() && !force {
-            report.files_skipped.push(f.path.clone());
-            continue;
-        }
-        // Don't clobber a `substitute` file (e.g. .claude/settings.json) the
-        // user has edited: we only overwrite ours, identified by the installer
-        // marker we write into it. `--force` overrides.
-        if f.substitute && !force && is_user_modified(&dest) {
-            report.files_skipped.push(f.path.clone());
-            continue;
-        }
-        let mut content = crate::agent::extension_config::fetch_file(&source, f.source_path())?;
-        if f.substitute {
-            content = content.replace(HOME_TOKEN, &home_str);
-        }
-        if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("create {}: {e}", parent.display()))?;
-        }
-        std::fs::write(&dest, content).map_err(|e| format!("write {}: {e}", dest.display()))?;
-        if f.executable {
-            set_executable(&dest)?;
-        }
-        report.files_written.push(f.path.clone());
+        install_payload_file(&source, f, &home, &home_str, force, &mut report)?;
     }
 
     // 2. Symlinks (never clobber a regular file the user owns).
     for s in &def.symlinks {
-        // Validate both ends before touching the filesystem, so a bad target
-        // can't leave a removed symlink behind.
-        let link = safe_join(&home, &s.link)?;
-        ensure_safe_relative(&s.target)?;
-        match std::fs::symlink_metadata(&link) {
-            Ok(m) if m.file_type().is_symlink() => {
-                std::fs::remove_file(&link)
-                    .map_err(|e| format!("replace symlink {}: {e}", link.display()))?;
-            }
-            Ok(_) => {
-                report.symlinks_skipped.push(s.link.clone());
-                continue;
-            }
-            Err(_) => {}
-        }
-        if let Some(parent) = link.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("create {}: {e}", parent.display()))?;
-        }
-        make_symlink(&s.target, &link)?;
-        report.symlinks_created.push(s.link.clone());
+        install_symlink(s, &home, &mut report)?;
     }
 
     // 3. Agents → agents.toml (idempotent).
@@ -254,6 +197,94 @@ pub fn install_extension(
     report.ensure = activate_extension(db, &resolved)?;
 
     Ok(report)
+}
+
+/// Fetch and parse an extension manifest for [`install_extension`], turning a
+/// failed bare-name fetch (almost always a typo or an unknown extension) into
+/// discovery guidance.
+fn load_manifest_for_install(
+    target: &str,
+    source: &crate::agent::extension_config::ExtensionSource,
+) -> Result<(ExtensionDef, Vec<String>), String> {
+    match crate::agent::extension_config::load_manifest_from_source(source) {
+        Ok(v) => Ok(v),
+        Err(e) if crate::agent::extension_config::is_bare_name(target) => Err(
+            crate::agent::extension_config::unknown_extension_help(target, &e),
+        ),
+        Err(e) => Err(e),
+    }
+}
+
+/// Lay down one payload file under the home dir, honouring `if_absent` /
+/// `substitute` skip rules and the path-traversal guard, recording the outcome
+/// in `report`.
+fn install_payload_file(
+    source: &crate::agent::extension_config::ExtensionSource,
+    f: &crate::session::extension_def::ExtensionFile,
+    home: &Path,
+    home_str: &str,
+    force: bool,
+    report: &mut InstallReport,
+) -> Result<(), String> {
+    // Reject absolute / `..` destinations and sources so a manifest can't
+    // write or read outside the home / source dir (path-traversal guard).
+    let dest = safe_join(home, &f.path)?;
+    ensure_safe_relative(f.source_path())?;
+    if f.if_absent && dest.exists() && !force {
+        report.files_skipped.push(f.path.clone());
+        return Ok(());
+    }
+    // Don't clobber a `substitute` file (e.g. .claude/settings.json) the
+    // user has edited: we only overwrite ours, identified by the installer
+    // marker we write into it. `--force` overrides.
+    if f.substitute && !force && is_user_modified(&dest) {
+        report.files_skipped.push(f.path.clone());
+        return Ok(());
+    }
+    let mut content = crate::agent::extension_config::fetch_file(source, f.source_path())?;
+    if f.substitute {
+        content = content.replace(HOME_TOKEN, home_str);
+    }
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    std::fs::write(&dest, content).map_err(|e| format!("write {}: {e}", dest.display()))?;
+    if f.executable {
+        set_executable(&dest)?;
+    }
+    report.files_written.push(f.path.clone());
+    Ok(())
+}
+
+/// Create one symlink under the home dir, replacing an existing symlink but
+/// never clobbering a regular file the user owns, recording the outcome in
+/// `report`.
+fn install_symlink(
+    s: &crate::session::extension_def::ExtensionSymlink,
+    home: &Path,
+    report: &mut InstallReport,
+) -> Result<(), String> {
+    // Validate both ends before touching the filesystem, so a bad target
+    // can't leave a removed symlink behind.
+    let link = safe_join(home, &s.link)?;
+    ensure_safe_relative(&s.target)?;
+    match std::fs::symlink_metadata(&link) {
+        Ok(m) if m.file_type().is_symlink() => {
+            std::fs::remove_file(&link)
+                .map_err(|e| format!("replace symlink {}: {e}", link.display()))?;
+        }
+        Ok(_) => {
+            report.symlinks_skipped.push(s.link.clone());
+            return Ok(());
+        }
+        Err(_) => {}
+    }
+    if let Some(parent) = link.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    make_symlink(&s.target, &link)?;
+    report.symlinks_created.push(s.link.clone());
+    Ok(())
 }
 
 /// What [`update_extension`] did to one extension.
@@ -669,58 +700,81 @@ pub fn heal_active_extensions(db: &Database) -> Vec<String> {
     let active = db.get_active_extensions().unwrap_or_default();
     let mut messages = Vec::new();
     for name in active {
-        // Fully-qualified agent reference (no `use`) per the session_ops →
-        // agent path-only architecture rule.
-        let Some(def) = crate::agent::extension_config::load_manifest(&name) else {
-            messages.push(format!(
-                "extension '{name}' is active but its manifest is missing; reinstall it \
-                 or run `thurbox-cli extension deactivate {name}`"
-            ));
-            continue;
-        };
-        // Nudge once-per-pass when the binary upgraded since install, or when the
-        // extension wants a newer thurbox than this one. Both clear after the
-        // user acts (`extension update` / a thurbox upgrade), so they don't
-        // persist as noise.
-        let current = crate::agent::extension_config::binary_version();
-        if let Some(w) = def.compat_warning(current) {
-            messages.push(w);
-        } else if def.is_stale(current) {
-            messages.push(format!(
-                "extension '{name}' was installed under thurbox {} but this binary is {current}; \
-                 run `thurbox-cli extension update {name}` to refresh it",
-                def.installed_with.as_deref().unwrap_or("an older version")
-            ));
-        }
-        match ensure_extension(db, &def) {
-            Ok(report) if report.created_anything() => {
-                let mut parts = Vec::new();
-                if !report.sessions_created.is_empty() {
-                    parts.push(format!("session(s) {}", report.sessions_created.join(", ")));
-                }
-                if !report.automations_created.is_empty() {
-                    parts.push(format!(
-                        "automation(s) {}",
-                        report.automations_created.join(", ")
-                    ));
-                }
-                if !report.automations_relinked.is_empty() {
-                    parts.push(format!(
-                        "re-linked automation(s) {}",
-                        report.automations_relinked.join(", ")
-                    ));
-                }
-                messages.push(format!(
-                    "Repaired {} for managed extension '{name}' \
-                     (`thurbox-cli extension deactivate {name}` to turn it off)",
-                    parts.join(" + ")
-                ));
-            }
-            Ok(_) => {}
-            Err(e) => messages.push(format!("extension '{name}' self-heal failed: {e}")),
-        }
+        heal_one_extension(db, &name, &mut messages);
     }
     messages
+}
+
+/// Self-heal a single active extension: surface a missing-manifest error, a
+/// compat/staleness nudge, and re-ensure its declared resources, appending any
+/// user-facing messages to `messages`.
+fn heal_one_extension(db: &Database, name: &str, messages: &mut Vec<String>) {
+    // Fully-qualified agent reference (no `use`) per the session_ops →
+    // agent path-only architecture rule.
+    let Some(def) = crate::agent::extension_config::load_manifest(name) else {
+        messages.push(format!(
+            "extension '{name}' is active but its manifest is missing; reinstall it \
+             or run `thurbox-cli extension deactivate {name}`"
+        ));
+        return;
+    };
+    // Nudge once-per-pass when the binary upgraded since install, or when the
+    // extension wants a newer thurbox than this one. Both clear after the
+    // user acts (`extension update` / a thurbox upgrade), so they don't
+    // persist as noise.
+    let current = crate::agent::extension_config::binary_version();
+    if let Some(w) = heal_compat_message(&def, name, current) {
+        messages.push(w);
+    }
+    match ensure_extension(db, &def) {
+        Ok(report) if report.created_anything() => {
+            messages.push(heal_recreated_message(&report, name));
+        }
+        Ok(_) => {}
+        Err(e) => messages.push(format!("extension '{name}' self-heal failed: {e}")),
+    }
+}
+
+/// A compatibility warning (binary too old) or a staleness nudge (extension
+/// installed under an older binary), or `None` when neither applies.
+fn heal_compat_message(def: &ExtensionDef, name: &str, current: &str) -> Option<String> {
+    if let Some(w) = def.compat_warning(current) {
+        Some(w)
+    } else if def.is_stale(current) {
+        Some(format!(
+            "extension '{name}' was installed under thurbox {} but this binary is {current}; \
+             run `thurbox-cli extension update {name}` to refresh it",
+            def.installed_with.as_deref().unwrap_or("an older version")
+        ))
+    } else {
+        None
+    }
+}
+
+/// Human-readable "Repaired …" message describing what a self-heal pass
+/// re-created or re-linked for an extension.
+fn heal_recreated_message(report: &EnsureReport, name: &str) -> String {
+    let mut parts = Vec::new();
+    if !report.sessions_created.is_empty() {
+        parts.push(format!("session(s) {}", report.sessions_created.join(", ")));
+    }
+    if !report.automations_created.is_empty() {
+        parts.push(format!(
+            "automation(s) {}",
+            report.automations_created.join(", ")
+        ));
+    }
+    if !report.automations_relinked.is_empty() {
+        parts.push(format!(
+            "re-linked automation(s) {}",
+            report.automations_relinked.join(", ")
+        ));
+    }
+    format!(
+        "Repaired {} for managed extension '{name}' \
+         (`thurbox-cli extension deactivate {name}` to turn it off)",
+        parts.join(" + ")
+    )
 }
 
 /// Snapshot which of a manifest's declared resources currently exist and whether

--- a/src/ui/automation_detail.rs
+++ b/src/ui/automation_detail.rs
@@ -90,44 +90,7 @@ pub fn render_run_history(
     let lines: Vec<Line> = runs[start..end]
         .iter()
         .enumerate()
-        .map(|(offset, run)| {
-            let i = start + offset;
-            let (glyph, word, color) = match run.status {
-                AutomationRunStatus::Success => ("✓", "ok", Theme::status_idle()),
-                AutomationRunStatus::Error => ("✗", "error", Theme::status_error()),
-                AutomationRunStatus::Skipped => ("–", "skipped", Theme::status_waiting()),
-            };
-            let is_selected = focused && i == selected;
-            let pointer = if is_selected { "▸" } else { " " };
-            let mut spans = vec![
-                // Status — colour + bold so each outcome stands out.
-                Span::styled(
-                    format!("{pointer}{glyph} {word:<7}"),
-                    Style::default().fg(color).add_modifier(Modifier::BOLD),
-                ),
-                // Absolute clock time, then the relative age.
-                Span::styled(
-                    format!("{:<11} ", run.at),
-                    Style::default().fg(Theme::text_secondary()),
-                ),
-                Span::styled(
-                    format!("{:<9} ", run.when),
-                    Style::default().fg(Theme::text_muted()),
-                ),
-            ];
-            if !run.detail.is_empty() {
-                spans.push(Span::styled(
-                    run.detail.to_string(),
-                    Style::default().fg(Theme::text_primary()),
-                ));
-            }
-            let line = Line::from(spans);
-            if is_selected {
-                line.style(Style::default().bg(Theme::selection_bg()))
-            } else {
-                line
-            }
-        })
+        .map(|(offset, run)| run_line(run, focused && start + offset == selected))
         .collect();
 
     frame.render_widget(Paragraph::new(lines), rows_area);
@@ -147,4 +110,43 @@ pub fn render_run_history(
     }
 
     track.and_then(|track| scrollbar::render_into(frame, track, runs.len(), height, selected))
+}
+
+/// Build one run-history row: a coloured status badge, the absolute clock time,
+/// the relative age, and any free-text detail. Highlighted when `is_selected`.
+fn run_line<'a>(run: &AutomationRunRow<'_>, is_selected: bool) -> Line<'a> {
+    let (glyph, word, color) = match run.status {
+        AutomationRunStatus::Success => ("✓", "ok", Theme::status_idle()),
+        AutomationRunStatus::Error => ("✗", "error", Theme::status_error()),
+        AutomationRunStatus::Skipped => ("–", "skipped", Theme::status_waiting()),
+    };
+    let pointer = if is_selected { "▸" } else { " " };
+    let mut spans = vec![
+        // Status — colour + bold so each outcome stands out.
+        Span::styled(
+            format!("{pointer}{glyph} {word:<7}"),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+        // Absolute clock time, then the relative age.
+        Span::styled(
+            format!("{:<11} ", run.at),
+            Style::default().fg(Theme::text_secondary()),
+        ),
+        Span::styled(
+            format!("{:<9} ", run.when),
+            Style::default().fg(Theme::text_muted()),
+        ),
+    ];
+    if !run.detail.is_empty() {
+        spans.push(Span::styled(
+            run.detail.to_string(),
+            Style::default().fg(Theme::text_primary()),
+        ));
+    }
+    let line = Line::from(spans);
+    if is_selected {
+        line.style(Style::default().bg(Theme::selection_bg()))
+    } else {
+        line
+    }
 }

--- a/src/ui/automations_panel.rs
+++ b/src/ui/automations_panel.rs
@@ -52,16 +52,7 @@ pub fn render_automations_pane(
     frame.render_widget(block, area);
 
     if state.entries.is_empty() {
-        let text = if matches!(state.focus, FocusLevel::Focused) {
-            "none — Ctrl+N to add"
-        } else {
-            "none"
-        };
-        let hint = Paragraph::new(Line::from(Span::styled(
-            text,
-            Style::default().fg(Theme::text_muted()),
-        )));
-        frame.render_widget(hint, inner);
+        render_empty(frame, inner, state.focus);
         return Vec::new();
     }
 
@@ -74,34 +65,54 @@ pub fn render_automations_pane(
         .enumerate()
         .map(|(i, e)| {
             let selected = (focused || state.preview_selected) && i == state.selected;
-            let marker = if e.enabled { "●" } else { "○" };
-            let prefix = format!(" {marker} ");
-            let tail = format!(" — {} ", e.summary);
-            // Reserve room for the prefix + tail so the (highlighted) name fits.
-            let name_budget = width
-                .saturating_sub(prefix.chars().count())
-                .saturating_sub(tail.chars().count());
-            let name = truncate_ellipsis(&e.name, name_budget);
-
-            // Matched characters are layered on top of this base (see
-            // `row_base_style`), so a selected/previewed row keeps its
-            // fuzzy-match highlight (mirrors the session list + tasks pane).
-            let normal = Style::default().fg(if e.enabled {
-                Theme::text_secondary()
-            } else {
-                Theme::text_muted()
-            });
-            let base = super::highlight::row_base_style(selected, e.dimmed, normal);
-            let mut spans = vec![Span::styled(prefix, base)];
-            let positions: &[usize] = if e.dimmed { &[] } else { &e.match_positions };
-            spans.extend(super::highlight::highlighted_spans_owned(
-                &name, positions, base,
-            ));
-            spans.push(Span::styled(tail, base));
-            Line::from(spans)
+            entry_line(e, selected, width)
         })
         .collect();
 
     frame.render_widget(Paragraph::new(lines), inner);
     super::single_line_row_hitboxes(inner, state.entries.len())
+}
+
+/// Render the placeholder shown when there are no automations.
+fn render_empty(frame: &mut Frame, inner: Rect, focus: FocusLevel) {
+    let text = if matches!(focus, FocusLevel::Focused) {
+        "none — Ctrl+N to add"
+    } else {
+        "none"
+    };
+    let hint = Paragraph::new(Line::from(Span::styled(
+        text,
+        Style::default().fg(Theme::text_muted()),
+    )));
+    frame.render_widget(hint, inner);
+}
+
+/// Build one automation row: an enabled marker, the (fuzzy-highlighted) name,
+/// and a dim summary tail, fitted to `width`.
+fn entry_line<'a>(e: &AutomationPaneEntry, selected: bool, width: usize) -> Line<'a> {
+    let marker = if e.enabled { "●" } else { "○" };
+    let prefix = format!(" {marker} ");
+    let tail = format!(" — {} ", e.summary);
+    // Reserve room for the prefix + tail so the (highlighted) name fits.
+    let name_budget = width
+        .saturating_sub(prefix.chars().count())
+        .saturating_sub(tail.chars().count());
+    let name = truncate_ellipsis(&e.name, name_budget);
+
+    // Matched characters are layered on top of this base (see `row_base_style`),
+    // so a selected/previewed row keeps its fuzzy-match highlight (mirrors the
+    // session list + tasks pane).
+    let normal = Style::default().fg(if e.enabled {
+        Theme::text_secondary()
+    } else {
+        Theme::text_muted()
+    });
+    let base = super::highlight::row_base_style(selected, e.dimmed, normal);
+    let mut spans = vec![Span::styled(prefix, base)];
+    let positions: &[usize] = if e.dimmed { &[] } else { &e.match_positions };
+    spans.extend(super::highlight::highlighted_spans_owned(
+        &name, positions, base,
+    ));
+    spans.push(Span::styled(tail, base));
+    Line::from(spans)
 }

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -258,35 +258,20 @@ impl FileViewerState {
             let Ok(rel) = target.strip_prefix(&root_path) else {
                 continue;
             };
-            // Walk the components, expanding each directory level.
-            let mut node = &mut self.roots[root_idx];
-            let mut current = root_path.clone();
-            node.expanded = true;
-            for comp in rel.components() {
-                current.push(comp);
-                if node.children.is_none() {
-                    node.children = Some(read_dir_sorted(&node.path));
-                }
-                let Some(children) = node.children.as_mut() else {
-                    break;
-                };
-                let Some(pos) = children.iter().position(|c| c.path == current) else {
-                    break;
-                };
-                node = &mut children[pos];
-                if node.is_dir {
-                    node.expanded = true;
-                }
-            }
-            // Now locate the target in the flattened view and select it.
-            if let Some(row) = self.flatten().iter().position(|r| {
-                self.path_for_index(&r.index_path)
-                    .map(|p| p == target)
-                    .unwrap_or(false)
-            }) {
-                self.selected = row;
-            }
+            expand_ancestors(&mut self.roots[root_idx], &root_path, rel);
+            self.select_target(target);
             return;
+        }
+    }
+
+    /// Locate `target` in the flattened view and move the selection onto it.
+    fn select_target(&mut self, target: &Path) {
+        if let Some(row) = self.flatten().iter().position(|r| {
+            self.path_for_index(&r.index_path)
+                .map(|p| p == target)
+                .unwrap_or(false)
+        }) {
+            self.selected = row;
         }
     }
 
@@ -465,6 +450,31 @@ fn traverse_mut<'a>(roots: &'a mut [FileNode], index_path: &[usize]) -> Option<&
     Some(node)
 }
 
+/// Expand `root` and every directory along `rel` (the target's path relative to
+/// `root_path`), reading child directories on demand. Stops early if a level is
+/// missing. Used by [`FileViewerState::reveal_path`].
+fn expand_ancestors(root: &mut FileNode, root_path: &Path, rel: &Path) {
+    let mut node = root;
+    let mut current = root_path.to_path_buf();
+    node.expanded = true;
+    for comp in rel.components() {
+        current.push(comp);
+        if node.children.is_none() {
+            node.children = Some(read_dir_sorted(&node.path));
+        }
+        let Some(children) = node.children.as_mut() else {
+            break;
+        };
+        let Some(pos) = children.iter().position(|c| c.path == current) else {
+            break;
+        };
+        node = &mut children[pos];
+        if node.is_dir {
+            node.expanded = true;
+        }
+    }
+}
+
 /// Recursively walk `node` and auto-expand directories that contain any
 /// descendant whose name matches `q_lc`. Returns true if a match was found at
 /// or below `node`. Reads child directories on demand.
@@ -480,11 +490,7 @@ fn expand_matches(node: &mut FileNode, q_lc: &str, depth: usize, budget: &mut us
         .map(|n| n.to_string_lossy().to_lowercase().contains(q_lc))
         .unwrap_or(false);
 
-    if !node.is_dir {
-        return self_matches;
-    }
-
-    if depth >= SEARCH_DEPTH_LIMIT {
+    if !node.is_dir || depth >= SEARCH_DEPTH_LIMIT {
         return self_matches;
     }
 
@@ -493,22 +499,34 @@ fn expand_matches(node: &mut FileNode, q_lc: &str, depth: usize, budget: &mut us
         node.children = Some(read_dir_sorted(&node.path));
     }
 
-    let mut child_match = false;
-    if let Some(children) = node.children.as_mut() {
-        for child in children.iter_mut() {
-            if expand_matches(child, q_lc, depth + 1, budget) {
-                child_match = true;
-            }
-            if *budget == 0 {
-                break;
-            }
-        }
-    }
-
+    let child_match = expand_matching_children(node, q_lc, depth, budget);
     if child_match {
         node.expanded = true;
     }
     self_matches || child_match
+}
+
+/// Recurse into `node`'s loaded children, returning true if any descendant
+/// matches `q_lc`. Honors the shared `budget`. Split out of [`expand_matches`].
+fn expand_matching_children(
+    node: &mut FileNode,
+    q_lc: &str,
+    depth: usize,
+    budget: &mut usize,
+) -> bool {
+    let Some(children) = node.children.as_mut() else {
+        return false;
+    };
+    let mut child_match = false;
+    for child in children.iter_mut() {
+        if expand_matches(child, q_lc, depth + 1, budget) {
+            child_match = true;
+        }
+        if *budget == 0 {
+            break;
+        }
+    }
+    child_match
 }
 
 fn short_root_label(path: &Path) -> String {
@@ -601,6 +619,32 @@ pub fn render_file_viewer(
     state: &FileViewerState,
     focus: FocusLevel,
 ) -> (Option<ScrollbarGeom>, Vec<super::RowHitbox>) {
+    let inner = render_chrome(frame, area, state, focus);
+
+    if inner.height == 0 || inner.width == 0 {
+        return (None, Vec::new());
+    }
+
+    if state.roots.is_empty() {
+        let p = Paragraph::new(Line::from(Span::styled(
+            "No folders",
+            Style::default().fg(Theme::text_muted()),
+        )));
+        frame.render_widget(p, inner);
+        return (None, Vec::new());
+    }
+
+    render_tree(frame, inner, state)
+}
+
+/// Lay out the viewer chrome — the bordered `Files` block plus the optional
+/// search bar below it — and return the inner list area.
+fn render_chrome(
+    frame: &mut Frame,
+    area: Rect,
+    state: &FileViewerState,
+    focus: FocusLevel,
+) -> Rect {
     use ratatui::layout::{Constraint, Direction, Layout};
 
     let search_visible = state.search_active || !state.search_query.is_empty();
@@ -614,20 +658,15 @@ pub fn render_file_viewer(
         .constraints(constraints)
         .split(area);
     let list_outer = chunks[0];
-    let search_outer = if search_visible {
-        Some(chunks[1])
-    } else {
-        None
-    };
 
     let block = focus_block(" Files ", focus);
     let inner = block.inner(list_outer);
     frame.render_widget(block, list_outer);
 
-    if let Some(sa) = search_outer {
+    if search_visible {
         render_search_bar(
             frame,
-            sa,
+            chunks[1],
             &state.search_query,
             state.search_active,
             state.search_cursor,
@@ -636,21 +675,16 @@ pub fn render_file_viewer(
         );
     }
 
-    if inner.height == 0 || inner.width == 0 {
-        return (None, Vec::new());
-    }
+    inner
+}
 
-    let list_area = inner;
-
-    if state.roots.is_empty() {
-        let p = Paragraph::new(Line::from(Span::styled(
-            "No folders",
-            Style::default().fg(Theme::text_muted()),
-        )));
-        frame.render_widget(p, list_area);
-        return (None, Vec::new());
-    }
-
+/// Render the flattened tree rows into `list_area` (with a scrollbar when they
+/// overflow). Returns the scrollbar geometry and one hitbox per visible row.
+fn render_tree(
+    frame: &mut Frame,
+    list_area: Rect,
+    state: &FileViewerState,
+) -> (Option<ScrollbarGeom>, Vec<super::RowHitbox>) {
     let rows = state.flatten();
     let height = list_area.height as usize;
     if height == 0 {

--- a/src/ui/global_search.rs
+++ b/src/ui/global_search.rs
@@ -78,34 +78,14 @@ fn render_results(frame: &mut Frame, area: Rect, state: &GlobalSearchView<'_>) {
     let mut last_kind: Option<SearchKind> = None;
     for (i, r) in state.results.iter().enumerate() {
         if last_kind != Some(r.kind) {
-            lines.push(Line::from(Span::styled(
-                format!(" {}", scope_header(r.kind)),
-                Style::default()
-                    .fg(Theme::text_muted())
-                    .add_modifier(Modifier::BOLD),
-            )));
+            lines.push(scope_header_line(r.kind));
             last_kind = Some(r.kind);
         }
         let selected = i == state.selected;
         if selected {
             selected_line = lines.len();
         }
-        let marker = if selected { "▸ " } else { "  " };
-        let row = truncate_ellipsis(&format!("{marker}{}", r.label), width);
-        let style = if selected {
-            Theme::selected_item()
-        } else {
-            Style::default().fg(Theme::text_primary())
-        };
-        lines.push(Line::from(Span::styled(row, style)));
-        if let Some(snippet) = &r.snippet {
-            lines.push(Line::from(Span::styled(
-                truncate_ellipsis(&format!("      {snippet}"), width),
-                Style::default()
-                    .fg(Theme::text_muted())
-                    .add_modifier(Modifier::ITALIC),
-            )));
-        }
+        push_result_row(&mut lines, r, selected, width);
     }
 
     // Scroll so the selected line stays visible within the result area.
@@ -113,6 +93,42 @@ fn render_results(frame: &mut Frame, area: Rect, state: &GlobalSearchView<'_>) {
     let offset = selected_line.saturating_sub(height.saturating_sub(1));
     let visible: Vec<Line> = lines.into_iter().skip(offset).collect();
     frame.render_widget(Paragraph::new(visible), area);
+}
+
+/// A dim, bold scope header line introducing a group of results.
+fn scope_header_line<'a>(kind: SearchKind) -> Line<'a> {
+    Line::from(Span::styled(
+        format!(" {}", scope_header(kind)),
+        Style::default()
+            .fg(Theme::text_muted())
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+/// Push a single result's row line (plus its optional dim snippet line) into
+/// `lines`, marking and highlighting it when `selected`.
+fn push_result_row<'a>(
+    lines: &mut Vec<Line<'a>>,
+    r: &'a GlobalSearchResult,
+    selected: bool,
+    width: usize,
+) {
+    let marker = if selected { "▸ " } else { "  " };
+    let row = truncate_ellipsis(&format!("{marker}{}", r.label), width);
+    let style = if selected {
+        Theme::selected_item()
+    } else {
+        Style::default().fg(Theme::text_primary())
+    };
+    lines.push(Line::from(Span::styled(row, style)));
+    if let Some(snippet) = &r.snippet {
+        lines.push(Line::from(Span::styled(
+            truncate_ellipsis(&format!("      {snippet}"), width),
+            Style::default()
+                .fg(Theme::text_muted())
+                .add_modifier(Modifier::ITALIC),
+        )));
+    }
 }
 
 fn render_query_line(frame: &mut Frame, area: Rect, state: &GlobalSearchView<'_>) {

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -48,6 +48,54 @@ pub fn render_info_panel(
     let mut lines = Vec::new();
 
     // ── Session section (most relevant: "what am I looking at") ──
+    append_session_section(&mut lines, info, parent_name);
+
+    // ── Repos ──
+    append_repos_section(&mut lines, info);
+
+    // ── Git change summary (real git state of the worktree) ──
+    if let Some(ref git) = info.git_stats {
+        append_git_section(&mut lines, git);
+    }
+
+    // ── Session CPU/RAM ──
+    if let Some(m) = metrics {
+        append_session_resources(&mut lines, m, inner_width);
+    }
+
+    // ── Agent section (Claude CLI metrics) ──
+    if let Some(ref metrics) = info.agent_metrics {
+        append_agent_section(&mut lines, metrics, inner_width);
+    }
+
+    // ── Usage / rate-limits (account-level, the `/usage` equivalent) ──
+    if let Some(u) = usage {
+        if !u.is_empty() {
+            append_usage_section(&mut lines, u, inner_width);
+        }
+    }
+
+    // ── System Resources section (global CPU/RAM) ──
+    if let Some(m) = metrics {
+        append_system_section(&mut lines, m, inner_width);
+    }
+
+    // ── Automations section ──
+    append_automations_section(&mut lines, automations, inner_width);
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+/// Append the session header rows: name, status, agent, and the optional
+/// parent / host / activity / signal rows.
+fn append_session_section<'a>(
+    lines: &mut Vec<Line<'a>>,
+    info: &'a SessionInfo,
+    parent_name: Option<&str>,
+) {
     lines.push(Line::from(vec![
         Span::styled("Name: ", Theme::label()),
         Span::styled(&info.name, Style::default().fg(Theme::text_primary())),
@@ -110,147 +158,124 @@ pub fn render_info_panel(
             Span::styled(signal, value_style),
         ]));
     }
-
-    // ── Repos ──
-    append_repos_section(&mut lines, info);
-
-    // ── Git change summary (real git state of the worktree) ──
-    if let Some(ref git) = info.git_stats {
-        append_git_section(&mut lines, git);
-    }
-
-    // ── Session CPU/RAM ──
-    if let Some(m) = metrics {
-        if m.session_cpu_percent > 0.0 || m.session_memory_bytes > 0 {
-            let cpu_gauge = render_gauge_lines("CPU", m.session_cpu_percent, None, inner_width);
-            lines.extend(cpu_gauge);
-
-            lines.push(Line::from(vec![
-                Span::styled("RAM", Style::default().fg(Theme::text_muted())),
-                Span::styled(
-                    format!("  {}", format_bytes(m.session_memory_bytes)),
-                    Style::default().fg(Theme::text_primary()),
-                ),
-            ]));
-        }
-    }
-
-    // ── Agent section (Claude CLI metrics) ──
-    if let Some(ref metrics) = info.agent_metrics {
-        append_agent_section(&mut lines, metrics, inner_width);
-    }
-
-    // ── Usage / rate-limits (account-level, the `/usage` equivalent) ──
-    if let Some(u) = usage {
-        if !u.is_empty() {
-            append_usage_section(&mut lines, u, inner_width);
-        }
-    }
-
-    // ── System Resources section (global CPU/RAM) ──
-    if let Some(m) = metrics {
-        lines.push(separator(inner_width));
-        lines.push(Line::from(Span::styled("System", Theme::section_header())));
-
-        let gauge_lines = render_gauge_lines("CPU", m.cpu_percent, None, inner_width);
-        lines.extend(gauge_lines);
-
-        let ram_lines = render_gauge_lines(
-            "RAM",
-            if m.memory_total > 0 {
-                (m.memory_used as f64 / m.memory_total as f64 * 100.0) as f32
-            } else {
-                0.0
-            },
-            Some(format_bytes_pair(m.memory_used, m.memory_total)),
-            inner_width,
-        );
-        lines.extend(ram_lines);
-    }
-
-    // ── Automations section ──
-    if !automations.is_empty() {
-        lines.push(separator(inner_width));
-        lines.push(Line::from(Span::styled(
-            format!("Automations ({})", automations.len()),
-            Theme::section_header(),
-        )));
-        for entry in automations {
-            lines.push(Line::from(vec![
-                Span::styled(&entry.countdown, Style::default().fg(Theme::accent())),
-                Span::styled("  ", Style::default()),
-                Span::styled(&entry.label, Style::default().fg(Theme::text_secondary())),
-            ]));
-        }
-    }
-
-    let paragraph = Paragraph::new(lines)
-        .block(block)
-        .wrap(Wrap { trim: false });
-    frame.render_widget(paragraph, area);
 }
 
-/// Append the Agent section showing Claude CLI metrics.
-fn append_agent_section(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner_width: usize) {
-    lines.push(separator(inner_width));
+/// Append the active session's CPU gauge + RAM line (only when non-zero).
+fn append_session_resources(lines: &mut Vec<Line<'_>>, m: &SystemMetrics, inner_width: usize) {
+    if m.session_cpu_percent > 0.0 || m.session_memory_bytes > 0 {
+        let cpu_gauge = render_gauge_lines("CPU", m.session_cpu_percent, None, inner_width);
+        lines.extend(cpu_gauge);
 
-    let header = match (&metrics.model_display_name, &metrics.cli_version) {
-        (Some(model), Some(ver)) => format!("Agent ({model} v{ver})"),
-        (Some(model), None) => format!("Agent ({model})"),
-        (None, Some(ver)) => format!("Agent (v{ver})"),
-        (None, None) => "Agent".to_string(),
-    };
-    lines.push(Line::from(Span::styled(header, Theme::section_header())));
-
-    // Cost (headline number, only when the agent reports a non-zero spend).
-    if let Some(cost) = metrics.total_cost_usd {
-        if cost > 0.0 {
-            lines.push(Line::from(vec![
-                Span::styled("Cost:    ", Theme::label()),
-                Span::styled(format_cost(cost), Style::default().fg(Theme::accent())),
-            ]));
-        }
-    }
-
-    // Elapsed wall time, with API time as a muted aside when present.
-    if let Some(ms) = metrics.total_duration_ms {
-        let mut spans = vec![
-            Span::styled("Time:    ", Theme::label()),
-            Span::styled(
-                format_duration(ms),
-                Style::default().fg(Theme::text_primary()),
-            ),
-        ];
-        if let Some(api_ms) = metrics.total_api_duration_ms.filter(|&v| v > 0) {
-            spans.push(Span::styled(
-                format!("  (api {})", format_duration(api_ms)),
-                Style::default().fg(Theme::text_muted()),
-            ));
-        }
-        lines.push(Line::from(spans));
-    }
-
-    // Tokens
-    if metrics.total_input_tokens.is_some() || metrics.total_output_tokens.is_some() {
-        let input = metrics
-            .total_input_tokens
-            .map(format_tokens)
-            .unwrap_or_else(|| "-".to_string());
-        let output = metrics
-            .total_output_tokens
-            .map(format_tokens)
-            .unwrap_or_else(|| "-".to_string());
         lines.push(Line::from(vec![
-            Span::styled("Tokens:  ", Theme::label()),
+            Span::styled("RAM", Style::default().fg(Theme::text_muted())),
             Span::styled(
-                format!("{input} in / {output} out"),
+                format!("  {}", format_bytes(m.session_memory_bytes)),
                 Style::default().fg(Theme::text_primary()),
             ),
         ]));
     }
+}
 
-    // Context window gauge. When the window size is known, show the gauge as
-    // used/total tokens rather than a bare percentage.
+/// Append the System Resources section (global CPU/RAM gauges).
+fn append_system_section(lines: &mut Vec<Line<'_>>, m: &SystemMetrics, inner_width: usize) {
+    lines.push(separator(inner_width));
+    lines.push(Line::from(Span::styled("System", Theme::section_header())));
+
+    let gauge_lines = render_gauge_lines("CPU", m.cpu_percent, None, inner_width);
+    lines.extend(gauge_lines);
+
+    let ram_lines = render_gauge_lines(
+        "RAM",
+        if m.memory_total > 0 {
+            (m.memory_used as f64 / m.memory_total as f64 * 100.0) as f32
+        } else {
+            0.0
+        },
+        Some(format_bytes_pair(m.memory_used, m.memory_total)),
+        inner_width,
+    );
+    lines.extend(ram_lines);
+}
+
+/// Append the upcoming-automations section (skipped when there are none).
+fn append_automations_section<'a>(
+    lines: &mut Vec<Line<'a>>,
+    automations: &'a [AutomationEntry],
+    inner_width: usize,
+) {
+    if automations.is_empty() {
+        return;
+    }
+    lines.push(separator(inner_width));
+    lines.push(Line::from(Span::styled(
+        format!("Automations ({})", automations.len()),
+        Theme::section_header(),
+    )));
+    for entry in automations {
+        lines.push(Line::from(vec![
+            Span::styled(&entry.countdown, Style::default().fg(Theme::accent())),
+            Span::styled("  ", Style::default()),
+            Span::styled(&entry.label, Style::default().fg(Theme::text_secondary())),
+        ]));
+    }
+}
+
+/// Build the Agent section header from the model name + CLI version.
+fn agent_section_header(metrics: &AgentMetrics) -> String {
+    match (&metrics.model_display_name, &metrics.cli_version) {
+        (Some(model), Some(ver)) => format!("Agent ({model} v{ver})"),
+        (Some(model), None) => format!("Agent ({model})"),
+        (None, Some(ver)) => format!("Agent (v{ver})"),
+        (None, None) => "Agent".to_string(),
+    }
+}
+
+/// Append the elapsed-time row, with API time as a muted aside when present.
+fn append_agent_time(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics) {
+    let Some(ms) = metrics.total_duration_ms else {
+        return;
+    };
+    let mut spans = vec![
+        Span::styled("Time:    ", Theme::label()),
+        Span::styled(
+            format_duration(ms),
+            Style::default().fg(Theme::text_primary()),
+        ),
+    ];
+    if let Some(api_ms) = metrics.total_api_duration_ms.filter(|&v| v > 0) {
+        spans.push(Span::styled(
+            format!("  (api {})", format_duration(api_ms)),
+            Style::default().fg(Theme::text_muted()),
+        ));
+    }
+    lines.push(Line::from(spans));
+}
+
+/// Append the tokens row (input / output), skipped when neither is reported.
+fn append_agent_tokens(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics) {
+    if metrics.total_input_tokens.is_none() && metrics.total_output_tokens.is_none() {
+        return;
+    }
+    let input = metrics
+        .total_input_tokens
+        .map(format_tokens)
+        .unwrap_or_else(|| "-".to_string());
+    let output = metrics
+        .total_output_tokens
+        .map(format_tokens)
+        .unwrap_or_else(|| "-".to_string());
+    lines.push(Line::from(vec![
+        Span::styled("Tokens:  ", Theme::label()),
+        Span::styled(
+            format!("{input} in / {output} out"),
+            Style::default().fg(Theme::text_primary()),
+        ),
+    ]));
+}
+
+/// Append the context-window gauge. When the window size is known, show the
+/// gauge as used/total tokens rather than a bare percentage.
+fn append_agent_context(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner_width: usize) {
     if let Some(pct) = metrics.used_percentage {
         let suffix = metrics.context_window_size.map(|size| {
             let used = (size as f64 * pct as f64 / 100.0).round() as u64;
@@ -259,26 +284,31 @@ fn append_agent_section(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner
         let gauge = render_gauge_lines("Context", pct as f32, suffix, inner_width);
         lines.extend(gauge);
     }
+}
 
-    // Lines changed
-    if metrics.total_lines_added.is_some() || metrics.total_lines_removed.is_some() {
-        let added = metrics.total_lines_added.unwrap_or(0);
-        let removed = metrics.total_lines_removed.unwrap_or(0);
-        lines.push(Line::from(vec![
-            Span::styled("Lines:   ", Theme::label()),
-            Span::styled(
-                format!("+{added}"),
-                Style::default().fg(Theme::status_busy()),
-            ),
-            Span::styled(" / ", Style::default().fg(Theme::text_muted())),
-            Span::styled(
-                format!("-{removed}"),
-                Style::default().fg(Theme::status_error()),
-            ),
-        ]));
+/// Append the lines-changed row, skipped when neither is reported.
+fn append_agent_lines_changed(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics) {
+    if metrics.total_lines_added.is_none() && metrics.total_lines_removed.is_none() {
+        return;
     }
+    let added = metrics.total_lines_added.unwrap_or(0);
+    let removed = metrics.total_lines_removed.unwrap_or(0);
+    lines.push(Line::from(vec![
+        Span::styled("Lines:   ", Theme::label()),
+        Span::styled(
+            format!("+{added}"),
+            Style::default().fg(Theme::status_busy()),
+        ),
+        Span::styled(" / ", Style::default().fg(Theme::text_muted())),
+        Span::styled(
+            format!("-{removed}"),
+            Style::default().fg(Theme::status_error()),
+        ),
+    ]));
+}
 
-    // Cache stats (only when non-zero)
+/// Append the cache-stats row (only when non-zero).
+fn append_agent_cache(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics) {
     let cache_read = metrics.cache_read_input_tokens.unwrap_or(0);
     let cache_create = metrics.cache_creation_input_tokens.unwrap_or(0);
     if cache_read > 0 || cache_create > 0 {
@@ -294,6 +324,31 @@ fn append_agent_section(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner
             ),
         ]));
     }
+}
+
+/// Append the Agent section showing Claude CLI metrics.
+fn append_agent_section(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics, inner_width: usize) {
+    lines.push(separator(inner_width));
+    lines.push(Line::from(Span::styled(
+        agent_section_header(metrics),
+        Theme::section_header(),
+    )));
+
+    // Cost (headline number, only when the agent reports a non-zero spend).
+    if let Some(cost) = metrics.total_cost_usd {
+        if cost > 0.0 {
+            lines.push(Line::from(vec![
+                Span::styled("Cost:    ", Theme::label()),
+                Span::styled(format_cost(cost), Style::default().fg(Theme::accent())),
+            ]));
+        }
+    }
+
+    append_agent_time(lines, metrics);
+    append_agent_tokens(lines, metrics);
+    append_agent_context(lines, metrics, inner_width);
+    append_agent_lines_changed(lines, metrics);
+    append_agent_cache(lines, metrics);
 }
 
 /// Append the repos section showing all repo paths for a session.

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -54,26 +54,17 @@ fn split_left_column(col: Rect, automation_count: usize) -> (Rect, Option<Rect>)
     (rows[0], Some(rows[1]))
 }
 
-/// Compute panel layout areas based on terminal dimensions and optional
-/// right-side panel visibility.
-///
-/// At width ≥ 120, the layout becomes
-/// `list | info? | terminal | tasks? | file_viewer?` with info (15%), tasks
-/// (20%), and file_viewer (20%) appearing only when requested. The tasks panel
-/// sits between the terminal and the file viewer (both right-side columns). The
-/// left column is further split into a session list and an automations pane
-/// beneath it (whenever the column is tall enough and `show_automations_pane`
-/// is set — false when the `automations` feature flag is off);
-/// `automation_count` only sizes that pane.
-pub fn compute_layout(
-    area: Rect,
-    show_info_panel: bool,
-    show_tasks_panel: bool,
-    show_file_viewer: bool,
-    show_global_search: bool,
-    show_automations_pane: bool,
-    automation_count: usize,
-) -> PanelAreas {
+/// Vertical bands carved from the full area: header, content region, optional
+/// global-search strip, and footer.
+struct VerticalBands {
+    header: Rect,
+    content: Rect,
+    global_search: Option<Rect>,
+    footer: Rect,
+}
+
+/// Split the full area into header / content / global-search / footer bands.
+fn split_vertical(area: Rect, show_global_search: bool) -> VerticalBands {
     // Compact mode: when the terminal is shorter than 20 rows, drop the
     // header line entirely so the content + footer get every row available.
     let header_height = if area.height < 20 { 0 } else { 1 };
@@ -97,113 +88,168 @@ pub fn compute_layout(
         ])
         .split(area);
 
-    let header = vertical[0];
-    let content = vertical[1];
-    let global_search = (search_height > 0).then_some(vertical[2]);
-    let footer = vertical[3];
+    VerticalBands {
+        header: vertical[0],
+        content: vertical[1],
+        global_search: (search_height > 0).then_some(vertical[2]),
+        footer: vertical[3],
+    }
+}
 
-    let settings = crate::session::settings::global();
-    if area.width < settings.two_panel_min_cols {
-        return PanelAreas {
-            header,
-            left_panel: None,
-            automations_panel: None,
-            info_panel: None,
-            tasks_panel: None,
-            file_viewer: None,
-            global_search,
-            terminal: content,
-            footer,
-        };
+/// Split a left-column rect into (session list, automations pane) honouring the
+/// `show_automations_pane` flag.
+fn left_column_split(
+    col: Rect,
+    show_automations_pane: bool,
+    automation_count: usize,
+) -> (Rect, Option<Rect>) {
+    if show_automations_pane {
+        split_left_column(col, automation_count)
+    } else {
+        (col, None)
+    }
+}
+
+/// Build the wide (≥ three_panel_min_cols) layout with optional info / tasks /
+/// file-viewer columns. Column order: list | info? | terminal | tasks? |
+/// file_viewer?.
+fn three_panel_layout(
+    bands: &VerticalBands,
+    content: Rect,
+    show_info_panel: bool,
+    show_tasks_panel: bool,
+    show_file_viewer: bool,
+    show_automations_pane: bool,
+    automation_count: usize,
+) -> PanelAreas {
+    let mut constraints: Vec<Constraint> = vec![Constraint::Percentage(18)]; // list
+    if show_info_panel {
+        constraints.push(Constraint::Percentage(15));
+    }
+    // terminal takes the remainder
+    let terminal_idx = constraints.len();
+    constraints.push(Constraint::Min(0));
+    if show_tasks_panel {
+        constraints.push(Constraint::Percentage(20));
+    }
+    if show_file_viewer {
+        constraints.push(Constraint::Percentage(20));
     }
 
-    // At width ≥ three_panel_min_cols (default 120), support optional info /
-    // tasks / file-viewer columns.
-    // Column order: list | info? | terminal | tasks? | file_viewer?.
-    if area.width >= settings.three_panel_min_cols
-        && (show_info_panel || show_tasks_panel || show_file_viewer)
-    {
-        let mut constraints: Vec<Constraint> = vec![Constraint::Percentage(18)]; // list
-        if show_info_panel {
-            constraints.push(Constraint::Percentage(15));
-        }
-        // terminal takes the remainder
-        let terminal_idx = constraints.len();
-        constraints.push(Constraint::Min(0));
-        if show_tasks_panel {
-            constraints.push(Constraint::Percentage(20));
-        }
-        if show_file_viewer {
-            constraints.push(Constraint::Percentage(20));
-        }
+    let horizontal = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(constraints)
+        .split(content);
 
-        let horizontal = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints(constraints)
-            .split(content);
+    let info_panel = show_info_panel.then(|| horizontal[1]);
+    let terminal = horizontal[terminal_idx];
+    // Tasks (if shown) immediately follow the terminal; the file viewer
+    // follows tasks (or the terminal when tasks are hidden).
+    let mut next = terminal_idx + 1;
+    let tasks_panel = show_tasks_panel.then(|| {
+        let r = horizontal[next];
+        next += 1;
+        r
+    });
+    let file_viewer = show_file_viewer.then(|| horizontal[next]);
 
-        let info_panel = if show_info_panel {
-            Some(horizontal[1])
-        } else {
-            None
-        };
-        let terminal = horizontal[terminal_idx];
-        // Tasks (if shown) immediately follow the terminal; the file viewer
-        // follows tasks (or the terminal when tasks are hidden).
-        let mut next = terminal_idx + 1;
-        let tasks_panel = if show_tasks_panel {
-            let r = horizontal[next];
-            next += 1;
-            Some(r)
-        } else {
-            None
-        };
-        let file_viewer = if show_file_viewer {
-            Some(horizontal[next])
-        } else {
-            None
-        };
-
-        let (left_panel, automations_panel) = if show_automations_pane {
-            split_left_column(horizontal[0], automation_count)
-        } else {
-            (horizontal[0], None)
-        };
-        return PanelAreas {
-            header,
-            left_panel: Some(left_panel),
-            automations_panel,
-            info_panel,
-            tasks_panel,
-            file_viewer,
-            global_search,
-            terminal,
-            footer,
-        };
+    let (left_panel, automations_panel) =
+        left_column_split(horizontal[0], show_automations_pane, automation_count);
+    PanelAreas {
+        header: bands.header,
+        left_panel: Some(left_panel),
+        automations_panel,
+        info_panel,
+        tasks_panel,
+        file_viewer,
+        global_search: bands.global_search,
+        terminal,
+        footer: bands.footer,
     }
+}
 
-    // 2-panel mode: 25% list | 75% terminal
+/// Build the 2-panel layout: 25% list | 75% terminal.
+fn two_panel_layout(
+    bands: &VerticalBands,
+    content: Rect,
+    show_automations_pane: bool,
+    automation_count: usize,
+) -> PanelAreas {
     let horizontal = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(25), Constraint::Percentage(75)])
         .split(content);
 
-    let (left_panel, automations_panel) = if show_automations_pane {
-        split_left_column(horizontal[0], automation_count)
-    } else {
-        (horizontal[0], None)
-    };
+    let (left_panel, automations_panel) =
+        left_column_split(horizontal[0], show_automations_pane, automation_count);
     PanelAreas {
-        header,
+        header: bands.header,
         left_panel: Some(left_panel),
         automations_panel,
         info_panel: None,
         tasks_panel: None,
         file_viewer: None,
-        global_search,
+        global_search: bands.global_search,
         terminal: horizontal[1],
-        footer,
+        footer: bands.footer,
     }
+}
+
+/// Compute panel layout areas based on terminal dimensions and optional
+/// right-side panel visibility.
+///
+/// At width ≥ 120, the layout becomes
+/// `list | info? | terminal | tasks? | file_viewer?` with info (15%), tasks
+/// (20%), and file_viewer (20%) appearing only when requested. The tasks panel
+/// sits between the terminal and the file viewer (both right-side columns). The
+/// left column is further split into a session list and an automations pane
+/// beneath it (whenever the column is tall enough and `show_automations_pane`
+/// is set — false when the `automations` feature flag is off);
+/// `automation_count` only sizes that pane.
+pub fn compute_layout(
+    area: Rect,
+    show_info_panel: bool,
+    show_tasks_panel: bool,
+    show_file_viewer: bool,
+    show_global_search: bool,
+    show_automations_pane: bool,
+    automation_count: usize,
+) -> PanelAreas {
+    let bands = split_vertical(area, show_global_search);
+    let content = bands.content;
+
+    let settings = crate::session::settings::global();
+    if area.width < settings.two_panel_min_cols {
+        return PanelAreas {
+            header: bands.header,
+            left_panel: None,
+            automations_panel: None,
+            info_panel: None,
+            tasks_panel: None,
+            file_viewer: None,
+            global_search: bands.global_search,
+            terminal: content,
+            footer: bands.footer,
+        };
+    }
+
+    // At width ≥ three_panel_min_cols (default 120), support optional info /
+    // tasks / file-viewer columns.
+    if area.width >= settings.three_panel_min_cols
+        && (show_info_panel || show_tasks_panel || show_file_viewer)
+    {
+        return three_panel_layout(
+            &bands,
+            content,
+            show_info_panel,
+            show_tasks_panel,
+            show_file_viewer,
+            show_automations_pane,
+            automation_count,
+        );
+    }
+
+    two_panel_layout(&bands, content, show_automations_pane, automation_count)
 }
 
 #[cfg(test)]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -176,32 +176,42 @@ pub fn editor_field_line_with_cursor<'a>(
     if selector {
         spans.push(Span::styled(format!("‹ {value} ›"), value_style));
     } else if active {
-        // Draw a real block cursor at the caret position so horizontal movement
-        // inside the text is visible. Fall back to a trailing block when no
-        // cursor is supplied (preserves the prior end-of-line affordance).
-        let chars: Vec<char> = value.chars().collect();
-        let caret = cursor.unwrap_or(chars.len()).min(chars.len());
-
-        let before: String = chars[..caret].iter().collect();
-        if !before.is_empty() {
-            spans.push(Span::styled(before, value_style));
-        }
-        let cursor_char = chars
-            .get(caret)
-            .map(|c| c.to_string())
-            .unwrap_or_else(|| " ".to_string());
-        spans.push(Span::styled(cursor_char, Theme::cursor()));
-        if caret < chars.len() {
-            let after: String = chars[caret + 1..].iter().collect();
-            if !after.is_empty() {
-                spans.push(Span::styled(after, value_style));
-            }
-        }
+        push_value_with_cursor(&mut spans, &value, cursor, value_style);
     } else {
         spans.push(Span::styled(value, value_style));
     }
 
     Line::from(spans)
+}
+
+/// Append `value` to `spans` with a real block cursor drawn at the caret
+/// position so horizontal movement inside the text is visible. Falls back to a
+/// trailing block when no cursor is supplied (preserves the prior end-of-line
+/// affordance).
+fn push_value_with_cursor<'a>(
+    spans: &mut Vec<Span<'a>>,
+    value: &str,
+    cursor: Option<usize>,
+    value_style: Style,
+) {
+    let chars: Vec<char> = value.chars().collect();
+    let caret = cursor.unwrap_or(chars.len()).min(chars.len());
+
+    let before: String = chars[..caret].iter().collect();
+    if !before.is_empty() {
+        spans.push(Span::styled(before, value_style));
+    }
+    let cursor_char = chars
+        .get(caret)
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| " ".to_string());
+    spans.push(Span::styled(cursor_char, Theme::cursor()));
+    if caret < chars.len() {
+        let after: String = chars[caret + 1..].iter().collect();
+        if !after.is_empty() {
+            spans.push(Span::styled(after, value_style));
+        }
+    }
 }
 
 /// Build a footer/hint [`Line`] from `(key, description)` pairs, styling keys

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -762,17 +762,9 @@ const AGENT_STATUS_MIN_WIDTH: usize = 4;
 /// the status dot and the name. The agent-reported status (see
 /// [`agent_status_text`]) is appended after the name, truncated with `…` to
 /// fit `inner_width`.
-#[allow(clippy::too_many_arguments)]
-fn build_session_line<'a>(
-    info: &'a SessionInfo,
-    session_match: Option<&SessionMatch>,
-    is_active: bool,
-    is_dimmed: bool,
-    depth: u8,
-    cross_group_child: bool,
-    inner_width: usize,
-) -> Line<'a> {
-    let name_style = if is_dimmed {
+/// Style for the session name span.
+fn name_span_style(is_active: bool, is_dimmed: bool) -> Style {
+    if is_dimmed {
         Style::default().fg(Theme::text_muted())
     } else if is_active {
         // The active row is painted with the list's `selection_bg`, so the name
@@ -783,18 +775,18 @@ fn build_session_line<'a>(
             .add_modifier(Modifier::BOLD)
     } else {
         Theme::normal_item()
-    };
-    let status_style = if is_dimmed {
-        Style::default().fg(Theme::text_muted())
-    } else {
-        Style::default().fg(super::status_color(info.status))
-    };
+    }
+}
 
-    let mut spans = vec![Span::styled(
-        format!(" {} ", info.status.icon()),
-        status_style,
-    )];
-
+/// Push the prefix marks that sit between the status dot and the name: the
+/// tree/cross-group child glyph, the remote-host cloud, and the worktree mark.
+fn push_prefix_marks(
+    spans: &mut Vec<Span<'_>>,
+    info: &SessionInfo,
+    is_dimmed: bool,
+    depth: u8,
+    cross_group_child: bool,
+) {
     // Tree prefix for children nested under their parent in the same repo
     // group; `↳` for children whose parent renders elsewhere in the list.
     let tree_style = Style::default().fg(Theme::text_muted());
@@ -808,23 +800,87 @@ fn build_session_line<'a>(
     // Remote (ssh:<host>) sessions get a cloud mark so it's clear at a glance
     // the agent runs on another machine. Sits right after the status dot.
     if info.remote_host.is_some() {
-        let remote_style = if is_dimmed {
-            Style::default().fg(Theme::text_muted())
-        } else {
-            Style::default().fg(Theme::accent())
-        };
-        spans.push(Span::styled("\u{2601} ", remote_style));
+        spans.push(Span::styled(
+            "\u{2601} ",
+            mark_style(is_dimmed, Theme::accent),
+        ));
     }
 
     // Worktree sessions get a dedicated mark, subordinate to the status dot.
     if !info.worktrees.is_empty() {
-        let wt_style = if is_dimmed {
-            Style::default().fg(Theme::text_muted())
-        } else {
-            Style::default().fg(Theme::branch_name())
-        };
-        spans.push(Span::styled("\u{2442} ", wt_style));
+        spans.push(Span::styled(
+            "\u{2442} ",
+            mark_style(is_dimmed, Theme::branch_name),
+        ));
     }
+}
+
+/// Style for a prefix mark: muted when the row is dimmed, otherwise the given
+/// accent color.
+fn mark_style(is_dimmed: bool, color: fn() -> ratatui::style::Color) -> Style {
+    if is_dimmed {
+        Style::default().fg(Theme::text_muted())
+    } else {
+        Style::default().fg(color())
+    }
+}
+
+/// Append the agent-reported status after the name, truncated to fit
+/// `inner_width`. An attention notification keeps the status color (same accent
+/// as the dot) so it stands out; plain activity text is muted so the name stays
+/// the visual anchor.
+fn push_agent_status(
+    spans: &mut Vec<Span<'_>>,
+    info: &SessionInfo,
+    status_style: Style,
+    inner_width: usize,
+) {
+    let Some(status_text) = agent_status_text(info) else {
+        return;
+    };
+    let agent_status_style = if info.status == crate::session::SessionStatus::Attention {
+        status_style
+    } else {
+        Style::default().fg(Theme::text_muted())
+    };
+    let used: usize = spans
+        .iter()
+        .map(|s| s.content.chars().count())
+        .sum::<usize>()
+        + AGENT_STATUS_SEPARATOR.chars().count();
+    let avail = inner_width.saturating_sub(used);
+    if avail >= AGENT_STATUS_MIN_WIDTH {
+        spans.push(Span::raw(AGENT_STATUS_SEPARATOR));
+        spans.push(Span::styled(
+            super::truncate_ellipsis(&status_text, avail),
+            agent_status_style,
+        ));
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_session_line<'a>(
+    info: &'a SessionInfo,
+    session_match: Option<&SessionMatch>,
+    is_active: bool,
+    is_dimmed: bool,
+    depth: u8,
+    cross_group_child: bool,
+    inner_width: usize,
+) -> Line<'a> {
+    let name_style = name_span_style(is_active, is_dimmed);
+    let status_style = if is_dimmed {
+        Style::default().fg(Theme::text_muted())
+    } else {
+        Style::default().fg(super::status_color(info.status))
+    };
+
+    let mut spans = vec![Span::styled(
+        format!(" {} ", info.status.icon()),
+        status_style,
+    )];
+
+    push_prefix_marks(&mut spans, info, is_dimmed, depth, cross_group_child);
 
     append_name_spans(
         &mut spans,
@@ -833,30 +889,7 @@ fn build_session_line<'a>(
         name_style,
     );
 
-    // Append the agent-reported status after the name, truncated to fit. An
-    // attention notification keeps the status color (same accent as the dot)
-    // so it stands out; plain activity text is muted so the name stays the
-    // visual anchor.
-    if let Some(status_text) = agent_status_text(info) {
-        let agent_status_style = if info.status == crate::session::SessionStatus::Attention {
-            status_style
-        } else {
-            Style::default().fg(Theme::text_muted())
-        };
-        let used: usize = spans
-            .iter()
-            .map(|s| s.content.chars().count())
-            .sum::<usize>()
-            + AGENT_STATUS_SEPARATOR.chars().count();
-        let avail = inner_width.saturating_sub(used);
-        if avail >= AGENT_STATUS_MIN_WIDTH {
-            spans.push(Span::raw(AGENT_STATUS_SEPARATOR));
-            spans.push(Span::styled(
-                super::truncate_ellipsis(&status_text, avail),
-                agent_status_style,
-            ));
-        }
-    }
+    push_agent_status(&mut spans, info, status_style, inner_width);
 
     Line::from(spans)
 }

--- a/src/ui/repo_picker_modal.rs
+++ b/src/ui/repo_picker_modal.rs
@@ -204,10 +204,7 @@ fn bookmark_item<'a>(
     list_focused: bool,
 ) -> ListItem<'a> {
     let path = &state.bookmarks[real_idx];
-    let checked = state.selected[real_idx];
-    let is_wt = state.worktree[real_idx];
     let is_header = state.is_header.get(real_idx).copied().unwrap_or(false);
-    let is_child = state.is_child.get(real_idx).copied().unwrap_or(false);
     let is_cursor = visible_index == state.list_index && list_focused;
 
     let style = if is_cursor {
@@ -218,19 +215,38 @@ fn bookmark_item<'a>(
 
     // Parent header row: no checkbox, a collapse glyph + basename + dim marker.
     if is_header {
-        let glyph = if state.collapsed.contains(path) {
-            "▸ "
-        } else {
-            "▾ "
-        };
-        return ListItem::new(Line::from(vec![
-            Span::styled(glyph, style),
-            Span::styled(crate::paths::display_path(path), style),
-            Span::styled(" (parent)", Style::default().fg(Theme::text_muted())),
-        ]));
+        return header_item(state, path, style);
     }
 
-    // Child rows are indented under their parent header.
+    child_item(state, real_idx, style)
+}
+
+/// Build a parent header row: a collapse glyph + basename + dim `(parent)` marker.
+fn header_item<'a>(
+    state: &RepoPickerState<'a>,
+    path: &std::path::Path,
+    style: Style,
+) -> ListItem<'a> {
+    let glyph = if state.collapsed.contains(path) {
+        "▸ "
+    } else {
+        "▾ "
+    };
+    ListItem::new(Line::from(vec![
+        Span::styled(glyph, style),
+        Span::styled(crate::paths::display_path(path), style),
+        Span::styled(" (parent)", Style::default().fg(Theme::text_muted())),
+    ]))
+}
+
+/// Build a (possibly indented) child bookmark row: checkbox + path + optional
+/// `[wt]` marker, with the search query highlighted when present.
+fn child_item<'a>(state: &RepoPickerState<'a>, real_idx: usize, style: Style) -> ListItem<'a> {
+    let path = &state.bookmarks[real_idx];
+    let checked = state.selected[real_idx];
+    let is_wt = state.worktree[real_idx];
+    let is_child = state.is_child.get(real_idx).copied().unwrap_or(false);
+
     let indent = if is_child { "  " } else { "" };
     let check = if checked { "[x] " } else { "[ ] " };
     let display = crate::paths::display_path(path);

--- a/src/ui/task_editor_modal.rs
+++ b/src/ui/task_editor_modal.rs
@@ -118,35 +118,63 @@ fn description_lines<'a>(state: &TaskEditorState<'a>, active: bool) -> Vec<Line<
         return lines;
     }
 
-    let (cur_line, cur_col) = state.description_cursor;
-    for (li, text) in state.description.split('\n').enumerate() {
-        let chars: Vec<char> = text.chars().collect();
-        let mut spans = vec![Span::raw("    ")];
-        if active && li == cur_line {
-            let caret = cur_col.min(chars.len());
-            let before: String = chars[..caret].iter().collect();
-            if !before.is_empty() {
-                spans.push(Span::styled(before, text_style));
-            }
-            let cursor_char = chars
-                .get(caret)
-                .map(|c| c.to_string())
-                .unwrap_or_else(|| " ".to_string());
-            spans.push(Span::styled(cursor_char, Theme::cursor()));
-            let after: String = chars
-                .get(caret + 1..)
-                .map(|s| s.iter().collect())
-                .unwrap_or_default();
-            if !after.is_empty() {
-                spans.push(Span::styled(after, text_style));
-            }
-        } else if !chars.is_empty() {
-            spans.push(Span::styled(text.to_string(), text_style));
-        }
-        lines.push(Line::from(spans));
-    }
-
+    lines.extend(description_text_rows(state, active, text_style));
     lines
+}
+
+/// Build the indented text rows of the description, drawing a block cursor on
+/// the cursor's row when `active`.
+fn description_text_rows<'a>(
+    state: &TaskEditorState<'a>,
+    active: bool,
+    text_style: Style,
+) -> Vec<Line<'a>> {
+    let (cur_line, cur_col) = state.description_cursor;
+    state
+        .description
+        .split('\n')
+        .enumerate()
+        .map(|(li, text)| {
+            if active && li == cur_line {
+                description_cursor_line(text, cur_col, text_style)
+            } else {
+                description_plain_line(text, text_style)
+            }
+        })
+        .collect()
+}
+
+/// Render one description row with a block cursor drawn at `cur_col`.
+fn description_cursor_line<'a>(text: &str, cur_col: usize, text_style: Style) -> Line<'a> {
+    let chars: Vec<char> = text.chars().collect();
+    let caret = cur_col.min(chars.len());
+    let mut spans = vec![Span::raw("    ")];
+    let before: String = chars[..caret].iter().collect();
+    if !before.is_empty() {
+        spans.push(Span::styled(before, text_style));
+    }
+    let cursor_char = chars
+        .get(caret)
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| " ".to_string());
+    spans.push(Span::styled(cursor_char, Theme::cursor()));
+    let after: String = chars
+        .get(caret + 1..)
+        .map(|s| s.iter().collect())
+        .unwrap_or_default();
+    if !after.is_empty() {
+        spans.push(Span::styled(after, text_style));
+    }
+    Line::from(spans)
+}
+
+/// Render one description row without a cursor (indented plain text).
+fn description_plain_line<'a>(text: &str, text_style: Style) -> Line<'a> {
+    let mut spans = vec![Span::raw("    ")];
+    if !text.is_empty() {
+        spans.push(Span::styled(text.to_string(), text_style));
+    }
+    Line::from(spans)
 }
 
 fn field_line<'a>(


### PR DESCRIPTION
## Summary

- Extracted cohesive private helpers across **25 files** to bring ~25 functions that exceeded SonarQube's cognitive-complexity threshold (S3776, >15) comfortably under it (most now ≤10).
- Pure, behavior-preserving refactor — no public signatures or observable behavior changed; insta snapshots render byte-identical.
- Context: the open SonarCloud board (scan 2026-04-14) is largely stale (6 flagged files deleted, big offenders already fixed); a fresh local measurement found the functions a new scan would actually flag, and this addresses them.

Notable reductions: `cli::automations::run` 39→1, `session_ops::install_extension` 30→6, `ui::compute_layout` 29→5, `agent::remove_agents_from_toml` 24→5, `ui::render_info_panel` 23→7, `app::modals::apply_text_input_key` 21→8, `main::run_loop` 19→8, `app::{tick,poll_config_reload}` 17→2.

## Test plan

- `cargo check --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`
- `cargo test --test architecture_rules` (11/11)
- Full lib suite passes (1221) under CI's nextest
- CI checks pass