### PR TITLE
feat(ui): add Settings panel for editing settings.toml in the TUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1157,6 +1157,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+Z` | Undo session delete | **Z** = undo |
 | `Ctrl+U` | Restore deleted sessions | **U**ndelete |
 | `Ctrl+Y` / `F4` | Pick TUI theme | Color **Y**oke |
+| `Ctrl+,` / `F6` | Settings panel (edit settings.toml) | **,** = preferences |
 | `F1` / `Ctrl+G` | Keybindings help + interactive editor | Universal |
 | `F2` | Toggle info panel (visible at width >= 120) | Next to F1 |
 | `F3` | Toggle file viewer | Next to F2 |
@@ -1293,6 +1294,45 @@ which avoids terminals that intercept Ctrl+Y as DSUSP); the choice
 is persisted in SQLite under `metadata.active_theme` and survives
 restarts. Other thurbox processes pick up theme changes within one
 tick via `PRAGMA data_version` polling.
+
+## Settings panel
+
+`Ctrl+,` (rebindable `Action::OpenSettings`; `F6` alternate) opens a
+centered **Settings modal** (`Modal::Settings(SettingsModal)`) that views
+and edits **all of settings.toml** — the `[features]` toggles, 4
+`[notifications]` knobs, and 4 scalars — without hand-editing the file.
+Persistence stays in `settings.toml`: `agent::settings_config::save_settings`
+writes it back through a `toml_edit::DocumentMut` so the seed's
+documentation comments survive (the first save adds real uncommented keys
+below the commented examples). The modal edits a working-copy `draft` and
+applies **only on `Ctrl+S`** (`Esc` discards — there is no live preview).
+
+Feature flags that gate UI panels (`tasks`, `file_viewer`, `info_panel`,
+`global_search`, `shell_pane`, `soft_delete`) are read from `App.features`
+every frame, so `submit_settings_panel` copies the draft's flags into
+`self.features` (via `App::apply_live_settings`) and they take effect
+immediately. Everything else is read once at startup from the write-once
+`settings::global()` `OnceLock` (which can't be re-applied in-process):
+those rows are marked `⟳`, and a save that changes one toasts "some changes
+apply after restart".
+
+`settings.toml` is **live-reloaded** like `agents.toml`/`keybindings.json`:
+`App::poll_config_reload` watches its mtime and, on any external change (a
+hand-edit, the panel in another instance), re-applies the live feature flags
+via the same `apply_live_settings` and toasts (noting a restart when
+`Settings::restart_only_differs` vs the global). The panel's own write calls
+`mark_settings_saved` so the poll doesn't re-toast it.
+
+`SettingsField` (in `app/modals.rs`) owns the field order, labels,
+descriptions (which avoid naming key chords, since those are rebindable),
+scalar-vs-bool/step logic (`adjust` with per-field clamping), and the
+per-row live/restart marker (`restart_required`); the canonical
+live/restart comparison is `Settings::restart_only_differs`
+(`session/settings.rs`), reused by both the panel toast and the reload path.
+The renderer is `ui::settings_modal::render_settings_modal` (modeled on
+`automation_editor_modal`, with blank separators between the Features /
+Notifications / Scalars sections, an aligned value column, and
+scroll-windowing for short terminals).
 
 ## Design Documentation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,6 +2551,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2666,6 +2667,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.1",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tracing-appender = "0.2"
 # Configuration
 serde = { version = "1", features = ["derive"] }
 toml = "1.0"
+toml_edit = "0.25"
 
 # Storage
 rusqlite = { version = "0.40", features = ["bundled"] }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -16,17 +16,30 @@ development checkout never touches your real setup.
 |------|--------|-----------|------|---------|
 | `~/.config/thurbox/agents.toml` | TOML | you | **live** (mtime poll) | coding-agent CLI definitions |
 | `~/.config/thurbox/hosts.toml` | TOML | you | startup | remote SSH hosts |
-| `~/.config/thurbox/settings.toml` | TOML | you | startup | tuning knobs + feature flags |
+| `~/.config/thurbox/settings.toml` | TOML | you + `Ctrl+,` panel | **live** (feature flags) / startup (rest) | tuning knobs + feature flags |
 | `~/.config/thurbox/themes.toml` | TOML | you | startup | custom theme palettes |
 | `~/.config/thurbox/keybindings.json` | JSON | F1 editor (or you) | **live** (mtime poll) | key chord overrides |
 | `~/.config/thurbox/extensions/<name>.toml` | TOML | `thurbox-cli extension install` | startup + tick | extension manifests (self-healed resources) |
 | `~/.local/share/thurbox/thurbox.db` | SQLite | thurbox | live | sessions, automations, tasks, theme, editor command |
 | `~/.local/share/thurbox/thurbox.log` | text | thurbox | — | logs (incl. config warnings) |
 
-`agents.toml` and `keybindings.json` reload **live**: the TUI polls
-their mtime (~1/s) and applies edits with a confirmation toast — no
-restart. `hosts.toml` (SSH backends register at startup),
-`settings.toml`, and `themes.toml` need a restart.
+`agents.toml`, `keybindings.json`, and `settings.toml` reload **live**:
+the TUI polls their mtime (~1/s) and applies edits with a confirmation
+toast — no restart. For `settings.toml` only the **feature flags that
+gate UI panels** (`tasks`, `file_viewer`, `info_panel`, `global_search`,
+`shell_pane`, `soft_delete`) apply live; the restart-only values stay
+published through a write-once global (so they can't drift mid-frame),
+and the reload toast says when a restart is needed. `hosts.toml` (SSH
+backends register at startup) and `themes.toml` need a restart.
+
+`settings.toml` can also be edited from the TUI: **`Ctrl+,`** (alt `F6`)
+opens a **Settings panel** listing every knob. It writes the file back
+**preserving its comments**, and feature flags that gate UI panels apply
+**live** on save; the rest (`mouse`, `notifications`, `automations`,
+`version_check`, the `[notifications]` knobs, and the scalars) take
+effect on the next launch — the panel marks those rows with `⟳` and
+toasts a restart note. Hand-editing the file (or the panel in another
+instance) is picked up the same way, via the live mtime poll.
 
 All paths respect `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME`.
 

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -163,6 +163,90 @@ pub fn load_or_seed_with_warnings() -> (Settings, Vec<String>) {
     }
 }
 
+/// Set a boolean key on a `toml_edit` table.
+fn set_table_bool(table: &mut toml_edit::Table, key: &str, v: bool) {
+    table[key] = toml_edit::value(v);
+}
+
+/// Write `settings` back to `settings.toml`, **preserving comments and
+/// layout**.
+///
+/// The existing file (or, when absent, the documented [`SEED_SETTINGS_TOML`])
+/// is parsed into a `toml_edit::DocumentMut` and each value is set in place, so
+/// the surrounding documentation survives a round-trip. A malformed file falls
+/// back to the seed text rather than blocking the save.
+///
+/// Note: the seed ships every knob as a *commented* `# key = …` line, which
+/// `toml_edit` cannot see. The first save therefore **adds real, uncommented
+/// keys** (below the documentation comments, which remain as reference); from
+/// then on those keys are edited in place.
+pub fn save_settings(settings: &Settings) -> std::io::Result<()> {
+    use toml_edit::{value, DocumentMut};
+
+    let Some(path) = settings_config_path() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "could not resolve settings.toml path",
+        ));
+    };
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => SEED_SETTINGS_TOML.to_string(),
+        Err(e) => return Err(e),
+    };
+
+    // A malformed file shouldn't block saving from the panel: fall back to the
+    // seed document (its comments are still useful) rather than erroring out.
+    let mut doc = contents
+        .parse::<DocumentMut>()
+        .or_else(|_| SEED_SETTINGS_TOML.parse::<DocumentMut>())
+        .unwrap_or_default();
+
+    // Top-level scalars (cast to i64 — TOML's only integer type).
+    doc["config_version"] = value(i64::from(settings.config_version.unwrap_or(1)));
+    doc["scrollback_lines"] = value(settings.scrollback_lines as i64);
+    doc["two_panel_min_cols"] = value(i64::from(settings.two_panel_min_cols));
+    doc["three_panel_min_cols"] = value(i64::from(settings.three_panel_min_cols));
+    doc["audit_retention_days"] = value(settings.audit_retention_days as i64);
+
+    // [features] table — create if missing.
+    if !doc.contains_key("features") {
+        doc["features"] = toml_edit::table();
+    }
+    if let Some(features) = doc["features"].as_table_mut() {
+        let f = &settings.features;
+        set_table_bool(features, "tasks", f.tasks);
+        set_table_bool(features, "automations", f.automations);
+        set_table_bool(features, "file_viewer", f.file_viewer);
+        set_table_bool(features, "global_search", f.global_search);
+        set_table_bool(features, "info_panel", f.info_panel);
+        set_table_bool(features, "shell_pane", f.shell_pane);
+        set_table_bool(features, "mouse", f.mouse);
+        set_table_bool(features, "notifications", f.notifications);
+        set_table_bool(features, "soft_delete", f.soft_delete);
+        set_table_bool(features, "version_check", f.version_check);
+        set_table_bool(features, "auto_update", f.auto_update);
+    }
+
+    // [notifications] table — create if missing.
+    if !doc.contains_key("notifications") {
+        doc["notifications"] = toml_edit::table();
+    }
+    if let Some(notifications) = doc["notifications"].as_table_mut() {
+        let n = &settings.notifications;
+        set_table_bool(notifications, "also_on_waiting", n.also_on_waiting);
+        set_table_bool(notifications, "suppress_for_active", n.suppress_for_active);
+        set_table_bool(notifications, "sound", n.sound);
+        notifications["min_interval_secs"] = value(n.min_interval_secs as i64);
+    }
+
+    std::fs::write(&path, doc.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -270,6 +354,95 @@ mod tests {
         assert_eq!(s.scrollback_lines, 4000);
         assert_eq!(s.audit_retention_days, 7);
         assert_eq!(s.two_panel_min_cols, 80);
+    }
+
+    #[test]
+    fn save_settings_round_trips() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        // Seed the documented file first, then save mutated settings.
+        let (mut s, _) = load_or_seed_with_warnings();
+        s.scrollback_lines = 4000;
+        s.audit_retention_days = 7;
+        s.features.tasks = false;
+        s.features.version_check = true;
+        s.features.auto_update = true;
+        s.notifications.min_interval_secs = 30;
+        s.notifications.suppress_for_active = false;
+
+        save_settings(&s).unwrap();
+
+        let (reloaded, warnings) = load_or_seed_with_warnings();
+        assert!(warnings.is_empty(), "got: {warnings:?}");
+        // save_settings always stamps config_version = 1 (a migration marker);
+        // every other field must round-trip exactly.
+        assert_eq!(reloaded.config_version, Some(1));
+        assert_eq!(
+            Settings {
+                config_version: None,
+                ..reloaded
+            },
+            Settings {
+                config_version: None,
+                ..s
+            }
+        );
+    }
+
+    #[test]
+    fn save_settings_preserves_comments() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let (s, _) = load_or_seed_with_warnings();
+
+        save_settings(&s).unwrap();
+
+        let raw = std::fs::read_to_string(settings_config_path().unwrap()).unwrap();
+        assert!(raw.contains("# Thurbox settings"));
+        assert!(raw.contains("Common recipes"));
+    }
+
+    #[test]
+    fn save_settings_writes_when_file_absent() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let path = settings_config_path().unwrap();
+        assert!(!path.exists());
+
+        save_settings(&Settings::default()).unwrap();
+
+        assert!(path.exists());
+        let (reloaded, warnings) = load_or_seed_with_warnings();
+        assert!(warnings.is_empty(), "got: {warnings:?}");
+        assert_eq!(
+            Settings {
+                config_version: None,
+                ..reloaded
+            },
+            Settings::default()
+        );
+    }
+
+    #[test]
+    fn save_settings_recovers_from_malformed_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let path = settings_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "garbage = ").unwrap();
+
+        save_settings(&Settings::default()).unwrap();
+
+        // The file must now parse back cleanly.
+        let (reloaded, warnings) = load_or_seed_with_warnings();
+        assert!(warnings.is_empty(), "got: {warnings:?}");
+        assert_eq!(
+            Settings {
+                config_version: None,
+                ..reloaded
+            },
+            Settings::default()
+        );
     }
 
     #[test]

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -358,6 +358,62 @@ fn ctrl_slash_opens_global_search_strip() {
 }
 
 #[test]
