### PR TITLE
feat: add opt-in version update indicator (TUI badge + CLI version --check)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,7 +381,9 @@ send/inbox/prune — the inter-session mailbox queue; see below), `editor`, `con
 (validate/show — strict-parses every config file / prints the
 effective resolved config; see `docs/CONFIG.md`), `extension`
 (alias `ext`: install/uninstall/reinstall/list/available/update/activate/
-deactivate/status — manage opt-in extensions; see below). Output is
+deactivate/status — manage opt-in extensions; see below), `version`
+(prints the running version; `--check` queries GitHub's latest release —
+gated on `[features] version_check`, off by default). Output is
 **human-readable by default** and switches to JSON automatically when stdout is
 piped (so `… | jq` keeps working); force a format with `--json` (compact),
 `--pretty` (indented JSON), or `--text` (human even when piped).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -117,22 +117,24 @@ wants are exposed; internals stay hardcoded.
 
 ### `[features]` — whole-feature switches
 
-Turn major TUI features off entirely. All default to `true`; like the
-rest of settings.toml, changes need a restart. A disabled feature's
-pane never renders, its keybinding shows a status toast instead of
-acting, and its global-search scope returns no results. Data is never
-touched, so re-enabling a flag is lossless.
+Turn major TUI features off entirely. All default to `true` **except
+`version_check`, which defaults to `false`** (it makes a network call,
+so it is opt-in). Like the rest of settings.toml, changes need a
+restart. A disabled feature's pane never renders, its keybinding shows
+a status toast instead of acting, and its global-search scope returns
+no results. Data is never touched, so re-enabling a flag is lossless.
 
-| Key | Disables |
-|-----|----------|
-| `tasks` | tasks panel (`F5`/`Ctrl+W`) and task search results |
-| `automations` | automations pane, `Ctrl+P`, TUI schedule firing, heartbeat arming |
-| `file_viewer` | file viewer column (`F3`) and file search results |
-| `global_search` | global search strip (`Ctrl+/`) |
-| `info_panel` | info panel column (`F2`) |
-| `shell_pane` | per-session shell toggle (`Ctrl+T`) |
-| `mouse` | mouse capture: clicks, wheel, drag-select, hover, scrollbars |
-| `notifications` | OS desktop notifications when a session needs attention |
+| Key | Default | Controls |
+|-----|---------|----------|
+| `tasks` | `true` | tasks panel (`F5`/`Ctrl+W`) and task search results |
+| `automations` | `true` | automations pane, `Ctrl+P`, TUI schedule firing, heartbeat arming |
+| `file_viewer` | `true` | file viewer column (`F3`) and file search results |
+| `global_search` | `true` | global search strip (`Ctrl+/`) |
+| `info_panel` | `true` | info panel column (`F2`) |
+| `shell_pane` | `true` | per-session shell toggle (`Ctrl+T`) |
+| `mouse` | `true` | mouse capture: clicks, wheel, drag-select, hover, scrollbars |
+| `notifications` | `true` | OS desktop notifications when a session needs attention |
+| `version_check` | `false` | GitHub update check: TUI header "update available" badge + `thurbox-cli version --check` |
 
 `automations = false` is a full stop on the TUI side: the pane
 disappears (the session list takes the whole left column and `j`/`k`
@@ -176,6 +178,18 @@ respects the terminal bell / OSC 9 / OSC 777 conventions (Claude Code
 out of the box, for example). For agents that only go quiet without
 ringing a bell, set `also_on_waiting = true` — note this fires once each
 time the agent goes idle after activity, so it can be chatty.
+
+`version_check = true` enables the update check. On launch the TUI
+reads a cached result (`~/.local/share/thurbox/version-check.json`) and,
+if it is older than 24 h, fires a single best-effort background fetch of
+GitHub's latest release (`api.github.com/repos/Thurbeen/thurbox/releases/latest`,
+via `curl`/`wget` — no new dependency); a newer release shows a `⬆ vX.Y.Z
+available` badge next to the version in the header. The fetch never runs
+on the render path and never blocks startup; failures are silent. Dev
+builds (`0.0.0-dev`) never show the badge. The same flag enables
+`thurbox-cli version --check`, which fetches fresh on demand and reports
+current vs. latest (`thurbox-cli version` with no flag always prints the
+current version, regardless of the flag).
 
 ## themes.toml
 

--- a/src/agent/extension_config.rs
+++ b/src/agent/extension_config.rs
@@ -326,7 +326,7 @@ pub fn fetch_file(source: &ExtensionSource, rel: &str) -> Result<String, String>
 ///
 /// Note: the body is decoded as UTF-8 (lossy); extension payloads are expected
 /// to be text files (specs, scripts, JSON), not binaries.
-fn http_get(url: &str) -> Result<String, String> {
+pub(crate) fn http_get(url: &str) -> Result<String, String> {
     let attempts: [(&str, Vec<&str>); 2] = [
         ("curl", vec!["-fsSL", "--max-time", "30", url]),
         ("wget", vec!["--timeout=30", "-O", "-", url]),

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -11,6 +11,7 @@ pub mod settings_config;
 pub mod themes_config;
 pub mod tmux;
 pub mod transport;
+pub mod version_check;
 
 pub use backend::{Session, SessionBackend, SessionParser, TermSignals};
 pub use generic::GenericProvider;

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -48,6 +48,11 @@ config_version = 1
 # shell_pane = true       # Ctrl+T per-session shell
 # mouse = true            # mouse capture: clicks, wheel, drag-select, hover
 # notifications = true    # OS desktop notifications when a session needs attention
+#
+# `version_check` is the one flag that defaults to FALSE: it makes a network
+# call to GitHub to learn the latest release. Enable it for the TUI header
+# "update available" badge and the `thurbox-cli version --check` command.
+# version_check = false   # GitHub update check (TUI badge + `version --check`)
 
 # OS desktop notifications. Linux gets click-to-focus (clicking the banner
 # selects the session in the running TUI); macOS shows a passive banner only.

--- a/src/agent/version_check.rs
+++ b/src/agent/version_check.rs
@@ -1,0 +1,240 @@
+//! Update check: is a newer thurbox release available?
+//!
+//! This is the side-effect half of the **opt-in** version-deployment indicator
+//! (gated behind `[features] version_check`, off by default — see
+//! [`crate::session::settings::FeatureFlags`]). It surfaces two ways:
+//!
+//! - **TUI** — a small "update available → vX.Y.Z" badge in the header. The
+//!   draw loop only ever reads a cached result ([`read_cached_status`]); the
+//!   network refresh ([`refresh_cache`]) runs off the render path.
+//! - **CLI** — `thurbox-cli version --check` fetches fresh and reports.
+//!
+//! The pure decision ([`decide_update`]) is built on the existing
+//! [`crate::session::extension_def::compare_versions`] /
+//! [`is_dev_version`](crate::session::extension_def::is_dev_version) helpers, so
+//! dev builds (`0.0.0-dev`) never report an update. The GitHub fetch shells out
+//! to `curl`/`wget` (no new crate dependency — same dependency-free approach as
+//! `scripts/install.sh` and the extension installer).
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::session::extension_def::{compare_versions, is_dev_version};
+
+/// GitHub "latest release" endpoint for the thurbox repo (same repo + API as
+/// `scripts/install.sh`).
+const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/Thurbeen/thurbox/releases/latest";
+
+/// How long a cached check stays fresh. The TUI reads the cache on startup and
+/// only refreshes over the network once it is older than this, so a normal
+/// launch never hits the network.
+const CACHE_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// The outcome of comparing the running binary against the latest release.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateStatus {
+    /// The running binary's version (e.g. `0.113.0`).
+    pub current: String,
+    /// The latest published release (e.g. `0.114.0`, "v" stripped).
+    pub latest: String,
+    /// Whether `latest` is strictly newer than `current`.
+    pub update_available: bool,
+}
+
+/// On-disk cache of the last successful check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedCheck {
+    /// Latest release tag observed (normalized, no leading `v`).
+    latest: String,
+    /// Unix seconds when the check ran.
+    checked_at: u64,
+}
+
+/// Decide whether `latest` is a newer release than `current`.
+///
+/// Returns `None` — i.e. "no badge / nothing to report" — when:
+/// - `current` is a dev build (its version doesn't order against tags), or
+/// - `latest` is empty / not parseable as newer, or
+/// - `latest` is not strictly greater than `current`.
+///
+/// Otherwise returns a populated [`UpdateStatus`] with `update_available =
+/// true`. Pure: no IO, fully unit-testable.
+pub fn decide_update(current: &str, latest: &str) -> Option<UpdateStatus> {
+    let current = current.trim();
+    let latest = latest.trim().trim_start_matches('v');
+    if current.is_empty() || latest.is_empty() {
+        return None;
+    }
+    // Dev builds (0.0.0-dev) intentionally never flag an update.
+    if is_dev_version(current) {
+        return None;
+    }
+    if compare_versions(latest, current) == std::cmp::Ordering::Greater {
+        Some(UpdateStatus {
+            current: current.to_string(),
+            latest: latest.to_string(),
+            update_available: true,
+        })
+    } else {
+        None
+    }
+}
+
+/// The running binary's version (re-exported from the shared helper).
+pub fn current_version() -> &'static str {
+    crate::agent::extension_config::binary_version()
+}
+
+/// Path to the cache file: `~/.local/share/thurbox/version-check.json`.
+fn cache_path() -> Option<PathBuf> {
+    crate::paths::log_directory().map(|d| d.join("version-check.json"))
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn read_cache() -> Option<CachedCheck> {
+    let path = cache_path()?;
+    let raw = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn write_cache(latest: &str) {
+    let Some(path) = cache_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let entry = CachedCheck {
+        latest: latest.trim_start_matches('v').to_string(),
+        checked_at: now_secs(),
+    };
+    if let Ok(json) = serde_json::to_string(&entry) {
+        let _ = std::fs::write(&path, json);
+    }
+}
+
+/// Whether the cache is missing or older than [`CACHE_TTL_SECS`].
+pub fn cache_is_stale() -> bool {
+    match read_cache() {
+        Some(c) => now_secs().saturating_sub(c.checked_at) >= CACHE_TTL_SECS,
+        None => true,
+    }
+}
+
+/// Read the cached check and compare it against the running binary, without
+/// any network IO. Returns `Some` only when a newer release is cached (so the
+/// caller can render a badge); `None` otherwise. Always safe to call from the
+/// TUI draw loop.
+pub fn read_cached_status() -> Option<UpdateStatus> {
+    let cached = read_cache()?;
+    decide_update(current_version(), &cached.latest)
+}
+
+/// Parse the latest release tag out of the GitHub `releases/latest` JSON. Kept
+/// separate from the fetch so it can be unit-tested against a fixed body. Uses
+/// the same field (`tag_name`) the install script scrapes.
+fn parse_tag_name(body: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    let tag = value.get("tag_name")?.as_str()?.trim();
+    if tag.is_empty() {
+        None
+    } else {
+        Some(tag.trim_start_matches('v').to_string())
+    }
+}
+
+/// Fetch the latest release tag from GitHub (network). Shells out to
+/// `curl`/`wget`; returns the normalized version (no leading `v`).
+pub fn fetch_latest_release() -> Result<String, String> {
+    let body = crate::agent::extension_config::http_get(LATEST_RELEASE_URL)?;
+    parse_tag_name(&body)
+        .ok_or_else(|| "could not parse latest release tag from GitHub response".to_string())
+}
+
+/// Fetch the latest release over the network and refresh the on-disk cache.
+/// Returns the fetched latest version plus the update decision (so callers can
+/// report "up to date" with the actual latest version, not just `None`). The
+/// cache is updated regardless, so the TUI badge reflects the newest release.
+pub fn refresh_cache() -> Result<(String, Option<UpdateStatus>), String> {
+    let latest = fetch_latest_release()?;
+    write_cache(&latest);
+    let status = decide_update(current_version(), &latest);
+    Ok((latest, status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn newer_release_is_reported() {
+        let s = decide_update("0.113.0", "0.114.0").expect("update");
+        assert_eq!(s.current, "0.113.0");
+        assert_eq!(s.latest, "0.114.0");
+        assert!(s.update_available);
+    }
+
+    #[test]
+    fn strips_leading_v_on_latest() {
+        let s = decide_update("0.113.0", "v0.114.0").expect("update");
+        assert_eq!(s.latest, "0.114.0");
+    }
+
+    #[test]
+    fn same_or_older_release_reports_nothing() {
+        assert!(decide_update("0.114.0", "0.114.0").is_none());
+        assert!(decide_update("0.114.0", "0.113.0").is_none());
+    }
+
+    #[test]
+    fn dev_build_never_reports_update() {
+        assert!(decide_update("0.0.0-dev", "9.9.9").is_none());
+        assert!(decide_update("0.0.0", "9.9.9").is_none());
+    }
+
+    #[test]
+    fn empty_inputs_report_nothing() {
+        assert!(decide_update("", "1.0.0").is_none());
+        assert!(decide_update("1.0.0", "").is_none());
+        assert!(decide_update("1.0.0", "   ").is_none());
+    }
+
+    #[test]
+    fn parses_tag_name_from_release_json() {
+        let body = r#"{"tag_name":"v0.120.0","name":"v0.120.0","draft":false}"#;
+        assert_eq!(parse_tag_name(body).as_deref(), Some("0.120.0"));
+    }
+
+    #[test]
+    fn parse_tag_name_handles_missing_or_blank() {
+        assert!(parse_tag_name(r#"{"message":"Not Found"}"#).is_none());
+        assert!(parse_tag_name(r#"{"tag_name":""}"#).is_none());
+        assert!(parse_tag_name("not json").is_none());
+    }
+
+    #[test]
+    fn cache_round_trips_and_drives_status() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+
+        // No cache yet: stale, no status.
+        assert!(cache_is_stale());
+        assert!(read_cached_status().is_none());
+
+        // A freshly written newer release is fresh and (for a non-dev current
+        // version) drives a status. We can't override the compiled-in current
+        // version, so assert the cache file itself round-trips.
+        write_cache("v9.9.9");
+        assert!(!cache_is_stale(), "just-written cache is fresh");
+        let cached = read_cache().expect("cache present");
+        assert_eq!(cached.latest, "9.9.9", "leading v stripped on write");
+    }
+}

--- a/src/agent/version_check.rs
+++ b/src/agent/version_check.rs
@@ -4,16 +4,15 @@
 //! (gated behind `[features] version_check`, off by default — see
 //! [`crate::session::settings::FeatureFlags`]). It surfaces two ways:
 //!
-//! - **TUI** — a small "update available → vX.Y.Z" badge in the header. The
-//!   draw loop only ever reads a cached result ([`read_cached_status`]); the
-//!   network refresh ([`refresh_cache`]) runs off the render path.
+//! - **TUI** — a small "⬆ vX.Y.Z available" badge in the header. The draw loop
+//!   only ever reads a cached result ([`read_cached_status`]); the network
+//!   refresh ([`refresh_cache`]) runs off the render path.
 //! - **CLI** — `thurbox-cli version --check` fetches fresh and reports.
 //!
 //! The pure decision ([`decide_update`]) is built on the existing
-//! [`crate::session::extension_def::compare_versions`] /
-//! [`is_dev_version`](crate::session::extension_def::is_dev_version) helpers, so
-//! dev builds (`0.0.0-dev`) never report an update. The GitHub fetch shells out
-//! to `curl`/`wget` (no new crate dependency — same dependency-free approach as
+//! [`compare_versions`] / [`is_dev_version`] helpers, so dev builds
+//! (`0.0.0-dev`) never report an update. The GitHub fetch shells out to
+//! `curl`/`wget` (no new crate dependency — same dependency-free approach as
 //! `scripts/install.sh` and the extension installer).
 
 use std::path::PathBuf;
@@ -32,15 +31,18 @@ const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/Thurbeen/thurbox/
 /// launch never hits the network.
 const CACHE_TTL_SECS: u64 = 24 * 60 * 60;
 
-/// The outcome of comparing the running binary against the latest release.
+/// A confirmed available update: `latest` is strictly newer than `current`.
+///
+/// The *existence* of this value is itself the "update available" signal —
+/// [`decide_update`] only ever returns `Some` when a newer release exists, so
+/// there is no redundant boolean flag to keep in sync.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UpdateStatus {
     /// The running binary's version (e.g. `0.113.0`).
     pub current: String,
-    /// The latest published release (e.g. `0.114.0`, "v" stripped).
+    /// The latest published release (e.g. `0.114.0`, "v" stripped), newer than
+    /// `current`.
     pub latest: String,
-    /// Whether `latest` is strictly newer than `current`.
-    pub update_available: bool,
 }
 
 /// On-disk cache of the last successful check.
@@ -75,14 +77,15 @@ pub fn decide_update(current: &str, latest: &str) -> Option<UpdateStatus> {
         Some(UpdateStatus {
             current: current.to_string(),
             latest: latest.to_string(),
-            update_available: true,
         })
     } else {
         None
     }
 }
 
-/// The running binary's version (re-exported from the shared helper).
+/// The running binary's version (thin wrapper over the shared
+/// [`binary_version`](crate::agent::extension_config::binary_version) helper, so
+/// callers in this feature have a single import).
 pub fn current_version() -> &'static str {
     crate::agent::extension_config::binary_version()
 }
@@ -121,7 +124,8 @@ fn write_cache(latest: &str) {
     }
 }
 
-/// Whether the cache is missing or older than [`CACHE_TTL_SECS`].
+/// Whether the cache is missing or older than the freshness window
+/// (`CACHE_TTL_SECS`, 24 h).
 pub fn cache_is_stale() -> bool {
     match read_cache() {
         Some(c) => now_secs().saturating_sub(c.checked_at) >= CACHE_TTL_SECS,
@@ -179,7 +183,6 @@ mod tests {
         let s = decide_update("0.113.0", "0.114.0").expect("update");
         assert_eq!(s.current, "0.113.0");
         assert_eq!(s.latest, "0.114.0");
-        assert!(s.update_available);
     }
 
     #[test]
@@ -236,5 +239,22 @@ mod tests {
         assert!(!cache_is_stale(), "just-written cache is fresh");
         let cached = read_cache().expect("cache present");
         assert_eq!(cached.latest, "9.9.9", "leading v stripped on write");
+    }
+
+    #[test]
+    fn cache_older_than_ttl_is_stale() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+
+        // Write a cache stamped at the epoch — far older than the TTL window.
+        let path = cache_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let entry = CachedCheck {
+            latest: "9.9.9".into(),
+            checked_at: 0,
+        };
+        std::fs::write(&path, serde_json::to_string(&entry).unwrap()).unwrap();
+
+        assert!(cache_is_stale(), "an epoch-stamped cache is past the TTL");
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -495,6 +495,15 @@ pub struct App {
     metrics_refresh: background::BackgroundTask<MetricsRefresh>,
     /// Background active-session git-stats refresh, polled each tick.
     git_stats: background::BackgroundTask<(SessionId, Option<crate::session::GitStats>)>,
+    /// Cached update-check result, rendered as the header "update available"
+    /// badge. `Some` only when `[features] version_check` is on and a newer
+    /// release is known (from the on-disk cache). Read off the network — see
+    /// [`crate::agent::version_check`].
+    update_status: Option<crate::agent::version_check::UpdateStatus>,
+    /// One-shot background GitHub update check (network), polled each tick. Fires
+    /// once on startup when the cache is stale; on success the cache is rewritten
+    /// and `update_status` re-read from it.
+    version_check_task: background::BackgroundTask<Result<(), String>>,
     /// Background worktree-creation (`git worktree add`) for the new-session
     /// wizard, polled each tick; in-flight state guards against re-entry and
     /// clobbering the pending continuation.
@@ -678,6 +687,14 @@ impl App {
             metrics: metrics_state::MetricsState::new(),
             metrics_refresh: background::BackgroundTask::default(),
             git_stats: background::BackgroundTask::default(),
+            // Seed the badge from the cache (no network); refreshed on first
+            // tick if the flag is on and the cache is stale.
+            update_status: if crate::session::settings::global().features.version_check {
+                crate::agent::version_check::read_cached_status()
+            } else {
+                None
+            },
+            version_check_task: background::BackgroundTask::default(),
             worktree_create: background::BackgroundTask::default(),
             pending_worktree_create: None,
             session_spawn: background::BackgroundTask::default(),
@@ -2869,6 +2886,35 @@ impl App {
         }
 
         self.tick_background_refreshes();
+
+        self.tick_version_check();
+    }
+
+    /// Drive the opt-in GitHub update check. Off the render path: on the first
+    /// tick (when the flag is on and the on-disk cache is stale) it fires a
+    /// single background network refresh; the result only ever lands by
+    /// re-reading the cache, so rendering never makes a network call.
+    fn tick_version_check(&mut self) {
+        if !self.features.version_check {
+            return;
+        }
+
+        // One attempt per launch: fire on the first tick if the cache is stale.
+        if self.metrics.tick_count == 1
+            && !self.version_check_task.in_progress()
+            && crate::agent::version_check::cache_is_stale()
+        {
+            let tx = self.version_check_task.start();
+            tokio::task::spawn_blocking(move || {
+                let _ = tx.send(crate::agent::version_check::refresh_cache().map(|_| ()));
+            });
+        }
+
+        // Apply a completed refresh by re-reading the cache (single source of
+        // truth). A failed/ dead refresh leaves the prior badge untouched.
+        if let background::TaskPoll::Done(Ok(())) = self.version_check_task.poll() {
+            self.update_status = crate::agent::version_check::read_cached_status();
+        }
     }
 
     /// Run the debounced global-search content scan once the query has been
@@ -6670,6 +6716,7 @@ mod tests {
             shell_pane: false,
             mouse: true,
             notifications: false,
+            version_check: false,
         };
 
         app.handle_key(KeyCode::F(5), KeyModifiers::NONE);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2911,7 +2911,7 @@ impl App {
         }
 
         // Apply a completed refresh by re-reading the cache (single source of
-        // truth). A failed/ dead refresh leaves the prior badge untouched.
+        // truth). A failed/dead refresh leaves the prior badge untouched.
         if let background::TaskPoll::Done(Ok(())) = self.version_check_task.poll() {
             self.update_status = crate::agent::version_check::read_cached_status();
         }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -111,12 +111,18 @@ impl App {
             .get(self.active_index)
             .map(|s| s.info.name.as_str());
         let theme_label = self.active_theme.display_name.as_str();
+        let update_latest = self
+            .update_status
+            .as_ref()
+            .filter(|s| s.update_available)
+            .map(|s| s.latest.as_str());
         status_bar::render_header(
             frame,
             header,
             Some(status_bar::HeaderBadge {
                 active_session: active_name,
                 theme_label,
+                update_latest,
             }),
         );
     }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -111,11 +111,9 @@ impl App {
             .get(self.active_index)
             .map(|s| s.info.name.as_str());
         let theme_label = self.active_theme.display_name.as_str();
-        let update_latest = self
-            .update_status
-            .as_ref()
-            .filter(|s| s.update_available)
-            .map(|s| s.latest.as_str());
+        // `update_status` is `Some` only when a newer release exists, so its
+        // presence alone drives the badge.
+        let update_latest = self.update_status.as_ref().map(|s| s.latest.as_str());
         status_bar::render_header(
             frame,
             header,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,7 @@ pub mod messages;
 pub mod output;
 pub mod sessions;
 pub mod tasks;
+pub mod version;
 
 use output::{CommandOutput, Format};
 
@@ -91,6 +92,8 @@ pub enum Command {
         #[command(subcommand)]
         action: extensions::Action,
     },
+    /// Print the version; `--check` queries GitHub for a newer release.
+    Version(version::VersionArgs),
 }
 
 /// Run a parsed CLI invocation against `db`, rendering the result in the
@@ -105,6 +108,7 @@ pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
         Command::Message { action } => messages::run(action, db),
         Command::Config { action } => config::run(action, db),
         Command::Extension { action } => extensions::run(action, db),
+        Command::Version(args) => Ok(version::run(args)),
     }?;
 
     println!("{}", format.render(&output));
@@ -675,6 +679,21 @@ mod tests {
             panic!("expected Message::Prune via msg alias");
         };
         assert_eq!(older_than_days, Some(30));
+    }
+
+    #[test]
+    fn parse_version_with_and_without_check() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "version"]).unwrap();
+        let Command::Version(args) = cli.command else {
+            panic!("expected Version");
+        };
+        assert!(!args.check);
+
+        let cli = Cli::try_parse_from(["thurbox-cli", "version", "--check"]).unwrap();
+        let Command::Version(args) = cli.command else {
+            panic!("expected Version");
+        };
+        assert!(args.check);
     }
 
     #[test]

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -1,0 +1,93 @@
+//! `thurbox-cli version [--check]` — print the running version and, with
+//! `--check`, query GitHub for the latest release.
+//!
+//! `--check` is gated behind the opt-in `[features] version_check` flag (off by
+//! default, since it makes a network call). When the flag is off, `--check`
+//! prints a one-line hint on how to enable it instead of reaching the network.
+//! A successful check also refreshes the on-disk cache the TUI badge reads.
+
+use clap::Args;
+use serde_json::json;
+
+use crate::session::settings;
+
+use super::output::{kv, CommandOutput};
+
+/// `version` subcommand arguments.
+#[derive(Args, Debug)]
+pub struct VersionArgs {
+    /// Check GitHub for a newer release (requires `[features] version_check`).
+    #[arg(long)]
+    pub check: bool,
+}
+
+/// Run the `version` command. Takes no database — it only reads the compiled-in
+/// version and (with `--check`) the network.
+pub fn run(args: VersionArgs) -> CommandOutput {
+    let current = crate::agent::version_check::current_version();
+
+    if !args.check {
+        return CommandOutput::new(json!({ "version": current }), format!("thurbox {current}"));
+    }
+
+    // --check is opt-in behind the feature flag.
+    if !settings::global().features.version_check {
+        let hint = "version --check is disabled. Enable it by setting \
+                    `[features] version_check = true` in settings.toml.";
+        return CommandOutput::new(
+            json!({
+                "version": current,
+                "check_enabled": false,
+                "summary": hint,
+            }),
+            format!("thurbox {current}\n{hint}"),
+        );
+    }
+
+    match crate::agent::version_check::refresh_cache() {
+        Ok((_, Some(status))) => {
+            let human = kv(&[
+                ("current", status.current.clone()),
+                ("latest", status.latest.clone()),
+                ("update", "available".to_string()),
+                (
+                    "upgrade",
+                    "curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh"
+                        .to_string(),
+                ),
+            ]);
+            CommandOutput::new(
+                json!({
+                    "version": status.current,
+                    "latest": status.latest,
+                    "update_available": true,
+                    "check_enabled": true,
+                    "summary": format!("Update available: {} → {}", status.current, status.latest),
+                }),
+                human,
+            )
+        }
+        Ok((latest, None)) => CommandOutput::new(
+            json!({
+                "version": current,
+                "latest": latest,
+                "update_available": false,
+                "check_enabled": true,
+                "summary": "Up to date — running the latest release.",
+            }),
+            format!(
+                "thurbox {current} (latest: {latest})\nUp to date — running the latest release."
+            ),
+        ),
+        Err(e) => CommandOutput::failed(
+            json!({
+                "version": current,
+                "check_enabled": true,
+                "update_available": null,
+                "error": e,
+            }),
+            format!("thurbox {current}\nUpdate check failed: {e}"),
+            format!("update check failed: {e}"),
+        ),
+    }
+}

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -47,7 +47,7 @@ pub fn run(args: VersionArgs) -> CommandOutput {
     match crate::agent::version_check::refresh_cache() {
         Ok((_, Some(status))) => {
             let human = kv(&[
-                ("current", status.current.clone()),
+                ("current", current.to_string()),
                 ("latest", status.latest.clone()),
                 ("update", "available".to_string()),
                 (
@@ -58,11 +58,11 @@ pub fn run(args: VersionArgs) -> CommandOutput {
             ]);
             CommandOutput::new(
                 json!({
-                    "version": status.current,
+                    "version": current,
                     "latest": status.latest,
                     "update_available": true,
                     "check_enabled": true,
-                    "summary": format!("Update available: {} → {}", status.current, status.latest),
+                    "summary": format!("Update available: {current} → {}", status.latest),
                 }),
                 human,
             )
@@ -89,5 +89,32 @@ pub fn run(args: VersionArgs) -> CommandOutput {
             format!("thurbox {current}\nUpdate check failed: {e}"),
             format!("update check failed: {e}"),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_without_check_prints_current_version() {
+        let out = run(VersionArgs { check: false });
+        assert!(out["version"].is_string(), "version field present");
+        assert!(out.human.starts_with("thurbox "), "got: {}", out.human);
+        assert!(out.failure.is_none(), "plain version never fails");
+    }
+
+    #[test]
+    fn version_check_when_flag_disabled_prints_enable_hint() {
+        // `settings::init` is only ever called by the binaries, so in the test
+        // process `settings::global()` is the all-default config — version_check
+        // is off — and `--check` degrades to the enable hint with no network.
+        let out = run(VersionArgs { check: true });
+        assert_eq!(out["check_enabled"], false);
+        assert!(out.human.contains("disabled"), "got: {}", out.human);
+        assert!(
+            out.failure.is_none(),
+            "the hint is informational, not an error"
+        );
     }
 }

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -82,6 +82,12 @@ pub struct FeatureFlags {
     /// passive banner only (the modern API requires a signed app bundle).
     #[serde(default = "default_true")]
     pub notifications: bool,
+    /// Version-update check: the TUI header "update available" badge and the
+    /// `thurbox-cli version --check` command. **Off by default** — unlike the
+    /// other flags, this one is opt-in because it makes a network call to
+    /// GitHub. Enable it to learn when a newer release is available.
+    #[serde(default = "default_false")]
+    pub version_check: bool,
 }
 
 /// Knobs for the OS notification feature (`[notifications]` table). All
@@ -128,6 +134,10 @@ fn default_true() -> bool {
     true
 }
 
+fn default_false() -> bool {
+    false
+}
+
 impl Default for FeatureFlags {
     fn default() -> Self {
         Self {
@@ -139,6 +149,7 @@ impl Default for FeatureFlags {
             shell_pane: true,
             mouse: true,
             notifications: true,
+            version_check: false,
         }
     }
 }
@@ -276,6 +287,18 @@ mod tests {
     fn notifications_type_mismatch_is_rejected() {
         let err = toml::from_str::<Settings>("[notifications]\nsound = \"loud\"").unwrap_err();
         assert!(err.to_string().contains("sound"));
+    }
+
+    #[test]
+    fn version_check_flag_defaults_off_and_parses() {
+        // Unlike the other flags, version_check is opt-in (network call).
+        let s: Settings = toml::from_str("[features]").unwrap();
+        assert!(!s.features.version_check, "version_check defaults off");
+        assert!(s.features.tasks, "other flags still default on");
+
+        let s: Settings = toml::from_str("[features]\nversion_check = true").unwrap();
+        assert!(s.features.version_check);
+        assert!(s.features.mouse, "untouched flags stay at their default");
     }
 
     #[test]

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -21,7 +21,7 @@ pub fn render_header(frame: &mut Frame, area: Rect, badge: Option<HeaderBadge<'_
     if area.height == 0 {
         return;
     }
-    let header = Paragraph::new(Line::from(vec![
+    let mut spans = vec![
         Span::styled(" thurbox", brand_style()),
         Span::styled(
             "  Multi-Session Agent Orchestrator",
@@ -31,8 +31,16 @@ pub fn render_header(frame: &mut Frame, area: Rect, badge: Option<HeaderBadge<'_
             concat!("  v", env!("THURBOX_VERSION")),
             Style::default().fg(Theme::text_muted()),
         ),
-    ]));
-    frame.render_widget(header, area);
+    ];
+    if let Some(latest) = badge.as_ref().and_then(|b| b.update_latest) {
+        spans.push(Span::styled(
+            format!("  ⬆ v{latest} available"),
+            Style::default()
+                .fg(Theme::accent())
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
 
     if let Some(badge) = badge {
         let mut spans: Vec<Span<'_>> = Vec::new();
@@ -52,10 +60,14 @@ pub fn render_header(frame: &mut Frame, area: Rect, badge: Option<HeaderBadge<'_
     }
 }
 
-/// Right-aligned overlay rendered on top of the header.
+/// Right-aligned overlay rendered on top of the header, plus the optional
+/// left-aligned "update available" version badge.
 pub struct HeaderBadge<'a> {
     pub active_session: Option<&'a str>,
     pub theme_label: &'a str,
+    /// When `Some`, the latest available release version (no leading `v`),
+    /// rendered as a left-aligned "⬆ vX.Y.Z available" badge after the version.
+    pub update_latest: Option<&'a str>,
 }
 
 /// State needed to render the footer bar.

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -188,3 +188,52 @@ fn push_spinner_badge<'a>(spans: &mut Vec<Span<'a>>, tick_count: u64, label: &'a
             .bg(Theme::accent()),
     ));
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    /// Render the header into a 120×1 buffer (a realistic three-panel width,
+    /// wide enough that the right-aligned theme overlay doesn't paint over the
+    /// left badge) and return its single line.
+    fn header_line(update_latest: Option<&str>) -> String {
+        let backend = TestBackend::new(120, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                render_header(
+                    f,
+                    Rect::new(0, 0, 120, 1),
+                    Some(HeaderBadge {
+                        active_session: None,
+                        theme_label: "Default",
+                        update_latest,
+                    }),
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        (0..buffer.area.width)
+            .map(|x| buffer[(x, 0)].symbol())
+            .collect()
+    }
+
+    #[test]
+    fn update_badge_renders_when_a_newer_release_is_available() {
+        let line = header_line(Some("0.114.0"));
+        assert!(
+            line.contains("⬆ v0.114.0 available"),
+            "badge missing from header: {line:?}"
+        );
+    }
+
+    #[test]
+    fn no_update_badge_without_a_newer_release() {
+        let line = header_line(None);
+        assert!(
+            !line.contains("available"),
+            "unexpected badge in header: {line:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **opt-in** version-deployment indicator so users can see when a newer thurbox release is available, surfaced two ways:

- **TUI** — a `⬆ vX.Y.Z available` badge next to the version in the header.
- **CLI** — `thurbox-cli version` (prints current version) and `thurbox-cli version --check` (queries GitHub's latest release on demand).

Both are gated behind a new `[features] version_check` flag that **defaults to `false`** (unlike every other feature flag), because the check makes a network call to GitHub. This allows safe rollout/testing, as requested.

## How it works

- **Pure decision** (`agent::version_check::decide_update`) builds on the existing `compare_versions` / `is_dev_version` helpers, so dev builds (`0.0.0-dev`) never flag an update.
- **Network fetch** shells out to `curl`/`wget` (no new crate dependency — same dependency-free approach + endpoint as `scripts/install.sh`).
- **TUI is cache-only on the render path**: on launch it reads a cached result (`~/.local/share/thurbox/version-check.json`); if older than 24h, a single best-effort background fetch fires off the render path on the first tick. Failures are silent and never block startup.
- **CLI `--check`** fetches fresh on demand and refreshes the same cache; with the flag off it prints a one-line enable hint instead of hitting the network. `thurbox-cli version` (no flag) always prints the current version regardless of the flag.

## Files

- `session/settings.rs` — new `version_check` flag (default off) + tests.
- `agent/version_check.rs` — new module: pure decision, GitHub fetch, JSON cache (unit-tested).
- `agent/extension_config.rs` — `http_get` made `pub(crate)` for reuse.
- `cli/version.rs` + `cli/mod.rs` — new `version [--check]` subcommand.
- `app/mod.rs`, `app/view.rs`, `ui/status_bar.rs` — cached `update_status`, one-shot background refresh, header badge.
- `agent/settings_config.rs`, `docs/CONFIG.md`, `CLAUDE.md` — docs.

## Testing

- `cargo build`, `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt`, and the architecture-rules test all pass.
- New unit tests for the update decision, tag parsing, cache round-trip, the feature-flag default, and CLI parsing all pass.
- Pre-existing test failures in this sandbox (`Ctrl+/` global-search encoding tests and a tmux-dependent reinstall test) are unrelated — confirmed they also fail on a clean checkout of this branch's base.

Implemented per the approved plan (clarify → plan → build) for thurbox task #53.