### PR TITLE
fix(core): never feed vt100 a mid-codepoint chunk (fixes glitched chars)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -295,6 +304,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -821,7 +836,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
 ]
 
@@ -1732,7 +1747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1829,6 +1844,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1881,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.12.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +1918,12 @@ checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -1918,7 +1967,27 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1926,6 +1995,24 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "ratatui"
@@ -2107,6 +2194,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2540,6 +2639,7 @@ dependencies = [
  "crossterm",
  "insta",
  "notify-rust",
+ "proptest",
  "pulldown-cmark",
  "ratatui",
  "regex",
@@ -2569,7 +2669,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -2795,6 +2895,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,6 +3007,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,3 +113,8 @@ strip = false
 # Snapshot assertions for the TUI acceptance tests (src/app/acceptance.rs).
 # default-features off keeps the dep tree minimal (just `similar`).
 insta = { version = "1.48.0", default-features = false }
+
+# Property/fuzz testing — proves thurbox's terminal pipeline is byte- and
+# render-transparent (control_mode transport + terminal_view rendering). Runs in
+# the normal `cargo nextest --all`.
+proptest = "1"

--- a/proptest-regressions/agent/backend.txt
+++ b/proptest-regressions/agent/backend.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 7c22487e7c845452d3ce68040f644b9f239f7774d4be0120a6fe3e1b4e620462 # shrinks to bytes = [32, 65, 48, 97, 228, 189, 160, 229, 165, 189, 27, 91, 48, 59, 59, 59, 48, 109, 99, 97, 102, 195, 169, 27, 93, 32, 65, 97, 48, 65, 32, 48, 32, 7, 10, 27, 91, 48, 109, 10, 10, 10, 10, 99, 97, 102, 195, 169, 99, 97, 102, 195, 169, 97, 204, 129], sizes = [15, 5, 32, 3]

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -21,6 +21,44 @@ pub(crate) fn now_millis() -> u64 {
         .as_millis() as u64
 }
 
+/// Length of the prefix of `buf` that is safe to feed to the vt100 parser
+/// without splitting a UTF-8 character. Returns `buf.len()` unless `buf` ends
+/// with the start of a multi-byte character whose continuation bytes have not
+/// all arrived yet, in which case it returns the offset of that incomplete
+/// lead byte (so the caller can carry the tail to the next read).
+///
+/// Only a *plausibly-complete-able* truncated tail is held back: a lead byte
+/// missing some of its continuations. A malformed tail (continuation bytes with
+/// no lead, or a fully-present sequence) is passed through as-is, so garbage is
+/// never buffered unboundedly — the carry is at most 3 bytes (a 4-byte char
+/// missing its last byte).
+fn utf8_ready_prefix_len(buf: &[u8]) -> usize {
+    let len = buf.len();
+    // A truncated tail is at most 3 bytes, so only the last 3 can matter.
+    let start = len.saturating_sub(3);
+    let mut i = len;
+    while i > start {
+        i -= 1;
+        let b = buf[i];
+        // Anything that is not a UTF-8 continuation byte (0x80..=0xbf) starts a
+        // character — ASCII or a multi-byte lead.
+        if !(0x80..=0xbf).contains(&b) {
+            // A lead byte (or ASCII). Determine the sequence's expected length;
+            // if not all of it is present yet, cut before it.
+            let expected = match b {
+                0x00..=0x7f => 1,
+                0xc0..=0xdf => 2,
+                0xe0..=0xef => 3,
+                _ => 4,
+            };
+            return if len - i < expected { i } else { len };
+        }
+        // Continuation byte (0x80..=0xbf): keep scanning back for its lead.
+    }
+    // No lead byte within the last 3 bytes — malformed tail; don't hold it back.
+    len
+}
+
 /// Captures terminal signals the agent emits into shared cells read by the app
 /// layer (mirrors the `last_output_at` side channel). The parser fires these
 /// callbacks while processing the PTY byte stream:
@@ -484,6 +522,14 @@ impl Session {
         last_output_at: Arc<AtomicU64>,
     ) {
         let mut buf = [0u8; 4096];
+        // Bytes of a trailing, not-yet-complete UTF-8 character held back from
+        // the previous read. The agent's output is a single byte stream, but
+        // the OS read boundary (and tmux's `%output` framing) can fall in the
+        // middle of a multi-byte character. vt100 is NOT robust to a `process()`
+        // chunk that ends mid-codepoint — it can swallow a following control
+        // byte (e.g. a newline), misplacing later output — so we never hand it a
+        // truncated tail. `carry` is at most 3 bytes (a 4-byte char missing one).
+        let mut carry: Vec<u8> = Vec::new();
         loop {
             match reader.read(&mut buf) {
                 Ok(0) => {
@@ -491,16 +537,28 @@ impl Session {
                     break;
                 }
                 Ok(n) => {
-                    let data = &buf[..n];
                     last_output_at.store(now_millis(), Ordering::Relaxed);
-                    if let Ok(mut p) = parser.lock() {
-                        p.process(data);
+                    let mut data = std::mem::take(&mut carry);
+                    data.extend_from_slice(&buf[..n]);
+                    let ready = utf8_ready_prefix_len(&data);
+                    carry = data.split_off(ready);
+                    if !data.is_empty() {
+                        if let Ok(mut p) = parser.lock() {
+                            p.process(&data);
+                        }
                     }
                 }
                 Err(e) => {
                     debug!("Session reader error: {e}");
                     break;
                 }
+            }
+        }
+        // Stream ended (EOF or error): flush any leftover partial UTF-8 sequence,
+        // since no more bytes are coming to complete it.
+        if !carry.is_empty() {
+            if let Ok(mut p) = parser.lock() {
+                p.process(&carry);
             }
         }
         exited.store(true, Ordering::SeqCst);
@@ -814,6 +872,156 @@ mod tests {
         let ms = now_millis();
         // Should be after 2024-01-01 (1704067200000 ms since epoch).
         assert!(ms > 1_704_067_200_000);
+    }
+
+    #[test]
+    fn utf8_ready_prefix_passes_complete_input() {
+        assert_eq!(utf8_ready_prefix_len(b""), 0);
+        assert_eq!(utf8_ready_prefix_len(b"hello"), 5);
+        // "é" = c3 a9, complete.
+        assert_eq!(utf8_ready_prefix_len(&[b'a', 0xc3, 0xa9]), 3);
+        // "你好" complete (two 3-byte chars).
+        assert_eq!(utf8_ready_prefix_len("你好".as_bytes()), 6);
+    }
+
+    #[test]
+    fn utf8_ready_prefix_holds_back_truncated_tail() {
+        // Lone 2-byte lead → hold all of it.
+        assert_eq!(utf8_ready_prefix_len(&[b'a', 0xc3]), 1);
+        // 3-byte lead with one continuation, missing one → hold the two.
+        assert_eq!(utf8_ready_prefix_len(&[b'x', 0xe4, 0xbd]), 1);
+        // 4-byte lead alone, and with 1 and 2 continuations → all held.
+        assert_eq!(utf8_ready_prefix_len(&[b'x', 0xf0]), 1);
+        assert_eq!(utf8_ready_prefix_len(&[b'x', 0xf0, 0x9f]), 1);
+        assert_eq!(utf8_ready_prefix_len(&[b'x', 0xf0, 0x9f, 0x8e]), 1);
+        // Same 4-byte char, fully present → nothing held.
+        assert_eq!(utf8_ready_prefix_len(&[b'x', 0xf0, 0x9f, 0x8e, 0x89]), 5);
+        // The realistic read-boundary case: a complete "é" (c3 a9) followed by
+        // the lead byte of the next char → hold only that fresh lead.
+        assert_eq!(utf8_ready_prefix_len(&[0xc3, 0xa9, 0xe6]), 2);
+    }
+
+    #[test]
+    fn utf8_ready_prefix_does_not_buffer_garbage() {
+        // Continuation bytes with no lead in the last 3 → pass through (no
+        // unbounded carry).
+        assert_eq!(utf8_ready_prefix_len(&[0x80, 0x80, 0x80, 0x80]), 4);
+    }
+
+    /// Property/regression tests for the reader-loop UTF-8 carry: feeding the
+    /// vt100 parser through `utf8_ready_prefix_len`-bounded chunks must render
+    /// identically to feeding the whole stream, for any chunking — proving
+    /// thurbox's read boundaries can never glitch valid agent output. vt100 on
+    /// its own does NOT have this property (it can swallow a newline that
+    /// follows a mid-codepoint chunk boundary); the carry is what restores it.
+    mod utf8_chunking {
+        use proptest::prelude::*;
+
+        use super::utf8_ready_prefix_len;
+
+        /// vt100 screen as normalized, right-trimmed visible rows.
+        fn rows(p: &vt100::Parser) -> Vec<String> {
+            let s = p.screen();
+            let (r, c) = s.size();
+            (0..r)
+                .map(|y| {
+                    let mut t = String::new();
+                    for x in 0..c {
+                        let sym = s.cell(y, x).map(|cl| cl.contents()).unwrap_or_default();
+                        t.push_str(if sym.is_empty() { " " } else { sym });
+                    }
+                    t.trim_end().to_string()
+                })
+                .collect()
+        }
+
+        fn whole(bytes: &[u8]) -> Vec<String> {
+            let mut p = vt100::Parser::new(10, 38, 0);
+            p.process(bytes);
+            rows(&p)
+        }
+
+        /// Replays the reader-loop carry logic over `bytes` cut into `sizes`.
+        fn carry_chunked(bytes: &[u8], sizes: &[usize]) -> Vec<String> {
+            let mut p = vt100::Parser::new(10, 38, 0);
+            let mut carry: Vec<u8> = Vec::new();
+            let (mut pos, mut i) = (0usize, 0usize);
+            while pos < bytes.len() {
+                let sz = sizes.get(i % sizes.len()).copied().unwrap_or(1).max(1);
+                let end = (pos + sz).min(bytes.len());
+                let mut data = std::mem::take(&mut carry);
+                data.extend_from_slice(&bytes[pos..end]);
+                let ready = utf8_ready_prefix_len(&data);
+                carry = data.split_off(ready);
+                assert!(carry.len() <= 3, "carry must stay bounded");
+                if !data.is_empty() {
+                    p.process(&data);
+                }
+                pos = end;
+                i += 1;
+            }
+            if !carry.is_empty() {
+                p.process(&carry);
+            }
+            rows(&p)
+        }
+
+        /// The exact minimal case that exposed the vt100 mid-codepoint bug:
+        /// "f" + lead of "é" delivered in one read, then "é"-tail + "\n日本語"
+        /// in the next. Without the carry the newline is swallowed and 日本語
+        /// lands on the wrong row.
+        #[test]
+        fn regression_midcodepoint_newline_widechars() {
+            // f é \n 日本語. Chunked [2, 100] so the first read ends on "f" plus
+            // the lead byte of "é" and the rest arrives next.
+            let bytes = b"f\xc3\xa9\n\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e";
+            assert_eq!(carry_chunked(bytes, &[2, 100]), whole(bytes));
+        }
+
+        /// Strategy producing valid-UTF-8 agent output: text, CSI/OSC escapes,
+        /// wide/combining chars, newlines.
+        fn valid_utf8_output() -> impl Strategy<Value = Vec<u8>> {
+            let token = prop_oneof![
+                proptest::string::string_regex("[ -~]{0,8}")
+                    .unwrap()
+                    .prop_map(String::into_bytes),
+                (
+                    proptest::string::string_regex("[0-9;]{0,6}").unwrap(),
+                    prop::sample::select(vec![b'm', b'H', b'J', b'K', b'A', b'B']),
+                )
+                    .prop_map(|(params, fin)| {
+                        let mut v = vec![0x1b, b'['];
+                        v.extend(params.bytes());
+                        v.push(fin);
+                        v
+                    }),
+                proptest::string::string_regex("[ -~]{0,8}")
+                    .unwrap()
+                    .prop_map(|s| {
+                        let mut v = vec![0x1b, b']'];
+                        v.extend(s.bytes());
+                        v.push(0x07);
+                        v
+                    }),
+                prop::sample::select(vec!["你好", "🎉", "café", "日本語", "→★", "a\u{0301}"])
+                    .prop_map(|s| s.as_bytes().to_vec()),
+                prop::sample::select(vec![b'\n', b'\r', b'\t', 0x08]).prop_map(|b| vec![b]),
+            ];
+            prop::collection::vec(token, 0..40).prop_map(|tokens| tokens.concat())
+        }
+
+        proptest! {
+            /// For valid UTF-8, the carry makes vt100 rendering independent of how
+            /// the byte stream is chunked across reads — the core guarantee that
+            /// thurbox's transport/read boundaries never corrupt agent output.
+            #[test]
+            fn carry_makes_chunking_invariant(
+                bytes in valid_utf8_output(),
+                sizes in prop::collection::vec(1usize..40, 1..16),
+            ) {
+                prop_assert_eq!(carry_chunked(&bytes, &sizes), whole(&bytes));
+            }
+        }
     }
 
     #[test]

--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -612,3 +612,161 @@ mod tests {
     // Compile-time check: channel capacity must be large enough to buffer heavy output.
     const _: () = assert!(PANE_CHANNEL_CAPACITY >= 1024);
 }
+
+/// Property/fuzz tests proving the tmux control-mode **transport** is byte
+/// transparent: whatever the agent writes is exactly what comes out of
+/// [`decode_octal`] + [`ControlModeReader`], regardless of how tmux escapes it
+/// or how the byte stream is chunked. If these stay green, thurbox's transport
+/// layer cannot be the source of glitched/stray characters in the rendered pane.
+#[cfg(test)]
+mod transport_proptests {
+    use std::fmt::Write as _;
+    use std::io::Read;
+    use std::sync::mpsc::channel;
+
+    use proptest::prelude::*;
+
+    use super::{
+        decode_octal, format_send_keys, parse_notification, ControlModeReader, Notification,
+    };
+
+    /// Reference encoder mirroring tmux's control-mode `%output` escaping:
+    /// printable ASCII passes through, backslash becomes `\134`, and every other
+    /// byte is emitted as a 3-digit `\ooo` octal escape. Because backslash is
+    /// always escaped, a bare `\` never appears in the payload except as the
+    /// start of a complete octal escape — exactly the input shape `decode_octal`
+    /// is meant to invert.
+    fn tmux_octal_encode(bytes: &[u8]) -> String {
+        let mut out = String::with_capacity(bytes.len());
+        for &b in bytes {
+            if b == b'\\' {
+                out.push_str("\\134");
+            } else if (0x20..=0x7e).contains(&b) {
+                out.push(b as char);
+            } else {
+                write!(out, "\\{b:03o}").unwrap();
+            }
+        }
+        out
+    }
+
+    /// Split `bytes` into contiguous, non-empty chunks at the given (wrapped)
+    /// offsets — models tmux emitting output across several `%output` lines.
+    fn chunk_bytes(bytes: &[u8], split_points: &[usize]) -> Vec<Vec<u8>> {
+        if bytes.is_empty() {
+            return Vec::new();
+        }
+        let mut points: Vec<usize> = split_points
+            .iter()
+            .map(|&p| p % (bytes.len() + 1))
+            .collect();
+        points.push(0);
+        points.push(bytes.len());
+        points.sort_unstable();
+        points.dedup();
+        points
+            .windows(2)
+            .map(|w| bytes[w[0]..w[1]].to_vec())
+            .filter(|c| !c.is_empty())
+            .collect()
+    }
+
+    /// Read a `ControlModeReader` to EOF using a cycling sequence of buffer
+    /// sizes, so reassembly is exercised across arbitrary read boundaries.
+    fn drain_reader(reader: &mut ControlModeReader, buf_sizes: &[usize]) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut i = 0;
+        loop {
+            let sz = buf_sizes[i % buf_sizes.len()].max(1);
+            let mut buf = vec![0u8; sz];
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => out.extend_from_slice(&buf[..n]),
+                Err(_) => break,
+            }
+            i += 1;
+        }
+        out
+    }
+
+    /// Parse our own `send-keys -t %1 -H XX XX …` command back into the bytes it
+    /// encodes, to confirm the *input* (typed/pasted) path is lossless too.
+    fn parse_send_keys_hex(cmd: &str) -> Vec<u8> {
+        let cmd = cmd.strip_suffix('\n').expect("trailing newline");
+        let rest = cmd
+            .strip_prefix("send-keys -t %1 -H")
+            .expect("send-keys prefix");
+        rest.split_whitespace()
+            .map(|h| u8::from_str_radix(h, 16).expect("hex byte"))
+            .collect()
+    }
+
+    proptest! {
+        /// `decode_octal` is the exact inverse of tmux's octal escaping for any
+        /// byte sequence (all 256 values, escapes, and digit runs that merely
+        /// look like octal).
+        #[test]
+        fn decode_octal_inverts_tmux_encoding(bytes in prop::collection::vec(any::<u8>(), 0..512)) {
+            let encoded = tmux_octal_encode(&bytes);
+            prop_assert_eq!(decode_octal(&encoded), bytes);
+        }
+
+        /// `ControlModeReader` reassembles a chunked byte stream identically,
+        /// regardless of how the stream is chunked or what read buffer sizes the
+        /// consumer uses.
+        #[test]
+        fn control_mode_reader_reassembles_losslessly(
+            chunks in prop::collection::vec(prop::collection::vec(any::<u8>(), 1..64), 0..32),
+            buf_sizes in prop::collection::vec(1usize..40, 1..16),
+        ) {
+            let expected: Vec<u8> = chunks.iter().flatten().copied().collect();
+            let (tx, rx) = channel();
+            for c in &chunks {
+                tx.send(c.clone()).unwrap();
+            }
+            drop(tx);
+            let mut reader = ControlModeReader::new(rx);
+            let got = drain_reader(&mut reader, &buf_sizes);
+            prop_assert_eq!(got, expected);
+        }
+
+        /// The full transport — agent bytes → tmux octal `%output` lines →
+        /// `parse_notification` → `decode_octal` → mpsc channel →
+        /// `ControlModeReader` — is the identity function on the byte stream,
+        /// for arbitrary bytes split across arbitrary `%output` boundaries and
+        /// drained with arbitrary read sizes.
+        #[test]
+        fn full_transport_is_byte_identity(
+            bytes in prop::collection::vec(any::<u8>(), 0..512),
+            split_points in prop::collection::vec(any::<usize>(), 0..16),
+            buf_sizes in prop::collection::vec(1usize..40, 1..16),
+        ) {
+            let chunks = chunk_bytes(&bytes, &split_points);
+            let (tx, rx) = channel();
+            for chunk in &chunks {
+                let line = format!("%output %1 {}", tmux_octal_encode(chunk));
+                match parse_notification(&line) {
+                    Notification::Output { pane_id, data } => {
+                        prop_assert_eq!(pane_id, "%1");
+                        if !data.is_empty() {
+                            tx.send(data).unwrap();
+                        }
+                    }
+                    other => prop_assert!(false, "expected Output, got {:?}", other),
+                }
+            }
+            drop(tx);
+            let mut reader = ControlModeReader::new(rx);
+            let got = drain_reader(&mut reader, &buf_sizes);
+            prop_assert_eq!(got, bytes);
+        }
+
+        /// `format_send_keys` (the `send-keys -H` hex encoding used for every
+        /// typed/pasted byte) round-trips losslessly.
+        #[test]
+        fn format_send_keys_round_trips(bytes in prop::collection::vec(any::<u8>(), 0..256)) {
+            let cmd = format_send_keys("%1", &bytes);
+            prop_assert_eq!(parse_send_keys_hex(&cmd), bytes);
+        }
+    }
+}

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -148,3 +148,222 @@ pub fn render_empty_terminal(frame: &mut Frame, area: Rect) {
         frame.render_widget(Paragraph::new(lines).alignment(Alignment::Left), hint_inner);
     }
 }
+
+/// Property/fuzz tests proving the **rendering** path is transparent: whatever
+/// the vt100 model holds is exactly what lands in the frame buffer, and no raw
+/// control byte ever leaks into a rendered cell. Complements the transport
+/// proptests in `agent::control_mode` — together they cover the whole
+/// agent-bytes → screen pipeline, so a green suite rules thurbox out as a source
+/// of glitched/stray characters.
+#[cfg(test)]
+mod render_proptests {
+    use proptest::prelude::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::{Position, Rect};
+    use ratatui::Terminal;
+
+    use super::render_terminal;
+    use crate::session::SessionInfo;
+    use crate::ui::selection::{PaneBounds, Selection, TermPos};
+    use crate::ui::FocusLevel;
+
+    const COLS: u16 = 40;
+    const ROWS: u16 = 12;
+    // The block draws a 1-cell border on each side, so the vt100 grid (and the
+    // rendered content region) is the area shrunk by one in every direction.
+    const INNER_COLS: u16 = COLS - 2;
+    const INNER_ROWS: u16 = ROWS - 2;
+
+    /// Treat empty and single-space symbols as equivalent, so blank cells
+    /// compare equal across ratatui (renders `" "`) and vt100 (empty contents
+    /// for a blank cell or a wide char's trailing column).
+    fn norm(sym: &str) -> &str {
+        if sym.is_empty() || sym == " " {
+            " "
+        } else {
+            sym
+        }
+    }
+
+    /// Render `bytes` through `render_terminal` into a headless `TestBackend`.
+    /// Returns the full frame buffer, the vt100 model's visible rows, and the
+    /// rendered content region's visible rows — the latter two with the cursor
+    /// cell masked on *both* sides (a focused pane draws a block cursor glyph
+    /// that has no counterpart in the model, and is UI chrome, not content).
+    fn render(bytes: &[u8]) -> (Buffer, Vec<String>, Vec<String>) {
+        crate::ui::theme::ensure_initialized();
+        let mut parser = vt100::Parser::new(INNER_ROWS, INNER_COLS, 0);
+        parser.process(bytes);
+        let info = SessionInfo::new("t".to_string());
+        let mut term = Terminal::new(TestBackend::new(COLS, ROWS)).unwrap();
+        term.draw(|f| {
+            render_terminal(
+                f,
+                Rect::new(0, 0, COLS, ROWS),
+                &mut parser,
+                &info,
+                FocusLevel::Focused,
+                false,
+            );
+        })
+        .unwrap();
+        let buf = term.backend().buffer().clone();
+
+        let screen = parser.screen();
+        let (cur_row, cur_col) = screen.cursor_position();
+        let cursor_visible = !screen.hide_cursor();
+        let masked = |r: u16, c: u16| cursor_visible && r == cur_row && c == cur_col;
+
+        let model: Vec<String> = (0..INNER_ROWS)
+            .map(|r| {
+                let mut s = String::new();
+                for c in 0..INNER_COLS {
+                    if masked(r, c) {
+                        s.push(' ');
+                        continue;
+                    }
+                    let sym = screen
+                        .cell(r, c)
+                        .map(|cell| cell.contents())
+                        .unwrap_or_default();
+                    s.push_str(norm(sym));
+                }
+                s.trim_end().to_string()
+            })
+            .collect();
+
+        let rendered: Vec<String> = (1..ROWS - 1)
+            .map(|y| {
+                let mut s = String::new();
+                for x in 1..COLS - 1 {
+                    if masked(y - 1, x - 1) {
+                        s.push(' ');
+                        continue;
+                    }
+                    let sym = buf
+                        .cell(Position::new(x, y))
+                        .map(|c| c.symbol())
+                        .unwrap_or("");
+                    s.push_str(norm(sym));
+                }
+                s.trim_end().to_string()
+            })
+            .collect();
+
+        (buf, model, rendered)
+    }
+
+    /// A strategy producing adversarial "agent output": text, CSI/OSC escape
+    /// sequences, wide/Unicode chars, control bytes, and raw bytes interleaved.
+    fn agent_output() -> impl Strategy<Value = Vec<u8>> {
+        let token = prop_oneof![
+            // printable ASCII runs
+            proptest::string::string_regex("[ -~]{0,8}")
+                .unwrap()
+                .prop_map(String::into_bytes),
+            // CSI sequence: ESC [ <params> <final>
+            (
+                proptest::string::string_regex("[0-9;]{0,6}").unwrap(),
+                prop::sample::select(vec![b'm', b'H', b'J', b'K', b'A', b'B', b'C', b'D']),
+            )
+                .prop_map(|(params, fin)| {
+                    let mut v = vec![0x1b, b'['];
+                    v.extend(params.bytes());
+                    v.push(fin);
+                    v
+                }),
+            // OSC sequence: ESC ] <text> BEL
+            proptest::string::string_regex("[ -~]{0,8}")
+                .unwrap()
+                .prop_map(|s| {
+                    let mut v = vec![0x1b, b']'];
+                    v.extend(s.bytes());
+                    v.push(0x07);
+                    v
+                }),
+            // wide / multi-byte / combining chars
+            prop::sample::select(vec!["你好", "🎉", "café", "日本語", "→★", "a\u{0301}"])
+                .prop_map(|s| s.as_bytes().to_vec()),
+            // lone control bytes
+            prop::sample::select(vec![b'\n', b'\r', b'\t', 0x08, 0x07]).prop_map(|b| vec![b]),
+            // arbitrary raw bytes (incl. invalid UTF-8 fragments)
+            prop::collection::vec(any::<u8>(), 0..4),
+        ];
+        prop::collection::vec(token, 0..40).prop_map(|tokens| tokens.concat())
+    }
+
+    proptest! {
+        /// No rendered cell — anywhere in the frame, content or chrome — ever
+        /// contains a control character. A glitch where an escape sequence is
+        /// shown as literal text would surface here.
+        #[test]
+        fn rendered_cells_never_contain_control_chars(bytes in agent_output()) {
+            let (buf, _, _) = render(&bytes);
+            for y in buf.area.y..buf.area.y + buf.area.height {
+                for x in buf.area.x..buf.area.x + buf.area.width {
+                    if let Some(cell) = buf.cell(Position::new(x, y)) {
+                        prop_assert!(
+                            !cell.symbol().chars().any(|c| c.is_control()),
+                            "control char rendered at ({},{}): {:?}",
+                            x,
+                            y,
+                            cell.symbol()
+                        );
+                    }
+                }
+            }
+        }
+
+        /// The rendered content region matches the vt100 model row for row — the
+        /// render step neither drops, duplicates, nor invents characters.
+        #[test]
+        fn rendered_content_matches_vt100_model(bytes in agent_output()) {
+            let (_buf, model, rendered) = render(&bytes);
+            prop_assert_eq!(rendered, model);
+        }
+
+        /// The selection overlay is non-destructive: highlighting an arbitrary
+        /// rectangle changes only cell *styles*, never the glyphs.
+        #[test]
+        fn selection_overlay_preserves_glyphs(
+            bytes in agent_output(),
+            a in (0u16..INNER_ROWS, 0u16..INNER_COLS),
+            b in (0u16..INNER_ROWS, 0u16..INNER_COLS),
+        ) {
+            let (original, _, _) = render(&bytes);
+            let mut buf = original.clone();
+            let pane = PaneBounds::from_rect(Rect::new(1, 1, INNER_COLS, INNER_ROWS));
+            let sel = Selection {
+                anchor: TermPos { row: (a.0 + 1) as usize, col: (a.1 + 1) as usize },
+                cursor: TermPos { row: (b.0 + 1) as usize, col: (b.1 + 1) as usize },
+                dragging: false,
+                pane,
+            };
+            crate::ui::selection::highlight_buffer(
+                &mut buf,
+                &sel,
+                ratatui::style::Style::default().fg(ratatui::style::Color::Red),
+            );
+            for y in buf.area.y..buf.area.y + buf.area.height {
+                for x in buf.area.x..buf.area.x + buf.area.width {
+                    let pos = Position::new(x, y);
+                    prop_assert_eq!(
+                        buf.cell(pos).map(|c| c.symbol()),
+                        original.cell(pos).map(|c| c.symbol()),
+                        "glyph changed by selection at ({},{})",
+                        x,
+                        y
+                    );
+                }
+            }
+        }
+
+        // NOTE: chunk-split invariance is tested in `agent::backend` instead,
+        // against the real UTF-8-boundary-safe chunker (`utf8_ready_prefix_len`)
+        // that feeds the vt100 parser. vt100 itself is *not* split-invariant for
+        // chunks that end mid-codepoint (it can swallow a following newline), so
+        // the guarantee lives in thurbox's reader loop, not in vt100 — and that
+        // is where the test belongs (the `ui` layer may not reference `agent`).
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix:** `agent::backend::reader_loop` now carries trailing incomplete UTF-8 bytes between reads (`utf8_ready_prefix_len`) so the vt100 parser never receives a `process()` chunk that ends mid-codepoint. vt100 can swallow a control byte (e.g. a newline) following a mid-codepoint boundary, misplacing later output as stray/glitched characters — and tmux `%output` framing + the 4 KiB read buffer can split a multi-byte char on perfectly valid agent UTF-8.
- **Fuzz/property safety net** (proptest, runs in normal `cargo test`): transport byte-transparency (`agent::control_mode`), rendering transparency (`ui::terminal_view`), and the carry's chunk-split invariance + minimal regression (`agent::backend`). The bug was found by this suite.

## Test plan

- `cargo test` — new proptests (14) green; bite-checked by neutering the fix
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `cargo test --test architecture_rules` green
- CI checks pass