+fn settings_panel_opens_and_closes() {
+    let mut h = Harness::standard(1);
+    h.ctrl(','); // OpenSettings
+    assert!(
+        matches!(h.app.modal, modals::Modal::Settings(_)),
+        "Ctrl+, should open the settings panel"
+    );
+
+    // The panel shows section headers, the selected field's description, and
+    // the restart marker on restart-required rows.
+    let screen = h.render();
+    assert!(screen.contains("FEATURES"), "section header renders");
+    assert!(
+        screen.contains("Tasks panel"),
+        "selected field's description renders in the footer"
+    );
+    assert!(screen.contains('⟳'), "restart marker renders");
+
+    h.key(KeyCode::Esc, KeyModifiers::NONE);
+    assert!(!h.app.modal.is_open(), "Esc closes the settings panel");
+}
+
+#[test]
+fn settings_panel_live_toggle_applies_on_save() {
+    let mut h = Harness::standard(1);
+    assert!(h.app.features.tasks, "tasks default on");
+
+    h.ctrl(','); // OpenSettings — starts on the `tasks` field
+    h.key(KeyCode::Char(' '), KeyModifiers::NONE); // toggle tasks off in the draft
+                                                   // Not applied until save.
+    assert!(h.app.features.tasks, "draft edits don't apply until save");
+
+    h.ctrl('s'); // Save
+    assert!(!h.app.modal.is_open(), "save closes the panel");
+    assert!(
+        !h.app.features.tasks,
+        "a live feature flag applies immediately on save"
+    );
+}
+
+#[test]
+fn settings_panel_esc_discards() {
+    let mut h = Harness::standard(1);
+    assert!(h.app.features.tasks);
+
+    h.ctrl(','); // OpenSettings
+    h.key(KeyCode::Char(' '), KeyModifiers::NONE); // toggle in the draft
+    h.key(KeyCode::Esc, KeyModifiers::NONE); // discard
+
+    assert!(
+        h.app.features.tasks,
+        "Esc discards the draft — no live preview applied"
+    );
+}
+
+#[test]
 fn ctrl_q_requests_quit() {
     let mut h = Harness::standard(1);
     assert!(!h.app.should_quit());

--- a/src/app/config_reload.rs
+++ b/src/app/config_reload.rs
@@ -1,13 +1,16 @@
 //! Live reload of hand-edited config files.
 //!
 //! Grouped out of the [`App`](super::App) god object. `tick` polls the
-//! mtimes of `agents.toml` and `keybindings.json` (~1/s, two `stat` calls)
-//! and reloads them in place on change — no restart needed after editing.
+//! mtimes of `agents.toml`, `keybindings.json`, and `settings.toml` (~1/s, a
+//! few `stat` calls) and reloads them in place on change — no restart needed
+//! after editing (or after the in-TUI settings panel writes the file).
 //!
-//! Deliberately *not* reloaded live: `hosts.toml` (SSH backends are
-//! registered in main's `BackendRegistry` at startup) and `settings.toml`
-//! (published through a write-once global so values can't drift mid-frame).
-//! Both stay restart-only, as documented in `docs/CONFIG.md`.
+//! `settings.toml` reloads only re-apply the **live** feature flags (the UI
+//! panel switches read from `App.features` every frame); the restart-only
+//! values stay published through the write-once global so they can't drift
+//! mid-frame, and the reload toast says so. Deliberately *not* reloaded live:
+//! `hosts.toml` (SSH backends are registered in main's `BackendRegistry` at
+//! startup). See `docs/CONFIG.md`.
 
 use std::path::Path;
 use std::time::SystemTime;
@@ -17,6 +20,7 @@ use std::time::SystemTime;
 pub(crate) struct ConfigReloadState {
     pub(crate) agents_mtime: Option<SystemTime>,
     pub(crate) keybindings_mtime: Option<SystemTime>,
+    pub(crate) settings_mtime: Option<SystemTime>,
 }
 
 /// The file's modification time, `None` when it is absent/unreadable.
@@ -33,4 +37,9 @@ pub(crate) fn agents_mtime() -> Option<SystemTime> {
 /// Current mtime of `keybindings.json`.
 pub(crate) fn keybindings_mtime() -> Option<SystemTime> {
     mtime(crate::paths::keybindings_file().as_deref())
+}
+
+/// Current mtime of `settings.toml`.
+pub(crate) fn settings_mtime() -> Option<SystemTime> {
+    mtime(crate::agent::settings_config::settings_config_path().as_deref())
 }

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -297,9 +297,23 @@ impl App {
             Modal::RepoPicker(_) => self.handle_repo_picker_key(code, mods),
             Modal::TaskActionPicker(_) => self.handle_task_action_picker_key(code),
             Modal::ConfirmDelete(_) => self.handle_confirm_delete_key(code),
+            Modal::Settings(_) => self.handle_settings_key(code, mods),
             _ => return false,
         }
         true
+    }
+
+    /// Drive the Settings panel: edits a working copy, persists on `Ctrl+S`,
+    /// discards on `Esc` (no live preview to revert).
+    fn handle_settings_key(&mut self, code: KeyCode, mods: KeyModifiers) {
+        let super::modals::Modal::Settings(ref mut m) = self.modal else {
+            return;
+        };
+        match m.handle_key(code, mods) {
+            super::modals::EditorOutcome::Continue => {}
+            super::modals::EditorOutcome::Save => self.submit_settings_panel(),
+            super::modals::EditorOutcome::Cancel => self.modal.close(),
+        }
     }
 
     /// Drive the hard-delete confirmation prompt: `Enter`/`y` tears the session
@@ -1341,6 +1355,10 @@ impl App {
                 "Global search",
                 Self::open_global_search,
             ),
+            Action::OpenSettings => {
+                self.open_settings_panel();
+                true
+            }
 
             // ── Clipboard (global) ──────────────────────────────────────
             // Copy only consumes the key when there's a selection; otherwise

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -722,6 +722,7 @@ impl App {
             config_reload: config_reload::ConfigReloadState {
                 agents_mtime: config_reload::agents_mtime(),
                 keybindings_mtime: config_reload::keybindings_mtime(),
+                settings_mtime: config_reload::settings_mtime(),
             },
             notification_state: build_notification_state(),
         };
@@ -756,6 +757,10 @@ impl App {
             self.config_reload.keybindings_mtime = kb_mtime;
             self.reload_keybindings_config();
         }
+
+        if config_reload::settings_mtime() != self.config_reload.settings_mtime {
+            self.reload_settings_config();
+        }
     }
 
     /// Reload `agents.toml` and toast the result. Caller has already detected an
