### PR TITLE
feat(core): multi-repo headless spawns + flow multi-repo dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,8 @@ per-session model/permission/prompt/tool knobs.
 ### Multi-repo sessions (symlink workspace)
 
 A session can span several repositories (the repo picker allows
-multiple). Because agent CLIs differ wildly in how — or whether —
+multiple; headless callers pass `--add-repo`/`--add-dir`, below). Because agent
+CLIs differ wildly in how — or whether —
 they accept extra directories, thurbox does **not** pass per-agent
 `--add-dir`-style flags. Instead, when a session has more than one
 member directory it is launched in a per-session **symlink
@@ -288,6 +289,20 @@ never stored. `workspace::ensure_workspace` / `remove_workspace`
 single `App::session_member_dirs` list that also feeds the rendered
 repo names, and `App::resolve_process_cwd` picks workspace-vs-primary.
 Single-repo sessions are unchanged (`cwd` = the repo directly).
+
+**Headless multi-repo.** The same multi-repo shape is reachable without the
+TUI: `SpawnRequest.extra_repos: Vec<ExtraRepo>` (`session/automation.rs`) carries
+each additional repo, where `ExtraRepo { repo_path, worktree: bool, base_branch }`
+either gets its **own isolated worktree** on the spawn's shared `worktree_branch`
+(off its own base — the per-repo-PR model flow uses) or is attached **as-is** as
+an additional dir. `session_ops::spawn::resolve_dirs` builds the worktrees +
+additional dirs and `resolve_launch_cwd` mirrors the TUI's `resolve_process_cwd`
+(symlink workspace when ≥2 members). The CLI exposes it on `session create` and
+`task create` via repeatable `--add-repo PATH[@BASE]` (worktree) and `--add-dir
+PATH` (as-is); `AutomationAction::Spawn` persists the list as JSON in the
+`action_extra_repos` column (schema v33, on both `tasks` and `automations`;
+`NULL`/empty = single-repo, so old rows are byte-identical). The flow extension's
+`create-task.sh` forwards these flags (see `extensions/flow/FLOW.md`).
 
 ## Remote SSH Sessions
 
@@ -368,6 +383,12 @@ thurbox-cli session create --name demo --repo-path /srv/repo \
 # Spawn a worker under a lead session (parent must exist):
 thurbox-cli session create --name worker --repo-path /path \
     --parent <lead-uuid>
+# Multi-repo: each --add-repo gets its own worktree on --worktree-branch;
+# --add-dir attaches a repo as-is (no branch). The agent launches in a
+# symlink workspace gathering every repo. Works on `task create` too.
+thurbox-cli session create --name demo --repo-path /a \
+    --agent claude --worktree-branch feat/x \
+    --add-repo /b@main --add-repo /c@master --add-dir /reference
 thurbox-cli session list                       # human-readable table
 thurbox-cli session list --json | jq           # machine output for scripts
 thurbox-cli session list --parent <lead-uuid> --json | jq  # direct children only
@@ -668,7 +689,12 @@ sync, but the TUI editor never sets it.)
   owns the worker prompt and injects a mandatory clarify → plan → build
   phase (≥3 clarifying questions, then a written plan gated on user
   approval, then implement; seeded from `--accept`) so each worker plans
-  before it codes and stays in scope. Worker↔flow coordination is
+  before it codes and stays in scope. A dump spanning several `repos.md`
+  repos becomes one **multi-repo** task: `create-task.sh` forwards
+  `--add-repo PATH@origin/<base>` (own isolated `flow/<slug>` worktree per
+  repo) / `--add-dir PATH` (attached as-is) to `task create`, and the worker
+  opens a **separate PR per repo it changes** (its `result` carries
+  `pr_urls`). Worker↔flow coordination is
   **event-driven over the [inter-session message queue](#inter-session-messages-mailbox-queue)**:
   a worker pushes `message send --to flow --kind questions|plan|result`
   (which wakes flow) — passing **no ids** (thurbox auto-stamps the sender + task

--- a/extensions/flow/FLOW.md
+++ b/extensions/flow/FLOW.md
@@ -109,7 +109,32 @@ the table, add a row when you learn its path.
    for non-git directories. **The worktree base is always the REMOTE
    default branch** — `origin/<base>` with the base column from
    `./repos.md` (e.g. `origin/main`), never a local branch; the helper
-   fetches origin first so the base is current. If the repo is not
+   fetches origin first so the base is current.
+
+   **Multi-repo tasks.** When a dump clearly spans **more than one repo**
+   (matches several `./repos.md` rows, or says "across X and Y", "share code
+   between …", "the API and its client"), dispatch ONE task that spans them
+   all rather than splitting it: pick the most-central repo as `--repo` and
+   add each other repo with a repeated `--add-repo
+   <abs-path>@origin/<base-from-repos.md>` (the base after `@` is per-repo;
+   omit `@base` to inherit the primary's `--base`). Every repo gets its **own
+   isolated `flow/<task-slug>` worktree**, and the worker sees them all as
+   sub-directories of one workspace, opening a **separate PR per repo it
+   changes** (the helper composes the per-repo-PR footer; its `result`
+   carries `pr_urls`). Use `--add-dir <abs-path>` instead of `--add-repo`
+   for a repo the worker only needs to **read** (attached as-is, no branch /
+   PR). Keep multi-repo for genuinely cross-repo work — a task touching one
+   repo stays single-`--repo`.
+
+   ```bash
+   ./scripts/create-task.sh --title "<title>" --description "<user words>" \
+     --accept "<criterion>" --priority <p> \
+     --repo <abs-primary> --agent flow-worker-heavy \
+     --worktree flow/<task-slug> --base origin/<base> \
+     --add-repo <abs-other>@origin/<base> --add-repo <abs-third>@origin/<base>
+   ```
+
+   Multi-repo work is usually `flow-worker-heavy` (it's larger by nature). If the repo is not
    confident → omit `--repo`/`--agent`/`--accept` (plain todo: the
    `--description` is then used verbatim, with no planning block); triage
    later or ask ONE question. Over capacity → add `--no-dispatch`. For a
@@ -204,8 +229,9 @@ first step of every TICK, so a missed wake never strands a worker.
      message `id`), and make clear it needs an **approve / change** decision.
    - **`result`** → the worker finished. Parse the `body` JSON: if
      `"status":"ok"`, mark the task done (`task edit <from_task_id> --status
-     done`) and note it; if `"status":"error"`, surface it under "Needs you".
-     Then run DISPATCH (a slot just freed).
+     done`) and note it (a multi-repo worker reports a `pr_urls` array — list
+     each PR; a single-repo worker reports one `pr_url`); if `"status":"error"`,
+     surface it under "Needs you". Then run DISPATCH (a slot just freed).
 3. End with the Output Contract footer. A DRAIN is not a brain-dump — create no
    task.
 

--- a/extensions/flow/README.md
+++ b/extensions/flow/README.md
@@ -104,6 +104,12 @@ tagged URL (`…/thurbox/v0.112.0/extensions/flow`) instead.
 - Dispatchable items spawn a worker immediately (a session named after the
   task title, `<title> · #<id>`, on a `flow/<slug>` worktree branch whenever
   the repo is git).
+- **Multi-repo tasks**: a dump spanning several `repos.md` repos becomes one
+  task across them all. Flow passes the central repo as `--repo` and each other
+  as `--add-repo <path>@origin/<base>` (or `--add-dir` for a read-only
+  reference). Every repo gets its own isolated `flow/<slug>` worktree, the
+  worker sees them as sub-directories of one workspace, and it opens a
+  **separate PR per repo it changes** (its `result` carries a `pr_urls` list).
 - **Plan-first dispatch**: every worker prompt carries a mandatory
   planning phase — clarify, then plan, then build. Before writing any code
   the worker (1) asks clarifying questions **one at a time** — a single question,

--- a/extensions/flow/repos.md
+++ b/extensions/flow/repos.md
@@ -7,3 +7,9 @@ learns new paths.
 | name | path | base | keywords |
 |------|------|------|----------|
 | example | /home/me/repositories/example | main | example, sample |
+
+A dump that spans several of these rows becomes ONE **multi-repo** task: flow
+passes the most-central repo as `--repo` and each other as `--add-repo
+<path>@origin/<base>`, so every repo gets its own isolated `flow/<slug>`
+worktree and the worker opens a separate PR per repo it changes. See FLOW.md
+("Multi-repo tasks").

--- a/extensions/flow/scripts/create-task.bats
+++ b/extensions/flow/scripts/create-task.bats
@@ -84,3 +84,41 @@ setup() {
   run "$SCRIPT" --description "no title" --dry-run
   [ "$status" -eq 2 ]
 }
+
+@test "multi-repo dispatch lists extra repos and uses the per-repo PR footer" {
+  run "$SCRIPT" --title "Cross-repo refactor" \
+    --description "share the X helper" \
+    --repo /tmp/primary --agent flow-worker-heavy \
+    --accept "both repos build" \
+    --worktree flow/cross-repo-refactor --base origin/main \
+    --add-repo /tmp/other@origin/master --add-dir /tmp/reference --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"repo: /tmp/primary"* ]]
+  # Extra repos surface in the header, distinguishing worktree vs attached-as-is.
+  [[ "$output" == *"repo (extra, worktree): /tmp/other@origin/master"* ]]
+  [[ "$output" == *"repo (extra, attached as-is): /tmp/reference"* ]]
+  # The multi-repo footer asks for a PR per changed repo and a pr_urls list.
+  [[ "$output" == *"multi-repo"* ]]
+  [[ "$output" == *"open a separate PR per"* ]]
+  [[ "$output" == *'"pr_urls"'* ]]
+  # ...and NOT the single-repo footer wording.
+  [[ "$output" != *"open a PR when the accept criterion is met"* ]]
+}
+
+@test "--add-repo without --worktree is rejected (needs the shared branch)" {
+  run "$SCRIPT" --title "Cross-repo" --description "x" \
+    --repo /tmp/primary --agent flow-worker --accept "ok" \
+    --add-repo /tmp/other
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"requires --worktree"* ]]
+}
+
+@test "single-repo dispatch keeps the original single-PR footer" {
+  run "$SCRIPT" --title "Add rate limiting" --description "Throttle." \
+    --repo /tmp/repo --agent flow-worker --accept "429s" \
+    --worktree flow/add-rate-limiting --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"open a PR when the accept criterion is met"* ]]
+  [[ "$output" == *'"pr_url"'* ]]
+  [[ "$output" != *"open a separate PR per"* ]]
+}

