### PR TITLE
feat(ui): add soft_delete feature flag with hard-delete confirmation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,6 +419,15 @@ when no TUI is running. Teardown is best-effort (failures land in
 the JSON report); the row is always soft-deleted last, so even a
 forced delete stays restorable.
 
+The **TUI** `Ctrl+D` soft-deletes by default too (with a `Ctrl+Z` undo
+window). The `[features] soft_delete` flag (settings.toml, default
+`true`) governs only this TUI path: set it `false` and `Ctrl+D` becomes
+a hard delete — the same `delete_session_headless(.., force=true)`
+teardown — gated behind a confirmation modal
+(`Modal::ConfirmDeleteSession`, rendered by `ui::confirm_delete_modal`),
+since there is no `Ctrl+Z` for it. The flag never changes
+`thurbox-cli session delete`, which stays soft unless `--force`.
+
 ### Parent sessions (lead/worker)
 
 Sessions carry an optional **`parent_session_id`** so orchestration

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -193,6 +193,7 @@ no results. Data is never touched, so re-enabling a flag is lossless.
 | `shell_pane` | `true` | per-session shell toggle (`Ctrl+T`) |
 | `mouse` | `true` | mouse capture: clicks, wheel, drag-select, hover, scrollbars |
 | `notifications` | `true` | OS desktop notifications when a session needs attention |
+| `soft_delete` | `true` | TUI `Ctrl+D` soft-deletes (Ctrl+Z undo); off = hard delete after a confirmation prompt |
 | `version_check` | `false` | GitHub update check: TUI header "update available" badge + `thurbox-cli version --check` |
 
 `automations = false` is a full stop on the TUI side: the pane
@@ -209,6 +210,17 @@ URL handling, etc.) and no click/wheel/hover handling runs in the TUI.
 `notifications = false` keeps the background dispatcher thread from
 ever starting (zero overhead) and silently no-ops every transition;
 the session status display itself is unaffected.
+
+`soft_delete = false` turns the TUI's `Ctrl+D` into a destructive
+**hard delete**: instead of marking the row deleted with a `Ctrl+Z`
+undo window, it kills the session's tmux window, removes its worktrees
+and symlink workspace, and disables any pending `Send` automations —
+after a confirmation prompt (`Enter`/`y` to delete, `Esc`/`n` to
+cancel), since the teardown is irreversible. The soft-deleted row is
+still written last, so the session remains restorable via `Ctrl+U`
+(which re-spawns it fresh). This flag governs the TUI only:
+`thurbox-cli session delete` always soft-deletes unless you pass
+`--force`, regardless of the setting.
 
 `version_check = true` enables the update check (default `false`, since
 it makes a network call). On launch the TUI reads a cached result

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -48,6 +48,7 @@ config_version = 1
 # shell_pane = true       # Ctrl+T per-session shell
 # mouse = true            # mouse capture: clicks, wheel, drag-select, hover
 # notifications = true    # OS desktop notifications when a session needs attention
+# soft_delete = true      # Ctrl+D soft-deletes (Ctrl+Z undo); false = hard delete after a prompt
 #
 # `version_check` is the one flag that defaults to FALSE: it makes a network
 # call to GitHub to learn the latest release. Enable it for the TUI header

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -466,6 +466,57 @@ fn ctrl_d_soft_deletes_and_ctrl_z_undoes() {
     );
 }
 
