### PR TITLE
feat(core): OS notifications when an agent needs attention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -859,6 +859,51 @@ global_search` in settings.toml; scopes whose feature is disabled
   (session list, tasks panel) were removed in favour of it. The file
   viewer's `/` (in-file text search) is unrelated and stays.
 
+## OS notifications
+
+When a session crosses into a "needs you" state — the agent rang the
+terminal bell or emitted an OSC 9 / OSC 777 notification (i.e. it
+transitions to `SessionStatus::Attention`) — thurbox fires an OS
+desktop notification so the user can react without watching the TUI.
+The trigger is the explicit signal by default; an opt-in
+`also_on_waiting` extends it to the timing-only `Busy → Waiting` edge
+for agents that don't ring a bell. The transition is observed once per
+tick in `App::refresh_session_statuses` (the *same* place
+`SessionStatus` is computed, so the rule never drifts from the icon
+in the list), dedup'd per session by `min_interval_secs`, and skipped
+when the target session is the one in focus (`suppress_for_active`).
+
+- **Click-to-focus** (Linux only). The dbus action callback writes a
+  session UUID to the SQLite `metadata` row keyed by
+  [`PENDING_FOCUS_SESSION_ID_KEY`](src/session/mod.rs) (= the single
+  source of truth shared by writer and reader). The TUI's
+  external-state poll (`App::poll_external_changes` →
+  `apply_pending_focus_request`) reads + deletes the row atomically
+  (`Database::take_pending_focus_session_id`, a single
+  `DELETE … RETURNING` statement) and switches `active_index` +
+  `InputFocus::Terminal`. macOS shows the banner but ignores clicks —
+  modern `UNUserNotificationCenter` actions require a signed app
+  bundle, which thurbox is not. **Terminal window-raising is
+  deliberately not implemented**: thurbox runs inside an arbitrary
+  terminal emulator it doesn't own, and per-emulator window control is
+  fragile (especially on Wayland). The session is pre-selected; the
+  user alt-tabs back themselves.
+- **TUI-only lifecycle**. The PTY parser that observes the bell only
+  runs while the TUI is alive, so notifications don't fire from
+  headless `automation tick`. The dispatcher thread itself
+  (`crate::notifications::start`) only starts when `[features]
+  notifications = true` — zero overhead when disabled.
+- **Gated by `[features] notifications`** (default on); knobs in
+  `[notifications]` (also_on_waiting / suppress_for_active / sound /
+  min_interval_secs). Settings live in `session::settings`; loader in
+  `agent::settings_config`; full doc in `docs/CONFIG.md`.
+- **Code shape**. `src/notifications.rs` is the leaf side-effect layer
+  (only knows `session` + `paths`) — a single background thread reads a
+  per-process mpsc channel and shells out to `notify-rust`. The
+  per-session bookkeeping (prior status, dedup timestamps) lives in
+  `src/app/notify_state.rs` as a pure unit-testable struct, owned by
+  `App` and constructed only when the feature is enabled.
+
 ## Demo Video
 
 The demo media is **generated**, not hand-recorded. A single

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +262,12 @@ checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -178,6 +315,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -249,7 +408,7 @@ checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -329,6 +488,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -557,6 +725,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +780,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -708,6 +924,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,7 +965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -810,6 +1051,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,7 +1074,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1039,6 +1286,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
+dependencies = [
+ "cc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1398,20 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify-rust"
+version = "4.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
 ]
 
 [[package]]
@@ -1250,6 +1525,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.12.1",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1308,6 +1585,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,7 +1644,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1480,6 +1773,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1800,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1518,6 +1836,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1554,6 +1881,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -1844,6 +2180,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,6 +2279,12 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2034,7 +2387,19 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "objc2-open-directory",
- "windows",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+ "windows-version",
 ]
 
 [[package]]
@@ -2174,6 +2539,7 @@ dependencies = [
  "cron",
  "crossterm",
  "insta",
+ "notify-rust",
  "pulldown-cmark",
  "ratatui",
  "regex",
@@ -2292,6 +2658,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 1.0.1",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,6 +2780,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicase"
@@ -2717,14 +3106,36 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2733,7 +3144,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -2744,9 +3168,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -2755,9 +3190,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -2784,9 +3219,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -2794,8 +3245,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2804,7 +3264,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2813,7 +3282,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2831,7 +3300,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2852,11 +3321,29 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2921,6 +3408,9 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -3028,6 +3518,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.1",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.1",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,4 +3617,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.1",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,12 @@ chrono-tz = "0.10"
 cron = "0.16"
 serde_ignored = "0.1.14"
 
+# OS notifications (Linux/macOS). On Linux: dbus with action callbacks
+# (click-to-focus works). On macOS: passive banner only — clicking does
+# nothing (the action API requires a signed app bundle). The notifications
+# module degrades gracefully on either platform if dispatch fails.
+notify-rust = "4"
+
 [[bin]]
 name = "thurbox-cli"
 path = "src/bin/thurbox-cli.rs"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -124,6 +124,7 @@ touched, so re-enabling a flag is lossless.
 | `info_panel` | info panel column (`F2`) |
 | `shell_pane` | per-session shell toggle (`Ctrl+T`) |
 | `mouse` | mouse capture: clicks, wheel, drag-select, hover, scrollbars |
+| `notifications` | OS desktop notifications when a session needs attention |
 
 `automations = false` is a full stop on the TUI side: the pane
 disappears (the session list takes the whole left column and `j`/`k`
@@ -136,6 +137,37 @@ heartbeat, so an already-armed keeper window (or an OS timer from
 processes. `mouse = false` skips terminal mouse capture entirely, so
 the terminal keeps its native mouse behavior (its own text selection,
 URL handling, etc.) and no click/wheel/hover handling runs in the TUI.
+`notifications = false` keeps the background dispatcher thread from
+ever starting (zero overhead) and silently no-ops every transition;
+the session status display itself is unaffected.
+
+### `[notifications]` — OS notification settings
+
+Surfaces an OS notification when a session crosses into a state that
+needs the user's attention (the agent rang the terminal bell or emitted
+an OSC 9 / OSC 777 message — usually because it's waiting on an answer
+or has finished a task). Linux dispatches via dbus and supports
+**click-to-focus**: clicking the banner writes a focus request that the
+running TUI reads on its next tick and switches to that session. macOS
+shows the notification banner but ignores clicks (the modern
+`UNUserNotificationCenter` API requires a signed app bundle, which
+thurbox is not). On both platforms the notification body is the agent's
+last OSC message when present, otherwise `Waiting for input`. **Only
+fires while the TUI is open** — the agent terminal parser is what sees
+the bell, and it doesn't run when thurbox isn't.
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `also_on_waiting` | `false` | also fire on `Busy → Waiting` (no explicit bell from the agent) |
+| `suppress_for_active` | `true` | skip the notification for the session you're currently viewing |
+| `sound` | `true` | play the OS default notification sound |
+| `min_interval_secs` | `5` | per-session floor between two notifications (dedup) |
+
+The default-on `Attention` trigger is the right knob for any agent that
+respects the terminal bell / OSC 9 / OSC 777 conventions (Claude Code
+out of the box, for example). For agents that only go quiet without
+ringing a bell, set `also_on_waiting = true` — note this fires once each
+time the agent goes idle after activity, so it can be chatty.
 
 ## themes.toml
 

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -47,6 +47,16 @@ config_version = 1
 # info_panel = true       # F2 info panel
 # shell_pane = true       # Ctrl+T per-session shell
 # mouse = true            # mouse capture: clicks, wheel, drag-select, hover
+# notifications = true    # OS desktop notifications when a session needs attention
+
+# OS desktop notifications. Linux gets click-to-focus (clicking the banner
+# selects the session in the running TUI); macOS shows a passive banner only.
+# The dispatcher only starts when [features] notifications = true.
+# [notifications]
+# also_on_waiting = false       # also fire on Busy → Waiting (no explicit OSC bell)
+# suppress_for_active = true    # don't notify if you're already viewing that session
+# sound = true                  # play the OS default notification sound
+# min_interval_secs = 5         # per-session dedup floor (seconds)
 "#;
 
 /// Path to the settings file: `~/.config/thurbox/settings.toml`.
@@ -143,6 +153,12 @@ mod tests {
             "global_search",
             "info_panel",
             "shell_pane",
+            "notifications",
+            "[notifications]",
+            "also_on_waiting",
+            "suppress_for_active",
+            "sound",
+            "min_interval_secs",
         ] {
             assert!(
                 SEED_SETTINGS_TOML.contains(field),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,6 +6,7 @@ mod key_handlers;
 mod metrics_state;
 pub(crate) mod modals;
 mod new_session_state;
+mod notify_state;
 pub(crate) mod search;
 mod state;
 mod sync_state;
@@ -29,12 +30,14 @@ use crate::session::{
     AgentDef, AgentRegistry, Automation, AutomationAction, AutomationRunStatus, AutomationSchedule,
     SessionConfig, SessionId, SessionInfo, SessionStatus, WorktreeInfo, DEFAULT_AGENT_NAME,
 };
+
 use crate::storage::Database;
 use crate::storage::DeletedSessionInfo;
 use crate::sync::{self, SharedWorktree, StateDelta, SyncState};
 use crate::ui::layout;
 use crate::ui::scrollbar::ScrollbarGeom;
 use crate::ui::selection::{PaneBounds, Selection, TermPos};
+use notify_state::NotificationState;
 
 const MOUSE_SCROLL_LINES: usize = 3;
 
@@ -565,10 +568,28 @@ pub struct App {
     /// Last-seen mtimes of the live-reloadable config files (see
     /// [`Self::poll_config_reload`]).
     config_reload: config_reload::ConfigReloadState,
+    /// OS notification dispatcher — `None` when the feature is disabled
+    /// (`[features] notifications = false`) so the background thread never
+    /// starts. The wrapper tracks per-session prior status + last-fired-at so
+    /// dedup and "only on transition" logic live next to the sender.
+    notification_state: Option<NotificationState>,
 }
 
 const EDITOR_NOT_CONFIGURED: &str =
     "No editor configured — set `editor_command` via MCP or export $EDITOR/$VISUAL";
+
+/// Spin up the OS notification dispatcher when the feature is enabled,
+/// returning `None` otherwise so the background thread never starts.
+/// Reads the process-wide settings directly — they're already published by
+/// `main` before `App::new` runs.
+fn build_notification_state() -> Option<NotificationState> {
+    let settings = crate::session::settings::global();
+    if !settings.features.notifications {
+        return None;
+    }
+    let sender = crate::notifications::start();
+    Some(NotificationState::new(sender, settings.notifications))
+}
 
 impl App {
     pub fn new(
@@ -685,6 +706,7 @@ impl App {
                 agents_mtime: config_reload::agents_mtime(),
                 keybindings_mtime: config_reload::keybindings_mtime(),
             },
+            notification_state: build_notification_state(),
         };
         app.report_config_warnings(config_warnings);
         app
@@ -2843,20 +2865,77 @@ impl App {
             // while the session is in the attention state.
             session.info.notification = session.notification();
         }
+
+        self.dispatch_status_notifications();
+    }
+
+    /// Fire OS notifications for any session that just crossed into a
+    /// needs-attention state this tick. No-op when the feature is disabled.
+    fn dispatch_status_notifications(&mut self) {
+        let Some(state) = self.notification_state.as_mut() else {
+            return;
+        };
+        let active_index = self.active_index;
+        let now = std::time::Instant::now();
+        for (idx, session) in self.sessions.iter().enumerate() {
+            let id = session.info.id;
+            let status = session.info.status;
+            let is_active = idx == active_index;
+            if state.observe(id, status, is_active, now) != notify_state::TransitionDecision::Fire {
+                continue;
+            }
+            let n = NotificationState::build_notification(
+                id,
+                &session.info.name,
+                &session.info.agent,
+                session.info.notification.as_deref(),
+                state.sound_enabled(),
+            );
+            state.send(n);
+        }
+        // Cheap: bounds the bookkeeping after deletions / restarts.
+        let live: Vec<SessionId> = self.sessions.iter().map(|s| s.info.id).collect();
+        state.prune_to(&live);
     }
 
     /// Poll for external state changes from other thurbox instances (DB-based)
     /// and apply any theme change / session delta they produced.
     fn poll_external_changes(&mut self) {
         let Ok(Some(result)) = sync::poll_for_changes(&mut self.sync_state, &mut self.db) else {
+            // Even with no broader DB change, a notification click may have
+            // landed: it writes a single row and the sync layer doesn't
+            // distinguish, so we always check.
+            self.apply_pending_focus_request();
             return;
         };
         if result.db_changed {
             self.apply_external_theme_change();
+            self.apply_pending_focus_request();
         }
         if !result.delta.is_empty() {
             self.handle_external_state_change(result.delta);
         }
+    }
+
+    /// Drain the OS-notification click handler's "focus this session" request
+    /// (written from another thread/process) and switch the active session.
+    /// Silently no-ops when the session has since been deleted or the
+    /// stored value isn't a valid UUID.
+    fn apply_pending_focus_request(&mut self) {
+        let Ok(Some(raw)) = self.db.take_pending_focus_session_id() else {
+            return;
+        };
+        let Ok(id) = raw.parse::<SessionId>() else {
+            debug!("ignoring malformed pending_focus_session_id: {raw}");
+            return;
+        };
+        let Some(idx) = self.sessions.iter().position(|s| s.info.id == id) else {
+            debug!("focus request for unknown session {id}; ignoring");
+            return;
+        };
+        self.active_index = idx;
+        self.focus = InputFocus::Terminal;
+        info!("focused session {id} from notification click");
     }
 
     /// Pick up theme changes made by other thurbox processes (e.g. an MCP
@@ -5403,6 +5482,79 @@ mod tests {
         assert!(app.status_message.is_none());
     }
 
+    /// A notification click handler writes `pending_focus_session_id` to the
+    /// shared SQLite metadata; the TUI's poll picks it up and switches the
+    /// active session + focus.
+    #[test]
+    fn apply_pending_focus_request_switches_active_session() {
+        let mut app = app_with_sessions(3);
+        let target_id = app.sessions[2].info.id;
+        app.active_index = 0;
+        app.focus = InputFocus::SessionList;
+
+        // Simulate the click-handler write.
+        app.db
+            .conn_ref()
+            .execute(
+                "INSERT INTO metadata (key, value) VALUES (?1, ?2)",
+                rusqlite::params![
+                    crate::session::PENDING_FOCUS_SESSION_ID_KEY,
+                    target_id.to_string()
+                ],
+            )
+            .unwrap();
+
+        app.apply_pending_focus_request();
+        assert_eq!(app.active_index, 2);
+        assert_eq!(app.focus, InputFocus::Terminal);
+        // The row is consumed atomically, so a second call is a no-op.
+        let prev_active = app.active_index;
+        app.apply_pending_focus_request();
+        assert_eq!(app.active_index, prev_active);
+    }
+
+    /// A focus request that doesn't match any current session is dropped
+    /// (the session may have been deleted before the click landed).
+    #[test]
+    fn apply_pending_focus_request_ignores_unknown_session() {
+        let mut app = app_with_sessions(2);
+        app.active_index = 0;
+        app.focus = InputFocus::SessionList;
+        let bogus = crate::session::SessionId::default();
+        app.db
+            .conn_ref()
+            .execute(
+                "INSERT INTO metadata (key, value) VALUES (?1, ?2)",
+                rusqlite::params![
+                    crate::session::PENDING_FOCUS_SESSION_ID_KEY,
+                    bogus.to_string()
+                ],
+            )
+            .unwrap();
+
+        app.apply_pending_focus_request();
+        assert_eq!(app.active_index, 0, "no match → leave selection alone");
+        assert_eq!(app.focus, InputFocus::SessionList);
+        // But the row is still consumed so a stale id doesn't sit forever.
+        assert_eq!(app.db.take_pending_focus_session_id().unwrap(), None);
+    }
+
+    /// Garbage in the metadata key is ignored gracefully and the row consumed.
+    #[test]
+    fn apply_pending_focus_request_tolerates_garbage() {
+        let mut app = app_with_sessions(2);
+        app.db
+            .conn_ref()
+            .execute(
+                "INSERT INTO metadata (key, value) VALUES (?1, ?2)",
+                rusqlite::params![crate::session::PENDING_FOCUS_SESSION_ID_KEY, "not-a-uuid"],
+            )
+            .unwrap();
+        app.apply_pending_focus_request();
+        assert_eq!(app.active_index, 0);
+        assert_eq!(app.db.take_pending_focus_session_id().unwrap(), None);
+    }
+
     #[test]
     fn apply_removed_sessions_detaches_pane_io() {
         let detached = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -6417,6 +6569,7 @@ mod tests {
             info_panel: false,
             shell_pane: false,
             mouse: true,
+            notifications: false,
         };
 
         app.handle_key(KeyCode::F(5), KeyModifiers::NONE);

--- a/src/app/notify_state.rs
+++ b/src/app/notify_state.rs
@@ -1,0 +1,334 @@
+//! Per-session bookkeeping for OS notifications: prior `SessionStatus`, last
+//! fire timestamp (for dedup), and the dispatcher handle. Pure logic — no
+//! direct dependence on `App` state — so the transition rule is unit-testable
+//! without spinning up an `App`.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::notifications::{Notification, NotificationSender};
+use crate::session::settings::NotificationSettings;
+use crate::session::{SessionId, SessionStatus};
+
+/// State the notification path keeps across ticks. Owned by `App` and only
+/// constructed when the feature is enabled.
+pub struct NotificationState {
+    sender: NotificationSender,
+    settings: NotificationSettings,
+    /// Status seen on the previous tick, keyed by session id. A first-time
+    /// observation is recorded with no notification — we only fire on a real
+    /// transition.
+    prev_status: HashMap<SessionId, SessionStatus>,
+    /// Per-session moment we last fired a notification. Drives the
+    /// `min_interval_secs` dedup floor.
+    last_fired_at: HashMap<SessionId, Instant>,
+}
+
+impl NotificationState {
+    pub fn new(sender: NotificationSender, settings: NotificationSettings) -> Self {
+        Self {
+            sender,
+            settings,
+            prev_status: HashMap::new(),
+            last_fired_at: HashMap::new(),
+        }
+    }
+
+    /// Drop bookkeeping for sessions that no longer exist so the maps stay
+    /// bounded across long sessions.
+    pub fn prune_to(&mut self, live: &[SessionId]) {
+        self.prev_status.retain(|id, _| live.contains(id));
+        self.last_fired_at.retain(|id, _| live.contains(id));
+    }
+
+    /// Observe one session's status this tick. Returns the notification to
+    /// fire when the transition crosses the "needs attention" threshold,
+    /// dedup window has elapsed, and the active-suppression rule allows it.
+    ///
+    /// `now` is taken as a parameter so tests are deterministic.
+    pub fn observe(
+        &mut self,
+        id: SessionId,
+        status: SessionStatus,
+        is_active: bool,
+        now: Instant,
+    ) -> TransitionDecision {
+        let prev = self.prev_status.insert(id, status);
+
+        // First time we see this session: only record, never fire. This
+        // prevents a flood of notifications on TUI startup, when every
+        // session's initial status looks like a "transition" from nothing.
+        let Some(prev) = prev else {
+            return TransitionDecision::NoFire;
+        };
+
+        if prev == status {
+            return TransitionDecision::NoFire;
+        }
+
+        if !self.should_notify_on(prev, status) {
+            return TransitionDecision::NoFire;
+        }
+
+        if is_active && self.settings.suppress_for_active {
+            return TransitionDecision::NoFire;
+        }
+
+        let interval = Duration::from_secs(self.settings.min_interval_secs);
+        if let Some(last) = self.last_fired_at.get(&id) {
+            if now.duration_since(*last) < interval {
+                return TransitionDecision::ThrottledByDedup;
+            }
+        }
+
+        self.last_fired_at.insert(id, now);
+        TransitionDecision::Fire
+    }
+
+    /// Whether a `prev → current` transition is one we notify about. Pure;
+    /// no state. The "attention" case is the explicit OSC bell / OSC 9 /
+    /// OSC 777 from the agent; the "waiting" case is the timing-only quiet
+    /// state, which a user can opt into for agents that don't ring a bell.
+    fn should_notify_on(&self, prev: SessionStatus, current: SessionStatus) -> bool {
+        match current {
+            SessionStatus::Attention => true,
+            SessionStatus::Waiting if self.settings.also_on_waiting => {
+                // Only the Busy → Waiting edge is interesting; an Idle
+                // (exited) → Waiting transition can't happen, and an
+                // Attention → Waiting transition is the user already
+                // having acknowledged the signal.
+                prev == SessionStatus::Busy
+            }
+            _ => false,
+        }
+    }
+
+    /// Build the notification body from the session's last OSC message, or a
+    /// generic fallback when the agent only rang a bell (no message text).
+    pub fn build_notification(
+        id: SessionId,
+        name: &str,
+        agent: &str,
+        notification_text: Option<&str>,
+        sound: bool,
+    ) -> Notification {
+        let title = format!("{name} · {agent}");
+        let body = notification_text
+            .map(str::to_string)
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| "Waiting for input".into());
+        Notification {
+            session_id: id,
+            title,
+            body,
+            sound,
+        }
+    }
+
+    pub fn send(&self, n: Notification) {
+        self.sender.send(n);
+    }
+
+    pub fn sound_enabled(&self) -> bool {
+        self.settings.sound
+    }
+}
+
+/// What `observe` decided to do this tick. Surface-level callers only care
+/// about `Fire`; the other variants are kept distinct for tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransitionDecision {
+    /// No transition / not a transition we notify on / active suppressed.
+    NoFire,
+    /// Transition was notify-worthy but we fired one too recently.
+    ThrottledByDedup,
+    /// Fire a notification.
+    Fire,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    fn test_state(
+        also_on_waiting: bool,
+        suppress_active: bool,
+        interval: u64,
+    ) -> NotificationState {
+        let (tx, _rx) = mpsc::channel();
+        let sender = crate::notifications::NotificationSender::__test_with_sender(tx);
+        NotificationState::new(
+            sender,
+            NotificationSettings {
+                also_on_waiting,
+                suppress_for_active: suppress_active,
+                sound: true,
+                min_interval_secs: interval,
+            },
+        )
+    }
+
+    #[test]
+    fn first_observation_never_fires() {
+        let mut s = test_state(false, true, 0);
+        let id = SessionId::default();
+        let now = Instant::now();
+        assert_eq!(
+            s.observe(id, SessionStatus::Attention, false, now),
+            TransitionDecision::NoFire
+        );
+    }
+
+    #[test]
+    fn same_status_never_fires() {
+        let mut s = test_state(false, true, 0);
+        let id = SessionId::default();
+        let now = Instant::now();
+        let _ = s.observe(id, SessionStatus::Attention, false, now);
+        assert_eq!(
+            s.observe(id, SessionStatus::Attention, false, now),
+            TransitionDecision::NoFire
+        );
+    }
+
+    #[test]
+    fn busy_to_attention_fires() {
+        let mut s = test_state(false, true, 0);
+        let id = SessionId::default();
+        let now = Instant::now();
+        let _ = s.observe(id, SessionStatus::Busy, false, now);
+        assert_eq!(
+            s.observe(id, SessionStatus::Attention, false, now),
+            TransitionDecision::Fire
+        );
+    }
+
+    #[test]
+    fn busy_to_waiting_only_fires_when_opted_in() {
+        let mut s = test_state(false, true, 0);
+        let id = SessionId::default();
+        let now = Instant::now();
+        let _ = s.observe(id, SessionStatus::Busy, false, now);
+        assert_eq!(
+            s.observe(id, SessionStatus::Waiting, false, now),
+            TransitionDecision::NoFire
+        );
+
+        let mut s = test_state(true, true, 0);
+        let _ = s.observe(id, SessionStatus::Busy, false, now);
+        assert_eq!(
+            s.observe(id, SessionStatus::Waiting, false, now),
+            TransitionDecision::Fire
+        );
+    }
+
+    #[test]
+    fn attention_to_waiting_never_fires_even_with_also_on_waiting() {
+        // The user has already seen the Attention signal; sliding back to
+        // Waiting is not a new event worth re-notifying.
+        let mut s = test_state(true, true, 0);
+        let id = SessionId::default();
+        let now = Instant::now();
+        let _ = s.observe(id, SessionStatus::Attention, false, now);
+        assert_eq!(
+            s.observe(id, SessionStatus::Waiting, false, now),
+            TransitionDecision::NoFire
+        );
+    }
+
+    #[test]
+    fn active_session_suppressed_by_default() {
+        let mut s = test_state(false, true, 0);
+        let id = SessionId::default();
+        let now = Instant::now();
+        let _ = s.observe(id, SessionStatus::Busy, true, now);
+        assert_eq!(
+            s.observe(id, SessionStatus::Attention, true, now),
+            TransitionDecision::NoFire
+        );
+    }
+
+    #[test]
+    fn active_session_fires_when_suppression_off() {
+        let mut s = test_state(false, false, 0);
+        let id = SessionId::default();
+        let now = Instant::now();
+        let _ = s.observe(id, SessionStatus::Busy, true, now);
+        assert_eq!(
+            s.observe(id, SessionStatus::Attention, true, now),
+            TransitionDecision::Fire
+        );
+    }
+
+    #[test]
+    fn rapid_re_attention_is_throttled() {
+        let mut s = test_state(false, true, 60);
+        let id = SessionId::default();
+        let t0 = Instant::now();
+        let _ = s.observe(id, SessionStatus::Busy, false, t0);
+        assert_eq!(
+            s.observe(id, SessionStatus::Attention, false, t0),
+            TransitionDecision::Fire
+        );
+
+        // Attention → Busy → Attention within the dedup window.
+        let _ = s.observe(id, SessionStatus::Busy, false, t0 + Duration::from_secs(1));
+        assert_eq!(
+            s.observe(
+                id,
+                SessionStatus::Attention,
+                false,
+                t0 + Duration::from_secs(2)
+            ),
+            TransitionDecision::ThrottledByDedup
+        );
+
+        // Past the window, a fresh fire is allowed.
+        let _ = s.observe(id, SessionStatus::Busy, false, t0 + Duration::from_secs(70));
+        assert_eq!(
+            s.observe(
+                id,
+                SessionStatus::Attention,
+                false,
+                t0 + Duration::from_secs(80)
+            ),
+            TransitionDecision::Fire
+        );
+    }
+
+    #[test]
+    fn prune_drops_stale_sessions() {
+        let mut s = test_state(false, true, 0);
+        let keep = SessionId::default();
+        let gone = SessionId::default();
+        let now = Instant::now();
+        let _ = s.observe(keep, SessionStatus::Busy, false, now);
+        let _ = s.observe(gone, SessionStatus::Busy, false, now);
+        s.prune_to(&[keep]);
+        // The pruned session's first observation post-prune is a fresh
+        // baseline → no fire.
+        assert_eq!(
+            s.observe(gone, SessionStatus::Attention, false, now),
+            TransitionDecision::NoFire
+        );
+        // The kept session still has its baseline → a transition fires.
+        assert_eq!(
+            s.observe(keep, SessionStatus::Attention, false, now),
+            TransitionDecision::Fire
+        );
+    }
+
+    #[test]
+    fn body_falls_back_when_message_is_empty() {
+        let id = SessionId::default();
+        let n = NotificationState::build_notification(id, "demo", "claude", None, true);
+        assert_eq!(n.body, "Waiting for input");
+        let n = NotificationState::build_notification(id, "demo", "claude", Some("   "), true);
+        assert_eq!(n.body, "Waiting for input");
+        let n =
+            NotificationState::build_notification(id, "demo", "claude", Some("approved?"), true);
+        assert_eq!(n.body, "approved?");
+        assert_eq!(n.title, "demo · claude");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod app;
 pub mod cli;
 pub(crate) mod fuzzy;
 pub mod git;
+pub mod notifications;
 pub mod paths;
 pub mod session;
 pub mod session_ops;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,0 +1,215 @@
+//! OS desktop notifications for the "agent needs you" event.
+//!
+//! Sends a notification when a session transitions into an attention-needing
+//! state (`Attention` always, plus `Waiting` when opted in). Click handling is
+//! Linux-only: the dbus action callback writes a `pending_focus_session_id`
+//! into the SQLite `metadata` table, which the running TUI picks up next tick
+//! via its normal external-state poll. On macOS the notification is purely
+//! informational — clicking it does nothing (the modern `UNUserNotificationCenter`
+//! API requires a signed app bundle, which thurbox is not).
+//!
+//! Notify-rust on Linux blocks on dbus; dispatch therefore runs on a dedicated
+//! background thread fed by an mpsc channel, so the UI tick is never stalled
+//! by a slow/missing notification daemon.
+//!
+//! Architecture: leaf module. Depends only on `session` (the `SessionId`
+//! type) and `paths` (for the DB path the click callback writes to). Never
+//! reaches into `app` / `agent` / `ui`.
+
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::OnceLock;
+use std::thread;
+
+use tracing::{debug, warn};
+
+use crate::session::{SessionId, PENDING_FOCUS_SESSION_ID_KEY};
+
+/// One notification to fire. Cheap to clone/move across the channel.
+#[derive(Debug, Clone)]
+pub struct Notification {
+    /// Stable session identifier — also the value written into the
+    /// `pending_focus_session_id` metadata key when the user clicks.
+    pub session_id: SessionId,
+    /// Title shown by the OS (e.g. `"my-feature · claude"`).
+    pub title: String,
+    /// Body text (e.g. the agent's last OSC notification message, or a
+    /// generic "waiting for input").
+    pub body: String,
+    /// Play the OS default notification sound.
+    pub sound: bool,
+}
+
+/// Sends notifications to the background dispatcher thread. Cloned freely;
+/// dropping all senders shuts the thread down on the next recv.
+#[derive(Clone)]
+pub struct NotificationSender {
+    tx: Sender<Notification>,
+}
+
+impl NotificationSender {
+    /// Best-effort send. A full channel or a dead receiver drops the
+    /// notification silently (notifications are advisory; we never block
+    /// the UI tick on them).
+    pub fn send(&self, n: Notification) {
+        if let Err(e) = self.tx.send(n) {
+            debug!("notification channel closed: {e}");
+        }
+    }
+
+    /// Test helper: build a sender around a caller-owned channel so tests
+    /// can construct `NotificationState` without spawning the dispatcher.
+    /// Not exported outside the crate.
+    #[cfg(test)]
+    pub fn __test_with_sender(tx: Sender<Notification>) -> Self {
+        Self { tx }
+    }
+}
+
+/// Start the background dispatcher thread. Returns a sender for the UI tick
+/// to push notifications into. The thread reads its DB path lazily on each
+/// click (we only write a single row, no persistent connection needed) so it
+/// is safe to spawn before the database file exists.
+///
+/// Only one dispatcher per process: re-entry returns the same sender.
+pub fn start() -> NotificationSender {
+    static SHARED: OnceLock<NotificationSender> = OnceLock::new();
+    SHARED
+        .get_or_init(|| {
+            let (tx, rx) = mpsc::channel::<Notification>();
+            thread::Builder::new()
+                .name("thurbox-notifications".into())
+                .spawn(move || dispatch_loop(rx))
+                .expect("spawn notification dispatcher thread");
+            NotificationSender { tx }
+        })
+        .clone()
+}
+
+fn dispatch_loop(rx: Receiver<Notification>) {
+    while let Ok(n) = rx.recv() {
+        if let Err(e) = dispatch_one(n) {
+            warn!("notification dispatch failed: {e}");
+        }
+    }
+    debug!("notification dispatcher exiting (all senders dropped)");
+}
+
+#[cfg(target_os = "linux")]
+fn dispatch_one(n: Notification) -> Result<(), Box<dyn std::error::Error>> {
+    use notify_rust::{Hint, Notification as NotifRust};
+
+    let mut notif = NotifRust::new();
+    notif
+        .summary(&n.title)
+        .body(&n.body)
+        .appname("thurbox")
+        .hint(Hint::Category("im.received".into()))
+        // The "default" action fires when the user clicks the banner body
+        // itself, distinct from the explicit "open" button — both route the
+        // same way below.
+        .action("default", "Open")
+        .action("open", "Open session");
+    if !n.sound {
+        notif.hint(Hint::SuppressSound(true));
+    }
+
+    let handle = notif.show()?;
+    let session_id = n.session_id;
+    // wait_for_action blocks until the user clicks, dismisses, or the
+    // notification times out — run it on its own short-lived thread so the
+    // dispatcher can move on to the next queued notification.
+    thread::Builder::new()
+        .name("thurbox-notification-wait".into())
+        .spawn(move || {
+            handle.wait_for_action(|action| match action {
+                "default" | "open" => {
+                    if let Err(e) = write_focus_request(session_id) {
+                        warn!("failed to record click-to-focus request: {e}");
+                    }
+                }
+                _ => {}
+            });
+        })?;
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn dispatch_one(n: Notification) -> Result<(), Box<dyn std::error::Error>> {
+    use notify_rust::Notification as NotifRust;
+
+    // macOS path: no action callbacks (UNUserNotificationCenter requires a
+    // signed app bundle). The notification is informational; the user
+    // navigates back to thurbox manually.
+    let mut notif = NotifRust::new();
+    notif.summary(&n.title).body(&n.body).appname("thurbox");
+    if !n.sound {
+        notif.sound_name("");
+    }
+    notif.show()?;
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn dispatch_one(_n: Notification) -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+/// SQLite `metadata` key the click handler writes to. The TUI's
+/// `poll_external_changes` reads + clears it on the next tick. The constant
+/// is defined in `session::` so both writer (here) and reader
+/// (`storage::settings`) point at the same value without crossing module
+/// boundaries.
+pub const FOCUS_REQUEST_KEY: &str = PENDING_FOCUS_SESSION_ID_KEY;
+
+/// Resolve the DB path the same way the rest of thurbox does. Returned as a
+/// PathBuf so the click handler can open a short-lived connection without
+/// holding any global state.
+#[cfg(target_os = "linux")]
+fn db_path() -> Option<PathBuf> {
+    crate::paths::database_file()
+}
+
+/// Click handler: write the focus request straight to the SQLite metadata
+/// table from the wait-for-action thread. We open a fresh connection per
+/// click because clicks are rare and the dispatcher thread has no DB handle
+/// of its own.
+#[cfg(target_os = "linux")]
+fn write_focus_request(session_id: SessionId) -> Result<(), Box<dyn std::error::Error>> {
+    let path = db_path().ok_or("could not resolve thurbox DB path")?;
+    let conn = rusqlite::Connection::open(&path)?;
+    conn.execute(
+        "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        rusqlite::params![FOCUS_REQUEST_KEY, session_id.to_string()],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sender_send_does_not_panic_when_receiver_dropped() {
+        let (tx, rx) = mpsc::channel::<Notification>();
+        drop(rx);
+        let sender = NotificationSender { tx };
+        // No receiver — silently dropped, no panic.
+        sender.send(Notification {
+            session_id: SessionId::default(),
+            title: "t".into(),
+            body: "b".into(),
+            sound: false,
+        });
+    }
+
+    #[test]
+    fn focus_request_key_is_stable() {
+        // Documenting the contract: the metadata key is part of the
+        // cross-process protocol with the TUI poll loop. Changing it is a
+        // breaking change for any in-flight clicks across an upgrade.
+        assert_eq!(FOCUS_REQUEST_KEY, "pending_focus_session_id");
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -34,6 +34,14 @@ use uuid::Uuid;
 /// [`AgentRegistry`].
 pub const DEFAULT_AGENT_NAME: &str = "claude";
 
+/// SQLite `metadata` key used to signal "focus this session" between
+/// processes. The `notifications` module writes it from the OS notification
+/// click handler; the running TUI reads + clears it on each tick via
+/// [`crate::storage::Database::take_pending_focus_session_id`]. Defined here
+/// in the pure-data layer so both sides reference one source of truth
+/// without crossing module boundaries.
+pub const PENDING_FOCUS_SESSION_ID_KEY: &str = "pending_focus_session_id";
+
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
     pub repo_path: PathBuf,

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -38,6 +38,11 @@ pub struct Settings {
     /// enabled.
     #[serde(default)]
     pub features: FeatureFlags,
+    /// Desktop-notification settings (`[notifications]` table). Absent table =
+    /// defaults (fire on `Attention`, skip the currently-focused session, 5s
+    /// per-session dedup).
+    #[serde(default)]
+    pub notifications: NotificationSettings,
 }
 
 /// Whole-feature switches (`[features]` in settings.toml). Each flag hides the
@@ -71,6 +76,52 @@ pub struct FeatureFlags {
     /// (e.g. its own text selection).
     #[serde(default = "default_true")]
     pub mouse: bool,
+    /// OS desktop notifications when a session needs the user's attention.
+    /// Disabled = no notifications fire and the dispatcher thread never
+    /// starts (zero overhead). Linux gets click-to-focus; macOS shows a
+    /// passive banner only (the modern API requires a signed app bundle).
+    #[serde(default = "default_true")]
+    pub notifications: bool,
+}
+
+/// Knobs for the OS notification feature (`[notifications]` table). All
+/// fields have defaults so an empty / absent table behaves like the seeded
+/// configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotificationSettings {
+    /// Also notify when a session goes `Busy → Waiting` (timing-only quiet
+    /// state, no explicit OSC bell from the agent). Off by default —
+    /// agents that respect `terminal_bell`/OSC 9 already drive the
+    /// `Attention` transition, which always fires.
+    #[serde(default)]
+    pub also_on_waiting: bool,
+    /// Skip notifications for the session currently in focus (you're already
+    /// looking at it). Defaults on; flip off if you run thurbox in a
+    /// background window and want every transition surfaced.
+    #[serde(default = "default_true")]
+    pub suppress_for_active: bool,
+    /// Play the OS default notification sound.
+    #[serde(default = "default_true")]
+    pub sound: bool,
+    /// Per-session floor between two notifications, in seconds. Prevents an
+    /// agent that flips Attention → Busy → Attention from spamming.
+    #[serde(default = "default_notification_min_interval_secs")]
+    pub min_interval_secs: u64,
+}
+
+fn default_notification_min_interval_secs() -> u64 {
+    5
+}
+
+impl Default for NotificationSettings {
+    fn default() -> Self {
+        Self {
+            also_on_waiting: false,
+            suppress_for_active: true,
+            sound: true,
+            min_interval_secs: default_notification_min_interval_secs(),
+        }
+    }
 }
 
 fn default_true() -> bool {
@@ -87,6 +138,7 @@ impl Default for FeatureFlags {
             info_panel: true,
             shell_pane: true,
             mouse: true,
+            notifications: true,
         }
     }
 }
@@ -113,6 +165,7 @@ impl Default for Settings {
             three_panel_min_cols: default_three_panel_min_cols(),
             audit_retention_days: default_audit_retention_days(),
             features: FeatureFlags::default(),
+            notifications: NotificationSettings::default(),
         }
     }
 }
@@ -188,6 +241,41 @@ mod tests {
         let s: Settings = toml::from_str("[features]\nmouse = false").unwrap();
         assert!(!s.features.mouse);
         assert!(s.features.tasks, "untouched flags stay enabled");
+    }
+
+    #[test]
+    fn notifications_feature_flag_parses() {
+        let s: Settings = toml::from_str("[features]\nnotifications = false").unwrap();
+        assert!(!s.features.notifications);
+        assert!(s.features.tasks, "untouched flags stay enabled");
+    }
+
+    #[test]
+    fn notifications_table_defaults() {
+        let s: Settings = toml::from_str("").unwrap();
+        assert_eq!(s.notifications, NotificationSettings::default());
+        assert!(!s.notifications.also_on_waiting);
+        assert!(s.notifications.suppress_for_active);
+        assert!(s.notifications.sound);
+        assert_eq!(s.notifications.min_interval_secs, 5);
+    }
+
+    #[test]
+    fn notifications_table_partial_override() {
+        let s: Settings =
+            toml::from_str("[notifications]\nalso_on_waiting = true\nmin_interval_secs = 30\n")
+                .unwrap();
+        assert!(s.notifications.also_on_waiting);
+        assert_eq!(s.notifications.min_interval_secs, 30);
+        // Untouched fields stay on defaults.
+        assert!(s.notifications.suppress_for_active);
+        assert!(s.notifications.sound);
+    }
+
+    #[test]
+    fn notifications_type_mismatch_is_rejected() {
+        let err = toml::from_str::<Settings>("[notifications]\nsound = \"loud\"").unwrap_err();
+        assert!(err.to_string().contains("sound"));
     }
 
     #[test]

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -4,6 +4,8 @@ use rusqlite::{params, OptionalExtension};
 
 use super::Database;
 
+use crate::session::PENDING_FOCUS_SESSION_ID_KEY;
+
 const EDITOR_COMMAND_KEY: &str = "editor_command";
 const THEME_KEY: &str = "active_theme";
 const ACTIVE_EXTENSIONS_KEY: &str = "active_extensions";
@@ -124,6 +126,22 @@ impl Database {
         self.set_active_extensions(&names)?;
         Ok(true)
     }
+
+    /// Atomically read + clear the pending "focus this session" request that
+    /// the notifications click handler writes. Returns the raw UUID string the
+    /// click handler stored, or `None` when no click is pending. Done under
+    /// SQLite's writer serialization so a concurrent click can't be lost:
+    /// the `RETURNING value` clause yields the value being deleted in the
+    /// same statement.
+    pub fn take_pending_focus_session_id(&self) -> rusqlite::Result<Option<String>> {
+        self.conn
+            .query_row(
+                "DELETE FROM metadata WHERE key = ?1 RETURNING value",
+                params![PENDING_FOCUS_SESSION_ID_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+    }
 }
 
 #[cfg(test)]
@@ -186,6 +204,32 @@ mod tests {
         assert_eq!(db.get_active_extensions().unwrap(), ["other"]);
         assert!(db.remove_active_extension("other").unwrap());
         assert!(db.get_active_extensions().unwrap().is_empty());
+    }
+
+    #[test]
+    fn pending_focus_session_id_round_trip() {
+        let db = Database::open_in_memory().unwrap();
+        // Nothing pending initially.
+        assert_eq!(db.take_pending_focus_session_id().unwrap(), None);
+
+        // The notifications module writes via raw SQL using the same key
+        // (`FOCUS_REQUEST_KEY`); this mirrors what the click handler does.
+        db.conn
+            .execute(
+                "INSERT INTO metadata (key, value) VALUES (?1, ?2)",
+                params![
+                    PENDING_FOCUS_SESSION_ID_KEY,
+                    "deadbeef-0000-0000-0000-000000000000"
+                ],
+            )
+            .unwrap();
+
+        // First take returns + clears it; second returns None.
+        assert_eq!(
+            db.take_pending_focus_session_id().unwrap().as_deref(),
+            Some("deadbeef-0000-0000-0000-000000000000")
+        );
+        assert_eq!(db.take_pending_focus_session_id().unwrap(), None);
     }
 
     #[test]

--- a/tests/architecture_rules.rs
+++ b/tests/architecture_rules.rs
@@ -106,6 +106,15 @@ const MODULE_RULES: &[ModuleRules] = &[
         allowed: &["paths"],
         allowed_path_only: &[],
     },
+    // Leaf side-effect module: OS desktop notifications. Knows about
+    // `session` (for `SessionId`) and `paths` (for the DB path the click
+    // callback writes to); never reaches into agent / ui / app / storage
+    // beyond a single SQL statement on its own short-lived connection.
+    ModuleRules {
+        name: "notifications",
+        allowed: &["session", "paths"],
+        allowed_path_only: &[],
+    },
 ];
 
 /// Modules exempt from the allowlist: `app` is the coordinator (imports
@@ -519,6 +528,11 @@ fn util_modules_are_leaves() {
     for name in ["fuzzy", "paths", "shell", "workspace"] {
         assert_module_clean(name);
     }
+}
+
+#[test]
+fn notifications_module_isolation() {
+    assert_module_clean("notifications");
 }
 
 /// Every module under `src/` must be governed: either a MODULE_RULES entry


### PR DESCRIPTION
## Summary

- Fire an OS desktop notification when a session crosses into `SessionStatus::Attention` (the agent rang the terminal bell or emitted OSC 9 / OSC 777 — i.e. it's waiting on you).
- Linux: clicking the banner pre-selects that session inside the running TUI (atomic write to a SQLite `metadata` row, drained on the next `poll_external_changes` tick). macOS: passive banner only — `UNUserNotificationCenter` actions require a signed app bundle.
- Gated by `[features] notifications` (default on, zero overhead when off) with `[notifications]` knobs: `also_on_waiting`, `suppress_for_active`, `sound`, `min_interval_secs`.

## Design notes

- The trigger lives inside `App::refresh_session_statuses`, the same place `SessionStatus` is computed, so the notification rule can't drift from the icon shown in the list.
- Per-session bookkeeping (prior status, last fire-at) lives in a new `app::notify_state` struct so the transition rule is pure and unit-testable — 10 unit tests cover `Busy → Attention`, the `also_on_waiting` opt-in, `Attention → Waiting` *not* re-firing, active-session suppression, dedup throttle, and pruning of stale sessions.
- The leaf `crate::notifications` module wraps `notify-rust` on a single background dispatcher thread fed by an mpsc channel, so the UI tick never blocks on dbus / a missing notification daemon.
- `PENDING_FOCUS_SESSION_ID_KEY` lives in `session/` so the writer (`notifications`) and reader (`storage`) share one source of truth without crossing module boundaries.
- **Terminal window-raising is deliberately not implemented** — thurbox runs inside an arbitrary terminal emulator it doesn't own, and per-emulator window control is fragile (especially on Wayland). The notification grabs your attention; you alt-tab back yourself, and the right session is already selected.
- **TUI-only**: the PTY parser that observes the bell only runs while the TUI is alive, so notifications don't fire from headless `automation tick`.

## Test plan

- [x] `cargo nextest run` — 22 new/affected tests pass (notify_state ×10, settings parsing ×4, storage round-trip ×1, apply_pending_focus ×3, plus existing feature-flag + arch coverage).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo test --test architecture_rules` — `notifications` slots in as a new leaf allowlist (`session` + `paths` only).
- [x] `cargo deny check bans licenses sources` — notify-rust + zbus transitive deps pass policy.
- [ ] Manual: trigger an Attention transition on Linux, click the banner, confirm focus switches.
- [ ] Manual: same on macOS, confirm the banner shows and clicking is a no-op (expected limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)