### PR TITLE
docs: align docs and website with current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ command = "codex"
 | `Ctrl+Z` | Undo session delete | **Z** = undo |
 | `Ctrl+U` | Restore deleted sessions | **U**ndelete |
 | `Ctrl+Y` / `F4` | Pick TUI theme | Color **Y**oke |
+| `Ctrl+,` / `F6` | Settings panel (edit settings.toml) | **,** = preferences |
 | `F1` / `Ctrl+G` | Keybindings help + interactive editor | Universal |
 | `Ctrl+B` / `F2` | Toggle info panel | **B**rief |
 | `Ctrl+E` / `F3` | Toggle file viewer | **E**xplorer |
@@ -562,8 +563,10 @@ for scripting and automation. It shares the same SQLite database
 and `tmux -L thurbox` server as the TUI, so changes made by either
 appear live in the other (the TUI polls `PRAGMA data_version`).
 
-Every command prints a JSON result to stdout; pass the global
-`--pretty` flag for indented output. The binary is intentionally
+Output is human-readable by default and switches to JSON
+automatically when stdout is piped (so `… | jq` keeps working);
+force a format with `--json` (compact), `--pretty` (indented JSON),
+or `--text` (human even when piped). The binary is intentionally
 thin — it parses arguments, calls into the database / tmux helpers,
 and prints the result. There is no TUI and no event loop.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -182,8 +182,8 @@ specifically for `perf` / `flamegraph` workflows.
 
 ## ADR-8: State storage — SQLite
 
-**Choice**: All persistent state (sessions, worktrees, VMs,
-containers, automations) is stored in a single SQLite
+**Choice**: All persistent state (sessions, worktrees,
+automations) is stored in a single SQLite
 database at `~/.local/share/thurbox/thurbox.db` (respects
 `$XDG_DATA_HOME`). WAL mode enables concurrent multi-instance
 access. Agent definitions are the one exception: they live in a
@@ -462,7 +462,7 @@ stalls. Worth the most manual testing.
 ## ADR-7b: Multi-Instance Sync — SQLite with PRAGMA data_version
 
 **Choice**: Multiple thurbox instances synchronize all state
-(sessions, worktrees, VMs, containers, automations)
+(sessions, worktrees, automations)
 via a shared SQLite database
 (`~/.local/share/thurbox/thurbox.db`). Each instance polls
 `PRAGMA data_version` to detect external changes. SQLite's WAL mode
@@ -535,16 +535,18 @@ I/O coordination.
 
 ---
 
-## ADR-13: Headless CLI as Separate Binary
+## ADR-15: Headless CLI as Separate Binary
 
 **Choice**: Headless automation lives in a separate binary
 (`thurbox-cli`) that shares the same SQLite database as the TUI.
-It exposes session, VM, container, scheduled-command, and
-editor-command management as subcommands, printing JSON results.
+It exposes `session`, `automation`, `task`, `message`, `editor`,
+`config`, `extension`, `version`, `update`, and `notify` management
+as subcommands, printing JSON results.
 
 **Why**: A separate binary keeps scripting/automation out of the
 TUI's event loop. The TUI already polls `PRAGMA data_version`
-every 250ms (ADR-7b), so changes made by `thurbox-cli` appear
+on every tick (~10 ms event-loop cadence) (ADR-7b), so changes
+made by `thurbox-cli` appear
 automatically — no new synchronization mechanism is needed. The
 `cli` module imports `storage`, `session`, `session_ops`, `sync`,
 and `agent::tmux`, but never `app` or `ui`, so it can operate

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -36,10 +36,14 @@ backends register at startup) and `themes.toml` need a restart.
 opens a **Settings panel** listing every knob. It writes the file back
 **preserving its comments**, and feature flags that gate UI panels apply
 **live** on save; the rest (`mouse`, `notifications`, `automations`,
-`version_check`, the `[notifications]` knobs, and the scalars) take
-effect on the next launch — the panel marks those rows with `⟳` and
-toasts a restart note. Hand-editing the file (or the panel in another
-instance) is picked up the same way, via the live mtime poll.
+`version_check`, the four editable `[notifications]` knobs, and the
+scalars) take effect on the next launch — the panel marks those rows
+with `⟳` and toasts a restart note. The panel exposes only the four
+editable notification knobs (`also_on_waiting`, `suppress_for_active`,
+`sound`, `min_interval_secs`); `[notifications] backend` is **not** in
+the panel — set it only by hand-editing `settings.toml`. Hand-editing
+the file (or the panel in another instance) is picked up the same way,
+via the live mtime poll.
 
 All paths respect `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME`.
 
@@ -518,12 +522,32 @@ up live via `PRAGMA data_version` polling.
 
 ## Environment variables
 
+User-set (read by thurbox):
+
 | Variable | Used for |
 |----------|----------|
 | `XDG_CONFIG_HOME`, `XDG_DATA_HOME` | config/data roots |
 | `VISUAL`, then `EDITOR` | `Ctrl+O` editor when `editor_command` is unset |
 | `SHELL` | the `Ctrl+T` companion shell pane (fallback `/bin/sh`) |
 | `RUST_LOG` | log filter for `thurbox.log` |