@@ -774,6 +779,36 @@ impl App {
         let (bindings, warnings) = Self::load_keybindings_with_warnings();
         self.keybindings = bindings;
         self.toast_config_reload("keybindings.json reloaded", &warnings);
+    }
+
+    /// Reload `settings.toml` when it changes on disk (a hand-edit, the in-TUI
+    /// panel, or another instance). Re-applies the live feature flags in place;
+    /// restart-only values stay frozen in the global, so the toast flags when a
+    /// restart is needed. Caller has already detected the mtime change; this
+    /// re-stats afterwards so a re-seeded file is recorded.
+    fn reload_settings_config(&mut self) {
+        let (settings, mut warnings) = crate::agent::settings_config::load_or_seed_with_warnings();
+        if settings.restart_only_differs(crate::session::settings::global()) {
+            warnings.push("restart to apply some changes".into());
+        }
+        self.apply_live_settings(&settings);
+        self.config_reload.settings_mtime = config_reload::settings_mtime();
+        self.toast_config_reload("settings.toml reloaded", &warnings);
+    }
+
+    /// Apply the **live** portion of `settings` (the UI-panel feature flags read
+    /// from `App.features` each frame) and resize panes to match. The
+    /// restart-only values are intentionally left to the next launch. Shared by
+    /// the settings panel's save path and the live-reload poll.
+    pub(crate) fn apply_live_settings(&mut self, settings: &crate::session::settings::Settings) {
+        self.features = settings.features;
+        self.resize_sessions_to_content_area();
+    }
+
+    /// Record the current `settings.toml` mtime so the next reload poll doesn't
+    /// treat the settings panel's own write as an external edit.
+    pub(crate) fn mark_settings_saved(&mut self) {
+        self.config_reload.settings_mtime = config_reload::settings_mtime();
     }
 
     /// Load the on-disk keybindings, falling back to defaults (with a warning)
@@ -1386,6 +1421,46 @@ impl App {
             .and_then(|name| entries.iter().position(|e| e.name == name))
             .unwrap_or(0);
         self.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index });