+#[test]
+fn ctrl_d_hard_delete_confirms_when_soft_delete_disabled() {
+    let mut h = Harness::standard(2);
+    h.app.features.soft_delete = false;
+
+    // Ctrl+D now opens a confirmation prompt instead of deleting immediately.
+    h.ctrl('d');
+    assert!(
+        matches!(h.app.modal, modals::Modal::ConfirmDelete(_)),
+        "Ctrl+D opens the hard-delete confirmation when soft_delete is off"
+    );
+    assert_eq!(
+        h.app.sessions.len(),
+        2,
+        "nothing is deleted before confirmation"
+    );
+
+    // Esc cancels, leaving the session untouched.
+    h.key(KeyCode::Esc, KeyModifiers::NONE);
+    assert!(!h.app.modal.is_open(), "Esc closes the confirmation");
+    assert_eq!(h.app.sessions.len(), 2, "cancel leaves the session intact");
+
+    // Re-open and confirm with Enter → the session is torn down, no undo.
+    h.ctrl('d');
+    h.key(KeyCode::Enter, KeyModifiers::NONE);
+    assert!(!h.app.modal.is_open(), "confirm closes the confirmation");
+    assert_eq!(h.app.sessions.len(), 1, "confirm removes the session");
+    assert!(
+        h.app.pending_delete.is_none(),
+        "a hard delete offers no Ctrl+Z undo"
+    );
+}
+
+#[test]
+fn hard_delete_confirmation_accepts_y_and_n_keys() {
+    let mut h = Harness::standard(2);
+    h.app.features.soft_delete = false;
+
+    // 'n' cancels, like Esc.
+    h.ctrl('d');
+    h.key(KeyCode::Char('n'), KeyModifiers::NONE);
+    assert!(!h.app.modal.is_open(), "'n' closes the confirmation");
+    assert_eq!(h.app.sessions.len(), 2, "'n' cancels the delete");
+
+    // 'y' confirms, like Enter.
+    h.ctrl('d');
+    h.key(KeyCode::Char('y'), KeyModifiers::NONE);
+    assert!(!h.app.modal.is_open(), "'y' closes the confirmation");
+    assert_eq!(h.app.sessions.len(), 1, "'y' confirms the delete");
+}
+
 // ── Pane focus cycling ───────────────────────────────────────────────────────
 
 #[test]

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -296,9 +296,29 @@ impl App {
             Modal::ThemePicker(_) => self.handle_theme_picker_key(code),
             Modal::RepoPicker(_) => self.handle_repo_picker_key(code, mods),
             Modal::TaskActionPicker(_) => self.handle_task_action_picker_key(code),
+            Modal::ConfirmDelete(_) => self.handle_confirm_delete_key(code),
             _ => return false,
         }
         true
+    }
+
+    /// Drive the hard-delete confirmation prompt: `Enter`/`y` tears the session
+    /// down, `Esc`/`n` cancels.
+    fn handle_confirm_delete_key(&mut self, code: KeyCode) {
+        let super::modals::Modal::ConfirmDelete(ref cd) = self.modal else {
+            return;
+        };
+        match code {
+            KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
+                let session_id = cd.session_id;
+                self.modal.close();
+                self.confirm_hard_delete_session(session_id);
+            }
+            KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
+                self.modal.close();
+            }
+            _ => {}
+        }
     }
 
     /// Drive the trigger-time task action picker: `j`/`k` (or arrows) select,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1229,6 +1229,17 @@ impl App {
 
         let session_id = session.info.id;
 
