### PR TITLE
fix(core): reference $THURBOX_TASK in shepherd/renovate worker prompts

### DIFF
--- a/extensions/ci-shepherd/scripts/dispatch-fix.sh
+++ b/extensions/ci-shepherd/scripts/dispatch-fix.sh
@@ -162,7 +162,7 @@ If you are blocked (a decision only the user can make, missing credentials, an
 ambiguous review request), do NOT guess — stop and report it in the result
 \`question\` field.
 
-When finished: mark this task done (thurbox-cli task edit <id> --status done),
+When finished: mark this task done (thurbox-cli task edit \$THURBOX_TASK --status done),
 print a final line \`===RESULT===\` followed by one line of JSON:
 {"status":"ok|error","url":"...","notes":"...","question":"..."}
 then notify the shepherd so the next request dispatches immediately:

--- a/extensions/renovate/scripts/dispatch-update.sh
+++ b/extensions/renovate/scripts/dispatch-update.sh
@@ -77,7 +77,7 @@ If you are blocked (a major upgrade that needs a human decision, test failures
 you can't resolve), do NOT guess — stop and report it in the result
 \`question\` field.
 
-When finished: mark this task done (thurbox-cli task edit <id> --status done),
+When finished: mark this task done (thurbox-cli task edit \$THURBOX_TASK --status done),
 print a final line \`===RESULT===\` followed by one line of JSON:
 {"status":"ok|error","artifact":"...","notes":"...","pr_url":"..."}
 then notify the renovate monitor so the next repo dispatches immediately:


### PR DESCRIPTION
## Summary

Automated PR from publish skill.

## Test plan

- CI checks pass