+    }
+
+    /// Open the Settings panel. The draft reflects the live source of truth:
+    /// `self.features` for the feature flags (so in-session changes show), and
+    /// `settings::global()` for the scalars + notifications (read once at
+    /// startup, never mutated in-process).
+    pub(crate) fn open_settings_panel(&mut self) {
+        let draft = crate::session::settings::Settings {
+            features: self.features,
+            ..crate::session::settings::global().clone()
+        };
+        self.modal = modals::Modal::Settings(modals::SettingsModal::new(draft));
+    }
+
+    /// Persist the Settings panel draft to `settings.toml`, apply the live
+    /// feature flags immediately, and toast the result. Keeps the modal open on
+    /// a write error so edits aren't lost.
+    pub(crate) fn submit_settings_panel(&mut self) {
+        let (draft, restart) = match self.modal {
+            modals::Modal::Settings(ref m) => (m.draft.clone(), m.restart_required_changed()),
+            _ => return,
+        };
+        if let Err(e) = crate::agent::settings_config::save_settings(&draft) {
+            self.set_error(format!("Failed to save settings: {e}"));
+            return;
+        }
+        // Live-apply the feature flags that gate UI panels; restart-required
+        // settings only take effect from the on-disk file on next launch.
+        self.apply_live_settings(&draft);
+        // Record our own write so the live-reload poll doesn't re-toast it.
+        self.mark_settings_saved();
+        self.modal.close();
+        if restart {
+            self.set_status(
+                StatusLevel::Info,
+                "Settings saved — some changes apply after restart",
+            );
+        } else {
+            self.set_status(StatusLevel::Success, "Settings saved");
+        }
     }
 
     fn open_restore_sessions_modal(&mut self) {
@@ -5711,6 +5786,48 @@ mod tests {
         app.mark_keybindings_saved();
         app.poll_config_reload();
         assert!(app.status_message.is_none());
+    }
+
+    #[test]
+    fn poll_config_reload_applies_settings_live_feature_flags() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = crate::paths::TestPathGuard::new(tmp.path());
+        let mut app = app_with_sessions(0);
+        app.status_message = None;
+        assert!(app.features.tasks);
+
+        // An external edit disabling a live flag applies on the next poll.
+        let path = crate::agent::settings_config::settings_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "[features]\ntasks = false\n").unwrap();
+
+        app.poll_config_reload();
+        assert!(!app.features.tasks, "live feature flag reloaded from disk");
+        assert!(app.status_message.is_some(), "reload toasts");
+
+        // Stable afterwards: no repeated toasts.
+        app.status_message = None;
+        app.poll_config_reload();
+        assert!(app.status_message.is_none());
+    }
+
+    #[test]
+    fn mark_settings_saved_suppresses_self_write_toast() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = crate::paths::TestPathGuard::new(tmp.path());
+        let mut app = app_with_sessions(0);
+        app.status_message = None;
+
+        let path = crate::agent::settings_config::settings_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "[features]\nfile_viewer = false\n").unwrap();
+        app.mark_settings_saved();
+
+        app.poll_config_reload();
+        assert!(
+            app.status_message.is_none(),
+            "a recorded self-write doesn't re-toast"
+        );
     }
 
     /// A notification click handler writes `pending_focus_session_id` to the

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -1352,6 +1352,306 @@ pub struct HelpModal {
 
 // ── Main Modal Enum ────────────────────────────────────────────────────────
 
+/// One editable row in the [`SettingsModal`]. Section headers are render-only,
+/// so this enum lists only the focusable fields, in display order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsField {
+    // ── [features] ──────────────────────────────────────────────────────
+    FeatTasks,
+    FeatAutomations,
+    FeatFileViewer,
+    FeatGlobalSearch,
+    FeatInfoPanel,
+    FeatShellPane,
+    FeatMouse,
+    FeatNotifications,
+    FeatSoftDelete,
+    FeatVersionCheck,
+    FeatAutoUpdate,
+    // ── [notifications] ─────────────────────────────────────────────────
+    NotifAlsoOnWaiting,
+    NotifSuppressForActive,
+    NotifSound,
+    NotifMinInterval,
+    // ── top-level scalars ───────────────────────────────────────────────
+    ScrollbackLines,
+    TwoPanelMinCols,
+    ThreePanelMinCols,
+    AuditRetentionDays,
+}
+
+impl SettingsField {
+    /// Field nav order — also the render order (headers are interleaved by the
+    /// renderer). Used by [`cycle_field`] and the scroll-windowing logic.
+    pub const ORDER: [SettingsField; 19] = [
+        SettingsField::FeatTasks,
+        SettingsField::FeatAutomations,
+        SettingsField::FeatFileViewer,
+        SettingsField::FeatGlobalSearch,
+        SettingsField::FeatInfoPanel,
+        SettingsField::FeatShellPane,
+        SettingsField::FeatMouse,
+        SettingsField::FeatNotifications,
+        SettingsField::FeatSoftDelete,
+        SettingsField::FeatVersionCheck,
+        SettingsField::FeatAutoUpdate,
+        SettingsField::NotifAlsoOnWaiting,
+        SettingsField::NotifSuppressForActive,
+        SettingsField::NotifSound,
+        SettingsField::NotifMinInterval,
+        SettingsField::ScrollbackLines,
+        SettingsField::TwoPanelMinCols,
+        SettingsField::ThreePanelMinCols,
+        SettingsField::AuditRetentionDays,
+    ];
+
+    /// The field's `settings.toml` key and one-line help, in a single table so
+    /// the two parallel lookups never drift (and stay one match, not two).
+    /// The help avoids naming key chords — those are user-configurable, so a
+    /// hard-coded hint would drift from the actual binding.
+    fn meta(self) -> (&'static str, &'static str) {
+        use SettingsField::*;
+        match self {
+            FeatTasks => ("tasks", "Tasks panel and task search"),
+            FeatAutomations => ("automations", "Automations pane and schedule firing"),
+            FeatFileViewer => ("file_viewer", "File viewer column"),
+            FeatGlobalSearch => ("global_search", "Global search strip"),
+            FeatInfoPanel => ("info_panel", "Info panel column"),
+            FeatShellPane => ("shell_pane", "Per-session shell pane"),
+            FeatMouse => ("mouse", "Mouse: clicks, wheel, drag-select, hover"),
+            FeatNotifications => ("notifications", "OS desktop notifications on attention"),
+            FeatSoftDelete => ("soft_delete", "Soft-delete sessions with an undo window"),
+            FeatVersionCheck => ("version_check", "Check GitHub for updates (network call)"),
+            FeatAutoUpdate => (
+                "auto_update",
+                "Silently self-update on launch (network call)",
+            ),
+            NotifAlsoOnWaiting => ("also_on_waiting", "Also notify on the Busy → Waiting edge"),
+            NotifSuppressForActive => (
+                "suppress_for_active",
+                "Skip the session you're already viewing",
+            ),
+            NotifSound => ("sound", "Play the OS notification sound"),
+            NotifMinInterval => (
+                "min_interval_secs",
+                "Min seconds between notifications per session",
+            ),
+            ScrollbackLines => (
+                "scrollback_lines",
+                "Terminal history lines kept per session",
+            ),
+            TwoPanelMinCols => (
+                "two_panel_min_cols",
+                "Min width (cols) to show the 2nd panel",
+            ),
+            ThreePanelMinCols => (
+                "three_panel_min_cols",
+                "Min width (cols) to show the 3rd panel",
+            ),
+            AuditRetentionDays => ("audit_retention_days", "Days of audit-log history kept"),
+        }
+    }
+
+    /// The field's `settings.toml` key (e.g. `tasks`).
+    pub fn label(self) -> &'static str {
+        self.meta().0
+    }
+
+    /// One-line help shown for the selected field in the panel footer.
+    pub fn description(self) -> &'static str {
+        self.meta().1
+    }
+
+    /// Whether the field holds a boolean (toggled with Space/Enter) vs. a
+    /// numeric scalar (stepped with ←/→).
+    pub fn is_scalar(self) -> bool {
+        use SettingsField::*;
+        matches!(
+            self,
+            NotifMinInterval
+                | ScrollbackLines
+                | TwoPanelMinCols
+                | ThreePanelMinCols
+                | AuditRetentionDays
+        )
+    }
+
+    /// Whether changing this field takes effect only after a restart. Feature
+    /// flags that gate UI panels (read from `App.features` every frame) apply
+    /// live; everything else is read once at startup from `settings::global()`,
+    /// which is a write-once value that can't be re-applied in-process.
+    pub fn restart_required(self) -> bool {
+        use SettingsField::*;
+        !matches!(
+            self,
+            FeatTasks
+                | FeatFileViewer
+                | FeatGlobalSearch
+                | FeatInfoPanel
+                | FeatShellPane
+                | FeatSoftDelete
+        )
+    }
+}
+
+/// Settings panel: a centered modal that edits a working copy of [`Settings`]
+/// (`draft`) and writes it back to `settings.toml` on save. Feature flags that
+/// gate UI panels apply live; the rest take effect after a restart. No live
+/// preview — edits apply only on save, so `Esc` is a clean discard.
+#[derive(Debug, Clone)]
+pub struct SettingsModal {
+    pub draft: crate::session::settings::Settings,
+    pub original: crate::session::settings::Settings,
+    pub field: SettingsField,
+}
+
+impl SettingsModal {
+    pub fn new(draft: crate::session::settings::Settings) -> Self {
+        Self {
+            original: draft.clone(),
+            draft,
+            field: SettingsField::FeatTasks,
+        }
+    }
+
+    pub fn next_field(&mut self) {
+        self.field = cycle_field(&SettingsField::ORDER, self.field, 1);
+    }
+
+    pub fn prev_field(&mut self) {
+        self.field = cycle_field(&SettingsField::ORDER, self.field, -1);
+    }
+
+    /// Toggle the boolean the current field maps to (no-op on scalar fields).
+    pub fn toggle(&mut self) {
+        use SettingsField::*;
+        let f = &mut self.draft.features;
+        let n = &mut self.draft.notifications;
+        match self.field {
+            FeatTasks => f.tasks = !f.tasks,
+            FeatAutomations => f.automations = !f.automations,
+            FeatFileViewer => f.file_viewer = !f.file_viewer,
+            FeatGlobalSearch => f.global_search = !f.global_search,
+            FeatInfoPanel => f.info_panel = !f.info_panel,
+            FeatShellPane => f.shell_pane = !f.shell_pane,
+            FeatMouse => f.mouse = !f.mouse,
+            FeatNotifications => f.notifications = !f.notifications,
+            FeatSoftDelete => f.soft_delete = !f.soft_delete,
+            FeatVersionCheck => f.version_check = !f.version_check,
+            FeatAutoUpdate => f.auto_update = !f.auto_update,
+            NotifAlsoOnWaiting => n.also_on_waiting = !n.also_on_waiting,
+            NotifSuppressForActive => n.suppress_for_active = !n.suppress_for_active,
+            NotifSound => n.sound = !n.sound,
+            NotifMinInterval | ScrollbackLines | TwoPanelMinCols | ThreePanelMinCols
+            | AuditRetentionDays => {}
+        }
+    }
+
+    /// Step a scalar field by `delta` (±1), with field-specific step sizes and
+    /// clamping (no-op on boolean fields).
+    pub fn adjust(&mut self, delta: i32) {
+        use SettingsField::*;
+        let d = &mut self.draft;
+        match self.field {
+            ScrollbackLines => {
+                d.scrollback_lines =
+                    step_clamp(d.scrollback_lines as i64, delta, 500, 100, 200_000) as usize;
+            }
+            TwoPanelMinCols => {
+                d.two_panel_min_cols =
+                    step_clamp(i64::from(d.two_panel_min_cols), delta, 5, 40, 400) as u16;
+            }
+            ThreePanelMinCols => {
+                d.three_panel_min_cols =
+                    step_clamp(i64::from(d.three_panel_min_cols), delta, 5, 40, 400) as u16;
+            }
+            AuditRetentionDays => {
+                d.audit_retention_days =
+                    step_clamp(d.audit_retention_days as i64, delta, 5, 1, 3650) as u64;
+            }
+            NotifMinInterval => {
+                d.notifications.min_interval_secs =
+                    step_clamp(d.notifications.min_interval_secs as i64, delta, 5, 0, 3600) as u64;
+            }
+            _ => {}
+        }
+    }
+
+    /// String value rendered for the current field.
+    pub fn value_string(&self, field: SettingsField) -> String {
+        use SettingsField::*;
+        let f = &self.draft.features;
+        let n = &self.draft.notifications;
+        let on = |b: bool| if b { "on" } else { "off" }.to_string();
+        match field {
+            FeatTasks => on(f.tasks),
+            FeatAutomations => on(f.automations),
+            FeatFileViewer => on(f.file_viewer),
+            FeatGlobalSearch => on(f.global_search),
+            FeatInfoPanel => on(f.info_panel),
+            FeatShellPane => on(f.shell_pane),
+            FeatMouse => on(f.mouse),
+            FeatNotifications => on(f.notifications),
+            FeatSoftDelete => on(f.soft_delete),
+            FeatVersionCheck => on(f.version_check),
+            FeatAutoUpdate => on(f.auto_update),
+            NotifAlsoOnWaiting => on(n.also_on_waiting),
+            NotifSuppressForActive => on(n.suppress_for_active),
+            NotifSound => on(n.sound),
+            NotifMinInterval => n.min_interval_secs.to_string(),
+            ScrollbackLines => self.draft.scrollback_lines.to_string(),
+            TwoPanelMinCols => self.draft.two_panel_min_cols.to_string(),
+            ThreePanelMinCols => self.draft.three_panel_min_cols.to_string(),
+            AuditRetentionDays => self.draft.audit_retention_days.to_string(),
+        }
+    }
+
+    /// True once any restart-required field differs from the opened state.
+    /// Drives the "some changes apply after restart" toast and indicator.
+    pub fn restart_required_changed(&self) -> bool {
+        self.draft.restart_only_differs(&self.original)
+    }
+
+    pub fn handle_key(&mut self, code: KeyCode, mods: KeyModifiers) -> EditorOutcome {
+        let scalar = self.field.is_scalar();
+        match code {
+            KeyCode::Esc => EditorOutcome::Cancel,
+            // Explicit save only (Ctrl+S) — keeps Enter free to toggle a bool.
+            KeyCode::Char('s') if mods.contains(KeyModifiers::CONTROL) => EditorOutcome::Save,
+            KeyCode::Tab | KeyCode::Down => {
+                self.next_field();
+                EditorOutcome::Continue
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                self.prev_field();
+                EditorOutcome::Continue
+            }
+            KeyCode::Left if scalar => {
+                self.adjust(-1);
+                EditorOutcome::Continue
+            }
+            KeyCode::Right if scalar => {
+                self.adjust(1);
+                EditorOutcome::Continue
+            }
+            KeyCode::Char(' ') if scalar => {
+                self.adjust(1);
+                EditorOutcome::Continue
+            }
+            KeyCode::Char(' ') | KeyCode::Enter => {
+                self.toggle();
+                EditorOutcome::Continue
+            }
+            _ => EditorOutcome::Continue,
+        }
+    }
+}
+
+/// Step `current` by `delta * step`, clamped to `[min, max]`.
+fn step_clamp(current: i64, delta: i32, step: i64, min: i64, max: i64) -> i64 {
+    (current + i64::from(delta) * step).clamp(min, max)
+}
+
 /// Single, discriminated union replacing boolean flags for modal state.
 /// Only one modal can be active at a time, making invalid states unrepresentable.
 #[derive(Debug, Clone, Default)]