--- a/extensions/flow/scripts/create-task.sh
+++ b/extensions/flow/scripts/create-task.sh
@@ -10,6 +10,19 @@
 #     [--worktree BRANCH] [--base origin/main] [--no-plan] [--no-dispatch]
 #   create-task.sh ... --dry-run        # print the composed description, create nothing
 #
+# Multi-repo (a task spanning several repositories): repeat --add-repo for each
+# EXTRA repo beyond --repo. Each extra gets its OWN isolated worktree on the same
+# --worktree branch, off its own base (PATH@origin/<base>, default origin/main):
+#
+#   create-task.sh --title T --description D \
+#     --repo /abs/primary --agent flow-worker-heavy --accept "..." \
+#     --worktree flow/<slug> --base origin/main \
+#     --add-repo /abs/other@origin/main --add-repo /abs/third@origin/master
+#
+# Use --add-dir /abs/path (repeatable) for a repo that should be attached AS-IS
+# (no new branch) — e.g. a read-only reference checkout. The worker sees every
+# repo as a sub-directory of a per-session symlink workspace.
+#
 # Plan-first dispatch: when an acceptance criterion is supplied (--accept) the
 # script OWNS the worker prompt. It composes a standardized description —
 #   priority/repo/accept header → the user's words → a mandatory **Planning
@@ -47,6 +60,7 @@ set -euo pipefail
 
 TITLE="" DESC="" REPO="" AGENT="" WORKTREE="" BASE="" ACCEPT="" PRIORITY=""
 DISPATCH=1 PLAN=1 DRYRUN=0
+ADD_REPOS=() ADD_DIRS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --title)       TITLE="$2"; shift 2 ;;
@@ -55,6 +69,8 @@ while [[ $# -gt 0 ]]; do
     --agent)       AGENT="$2"; shift 2 ;;
     --worktree)    WORKTREE="$2"; shift 2 ;;
     --base)        BASE="$2"; shift 2 ;;
+    --add-repo)    ADD_REPOS+=("$2"); shift 2 ;;
+    --add-dir)     ADD_DIRS+=("$2"); shift 2 ;;
     --accept)      ACCEPT="$2"; shift 2 ;;
     --priority)    PRIORITY="$2"; shift 2 ;;
     --no-plan)     PLAN=0; shift ;;
@@ -69,6 +85,10 @@ done
 WORKER=0
 [[ -n "$REPO" && -n "$AGENT" ]] && WORKER=1
 