+        // When soft-delete is disabled, a TUI delete is a destructive hard
+        // delete (kills the tmux window, removes worktrees) with no Ctrl+Z
+        // undo — confirm before tearing anything down.
+        if !self.features.soft_delete {
+            self.modal = modals::Modal::ConfirmDelete(modals::ConfirmDeleteModal {
+                session_id,
+                session_name: session.info.name.clone(),
+            });
+            return;
+        }
+
         // Soft-delete in DB
         if let Err(e) = self.db.soft_delete_session(session_id) {
             error!("Failed to soft-delete session in DB: {e}");
@@ -1258,6 +1269,45 @@ impl App {
         );
 
         // Sync to shared state for other instances
+        self.save_state();
+    }
+
+    /// Hard-delete a session after the confirmation prompt (soft_delete off):
+    /// tear down the tmux window, worktrees, symlink workspace, and pending
+    /// send automations, then drop the live session. There is no Ctrl+Z undo
+    /// (the row stays restorable via Ctrl+U, which re-spawns fresh) — the
+    /// confirmation modal is the safety net instead.
+    fn confirm_hard_delete_session(&mut self, session_id: SessionId) {
+        let Some(idx) = self.sessions.iter().position(|s| s.info.id == session_id) else {
+            return;
+        };
+
+        // Reuse the headless teardown so the destructive logic stays in one
+        // place. Best-effort: failures are logged, never abort the delete.
+        if let Err(e) =
+            crate::session_ops::delete::delete_session_headless(&self.db, session_id, true)
+        {
+            error!("Hard-delete of session {session_id} failed: {e}");
+        }
+
+        let removed_session = self.sessions.remove(idx);
+        let session_name = removed_session.info.name.clone();
+        self.session_terminal_views.remove(&session_id);
+
+        if self.active_index >= self.sessions.len() {
+            self.active_index = self.sessions.len().saturating_sub(1);
+        }
+        self.sync_active_session_to_project();
+
+        // Drop the live PTY connection (the tmux window was already killed by
+        // the teardown above).
+        removed_session.kill();
+
+        self.set_status(
+            StatusLevel::Info,
+            format!("Permanently deleted '{session_name}'"),
+        );
+
         self.save_state();
     }
 
@@ -6751,6 +6801,7 @@ mod tests {
             shell_pane: false,
             mouse: true,
             notifications: false,
+            soft_delete: true,
             version_check: false,
         };
 

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -513,6 +513,15 @@ pub struct ThemePickerModal {
     pub index: usize,
 }
 
+/// Confirmation prompt for a destructive (hard) session delete, shown only when
+/// the `soft_delete` feature flag is off. Carries the target session so the
+/// confirm handler can tear it down without re-resolving the active index.
+#[derive(Debug, Clone)]
+pub struct ConfirmDeleteModal {
+    pub session_id: crate::session::SessionId,
+    pub session_name: String,
+}
+
 // ── RestoreSessionsModal ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Default)]
@@ -1361,6 +1370,7 @@ pub enum Modal {
     SessionName(SessionNameModal),
     ThemePicker(ThemePickerModal),
     TaskActionPicker(TaskActionPickerModal),
+    ConfirmDelete(ConfirmDeleteModal),
 }
 
 impl Modal {

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -584,6 +584,16 @@ impl App {
                 },
             );
         }
+
+        // Hard-delete confirmation prompt (soft_delete feature off)
+        if let super::modals::Modal::ConfirmDelete(ref cd) = self.modal {
+            crate::ui::confirm_delete_modal::render_confirm_delete_modal(
+                frame,
+                &crate::ui::confirm_delete_modal::ConfirmDeleteState {
+                    session_name: &cd.session_name,
+                },
+            );
+        }
     }
 
     /// Render whichever selector-style modal is active, returning its row

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -82,6 +82,14 @@ pub struct FeatureFlags {
     /// passive banner only (the modern API requires a signed app bundle).
     #[serde(default = "default_true")]
     pub notifications: bool,
+    /// Soft-delete sessions in the TUI (Ctrl+D): mark the DB row deleted and
+    /// offer Ctrl+Z undo, leaving the tmux window + worktrees intact. Disabled
+    /// = the TUI **hard-deletes** (kills the tmux window, removes worktrees +
+    /// symlink workspace, disables send automations) after a confirmation
+    /// prompt. `thurbox-cli session delete` is unaffected (always soft unless
+    /// `--force`).
+    #[serde(default = "default_true")]
+    pub soft_delete: bool,
     /// Version-update check: the TUI header "update available" badge and the
     /// `thurbox-cli version --check` command. **Off by default** — unlike the
     /// other flags, this one is opt-in because it makes a network call to
@@ -149,6 +157,7 @@ impl Default for FeatureFlags {
             shell_pane: true,
             mouse: true,
             notifications: true,
+            soft_delete: true,
             version_check: false,
         }
     }
