### PR TITLE
fix(core): deliver notifications on WSL via Windows toast fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,7 +408,10 @@ gated on `[features] version_check`, off by default), `update`
 (downloads, verifies, and replaces the installed binaries with the latest
 release — `--force` bypasses the up-to-date/dev-build guards; gated on
 `[features] auto_update`, off by default; the TUI also runs this silently on
-startup when the flag is on). Output is
+startup when the flag is on), `notify`
+(diagnose OS desktop notifications: prints the detected delivery backend
+and last error; `--test` fires a sample — see OS notifications below).
+Output is
 **human-readable by default** and switches to JSON automatically when stdout is
 piped (so `… | jq` keeps working); force a format with `--json` (compact),
 `--pretty` (indented JSON), or `--text` (human even when piped).
@@ -922,7 +925,26 @@ tick in `App::refresh_session_statuses` (the *same* place
 in the list), dedup'd per session by `min_interval_secs`, and skipped
 when the target session is the one in focus (`suppress_for_active`).
 
-- **Click-to-focus** (Linux only). The dbus action callback writes a
+- **Delivery backend** (auto-detected). `notifications::detect_backend`
+  resolves the configured `[notifications] backend` (`auto` by default)
+  plus host probing (`probe_host`) into a concrete `DeliveryBackend`
+  (`Dbus` / `WindowsToast` / `Macos` / `None`) via the pure, table-driven
+  `resolve_backend`. `auto` picks **dbus** on a normal Linux desktop
+  (a session-bus `org.freedesktop.Notifications` socket is reachable),
+  the **Windows toast** path under WSL when no dbus daemon answers
+  (`/proc/version` carries the Microsoft marker and `powershell.exe` is on
+  PATH — we shell out a WinRT toast script, `build_powershell_toast_script`,
+  single-quote-escaped), and the **macOS** native banner. This fixed a
+  silent-failure bug: under WSL the dbus path errored on connect but only
+  logged a `warn!`, so the user saw nothing. Delivery errors are now
+  recorded in a process-wide `LAST_ERROR` slot (`notifications::last_error`)
+  and surfaced by the diagnostic.
+- **Diagnostic**: `thurbox-cli notify` (`cli/notify.rs`) prints the
+  detected backend, whether it can deliver, click-to-focus support, and
+  the last delivery error; `--test` fires a sample notification
+  *synchronously* (`notifications::send_blocking`, since the short-lived
+  CLI has no dispatcher thread) so the user can confirm end-to-end.
+- **Click-to-focus** (dbus path only). The dbus action callback writes a
   session UUID to the SQLite `metadata` row keyed by
   [`PENDING_FOCUS_SESSION_ID_KEY`](src/session/mod.rs) (= the single
   source of truth shared by writer and reader). The TUI's
@@ -930,9 +952,10 @@ when the target session is the one in focus (`suppress_for_active`).
   `apply_pending_focus_request`) reads + deletes the row atomically
   (`Database::take_pending_focus_session_id`, a single
   `DELETE … RETURNING` statement) and switches `active_index` +
-  `InputFocus::Terminal`. macOS shows the banner but ignores clicks —
-  modern `UNUserNotificationCenter` actions require a signed app
-  bundle, which thurbox is not. **Terminal window-raising is
+  `InputFocus::Terminal`. The Windows-toast and macOS paths show the
+  banner but ignore clicks (a Windows toast can't call back into WSL;
+  modern macOS `UNUserNotificationCenter` actions need a signed app
+  bundle, which thurbox is not). **Terminal window-raising is
   deliberately not implemented**: thurbox runs inside an arbitrary
   terminal emulator it doesn't own, and per-emulator window control is
   fragile (especially on Wayland). The session is pre-selected; the
