### PR TITLE
feat(core): add opt-in auto-update behind a feature flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,7 +404,11 @@ effective resolved config; see `docs/CONFIG.md`), `extension`
 (alias `ext`: install/uninstall/reinstall/list/available/update/activate/
 deactivate/status — manage opt-in extensions; see below), `version`
 (prints the running version; `--check` queries GitHub's latest release —
-gated on `[features] version_check`, off by default). Output is
+gated on `[features] version_check`, off by default), `update`
+(downloads, verifies, and replaces the installed binaries with the latest
+release — `--force` bypasses the up-to-date/dev-build guards; gated on
+`[features] auto_update`, off by default; the TUI also runs this silently on
+startup when the flag is on). Output is
 **human-readable by default** and switches to JSON automatically when stdout is
 piped (so `… | jq` keeps working); force a format with `--json` (compact),
 `--pretty` (indented JSON), or `--text` (human even when piped).

--- a/README.md
+++ b/README.md
@@ -310,8 +310,9 @@ entirely and keep your terminal's native selection / URL handling.
 
 Whole TUI features can be switched off in
 `~/.config/thurbox/settings.toml` under `[features]` (seeded
-commented-out; everything defaults to `true` except `version_check`,
-which is opt-in because it makes a network call). A disabled feature
+commented-out; everything defaults to `true` except `version_check`
+and `auto_update`, which are opt-in because they reach the network). A
+disabled feature
 hides its pane and turns its keybinding into an explanatory toast,
 but its data and the `thurbox-cli` surface keep working — so
 flipping a flag back on is lossless.
@@ -327,6 +328,7 @@ shell_pane = true     # Ctrl+T per-session shell
 mouse = true          # mouse capture: clicks, wheel, drag-select, hover
 notifications = true  # OS desktop alerts when a session needs attention
 version_check = false # opt-in GitHub update check (makes a network call)