+# Multi-repo when any extra repo/dir is attached.
+MULTI=0
+[[ ${#ADD_REPOS[@]} -gt 0 || ${#ADD_DIRS[@]} -gt 0 ]] && MULTI=1
+
 # --- compose the worker prompt body ------------------------------------------
 # With --accept we own the full description; the planning phase + footer make
 # the plan-first contract identical on every dispatch.
@@ -76,6 +96,11 @@ build_description() {
   local branch="${WORKTREE:-flow/<task-slug>}"
   printf 'priority: %s\n' "${PRIORITY:-normal}"
   printf 'repo: %s\n' "${REPO:-unknown}"
+  if [[ "$MULTI" -eq 1 ]]; then
+    local extra
+    for extra in ${ADD_REPOS[@]+"${ADD_REPOS[@]}"}; do printf 'repo (extra, worktree): %s\n' "$extra"; done
+    for extra in ${ADD_DIRS[@]+"${ADD_DIRS[@]}"}; do printf 'repo (extra, attached as-is): %s\n' "$extra"; done
+  fi
   printf 'accept: %s\n' "$ACCEPT"
   if [[ -n "$DESC" ]]; then
     printf '\n%s\n' "$DESC"
@@ -132,7 +157,22 @@ the moment you see it, read the reply with:
    outside it, stop and note the change rather than silently expanding scope.
 PLAN_BLOCK
   fi
-  if [[ "$WORKER" -eq 1 ]]; then
+  if [[ "$WORKER" -eq 1 && "$MULTI" -eq 1 ]]; then
+    cat <<FOOTER
+
+You are working in a **multi-repo** session: each repository above is its own
+sub-directory of your working dir, and the worktree repos are each on a dedicated
+branch ${branch} (off their own base). Make each repo's changes in ITS OWN
+sub-directory, commit them on that repo's branch, and **open a separate PR per
+repo you changed** (do not touch a repo you did not need to change). When
+finished: mark this task done (thurbox-cli task edit \$THURBOX_TASK --status done),
+then report the result to the flow agent — this also wakes flow so the next task
+dispatches immediately (no ids: thurbox tags the message with your task for you):
+
+    thurbox-cli message send --to flow --kind result \\
+      --body '{"status":"ok|error","artifact":"...","notes":"...","pr_urls":["...","..."]}'
+FOOTER
+  elif [[ "$WORKER" -eq 1 ]]; then
     cat <<FOOTER
 
 You are working in a dedicated git worktree on branch ${branch}; commit
@@ -156,6 +196,11 @@ if [[ "$DRYRUN" -eq 1 ]]; then
   exit 0
 fi
 
+# A worktree base is only as fresh as the last fetch when it tracks a remote.
+fetch_if_remote() {  # $1 = repo dir, $2 = base ref
+  [[ "$2" == origin/* ]] && git -C "$1" fetch origin --quiet 2>/dev/null || true
+}
+
 ARGS=(task create --title "$TITLE")
 [[ -n "$DESC" ]] && ARGS+=(--description "$DESC")
 if [[ -n "$REPO" ]]; then
@@ -164,11 +209,22 @@ if [[ -n "$REPO" ]]; then
   if [[ -n "$WORKTREE" ]]; then
     [[ -n "$BASE" ]] || BASE="origin/main"
     ARGS+=(--worktree "$WORKTREE" --base "$BASE")
-    # A remote-tracking base is only as fresh as the last fetch.
-    if [[ "$BASE" == origin/* ]]; then
-      git -C "$REPO" fetch origin --quiet 2>/dev/null || true
-    fi
+    fetch_if_remote "$REPO" "$BASE"
   fi
+  # Multi-repo: forward each extra. A worktree extra is `PATH@base` (default the
+  # primary's --base); a plain --add-dir is attached as-is (no branch).
+  if [[ "$MULTI" -eq 1 && -z "$WORKTREE" ]]; then
+    echo "--add-repo requires --worktree (the shared branch)" >&2; exit 2
+  fi
+  for extra in ${ADD_REPOS[@]+"${ADD_REPOS[@]}"}; do
+    epath="${extra%@*}"; ebase="${extra#*@}"
+    [[ "$ebase" == "$extra" ]] && ebase="$BASE"   # no @base → primary base
+    ARGS+=(--add-repo "${epath}@${ebase}")
+    fetch_if_remote "$epath" "$ebase"
+  done
+  for extra in ${ADD_DIRS[@]+"${ADD_DIRS[@]}"}; do
+    ARGS+=(--add-dir "$extra")
+  done
 fi
 
 CREATED="$(thurbox-cli "${ARGS[@]}")"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4056,12 +4056,14 @@ impl App {
                 worktree_branch,
                 base_branch,
                 agent,
+                extra_repos,
             } => match self.spawn_for_automation(
                 auto,
                 repo_path,
                 worktree_branch.as_deref(),
                 base_branch.as_deref(),
                 agent.as_deref(),
+                extra_repos,
             ) {
                 Ok(session_id) => (
                     AutomationRunStatus::Success,
@@ -4121,6 +4123,7 @@ impl App {
         worktree_branch: Option<&str>,
         base_branch: Option<&str>,
         agent: Option<&str>,
+        extra_repos: &[crate::session::ExtraRepo],
     ) -> Result<SessionId, String> {
         self.spawn_and_prompt(
             format!("auto-{}", auto.id),
@@ -4128,6 +4131,7 @@ impl App {
             worktree_branch,
             base_branch,
             agent,
+            extra_repos,
             &auto.prompt,
         )
     }
@@ -4137,6 +4141,7 @@ impl App {
     /// reuses that session on later invocations (and after a TUI restart, where
     /// it is restored from the database by name). Shared by automations
     /// (`auto-<id>`) and tasks (`<title> · #<id>`).
+    #[allow(clippy::too_many_arguments)]
     fn spawn_and_prompt(
         &mut self,
         name: String,
@@ -4144,6 +4149,7 @@ impl App {
         worktree_branch: Option<&str>,
         base_branch: Option<&str>,
         agent: Option<&str>,
+        extra_repos: &[crate::session::ExtraRepo],
         prompt: &str,
     ) -> Result<SessionId, String> {
         // Reuse an existing session (this run or restored after restart).
@@ -4158,20 +4164,45 @@ impl App {
         let repo_path = crate::paths::expand_tilde(&repo_path.to_string_lossy());
         let repo_path = repo_path.as_path();
 
-        let worktrees = if let Some(branch) = worktree_branch {
+        let mut worktrees: Vec<WorktreeInfo> = Vec::new();
+        if let Some(branch) = worktree_branch {
             let base = base_branch.unwrap_or("main");
             // Idempotent: a recurring caller reuses the worktree it made on the
             // first invocation instead of failing because the branch exists.
             let path = git::create_or_attach_worktree(repo_path, branch, base)
                 .map_err(|e| format!("create worktree {branch} off {base}: {e}"))?;
-            vec![WorktreeInfo {
+            worktrees.push(WorktreeInfo {
                 repo_path: repo_path.to_path_buf(),
                 worktree_path: path,
                 branch: branch.to_string(),
-            }]
-        } else {
-            Vec::new()
-        };
+            });
+        }
+
+        // Multi-repo: each extra repo gets its own worktree on the shared branch
+        // (off its own base, falling back to the primary's) or is attached as-is.
+        let mut additional_dirs: Vec<PathBuf> = Vec::new();
+        for extra in extra_repos {
+            let extra_path = crate::paths::expand_tilde(&extra.repo_path.to_string_lossy());
+            if extra.worktree {
+                let branch = worktree_branch.ok_or_else(|| {
+                    "a worktree extra-repo requires a worktree branch".to_string()
+                })?;
+                let base = extra
+                    .base_branch
+                    .as_deref()
+                    .or(base_branch)
+                    .unwrap_or("main");
+                let path = git::create_or_attach_worktree(&extra_path, branch, base)
+                    .map_err(|e| format!("create worktree {branch} off {base}: {e}"))?;
+                worktrees.push(WorktreeInfo {
+                    repo_path: extra_path.clone(),
+                    worktree_path: path,
+                    branch: branch.to_string(),
+                });
+            } else {
+                additional_dirs.push(extra_path);
+            }
+        }
 
         let cwd = worktrees
             .first()
@@ -4185,6 +4216,7 @@ impl App {
             config.agent = a.to_string();
         }
 
+        self.new_session.additional_dirs = additional_dirs;
         self.do_spawn_session(name.clone(), &config, worktrees);
         let session = self
             .sessions
@@ -4456,6 +4488,9 @@ impl App {
                     worktree_branch: (!worktree.is_empty()).then(|| worktree.to_string()),
                     base_branch: None,
                     agent: (!agent.is_empty()).then(|| agent.to_string()),
+                    // The TUI automation editor is single-repo; multi-repo spawns
+                    // are authored via the CLI (`--add-repo`/`--add-dir`).
+                    extra_repos: Vec::new(),
                 })
             }
         }
@@ -8231,6 +8266,7 @@ mod tests {
                 worktree_branch: None,
                 base_branch: None,
                 agent: None,
+                extra_repos: Vec::new(),
             },
             prompt: "do stuff".to_string(),
             next_run_at: None,

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -1973,6 +1973,7 @@ mod tests {
                 worktree_branch: Some("feat/x".into()),
                 base_branch: None,
                 agent: Some("codex".into()),
+                extra_repos: Vec::new(),
             },
             prompt: "triage".into(),
             created_at: 0,

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -470,7 +470,16 @@ fn fire_headless(
             worktree_branch,
             base_branch,
             agent,
-        } => fire_spawn(db, auto, repo_path, worktree_branch, base_branch, agent),
+            extra_repos,
+        } => fire_spawn(
+            db,
+            auto,
+            repo_path,
+            worktree_branch,
+            base_branch,
+            agent,
+            extra_repos,
+        ),
     }
 }
 
@@ -517,6 +526,7 @@ fn fire_send(
 
 /// Execute a `spawn` automation: reuse an existing window or spawn a new
 /// headless session, then deliver the prompt once the agent boots.
+#[allow(clippy::too_many_arguments)]
 fn fire_spawn(
     db: &Database,
     auto: &Automation,
@@ -524,6 +534,7 @@ fn fire_spawn(
     worktree_branch: &Option<String>,
     base_branch: &Option<String>,
     agent: &Option<String>,
+    extra_repos: &[crate::session::ExtraRepo],
 ) -> (AutomationRunStatus, String, Option<SessionId>) {
     let name = format!("auto-{}", auto.id);
     // Reuse an existing session window (later fires / restored sessions).
@@ -544,6 +555,7 @@ fn fire_spawn(
         host: None,
         parent_session_id: None,
         task_id: None,
+        extra_repos: extra_repos.to_vec(),
     };
     match crate::session_ops::spawn_session_headless(db, req) {
         Ok(result) => {
@@ -600,6 +612,7 @@ fn resolve_action(
             worktree_branch: worktree,
             base_branch: base,
             agent,
+            extra_repos: Vec::new(),
         }),
     }
 }
@@ -615,12 +628,14 @@ fn automation_to_json(a: &Automation) -> Value {
             worktree_branch,
             base_branch,
             agent,
+            extra_repos,
         } => json!({
             "kind": "spawn",
             "repo_path": repo_path.to_string_lossy(),
             "worktree_branch": worktree_branch,
             "base_branch": base_branch,
             "agent": agent,
+            "extra_repos": serde_json::to_value(extra_repos).unwrap_or(Value::Null),
         }),
     };
     json!({
@@ -703,6 +718,7 @@ mod tests {
                 worktree_branch: None,
                 base_branch: None,
                 agent: None,
+                extra_repos: Vec::new(),
             }),
             "spawn"
         );

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -96,6 +96,41 @@ pub enum Command {
     Version(version::VersionArgs),
 }
 
+/// Build the additional-repo list for a multi-repo `Spawn` from the repeatable
+/// `--add-repo`/`--add-dir` flags shared by `session create` and `task create`.
+///
+/// Each `--add-repo` token is `PATH` or `PATH@BASE` — the repo gets its own
+/// isolated worktree on the spawn's shared `--worktree`/`--worktree-branch`,
+/// off `BASE` (falling back to the primary's base when omitted). Each
+/// `--add-dir` token is attached as-is (no worktree). The base is split on the
+/// last `@`, so paths without `@` (the norm) are taken verbatim.
+pub(crate) fn parse_extra_repos(
+    add_repo: &[String],
+    add_dir: &[String],
+) -> Vec<crate::session::ExtraRepo> {
+    use crate::session::ExtraRepo;
+    let mut extra: Vec<ExtraRepo> = Vec::new();
+    for tok in add_repo {
+        let (path, base) = match tok.rsplit_once('@') {
+            Some((p, b)) if !p.is_empty() && !b.is_empty() => (p.to_string(), Some(b.to_string())),
+            _ => (tok.clone(), None),
+        };
+        extra.push(ExtraRepo {
+            repo_path: std::path::PathBuf::from(path),
+            worktree: true,
+            base_branch: base,
+        });
+    }
+    for dir in add_dir {
+        extra.push(ExtraRepo {
+            repo_path: std::path::PathBuf::from(dir),
+            worktree: false,
+            base_branch: None,
+        });
+    }
+    extra
+}
+
 /// Run a parsed CLI invocation against `db`, rendering the result in the
 /// resolved [`Format`] (human by default, JSON when piped or forced).
 pub fn run(cli: Cli, db: &Database) -> Result<(), String> {

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -49,6 +49,15 @@ pub enum Action {
         /// Must reference an existing active session.
         #[arg(long)]
         parent: Option<String>,
+        /// Additional repo to span (repeatable). `PATH` or `PATH@BASE` — each
+        /// gets its own isolated worktree on `--worktree-branch` off `BASE`
+        /// (default: the primary's `--base-branch`). Makes a multi-repo session.
+        #[arg(long = "add-repo")]
+        add_repo: Vec<String>,
+        /// Additional directory to span (repeatable), attached as-is (no
+        /// worktree / branch). Makes a multi-repo session.
+        #[arg(long = "add-dir")]
+        add_dir: Vec<String>,
     },
     /// Soft-delete a session.
     ///
@@ -120,8 +129,11 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             base_branch,
             host,
             parent,
+            add_repo,
+            add_dir,
         } => {
             let parent_session_id = parent.as_deref().map(parse_session_id).transpose()?;
+            let extra_repos = super::parse_extra_repos(&add_repo, &add_dir);
             let req = crate::session_ops::SpawnRequest {
                 name,
                 repo_path,
@@ -132,6 +144,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 host,
                 parent_session_id,
                 task_id: None,
+                extra_repos,
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
             let human = format!(

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -46,6 +46,15 @@ pub enum Action {
         /// Agent name (spawn action; default registry agent).
         #[arg(long)]
         agent: Option<String>,
+        /// Spawn action: additional repo to span (repeatable). `PATH` or
+        /// `PATH@BASE` — each gets its own isolated worktree on `--worktree`
+        /// off `BASE` (default `--base`). Makes a multi-repo task session.
+        #[arg(long = "add-repo")]
+        add_repo: Vec<String>,
+        /// Spawn action: additional directory to span (repeatable), attached
+        /// as-is (no worktree / branch). Makes a multi-repo task session.
+        #[arg(long = "add-dir")]
+        add_dir: Vec<String>,
     },
     /// List all active tasks.
     List,
@@ -89,12 +98,15 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             worktree,
             base,
             agent,
+            add_repo,
+            add_dir,
         } => {
             if title.is_empty() {
                 return Err("title must not be empty".into());
             }
             let status = parse_status(status.as_deref())?;
-            let action = resolve_action(session, repo, worktree, base, agent, db)?;
+            let extra_repos = super::parse_extra_repos(&add_repo, &add_dir);
+            let action = resolve_action(session, repo, worktree, base, agent, extra_repos, db)?;
             let new = NewTask {
                 title,
                 description: normalize_description(description),
@@ -271,6 +283,7 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
             worktree_branch,
             base_branch,
             agent,
+            extra_repos,
         }) => {
             let name = task.spawn_session_name();
             // Reuse an existing session window (re-trigger / restored session).
@@ -298,6 +311,7 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
                 host: None,
                 parent_session_id: None,
                 task_id: Some(task.id),
+                extra_repos: extra_repos.clone(),
             };
             crate::session_ops::spawn_session_headless(db, req)?;
             crate::agent::tmux::send_prompt_after_delay(&name, &prompt, BOOT_DELAY_SECS)
@@ -349,19 +363,29 @@ fn parse_status(s: Option<&str>) -> Result<TaskStatus, String> {
 
 /// Resolve the optional action from the send/spawn flags. Neither flag → a plain
 /// local todo (`None`), unlike automations where an action is required.
+#[allow(clippy::too_many_arguments)]
 fn resolve_action(
     session: Option<String>,
     repo: Option<String>,
     worktree: Option<String>,
     base: Option<String>,
     agent: Option<String>,
+    extra_repos: Vec<crate::session::ExtraRepo>,
     db: &Database,
 ) -> Result<Option<AutomationAction>, String> {
     match (session, repo) {
         (Some(_), Some(_)) => {
             Err("specify either --session (send) or --repo (spawn), not both".into())
         }
-        (None, None) => Ok(None),
+        (None, None) => {
+            if !extra_repos.is_empty() {
+                return Err("--add-repo/--add-dir require --repo (a spawn action)".into());
+            }
+            Ok(None)
+        }
+        (Some(_), None) if !extra_repos.is_empty() => {
+            Err("--add-repo/--add-dir apply to --repo (spawn), not --session (send)".into())
+        }
         (Some(s), None) => {
             let session_id: SessionId = s
                 .parse()
@@ -376,6 +400,7 @@ fn resolve_action(
             worktree_branch: worktree,
             base_branch: base,
             agent,
+            extra_repos,
         })),
     }
 }
@@ -392,12 +417,14 @@ fn task_to_json(t: &Task) -> Value {
             worktree_branch,
             base_branch,
             agent,
+            extra_repos,
         }) => json!({
             "kind": "spawn",
             "repo_path": repo_path.to_string_lossy(),
             "worktree_branch": worktree_branch,
             "base_branch": base_branch,
             "agent": agent,
+            "extra_repos": serde_json::to_value(extra_repos).unwrap_or(Value::Null),
         }),
     };
     json!({
@@ -457,6 +484,7 @@ mod tests {
                 worktree_branch: None,
                 base_branch: None,
                 agent: None,
+                extra_repos: Vec::new(),
             })),
             "spawn"
         );

--- a/src/session/automation.rs
+++ b/src/session/automation.rs
@@ -12,8 +12,32 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use chrono::{TimeZone, Utc};
+use serde::{Deserialize, Serialize};
 
 use super::SessionId;
+
+/// An additional repository attached to a multi-repo `Spawn`, beyond the
+/// primary `repo_path`.
+///
+/// Each extra repo either gets its **own isolated worktree** — on the session's
+/// shared `worktree_branch`, off its own `base_branch` — so its changes stay
+/// isolated and PR-able per repo (the flow default), or is attached **as-is** as
+/// an additional directory in the multi-repo symlink workspace (no new branch).
+/// The whole list is persisted as JSON in the `action_extra_repos` column, so an
+/// empty list (the common single-repo case) stores `NULL` and is byte-identical
+/// to the pre-multi-repo behavior.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtraRepo {
+    /// Absolute path to the repository (worktree mode) or directory (dir mode).
+    pub repo_path: PathBuf,
+    /// `true` = create a worktree on the session's shared branch off
+    /// `base_branch`; `false` = attach the directory as-is (no branch).
+    pub worktree: bool,
+    /// Base branch for the worktree when `worktree` is `true`. `None` falls back
+    /// to the primary repo's base (`base_branch` on the `Spawn`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_branch: Option<String>,
+}
 
 /// A persisted automation definition.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -106,6 +130,10 @@ pub enum AutomationAction {
     /// Paste the prompt into an existing running session.
     Send { session_id: SessionId },
     /// Spawn a new session (optionally on a fresh worktree) and prompt it.
+    ///
+    /// A single-repo spawn leaves `extra_repos` empty (the common case). When it
+    /// is non-empty the session spans multiple repos: the primary plus each
+    /// extra, launched in a per-session symlink workspace. See [`ExtraRepo`].
     Spawn {
         repo_path: PathBuf,
         /// `None` = run in the repo root; `Some` = create/use a worktree branch.
@@ -114,6 +142,8 @@ pub enum AutomationAction {
         base_branch: Option<String>,
         /// Agent name; `None` = registry default.
         agent: Option<String>,
+        /// Additional repositories spanned by this session (empty = single-repo).
+        extra_repos: Vec<ExtraRepo>,
     },
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -11,7 +11,7 @@ pub mod theme_config;
 pub use agent_def::{AgentDef, AgentRegistry};
 pub use automation::{
     parse_hhmm, preset_to_cron, Automation, AutomationAction, AutomationRun, AutomationRunStatus,
-    AutomationSchedule, SchedulePreset,
+    AutomationSchedule, ExtraRepo, SchedulePreset,
 };
 pub use extension_def::{
     ExtensionAutomation, ExtensionDef, ExtensionFile, ExtensionSession, ExtensionSymlink,

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -567,6 +567,7 @@ pub fn ensure_extension(db: &Database, def: &ExtensionDef) -> Result<EnsureRepor
                         host: None,
                         parent_session_id: None,
                         task_id: None,
+                        extra_repos: Vec::new(),
                     },
                 )?;
                 report.sessions_created.push(sess.name.clone());

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use crate::session::{HostDef, SessionConfig, SessionId, DEFAULT_AGENT_NAME};
+use crate::session::{ExtraRepo, HostDef, SessionConfig, SessionId, DEFAULT_AGENT_NAME};
 use crate::storage::Database;
 use crate::sync::{SharedSession, SharedWorktree};
 
@@ -41,6 +41,12 @@ pub struct SpawnRequest {
     /// so the session's outgoing messages auto-tag `from_task_id` without the
     /// agent passing any id by hand.
     pub task_id: Option<i64>,
+    /// Additional repositories this session spans (empty = single-repo, the
+    /// unchanged common case). Each either gets its own isolated worktree on
+    /// the shared `worktree_branch` (off its own `base_branch`) or is attached
+    /// as-is as an additional directory. When any extra is non-empty the agent
+    /// launches in a per-session symlink workspace gathering every member.
+    pub extra_repos: Vec<ExtraRepo>,
 }
 
 /// Result returned on successful headless spawn.
@@ -66,12 +72,24 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     // Resolve the optional remote host. `backend_type` is `local-tmux` or
     // `ssh:<host>`; `host` is the matching HostDef for remote git/tmux ops.
     let (backend_type, host) = resolve_host(req.host.as_deref())?;
-    let (cwd, worktrees) = resolve_cwd(&req, host.as_ref())?;
+    let (primary_cwd, worktrees, additional_dirs) = resolve_dirs(&req, host.as_ref())?;
 
     let agent_session_id = req
         .agent_session_id
         .clone()
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    // For a multi-repo session, launch the agent in a per-session symlink
+    // workspace gathering every member dir (so each repo is a visible subdir,
+    // agent-neutral). `info.cwd` keeps the *primary* repo. Single-repo sessions
+    // launch directly in the primary cwd, unchanged. Mirrors the TUI's
+    // `App::resolve_process_cwd`.
+    let launch_cwd = resolve_launch_cwd(
+        &agent_session_id,
+        &primary_cwd,
+        &worktrees,
+        &additional_dirs,
+    );
 
     // Mint the thurbox SessionId up front so it can be injected into the
     // process env (`THURBOX_SESSION`) before the agent launches.
@@ -80,7 +98,7 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     let mut config = SessionConfig {
         session_id: Some(session_id),
         agent_session_id: Some(agent_session_id.clone()),
-        cwd: Some(cwd.clone()),
+        cwd: Some(launch_cwd.clone()),
         agent: agent_name.clone(),
         backend: (backend_type != LOCAL_TMUX_BACKEND_TYPE).then(|| backend_type.clone()),
         ..SessionConfig::default()
@@ -97,13 +115,19 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
             &req.name,
             &command,
             &args,
-            Some(&cwd),
+            Some(&launch_cwd),
             &config.env,
         )
         .map_err(|e| format!("Failed to spawn remote tmux window: {e:#}"))?,
         None => {
-            crate::agent::tmux::spawn_window(&req.name, &command, &args, Some(&cwd), &config.env)
-                .map_err(|e| format!("Failed to spawn tmux window: {e}"))?;
+            crate::agent::tmux::spawn_window(
+                &req.name,
+                &command,
+                &args,
+                Some(&launch_cwd),
+                &config.env,
+            )
+            .map_err(|e| format!("Failed to spawn tmux window: {e}"))?;
             String::new()
         }
     };
@@ -115,8 +139,10 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         backend_id: backend_id.clone(),
         backend_type,
         agent_session_id: Some(agent_session_id.clone()),
-        cwd: Some(cwd.clone()),
-        additional_dirs: Vec::new(),
+        // `cwd` is the *primary* repo (for display / git context); the workspace
+        // is a spawn-time launch detail, re-derived idempotently on every launch.
+        cwd: Some(primary_cwd.clone()),
+        additional_dirs: additional_dirs.clone(),
         worktrees: worktrees.clone(),
         shell_backend_id: None,
         parent_session_id: req.parent_session_id,
@@ -152,7 +178,7 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         name: req.name,
         agent: agent_name,
         agent_session_id,
-        cwd,
+        cwd: primary_cwd,
         worktrees,
         parent_session_id: req.parent_session_id,
     })
@@ -191,27 +217,120 @@ fn resolve_agent_name(requested: Option<&str>) -> String {
     }
 }
 
-/// Resolve the working directory and worktree records.
+/// Resolve the primary working directory, all worktree records, and the
+/// non-worktree additional directories for a (possibly multi-repo) spawn.
 ///
-/// Returns the bare repo path when no worktree branch is given; otherwise
-/// creates the worktree and returns its path plus a single
-/// [`SharedWorktree`] entry.
-fn resolve_cwd(
+/// Single-repo (no `extra_repos`): returns the bare repo path when no worktree
+/// branch is given, otherwise the primary worktree path plus one
+/// [`SharedWorktree`] — byte-identical to the pre-multi-repo behavior.
+///
+/// Multi-repo: the primary is resolved as above; each [`ExtraRepo`] either gets
+/// its own worktree on the **shared** `worktree_branch` (off its own
+/// `base_branch`, falling back to the primary's base) appended to `worktrees`,
+/// or — when `worktree == false` — is attached as-is in `additional_dirs`. The
+/// member set (worktrees + additional dirs) is what the symlink workspace
+/// gathers; see [`crate::workspace::ensure_workspace`].
+fn resolve_dirs(
     req: &SpawnRequest,
     host: Option<&HostDef>,
-) -> Result<(PathBuf, Vec<SharedWorktree>), String> {
-    let Some(branch) = req.worktree_branch.as_deref() else {
-        return Ok((req.repo_path.clone(), Vec::new()));
+) -> Result<(PathBuf, Vec<SharedWorktree>, Vec<PathBuf>), String> {
+    let mut worktrees: Vec<SharedWorktree> = Vec::new();
+    let mut additional_dirs: Vec<PathBuf> = Vec::new();
+
+    // Primary repo: worktree when a branch is set, otherwise the repo root.
+    let primary_cwd = match req.worktree_branch.as_deref() {
+        None => req.repo_path.clone(),
+        Some(branch) => {
+            let base = req.base_branch.as_deref().unwrap_or(DEFAULT_BASE_BRANCH);
+            let path = create_worktree(host, &req.repo_path, branch, base)?;
+            worktrees.push(SharedWorktree {
+                repo_path: req.repo_path.clone(),
+                worktree_path: path.clone(),
+                branch: branch.to_string(),
+            });
+            path
+        }
     };
-    let base_branch = req.base_branch.as_deref().unwrap_or(DEFAULT_BASE_BRANCH);
-    let path = crate::git::create_worktree_on(host, &req.repo_path, branch, base_branch)
-        .map_err(|e| format!("Failed to create worktree {branch} off {base_branch}: {e}"))?;
-    let wt = SharedWorktree {
-        repo_path: req.repo_path.clone(),
-        worktree_path: path.clone(),
-        branch: branch.to_string(),
-    };
-    Ok((path, vec![wt]))
+
+    // Extra repos: each its own isolated worktree on the shared branch, or a
+    // plain additional directory.
+    for extra in &req.extra_repos {
+        if extra.worktree {
+            let branch = req.worktree_branch.as_deref().ok_or_else(|| {
+                "a worktree extra-repo requires --worktree-branch (the shared branch)".to_string()
+            })?;
+            let base = extra
+                .base_branch
+                .as_deref()
+                .or(req.base_branch.as_deref())
+                .unwrap_or(DEFAULT_BASE_BRANCH);
+            let path = create_worktree(host, &extra.repo_path, branch, base)?;
+            worktrees.push(SharedWorktree {
+                repo_path: extra.repo_path.clone(),
+                worktree_path: path.clone(),
+                branch: branch.to_string(),
+            });
+        } else {
+            additional_dirs.push(extra.repo_path.clone());
+        }
+    }
+
+    Ok((primary_cwd, worktrees, additional_dirs))
+}
+
+/// Create a worktree, wrapping the error with the branch/base for context.
+fn create_worktree(
+    host: Option<&HostDef>,
+    repo: &std::path::Path,
+    branch: &str,
+    base: &str,
+) -> Result<PathBuf, String> {
+    crate::git::create_worktree_on(host, repo, branch, base)
+        .map_err(|e| format!("Failed to create worktree {branch} off {base} in {repo:?}: {e}"))
+}
+
+/// The directory the agent process should launch in: a per-session symlink
+/// workspace for a multi-repo session (≥2 members), else the primary cwd.
+///
+/// Mirrors the TUI's `App::resolve_process_cwd`: members are the worktree repos
+/// (labeled by their original repo name) followed by the non-worktree
+/// additional dirs; a workspace build failure falls back to the primary cwd.
+fn resolve_launch_cwd(
+    agent_session_id: &str,
+    primary_cwd: &std::path::Path,
+    worktrees: &[SharedWorktree],
+    additional_dirs: &[PathBuf],
+) -> PathBuf {
+    let mut members: Vec<(String, PathBuf)> = Vec::new();
+    if worktrees.is_empty() {
+        members.push((dir_label(primary_cwd), primary_cwd.to_path_buf()));
+    } else {
+        for wt in worktrees {
+            members.push((dir_label(&wt.repo_path), wt.worktree_path.clone()));
+        }
+    }
+    for dir in additional_dirs {
+        members.push((dir_label(dir), dir.clone()));
+    }
+
+    if members.len() < 2 {
+        return primary_cwd.to_path_buf();
+    }
+    match crate::workspace::ensure_workspace(agent_session_id, &members) {
+        Ok(ws) => ws,
+        Err(e) => {
+            tracing::error!("Failed to build multi-repo workspace: {e}");
+            primary_cwd.to_path_buf()
+        }
+    }
+}
+
+/// A human-friendly label for a member directory in the symlink workspace:
+/// the git repo display name, falling back to the final path component.
+fn dir_label(path: &std::path::Path) -> String {
+    crate::git::repo_display_name(path)
+        .or_else(|| path.file_name().and_then(|s| s.to_str()).map(String::from))
+        .unwrap_or_else(|| "repo".to_string())
 }
 
 /// Resolve `--host` to `(backend_type, host)`.
@@ -254,6 +373,7 @@ mod tests {
             host: None,
             parent_session_id: None,
             task_id: None,
+            extra_repos: Vec::new(),
         }
     }
 
@@ -350,5 +470,78 @@ mod tests {
         let (backend_type, host) = resolve_host(Some("devbox")).unwrap();
         assert_eq!(backend_type, "ssh:devbox");
         assert_eq!(host.unwrap().destination, "me@devbox");
+    }
+
+    #[test]
+    fn resolve_dirs_single_repo_no_worktree_is_unchanged() {
+        let mut r = req("s");
+        r.repo_path = PathBuf::from("/tmp/primary");
+        let (cwd, worktrees, additional) = resolve_dirs(&r, None).unwrap();
+        assert_eq!(cwd, PathBuf::from("/tmp/primary"));
+        assert!(worktrees.is_empty());
+        assert!(additional.is_empty());
+    }
+
+    #[test]
+    fn resolve_dirs_attaches_dir_extras_without_git() {
+        // dir-only extras (worktree == false) never touch git, so this is
+        // hermetic. The primary has no worktree branch either.
+        let mut r = req("s");
+        r.repo_path = PathBuf::from("/tmp/primary");
+        r.extra_repos = vec![
+            ExtraRepo {
+                repo_path: PathBuf::from("/tmp/extra-a"),
+                worktree: false,
+                base_branch: None,
+            },
+            ExtraRepo {
+                repo_path: PathBuf::from("/tmp/extra-b"),
+                worktree: false,
+                base_branch: None,
+            },
+        ];
+        let (cwd, worktrees, additional) = resolve_dirs(&r, None).unwrap();
+        assert_eq!(cwd, PathBuf::from("/tmp/primary"));
+        assert!(worktrees.is_empty());
+        assert_eq!(
+            additional,
+            vec![PathBuf::from("/tmp/extra-a"), PathBuf::from("/tmp/extra-b")]
+        );
+    }
+
+    #[test]
+    fn resolve_dirs_worktree_extra_without_shared_branch_errors() {
+        let mut r = req("s");
+        r.repo_path = PathBuf::from("/tmp/primary");
+        // No worktree_branch on the primary, but an extra wants a worktree.
+        r.extra_repos = vec![ExtraRepo {
+            repo_path: PathBuf::from("/tmp/extra"),
+            worktree: true,
+            base_branch: None,
+        }];
+        let err = resolve_dirs(&r, None).unwrap_err();
+        assert!(err.contains("worktree-branch"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_launch_cwd_single_member_is_primary() {
+        let primary = PathBuf::from("/tmp/primary");
+        // No worktrees, no extra dirs → 1 member → primary cwd, no workspace.
+        let got = resolve_launch_cwd("sid-1", &primary, &[], &[]);
+        assert_eq!(got, primary);
+    }
+
+    #[test]
+    fn resolve_launch_cwd_multi_member_builds_workspace() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let primary = temp.path().join("primary");
+        std::fs::create_dir_all(&primary).unwrap();
+        let extra = temp.path().join("extra");
+        std::fs::create_dir_all(&extra).unwrap();
+        let got = resolve_launch_cwd("sid-multi", &primary, &[], &[extra]);
+        // Two members → a symlink workspace, not the primary itself.
+        assert_ne!(got, primary);
+        assert!(got.join("primary").exists() || got.exists());
     }
 }

--- a/src/storage/automations.rs
+++ b/src/storage/automations.rs
@@ -31,15 +31,15 @@ impl Database {
     /// Insert a new automation, returning its row id.
     pub fn create_automation(&self, new: &NewAutomation) -> rusqlite::Result<i64> {
         let now = current_time_millis() as i64;
-        let (target_session, repo_path, worktree_branch, base_branch, agent) =
+        let (target_session, repo_path, worktree_branch, base_branch, agent, extra) =
             action_columns(&new.action);
         self.conn.execute(
             "INSERT INTO automations
                 (name, enabled, schedule_kind, schedule_spec, timezone,
                  action_kind, target_session, repo_path, worktree_branch,
                  base_branch, agent, prompt, created_at, updated_at,
-                 last_run_at, next_run_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?13, NULL, ?14)",
+                 last_run_at, next_run_at, action_extra_repos)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?13, NULL, ?14, ?15)",
             params![
                 new.name,
                 new.enabled as i64,
@@ -55,6 +55,7 @@ impl Database {
                 new.prompt,
                 now,
                 new.next_run_at.map(|v| v as i64),
+                extra,
             ],
         )?;
         Ok(self.conn.last_insert_rowid())
@@ -93,7 +94,7 @@ impl Database {
 
     /// Replace an automation's definition (everything except id/created_at).
     pub fn update_automation(&self, auto: &Automation) -> rusqlite::Result<()> {
-        let (target_session, repo_path, worktree_branch, base_branch, agent) =
+        let (target_session, repo_path, worktree_branch, base_branch, agent, extra) =
             action_columns(&auto.action);
         let now = current_time_millis() as i64;
         self.conn.execute(
@@ -101,7 +102,8 @@ impl Database {
                 name = ?2, enabled = ?3, schedule_kind = ?4, schedule_spec = ?5,
                 timezone = ?6, action_kind = ?7, target_session = ?8, repo_path = ?9,
                 worktree_branch = ?10, base_branch = ?11, agent = ?12, prompt = ?13,
-                updated_at = ?14, last_run_at = ?15, next_run_at = ?16
+                updated_at = ?14, last_run_at = ?15, next_run_at = ?16,
+                action_extra_repos = ?17
              WHERE id = ?1",
             params![
                 auto.id,
@@ -120,6 +122,7 @@ impl Database {
                 now,
                 auto.last_run_at.map(|v| v as i64),
                 auto.next_run_at.map(|v| v as i64),
+                extra,
             ],
         )?;
         Ok(())
@@ -294,33 +297,37 @@ impl Database {
 /// Column list for automation SELECTs (keep in sync with [`map_automation`]).
 const COLS: &str = "id, name, enabled, schedule_kind, schedule_spec, timezone, \
     action_kind, target_session, repo_path, worktree_branch, base_branch, agent, \
-    prompt, created_at, updated_at, last_run_at, next_run_at";
+    prompt, created_at, updated_at, last_run_at, next_run_at, action_extra_repos";
 
-/// Decompose an action into its persisted columns.
+/// Decompose an action into its persisted columns. The final element is the
+/// JSON-encoded extra-repo list (`None` for single-repo spawns / `Send`).
 type ActionColumns = (
     Option<String>, // target_session
     Option<String>, // repo_path
     Option<String>, // worktree_branch
     Option<String>, // base_branch
     Option<String>, // agent
+    Option<String>, // action_extra_repos (JSON)
 );
 
 fn action_columns(action: &AutomationAction) -> ActionColumns {
     match action {
         AutomationAction::Send { session_id } => {
-            (Some(session_id.to_string()), None, None, None, None)
+            (Some(session_id.to_string()), None, None, None, None, None)
         }
         AutomationAction::Spawn {
             repo_path,
             worktree_branch,
             base_branch,
             agent,
+            extra_repos,
         } => (
             None,
             Some(repo_path.to_string_lossy().into_owned()),
             worktree_branch.clone(),
             base_branch.clone(),
             agent.clone(),
+            super::extra_repos_to_json(extra_repos),
         ),
     }
 }
@@ -335,6 +342,7 @@ fn map_automation(row: &rusqlite::Row) -> rusqlite::Result<Automation> {
     let worktree_branch: Option<String> = row.get(9)?;
     let base_branch: Option<String> = row.get(10)?;
     let agent: Option<String> = row.get(11)?;
+    let extra_repos_json: Option<String> = row.get(17)?;
 
     let schedule =
         AutomationSchedule::from_parts(&schedule_kind, &schedule_spec).ok_or_else(|| {
@@ -357,6 +365,7 @@ fn map_automation(row: &rusqlite::Row) -> rusqlite::Result<Automation> {
             worktree_branch,
             base_branch,
             agent,
+            extra_repos: super::extra_repos_from_json(extra_repos_json),
         },
     };
 
@@ -427,6 +436,7 @@ mod tests {
                 worktree_branch: Some("feat/auto".into()),
                 base_branch: Some("main".into()),
                 agent: Some("codex".into()),
+                extra_repos: Vec::new(),
             },
             prompt: "triage issues".into(),
             next_run_at: Some(999),
@@ -441,11 +451,13 @@ mod tests {
                 worktree_branch,
                 base_branch,
                 agent,
+                extra_repos,
             } => {
                 assert_eq!(repo_path, PathBuf::from("/tmp/repo"));
                 assert_eq!(worktree_branch.as_deref(), Some("feat/auto"));
                 assert_eq!(base_branch.as_deref(), Some("main"));
                 assert_eq!(agent.as_deref(), Some("codex"));
+                assert!(extra_repos.is_empty());
             }
             _ => panic!("expected spawn"),
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -28,6 +28,26 @@ use std::path::Path;
 use rusqlite::Connection;
 use uuid::Uuid;
 
+/// Serialize a `Spawn` action's extra-repo list for the `action_extra_repos`
+/// column. An empty list (the single-repo common case) stores `NULL`, so old
+/// and new single-repo rows are byte-identical. Shared by the `tasks` and
+/// `automations` storage layers.
+pub(super) fn extra_repos_to_json(extra_repos: &[crate::session::ExtraRepo]) -> Option<String> {
+    if extra_repos.is_empty() {
+        return None;
+    }
+    // Serialization of a plain struct list cannot fail; fall back to `None`.
+    serde_json::to_string(extra_repos).ok()
+}
+
+/// Decode the `action_extra_repos` column back into an extra-repo list.
+/// `NULL`/empty/malformed → an empty list (a single-repo spawn), never an error.
+pub(super) fn extra_repos_from_json(raw: Option<String>) -> Vec<crate::session::ExtraRepo> {
+    raw.filter(|s| !s.is_empty())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
 /// SQLite-backed database for application state.
 pub struct Database {
     conn: Connection,

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -4,10 +4,11 @@ use rusqlite::Connection;
 ///
 /// v29 is reserved by the in-flight `improve-agent-thurbox-cli` branch
 /// (`session_labels` + `session_spawn_config`); v30 added
-/// `parent_session_id`, v31 added `display_order`, v32 adds
-/// `session_messages` (the inter-session mailbox).
+/// `parent_session_id`, v31 added `display_order`, v32 added
+/// `session_messages` (the inter-session mailbox), v33 adds
+/// `action_extra_repos` to `tasks` + `automations` (multi-repo spawns).
 /// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 32;
+pub const SCHEMA_VERSION: u32 = 33;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -94,7 +95,8 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             created_at      INTEGER NOT NULL,
             updated_at      INTEGER NOT NULL,
             last_run_at     INTEGER,
-            next_run_at     INTEGER
+            next_run_at     INTEGER,
+            action_extra_repos TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_automations_due
             ON automations(next_run_at)
@@ -135,7 +137,8 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             created_at      INTEGER NOT NULL,
             updated_at      INTEGER NOT NULL,
             deleted_at      INTEGER,
-            description     TEXT
+            description     TEXT,
+            action_extra_repos TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_tasks_status
             ON tasks(status) WHERE deleted_at IS NULL;
@@ -216,6 +219,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (30, migrate_v30_parent_session_id),
         (31, migrate_v31_display_order),
         (32, migrate_v32_session_messages),
+        (33, migrate_v33_action_extra_repos),
     ];
 
     for &(target, step) in steps {
@@ -765,7 +769,8 @@ fn migrate_v24_automations(conn: &Connection) -> rusqlite::Result<()> {
             created_at      INTEGER NOT NULL,
             updated_at      INTEGER NOT NULL,
             last_run_at     INTEGER,
-            next_run_at     INTEGER
+            next_run_at     INTEGER,
+            action_extra_repos TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_automations_due
             ON automations(next_run_at)
@@ -913,6 +918,23 @@ fn migrate_v32_session_messages(conn: &Connection) -> rusqlite::Result<()> {
         CREATE INDEX IF NOT EXISTS idx_session_messages_created
             ON session_messages(created_at);",
     )?;
+    Ok(())
+}
+
+/// v32 → v33: add a nullable `action_extra_repos` column to `tasks` and
+/// `automations`, storing the JSON list of additional repos a multi-repo
+/// `Spawn` action spans. `NULL`/empty = a single-repo spawn (the common case),
+/// so existing rows decode byte-identically to the pre-multi-repo behavior.
+///
+/// Fresh v33 databases already have the columns from `initialize` and skip this
+/// step; existing databases get them via the ALTERs. `let _` swallows the
+/// "duplicate column" error so a re-run is a no-op.
+fn migrate_v33_action_extra_repos(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute("ALTER TABLE tasks ADD COLUMN action_extra_repos TEXT", []);
+    let _ = conn.execute(
+        "ALTER TABLE automations ADD COLUMN action_extra_repos TEXT",
+        [],
+    );
     Ok(())
 }
 

--- a/src/storage/tasks.rs
+++ b/src/storage/tasks.rs
@@ -48,14 +48,15 @@ impl Database {
     /// Insert a new task, returning its row id.
     pub fn create_task(&self, new: &NewTask) -> rusqlite::Result<i64> {
         let now = current_time_millis() as i64;
-        let (action_kind, target_session, repo_path, worktree_branch, base_branch, agent) =
+        let (action_kind, target_session, repo_path, worktree_branch, base_branch, agent, extra) =
             action_columns(new.action.as_ref());
         self.conn.execute(
             "INSERT INTO tasks
                 (title, status, action_kind, target_session, repo_path,
                  worktree_branch, base_branch, agent, source, external_id,
-                 external_url, created_at, updated_at, deleted_at, description)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12, NULL, ?13)",
+                 external_url, created_at, updated_at, deleted_at, description,
+                 action_extra_repos)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12, NULL, ?13, ?14)",
             params![
                 new.title,
                 new.status.as_str(),
@@ -70,6 +71,7 @@ impl Database {
                 new.external_url,
                 now,
                 new.description,
+                extra,
             ],
         )?;
         let id = self.conn.last_insert_rowid();
@@ -106,7 +108,7 @@ impl Database {
 
     /// Replace a task's definition (everything except id/created_at/deleted_at).
     pub fn update_task(&self, task: &Task) -> rusqlite::Result<()> {
-        let (action_kind, target_session, repo_path, worktree_branch, base_branch, agent) =
+        let (action_kind, target_session, repo_path, worktree_branch, base_branch, agent, extra) =
             action_columns(task.action.as_ref());
         let now = current_time_millis() as i64;
         self.conn.execute(
@@ -114,7 +116,7 @@ impl Database {
                 title = ?2, status = ?3, action_kind = ?4, target_session = ?5,
                 repo_path = ?6, worktree_branch = ?7, base_branch = ?8, agent = ?9,
                 source = ?10, external_id = ?11, external_url = ?12, updated_at = ?13,
-                description = ?14
+                description = ?14, action_extra_repos = ?15
              WHERE id = ?1",
             params![
                 task.id,
@@ -131,6 +133,7 @@ impl Database {
                 task.external_url,
                 now,
                 task.description,
+                extra,
             ],
         )?;
         self.log_audit(
@@ -188,10 +191,11 @@ impl Database {
 /// Column list for task SELECTs (keep in sync with [`map_task`]).
 const COLS: &str = "id, title, status, action_kind, target_session, repo_path, \
     worktree_branch, base_branch, agent, source, external_id, external_url, \
-    created_at, updated_at, deleted_at, description";
+    created_at, updated_at, deleted_at, description, action_extra_repos";
 
 /// Decompose an optional action into its persisted columns. All `None` when the
-/// task is unconnected (`action_kind` is then NULL).
+/// task is unconnected (`action_kind` is then NULL). The final element is the
+/// JSON-encoded extra-repo list (`None` for single-repo spawns / non-spawns).
 type ActionColumns = (
     Option<String>, // action_kind
     Option<String>, // target_session
@@ -199,14 +203,16 @@ type ActionColumns = (
     Option<String>, // worktree_branch
     Option<String>, // base_branch
     Option<String>, // agent
+    Option<String>, // action_extra_repos (JSON)
 );
 
 fn action_columns(action: Option<&AutomationAction>) -> ActionColumns {
     match action {
-        None => (None, None, None, None, None, None),
+        None => (None, None, None, None, None, None, None),
         Some(AutomationAction::Send { session_id }) => (
             Some("send".to_string()),
             Some(session_id.to_string()),
+            None,
             None,
             None,
             None,
@@ -217,6 +223,7 @@ fn action_columns(action: Option<&AutomationAction>) -> ActionColumns {
             worktree_branch,
             base_branch,
             agent,
+            extra_repos,
         }) => (
             Some("spawn".to_string()),
             None,
@@ -224,6 +231,7 @@ fn action_columns(action: Option<&AutomationAction>) -> ActionColumns {
             worktree_branch.clone(),
             base_branch.clone(),
             agent.clone(),
+            super::extra_repos_to_json(extra_repos),
         ),
     }
 }
@@ -235,6 +243,7 @@ fn map_task(row: &rusqlite::Row) -> rusqlite::Result<Task> {
     let worktree_branch: Option<String> = row.get(6)?;
     let base_branch: Option<String> = row.get(7)?;
     let agent: Option<String> = row.get(8)?;
+    let extra_repos_json: Option<String> = row.get(16)?;
 
     let action = match action_kind.as_deref() {
         Some("send") => Some(AutomationAction::Send {
@@ -248,6 +257,7 @@ fn map_task(row: &rusqlite::Row) -> rusqlite::Result<Task> {
             worktree_branch,
             base_branch,
             agent,
+            extra_repos: super::extra_repos_from_json(extra_repos_json),
         }),
         _ => None,
     };
@@ -312,6 +322,7 @@ mod tests {
                 worktree_branch: Some("feat/task".into()),
                 base_branch: Some("main".into()),
                 agent: Some("codex".into()),
+                extra_repos: Vec::new(),
             }),
             ..NewTask::local("Refactor")
         };
@@ -323,11 +334,53 @@ mod tests {
                 worktree_branch,
                 base_branch,
                 agent,
+                extra_repos,
             }) => {
                 assert_eq!(repo_path, PathBuf::from("/tmp/repo"));
                 assert_eq!(worktree_branch.as_deref(), Some("feat/task"));
                 assert_eq!(base_branch.as_deref(), Some("main"));
                 assert_eq!(agent.as_deref(), Some("codex"));
+                assert!(extra_repos.is_empty());
+            }
+            other => panic!("expected spawn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spawn_action_multi_repo_round_trip() {
+        use crate::session::ExtraRepo;
+        let db = Database::open_in_memory().unwrap();
+        let new = NewTask {
+            action: Some(AutomationAction::Spawn {
+                repo_path: PathBuf::from("/tmp/primary"),
+                worktree_branch: Some("flow/multi".into()),
+                base_branch: Some("main".into()),
+                agent: Some("flow-worker".into()),
+                extra_repos: vec![
+                    ExtraRepo {
+                        repo_path: PathBuf::from("/tmp/extra-wt"),
+                        worktree: true,
+                        base_branch: Some("master".into()),
+                    },
+                    ExtraRepo {
+                        repo_path: PathBuf::from("/tmp/extra-dir"),
+                        worktree: false,
+                        base_branch: None,
+                    },
+                ],
+            }),
+            ..NewTask::local("Multi-repo")
+        };
+        let id = db.create_task(&new).unwrap();
+        let got = db.get_task(id).unwrap().unwrap();
+        match got.action {
+            Some(AutomationAction::Spawn { extra_repos, .. }) => {
+                assert_eq!(extra_repos.len(), 2);
+                assert_eq!(extra_repos[0].repo_path, PathBuf::from("/tmp/extra-wt"));
+                assert!(extra_repos[0].worktree);
+                assert_eq!(extra_repos[0].base_branch.as_deref(), Some("master"));
+                assert!(!extra_repos[1].worktree);
+                assert_eq!(extra_repos[1].base_branch, None);
             }
             other => panic!("expected spawn, got {other:?}"),
         }


### PR DESCRIPTION
## Problem

Flow dispatches entirely through the headless spawn chain (`create-task.sh` → `thurbox-cli task create --repo --worktree` → `task run` → `AutomationAction::Spawn` → `SpawnRequest` → `spawn_session_headless`), and every link was **single-repo**: `additional_dirs` was hard-coded empty and only one worktree was ever created. Multi-repo symlink workspaces + per-repo worktree selection existed only in the TUI repo-picker. So flow could not create or manage sessions spanning multiple repositories.

## What changed

Per the agreed plan (clarify → plan → build via the flow message queue), extend the **core** headless spawn path and wire the **flow extension** to it. Decision: **worktree-per-repo** (each repo its own isolated `flow/<slug>` worktree off its own base, enabling **one PR per changed repo**).

### Core (Rust)
- `SpawnRequest.extra_repos: Vec<ExtraRepo>` and `AutomationAction::Spawn.extra_repos`. `ExtraRepo { repo_path, worktree: bool, base_branch }` either gets its **own isolated worktree** on the shared `worktree_branch` or is attached **as-is** as an additional dir.
- `session_ops::spawn::resolve_dirs` builds the worktrees + additional dirs; `resolve_launch_cwd` mirrors the TUI's `resolve_process_cwd` (per-session **symlink workspace** when ≥2 members). Single-repo spawns are **byte-identical** to before.
- CLI: `session create` and `task create` gain repeatable `--add-repo PATH[@BASE]` (worktree) and `--add-dir PATH` (as-is).
- Storage: nullable JSON `action_extra_repos` column on `tasks` + `automations` (**schema v33**; `NULL`/empty = single-repo, old rows decode unchanged).
- TUI automation/task fire path threads `extra_repos` through too.

### Flow extension
- `create-task.sh` forwards `--add-repo`/`--add-dir`, lists the extra repos in the worker prompt, and uses a **per-repo-PR footer** (the `result` carries `pr_urls`).
- `FLOW.md` / `README.md` / `repos.md` document multi-repo routing.

### Deferred (per discussion)
"Read-only" symlinks — thurbox is agent-neutral and can't enforce read-only on an arbitrary CLI; the worktree-vs-additional-dir choice already covers the attachment model. The TUI repo-picker already has a per-repo worktree toggle.

## Tests / verification
- New round-trip + unit tests: `spawn_action_multi_repo_round_trip`, `resolve_dirs_*`, `resolve_launch_cwd_*`; 3 new `create-task.bats` cases. `cargo clippy` + `architecture_rules` green; lib suite passes (4 pre-existing unrelated global-search/feature failures only).
- **Real isolated end-to-end**: created a headless session across two git repos — both got their own `flow/<slug>` worktree, `--add-dir` attached a third as-is, and the agent's tmux window launched in the symlink workspace gathering all three.

Closes thurbox task #55.