### PR TITLE
docs(config): add worked examples to seeded config files

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -82,6 +82,12 @@ fork > resume > new-session. See the seeded file's comments and
 CLAUDE.md's *Agent Definitions* section for the `resume_latest`
 semantics.
 
+The seeded file also ships two commented, copy-pasteable templates
+below the built-ins — **Add your own agent** (every field annotated)
+and **Pin a model** (a `claude-opus` variant baking `--model opus`
+into `args`). Both stay commented, so a fresh install still resolves
+to exactly the six built-ins.
+
 ## hosts.toml
 
 Declares remote SSH hosts; each `[[hosts]]` entry registers a session
@@ -106,7 +112,10 @@ lifetime).
 
 Scalar tuning knobs plus the `[features]` switches, seeded fully
 commented-out (defaults apply when absent). Only knobs a user plausibly
-wants are exposed; internals stay hardcoded.
+wants are exposed; internals stay hardcoded. The seed closes with a
+**Common recipes** block — copy-pasteable groupings (bigger scrollback,
+a minimal/focused TUI, notification tuning, enabling the update badge),
+all commented so defaults still apply out of the box.
 
 | Key | Default | Purpose |
 |-----|---------|---------|

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -78,6 +78,47 @@ resume_latest = true
 [[agents]]
 name = "vibe"
 command = "vibe"
+
+# ──────────────────────────────────────────────────────────────────────────
+# Add your own agent (uncomment and edit)
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Any CLI works — thurbox only needs `command` plus the optional `*_args`
+# groups below. The agent uses its OWN default config; thurbox never passes a
+# model or permissions of its own.
+#
+# [[agents]]
+# name = "my-agent"             # shown in the new-session agent picker
+# command = "my-agent-cli"      # the executable on your PATH
+# args = []                     # ALWAYS passed (see "Pin a model" below)
+# resume_args = []              # appended on restart/resume, with {id} substituted
+# fork_args = []                # appended on Ctrl+F fork, with {id} substituted
+# new_session_args = []         # appended on a fresh spawn, with {id} substituted
+# resume_latest = false         # true ⇒ resume "the last session in this dir"
+#                               #   (id-less flags); leave false to pin by {id}
+#
+# {id} is a thurbox-generated UUID. Only agents that accept it at creation
+# (like claude's `--session-id {id}`) can resume/fork by that exact id; for
+# everything else use `resume_latest = true` with id-less, cwd-scoped flags
+# (e.g. `["resume", "--last"]`). Omit every resume group to start fresh on
+# restart.
+#
+# ──────────────────────────────────────────────────────────────────────────
+# Pin a model (or any flag) — put it in `args`, which is always passed
+# ──────────────────────────────────────────────────────────────────────────
+#
+# thurbox is model-neutral; to force a model, bake the flag into `args`. E.g.
+# a claude variant pinned to Opus, kept alongside the default `claude` entry:
+#
+# [[agents]]
+# name = "claude-opus"
+# command = "claude"
+# args = ["--model", "opus"]    # always-on flag
+# resume_args = ["--resume", "{id}"]
+# fork_args = ["--resume", "{id}", "--fork-session"]
+# new_session_args = ["--session-id", "{id}"]
+#
+# Set `default = "claude-opus"` at the top of this file to make it the default.
 "#;
 
 /// Path to the agent-definition config file:
@@ -349,6 +390,32 @@ mod tests {
                 "{name} must use id-less resume/fork flags"
             );
         }
+    }
+
+    /// The seed must carry copy-pasteable examples (add-your-own-agent +
+    /// pin-a-model) but keep them commented, so parsing still yields exactly
+    /// the six built-ins — a fresh install boots on pure defaults.
+    #[test]
+    fn seed_documents_examples_yet_stays_builtin_only() {
+        for marker in [
+            "Add your own agent",
+            "Pin a model",
+            "claude-opus",
+            "[\"--model\", \"opus\"]",
+        ] {
+            assert!(
+                BUILTIN_AGENTS_TOML.contains(marker),
+                "agents.toml seed must document example '{marker}'"
+            );
+        }
+        // Examples are commented, so the seed parses to just the built-ins.
+        let reg = builtin_registry();
+        assert_eq!(reg.default, "claude");
+        assert_eq!(reg.agents.len(), 6, "examples must stay commented out");
+        assert!(
+            reg.get("claude-opus").is_none(),
+            "example must not register"
+        );
     }
 
     #[test]

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -62,7 +62,20 @@ pub const SEED_HOSTS_TOML: &str = r#"# Thurbox remote SSH hosts  —  ~/.config/
 #
 config_version = 1
 
