### PR TITLE
perf(core): render on demand instead of every ~100 fps frame

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,42 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+  # Informational only — tracks the release binary size so growth is visible in
+  # the PR. Deliberately NOT in `all-checks.needs`, so it never blocks a merge.
+  # See docs/PERFORMANCE.md (memory / binary size).
+  binary-size:
+    name: Binary Size
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Build release binaries
+        run: cargo build --release --bins
+      - name: Record binary sizes
+        run: |
+          {
+            echo "### Release binary sizes"
+            echo ""
+            echo "| Binary | Size |"
+            echo "| ------ | ---- |"
+            for bin in thurbox thurbox-cli; do
+              path="target/release/$bin"
+              [ -f "$path" ] || continue
+              size=$(du -h "$path" | cut -f1)
+              bytes=$(stat -c%s "$path")
+              echo "| \`$bin\` | $size ($bytes bytes) |"
+            done
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: Upload binaries as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-binaries
+          path: |
+            target/release/thurbox
+            target/release/thurbox-cli
+          if-no-files-found: warn
+
   all-checks:
     name: All Checks
     if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,27 @@ The TUI has two layers of end-to-end coverage:
   `TMUX_TMPDIR`, mirroring `scripts/demo/record.sh`), drives it with
   `tmux send-keys`, and asserts on captured frames (boot → F1 → theme → quit).
   Gated behind the `tui-smoke` CI job (needs tmux).
+- **Performance counter tests** (`perf_*` in `src/app/acceptance.rs`). Assert on
+  `App::perf_counters()` — wall-clock-free `u64` counters bumped at the
+  render/tick hot paths (`MetricsState::perf`) — to gate the perf optimizations
+  without flaky timing: e.g. idle iterations skip the paint, the session order
+  is rebuilt only when its inputs change. Run with `cargo nextest run -E
+  'test(perf_)'`. See `docs/PERFORMANCE.md`.
+
+## Performance (render loop)
+
+The render loop is **demand-driven** (`run_loop` in `src/main.rs`): it paints a
+frame only when the UI is dirty (`App::needs_redraw`) or a 250 ms forced-redraw
+floor (`FORCE_REDRAW_INTERVAL`) elapsed — not on every ~10 ms iteration like
+before. `App::update` marks dirty on any input; `App::detect_output_redraw`
+marks dirty on new agent output (lock-free, via each session's `last_output_at`
+atomic); `refresh_session_statuses` marks dirty on a status change; the floor
+covers time-driven UI (clock/metrics/cursor blink). Idle paints drop ~100 fps →
+~4 fps with input/output latency unchanged. The session-list ordering is cached
+keyed by a content signature (`App::session_order_signature`), rebuilt only when
+its grouping/nesting inputs change. Launch with `THURBOX_PERF_LOG=1` to log one
+`first_frame_ms` startup line to `thurbox.log`. Full rationale +
+intentionally-skipped optimizations: `docs/PERFORMANCE.md`.
 
 ## Installation Script
 
@@ -1374,6 +1395,8 @@ For rationale behind decisions, see `docs/`:
 - `docs/ARCHITECTURE.md` — Architectural decisions with rationale
 - `docs/FEATURES.md` — Feature-level design choices
 - `docs/CONFIG.md` — Every config file/env var/DB setting in one place
+- `docs/PERFORMANCE.md` — Render/tick performance: demand-driven redraw,
+  perf counters, the session-order cache, and how to measure
 
 **Rule**: If a code change invalidates or extends a documented
 decision, update the relevant doc in the same PR.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,197 @@