@@ -944,14 +967,23 @@ when the target session is the one in focus (`suppress_for_active`).
   notifications = true` — zero overhead when disabled.
 - **Gated by `[features] notifications`** (default on); knobs in
   `[notifications]` (also_on_waiting / suppress_for_active / sound /
-  min_interval_secs). Settings live in `session::settings`; loader in
-  `agent::settings_config`; full doc in `docs/CONFIG.md`.
+  min_interval_secs / backend). `backend = "off"` is a soft delivery
+  switch distinct from the `[features]` flag (the dispatcher still runs
+  but drops everything). Settings live in `session::settings`
+  (`NotificationBackend` enum); loader in `agent::settings_config`; full
+  doc in `docs/CONFIG.md`.
 - **Code shape**. `src/notifications.rs` is the leaf side-effect layer
   (only knows `session` + `paths`) — a single background thread reads a
-  per-process mpsc channel and shells out to `notify-rust`. The
-  per-session bookkeeping (prior status, dedup timestamps) lives in
+  per-process mpsc channel and dispatches over the resolved backend
+  (`notify-rust` for dbus/macOS, `powershell.exe` for the WSL toast). The
+  notification body is bounded to 200 chars (`notify_state::truncate_body`)
+  so a huge OSC message can't overflow the banner. The per-session
+  bookkeeping (prior status, dedup timestamps) lives in
   `src/app/notify_state.rs` as a pure unit-testable struct, owned by
-  `App` and constructed only when the feature is enabled.
+  `App` and constructed only when the feature is enabled. Backend
+  selection (`resolve_backend`), the WSL marker check, powershell
+  escaping, and body truncation are all pure functions with table-driven
+  tests.
 
 ## Demo Video
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -275,15 +275,34 @@ and `auto_update` are independent — enable either or both.
 Surfaces an OS notification when a session crosses into a state that
 needs the user's attention (the agent rang the terminal bell or emitted
 an OSC 9 / OSC 777 message — usually because it's waiting on an answer
-or has finished a task). Linux dispatches via dbus and supports
-**click-to-focus**: clicking the banner writes a focus request that the
-running TUI reads on its next tick and switches to that session. macOS
-shows the notification banner but ignores clicks (the modern
-`UNUserNotificationCenter` API requires a signed app bundle, which
-thurbox is not). On both platforms the notification body is the agent's
-last OSC message when present, otherwise `Waiting for input`. **Only
-fires while the TUI is open** — the agent terminal parser is what sees
-the bell, and it doesn't run when thurbox isn't.
+or has finished a task). The notification body is the agent's last OSC
+message when present (truncated to 200 chars), otherwise `Waiting for
+input`. **Only fires while the TUI is open** — the agent terminal parser
+is what sees the bell, and it doesn't run when thurbox isn't.
+
+**Delivery backend** (`backend`, default `auto`) is detected at startup:
+
+| Backend | When | Click-to-focus |
+|---------|------|----------------|
+| `dbus` | normal Linux desktop with a running notification daemon (`org.freedesktop.Notifications`) | **yes** — clicking the banner writes a focus request the running TUI reads next tick and switches to that session |
+| `windows` (toast) | **WSL** (or any Linux with no dbus daemon) — delivers a Windows toast via `powershell.exe` (needs WSL interop, on by default) | no (a Windows toast can't call back into the WSL process) |
+| `macos` | macOS native banner — informational only (the modern `UNUserNotificationCenter` click API needs a signed app bundle, which thurbox is not) | no |
+
+`auto` prefers `dbus` whenever a daemon answers, and only falls back to
+the Windows toast when no dbus service is reachable. Force a specific
+path or disable delivery with `backend = "dbus" | "windows" | "off"`
+(`off` is a soft switch distinct from `[features] notifications`, which
+stops the dispatcher thread entirely).
+
+This auto-detection fixes a previously **silent failure** on WSL: the
+dbus path errored on connect, but the only signal was a line in the
+logfile, so the user saw nothing. Delivery errors are now recorded and
+surfaced by the diagnostic:
+
+```bash
+thurbox-cli notify          # show the detected backend + last delivery error
+thurbox-cli notify --test   # fire a sample notification to confirm it works
+```
 
 | Key | Default | Purpose |
 |-----|---------|---------|
@@ -291,6 +310,7 @@ the bell, and it doesn't run when thurbox isn't.
 | `suppress_for_active` | `true` | skip the notification for the session you're currently viewing |
 | `sound` | `true` | play the OS default notification sound |
 | `min_interval_secs` | `5` | per-session floor between two notifications (dedup) |
+| `backend` | `auto` | delivery backend: `auto` \| `dbus` \| `windows` \| `off` |
 
 The default-on `Attention` trigger is the right knob for any agent that
 respects the terminal bell / OSC 9 / OSC 777 conventions (Claude Code

--- a/docs/NOTIFICATIONS_TEST_PLAN.md
+++ b/docs/NOTIFICATIONS_TEST_PLAN.md
@@ -1,0 +1,97 @@
+# OS Notifications — Test Plan
+
+This documents how thurbox's OS desktop-notification delivery is tested,
+the findings that motivated the WSL fix, and the manual steps to verify
+delivery end-to-end on each platform.
+
+## Background: the bug this addresses
+
+On **WSL2** (e.g. Windows Terminal) notifications never appeared. Root
+cause: `DBUS_SESSION_BUS_ADDRESS` points at `/run/user/<uid>/bus`, but no
+session bus / `org.freedesktop.Notifications` service exists, so
+`notify-rust`'s `show()` errors on connect. The only signal was a `warn!`
+to the logfile — the user saw **nothing**: no banner, no error, no
+diagnostic. The fix auto-detects this case and delivers a Windows toast
+via `powershell.exe` instead, records delivery errors, and adds a
+`thurbox-cli notify` diagnostic so the failure is never silent again.
+
+## What changed
+
+- **Backend auto-detection** (`notifications::detect_backend` /
+  `resolve_backend`): `auto` → dbus on a normal Linux desktop,
+  Windows-toast under WSL with no dbus daemon, macOS native banner.
+- **`[notifications] backend`** override: `auto | dbus | windows | off`.
+- **Non-silent failures**: `notifications::last_error` records the last
+  delivery error.
+- **`thurbox-cli notify`** diagnostic + `--test`.
+- **Body truncation** to 200 chars so a huge OSC message can't overflow.
+
+## Automated tests
+
+Run with `cargo nextest run --all` (or the subset
+`cargo nextest run -E 'test(backend) + test(toast) + test(notif) + test(wsl) + test(body)'`).
+
+| Area | Test(s) | What it asserts |
+|------|---------|-----------------|
+| Backend selection (pure table) | `notifications::tests::auto_*`, `forced_*`, `off_always_disables` | dbus on desktop Linux; Windows-toast under WSL w/o dbus; `None` when WSL lacks powershell; dbus still preferred under WSL if a daemon answers; macOS banner; forced/off variants |
+| WSL detection | `proc_version_wsl_marker` | Microsoft/WSL marker in `/proc/version` is recognised; arch kernel is not |
+| PowerShell escaping | `powershell_escape_doubles_single_quotes_and_strips_controls` | single quotes doubled, control chars stripped, newlines → spaces |
+| Toast script | `toast_script_embeds_escaped_title_and_body`, `toast_script_suppresses_sound_when_off` | title/body embedded + escaped; silent `<audio>` node only when sound off |
+| Last-error slot | `last_error_round_trips` | recorded error is retrievable |
+| Capability helpers | `backend_capability_helpers` | `is_deliverable` / `supports_click_to_focus` per backend |
+| Body truncation | `notify_state::tests::body_is_truncated_when_too_long`, `body_at_limit_is_not_truncated`, `truncate_respects_char_boundaries` | caps at 200 chars + ellipsis; never splits a UTF-8 codepoint |
+| Transition / dedup rules (pre-existing) | `notify_state::tests::*` | only fires on real transitions, dedup window, active-suppression, opt-in waiting |
+| Settings parsing | `settings::tests::notifications_backend_parses_each_variant`, `notifications_backend_rejects_unknown_value`, `notifications_table_defaults` | `backend` parses all four variants, rejects junk, defaults to `auto` |
+| CLI | `cli::notify::tests::*`, `cli::tests::parse_notify_with_and_without_test` | diagnostic shape, headline branches, arg parsing |
+| Architecture | `architecture_rules` | `cli` may use `notifications`; `notifications` stays a leaf (`session` + `paths`) |
+
+## Manual verification
+
+### WSL2 (Windows Terminal) — the fixed case
+
+```bash
+cargo build --bin thurbox-cli
+./target/debug/thurbox-cli notify          # expect backend = windows-toast, deliverable = yes
+./target/debug/thurbox-cli notify --test   # expect a Windows toast to appear in the Action Center
+```
+
+Verified on `microsoft-standard-WSL2`: `notify` reports
+`windows-toast (powershell.exe)` and `--test` shows the toast.
+
+### Forced backends / failure surfacing
+
+```bash
+# In settings.toml: [notifications] backend = "dbus"
+./target/debug/thurbox-cli notify --test
+# On a host with no dbus daemon this now FAILS LOUDLY (prints the dbus
+# I/O error and exits non-zero) instead of dropping silently.
+
+# [notifications] backend = "off"
+./target/debug/thurbox-cli notify   # headline: "no working backend"; --test refuses
+```
+
+### Normal Linux desktop (dbus)
+
+```bash
+./target/debug/thurbox-cli notify          # backend = dbus, click-to-focus = yes
+./target/debug/thurbox-cli notify --test   # banner via the desktop notification daemon
+```
+
+In the TUI, trigger a real `Attention` (let an agent ring the bell / emit
+OSC 9) in a non-focused session and confirm the banner fires; click it and
+confirm the TUI switches to that session.
+
+### macOS
+
+```bash
+./target/debug/thurbox-cli notify --test   # native banner; clicks are ignored (documented)
+```
+
+## Notes / limitations
+
+- The Windows-toast path does **not** support click-to-focus (a Windows
+  toast can't call back into the WSL process); the banner is informational.
+- Notifications only fire while the **TUI is open** (the PTY parser that
+  observes the bell isn't running during a headless `automation tick`).
+- `powershell.exe` cold-start latency (~1–2 s) is absorbed by the
+  background dispatcher thread and never blocks the UI tick.

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -61,12 +61,16 @@ config_version = 1
 
 # OS desktop notifications. Linux gets click-to-focus (clicking the banner
 # selects the session in the running TUI); macOS shows a passive banner only.
-# The dispatcher only starts when [features] notifications = true.
+# Under WSL (no dbus notification daemon) the `auto` backend delivers a Windows
+# toast via powershell.exe instead — click-to-focus is unavailable on that path.
+# Run `thurbox-cli notify` to see the detected backend, or `--test` to fire a
+# sample. The dispatcher only starts when [features] notifications = true.
 # [notifications]
 # also_on_waiting = false       # also fire on Busy → Waiting (no explicit OSC bell)
 # suppress_for_active = true    # don't notify if you're already viewing that session
 # sound = true                  # play the OS default notification sound
 # min_interval_secs = 5         # per-session dedup floor (seconds)
+# backend = "auto"              # delivery backend: auto | dbus | windows | off
 
 # ──────────────────────────────────────────────────────────────────────────
 # Common recipes (uncomment the lines under the recipe you want)
@@ -286,6 +290,7 @@ mod tests {
             "suppress_for_active",
             "sound",
             "min_interval_secs",
+            "backend",
         ] {
             assert!(
                 SEED_SETTINGS_TOML.contains(field),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -596,7 +596,20 @@ fn build_notification_state() -> Option<NotificationState> {
     if !settings.features.notifications {
         return None;
     }
-    let sender = crate::notifications::start();
+    // Resolve the delivery backend (dbus / Windows-toast / macOS / none) from
+    // the configured preference plus host probing, then start the dispatcher
+    // for it. A `none` backend (e.g. WSL without powershell, or backend="off")
+    // still starts the thread but drops every notification — the reason is
+    // recorded for the `thurbox-cli notify` diagnostic rather than silently
+    // lost as before.
+    let backend = crate::notifications::detect_backend(settings.notifications.backend);
+    if !backend.is_deliverable() {
+        debug!(
+            "notifications enabled but no deliverable backend: {}",
+            backend.label()
+        );
+    }
+    let sender = crate::notifications::start(backend);
     Some(NotificationState::new(sender, settings.notifications))
 }
 

--- a/src/app/notify_state.rs
+++ b/src/app/notify_state.rs
@@ -10,6 +10,23 @@ use crate::notifications::{Notification, NotificationSender};
 use crate::session::settings::NotificationSettings;
 use crate::session::{SessionId, SessionStatus};
 
+/// Maximum notification body length (characters). Agent OSC messages are
+/// usually short, but a misbehaving agent can push a huge string; OS
+/// notification surfaces truncate or misbehave on very long bodies, so we cap
+/// it ourselves and append an ellipsis.
+const MAX_BODY_CHARS: usize = 200;
+
+/// Truncate an over-long body on a char boundary, appending `…`. Short bodies
+/// pass through unchanged.
+fn truncate_body(s: &str) -> String {
+    if s.chars().count() <= MAX_BODY_CHARS {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(MAX_BODY_CHARS).collect();
+    out.push('…');
+    out
+}
+
 /// State the notification path keeps across ticks. Owned by `App` and only
 /// constructed when the feature is enabled.
 pub struct NotificationState {
@@ -104,7 +121,9 @@ impl NotificationState {
     }
 
     /// Build the notification body from the session's last OSC message, or a
-    /// generic fallback when the agent only rang a bell (no message text).
+    /// generic fallback when the agent only rang a bell (no message text). A
+    /// long OSC message is truncated so the banner/toast stays readable and
+    /// never overflows the OS notification surface.
     pub fn build_notification(
         id: SessionId,
         name: &str,
@@ -114,8 +133,9 @@ impl NotificationState {
     ) -> Notification {
         let title = format!("{name} · {agent}");
         let body = notification_text
-            .map(str::to_string)
-            .filter(|s| !s.trim().is_empty())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(truncate_body)
             .unwrap_or_else(|| "Waiting for input".into());
         Notification {
             session_id: id,
@@ -165,6 +185,7 @@ mod tests {
                 suppress_for_active: suppress_active,
                 sound: true,
                 min_interval_secs: interval,
+                ..NotificationSettings::default()
             },
         )
     }
@@ -330,5 +351,33 @@ mod tests {
             NotificationState::build_notification(id, "demo", "claude", Some("approved?"), true);
         assert_eq!(n.body, "approved?");
         assert_eq!(n.title, "demo · claude");
+    }
+
+    #[test]
+    fn body_is_truncated_when_too_long() {
+        let id = SessionId::default();
+        let long = "x".repeat(500);
+        let n = NotificationState::build_notification(id, "demo", "claude", Some(&long), true);
+        // 200 chars + the ellipsis.
+        assert_eq!(n.body.chars().count(), MAX_BODY_CHARS + 1);
+        assert!(n.body.ends_with('…'));
+    }
+
+    #[test]
+    fn body_at_limit_is_not_truncated() {
+        let id = SessionId::default();
+        let exact = "y".repeat(MAX_BODY_CHARS);
+        let n = NotificationState::build_notification(id, "demo", "claude", Some(&exact), true);
+        assert_eq!(n.body, exact);
+        assert!(!n.body.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_respects_char_boundaries() {
+        // Multi-byte chars must not be split mid-codepoint.
+        let s = "é".repeat(500);
+        let out = truncate_body(&s);
+        assert_eq!(out.chars().count(), MAX_BODY_CHARS + 1);
+        assert!(out.is_char_boundary(out.len() - '…'.len_utf8()));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,6 +18,7 @@ pub mod config;
 pub mod editor;
 pub mod extensions;
 pub mod messages;
+pub mod notify;
 pub mod output;
 pub mod sessions;
 pub mod tasks;
@@ -97,6 +98,8 @@ pub enum Command {
     Version(version::VersionArgs),
     /// Download, verify, and replace the installed binaries with the latest release.
     Update(update::UpdateArgs),
+    /// Diagnose OS desktop notifications; `--test` fires a sample.
+    Notify(notify::NotifyArgs),
 }
 
 /// Build the additional-repo list for a multi-repo `Spawn` from the repeatable
@@ -148,6 +151,7 @@ pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
         Command::Extension { action } => extensions::run(action, db),
         Command::Version(args) => Ok(version::run(args)),
         Command::Update(args) => Ok(update::run(args)),
+        Command::Notify(args) => Ok(notify::run(args)),
     }?;
 
     println!("{}", format.render(&output));
@@ -748,6 +752,21 @@ mod tests {
             panic!("expected Update");
         };
         assert!(args.force);
+    }
+
+    #[test]
+    fn parse_notify_with_and_without_test() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "notify"]).unwrap();
+        let Command::Notify(args) = cli.command else {
+            panic!("expected Notify");
+        };
+        assert!(!args.test);
+
+        let cli = Cli::try_parse_from(["thurbox-cli", "notify", "--test"]).unwrap();
+        let Command::Notify(args) = cli.command else {
+            panic!("expected Notify");
+        };
+        assert!(args.test);
     }
 
     #[test]

--- a/src/cli/notify.rs
+++ b/src/cli/notify.rs
@@ -1,0 +1,198 @@
+//! `thurbox-cli notify` — diagnose OS desktop notifications.
+//!
+//! The default (no flags) prints which delivery backend thurbox would use on
+//! this host, whether it can actually deliver, whether click-to-focus is
+//! supported, and the last recorded delivery error (if any). This exists
+//! because the WSL failure mode used to be entirely silent — the dbus path
+//! errored and only logged a `warn!` to the file logger.
+//!
+//! With `--test`, it fires a sample notification *synchronously* so the user
+//! can confirm end-to-end that a banner/toast actually appears.
+
+use clap::Args;
+use serde_json::json;
+
+use crate::notifications::{self, DeliveryBackend, Notification};
+use crate::session::settings;
+use crate::session::SessionId;
+
+use super::output::{kv, CommandOutput};
+
+/// `notify` subcommand arguments.
+#[derive(Args, Debug)]
+pub struct NotifyArgs {
+    /// Fire a sample notification to confirm delivery works end-to-end.
+    #[arg(long)]
+    pub test: bool,
+}
+
+/// Run the `notify` command. Takes no database — it reads the process-wide
+/// settings (for the configured backend) and probes the host.
+pub fn run(args: NotifyArgs) -> CommandOutput {
+    let s = settings::global();
+    let feature_on = s.features.notifications;
+    let configured = s.notifications.backend;
+    let backend = notifications::detect_backend(configured);
+
+    if args.test {
+        return run_test(feature_on, backend);
+    }
+
+    let last_error = notifications::last_error();
+    let mut pairs = vec![
+        ("feature", on_off(feature_on)),
+        ("configured", format!("{configured:?}").to_lowercase()),
+        ("backend", backend.label().to_string()),
+        ("deliverable", yes_no(backend.is_deliverable())),
+        ("click-to-focus", yes_no(backend.supports_click_to_focus())),
+    ];
+    if let Some(err) = &last_error {
+        pairs.push(("last_error", err.clone()));
+    }
+
+    // Lead with the most actionable line, then the detail block.
+    let headline = diagnose_headline(feature_on, backend);
+    let human = format!("{headline}\n\n{}", kv(&pairs));
+
+    CommandOutput::new(
+        json!({
+            "feature_enabled": feature_on,
+            "configured_backend": format!("{configured:?}").to_lowercase(),
+            "resolved_backend": backend.label(),
+            "deliverable": backend.is_deliverable(),
+            "click_to_focus": backend.supports_click_to_focus(),
+            "last_error": last_error,
+            "summary": headline,
+        }),
+        human,
+    )
+}
+
+fn run_test(feature_on: bool, backend: DeliveryBackend) -> CommandOutput {
+    if !feature_on {
+        let msg = "Notifications are disabled ([features] notifications = false); \
+                   nothing to test. Enable the feature first.";
+        return CommandOutput::new(
+            json!({
+                "feature_enabled": false,
+                "tested": false,
+                "summary": msg,
+            }),
+            msg,
+        );
+    }
+
+    let n = Notification {
+        session_id: SessionId::default(),
+        title: "thurbox · test".into(),
+        body: "Notifications are working. This is a test from `thurbox-cli notify --test`.".into(),
+        sound: settings::global().notifications.sound,
+    };
+
+    match notifications::send_blocking(&n, backend) {
+        Ok(()) => {
+            let msg = format!(
+                "Sent a test notification via {}. If you don't see it, check your OS \
+                 notification settings.",
+                backend.label()
+            );
+            CommandOutput::new(
+                json!({
+                    "feature_enabled": true,
+                    "tested": true,
+                    "delivered": true,
+                    "resolved_backend": backend.label(),
+                    "summary": msg,
+                }),
+                msg,
+            )
+        }
+        Err(e) => {
+            let msg = format!("Test notification failed via {}: {e}", backend.label());
+            CommandOutput::failed(
+                json!({
+                    "feature_enabled": true,
+                    "tested": true,
+                    "delivered": false,
+                    "resolved_backend": backend.label(),
+                    "error": e,
+                    "summary": msg,
+                }),
+                msg.clone(),
+                msg,
+            )
+        }
+    }
+}
+
+/// One actionable summary line tailored to the resolved state.
+fn diagnose_headline(feature_on: bool, backend: DeliveryBackend) -> String {
+    if !feature_on {
+        return "Notifications are OFF ([features] notifications = false).".into();
+    }
+    if !backend.is_deliverable() {
+        return format!(
+            "Notifications are enabled but have no working backend ({}). On WSL, ensure \
+             powershell.exe is on PATH; otherwise install a notification daemon or set \
+             [notifications] backend.",
+            backend.label()
+        );
+    }
+    format!(
+        "Notifications enabled — delivering via {}. Run `thurbox-cli notify --test` to confirm.",
+        backend.label()
+    )
+}
+
+fn on_off(b: bool) -> String {
+    if b {
+        "on".into()
+    } else {
+        "off".into()
+    }
+}
+
+fn yes_no(b: bool) -> String {
+    if b {
+        "yes".into()
+    } else {
+        "no".into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notify_default_reports_backend_fields() {
+        // In the test process settings::global() is the all-default config
+        // (feature on, backend auto); host probing runs against the real test
+        // host, so we only assert the shape, not the concrete backend.
+        let out = run(NotifyArgs { test: false });
+        assert!(out["feature_enabled"].is_boolean());
+        assert!(out["resolved_backend"].is_string());
+        assert!(out["deliverable"].is_boolean());
+        assert!(out["summary"].is_string());
+        assert!(out.failure.is_none(), "the report itself never fails");
+    }
+
+    #[test]
+    fn headline_calls_out_disabled_feature() {
+        let h = diagnose_headline(false, DeliveryBackend::Dbus);
+        assert!(h.contains("OFF"), "got: {h}");
+    }
+
+    #[test]
+    fn headline_calls_out_no_backend() {
+        let h = diagnose_headline(true, DeliveryBackend::None);
+        assert!(h.contains("no working backend"), "got: {h}");
+        assert!(h.contains("WSL"), "should hint at the WSL case: {h}");
+    }
+
+    #[test]
+    fn headline_confirms_a_working_backend() {
+        let h = diagnose_headline(true, DeliveryBackend::Dbus);
+        assert!(h.contains("delivering via"), "got: {h}");
+    }
+}

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,30 +1,87 @@
 //! OS desktop notifications for the "agent needs you" event.
 //!
 //! Sends a notification when a session transitions into an attention-needing
-//! state (`Attention` always, plus `Waiting` when opted in). Click handling is
-//! Linux-only: the dbus action callback writes a `pending_focus_session_id`
-//! into the SQLite `metadata` table, which the running TUI picks up next tick
-//! via its normal external-state poll. On macOS the notification is purely
-//! informational — clicking it does nothing (the modern `UNUserNotificationCenter`
-//! API requires a signed app bundle, which thurbox is not).
+//! state (`Attention` always, plus `Waiting` when opted in). Delivery picks a
+//! **backend** at startup ([`detect_backend`]):
 //!
-//! Notify-rust on Linux blocks on dbus; dispatch therefore runs on a dedicated
-//! background thread fed by an mpsc channel, so the UI tick is never stalled
-//! by a slow/missing notification daemon.
+//! - **dbus** (`org.freedesktop.Notifications`) on a normal Linux desktop.
+//!   Click-to-focus works: the dbus action callback writes a
+//!   `pending_focus_session_id` into the SQLite `metadata` table, which the
+//!   running TUI picks up next tick via its normal external-state poll.
+//! - **Windows toast** under WSL when no dbus notification daemon is reachable.
+//!   We shell out to `powershell.exe` and raise a WinRT toast, so notifications
+//!   appear in the Windows Action Center. Click-to-focus is *not* supported on
+//!   this path (a Windows toast can't call back into the WSL process), so the
+//!   banner is informational — the user alt-tabs back themselves.
+//! - **macOS** native banner (informational; the modern
+//!   `UNUserNotificationCenter` click API needs a signed app bundle, which
+//!   thurbox is not).
 //!
-//! Architecture: leaf module. Depends only on `session` (the `SessionId`
-//! type) and `paths` (for the DB path the click callback writes to). Never
-//! reaches into `app` / `agent` / `ui`.
+//! A previous silent-failure bug motivated this: under WSL the dbus path errors
+//! on connect, but the only signal was a `warn!` to the logfile — the user saw
+//! nothing. We now (a) auto-detect the working backend, (b) record the last
+//! delivery error so `thurbox-cli notify` can surface it, and (c) treat "no
+//! backend at all" as a reported condition rather than a silent drop.
+//!
+//! Notify-rust on Linux blocks on dbus, and `powershell.exe` is slow to spawn;
+//! dispatch therefore runs on a dedicated background thread fed by an mpsc
+//! channel, so the UI tick is never stalled by a slow/missing notification
+//! daemon.
+//!
+//! Architecture: leaf module. Depends only on `session` (the `SessionId` /
+//! `NotificationBackend` types) and `paths` (for the DB path the click callback
+//! writes to). Never reaches into `app` / `agent` / `ui`.
 
 #[cfg(target_os = "linux")]
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, Sender};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 
 use tracing::{debug, warn};
 
+use crate::session::settings::NotificationBackend;
 use crate::session::{SessionId, PENDING_FOCUS_SESSION_ID_KEY};
+
+/// The resolved delivery mechanism, decided once at startup from the
+/// configured [`NotificationBackend`] plus host probing. This is the concrete
+/// transport, with no `Auto` ambiguity left.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryBackend {
+    /// freedesktop dbus (`notify-rust` → `org.freedesktop.Notifications`).
+    Dbus,
+    /// WSL → Windows toast via `powershell.exe`.
+    WindowsToast,
+    /// macOS native banner.
+    Macos,
+    /// No working delivery path (e.g. `backend = "off"`, or WSL without
+    /// `powershell.exe`, or an unsupported OS). Notifications are dropped, but
+    /// the reason is reported via [`last_error`].
+    None,
+}
+
+impl DeliveryBackend {
+    /// Short, user-facing label for the diagnostic output.
+    pub fn label(self) -> &'static str {
+        match self {
+            DeliveryBackend::Dbus => "dbus (org.freedesktop.Notifications)",
+            DeliveryBackend::WindowsToast => "windows-toast (powershell.exe)",
+            DeliveryBackend::Macos => "macos (native banner)",
+            DeliveryBackend::None => "none (delivery disabled)",
+        }
+    }
+
+    /// Whether the backend can actually deliver a notification.
+    pub fn is_deliverable(self) -> bool {
+        !matches!(self, DeliveryBackend::None)
+    }
+
+    /// Whether clicking the notification focuses the session in the TUI.
+    /// Only the dbus path wires this up.
+    pub fn supports_click_to_focus(self) -> bool {
+        matches!(self, DeliveryBackend::Dbus)
+    }
+}
 
 /// One notification to fire. Cheap to clone/move across the channel.
 #[derive(Debug, Clone)]
@@ -67,37 +124,88 @@ impl NotificationSender {
     }
 }
 
-/// Start the background dispatcher thread. Returns a sender for the UI tick
-/// to push notifications into. The thread reads its DB path lazily on each
-/// click (we only write a single row, no persistent connection needed) so it
-/// is safe to spawn before the database file exists.
+/// Process-wide record of the last delivery failure, so the diagnostic
+/// (`thurbox-cli notify`) and a future TUI warning can surface what would
+/// otherwise be a silent drop. `None` = no failure recorded yet.
+static LAST_ERROR: Mutex<Option<String>> = Mutex::new(None);
+
+fn record_error(msg: impl Into<String>) {
+    let msg = msg.into();
+    warn!("notification dispatch failed: {msg}");
+    if let Ok(mut slot) = LAST_ERROR.lock() {
+        *slot = Some(msg);
+    }
+}
+
+/// The most recent delivery error, if any. Used by the CLI diagnostic.
+pub fn last_error() -> Option<String> {
+    LAST_ERROR.lock().ok().and_then(|s| s.clone())
+}
+
+/// Start the background dispatcher thread for the given backend. Returns a
+/// sender for the UI tick to push notifications into. The thread reads its DB
+/// path lazily on each click (we only write a single row, no persistent
+/// connection needed) so it is safe to spawn before the database file exists.
 ///
-/// Only one dispatcher per process: re-entry returns the same sender.
-pub fn start() -> NotificationSender {
+/// Only one dispatcher per process: re-entry returns the same sender and the
+/// backend chosen on the first call wins.
+pub fn start(backend: DeliveryBackend) -> NotificationSender {
     static SHARED: OnceLock<NotificationSender> = OnceLock::new();
     SHARED
         .get_or_init(|| {
             let (tx, rx) = mpsc::channel::<Notification>();
             thread::Builder::new()
                 .name("thurbox-notifications".into())
-                .spawn(move || dispatch_loop(rx))
+                .spawn(move || dispatch_loop(rx, backend))
                 .expect("spawn notification dispatcher thread");
             NotificationSender { tx }
         })
         .clone()
 }
 
-fn dispatch_loop(rx: Receiver<Notification>) {
+fn dispatch_loop(rx: Receiver<Notification>, backend: DeliveryBackend) {
     while let Ok(n) = rx.recv() {
-        if let Err(e) = dispatch_one(n) {
-            warn!("notification dispatch failed: {e}");
+        if let Err(e) = dispatch_one(&n, backend) {
+            record_error(e.to_string());
         }
     }
     debug!("notification dispatcher exiting (all senders dropped)");
 }
 
+/// Synchronously deliver a single notification over `backend`, blocking until
+/// the OS call returns. Used by the `thurbox-cli notify --test` diagnostic,
+/// which is a short-lived process with no dispatcher thread — it must complete
+/// the delivery before exiting. Returns an error string on failure (the dbus
+/// path's click-wait thread is still spawned but the process may exit before a
+/// click; that's fine for a one-shot test).
+pub fn send_blocking(n: &Notification, backend: DeliveryBackend) -> Result<(), String> {
+    if !backend.is_deliverable() {
+        return Err(format!("no deliverable backend ({})", backend.label()));
+    }
+    dispatch_one(n, backend).map_err(|e| e.to_string())
+}
+
+/// Dispatch one notification over the resolved backend.
+fn dispatch_one(
+    n: &Notification,
+    backend: DeliveryBackend,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match backend {
+        #[cfg(target_os = "linux")]
+        DeliveryBackend::Dbus => dispatch_dbus(n),
+        DeliveryBackend::WindowsToast => dispatch_windows_toast(n),
+        #[cfg(target_os = "macos")]
+        DeliveryBackend::Macos => dispatch_macos(n),
+        DeliveryBackend::None => Ok(()),
+        // A backend that isn't compiled for this target (e.g. Dbus on macOS):
+        // nothing to do. detect_backend never returns these combinations.
+        #[allow(unreachable_patterns)]
+        _ => Ok(()),
+    }
+}
+
 #[cfg(target_os = "linux")]
-fn dispatch_one(n: Notification) -> Result<(), Box<dyn std::error::Error>> {
+fn dispatch_dbus(n: &Notification) -> Result<(), Box<dyn std::error::Error>> {
     use notify_rust::{Hint, Notification as NotifRust};
 
     let mut notif = NotifRust::new();
@@ -136,7 +244,7 @@ fn dispatch_one(n: Notification) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(target_os = "macos")]
-fn dispatch_one(n: Notification) -> Result<(), Box<dyn std::error::Error>> {
+fn dispatch_macos(n: &Notification) -> Result<(), Box<dyn std::error::Error>> {
     use notify_rust::Notification as NotifRust;
 
     // macOS path: no action callbacks (UNUserNotificationCenter requires a
@@ -151,9 +259,214 @@ fn dispatch_one(n: Notification) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn dispatch_one(_n: Notification) -> Result<(), Box<dyn std::error::Error>> {
+/// Deliver a Windows toast from WSL by invoking `powershell.exe` with a small
+/// WinRT script. This is the only path that crosses the WSL → Windows
+/// boundary; it needs WSL interop enabled (the default) and `powershell.exe`
+/// on `PATH` (also the default). Click-to-focus is not wired up here.
+fn dispatch_windows_toast(n: &Notification) -> Result<(), Box<dyn std::error::Error>> {
+    use std::process::Command;
+
+    let script = build_powershell_toast_script(&n.title, &n.body, n.sound);
+    let output = Command::new("powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+        .map_err(|e| format!("could not run powershell.exe (WSL interop?): {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "powershell.exe toast failed ({}): {}",
+            output.status,
+            stderr.trim()
+        )
+        .into());
+    }
     Ok(())
+}
+
+/// Single-quote a string for safe interpolation into a PowerShell literal.
+/// PowerShell escapes a literal single quote by doubling it (`''`). We also
+/// strip control characters that could break the one-liner; the body has
+/// already been length-bounded upstream.
+pub(crate) fn powershell_escape(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_control() || *c == '\n')
+        .map(|c| if c == '\n' { ' ' } else { c })
+        .collect::<String>()
+        .replace('\'', "''")
+}
+
+/// Build the PowerShell script that raises a WinRT toast. Title/body are
+/// single-quote-escaped and embedded as XML text nodes (the WinRT API takes
+/// raw text, so XML-special characters are passed as-is by `CreateTextNode`).
+pub(crate) fn build_powershell_toast_script(title: &str, body: &str, sound: bool) -> String {
+    let title = powershell_escape(title);
+    let body = powershell_escape(body);
+    // ToastText02 = one bold heading line + one wrapped body line.
+    // A generic AppUserModelID ("Windows Terminal") lets the toast show
+    // without registering a Start-menu shortcut.
+    let audio = if sound {
+        String::new()
+    } else {
+        // Suppress the default toast sound by appending a silent <audio> node.
+        "$audio = $template.CreateElement('audio'); \
+         $audio.SetAttribute('silent','true'); \
+         $template.DocumentElement.AppendChild($audio) | Out-Null; "
+            .to_string()
+    };
+    format!(
+        "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null; \
+         $template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); \
+         $texts = $template.GetElementsByTagName('text'); \
+         $texts.Item(0).AppendChild($template.CreateTextNode('{title}')) | Out-Null; \
+         $texts.Item(1).AppendChild($template.CreateTextNode('{body}')) | Out-Null; \
+         {audio}\
+         $toast = [Windows.UI.Notifications.ToastNotification]::new($template); \
+         $notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Windows Terminal'); \
+         $notifier.Show($toast)"
+    )
+}
+
+/// Decide the concrete delivery backend for this host from the configured
+/// preference. `Auto` probes the environment; the explicit variants force a
+/// path (or disable). Probing is delegated to [`probe_host`] so the decision
+/// table is pure and unit-testable.
+pub fn detect_backend(configured: NotificationBackend) -> DeliveryBackend {
+    resolve_backend(configured, probe_host())
+}
+
+/// Observable facts about the host that drive backend selection. Kept as a
+/// plain struct so `resolve_backend` is a pure function of (config, facts).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostProbe {
+    /// Compiled for `target_os = "linux"`.
+    pub is_linux: bool,
+    /// Compiled for `target_os = "macos"`.
+    pub is_macos: bool,
+    /// Running under WSL (Microsoft kernel marker in `/proc/version`).
+    pub is_wsl: bool,
+    /// A reachable freedesktop notification service on the session bus.
+    pub has_dbus_service: bool,
+    /// `powershell.exe` resolves on `PATH` (WSL interop available).
+    pub has_powershell: bool,
+}
+
+/// Pure backend-selection table. Separated from probing so every branch is
+/// testable without a real host.
+pub fn resolve_backend(configured: NotificationBackend, probe: HostProbe) -> DeliveryBackend {
+    match configured {
+        NotificationBackend::Off => DeliveryBackend::None,
+        NotificationBackend::Dbus => {
+            if probe.is_linux {
+                DeliveryBackend::Dbus
+            } else {
+                DeliveryBackend::None
+            }
+        }
+        NotificationBackend::Windows => {
+            if probe.has_powershell {
+                DeliveryBackend::WindowsToast
+            } else {
+                DeliveryBackend::None
+            }
+        }
+        NotificationBackend::Auto => {
+            if probe.is_macos {
+                DeliveryBackend::Macos
+            } else if probe.is_linux {
+                // Prefer dbus when a real notification daemon answers. The
+                // common WSL case has no daemon, so fall back to a Windows
+                // toast whenever interop (`powershell.exe`) is available —
+                // this also covers the unusual non-WSL Linux host with
+                // powershell on PATH, still better than dropping silently.
+                // Without either we have nothing (reported via `last_error`).
+                if probe.has_dbus_service {
+                    DeliveryBackend::Dbus
+                } else if probe.has_powershell {
+                    DeliveryBackend::WindowsToast
+                } else {
+                    DeliveryBackend::None
+                }
+            } else {
+                DeliveryBackend::None
+            }
+        }
+    }
+}
+
+/// Gather host facts for [`detect_backend`]. The `cfg!` flags are
+/// compile-time; the dynamic probes (WSL marker, dbus service, powershell)
+/// are best-effort and never panic.
+pub fn probe_host() -> HostProbe {
+    HostProbe {
+        is_linux: cfg!(target_os = "linux"),
+        is_macos: cfg!(target_os = "macos"),
+        is_wsl: detect_wsl(),
+        has_dbus_service: detect_dbus_service(),
+        has_powershell: detect_powershell(),
+    }
+}
+
+/// WSL is detected by the Microsoft marker the WSL kernel writes into
+/// `/proc/version` (e.g. "...microsoft-standard-WSL2..."). Pure check exposed
+/// for tests via [`proc_version_is_wsl`].
+fn detect_wsl() -> bool {
+    std::fs::read_to_string("/proc/version")
+        .map(|v| proc_version_is_wsl(&v))
+        .unwrap_or(false)
+}
+
+/// Pure WSL test over a `/proc/version` string.
+pub(crate) fn proc_version_is_wsl(proc_version: &str) -> bool {
+    let lower = proc_version.to_ascii_lowercase();
+    lower.contains("microsoft") || lower.contains("wsl")
+}
+
+/// Probe for a working freedesktop notification service. We deliberately do a
+/// cheap socket-existence check rather than a full dbus round-trip: the common
+/// failure (WSL) is that `DBUS_SESSION_BUS_ADDRESS` points at a socket path
+/// that does not exist, so even opening the bus fails. A present socket is a
+/// good-enough signal to attempt the dbus path (a misbehaving daemon then
+/// surfaces via `last_error`, no longer silent).
+#[cfg(target_os = "linux")]
+fn detect_dbus_service() -> bool {
+    // Honour an explicit address first.
+    if let Ok(addr) = std::env::var("DBUS_SESSION_BUS_ADDRESS") {
+        if let Some(path) = addr
+            .split(',')
+            .find_map(|kv| kv.strip_prefix("unix:path="))
+            .or_else(|| addr.strip_prefix("unix:path="))
+        {
+            return std::path::Path::new(path).exists();
+        }
+        // Non-unix transport (tcp, etc.) — assume reachable; let dbus try.
+        if !addr.is_empty() {
+            return true;
+        }
+    }
+    // Fall back to the conventional per-user bus socket location.
+    if let Ok(runtime) = std::env::var("XDG_RUNTIME_DIR") {
+        return std::path::Path::new(&runtime).join("bus").exists();
+    }
+    false
+}
+
+#[cfg(not(target_os = "linux"))]
+fn detect_dbus_service() -> bool {
+    false
+}
+
+/// `powershell.exe` on `PATH` (WSL interop). Cheap PATH scan; no process spawn.
+fn detect_powershell() -> bool {
+    which_on_path("powershell.exe")
+}
+
+/// Minimal `PATH` lookup (avoids pulling in a `which` crate for one probe).
+fn which_on_path(exe: &str) -> bool {
+    let Ok(path) = std::env::var("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(exe).exists())
 }
 
 /// SQLite `metadata` key the click handler writes to. The TUI's
@@ -191,6 +504,22 @@ fn write_focus_request(session_id: SessionId) -> Result<(), Box<dyn std::error::
 mod tests {
     use super::*;
 
+    fn probe(
+        is_linux: bool,
+        is_macos: bool,
+        is_wsl: bool,
+        has_dbus: bool,
+        has_ps: bool,
+    ) -> HostProbe {
+        HostProbe {
+            is_linux,
+            is_macos,
+            is_wsl,
+            has_dbus_service: has_dbus,
+            has_powershell: has_ps,
+        }
+    }
+
     #[test]
     fn sender_send_does_not_panic_when_receiver_dropped() {
         let (tx, rx) = mpsc::channel::<Notification>();
@@ -211,5 +540,148 @@ mod tests {
         // cross-process protocol with the TUI poll loop. Changing it is a
         // breaking change for any in-flight clicks across an upgrade.
         assert_eq!(FOCUS_REQUEST_KEY, "pending_focus_session_id");
+    }
+
+    #[test]
+    fn proc_version_wsl_marker() {
+        assert!(proc_version_is_wsl(
+            "Linux version 6.6.0-microsoft-standard-WSL2 (gcc ...)"
+        ));
+        assert!(proc_version_is_wsl("... WSL ..."));
+        assert!(!proc_version_is_wsl(
+            "Linux version 6.6.0-arch1-1 (linux@archlinux) ..."
+        ));
+    }
+
+    #[test]
+    fn auto_picks_dbus_on_normal_linux_desktop() {
+        let p = probe(true, false, false, true, false);
+        assert_eq!(
+            resolve_backend(NotificationBackend::Auto, p),
+            DeliveryBackend::Dbus
+        );
+    }
+
+    #[test]
+    fn auto_falls_back_to_windows_toast_under_wsl_without_dbus() {
+        // The exact WSL failure case: linux + WSL marker + no dbus service,
+        // but powershell.exe is reachable.
+        let p = probe(true, false, true, false, true);
+        assert_eq!(
+            resolve_backend(NotificationBackend::Auto, p),
+            DeliveryBackend::WindowsToast
+        );
+    }
+
+    #[test]
+    fn auto_under_wsl_without_powershell_reports_none() {
+        let p = probe(true, false, true, false, false);
+        assert_eq!(
+            resolve_backend(NotificationBackend::Auto, p),
+            DeliveryBackend::None
+        );
+    }
+
+    #[test]
+    fn auto_prefers_dbus_even_under_wsl_if_a_daemon_answers() {
+        // A WSL setup that *does* run a notification daemon should still use it.
+        let p = probe(true, false, true, true, true);
+        assert_eq!(
+            resolve_backend(NotificationBackend::Auto, p),
+            DeliveryBackend::Dbus
+        );
+    }
+
+    #[test]
+    fn auto_picks_macos_banner() {
+        let p = probe(false, true, false, false, false);
+        assert_eq!(
+            resolve_backend(NotificationBackend::Auto, p),
+            DeliveryBackend::Macos
+        );
+    }
+
+    #[test]
+    fn off_always_disables() {
+        let p = probe(true, false, false, true, true);
+        assert_eq!(
+            resolve_backend(NotificationBackend::Off, p),
+            DeliveryBackend::None
+        );
+    }
+
+    #[test]
+    fn forced_dbus_requires_linux() {
+        assert_eq!(
+            resolve_backend(
+                NotificationBackend::Dbus,
+                probe(true, false, false, false, false)
+            ),
+            DeliveryBackend::Dbus
+        );
+        assert_eq!(
+            resolve_backend(
+                NotificationBackend::Dbus,
+                probe(false, true, false, false, false)
+            ),
+            DeliveryBackend::None
+        );
+    }
+
+    #[test]
+    fn forced_windows_requires_powershell() {
+        assert_eq!(
+            resolve_backend(
+                NotificationBackend::Windows,
+                probe(true, false, true, false, true)
+            ),
+            DeliveryBackend::WindowsToast
+        );
+        assert_eq!(
+            resolve_backend(
+                NotificationBackend::Windows,
+                probe(true, false, true, false, false)
+            ),
+            DeliveryBackend::None
+        );
+    }
+
+    #[test]
+    fn backend_capability_helpers() {
+        assert!(DeliveryBackend::Dbus.supports_click_to_focus());
+        assert!(!DeliveryBackend::WindowsToast.supports_click_to_focus());
+        assert!(DeliveryBackend::WindowsToast.is_deliverable());
+        assert!(!DeliveryBackend::None.is_deliverable());
+    }
+
+    #[test]
+    fn powershell_escape_doubles_single_quotes_and_strips_controls() {
+        assert_eq!(powershell_escape("it's fine"), "it''s fine");
+        // Newlines collapse to spaces; other control chars are dropped.
+        assert_eq!(powershell_escape("a\nb\tc"), "a bc");
+        assert_eq!(powershell_escape("plain"), "plain");
+    }
+
+    #[test]
+    fn toast_script_embeds_escaped_title_and_body() {
+        let script = build_powershell_toast_script("my-feat · claude", "can't proceed", true);
+        assert!(script.contains("my-feat · claude"));
+        // The single quote in the body is doubled for PowerShell.
+        assert!(script.contains("can''t proceed"));
+        assert!(script.contains("ToastNotificationManager"));
+        // Sound on → no silent audio node.
+        assert!(!script.contains("silent"));
+    }
+
+    #[test]
+    fn toast_script_suppresses_sound_when_off() {
+        let script = build_powershell_toast_script("t", "b", false);
+        assert!(script.contains("silent"));
+    }
+
+    #[test]
+    fn last_error_round_trips() {
+        record_error("boom");
+        assert_eq!(last_error().as_deref(), Some("boom"));
     }
 }

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -105,6 +105,27 @@ pub struct FeatureFlags {
     pub auto_update: bool,
 }
 
+/// Which OS-notification delivery backend to use (`[notifications] backend`).
+/// `Auto` (the default) detects the right one at startup: dbus on a normal
+/// Linux desktop, a Windows toast (via `powershell.exe`) under WSL when no
+/// dbus notification daemon is reachable, the native banner on macOS. The
+/// other variants force a specific path, and `Off` disables delivery entirely
+/// without touching the `[features] notifications` switch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum NotificationBackend {
+    /// Detect the best backend for the host at startup.
+    #[default]
+    Auto,
+    /// Force the freedesktop dbus path (`org.freedesktop.Notifications`).
+    Dbus,
+    /// Force the WSL → Windows toast path (`powershell.exe`).
+    Windows,
+    /// Disable delivery (the dispatcher still starts but drops every
+    /// notification — a soft off-switch distinct from `[features]`).
+    Off,
+}
+
 /// Knobs for the OS notification feature (`[notifications]` table). All
 /// fields have defaults so an empty / absent table behaves like the seeded
 /// configuration.
@@ -128,6 +149,10 @@ pub struct NotificationSettings {
     /// agent that flips Attention → Busy → Attention from spamming.
     #[serde(default = "default_notification_min_interval_secs")]
     pub min_interval_secs: u64,
+    /// Delivery backend. `auto` (default) detects dbus vs. Windows-toast vs.
+    /// macOS at startup; `dbus`/`windows` force one; `off` disables delivery.
+    #[serde(default)]
+    pub backend: NotificationBackend,
 }
 
 fn default_notification_min_interval_secs() -> u64 {
@@ -141,6 +166,7 @@ impl Default for NotificationSettings {
             suppress_for_active: true,
             sound: true,
             min_interval_secs: default_notification_min_interval_secs(),
+            backend: NotificationBackend::Auto,
         }
     }
 }
@@ -318,6 +344,28 @@ mod tests {
         assert!(s.notifications.suppress_for_active);
         assert!(s.notifications.sound);
         assert_eq!(s.notifications.min_interval_secs, 5);
+        assert_eq!(s.notifications.backend, NotificationBackend::Auto);
+    }
+
+    #[test]
+    fn notifications_backend_parses_each_variant() {
+        for (raw, want) in [
+            ("auto", NotificationBackend::Auto),
+            ("dbus", NotificationBackend::Dbus),
+            ("windows", NotificationBackend::Windows),
+            ("off", NotificationBackend::Off),
+        ] {
+            let s: Settings =
+                toml::from_str(&format!("[notifications]\nbackend = \"{raw}\"\n")).unwrap();
+            assert_eq!(s.notifications.backend, want, "backend = {raw}");
+        }
+    }
+
+    #[test]
+    fn notifications_backend_rejects_unknown_value() {
+        let err =
+            toml::from_str::<Settings>("[notifications]\nbackend = \"telepathy\"").unwrap_err();
+        assert!(err.to_string().contains("backend") || err.to_string().contains("variant"));
     }
 
     #[test]

--- a/tests/architecture_rules.rs
+++ b/tests/architecture_rules.rs
@@ -82,7 +82,14 @@ const MODULE_RULES: &[ModuleRules] = &[
     // Thin headless dispatch — must not depend on TUI or the live backend.
     ModuleRules {
         name: "cli",
-        allowed: &["session", "storage", "session_ops", "sync", "paths"],
+        allowed: &[
+            "session",
+            "storage",
+            "session_ops",
+            "sync",
+            "paths",
+            "notifications",
+        ],
         allowed_path_only: &["agent"],
     },
     // Leaf utilities.


### PR DESCRIPTION
## Problem

OS desktop notifications were **entirely silent under WSL2** (e.g. Windows Terminal). `notify-rust`'s dbus path errors on connect — `DBUS_SESSION_BUS_ADDRESS` points at a socket that doesn't exist and there's no `org.freedesktop.Notifications` service — and the only signal was a `warn!` to the logfile. The user saw nothing: no banner, no error, no diagnostic.

## What this does

- **Auto-detects the delivery backend** (`notifications::detect_backend` / pure `resolve_backend`): dbus on a normal Linux desktop, **Windows toast via `powershell.exe`** under WSL when no dbus daemon answers, macOS native banner.
- Adds **`[notifications] backend = "auto|dbus|windows|off"`** (default `auto`). `off` is a soft delivery switch distinct from `[features] notifications`.
- **Stops swallowing failures**: records the last delivery error (`last_error`).
- Adds **`thurbox-cli notify`** diagnostic — prints the detected backend, deliverability, click-to-focus support, and last error; **`--test`** fires a sample notification synchronously.
- **Bounds the notification body** to 200 chars (char-boundary safe) so a huge OSC message can't overflow the banner.
- Documents behavior in `CLAUDE.md` / `docs/CONFIG.md` and adds **`docs/NOTIFICATIONS_TEST_PLAN.md`**.

## Verification

Verified end-to-end on `microsoft-standard-WSL2`:

```
$ thurbox-cli notify
Notifications enabled — delivering via windows-toast (powershell.exe). ...
backend:  windows-toast (powershell.exe)

$ thurbox-cli notify --test
Sent a test notification via windows-toast (powershell.exe).   # → real Windows toast appears
```

Forced `backend = "dbus"` on this no-daemon host now **fails loudly** (prints the dbus I/O error, non-zero exit) instead of dropping silently.

## Tests

- `cargo nextest run --all` → 1335 pass (the one skipped, `uninstall_reverses_install`, needs a tmux server unavailable in the dev shell; untouched by this change).
- New pure/table-driven tests: backend selection, WSL marker, powershell escaping, toast script, body truncation, settings parsing, CLI diagnostic + arg parsing.
- `cargo fmt`, `clippy -D warnings`, `cargo doc -D warnings`, architecture rules, rumdl all clean.

Click-to-focus stays on the dbus path; it is intentionally **not** supported on the Windows-toast path (a Windows toast can't call back into the WSL process) — documented inline.