@@ -258,6 +267,14 @@ mod tests {
     fn notifications_feature_flag_parses() {
         let s: Settings = toml::from_str("[features]\nnotifications = false").unwrap();
         assert!(!s.features.notifications);
+        assert!(s.features.tasks, "untouched flags stay enabled");
+    }
+
+    #[test]
+    fn soft_delete_feature_flag_defaults_true_and_parses() {
+        assert!(FeatureFlags::default().soft_delete);
+        let s: Settings = toml::from_str("[features]\nsoft_delete = false").unwrap();
+        assert!(!s.features.soft_delete);
         assert!(s.features.tasks, "untouched flags stay enabled");
     }
 

--- a/src/ui/confirm_delete_modal.rs
+++ b/src/ui/confirm_delete_modal.rs
@@ -1,0 +1,59 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::centered_fixed_height_rect;
+use super::render_modal_frame_danger;
+use super::theme::Theme;
+
+pub struct ConfirmDeleteState<'a> {
+    pub session_name: &'a str,
+}
+
+/// Render the hard-delete confirmation prompt. Shown only when the
+/// `soft_delete` feature flag is off, where a delete is irreversible (the tmux
+/// window + worktrees are torn down with no Ctrl+Z undo), so it warns before
+/// acting.
+pub fn render_confirm_delete_modal(frame: &mut Frame, state: &ConfirmDeleteState<'_>) {
+    let area = centered_fixed_height_rect(60, 9, frame.area());
+
+    let inner = render_modal_frame_danger(frame, area, "Delete session");
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // Prompt
+            Constraint::Length(1), // Spacer
+            Constraint::Length(1), // Warning
+            Constraint::Min(1),    // Footer
+        ])
+        .split(inner);
+
+    let prompt = Line::from(vec![
+        Span::raw("Permanently delete "),
+        Span::styled(
+            format!("'{}'", state.session_name),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("?"),
+    ]);
+    frame.render_widget(Paragraph::new(prompt), chunks[0]);
+
+    let warning = Line::from(Span::styled(
+        "This kills the tmux window and removes its worktrees. Cannot be undone.",
+        Style::default().fg(Theme::danger()),
+    ));
+    frame.render_widget(Paragraph::new(warning), chunks[2]);
+
+    let footer = Line::from(vec![
+        Span::styled("Enter/y", Theme::keybind()),
+        Span::styled(" delete  ", Theme::keybind_desc()),
+        Span::styled("Esc/n", Theme::keybind()),
+        Span::styled(" cancel", Theme::keybind_desc()),
+    ]);
+    frame.render_widget(Paragraph::new(footer), chunks[3]);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub mod automation_editor_modal;
 pub mod automations_list_modal;
 pub mod automations_panel;
 pub mod branch_selector_modal;
+pub mod confirm_delete_modal;
 pub mod file_viewer;
 pub mod global_search;
 pub mod highlight;


### PR DESCRIPTION
## Summary

- Add a `[features] soft_delete` flag (default `true`). When off, the TUI's `Ctrl+D` becomes a destructive **hard delete** (kills the tmux window, removes worktrees + symlink workspace, disables send automations) instead of a soft delete.
- Because a hard delete has no `Ctrl+Z` undo, it is gated behind a new confirmation modal (`Modal::ConfirmDelete`, rendered by `ui::confirm_delete_modal`). `Enter`/`y` confirms, `Esc`/`n` cancels.
- Reuses the existing `session_ops::delete::delete_session_headless(.., force=true)` teardown so the destructive logic stays in one place.
- The flag governs the TUI only: `thurbox-cli session delete` is unchanged (soft unless `--force`).
- Docs updated: `docs/CONFIG.md` `[features]` table + paragraph, seed `settings.toml` comment, and `CLAUDE.md`.

## Test plan

- New unit test: `soft_delete` defaults `true` and parses `soft_delete = false`.
- New acceptance tests: confirmation modal opens with the flag off (nothing deleted yet), `Esc`/`n` cancels, `Enter`/`y` tears the session down with no `Ctrl+Z` undo; default flag keeps instant soft-delete.
- `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt`, and `cargo test --test architecture_rules` pass.
- CI checks pass.