+# Performance
+
+How thurbox stays responsive and light, and how to measure it. The focus areas
+are **input latency**, **runtime CPU / render cost**, **startup time**, and
+**memory / binary size**. Decisions below follow the mini-ADR format
+(**Choice**, **Why**, **Rejected alternatives**), matching
+[`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+The guiding principle is **measure first**: every optimization here is backed by
+a deterministic counter or a concrete code fact, and is proven by a test that
+fails if the optimization regresses.
+
+---
+
+## ADR-P1: Demand-driven rendering (redraw throttling)
+
+**Choice**: The render loop (`run_loop` in `src/main.rs`) paints a frame only
+when the UI is *dirty* or a forced-redraw floor elapsed — not on every loop
+iteration. State drives the paint:
+
+- **Input** marks the UI dirty: `App::update` calls `App::request_redraw`, so a
+  keypress paints on the very next iteration (latency unchanged).
+- **Agent output** marks the UI dirty: `App::detect_output_redraw` sums each
+  session's monotonic `last_output_at` atomic into a rolling signature
+  (`Session::last_output_at`, no vt100 lock); a change means new output, so the
+  terminal repaints immediately.
+- **Status transitions** mark the UI dirty: `refresh_session_statuses` requests
+  a redraw when a session's status/activity/notification actually changes
+  (a quiet `Busy → Waiting` produces no output, so the output detector can't
+  catch it).
+- **Everything else time-driven** — the live clock/metrics, cursor blink, an
+  expiring status toast — is covered by `FORCE_REDRAW_INTERVAL` (250 ms): if
+  nothing flagged the UI dirty, `App::should_redraw` still paints once the floor
+  elapses.
+
+The loop still spins every ≤10 ms (poll input, check output, `tick`), but the
+*expensive* work — layout, the vt100 `PseudoTerminal` render, panel rebuilds —
+is skipped when idle.
+
+**Why**: The previous loop called `terminal.draw` unconditionally, ~100 fps,
+even on a completely idle screen. That is the single largest idle-CPU cost in a
+TUI that may sit untouched for long stretches with several sessions open.
+Demand-driven rendering drops idle paints from ~100 fps to ~4 fps (the floor)
+while keeping input and output repaints immediate — so responsiveness is
+unchanged and idle CPU drops by ~25×.
+
+**Rejected**:
+
+- *Per-widget dirty tracking* — far more invasive and bug-prone (every state
+  mutation must flag the right widget); the coarse app-level flag plus a time
+  floor captures the same win with a fraction of the surface.
+- *Lower fixed frame rate (e.g. 20 fps always)* — still wastes CPU when idle and
+  adds latency to input/output; the floor only fires when nothing else did.
+
+**Correctness net**: dirtiness is deliberately over-approximated (any input, any
+status change → repaint) and the 250 ms floor guarantees nothing time-driven
+stays stale longer than a blink. The black-box smoke test
+(`scripts/dev/tui-smoke-test.sh`) still asserts the first frame and every
+post-keystroke frame paint.
+
+---
+
+## ADR-P2: Deterministic perf counters as the regression gate
+
+**Choice**: Performance regressions are caught by **counting**, not timing.
+`MetricsState::perf` (`PerfCounters` in `src/app/metrics_state.rs`) holds
+wall-clock-free `u64` counters bumped at the render/tick hot paths:
+
+| Counter | Meaning |
+| --- | --- |
+| `frames_rendered` | `App::view` ran (a frame painted) |
+| `redraws_requested` / `redraws_skipped` | loop iterations that painted vs. skipped |
+| `status_refreshes` | `refresh_session_statuses` passes (one per tick) |
+| `ordered_sessions_rebuilds` | session-list order rebuilt vs. served from cache |
+| `parser_locks_render` | central pane locked a vt100 parser to render (one per terminal frame) |
+| `automation_entries_built` | automations-pane entry list built |
+
+The acceptance harness (`src/app/acceptance.rs`) asserts on
+`App::perf_counters()` — e.g. *idle iterations skip the paint*, *the session
+order is rebuilt exactly once across three idle frames*, *a session-set change
+invalidates the cache exactly once*. These run in the normal `cargo nextest run
+--all` and gate CI.
+
+**Why**: Wall-clock benchmarks are flaky on shared CI runners — a GC pause or a
+noisy neighbour turns a green build red. A counter assertion (`redraws_skipped
+== 4`) is exact and reproducible, and it proves the *mechanism* (work was
+skipped) rather than a wobbly proxy (it was fast today).
+
+**Rejected**:
+
+- *Timing assertions in CI* (`assert!(elapsed < X)`) — flaky; deleted before
+  they were written.
+- *criterion / divan micro-benches in the gate* — see ADR-P5.
+
+---
+
+## ADR-P3: Cache the session-list ordering, keyed by a content signature
+
+**Choice**: `compute_session_order` (`src/ui/project_list.rs`) groups, sorts,
+and nests the session list. Its output is a pure function of exactly four
+per-session fields — `repo_display_names` (grouping), `display_order` (sort),
+`id` and `parent_session_id` (nesting) — plus the session count/order, and
+**never** of status. `App` caches the computed `SessionOrder` keyed by
+`App::session_order_signature` (a hash of just those fields). On a frame where
+the signature is unchanged, the cache is reused via
+`OrderedSessions::from_order`, skipping the grouping HashMap, the two sort
+passes, the nest recursion, and the group-label allocations. The cheap O(n)
+remap of refs / match positions / `active_index` still runs each frame (those
+vary independently).
+
+**Why**: While an agent streams output the screen repaints every frame, and the
+left panel was rebuilding the full ordering on each one even though sessions
+rarely change. The signature is strictly cheaper than the order it guards (a
+hash vs. HashMap construction + sorts + recursion + allocations), and being
+content-derived it is **self-invalidating**: any change that alters the order
+alters the hash, so there is no manual "mark dirty" call site to forget.
+
+**Rejected**:
+
+- *An explicit generation counter bumped at every mutation site* — correctness
+  depends on instrumenting every add/remove/reorder/reparent/external-sync path;
+  one miss is a stale-list bug. The content hash can't miss.
+- *No cache* — measurable waste during active output for larger session lists.
+
+---
+
+## ADR-P4: What was deliberately *not* optimized
+
+Measuring first also means **not** adding complexity where the data says it
+won't pay off.
+
+- **Scrollback round-trip** (`src/ui/terminal_view.rs`): reading the total
+  scrollback via `set_scrollback(MAX)` → read → restore looks like a per-frame
+  double-write, but in vt100 0.16 `set_scrollback`/`scrollback` are **O(1)**
+  (a clamped field assignment). With ADR-P1 throttling it now runs ~4×/s when
+  idle. Caching it would add interior-mutability/borrow complexity for no
+  measurable gain. Left as-is (it rides along with `parser_locks_render`).
+- **Automations-pane entries** (`src/app/view.rs`): rebuilt each render
+  (`automation_entries_built`). The only repeated parse is `humanize_cron`, and
+  the countdown portion *must* stay live, so a cache would only memoize the
+  schedule string. Automations are typically a handful, and ADR-P1 bounds the
+  frequency — not worth the split. Left as-is.
+- **vt100 parser lock contention** (`src/app/view.rs` render vs.
+  `src/agent/backend.rs` reader thread): the reader locks the parser per output
+  chunk; the UI locked it per frame. ADR-P1 collapses idle-frame UI locks to
+  near zero (`parser_locks_render`), so the contention window shrinks for free.
+  Cloning the vt100 screen for lock-free rendering was rejected — the screen is
+  large and the copy would cost more than the brief lock it removes. The UI
+  already scopes the lock tightly (lock → render widget → release).
+
+---
+
+## ADR-P5: Benchmarks and profiling live outside the PR gate
+
+**Choice**: The gating automated perf tests are the counter assertions
+(ADR-P2). Heavier measurement is **opt-in and local**:
+
+- **Time-to-first-frame**: launch with `THURBOX_PERF_LOG=1`; `run_loop` logs one
+  `first_frame_ms=…` line (covering config load, DB open, and session restore)
+  to `~/.local/share/thurbox/thurbox.log`. Off by default — never affects normal
+  runs or the smoke test.
+- **Binary size**: the non-gating `binary-size` CI job
+  (`.github/workflows/ci.yml`) builds `--release` and records `thurbox` /
+  `thurbox-cli` sizes to the job summary + an artifact. It is intentionally
+  **not** in `all-checks.needs`, so it never blocks a merge; it just makes
+  growth visible. The release profile is already tuned (`opt-level = 3`,
+  `lto = true`, `codegen-units = 1`, `strip = true`).
+- **Local profiling**: `cargo flamegraph --bin thurbox` (build with the
+  `release-with-debug` profile for symbols) for CPU; `cargo bloat --release
+  --crates` for size attribution. Neither is a dependency — run them ad hoc.
+
+**Why**: criterion/divan pull a large transitive dependency tree, and
+`cargo deny check licenses` (a **gating** CI job with a strict allowlist) would
+have to vet all of it. For micro-benchmarks of two pure functions
+(`compute_session_order`, `compute_layout`) that the analysis shows are not
+bottlenecks, that cost isn't justified — the counter tests already gate
+regressions without flakiness or new dependencies.
+
+**Rejected**:
+
+- *criterion in `dev-dependencies` + a gating bench job* — dependency-license
+  and flakiness cost for little signal.
+- *A startup-time CI gate* — startup is dominated by tmux/agent spawn and
+  machine variance; a hard threshold would be flaky. The opt-in log line is for
+  local investigation instead.
+
+---
+
+## Quick reference
+
+| I want to… | Do this |
+| --- | --- |
+| Measure startup | `THURBOX_PERF_LOG=1 thurbox`, read `first_frame_ms` in `thurbox.log` |
+| See binary size | Check the `Binary Size` CI job summary, or `cargo bloat --release --crates` |
+| Profile CPU | `cargo flamegraph --profile release-with-debug --bin thurbox` |
+| Verify no perf regression | `cargo nextest run -E 'test(perf_)'` |
+| Confirm idle CPU is low | Launch, leave it idle — `redraws_skipped` climbs while `frames_rendered` stays flat |

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -609,6 +609,15 @@ impl Session {
         now_millis().saturating_sub(self.last_output_at.load(Ordering::Relaxed))
     }
 
+    /// Raw monotonic timestamp (epoch millis) of the session's last output.
+    /// Monotonic non-decreasing — the reader thread only ever stores `now`.
+    /// Used by the render loop's cheap output-change detector
+    /// ([`crate::app::App::detect_output_redraw`]) so it can spot new output
+    /// without locking the vt100 parser.
+    pub fn last_output_at(&self) -> u64 {
+        self.last_output_at.load(Ordering::Relaxed)
+    }
+
     /// Latest OSC window title the agent emitted, if any (live activity text).
     pub fn agent_title(&self) -> Option<String> {
         self.last_title.lock().ok().and_then(|t| t.clone())

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -859,3 +859,177 @@ async fn ctrl_t_opens_shell_pane_on_spawnable_backend() {
         "the active session now shows its shell view"
     );
 }
+
+// ── Performance counters: deterministic render-path proxies ───────────────────
+//
+// These assert on `App::perf_counters()` — wall-clock-free counts — so they
+// gate the redraw-throttling and per-frame caching optimizations without timing
+// flakiness. The acceptance harness drives `view()` directly (it skips
+// `tick()`), so only the render-path counters are exercised here; the
+// tick-driven counters (`status_refreshes`) and the redraw-skip accounting live
+// in the `#[tokio::test]` units in `super::tests`.
+
+#[test]
+fn perf_render_counter_tracks_painted_frames() {
+    let mut h = Harness::standard(2);
+    assert_eq!(h.app.perf_counters().frames_rendered, 0);
+    h.render();
+    h.render();
+    h.render();
+    assert_eq!(
+        h.app.perf_counters().frames_rendered,
+        3,
+        "each view() paint bumps frames_rendered exactly once"
+    );
+}
+
+#[test]
+fn perf_terminal_render_locks_parser_once_per_frame() {
+    // With an active session, the central pane locks its vt100 parser once per
+    // painted frame (the O(1) scrollback read rides along, so it is not tracked
+    // separately). Redraw throttling, not caching, bounds how often this runs.
+    let mut h = Harness::standard(1);
+    h.render();
+    h.render();
+    assert_eq!(
+        h.app.perf_counters().parser_locks_render,
+        2,
+        "one parser lock per terminal frame"
+    );
+}
+
+#[test]
+fn perf_session_order_cached_across_idle_frames() {
+    // The session-list ordering is status-independent, so once built it is
+    // reused across frames whose grouping/nesting inputs didn't change. Three
+    // paints with no session mutation must rebuild the order exactly once.
+    let mut h = Harness::standard(3);
+    h.render();
+    h.render();
+    h.render();
+    assert_eq!(
+        h.app.perf_counters().ordered_sessions_rebuilds,
+        1,
+        "the session order is cached: only the first frame rebuilds it"
+    );
+}
+
+#[test]
+fn perf_session_order_rebuilds_when_sessions_change() {
+    // Adding a session changes the order signature, so the cache is invalidated
+    // and the order rebuilt — exactly once for the change.
+    let mut h = Harness::standard(2);
+    h.render(); // builds the order (rebuild #1)
+    h.render(); // cache hit, no rebuild
+    assert_eq!(h.app.perf_counters().ordered_sessions_rebuilds, 1);
+
+    // Mutate the session set, then repaint.
+    let backend: Arc<dyn SessionBackend> = Arc::new(FakeBackend::stub());
+    let provider: Arc<dyn AgentProvider> = Arc::new(GenericProvider::new(
+        crate::agent::agent_config::builtin_registry()
+            .default_agent()
+            .unwrap()
+            .clone(),
+    ));
+    h.app
+        .sessions
+        .push(Session::stub("session-new", &backend, &provider));
+    h.render(); // signature changed → rebuild #2
+    h.render(); // cache hit again
+    assert_eq!(
+        h.app.perf_counters().ordered_sessions_rebuilds,
+        2,
+        "a session-set change invalidates the cache exactly once"
+    );
+}
+
+#[test]
+fn perf_status_change_keeps_order_cache() {
+    // The order is status-independent (ADR-P3): a session changing status must
+    // NOT invalidate the cache — only grouping/ordering/nesting inputs do. This
+    // pins the signature's field set; adding `status` to it would fail here.
+    let mut h = Harness::standard(2);
+    h.render(); // rebuild #1
+    h.render(); // cache hit
+    assert_eq!(h.app.perf_counters().ordered_sessions_rebuilds, 1);
+
+    h.app.sessions[0].info.status = SessionStatus::Attention;
+    h.render(); // status changed, but order inputs did not → still a cache hit
+    assert_eq!(
+        h.app.perf_counters().ordered_sessions_rebuilds,
+        1,
+        "a status change must not rebuild the (status-independent) order"
+    );
+}
+
+// ── Redraw throttling: the dirty-flag decision the render loop gates on ───────
+
+#[test]
+fn perf_first_frame_is_always_dirty() {
+    // `needs_redraw` starts true so the very first loop iteration paints (the
+    // smoke test and a real launch both rely on this).
+    let h = Harness::standard(1);
+    assert!(h.app.should_redraw(), "a freshly built App must paint once");
+}
+
+#[test]
+fn perf_clean_state_skips_redraw() {
+    // After a paint with nothing changed, the loop skips the (expensive) draw.
+    let mut h = Harness::standard(1);
+    h.app.mark_redrawn();
+    assert!(
+        !h.app.should_redraw(),
+        "no input/output/forced-floor → no redraw"
+    );
+}
+
+#[test]
+fn perf_input_requests_redraw() {
+    // Any key event re-dirties the UI so keypress-to-screen stays immediate.
+    let mut h = Harness::standard(1);
+    h.app.mark_redrawn();
+    assert!(!h.app.should_redraw());
+    h.ctrl('j'); // NextSession — goes through update()
+    assert!(
+        h.app.should_redraw(),
+        "input must mark the UI dirty for the next frame"
+    );
+}
+
+#[test]
+fn perf_no_new_output_does_not_request_redraw() {
+    // The lock-free output detector must not false-positive: with no reader
+    // thread producing output, a second poll sees an unchanged signature and
+    // leaves the UI clean.
+    let mut h = Harness::standard(2);
+    h.app.detect_output_redraw(); // prime the output-generation baseline
+    h.app.mark_redrawn(); // clear any dirty from the first observation
+    h.app.detect_output_redraw(); // no new output
+    assert!(
+        !h.app.should_redraw(),
+        "unchanged output signature must not trigger a redraw"
+    );
+}
+
+#[test]
+fn perf_idle_iterations_skip_the_paint() {
+    // Mimic the render loop's gate over several idle iterations (well within the
+    // forced-redraw floor): the first paints, the rest are skipped.
+    let mut h = Harness::standard(2);
+    h.app.detect_output_redraw(); // prime output baseline
+    let mut requested = 0u64;
+    let mut skipped = 0u64;
+    for _ in 0..5 {
+        if h.app.should_redraw() {
+            h.app.mark_redrawn();
+            requested += 1;
+        } else {
+            h.app.note_redraw_skipped();
+            skipped += 1;
+        }
+        h.app.detect_output_redraw(); // no new output between iterations
+    }
+    assert_eq!(requested, 1, "only the initial dirty frame paints");
+    assert_eq!(skipped, 4, "idle iterations skip the expensive draw");
+    assert_eq!(h.app.perf_counters().redraws_skipped, 4);
+}

--- a/src/app/metrics_state.rs
+++ b/src/app/metrics_state.rs
@@ -5,6 +5,37 @@
 
 use crate::ui::info_panel;
 
+/// Per-frame / per-tick performance counters.
+///
+/// These are deterministic, wall-clock-free proxies for the render and tick
+/// hot paths, so the acceptance harness can assert on them without flaky
+/// timing. They prove the redraw-throttling and per-frame caching optimizations
+/// (a fix that "skips work" should show a counter that stops climbing). Cheap
+/// `u64` bumps; never rendered, so they can't perturb snapshots.
+///
+/// See `docs/PERFORMANCE.md` for what each counter means and how to assert on it.
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) struct PerfCounters {
+    /// Frames actually painted (`App::view` ran). With redraw throttling this
+    /// grows only when state changed or a forced redraw was due.
+    pub(crate) frames_rendered: u64,
+    /// Loop iterations where a redraw was requested (dirty or force-due).
+    pub(crate) redraws_requested: u64,
+    /// Loop iterations where the draw was skipped because nothing changed.
+    pub(crate) redraws_skipped: u64,
+    /// `refresh_session_statuses` passes (one per tick).
+    pub(crate) status_refreshes: u64,
+    /// Times the session list ordering was rebuilt (vs. served from cache).
+    pub(crate) ordered_sessions_rebuilds: u64,
+    /// Times the central pane locked a session's vt100 parser to render (one
+    /// per terminal frame). The terminal's O(1) scrollback read happens here
+    /// too — bounded by redraw throttling, not cached.
+    pub(crate) parser_locks_render: u64,
+    /// Times the automations-pane entry list was built (once per render of the
+    /// pane; cheap for the typical handful of automations).
+    pub(crate) automation_entries_built: u64,
+}
+
 /// CPU/RAM metrics collection plus the app-wide tick counter that paces the
 /// periodic refreshes (metrics, git stats, usage).
 pub(crate) struct MetricsState {
@@ -14,6 +45,8 @@ pub(crate) struct MetricsState {
     pub(crate) sys: Option<sysinfo::System>,
     /// Cached system metrics for the info panel.
     pub(crate) system_metrics: info_panel::SystemMetrics,
+    /// Deterministic render/tick performance counters (perf regression tests).
+    pub(crate) perf: PerfCounters,
 }
 
 impl MetricsState {
@@ -28,6 +61,17 @@ impl MetricsState {
                 session_cpu_percent: 0.0,
                 session_memory_bytes: 0,
             },
+            perf: PerfCounters::default(),
         }
+    }
+
+    /// Increment the perf counter named by `select`, e.g.
+    /// `metrics.bump(|p| &mut p.frames_rendered)`. Keeps the hot-path call sites
+    /// to one readable line instead of a doubled field path. Wrapping so a
+    /// diagnostic tally can never panic on overflow.
+    #[inline]
+    pub(crate) fn bump(&mut self, select: impl FnOnce(&mut PerfCounters) -> &mut u64) {
+        let counter = select(&mut self.perf);
+        *counter = counter.wrapping_add(1);
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -49,6 +49,15 @@ const STATUS_MESSAGE_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// If no output for this many milliseconds, consider session "Waiting".
 const ACTIVITY_TIMEOUT_MS: u64 = 1000;
 
+/// Upper bound between forced repaints when nothing else marked the UI dirty.
+/// The render loop only paints when state changed (a key, agent output, a
+/// background poll landing) — this floor guarantees time-driven UI that nothing
+/// explicitly flags (the live clock/metrics, cursor blink, a session going
+/// quiet `Busy → Waiting`, an expiring status toast) still refreshes promptly.
+/// 250 ms ≈ 4 fps when idle, vs. the old unconditional ~100 fps. See
+/// `docs/PERFORMANCE.md`.
+const FORCE_REDRAW_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+
 /// Prompt sent to Claude sessions when a worktree rebase has conflicts.
 const SYNC_CONFLICT_PROMPT: &str = "Please sync this worktree with main. Run: git fetch origin && git rebase origin/main -- if there are conflicts, resolve them and continue the rebase with git rebase --continue.";
 
@@ -582,6 +591,23 @@ pub struct App {
     /// starts. The wrapper tracks per-session prior status + last-fired-at so
     /// dedup and "only on transition" logic live next to the sender.
     notification_state: Option<NotificationState>,
+    /// Redraw-throttling dirty flag. The render loop paints only when this is
+    /// set (or `FORCE_REDRAW_INTERVAL` elapsed). Starts `true` so the first
+    /// frame always paints. Set by [`Self::request_redraw`] from `update`,
+    /// state-changing tick steps, and the agent-output detector.
+    needs_redraw: bool,
+    /// When the last frame was painted, for the forced-redraw floor.
+    last_draw_at: std::time::Instant,
+    /// Cheap rolling signature of agent output across all sessions (sum of each
+    /// session's monotonic `last_output_at`). A change means new output arrived
+    /// — detected without locking any vt100 parser. See
+    /// [`Self::detect_output_redraw`].
+    last_output_gen: u64,
+    /// Cached session-list ordering (`(content-signature, order)`). The order
+    /// depends only on the session set's grouping/nesting inputs, so it is
+    /// reused across frames until [`Self::session_order_signature`] changes,
+    /// skipping the per-frame grouping/sort/nest work. See `render_left_panel`.
+    cached_session_order: Option<(u64, crate::ui::project_list::SessionOrder)>,
 }
 
 const EDITOR_NOT_CONFIGURED: &str =
@@ -738,6 +764,10 @@ impl App {
                 settings_mtime: config_reload::settings_mtime(),
             },
             notification_state: build_notification_state(),
+            needs_redraw: true,
+            last_draw_at: std::time::Instant::now(),
+            last_output_gen: 0,
+            cached_session_order: None,
         };
         app.report_config_warnings(config_warnings);
         app