-# Example (uncomment and edit):
+# ──────────────────────────────────────────────────────────────────────────
+# Minimal host — the two required fields are enough (uncomment and edit)
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Relies on your ~/.ssh/config for auth and connection tuning. Registers the
+# "ssh:laptop" backend, selectable in the host picker / with --host laptop.
+#
+# [[hosts]]
+# name = "laptop"               # → backend "ssh:laptop", value for --host
+# destination = "me@laptop"     # "user@host" or a ~/.ssh/config Host alias
+#
+# ──────────────────────────────────────────────────────────────────────────
+# Fully annotated host — every optional field, shown with its default
+# ──────────────────────────────────────────────────────────────────────────
 #
 # [[hosts]]
 # name = "devbox"
@@ -70,12 +83,13 @@ config_version = 1
 #
 # # ControlMaster reuses one SSH connection so reconnects are instant;
 # # ControlPersist keeps it warm; ServerAliveInterval drops half-open links.
+# # One token per array element; thurbox does NOT expand `~` (use abs paths).
 # ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m", "-o", "ServerAliveInterval=15"]
 #
 # # Optional overrides, shown with their defaults:
-# # socket = "thurbox"
-# # session = "thurbox"
-# # worktrees_dir = "/home/me/.local/share/thurbox/worktrees"
+# # socket = "thurbox"          # remote `tmux -L` socket; change to avoid a clash
+# # session = "thurbox"         # remote tmux session grouping thurbox windows
+# # worktrees_dir = "/home/me/.local/share/thurbox/worktrees"  # abs remote path
 "#;
 
 /// Path to the remote-host config file: `~/.config/thurbox/hosts.toml`
@@ -157,6 +171,18 @@ mod tests {
     fn seed_toml_parses_to_empty_registry() {
         let reg: HostRegistry = toml::from_str(SEED_HOSTS_TOML).unwrap();
         assert!(reg.is_empty());
+    }
+
+    /// Seed ships both a minimal and a fully-annotated example, kept commented
+    /// (the empty-registry test above proves they don't register).
+    #[test]
+    fn seed_toml_documents_minimal_and_full_examples() {
+        for marker in ["Minimal host", "Fully annotated host"] {
+            assert!(
+                SEED_HOSTS_TOML.contains(marker),
+                "hosts.toml seed must include the '{marker}' example"
+            );
+        }
     }
 
     /// The seeded `hosts.toml` is the primary documentation users see, so it

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -62,6 +62,34 @@ config_version = 1
 # suppress_for_active = true    # don't notify if you're already viewing that session
 # sound = true                  # play the OS default notification sound
 # min_interval_secs = 5         # per-session dedup floor (seconds)
+
+# ──────────────────────────────────────────────────────────────────────────
+# Common recipes (uncomment the lines under the recipe you want)
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Keep more terminal history (e.g. long build logs):
+# scrollback_lines = 10000
+#
+# Minimal / focused TUI — turn off panels you don't use (frees key chords too):
+# [features]
+# tasks = false
+# automations = false
+# file_viewer = false
+# global_search = false
+#
+# Get notified the moment a session needs you, even on quiet agents, and never
+# for the one you're already watching:
+# [features]
+# notifications = true
+# [notifications]
+# also_on_waiting = true        # also fire on the timing-only Busy → Waiting edge
+# suppress_for_active = false   # also notify the focused session
+# min_interval_secs = 30        # at most one notification / 30 s per session
+#
+# Show an "update available" badge in the TUI header (makes a network call to
+# GitHub on startup):
+# [features]
+# version_check = true
 "#;
 
 /// Path to the settings file: `~/.config/thurbox/settings.toml`.
@@ -168,6 +196,22 @@ mod tests {
             assert!(
                 SEED_SETTINGS_TOML.contains(field),
                 "settings.toml seed must document '{field}'"
+            );
+        }
+    }
+
+    /// The seed carries a "common recipes" block of copy-pasteable settings,
+    /// kept commented so `seed_toml_parses_to_defaults` still holds.
+    #[test]
+    fn seed_documents_common_recipes() {
+        for marker in [
+            "Common recipes",
+            "scrollback_lines = 10000",
+            "version_check = true",
+        ] {
+            assert!(
+                SEED_SETTINGS_TOML.contains(marker),
+                "settings.toml seed must include recipe '{marker}'"
             );
         }
     }

