### PR TITLE
fix(core): preserve env, backend, and workspace across session lifecycle ops

### DIFF
--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -677,6 +677,14 @@ impl Session {
         self.backend.name()
     }
 
+    /// The session's current environment — the env it was last (re)spawned
+    /// with. Used by acceptance tests to assert the identity env (`THURBOX_*`)
+    /// is preserved across a restart.
+    #[cfg(test)]
+    pub(crate) fn env(&self) -> &HashMap<String, String> {
+        &self.env
+    }
+
     /// Return the PID of the process running in this session's backend pane.
     pub fn pane_pid(&self) -> Result<Option<u32>> {
         self.backend.pane_pid(&self.backend_id)

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -833,6 +833,34 @@ async fn ctrl_r_restarts_session_on_spawnable_backend() {
 }
 
 #[tokio::test]
+async fn ctrl_r_restart_preserves_thurbox_identity_env() {
+    // `Session::restart` replaces the session env wholesale, so the restart path
+    // must re-inject the `THURBOX_*` identity vars — otherwise the restarted
+    // agent loses its identity and the metrics/status hooks break.
+    let mut h = Harness::spawnable(1);
+    let session_id = h.app.sessions[0].info.id;
+    let agent_session_id = h.app.sessions[0]
+        .info
+        .agent_session_id
+        .clone()
+        .expect("spawnable sessions have an agent_session_id");
+
+    h.ctrl('r'); // RestartSession
+
+    let env = h.app.sessions[0].env();
+    assert_eq!(
+        env.get("THURBOX_SESSION"),
+        Some(&session_id.to_string()),
+        "the thurbox session key survives the restart"
+    );
+    assert_eq!(
+        env.get("THURBOX_SESSION_ID"),
+        Some(&agent_session_id),
+        "the agent conversation id survives the restart"
+    );
+}
+
+#[tokio::test]
 async fn ctrl_t_opens_shell_pane_on_spawnable_backend() {
     // Ctrl+T lazily spawns a shell pane via the backend and flips the session's
     // terminal view to the shell.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1246,18 +1246,27 @@ impl App {
         };
 
         let agent = session.info.agent.clone();
+        // Keep the same thurbox identity across a restart so injected env stays
+        // stable (`THURBOX_SESSION`).
+        let session_id = session.info.id;
         // Rebuild the process cwd: the primary repo for a single-repo session,
         // or the (idempotently rebuilt) symlink workspace for a multi-repo one.
         let cwd = session_process_cwd(&session.info);
 
         let mut config = SessionConfig {
             resume_session_id: None,
+            session_id: Some(session_id),
             agent_session_id: Some(agent_session_id.clone()),
             cwd,
             agent,
             fork_session_id: None,
             ..SessionConfig::default()
         };
+        // `Session::restart` replaces the session env wholesale, so re-inject the
+        // standard `THURBOX_*` identity vars (the same set a fresh spawn gets via
+        // `build_spawn_inputs`); otherwise the restarted agent loses its identity
+        // and the metrics/status hooks break.
+        crate::session_ops::inject_thurbox_env(&mut config, &agent_session_id, None);
         let def = self.agent_def_for(&config.agent);
         config.resume_session_id =
             crate::session_ops::resume_trigger_for(&def, &agent_session_id, &config.env);
@@ -1636,6 +1645,18 @@ impl App {
             .map(|wt| wt.worktree_path.clone())
             .or(deleted.cwd.clone());
 
+        // Re-spawn on the session's *persisted* backend, not the local default:
+        // a remote (`ssh:<host>`) session must land on its own host, or its
+        // `backend_type` is corrupted (and a remote pane-id could collide with a
+        // local one). Skip restore when this instance can't manage that backend.
+        let Some(backend) = self.resolve_persisted_backend(&deleted.backend_type) else {
+            self.set_error(format!(
+                "Cannot restore '{}': backend '{}' is not available on this instance",
+                deleted.name, deleted.backend_type
+            ));
+            return;
+        };
+
         // Reuse the existing SessionId + inject identity/dir env so the restored
         // session's status hooks can attribute their `session signal` (otherwise
         // it renders Idle forever).
@@ -1646,6 +1667,11 @@ impl App {
             cwd,
         );
         config.resume_session_id = deleted.agent_session_id;
+        // Preserve the persisted backend so a restored remote (`ssh:<host>`)
+        // session keeps its backend name on the config; local sessions stay `None`.
+        if crate::session::is_ssh_backend(&deleted.backend_type) {
+            config.backend = Some(deleted.backend_type.clone());
+        }
 
         let session_name = deleted.name.clone();
         let (rows, cols) = self.content_area_size();
@@ -1656,7 +1682,7 @@ impl App {
             rows,
             cols,
             &config,
-            self.backends.default_backend(),
+            &backend,
             &provider,
         ) {
             Ok(mut session) => {
@@ -3687,16 +3713,34 @@ impl App {
 
     /// Poll for completed worktree sync results and handle them.
     fn poll_sync_results(&mut self) {
-        if let Some(rx) = &self.worktree_sync.rx {
-            while let Ok((session_id, result)) = rx.try_recv() {
-                self.worktree_sync.completed.push((session_id, result));
-            }
+        let Some(rx) = &self.worktree_sync.rx else {
+            return;
+        };
 
-            if self.worktree_sync.completed.len() >= self.worktree_sync.pending {
-                self.worktree_sync.in_progress = false;
-                self.worktree_sync.rx = None;
-                self.finish_sync();
+        // Drain everything currently buffered. A worker thread that *panics*
+        // drops its sender without sending every result, so `completed` may
+        // never reach `pending`; detecting the channel disconnecting (all
+        // senders gone) lets us finalize with whatever arrived instead of
+        // leaving `in_progress` stuck forever.
+        let mut disconnected = false;
+        loop {
+            match rx.try_recv() {
+                Ok((session_id, result)) => {
+                    self.worktree_sync.completed.push((session_id, result));
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    disconnected = true;
+                    break;
+                }
             }
+        }
+
+        let all_received = self.worktree_sync.completed.len() >= self.worktree_sync.pending;
+        if all_received || disconnected {
+            self.worktree_sync.in_progress = false;
+            self.worktree_sync.rx = None;
+            self.finish_sync();
         }
     }
 
@@ -10612,6 +10656,30 @@ mod tests {
         assert!(app.auto_update_rx.is_none());
         app.poll_auto_update();
         assert!(app.status_message.is_none());
+    }
+
+    #[test]
+    fn poll_sync_results_finishes_when_a_worker_dies_without_sending_all() {
+        // A panicked worker drops its sender without sending every result, so
+        // `completed` can never reach `pending`. The channel disconnecting must
+        // still finalize, or `in_progress` would be stuck forever.
+        let mut app = App::new(24, 80, stub_backend(), stub_agents(), test_db());
+        let (tx, rx) = mpsc::channel();
+
+        tx.send((SessionId::default(), git::SyncResult::Synced))
+            .unwrap();
+        // Simulate the other worker panicking: its sender is gone, and so is
+        // ours — the channel is now fully disconnected with 1 of 2 results.
+        drop(tx);
+
+        app.worktree_sync.in_progress = true;
+        app.worktree_sync.rx = Some(rx);
+        app.worktree_sync.pending = 2;
+
+        app.poll_sync_results();
+
+        assert!(!app.worktree_sync.in_progress);
+        assert!(app.worktree_sync.rx.is_none());
     }
 
     #[test]

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -127,6 +127,10 @@ fn build_agent_invocation(config: &SessionConfig) -> (String, Vec<String>) {
 ///
 /// Kept in sync with `App::build_spawn_inputs` so headless and TUI sessions look
 /// identical to the spawned process (modulo `THURBOX_TASK` as noted above).
+///
+/// Shared by the headless spawn/restart paths and the TUI `Ctrl+R` restart
+/// (`App::restart_active_session`), so a restarted session keeps the same
+/// identity env a fresh spawn would have had.
 pub(crate) fn inject_thurbox_env(
     config: &mut SessionConfig,
     agent_session_id: &str,

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -2,8 +2,74 @@
 //! the agent CLI, resuming the existing conversation when the agent supports
 //! it and a transcript exists, starting fresh otherwise.
 
+use std::collections::HashMap;
+use std::path::PathBuf;
+
 use crate::session::{SessionConfig, SessionId};
 use crate::storage::Database;
+use crate::sync::SharedSession;
+
+/// The resolved inputs for re-spawning a session's tmux window: the agent
+/// command + args, the process cwd, and the identity env. Extracted from the
+/// side-effecting [`restart_session_headless`] so the resolution logic (env
+/// injection, resume trigger, multi-repo workspace cwd) is unit-testable
+/// without driving tmux.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RestartPlan {
+    window_name: String,
+    command: String,
+    args: Vec<String>,
+    cwd: Option<PathBuf>,
+    env: HashMap<String, String>,
+}
+
+/// Build the [`RestartPlan`] for a persisted session: keep its identity stable,
+/// inject the standard `THURBOX_*` env, decide the resume trigger from the
+/// agent definition, and resolve the process cwd (the symlink workspace for a
+/// multi-repo session, else the primary repo — mirroring the TUI's
+/// `App::resolve_process_cwd`).
+fn build_restart_plan(session: &SharedSession) -> Result<RestartPlan, String> {
+    let agent_session_id = session.agent_session_id.clone().ok_or_else(|| {
+        format!(
+            "Cannot restart session {} without agent_session_id",
+            session.id
+        )
+    })?;
+
+    let mut config = SessionConfig {
+        // Keep the same identity across a restart so `THURBOX_SESSION` is stable.
+        session_id: Some(session.id),
+        agent_session_id: Some(agent_session_id.clone()),
+        cwd: session.cwd.clone(),
+        agent: session.agent.clone(),
+        ..SessionConfig::default()
+    };
+    super::inject_thurbox_env(&mut config, &agent_session_id, None);
+    let def = super::resolve_agent_def(&config.agent);
+    config.resume_session_id = super::resume_trigger_for(&def, &agent_session_id, &config.env);
+
+    // A multi-repo session (≥2 members) launches in its per-session symlink
+    // workspace, gathering every member dir; a single-repo session keeps the
+    // primary repo. Only resolve when there is a primary cwd to anchor on.
+    if let Some(primary) = session.cwd.clone() {
+        config.cwd = Some(super::spawn::resolve_launch_cwd(
+            &agent_session_id,
+            &primary,
+            &session.worktrees,
+            &session.additional_dirs,
+        ));
+    }
+
+    let (command, args) = super::build_agent_invocation(&config);
+
+    Ok(RestartPlan {
+        window_name: session.name.clone(),
+        command,
+        args,
+        cwd: config.cwd,
+        env: config.env,
+    })
+}
 
 /// Restart an existing session in-place — kills its tmux window and
 /// re-spawns the agent CLI.
@@ -19,33 +85,16 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
         .map_err(|e| format!("Failed to load session: {e}"))?
         .ok_or_else(|| format!("Session not found: {session_id}"))?;
 
-    let agent_session_id = session
-        .agent_session_id
-        .clone()
-        .ok_or_else(|| format!("Cannot restart session {session_id} without agent_session_id"))?;
+    let plan = build_restart_plan(&session)?;
 
-    let mut config = SessionConfig {
-        // Keep the same identity across a restart so `THURBOX_SESSION` is stable.
-        session_id: Some(session_id),
-        agent_session_id: Some(agent_session_id.clone()),
-        cwd: session.cwd.clone(),
-        agent: session.agent.clone(),
-        ..SessionConfig::default()
-    };
-    super::inject_thurbox_env(&mut config, &agent_session_id, None);
-    let def = super::resolve_agent_def(&config.agent);
-    config.resume_session_id = super::resume_trigger_for(&def, &agent_session_id, &config.env);
-
-    let (command, args) = super::build_agent_invocation(&config);
-
-    crate::agent::tmux::kill_window(&session.name)
+    crate::agent::tmux::kill_window(&plan.window_name)
         .map_err(|e| format!("Failed to kill tmux window: {e}"))?;
     crate::agent::tmux::spawn_window(
-        &session.name,
-        &command,
-        &args,
-        config.cwd.as_deref(),
-        &config.env,
+        &plan.window_name,
+        &plan.command,
+        &plan.args,
+        plan.cwd.as_deref(),
+        &plan.env,
     )
     .map_err(|e| format!("Failed to re-spawn tmux window: {e}"))?;
 
@@ -55,4 +104,80 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
     let _ = db.clear_hook_state(session_id);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(agent_session_id: Option<&str>, cwd: Option<PathBuf>) -> SharedSession {
+        SharedSession {
+            id: SessionId::default(),
+            name: "demo".into(),
+            agent: "claude".into(),
+            backend_id: String::new(),
+            backend_type: "local-tmux".into(),
+            agent_session_id: agent_session_id.map(String::from),
+            cwd,
+            additional_dirs: Vec::new(),
+            worktrees: Vec::new(),
+            shell_backend_id: None,
+            parent_session_id: None,
+            display_order: None,
+            tombstone: false,
+            tombstone_at: None,
+        }
+    }
+
+    #[test]
+    fn restart_plan_requires_agent_session_id() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let err = build_restart_plan(&session(None, None)).unwrap_err();
+        assert!(err.contains("agent_session_id"), "got: {err}");
+    }
+
+    #[test]
+    fn restart_plan_injects_identity_env() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let sess = session(Some("agent-conv-uuid"), Some(PathBuf::from("/tmp/repo")));
+        let plan = build_restart_plan(&sess).unwrap();
+
+        // The thurbox session key and the agent conversation id are both present
+        // and distinct, exactly as a fresh spawn would inject them.
+        assert_eq!(plan.env.get("THURBOX_SESSION"), Some(&sess.id.to_string()));
+        assert_eq!(
+            plan.env.get("THURBOX_SESSION_ID"),
+            Some(&"agent-conv-uuid".to_string())
+        );
+    }
+
+    #[test]
+    fn restart_plan_single_repo_launches_in_primary() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let primary = temp.path().join("primary");
+        std::fs::create_dir_all(&primary).unwrap();
+        let plan = build_restart_plan(&session(Some("sid"), Some(primary.clone()))).unwrap();
+        assert_eq!(plan.cwd, Some(primary));
+    }
+
+    #[test]
+    fn restart_plan_multi_repo_launches_in_workspace() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let primary = temp.path().join("primary");
+        std::fs::create_dir_all(&primary).unwrap();
+        let extra = temp.path().join("extra");
+        std::fs::create_dir_all(&extra).unwrap();
+
+        let mut sess = session(Some("sid-multi"), Some(primary.clone()));
+        sess.additional_dirs = vec![extra];
+
+        let plan = build_restart_plan(&sess).unwrap();
+        // ≥2 members → the symlink workspace, not the primary repo itself.
+        assert_ne!(plan.cwd.as_deref(), Some(primary.as_path()));
+        assert!(plan.cwd.is_some());
+    }
 }

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -300,7 +300,10 @@ fn create_worktree(
 /// Mirrors the TUI's `App::resolve_process_cwd`: members are the worktree repos
 /// (labeled by their original repo name) followed by the non-worktree
 /// additional dirs; a workspace build failure falls back to the primary cwd.
-fn resolve_launch_cwd(
+///
+/// Shared with [`super::restart`] so the headless restart launches a multi-repo
+/// session in its symlink workspace, not the primary repo.
+pub(crate) fn resolve_launch_cwd(
     agent_session_id: &str,
     primary_cwd: &std::path::Path,
     worktrees: &[SharedWorktree],

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -31,6 +31,9 @@ pub struct DeletedSessionInfo {
     pub agent_session_id: Option<String>,
     pub cwd: Option<PathBuf>,
     pub parent_session_id: Option<SessionId>,
+    /// Persisted backend (`local-tmux` or `ssh:<host>`). Preserved on restore so
+    /// a remote session re-spawns against its own host, not the local default.
+    pub backend_type: String,
     pub deleted_at: u64,
     pub worktrees: Vec<SharedWorktree>,
 }
@@ -308,7 +311,7 @@ impl Database {
     ) -> rusqlite::Result<Vec<DeletedSessionInfo>> {
         let sql = format!(
             "SELECT s.id, s.name, s.agent, s.agent_session_id, \
-             s.cwd, s.parent_session_id, s.deleted_at, \
+             s.cwd, s.parent_session_id, s.deleted_at, s.backend_type, \
              w.repo_path, w.worktree_path, w.branch \
              FROM sessions s \
              LEFT JOIN worktrees w ON s.id = w.session_id \
@@ -322,9 +325,10 @@ impl Database {
             let cwd: Option<String> = row.get(4)?;
             let parent_str: Option<String> = row.get(5)?;
             let deleted_at: i64 = row.get(6)?;
-            let wt_repo: Option<String> = row.get(7)?;
-            let wt_path: Option<String> = row.get(8)?;
-            let wt_branch: Option<String> = row.get(9)?;
+            let backend_type: String = row.get(7)?;
+            let wt_repo: Option<String> = row.get(8)?;
+            let wt_path: Option<String> = row.get(9)?;
+            let wt_branch: Option<String> = row.get(10)?;
 
             let worktree = worktree_from_cols(wt_repo, wt_path, wt_branch);
 
@@ -336,6 +340,7 @@ impl Database {
                     agent_session_id: row.get(3)?,
                     cwd: cwd.map(PathBuf::from),
                     parent_session_id: parent_str.and_then(|s| s.parse().ok()),
+                    backend_type,
                     deleted_at: deleted_at as u64,
                     worktrees: Vec::new(),
                 },
@@ -866,6 +871,21 @@ mod tests {
         assert_eq!(deleted.len(), 1);
         assert_eq!(deleted[0].id, s1_id);
         assert_eq!(deleted[0].name, "S1");
+    }
+
+    #[test]
+    fn deleted_session_preserves_backend_type() {
+        // A remote session must restore against its own host, so the persisted
+        // `backend_type` has to survive soft-delete + listing.
+        let db = Database::open_in_memory().unwrap();
+        let mut s = make_session("remote");
+        s.backend_type = "ssh:devbox".to_string();
+        let sid = s.id;
+        db.upsert_session(&s).unwrap();
+        db.soft_delete_session(sid).unwrap();
+
+        let deleted = db.get_deleted_session_by_id(sid).unwrap().unwrap();
+        assert_eq!(deleted.backend_type, "ssh:devbox");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Session restart and restore previously dropped persisted state, breaking restarted/restored sessions. This groups the session-lifecycle fixes:

- **TUI `Ctrl+R` restart** built a `SessionConfig` with an empty env and no `session_id`, so `Session::restart` (which replaces env wholesale) wiped the `THURBOX_*` identity vars and broke the agent's status/metrics hooks. Now injects identity env via the shared `session_ops::inject_thurbox_env` helper and pins `session_id`.
- **Headless restart** launched a multi-repo session in the primary repo instead of the symlink workspace. Now mirrors the TUI's `resolve_process_cwd` via the shared `resolve_launch_cwd`, and extracts a testable `build_restart_plan` (first headless-restart tests).
- **TUI `Ctrl+U` restore** always re-spawned on the local default backend, corrupting remote (`ssh:`) sessions. Now preserves the persisted `backend_type` (added to `DeletedSessionInfo`) and skips restore when the backend is unavailable on this instance.
- **Worktree sync** could stay `in_progress` forever if a sync worker thread panicked (its sender drops without sending all results). `poll_sync_results` now detects channel disconnection and finalizes.

## Tests

- New `build_restart_plan` tests (env injection, single- vs multi-repo workspace cwd).
- `deleted_session_preserves_backend_type` storage round-trip test.
- `poll_sync_results_finishes_when_a_worker_dies_without_sending_all` sync test.
- Extended the restart acceptance test to assert `THURBOX_*` identity env survives a restart.

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo nextest run --all` (1482 passed) all green locally.

Resolves Thurbox task #2.