### PR TITLE
feat(ui): sort session list alphabetically with Shift+S

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,6 +434,14 @@ restarts and syncs across instances via the existing
 `data_version` polling. Storage: nullable `sessions.display_order`
 column (schema v31); `None` = never moved, renders after ordered
 sessions in creation order (new sessions append to their group).
+**`Shift+S`** (rebindable `SessionListSortAlphabetically`) sorts
+sessions alphabetically by name **within each repo group** in one
+shot: group order is preserved (still by lowest `display_order`),
+and parent/child nesting is preserved (children sort among their
+siblings). It reuses the same dense-renumber-and-persist path, so
+the alphabetised order survives restarts just like a manual move
+(pure helper: `ui::project_list::sort_alphabetically_within_groups`;
+`App::sort_sessions_alphabetically` applies it).
 
 ### Inter-session messages (mailbox queue)
 

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1361,6 +1361,10 @@ impl App {
                 self.move_active_session(false);
                 true
             }
+            Action::SessionListSortAlphabetically => {
+                self.sort_sessions_alphabetically();
+                true
+            }
 
             // ── File viewer + terminal scroll (scoped) ──────────────────
             Action::FileViewerDown

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2624,6 +2624,25 @@ impl App {
         self.save_state();
     }
 
+    /// Sort sessions alphabetically by name within each repo group
+    /// (`Shift+S` in the session list). Group order is unchanged; parent/child
+    /// nesting is preserved (children sort among their siblings). Renumbers
+    /// every session's `display_order` densely along the new order so the
+    /// arrangement survives restarts and reaches other instances via the DB
+    /// poll. No-op on an empty list.
+    pub(crate) fn sort_sessions_alphabetically(&mut self) {
+        if self.sessions.is_empty() {
+            return;
+        }
+        let infos: Vec<&crate::session::SessionInfo> =
+            self.sessions.iter().map(|s| &s.info).collect();
+        let new_order = crate::ui::project_list::sort_alphabetically_within_groups(&infos);
+        for (pos, &idx) in new_order.iter().enumerate() {
+            self.sessions[idx].info.display_order = Some(pos as i64);
+        }
+        self.save_state();
+    }
+
     /// Whether the active session is the first row in render order (top of the
     /// left column). Treats an empty list as "first" so `k` is a no-op there.
     pub(crate) fn active_is_first_in_order(&self) -> bool {
@@ -8499,6 +8518,47 @@ mod tests {
         app.move_active_session(false); // already at the top
         assert_eq!(app.render_order_indices(), vec![0, 1]);
         assert!(app.sessions.iter().all(|s| s.info.display_order.is_none()));
+    }
+
+    #[test]
+    fn sort_sessions_alphabetically_renumbers_and_persists() {
+        let mut app = app_with_sessions(3);
+        // Names in deliberately non-alphabetical order: c, a, b.
+        app.sessions[0].info.name = "c".to_string();
+        app.sessions[1].info.name = "a".to_string();
+        app.sessions[2].info.name = "b".to_string();
+        app.active_index = 0;
+
+        app.sort_sessions_alphabetically();
+
+        // Render order is now [a, b, c], densely renumbered 0..n.
+        assert_eq!(app.render_order_indices(), vec![1, 2, 0]);
+        assert_eq!(app.sessions[1].info.display_order, Some(0));
+        assert_eq!(app.sessions[2].info.display_order, Some(1));
+        assert_eq!(app.sessions[0].info.display_order, Some(2));
+
+        // Persisted: the DB lists sessions in the new order.
+        let names: Vec<String> = app
+            .db
+            .list_active_sessions()
+            .unwrap()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(names, ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn sort_sessions_alphabetically_empty_is_noop() {
+        let mut app = App::new(
+            24,
+            120,
+            BackendRegistry::new(stub_backend_arc()),
+            stub_agents(),
+            test_db(),
+        );
+        app.sort_sessions_alphabetically(); // must not panic
+        assert!(app.sessions.is_empty());
     }
 
     #[test]

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -62,6 +62,9 @@ pub enum Action {
     SessionListMoveDown,
     /// Move the selected session one row up (manual reordering).
     SessionListMoveUp,
+    /// Sort sessions alphabetically by name within each repo group, preserving
+    /// group order and parent/child nesting (children sort among siblings).
+    SessionListSortAlphabetically,
     // ── File viewer (scoped) ────────────────────────────────────────────
     FileViewerDown,
     FileViewerUp,
@@ -121,6 +124,7 @@ impl Action {
             Action::SessionListOpen,
             Action::SessionListMoveDown,
             Action::SessionListMoveUp,
+            Action::SessionListSortAlphabetically,
             Action::FileViewerDown,
             Action::FileViewerUp,
             Action::FileViewerCollapse,
@@ -166,6 +170,7 @@ impl Action {
             Action::SessionListOpen => "Focus terminal",
             Action::SessionListMoveDown => "Move session down",
             Action::SessionListMoveUp => "Move session up",
+            Action::SessionListSortAlphabetically => "Sort sessions A→Z",
             Action::FileViewerDown => "Move down",
             Action::FileViewerUp => "Move up",
             Action::FileViewerCollapse => "Collapse / parent",
@@ -191,7 +196,8 @@ impl Action {
             | Action::SessionListPrev
             | Action::SessionListOpen
             | Action::SessionListMoveDown
-            | Action::SessionListMoveUp => KeyContext::SessionList,
+            | Action::SessionListMoveUp
+            | Action::SessionListSortAlphabetically => KeyContext::SessionList,
             Action::FileViewerDown
             | Action::FileViewerUp
             | Action::FileViewerCollapse
@@ -312,6 +318,10 @@ impl Action {
             Action::SessionListMoveUp => {
                 vec![KeyChord::normalized(KeyModifiers::NONE, KeyCode::Char('K'))]
             }
+            // Shift+S — normalized like SessionListMoveDown/Up's Shift+J/K.
+            Action::SessionListSortAlphabetically => {
+                vec![KeyChord::normalized(KeyModifiers::NONE, KeyCode::Char('S'))]
+            }
             Action::FileViewerDown => vec![KeyChord::plain('j'), KeyChord::key(KeyCode::Down)],
             Action::FileViewerUp => vec![KeyChord::plain('k'), KeyChord::key(KeyCode::Up)],
             Action::FileViewerCollapse => vec![KeyChord::plain('h'), KeyChord::key(KeyCode::Left)],
@@ -418,6 +428,7 @@ pub fn help_sections() -> Vec<(&'static str, Vec<Action>)> {
                 SessionListOpen,
                 SessionListMoveDown,
                 SessionListMoveUp,
+                SessionListSortAlphabetically,
             ],
         ),
         (
@@ -1069,6 +1080,7 @@ mod tests {
                 Action::SessionListOpen => 0,
                 Action::SessionListMoveDown => 0,
                 Action::SessionListMoveUp => 0,
+                Action::SessionListSortAlphabetically => 0,
                 Action::FileViewerDown => 0,
                 Action::FileViewerUp => 0,
                 Action::FileViewerCollapse => 0,
@@ -1082,9 +1094,9 @@ mod tests {
                 Action::TerminalPageDown => 0,
             }
         }
-        // 39 listed variants must equal Action::all().len(). If you add
+        // 40 listed variants must equal Action::all().len(). If you add
         // a variant, update both `Action::all()` and the match above.
-        const EXPECTED: usize = 39;
+        const EXPECTED: usize = 40;
         assert_eq!(Action::all().len(), EXPECTED);
         for a in Action::all() {
             classify(*a);

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -251,6 +251,103 @@ fn nest_group_members(sessions: &[&SessionInfo], members: &[usize]) -> Vec<(usiz
     out
 }
 
+/// Return a new flat order of **input indices** with each repo group's members
+/// sorted alphabetically (case-insensitively) by `name`. Group order is
+/// **unchanged** — groups stay in the order [`compute_session_order`] picked
+/// them, only their inner ordering changes. Within a group, children sort
+/// among their siblings under each parent (recursive DFS, parent first), so
+/// the existing parent/child nesting is preserved.
+///
+/// The caller is expected to renumber `display_order` densely (`0..n`) along
+/// the returned order; [`compute_session_order`] then reproduces it exactly.
+/// On an empty input returns an empty `Vec`, so a no-op `Shift+S` is safe.
+pub fn sort_alphabetically_within_groups(sessions: &[&SessionInfo]) -> Vec<usize> {
+    let ord = compute_session_order(sessions);
+    let mut out: Vec<usize> = Vec::with_capacity(sessions.len());
+    let mut group_start = 0usize;
+    for i in 1..=ord.order.len() {
+        // Flush at every group boundary (a header on the next row) and at the
+        // end of the order. `headers[group_start]` is always `Some`, so the
+        // first iteration's check is gated on `i > group_start`.
+        let at_boundary = i == ord.order.len() || ord.headers[i].is_some();
+        if at_boundary {
+            let group: Vec<usize> = ord.order[group_start..i].to_vec();
+            out.extend(sort_group_alphabetically(sessions, &group));
+            group_start = i;
+        }
+    }
+    out
+}
+
+/// Sort one group's members alphabetically while preserving the parent/child
+/// nesting `compute_session_order` would render: children stay under their
+/// parent and sort among their siblings, recursively. Mirrors the
+/// `nest_group_members` DFS, swapping its index-stable comparator for a
+/// case-insensitive name comparator (with input index as a stable tiebreak).
+fn sort_group_alphabetically(sessions: &[&SessionInfo], members: &[usize]) -> Vec<usize> {
+    use std::collections::{HashMap, HashSet};
+
+    let id_to_member: HashMap<crate::session::SessionId, usize> =
+        members.iter().map(|&i| (sessions[i].id, i)).collect();
+
+    let mut roots: Vec<usize> = Vec::new();
+    let mut children: HashMap<usize, Vec<usize>> = HashMap::new();
+    for &i in members {
+        let parent = sessions[i]
+            .parent_session_id
+            .and_then(|p| id_to_member.get(&p))
+            .copied()
+            .filter(|&p| p != i);
+        match parent {
+            Some(p) => children.entry(p).or_default().push(i),
+            None => roots.push(i),
+        }
+    }
+
+    let sort_key = |i: &usize| (sessions[*i].name.to_lowercase(), *i);
+    roots.sort_by_key(sort_key);
+    for kids in children.values_mut() {
+        kids.sort_by_key(sort_key);
+    }
+
+    fn emit(
+        i: usize,
+        children: &HashMap<usize, Vec<usize>>,
+        visited: &mut HashSet<usize>,
+        out: &mut Vec<usize>,
+    ) {
+        if !visited.insert(i) {
+            return;
+        }
+        out.push(i);
+        if let Some(kids) = children.get(&i) {
+            for &k in kids {
+                emit(k, children, visited, out);
+            }
+        }
+    }
+
+    let mut out = Vec::with_capacity(members.len());
+    let mut visited = HashSet::new();
+    for &r in &roots {
+        emit(r, &children, &mut visited, &mut out);
+    }
+    // Members unreachable from any root (a parent cycle): emit flat in their
+    // own alphabetical order, matching `nest_group_members`'s fallback.
+    let mut leftovers: Vec<usize> = members
+        .iter()
+        .copied()
+        .filter(|i| !visited.contains(i))
+        .collect();
+    leftovers.sort_by_key(|i| sort_key(i));
+    for i in leftovers {
+        if visited.insert(i) {
+            out.push(i);
+        }
+    }
+    out
+}
+
 /// Move the session `active_input_idx` one step up or down in the rendered
 /// order, returning the new flat order of **input indices** — or `None` when
 /// the move is a no-op (active session missing, or already at an edge it
@@ -1610,6 +1707,86 @@ mod tests {
         }
         let sessions: Vec<&SessionInfo> = sessions_owned.iter().collect();
         assert_eq!(order_names(&sessions), vec!["lead", "w1", "i1", "i2"]);
+    }
+
+    // --- sort_alphabetically_within_groups ---
+
+    /// Apply `sort_alphabetically_within_groups` and return the resulting names.
+    fn sort_names<'a>(sessions: &[&'a SessionInfo]) -> Vec<&'a str> {
+        sort_alphabetically_within_groups(sessions)
+            .into_iter()
+            .map(|i| sessions[i].name.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn sort_orders_members_alphabetically_within_a_group() {
+        let c = info_repo("c", "webapp", SessionStatus::Idle);
+        let a = info_repo("a", "webapp", SessionStatus::Idle);
+        let b = info_repo("b", "webapp", SessionStatus::Idle);
+        let sessions = vec![&c, &a, &b];
+        assert_eq!(sort_names(&sessions), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn sort_is_case_insensitive() {
+        let z = info_repo("Zeta", "webapp", SessionStatus::Idle);
+        let a = info_repo("apple", "webapp", SessionStatus::Idle);
+        let b = info_repo("Banana", "webapp", SessionStatus::Idle);
+        let sessions = vec![&z, &a, &b];
+        assert_eq!(sort_names(&sessions), vec!["apple", "Banana", "Zeta"]);
+    }
+
+    #[test]
+    fn sort_preserves_group_order() {
+        // "webapp" holds the lowest display_order, so its group renders first.
+        // Sorting within groups must NOT bubble the alphabetically-earlier
+        // "infra" group above it.
+        let mut w_b = info_repo("w-b", "webapp", SessionStatus::Idle);
+        let mut w_a = info_repo("w-a", "webapp", SessionStatus::Idle);
+        let mut i_c = info_repo("i-c", "infra", SessionStatus::Idle);
+        w_b.display_order = Some(0);
+        w_a.display_order = Some(1);
+        i_c.display_order = Some(2);
+        let sessions = vec![&i_c, &w_b, &w_a];
+        // webapp group stays first, but its members are sorted A→Z.
+        assert_eq!(sort_names(&sessions), vec!["w-a", "w-b", "i-c"]);
+    }
+
+    #[test]
+    fn sort_keeps_children_under_their_parent_sorted_among_siblings() {
+        let lead = info_repo("lead", "webapp", SessionStatus::Idle);
+        // Insert children in non-alphabetical order to prove they're resorted.
+        let w_b = info_child("w-b", "webapp", SessionStatus::Idle, &lead);
+        let w_a = info_child("w-a", "webapp", SessionStatus::Idle, &lead);
+        let sessions = vec![&w_b, &lead, &w_a];
+        // Parent first (sorted among roots), children sorted A→Z under it.
+        assert_eq!(sort_names(&sessions), vec!["lead", "w-a", "w-b"]);
+    }
+
+    #[test]
+    fn sort_renumbers_reproduce_alphabetical_order() {
+        // After densely renumbering display_order along the sorted order,
+        // compute_session_order must reproduce that exact order — the
+        // round-trip the App relies on for persistence.
+        let mut owned = [
+            info_repo("c", "webapp", SessionStatus::Idle),
+            info_repo("a", "webapp", SessionStatus::Idle),
+            info_repo("b", "webapp", SessionStatus::Idle),
+        ];
+        let sessions: Vec<&SessionInfo> = owned.iter().collect();
+        let new_order = sort_alphabetically_within_groups(&sessions);
+        for (pos, &idx) in new_order.iter().enumerate() {
+            owned[idx].display_order = Some(pos as i64);
+        }
+        let sessions: Vec<&SessionInfo> = owned.iter().collect();
+        assert_eq!(order_names(&sessions), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn sort_empty_input_returns_empty() {
+        let sessions: Vec<&SessionInfo> = vec![];
+        assert!(sort_alphabetically_within_groups(&sessions).is_empty());
     }
 
     // --- compute_session_order (parent/child nesting) ---

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -281,71 +281,18 @@ pub fn sort_alphabetically_within_groups(sessions: &[&SessionInfo]) -> Vec<usize
 
 /// Sort one group's members alphabetically while preserving the parent/child
 /// nesting `compute_session_order` would render: children stay under their
-/// parent and sort among their siblings, recursively. Mirrors the
-/// `nest_group_members` DFS, swapping its index-stable comparator for a
-/// case-insensitive name comparator (with input index as a stable tiebreak).
+/// parent and sort among their siblings, recursively. Pre-sorts members by
+/// case-insensitive name (with input index as a stable tiebreak) and reuses
+/// the existing [`nest_group_members`] DFS — its root/child partitioning and
+/// cycle-fallback walk both honor the input order, so the alphabetical
+/// pre-sort flows through to roots, children, and leftovers alike.
 fn sort_group_alphabetically(sessions: &[&SessionInfo], members: &[usize]) -> Vec<usize> {
-    use std::collections::{HashMap, HashSet};
-
-    let id_to_member: HashMap<crate::session::SessionId, usize> =
-        members.iter().map(|&i| (sessions[i].id, i)).collect();
-
-    let mut roots: Vec<usize> = Vec::new();
-    let mut children: HashMap<usize, Vec<usize>> = HashMap::new();
-    for &i in members {
-        let parent = sessions[i]
-            .parent_session_id
-            .and_then(|p| id_to_member.get(&p))
-            .copied()
-            .filter(|&p| p != i);
-        match parent {
-            Some(p) => children.entry(p).or_default().push(i),
-            None => roots.push(i),
-        }
-    }
-
-    let sort_key = |i: &usize| (sessions[*i].name.to_lowercase(), *i);
-    roots.sort_by_key(sort_key);
-    for kids in children.values_mut() {
-        kids.sort_by_key(sort_key);
-    }
-
-    fn emit(
-        i: usize,
-        children: &HashMap<usize, Vec<usize>>,
-        visited: &mut HashSet<usize>,
-        out: &mut Vec<usize>,
-    ) {
-        if !visited.insert(i) {
-            return;
-        }
-        out.push(i);
-        if let Some(kids) = children.get(&i) {
-            for &k in kids {
-                emit(k, children, visited, out);
-            }
-        }
-    }
-
-    let mut out = Vec::with_capacity(members.len());
-    let mut visited = HashSet::new();
-    for &r in &roots {
-        emit(r, &children, &mut visited, &mut out);
-    }
-    // Members unreachable from any root (a parent cycle): emit flat in their
-    // own alphabetical order, matching `nest_group_members`'s fallback.
-    let mut leftovers: Vec<usize> = members
-        .iter()
-        .copied()
-        .filter(|i| !visited.contains(i))
-        .collect();
-    leftovers.sort_by_key(|i| sort_key(i));
-    for i in leftovers {
-        if visited.insert(i) {
-            out.push(i);
-        }
-    }
-    out
+    let mut sorted: Vec<usize> = members.to_vec();
+    sorted.sort_by_key(|&i| (sessions[i].name.to_lowercase(), i));
+    nest_group_members(sessions, &sorted)
+        .into_iter()
+        .map(|(i, _depth)| i)
+        .collect()
 }
 
 /// Move the session `active_input_idx` one step up or down in the rendered


### PR DESCRIPTION
## Summary

- Adds `Action::SessionListSortAlphabetically` (rebindable; default `Shift+S` in the focused session list) that sorts sessions A→Z by name **within each repo group**. Group order is preserved (still by lowest `display_order`); parent/child nesting is preserved (children sort among siblings under their parent, recursively).
- Pure helper `ui::project_list::sort_alphabetically_within_groups` returns a new flat input-index order; `App::sort_sessions_alphabetically` renumbers `display_order` densely along it and persists via `save_state` — same path as `Shift+J`/`Shift+K` manual moves, so the alphabetised order survives restarts and reaches other instances via the existing `data_version` polling.
- Help-section entry under "Session list (when focused)" so the action is discoverable + rebindable from the F1 editor.

## Test plan

- [x] `cargo fmt --all` clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo nextest run --all` — all suites green except a pre-existing, environment-dependent `paths::tests::complete_directory_path_with_real_dir` failure that also fails on clean `main` (verified by stashing this PR's diff and reproducing).
- [x] New unit coverage in `src/ui/project_list.rs` for the pure helper: within-group sort, case-insensitivity, group-order preservation, child nesting under sorted parents, dense-renumber round-trip via `compute_session_order`, empty input.
- [x] New app-level coverage in `src/app/mod.rs`: `sort_sessions_alphabetically_renumbers_and_persists` (asserts both the in-memory render order and the persisted DB ordering) and `sort_sessions_alphabetically_empty_is_noop`.
- [ ] Manual: open the TUI with several sessions in a repo group, press `Shift+S`, confirm they reorder A→Z while groups stay put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)