@@ -1371,6 +1671,7 @@ pub enum Modal {
     ThemePicker(ThemePickerModal),
     TaskActionPicker(TaskActionPickerModal),
     ConfirmDelete(ConfirmDeleteModal),
+    Settings(SettingsModal),
 }
 
 impl Modal {
@@ -2470,5 +2771,118 @@ mod tests {
         assert_eq!(m.description.cursor_line_col(), (0, 1));
         m.handle_key(KeyCode::Down, KeyModifiers::NONE);
         assert_eq!(m.description.cursor_line_col(), (1, 1));
+    }
+
+    #[test]
+    fn settings_order_lists_every_field_once() {
+        assert_eq!(SettingsField::ORDER.len(), 19);
+        for f in SettingsField::ORDER {
+            assert_eq!(
+                SettingsField::ORDER.iter().filter(|x| **x == f).count(),
+                1,
+                "{f:?} duplicated"
+            );
+        }
+    }
+
+    #[test]
+    fn settings_space_toggles_bool_and_enter_does_too() {
+        let mut m = SettingsModal::new(crate::session::settings::Settings::default());
+        assert!(m.draft.features.tasks);
+        m.handle_key(KeyCode::Char(' '), KeyModifiers::NONE);
+        assert!(!m.draft.features.tasks);
+        m.handle_key(KeyCode::Enter, KeyModifiers::NONE);
+        assert!(m.draft.features.tasks);
+    }
+
+    #[test]
+    fn settings_scalar_steps_and_clamps() {
+        let mut m = SettingsModal::new(crate::session::settings::Settings::default());
+        m.field = SettingsField::ScrollbackLines;
+        m.handle_key(KeyCode::Right, KeyModifiers::NONE);
+        assert_eq!(m.draft.scrollback_lines, 1500);
+        m.handle_key(KeyCode::Left, KeyModifiers::NONE);
+        assert_eq!(m.draft.scrollback_lines, 1000);
+        // Space adjusts scalars (does not toggle).
+        m.handle_key(KeyCode::Char(' '), KeyModifiers::NONE);
+        assert_eq!(m.draft.scrollback_lines, 1500);
+        // Clamp at the floor.
+        m.field = SettingsField::TwoPanelMinCols;
+        for _ in 0..100 {
+            m.handle_key(KeyCode::Left, KeyModifiers::NONE);
+        }
+        assert_eq!(m.draft.two_panel_min_cols, 40);
+    }
+
+    #[test]
+    fn settings_save_and_cancel_outcomes() {
+        let mut m = SettingsModal::new(crate::session::settings::Settings::default());
+        assert_eq!(
+            m.handle_key(KeyCode::Char('s'), KeyModifiers::CONTROL),
+            EditorOutcome::Save
+        );
+        assert_eq!(
+            m.handle_key(KeyCode::Esc, KeyModifiers::NONE),
+            EditorOutcome::Cancel
+        );
+    }
+
+    #[test]
+    fn settings_restart_required_tracks_only_restart_fields() {
+        let mut m = SettingsModal::new(crate::session::settings::Settings::default());
+        // A live flag changing does not arm the restart note.
+        m.field = SettingsField::FeatTasks;
+        m.toggle();
+        assert!(!m.restart_required_changed());
+        // A restart-required flag does.
+        m.field = SettingsField::FeatMouse;
+        m.toggle();
+        assert!(m.restart_required_changed());
+    }
+
+    #[test]
+    fn settings_restart_required_classification() {
+        use SettingsField::*;
+        for f in [
+            FeatTasks,
+            FeatFileViewer,
+            FeatGlobalSearch,
+            FeatInfoPanel,
+            FeatShellPane,
+            FeatSoftDelete,
+        ] {
+            assert!(!f.restart_required(), "{f:?} should be live");
+        }
+        for f in [
+            FeatMouse,
+            FeatNotifications,
+            FeatAutomations,
+            ScrollbackLines,
+        ] {
+            assert!(f.restart_required(), "{f:?} should need restart");
+        }
+    }
+
+    /// The per-field `restart_required` flag (UI marker) and
+    /// `Settings::restart_only_differs` (the comparison driving the toast) are
+    /// two encodings of the same live/restart split — toggling any
+    /// restart-required field must register as a restart-only difference, and a
+    /// live field must not.
+    #[test]
+    fn settings_restart_classifications_agree() {
+        for field in SettingsField::ORDER {
+            let mut m = SettingsModal::new(crate::session::settings::Settings::default());
+            m.field = field;
+            if field.is_scalar() {
+                m.adjust(1);
+            } else {
+                m.toggle();
+            }
+            assert_eq!(
+                m.draft.restart_only_differs(&m.original),
+                field.restart_required(),
+                "{field:?}: restart_required and restart_only_differs disagree",
+            );
+        }
     }
 }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -645,6 +645,18 @@ impl App {
             ));
         }
 
