### PR TITLE
fix(cli): disambiguate global --text flag from session send positional

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,7 +37,13 @@ pub struct Cli {
     pub pretty: bool,
 
     /// Force human-readable output even when piped.
-    #[arg(long, global = true)]
+    ///
+    /// `id = "text_format"` disambiguates from subcommand positional args also
+    /// named `text` (e.g. `sessions::Action::Send`). Without the explicit id,
+    /// clap registers two args with id "text" (this bool flag and the String
+    /// positional), and `get_one::<String>("text")` at parse time panics with
+    /// a TypeId downcast mismatch.
+    #[arg(long, global = true, id = "text_format")]
     pub text: bool,
 
     #[command(subcommand)]
@@ -200,6 +206,52 @@ mod tests {
             parent.as_deref(),
             Some("0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a")
         );
+    }
+
+    #[test]
+    fn parse_session_send_disambiguates_global_text_flag() {
+        // Regression: the global `--text` flag (bool) and the `text: String`
+        // positional in `sessions::Action::Send` both default to clap arg id
+        // "text", which causes a TypeId-mismatch panic at parse time when
+        // constructing Send. The global flag uses `id = "text_format"` to
+        // disambiguate; this test fails-to-compile-or-panics if either side
+        // regresses back to the colliding id.
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "session",
+            "send",
+            "0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a",
+            "hello",
+        ])
+        .unwrap();
+        let Command::Session {
+            action: sessions::Action::Send { uuid, text },
+        } = cli.command
+        else {
+            panic!("expected Session::Send");
+        };
+        assert_eq!(uuid, "0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a");
+        assert_eq!(text, "hello");
+
+        // Same subcommand, with the global `--text` flag set — the original
+        // collision-triggering invocation. Must still parse and set both.
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "--text",
+            "session",
+            "send",
+            "0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a",
+            "hello",
+        ])
+        .unwrap();
+        assert!(cli.text);
+        let Command::Session {
+            action: sessions::Action::Send { text, .. },
+        } = cli.command
+        else {
+            panic!("expected Session::Send");
+        };
+        assert_eq!(text, "hello");
     }
 
     #[test]


### PR DESCRIPTION
## Bug

\`thurbox-cli session send <UUID> <TEXT>\` panics on every invocation:

\`\`\`
$ thurbox-cli session send 0f4dec1e-... "hello"
thread 'main' panicked at clap_builder-4.6.0/src/parser/error.rs:32:
  Mismatch between definition and access of \`text\`.
  Could not downcast to TypeId(<String>), need to downcast to TypeId(<bool>)
\`\`\`

## Cause

`Cli::text` (global `--text` bool, `src/cli/mod.rs:41`) and `sessions::Action::Send::text` (positional `String`, `src/cli/sessions.rs:74`) both default to clap arg id `"text"`. clap's value store keys by id — the global registers first as `bool`, so when the Send variant's derive-emitted constructor runs `get_one::<String>("text")`, the downcast fails.

Same root cause for every other subcommand if a future positional happens to be named `text`. Affects all clap 4.6.x — not a version-pin issue.

## Fix

`#[arg(long, global = true, id = "text_format")]` on the global flag. One line of code + a five-line comment explaining why.

- CLI surface: unchanged (`--text` still works)
- Rust accessor: unchanged (`cli.text` still works)
- Internal clap id: now `"text_format"`, no collision

## Verified

- `thurbox-cli session send <uuid> "hello"` — works, no panic
- `thurbox-cli --text session send <uuid> "hello"` — works (the original collision invocation), `--text` flag still forces human output
- `thurbox-cli session list/get/create/capture` — unaffected (regression check on adjacent subcommands)
- All existing tests pass; full test suite untouched

## Regression test

Added `cli::tests::parse_session_send_disambiguates_global_text_flag` that parses `session send <uuid> <text>` both with and without `--text` and asserts no panic + correct field population. Fails if either side regresses back to the colliding id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)