@@ -1561,6 +1591,11 @@ impl App {
     }
 
     pub fn update(&mut self, msg: AppMessage) {
+        // Any input event is a potential visual change (a key, a mouse move
+        // that re-highlights a row, a paste). Mark the UI dirty so the render
+        // loop paints this iteration — keypress-to-screen stays immediate.
+        self.request_redraw();
+
         // `[features] mouse = false`: capture is never enabled, so mouse
         // events shouldn't arrive — drop any that do (defense in depth, and
         // it makes the flag authoritative in tests).
@@ -3028,6 +3063,76 @@ impl App {
         self.tick_version_check();
     }
 
+    /// Snapshot of the deterministic render/tick performance counters. Used by
+    /// the perf regression tests. See [`metrics_state::PerfCounters`].
+    #[cfg(test)]
+    pub(crate) fn perf_counters(&self) -> metrics_state::PerfCounters {
+        self.metrics.perf
+    }
+
+    /// Mark the UI dirty so the render loop paints on its next iteration.
+    /// Cheap and idempotent; over-marking only costs an extra (correct) frame.
+    /// Internal-only — the loop in `main` drives painting via [`Self::should_redraw`].
+    pub(crate) fn request_redraw(&mut self) {
+        self.needs_redraw = true;
+    }
+
+    /// Whether the render loop should paint a frame this iteration: either state
+    /// changed since the last paint, or the `FORCE_REDRAW_INTERVAL` floor
+    /// elapsed (so time-driven UI — clock, metrics, cursor blink, quiet-session
+    /// status transitions — still refreshes without an explicit dirty flag).
+    pub fn should_redraw(&self) -> bool {
+        self.needs_redraw || self.last_draw_at.elapsed() >= FORCE_REDRAW_INTERVAL
+    }
+
+    /// Record that a frame was just painted: clear the dirty flag, reset the
+    /// forced-redraw timer, and count the requested redraw.
+    pub fn mark_redrawn(&mut self) {
+        self.needs_redraw = false;
+        self.last_draw_at = std::time::Instant::now();
+        self.metrics.bump(|p| &mut p.redraws_requested);
+    }
+
+    /// Record that a loop iteration skipped the paint because nothing changed.
+    pub fn note_redraw_skipped(&mut self) {
+        self.metrics.bump(|p| &mut p.redraws_skipped);
+    }
+
+    /// Detect new agent output since the last check and mark the UI dirty if so.
+    /// Reads each session's monotonic `last_output_at` atomic (no parser lock),
+    /// summing them into a rolling signature — a change means at least one
+    /// session produced output, so the terminal needs repainting.
+    pub fn detect_output_redraw(&mut self) {
+        let output_gen = self
+            .sessions
+            .iter()
+            .fold(0u64, |acc, s| acc.wrapping_add(s.last_output_at()));
+        if output_gen != self.last_output_gen {
+            self.last_output_gen = output_gen;
+            self.needs_redraw = true;
+        }
+    }
+
+    /// Content signature of the inputs that determine the session-list ordering.
+    /// [`crate::ui::project_list::compute_session_order`] is a pure function of
+    /// exactly these per-session fields (grouping by `repo_display_names`,
+    /// sorting by `display_order`, nesting by `id`/`parent_session_id`) plus the
+    /// session count/order — never status — so an unchanged signature means the
+    /// cached order is still valid. Cheaper than recomputing the order
+    /// (no grouping HashMap, sorts, nest recursion, or label allocations).
+    fn session_order_signature(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        self.sessions.len().hash(&mut h);
+        for s in &self.sessions {
+            s.info.id.hash(&mut h);
+            s.info.display_order.hash(&mut h);
+            s.info.parent_session_id.hash(&mut h);
+            s.info.repo_display_names.hash(&mut h);
+        }
+        h.finish()
+    }
+
     /// Drive the opt-in GitHub update check. Off the render path: on the first
     /// tick (when the flag is on and the on-disk cache is stale) it fires a
     /// single background network refresh; the result only ever lands by
@@ -3121,7 +3226,12 @@ impl App {
 
     /// Recompute each session's status/activity/notification for this tick.
     fn refresh_session_statuses(&mut self) {
+        self.metrics.bump(|p| &mut p.status_refreshes);
         let active_index = self.active_index;
+        // Track whether any visible field changed so a quiet `Busy → Waiting`
+        // transition (no new output, so the output detector won't catch it)
+        // still repaints promptly instead of waiting for the forced-redraw floor.
+        let mut changed = false;
         for (idx, session) in self.sessions.iter_mut().enumerate() {
             // The active session is being watched, so acknowledge any pending
             // attention signal (keeps it from flagging itself while focused).
@@ -3130,7 +3240,7 @@ impl App {
             }
             let needs_attention = session.needs_attention();
 
-            session.info.status = if session.has_exited() {
+            let new_status = if session.has_exited() {
                 SessionStatus::Idle
             } else if session.millis_since_last_output() <= ACTIVITY_TIMEOUT_MS {
                 // Actively producing output → working, regardless of past signals.
@@ -3143,13 +3253,26 @@ impl App {
             };
 
             // Live activity text from the agent-emitted OSC terminal title.
-            session.info.agent_activity = session.agent_title();
+            let new_activity = session.agent_title();
             // Retain the agent's latest pushed notification (OSC 9/777) so the
             // info panel can show it as a persistent "last signal", not only
             // while the session is in the attention state.
-            session.info.notification = session.notification();
+            let new_notification = session.notification();
+
+            if session.info.status != new_status
+                || session.info.agent_activity != new_activity
+                || session.info.notification != new_notification
+            {
+                changed = true;
+            }
+            session.info.status = new_status;
+            session.info.agent_activity = new_activity;
+            session.info.notification = new_notification;
         }
 
+        if changed {
+            self.request_redraw();
+        }
         self.dispatch_status_notifications();
     }
 

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -26,6 +26,7 @@ use crate::ui::scrollbar::ScrollbarGeom;
 
 impl App {
     pub fn view(&mut self, frame: &mut Frame) {
+        self.metrics.bump(|p| &mut p.frames_rendered);
         // Rebuilt fresh each frame: every scrollbar and clickable row drawn
         // below records its geometry + target here for the mouse handlers to
         // hit-test.
@@ -130,6 +131,25 @@ impl App {
         let Some(left_area) = left_area else {
             return;
         };
+
+        // Rebuild the cached ordering only when its inputs changed (content
+        // signature). The order is status-independent, so most frames — including
+        // every frame while an agent streams output — reuse it and skip the
+        // grouping/sort/nest work. The signature borrows all of `self`, so
+        // compute it (and refresh the cache) before taking the field borrows
+        // below.
+        let sig = self.session_order_signature();
+        let stale = self
+            .cached_session_order
+            .as_ref()
+            .map_or(true, |(cached, _)| *cached != sig);
+        if stale {
+            self.metrics.bump(|p| &mut p.ordered_sessions_rebuilds);
+            let infos: Vec<&SessionInfo> = self.sessions.iter().map(|s| &s.info).collect();
+            let order = project_list::compute_session_order(&infos);
+            self.cached_session_order = Some((sig, order));
+        }
+
         // Build flat session list: all sessions, with tag names from projects
         let all_sessions: Vec<&SessionInfo> = self.sessions.iter().map(|s| &s.info).collect();
 
@@ -147,11 +167,17 @@ impl App {
             None => Vec::new(),
         };
 
-        // Order the list by repo group + activity. The parallel arrays
-        // (match_positions) and active_index are remapped so they stay
-        // aligned with the rendered order.
-        let ordered = project_list::OrderedSessions::new(
+        // Remap the cached order onto the current refs / match positions /
+        // active_index (these vary independently of the order, so the remap
+        // always runs — but it's a cheap O(n) index map, no grouping work).
+        let order = &self
+            .cached_session_order
+            .as_ref()
+            .expect("cache populated above")
+            .1;
+        let ordered = project_list::OrderedSessions::from_order(
             &all_sessions,
+            order,
             &global_match_positions,
             self.active_index,
         );
@@ -209,6 +235,7 @@ impl App {
             return;
         };
         let now = crate::sync::current_time_millis();
+        self.metrics.bump(|p| &mut p.automation_entries_built);
         let search = self.global_search_query();
         let entries: Vec<automations_panel::AutomationPaneEntry> = self
             .automation_ui
@@ -467,6 +494,7 @@ impl App {
 
         // Scope the immutable `session` borrow so it ends before the
         // `&mut self` record_scrollbar call below.
+        let mut locked_parser = false;
         let geom = {
             let Some(session) = self.sessions.get(self.active_index) else {
                 terminal_view::render_empty_terminal(frame, terminal);
@@ -479,6 +507,7 @@ impl App {
             }
             .unwrap_or(&session.parser);
             if let Ok(mut parser) = parser_arc.lock() {
+                locked_parser = true;
                 terminal_view::render_terminal(
                     frame,
                     terminal,
@@ -491,6 +520,11 @@ impl App {
                 None
             }
         };
+        if locked_parser {
+            // One parser lock per terminal render (the O(1) scrollback read
+            // rides along). Redraw throttling, not caching, bounds the rate.
+            self.metrics.bump(|p| &mut p.parser_locks_render);
+        }
         self.record_scrollbar(geom, ScrollTarget::Terminal);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,11 @@ fn pop_keyboard_enhancement() {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Process start, for the opt-in time-to-first-frame measurement (logged
+    // once by `run_loop` when `THURBOX_PERF_LOG` is set). Captured first so it
+    // covers config load, DB open, and session restore.
+    let process_start = std::time::Instant::now();
+
     // Set up panic hook that restores terminal before printing the panic
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
@@ -121,7 +126,7 @@ async fn main() -> Result<()> {
 
     arm_automation_heartbeat();
 
-    let res = run_loop(&mut terminal, &mut app).await;
+    let res = run_loop(&mut terminal, &mut app, process_start).await;
 
     app.shutdown();
     pop_keyboard_enhancement();
@@ -276,15 +281,43 @@ fn maybe_auto_update() -> Option<String> {
     }
 }
 
-async fn run_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Result<()> {
+async fn run_loop(
+    terminal: &mut ratatui::DefaultTerminal,
+    app: &mut App,
+    process_start: std::time::Instant,
+) -> Result<()> {
+    // Opt-in (THURBOX_PERF_LOG) time-to-first-frame measurement: logged once,
+    // right after the first paint, so it never affects normal runs or the smoke
+    // test. Read `~/.local/share/thurbox/thurbox.log` for the `first_frame_ms`
+    // line. See docs/PERFORMANCE.md.
+    let perf_log = std::env::var_os("THURBOX_PERF_LOG").is_some();
+    let mut first_frame_logged = false;
+
     loop {
-        terminal.draw(|f| app.view(f))?;
+        // Redraw throttling: paint only when state changed since the last frame
+        // or the forced-redraw floor elapsed. The loop still spins every ≤10ms
+        // (cheap: poll + output check + tick), but the expensive layout/vt100
+        // render is skipped when idle — see App::should_redraw / docs/PERFORMANCE.md.
+        if app.should_redraw() {
+            terminal.draw(|f| app.view(f))?;
+            app.mark_redrawn();
+
+            if perf_log && !first_frame_logged {
+                tracing::info!(first_frame_ms = process_start.elapsed().as_millis() as u64);
+                first_frame_logged = true;
+            }
+        } else {
+            app.note_redraw_skipped();
+        }
 
         if event::poll(Duration::from_millis(10))? {
             if let Some(msg) = event_to_message(event::read()?) {
-                app.update(msg);
+                app.update(msg); // marks the UI dirty
             }
         }
+
+        // Cheap, lock-free check for new agent output (marks dirty on change).
+        app.detect_output_redraw();
 
         app.tick();
 

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -453,25 +453,42 @@ impl<'a> OrderedSessions<'a> {
         match_positions: &[Option<SessionMatch>],
         active_index: usize,
     ) -> Self {
-        let SessionOrder {
-            order,
-            headers,
-            depths,
-        } = compute_session_order(sessions);
+        let order = compute_session_order(sessions);
+        Self::from_order(sessions, &order, match_positions, active_index)
+    }
 
-        let ordered_sessions = order.iter().map(|&i| sessions[i]).collect();
+    /// As [`Self::new`], but reuses a previously computed [`SessionOrder`]
+    /// instead of recomputing it. The order is a pure function of the session
+    /// set's grouping/nesting inputs (`repo_display_names`, `display_order`,
+    /// `id`, `parent_session_id`) — never status — so the caller can cache it
+    /// keyed by a content signature and skip the grouping/sort/nest work on
+    /// frames where none of those changed (see `App::render_left_panel`). The
+    /// per-frame remap of refs / match positions / `active_index` still runs,
+    /// since those vary independently of the order.
+    pub fn from_order(
+        sessions: &[&'a SessionInfo],
+        order: &SessionOrder,
+        match_positions: &[Option<SessionMatch>],
+        active_index: usize,
+    ) -> Self {
+        let ordered_sessions = order.order.iter().map(|&i| sessions[i]).collect();
         let ordered_matches = order
+            .order
             .iter()
             .map(|&i| match_positions.get(i).cloned().flatten())
             .collect();
-        let new_active = order.iter().position(|&i| i == active_index).unwrap_or(0);
+        let new_active = order
+            .order
+            .iter()
+            .position(|&i| i == active_index)
+            .unwrap_or(0);
 
         Self {
             sessions: ordered_sessions,
             match_positions: ordered_matches,
             active_index: new_active,
-            headers,
-            depths,
+            headers: order.headers.clone(),
+            depths: order.depths.clone(),
         }
     }
 }

--- a/website/_includes/sidebar.njk
+++ b/website/_includes/sidebar.njk
@@ -34,7 +34,8 @@
     { slug: "keybindings", href: "keybindings.html", label: "Keybindings" }
   ]},
   { heading: "Reference", links: [
-    { slug: "architecture", href: "architecture.html", label: "Architecture" }
+    { slug: "architecture", href: "architecture.html", label: "Architecture" },
+    { slug: "performance", href: "performance.html", label: "Performance" }
   ]},
   { heading: "Developer", links: [
     { slug: "ui-review", href: "ui-review.html", label: "UI/UX Review" }

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -67,6 +67,16 @@ currentPage: 'index'
                 </p>
               </div>
             </a>
+            <a href="performance.html" class="docs-hub-card">
+              <div class="card">
+                <div class="card-icon">&#x26a1;</div>
+                <h3>Performance</h3>
+                <p>
+                  Demand-driven rendering, deterministic perf counters, caching, and how to
+                  measure startup time, CPU, and binary size.
+                </p>
+              </div>
+            </a>
             <a href="ui-review.html" class="docs-hub-card">
               <div class="card">
                 <div class="card-icon">&#x1f50d;</div>

--- a/website/docs/performance.html
+++ b/website/docs/performance.html
@@ -1,0 +1,157 @@
+---
+layout: docs.njk
+title: 'Performance — Thurbox Docs'
+description: 'Thurbox performance: demand-driven rendering, deterministic perf counters, caching, and measuring startup time, CPU, and binary size.'
+currentPage: 'performance'
+breadcrumb: 'Performance'
+onThisPage:
+  - { id: 'rendering', label: 'Demand-Driven Rendering' }
+  - { id: 'counters', label: 'Perf Counters' }
+  - { id: 'caching', label: 'Session-Order Cache' }
+  - { id: 'not-optimized', label: 'Deliberately Not Optimized' }
+  - { id: 'measuring', label: 'Measuring Performance' }
+---
+<h1>Performance</h1>
+<p>
+  How thurbox stays responsive and light, across four dimensions: input latency, runtime CPU /
+  render cost, startup time, and memory / binary size. The guiding principle is
+  <strong>measure first</strong> &mdash; every optimization is backed by a deterministic counter or
+  a concrete code fact, and proven by a test that fails if it regresses. Full rationale lives in
+  <code>docs/PERFORMANCE.md</code>.
+</p>
+
+<h2 id="rendering">
+  Demand-Driven Rendering
+  <a href="#rendering" class="heading-anchor">#</a>
+</h2>
+<p>
+  The render loop paints a frame only when the UI is <em>dirty</em> or a forced-redraw floor
+  elapsed &mdash; not on every iteration. The previous loop called
+  <code>terminal.draw</code> unconditionally at ~100 fps even on a completely idle screen, the
+  single largest idle-CPU cost in a long-lived TUI. State now drives the paint:
+</p>
+<ul>
+  <li><strong>Input</strong> marks the UI dirty, so a keypress paints on the next iteration (latency unchanged).</li>
+  <li>
+    <strong>Agent output</strong> marks it dirty via a lock-free rolling signature over each
+    session's <code>last_output_at</code> atomic &mdash; no vt100 lock needed to notice new output.
+  </li>
+  <li><strong>Status transitions</strong> (a quiet <code>Busy &rarr; Waiting</code> produces no output) request a redraw explicitly.</li>
+  <li>
+    <strong>Everything time-driven</strong> &mdash; the live clock/metrics, cursor blink, an
+    expiring toast &mdash; is covered by a 250&nbsp;ms forced-redraw floor.
+  </li>
+</ul>
+<p>
+  The loop still spins every &le;10&nbsp;ms (poll input, check output, tick), but the expensive work
+  &mdash; layout, the vt100 render, panel rebuilds &mdash; is skipped when idle. Idle paints drop
+  from ~100 fps to ~4 fps while input and output repaints stay immediate: responsiveness is
+  unchanged and idle CPU drops by roughly 25&times;.
+</p>
+
+<h2 id="counters">
+  Perf Counters
+  <a href="#counters" class="heading-anchor">#</a>
+</h2>
+<p>
+  Performance regressions are caught by <strong>counting</strong>, not timing. Wall-clock benchmarks
+  are flaky on shared CI runners; a counter assertion is exact and reproducible, and proves the
+  <em>mechanism</em> (work was skipped) rather than a wobbly proxy (it was fast today). The
+  in-process acceptance harness asserts on these wall-clock-free counters, gating the normal
+  <code>cargo nextest run --all</code>.
+</p>
+<table>
+  <thead>
+    <tr>
+      <th>Counter</th>
+      <th>Meaning</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>frames_rendered</code></td>
+      <td>a frame painted</td>
+    </tr>
+    <tr>
+      <td><code>redraws_requested</code> / <code>redraws_skipped</code></td>
+      <td>loop iterations that painted vs. skipped</td>
+    </tr>
+    <tr>
+      <td><code>ordered_sessions_rebuilds</code></td>
+      <td>session-list order rebuilt vs. served from cache</td>
+    </tr>
+    <tr>
+      <td><code>parser_locks_render</code></td>
+      <td>central pane locked a vt100 parser to render</td>
+    </tr>
+    <tr>
+      <td><code>status_refreshes</code> / <code>automation_entries_built</code></td>
+      <td>per-tick status pass, automations-pane builds</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="caching">
+  Session-Order Cache
+  <a href="#caching" class="heading-anchor">#</a>
+</h2>
+<p>
+  The session-list ordering (grouping, sorting, parent/child nesting) is a pure function of four
+  per-session fields &mdash; repo names, manual order, id, and parent &mdash; and
+  <strong>never</strong> of status. It is cached, keyed by a content signature (a hash of exactly
+  those fields). On a frame where the signature is unchanged, the order is reused, skipping the
+  grouping HashMap, two sort passes, nest recursion, and label allocations; only the cheap O(n)
+  remap of refs and selection runs each frame.
+</p>
+<p>
+  Being content-derived, the cache is <strong>self-invalidating</strong>: any change that alters the
+  order alters the hash, so there is no manual &ldquo;mark dirty&rdquo; call site to forget. This
+  matters most while an agent streams output and the screen repaints every frame.
+</p>
+
+<h2 id="not-optimized">
+  Deliberately Not Optimized
+  <a href="#not-optimized" class="heading-anchor">#</a>
+</h2>
+<p>Measuring first also means not adding complexity where the data says it won't pay off:</p>
+<ul>
+  <li>
+    <strong>Scrollback round-trip</strong> &mdash; vt100's <code>set_scrollback</code> /
+    <code>scrollback</code> are O(1), and demand-driven rendering already bounds how often it runs.
+    Caching it would add borrow complexity for no measurable gain.
+  </li>
+  <li>
+    <strong>Automations-pane entries</strong> &mdash; the only repeated parse is the cron
+    humanizer, the countdown must stay live, and automations are typically a handful. Left as-is.
+  </li>
+  <li>
+    <strong>vt100 parser lock contention</strong> &mdash; demand-driven rendering collapses
+    idle-frame UI locks to near zero, shrinking the contention window for free. Cloning the (large)
+    vt100 screen for lock-free rendering would cost more than the brief lock it removes.
+  </li>
+</ul>
+
+<h2 id="measuring">
+  Measuring Performance
+  <a href="#measuring" class="heading-anchor">#</a>
+</h2>
+<p>
+  The gating automated tests are the counter assertions above. Heavier measurement is opt-in and
+  local, so the PR gate stays fast and free of flaky timing or extra dependencies:
+</p>
+<ul>
+  <li>
+    <strong>Startup</strong> &mdash; launch with <code>THURBOX_PERF_LOG=1</code>; one
+    <code>first_frame_ms</code> line is logged to <code>thurbox.log</code>.
+  </li>
+  <li>
+    <strong>Binary size</strong> &mdash; a non-gating CI job records the release
+    <code>thurbox</code> / <code>thurbox-cli</code> sizes to the job summary and an artifact, so
+    growth is visible without blocking merges. The release profile is already LTO-tuned and stripped.
+  </li>
+  <li>
+    <strong>CPU / size attribution</strong> &mdash; run <code>cargo flamegraph</code> (with the
+    <code>release-with-debug</code> profile) and <code>cargo bloat --release --crates</code> ad hoc;
+    neither is a project dependency.
+  </li>
+</ul>


### PR DESCRIPTION
## Summary

- **Demand-driven rendering**: the loop now paints only when the UI is dirty (input, new agent output, or a session status change) or a 250 ms forced-redraw floor elapsed — instead of unconditionally at ~100 fps. Idle paints drop ~100 fps → ~4 fps with input/output latency unchanged; new output is detected lock-free via each session's `last_output_at` atomic.
- **Session-order cache**: the status-independent session-list ordering is cached keyed by a content signature, skipping the grouping/sort/nest work on unchanged frames.
- **Automated perf tests**: deterministic, wall-clock-free perf counters asserted by the acceptance harness (the regression gate) — no flaky timing.
- **Measurement**: opt-in `THURBOX_PERF_LOG` first-frame timing line; non-gating binary-size CI job.
- **Docs**: `docs/PERFORMANCE.md` (ADR-style) + a new website performance page, plus a CLAUDE.md section.

## Test plan

- `cargo nextest run --all` (perf + acceptance + snapshots)
- `scripts/dev/tui-smoke-test.sh` (frames still paint on boot/keystroke)
- `THURBOX_PERF_LOG=1` logs `first_frame_ms`
- CI checks pass