+        // Settings panel (centered overlay).
+        if let super::modals::Modal::Settings(ref m) = self.modal {
+            crate::ui::settings_modal::render_settings_modal(
+                frame,
+                &crate::ui::settings_modal::SettingsModalState {
+                    modal: m,
+                    restart_pending: m.restart_required_changed(),
+                },
+            );
+            return Some((Vec::new(), None));
+        }
+
         // Restore sessions modal
         if let super::modals::Modal::RestoreSessions(ref rsm) = self.modal {
             return Some(self.render_restore_sessions_modal(frame, rsm));

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -49,6 +49,8 @@ pub enum Action {
     ToggleFileViewer,
     FocusTasks,
     GlobalSearch,
+    /// Open the Settings panel (view/edit settings.toml in the TUI).
+    OpenSettings,
     /// Copy the active mouse selection (falls through to terminal SIGINT when
     /// there is no selection).
     Copy,
@@ -117,6 +119,7 @@ impl Action {
             Action::ToggleFileViewer,
             Action::FocusTasks,
             Action::GlobalSearch,
+            Action::OpenSettings,
             Action::Copy,
             Action::Paste,
             Action::SessionListNext,
@@ -163,6 +166,7 @@ impl Action {
             Action::ToggleFileViewer => "Toggle file viewer",
             Action::FocusTasks => "Tasks",
             Action::GlobalSearch => "Global search",
+            Action::OpenSettings => "Settings",
             Action::Copy => "Copy selection",
             Action::Paste => "Paste",
             Action::SessionListNext => "Next item",
@@ -304,6 +308,11 @@ impl Action {
                     KeyChord::ctrl('_'),
                 ]
             }
+            // Ctrl+, — the near-universal "preferences/settings" chord. Not a
+            // bare Ctrl+<letter>, so it never defers to the PTY (the panel opens
+            // from a focused terminal too). F6 is a discoverable alternate
+            // (F1–F5 are already bound). Fully rebindable.
+            Action::OpenSettings => vec![KeyChord::ctrl(','), KeyChord::function(6)],
             Action::Copy => vec![KeyChord::ctrl('c')],
             Action::Paste => vec![KeyChord::ctrl('v')],
             // Scoped single-letter / arrow nav. These only fire while their
@@ -416,6 +425,7 @@ pub fn help_sections() -> Vec<(&'static str, Vec<Action>)> {
                 ToggleInfoPanel,
                 ToggleFileViewer,
                 OpenThemePicker,
+                OpenSettings,
                 GlobalSearch,
             ],
         ),
@@ -963,6 +973,20 @@ mod tests {
     }
 
     #[test]
+    fn settings_panel_has_dual_chord() {
+        let kb = KeyBindings::default();
+        assert_eq!(
+            kb.lookup(KeyCode::Char(','), KeyModifiers::CONTROL),
+            Some(Action::OpenSettings)
+        );
+        assert_eq!(
+            kb.lookup(KeyCode::F(6), KeyModifiers::NONE),
+            Some(Action::OpenSettings)
+        );
+        assert_eq!(Action::OpenSettings.context(), KeyContext::Global);
+    }
+
+    #[test]
     fn json_round_trip() {
         let kb = KeyBindings::default();
         let json = kb.to_json().unwrap();
@@ -1073,6 +1097,7 @@ mod tests {
                 Action::ToggleFileViewer => 0,
                 Action::FocusTasks => 0,
                 Action::GlobalSearch => 0,
+                Action::OpenSettings => 0,
                 Action::Copy => 0,
                 Action::Paste => 0,
                 Action::SessionListNext => 0,
@@ -1094,9 +1119,9 @@ mod tests {
                 Action::TerminalPageDown => 0,
             }
         }
-        // 40 listed variants must equal Action::all().len(). If you add
+        // The listed variants must equal Action::all().len(). If you add
         // a variant, update both `Action::all()` and the match above.
-        const EXPECTED: usize = 40;
+        const EXPECTED: usize = 41;
         assert_eq!(Action::all().len(), EXPECTED);
         for a in Action::all() {
             classify(*a);

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -184,6 +184,30 @@ fn default_audit_retention_days() -> u64 {
     90
 }
 
+impl Settings {
+    /// Whether any **restart-only** setting differs between `self` and `other`.
+    ///
+    /// These are the values read once at startup (the scalars, every
+    /// `[notifications]` knob, and the feature flags whose effect is wired at
+    /// launch — `automations`, `mouse`, `notifications`, `version_check`). The
+    /// remaining feature flags gate UI panels read from `App.features` every
+    /// frame, so they apply live and are intentionally excluded here. Drives the
+    /// "some changes apply after restart" hint shown by the settings panel and
+    /// the live-reload toast.
+    pub fn restart_only_differs(&self, other: &Settings) -> bool {
+        self.scrollback_lines != other.scrollback_lines
+            || self.two_panel_min_cols != other.two_panel_min_cols
+            || self.three_panel_min_cols != other.three_panel_min_cols
+            || self.audit_retention_days != other.audit_retention_days
+            || self.notifications != other.notifications
+            || self.features.automations != other.features.automations
+            || self.features.mouse != other.features.mouse
+            || self.features.notifications != other.features.notifications
+            || self.features.version_check != other.features.version_check
+            || self.features.auto_update != other.features.auto_update
+    }
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {
@@ -342,6 +366,32 @@ mod tests {
     fn feature_flag_type_mismatch_is_rejected() {
         let err = toml::from_str::<Settings>("[features]\ntasks = \"no\"").unwrap_err();
         assert!(err.to_string().contains("tasks"));
+    }
+
+    #[test]
+    fn restart_only_differs_ignores_live_flags_but_catches_restart_ones() {
+        let base = Settings::default();
+
+        // A live UI-panel flag is not a restart-only difference.
+        let mut live = base.clone();
+        live.features.tasks = !live.features.tasks;
+        assert!(!base.restart_only_differs(&live));
+
+        // A restart-only feature flag, a scalar, and a notification knob all are.
+        let mut mouse = base.clone();
+        mouse.features.mouse = !mouse.features.mouse;
+        assert!(base.restart_only_differs(&mouse));
+
+        let mut scrollback = base.clone();
+        scrollback.scrollback_lines += 1;
+        assert!(base.restart_only_differs(&scrollback));
+
+        let mut notif = base.clone();
+        notif.notifications.sound = !notif.notifications.sound;
+        assert!(base.restart_only_differs(&notif));
+
+        // Identical settings never differ.
+        assert!(!base.restart_only_differs(&base.clone()));
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -19,6 +19,7 @@ pub mod restore_sessions_modal;
 pub mod scrollbar;
 pub mod selection;
 pub mod session_name_modal;
+pub mod settings_modal;
 pub mod status_bar;
 pub mod task_action_picker_modal;
 pub mod task_detail;

--- a/src/ui/settings_modal.rs
+++ b/src/ui/settings_modal.rs
@@ -1,0 +1,268 @@
+//! Renderer for the Settings panel (`crate::app::modals::SettingsModal`) — a
+//! centered modal that lists every `settings.toml` knob grouped into Features /
+//! Notifications / Scalars sections. Modeled on
+//! [`super::automation_editor_modal`].
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use crate::app::modals::SettingsField;
+
+use super::theme::Theme;
+use super::{key_hint_line, render_modal_frame};
+
+/// Preferred modal width. Sized to fit the longest description plus the value
+/// column with a tidy gap, so values aren't flung to the far edge of a wide
+/// terminal. Clamped to the screen on narrow terminals.
+const MODAL_WIDTH: u16 = 66;
+
+/// A fixed `width × height` rect centered in `area` (clamped to it).
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    let col = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Min(0),
+            Constraint::Length(w),
+            Constraint::Min(0),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(0),
+            Constraint::Length(h),
+            Constraint::Min(0),
+        ])
+        .split(col[1])[1]
+}
+
+/// Borrowed view of a `SettingsModal` (`crate::app::modals`) for rendering.
+pub struct SettingsModalState<'a> {
+    pub modal: &'a crate::app::modals::SettingsModal,
+    /// Whether any restart-required field has changed (drives the note).
+    pub restart_pending: bool,
+}
+
+/// Sections, in render order: a header label and the fields under it.
+const SECTIONS: [(&str, &[SettingsField]); 3] = [
+    (
+        "Features",
+        &[
+            SettingsField::FeatTasks,
+            SettingsField::FeatAutomations,
+            SettingsField::FeatFileViewer,
+            SettingsField::FeatGlobalSearch,
+            SettingsField::FeatInfoPanel,
+            SettingsField::FeatShellPane,
+            SettingsField::FeatMouse,
+            SettingsField::FeatNotifications,
+            SettingsField::FeatSoftDelete,
+            SettingsField::FeatVersionCheck,
+            SettingsField::FeatAutoUpdate,
+        ],
+    ),
+    (
+        "Notifications",
+        &[
+            SettingsField::NotifAlsoOnWaiting,
+            SettingsField::NotifSuppressForActive,
+            SettingsField::NotifSound,
+            SettingsField::NotifMinInterval,
+        ],
+    ),
+    (
+        "Scalars",
+        &[
+            SettingsField::ScrollbackLines,
+            SettingsField::TwoPanelMinCols,
+            SettingsField::ThreePanelMinCols,
+            SettingsField::AuditRetentionDays,
+        ],
+    ),
+];
+
+pub fn render_settings_modal(frame: &mut Frame, state: &SettingsModalState<'_>) {
+    // The footer (the selected field's settings.toml key, optional restart note,
+    // key hints) is pinned to the bottom; the field list above it scroll-windows
+    // around the active field when the modal is shorter than the content.
+    let footer = footer_lines(state);
+    // Build the rows first so the modal height matches the real content
+    // (section headers, blank separators between sections, and field rows).
+    let rows = build_rows(state.modal, (MODAL_WIDTH - 2) as usize);
+    let desired = rows.len() as u16 + footer.len() as u16 + 2;
+    let height = desired.min(frame.area().height.saturating_sub(2)).max(6);
+    let area = centered_rect(MODAL_WIDTH, height, frame.area());
+
+    let inner = render_modal_frame(frame, area, "Settings");
+
+    let visible = (inner.height as usize).saturating_sub(footer.len());
+    let active_disp = rows
+        .iter()
+        .position(|(_, f)| *f == Some(state.modal.field))
+        .unwrap_or(0);
+
+    let mut lines: Vec<Line> = if rows.len() <= visible || visible == 0 {
+        rows.into_iter().map(|(line, _)| line).collect()
+    } else {
+        // Keep the active row centered in the window where possible.
+        let start = active_disp
+            .saturating_sub(visible / 2)
+            .min(rows.len() - visible);
+        rows.into_iter()
+            .skip(start)
+            .take(visible)
+            .map(|(line, _)| line)
+            .collect()
+    };
+    lines.extend(footer);
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+/// The pinned footer: the selected field's settings.toml key, an optional
+/// restart note, and the key-hint line.
+fn footer_lines<'a>(state: &SettingsModalState<'_>) -> Vec<Line<'a>> {
+    let mut footer = Vec::new();
+    footer.push(Line::from(vec![
+        Span::styled("  key  ", Theme::label()),
+        Span::styled(
+            state.modal.field.label().to_string(),
+            Style::default().fg(Theme::text_muted()),
+        ),
+    ]));
+    if state.restart_pending {
+        footer.push(Line::from(Span::styled(
+            "  ⟳ some changes apply after restart",
+            Style::default().fg(Theme::status_waiting()),
+        )));
+    }
+    footer.push(key_hint_line(&[
+        ("Tab/↑↓", " move  "),
+        ("←→", " adjust  "),
+        ("Space", " toggle  "),
+        ("^S", " save  "),
+        ("Esc", " cancel"),
+    ]));
+    footer
+}
+
+/// Build the display rows: each section header (no field) followed by its field
+/// rows (carrying their [`SettingsField`] so the active row can be located).
+/// `width` is the modal's inner column count, used to right-align the values.
+fn build_rows<'a>(
+    m: &crate::app::modals::SettingsModal,
+    width: usize,
+) -> Vec<(Line<'a>, Option<SettingsField>)> {
+    // Width of the value column: the widest value across all fields, so every
+    // value (and the `⟳` markers after it) aligns into a single column.
+    let value_width = SettingsField::ORDER
+        .iter()
+        .map(|f| value_text(m, *f).chars().count())
+        .max()
+        .unwrap_or(3);
+
+    let mut rows: Vec<(Line<'a>, Option<SettingsField>)> = Vec::new();
+    for (section_idx, (title, fields)) in SECTIONS.iter().enumerate() {
+        // Blank separator above every section but the first, so the titles
+        // stand clearly apart.
+        if section_idx > 0 {
+            rows.push((Line::default(), None));
+        }
+        rows.push((
+            Line::from(Span::styled(
+                format!("  {}", title.to_uppercase()),
+                Style::default()
+                    .fg(Theme::accent())
+                    .add_modifier(Modifier::BOLD),
+            )),
+            None,
+        ));
+        for field in *fields {
+            rows.push((field_line(m, *field, width, value_width), Some(*field)));
+        }
+    }
+    rows
+}
+
+/// The rendered value for a field: a `‹ n ›` stepper for scalars, `on`/`off`
+/// for booleans.
+fn value_text(m: &crate::app::modals::SettingsModal, field: SettingsField) -> String {
+    let v = m.value_string(field);
+    if field.is_scalar() {
+        format!("‹ {v} ›")
+    } else {
+        v
+    }
+}
+
+/// One field row laid out in fixed columns so values and markers align:
+/// `▸ <description> … <value right-justified in value_width><⟳ marker>`.
+fn field_line<'a>(
+    m: &crate::app::modals::SettingsModal,
+    field: SettingsField,
+    width: usize,
+    value_width: usize,
+) -> Line<'a> {
+    let active = field == m.field;
+
+    // ── Left: pointer + description ─────────────────────────────────────────
+    let pointer = if active { "▸ " } else { "  " };
+    let desc_style = if active {
+        Style::default()
+            .fg(Theme::accent_bright())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Theme::text_secondary())
+    };
+
+    // ── Right: value column + a reserved 2-col marker column ────────────────
+    let value = m.value_string(field);
+    let value_str = value_text(m, field);
+    let value_style = if field.is_scalar() {
+        Style::default()
+            .fg(Theme::accent())
+            .add_modifier(Modifier::BOLD)
+    } else if value == "on" {
+        // Enabled: a calm "on" that stands out without shouting.
+        Style::default()
+            .fg(Theme::tool_allowed())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        // Disabled: dim, so "off" recedes rather than reading like an error.
+        Style::default().fg(Theme::text_muted())
+    };
+    // Always reserve the marker column (2 cols) so value right-edges align on
+    // every row, restart-required or not.
+    let marker = if field.restart_required() {
+        " ⟳"
+    } else {
+        "  "
+    };
+
+    // Columns: pointer(2) + desc + pad + value(value_width) + marker(2).
+    let right_block = value_width + marker.chars().count();
+    let mut desc = field.description().to_string();
+    let left_budget = width.saturating_sub(2 + right_block + 1); // +1 minimum gap
+    if desc.chars().count() > left_budget {
+        desc = desc.chars().take(left_budget.saturating_sub(1)).collect();
+        desc.push('…');
+    }
+    let pad = width
+        .saturating_sub(2 + desc.chars().count() + right_block)
+        .max(1);
+    let value_pad = value_width.saturating_sub(value_str.chars().count());
+
+    Line::from(vec![
+        Span::styled(format!("{pointer}{desc}"), desc_style),
+        Span::raw(" ".repeat(pad + value_pad)),
+        Span::styled(value_str, value_style),
+        Span::styled(marker, Style::default().fg(Theme::text_muted())),
+    ])
+}


### PR DESCRIPTION
## Summary

- New centered **Settings modal** (`Ctrl+,` / `F6`, rebindable `Action::OpenSettings`) to view/edit **all of settings.toml** — `[features]` toggles (incl. `auto_update`), `[notifications]` knobs, and scalar tuning values — without hand-editing the file.
- Comment-preserving write-back via `toml_edit` (`save_settings`); the seed's documentation survives a round-trip.
- Live where safe: UI-panel feature flags apply immediately on save; restart-only values are marked `⟳` and toast a restart note. `settings.toml` is now **live-reloaded** (mtime poll, like `agents.toml`/`keybindings.json`), so hand-edits and another instance's panel propagate.
- Renderer groups Features / Notifications / Scalars with blank separators, an aligned value column, and scroll-windowing for short terminals.

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo doc` (warnings-as-errors) clean; architecture rules pass.
- Added unit (`settings_config`, `settings.rs`, `modals.rs`), acceptance (`acceptance.rs`), and live-reload (`mod.rs`) tests — all pass.
- CI checks pass.