### PR TITLE
fix(core): stop version_check from starving auto-update on startup

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -252,8 +252,10 @@ current vs. latest (`thurbox-cli version` with no flag always prints the
 current version, regardless of the flag).
 
 `auto_update = true` goes a step further than `version_check`: instead of
-just showing a badge, the TUI **silently updates itself** on startup. After
-the same 24 h cache check, if a newer release exists it downloads that
+just showing a badge, the TUI **silently updates itself** on startup. On every
+launch (it does **not** reuse the `version_check` badge's 24 h cache — sharing
+that gate let the badge keep the cache "fresh" and starve the updater) it
+fetches the latest release tag; if a newer release exists it downloads that
 release's tarball + checksums from GitHub Releases (`curl`/`wget`, no new
 dependency), verifies the SHA256 (`sha256sum`/`shasum`), extracts it
 (`tar`), and atomically replaces the installed `thurbox`/`thurbox-cli`

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,11 +238,17 @@ fn arm_automation_heartbeat() {
 }
 
 /// Silently auto-update the installed binaries when `[features] auto_update` is
-/// on, this is not a dev build, and the version-check cache is stale (so a normal
-/// relaunch within the 24h window does zero network IO, matching the version
-/// badge's "a normal launch never hits the network" contract). Best-effort: any
-/// failure is logged and startup continues on the current binary. Returns a
-/// one-line "updated" message to surface in the status bar, or `None`.
+/// on and this is not a dev build. Best-effort: any failure is logged and
+/// startup continues on the current binary. Returns a one-line "updated" message
+/// to surface in the status bar, or `None`.
+///
+/// Deliberately **not** gated on the version-check cache staleness: that cache is
+/// shared with the `version_check` badge, which rewrites it (resetting the 24h
+/// window) on every launch it refreshes. Gating auto-update on it let the badge
+/// starve the updater — the cache was almost always "fresh", so `perform_update`
+/// never ran. Instead we fetch on every launch (one cheap network call when the
+/// feature is opted into); `perform_update(false)` short-circuits to `UpToDate`
+/// after that single fetch when already current.
 fn maybe_auto_update() -> Option<String> {
     let features = &thurbox::session::settings::global().features;
     if !features.auto_update {
@@ -251,14 +257,10 @@ fn maybe_auto_update() -> Option<String> {
     if thurbox::agent::extension_config::is_dev_build() {
         return None;
     }
-    if !thurbox::agent::version_check::cache_is_stale() {
-        return None;
-    }
     match thurbox::agent::self_update::perform_update(false) {
         Ok(outcome) => {
-            // Either way the check ran, so freshen the version-check cache: the
-            // badge stays accurate and the 24h throttle resets (no immediate
-            // re-attempt next launch).
+            // The update ran, so freshen the version-check cache too — the badge
+            // stays accurate and reflects the newest release on the next launch.
             let _ = thurbox::agent::version_check::refresh_cache();
             match outcome {
                 thurbox::agent::self_update::UpdateOutcome::Updated { to, .. } => {


### PR DESCRIPTION
## Summary

- The TUI startup auto-updater (`maybe_auto_update` in `main.rs`) gated on `version_check::cache_is_stale()`, but that 24h cache is **shared** with the `version_check` badge.
- The badge (and any `thurbox-cli version --check`) rewrites that cache on every launch it refreshes, resetting the 24h window. So the startup auto-updater almost always saw a non-stale cache and returned early — `perform_update` never ran. With both flags on, `version_check` **starved** `auto_update` and it silently never updated.
- Fix: drop the cache-staleness gate from `maybe_auto_update`. With `auto_update` on, it fetches on every launch (one cheap network call — the opt-in cost). `perform_update(false)` short-circuits to `UpToDate` after that single fetch when already current. The two features are now independent.
- Updated `docs/CONFIG.md` to match (auto-update no longer reuses the badge's 24h cache).

`cache_is_stale()` is still used by the version-check badge, so it is not dead code.

## Test plan

- `cargo build` (both bins) — clean
- `cargo clippy --bin thurbox --bin thurbox-cli` — no warnings
- `cargo nextest run -E 'test(self_update) + test(version_check)'` — 21 passed
- Verified against the installed v0.135.1 binary: `version --check` correctly reports `0.135.1 → 0.135.2 available`; cache file was being refreshed within seconds by the badge/`--check`, confirming the starvation.