--- a/src/agent/themes_config.rs
+++ b/src/agent/themes_config.rs
@@ -35,7 +35,12 @@ pub const SEED_THEMES_TOML: &str = r##"# Thurbox custom themes  —  ~/.config/t
 
 config_version = 1
 
-# Example (uncomment and edit):
+# ──────────────────────────────────────────────────────────────────────────
+# Minimal tweak — restyle a built-in by overriding one colour (uncomment)
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Inherits everything from catppuccin-mocha; only the accent changes. Setting
+# app_bg = "reset" keeps your terminal's own background (nice for transparency).
 #
 # [[themes]]
 # name = "my-mocha"
@@ -43,6 +48,25 @@ config_version = 1
 # base = "catppuccin-mocha"
 # accent = "#fab387"
 # app_bg = "reset"
+#
+# ──────────────────────────────────────────────────────────────────────────
+# Fuller theme — light base + several overrides + nerd-font glyphs
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Mix hex, ANSI names, and indexed colours freely. `light = true` tunes a few
+# contrast-sensitive defaults; `nerd_font = true` opts into nerd-font icons.
+#
+# [[themes]]
+# name = "solar-soft"
+# display_name = "Solar Soft"
+# base = "solarized-light"
+# light = true
+# nerd_font = true
+# accent = "#268bd2"
+# accent_bright = "#2aa198"
+# status_busy = "yellow"
+# status_error = "#dc322f"
+# selection_bg = "14"
 "##;
 
 /// Path to the custom-themes file: `~/.config/thurbox/themes.toml`.
@@ -135,6 +159,18 @@ mod tests {
         let file: ThemesFile = toml::from_str(SEED_THEMES_TOML).unwrap();
         assert!(file.themes.is_empty());
         assert_eq!(file.config_version, Some(1));
+    }
+
+    /// Seed ships a minimal one-override example plus a fuller multi-override
+    /// one, both commented (the no-themes test above proves they don't load).
+    #[test]
+    fn seed_toml_documents_minimal_and_full_examples() {
+        for marker in ["Minimal tweak", "Fuller theme", "my-mocha", "solar-soft"] {
+            assert!(
+                SEED_THEMES_TOML.contains(marker),
+                "themes.toml seed must include the '{marker}' example"
+            );
+        }
     }
 
     /// The seeded `themes.toml` is the primary documentation users see, so it


### PR DESCRIPTION
## Problem

Thurbox seeds four config files on first run (`agents.toml`, `settings.toml`,
`hosts.toml`, `themes.toml`). They documented every knob with its default but
lacked **copy-pasteable examples for common use cases** — most notably
`agents.toml` had no "add your own agent / pin a model" template at all.

## Changes

All examples stay **commented out**, so a fresh install still boots on pure
defaults.

- **agents.toml** — add a commented **Add your own agent** template (every
  field annotated) and a **Pin a model** template (a `claude-opus` variant
  baking `--model opus` into `args`). Biggest gap; previously absent.
- **settings.toml** — add a **Common recipes** block: bigger scrollback, a
  minimal/focused TUI, notification tuning, enabling the update badge.
- **hosts.toml** — split the example into a **minimal** entry (two required
  fields) and a **fully annotated** entry with per-field why-comments.
- **themes.toml** — add a fuller second example (light base, several
  overrides, nerd-font) alongside the minimal one-override example.
- **docs/CONFIG.md** — note the new inline templates (repo doc-sync rule).

## Tests

New assertions per file verify both the example markers exist **and** the
seeds still parse to exactly the built-ins / empty registries (examples stay
commented). Full suite green:

- `cargo nextest run --all` → 1322 passed
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `cargo test --test architecture_rules` → 12 passed
- `cargo fmt --all`

## Acceptance

> Installation creates a config file with all settings documented, defaults
> set, and examples provided for key options

Met: every seeded config now carries documented defaults **plus** worked,
copy-pasteable examples for its key options.