+auto_update = false   # opt-in: silently download+verify+replace binaries on startup
 ```
 
 `automations = false` is the one flag with teeth beyond the UI: it

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -166,6 +166,7 @@ shell_pane    = true
 mouse         = true
 notifications = true
 version_check = false          # opt-in: makes a network call
+auto_update   = false          # opt-in: downloads + replaces binaries
 
 [notifications]
 also_on_waiting     = false    # also fire on Busy → Waiting (no bell)
@@ -177,8 +178,9 @@ min_interval_secs   = 5        # per-session floor between notifications
 ### `[features]` — whole-feature switches
 
 Turn major TUI features off entirely. All default to `true` **except
-`version_check`, which defaults to `false`** (it makes a network call,
-so it is opt-in). Like the rest of settings.toml, changes need a
+`version_check` and `auto_update`, which default to `false`** (both
+reach the network, so they are opt-in). Like the rest of settings.toml,
+changes need a
 restart. A disabled feature's pane never renders, its keybinding shows
 a status toast instead of acting, and its global-search scope returns
 no results. Data is never touched, so re-enabling a flag is lossless.
@@ -195,6 +197,7 @@ no results. Data is never touched, so re-enabling a flag is lossless.
 | `notifications` | `true` | OS desktop notifications when a session needs attention |
 | `soft_delete` | `true` | TUI `Ctrl+D` soft-deletes (Ctrl+Z undo); off = hard delete after a confirmation prompt |
 | `version_check` | `false` | GitHub update check: TUI header "update available" badge + `thurbox-cli version --check` |
+| `auto_update` | `false` | Silent self-update: download + verify + replace the binaries on startup + `thurbox-cli update` |
 
 `automations = false` is a full stop on the TUI side: the pane
 disappears (the session list takes the whole left column and `j`/`k`
@@ -234,6 +237,25 @@ builds (`0.0.0-dev`) never show the badge. The same flag enables
 `thurbox-cli version --check`, which fetches fresh on demand and reports
 current vs. latest (`thurbox-cli version` with no flag always prints the
 current version, regardless of the flag).
+
+`auto_update = true` goes a step further than `version_check`: instead of
+just showing a badge, the TUI **silently updates itself** on startup. After
+the same 24 h cache check, if a newer release exists it downloads that
+release's tarball + checksums from GitHub Releases (`curl`/`wget`, no new
+dependency), verifies the SHA256 (`sha256sum`/`shasum`), extracts it
+(`tar`), and atomically replaces the installed `thurbox`/`thurbox-cli`
+binaries in place — mirroring `scripts/install.sh`. The download is verified
+**before** any installed file is touched, so a failed/corrupt download leaves
+the current binaries untouched; the whole step runs before the TUI takes the
+terminal and is best-effort (any failure is logged and startup continues on
+the current version). The replaced binary takes effect on the **next launch**
+(the running process keeps its open file), so the TUI shows an "Updated to
+vX.Y.Z — restart to apply" status line. `thurbox-cli update` performs the
+same update on demand (with `--force` to bypass the up-to-date and dev-build
+guards); dev builds (`0.0.0-dev`) never auto-update. The default install
+location (`~/.local/bin`) is user-writable; a system-wide install in a
+root-owned directory will fail the replace (logged, non-fatal). `version_check`
+and `auto_update` are independent — enable either or both.
 
 ### `[notifications]` — OS notification settings
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -908,7 +908,11 @@ viewer's `/` is an unrelated in-file text search and is unchanged.
 
 Whole features can be switched off declaratively: `tasks`,
 `automations`, `file_viewer`, `global_search`, `info_panel`,
-`shell_pane`, `mouse` — all default `true` (see `docs/CONFIG.md`).
+`shell_pane`, `mouse`, `notifications` — all default `true`. Two flags
+are the opposite — opt-in (default `false`, because they reach the
+network): `version_check` (the "update available" badge +
+`thurbox-cli version --check`) and `auto_update` (silent self-update on
+startup + `thurbox-cli update`). See `docs/CONFIG.md`.
 
 **Decision: flags are UI-level gates, not data switches.** A disabled
 feature hides its pane, consumes its keybinding with an explanatory

--- a/src/agent/extension_config.rs
+++ b/src/agent/extension_config.rs
@@ -318,25 +318,16 @@ pub fn fetch_file(source: &ExtensionSource, rel: &str) -> Result<String, String>
     }
 }
 
-/// HTTP GET to stdout via `curl` (falling back to `wget`) — same dependency-free
-/// approach as the shell installer. Both run with a timeout. On failure the
-/// real cause is surfaced: a missing tool is distinguished from a tool that ran
-/// but failed (e.g. HTTP 404 for a misspelled extension name), whose stderr is
-/// included so the user sees the actual status.
-///
-/// Note: the body is decoded as UTF-8 (lossy); extension payloads are expected
-/// to be text files (specs, scripts, JSON), not binaries.
-pub(crate) fn http_get(url: &str) -> Result<String, String> {
-    let attempts: [(&str, Vec<&str>); 2] = [
-        ("curl", vec!["-fsSL", "--max-time", "30", url]),
-        ("wget", vec!["--timeout=30", "-O", "-", url]),
-    ];
+/// Run the first of `attempts` (a `(binary, args)` list) that succeeds,
+/// returning its raw stdout. On failure the aggregated cause is surfaced: a
+/// missing tool is distinguished from a tool that ran but failed (e.g. HTTP 404
+/// for a misspelled name), whose last stderr line is included. Shared by the
+/// `curl`-then-`wget` downloaders below; the caller adds the URL context.
+fn run_first_ok(attempts: &[(&str, Vec<&str>)]) -> Result<Vec<u8>, String> {
     let mut errors = Vec::new();
     for (bin, args) in attempts {
-        match Command::new(bin).args(&args).output() {
-            Ok(out) if out.status.success() => {
-                return Ok(String::from_utf8_lossy(&out.stdout).into_owned());
-            }
+        match Command::new(bin).args(args).output() {
+            Ok(out) if out.status.success() => return Ok(out.stdout),
             Ok(out) => {
                 // The tool ran but failed (404, DNS, refused…) — keep its stderr.
                 let stderr = String::from_utf8_lossy(&out.stderr);
@@ -351,7 +342,42 @@ pub(crate) fn http_get(url: &str) -> Result<String, String> {
             Err(_) => errors.push(format!("{bin}: not found")),
         }
     }
-    Err(format!("failed to fetch {url} ({})", errors.join("; ")))
+    Err(errors.join("; "))
+}
+
+/// HTTP GET to stdout via `curl` (falling back to `wget`) — same dependency-free
+/// approach as the shell installer, both run with a timeout.
+///
+/// Note: the body is decoded as UTF-8 (lossy); extension payloads are expected
+/// to be text files (specs, scripts, JSON), not binaries.
+pub(crate) fn http_get(url: &str) -> Result<String, String> {
+    let attempts: [(&str, Vec<&str>); 2] = [
+        ("curl", vec!["-fsSL", "--max-time", "30", url]),
+        ("wget", vec!["--timeout=30", "-O", "-", url]),
+    ];
+    run_first_ok(&attempts)
+        .map(|stdout| String::from_utf8_lossy(&stdout).into_owned())
+        .map_err(|e| format!("failed to fetch {url} ({e})"))
+}
+
+/// Download a URL's raw bytes to `dest` via `curl` (falling back to `wget`) —
+/// the bytes sibling of [`http_get`], for binary artifacts (release tarballs)
+/// that must not be UTF-8-decoded. Same approach, but a longer timeout (a
+/// tarball is larger than a text file).
+pub(crate) fn http_get_to_file(url: &str, dest: &std::path::Path) -> Result<(), String> {
+    let dest_str = dest
+        .to_str()
+        .ok_or_else(|| format!("non-UTF-8 destination path: {}", dest.display()))?;
+    let attempts: [(&str, Vec<&str>); 2] = [
+        (
+            "curl",
+            vec!["-fsSL", "--max-time", "120", "-o", dest_str, url],
+        ),
+        ("wget", vec!["--timeout=120", "-O", dest_str, url]),
+    ];
+    run_first_ok(&attempts)
+        .map(|_| ())
+        .map_err(|e| format!("failed to download {url} ({e})"))
 }
 
 /// Fetch + parse the `extension.toml` manifest from a source.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,6 +7,7 @@ pub mod host_config;
 pub mod input;
 pub mod provider;
 pub mod registry;
+pub mod self_update;
 pub mod settings_config;
 pub mod themes_config;
 pub mod tmux;

--- a/src/agent/self_update.rs
+++ b/src/agent/self_update.rs
@@ -1,0 +1,446 @@
+//! Self-update: download, verify, and replace the installed thurbox binaries.
+//!
+//! This is the **opt-in** auto-update feature (gated behind `[features]
+//! auto_update`, off by default — see
+//! [`crate::session::settings::FeatureFlags`]). It surfaces two ways, both
+//! calling [`perform_update`]:
+//!
+//! - **TUI** — a silent check on startup (`main.rs`), before the TUI takes the
+//!   terminal. A newer release is downloaded + installed in place; the new
+//!   version applies on the next launch.
+//! - **CLI** — `thurbox-cli update` does the same on demand (`--force` bypasses
+//!   the up-to-date / dev-build guards).
+//!
+//! It reuses the version-check plumbing ([`fetch_latest_release`],
+//! [`decide_update`], [`current_version`]) so dev builds (`0.0.0-dev`) never
+//! auto-update, and mirrors `scripts/install.sh` exactly: the same release
+//! artifacts, target-triple mapping, and SHA256 verification. Like the rest of
+//! thurbox it adds no new crate dependency — downloads go through the
+//! `curl`/`wget` helpers and `tar` / `sha256sum`/`shasum` are shelled out to.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::agent::version_check::{current_version, decide_update, fetch_latest_release};
+
+/// GitHub release-download base for the thurbox repo (same repo as
+/// `scripts/install.sh`); the per-release directory is `<base>/v{version}/`.
+const RELEASE_BASE: &str = "https://github.com/Thurbeen/thurbox/releases/download";
+
+/// The binaries shipped in a release tarball, replaced in place on update.
+const BINARIES: [&str; 2] = ["thurbox", "thurbox-cli"];
+
+/// Outcome of an update attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateOutcome {
+    /// Already on the latest release; nothing was downloaded.
+    UpToDate { current: String, latest: String },
+    /// Binaries were replaced; the new version applies on the next launch.
+    Updated { from: String, to: String },
+    /// A development build — skipped (its version doesn't order against tags).
+    /// Only returned when `force` is false.
+    SkippedDevBuild { current: String },
+}
+
+/// Map an OS/arch pair to the release artifact's Rust target triple. Mirrors
+/// `scripts/install.sh`'s `get_target`. Pure (takes os/arch) so it's testable;
+/// note Rust spells these `"macos"`/`"aarch64"` where `uname` says
+/// `darwin`/`arm64`, but they map to the same triples.
+fn target_triple(os: &str, arch: &str) -> Result<&'static str, String> {
+    match (os, arch) {
+        ("linux", "x86_64") => Ok("x86_64-unknown-linux-musl"),
+        ("linux", "aarch64") => Ok("aarch64-unknown-linux-gnu"),
+        ("macos", "x86_64") => Ok("x86_64-apple-darwin"),
+        ("macos", "aarch64") => Ok("aarch64-apple-darwin"),
+        _ => Err(format!("unsupported platform: {os}-{arch}")),
+    }
+}
+
+/// The target triple for the running binary's platform.
+fn current_target() -> Result<&'static str, String> {
+    target_triple(std::env::consts::OS, std::env::consts::ARCH)
+}
+
+/// Release tarball filename for `version` (no leading `v`) + `target`.
+fn tarball_name(version: &str, target: &str) -> String {
+    format!("thurbox-v{version}-{target}.tar.gz")
+}
+
+/// Release checksums filename for `version` (no leading `v`).
+fn checksums_name(version: &str) -> String {
+    format!("thurbox-v{version}-checksums.txt")
+}
+
+fn tarball_url(version: &str, target: &str) -> String {
+    format!(
+        "{RELEASE_BASE}/v{version}/{}",
+        tarball_name(version, target)
+    )
+}
+
+fn checksums_url(version: &str) -> String {
+    format!("{RELEASE_BASE}/v{version}/{}", checksums_name(version))
+}
+
+/// Pull the expected SHA256 digest for `artifact` out of a checksums file.
+/// Each line is `<hex>␠␠<filename>`; find the line naming our tarball and take
+/// the first whitespace token. Pure, so it's unit-testable. Mirrors
+/// `install.sh`'s `get_checksum`.
+fn parse_checksum(checksums: &str, artifact: &str) -> Option<String> {
+    checksums
+        .lines()
+        .find(|line| line.contains(artifact))
+        .and_then(|line| line.split_whitespace().next())
+        .map(|s| s.to_string())
+}
+
+/// Verify `file`'s SHA256 against `expected`, shelling out to `sha256sum`
+/// (falling back to `shasum -a 256`) — same tools as `install.sh`.
+fn verify_sha256(file: &Path, expected: &str) -> Result<(), String> {
+    let attempts: [(&str, &[&str]); 2] = [("sha256sum", &[]), ("shasum", &["-a", "256"])];
+    let mut errors = Vec::new();
+    for (bin, extra) in attempts {
+        let mut cmd = Command::new(bin);
+        cmd.args(extra).arg(file);
+        match cmd.output() {
+            Ok(out) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let actual = stdout.split_whitespace().next().unwrap_or("");
+                return if actual.eq_ignore_ascii_case(expected.trim()) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "checksum mismatch (expected {expected}, got {actual})"
+                    ))
+                };
+            }
+            Ok(out) => errors.push(format!("{bin}: exit {}", out.status)),
+            Err(_) => errors.push(format!("{bin}: not found")),
+        }
+    }
+    Err(format!("could not compute SHA256 ({})", errors.join("; ")))
+}
+
+/// A temp dir removed (best-effort) when dropped, so a failed/early-returned
+/// update leaves nothing behind. Avoids the `tempfile` crate (dev-only).
+struct ScratchDir {
+    path: PathBuf,
+}
+
+impl ScratchDir {
+    fn new() -> Result<Self, String> {
+        let base = crate::paths::log_directory().unwrap_or_else(std::env::temp_dir);
+        let path = base.join(format!(".update-{}", std::process::id()));
+        std::fs::create_dir_all(&path)
+            .map_err(|e| format!("create temp dir {}: {e}", path.display()))?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Copy `src` into `dest`'s directory as a hidden `.{name}.new` staging file
+/// (same filesystem as `dest`, so the later rename is atomic), made executable.
+/// Returns the staged path, ready to commit.
+fn stage_binary(src: &Path, dest: &Path) -> Result<PathBuf, String> {
+    let dir = dest
+        .parent()
+        .ok_or_else(|| format!("no parent dir for {}", dest.display()))?;
+    let name = dest
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| format!("bad destination name {}", dest.display()))?;
+    let staged = dir.join(format!(".{name}.new"));
+    std::fs::copy(src, &staged)
+        .map_err(|e| format!("copy {} -> {}: {e}", src.display(), staged.display()))?;
+    set_executable(&staged)?;
+    Ok(staged)
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+        .map_err(|e| format!("chmod {}: {e}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+/// Replace the installed binaries in `install_dir` with the ones extracted into
+/// `extract_dir`. Two-phase to minimise the version-mismatch window: every
+/// binary is staged + verified first, then the renames run back-to-back.
+/// Returns the names actually replaced (binaries absent from either side are
+/// skipped). Unit-testable: takes plain dirs, no network.
+fn install_binaries(extract_dir: &Path, install_dir: &Path) -> Result<Vec<String>, String> {
+    // Phase 1: stage every binary present both in the tarball and on disk.
+    let mut staged: Vec<(PathBuf, PathBuf, String)> = Vec::new(); // (staged, dest, name)
+    let mut skipped: Vec<String> = Vec::new();
+    for name in BINARIES {
+        let src = extract_dir.join(name);
+        let dest = install_dir.join(name);
+        if !src.exists() {
+            return Err(format!("release tarball is missing `{name}`"));
+        }
+        if std::fs::metadata(&src).map(|m| m.len()).unwrap_or(0) == 0 {
+            return Err(format!("extracted `{name}` is empty"));
+        }
+        if !dest.exists() {
+            // e.g. thurbox-cli not co-located next to the running thurbox.
+            skipped.push(name.to_string());
+            continue;
+        }
+        let s = stage_binary(&src, &dest)?;
+        staged.push((s, dest, name.to_string()));
+    }
+    if staged.is_empty() {
+        return Err("no installed binaries to replace in the install directory".to_string());
+    }
+    // Phase 2: commit staged files with atomic renames, back-to-back.
+    let mut replaced = Vec::new();
+    for (s, dest, name) in &staged {
+        std::fs::rename(s, dest).map_err(|e| {
+            format!(
+                "replace {} failed: {e}. Update may be partial — reinstall with scripts/install.sh",
+                dest.display()
+            )
+        })?;
+        replaced.push(name.clone());
+    }
+    if !skipped.is_empty() {
+        tracing::warn!(
+            "auto-update: skipped {} (not in install dir)",
+            skipped.join(", ")
+        );
+    }
+    Ok(replaced)
+}
+
+/// Download, verify, extract, and install the latest release in place.
+///
+/// `force` bypasses the up-to-date and dev-build guards (re-downloads + replaces
+/// regardless). Best-effort and side-effect-free until the checksum passes — any
+/// failure before the swap leaves the installed binaries untouched.
+pub fn perform_update(force: bool) -> Result<UpdateOutcome, String> {
+    let current = current_version().to_string();
+
+    // Dev builds never auto-update (their version doesn't order against tags).
+    if !force && crate::agent::extension_config::is_dev_build() {
+        return Ok(UpdateOutcome::SkippedDevBuild { current });
+    }
+
+    let latest = fetch_latest_release()?;
+    if !force && decide_update(&current, &latest).is_none() {
+        return Ok(UpdateOutcome::UpToDate { current, latest });
+    }
+
+    let target = current_target()?;
+    let scratch = ScratchDir::new()?;
+
+    // Download checksums + tarball.
+    let checksums_path = scratch.path.join(checksums_name(&latest));
+    crate::agent::extension_config::http_get_to_file(&checksums_url(&latest), &checksums_path)?;
+    let tarball = tarball_name(&latest, target);
+    let tarball_path = scratch.path.join(&tarball);
+    crate::agent::extension_config::http_get_to_file(&tarball_url(&latest, target), &tarball_path)?;
+
+    // Verify the download BEFORE touching anything installed.
+    let checksums =
+        std::fs::read_to_string(&checksums_path).map_err(|e| format!("read checksums: {e}"))?;
+    let expected = parse_checksum(&checksums, &tarball)
+        .ok_or_else(|| format!("no checksum for {tarball} in release checksums"))?;
+    verify_sha256(&tarball_path, &expected)?;
+
+    // Extract and install.
+    let extract_dir = scratch.path.join("extract");
+    std::fs::create_dir_all(&extract_dir).map_err(|e| format!("create extract dir: {e}"))?;
+    let status = Command::new("tar")
+        .arg("-xzf")
+        .arg(&tarball_path)
+        .arg("-C")
+        .arg(&extract_dir)
+        .status()
+        .map_err(|e| format!("run tar: {e}"))?;
+    if !status.success() {
+        return Err(format!("tar extraction failed (exit {status})"));
+    }
+
+    let install_dir = std::env::current_exe()
+        .map_err(|e| format!("resolve current executable: {e}"))?
+        .parent()
+        .ok_or("running executable has no parent directory")?
+        .to_path_buf();
+    install_binaries(&extract_dir, &install_dir)?;
+
+    Ok(UpdateOutcome::Updated {
+        from: current,
+        to: latest,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_triple_maps_supported_platforms() {
+        assert_eq!(
+            target_triple("linux", "x86_64").unwrap(),
+            "x86_64-unknown-linux-musl"
+        );
+        assert_eq!(
+            target_triple("linux", "aarch64").unwrap(),
+            "aarch64-unknown-linux-gnu"
+        );
+        assert_eq!(
+            target_triple("macos", "x86_64").unwrap(),
+            "x86_64-apple-darwin"
+        );
+        assert_eq!(
+            target_triple("macos", "aarch64").unwrap(),
+            "aarch64-apple-darwin"
+        );
+    }
+
+    #[test]
+    fn target_triple_rejects_unknown_platform() {
+        assert!(target_triple("windows", "x86_64").is_err());
+        assert!(target_triple("linux", "riscv64").is_err());
+    }
+
+    #[test]
+    fn artifact_names_and_urls_match_install_sh() {
+        assert_eq!(
+            tarball_name("0.114.0", "x86_64-unknown-linux-musl"),
+            "thurbox-v0.114.0-x86_64-unknown-linux-musl.tar.gz"
+        );
+        assert_eq!(checksums_name("0.114.0"), "thurbox-v0.114.0-checksums.txt");
+        let url = tarball_url("0.114.0", "aarch64-apple-darwin");
+        assert!(url.starts_with(RELEASE_BASE), "got: {url}");
+        assert!(url.contains("/v0.114.0/"), "got: {url}");
+        assert!(url.ends_with(".tar.gz"), "got: {url}");
+        assert!(checksums_url("0.114.0").contains("/v0.114.0/"));
+    }
+
+    #[test]
+    fn parse_checksum_picks_the_matching_line() {
+        let body = "\
+aaaa1111  thurbox-v0.114.0-x86_64-apple-darwin.tar.gz
+bbbb2222  thurbox-v0.114.0-x86_64-unknown-linux-musl.tar.gz
+cccc3333  thurbox-v0.114.0-aarch64-apple-darwin.tar.gz
+";
+        assert_eq!(
+            parse_checksum(body, "thurbox-v0.114.0-x86_64-unknown-linux-musl.tar.gz").as_deref(),
+            Some("bbbb2222")
+        );
+        assert_eq!(
+            parse_checksum(body, "thurbox-v0.114.0-aarch64-apple-darwin.tar.gz").as_deref(),
+            Some("cccc3333")
+        );
+    }
+
+    #[test]
+    fn parse_checksum_missing_entry_is_none() {
+        let body = "aaaa1111  thurbox-v0.114.0-x86_64-apple-darwin.tar.gz\n";
+        assert!(parse_checksum(body, "thurbox-v9.9.9-x86_64-unknown-linux-musl.tar.gz").is_none());
+        assert!(parse_checksum("", "anything").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_binaries_replaces_contents_and_sets_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let install = tempfile::TempDir::new().unwrap();
+        let extract = tempfile::TempDir::new().unwrap();
+
+        // Old installed binaries (non-executable, old contents).
+        for name in BINARIES {
+            let p = install.path().join(name);
+            std::fs::write(&p, b"OLD").unwrap();
+            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644)).unwrap();
+            // New extracted binaries with fresh contents.
+            std::fs::write(extract.path().join(name), format!("NEW-{name}")).unwrap();
+        }
+
+        let replaced = install_binaries(extract.path(), install.path()).unwrap();
+        assert_eq!(replaced.len(), BINARIES.len());
+
+        for name in BINARIES {
+            let dest = install.path().join(name);
+            assert_eq!(
+                std::fs::read_to_string(&dest).unwrap(),
+                format!("NEW-{name}")
+            );
+            let mode = std::fs::metadata(&dest).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o755, "binary should be executable");
+            // No staging files left behind.
+            assert!(!install.path().join(format!(".{name}.new")).exists());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_binaries_skips_binaries_absent_from_install_dir() {
+        let install = tempfile::TempDir::new().unwrap();
+        let extract = tempfile::TempDir::new().unwrap();
+        for name in BINARIES {
+            std::fs::write(extract.path().join(name), b"NEW").unwrap();
+        }
+        // Only `thurbox` is installed; `thurbox-cli` is not co-located.
+        std::fs::write(install.path().join("thurbox"), b"OLD").unwrap();
+
+        let replaced = install_binaries(extract.path(), install.path()).unwrap();
+        assert_eq!(replaced, vec!["thurbox".to_string()]);
+        assert!(!install.path().join("thurbox-cli").exists());
+    }
+
+    #[test]
+    fn install_binaries_errors_when_tarball_missing_a_binary() {
+        let install = tempfile::TempDir::new().unwrap();
+        let extract = tempfile::TempDir::new().unwrap();
+        std::fs::write(install.path().join("thurbox"), b"OLD").unwrap();
+        // extract dir has neither binary
+        let err = install_binaries(extract.path(), install.path()).unwrap_err();
+        assert!(err.contains("missing"), "got: {err}");
+    }
+
+    #[test]
+    fn verify_sha256_matches_and_detects_mismatch() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("empty");
+        std::fs::write(&file, b"").unwrap();
+        // SHA256 of empty input — the canonical value.
+        let empty = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        match verify_sha256(&file, empty) {
+            Ok(()) => {
+                // Compare is case-insensitive.
+                assert!(verify_sha256(&file, &empty.to_uppercase()).is_ok());
+                // A wrong digest is rejected.
+                let err = verify_sha256(&file, &"0".repeat(64)).unwrap_err();
+                assert!(err.contains("mismatch"), "got: {err}");
+            }
+            // No sha256sum/shasum on this machine — only the tool-missing path
+            // is reachable, so assert that and stop.
+            Err(e) => assert!(e.contains("could not compute"), "unexpected: {e}"),
+        }
+    }
+
+    #[test]
+    fn perform_update_skips_dev_build_without_force() {
+        // The dev-build guard must short-circuit before any network IO. Only
+        // assert when the test binary is itself a dev build (the normal case);
+        // a release-versioned test build would legitimately hit the network.
+        if !crate::agent::extension_config::is_dev_build() {
+            return;
+        }
+        let outcome = perform_update(false).expect("dev build short-circuits, no network");
+        assert!(matches!(outcome, UpdateOutcome::SkippedDevBuild { .. }));
+    }
+}

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -50,10 +50,14 @@ config_version = 1
 # notifications = true    # OS desktop notifications when a session needs attention
 # soft_delete = true      # Ctrl+D soft-deletes (Ctrl+Z undo); false = hard delete after a prompt
 #
-# `version_check` is the one flag that defaults to FALSE: it makes a network
-# call to GitHub to learn the latest release. Enable it for the TUI header
-# "update available" badge and the `thurbox-cli version --check` command.
+# `version_check` and `auto_update` are the two flags that default to FALSE:
+# both reach the network (GitHub) on startup. `version_check` only *notifies*
+# (TUI header "update available" badge + `thurbox-cli version --check`);
+# `auto_update` goes further and silently downloads, verifies, and replaces the
+# installed binaries when a newer release exists (the new version applies on the
+# next launch). `thurbox-cli update` does the same on demand.
 # version_check = false   # GitHub update check (TUI badge + `version --check`)
+# auto_update = false     # silently download+verify+replace binaries on startup
 
 # OS desktop notifications. Linux gets click-to-focus (clicking the banner
 # selects the session in the running TUI); macOS shows a passive banner only.
@@ -91,6 +95,11 @@ config_version = 1
 # GitHub on startup):
 # [features]
 # version_check = true
+#
+# Keep thurbox up to date automatically — silently download+verify+replace the
+# binaries on startup when a newer release exists (restart to apply):
+# [features]
+# auto_update = true
 "#;
 
 /// Path to the settings file: `~/.config/thurbox/settings.toml`.
@@ -209,6 +218,7 @@ mod tests {
             "Common recipes",
             "scrollback_lines = 10000",
             "version_check = true",
+            "auto_update = true",
         ] {
             assert!(
                 SEED_SETTINGS_TOML.contains(marker),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6803,6 +6803,7 @@ mod tests {
             notifications: false,
             soft_delete: true,
             version_check: false,
+            auto_update: false,
         };
 
         app.handle_key(KeyCode::F(5), KeyModifiers::NONE);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,7 @@ pub mod messages;
 pub mod output;
 pub mod sessions;
 pub mod tasks;
+pub mod update;
 pub mod version;
 
 use output::{CommandOutput, Format};
@@ -94,6 +95,8 @@ pub enum Command {
     },
     /// Print the version; `--check` queries GitHub for a newer release.
     Version(version::VersionArgs),
+    /// Download, verify, and replace the installed binaries with the latest release.
+    Update(update::UpdateArgs),
 }
 
 /// Build the additional-repo list for a multi-repo `Spawn` from the repeatable
@@ -144,6 +147,7 @@ pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
         Command::Config { action } => config::run(action, db),
         Command::Extension { action } => extensions::run(action, db),
         Command::Version(args) => Ok(version::run(args)),
+        Command::Update(args) => Ok(update::run(args)),
     }?;
 
     println!("{}", format.render(&output));
@@ -729,6 +733,21 @@ mod tests {
             panic!("expected Version");
         };
         assert!(args.check);
+    }
+
+    #[test]
+    fn parse_update_with_and_without_force() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "update"]).unwrap();
+        let Command::Update(args) = cli.command else {
+            panic!("expected Update");
+        };
+        assert!(!args.force);
+
+        let cli = Cli::try_parse_from(["thurbox-cli", "update", "--force"]).unwrap();
+        let Command::Update(args) = cli.command else {
+            panic!("expected Update");
+        };
+        assert!(args.force);
     }
 
     #[test]

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -1,0 +1,121 @@
+//! `thurbox-cli update` — download, verify, and replace the installed binaries
+//! with the latest GitHub release.
+//!
+//! Gated behind the opt-in `[features] auto_update` flag (off by default, since
+//! it makes a network call and replaces files on disk). When the flag is off,
+//! `update` prints a one-line hint on how to enable it instead of reaching the
+//! network. `--force` re-downloads and replaces even when up to date or on a
+//! development build.
+
+use clap::Args;
+use serde_json::json;
+
+use crate::session::settings;
+
+use super::output::{kv, CommandOutput};
+
+/// `update` subcommand arguments.
+#[derive(Args, Debug)]
+pub struct UpdateArgs {
+    /// Update even if up to date or on a dev build (re-download + replace).
+    #[arg(long)]
+    pub force: bool,
+}
+
+/// Run the `update` command. Takes no database — it only reads the compiled-in
+/// version, the network, and the install directory.
+pub fn run(args: UpdateArgs) -> CommandOutput {
+    let current = crate::agent::version_check::current_version();
+
+    // Auto-update is opt-in behind the feature flag.
+    if !settings::global().features.auto_update {
+        let hint = "update is disabled. Enable it by setting \
+                    `[features] auto_update = true` in settings.toml.";
+        return CommandOutput::new(
+            json!({
+                "version": current,
+                "update_enabled": false,
+                "summary": hint,
+            }),
+            format!("thurbox {current}\n{hint}"),
+        );
+    }
+
+    match crate::agent::self_update::perform_update(args.force) {
+        Ok(crate::agent::self_update::UpdateOutcome::Updated { from, to }) => {
+            let human = kv(&[
+                ("from", from.clone()),
+                ("to", to.clone()),
+                ("updated", "true".to_string()),
+                ("note", "restart thurbox to apply".to_string()),
+            ]);
+            CommandOutput::new(
+                json!({
+                    "version": from,
+                    "latest": to,
+                    "updated": true,
+                    "update_enabled": true,
+                    "summary": format!("Updated {from} → {to}. Restart thurbox to apply."),
+                }),
+                human,
+            )
+        }
+        Ok(crate::agent::self_update::UpdateOutcome::UpToDate { current, latest }) => {
+            CommandOutput::new(
+                json!({
+                    "version": current,
+                    "latest": latest,
+                    "updated": false,
+                    "update_enabled": true,
+                    "summary": "Up to date — running the latest release.",
+                }),
+                format!(
+                "thurbox {current} (latest: {latest})\nUp to date — running the latest release."
+            ),
+            )
+        }
+        Ok(crate::agent::self_update::UpdateOutcome::SkippedDevBuild { current }) => {
+            CommandOutput::new(
+                json!({
+                    "version": current,
+                    "updated": false,
+                    "update_enabled": true,
+                    "summary": "Development build — skipped. Use --force to update anyway.",
+                }),
+                format!(
+                "thurbox {current}\nDevelopment build — skipped (use --force to update anyway)."
+            ),
+            )
+        }
+        Err(e) => CommandOutput::failed(
+            json!({
+                "version": current,
+                "updated": false,
+                "update_enabled": true,
+                "error": e,
+            }),
+            format!("thurbox {current}\nUpdate failed: {e}"),
+            format!("update failed: {e}"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_when_flag_disabled_prints_enable_hint() {
+        // `settings::init` is only ever called by the binaries, so in the test
+        // process `settings::global()` is the all-default config — auto_update
+        // is off — and `update` degrades to the enable hint with no network or
+        // disk touch.
+        let out = run(UpdateArgs { force: false });
+        assert_eq!(out["update_enabled"], false);
+        assert!(out.human.contains("disabled"), "got: {}", out.human);
+        assert!(
+            out.failure.is_none(),
+            "the hint is informational, not an error"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,15 @@ async fn main() -> Result<()> {
     }
     config_warnings.extend(heal_messages);
 
+    // Silent auto-update (opt-in via [features] auto_update). Runs here — after
+    // config load, before the TUI takes the terminal — so download output can't
+    // corrupt the alternate screen and the self-replace can't race the render.
+    if let Some(msg) = maybe_auto_update() {
+        tracing::info!("{msg}");
+        eprintln!("{msg}");
+        config_warnings.push(msg);
+    }
+
     let mut terminal = ratatui::init();
     enable_terminal_features()?;
     push_keyboard_enhancement();
@@ -224,6 +233,43 @@ fn arm_automation_heartbeat() {
         let cli = thurbox::agent::tmux::resolve_cli_binary();
         if let Err(e) = thurbox::agent::tmux::ensure_automation_heartbeat(&cli) {
             tracing::warn!("Failed to arm automation heartbeat: {e}");
+        }
+    }
+}
+
+/// Silently auto-update the installed binaries when `[features] auto_update` is
+/// on, this is not a dev build, and the version-check cache is stale (so a normal
+/// relaunch within the 24h window does zero network IO, matching the version
+/// badge's "a normal launch never hits the network" contract). Best-effort: any
+/// failure is logged and startup continues on the current binary. Returns a
+/// one-line "updated" message to surface in the status bar, or `None`.
+fn maybe_auto_update() -> Option<String> {
+    let features = &thurbox::session::settings::global().features;
+    if !features.auto_update {
+        return None;
+    }
+    if thurbox::agent::extension_config::is_dev_build() {
+        return None;
+    }
+    if !thurbox::agent::version_check::cache_is_stale() {
+        return None;
+    }
+    match thurbox::agent::self_update::perform_update(false) {
+        Ok(outcome) => {
+            // Either way the check ran, so freshen the version-check cache: the
+            // badge stays accurate and the 24h throttle resets (no immediate
+            // re-attempt next launch).
+            let _ = thurbox::agent::version_check::refresh_cache();
+            match outcome {
+                thurbox::agent::self_update::UpdateOutcome::Updated { to, .. } => {
+                    Some(format!("Updated to v{to} — restart thurbox to apply."))
+                }
+                _ => None,
+            }
+        }
+        Err(e) => {
+            tracing::warn!("auto-update failed: {e}");
+            None
         }
     }
 }

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -96,6 +96,13 @@ pub struct FeatureFlags {
     /// GitHub. Enable it to learn when a newer release is available.
     #[serde(default = "default_false")]
     pub version_check: bool,
+    /// Silent auto-update: the TUI silently downloads, verifies, and replaces
+    /// the installed binaries on startup when a newer release exists, and the
+    /// `thurbox-cli update` command does the same on demand. **Off by default**
+    /// — opt-in because it makes a network call and replaces files on disk. The
+    /// new version applies on the next launch.
+    #[serde(default = "default_false")]
+    pub auto_update: bool,
 }
 
 /// Knobs for the OS notification feature (`[notifications]` table). All
@@ -159,6 +166,7 @@ impl Default for FeatureFlags {
             notifications: true,
             soft_delete: true,
             version_check: false,
+            auto_update: false,
         }
     }
 }
@@ -315,6 +323,18 @@ mod tests {
 
         let s: Settings = toml::from_str("[features]\nversion_check = true").unwrap();
         assert!(s.features.version_check);
+        assert!(s.features.mouse, "untouched flags stay at their default");
+    }
+
+    #[test]
+    fn auto_update_flag_defaults_off_and_parses() {
+        // Like version_check, auto_update is opt-in (network call + writes to disk).
+        let s: Settings = toml::from_str("[features]").unwrap();
+        assert!(!s.features.auto_update, "auto_update defaults off");
+        assert!(s.features.tasks, "other flags still default on");
+
+        let s: Settings = toml::from_str("[features]\nauto_update = true").unwrap();
+        assert!(s.features.auto_update);
         assert!(s.features.mouse, "untouched flags stay at their default");
     }
 

--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -362,6 +362,7 @@ shell_pane    = true
 mouse         = true
 notifications = true
 version_check = false          # opt-in: makes a network call
+auto_update   = false          # opt-in: downloads + replaces binaries
 
 [notifications]
 also_on_waiting     = false    # also fire on Busy &rarr; Waiting (no bell)
@@ -373,8 +374,8 @@ min_interval_secs   = 5        # per-session floor between notifications</code><
           <p>
             Turn major TUI features off entirely. All default to
             <code>true</code>
-            <strong>except <code>version_check</code>, which defaults to <code>false</code></strong>
-            (it makes a network call, so it is opt-in). Like the rest of settings.toml, changes need
+            <strong>except <code>version_check</code> and <code>auto_update</code>, which default to <code>false</code></strong>
+            (both reach the network, so they are opt-in). Like the rest of settings.toml, changes need
             a restart. A disabled feature's pane never renders, its keybinding shows a status toast
             instead of acting, and its global-search scope returns no results. Data is never
             touched, so re-enabling a flag is lossless.
@@ -436,6 +437,14 @@ min_interval_secs   = 5        # per-session floor between notifications</code><
                   <code>thurbox-cli version --check</code>
                 </td>
               </tr>
+              <tr>
+                <td><code>auto_update</code></td>
+                <td><code>false</code></td>
+                <td>
+                  silent self-update: download + verify + replace the binaries on startup +
+                  <code>thurbox-cli update</code>
+                </td>
+              </tr>
             </tbody>
           </table>
           <p>
@@ -461,6 +470,25 @@ min_interval_secs   = 5        # per-session floor between notifications</code><
             silent. Dev builds (<code>0.0.0-dev</code>) never show the badge. The same flag enables
             <code>thurbox-cli version --check</code>
             (<code>thurbox-cli version</code> with no flag always prints the current version).
+          </p>
+          <p>
+            <code>auto_update = true</code>
+            goes a step further than <code>version_check</code>: instead of just showing a badge, the
+            TUI <strong>silently updates itself</strong> on startup. After the same 24&nbsp;h cache
+            check, if a newer release exists it downloads that release's tarball + checksums from
+            GitHub Releases (<code>curl</code>/<code>wget</code>), verifies the SHA256
+            (<code>sha256sum</code>/<code>shasum</code>), extracts it (<code>tar</code>), and
+            atomically replaces the installed <code>thurbox</code>/<code>thurbox-cli</code> binaries
+            in place &mdash; mirroring <code>scripts/install.sh</code>. The download is verified
+            <strong>before</strong> any installed file is touched, so a failed download leaves the
+            current binaries untouched; the step runs before the TUI takes the terminal and is
+            best-effort. The replaced binary takes effect on the <strong>next launch</strong>, so the
+            TUI shows an &ldquo;Updated to vX.Y.Z &mdash; restart to apply&rdquo; status line.
+            <code>thurbox-cli update</code>
+            performs the same update on demand (<code>--force</code> bypasses the up-to-date and
+            dev-build guards); dev builds (<code>0.0.0-dev</code>) never auto-update.
+            <code>version_check</code> and <code>auto_update</code> are independent &mdash; enable
+            either or both.
           </p>
 
           <h3 id="notifications"><code>[notifications]</code> &mdash; OS notification settings</h3>

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -818,7 +818,9 @@ ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m"]
             <code>true</code>
             except
             <code>version_check</code>
-            , which is opt-in because it makes a network call). A disabled feature hides its pane
+            and
+            <code>auto_update</code>
+            , which are opt-in because they reach the network). A disabled feature hides its pane
             and turns its keybinding into an explanatory toast,
             but its data and the
             <code>thurbox-cli</code>
@@ -833,7 +835,8 @@ info_panel = true     # F2/Ctrl+B info panel
 shell_pane = true     # Ctrl+T per-session shell
 mouse = true          # mouse capture: clicks, wheel, drag-select, hover
 notifications = true  # OS desktop alerts when a session needs attention
-version_check = false # opt-in GitHub update check (makes a network call)</code></pre>
+version_check = false # opt-in GitHub update check (makes a network call)
+auto_update = false   # opt-in: silently download+verify+replace binaries on startup</code></pre>
           <p>
             <code>automations = false</code>
             is the one flag with teeth beyond the UI: it also stops the TUI from firing due


### PR DESCRIPTION
## Summary

- Add an opt-in `[features] auto_update` flag (off by default, like `version_check`) that lets thurbox update itself.
- New `agent::self_update` module downloads + SHA256-verifies + extracts the latest GitHub release and atomically replaces the installed `thurbox`/`thurbox-cli` binaries in place, mirroring `scripts/install.sh` (no new crate deps; shells out to curl/wget, tar, sha256sum/shasum). Reuses the version-check plumbing so dev builds never auto-update.
- TUI runs it silently on startup (throttled by the 24h version-check cache, before the terminal is taken); `thurbox-cli update [--force]` does it on demand.
- Docs updated across CONFIG.md, FEATURES.md, README, CLAUDE.md, and the website (features + configuration).

## Test plan

- New unit tests: target-triple mapping, artifact/URL naming, checksum parse, SHA256 verify, two-phase atomic binary swap, and the no-network dev-build guard.
- CI checks pass.