### PR TITLE
fix: make forge proposals.sh error path reachable and harden apply guard

### DIFF
--- a/extensions/forge/scripts/proposals.sh
+++ b/extensions/forge/scripts/proposals.sh
@@ -27,6 +27,51 @@ RENDER="$HOME_DIR/proposals.md"
 
 src() { [ -f "$STORE" ] && printf '%s' "$STORE" || printf '/dev/null'; }
 
+# is_single_thurbox_cli COMMAND
+# True iff COMMAND is exactly one `thurbox-cli` invocation: its first word is
+# `thurbox-cli` AND it contains no shell command-chaining (`;`, `&`, `|`,
+# newline) or command/process substitution (`$(...)`, backticks, `<(...)`,
+# `>(...)`) *outside* of quotes. A prefix match alone is not enough — `sh -c`
+# would happily run a second, arbitrary command chained after a `thurbox-cli `
+# prefix. The scan is quote-aware so a legitimately quoted argument (e.g.
+# `--prompt "do a; then b"`) is still allowed; only operators that would let
+# `sh` execute *another* program are rejected.
+is_single_thurbox_cli() {
+  local s=$1 n i ch nxt state=none bs=$'\\'
+  [ "${s%%[[:space:]]*}" = "thurbox-cli" ] || return 1
+  n=${#s}
+  for (( i = 0; i < n; i++ )); do
+    ch=${s:i:1}
+    nxt=${s:i+1:1}
+    case "$state" in
+      single)
+        [ "$ch" = "'" ] && state=none
+        ;;
+      double)
+        if [ "$ch" = '"' ]; then state=none
+        elif [ "$ch" = "$bs" ]; then i=$(( i + 1 ))    # escaped char, skip
+        elif [ "$ch" = '`' ]; then return 1            # backtick subst (active in "")
+        elif [ "$ch" = '$' ] && [ "$nxt" = '(' ]; then return 1
+        fi
+        ;;
+      *)  # outside quotes
+        case "$ch" in
+          "'") state=single ;;
+          '"') state=double ;;
+          "$bs") i=$(( i + 1 )) ;;                       # escaped char, skip
+          ';'|'&'|'|') return 1 ;;                      # chaining
+          '`') return 1 ;;                              # command substitution
+          '$') [ "$nxt" = '(' ] && return 1 ;;          # $(...) substitution
+          '<'|'>') [ "$nxt" = '(' ] && return 1 ;;      # <(...)/>(...) process subst
+          *) [ "$ch" = $'\n' ] && return 1 ;;           # newline separates commands
+        esac
+        ;;
+    esac
+  done
+  [ "$state" = none ] || return 1                        # unterminated quote → suspect
+  return 0
+}
+
 render() {
   {
     echo "# Forge proposals"
@@ -104,12 +149,14 @@ case "$cmd" in
     REC="$(jq -c --arg s "$SLUG" 'select(.slug==$s)' "$STORE" | head -1)"
     [ -n "$REC" ] || { echo "no such proposal: $SLUG" >&2; exit 1; }
     CMD="$(printf '%s' "$REC" | jq -r '.command')"
-    case "$CMD" in
-      "thurbox-cli "*) : ;;
-      *) echo "refusing to run command that is not 'thurbox-cli ...': $CMD" >&2; exit 3 ;;
-    esac
+    if ! is_single_thurbox_cli "$CMD"; then
+      echo "refusing to run command that is not a single 'thurbox-cli ...' invocation: $CMD" >&2
+      exit 3
+    fi
     echo "+ $CMD"
-    OUT="$(sh -c "$CMD")"; rc=$?
+    # `if` exempts the assignment from `set -e`, so a failing command does not
+    # abort the script before we capture its status and run the graceful path.
+    if OUT="$(sh -c "$CMD")"; then rc=0; else rc=$?; fi
     printf '%s\n' "$OUT"
     [ "$rc" -eq 0 ] || { echo "command failed (rc=$rc); leaving proposal open" >&2; exit "$rc"; }
     jq -c --arg s "$SLUG" 'if .slug==$s then .status="applied" else . end' "$STORE" > "$STORE.tmp"


### PR DESCRIPTION
## What

Fixes two defects in `extensions/forge/scripts/proposals.sh` (task #14).

### 1. `set -e` made the error-handling path dead code
Under `set -euo pipefail`, the line `OUT="$(sh -c "$CMD")"; rc=$?` aborts the
whole script at the *assignment* whenever the applied command fails — so
`rc=$?` and the graceful `command failed (rc=…); leaving proposal open` branch
never ran. Capturing the status inside an `if` (which is exempt from errexit)
makes the failure reportable and keeps the proposal `open`:

```sh
if OUT="$(sh -c "$CMD")"; then rc=0; else rc=$?; fi
```

### 2. The `apply` guard was a loose prefix match
`case "$CMD" in "thurbox-cli "*)` only checks the prefix, so a chained or
substituted command slips through (`thurbox-cli x; rm -rf …`, `thurbox-cli
$(…)`), defeating the documented promise that only a `thurbox-cli` command is
ever run. Replaced with a quote-aware scan, `is_single_thurbox_cli`, that:

- requires the first word to be exactly `thurbox-cli`, and
- rejects shell chaining (`;` `&` `|` newline) and command/process substitution
  (`$(…)`, backticks, `<(…)`, `>(…)`) **outside** quotes,
- while still allowing those characters **inside** quoted arguments (e.g.
  `--prompt "do a; then b"`), which forge proposals legitimately use.

## Testing

- `shellcheck` clean.
- Behavioral harness (15 cases) covering allow/block/error-path, including
  quoted metacharacters, escaped `$`, `$(...)`/backtick/`<()` substitution,
  newline chaining, the `thurbox-clinasty` prefix trick, and the graceful
  error path leaving the proposal `open` with the command's exit code preserved.

Scoped strictly to the one file named in the task.