### PR TITLE
fix(core): fire macOS notifications + click-to-focus via terminal-notifier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,7 +508,7 @@ thurbox-cli session list --parent <lead-uuid> --json | jq  # direct children onl
 ```
 
 Subcommands: `session` (create/list/get/delete/restore/restart/
-send/capture), `automation` (alias `auto`:
+send/capture/focus/signal), `automation` (alias `auto`:
 create/list/show/edit/remove/run/runs/tick), `task` (alias `todo`:
 create/list/show/edit/remove/run), `message` (alias `msg`:
 send/inbox/prune — the inter-session mailbox queue; see below), `editor`, `config`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,10 +73,14 @@ chrono-tz = "0.10"
 cron = "0.16"
 serde_ignored = "0.1.14"
 
-# OS notifications (Linux/macOS). On Linux: dbus with action callbacks
-# (click-to-focus works). On macOS: passive banner only — clicking does
-# nothing (the action API requires a signed app bundle). The notifications
-# module degrades gracefully on either platform if dispatch fails.
+# OS notifications. Linux-only: dbus with action callbacks (click-to-focus
+# works). macOS dispatches via `terminal-notifier` if installed, else the
+# system `osascript` binary — both inside `src/notifications.rs`, neither
+# needs notify-rust. notify-rust's macOS backend (`mac-notification-sys`)
+# rides the deprecated `NSUserNotificationCenter` API and is non-functional
+# for unbundled CLIs on macOS 12+, so it isn't pulled in there. Windows
+# (WSL toast) shells out to `powershell.exe`, also no notify-rust.
+[target.'cfg(target_os = "linux")'.dependencies]
 notify-rust = "4"
 
 [[bin]]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -304,7 +304,7 @@ is what sees the bell, and it doesn't run when thurbox isn't.
 |---------|------|----------------|
 | `dbus` | normal Linux desktop with a running notification daemon (`org.freedesktop.Notifications`) | **yes** — clicking the banner writes a focus request the running TUI reads next tick and switches to that session |
 | `windows` (toast) | **native Windows**, or **WSL** / any Linux with no dbus daemon — delivers a Windows toast via `powershell.exe` (WSL needs interop, on by default) | no (a Windows toast can't call back into the thurbox process) |
-| `macos` | macOS native banner — informational only (the modern `UNUserNotificationCenter` click API needs a signed app bundle, which thurbox is not) | no |
+| `macos` | macOS native banner. Uses **`terminal-notifier`** when it's in `PATH` (own bundle + icon, looks like a real app notification — `brew install terminal-notifier`), otherwise the built-in **`osascript`** `display notification` (attributed to Apple's Script Editor). The `UNUserNotificationCenter` click API needs a signed `.app` bundle, which thurbox is not, so the `osascript` path is informational | **with `terminal-notifier`** — clicking the banner runs `thurbox-cli session focus <id>`, which writes the same metadata row the dbus path does and the TUI picks it up next tick. Without `terminal-notifier` (osascript fallback): no |
 
 `auto` prefers `dbus` whenever a daemon answers, and only falls back to
 the Windows toast when no dbus service is reachable. Force a specific

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -302,6 +302,27 @@ mod tests {
     }
 
     #[test]
+    fn parse_session_focus_takes_uuid() {
+        let cli = Cli::try_parse_from([
+            "thurbox-cli",
+            "session",
+            "focus",
+            "0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a",
+        ])
+        .unwrap();
+        let Command::Session {
+            action: sessions::Action::Focus { uuid },
+        } = cli.command
+        else {
+            panic!("expected Session::Focus");
+        };
+        assert_eq!(uuid, "0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a");
+
+        // No UUID arg fails.
+        assert!(Cli::try_parse_from(["thurbox-cli", "session", "focus"]).is_err());
+    }
+
+    #[test]
     fn parse_session_signal_accepts_state_and_rejects_garbage() {
         let cli = Cli::try_parse_from(["thurbox-cli", "session", "signal", "--state", "blocked"])
             .unwrap();

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -99,6 +99,19 @@ pub enum Action {
         #[arg(long, default_value_t = 200)]
         lines: u32,
     },
+    /// Mark a session as the pending focus target for the running TUI.
+    ///
+    /// Writes the session id into the SQLite `metadata` row the TUI polls;
+    /// the next external-state tick reads + clears it and switches the
+    /// active terminal. Used by the macOS click-to-focus path
+    /// (`terminal-notifier -execute` shells back into this), and works as
+    /// a generic "switch the TUI to <session>" hook from any external
+    /// trigger. A no-op when the TUI isn't running (the request just
+    /// sits in the DB until either it is or the row is overwritten).
+    Focus {
+        /// Session UUID.
+        uuid: String,
+    },
     /// Report an agent lifecycle transition (called from an agent hook).
     ///
     /// Records the session's state so the TUI can render it (working/blocked/
@@ -281,6 +294,19 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                     "output": output,
                 }),
                 human,
+            ))
+        }
+        Action::Focus { uuid } => {
+            let session = resolve(db, &uuid)?;
+            db.set_pending_focus_session_id(session.id)
+                .map_err(|e| format!("set_pending_focus_session_id: {e}"))?;
+            Ok(CommandOutput::new(
+                json!({
+                    "focused": true,
+                    "session_id": session.id.to_string(),
+                    "session_name": session.name,
+                }),
+                format!("Focus requested for '{}'.", session.name),
             ))
         }
         Action::Signal { state, session } => {

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -105,7 +105,7 @@ pub enum Action {
     /// the next external-state tick reads + clears it and switches the
     /// active terminal. Used by the macOS click-to-focus path
     /// (`terminal-notifier -execute` shells back into this), and works as
-    /// a generic "switch the TUI to <session>" hook from any external
+    /// a generic "switch the TUI to `<session>`" hook from any external
     /// trigger. A no-op when the TUI isn't running (the request just
     /// sits in the DB until either it is or the row is overwritten).
     Focus {

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -13,9 +13,15 @@
 //!   appear in the Windows Action Center. Click-to-focus is *not* supported on
 //!   this path (a Windows toast can't call back into the WSL process), so the
 //!   banner is informational — the user alt-tabs back themselves.
-//! - **macOS** native banner (informational; the modern
-//!   `UNUserNotificationCenter` click API needs a signed app bundle, which
-//!   thurbox is not).
+//! - **macOS** native banner via `terminal-notifier` if installed (own
+//!   bundle + icon, looks like a real app), falling back to `osascript`'s
+//!   `display notification` (always available, attributed to Apple's
+//!   Script Editor). Both paths are informational; the
+//!   `UNUserNotificationCenter` click API needs a signed app bundle,
+//!   which thurbox is not. `notify-rust`'s macOS backend
+//!   (`mac-notification-sys`) is intentionally not used: it rides the
+//!   deprecated `NSUserNotificationCenter` API, which silently no-ops on
+//!   macOS 12+ for unbundled CLIs.
 //!
 //! A previous silent-failure bug motivated this: under WSL the dbus path errors
 //! on connect, but the only signal was a `warn!` to the logfile — the user saw
@@ -77,9 +83,18 @@ impl DeliveryBackend {
     }
 
     /// Whether clicking the notification focuses the session in the TUI.
-    /// Only the dbus path wires this up.
+    /// Linux dbus wires this up natively (action callback); macOS does too
+    /// when `terminal-notifier` is in PATH (its `-execute` flag shells back
+    /// into `thurbox-cli session focus <id>`). The `osascript` fallback
+    /// can't, so on macOS this flips to false when only the fallback path
+    /// is available.
     pub fn supports_click_to_focus(self) -> bool {
-        matches!(self, DeliveryBackend::Dbus)
+        match self {
+            DeliveryBackend::Dbus => true,
+            #[cfg(target_os = "macos")]
+            DeliveryBackend::Macos => terminal_notifier_available(),
+            _ => false,
+        }
     }
 }
 
@@ -245,17 +260,151 @@ fn dispatch_dbus(n: &Notification) -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(target_os = "macos")]
 fn dispatch_macos(n: &Notification) -> Result<(), Box<dyn std::error::Error>> {
-    use notify_rust::Notification as NotifRust;
-
-    // macOS path: no action callbacks (UNUserNotificationCenter requires a
-    // signed app bundle). The notification is informational; the user
-    // navigates back to thurbox manually.
-    let mut notif = NotifRust::new();
-    notif.summary(&n.title).body(&n.body).appname("thurbox");
-    if !n.sound {
-        notif.sound_name("");
+    // notify-rust's macOS backend (`mac-notification-sys`) uses the
+    // deprecated `NSUserNotificationCenter` API, which silently no-ops on
+    // macOS 12+ for unbundled CLIs — the cause of "thurbox notifications
+    // don't fire on Mac". Two viable replacements that need no `.app`
+    // bundle / no code signing:
+    //
+    //   1. `terminal-notifier` — a small signed helper distributed via
+    //      Homebrew. Banner attribution + icon belong to the helper (a
+    //      bell-on-terminal mark), so it looks like a normal app
+    //      notification. Opt-in: the user must `brew install terminal-notifier`.
+    //   2. `osascript` (`display notification`) — built into every macOS
+    //      release, so always available. Banner attribution is "Script
+    //      Editor" (Apple's Script Editor agent owns the notification
+    //      permission `display notification` rides on).
+    //
+    // Try (1) and fall back to (2). The first attempt also acts as a
+    // failure escape hatch: if `terminal-notifier` is in PATH but broken
+    // we still land on the `osascript` path.
+    //
+    // No action callbacks on either path: those need `UNUserNotificationCenter`
+    // (a signed `.app`), which thurbox is not.
+    if terminal_notifier_available() {
+        match dispatch_macos_terminal_notifier(n) {
+            Ok(()) => return Ok(()),
+            Err(e) => debug!("terminal-notifier failed, falling back to osascript: {e}"),
+        }
     }
-    notif.show()?;
+    dispatch_macos_osascript(n)
+}
+
+/// Cached check for `terminal-notifier` in `PATH`. We probe once per
+/// process (it won't appear mid-session) and reuse the answer so every
+/// notification doesn't pay a spawn.
+#[cfg(target_os = "macos")]
+fn terminal_notifier_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| which_on_path("terminal-notifier"))
+}
+
+#[cfg(target_os = "macos")]
+fn dispatch_macos_terminal_notifier(n: &Notification) -> Result<(), Box<dyn std::error::Error>> {
+    use std::process::{Command, Stdio};
+
+    // `-group <id>` collapses repeat notifications for the same session
+    // into a single banner instead of stacking — the per-session dedup
+    // floor already bounds frequency, but if a long-running session fires
+    // across the floor we still want the latest one to replace the prior.
+    let mut cmd = Command::new("terminal-notifier");
+    cmd.arg("-title")
+        .arg(&n.title)
+        .arg("-message")
+        .arg(&n.body)
+        .arg("-group")
+        .arg(format!("thurbox-{}", n.session_id));
+    if n.sound {
+        cmd.arg("-sound").arg("default");
+    }
+    // Click-to-focus: `terminal-notifier -execute "<cmd>"` runs the command
+    // via `/bin/sh -c` when the user clicks the banner. We point it at
+    // `thurbox-cli session focus <id>`, which writes the same
+    // `pending_focus_session_id` metadata row the Linux dbus path writes;
+    // the TUI's external-state poll then switches active_index. We resolve
+    // an *absolute* `thurbox-cli` path from the running binary's directory
+    // — the click handler runs under launchd's environment, which has a
+    // very sparse PATH, so a bare `thurbox-cli` would often not resolve.
+    // If we can't locate the CLI binary the click is simply non-interactive
+    // (the banner still shows).
+    if let Some(focus_cmd) = thurbox_cli_focus_command(n.session_id) {
+        cmd.arg("-execute").arg(focus_cmd);
+    }
+    let status = cmd.stdout(Stdio::null()).stderr(Stdio::null()).status()?;
+    if !status.success() {
+        return Err(format!("terminal-notifier exited with {status}").into());
+    }
+    Ok(())
+}
+
+/// Build the shell command `terminal-notifier -execute` should run on click:
+/// `<thurbox-cli> session focus <session-id>`, with the thurbox-cli path
+/// quoted for `/bin/sh`. Returns `None` if we can't find a sibling
+/// `thurbox-cli` binary next to the running executable — the path probe
+/// is cached, the resolution is not, because `current_exe()` is cheap.
+#[cfg(target_os = "macos")]
+fn thurbox_cli_focus_command(session_id: SessionId) -> Option<String> {
+    let exe = std::env::current_exe().ok()?;
+    let parent = exe.parent()?;
+    let cli = parent.join("thurbox-cli");
+    if !cli.exists() {
+        return None;
+    }
+    // SessionId is a UUID (hex + dashes), shell-safe without quoting.
+    Some(format!(
+        "{} session focus {}",
+        sh_single_quote(&cli.to_string_lossy()),
+        session_id
+    ))
+}
+
+/// POSIX single-quote a string so it survives `/bin/sh -c "<cmd>"`. The
+/// terminal-notifier `-execute` argument is interpreted by `sh`, and a user
+/// `HOME` containing a space or apostrophe would otherwise break the
+/// command. The trick: close the quote, emit an escaped quote, re-open
+/// (`'\''`).
+#[cfg(target_os = "macos")]
+fn sh_single_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+#[cfg(target_os = "macos")]
+fn dispatch_macos_osascript(n: &Notification) -> Result<(), Box<dyn std::error::Error>> {
+    use std::process::Command;
+
+    // Arguments are passed via AppleScript's `argv` (rather than spliced
+    // into the script text) so the body/title can contain any characters —
+    // quotes, backslashes, newlines — with zero escaping.
+    let script = if n.sound {
+        "on run argv\n\
+         display notification (item 1 of argv) with title (item 2 of argv) \
+         sound name \"default\"\n\
+         end run"
+    } else {
+        "on run argv\n\
+         display notification (item 1 of argv) with title (item 2 of argv)\n\
+         end run"
+    };
+    let status = Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .arg("--")
+        .arg(&n.body)
+        .arg(&n.title)
+        .status()?;
+    if !status.success() {
+        return Err(format!("osascript exited with {status}").into());
+    }
     Ok(())
 }
 

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -4,7 +4,7 @@ use rusqlite::{params, OptionalExtension};
 
 use super::Database;
 
-use crate::session::PENDING_FOCUS_SESSION_ID_KEY;
+use crate::session::{SessionId, PENDING_FOCUS_SESSION_ID_KEY};
 
 const EDITOR_COMMAND_KEY: &str = "editor_command";
 const THEME_KEY: &str = "active_theme";
@@ -175,6 +175,21 @@ impl Database {
             )
             .optional()
     }
+
+    /// Record a "focus this session" request for the running TUI to consume.
+    /// Used by the macOS click-to-focus CLI (`thurbox-cli session focus`) —
+    /// the symmetric writer to [`Self::take_pending_focus_session_id`].
+    /// Linux dispatches in-process from the dbus action callback and writes
+    /// the metadata row directly; the CLI path needs this helper because it
+    /// runs in a separate process spawned by `terminal-notifier -execute`.
+    pub fn set_pending_focus_session_id(&self, session_id: SessionId) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![PENDING_FOCUS_SESSION_ID_KEY, session_id.to_string()],
+        )?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -261,6 +276,25 @@ mod tests {
         assert_eq!(
             db.take_pending_focus_session_id().unwrap().as_deref(),
             Some("deadbeef-0000-0000-0000-000000000000")
+        );
+        assert_eq!(db.take_pending_focus_session_id().unwrap(), None);
+    }
+
+    #[test]
+    fn set_pending_focus_session_id_is_idempotent_and_overwrites() {
+        let db = Database::open_in_memory().unwrap();
+        let first = SessionId::default();
+        let second = SessionId::default();
+        // Two distinct ids (UUIDs are unique).
+        assert_ne!(first, second);
+
+        db.set_pending_focus_session_id(first).unwrap();
+        // A second set overwrites — the latest click wins, no stacking.
+        db.set_pending_focus_session_id(second).unwrap();
+
+        assert_eq!(
+            db.take_pending_focus_session_id().unwrap().as_deref(),
+            Some(second.to_string().as_str())
         );
         assert_eq!(db.take_pending_focus_session_id().unwrap(), None);
     }


### PR DESCRIPTION
## Summary

- macOS notifications never appeared: `notify-rust`'s backend (`mac-notification-sys` → `NSUserNotificationCenter`) is deprecated and silently no-ops on macOS 12+ for unbundled CLIs. Dispatch instead via `terminal-notifier` when it's in `PATH` (own bundle + icon, native-looking) and `osascript`'s `display notification` otherwise (always available, attributed to Apple's Script Editor).
- Click-to-focus on macOS now mirrors the Linux dbus path: `terminal-notifier -execute` shells back into a new `thurbox-cli session focus <id>` subcommand, which writes the same `pending_focus_session_id` metadata row the TUI already polls and atomically clears.
- `notify-rust` becomes a Linux-only target dependency — the dead ObjC bridge no longer compiles on macOS.

## What changed

- `src/notifications.rs` — split `dispatch_macos` into `dispatch_macos_terminal_notifier` / `dispatch_macos_osascript` with a cached `terminal_notifier_available()` probe and runtime fallback. Wire `-execute` to a sibling-resolved absolute `thurbox-cli` path (launchd's environment has no PATH to trust); single-quoted for `/bin/sh`. `supports_click_to_focus()` now flips to `true` on macOS when terminal-notifier is in PATH.
- `src/storage/settings.rs` — new `Database::set_pending_focus_session_id(SessionId)`, symmetric writer to the existing `take_…`.
- `src/cli/sessions.rs` + `src/cli/mod.rs` — new `Action::Focus { uuid }` + parse test. Resolves the session and writes the metadata row via the storage helper.
- `Cargo.toml` — `notify-rust` moved to `[target.'cfg(target_os = "linux")'.dependencies]`.
- Docs: `docs/CONFIG.md` and `CLAUDE.md` updated for the new macOS path and the `session focus` subcommand.

The TUI's `apply_pending_focus_request` polling was already platform-neutral — no TUI change needed.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo nextest run` — 518 in the focused suite pass (`set_pending_focus_session_id_is_idempotent_and_overwrites`, `parse_session_focus_takes_uuid`, all existing notification + architecture tests).
- [x] `cargo deny check bans licenses sources` clean.
- [x] Live: `thurbox-cli notify` reports `click-to-focus: no` when terminal-notifier is missing, and the osascript path was confirmed to fire a banner on Darwin 25.5.
- [ ] Manual: after `brew install terminal-notifier`, `thurbox-cli notify` should flip to `click-to-focus: yes`, and clicking a real session's banner should switch the TUI to that session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)