### PR TITLE
feat(core): hooks-driven session status with codex/gemini wiring

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,13 @@
+# Auto-enter the pinned dev toolchain (flake.nix) on `cd`, via direnv.
+#
+# Setup:
+#   - install direnv (https://direnv.net) and hook it into your shell
+#   - run `direnv allow` once in this directory
+#
+# Falls back to a plain message if Nix/direnv's flake support is unavailable.
+# Requires Nix flakes enabled (experimental-features = nix-command flakes).
+if has nix; then
+  use flake
+else
+  echo "direnv: nix not found — install Nix, or set up the toolchain with scripts/install-dev-tools.sh" >&2
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 **/*.rs.bk
 *.pdb
 
+# Nix / direnv dev environment (flake.nix is committed; flake.lock is too —
+# generate it with `nix flake lock`). The direnv cache is local-only.
+.direnv/
+# Persistent dev sandboxes live under /target (already ignored above):
+#   target/dev-sandbox/<profile>/  — see scripts/dev/sandbox.sh
+
 # IDE
 .vscode/
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,42 @@ you want them).
 
 ## Build & Development Commands
 
+The reproducible dev environment is a **Nix flake** (`flake.nix`, pins the Rust
+toolchain + tmux/shellcheck/node/cargo-tools/just/demo stack) — enter it with
+`nix develop` (or `direnv allow` once; see `.envrc`). Non-Nix fallback:
+`scripts/install-dev-tools.sh`. Task entrypoint is **`just`** (`justfile`); full
+guide in **`docs/DEVELOPMENT.md`**.
+
 ```bash
-cargo check --all                    # Type check
-cargo build                          # Debug build
+just build                           # cargo build --bin thurbox --bin thurbox-cli
+just test                            # cargo nextest run --all
+just lint                            # fmt-check + clippy + deny + rumdl + shellcheck
+
+cargo check --all                    # Type check (bare cargo still works)
 cargo build --release                # Release build (LTO, stripped)
-cargo run                            # Run in dev mode
 ```
+
+To **run thurbox in an isolated sandbox** use `scripts/dev/sandbox.sh` (a.k.a.
+`just sandbox*`). By default it does **thurbox-only isolation**: redirects only
+thurbox's config/data into the sandbox (via the `THURBOX_CONFIG_DIR`/
+`THURBOX_DATA_DIR` overrides paths.rs honors) while keeping your real `HOME` —
+so your authenticated agent CLIs (claude/codex/…) work — and puts dev
+`target/debug` first on PATH so an agent hook's `thurbox-cli` hits the sandbox DB.
+
+```bash
+scripts/dev/sandbox.sh               # persistent "default" profile, launch the TUI
+scripts/dev/sandbox.sh --fresh       # throwaway env, wiped on exit
+scripts/dev/sandbox.sh --isolate-home    # full hermetic isolation (fresh HOME; agents have no creds)
+scripts/dev/sandbox.sh --shell       # shell with the sandbox env (run thurbox-cli by hand)
+scripts/dev/sandbox.sh -- session list   # run a thurbox-cli command in the sandbox
+scripts/dev/sandbox.sh --clean       # wipe the persistent profile
+```
+
+The isolation lives in one helper, `scripts/dev/lib/sandbox-env.sh`
+(`tbx_sandbox_init` = thurbox-only, `tbx_sandbox_init_full` = full HOME/XDG),
+sourced by the sandbox entrypoint plus `scripts/demo/record.sh` and
+`scripts/dev/tui-smoke-test.sh` (which use the full flavor). Single source of
+truth for the `thurbox-dev` sandbox pattern.
 
 ## Testing
 
@@ -853,9 +883,46 @@ declarative **manifest format**, never a specific extension. Each
 extension ships an `extension.toml` (`session::ExtensionDef`, pure data in
 `session/extension_def.rs`; loaded by `agent::extension_config`). It has
 two halves: an **install** spec (`home`, `[[agents]]` to register in
-agents.toml, `[[files]]` payload, `[[symlinks]]`) and a **runtime** spec
+agents.toml, `[[files]]` payload, `[[symlinks]]`, `[[external_files]]`,
+`[[agent_patches]]`, `[[config_merges]]`) and a **runtime** spec
 (`[[sessions]]` + `[[automations]]` to ensure/self-heal). The `{home}`
 token is substituted with the resolved home dir.
+
+Three install-spec capabilities exist for reaching **outside** the extension
+home (added for the built-in hooks extension): `[[external_files]]` places
+a file into an agent's own config dir (absolute / `~` / `{home}` path,
+guarded by `requires_dir` so it's skipped when that agent isn't installed);
+`[[agent_patches]]` appends args to an **existing** agent in
+agents.toml (`apply_agent_patches` via `toml_edit`, reversible — uninstall
+removes exactly the injected subsequence); and `[[config_merges]]`
+**reversibly deep-merges** shipped JSON into an agent's own *shared* config
+file (`{path, source, requires_dir}`) — for agents whose hooks live in a
+file that would be clobbered by `[[external_files]]` (gemini's
+`settings.json`). The merge (`agent::json_merge`) recurses objects, unions
+arrays by deep-equality, and leaves a user's conflicting value untouched;
+uninstall **prunes by marker** (every shipped hook command contains
+`thurbox-cli session signal`), so removal stays correct even after the
+payload's schema changes across an update — no orphans. Writes are skipped
+when unchanged (it re-runs every startup + heartbeat tick). All three are
+honoured by `install_extension`/`uninstall_extension`.
+
+**Built-in `hooks` extension** (`session_ops::builtin_hooks`,
+`extensions/hooks/`). Unlike user extensions it ships **embedded** in the
+binary and is **auto-activated by default** (`ensure_builtin_hooks_extension`
+at TUI startup + headless tick) so the default agent's status hook is
+pre-configured with zero setup. It materializes its embedded assets to a
+local dir and installs through the ordinary machinery: an `[[agent_patches]]`
+adds `--settings {home}/claude.json` to `claude` (claude merges it, never
+clobbering user settings), aider gets `--notifications-command` (blocked-only),
+`codex` gets a `-c notify=…` override via `[[agent_patches]]` (codex's stable
+turn-complete hook → done, no `~/.codex` write), an `[[external_files]]` drops
+an opencode plugin into `~/.config/opencode/plugin/`, and a `[[config_merges]]`
+deep-merges hook entries into `gemini`'s shared `~/.gemini/settings.json`
+(idle/working/done, no blocked; **experimental** — doc-sourced schema +
+possible hook-env sanitization, see `extensions/hooks/README.md`).
+Opt out with `thurbox-cli extension deactivate hooks` (records a
+`builtin_hooks_optout` metadata flag so self-heal won't resurrect it);
+`activate`/`install hooks` clears it. See the Session-status section.
 
 `thurbox-cli extension install <name|url|dir> [--home <dir>] [--force]`
 (`session_ops::install_extension`) is the one-command installer: it
@@ -987,15 +1054,70 @@ global_search` in settings.toml; scopes whose feature is disabled
   (session list, tasks panel) were removed in favour of it. The file
   viewer's `/` (in-file text search) is unrelated and stays.
 
+## Session status (hooks-driven)
+
+The session list shows, at a glance, which agents are blocked, working,
+or done. `SessionStatus` (`src/session/mod.rs`) has five states driven by
+**agent hooks**, not heuristics:
+
+| State | Colour | Glyph | Meaning |
+|-------|--------|-------|---------|
+| `Working` | yellow | animated braille spinner (`⠋⠙⠹…`; static `◐`) | agent is actively running |
+| `Blocked` | red | `◆` | agent needs input or approval |
+| `Done` | blue | `●` (filled) | a turn just finished; shown until you switch away |
+| `Idle` | green | `○` (hollow) | acknowledged (you moved off a Done), never active, or at rest |
+| `Error` | red | `✗` | reserved for a crashed agent — **not derived yet** (no exit-code signal; exited → `Idle`) |
+
+The live session list **animates** the `Working` spinner (`ui::SPINNER_FRAMES`,
+`App::spinner_frame` advanced from `tick_count`, ~8 fps, repaints forced only
+while something is working). The filled `●` (Done) vs hollow `○` (Idle) pair
+reads done-vs-seen at a glance. `ui::status_glyph(status, spinner)` picks the
+frame; the static `icon()` is used in non-animated contexts (info panel).
+
+- **The callback.** Agents report transitions with
+  `thurbox-cli session signal --state <working|blocked|done|idle>`
+  (`cli::sessions::Action::Signal`). Identity is the injected
+  `THURBOX_SESSION` (falling back to a lookup by `agent_session_id` /
+  `THURBOX_SESSION_ID`), so a hook passes no id. It writes the persisted
+  state and the TUI picks it up via `PRAGMA data_version` — works headless.
+  (`idle` = agent at rest, e.g. a boot-time hook; `done` = a turn just finished.)
+- **Persistence.** `sessions.hook_state` / `hook_state_at` / `seen_at`
+  (schema **v34**), with targeted-UPDATE accessors `set_hook_state` /
+  `mark_session_seen` / `load_hook_states` (`storage/sessions.rs`).
+  `upsert_session` deliberately **never** lists the hook columns, so the
+  TUI's full-row write-back can't clobber a state a headless hook set. A
+  fresh spawn seeds **nothing** — a never-reported session is `Idle`, and the
+  agent's hooks drive it from there (so an idle, just-booted agent doesn't look
+  stuck working).
+- **Derivation.** `App::refresh_session_statuses` (`src/app/mod.rs`) reads
+  all hook rows once per tick: exited → `Idle`; else the persisted state
+  (`working`/`blocked`; `idle`/none → `Idle`). `done` shows as `Done` (blue)
+  **whether focused or not** — so a turn you're watching visibly completes — and
+  becomes `Idle` only when you **move focus off it** (acknowledge it): the focus
+  change vs. `last_active_session_id` marks the just-left `done` session `seen`
+  (persists `seen_at`, one-shot). A single focused session therefore reads
+  `working ↔ done`; `idle` is the at-rest/acknowledged state.
+- **Rollup.** Repo groups roll up to their most-urgent member
+  (`Blocked > Error > Working > Done > Idle`), rendered as a colored dot on
+  the group header (`ui::project_list::group_status` +
+  `group_header_line`). Status only recolors — it **never** reorders rows
+  (the order cache stays status-independent).
+- **Colours** are tunable theme fields: `status_working` / `status_blocked`
+  / `status_done` / `status_idle` / `status_error`
+  (`session::theme_config`, all 9 presets + custom-theme overrides), mapped
+  by `ui::status_color`.
+- **Wiring the hooks** is the job of the built-in **hooks extension**
+  (auto-activated; see the Extensions section) — core thurbox only knows
+  the generic `session signal` command.
+
 ## OS notifications
 
-When a session crosses into a "needs you" state — the agent rang the
-terminal bell or emitted an OSC 9 / OSC 777 notification (i.e. it
-transitions to `SessionStatus::Attention`) — thurbox fires an OS
-desktop notification so the user can react without watching the TUI.
-The trigger is the explicit signal by default; an opt-in
-`also_on_waiting` extends it to the timing-only `Busy → Waiting` edge
-for agents that don't ring a bell. The transition is observed once per
+When a session transitions to `SessionStatus::Blocked` (the agent needs
+the user, reported by a hook) thurbox fires an OS desktop notification so
+the user can react without watching the TUI.
+The trigger is the block edge by default; an opt-in
+`also_on_waiting` extends it to the `Working → Done` (finished) edge
+(the field name is historical). The transition is observed once per
 tick in `App::refresh_session_statuses` (the *same* place
 `SessionStatus` is computed, so the rule never drifts from the icon
 in the list), dedup'd per session by `min_interval_secs`, and skipped

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ cargo build --release
 
 See [Prerequisites](#prerequisites) for required tooling.
 
+**Contributing / hacking on thurbox?** The dev environment is a reproducible Nix
+flake (`nix develop` / `direnv allow`) with `just` tasks and an isolated runtime
+sandbox (`scripts/dev/sandbox.sh`) — see
+[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
+
 ## Why Thurbox
 
 Running a coding agent in several terminals gets you far — until

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -187,7 +187,7 @@ version_check = false          # opt-in: makes a network call
 auto_update   = false          # opt-in: downloads + replaces binaries
 
 [notifications]
-also_on_waiting     = false    # also fire on Busy → Waiting (no bell)
+also_on_waiting     = false    # also fire when a session finishes (Working → Done)
 suppress_for_active = true     # skip the session you're currently viewing
 sound               = true     # play the OS default notification sound
 min_interval_secs   = 5        # per-session floor between notifications
@@ -313,17 +313,32 @@ thurbox-cli notify --test   # fire a sample notification to confirm it works
 
 | Key | Default | Purpose |
 |-----|---------|---------|
-| `also_on_waiting` | `false` | also fire on `Busy → Waiting` (no explicit bell from the agent) |
+| `also_on_waiting` | `false` | also fire when a session finishes (`Working → Done`); the field name is historical |
 | `suppress_for_active` | `true` | skip the notification for the session you're currently viewing |
 | `sound` | `true` | play the OS default notification sound |
 | `min_interval_secs` | `5` | per-session floor between two notifications (dedup) |
 | `backend` | `auto` | delivery backend: `auto` \| `dbus` \| `windows` \| `off` |
 
-The default-on `Attention` trigger is the right knob for any agent that
-respects the terminal bell / OSC 9 / OSC 777 conventions (Claude Code
-out of the box, for example). For agents that only go quiet without
-ringing a bell, set `also_on_waiting = true` — note this fires once each
-time the agent goes idle after activity, so it can be chatty.
+Notifications fire on the hooks-driven status transitions (see
+[Session status](#session-status)): always on `→ Blocked` (the agent needs
+you), and with `also_on_waiting = true` also on `Working → Done`.
+
+## Session status
+
+Each session's state (Blocked / Working / Done / Idle / Error) is driven by
+**agent hooks** that call `thurbox-cli session signal --state
+<working|blocked|done|idle>`. The state is persisted on the `sessions` row
+(`hook_state`, `hook_state_at`, `seen_at` — schema v34) and survives the TUI
+being closed; a hook fired headlessly is picked up via `PRAGMA data_version`.
+Identity comes from the injected `THURBOX_SESSION` env var, so a hook passes
+no id. A finished turn shows `Done` (blue) — for the session you're watching too
+— and becomes `Idle` once you switch focus off it.
+
+The hooks are wired up automatically by the built-in **hooks** extension
+(auto-activated on first run). Opt out with `thurbox-cli extension deactivate
+hooks`. See `extensions/hooks/README.md`. The status colours are tunable theme
+keys (`status_working` / `status_blocked` / `status_done` / `status_idle` /
+`status_error` — see `themes.toml`).
 
 ## themes.toml
 
@@ -419,6 +434,22 @@ substitute = true               # replace {home} in the content
 [[symlinks]]                    # never clobbers a real file at `link`
 link = "CLAUDE.md"
 target = "FLOW.md"
+
+# Reaching OUTSIDE the extension home (used by the built-in hooks extension):
+[[external_files]]              # write a file into an agent's OWN config dir
+path = "~/.config/opencode/plugin/x.js"
+source = "x.js"
+requires_dir = "~/.config/opencode"  # skip when that agent isn't installed
+
+[[agent_patches]]               # append args to an EXISTING agent (reversible)
+name = "claude"
+append_args = ["--settings", "{home}/claude.json"]
+
+[[config_merges]]               # reversibly deep-merge JSON into an agent's own
+path = "~/.gemini/settings.json"  #   SHARED config file (never clobbered)
+source = "gemini-hooks.json"    # objects recurse, arrays union; uninstall prunes
+requires_dir = "~/.gemini"      #   exactly our entries (by marker). no-op write
+                                #   when unchanged; malformed target soft-skipped
 
 # runtime spec (ensured on activate, self-healed if deleted) -----------------
 [[sessions]]
@@ -516,6 +547,7 @@ Live in the `metadata` table and apply immediately (no restart):
 | `active_theme` | `Ctrl+Y` / `F4` picker | TUI palette (nine built-ins) |
 | `editor_command` | `thurbox-cli editor set "<cmd>"` | what `Ctrl+O` runs |
 | `active_extensions` | `thurbox-cli extension activate/deactivate` | JSON array of active extensions to self-heal |
+| `builtin_hooks_optout` | `thurbox-cli extension deactivate hooks` | `1` when the user opted out of the auto-activated hooks extension |
 
 These are in the DB rather than a file because they are written
 concurrently by multiple thurbox processes (TUI, CLI, MCP) and picked
@@ -543,6 +575,7 @@ these to prove its own identity without scraping panes or names:
 | `THURBOX_SESSION_ID` | the agent's own conversation id (`agent_session_id`); consumed by the metrics statusline. Distinct from `THURBOX_SESSION` |
 | `THURBOX_TASK` | the originating task id; task-spawned sessions only (headless `task run`) |
 | `THURBOX_METRICS_DIR` | metrics output dir |
+| `THURBOX_CONFIG_DIR` / `THURBOX_DATA_DIR` | the resolved config/data dirs, so the agent's `thurbox-cli` (its status hook) targets the same DB the TUI reads — independent of XDG, which `thurbox-cli` is on PATH, or a stale tmux-server env. Also honored if you set them yourself to relocate thurbox's state. |
 
 Set **at build time** (not runtime):
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,105 @@
+# Development
+
+How to set up a reproducible thurbox dev environment and run the app in an
+isolated sandbox.
+
+## 1. Toolchain — the dev environment
+
+### Recommended: Nix flake
+
+The `flake.nix` pins the whole toolchain CI uses — the Rust toolchain (read from
+`rust-toolchain.toml`), `tmux`, `shellcheck`, `bats`, Node, `cargo-nextest`,
+`cargo-deny`, `cocogitto`, `just`, and the demo stack (`vhs`/`ffmpeg`/`ttyd`).
+
+```bash
+# one-time, if not done already: enable flakes
+#   mkdir -p ~/.config/nix && echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+
+nix flake lock        # one-time: generate/commit flake.lock (pins inputs)
+nix develop           # enter the pinned shell
+# ...or, with direnv installed, once:
+direnv allow          # auto-enters the shell on `cd` (see .envrc)
+```
+
+A couple of tools aren't packaged in nixpkgs yet (`prek`, `rumdl`, nightly
+`cargo-pup`); the shell prints a hint to install them via
+`scripts/install-dev-tools.sh`.
+
+### Fallback: no Nix
+
+```bash
+scripts/install-dev-tools.sh   # cargo-binstall/cargo install the dev tools
+prek install                   # install the git hooks
+```
+
+You'll also need, from your package manager: `tmux >= 3.2`, `shellcheck`,
+`bats`, Node + npm (website linters), and `git`.
+
+## 2. Everyday tasks — `just`
+
+`just` (in the dev shell) is the task entrypoint — run `just` for the list:
+
+| Task | What it does |
+|------|--------------|
+| `just build` | build the dev binaries (`thurbox` + `thurbox-cli`) |
+| `just test` | `cargo nextest run --all` |
+| `just lint` | fmt-check + clippy + cargo-deny + rumdl + shellcheck |
+| `just fmt` | format Rust + website |
+| `just arch` | architecture-rule + rustdoc checks |
+| `just hooks-install` | `prek install` |
+| `just smoke` | black-box TUI smoke test |
+| `just sandbox*` | dev runtime sandbox (below) |
+
+## 3. Runtime sandbox — run thurbox isolated
+
+The sandbox runs the dev build (`0.0.0-dev` → `dev_build` cfg, which uses a
+`thurbox-dev` tmux socket) with **thurbox's own config/data redirected** into the
+sandbox (via `THURBOX_CONFIG_DIR` / `THURBOX_DATA_DIR`), so it never touches your
+real `~/.config/thurbox` or sessions. It **keeps your real `HOME`**, so your
+authenticated agent CLIs (`claude`/`codex`/`gemini`/…) work normally — and it puts
+the dev `target/debug` first on `PATH`, so an agent's status hook calls *this*
+`thurbox-cli` and writes to the sandbox DB the TUI reads.
+
+```bash
+scripts/dev/sandbox.sh                 # persistent "default" profile, launch the TUI
+scripts/dev/sandbox.sh --fresh         # throwaway env, wiped on exit
+scripts/dev/sandbox.sh --profile foo   # a named persistent profile
+scripts/dev/sandbox.sh --isolate-home  # full hermetic isolation (fresh HOME; agents have NO creds)
+scripts/dev/sandbox.sh --shell         # a shell with the sandbox env (run thurbox-cli by hand)
+scripts/dev/sandbox.sh -- session list # run a thurbox-cli command in the sandbox
+scripts/dev/sandbox.sh --clean [name]  # kill + wipe a persistent profile
+```
+
+Or via `just`: `just sandbox`, `just sandbox-fresh`, `just sandbox-shell`,
+`just sandbox-clean [profile]`.
+
+**Isolation flavors:**
+
+- **thurbox-only (default)** — real `HOME`/agents; only `thurbox-config` +
+  `thurbox-data` (+ a private `TMUX_TMPDIR`) are redirected. Use this to dev with
+  your real, logged-in agents without polluting your real thurbox state.
+- **full (`--isolate-home`)** — also overrides `HOME` + `XDG_*`, so the env is
+  hermetic and agents boot with no credentials. This is what `scripts/demo/
+  record.sh` and `scripts/dev/tui-smoke-test.sh` use (via
+  `tbx_sandbox_init_full`).
+
+- **Persistent** profiles live under `target/dev-sandbox/<profile>/` (gitignored;
+  `cargo clean` or `--clean` removes them). Their tmux socket dir is kept short
+  under `$XDG_RUNTIME_DIR` (AF_UNIX socket paths are length-limited, and the
+  repo's `target/` path is often too long). Sessions survive across runs.
+- **Fresh** (`--fresh`) is a `mktemp` dir wiped on exit — same isolation the
+  demo/smoke scripts use.
+
+The isolation logic is one helper, `scripts/dev/lib/sandbox-env.sh`, sourced by
+`scripts/dev/sandbox.sh`, `scripts/demo/record.sh`, and
+`scripts/dev/tui-smoke-test.sh` (one source of truth).
+
+### Example: watch a session's status hook end-to-end
+
+```bash
+scripts/dev/sandbox.sh --shell
+# inside the sandbox shell (thurbox/thurbox-cli target the sandbox):
+thurbox-cli session create --name demo --repo-path "$PWD" --agent claude
+thurbox-cli session signal --state blocked --session <id>   # what an agent hook does
+thurbox-cli session list --json | jq '.[].name'
+```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -83,6 +83,8 @@ Or via `just`: `just sandbox`, `just sandbox-fresh`, `just sandbox-shell`,
   record.sh` and `scripts/dev/tui-smoke-test.sh` use (via
   `tbx_sandbox_init_full`).
 
+**Profile lifetimes:**
+
 - **Persistent** profiles live under `target/dev-sandbox/<profile>/` (gitignored;
   `cargo clean` or `--clean` removes them). Their tmux socket dir is kept short
   under `$XDG_RUNTIME_DIR` (AF_UNIX socket paths are length-limited, and the

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -1,0 +1,86 @@
+# hooks — agent lifecycle → thurbox session status
+
+The **hooks** extension wires each coding agent's lifecycle hooks to
+`thurbox-cli session signal` so every session reports its state back to thurbox
+and the sidebar shows, at a glance, which agents are **blocked**, **working**,
+or **done**:
+
+| State | Colour | Meaning |
+|-------|--------|---------|
+| 🔴 blocked | red | the agent needs input or approval |
+| 🟡 working | yellow | the agent is actively running |
+| 🔵 done | blue | a turn just finished; shown until you switch away |
+| 🟢 idle | green | acknowledged (you moved off it), or at rest |
+
+Repo groups in the session list roll up to their most-urgent member, so the
+whole list scans in one pass.
+
+## It's on by default
+
+Unlike other extensions, **hooks ships built into thurbox and is auto-activated**
+on first run — the default agent's hook is pre-configured with zero setup. Opt
+out at any time:
+
+```bash
+thurbox-cli extension deactivate hooks   # remove the wiring; won't come back
+thurbox-cli extension activate hooks      # re-enable it
+```
+
+## How each agent is wired
+
+The hook command is always `thurbox-cli session signal --state <working|blocked|done>`,
+which identifies the calling session from the injected `$THURBOX_SESSION` (no ids
+passed by hand) and is suffixed `|| true` so it can never break the agent.
+
+- **claude** — a managed settings file (under the extension home) is passed via
+  `--settings` (an `[[agent_patches]]` that appends the flag to the built-in
+  `claude` agent, reversibly). claude merges it with your own settings, so your
+  hooks are preserved. Events: `SessionStart` → idle (so a just-booted, idle
+  session isn't shown as working), `UserPromptSubmit`/`PreToolUse` → working,
+  `Stop` → done. `Notification` → blocked **only for permission/approval
+  prompts** — claude also fires `Notification` for its "waiting for your input"
+  idle nudge, which the hook ignores (parses the payload) so an idle session
+  doesn't flip to red.
+- **aider** — `--notifications-command` reports the only edge aider exposes:
+  blocked (waiting for input).
+- **opencode** — a plugin dropped into `~/.config/opencode/plugin/` (only when
+  opencode is installed). Events: `chat.message` → working, `permission.asked`
+  → blocked, `session.idle` → done.
+- **codex** — codex's stable `notify` program runs on **agent-turn-complete**,
+  which maps to **done**. It's injected as a launch `-c notify=…` override (an
+  `[[agent_patches]]`), so your `~/.codex/config.toml` is never written and the
+  wiring is fully reversible. codex has no per-event notify, so working/blocked/
+  idle aren't expressible this way — the dot is accurate for the turn-complete
+  edge (complementary to aider's blocked-only).
+- **gemini** *(experimental)* — gemini loads hooks only from its shared
+  `~/.gemini/settings.json`, so we **JSON-merge** our entries in (a
+  `[[config_merges]]`, guarded by `requires_dir`) without clobbering your
+  settings; uninstall prunes exactly ours back out. Events: `SessionStart` →
+  idle, `BeforeTool` → working, `AfterAgent` → done. **No blocked** — gemini has
+  no permission-only event (only an ambiguous `Notification` that also fires on
+  idle, the false-red trap we avoid for claude). **Caveats:** the event
+  names/settings shape are doc-sourced and unverified against a live binary — if
+  they differ, edit `gemini-hooks.json` (no code change). And if gemini sanitizes
+  the hook environment, `$THURBOX_SESSION` may not reach the hook, in which case
+  the signal is a fail-open no-op. Validate end-to-end before relying on it.
+
+## Mechanism
+
+This extension exercises two extension-manifest capabilities (see
+`src/session/extension_def.rs`):
+
+- `[[agent_patches]]` — append args to an **existing** agent in `agents.toml`
+  (reversible; uninstall removes exactly the injected subsequence).
+- `[[external_files]]` — place a file into an agent's **own** config dir
+  (outside the extension home), guarded by `requires_dir`.
+- `[[config_merges]]` — **reversibly deep-merge** shipped JSON into an agent's
+  own *shared* config file (gemini's `settings.json`) without clobbering the
+  user's other settings: objects recurse, arrays union, and uninstall prunes
+  exactly the entries we shipped (matched by the `session signal` marker, so it
+  stays correct across payload changes). Guarded by `requires_dir`; no-op when
+  the merge is already present. A merge whose target is malformed JSON is
+  soft-skipped (logged, never aborts the rest of the install).
+
+  Note: on the **first** merge, thurbox rewrites `settings.json` with normalized
+  formatting (alphabetized keys, 2-space indent). This is one-time and lossless —
+  your values are untouched and the file is stable afterward.

--- a/extensions/hooks/claude.json
+++ b/extensions/hooks/claude.json
@@ -1,0 +1,59 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state idle || true",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state working || true",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state working || true",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "case \"$(cat)\" in *permission*|*Permission*|*approval*|*approve*) thurbox-cli session signal --state blocked ;; esac; true",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state done || true",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/extensions/hooks/extension.toml
+++ b/extensions/hooks/extension.toml
@@ -1,0 +1,80 @@
+# The built-in "hooks" extension.
+#
+# Wires each coding agent's lifecycle hooks to `thurbox-cli session signal` so
+# every session reports its state (working / blocked / done) back to thurbox.
+# Unlike user extensions this one ships embedded in the binary and is
+# auto-activated on first run. Opt out with:
+#
+#     thurbox-cli extension deactivate hooks
+#
+# Identity is the injected $THURBOX_SESSION env var (no ids passed by hand), and
+# every hook command is `… || true` so a missing thurbox-cli or a hook firing
+# outside a thurbox session can never break the agent.
+
+name = "hooks"
+description = "Report each agent's lifecycle state (working/blocked/done) to thurbox via agent hooks."
+config_version = 1
+version = "1.3.0"
+# Default home; the auto-activation path overrides this with *this build's*
+# resolved config dir (`~/.config/thurbox` or `~/.config/thurbox-dev`) so dev and
+# release installs stay isolated. See `session_ops::builtin_hooks::hooks_home`.
+home = "~/.config/thurbox/hooks"
+
+# claude reads hooks from a settings file we pass via --settings (merged with the
+# user's own settings, never clobbering them). The file lives under the home dir.
+[[files]]
+path = "claude.json"
+
+# Inject the --settings flag into the existing built-in `claude` agent (reversible).
+[[agent_patches]]
+name = "claude"
+append_args = ["--settings", "{home}/claude.json"]
+
+# aider has no lifecycle hook system — only a "waiting for input" callback, which
+# maps to blocked. (working/done aren't expressible; the dot stays accurate for
+# the block edge.)
+[[agent_patches]]
+name = "aider"
+append_args = [
+  "--notifications",
+  "--notifications-command",
+  "thurbox-cli session signal --state blocked",
+]
+
+# opencode loads plugins from its own config dir; drop one in (only when opencode
+# is actually installed, guarded by requires_dir).
+[[external_files]]
+path = "~/.config/opencode/plugin/thurbox-status.js"
+source = "opencode-status.js"
+requires_dir = "~/.config/opencode"
+
+# codex's stable, long-documented hook is `notify` — a single program codex runs
+# on agent-turn-complete (it appends a JSON event arg, which the inline `sh -c`
+# ignores). That maps cleanly to `done`. codex has no per-event notify, so
+# working/blocked/idle aren't expressible this way — the dot is accurate for the
+# turn-complete edge (complementary to aider's blocked-only). Passed as a launch
+# `-c` override so we never write into the user's ~/.codex/config.toml, and it's
+# fully reversible (uninstall strips these args).
+[[agent_patches]]
+name = "codex"
+append_args = [
+  "-c",
+  'notify=["sh","-c","thurbox-cli session signal --state done || true"]',
+]
+
+# gemini loads hooks only from its shared ~/.gemini/settings.json, which we must
+# NOT clobber — so we JSON-merge our entries in (reversibly; uninstall prunes
+# exactly ours, leaving the user's settings intact). Guarded by requires_dir so
+# it's a no-op when gemini isn't installed.
+#
+# EXPERIMENTAL: gemini's hook event names + settings shape here are doc-sourced
+# and unverified against a live binary; if they differ, fix gemini-hooks.json
+# (no code change needed). gemini also has no permission-only event, so we map
+# only idle/working/done (NO blocked — its ambiguous Notification fires on idle
+# too, the false-red trap we avoid for claude). Identity needs $THURBOX_SESSION
+# to reach the hook process; if gemini sanitizes the hook env the signal is a
+# fail-open no-op (`|| true`). Validate end-to-end before relying on it.
+[[config_merges]]
+path = "~/.gemini/settings.json"
+source = "gemini-hooks.json"
+requires_dir = "~/.gemini"

--- a/extensions/hooks/gemini-hooks.json
+++ b/extensions/hooks/gemini-hooks.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state idle || true"
+          }
+        ]
+      }
+    ],
+    "BeforeTool": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state working || true"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "thurbox-cli session signal --state done || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/extensions/hooks/opencode-status.js
+++ b/extensions/hooks/opencode-status.js
@@ -1,0 +1,25 @@
+// Managed by thurbox `extension install` (the built-in "hooks" extension).
+// Reinstalling or updating overwrites this file — do not edit; uninstalling
+// removes it. Reports opencode's lifecycle state to thurbox via
+// `thurbox-cli session signal`. Identity comes from the inherited
+// $THURBOX_SESSION env var; every call is best-effort so it can never break a
+// session running outside thurbox.
+export const ThurboxStatus = async ({ $ }) => {
+  const signal = async (state) => {
+    try {
+      await $`thurbox-cli session signal --state ${state}`.quiet().nothrow();
+    } catch (_) {
+      // best-effort: never surface hook errors into the agent
+    }
+  };
+  return {
+    "chat.message": async () => {
+      await signal("working");
+    },
+    event: async ({ event }) => {
+      if (!event || !event.type) return;
+      if (event.type === "permission.asked") await signal("blocked");
+      else if (event.type === "session.idle") await signal("done");
+    },
+  };
+};

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "thurbox — multi-session coding-agent TUI orchestrator (dev environment)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+
+        # Single source of truth for the Rust toolchain: the same
+        # rust-toolchain.toml cargo/rustup already honor (stable + rustfmt,
+        # clippy, rust-src). No version drift between flake users and others.
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        # Cargo dev tools that ARE packaged in nixpkgs (pinned by flake.lock).
+        cargoTools = with pkgs; [
+          cargo-nextest
+          cargo-deny
+          cargo-audit
+          cargo-modules
+          cocogitto
+        ];
+
+        # System deps to build/test/lint thurbox (mirrors .github/workflows/ci.yml).
+        systemTools = with pkgs; [
+          tmux # session backend (CLAUDE.md: >= 3.2)
+          git
+          shellcheck # shell linter (pre-commit + CI)
+          bats # install-script tests
+          nodejs_22 # website linters (CI uses 26; 22 runs eleventy/eslint/etc.)
+          just # task runner (see justfile)
+          sqlite # demo/record.sh queries the dev DB
+          jq # handy for `thurbox-cli … --json` in the sandbox
+        ];
+
+        # Optional demo-recording stack (scripts/demo/record.sh).
+        demoTools = with pkgs; [
+          vhs
+          ffmpeg
+          ttyd
+        ];
+
+        # Dev tools NOT in nixpkgs — the shellHook nudges the user to install
+        # them via scripts/install-dev-tools.sh (cargo-binstall). Keeping the
+        # flake the single entrypoint without blocking on un-packaged tools.
+        # (prek = pre-commit runner, rumdl = markdown linter, cargo-pup = nightly.)
+        missingHint = ''
+          for t in prek rumdl; do
+            command -v "$t" >/dev/null 2>&1 || {
+              echo "note: '$t' is not packaged in nixpkgs — install the remaining dev tools with:"
+              echo "        scripts/install-dev-tools.sh"
+              break
+            }
+          done
+        '';
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [ rustToolchain ] ++ cargoTools ++ systemTools ++ demoTools;
+
+          # rust-analyzer / some tools want the std sources.
+          RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+
+          shellHook = ''
+            echo "thurbox dev shell — rust $(rustc --version | cut -d' ' -f2), tmux $(tmux -V | cut -d' ' -f2)"
+            echo "  build/test/lint: just <task>   |   run isolated: scripts/dev/sandbox.sh   |   git hooks: prek install"
+            ${missingHint}
+          '';
+        };
+      }
+    );
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,72 @@
+# thurbox dev task runner. Run `just` (or `just --list`) to see tasks.
+#
+# Enter the pinned toolchain first with `nix develop` (or `direnv allow`); these
+# tasks assume the dev tools (cargo-nextest, cargo-deny, rumdl, shellcheck, …)
+# are on PATH. See docs/DEVELOPMENT.md.
+
+# Default: show the task list.
+default:
+    @just --list
+
+# Type-check everything.
+check:
+    cargo check --all
+
+# Build the dev binaries (TUI + CLI).
+build:
+    cargo build --bin thurbox --bin thurbox-cli
+
+# Run the full test suite (nextest).
+test:
+    cargo nextest run --all
+
+# Run a single test by name: `just test-one perf_`.
+test-one NAME:
+    cargo nextest run -E 'test({{NAME}})'
+
+# Format Rust + website code.
+fmt:
+    cargo fmt --all
+    npm run fmt:website
+
+# Lint everything CI lints (Rust + deny + markdown + shell).
+lint:
+    cargo fmt --all -- --check
+    cargo clippy --all-targets --all-features -- -D warnings
+    cargo deny check advisories
+    cargo deny check bans licenses sources
+    rumdl check .
+    git ls-files -z '*.sh' | xargs -0 shellcheck
+
+# Architecture-rule + doc checks.
+arch:
+    cargo test --test architecture_rules
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+
+# Install the non-Nix dev tools (fallback when not using the flake).
+dev-tools:
+    scripts/install-dev-tools.sh
+
+# Install the prek git hooks.
+hooks-install:
+    prek install
+
+# Run the dev TUI in the persistent default sandbox.
+sandbox *ARGS:
+    scripts/dev/sandbox.sh {{ARGS}}
+
+# Run the dev TUI in a throwaway sandbox (wiped on exit).
+sandbox-fresh:
+    scripts/dev/sandbox.sh --fresh
+
+# Drop into a shell with the sandbox env (run `thurbox-cli …` by hand).
+sandbox-shell:
+    scripts/dev/sandbox.sh --shell
+
+# Wipe a persistent sandbox profile (default: "default").
+sandbox-clean PROFILE="default":
+    scripts/dev/sandbox.sh --clean {{PROFILE}}
+
+# Black-box TUI smoke test (real binary in a throwaway tmux pane).
+smoke:
+    scripts/dev/tui-smoke-test.sh

--- a/scripts/demo/record.sh
+++ b/scripts/demo/record.sh
@@ -103,26 +103,22 @@ THURBOX_BIN="$REPO_ROOT/target/debug/thurbox"
 CLI_BIN="$REPO_ROOT/target/debug/thurbox-cli"
 export THURBOX_BIN   # consumed by the tapes (they `exec "$THURBOX_BIN"`)
 
-# --- Isolated environment ----------------------------------------------------
+# --- Isolated environment (shared dev-sandbox helper) ------------------------
 REAL_HOME="$HOME"                        # captured before the override below
-DEMO_HOME=$(mktemp -d "${TMPDIR:-/tmp}/thurbox-demo.XXXXXX")
-export HOME="$DEMO_HOME/home"            # fresh agent auth (no real creds/history)
-export XDG_DATA_HOME="$DEMO_HOME/data"
-export XDG_CONFIG_HOME="$DEMO_HOME/config"
-export XDG_STATE_HOME="$DEMO_HOME/state"
-export XDG_CACHE_HOME="$DEMO_HOME/cache"
-export TMUX_TMPDIR="$DEMO_HOME/tmux"     # isolate the tmux socket DIRECTORY
+# shellcheck source=scripts/dev/lib/sandbox-env.sh
+# shellcheck disable=SC1091
+. "$REPO_ROOT/scripts/dev/lib/sandbox-env.sh"
+tbx_sandbox_init_full fresh              # throwaway temp HOME/XDG/TMUX_TMPDIR
+DEMO_HOME="$TBX_SANDBOX_ROOT"            # fresh agent auth (no real creds/history)
 CFG_DIR="$XDG_CONFIG_HOME/thurbox-dev"   # dev_build subdir
 DB_FILE="$XDG_DATA_HOME/thurbox-dev/thurbox.db"  # SQLite db (dev_build subdir)
-mkdir -p "$HOME" "$CFG_DIR" "$XDG_DATA_HOME" "$XDG_STATE_HOME" \
-    "$XDG_CACHE_HOME" "$TMUX_TMPDIR"
+mkdir -p "$CFG_DIR"
 
 cleanup() {
-    # The isolated tmux server (in TMUX_TMPDIR) hosts every agent pane, so this
-    # single kill reaps all the real agent processes too — and cannot reach any
-    # tmux server outside this throwaway directory.
-    tmux -L thurbox-dev kill-server >/dev/null 2>&1 || true
-    rm -rf "$DEMO_HOME"
+    # The isolated tmux server (in TMUX_TMPDIR) hosts every agent pane, so the
+    # helper's single kill reaps all the real agent processes too — and cannot
+    # reach any tmux server outside this throwaway directory — then wipes it.
+    tbx_sandbox_teardown
 }
 trap cleanup EXIT INT TERM
 

--- a/scripts/dev/lib/sandbox-env.sh
+++ b/scripts/dev/lib/sandbox-env.sh
@@ -1,0 +1,135 @@
+# shellcheck shell=sh
+#
+# Shared dev-sandbox isolation helper — the single source of truth for running a
+# thurbox *dev build* (`0.0.0-dev` => `dev_build` cfg, which uses the
+# `thurbox-dev` tmux socket) against an isolated environment, without polluting
+# your real thurbox config/sessions.
+#
+# Two isolation flavors:
+#
+#   tbx_sandbox_init      — *thurbox-only* isolation (DEFAULT for sandbox.sh):
+#                           redirects only THURBOX_CONFIG_DIR / THURBOX_DATA_DIR
+#                           (+ TMUX_TMPDIR), leaving HOME/XDG real so your real,
+#                           authenticated agent CLIs (claude/codex/gemini/…) work.
+#   tbx_sandbox_init_full — *full* isolation: also overrides HOME + XDG_* under
+#                           the sandbox (hermetic; agents boot with no creds).
+#                           Used by the demo recorder + TUI smoke test.
+#
+# Source it (don't execute) AFTER setting REPO_ROOT (or TBX_REPO_ROOT). Written
+# in POSIX sh so both bash callers (sandbox.sh, tui-smoke-test.sh) and the
+# /usr/bin/env sh caller (record.sh) can source it. Both flavors prepend the
+# repo's target/debug to PATH so an agent hook's `thurbox-cli` resolves to *this*
+# dev binary (and writes to the sandbox DB the dev TUI reads).
+#
+# Build the binaries BEFORE calling init so cargo still resolves your ~/.cargo
+# (the full flavor overrides $HOME).
+
+: "${TBX_REPO_ROOT:=${REPO_ROOT:-}}"
+if [ -z "$TBX_REPO_ROOT" ]; then
+    echo "sandbox-env.sh: set REPO_ROOT (or TBX_REPO_ROOT) before sourcing" >&2
+    # `return` works when sourced (the intended use); `exit` covers the mistake
+    # of executing this file directly.
+    # shellcheck disable=SC2317
+    return 2 2>/dev/null || exit 2
+fi
+export TBX_REPO_ROOT
+
+# The dev build's tmux socket name (mirrors src/agent/tmux.rs TMUX_SOCKET for a
+# dev_build). It lives inside the sandbox's private TMUX_TMPDIR, so killing it
+# can never reach a real server.
+export TBX_DEV_SOCKET="thurbox-dev"
+
+# Populated by an init call.
+export TBX_SANDBOX_ROOT=""
+export TBX_SANDBOX_FRESH=0
+
+# tbx_sandbox_tmux_dir <profile> — short, stable tmux socket dir for a persistent
+# profile (kept off the deep target/ path; AF_UNIX socket paths are length-limited).
+tbx_sandbox_tmux_dir() {
+    echo "${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/thurbox-sbx-${1:-default}"
+}
+
+# _tbx_resolve_root <fresh|persistent> [profile] — common setup shared by both
+# init flavors: resolves TBX_SANDBOX_ROOT, exports TMUX_TMPDIR (short, see above),
+# and prepends target/debug to PATH. Internal.
+_tbx_resolve_root() {
+    mode="${1:-persistent}"
+    profile="${2:-default}"
+
+    case "$mode" in
+        fresh)
+            TBX_SANDBOX_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/thurbox-sandbox.XXXXXX")"
+            TBX_SANDBOX_FRESH=1
+            TMUX_TMPDIR="$TBX_SANDBOX_ROOT/tmux"
+            ;;
+        persistent)
+            TBX_SANDBOX_ROOT="$TBX_REPO_ROOT/target/dev-sandbox/$profile"
+            TBX_SANDBOX_FRESH=0
+            mkdir -p "$TBX_SANDBOX_ROOT"
+            # The deep target/ path overflows tmux's socket-path limit, so keep
+            # the persistent socket dir short + stable per profile.
+            TMUX_TMPDIR="$(tbx_sandbox_tmux_dir "$profile")"
+            ;;
+        *)
+            echo "sandbox init: unknown mode '$mode' (want fresh|persistent)" >&2
+            return 2
+            ;;
+    esac
+
+    export TMUX_TMPDIR
+    mkdir -p "$TMUX_TMPDIR"
+    PATH="$TBX_REPO_ROOT/target/debug:$PATH"
+    export PATH
+}
+
+# tbx_sandbox_init <fresh|persistent> [profile] — THURBOX-ONLY isolation.
+# Real HOME/XDG (so authenticated agent CLIs work); only thurbox's config/data
+# are redirected into the sandbox via the THURBOX_*_DIR overrides paths.rs honors.
+tbx_sandbox_init() {
+    _tbx_resolve_root "$@" || return $?
+    THURBOX_CONFIG_DIR="$TBX_SANDBOX_ROOT/thurbox-config"
+    THURBOX_DATA_DIR="$TBX_SANDBOX_ROOT/thurbox-data"
+    export THURBOX_CONFIG_DIR THURBOX_DATA_DIR
+    mkdir -p "$THURBOX_CONFIG_DIR" "$THURBOX_DATA_DIR"
+}
+
+# tbx_sandbox_init_full <fresh|persistent> [profile] — FULL isolation.
+# Overrides HOME + XDG_* under the sandbox too (hermetic; agents boot fresh with
+# no creds). For the demo recorder + smoke test. Uses the dev_build `thurbox-dev`
+# XDG subdir (no THURBOX_*_DIR override needed).
+tbx_sandbox_init_full() {
+    _tbx_resolve_root "$@" || return $?
+    # Hermetic: drop any inherited THURBOX_*_DIR overrides — paths.rs honors them
+    # ahead of XDG, so an inherited one would silently defeat the isolation.
+    unset THURBOX_CONFIG_DIR THURBOX_DATA_DIR
+    HOME="$TBX_SANDBOX_ROOT/home"
+    XDG_CONFIG_HOME="$TBX_SANDBOX_ROOT/config"
+    XDG_DATA_HOME="$TBX_SANDBOX_ROOT/data"
+    XDG_STATE_HOME="$TBX_SANDBOX_ROOT/state"
+    XDG_CACHE_HOME="$TBX_SANDBOX_ROOT/cache"
+    export HOME XDG_CONFIG_HOME XDG_DATA_HOME XDG_STATE_HOME XDG_CACHE_HOME
+    mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME" \
+        "$XDG_CACHE_HOME"
+}
+
+# tbx_sandbox_teardown — kill the sandbox's tmux server (safe: private
+# TMUX_TMPDIR) and, for a `fresh` sandbox, remove the whole root. Persistent
+# sandboxes are left intact (use tbx_sandbox_clean to wipe them).
+tbx_sandbox_teardown() {
+    tmux -L "$TBX_DEV_SOCKET" kill-server >/dev/null 2>&1 || true
+    if [ "$TBX_SANDBOX_FRESH" = "1" ] && [ -n "$TBX_SANDBOX_ROOT" ]; then
+        rm -rf "$TBX_SANDBOX_ROOT"
+    fi
+}
+
+# tbx_sandbox_clean [profile] — kill a persistent profile's tmux server and
+# remove its root + short tmux dir. Default profile "default".
+tbx_sandbox_clean() {
+    profile="${1:-default}"
+    root="$TBX_REPO_ROOT/target/dev-sandbox/$profile"
+    tdir="$(tbx_sandbox_tmux_dir "$profile")"
+    if [ -d "$tdir" ]; then
+        TMUX_TMPDIR="$tdir" tmux -L "$TBX_DEV_SOCKET" kill-server >/dev/null 2>&1 || true
+    fi
+    rm -rf "$root" "$tdir"
+}

--- a/scripts/dev/sandbox.sh
+++ b/scripts/dev/sandbox.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Run a thurbox *dev build* in an isolated sandbox — one command to launch the
+# `thurbox-dev` TUI/CLI against a throwaway or persistent environment that never
+# touches your real ~/.config/thurbox or tmux server.
+#
+# By default only *thurbox's own* config/data are redirected (via THURBOX_*_DIR)
+# — your real HOME/agents stay intact, so authenticated claude/codex/gemini work.
+# Pass --isolate-home for a fully hermetic env (fresh HOME, agents boot without
+# credentials), e.g. to reproduce the demo/smoke conditions.
+#
+# Usage:
+#   scripts/dev/sandbox.sh                 # persistent "default" profile, launch the TUI
+#   scripts/dev/sandbox.sh --fresh         # throwaway env, wiped on exit
+#   scripts/dev/sandbox.sh --profile foo   # named persistent profile
+#   scripts/dev/sandbox.sh --isolate-home  # full isolation (fresh HOME; no agent creds)
+#   scripts/dev/sandbox.sh --shell         # drop into a shell with the sandbox env
+#                                          #   (run `thurbox-cli ...` against the sandbox DB)
+#   scripts/dev/sandbox.sh -- session list # run `thurbox-cli <args>` in the sandbox
+#   scripts/dev/sandbox.sh --clean [name]  # kill + wipe a persistent profile, then exit
+#
+# State (persistent mode): target/dev-sandbox/<profile>/ (gitignored). Sessions
+# survive across runs — its tmux-dev server is left alive on exit. `--clean`
+# (or `cargo clean`) removes it.
+#
+# Requires: cargo, tmux >= 3.2. Build happens before any HOME override so cargo
+# still resolves your real ~/.cargo.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export TBX_REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)" # consumed by the helper
+# shellcheck source=scripts/dev/lib/sandbox-env.sh
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/sandbox-env.sh"
+
+# Logs go to stderr so `--` CLI passthrough keeps stdout clean (e.g. `--json`).
+log() { printf '\033[1;36m==>\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+mode="persistent"
+profile="default"
+isolation="thurbox" # thurbox | full
+action="tui"        # tui | shell | cli | clean
+cli_args=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --fresh) mode="fresh"; shift ;;
+        --profile) profile="${2:?--profile needs a name}"; shift 2 ;;
+        --isolate-home) isolation="full"; shift ;;
+        --shell) action="shell"; shift ;;
+        --clean) action="clean"; shift; case "${1:-}" in ""|-*) ;; *) profile="$1"; shift ;; esac ;;
+        --) shift; action="cli"; cli_args=("$@"); break ;;
+        -h|--help) sed -n '2,32p' "$0"; exit 0 ;;
+        *) die "unknown argument: $1 (try --help)" ;;
+    esac
+done
+
+command -v cargo >/dev/null || die "cargo not found"
+
+if [ "$action" = "clean" ]; then
+    log "cleaning sandbox profile '$profile'"
+    tbx_sandbox_clean "$profile"
+    exit 0
+fi
+
+# Build the dev binaries BEFORE the HOME override (so cargo finds ~/.cargo).
+log "building thurbox (dev)"
+( cd "$TBX_REPO_ROOT" && cargo build --bin thurbox --bin thurbox-cli >&2 )
+
+if [ "$isolation" = "full" ]; then
+    tbx_sandbox_init_full "$mode" "$profile"
+else
+    tbx_sandbox_init "$mode" "$profile"
+fi
+export TBX_IN_SANDBOX="$profile"
+
+log "sandbox root: $TBX_SANDBOX_ROOT ($mode, $isolation isolation)"
+
+# What to run in the sandbox env.
+run_in_sandbox() {
+    case "$action" in
+        shell)
+            log "entering sandbox shell — \`thurbox\`/\`thurbox-cli\` target this sandbox; exit to leave"
+            "${SHELL:-bash}" -i
+            ;;
+        cli) "$TBX_REPO_ROOT/target/debug/thurbox-cli" "${cli_args[@]}" ;;
+        tui) "$TBX_REPO_ROOT/target/debug/thurbox" ;;
+    esac
+}
+
+# Run as a child (NOT exec): a `fresh` sandbox needs the teardown trap to fire on
+# exit to reap its throwaway dir + tmux server, and `exec` would discard the
+# trap. Persistent sandboxes have nothing to tear down.
+[ "$TBX_SANDBOX_FRESH" = "1" ] && trap tbx_sandbox_teardown EXIT INT TERM
+run_in_sandbox

--- a/scripts/dev/tui-smoke-test.sh
+++ b/scripts/dev/tui-smoke-test.sh
@@ -33,27 +33,7 @@ die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
 
 command -v tmux >/dev/null || die "tmux not found (need >= 3.2)"
 
-# --- isolated environment -----------------------------------------------------
-WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/thurbox-smoke.XXXXXX")"
-export HOME="$WORKDIR/home"
-export XDG_CONFIG_HOME="$WORKDIR/config"
-export XDG_DATA_HOME="$WORKDIR/data"
-export XDG_STATE_HOME="$WORKDIR/state"
-export XDG_CACHE_HOME="$WORKDIR/cache"
-export TMUX_TMPDIR="$WORKDIR/tmux"
-mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME" \
-  "$XDG_CACHE_HOME" "$TMUX_TMPDIR"
-
-# shellcheck disable=SC2317 # body runs via the `trap` below; not unreachable
-cleanup() {
-  tmux -L "$SOCKET" kill-server >/dev/null 2>&1 || true
-  # thurbox's own dev socket lives under our private TMUX_TMPDIR too.
-  tmux -L thurbox-dev kill-server >/dev/null 2>&1 || true
-  rm -rf "$WORKDIR"
-}
-trap cleanup EXIT INT TERM
-
-# --- build (unless a binary was provided) ------------------------------------
+# --- build (unless a binary was provided) — before the HOME override below ----
 if [ -n "${THURBOX_BIN:-}" ]; then
   BIN="$THURBOX_BIN"
   [ -x "$BIN" ] || die "THURBOX_BIN=$BIN is not executable"
@@ -63,6 +43,21 @@ else
   BIN="$REPO_ROOT/target/debug/thurbox"
 fi
 [ -x "$BIN" ] || die "thurbox binary not found at $BIN"
+
+# --- isolated environment (shared dev-sandbox helper) ------------------------
+# shellcheck source=scripts/dev/lib/sandbox-env.sh
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/dev/lib/sandbox-env.sh"
+tbx_sandbox_init_full fresh   # hermetic: temp HOME/XDG so it never touches real config
+
+# shellcheck disable=SC2317,SC2329 # body runs via the `trap` below; not unreachable
+cleanup() {
+  # The outer "driver" tmux (socket `tui-smoke`) lives in the same private
+  # TMUX_TMPDIR; kill it, then let the helper kill thurbox-dev + wipe the root.
+  tmux -L "$SOCKET" kill-server >/dev/null 2>&1 || true
+  tbx_sandbox_teardown
+}
+trap cleanup EXIT INT TERM
 
 # --- launch the TUI in an isolated tmux pane ---------------------------------
 log "launching TUI in tmux ($COLS x $ROWS)"

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
-# Install all required development tools for thurbox
+# Install all required development tools for thurbox.
+#
+# This is the NON-NIX fallback. The recommended path is the Nix flake, which
+# pins the whole toolchain reproducibly:
+#
+#     nix develop            # or `direnv allow` once, then it auto-enters
+#
+# Use this script if you don't have Nix. It also installs the couple of tools
+# not yet packaged in nixpkgs (prek, rumdl, nightly cargo-pup), so the flake's
+# shellHook points here for those. See docs/DEVELOPMENT.md.
 
 set -e
 

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -615,6 +615,13 @@ impl Session {
         self.exited.load(Ordering::SeqCst)
     }
 
+    /// Force the session into the "process exited" state, for tests that need to
+    /// exercise the exited → `Idle` status branch.
+    #[cfg(test)]
+    pub fn mark_exited_for_test(&self) {
+        self.exited.store(true, Ordering::SeqCst);
+    }
+
     pub fn millis_since_last_output(&self) -> u64 {
         now_millis().saturating_sub(self.last_output_at.load(Ordering::Relaxed))
     }

--- a/src/agent/extension_config.rs
+++ b/src/agent/extension_config.rs
@@ -15,7 +15,7 @@ use std::process::Command;
 
 use serde::Serialize;
 
-use crate::session::{AgentDef, ExtensionDef};
+use crate::session::{AgentDef, AgentPatch, ExtensionDef};
 
 /// Raw-content root of the thurbox repo (no git ref).
 const OFFICIAL_REPO_RAW: &str = "https://raw.githubusercontent.com/Thurbeen/thurbox";
@@ -481,6 +481,110 @@ pub fn remove_agents_from_toml(names: &[String]) -> Result<Vec<String>, String> 
     Ok(removed)
 }
 
+/// Append each patch's `append_args` to the named existing agent's `args` in
+/// `agents.toml`, idempotently and preserving comments/formatting (toml_edit).
+/// Unlike [`ensure_agents_registered`] (which only adds *new* agents), this
+/// extends an agent the extension does not own (e.g. the built-in `claude`).
+/// Agents not present are skipped. Returns the names actually patched.
+pub fn apply_agent_patches(patches: &[AgentPatch]) -> Result<Vec<String>, String> {
+    edit_agent_patches(patches, true)
+}
+
+/// Reverse of [`apply_agent_patches`]: remove each patch's `append_args`
+/// subsequence from the named agent's `args`. Returns the names actually changed.
+pub fn remove_agent_patches(patches: &[AgentPatch]) -> Result<Vec<String>, String> {
+    edit_agent_patches(patches, false)
+}
+
+fn edit_agent_patches(patches: &[AgentPatch], add: bool) -> Result<Vec<String>, String> {
+    use toml_edit::{Array, DocumentMut};
+
+    if patches.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Ensure the file exists (seeds built-ins if absent).
+    super::agent_config::load_or_seed();
+    let Some(path) = super::agent_config::agents_config_path() else {
+        return Err("could not resolve agents.toml path".into());
+    };
+    let text =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let mut doc: DocumentMut = text
+        .parse()
+        .map_err(|e| format!("parse {}: {e}", path.display()))?;
+    let Some(agents) = doc
+        .get_mut("agents")
+        .and_then(|i| i.as_array_of_tables_mut())
+    else {
+        return Ok(Vec::new());
+    };
+
+    let mut changed = Vec::new();
+    for patch in patches {
+        if patch.append_args.is_empty() {
+            continue;
+        }
+        for table in agents.iter_mut() {
+            if table.get("name").and_then(|v| v.as_str()) != Some(patch.name.as_str()) {
+                continue;
+            }
+            if table.get("args").is_none() {
+                table["args"] = toml_edit::value(Array::new());
+            }
+            let Some(args) = table.get_mut("args").and_then(|i| i.as_array_mut()) else {
+                break;
+            };
+            let current: Vec<String> = args
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            let present = contains_subsequence(&current, &patch.append_args);
+            if add && !present {
+                for a in &patch.append_args {
+                    args.push(a.as_str());
+                }
+                changed.push(patch.name.clone());
+            } else if !add && present {
+                let mut arr = Array::new();
+                for a in remove_subsequence(&current, &patch.append_args) {
+                    arr.push(a.as_str());
+                }
+                table["args"] = toml_edit::value(arr);
+                changed.push(patch.name.clone());
+            }
+            break;
+        }
+    }
+
+    if !changed.is_empty() {
+        std::fs::write(&path, doc.to_string())
+            .map_err(|e| format!("write {}: {e}", path.display()))?;
+    }
+    Ok(changed)
+}
+
+/// Whether `hay` contains `needle` as a contiguous subsequence.
+fn contains_subsequence(hay: &[String], needle: &[String]) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    needle.len() <= hay.len() && hay.windows(needle.len()).any(|w| w == needle)
+}
+
+/// `hay` with the first contiguous occurrence of `needle` removed.
+fn remove_subsequence(hay: &[String], needle: &[String]) -> Vec<String> {
+    if needle.is_empty() {
+        return hay.to_vec();
+    }
+    if let Some(pos) = hay.windows(needle.len()).position(|w| w == needle) {
+        let mut out = hay[..pos].to_vec();
+        out.extend_from_slice(&hay[pos + needle.len()..]);
+        out
+    } else {
+        hay.to_vec()
+    }
+}
+
 /// Walk `lines`, dropping every `[[agents]]` block whose `name` is in `names`
 /// (with a single trailing blank separator). Returns the kept lines and the
 /// names actually removed.
@@ -799,6 +903,50 @@ mod tests {
         assert!(remove_agents_from_toml(&["ghost".to_string()])
             .unwrap()
             .is_empty());
+    }
+
+    #[test]
+    fn agent_patches_apply_idempotently_and_reverse() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        let patch = AgentPatch {
+            name: "claude".into(),
+            append_args: vec!["--settings".into(), "/x/hooks.json".into()],
+        };
+
+        // Applies to the seeded built-in `claude`.
+        let patched = apply_agent_patches(std::slice::from_ref(&patch)).unwrap();
+        assert_eq!(patched, ["claude"]);
+        let reg = super::super::agent_config::load_or_seed();
+        let args = &reg.get("claude").unwrap().args;
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--settings".to_string(), "/x/hooks.json".to_string()]),
+            "args carry the injected flag: {args:?}"
+        );
+
+        // Idempotent: re-applying changes nothing.
+        assert!(apply_agent_patches(std::slice::from_ref(&patch))
+            .unwrap()
+            .is_empty());
+
+        // Reverse removes exactly the injected subsequence.
+        let removed = remove_agent_patches(std::slice::from_ref(&patch)).unwrap();
+        assert_eq!(removed, ["claude"]);
+        let reg = super::super::agent_config::load_or_seed();
+        assert!(!reg
+            .get("claude")
+            .unwrap()
+            .args
+            .contains(&"--settings".to_string()));
+
+        // Patching an absent agent is a silent no-op.
+        let ghost = AgentPatch {
+            name: "ghost".into(),
+            append_args: vec!["--x".into()],
+        };
+        assert!(apply_agent_patches(&[ghost]).unwrap().is_empty());
     }
 
     #[test]

--- a/src/agent/json_merge.rs
+++ b/src/agent/json_merge.rs
@@ -1,0 +1,183 @@
+//! Reversible, non-destructive JSON deep-merge — the primitive behind the
+//! `[[config_merges]]` extension directive, used to inject agent hook entries
+//! into an agent's *own* shared config file (e.g. `~/.gemini/settings.json`)
+//! without clobbering the user's other settings.
+//!
+//! - [`merge`]: objects merge recursively; arrays union by deep-equality (append
+//!   source items not already present). Idempotent, and a type conflict with the
+//!   user's value is left alone (never overwritten/corrupted).
+//! - [`prune_marked`]: remove our entries on uninstall by a **marker** the
+//!   shipped entries carry (our hook commands all contain the `session signal`
+//!   marker). Marker-based — not value-based — so it stays correct even after the
+//!   shipped payload's schema changes across an extension update (no orphans).
+
+use serde_json::Value;
+
+/// Deep-merge `source` into `target` in place (see module docs).
+pub fn merge(target: &mut Value, source: &Value) {
+    match (target, source) {
+        (Value::Object(t), Value::Object(s)) => {
+            for (k, sv) in s {
+                merge(t.entry(k.clone()).or_insert(Value::Null), sv);
+            }
+        }
+        (Value::Array(t), Value::Array(s)) => {
+            for sv in s {
+                if !t.iter().any(|tv| tv == sv) {
+                    t.push(sv.clone());
+                }
+            }
+        }
+        // Target absent (a freshly-inserted `Null`): take the source.
+        (t @ Value::Null, s) => *t = s.clone(),
+        // Type conflict (the user has a different shape here): leave their value
+        // untouched rather than corrupt it.
+        _ => {}
+    }
+}
+
+/// Remove every array element whose serialized JSON contains `marker`, anywhere
+/// in `value`, then prune object keys whose value became an empty object/array.
+/// Used to reverse a [`merge`] of hook entries on uninstall: every entry we ship
+/// carries the marker, so this removes exactly (and only) ours, regardless of
+/// which payload version added them.
+pub fn prune_marked(value: &mut Value, marker: &str) {
+    match value {
+        Value::Object(map) => {
+            let keys: Vec<String> = map.keys().cloned().collect();
+            for k in keys {
+                if let Some(v) = map.get_mut(&k) {
+                    // Only prune a key that *we* emptied (it held marked entries):
+                    // a user's pre-existing empty `{}`/`[]` must survive untouched.
+                    let was_empty = is_empty_container(v);
+                    prune_marked(v, marker);
+                    if !was_empty && is_empty_container(v) {
+                        map.remove(&k);
+                    }
+                }
+            }
+        }
+        Value::Array(arr) => {
+            arr.retain(|item| {
+                !serde_json::to_string(item)
+                    .map(|s| s.contains(marker))
+                    .unwrap_or(false)
+            });
+            for item in arr.iter_mut() {
+                prune_marked(item, marker);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// An empty object or empty array.
+fn is_empty_container(v: &Value) -> bool {
+    matches!(v, Value::Object(o) if o.is_empty()) || matches!(v, Value::Array(a) if a.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const M: &str = "thurbox-cli session signal";
+
+    fn ours(state: &str) -> Value {
+        json!({"hooks": [{"type": "command", "command": format!("{M} --state {state} || true")}]})
+    }
+
+    #[test]
+    fn merge_into_empty_takes_source() {
+        let mut t = json!({});
+        let s = json!({"hooks": {"Stop": [ours("done")]}});
+        merge(&mut t, &s);
+        assert_eq!(t, s);
+    }
+
+    #[test]
+    fn merge_preserves_user_entries_and_unions_arrays() {
+        let mut t = json!({
+            "theme": "dark",
+            "hooks": {"Stop": [{"command": "user"}], "Other": [1]}
+        });
+        merge(&mut t, &json!({"hooks": {"Stop": [ours("done")]}}));
+        assert_eq!(t["theme"], json!("dark"));
+        assert_eq!(t["hooks"]["Other"], json!([1]));
+        let stop = t["hooks"]["Stop"].as_array().unwrap();
+        assert_eq!(stop.len(), 2); // user's + ours
+        assert_eq!(stop[0], json!({"command": "user"}));
+    }
+
+    #[test]
+    fn merge_is_idempotent() {
+        let mut t = json!({});
+        let s = json!({"hooks": {"Stop": [ours("done")]}});
+        merge(&mut t, &s);
+        merge(&mut t, &s);
+        assert_eq!(t["hooks"]["Stop"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn merge_does_not_corrupt_a_type_conflict() {
+        // User has `hooks` as a string; we must not overwrite it with our object.
+        let mut t = json!({"hooks": "disabled"});
+        merge(&mut t, &json!({"hooks": {"Stop": [ours("done")]}}));
+        assert_eq!(t, json!({"hooks": "disabled"}));
+    }
+
+    #[test]
+    fn prune_removes_only_marked_and_prunes_empties() {
+        let mut t = json!({"hooks": {"Stop": [{"command": "user"}, ours("done")]}});
+        prune_marked(&mut t, M);
+        // ours gone, user kept, Stop not pruned (still has the user entry).
+        assert_eq!(t, json!({"hooks": {"Stop": [{"command": "user"}]}}));
+    }
+
+    #[test]
+    fn merge_then_prune_restores_original() {
+        let original = json!({"theme": "dark", "hooks": {"PreToolUse": [{"command": "user"}]}});
+        let source = json!({"hooks": {"Stop": [ours("done")], "PreToolUse": [ours("working")]}});
+        let mut doc = original.clone();
+        merge(&mut doc, &source);
+        prune_marked(&mut doc, M);
+        assert_eq!(doc, original);
+    }
+
+    #[test]
+    fn prune_keeps_user_preexisting_empties() {
+        // Empty `{}`/`[]` are common in real settings.json — we must never
+        // destroy the user's own, only ones we emptied.
+        let original = json!({"mcpServers": {}, "excludeTools": [], "hooks": {}});
+        let mut doc = original.clone();
+        prune_marked(&mut doc, M);
+        assert_eq!(doc, original);
+    }
+
+    #[test]
+    fn prune_handles_empty_and_nonempty_siblings_at_merged_path() {
+        let mut doc = json!({
+            "hooks": {
+                "OurEvent": [ours("done")],     // we own this
+                "UserEmpty": [],                // user's empty sibling — keep
+                "UserKept": [{"command": "x"}]  // user's real sibling — keep
+            }
+        });
+        prune_marked(&mut doc, M);
+        assert_eq!(
+            doc,
+            json!({"hooks": {"UserEmpty": [], "UserKept": [{"command": "x"}]}})
+        );
+    }
+
+    #[test]
+    fn prune_is_version_skew_proof() {
+        // Old payload merged schema A; later payload ships schema B. Prune by the
+        // shared marker removes BOTH (no orphans), leaving only the user's entry.
+        let mut doc = json!({"hooks": {"Stop": [{"command": "user"}]}});
+        merge(&mut doc, &json!({"hooks": {"OldEvent": [ours("done")]}})); // vA
+        merge(&mut doc, &json!({"hooks": {"NewEvent": [ours("done")]}})); // vB
+        prune_marked(&mut doc, M);
+        assert_eq!(doc, json!({"hooks": {"Stop": [{"command": "user"}]}}));
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,7 @@ pub mod extension_config;
 pub mod generic;
 pub mod host_config;
 pub mod input;
+pub mod json_merge;
 pub mod provider;
 pub mod registry;
 pub mod self_update;

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -66,7 +66,7 @@ config_version = 1
 # Run `thurbox-cli notify` to see the detected backend, or `--test` to fire a
 # sample. The dispatcher only starts when [features] notifications = true.
 # [notifications]
-# also_on_waiting = false       # also fire on Busy → Waiting (no explicit OSC bell)
+# also_on_waiting = false       # also fire when a session finishes (Working → Done)
 # suppress_for_active = true    # don't notify if you're already viewing that session
 # sound = true                  # play the OS default notification sound
 # min_interval_secs = 5         # per-session dedup floor (seconds)
@@ -91,7 +91,7 @@ config_version = 1
 # [features]
 # notifications = true
 # [notifications]
-# also_on_waiting = true        # also fire on the timing-only Busy → Waiting edge
+# also_on_waiting = true        # also fire when a session finishes (Working → Done)
 # suppress_for_active = false   # also notify the focused session
 # min_interval_secs = 30        # at most one notification / 30 s per session
 #

--- a/src/agent/themes_config.rs
+++ b/src/agent/themes_config.rs
@@ -23,8 +23,9 @@ pub const SEED_THEMES_TOML: &str = r##"# Thurbox custom themes  —  ~/.config/t
 # app_bg). Bases: default, catppuccin-mocha, tokyo-night, gruvbox-dark, doom,
 # catppuccin-latte, tokyo-night-day, gruvbox-light, solarized-light.
 #
-# Overridable colour keys: accent, accent_bright, status_busy, status_waiting,
-# status_idle, status_error, text_primary, text_secondary, text_muted,
+# Overridable colour keys: accent, accent_bright, status_working,
+# status_blocked, status_done, status_idle, status_error,
+# text_primary, text_secondary, text_muted,
 # border_focused, border_unfocused, role_name, branch_name, search_bar,
 # keybind_hint, tool_allowed, tool_disallowed, danger, selection_bg,
 # selection_fg, modal_dim_bg, modal_bg, modal_border, inverted_fg, app_bg.
@@ -64,7 +65,7 @@ config_version = 1
 # nerd_font = true
 # accent = "#268bd2"
 # accent_bright = "#2aa198"
-# status_busy = "yellow"
+# status_working = "yellow"
 # status_error = "#dc322f"
 # selection_bg = "14"
 "##;
@@ -181,8 +182,9 @@ mod tests {
         for field in [
             "accent",
             "accent_bright",
-            "status_busy",
-            "status_waiting",
+            "status_working",
+            "status_blocked",
+            "status_done",
             "status_idle",
             "status_error",
             "text_primary",

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -953,7 +953,7 @@ fn perf_status_change_keeps_order_cache() {
     h.render(); // cache hit
     assert_eq!(h.app.perf_counters().ordered_sessions_rebuilds, 1);
 
-    h.app.sessions[0].info.status = SessionStatus::Attention;
+    h.app.sessions[0].info.status = SessionStatus::Blocked;
     h.render(); // status changed, but order inputs did not → still a cache hit
     assert_eq!(
         h.app.perf_counters().ordered_sessions_rebuilds,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -46,8 +46,9 @@ const UNDO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// How long a status-bar message is shown before reverting to default counts.
 const STATUS_MESSAGE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
-/// If no output for this many milliseconds, consider session "Waiting".
-const ACTIVITY_TIMEOUT_MS: u64 = 1000;
+/// Ticks per `Working`-spinner frame. The loop ticks ~every 10 ms, so 12 ticks
+/// ≈ 125 ms/frame ≈ 8 fps — a smooth spinner without thrashing the renderer.
+const SPINNER_TICKS_PER_FRAME: u64 = 12;
 
 /// Upper bound between forced repaints when nothing else marked the UI dirty.
 /// The render loop only paints when state changed (a key, agent output, a
@@ -603,6 +604,15 @@ pub struct App {
     /// frame always paints. Set by [`Self::request_redraw`] from `update`,
     /// state-changing tick steps, and the agent-output detector.
     needs_redraw: bool,
+    /// Current frame of the `Working` status spinner (index into
+    /// [`crate::ui::SPINNER_FRAMES`]). Advanced from `tick_count` in
+    /// [`Self::refresh_session_statuses`]; only forces a repaint while a session
+    /// is actually working, so an idle TUI still paints ~4 fps.
+    spinner_frame: usize,
+    /// The session that was focused on the previous status refresh. When focus
+    /// moves off a `done` session, that session is marked "seen" (→ `Idle`), so
+    /// the blue `Done` state stays visible until you actually switch away.
+    last_active_session_id: Option<crate::session::SessionId>,
     /// When the last frame was painted, for the forced-redraw floor.
     last_draw_at: std::time::Instant,
     /// Cheap rolling signature of agent output across all sessions (sum of each
@@ -619,6 +629,35 @@ pub struct App {
 
 const EDITOR_NOT_CONFIGURED: &str =
     "No editor configured — set `editor_command` via MCP or export $EDITOR/$VISUAL";
+
+/// Map a session's persisted hook state to its rendered [`SessionStatus`]. Pure
+/// so it's unit-testable without an `App`/DB. `exited` forces `Idle` (a crashed/
+/// finished process); `just_seen` is `true` when the user just moved focus off a
+/// `done` session this tick (acknowledged → `Idle`). A `done` session is `Done`
+/// (blue) until seen; `idle`/missing/unknown states are `Idle`.
+fn derive_session_status(
+    hook: Option<&crate::storage::HookRow>,
+    exited: bool,
+    just_seen: bool,
+) -> SessionStatus {
+    if exited {
+        return SessionStatus::Idle;
+    }
+    match hook.and_then(|h| h.state.as_deref()) {
+        Some("working") => SessionStatus::Working,
+        Some("blocked") => SessionStatus::Blocked,
+        Some("done") => {
+            let state_at = hook.and_then(|h| h.state_at).unwrap_or(0);
+            let seen_at = hook.and_then(|h| h.seen_at).unwrap_or(0);
+            if just_seen || seen_at >= state_at {
+                SessionStatus::Idle
+            } else {
+                SessionStatus::Done
+            }
+        }
+        _ => SessionStatus::Idle,
+    }
+}
 
 /// Spin up the OS notification dispatcher when the feature is enabled,
 /// returning `None` otherwise so the background thread never starts.
@@ -773,6 +812,8 @@ impl App {
             },
             notification_state: build_notification_state(),
             needs_redraw: true,
+            spinner_frame: 0,
+            last_active_session_id: None,
             last_draw_at: std::time::Instant::now(),
             last_output_gen: 0,
             cached_session_order: None,
@@ -1213,8 +1254,14 @@ impl App {
             self.new_session.restart = false;
             return;
         };
+        let session_id = session.info.id;
         match session.restart(&config, rows, cols) {
             Ok(()) => {
+                // Re-spawned fresh: clear stale hook-driven status so it doesn't
+                // linger as Blocked/Working/Done until the agent re-reports (a
+                // resumed agent may not re-fire its boot hook). Mirrors the
+                // headless `restart_session_headless` path.
+                let _ = self.db.clear_hook_state(session_id);
                 self.save_state();
                 self.set_status(StatusLevel::Info, "Session restarted");
             }
@@ -2701,6 +2748,26 @@ impl App {
                 metrics_dir.to_string_lossy().into(),
             );
         }
+        // Pin the agent's `thurbox-cli` (status hook) to this thurbox's resolved
+        // config/data dirs, so a `session signal` lands in the DB the TUI reads
+        // regardless of XDG / PATH / stale tmux-server env. Mirrors
+        // `session_ops::inject_thurbox_env`.
+        if let Some(dir) =
+            crate::paths::config_file().and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        {
+            config.env.insert(
+                crate::paths::CONFIG_DIR_OVERRIDE_ENV.into(),
+                dir.to_string_lossy().into(),
+            );
+        }
+        if let Some(dir) =
+            crate::paths::database_file().and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        {
+            config.env.insert(
+                crate::paths::DATA_DIR_OVERRIDE_ENV.into(),
+                dir.to_string_lossy().into(),
+            );
+        }
 
         // For a multi-repo session, launch the agent in a symlink workspace that
         // gathers every member dir; `info.cwd` keeps the primary repo (restored
@@ -2757,6 +2824,10 @@ impl App {
         self.status_message = None;
 
         self.save_state();
+        // No spawn-time status seed: a fresh session is `Idle` until the agent's
+        // hooks report otherwise (claude's SessionStart → idle on boot, then
+        // working/blocked/done). Seeding `working` made an idle session look
+        // stuck working.
 
         // A task-initiated spawn (the trigger-time picker's "Spawn new session")
         // delivers the task title once the agent has booted, then advances the
@@ -3263,38 +3334,57 @@ impl App {
     }
 
     /// Recompute each session's status/activity/notification for this tick.
+    ///
+    /// Status is **hooks-driven**: agents report `working`/`blocked`/`done` via
+    /// `thurbox-cli session signal`, persisted in `sessions` and read here in one
+    /// batch (see [`derive_session_status`]). A `done` session stays `Done` until
+    /// the user moves focus *off* it (acknowledged → `Idle`). The OSC terminal
+    /// title is still captured for the live activity line, but no longer drives
+    /// status.
     fn refresh_session_statuses(&mut self) {
         self.metrics.bump(|p| &mut p.status_refreshes);
         let active_index = self.active_index;
-        // Track whether any visible field changed so a quiet `Busy → Waiting`
-        // transition (no new output, so the output detector won't catch it)
-        // still repaints promptly instead of waiting for the forced-redraw floor.
+        // One indexed scan per tick for the persisted hook columns.
+        let hooks = self.db.load_hook_states().unwrap_or_default();
+        // Track whether any visible field changed so a quiet transition (no new
+        // output, so the output detector won't catch it) still repaints promptly
+        // instead of waiting for the forced-redraw floor.
         let mut changed = false;
-        for (idx, session) in self.sessions.iter_mut().enumerate() {
-            // The active session is being watched, so acknowledge any pending
-            // attention signal (keeps it from flagging itself while focused).
-            if idx == active_index {
-                session.acknowledge_attention();
-            }
-            let needs_attention = session.needs_attention();
+        // "Seen" writes are deferred past the &mut self.sessions borrow below.
+        let mut seen_writes: Vec<(crate::session::SessionId, i64)> = Vec::new();
 
-            let new_status = if session.has_exited() {
-                SessionStatus::Idle
-            } else if session.millis_since_last_output() <= ACTIVITY_TIMEOUT_MS {
-                // Actively producing output → working, regardless of past signals.
-                SessionStatus::Busy
-            } else if needs_attention {
-                // Quiet after a bell / OSC 9 / OSC 777 → finished or needs input.
-                SessionStatus::Attention
-            } else {
-                SessionStatus::Waiting
-            };
+        // A `done` session is acknowledged ("seen" → Idle) when the user moves
+        // *off* it — not the instant it finishes under them — so the blue `Done`
+        // state is actually visible after a turn for the session you're watching.
+        // Detect the focus change and mark the session you just left, if it was
+        // an unseen `done`.
+        let active_id = self.sessions.get(active_index).map(|s| s.info.id);
+        if active_id != self.last_active_session_id {
+            if let Some(prev) = self.last_active_session_id {
+                if let Some(h) = hooks.get(&prev) {
+                    if h.state.as_deref() == Some("done") {
+                        let sa = h.state_at.unwrap_or(0);
+                        if h.seen_at.unwrap_or(0) < sa {
+                            seen_writes.push((prev, sa));
+                        }
+                    }
+                }
+            }
+            self.last_active_session_id = active_id;
+        }
+
+        for session in self.sessions.iter_mut() {
+            let id = session.info.id;
+            // `just_seen`: the focus-leave check above queued this session's seen
+            // mark this tick (the DB write lands after this loop), so reflect it
+            // now rather than waiting a tick.
+            let just_seen = seen_writes.iter().any(|(sid, _)| *sid == id);
+            let new_status = derive_session_status(hooks.get(&id), session.has_exited(), just_seen);
 
             // Live activity text from the agent-emitted OSC terminal title.
             let new_activity = session.agent_title();
             // Retain the agent's latest pushed notification (OSC 9/777) so the
-            // info panel can show it as a persistent "last signal", not only
-            // while the session is in the attention state.
+            // info panel can show it as a persistent "last signal".
             let new_notification = session.notification();
 
             if session.info.status != new_status
@@ -3308,10 +3398,34 @@ impl App {
             session.info.notification = new_notification;
         }
 
-        if changed {
+        // Persist the seen marks now that the sessions borrow is released. Done
+        // only on the transition (guarded above by `seen_at < state_at`), so the
+        // focused session doesn't bump `data_version` every tick.
+        for (id, state_at) in seen_writes {
+            let _ = self.db.mark_session_seen(id, state_at);
+        }
+
+        // Advance the Working spinner from the (deterministic) tick counter, and
+        // force a repaint when it ticks over *while* something is working — so an
+        // idle TUI still rests at ~4 fps but a working session animates smoothly.
+        let new_frame = (self.metrics.tick_count / SPINNER_TICKS_PER_FRAME) as usize
+            % crate::ui::SPINNER_FRAMES.len();
+        let spinner_advanced = new_frame != self.spinner_frame;
+        self.spinner_frame = new_frame;
+        let any_working = self
+            .sessions
+            .iter()
+            .any(|s| s.info.status == SessionStatus::Working);
+
+        if changed || (any_working && spinner_advanced) {
             self.request_redraw();
         }
         self.dispatch_status_notifications();
+    }
+
+    /// Current `Working`-spinner frame index (into [`crate::ui::SPINNER_FRAMES`]).
+    pub(crate) fn spinner_frame(&self) -> usize {
+        self.spinner_frame
     }
 
     /// Fire OS notifications for any session that just crossed into a
@@ -6128,6 +6242,202 @@ mod tests {
         app
     }
 
+    /// Persist `app.sessions[idx]` to the DB so `load_hook_states` can find it
+    /// by id (the stub harness pushes sessions without DB rows).
+    fn persist_session(app: &App, idx: usize) -> crate::session::SessionId {
+        let shared = app.session_to_shared(&app.sessions[idx]);
+        app.db.upsert_session(&shared).unwrap();
+        shared.id
+    }
+
+    #[test]
+    fn derive_session_status_covers_every_state() {
+        use crate::storage::HookRow;
+        let row = |state: &str, state_at: i64, seen_at: i64| HookRow {
+            state: Some(state.into()),
+            state_at: Some(state_at),
+            seen_at: Some(seen_at),
+        };
+
+        // Exited forces Idle, even with a live hook state.
+        assert_eq!(
+            derive_session_status(Some(&row("working", 1, 0)), true, false),
+            SessionStatus::Idle
+        );
+        // No hook / idle / unknown → Idle.
+        assert_eq!(
+            derive_session_status(None, false, false),
+            SessionStatus::Idle
+        );
+        assert_eq!(
+            derive_session_status(Some(&row("idle", 1, 0)), false, false),
+            SessionStatus::Idle
+        );
+        assert_eq!(
+            derive_session_status(Some(&row("nonsense", 1, 0)), false, false),
+            SessionStatus::Idle
+        );
+        // working / blocked map straight through.
+        assert_eq!(
+            derive_session_status(Some(&row("working", 1, 0)), false, false),
+            SessionStatus::Working
+        );
+        assert_eq!(
+            derive_session_status(Some(&row("blocked", 1, 0)), false, false),
+            SessionStatus::Blocked
+        );
+        // done: unseen → Done; already-seen or just-seen → Idle.
+        assert_eq!(
+            derive_session_status(Some(&row("done", 5, 0)), false, false),
+            SessionStatus::Done
+        );
+        assert_eq!(
+            derive_session_status(Some(&row("done", 5, 5)), false, false),
+            SessionStatus::Idle
+        );
+        assert_eq!(
+            derive_session_status(Some(&row("done", 5, 0)), false, true),
+            SessionStatus::Idle
+        );
+    }
+
+    #[test]
+    fn refresh_maps_hook_state_to_status() {
+        let mut app = app_with_sessions(1);
+        let id = persist_session(&app, 0);
+
+        // No hook fired yet → Idle (never-active default).
+        app.refresh_session_statuses();
+        assert_eq!(app.sessions[0].info.status, SessionStatus::Idle);
+
+        for (state, expected) in [
+            ("working", SessionStatus::Working),
+            ("blocked", SessionStatus::Blocked),
+        ] {
+            app.db.set_hook_state(id, state).unwrap();
+            app.refresh_session_statuses();
+            assert_eq!(
+                app.sessions[0].info.status, expected,
+                "hook '{state}' should map to {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn refresh_done_shows_until_focus_leaves_then_idle() {
+        // Two sessions; session 0 is the active (focused) one.
+        let mut app = app_with_sessions(2);
+        let _id0 = persist_session(&app, 0);
+        let id1 = persist_session(&app, 1);
+        app.active_index = 0;
+        app.refresh_session_statuses(); // establish focus baseline (on session 0)
+
+        // The FOCUSED session finishes: `Done` is visible (not instantly Idle) —
+        // you should see the blue "done" for the session you're watching.
+        app.active_index = 1;
+        app.refresh_session_statuses(); // focus moves to 1 (baseline update)
+        app.db.set_hook_state(id1, "done").unwrap();
+        app.refresh_session_statuses();
+        assert_eq!(
+            app.sessions[1].info.status,
+            SessionStatus::Done,
+            "a done session you're viewing shows Done, not instant Idle"
+        );
+
+        // Move focus OFF it → acknowledged → seen → Idle (persisted).
+        app.active_index = 0;
+        app.refresh_session_statuses();
+        assert_eq!(app.sessions[1].info.status, SessionStatus::Idle);
+        let row = app.db.load_hook_states().unwrap();
+        let row = row.get(&id1).unwrap();
+        assert!(
+            row.seen_at.unwrap_or(0) >= row.state_at.unwrap_or(i64::MAX),
+            "seen_at persisted at/after the done timestamp"
+        );
+    }
+
+    #[test]
+    fn refresh_done_unfocused_shows_done() {
+        // A background session that finishes shows Done (blue) until visited.
+        let mut app = app_with_sessions(2);
+        persist_session(&app, 0);
+        let id1 = persist_session(&app, 1);
+        app.active_index = 0;
+        app.db.set_hook_state(id1, "done").unwrap();
+        app.refresh_session_statuses();
+        assert_eq!(app.sessions[1].info.status, SessionStatus::Done);
+    }
+
+    #[test]
+    fn refresh_marks_dirty_on_status_change() {
+        let mut app = app_with_sessions(1);
+        let id = persist_session(&app, 0);
+        app.refresh_session_statuses();
+        app.mark_redrawn();
+        assert!(!app.should_redraw(), "quiescent after a redraw");
+
+        // An external hook write must make the next refresh repaint.
+        app.db.set_hook_state(id, "blocked").unwrap();
+        app.refresh_session_statuses();
+        assert!(
+            app.should_redraw(),
+            "a hook-driven status change must mark the UI dirty"
+        );
+    }
+
+    #[test]
+    fn working_session_animates_spinner_and_repaints() {
+        let mut app = app_with_sessions(1);
+        let id = persist_session(&app, 0);
+        app.db.set_hook_state(id, "working").unwrap();
+
+        // Advance enough ticks to cross a spinner-frame boundary and confirm the
+        // frame moves and the UI is marked dirty (so the live list animates).
+        app.metrics.tick_count = 0;
+        app.refresh_session_statuses();
+        let f0 = app.spinner_frame();
+        app.mark_redrawn();
+        app.metrics.tick_count = SPINNER_TICKS_PER_FRAME; // next frame
+        app.refresh_session_statuses();
+        assert_ne!(app.spinner_frame(), f0, "spinner frame advances");
+        assert!(
+            app.should_redraw(),
+            "a working session keeps the list repainting"
+        );
+
+        // The live glyph for Working is a spinner frame, not the static icon.
+        let g = crate::ui::status_glyph(
+            SessionStatus::Working,
+            crate::ui::SPINNER_FRAMES[app.spinner_frame()],
+        );
+        assert!(crate::ui::SPINNER_FRAMES.contains(&g));
+    }
+
+    #[test]
+    fn idle_session_does_not_force_spinner_repaints() {
+        let mut app = app_with_sessions(1);
+        persist_session(&app, 0); // no hook → Idle
+        app.refresh_session_statuses();
+        app.mark_redrawn();
+        // No working session: crossing a spinner boundary must NOT force a paint.
+        app.metrics.tick_count += SPINNER_TICKS_PER_FRAME;
+        app.refresh_session_statuses();
+        assert!(
+            !app.should_redraw(),
+            "an idle TUI must not repaint just to animate a (nonexistent) spinner"
+        );
+    }
+
+    #[test]
+    fn refresh_exited_session_is_idle_regardless_of_hook() {
+        let mut app = app_with_sessions(1);
+        let id = persist_session(&app, 0);
+        app.db.set_hook_state(id, "blocked").unwrap();
+        app.sessions[0].mark_exited_for_test();
+        app.refresh_session_statuses();
+        assert_eq!(app.sessions[0].info.status, SessionStatus::Idle);
+    }
+
     #[test]
     fn start_new_session_skips_host_picker_when_no_hosts() {
         let mut app = app_with_sessions(0);
@@ -6353,23 +6663,24 @@ mod tests {
     #[test]
     fn switch_follows_activity_and_repo_group_order() {
         use crate::session::SessionStatus;
-        // DB order: [webapp/Busy, infra/Attention, webapp/Busy].
+        // DB order: [webapp/Working, infra/Blocked, webapp/Working].
         let mut app = app_with_sessions(3);
         app.sessions[0].info.repo_display_names = vec!["webapp".to_string()];
-        app.sessions[0].info.status = SessionStatus::Busy;
+        app.sessions[0].info.status = SessionStatus::Working;
         app.sessions[1].info.repo_display_names = vec!["infra".to_string()];
-        app.sessions[1].info.status = SessionStatus::Attention;
+        app.sessions[1].info.status = SessionStatus::Blocked;
         app.sessions[2].info.repo_display_names = vec!["webapp".to_string()];
-        app.sessions[2].info.status = SessionStatus::Busy;
+        app.sessions[2].info.status = SessionStatus::Working;
 
-        // Rendered order: infra group (Attention) first → [1], then webapp → [0, 2].
+        // Order is status-independent: by repo group (infra before webapp by
+        // group label), so navigation visits [1] then [0, 2].
         app.active_index = 1;
         app.switch_session_forward();
-        assert_eq!(app.active_index, 0, "infra/attn → webapp/0");
+        assert_eq!(app.active_index, 0, "infra → webapp/0");
         app.switch_session_forward();
         assert_eq!(app.active_index, 2, "webapp/0 → webapp/2");
         app.switch_session_forward();
-        assert_eq!(app.active_index, 1, "webapp/2 → wrap to infra/attn");
+        assert_eq!(app.active_index, 1, "webapp/2 → wrap to infra");
     }
 
     #[test]
@@ -9284,7 +9595,7 @@ mod tests {
         assert_eq!(names, ["s1", "s0", "s2"]);
 
         // A status change never moves a row.
-        app.sessions[2].info.status = SessionStatus::Attention;
+        app.sessions[2].info.status = SessionStatus::Blocked;
         assert_eq!(app.render_order_indices(), vec![1, 0, 2]);
     }
 

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -1426,7 +1426,10 @@ impl SettingsField {
                 "auto_update",
                 "Silently self-update on launch (network call)",
             ),
-            NotifAlsoOnWaiting => ("also_on_waiting", "Also notify on the Busy → Waiting edge"),
+            NotifAlsoOnWaiting => (
+                "also_on_waiting",
+                "Also notify when a session finishes (Done)",
+            ),
             NotifSuppressForActive => (
                 "suppress_for_active",
                 "Skip the session you're already viewing",

--- a/src/app/notify_state.rs
+++ b/src/app/notify_state.rs
@@ -102,19 +102,18 @@ impl NotificationState {
         TransitionDecision::Fire
     }
 
-    /// Whether a `prev → current` transition is one we notify about. Pure;
-    /// no state. The "attention" case is the explicit OSC bell / OSC 9 /
-    /// OSC 777 from the agent; the "waiting" case is the timing-only quiet
-    /// state, which a user can opt into for agents that don't ring a bell.
+    /// Whether a `prev → current` transition is one we notify about. Pure; no
+    /// state. We always notify when a session becomes `Blocked` (the agent needs
+    /// the user). The `also_on_waiting` setting additionally fires when a session
+    /// becomes `Done` (work finished) — useful when the user wants a ping on
+    /// completion, not just on a block.
     fn should_notify_on(&self, prev: SessionStatus, current: SessionStatus) -> bool {
         match current {
-            SessionStatus::Attention => true,
-            SessionStatus::Waiting if self.settings.also_on_waiting => {
-                // Only the Busy → Waiting edge is interesting; an Idle
-                // (exited) → Waiting transition can't happen, and an
-                // Attention → Waiting transition is the user already
-                // having acknowledged the signal.
-                prev == SessionStatus::Busy
+            SessionStatus::Blocked => true,
+            SessionStatus::Done if self.settings.also_on_waiting => {
+                // Only the Working → Done edge is interesting; a Done re-derived
+                // from itself (or seen → Idle → Done) shouldn't re-fire.
+                prev == SessionStatus::Working
             }
             _ => false,
         }
@@ -196,7 +195,7 @@ mod tests {
         let id = SessionId::default();
         let now = Instant::now();
         assert_eq!(
-            s.observe(id, SessionStatus::Attention, false, now),
+            s.observe(id, SessionStatus::Blocked, false, now),
             TransitionDecision::NoFire
         );
     }
@@ -206,54 +205,54 @@ mod tests {
         let mut s = test_state(false, true, 0);
         let id = SessionId::default();
         let now = Instant::now();
-        let _ = s.observe(id, SessionStatus::Attention, false, now);
+        let _ = s.observe(id, SessionStatus::Blocked, false, now);
         assert_eq!(
-            s.observe(id, SessionStatus::Attention, false, now),
+            s.observe(id, SessionStatus::Blocked, false, now),
             TransitionDecision::NoFire
         );
     }
 
     #[test]
-    fn busy_to_attention_fires() {
+    fn working_to_blocked_fires() {
         let mut s = test_state(false, true, 0);
         let id = SessionId::default();
         let now = Instant::now();
-        let _ = s.observe(id, SessionStatus::Busy, false, now);
+        let _ = s.observe(id, SessionStatus::Working, false, now);
         assert_eq!(
-            s.observe(id, SessionStatus::Attention, false, now),
+            s.observe(id, SessionStatus::Blocked, false, now),
             TransitionDecision::Fire
         );
     }
 
     #[test]
-    fn busy_to_waiting_only_fires_when_opted_in() {
+    fn working_to_done_only_fires_when_opted_in() {
         let mut s = test_state(false, true, 0);
         let id = SessionId::default();
         let now = Instant::now();
-        let _ = s.observe(id, SessionStatus::Busy, false, now);
+        let _ = s.observe(id, SessionStatus::Working, false, now);
         assert_eq!(
-            s.observe(id, SessionStatus::Waiting, false, now),
+            s.observe(id, SessionStatus::Done, false, now),
             TransitionDecision::NoFire
         );
 
         let mut s = test_state(true, true, 0);
-        let _ = s.observe(id, SessionStatus::Busy, false, now);
+        let _ = s.observe(id, SessionStatus::Working, false, now);
         assert_eq!(
-            s.observe(id, SessionStatus::Waiting, false, now),
+            s.observe(id, SessionStatus::Done, false, now),
             TransitionDecision::Fire
         );
     }
 
     #[test]
-    fn attention_to_waiting_never_fires_even_with_also_on_waiting() {
-        // The user has already seen the Attention signal; sliding back to
-        // Waiting is not a new event worth re-notifying.
+    fn blocked_to_done_never_fires_even_with_also_on_done() {
+        // `also_on_done` fires only on the Working → Done edge; a Blocked → Done
+        // slide is not a fresh completion worth re-notifying.
         let mut s = test_state(true, true, 0);
         let id = SessionId::default();
         let now = Instant::now();
-        let _ = s.observe(id, SessionStatus::Attention, false, now);
+        let _ = s.observe(id, SessionStatus::Blocked, false, now);
         assert_eq!(
-            s.observe(id, SessionStatus::Waiting, false, now),
+            s.observe(id, SessionStatus::Done, false, now),
             TransitionDecision::NoFire
         );
     }
@@ -263,9 +262,9 @@ mod tests {
         let mut s = test_state(false, true, 0);
         let id = SessionId::default();
         let now = Instant::now();
-        let _ = s.observe(id, SessionStatus::Busy, true, now);
+        let _ = s.observe(id, SessionStatus::Working, true, now);
         assert_eq!(
-            s.observe(id, SessionStatus::Attention, true, now),
+            s.observe(id, SessionStatus::Blocked, true, now),
             TransitionDecision::NoFire
         );
     }
@@ -275,30 +274,35 @@ mod tests {
         let mut s = test_state(false, false, 0);
         let id = SessionId::default();
         let now = Instant::now();
-        let _ = s.observe(id, SessionStatus::Busy, true, now);
+        let _ = s.observe(id, SessionStatus::Working, true, now);
         assert_eq!(
-            s.observe(id, SessionStatus::Attention, true, now),
+            s.observe(id, SessionStatus::Blocked, true, now),
             TransitionDecision::Fire
         );
     }
 
     #[test]
-    fn rapid_re_attention_is_throttled() {
+    fn rapid_re_blocked_is_throttled() {
         let mut s = test_state(false, true, 60);
         let id = SessionId::default();
         let t0 = Instant::now();
-        let _ = s.observe(id, SessionStatus::Busy, false, t0);
+        let _ = s.observe(id, SessionStatus::Working, false, t0);
         assert_eq!(
-            s.observe(id, SessionStatus::Attention, false, t0),
+            s.observe(id, SessionStatus::Blocked, false, t0),
             TransitionDecision::Fire
         );
 
-        // Attention → Busy → Attention within the dedup window.
-        let _ = s.observe(id, SessionStatus::Busy, false, t0 + Duration::from_secs(1));
+        // Blocked → Working → Blocked within the dedup window.
+        let _ = s.observe(
+            id,
+            SessionStatus::Working,
+            false,
+            t0 + Duration::from_secs(1),
+        );
         assert_eq!(
             s.observe(
                 id,
-                SessionStatus::Attention,
+                SessionStatus::Blocked,
                 false,
                 t0 + Duration::from_secs(2)
             ),
@@ -306,11 +310,16 @@ mod tests {
         );
 
         // Past the window, a fresh fire is allowed.
-        let _ = s.observe(id, SessionStatus::Busy, false, t0 + Duration::from_secs(70));
+        let _ = s.observe(
+            id,
+            SessionStatus::Working,
+            false,
+            t0 + Duration::from_secs(70),
+        );
         assert_eq!(
             s.observe(
                 id,
-                SessionStatus::Attention,
+                SessionStatus::Blocked,
                 false,
                 t0 + Duration::from_secs(80)
             ),
@@ -324,18 +333,18 @@ mod tests {
         let keep = SessionId::default();
         let gone = SessionId::default();
         let now = Instant::now();
-        let _ = s.observe(keep, SessionStatus::Busy, false, now);
-        let _ = s.observe(gone, SessionStatus::Busy, false, now);
+        let _ = s.observe(keep, SessionStatus::Working, false, now);
+        let _ = s.observe(gone, SessionStatus::Working, false, now);
         s.prune_to(&[keep]);
         // The pruned session's first observation post-prune is a fresh
         // baseline → no fire.
         assert_eq!(
-            s.observe(gone, SessionStatus::Attention, false, now),
+            s.observe(gone, SessionStatus::Blocked, false, now),
             TransitionDecision::NoFire
         );
         // The kept session still has its baseline → a transition fires.
         assert_eq!(
-            s.observe(keep, SessionStatus::Attention, false, now),
+            s.observe(keep, SessionStatus::Blocked, false, now),
             TransitionDecision::Fire
         );
     }

--- a/src/app/snapshots/thurbox__app__acceptance__theme_picker_lists_palettes.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__theme_picker_lists_palettes.snap
@@ -12,7 +12,7 @@ expression: h.render()
 │                       ││                                                                         │
 │                   ╭ Theme ───────────────────────────────────────────────────╮                   │
 │                   │▸ Default                   Accent      █████ █████       │                   │
-│                   │  Catppuccin Mocha          Status      ● ◆ ○ ✗           │                   │
+│                   │  Catppuccin Mocha          Status      ◐ ◆ ● ○ ✗         │                   │
 │                   │  Tokyo Night               Border      ╭─────╮           │                   │
 │                   │  Gruvbox Dark              Modal bg                      │                   │
 │                   │  Catppuccin Latte (light)                                │                   │

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -206,6 +206,8 @@ impl App {
         // A (global) search is active iff there's a query — non-matching rows dim.
         let session_search_active = global_query.is_some();
 
+        let spinner =
+            crate::ui::SPINNER_FRAMES[self.spinner_frame() % crate::ui::SPINNER_FRAMES.len()];
         let rows = project_list::render_left_panel(
             frame,
             left_area,
@@ -219,6 +221,7 @@ impl App {
                 session_search_active,
                 headers: &ordered.headers,
                 depths: &ordered.depths,
+                spinner,
             },
         );
         self.record_row_clicks(

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -412,6 +412,10 @@ fn tick(db: &Database) -> Result<Value, String> {
     for m in &healed {
         tracing::info!("{m}");
     }
+    // Keep the auto-activated built-in `hooks` extension wired up headlessly too.
+    for m in &crate::session_ops::ensure_builtin_hooks_extension(db) {
+        tracing::info!("{m}");
+    }
     // Best-effort retention sweep of the inter-session mailbox (read messages
     // older than the default window), so the queue self-bounds with the TUI
     // closed. Never abort the due-automation pass over it.

--- a/src/cli/extensions.rs
+++ b/src/cli/extensions.rs
@@ -125,6 +125,10 @@ fn install_extension(
     force: bool,
 ) -> Result<CommandOutput, String> {
     let report = crate::session_ops::install_extension(db, &target, home.as_deref(), force)?;
+    // Re-installing the built-in hooks extension clears any prior opt-out.
+    if report.name == crate::session_ops::HOOKS_EXTENSION_NAME {
+        let _ = db.set_builtin_hooks_optout(false);
+    }
     // Arm the heartbeat so the extension's automations fire headlessly.
     arm_heartbeat();
     Ok(CommandOutput::from_summary(install_report_to_json(&report)))
@@ -133,6 +137,11 @@ fn install_extension(
 /// Handle `extension uninstall`.
 fn uninstall_extension(db: &Database, name: String, purge: bool) -> Result<CommandOutput, String> {
     let report = crate::session_ops::uninstall_extension(db, &name, purge)?;
+    // Uninstalling the auto-activated built-in extension is an explicit opt-out,
+    // so startup self-heal won't reinstall it.
+    if name == crate::session_ops::HOOKS_EXTENSION_NAME {
+        let _ = db.set_builtin_hooks_optout(true);
+    }
     Ok(CommandOutput::from_summary(json!({
         "ok": true,
         "summary": format!("Uninstalled extension '{}'", report.name),
@@ -232,6 +241,20 @@ fn reinstall_extension(db: &Database, name: String, purge: bool) -> Result<Comma
 
 /// Handle `extension activate`.
 fn activate_extension(db: &Database, name: String) -> Result<CommandOutput, String> {
+    // The built-in hooks extension is installed from embedded assets, not a
+    // discovery manifest — clear the opt-out and (re)apply the wiring directly.
+    if name == crate::session_ops::HOOKS_EXTENSION_NAME {
+        db.set_builtin_hooks_optout(false)
+            .map_err(|e| format!("clear opt-out: {e}"))?;
+        let msgs = crate::session_ops::ensure_builtin_hooks_extension(db);
+        arm_heartbeat();
+        return Ok(CommandOutput::from_summary(json!({
+            "ok": true,
+            "summary": "Activated 'hooks' (agent status hooks re-applied)",
+            "activated": name,
+            "messages": msgs,
+        })));
+    }
     let def = load_manifest(&name)?;
     let report = crate::session_ops::activate_extension(db, &def)?;
     // A `Send` automation only fires while something ticks it. Arm the
@@ -260,6 +283,23 @@ fn deactivate_extension(
     force: bool,
     purge: bool,
 ) -> Result<CommandOutput, String> {
+    // Deactivating the auto-activated built-in extension is an explicit opt-out:
+    // record the flag (so self-heal won't resurrect it) and fully reverse the
+    // wiring — uninstall removes the agent patches + external plugin files.
+    if name == crate::session_ops::HOOKS_EXTENSION_NAME {
+        db.set_builtin_hooks_optout(true)
+            .map_err(|e| format!("set opt-out: {e}"))?;
+        let report = crate::session_ops::uninstall_extension(db, &name, purge)?;
+        return Ok(CommandOutput::from_summary(json!({
+            "ok": true,
+            "summary": "Deactivated 'hooks' (agent status hooks removed)",
+            "deactivated": name,
+            "was_active": true,
+            "agents_unpatched": report.agents_unpatched,
+            "external_files_removed": report.external_files_removed,
+            "config_merges_reverted": report.config_merges_reverted,
+        })));
+    }
     // Tear down whatever the manifest declares. If the manifest is gone
     // we can't know the resources, but still clear the active-set entry.
     let report = match crate::agent::extension_config::load_manifest(&name) {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -302,6 +302,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_session_signal_accepts_state_and_rejects_garbage() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "session", "signal", "--state", "blocked"])
+            .unwrap();
+        let Command::Session {
+            action: sessions::Action::Signal { state, session },
+        } = cli.command
+        else {
+            panic!("expected Session::Signal");
+        };
+        assert_eq!(state, "blocked");
+        assert_eq!(session, None);
+
+        // The value_parser allow-list rejects unknown states.
+        assert!(
+            Cli::try_parse_from(["thurbox-cli", "session", "signal", "--state", "exploded",])
+                .is_err()
+        );
+    }
+
+    #[test]
     fn parse_session_list_accepts_parent_filter() {
         let cli = Cli::try_parse_from([
             "thurbox-cli",

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -99,6 +99,22 @@ pub enum Action {
         #[arg(long, default_value_t = 200)]
         lines: u32,
     },
+    /// Report an agent lifecycle transition (called from an agent hook).
+    ///
+    /// Records the session's state so the TUI can render it (working/blocked/
+    /// done/idle) — works headless; the TUI picks it up via its data_version
+    /// poll. Identity defaults to the calling session ($THURBOX_SESSION,
+    /// injected at spawn), so an agent hook passes no id.
+    Signal {
+        /// The reported state. `idle` = agent ready/at-rest (e.g. a fresh
+        /// session boot); `done` = a turn just finished (shows until you look).
+        #[arg(long, value_parser = ["working", "blocked", "done", "idle"])]
+        state: String,
+        /// Override the calling session (UUID). Defaults to $THURBOX_SESSION,
+        /// then a lookup by the agent conversation id ($THURBOX_SESSION_ID).
+        #[arg(long)]
+        session: Option<String>,
+    },
 }
 
 pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
@@ -267,7 +283,50 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 human,
             ))
         }
+        Action::Signal { state, session } => {
+            let target = resolve_signal_target(db, session.as_deref())?;
+            db.set_hook_state(target.id, &state)
+                .map_err(|e| format!("set_hook_state: {e}"))?;
+            Ok(CommandOutput::new(
+                json!({
+                    "signaled": true,
+                    "session_id": target.id.to_string(),
+                    "session_name": target.name,
+                    "state": state,
+                }),
+                format!("Signaled {state} for '{}'.", target.name),
+            ))
+        }
     }
+}
+
+/// Resolve the session a `signal` targets: an explicit `--session` UUID, else
+/// the calling session from `$THURBOX_SESSION`, else a lookup by the agent
+/// conversation id from `$THURBOX_SESSION_ID` (the env fallback for agents whose
+/// hooks don't inherit `$THURBOX_SESSION`). Errors when none resolves.
+fn resolve_signal_target(db: &Database, session: Option<&str>) -> Result<SharedSession, String> {
+    if let Some(uuid) = session {
+        return resolve(db, uuid);
+    }
+    if let Ok(raw) = std::env::var("THURBOX_SESSION") {
+        if let Ok(id) = raw.parse::<SessionId>() {
+            if let Some(s) = db
+                .get_session_by_id(id)
+                .map_err(|e| format!("get_session_by_id: {e}"))?
+            {
+                return Ok(s);
+            }
+        }
+    }
+    if let Ok(agent_sid) = std::env::var("THURBOX_SESSION_ID") {
+        if let Some(s) = db
+            .get_session_by_agent_session_id(&agent_sid)
+            .map_err(|e| format!("get_session_by_agent_session_id: {e}"))?
+        {
+            return Ok(s);
+        }
+    }
+    Err("not inside a thurbox session; pass --session <uuid>".into())
 }
 
 /// Render the session list as an aligned table (or a friendly empty line).
@@ -371,6 +430,64 @@ mod tests {
         assert_eq!(v.as_array().unwrap().len(), 0);
         // The human rendering for an empty list is a friendly line, not a table.
         assert_eq!(v.human, "No active sessions.");
+    }
+
+    #[test]
+    fn signal_explicit_session_sets_hook_state() {
+        let db = db();
+        let shared = make_test_session("worker");
+        let id = shared.id;
+        db.upsert_session(&shared).unwrap();
+
+        let out = run(
+            Action::Signal {
+                state: "blocked".into(),
+                session: Some(id.to_string()),
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(out["state"], "blocked");
+        assert_eq!(out["signaled"], true);
+
+        let states = db.load_hook_states().unwrap();
+        assert_eq!(states.get(&id).unwrap().state.as_deref(), Some("blocked"));
+    }
+
+    #[test]
+    fn signal_without_identity_errors() {
+        let db = db();
+        // No --session and (in test) no THURBOX_SESSION env → clear error.
+        std::env::remove_var("THURBOX_SESSION");
+        std::env::remove_var("THURBOX_SESSION_ID");
+        let err = run(
+            Action::Signal {
+                state: "done".into(),
+                session: None,
+            },
+            &db,
+        )
+        .unwrap_err();
+        assert!(err.contains("not inside a thurbox session"), "got {err}");
+    }
+
+    fn make_test_session(name: &str) -> SharedSession {
+        SharedSession {
+            id: SessionId::default(),
+            name: name.into(),
+            agent: "claude".into(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: None,
+            cwd: None,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,9 @@ async fn main() -> Result<()> {
         .init();
 
     // Initialize session backends, load every config file, and open the DB.
-    let (backends, agents, hosts, mut config_warnings) = init_backends_and_config()?;
+    // `agents` is reloaded after the extension heal below (which may patch
+    // agents.toml), so the initial copy here is only used for its warnings.
+    let (backends, _agents, hosts, mut config_warnings) = init_backends_and_config()?;
     let db = open_database();
     activate_persisted_theme(&db);
 
@@ -98,6 +100,26 @@ async fn main() -> Result<()> {
         tracing::info!("{m}");
     }
     config_warnings.extend(heal_messages);
+
+    // Auto-activate the built-in `hooks` extension so the default agent reports
+    // its lifecycle state out of the box (working/blocked/done). Idempotent;
+    // re-applies the agent hook wiring on every launch. Opt out with
+    // `thurbox-cli extension deactivate hooks`.
+    let hook_messages = thurbox::session_ops::ensure_builtin_hooks_extension(&db);
+    for m in &hook_messages {
+        tracing::info!("{m}");
+    }
+    // Surface hook-wiring outcomes in the status bar too (not just the log) so a
+    // wiring failure is visible. Idempotent, so this is non-empty only on the
+    // first wire-up of a profile or on an error — never noisy per launch.
+    config_warnings.extend(hook_messages);
+    // The hooks extension (and any other extension heal above) may have just
+    // patched `agents.toml` on disk — e.g. injecting `--settings <hooks>` into
+    // the `claude` agent so its lifecycle hooks fire. Reload the registry so the
+    // in-memory copy App spawns from reflects that on the *first* run too
+    // (otherwise a freshly-seeded profile would spawn agents without their hooks
+    // and statuses would be stuck until the next launch).
+    let agents = thurbox::agent::agent_config::load_or_seed();
 
     // Silent auto-update (opt-in via [features] auto_update). Kicked off on a
     // background thread *before* the TUI starts so a slow download never blocks

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -32,6 +32,14 @@
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
+/// Env var pinning the resolved config app dir for a child process (an agent
+/// whose hook calls `thurbox-cli`), so it targets the same config the spawning
+/// thurbox uses regardless of XDG/binary-flavor/tmux-server-env drift. Injected
+/// at spawn ([`crate::session_ops`]); consumed by `config_app_dir`.
+pub const CONFIG_DIR_OVERRIDE_ENV: &str = "THURBOX_CONFIG_DIR";
+/// Data counterpart of [`CONFIG_DIR_OVERRIDE_ENV`] (`THURBOX_DATA_DIR`).
+pub const DATA_DIR_OVERRIDE_ENV: &str = "THURBOX_DATA_DIR";
+
 /// Returns "thurbox-dev" for dev builds, "thurbox" for release builds.
 fn app_dir_name() -> &'static str {
     if cfg!(dev_build) {
@@ -80,16 +88,34 @@ fn data_base() -> Option<PathBuf> {
     }
 }
 
-/// `<config_base>/<app>/<filename>` (e.g.
-/// `$XDG_CONFIG_HOME/thurbox/<filename>` or `%APPDATA%\thurbox\<filename>`).
-fn xdg_config_subpath(filename: &str) -> Option<PathBuf> {
-    Some(config_base()?.join(app_dir_name()).join(filename))
+/// Resolved thurbox config app dir. A `THURBOX_CONFIG_DIR` env override (the
+/// already-resolved dir, incl. the `thurbox`/`thurbox-dev` segment) wins — this
+/// is how the TUI pins child processes (agent hooks calling `thurbox-cli`) to
+/// the *same* config it uses, immune to a stale tmux-server env or which
+/// `thurbox-cli` binary is on PATH. Otherwise `<config_base>/<app>`.
+fn config_app_dir() -> Option<PathBuf> {
+    if let Some(x) = std::env::var_os(CONFIG_DIR_OVERRIDE_ENV).filter(|s| !s.is_empty()) {
+        return Some(PathBuf::from(x));
+    }
+    Some(config_base()?.join(app_dir_name()))
 }
 
-/// `<data_base>/<app>/<segments...>` (e.g.
-/// `$XDG_DATA_HOME/thurbox/<segments>` or `%LOCALAPPDATA%\thurbox\<segments>`).
+/// Resolved thurbox data app dir; see [`config_app_dir`] (`THURBOX_DATA_DIR`).
+fn data_app_dir() -> Option<PathBuf> {
+    if let Some(x) = std::env::var_os(DATA_DIR_OVERRIDE_ENV).filter(|s| !s.is_empty()) {
+        return Some(PathBuf::from(x));
+    }
+    Some(data_base()?.join(app_dir_name()))
+}
+
+/// `<config_app_dir>/<filename>`.
+fn xdg_config_subpath(filename: &str) -> Option<PathBuf> {
+    Some(config_app_dir()?.join(filename))
+}
+
+/// `<data_app_dir>/<segments...>`.
 fn xdg_data_subpath(segments: &[&str]) -> Option<PathBuf> {
-    let mut p = data_base()?.join(app_dir_name());
+    let mut p = data_app_dir()?;
     for seg in segments {
         p.push(seg);
     }
@@ -107,6 +133,9 @@ pub enum PathKind {
     Database,
     /// Agent metrics files: `~/.local/share/thurbox/metrics/`
     MetricsDir,
+    /// Embedded built-in extensions materialized for install:
+    /// `~/.local/share/thurbox/builtin-extensions/`
+    BuiltinExtensionsDir,
     /// Git worktrees: `~/.local/share/thurbox/worktrees/`
     WorktreesDir,
     /// Per-session multi-repo symlink workspaces:
@@ -152,6 +181,7 @@ fn resolve_xdg(kind: PathKind) -> Option<PathBuf> {
         PathKind::Database => xdg_data_subpath(&["thurbox.db"]),
         PathKind::LogDir => xdg_data_subpath(&[]),
         PathKind::MetricsDir => xdg_data_subpath(&["metrics"]),
+        PathKind::BuiltinExtensionsDir => xdg_data_subpath(&["builtin-extensions"]),
         PathKind::WorktreesDir => xdg_data_subpath(&["worktrees"]),
         PathKind::WorkspacesDir => xdg_data_subpath(&["workspaces"]),
         PathKind::KeybindingsFile => xdg_config_subpath("keybindings.json"),
@@ -165,6 +195,7 @@ fn resolve_override(base: &Path, kind: PathKind) -> PathBuf {
         PathKind::LogDir => base.to_path_buf(),
         PathKind::Database => base.join("thurbox.db"),
         PathKind::MetricsDir => base.join("metrics"),
+        PathKind::BuiltinExtensionsDir => base.join("builtin-extensions"),
         PathKind::WorktreesDir => base.join("worktrees"),
         PathKind::WorkspacesDir => base.join("workspaces"),
         PathKind::KeybindingsFile => base.join("keybindings.json"),
@@ -216,6 +247,15 @@ pub fn validate_safe_name(name: &str) -> Result<(), String> {
 /// Returns: `$XDG_DATA_HOME/thurbox/metrics/` or `$HOME/.local/share/thurbox/metrics/`
 pub fn metrics_directory() -> Option<PathBuf> {
     resolve(PathKind::MetricsDir)
+}
+
+/// Directory where embedded built-in extensions are materialized so the
+/// extension installer can treat them as a local source.
+///
+/// Returns: `$XDG_DATA_HOME/thurbox/builtin-extensions/` or
+/// `$HOME/.local/share/thurbox/builtin-extensions/`
+pub fn builtin_extensions_directory() -> Option<PathBuf> {
+    resolve(PathKind::BuiltinExtensionsDir)
 }
 
 /// Resolve the worktrees directory path.

--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -56,6 +56,98 @@ impl ExtensionFile {
     }
 }
 
+/// A file the installer places **outside** the extension home — into an agent's
+/// own config dir (e.g. `~/.config/opencode/plugin/thurbox-status.js`). `path`
+/// may be absolute, start with `~`, or contain [`HOME_TOKEN`]. Unlike
+/// [`ExtensionFile`] (home-confined), this is how a hook plugin reaches an agent
+/// that has no launch flag. Removed on uninstall when still thurbox-managed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExternalFile {
+    /// Destination path: absolute, `~`-relative, or containing `{home}`.
+    pub path: String,
+    /// Source path relative to the install source (defaults to `path`'s file name).
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Mark the written file executable (`chmod +x`).
+    #[serde(default)]
+    pub executable: bool,
+    /// Only write when the destination is absent (don't clobber a user file).
+    #[serde(default)]
+    pub if_absent: bool,
+    /// Replace [`HOME_TOKEN`] in the content before writing.
+    #[serde(default)]
+    pub substitute: bool,
+    /// Only write when this directory exists (absolute / `~`). Guards against
+    /// creating an agent's config tree for an agent the user hasn't installed —
+    /// e.g. `~/.config/opencode` for the opencode plugin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_dir: Option<String>,
+}
+
+/// Source-relative path for a payload whose `source` defaults to the
+/// destination's *file name* (used by [`ExternalFile`] and [`ConfigMerge`],
+/// which write outside the home dir to an absolute/`~` destination).
+fn source_or_dest_filename<'a>(source: &'a Option<String>, dest: &'a str) -> &'a str {
+    source.as_deref().unwrap_or_else(|| {
+        std::path::Path::new(dest)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(dest)
+    })
+}
+
+impl ExternalFile {
+    /// Source-relative path to fetch this file's content from (defaults to the
+    /// destination's file name when `source` is unset).
+    pub fn source_path(&self) -> &str {
+        source_or_dest_filename(&self.source, &self.path)
+    }
+}
+
+/// An append-args patch applied to an **existing** agent in `agents.toml` — one
+/// the extension does not own (e.g. the built-in `claude`). Unlike `[[agents]]`
+/// (which only *adds* new agents), this injects `append_args` into the named
+/// agent's `args`, reversibly: uninstall removes exactly this subsequence.
+/// [`HOME_TOKEN`] is substituted in `append_args`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentPatch {
+    /// Name of the existing agent whose `args` to extend.
+    pub name: String,
+    /// Args appended to the agent's `args` (idempotent; removed on uninstall).
+    #[serde(default)]
+    pub append_args: Vec<String>,
+}
+
+/// A **non-destructive, reversible JSON merge** into a config file an agent owns
+/// (e.g. `~/.gemini/settings.json`). Unlike [`ExternalFile`] (which writes a
+/// whole file and would clobber the user's config), this deep-merges the shipped
+/// `source` JSON into the target in place: objects recurse, arrays union by
+/// deep-equality, and uninstall removes exactly our entries (see
+/// `agent::json_merge`). For agents whose hooks live in a *shared* config file
+/// that has no drop-in plugin location.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigMerge {
+    /// Target config file: absolute, `~`-relative, or containing [`HOME_TOKEN`].
+    pub path: String,
+    /// Source path (relative to the install source) of the JSON to merge in;
+    /// defaults to `path`'s file name.
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Only merge when this directory exists (absolute / `~`) — skips the merge
+    /// when the agent isn't installed (e.g. `~/.gemini`), mirroring
+    /// [`ExternalFile::requires_dir`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_dir: Option<String>,
+}
+
+impl ConfigMerge {
+    /// Source-relative path to read the JSON-to-merge from (defaults to the
+    /// destination's file name).
+    pub fn source_path(&self) -> &str {
+        source_or_dest_filename(&self.source, &self.path)
+    }
+}
+
 /// A symlink the installer creates under the extension home directory. Used to
 /// surface a spec file under each agent CLI's context-file name
 /// (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` → `FLOW.md`). An existing *regular* file
@@ -145,6 +237,18 @@ pub struct ExtensionDef {
     /// Payload files the installer lays down under the home dir. Install-time only.
     #[serde(default)]
     pub files: Vec<ExtensionFile>,
+    /// Files the installer places **outside** the home dir, into agents' own
+    /// config dirs (hook plugins, etc.). Install-time only.
+    #[serde(default)]
+    pub external_files: Vec<ExternalFile>,
+    /// Append-args patches applied to existing agents in `agents.toml`
+    /// (reversible). Install-time only.
+    #[serde(default)]
+    pub agent_patches: Vec<AgentPatch>,
+    /// Reversible JSON merges into agents' own config files (hooks into a shared
+    /// `settings.json`/`hooks.json`). Install-time only.
+    #[serde(default)]
+    pub config_merges: Vec<ConfigMerge>,
     /// Symlinks the installer creates under the home dir. Install-time only.
     #[serde(default)]
     pub symlinks: Vec<ExtensionSymlink>,
@@ -173,6 +277,23 @@ impl ExtensionDef {
         for s in &mut out.sessions {
             let p = s.repo_path.to_string_lossy().replace(HOME_TOKEN, home);
             s.repo_path = PathBuf::from(p);
+        }
+        // External-file destinations and patched agent args may reference the
+        // home dir (e.g. `--settings {home}/hooks/claude.json`); resolve them so
+        // activate/heal/uninstall read absolute paths without expanding tokens.
+        for f in &mut out.external_files {
+            f.path = f.path.replace(HOME_TOKEN, home);
+        }
+        for p in &mut out.agent_patches {
+            for arg in &mut p.append_args {
+                *arg = arg.replace(HOME_TOKEN, home);
+            }
+        }
+        for m in &mut out.config_merges {
+            m.path = m.path.replace(HOME_TOKEN, home);
+            if let Some(req) = &m.requires_dir {
+                m.requires_dir = Some(req.replace(HOME_TOKEN, home));
+            }
         }
         out
     }
@@ -320,6 +441,9 @@ prompt = "tick"
                 if_absent: false,
                 substitute: false,
             }],
+            external_files: vec![],
+            agent_patches: vec![],
+            config_merges: vec![],
             symlinks: vec![ExtensionSymlink {
                 link: "CLAUDE.md".into(),
                 target: "FLOW.md".into(),
@@ -348,6 +472,44 @@ prompt = "tick"
         assert!(def.is_empty());
         assert!(def.agents.is_empty());
         assert!(def.files.is_empty());
+    }
+
+    #[test]
+    fn config_merge_source_path_defaults_to_dest_filename() {
+        // Explicit source wins.
+        let explicit = ConfigMerge {
+            path: "~/.gemini/settings.json".into(),
+            source: Some("gemini-hooks.json".into()),
+            requires_dir: None,
+        };
+        assert_eq!(explicit.source_path(), "gemini-hooks.json");
+        // Unset source falls back to the destination's file name (not its full
+        // path) — the shared `source_or_dest_filename` behavior.
+        let defaulted = ConfigMerge {
+            path: "~/.gemini/settings.json".into(),
+            source: None,
+            requires_dir: None,
+        };
+        assert_eq!(defaulted.source_path(), "settings.json");
+    }
+
+    #[test]
+    fn resolved_for_home_substitutes_config_merge_paths() {
+        let def: ExtensionDef = toml::from_str(
+            "name = \"hooks\"\n[[config_merges]]\npath = \"{home}/settings.json\"\nrequires_dir = \"{home}\"\n",
+        )
+        .unwrap();
+        let resolved = def.resolved_for_home("/home/me/.gemini");
+        assert_eq!(
+            resolved.config_merges[0].path,
+            "/home/me/.gemini/settings.json"
+        );
+        assert_eq!(
+            resolved.config_merges[0].requires_dir.as_deref(),
+            Some("/home/me/.gemini")
+        );
+        // Original untouched.
+        assert_eq!(def.config_merges[0].path, "{home}/settings.json");
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -14,7 +14,8 @@ pub use automation::{
     AutomationSchedule, ExtraRepo, SchedulePreset,
 };
 pub use extension_def::{
-    ExtensionAutomation, ExtensionDef, ExtensionFile, ExtensionSession, ExtensionSymlink,
+    AgentPatch, ConfigMerge, ExtensionAutomation, ExtensionDef, ExtensionFile, ExtensionSession,
+    ExtensionSymlink, ExternalFile,
 };
 pub use host_def::{is_ssh_backend, HostDef, HostRegistry, SSH_BACKEND_PREFIX};
 pub use keybindings::{Action, KeyBindings, KeyChord, KeyContext};
@@ -72,29 +73,40 @@ impl std::str::FromStr for SessionId {
     }
 }
 
+/// A session's lifecycle state, driven by agent hooks (see
+/// `thurbox-cli session signal`). Repo groups in the session list roll up to
+/// their most-urgent member so the whole list scans at a glance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionStatus {
-    Busy,
-    Waiting,
+    /// 🟡 The agent is actively running (reported by a hook).
+    Working,
+    /// 🔴 The agent needs user input or approval (reported by a hook).
+    Blocked,
+    /// 🔵 A turn just finished; shown until the user switches focus off it.
+    Done,
+    /// 🟢 Acknowledged (focus moved off a `Done`), at rest, or never-active.
     Idle,
+    /// Reserved for a crashed agent. **Not currently derived** — process exit has
+    /// no failure signal yet (a clean or crashed exit both map to `Idle`), so this
+    /// variant is wired through colour/glyph/rollup but never assigned. Kept for
+    /// when exit-code plumbing lands.
     Error,
-    /// The agent signalled it finished or needs input (bell / OSC 9 / OSC 777).
-    /// Latched until the user looks at the session; sorts to the top of the list.
-    Attention,
 }
 
 impl SessionStatus {
     /// A status glyph chosen for **shape** distinctiveness, not just colour, so
-    /// the state survives in greyscale / for colour-blind users: filled circle
-    /// (busy) vs. diamond (waiting) vs. hollow circle (idle) vs. cross (error)
-    /// vs. triangle (attention).
+    /// the state survives in greyscale / for colour-blind users: a spinner
+    /// (working — the live session list animates it, see `ui::SPINNER_FRAMES`)
+    /// vs. diamond (blocked) vs. filled circle (done, unseen) vs. hollow circle
+    /// (idle, seen) vs. cross (error). The filled/hollow pair makes
+    /// done-vs-idle read at a glance.
     pub fn icon(self) -> &'static str {
         match self {
-            Self::Busy => "●",
-            Self::Waiting => "◆",
+            Self::Working => "◐",
+            Self::Blocked => "◆",
+            Self::Done => "●",
             Self::Idle => "○",
             Self::Error => "✗",
-            Self::Attention => "▲",
         }
     }
 }
@@ -102,11 +114,11 @@ impl SessionStatus {
 impl fmt::Display for SessionStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Busy => write!(f, "Busy"),
-            Self::Waiting => write!(f, "Waiting"),
+            Self::Working => write!(f, "Working"),
+            Self::Blocked => write!(f, "Blocked"),
+            Self::Done => write!(f, "Done"),
             Self::Idle => write!(f, "Idle"),
             Self::Error => write!(f, "Error"),
-            Self::Attention => write!(f, "Needs attention"),
         }
     }
 }
@@ -200,7 +212,7 @@ pub struct SessionInfo {
     /// captured from the terminal and refreshed each tick. Agent-neutral.
     pub agent_activity: Option<String>,
     /// Message text from the agent's latest attention notification (OSC 9/777),
-    /// shown as the status when `status == SessionStatus::Attention`.
+    /// shown as the status when `status == SessionStatus::Blocked`.
     pub notification: Option<String>,
     /// Real git state of the session's worktree(s), refreshed periodically by
     /// the app layer. `None` until first computed (or for non-git sessions).
@@ -222,7 +234,7 @@ impl SessionInfo {
         Self {
             id: SessionId::default(),
             name,
-            status: SessionStatus::Busy,
+            status: SessionStatus::Working,
             agent: DEFAULT_AGENT_NAME.to_string(),
             worktrees: Vec::new(),
             agent_session_id: None,
@@ -295,20 +307,20 @@ mod tests {
 
     #[test]
     fn session_status_display_and_icon() {
-        assert_eq!(SessionStatus::Busy.to_string(), "Busy");
+        assert_eq!(SessionStatus::Working.to_string(), "Working");
         // Glyphs are shape-distinct (not all circles) so status reads without colour.
-        assert_eq!(SessionStatus::Busy.icon(), "●");
-        assert_eq!(SessionStatus::Waiting.icon(), "◆");
+        assert_eq!(SessionStatus::Working.icon(), "◐");
+        assert_eq!(SessionStatus::Blocked.icon(), "◆");
+        assert_eq!(SessionStatus::Done.icon(), "●");
         assert_eq!(SessionStatus::Idle.icon(), "○");
         assert_eq!(SessionStatus::Error.icon(), "✗");
-        assert_eq!(SessionStatus::Attention.icon(), "▲");
     }
 
     #[test]
     fn session_info_new_defaults() {
         let info = SessionInfo::new("Test".to_string());
         assert_eq!(info.name, "Test");
-        assert_eq!(info.status, SessionStatus::Busy);
+        assert_eq!(info.status, SessionStatus::Working);
         assert_eq!(info.agent, DEFAULT_AGENT_NAME);
         assert!(info.worktrees.is_empty());
         assert!(info.agent_session_id.is_none());
@@ -317,7 +329,6 @@ mod tests {
         assert!(info.agent_metrics.is_none());
         assert!(info.agent_activity.is_none());
         assert!(info.notification.is_none());
-        assert_eq!(info.status, SessionStatus::Busy);
     }
 
     #[test]

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -131,10 +131,10 @@ pub enum NotificationBackend {
 /// configuration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NotificationSettings {
-    /// Also notify when a session goes `Busy → Waiting` (timing-only quiet
-    /// state, no explicit OSC bell from the agent). Off by default —
-    /// agents that respect `terminal_bell`/OSC 9 already drive the
-    /// `Attention` transition, which always fires.
+    /// Also notify when a session **finishes** (`Working → Done`, reported by an
+    /// agent hook), not just when it becomes `Blocked` (which always fires).
+    /// Off by default. (The field name is historical — it now governs the Done
+    /// edge.)
     #[serde(default)]
     pub also_on_waiting: bool,
     /// Skip notifications for the session currently in focus (you're already

--- a/src/session/theme_config.rs
+++ b/src/session/theme_config.rs
@@ -21,8 +21,9 @@ pub struct ThemePalette {
     pub accent: Color,
     pub accent_bright: Color,
 
-    pub status_busy: Color,
-    pub status_waiting: Color,
+    pub status_working: Color,
+    pub status_blocked: Color,
+    pub status_done: Color,
     pub status_idle: Color,
     pub status_error: Color,
 
@@ -228,9 +229,11 @@ pub struct CustomThemeDef {
     #[serde(default)]
     pub accent_bright: Option<String>,
     #[serde(default)]
-    pub status_busy: Option<String>,
+    pub status_working: Option<String>,
     #[serde(default)]
-    pub status_waiting: Option<String>,
+    pub status_blocked: Option<String>,
+    #[serde(default)]
+    pub status_done: Option<String>,
     #[serde(default)]
     pub status_idle: Option<String>,
     #[serde(default)]
@@ -324,19 +327,24 @@ impl CustomThemeDef {
             palette.nerd_font_enabled = nerd;
         }
 
-        let fields: [(&str, &Option<String>, &mut Color); 25] = [
+        let fields: [(&str, &Option<String>, &mut Color); 26] = [
             ("accent", &self.accent, &mut palette.accent),
             (
                 "accent_bright",
                 &self.accent_bright,
                 &mut palette.accent_bright,
             ),
-            ("status_busy", &self.status_busy, &mut palette.status_busy),
             (
-                "status_waiting",
-                &self.status_waiting,
-                &mut palette.status_waiting,
+                "status_working",
+                &self.status_working,
+                &mut palette.status_working,
             ),
+            (
+                "status_blocked",
+                &self.status_blocked,
+                &mut palette.status_blocked,
+            ),
+            ("status_done", &self.status_done, &mut palette.status_done),
             ("status_idle", &self.status_idle, &mut palette.status_idle),
             (
                 "status_error",
@@ -429,9 +437,10 @@ fn default_palette() -> ThemePalette {
         accent: Color::Cyan,
         accent_bright: Color::LightCyan,
 
-        status_busy: Color::Green,
-        status_waiting: Color::Yellow,
-        status_idle: Color::DarkGray,
+        status_working: Color::Yellow,
+        status_blocked: Color::Red,
+        status_done: Color::LightBlue,
+        status_idle: Color::Green,
         status_error: Color::Red,
 
         text_primary: Color::White,
@@ -478,6 +487,7 @@ struct PaletteSlots {
     green: Color,
     yellow: Color,
     red: Color,
+    blue: Color,
     text_primary: Color,
     text_secondary: Color,
     text_muted: Color,
@@ -499,9 +509,10 @@ impl PaletteSlots {
         ThemePalette {
             accent: self.accent,
             accent_bright: self.accent_bright,
-            status_busy: self.green,
-            status_waiting: self.yellow,
-            status_idle: self.text_muted,
+            status_working: self.yellow,
+            status_blocked: self.red,
+            status_done: self.blue,
+            status_idle: self.green,
             status_error: self.red,
             text_primary: self.text_primary,
             text_secondary: self.text_secondary,
@@ -547,6 +558,7 @@ fn catppuccin_mocha_palette() -> ThemePalette {
         green,
         yellow,
         red,
+        blue,
         text_primary: text,
         text_secondary: subtext,
         text_muted: overlay,
@@ -585,6 +597,7 @@ fn tokyo_night_palette() -> ThemePalette {
         green,
         yellow,
         red,
+        blue,
         text_primary: text,
         text_secondary: subtext,
         text_muted: muted,
@@ -623,6 +636,7 @@ fn gruvbox_dark_palette() -> ThemePalette {
         green,
         yellow,
         red,
+        blue,
         text_primary: fg,
         text_secondary: fg2,
         text_muted: gray,
@@ -662,6 +676,7 @@ fn catppuccin_latte_palette() -> ThemePalette {
         green,
         yellow,
         red,
+        blue,
         text_primary: text,
         text_secondary: subtext,
         text_muted: overlay,
@@ -703,6 +718,7 @@ fn tokyo_night_day_palette() -> ThemePalette {
         green,
         yellow,
         red,
+        blue,
         text_primary: text,
         text_secondary: subtext,
         text_muted: muted,
@@ -741,6 +757,7 @@ fn gruvbox_light_palette() -> ThemePalette {
         green,
         yellow,
         red,
+        blue,
         text_primary: fg,
         text_secondary: fg2,
         text_muted: gray,
@@ -779,6 +796,7 @@ fn solarized_light_palette() -> ThemePalette {
         green,
         yellow,
         red,
+        blue,
         text_primary: base01,
         text_secondary: base00,
         text_muted: base1,
@@ -814,6 +832,7 @@ fn doom_palette() -> ThemePalette {
         green: bright_green,
         yellow: red,
         red,
+        blue: cyan,
         text_primary: text,
         text_secondary: subtext,
         text_muted: muted,

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -1,0 +1,180 @@
+//! The built-in **hooks** extension: wires each coding agent's lifecycle hooks
+//! to `thurbox-cli session signal` so sessions report `working`/`blocked`/`done`
+//! back to thurbox (see the hooks-driven `SessionStatus`).
+//!
+//! Unlike user extensions (which are fetched from a source on demand, ADR-20),
+//! this one ships **embedded** in the binary and is **auto-activated by default**
+//! so the default agent has its hook pre-configured with zero setup. It is
+//! delivered through the ordinary extension machinery: the embedded assets are
+//! materialized into a stable local dir, then [`install_extension`] installs them
+//! from there — so all the install/heal/uninstall logic is shared.
+//!
+//! Opt out with `thurbox-cli extension deactivate hooks`, which records an
+//! opt-out flag so startup self-heal won't resurrect it.
+
+use std::path::PathBuf;
+
+use crate::storage::Database;
+
+use super::install_extension;
+
+/// The extension name (matches `extensions/hooks/extension.toml`).
+pub const HOOKS_EXTENSION_NAME: &str = "hooks";
+
+const MANIFEST: &str = include_str!("../../extensions/hooks/extension.toml");
+const CLAUDE_SETTINGS: &str = include_str!("../../extensions/hooks/claude.json");
+const OPENCODE_PLUGIN: &str = include_str!("../../extensions/hooks/opencode-status.js");
+const GEMINI_HOOKS: &str = include_str!("../../extensions/hooks/gemini-hooks.json");
+
+/// The hooks extension's home, under this build's resolved config dir
+/// (`~/.config/thurbox/hooks` for a release build, `~/.config/thurbox-dev/hooks`
+/// for a dev build) — so dev and release installs stay isolated and the injected
+/// `--settings` path always points inside the same tree the binary uses.
+fn hooks_home() -> Option<String> {
+    crate::paths::config_file()
+        .and_then(|p| p.parent().map(|d| d.join("hooks")))
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
+/// Materialize the embedded hooks-extension assets into a stable local dir under
+/// the data directory and return it, so [`install_extension`] can treat it as a
+/// local source. Rewritten on every call so the assets track the binary.
+fn materialize_source() -> Result<PathBuf, String> {
+    let base = crate::paths::builtin_extensions_directory()
+        .ok_or("cannot resolve builtin-extensions dir")?;
+    let dir = base.join(HOOKS_EXTENSION_NAME);
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    let writes = [
+        ("extension.toml", MANIFEST),
+        ("claude.json", CLAUDE_SETTINGS),
+        ("opencode-status.js", OPENCODE_PLUGIN),
+        ("gemini-hooks.json", GEMINI_HOOKS),
+    ];
+    for (name, contents) in writes {
+        let path = dir.join(name);
+        // Skip the write when unchanged — this runs on every startup + 60s tick.
+        if std::fs::read_to_string(&path).is_ok_and(|c| c == contents) {
+            continue;
+        }
+        std::fs::write(&path, contents).map_err(|e| format!("write {}: {e}", path.display()))?;
+    }
+    Ok(dir)
+}
+
+/// Ensure the built-in hooks extension is installed + active, unless the user
+/// opted out. Idempotent — safe to call at every TUI startup / automation tick;
+/// it re-applies the agent patches, payload + external files, and re-stamps the
+/// manifest so an upgrade refreshes the wiring. Returns human-readable status
+/// lines (empty when there's nothing to report).
+pub fn ensure_builtin_hooks_extension(db: &Database) -> Vec<String> {
+    if db.builtin_hooks_opted_out().unwrap_or(false) {
+        return Vec::new();
+    }
+    let dir = match materialize_source() {
+        Ok(d) => d,
+        Err(e) => return vec![format!("hooks extension: {e}")],
+    };
+    // Home lives under *this build's* config dir (`thurbox` vs `thurbox-dev`), so
+    // a dev build patches its dev `agents.toml` with a `--settings` path inside
+    // the dev tree — never the release config. Manifest `home` is ignored.
+    let Some(home) = hooks_home() else {
+        return vec!["hooks extension: cannot resolve config dir".into()];
+    };
+
+    // Migrate a stale install whose home points elsewhere (e.g. an earlier build
+    // that used the release path): tear down its patches/files before reinstalling
+    // under the correct home, so claude doesn't end up with two `--settings`.
+    if let Some(existing) = crate::agent::extension_config::load_manifest(HOOKS_EXTENSION_NAME) {
+        if existing.home.as_deref() != Some(home.as_str()) {
+            let _ = super::uninstall_extension(db, HOOKS_EXTENSION_NAME, false);
+        }
+    }
+
+    match install_extension(db, &dir.to_string_lossy(), Some(&home), false) {
+        Ok(report) => {
+            let mut msgs = Vec::new();
+            if !report.agents_patched.is_empty() {
+                msgs.push(format!(
+                    "hooks: wired agent hooks for {}",
+                    report.agents_patched.join(", ")
+                ));
+            }
+            if !report.external_files_written.is_empty() {
+                msgs.push("hooks: installed opencode status plugin".to_string());
+            }
+            msgs
+        }
+        Err(e) => vec![format!("hooks extension: {e}")],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_assets_are_present() {
+        assert!(MANIFEST.contains("name = \"hooks\""));
+        assert!(CLAUDE_SETTINGS.contains("session signal --state working"));
+        // The opencode plugin must carry the managed marker so uninstall can
+        // safely remove it (see `is_user_modified`).
+        assert!(OPENCODE_PLUGIN.contains("thurbox `extension install`"));
+    }
+
+    #[test]
+    fn embedded_manifest_parses_with_codex_and_gemini_wiring() {
+        // Parse the embedded manifest exactly as the installer does — this guards
+        // the tricky codex `notify` arg (a single-quoted TOML string holding JSON)
+        // and the gemini config_merge from silently breaking the build.
+        let def: crate::session::ExtensionDef =
+            toml::from_str(MANIFEST).expect("embedded manifest parses");
+
+        let codex = def
+            .agent_patches
+            .iter()
+            .find(|p| p.name == "codex")
+            .expect("codex agent patch present");
+        assert!(codex.append_args.iter().any(|a| a == "-c"));
+        assert!(codex
+            .append_args
+            .iter()
+            .any(|a| a.contains("notify=") && a.contains("session signal --state done")));
+
+        let gemini = def
+            .config_merges
+            .iter()
+            .find(|m| m.path.contains(".gemini"))
+            .expect("gemini config merge present");
+        assert_eq!(gemini.source_path(), "gemini-hooks.json");
+        assert_eq!(gemini.requires_dir.as_deref(), Some("~/.gemini"));
+
+        // The gemini payload is valid JSON and carries the prune marker.
+        let payload: serde_json::Value =
+            serde_json::from_str(GEMINI_HOOKS).expect("gemini payload is valid JSON");
+        assert!(payload["hooks"]["SessionStart"].is_array());
+        assert!(GEMINI_HOOKS.contains("thurbox-cli session signal"));
+    }
+
+    #[test]
+    fn hooks_home_derives_from_build_config_dir() {
+        // Home must track the resolved config dir (so a dev build lands under
+        // `thurbox-dev`, not the release tree) — never a hardcoded path.
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+        let home = hooks_home().expect("home resolves");
+        let expected = crate::paths::config_file()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("hooks");
+        assert_eq!(std::path::Path::new(&home), expected);
+    }
+
+    #[test]
+    fn opt_out_skips_install() {
+        let db = Database::open_in_memory().unwrap();
+        db.set_builtin_hooks_optout(true).unwrap();
+        // With opt-out set, ensure is a no-op (no install attempted).
+        assert!(ensure_builtin_hooks_extension(&db).is_empty());
+    }
+}

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -107,7 +107,19 @@ pub struct InstallReport {
     pub symlinks_created: Vec<String>,
     /// Symlinks skipped because a regular file already occupies the link path.
     pub symlinks_skipped: Vec<String>,
+    /// External files written into agents' own config dirs (hook plugins).
+    pub external_files_written: Vec<String>,
+    /// External files skipped (`if_absent`/user-modified/`requires_dir` absent).
+    pub external_files_skipped: Vec<String>,
     pub agents_added: Vec<String>,
+    /// Existing agents whose `args` were extended with a hook patch.
+    pub agents_patched: Vec<String>,
+    /// Config files an extension JSON-merged hook entries into (e.g.
+    /// `~/.gemini/settings.json`).
+    pub config_merges_applied: Vec<String>,
+    /// Config merges skipped because their `requires_dir` was absent (the agent
+    /// isn't installed) or the merge was already present (no-op).
+    pub config_merges_skipped: Vec<String>,
     /// The activate result (sessions/automations created).
     pub ensure: EnsureReport,
     /// The newly-installed extension's declared `version` (if any).
@@ -186,6 +198,55 @@ pub fn install_extension(
     // 3. Agents → agents.toml (idempotent).
     report.agents_added = crate::agent::extension_config::ensure_agents_registered(&def.agents)?;
 
+    // 3b. External files (hook plugins) into agents' own config dirs. These take
+    //     absolute / `~` paths, so `{home}` is resolved first.
+    let resolved_externals: Vec<crate::session::ExternalFile> = def
+        .external_files
+        .iter()
+        .map(|f| {
+            let mut f = f.clone();
+            f.path = f.path.replace(HOME_TOKEN, &home_str);
+            if let Some(req) = &f.requires_dir {
+                f.requires_dir = Some(req.replace(HOME_TOKEN, &home_str));
+            }
+            f
+        })
+        .collect();
+    for f in &resolved_externals {
+        install_external_file(&source, f, &home_str, force, &mut report)?;
+    }
+
+    // 3c. Hook-arg patches into existing agents (reversible).
+    let resolved_patches: Vec<crate::session::AgentPatch> = def
+        .agent_patches
+        .iter()
+        .map(|p| {
+            let mut p = p.clone();
+            for a in &mut p.append_args {
+                *a = a.replace(HOME_TOKEN, &home_str);
+            }
+            p
+        })
+        .collect();
+    report.agents_patched = crate::agent::extension_config::apply_agent_patches(&resolved_patches)?;
+
+    // 3d. JSON merges into agents' own config files (reversible, non-clobbering).
+    let resolved_merges: Vec<crate::session::ConfigMerge> = def
+        .config_merges
+        .iter()
+        .map(|m| {
+            let mut m = m.clone();
+            m.path = m.path.replace(HOME_TOKEN, &home_str);
+            if let Some(req) = &m.requires_dir {
+                m.requires_dir = Some(req.replace(HOME_TOKEN, &home_str));
+            }
+            m
+        })
+        .collect();
+    for m in &resolved_merges {
+        install_config_merge(&source, m, &mut report)?;
+    }
+
     // 4. Persist the home-resolved manifest (stamped with install provenance —
     //    which binary installed it + where from) to the discovery dir, then
     //    activate. `target` is recorded verbatim so `update` re-fetches the same
@@ -245,6 +306,12 @@ fn install_payload_file(
     if f.substitute {
         content = content.replace(HOME_TOKEN, home_str);
     }
+    // Skip the write when nothing changed: `ensure` re-runs this on every TUI
+    // startup and every 60 s heartbeat tick, so a no-op rewrite each time is
+    // wasted disk churn.
+    if file_has_content(&dest, &content) {
+        return Ok(());
+    }
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
     }
@@ -254,6 +321,151 @@ fn install_payload_file(
     }
     report.files_written.push(f.path.clone());
     Ok(())
+}
+
+/// Whether `dest` already holds exactly `content` (so a rewrite would be a no-op).
+fn file_has_content(dest: &Path, content: &str) -> bool {
+    std::fs::read_to_string(dest).is_ok_and(|existing| existing == content)
+}
+
+/// Write one external file into an agent's own config dir (absolute / `~`
+/// path). Unlike [`install_payload_file`] this deliberately escapes the home
+/// dir, so it never uses the relative-path guard. Skips when `requires_dir` is
+/// absent (the agent isn't installed), when `if_absent` and the file exists, or
+/// when a user has edited our managed file (no marker) — unless `force`.
+fn install_external_file(
+    source: &crate::agent::extension_config::ExtensionSource,
+    f: &crate::session::ExternalFile,
+    home_str: &str,
+    force: bool,
+    report: &mut InstallReport,
+) -> Result<(), String> {
+    if let Some(req) = &f.requires_dir {
+        if !crate::agent::extension_config::expand_tilde(req).is_dir() {
+            report.external_files_skipped.push(f.path.clone());
+            return Ok(());
+        }
+    }
+    let dest = crate::agent::extension_config::expand_tilde(&f.path);
+    if f.if_absent && dest.exists() && !force {
+        report.external_files_skipped.push(f.path.clone());
+        return Ok(());
+    }
+    // Never clobber a file a user has edited (one lacking our managed marker).
+    if !force && dest.exists() && is_user_modified(&dest) {
+        report.external_files_skipped.push(f.path.clone());
+        return Ok(());
+    }
+    let mut content = crate::agent::extension_config::fetch_file(source, f.source_path())?;
+    if f.substitute {
+        content = content.replace(HOME_TOKEN, home_str);
+    }
+    // Skip the write when unchanged (re-run every startup + heartbeat tick).
+    if file_has_content(&dest, &content) {
+        return Ok(());
+    }
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    std::fs::write(&dest, content).map_err(|e| format!("write {}: {e}", dest.display()))?;
+    if f.executable {
+        set_executable(&dest)?;
+    }
+    report.external_files_written.push(f.path.clone());
+    Ok(())
+}
+
+/// Marker present in every hook command we ship (`thurbox-cli session signal
+/// …`). [`crate::agent::json_merge::prune_marked`] uses it to remove exactly our
+/// merged entries on uninstall — robust across payload schema changes.
+const HOOK_SIGNAL_MARKER: &str = "thurbox-cli session signal";
+
+/// Read the JSON config at `path` (or `{}` when absent), parsed. A malformed
+/// file is an error rather than a silent overwrite — we never clobber config we
+/// can't safely round-trip.
+fn read_json_or_empty(path: &Path) -> Result<serde_json::Value, String> {
+    match std::fs::read_to_string(path) {
+        Ok(s) if s.trim().is_empty() => Ok(serde_json::json!({})),
+        Ok(s) => serde_json::from_str(&s).map_err(|e| format!("parse {}: {e}", path.display())),
+        Err(_) => Ok(serde_json::json!({})),
+    }
+}
+
+/// Write `value` as pretty JSON to `path` only when it differs from the current
+/// contents (the merge runs every startup + heartbeat tick, so a no-op write
+/// would be churn). Returns whether it wrote.
+fn write_json_if_changed(path: &Path, value: &serde_json::Value) -> Result<bool, String> {
+    let content = serde_json::to_string_pretty(value)
+        .map_err(|e| format!("serialize {}: {e}", path.display()))?;
+    if file_has_content(path, &content) {
+        return Ok(false);
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    std::fs::write(path, content).map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(true)
+}
+
+/// Deep-merge an extension's shipped JSON into an agent's *own* config file
+/// (`~/.gemini/settings.json`, …) in place — reversibly and without clobbering
+/// the user's other settings. Skips when `requires_dir` is absent (the agent
+/// isn't installed) or when the merge is already present (no-op write).
+fn install_config_merge(
+    source: &crate::agent::extension_config::ExtensionSource,
+    m: &crate::session::ConfigMerge,
+    report: &mut InstallReport,
+) -> Result<(), String> {
+    if let Some(req) = &m.requires_dir {
+        if !crate::agent::extension_config::expand_tilde(req).is_dir() {
+            report.config_merges_skipped.push(m.path.clone());
+            return Ok(());
+        }
+    }
+    let dest = crate::agent::extension_config::expand_tilde(&m.path);
+    let to_merge: serde_json::Value = serde_json::from_str(
+        &crate::agent::extension_config::fetch_file(source, m.source_path())?,
+    )
+    .map_err(|e| format!("parse merge source {}: {e}", m.source_path()))?;
+    // A user's malformed target must NOT abort the whole install: this runs every
+    // startup + heartbeat tick, so one broken file would degrade every agent's
+    // wiring. Soft-skip it (mirroring the `requires_dir` guard) and carry on.
+    let mut doc = match read_json_or_empty(&dest) {
+        Ok(doc) => doc,
+        Err(e) => {
+            tracing::warn!("skipping config merge into {}: {e}", dest.display());
+            report.config_merges_skipped.push(m.path.clone());
+            return Ok(());
+        }
+    };
+    crate::agent::json_merge::merge(&mut doc, &to_merge);
+    if write_json_if_changed(&dest, &doc)? {
+        report.config_merges_applied.push(m.path.clone());
+    } else {
+        report.config_merges_skipped.push(m.path.clone());
+    }
+    Ok(())
+}
+
+/// Reverse an [`install_config_merge`]: prune our marked hook entries out of the
+/// agent's config file, leaving the user's own settings intact. A missing file
+/// is a no-op. Returns whether the path was touched.
+fn revert_config_merge(m: &crate::session::ConfigMerge) -> Result<bool, String> {
+    let dest = crate::agent::extension_config::expand_tilde(&m.path);
+    if !dest.exists() {
+        return Ok(false);
+    }
+    // A malformed target can't be safely pruned; leave it rather than abort the
+    // rest of the uninstall (consistent with the install soft-skip).
+    let mut doc = match read_json_or_empty(&dest) {
+        Ok(doc) => doc,
+        Err(e) => {
+            tracing::warn!("skipping config-merge revert in {}: {e}", dest.display());
+            return Ok(false);
+        }
+    };
+    crate::agent::json_merge::prune_marked(&mut doc, HOOK_SIGNAL_MARKER);
+    write_json_if_changed(&dest, &doc)
 }
 
 /// Create one symlink under the home dir, replacing an existing symlink but
@@ -397,6 +609,12 @@ pub struct UninstallReport {
     /// The teardown of runtime resources (session/automation) + active set.
     pub deactivate: DeactivateReport,
     pub agents_removed: Vec<String>,
+    /// Existing agents whose hook-patch args were removed.
+    pub agents_unpatched: Vec<String>,
+    /// External files (hook plugins) removed from agents' config dirs.
+    pub external_files_removed: Vec<String>,
+    /// Config files our JSON-merged hook entries were pruned out of.
+    pub config_merges_reverted: Vec<String>,
     pub manifest_removed: bool,
     /// The home dir, if it was removed (`purge_home`).
     pub home_removed: Option<String>,
@@ -425,6 +643,26 @@ pub fn uninstall_extension(
     // Remove the agents this extension registered.
     let agent_names: Vec<String> = def.agents.iter().map(|a| a.name.clone()).collect();
     report.agents_removed = crate::agent::extension_config::remove_agents_from_toml(&agent_names)?;
+
+    // Reverse hook-arg patches on existing agents (manifest stores resolved args).
+    report.agents_unpatched =
+        crate::agent::extension_config::remove_agent_patches(&def.agent_patches)?;
+
+    // Remove external hook files we still own (those carrying our managed marker).
+    for f in &def.external_files {
+        let dest = crate::agent::extension_config::expand_tilde(&f.path);
+        if dest.is_file() && !is_user_modified(&dest) && std::fs::remove_file(&dest).is_ok() {
+            report.external_files_removed.push(f.path.clone());
+        }
+    }
+
+    // Prune our merged hook entries out of agents' own config files, leaving the
+    // user's other settings intact.
+    for m in &def.config_merges {
+        if revert_config_merge(m)? {
+            report.config_merges_reverted.push(m.path.clone());
+        }
+    }
 
     // Optionally delete the install home (payload + user data).
     if purge_home {
@@ -934,6 +1172,9 @@ mod tests {
             home: None,
             agents: Vec::new(),
             files: Vec::new(),
+            external_files: Vec::new(),
+            agent_patches: Vec::new(),
+            config_merges: Vec::new(),
             symlinks: Vec::new(),
             sessions: vec![ExtensionSession {
                 name: "flow".into(),
@@ -1170,6 +1411,335 @@ prompt = "tick"
             "if_absent file must not be clobbered on reinstall"
         );
         assert!(again.agents_added.is_empty());
+    }
+
+    #[test]
+    fn install_applies_agent_patches_and_external_files() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // An out-of-home dir that exists (the "agent is installed" case) and a
+        // plugin destination under it — kept inside the tempdir so the test
+        // never touches the real home.
+        let plugin_dir = temp.path().join("opencode");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        let plugin_dest = plugin_dir.join("plugin/status.js");
+        let home = temp.path().join("hookshome");
+
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                r#"name = "hooks"
+home = '{home}'
+
+[[agent_patches]]
+name = "claude"
+append_args = ["--settings", "{{home}}/claude.json"]
+
+[[external_files]]
+path = '{plugin}'
+source = "status.js"
+requires_dir = '{plugin_dir}'
+"#,
+                home = home.display(),
+                plugin = plugin_dest.display(),
+                plugin_dir = plugin_dir.display(),
+            ),
+        )
+        .unwrap();
+        // The plugin payload carries the managed marker so uninstall can remove it.
+        std::fs::write(
+            src.path().join("status.js"),
+            "// thurbox `extension install` managed\n",
+        )
+        .unwrap();
+
+        let target = src.path().to_string_lossy().to_string();
+        let report = install_extension(&db, &target, None, false).unwrap();
+
+        // The built-in claude agent's args gained the --settings flag, resolved.
+        assert_eq!(report.agents_patched, ["claude"]);
+        let reg = crate::agent::agent_config::load_or_seed();
+        let args = &reg.get("claude").unwrap().args;
+        let expected = format!("{}/claude.json", home.display());
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--settings".to_string(), expected.clone()]),
+            "claude args carry the resolved --settings: {args:?}"
+        );
+
+        // The external plugin file landed in the out-of-home config dir.
+        assert!(plugin_dest.is_file());
+        assert!(report
+            .external_files_written
+            .iter()
+            .any(|p| p == &plugin_dest.to_string_lossy()));
+
+        // Uninstall reverses both: the patch is removed and the plugin deleted.
+        let un = uninstall_extension(&db, "hooks", false).unwrap();
+        assert_eq!(un.agents_unpatched, ["claude"]);
+        assert!(!plugin_dest.exists(), "managed plugin removed on uninstall");
+        let reg = crate::agent::agent_config::load_or_seed();
+        assert!(!reg
+            .get("claude")
+            .unwrap()
+            .args
+            .contains(&"--settings".to_string()));
+    }
+
+    #[test]
+    fn config_merge_installs_and_reverts_without_clobbering_user_config() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // The agent's config dir (gates the merge) + its shared settings file,
+        // seeded with the user's own settings incl. a pre-existing empty map.
+        let agent_dir = temp.path().join("dotgemini");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        let settings = agent_dir.join("settings.json");
+        std::fs::write(
+            &settings,
+            r#"{"theme":"dark","mcpServers":{},"hooks":{"BeforeTool":[{"command":"user"}]}}"#,
+        )
+        .unwrap();
+        let home = temp.path().join("hookshome");
+
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                r#"name = "hooks"
+home = '{home}'
+
+[[config_merges]]
+path = '{settings}'
+source = "gemini-hooks.json"
+requires_dir = '{agent_dir}'
+"#,
+                home = home.display(),
+                settings = settings.display(),
+                agent_dir = agent_dir.display(),
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            src.path().join("gemini-hooks.json"),
+            r#"{"hooks":{"BeforeTool":[{"hooks":[{"type":"command","command":"thurbox-cli session signal --state working || true"}]}],"AfterAgent":[{"hooks":[{"type":"command","command":"thurbox-cli session signal --state done || true"}]}]}}"#,
+        )
+        .unwrap();
+
+        let target = src.path().to_string_lossy().to_string();
+        let report = install_extension(&db, &target, None, false).unwrap();
+        assert_eq!(report.config_merges_applied, [settings.to_string_lossy()]);
+
+        let merged: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings).unwrap()).unwrap();
+        // User settings preserved (incl. the empty map) ...
+        assert_eq!(merged["theme"], serde_json::json!("dark"));
+        assert_eq!(merged["mcpServers"], serde_json::json!({}));
+        // ... the user's own BeforeTool hook survived, ours was unioned in ...
+        assert_eq!(merged["hooks"]["BeforeTool"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            merged["hooks"]["BeforeTool"][0],
+            serde_json::json!({"command": "user"})
+        );
+        // ... and our AfterAgent hook was added.
+        assert!(merged["hooks"]["AfterAgent"].is_array());
+
+        // A re-install is a no-op write (skipped, not re-applied).
+        let again = install_extension(&db, &target, None, false).unwrap();
+        assert!(again.config_merges_applied.is_empty());
+        assert_eq!(again.config_merges_skipped, [settings.to_string_lossy()]);
+
+        // Uninstall prunes exactly our entries; the user's config is restored.
+        let un = uninstall_extension(&db, "hooks", false).unwrap();
+        assert_eq!(un.config_merges_reverted, [settings.to_string_lossy()]);
+        let restored: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(
+            restored,
+            serde_json::json!({"theme":"dark","mcpServers":{},"hooks":{"BeforeTool":[{"command":"user"}]}})
+        );
+    }
+
+    #[test]
+    fn config_merge_skipped_when_requires_dir_absent() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // requires_dir points at a path that does NOT exist (agent not installed).
+        let missing_dir = temp.path().join("not-installed");
+        let settings = missing_dir.join("settings.json");
+        let home = temp.path().join("hookshome");
+
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                r#"name = "hooks"
+home = '{home}'
+
+[[config_merges]]
+path = '{settings}'
+source = "gemini-hooks.json"
+requires_dir = '{missing}'
+"#,
+                home = home.display(),
+                settings = settings.display(),
+                missing = missing_dir.display(),
+            ),
+        )
+        .unwrap();
+        std::fs::write(src.path().join("gemini-hooks.json"), "{}").unwrap();
+
+        let target = src.path().to_string_lossy().to_string();
+        let report = install_extension(&db, &target, None, false).unwrap();
+        assert_eq!(report.config_merges_skipped, [settings.to_string_lossy()]);
+        assert!(report.config_merges_applied.is_empty());
+        assert!(
+            !settings.exists(),
+            "no file created when the agent is absent"
+        );
+    }
+
+    #[test]
+    fn config_merge_soft_skips_a_malformed_user_target() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // The agent is installed (dir exists) but the user's settings file is
+        // broken JSON. Install must NOT abort — it runs every startup + tick.
+        let agent_dir = temp.path().join("dotgemini");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        let settings = agent_dir.join("settings.json");
+        std::fs::write(&settings, "{ this is not valid json").unwrap();
+        let home = temp.path().join("hookshome");
+
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                r#"name = "hooks"
+home = '{home}'
+
+[[config_merges]]
+path = '{settings}'
+source = "gemini-hooks.json"
+requires_dir = '{agent_dir}'
+"#,
+                home = home.display(),
+                settings = settings.display(),
+                agent_dir = agent_dir.display(),
+            ),
+        )
+        .unwrap();
+        std::fs::write(src.path().join("gemini-hooks.json"), r#"{"hooks":{}}"#).unwrap();
+
+        let target = src.path().to_string_lossy().to_string();
+        // Install succeeds despite the broken target; the merge is soft-skipped...
+        let report = install_extension(&db, &target, None, false).unwrap();
+        assert_eq!(report.config_merges_skipped, [settings.to_string_lossy()]);
+        assert!(report.config_merges_applied.is_empty());
+        // ...and the user's (broken) file is left exactly as-is, not overwritten.
+        assert_eq!(
+            std::fs::read_to_string(&settings).unwrap(),
+            "{ this is not valid json"
+        );
+    }
+
+    #[test]
+    fn config_merge_revert_soft_skips_a_malformed_target() {
+        // If the user corrupts settings.json AFTER install, uninstall must not
+        // abort on the unparseable file — it leaves it and reverts nothing.
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let agent_dir = temp.path().join("dotgemini");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        let settings = agent_dir.join("settings.json");
+        std::fs::write(&settings, "{}").unwrap();
+        let home = temp.path().join("hookshome");
+
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                r#"name = "hooks"
+home = '{home}'
+
+[[config_merges]]
+path = '{settings}'
+source = "gemini-hooks.json"
+requires_dir = '{agent_dir}'
+"#,
+                home = home.display(),
+                settings = settings.display(),
+                agent_dir = agent_dir.display(),
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            src.path().join("gemini-hooks.json"),
+            r#"{"hooks":{"AfterAgent":[{"hooks":[{"type":"command","command":"thurbox-cli session signal --state done || true"}]}]}}"#,
+        )
+        .unwrap();
+
+        let target = src.path().to_string_lossy().to_string();
+        install_extension(&db, &target, None, false).unwrap();
+        // The user corrupts the file after install.
+        std::fs::write(&settings, "}{ broken").unwrap();
+
+        // Uninstall succeeds, reverts nothing, leaves the broken file untouched.
+        let un = uninstall_extension(&db, "hooks", false).unwrap();
+        assert!(un.config_merges_reverted.is_empty());
+        assert_eq!(std::fs::read_to_string(&settings).unwrap(), "}{ broken");
+    }
+
+    #[test]
+    fn external_file_skipped_when_requires_dir_absent() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        let missing_dir = temp.path().join("not-installed");
+        let dest = missing_dir.join("plugin/status.js");
+        let home = temp.path().join("h");
+        let src = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            src.path().join("extension.toml"),
+            format!(
+                r#"name = "hooks"
+home = '{home}'
+
+[[external_files]]
+path = '{dest}'
+source = "status.js"
+requires_dir = '{req}'
+"#,
+                home = home.display(),
+                dest = dest.display(),
+                req = missing_dir.display(),
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            src.path().join("status.js"),
+            "// thurbox `extension install`\n",
+        )
+        .unwrap();
+
+        let report = install_extension(&db, &src.path().to_string_lossy(), None, false).unwrap();
+        assert!(!dest.exists(), "skipped because requires_dir is absent");
+        assert!(report
+            .external_files_skipped
+            .iter()
+            .any(|p| p == &dest.to_string_lossy()));
     }
 
     #[test]

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -5,11 +5,13 @@
 //! operations are synchronous against the SQLite database and the `tmux -L
 //! thurbox` server.
 
+pub mod builtin_hooks;
 pub mod delete;
 pub mod extensions;
 pub mod restart;
 pub mod spawn;
 
+pub use builtin_hooks::{ensure_builtin_hooks_extension, HOOKS_EXTENSION_NAME};
 pub use delete::{delete_session_headless, ForceDeleteReport};
 pub use extensions::{
     activate_extension, deactivate_extension, ensure_extension, extension_health,
@@ -119,6 +121,9 @@ fn build_agent_invocation(config: &SessionConfig) -> (String, Vec<String>) {
 ///   a task (so messages auto-tag `from_task_id`). Headless `task run` only; the
 ///   TUI task-spawn path tracks the link in-memory instead.
 /// - `THURBOX_METRICS_DIR` — metrics output dir.
+/// - `THURBOX_CONFIG_DIR` / `THURBOX_DATA_DIR` — the resolved config/data dirs,
+///   so the agent's `thurbox-cli` (its status hook) targets the same DB the TUI
+///   reads regardless of XDG / PATH / a stale tmux-server env.
 ///
 /// Kept in sync with `App::build_spawn_inputs` so headless and TUI sessions look
 /// identical to the spawned process (modulo `THURBOX_TASK` as noted above).
@@ -138,6 +143,25 @@ fn inject_thurbox_env(config: &mut SessionConfig, agent_session_id: &str, task_i
         config
             .env
             .insert("THURBOX_METRICS_DIR".into(), dir.to_string_lossy().into());
+    }
+    // Pin the agent's `thurbox-cli` (its status hook) to the *same* config/data
+    // dirs this thurbox resolved, so a status `signal` always lands in the DB
+    // the TUI reads — independent of XDG, which `thurbox-cli` is on PATH, or a
+    // stale tmux-server env. Derived from the resolved file paths' parents.
+    if let Some(dir) = crate::paths::config_file().and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    {
+        config.env.insert(
+            crate::paths::CONFIG_DIR_OVERRIDE_ENV.into(),
+            dir.to_string_lossy().into(),
+        );
+    }
+    if let Some(dir) =
+        crate::paths::database_file().and_then(|p| p.parent().map(|d| d.to_path_buf()))
+    {
+        config.env.insert(
+            crate::paths::DATA_DIR_OVERRIDE_ENV.into(),
+            dir.to_string_lossy().into(),
+        );
     }
 }
 
@@ -161,6 +185,41 @@ mod tests {
             Some(&"agent-conv-uuid".to_string())
         );
         assert_eq!(config.env.get("THURBOX_TASK"), Some(&"42".to_string()));
+    }
+
+    #[test]
+    fn inject_env_pins_config_and_data_dirs() {
+        // The agent's status hook must target the same DB the TUI reads, so the
+        // resolved config/data dirs are injected for `thurbox-cli` to honour.
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+        let mut config = SessionConfig {
+            session_id: Some(SessionId::default()),
+            ..SessionConfig::default()
+        };
+        inject_thurbox_env(&mut config, "agent-conv-uuid", None);
+
+        let cfg_dir = config
+            .env
+            .get(crate::paths::CONFIG_DIR_OVERRIDE_ENV)
+            .expect("config dir injected");
+        let data_dir = config
+            .env
+            .get(crate::paths::DATA_DIR_OVERRIDE_ENV)
+            .expect("data dir injected");
+        // They match the parents of the resolved config/db files.
+        assert_eq!(
+            Some(std::path::Path::new(cfg_dir)),
+            crate::paths::config_file()
+                .as_deref()
+                .and_then(|p| p.parent())
+        );
+        assert_eq!(
+            Some(std::path::Path::new(data_dir)),
+            crate::paths::database_file()
+                .as_deref()
+                .and_then(|p| p.parent())
+        );
     }
 
     #[test]

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -49,5 +49,10 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
     )
     .map_err(|e| format!("Failed to re-spawn tmux window: {e}"))?;
 
+    // The agent was re-spawned fresh; clear any stale hook-driven status so it
+    // doesn't show a leftover Blocked/Working/Done until the agent re-reports
+    // (a resumed agent may not re-fire its boot hook). Best-effort.
+    let _ = db.clear_hook_state(session_id);
+
     Ok(())
 }

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -173,6 +173,11 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         return Err(format!("Failed to persist session: {e}"));
     }
 
+    // No spawn-time status seed: a fresh session is `Idle` (the hooks-driven
+    // default) until the agent's hooks report otherwise — e.g. claude's
+    // SessionStart → idle on boot, then working/blocked/done through the turn.
+    // Seeding `working` here made an idle, just-booted agent look stuck working.
+
     Ok(SpawnResult {
         session_id,
         name: req.name,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -18,7 +18,7 @@ pub mod repo_bookmarks;
 mod schema;
 mod sessions;
 mod settings;
-pub use sessions::DeletedSessionInfo;
+pub use sessions::{DeletedSessionInfo, HookRow};
 pub mod sync;
 pub mod tasks;
 mod worktrees;

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -6,9 +6,11 @@ use rusqlite::Connection;
 /// (`session_labels` + `session_spawn_config`); v30 added
 /// `parent_session_id`, v31 added `display_order`, v32 added
 /// `session_messages` (the inter-session mailbox), v33 adds
-/// `action_extra_repos` to `tasks` + `automations` (multi-repo spawns).
+/// `action_extra_repos` to `tasks` + `automations` (multi-repo spawns),
+/// v34 adds `hook_state` / `hook_state_at` / `seen_at` to `sessions`
+/// (hooks-driven session status).
 /// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 33;
+pub const SCHEMA_VERSION: u32 = 34;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -44,6 +46,9 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             shell_backend_id  TEXT,
             parent_session_id TEXT,
             display_order     INTEGER,
+            hook_state        TEXT,
+            hook_state_at     INTEGER,
+            seen_at           INTEGER,
             created_at        INTEGER NOT NULL,
             updated_at        INTEGER NOT NULL,
             deleted_at        INTEGER
@@ -220,6 +225,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (31, migrate_v31_display_order),
         (32, migrate_v32_session_messages),
         (33, migrate_v33_action_extra_repos),
+        (34, migrate_v34_hook_status),
     ];
 
     for &(target, step) in steps {
@@ -938,6 +944,25 @@ fn migrate_v33_action_extra_repos(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
+/// v33 → v34: add the hooks-driven session-status columns to `sessions`.
+///
+/// `hook_state` (`working`/`blocked`/`done`, NULL = no hook fired yet) and
+/// `hook_state_at` (epoch ms it was reported) are written by
+/// `thurbox-cli session signal` from an agent hook; `seen_at` (epoch ms) is
+/// written by the TUI when the user views a `done` session, so it renders
+/// `Idle` instead of `Done`. NULL on every existing row, so they decode
+/// identically to the pre-hooks behaviour.
+///
+/// Fresh v34 databases already have the columns from `initialize` and skip this
+/// step; existing databases get them via the ALTERs. `let _` swallows the
+/// "duplicate column" error so a re-run is a no-op.
+fn migrate_v34_hook_status(conn: &Connection) -> rusqlite::Result<()> {
+    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN hook_state TEXT", []);
+    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN hook_state_at INTEGER", []);
+    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN seen_at INTEGER", []);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1252,6 +1277,61 @@ mod tests {
             )
             .unwrap();
         assert!(parent.is_none());
+
+        let version: String = conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn migrate_from_v33_adds_hook_status_columns() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Minimal v33 state: a sessions table without the hook-status columns.
+        conn.execute_batch(
+            "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO metadata (key, value) VALUES ('schema_version', '33');
+             CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, name TEXT NOT NULL,
+                agent TEXT NOT NULL DEFAULT 'claude',
+                backend_id TEXT NOT NULL DEFAULT '',
+                backend_type TEXT NOT NULL DEFAULT 'tmux',
+                agent_session_id TEXT, cwd TEXT,
+                additional_dirs TEXT NOT NULL DEFAULT '',
+                shell_backend_id TEXT, parent_session_id TEXT,
+                display_order INTEGER, created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL, deleted_at INTEGER);
+             INSERT INTO sessions (id, name, created_at, updated_at)
+                VALUES ('s1', 'demo', 0, 0);",
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        for col in ["hook_state", "hook_state_at", "seen_at"] {
+            let exists: bool = conn
+                .prepare(&format!(
+                    "SELECT 1 FROM pragma_table_info('sessions') WHERE name='{col}'"
+                ))
+                .unwrap()
+                .exists([])
+                .unwrap();
+            assert!(exists, "{col} column should be added at v34");
+        }
+
+        // Existing rows survive with NULL hook state.
+        let state: Option<String> = conn
+            .query_row(
+                "SELECT hook_state FROM sessions WHERE id = 's1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(state.is_none());
 
         let version: String = conn
             .query_row(

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use rusqlite::params;
@@ -7,6 +8,19 @@ use crate::sync::{current_time_millis, SharedSession, SharedWorktree};
 
 use super::audit::{AuditAction, EntityType};
 use super::Database;
+
+/// The hooks-driven status columns of a session, read in one batch by the TUI
+/// each tick to derive [`crate::session::SessionStatus`]. See schema v34.
+#[derive(Debug, Clone, Default)]
+pub struct HookRow {
+    /// `working` / `blocked` / `done` / `idle`, or `None` when no hook has fired
+    /// yet. (`idle` and unknown values render as [`crate::session::SessionStatus`]`::Idle`.)
+    pub state: Option<String>,
+    /// Epoch ms the state was last reported.
+    pub state_at: Option<i64>,
+    /// Epoch ms the user last "saw" a `done` state (drives Done → Idle).
+    pub seen_at: Option<i64>,
+}
 
 /// Information about a soft-deleted session, including its worktrees.
 #[derive(Debug, Clone)]
@@ -348,6 +362,92 @@ impl Database {
         }
 
         Ok(sessions)
+    }
+
+    /// Get a single active (non-deleted) session by its agent conversation id
+    /// (`agent_session_id`, the value injected as `THURBOX_SESSION_ID`). Used by
+    /// `session signal` as an identity fallback when `$THURBOX_SESSION` is not
+    /// available to the hook process (e.g. an agent that sanitizes its env).
+    pub fn get_session_by_agent_session_id(
+        &self,
+        agent_session_id: &str,
+    ) -> rusqlite::Result<Option<SharedSession>> {
+        let sessions = self.query_sessions(
+            "s.deleted_at IS NULL AND s.agent_session_id = ?1",
+            params![agent_session_id],
+        )?;
+        Ok(sessions.into_iter().next())
+    }
+
+    /// Record an agent-reported lifecycle state (`working`/`blocked`/`done`) for
+    /// a session, stamping `hook_state_at` to now. Written by
+    /// `thurbox-cli session signal` (and at spawn, defaulting to `working`).
+    ///
+    /// Deliberately a targeted UPDATE that touches only the hook columns —
+    /// [`upsert_session`](Self::upsert_session) must never list them, so the
+    /// TUI's full-row write-back can't clobber a state a headless hook just set.
+    pub fn set_hook_state(&self, id: SessionId, state: &str) -> rusqlite::Result<()> {
+        let now = current_time_millis() as i64;
+        self.conn.execute(
+            "UPDATE sessions SET hook_state = ?1, hook_state_at = ?2 \
+             WHERE id = ?3 AND deleted_at IS NULL",
+            params![state, now, id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// Mark a session as "seen" at `at_least` (epoch ms), so a `done` session
+    /// the user has looked at renders `Idle` instead of `Done`. The TUI calls
+    /// this once, on the transition (when `seen_at < hook_state_at`), never
+    /// every tick.
+    pub fn mark_session_seen(&self, id: SessionId, at_least: i64) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "UPDATE sessions SET seen_at = ?1 WHERE id = ?2",
+            params![at_least, id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// Clear a session's hooks-driven status (NULL all three columns), returning
+    /// it to the never-reported `Idle` default. Called on **restart**: the agent
+    /// is re-spawned fresh, so a stale `Blocked`/`Working`/`Done` must not linger
+    /// until the agent's hooks re-report (which a resumed agent may not do).
+    pub fn clear_hook_state(&self, id: SessionId) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "UPDATE sessions SET hook_state = NULL, hook_state_at = NULL, seen_at = NULL \
+             WHERE id = ?1",
+            params![id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// Load the hook-status columns for every active session in one indexed
+    /// scan, keyed by id. Called once per tick by the TUI to derive statuses.
+    pub fn load_hook_states(&self) -> rusqlite::Result<HashMap<SessionId, HookRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, hook_state, hook_state_at, seen_at \
+             FROM sessions WHERE deleted_at IS NULL",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let id_str: String = row.get(0)?;
+            Ok((
+                id_str,
+                HookRow {
+                    state: row.get(1)?,
+                    state_at: row.get(2)?,
+                    seen_at: row.get(3)?,
+                },
+            ))
+        })?;
+
+        let mut map = HashMap::new();
+        for row in rows {
+            let (id_str, hook) = row?;
+            if let Ok(id) = id_str.parse::<SessionId>() {
+                map.insert(id, hook);
+            }
+        }
+        Ok(map)
     }
 }
 
@@ -795,5 +895,97 @@ mod tests {
 
         let active = db.list_active_sessions().unwrap();
         assert_eq!(active.len(), 1);
+    }
+
+    #[test]
+    fn hook_state_roundtrips_and_defaults_null() {
+        let db = Database::open_in_memory().unwrap();
+        let session = make_session("S1");
+        let sid = session.id;
+        db.upsert_session(&session).unwrap();
+
+        // No hook fired yet: row exists, hook state is NULL.
+        let states = db.load_hook_states().unwrap();
+        let hook = states.get(&sid).expect("session present in hook map");
+        assert_eq!(hook.state, None);
+        assert_eq!(hook.state_at, None);
+        assert_eq!(hook.seen_at, None);
+
+        db.set_hook_state(sid, "blocked").unwrap();
+        let states = db.load_hook_states().unwrap();
+        let hook = states.get(&sid).unwrap();
+        assert_eq!(hook.state.as_deref(), Some("blocked"));
+        assert!(hook.state_at.is_some());
+    }
+
+    #[test]
+    fn upsert_does_not_clobber_hook_state() {
+        // The TUI's full-row upsert must preserve a state a headless hook set.
+        let db = Database::open_in_memory().unwrap();
+        let mut session = make_session("S1");
+        let sid = session.id;
+        db.upsert_session(&session).unwrap();
+        db.set_hook_state(sid, "done").unwrap();
+
+        // Simulate the TUI writing the session back (e.g. a rename).
+        session.name = "S1-renamed".to_string();
+        db.upsert_session(&session).unwrap();
+
+        let states = db.load_hook_states().unwrap();
+        assert_eq!(states.get(&sid).unwrap().state.as_deref(), Some("done"));
+    }
+
+    #[test]
+    fn mark_seen_records_timestamp() {
+        let db = Database::open_in_memory().unwrap();
+        let session = make_session("S1");
+        let sid = session.id;
+        db.upsert_session(&session).unwrap();
+        db.set_hook_state(sid, "done").unwrap();
+
+        let done_at = db.load_hook_states().unwrap().get(&sid).unwrap().state_at;
+        db.mark_session_seen(sid, done_at.unwrap()).unwrap();
+
+        let hook = db.load_hook_states().unwrap();
+        let hook = hook.get(&sid).unwrap();
+        assert_eq!(hook.seen_at, done_at);
+        assert!(hook.seen_at >= hook.state_at);
+    }
+
+    #[test]
+    fn clear_hook_state_nulls_all_columns() {
+        // On restart, a stale Blocked/Working/Done must be wiped so the
+        // re-spawned session falls back to the never-reported Idle default.
+        let db = Database::open_in_memory().unwrap();
+        let session = make_session("S1");
+        let sid = session.id;
+        db.upsert_session(&session).unwrap();
+        db.set_hook_state(sid, "blocked").unwrap();
+        let at = db.load_hook_states().unwrap().get(&sid).unwrap().state_at;
+        db.mark_session_seen(sid, at.unwrap()).unwrap();
+
+        db.clear_hook_state(sid).unwrap();
+
+        let hook = db.load_hook_states().unwrap();
+        let row = hook.get(&sid).unwrap();
+        assert_eq!(row.state, None);
+        assert_eq!(row.state_at, None);
+        assert_eq!(row.seen_at, None);
+    }
+
+    #[test]
+    fn lookup_by_agent_session_id() {
+        let db = Database::open_in_memory().unwrap();
+        let mut session = make_session("S1");
+        session.agent_session_id = Some("conv-123".to_string());
+        let sid = session.id;
+        db.upsert_session(&session).unwrap();
+
+        let found = db.get_session_by_agent_session_id("conv-123").unwrap();
+        assert_eq!(found.map(|s| s.id), Some(sid));
+        assert!(db
+            .get_session_by_agent_session_id("nope")
+            .unwrap()
+            .is_none());
     }
 }

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -9,6 +9,7 @@ use crate::session::PENDING_FOCUS_SESSION_ID_KEY;
 const EDITOR_COMMAND_KEY: &str = "editor_command";
 const THEME_KEY: &str = "active_theme";
 const ACTIVE_EXTENSIONS_KEY: &str = "active_extensions";
+const BUILTIN_HOOKS_OPTOUT_KEY: &str = "builtin_hooks_optout";
 
 impl Database {
     /// Get the configured editor command (e.g. `code`, `nvim --remote-tab`).
@@ -97,6 +98,38 @@ impl Database {
                 "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
                  ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                 params![ACTIVE_EXTENSIONS_KEY, json],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Whether the user has opted out of the auto-activated built-in `hooks`
+    /// extension. Set when they `extension deactivate hooks`, so startup self-heal
+    /// won't resurrect it.
+    pub fn builtin_hooks_opted_out(&self) -> rusqlite::Result<bool> {
+        let raw: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![BUILTIN_HOOKS_OPTOUT_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(raw.as_deref() == Some("1"))
+    }
+
+    /// Record (or clear) the opt-out of the built-in `hooks` extension.
+    pub fn set_builtin_hooks_optout(&self, optout: bool) -> rusqlite::Result<()> {
+        if optout {
+            self.conn.execute(
+                "INSERT INTO metadata (key, value) VALUES (?1, '1') \
+                 ON CONFLICT(key) DO UPDATE SET value = '1'",
+                params![BUILTIN_HOOKS_OPTOUT_KEY],
+            )?;
+        } else {
+            self.conn.execute(
+                "DELETE FROM metadata WHERE key = ?1",
+                params![BUILTIN_HOOKS_OPTOUT_KEY],
             )?;
         }
         Ok(())

--- a/src/ui/automation_detail.rs
+++ b/src/ui/automation_detail.rs
@@ -116,9 +116,9 @@ pub fn render_run_history(
 /// the relative age, and any free-text detail. Highlighted when `is_selected`.
 fn run_line<'a>(run: &AutomationRunRow<'_>, is_selected: bool) -> Line<'a> {
     let (glyph, word, color) = match run.status {
-        AutomationRunStatus::Success => ("✓", "ok", Theme::status_idle()),
+        AutomationRunStatus::Success => ("✓", "ok", Theme::tool_allowed()),
         AutomationRunStatus::Error => ("✗", "error", Theme::status_error()),
-        AutomationRunStatus::Skipped => ("–", "skipped", Theme::status_waiting()),
+        AutomationRunStatus::Skipped => ("–", "skipped", Theme::keybind_hint()),
     };
     let pointer = if is_selected { "▸" } else { " " };
     let mut spans = vec![

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -146,9 +146,9 @@ fn append_session_section<'a>(
         ]));
     }
     // Latest signal the agent pushed (OSC 9/777 notification). Highlighted while
-    // the session is in the attention state, muted otherwise.
+    // the session is blocked, muted otherwise.
     if let Some(signal) = info.notification.as_deref() {
-        let value_style = if info.status == crate::session::SessionStatus::Attention {
+        let value_style = if info.status == crate::session::SessionStatus::Blocked {
             Style::default().fg(super::status_color(info.status))
         } else {
             Style::default().fg(Theme::text_muted())
@@ -297,7 +297,7 @@ fn append_agent_lines_changed(lines: &mut Vec<Line<'_>>, metrics: &AgentMetrics)
         Span::styled("Lines:   ", Theme::label()),
         Span::styled(
             format!("+{added}"),
-            Style::default().fg(Theme::status_busy()),
+            Style::default().fg(Theme::tool_allowed()),
         ),
         Span::styled(" / ", Style::default().fg(Theme::text_muted())),
         Span::styled(
@@ -416,7 +416,7 @@ fn append_git_section(lines: &mut Vec<Line<'_>>, git: &crate::session::GitStats)
             Span::raw(" "),
             Span::styled(
                 format!("+{}", git.insertions),
-                Style::default().fg(Theme::status_busy()),
+                Style::default().fg(Theme::tool_allowed()),
             ),
             Span::styled(" / ", Style::default().fg(Theme::text_muted())),
             Span::styled(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -102,11 +102,27 @@ pub fn render_selector_rows(
 
 pub fn status_color(status: SessionStatus) -> Color {
     match status {
-        SessionStatus::Busy => Theme::status_busy(),
-        SessionStatus::Waiting => Theme::status_waiting(),
+        SessionStatus::Working => Theme::status_working(),
+        SessionStatus::Blocked => Theme::status_blocked(),
+        SessionStatus::Done => Theme::status_done(),
         SessionStatus::Idle => Theme::status_idle(),
         SessionStatus::Error => Theme::status_error(),
-        SessionStatus::Attention => Theme::accent_bright(),
+    }
+}
+
+/// Braille spinner frames for the `Working` status, animated in the live session
+/// list (`App::spinner_frame` advances them). Ten frames at ~8 fps reads as a
+/// smooth "in progress" spinner.
+pub const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// The glyph to render for `status`: the animated spinner frame `spinner` while
+/// `Working`, otherwise the status's static [`SessionStatus::icon`]. `spinner`
+/// is the caller's current frame (e.g. `SPINNER_FRAMES[app.spinner_frame()]`).
+pub fn status_glyph(status: SessionStatus, spinner: &str) -> &str {
+    if status == SessionStatus::Working {
+        spinner
+    } else {
+        status.icon()
     }
 }
 
@@ -802,15 +818,12 @@ mod tests {
 
     #[test]
     fn status_color_maps_all_variants() {
-        assert_eq!(status_color(SessionStatus::Busy), Color::Green);
-        assert_eq!(status_color(SessionStatus::Waiting), Color::Yellow);
-        assert_eq!(status_color(SessionStatus::Idle), Color::DarkGray);
+        // The default palette colours for the hooks-driven states.
+        assert_eq!(status_color(SessionStatus::Working), Color::Yellow);
+        assert_eq!(status_color(SessionStatus::Blocked), Color::Red);
+        assert_eq!(status_color(SessionStatus::Done), Color::LightBlue);
+        assert_eq!(status_color(SessionStatus::Idle), Color::Green);
         assert_eq!(status_color(SessionStatus::Error), Color::Red);
-        // Attention reuses the bright accent (distinct from the four above).
-        assert_eq!(
-            status_color(SessionStatus::Attention),
-            Theme::accent_bright()
-        );
     }
 
     #[test]

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use super::highlight::append_highlighted as append_name_spans;
 use super::theme::Theme;
 use super::{focus_block, status_color, FocusLevel};
-use crate::session::SessionInfo;
+use crate::session::{SessionInfo, SessionStatus};
 
 /// Per-field fuzzy match positions for a session entry.
 #[derive(Clone)]
@@ -514,6 +514,9 @@ pub struct LeftPanelState<'a> {
     /// Parallel to `sessions`: tree depth within the repo group
     /// (see [`SessionOrder::depths`]). Children render indented.
     pub depths: &'a [u8],
+    /// Current animated spinner frame for the `Working` status
+    /// (`SPINNER_FRAMES[App::spinner_frame()]`).
+    pub spinner: &'a str,
 }
 
 pub fn render_left_panel(
@@ -535,6 +538,7 @@ pub fn render_left_panel(
         state.session_search_active,
         state.headers,
         state.depths,
+        state.spinner,
     )
 }
 
@@ -618,6 +622,7 @@ fn render_session_section(
     search_active: bool,
     headers: &[Option<String>],
     depths: &[u8],
+    spinner: &str,
 ) -> Vec<super::RowHitbox> {
     let mut block = focus_block(" Sessions ", level);
 
@@ -626,7 +631,7 @@ fn render_session_section(
             .iter()
             .map(|info| {
                 Span::styled(
-                    info.status.icon(),
+                    super::status_glyph(info.status, spinner).to_string(),
                     Style::default().fg(status_color(info.status)),
                 )
             })
@@ -648,6 +653,20 @@ fn render_session_section(
     let active_group = show_selection
         .then(|| group_of.get(active_index).copied())
         .flatten();
+
+    // Roll each repo group up to its most-urgent member status, keyed by the
+    // group's header row index, so the header shows a single dot you can scan.
+    // Computed at render time (not in `SessionOrder`) so status never feeds the
+    // order cache or reorders rows — it only recolors.
+    let mut group_rollup: std::collections::HashMap<usize, SessionStatus> =
+        std::collections::HashMap::new();
+    for (i, info) in sessions.iter().enumerate() {
+        let h = group_of[i];
+        group_rollup
+            .entry(h)
+            .and_modify(|s| *s = group_status([*s, info.status]))
+            .or_insert(info.status);
+    }
 
     let mut item_heights: Vec<u16> = Vec::with_capacity(sessions.len());
 
@@ -677,6 +696,7 @@ fn render_session_section(
                 depth,
                 cross_group_child,
                 inner_width,
+                spinner,
             )];
 
             // Prepend a subtle repo-group header above the first session of
@@ -684,7 +704,11 @@ fn render_session_section(
             // anywhere in its group.
             if let Some(Some(label)) = headers.get(i) {
                 let selected = active_group == Some(i);
-                item_lines.insert(0, group_header_line(label, inner_width, selected));
+                let rollup = group_rollup.get(&i).copied().unwrap_or(info.status);
+                item_lines.insert(
+                    0,
+                    group_header_line(label, rollup, inner_width, selected, spinner),
+                );
             }
 
             item_heights.push(item_lines.len() as u16);
@@ -765,9 +789,16 @@ fn header_group_of(headers: &[Option<String>]) -> Vec<usize> {
     out
 }
 
-/// A full-width repo-group header: `── label ──────────`. Muted by default;
+/// A full-width repo-group header: `● ── label ──────────`. The leading dot is
+/// the group's rolled-up most-urgent status; the label is muted by default and
 /// painted with the selection background when the active row is in its group.
-fn group_header_line(label: &str, inner_width: usize, selected: bool) -> Line<'static> {
+fn group_header_line(
+    label: &str,
+    rollup: SessionStatus,
+    inner_width: usize,
+    selected: bool,
+    spinner: &str,
+) -> Line<'static> {
     let style = if selected {
         Style::default()
             .bg(Theme::selection_bg())
@@ -776,24 +807,48 @@ fn group_header_line(label: &str, inner_width: usize, selected: bool) -> Line<'s
     } else {
         Style::default().fg(Theme::text_muted())
     };
+    let dot = format!("{} ", super::status_glyph(rollup, spinner));
     let mut text = format!("\u{2500}\u{2500} {label} ");
-    let used = text.chars().count();
+    let used = dot.chars().count() + text.chars().count();
     if inner_width > used {
         text.push_str(&"\u{2500}".repeat(inner_width - used));
     }
-    Line::from(Span::styled(text, style))
+    Line::from(vec![
+        Span::styled(dot, Style::default().fg(status_color(rollup))),
+        Span::styled(text, style),
+    ])
+}
+
+/// Urgency rank for the repo-group rollup; higher is more urgent.
+fn status_urgency(s: SessionStatus) -> u8 {
+    match s {
+        SessionStatus::Blocked => 4,
+        SessionStatus::Error => 3,
+        SessionStatus::Working => 2,
+        SessionStatus::Done => 1,
+        SessionStatus::Idle => 0,
+    }
+}
+
+/// The most-urgent status across a group's members (Blocked > Error > Working >
+/// Done > Idle), so the group header dot surfaces whatever needs attention
+/// first. Empty input rolls up to `Idle`.
+pub fn group_status(statuses: impl IntoIterator<Item = SessionStatus>) -> SessionStatus {
+    statuses
+        .into_iter()
+        .max_by_key(|s| status_urgency(*s))
+        .unwrap_or(SessionStatus::Idle)
 }
 
 /// Resolve the agent-reported status text for a session row, if any.
 /// Priority:
-///   1. Attention → the agent's notification message ("Needs attention").
+///   1. Blocked → the agent's notification message (falls back to "Blocked").
 ///   2. The agent-reported OSC activity title (richer "insight").
 ///
-/// Timing-based Waiting/Busy text is deliberately *not* a fallback — the
-/// colored status dot already conveys that state, so a row with no
-/// agent-reported status carries no status text at all.
+/// The colored status dot already conveys the state, so a row with no
+/// agent-reported text carries no status text at all.
 fn agent_status_text(info: &SessionInfo) -> Option<String> {
-    if info.status == crate::session::SessionStatus::Attention {
+    if info.status == crate::session::SessionStatus::Blocked {
         return Some(
             info.notification
                 .clone()
@@ -899,7 +954,7 @@ fn push_agent_status(
     let Some(status_text) = agent_status_text(info) else {
         return;
     };
-    let agent_status_style = if info.status == crate::session::SessionStatus::Attention {
+    let agent_status_style = if info.status == crate::session::SessionStatus::Blocked {
         status_style
     } else {
         Style::default().fg(Theme::text_muted())
@@ -928,6 +983,7 @@ fn build_session_line<'a>(
     depth: u8,
     cross_group_child: bool,
     inner_width: usize,
+    spinner: &str,
 ) -> Line<'a> {
     let name_style = name_span_style(is_active, is_dimmed);
     let status_style = if is_dimmed {
@@ -937,7 +993,7 @@ fn build_session_line<'a>(
     };
 
     let mut spans = vec![Span::styled(
-        format!(" {} ", info.status.icon()),
+        format!(" {} ", super::status_glyph(info.status, spinner)),
         status_style,
     )];
 
@@ -983,10 +1039,10 @@ mod tests {
 
     #[test]
     fn agent_status_none_without_agent_report() {
-        // Waiting/Busy/Idle carry no status text — the colored dot is enough.
+        // Working/Done/Idle carry no status text — the colored dot is enough.
         for status in [
-            SessionStatus::Waiting,
-            SessionStatus::Busy,
+            SessionStatus::Working,
+            SessionStatus::Done,
             SessionStatus::Idle,
             SessionStatus::Error,
         ] {
@@ -999,7 +1055,7 @@ mod tests {
     #[test]
     fn agent_status_uses_activity_title() {
         let mut s = info("active");
-        s.status = SessionStatus::Busy;
+        s.status = SessionStatus::Working;
         s.agent_activity = Some("  Compacting conversation  ".to_string());
         assert_eq!(
             agent_status_text(&s),
@@ -1015,9 +1071,9 @@ mod tests {
     }
 
     #[test]
-    fn agent_status_attention_prefers_notification() {
-        let mut s = info("attn");
-        s.status = SessionStatus::Attention;
+    fn agent_status_blocked_prefers_notification() {
+        let mut s = info("blocked");
+        s.status = SessionStatus::Blocked;
         s.agent_activity = Some("working".to_string());
         s.notification = Some("Needs your approval".to_string());
         assert_eq!(
@@ -1027,12 +1083,12 @@ mod tests {
     }
 
     #[test]
-    fn agent_status_attention_without_notification_shows_status() {
-        let mut s = info("attn");
-        s.status = SessionStatus::Attention;
+    fn agent_status_blocked_without_notification_shows_status() {
+        let mut s = info("blocked");
+        s.status = SessionStatus::Blocked;
         assert_eq!(
             agent_status_text(&s),
-            Some(SessionStatus::Attention.to_string())
+            Some(SessionStatus::Blocked.to_string())
         );
     }
 
@@ -1223,6 +1279,7 @@ mod tests {
                         session_search_active: false,
                         headers: &ordered.headers,
                         depths: &ordered.depths,
+                        spinner: "◐",
                     },
                 );
             })
@@ -1260,14 +1317,14 @@ mod tests {
             worktree_path: std::path::PathBuf::from("/tmp/wt/feat"),
             branch: "feat".to_string(),
         });
-        let line = build_session_line(&s, None, false, false, 0, false, WIDE);
+        let line = build_session_line(&s, None, false, false, 0, false, WIDE, "◐");
         assert!(line_text(&line).contains('\u{2442}'));
     }
 
     #[test]
     fn line_no_worktree_glyph_for_plain_session() {
         let s = info("plain");
-        let line = build_session_line(&s, None, false, false, 0, false, WIDE);
+        let line = build_session_line(&s, None, false, false, 0, false, WIDE, "◐");
         assert!(!line_text(&line).contains('\u{2442}'));
     }
 
@@ -1275,28 +1332,28 @@ mod tests {
     fn line_shows_remote_glyph_when_remote_host_present() {
         let mut s = info("remote");
         s.remote_host = Some("devbox".to_string());
-        let line = build_session_line(&s, None, false, false, 0, false, WIDE);
+        let line = build_session_line(&s, None, false, false, 0, false, WIDE, "◐");
         assert!(line_text(&line).contains('\u{2601}'));
     }
 
     #[test]
     fn line_no_remote_glyph_for_local_session() {
         let s = info("local");
-        let line = build_session_line(&s, None, false, false, 0, false, WIDE);
+        let line = build_session_line(&s, None, false, false, 0, false, WIDE, "◐");
         assert!(!line_text(&line).contains('\u{2601}'));
     }
 
     #[test]
     fn line_shows_tree_prefix_for_nested_child() {
         let s = info("worker");
-        let line = build_session_line(&s, None, false, false, 1, false, WIDE);
+        let line = build_session_line(&s, None, false, false, 1, false, WIDE, "◐");
         assert!(line_text(&line).contains('\u{2514}')); // └
     }
 
     #[test]
     fn line_shows_arrow_for_cross_group_child() {
         let s = info("worker");
-        let line = build_session_line(&s, None, false, false, 0, true, WIDE);
+        let line = build_session_line(&s, None, false, false, 0, true, WIDE, "◐");
         let text = line_text(&line);
         assert!(text.contains('\u{21b3}')); // ↳
         assert!(!text.contains('\u{2514}'));
@@ -1305,8 +1362,10 @@ mod tests {
     #[test]
     fn line_carries_no_status_text_without_agent_report() {
         let mut s = info("quiet");
-        s.status = SessionStatus::Waiting;
-        let text = line_text(&build_session_line(&s, None, false, false, 0, false, WIDE));
+        s.status = SessionStatus::Done;
+        let text = line_text(&build_session_line(
+            &s, None, false, false, 0, false, WIDE, "◐",
+        ));
         assert!(!text.contains("Waiting"));
         assert!(text.trim_end().ends_with("quiet"));
     }
@@ -1314,18 +1373,22 @@ mod tests {
     #[test]
     fn line_appends_agent_activity_after_name() {
         let mut s = info("busy");
-        s.status = SessionStatus::Busy;
+        s.status = SessionStatus::Working;
         s.agent_activity = Some("Compacting conversation".to_string());
-        let text = line_text(&build_session_line(&s, None, false, false, 0, false, WIDE));
+        let text = line_text(&build_session_line(
+            &s, None, false, false, 0, false, WIDE, "◐",
+        ));
         assert!(text.contains("busy  Compacting conversation"));
     }
 
     #[test]
     fn line_attention_appends_notification() {
         let mut s = info("attn");
-        s.status = SessionStatus::Attention;
+        s.status = SessionStatus::Blocked;
         s.notification = Some("Review this diff".to_string());
-        let text = line_text(&build_session_line(&s, None, false, false, 0, false, WIDE));
+        let text = line_text(&build_session_line(
+            &s, None, false, false, 0, false, WIDE, "◐",
+        ));
         assert!(text.contains("attn  Review this diff"));
     }
 
@@ -1333,7 +1396,7 @@ mod tests {
     fn line_truncates_agent_status_with_ellipsis() {
         let mut s = info("busy");
         s.agent_activity = Some("a very long activity title that cannot fit".to_string());
-        let line = build_session_line(&s, None, false, false, 0, false, 20);
+        let line = build_session_line(&s, None, false, false, 0, false, 20, "◐");
         let text = line_text(&line);
         assert!(text.chars().count() <= 20);
         assert!(text.ends_with('\u{2026}'));
@@ -1344,7 +1407,9 @@ mod tests {
         let mut s = info("busy");
         s.agent_activity = Some("Ready".to_string());
         // used = " ● " (3) + "busy" (4) + separator (2) = 9; "Ready" fits exactly.
-        let text = line_text(&build_session_line(&s, None, false, false, 0, false, 14));
+        let text = line_text(&build_session_line(
+            &s, None, false, false, 0, false, 14, "◐",
+        ));
         assert!(text.ends_with("busy  Ready"));
         assert!(!text.contains('\u{2026}'));
     }
@@ -1354,9 +1419,13 @@ mod tests {
         let mut s = info("busy");
         s.agent_activity = Some("Ready".to_string());
         // avail = AGENT_STATUS_MIN_WIDTH → shown truncated; one column less → skipped.
-        let shown = line_text(&build_session_line(&s, None, false, false, 0, false, 13));
+        let shown = line_text(&build_session_line(
+            &s, None, false, false, 0, false, 13, "◐",
+        ));
         assert!(shown.ends_with("Rea\u{2026}"));
-        let skipped = line_text(&build_session_line(&s, None, false, false, 0, false, 12));
+        let skipped = line_text(&build_session_line(
+            &s, None, false, false, 0, false, 12, "◐",
+        ));
         assert!(skipped.trim_end().ends_with("busy"));
     }
 
@@ -1364,7 +1433,9 @@ mod tests {
     fn line_skips_agent_status_when_no_room() {
         let mut s = info("a-rather-long-session-name");
         s.agent_activity = Some("activity".to_string());
-        let text = line_text(&build_session_line(&s, None, false, false, 0, false, 30));
+        let text = line_text(&build_session_line(
+            &s, None, false, false, 0, false, 30, "◐",
+        ));
         assert!(!text.contains("activity"));
         assert!(text.trim_end().ends_with("a-rather-long-session-name"));
     }
@@ -1414,9 +1485,9 @@ mod tests {
 
     #[test]
     fn groups_keep_same_repo_sessions_together() {
-        let a = info_repo("a", "webapp", SessionStatus::Waiting);
-        let b = info_repo("b", "infra", SessionStatus::Waiting);
-        let c = info_repo("c", "webapp", SessionStatus::Waiting);
+        let a = info_repo("a", "webapp", SessionStatus::Done);
+        let b = info_repo("b", "infra", SessionStatus::Done);
+        let c = info_repo("c", "webapp", SessionStatus::Done);
         let sessions = vec![&a, &b, &c];
         // Equal status: groups ordered by label ("infra" < "webapp"),
         // members of each group adjacent.
@@ -1428,9 +1499,9 @@ mod tests {
     fn status_never_reorders_groups() {
         // Manual order wins: an Attention session recolors its dot but never
         // bubbles its group. Groups stay in label order ("infra" < "webapp").
-        let waiting = info_repo("infra-1", "infra", SessionStatus::Waiting);
-        let attn = info_repo("web-attn", "webapp", SessionStatus::Attention);
-        let busy = info_repo("web-busy", "webapp", SessionStatus::Busy);
+        let waiting = info_repo("infra-1", "infra", SessionStatus::Done);
+        let attn = info_repo("web-attn", "webapp", SessionStatus::Blocked);
+        let busy = info_repo("web-busy", "webapp", SessionStatus::Working);
         let sessions = vec![&waiting, &attn, &busy];
         assert_eq!(
             order_names(&sessions),
@@ -1438,7 +1509,7 @@ mod tests {
         );
 
         // Flip every status: the order is identical.
-        let waiting2 = info_repo("infra-1", "infra", SessionStatus::Attention);
+        let waiting2 = info_repo("infra-1", "infra", SessionStatus::Blocked);
         let attn2 = info_repo("web-attn", "webapp", SessionStatus::Idle);
         let busy2 = info_repo("web-busy", "webapp", SessionStatus::Error);
         let flipped = vec![&waiting2, &attn2, &busy2];
@@ -1449,17 +1520,30 @@ mod tests {
     }
 
     #[test]
+    fn group_status_rolls_up_to_most_urgent() {
+        use SessionStatus::*;
+        // Precedence: Blocked > Error > Working > Done > Idle.
+        assert_eq!(group_status([Idle, Done, Working]), Working);
+        assert_eq!(group_status([Done, Idle]), Done);
+        assert_eq!(group_status([Working, Error]), Error);
+        assert_eq!(group_status([Working, Blocked, Error]), Blocked);
+        assert_eq!(group_status([Idle, Idle]), Idle);
+        // Empty rolls up to Idle.
+        assert_eq!(group_status(std::iter::empty()), Idle);
+    }
+
+    #[test]
     fn status_changes_never_reorder_within_a_group() {
-        // A live agent flickers Busy↔Waiting every tick, and sessions go
-        // Idle/Attention; none of it may move a row.
-        let a = info_repo("a", "webapp", SessionStatus::Busy);
-        let b = info_repo("b", "webapp", SessionStatus::Waiting);
-        let c = info_repo("c", "webapp", SessionStatus::Busy);
+        // A live agent flips Working↔Done every tick, and sessions go
+        // Idle/Blocked; none of it may move a row.
+        let a = info_repo("a", "webapp", SessionStatus::Working);
+        let b = info_repo("b", "webapp", SessionStatus::Done);
+        let c = info_repo("c", "webapp", SessionStatus::Working);
         let sessions = vec![&a, &b, &c];
         assert_eq!(order_names(&sessions), vec!["a", "b", "c"]);
 
         // Flip a→Attention and b→Idle: order is unchanged.
-        let a2 = info_repo("a", "webapp", SessionStatus::Attention);
+        let a2 = info_repo("a", "webapp", SessionStatus::Blocked);
         let b2 = info_repo("b", "webapp", SessionStatus::Idle);
         let flipped = vec![&a2, &b2, &c];
         assert_eq!(order_names(&flipped), vec!["a", "b", "c"]);
@@ -1467,9 +1551,9 @@ mod tests {
 
     #[test]
     fn headers_label_only_first_row_of_each_group() {
-        let a = info_repo("a", "webapp", SessionStatus::Busy);
-        let b = info_repo("b", "webapp", SessionStatus::Busy);
-        let c = info_repo("c", "infra", SessionStatus::Attention);
+        let a = info_repo("a", "webapp", SessionStatus::Working);
+        let b = info_repo("b", "webapp", SessionStatus::Working);
+        let c = info_repo("c", "infra", SessionStatus::Blocked);
         let sessions = vec![&a, &b, &c];
         let SessionOrder { order, headers, .. } = compute_session_order(&sessions);
         let labelled: Vec<(&str, Option<String>)> = order
@@ -1502,9 +1586,9 @@ mod tests {
     fn multi_repo_session_forms_its_own_composite_group() {
         // A {webapp}, B {webapp, infra}, C {infra}: three distinct groups, the
         // multi-repo session is NOT folded into either single-repo group.
-        let a = info_repo("a", "webapp", SessionStatus::Waiting);
-        let b = info_repos("b", &["webapp", "infra"], SessionStatus::Waiting);
-        let c = info_repo("c", "infra", SessionStatus::Waiting);
+        let a = info_repo("a", "webapp", SessionStatus::Done);
+        let b = info_repos("b", &["webapp", "infra"], SessionStatus::Done);
+        let c = info_repo("c", "infra", SessionStatus::Done);
         let sessions = vec![&a, &b, &c];
 
         let SessionOrder { order, headers, .. } = compute_session_order(&sessions);
@@ -1785,8 +1869,8 @@ mod tests {
     #[test]
     fn attention_child_does_not_move_its_group() {
         let lead = info_repo("lead", "webapp", SessionStatus::Idle);
-        let worker = info_child("worker", "webapp", SessionStatus::Attention, &lead);
-        let busy = info_repo("busy", "infra", SessionStatus::Busy);
+        let worker = info_child("worker", "webapp", SessionStatus::Blocked, &lead);
+        let busy = info_repo("busy", "infra", SessionStatus::Working);
         let sessions = vec![&busy, &lead, &worker];
         // The child's Attention status doesn't bubble its group: groups stay
         // in label order ("infra" < "webapp"); the child stays nested.
@@ -1848,8 +1932,8 @@ mod tests {
     fn duplicate_repos_collapse_to_one_group() {
         // A repo set with the same repo twice (e.g. two worktrees of one repo)
         // groups under that single repo, alongside a plain single-repo session.
-        let multi = info_repos("multi", &["webapp", "webapp"], SessionStatus::Waiting);
-        let single = info_repo("single", "webapp", SessionStatus::Waiting);
+        let multi = info_repos("multi", &["webapp", "webapp"], SessionStatus::Done);
+        let single = info_repo("single", "webapp", SessionStatus::Done);
         let sessions = vec![&multi, &single];
 
         let SessionOrder { order, headers, .. } = compute_session_order(&sessions);
@@ -1862,8 +1946,8 @@ mod tests {
     fn multi_repo_grouping_is_order_independent() {
         // Same repo *set*, different selection order → one group; the header
         // reflects the first session's natural order.
-        let b = info_repos("b", &["webapp", "infra"], SessionStatus::Waiting);
-        let d = info_repos("d", &["infra", "webapp"], SessionStatus::Waiting);
+        let b = info_repos("b", &["webapp", "infra"], SessionStatus::Done);
+        let d = info_repos("d", &["infra", "webapp"], SessionStatus::Done);
         let sessions = vec![&b, &d];
 
         let SessionOrder { order, headers, .. } = compute_session_order(&sessions);

--- a/src/ui/settings_modal.rs
+++ b/src/ui/settings_modal.rs
@@ -140,7 +140,7 @@ fn footer_lines<'a>(state: &SettingsModalState<'_>) -> Vec<Line<'a>> {
     if state.restart_pending {
         footer.push(Line::from(Span::styled(
             "  ⟳ some changes apply after restart",
-            Style::default().fg(Theme::status_waiting()),
+            Style::default().fg(Theme::keybind_hint()),
         )));
     }
     footer.push(key_hint_line(&[

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -118,7 +118,7 @@ fn push_status_section<'a>(spans: &mut Vec<Span<'a>>, state: &'a FooterState<'a>
 fn push_status_message<'a>(spans: &mut Vec<Span<'a>>, msg: &'a StatusMessage) {
     let (badge_text, badge_bg, text_color) = match msg.level {
         StatusLevel::Info => (" INFO ", Theme::accent(), Theme::text_secondary()),
-        StatusLevel::Success => (" ✓ SYNC ", Theme::status_busy(), Theme::status_busy()),
+        StatusLevel::Success => (" ✓ SYNC ", Theme::tool_allowed(), Theme::tool_allowed()),
         StatusLevel::Error => (" ERROR ", Theme::status_error(), Theme::status_error()),
     };
     spans.push(Span::styled(

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -102,11 +102,14 @@ impl Theme {
 
     // ── Status colours ──────────────────────────────────────────────────────
 
-    pub fn status_busy() -> Color {
-        current().status_busy
+    pub fn status_working() -> Color {
+        current().status_working
     }
-    pub fn status_waiting() -> Color {
-        current().status_waiting
+    pub fn status_blocked() -> Color {
+        current().status_blocked
+    }
+    pub fn status_done() -> Color {
+        current().status_done
     }
     pub fn status_idle() -> Color {
         current().status_idle

--- a/src/ui/theme_picker_modal.rs
+++ b/src/ui/theme_picker_modal.rs
@@ -73,9 +73,11 @@ pub fn render_theme_picker_modal(
             ]),
             Line::from(vec![
                 Span::styled("  Status      ", Style::default().fg(Theme::text_muted())),
-                Span::styled("●", Style::default().fg(palette.status_busy)),
+                Span::styled("◐", Style::default().fg(palette.status_working)),
                 Span::styled(" ", Style::default()),
-                Span::styled("◆", Style::default().fg(palette.status_waiting)),
+                Span::styled("◆", Style::default().fg(palette.status_blocked)),
+                Span::styled(" ", Style::default()),
+                Span::styled("●", Style::default().fg(palette.status_done)),
                 Span::styled(" ", Style::default()),
                 Span::styled("○", Style::default().fg(palette.status_idle)),
                 Span::styled(" ", Style::default()),


### PR DESCRIPTION
## Summary

Reworks how session status is shown and adds a reproducible dev environment.

**Hooks-driven session status.** The session list now reports each agent's
state — **working** (animated spinner), **blocked** (needs input/approval),
**done** (turn just finished), **idle** (at rest/acknowledged) — driven by
**agent lifecycle hooks** instead of heuristics. Agents call
`thurbox-cli session signal --state <…>`, which persists per-session hook state
(SQLite schema **v34**); identity comes from the injected `$THURBOX_SESSION`, so
hooks pass no ids and it works headless. The TUI derives + animates the status,
done→idle is acknowledged on focus-leave, and repo groups roll up to their
most-urgent member. OS notifications fire on the block edge.

**Auto-wired per agent** by the built-in, auto-activated `hooks` extension
(opt out with `thurbox-cli extension deactivate hooks`):

| Agent | Mechanism | Coverage |
|-------|-----------|----------|
| claude | `--settings` (agent patch) | idle/working/blocked/done |
| aider | `--notifications-command` | blocked-only |
| opencode | drop-in plugin | working/blocked/done |
| codex | `-c notify` override (no `~/.codex` write) | done-only |
| gemini *(experimental)* | `settings.json` JSON-merge | idle/working/done |

**New reversible merge primitive.** gemini's hooks live in its *shared*
`~/.gemini/settings.json`, which a whole-file write would clobber. So this adds
`agent::json_merge` (deep-merge: objects recurse, arrays union; type conflicts
left untouched) behind a new `[[config_merges]]` manifest capability. Uninstall
**prunes our entries by marker** (version-skew-proof — survives payload schema
changes), no-op writes are skipped, and a malformed user target is soft-skipped
(never aborts the install, which auto-runs every startup + heartbeat tick).

**Reproducible dev environment** (separate commit): a Nix flake + direnv pinning
the toolchain/runtime deps, a `just` entrypoint, and `scripts/dev/sandbox.sh`
(thurbox-only vs full HOME/XDG isolation via one shared helper). See
`docs/DEVELOPMENT.md`.

## Caveats
- **codex/gemini hook formats are doc-sourced** (neither CLI installed in the
  dev env). They live entirely in the payload JSON / manifest, so they're
  trivially adjustable; **validate against a live binary** before relying on
  them. codex took the *verified* `notify` route deliberately, to avoid betting
  full lifecycle on an unverified `hooks.json` schema (a wrong schema would be a
  silent no-op).
- gemini may sanitize the hook env; if `$THURBOX_SESSION` doesn't reach the
  hook, the signal is a fail-open no-op (`|| true`).
- On the **first** gemini merge, `settings.json` formatting is normalized
  (one-time, lossless).

## Testing
- `cargo nextest run --all` → **1455 passed / 0 failed**
- clippy `-D warnings`, rustdoc `-D warnings`, architecture_rules — all clean
- New coverage: `agent::json_merge` (merge/prune incl. version-skew + empty-
  container edge cases), config_merge install/uninstall/soft-skip integration,
  embedded-manifest parse, `ConfigMerge` source-path/`{home}` substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)