+
+Set **by** thurbox into every spawned agent process (not user-set;
+`session_ops::inject_thurbox_env` / `App::build_spawn_inputs`). An
+agent — or a `thurbox-cli` call running inside the session — reads
+these to prove its own identity without scraping panes or names:
+
+| Variable | Set into agent process |
+|----------|------------------------|
+| `THURBOX_SESSION` | the stable thurbox `SessionId` (the registry key); read back by `thurbox-cli message`/`inbox` for self-identity |
+| `THURBOX_SESSION_ID` | the agent's own conversation id (`agent_session_id`); consumed by the metrics statusline. Distinct from `THURBOX_SESSION` |
+| `THURBOX_TASK` | the originating task id; task-spawned sessions only (headless `task run`) |
+| `THURBOX_METRICS_DIR` | metrics output dir |
+
+Set **at build time** (not runtime):
+
+| Variable | Used for |
+|----------|----------|
+| `THURBOX_RELEASE_VERSION` | read by `build.rs` to inject the binary version at build (CI release workflow sets it, e.g. `v0.7.0`); absent → falls back to `CARGO_PKG_VERSION` |
 
 Editor resolution order: DB `editor_command` → `$VISUAL` → `$EDITOR` →
 error toast.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -71,25 +71,30 @@ used for the window title):
   escape (**OSC 9**, **OSC 777**) means the agent finished or is
   waiting for input. This latches a distinct `Needs attention` status
   (`▲`, accent colour) that shows the notification's message text when
-  present, and **floats the session to the top** so blocked or finished
-  agents surface first (see *Smart ordering* below). It clears
-  automatically once you select the session (you're now looking at it).
+  present, marking the row so blocked or finished agents stand out
+  (the dot recolors in place — the manual order is never disturbed; see
+  *Smart ordering* below). It clears automatically once you select the
+  session (you're now looking at it).
 
 ### Smart ordering & repo groups
 
-The list is ordered by **activity and status**, then **grouped by
-repository** under subtle headers (`── webapp ─────`):
+The list is **grouped by repository** under subtle headers
+(`── webapp ─────`), and within a group sessions follow their **manual
+order** (`display_order`, see *Manual ordering* below). Manual order is
+authoritative: once a row has been placed, a status change only
+**recolors its dot**, it never moves the row. Sessions that were never
+moved fall back to creation order:
 
-- Within a group, sessions sort by status rank
-  (`Attention → running → Idle → Error`), tie-broken by stable insertion
-  order. `Busy` and `Waiting` deliberately **share one "running" rank**: a
-  live agent flickers across the ~1s output boundary every tick, so ranking
-  them apart (or sorting by live recency) would make active sessions churn up
-  and down the list endlessly. Ordering is a pure function of *status* and
-  *stable order*, never of live timing — so the list only re-sorts on a real
-  transition (a session needs attention, or exits).
-- Groups are ordered by their **most-urgent member**, then by name, so a repo
-  holding an `Attention` session bubbles above a merely-running one.
+- Sessions with no manual order render after ordered ones in stable
+  insertion order. `Busy` and `Waiting` deliberately **share one
+  "running" status**: a live agent flickers across the ~1s output
+  boundary every tick, so they share a single dot colour rather than
+  jittering between two. Ordering is a pure function of *manual order*
+  and *stable order*, never of live timing — so the list never re-sorts
+  itself, even when a session needs attention or exits.
+- Groups are ordered by their **lowest member `display_order`**, then by name
+  for determinism — so moving a session to the top of its group can pull the
+  whole group up, but a status change never reshuffles the groups.
 - The group key is the **set of repos a session spans** (order-independent), so
   a multi-repo session forms its own group with a combined header
   (`webapp + infra`) rather than being filed arbitrarily under one repo;
@@ -98,11 +103,11 @@ repository** under subtle headers (`── webapp ─────`):
 
 **Why group by repo?** With several parallel agents the dominant question
 is "which project is this?" — clustering same-repo sessions answers it at a
-glance while urgency still wins globally (an `Attention` session never hides
-below a quiet repo). A single comparator
-(`ui::project_list::compute_session_order`) drives both rendering and
-`Ctrl+J`/`Ctrl+K` navigation, so the keyboard always steps through the exact
-order shown.
+glance, and a stable manual order means a row stays where you put it (a
+blinking status dot still flags urgency without yanking the row around). A
+single comparator (`ui::project_list::compute_session_order`) drives both
+rendering and `Ctrl+J`/`Ctrl+K` navigation, so the keyboard always steps
+through the exact order shown.
 
 **Why signals instead of guessing?** Pure output-timing can only say
 "quiet for >1s"; it can't tell a thinking pause from "done" or "needs
@@ -114,6 +119,32 @@ notification for Ghostty/Kitty/iTerm2, so inside thurbox's tmux pane
 set `claude config set --global preferredNotifChannel terminal_bell`
 to get the bell we can detect. We capture bell + OSC 9 + OSC 777,
 whichever the agent produces.
+
+### Manual ordering & alphabetical sort
+
+The list is manually orderable. With the session list focused,
+`Shift+J`/`Shift+K` move the selected session one row down/up
+(rebindable `SessionListMoveDown`/`SessionListMoveUp`). A move swaps two
+adjacent **blocks** — a row plus its nested children, so a parent drags
+its whole subtree: root rows swap within their repo group, the **whole
+group** swaps past a group edge, and nested children move among their
+siblings only. `Shift+S` (rebindable `SessionListSortAlphabetically`)
+sorts every group's sessions alphabetically by name in one shot,
+preserving group order and parent/child nesting.
+
+Both paths densely renumber every session's `display_order` `0..n` and
+persist it, so the order survives restarts and syncs across instances
+via the existing `data_version` polling. The pure helpers
+(`ui::project_list::move_in_order` / `sort_alphabetically_within_groups`)
+back `App::move_active_session` / `sort_sessions_alphabetically`; storage
+is the nullable `sessions.display_order` column (schema v31, `None` =
+never moved).
+
+**Why manual order wins over status.** Earlier the list re-sorted itself
+by status, which meant a row jumped around under your cursor every time
+an agent finished or started thinking. Letting the user pin the order —
+and only recoloring the status dot in place — keeps the list a stable
+spatial map you can build muscle memory against.
 
 ---
 
@@ -164,6 +195,16 @@ no `agents.toml` changes. The workspace is only symlinks, rebuilt
 idempotently on each launch and removed (without touching the repos)
 when the session is deleted. Single-repo sessions launch directly in
 the repo as before.
+
+**Headless multi-repo.** The same shape is reachable without the TUI.
+`thurbox-cli session create` (and `task create`) take repeatable
+`--add-repo PATH[@BASE]` — each gets its **own isolated worktree** on
+the spawn's shared `--worktree-branch`, off its own base — and `--add-dir
+PATH`, which attaches a repo **as-is** (no branch). A spawn with two or
+more members lands in the same symlink workspace the TUI builds, so every
+agent sees each repo as a subdirectory. The extra-repo list is persisted
+as JSON (schema v33) so a restored session rebuilds the identical
+workspace.
 
 **Why per-session agent?** Different tasks suit different agents.
 Choosing the agent at creation time keeps each session
@@ -332,9 +373,13 @@ applicable: `h/j/k/l` for navigation, semantic letters for actions
 | `Ctrl+Z` | Global | Undo session delete | **Z** = undo |
 | `Ctrl+U` | Global | Restore deleted sessions list | **U**ndelete |
 | `Ctrl+Y` / `F4` | Global | Pick TUI theme | Color **Y**oke |
+| `Ctrl+,` / `F6` | Global | Settings panel (edit settings.toml) | **,** = preferences |
 | `F1` / `Ctrl+G` | Global | Keybindings help + interactive editor | Universal help |
-| `F2` | Global | Toggle info panel | Next to F1 |
-| `F3` | Global | Toggle file viewer | Next to F2 |
+| `Ctrl+B` / `F2` | Global | Toggle info panel | **B**rowse info |
+| `Ctrl+E` / `F3` | Global | Toggle file viewer | **E**xplore files |
+| `Shift+J` | Session list | Move selected session down | Reorder |
+| `Shift+K` | Session list | Move selected session up | Reorder |
+| `Shift+S` | Session list | Sort sessions alphabetically within repo groups | **S**ort |
 | `j` / `k` | F1 editor | Select action to rebind | |
 | `Enter` / `r` | F1 editor | Capture a new chord for the selected action | **R**ebind |
 | `d` | F1 editor | Reset selected action to its default chord(s) | **D**efault |
@@ -387,6 +432,17 @@ actions whose scopes overlap. A handful of stateful keys stay fixed (shown in
 the F1 panel under *Fixed (not rebindable)*): modal selectors
 (`j`/`k`/`Enter`/`Esc`), the automations/tasks panes, the file-viewer search
 sub-mode, and the terminal's catch-all PTY forwarding.
+
+**Readline editing in modal text fields.** Thurbox's own text inputs
+(session / branch name, repo-picker path & search, automation editor,
+task title / description) accept the standard emacs/readline
+line-editing chords, so the muscle memory that works in a terminal works
+there too: `Ctrl+A`/`Ctrl+E` (line start/end), `Ctrl+B`/`Ctrl+F` (move
+by char), `Ctrl+H`/`Ctrl+D` (delete before/under the cursor),
+`Ctrl+W` (delete word), `Ctrl+U`/`Ctrl+K` (kill to line start/end). The
+dispatch lives in one place (`modals::apply_ctrl_line_edit` over the
+`LineEdit` trait), and **every** `Ctrl`+letter is consumed (mapped or
+swallowed) so a bare control letter never leaks into the field.
 
 ### macOS
 
@@ -908,9 +964,13 @@ viewer's `/` is an unrelated in-file text search and is unchanged.
 
 Whole features can be switched off declaratively: `tasks`,
 `automations`, `file_viewer`, `global_search`, `info_panel`,
-`shell_pane`, `mouse`, `notifications` — all default `true`. Two flags
-are the opposite — opt-in (default `false`, because they reach the
-network): `version_check` (the "update available" badge +
+`shell_pane`, `mouse`, `notifications`, `soft_delete` — all default
+`true`. `soft_delete` is the odd one out: it is not a pane gate but a
+behaviour switch for the TUI `Ctrl+D` delete (soft-delete with a
+`Ctrl+Z` undo window when on; a confirmation-gated hard delete when
+off — see *Explicit close vs quit*). Two flags are the opposite —
+opt-in (default `false`, because they reach the network):
+`version_check` (the "update available" badge +
 `thurbox-cli version --check`) and `auto_update` (silent self-update on
 startup + `thurbox-cli update`). See `docs/CONFIG.md`.
 
@@ -933,6 +993,55 @@ The F1 help panel intentionally keeps disabled actions listed: hiding
 rows would break the selection-index contract with
 `Action::rebindable_in_order()`, and the toast already explains why a
 chord did nothing.
+
+---
+
+## Settings Panel (`Ctrl+,` / `F6`)
+
+`Ctrl+,` (rebindable `Action::OpenSettings`; `F6` alternate) opens a
+centered Settings modal that views and edits **all of settings.toml** —
+the `[features]` toggles, the `[notifications]` knobs, and the scalars —
+without hand-editing the file.
+
+**Why apply-on-save, not live preview.** The modal edits a working-copy
+`draft` and writes it back only on `Ctrl+S` (`Esc` discards). Persistence
+stays in `settings.toml`, written through a `toml_edit::DocumentMut` so
+the seed's documentation comments survive the round-trip.
+
+**Why some rows take effect immediately and others need a restart.** The
+feature flags that gate UI panels are read every frame, so a save copies
+them into the live `App.features` and they apply at once. Everything else
+is read once at startup from a write-once `OnceLock` that can't be
+re-applied in-process; those rows are marked `⟳`, and a save that touches
+one toasts "some changes apply after restart". The canonical comparison
+(`Settings::restart_only_differs`) is shared by the toast and the reload
+path so the two never disagree.
+
+**Why live-reload the file too.** `settings.toml` is watched by mtime
+(like `agents.toml` / `keybindings.json`): an external edit — a
+hand-edit, or the panel in another instance — re-applies the live feature
+flags and toasts (noting a restart when only restart-only fields
+differ). The panel's own write marks the file saved so the poll doesn't
+re-toast it.
+
+---
+
+## Update Notifications & Auto-Update
+
+Two opt-in `[features]` flags (default `false`, because they reach the
+network — see *Feature Flags*) cover staying current:
+
+- **`version_check`** adds an "update available" badge in the TUI header
+  and the `thurbox-cli version --check` query. The latest release is
+  fetched from GitHub and cached for 24 h, so it costs at most one
+  request a day.
+- **`auto_update`** adds a silent self-update on TUI startup and the
+  `thurbox-cli update` command, which downloads, checksum-verifies, and
+  replaces the installed binaries with the latest release. `--force`
+  bypasses the up-to-date and dev-build guards.
+
+Both are off by default so a fresh install makes **no** network calls and
+never mutates its own binary unless the user asks.
 
 ---
 
@@ -1143,7 +1252,12 @@ branch name) is saved in the database and reconstructed on restore.
   is killed and its worktree (if any) is removed. The database
   row is retained with `deleted_at` set so the deletion can be
   undone with `Ctrl+Z` (most recent) or restored from the
-  `Ctrl+U` list.
+  `Ctrl+U` list. This is governed by `[features] soft_delete`
+  (default `true`): set it `false` and `Ctrl+D` becomes a **hard
+  delete** — the full teardown with no `Ctrl+Z` undo, so it is gated
+  behind a confirmation modal (`Modal::ConfirmDeleteSession`) instead.
+  The flag never affects `thurbox-cli session delete`, which stays soft
+  unless `--force`.
 
 ### Multi-instance support
 
@@ -1200,6 +1314,19 @@ payload** — addressed to a session, with a free-form `kind` tag, a `body`,
 and optional `from_session_id`/`from_task_id` provenance. It is the channel
 extensions use for agent↔agent coordination; flow's clarify→plan→build
 relay is the first consumer.
+
+### Identity-aware, no ids to pass
+
+At spawn thurbox injects each session's own identity into its environment
+(`THURBOX_SESSION` = the stable `SessionId`, and `THURBOX_TASK` for
+task-spawned sessions), so a `thurbox-cli` call running *inside* a session
+knows who it is. `message send`/`inbox` therefore default the
+sender + task provenance (and `--for`) to the caller's own identity — an
+agent sends and reads its own mail with **no ids**. Replies never need a
+peer's id either: `message reply <message_id> --body …` looks the original
+message up and routes back to *its* sender, carrying the original task tag.
+This is how flow relays a user's answer back to a worker without ever
+mapping a task to a session id.
 
 ### Why push, not pane-scraping
 
@@ -1362,14 +1489,29 @@ deduplicated per session by `min_interval_secs`, and the session you
 are currently viewing is skipped by default (`suppress_for_active`),
 since you don't need an alert for the pane you're already watching.
 
-### Click-to-focus (Linux), passive banner (macOS)
+### Delivery backend (auto-detected)
+
+The concrete backend is resolved by `detect_backend` from the configured
+`[notifications] backend` (default `auto`) plus host probing. `auto`
+picks **dbus** on a normal Linux desktop (a session-bus
+`org.freedesktop.Notifications` socket answers), the native **macOS**
+banner, and — the case the doc previously omitted — a **Windows toast**
+under WSL when no dbus daemon answers (`/proc/version` carries the
+Microsoft marker and `powershell.exe` is on PATH; we shell out a WinRT
+toast script). The WSL path fixed a silent-failure bug: the dbus path
+used to error on connect there but only log a `warn!`, so the user saw
+nothing. Delivery errors now land in a process-wide slot surfaced by
+`thurbox-cli notify`.
+
+### Click-to-focus (Linux), passive banner (macOS / WSL)
 
 On Linux the dbus action callback writes a session id to the SQLite
 `metadata` row; the TUI's external-state poll reads and **deletes it
 atomically** (a single `DELETE … RETURNING`) on its next tick and
-switches to that session. macOS shows the banner but ignores clicks —
-the modern `UNUserNotificationCenter` actions require a signed app
-bundle, which thurbox is not. **Terminal window-raising is
+switches to that session. macOS and the WSL Windows toast show the banner
+but ignore clicks — modern `UNUserNotificationCenter` actions require a
+signed app bundle (which thurbox is not), and a Windows toast can't call
+back into WSL. **Terminal window-raising is
 deliberately not implemented**: thurbox runs inside an arbitrary
 terminal emulator it doesn't own, and per-emulator window control is
 fragile (especially on Wayland), so the session is merely pre-selected
@@ -1383,7 +1525,10 @@ The dispatcher thread (`crate::notifications::start`) starts only when
 `[features] notifications = true`, so the feature is zero-overhead when
 disabled. Knobs live in the `[notifications]` block of `settings.toml`
 (`also_on_waiting` / `suppress_for_active` / `sound` /
-`min_interval_secs`) — see [CONFIG.md](CONFIG.md).
+`min_interval_secs` / `backend`) — see [CONFIG.md](CONFIG.md). `backend`
+forces the delivery path (`auto` / `dbus` / `windows` / `macos`) or
+silently drops everything (`off`, a soft switch distinct from the
+`[features]` flag, which stops the dispatcher thread entirely).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ event loop), see [`CLAUDE.md`](../CLAUDE.md).
 | [CONSTITUTION.md](CONSTITUTION.md) | Core principles | Adding/removing an enforced invariant |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Architecture decisions | Changing a technology or structural pattern |
 | [FEATURES.md](FEATURES.md) | Feature-level design | Altering keybindings, lifecycle, layout, or UX |
+| [CONFIG.md](CONFIG.md) | Every config file / env var / DB setting in one place | Adding/changing a config file, env var, or DB setting |
+| [NOTIFICATIONS_TEST_PLAN.md](NOTIFICATIONS_TEST_PLAN.md) | Manual test plan for OS desktop notifications | Changing notification delivery or backends |
 
 ## Keeping Docs Current
 

--- a/website/docs/architecture.html
+++ b/website/docs/architecture.html
@@ -53,7 +53,7 @@ onThisPage:
               <span class="terminal-title">main.rs</span>
             </div>
             <div class="terminal-body">
-              <pre><code><span class="syn-keyword">tokio::main</span> <span class="syn-flag">&rarr;</span> init backend (<span class="syn-string">LocalTmuxBackend</span>)
+              <pre><code><span class="syn-keyword">tokio::main</span> <span class="syn-flag">&rarr;</span> init backend (<span class="syn-string">TmuxBackend</span>)
   <span class="syn-flag">&rarr;</span> open SQLite DB
   <span class="syn-flag">&rarr;</span> init terminal
   <span class="syn-flag">&rarr;</span> spawn/restore sessions
@@ -129,10 +129,16 @@ onThisPage:
                   wraps
                   <code>SessionBackend</code>
                   , backed by
-                  <code>LocalTmuxBackend</code>
-                  (
+                  <code>TmuxBackend</code>
+                  over a
+                  <code>TmuxTransport</code>
+                  (local
                   <code>tmux -L thurbox</code>
-                  ).
+                  , or
+                  <code>ssh &lt;dest&gt; tmux</code>
+                  for
+                  <code>ssh:&lt;host&gt;</code>
+                  backends).
                 </td>
               </tr>
               <tr>
@@ -182,7 +188,9 @@ onThisPage:
             A
             <code>SessionBackend</code>
             trait abstracts session lifecycle. The default is
-            <code>LocalTmuxBackend</code>
+            <code>TmuxBackend</code>
+            over a local
+            <code>TmuxTransport</code>
             (
             <code>tmux -L thurbox</code>
             ).
@@ -253,11 +261,28 @@ onThisPage:
           <p>
             Session lifecycle (spawn, adopt, resize, kill, detach, discover) is abstracted behind a
             <code>SessionBackend</code>
-            trait. The only implementation is
-            <code>LocalTmuxBackend</code>
+            trait. The implementation is
+            <code>TmuxBackend</code>
             , which runs every session in a dedicated
             <code>tmux -L thurbox</code>
             server. The trait boundary keeps the app layer transport-agnostic.
+          </p>
+          <p>
+            <code>TmuxBackend</code>
+            is itself transport-neutral via a
+            <code>TmuxTransport</code>
+            : sessions can run on a
+            <strong>remote host over SSH</strong>
+            while the TUI runs locally. The local backend launches
+            <code>tmux -L thurbox</code>
+            ; a remote one launches
+            <code>ssh &lt;dest&gt; tmux -L thurbox</code>
+            &mdash; the tmux control-mode protocol is byte-identical over either transport. Each host
+            declared in
+            <code>hosts.toml</code>
+            registers a backend named
+            <code>ssh:&lt;host&gt;</code>
+            .
           </p>
 
           <h2 id="async">

--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -77,8 +77,8 @@ onThisPage:
               <tr>
                 <td><code>~/.config/thurbox/settings.toml</code></td>
                 <td>TOML</td>
-                <td>you</td>
-                <td>startup</td>
+                <td>you / Settings panel</td>
+                <td>live (mtime poll)</td>
                 <td>tuning knobs + feature flags</td>
               </tr>
               <tr>
@@ -120,16 +120,24 @@ onThisPage:
           </table>
           <p>
             <code>agents.toml</code>
-            and
+            ,
             <code>keybindings.json</code>
+            , and
+            <code>settings.toml</code>
             reload
             <strong>live</strong>
             : the TUI polls their mtime (~1/s) and applies edits with a confirmation toast &mdash;
-            no restart.
-            <code>hosts.toml</code>
-            ,
+            no restart. For
             <code>settings.toml</code>
-            , and
+            the feature flags and
+            <code>[notifications]</code>
+            knobs apply immediately; the write-once scalars (plus
+            <code>version_check</code>
+            /
+            <code>auto_update</code>
+            ) take effect on the next launch and the toast says so.
+            <code>hosts.toml</code>
+            and
             <code>themes.toml</code>
             need a restart.
           </p>
@@ -307,8 +315,39 @@ resume_latest = false       # true = id-less "resume last session in cwd"</code>
             Scalar tuning knobs plus the
             <code>[features]</code>
             switches, seeded fully commented-out (defaults apply when absent). Only knobs a user
-            plausibly wants are exposed; internals stay hardcoded.
+            plausibly wants are exposed; internals stay hardcoded. The file is
+            <strong>live-reloaded</strong>
+            via mtime poll: the feature flags and
+            <code>[notifications]</code>
+            knobs apply immediately, while the write-once scalars (plus
+            <code>version_check</code>
+            /
+            <code>auto_update</code>
+            ) take effect on the next launch.
           </p>
+          <div class="info-box">
+            <p>
+              <strong>Settings panel.</strong>
+              You don't have to hand-edit the file: the TUI has a
+              <strong>Settings modal</strong>
+              opened with
+              <code>Ctrl+,</code>
+              (or
+              <code>F6</code>
+              ) that views and edits all of
+              <code>settings.toml</code>
+              &mdash; the
+              <code>[features]</code>
+              toggles,
+              <code>[notifications]</code>
+              knobs, and scalars. It edits a working copy and applies
+              <strong>only on
+              <code>Ctrl+S</code>
+              </strong>
+              (<code>Esc</code> discards); the panel writes back through the same file, preserving
+              its documentation comments.
+            </p>
+          </div>
           <table>
             <thead>
               <tr>
@@ -342,7 +381,9 @@ resume_latest = false       # true = id-less "resume last session in cwd"</code>
           </table>
           <p>
             A complete <code>settings.toml</code> showing every knob at its default &mdash; copy
-            this, uncomment what you want to change, and restart:
+            this and uncomment what you want to change (feature flags and
+            <code>[notifications]</code> apply live; the write-once scalars take effect on the next
+            launch):
           </p>
           <pre><code>config_version = 1
 
@@ -361,10 +402,12 @@ info_panel    = true
 shell_pane    = true
 mouse         = true
 notifications = true
+soft_delete   = true           # Ctrl+D soft-deletes (Ctrl+Z undo); false = hard-delete
 version_check = false          # opt-in: makes a network call
 auto_update   = false          # opt-in: downloads + replaces binaries
 
 [notifications]
+backend             = "auto"   # auto / dbus / windows / off
 also_on_waiting     = false    # also fire on Busy &rarr; Waiting (no bell)
 suppress_for_active = true     # skip the session you're currently viewing
 sound               = true     # play the OS default notification sound
@@ -375,9 +418,11 @@ min_interval_secs   = 5        # per-session floor between notifications</code><
             Turn major TUI features off entirely. All default to
             <code>true</code>
             <strong>except <code>version_check</code> and <code>auto_update</code>, which default to <code>false</code></strong>
-            (both reach the network, so they are opt-in). Like the rest of settings.toml, changes need
-            a restart. A disabled feature's pane never renders, its keybinding shows a status toast
-            instead of acting, and its global-search scope returns no results. Data is never
+            (both reach the network, so they are opt-in). Feature-flag changes are
+            <strong>live-reloaded</strong> &mdash; they take effect immediately, no restart (only the
+            write-once scalars and <code>version_check</code>/<code>auto_update</code> wait for the
+            next launch). A disabled feature's pane never renders, its keybinding shows a status
+            toast instead of acting, and its global-search scope returns no results. Data is never
             touched, so re-enabling a flag is lossless.
           </p>
           <table>
@@ -428,6 +473,15 @@ min_interval_secs   = 5        # per-session floor between notifications</code><
                 <td><code>notifications</code></td>
                 <td><code>true</code></td>
                 <td>OS desktop notifications when a session needs attention</td>
+              </tr>
+              <tr>
+                <td><code>soft_delete</code></td>
+                <td><code>true</code></td>
+                <td>
+                  TUI <code>Ctrl+D</code> soft-deletes (with a <code>Ctrl+Z</code> undo window);
+                  <code>false</code> makes it a hard delete behind a confirmation modal. Never affects
+                  <code>thurbox-cli session delete</code> (soft unless <code>--force</code>).
+                </td>
               </tr>
               <tr>
                 <td><code>version_check</code></td>
@@ -515,6 +569,16 @@ min_interval_secs   = 5        # per-session floor between notifications</code><
               </tr>
             </thead>
             <tbody>
+              <tr>
+                <td><code>backend</code></td>
+                <td><code>auto</code></td>
+                <td>
+                  delivery backend (<code>auto</code> / <code>dbus</code> / <code>windows</code> /
+                  <code>off</code>): <code>auto</code> picks dbus on a Linux desktop, the WSL
+                  Windows-toast fallback, or the macOS native banner; <code>off</code> drops every
+                  notification (a soft switch distinct from the feature flag)
+                </td>
+              </tr>
               <tr>
                 <td><code>also_on_waiting</code></td>
                 <td><code>false</code></td>

--- a/website/docs/extension-ci-shepherd.html
+++ b/website/docs/extension-ci-shepherd.html
@@ -1,7 +1,7 @@
 ---
 layout: docs.njk
 title: 'ci-shepherd extension — Thurbox Docs'
-description: 'The ci-shepherd extension: watches your open change requests (GitHub PRs, GitLab MRs, Bitbucket PRs, and any git forge) and dispatches a worker to fix failing CI or a changes-requested review.'
+description: 'The ci-shepherd extension: watches your open change requests (GitHub PRs, GitLab MRs, Bitbucket PRs, and any git forge) and dispatches a worker to fix failing CI, a changes-requested review, or a branch that is behind its target (needs rebase).'
 currentPage: 'extension-ci-shepherd'
 breadcrumb: 'ci-shepherd'
 onThisPage:
@@ -19,12 +19,14 @@ onThisPage:
             <strong>change requests</strong>
             &mdash; GitHub PRs, GitLab MRs, Bitbucket PRs &mdash; and whenever one picks up
             <strong>failing CI</strong>
-            or a
+            , a
             <strong>changes-requested review</strong>
+            , or a branch that has fallen
+            <strong>behind its target (needs rebase)</strong>
             , dispatches a worker session to address it: the worker checks out the request branch,
-            fixes the feedback, pushes to the same branch (so the request updates), and leaves a
-            comment &mdash; then pings the shepherd so the next one dispatches. It turns review
-            round-trips into background work.
+            fixes the feedback (or rebases onto the base and force-pushes), pushes to the same
+            branch (so the request updates), and leaves a comment &mdash; then pings the shepherd so
+            the next one dispatches. It turns review round-trips into background work.
           </p>
           <div class="info-box warning">
             <p>
@@ -56,6 +58,20 @@ onThisPage:
             ,
             <code>shepherd-worker</code>
             ), so each can be any CLI.
+          </p>
+          <p>
+            A fixer is dispatched for any of three signals on a watched request: failing CI, a
+            changes-requested review, or a branch that is
+            <strong>behind its target</strong>
+            and needs a rebase &mdash; the normalized
+            <code>rebase</code>
+            signal surfaced as the
+            <code>REBASE</code>
+            action flag by
+            <code>scripts/classify.sh</code>
+            .
+            <code>dispatch-fix.sh --rebase</code>
+            makes the worker rebase onto the base and force-push before fixing.
           </p>
 
           <h2 id="forges">

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -323,6 +323,22 @@ breadcrumb: 'Features'
             .
           </p>
 
+          <h3>Multi-repo sessions</h3>
+          <p>
+            A session can span several repositories. The repo picker lets you select more than one,
+            and headless callers pass
+            <code>--add-repo PATH[@BASE]</code>
+            (each gets its own isolated worktree on the session's branch) or
+            <code>--add-dir PATH</code>
+            (attached as-is, no branch). Because agent CLIs differ wildly in how they accept extra
+            directories, Thurbox launches a multi-repo session in a per-session
+            <strong>symlink workspace</strong>
+            (
+            <code>~/.local/share/thurbox/workspaces/&lt;id&gt;/</code>
+            , one symlink per repo) and starts the agent there, so every agent sees each repo as a
+            subdirectory &mdash; fully agent-neutral. Single-repo sessions are unchanged.
+          </p>
+
           <h2 id="remote-ssh-sessions">
             Remote SSH Sessions
             <a href="#remote-ssh-sessions" class="heading-anchor">#</a>
@@ -835,6 +851,7 @@ info_panel = true     # F2/Ctrl+B info panel
 shell_pane = true     # Ctrl+T per-session shell
 mouse = true          # mouse capture: clicks, wheel, drag-select, hover
 notifications = true  # OS desktop alerts when a session needs attention
+soft_delete = true    # Ctrl+D soft-deletes (Ctrl+Z undo); false = hard-delete behind a confirm
 version_check = false # opt-in GitHub update check (makes a network call)
 auto_update = false   # opt-in: silently download+verify+replace binaries on startup</code></pre>
           <p>
@@ -843,6 +860,26 @@ auto_update = false   # opt-in: silently download+verify+replace binaries on sta
             schedules and arming the tmux heartbeat at startup (explicit
             <code>thurbox-cli automation</code>
             commands still work).
+          </p>
+          <p>
+            You don't have to hand-edit the file: press
+            <code>Ctrl+,</code>
+            (or
+            <code>F6</code>
+            ) to open the
+            <strong>Settings panel</strong>
+            &mdash; a modal that views and edits all of
+            <code>settings.toml</code>
+            (the
+            <code>[features]</code>
+            toggles, the
+            <code>[notifications]</code>
+            knobs, and the scalars). Edits apply on
+            <code>Ctrl+S</code>
+            (
+            <code>Esc</code>
+            discards); the file is also live-reloaded, so feature flags and notification knobs take
+            effect immediately.
           </p>
 
           <h2 id="session-persistence">
@@ -913,10 +950,17 @@ auto_update = false   # opt-in: silently download+verify+replace binaries on sta
             binary drives the same sessions, automations, and editor settings without the TUI
             &mdash; ideal for scripting. It shares the TUI's SQLite database and
             <code>tmux -L thurbox</code>
-            server, so changes made by either show up live in the other. Every command prints JSON;
-            pass the global
+            server, so changes made by either show up live in the other. Output is
+            <strong>human-readable by default</strong>
+            and switches to JSON automatically when stdout is piped (so
+            <code>&hellip; | jq</code>
+            keeps working); force a format with
+            <code>--json</code>
+            (compact),
             <code>--pretty</code>
-            flag for indented output.
+            (indented), or
+            <code>--text</code>
+            (human even when piped).
           </p>
           <pre><code><span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> session list
 <span class="syn-prompt">$</span> <span class="syn-cmd">thurbox-cli</span> session create <span class="syn-flag">--name</span> reviewer <span class="syn-flag">--repo-path</span> <span class="syn-string">/path/to/repo</span> <span class="syn-flag">--agent</span> codex
@@ -1067,6 +1111,30 @@ auto_update = false   # opt-in: silently download+verify+replace binaries on sta
               on a problem &mdash; handy in dotfiles CI), and
               <code>show</code>
               prints the effective resolved configuration.
+            </li>
+            <li>
+              <strong>version</strong>
+              &mdash; prints the running version;
+              <code>--check</code>
+              queries GitHub's latest release (gated on the
+              <code>version_check</code>
+              feature).
+            </li>
+            <li>
+              <strong>update</strong>
+              &mdash; downloads, verifies, and replaces the installed binaries with the latest
+              release (
+              <code>--force</code>
+              bypasses the up-to-date / dev-build guards; gated on the
+              <code>auto_update</code>
+              feature).
+            </li>
+            <li>
+              <strong>notify</strong>
+              &mdash; diagnoses OS desktop notifications: prints the detected delivery backend and
+              last error;
+              <code>--test</code>
+              fires a sample.
             </li>
           </ul>
 

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -234,12 +234,32 @@ onThisPage:
                 <td>Universal</td>
               </tr>
               <tr>
-                <td><code>F2</code></td>
+                <td>
+                  <code>Ctrl+,</code>
+                  /
+                  <code>F6</code>
+                </td>
+                <td>Settings panel (edit settings.toml)</td>
+                <td>
+                  <strong>,</strong>
+                  = preferences
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <code>Ctrl+B</code>
+                  /
+                  <code>F2</code>
+                </td>
                 <td>Toggle info panel</td>
                 <td>Next to F1</td>
               </tr>
               <tr>
-                <td><code>F3</code></td>
+                <td>
+                  <code>Ctrl+E</code>
+                  /
+                  <code>F3</code>
+                </td>
                 <td>Toggle file viewer</td>
                 <td>Next to F2</td>
               </tr>


### PR DESCRIPTION
## Summary

Audited `docs/` and `website/` against the current implementation and fixed accumulated drift across 10 files (documentation-only — no code changes).

- **FEATURES.md** — added Settings panel, auto-update/version-check, hard-delete (`soft_delete=false`) path, manual ordering + alphabetical sort, headless multi-repo (`--add-repo`/`--add-dir`), readline editing in modal fields, mailbox `reply`/identity, and the WSL Windows-toast backend; fixed the keybinding table (`Ctrl+B`/`F2`, `Ctrl+E`/`F3`, `Ctrl+,`/`F6`, `Shift+J`/`K`, `Shift+S`) and the `soft_delete` feature flag.
- **CONFIG.md** — documented the thurbox-injected `THURBOX_*` env vars + build-time `THURBOX_RELEASE_VERSION`; clarified the Settings panel edits only the four notification knobs (`backend` is hand-edit only).
- **ARCHITECTURE.md** — deduped the two `ADR-13`s (Headless CLI → `ADR-15`), fixed the stale "every 250ms" poll claim (→ every tick), dropped dead VMs/containers subsystem references.
- **docs/README.md** — indexed `CONFIG.md` and `NOTIFICATIONS_TEST_PLAN.md`.
- **README.md** — added the Settings keybinding row; fixed the stale "always prints JSON" CLI claim (human-readable by default, JSON when piped).
- **website/** — ci-shepherd rebase/behind-target trigger; `LocalTmuxBackend` → `TmuxBackend` + remote SSH note; configuration live-reload + Settings panel + `soft_delete` + notifications `backend`; keybindings Settings + `Ctrl+B`/`Ctrl+E`; features CLI subcommands + Settings panel + multi-repo.

## Test plan

- `rumdl check docs/ README.md` — clean
- Website HTML verified tag-balanced
- CI checks pass