### PR TITLE
fix(ui): restore previewed theme when theme picker is cancelled

### DIFF
--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -736,6 +736,43 @@ fn theme_picker_selection_applies_and_persists() {
 }
 
 #[test]
+fn theme_picker_cancel_restores_previewed_theme() {
+    // The picker live-previews by mutating the global palette as the selection
+    // moves; cancelling (`Esc`) must undo that preview, leaving the original
+    // theme active and unpersisted.
+    let mut h = Harness::standard(0);
+    let entries = crate::ui::theme::all_theme_entries();
+    let original_name = h.app.active_theme.name.clone();
+    let original_palette = crate::ui::theme::current();
+
+    h.ctrl('y'); // open the picker (opens on the active theme, index 0)
+    h.key(KeyCode::Char('j'), KeyModifiers::NONE); // preview the next palette
+    assert_eq!(
+        crate::ui::theme::current(),
+        entries[1].palette,
+        "navigating previews the highlighted palette globally"
+    );
+
+    h.key(KeyCode::Esc, KeyModifiers::NONE); // cancel
+
+    assert!(!h.app.modal.is_open(), "Esc closes the picker");
+    assert_eq!(
+        crate::ui::theme::current(),
+        original_palette,
+        "cancelling restores the palette active when the picker opened"
+    );
+    assert_eq!(
+        h.app.active_theme.name, original_name,
+        "the active theme is unchanged after cancel"
+    );
+    assert_eq!(
+        h.app.db.get_active_theme().ok().flatten(),
+        None,
+        "cancelling persists nothing to the database"
+    );
+}
+
+#[test]
 fn help_editor_capture_rebinds_the_selected_action() {
     // The help editor opens with the first rebindable action selected; capturing
     // a fresh chord must reassign exactly that action.

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1575,6 +1575,9 @@ impl App {
         };
         match code {
             KeyCode::Esc => {
+                // Cancel: undo the live preview by restoring the palette that
+                // was active when the picker opened (nothing is persisted).
+                crate::ui::theme::set_active(tp.original.clone());
                 self.modal.close();
             }
             KeyCode::Char('j') | KeyCode::Down if tp.index + 1 < entry_count => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1463,7 +1463,8 @@ impl App {
             .as_deref()
             .and_then(|name| entries.iter().position(|e| e.name == name))
             .unwrap_or(0);
-        self.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index });
+        let original = crate::ui::theme::current();
+        self.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index, original });
     }
 
     /// Open the Settings panel. The draft reflects the live source of truth:
@@ -7671,7 +7672,10 @@ mod tests {
     #[test]
     fn click_with_modal_open_is_swallowed() {
         let mut app = app_with_sessions(1);
-        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index: 0 });
+        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal {
+            index: 0,
+            original: crate::ui::theme::current(),
+        });
         // A scrollbar track and a pane target beneath the overlay must both
         // be unreachable while the modal is open.
         app.scrollbar_hits.push(ScrollbarHit {
@@ -7697,7 +7701,10 @@ mod tests {
     #[test]
     fn click_theme_picker_row_confirms_theme() {
         let mut app = app_with_sessions(1);
-        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index: 2 });
+        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal {
+            index: 2,
+            original: crate::ui::theme::current(),
+        });
         // As in a real frame: the pane targets beneath the overlay are
         // recorded first and overlap the modal — the modal row must still
         // win while a modal is open.
@@ -7827,7 +7834,10 @@ mod tests {
         // targets *and* the theme-picker rows; clicking a rendered row must
         // reach the modal, not the pane beneath it.
         let mut app = app_with_sessions(1);
-        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index: 1 });
+        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal {
+            index: 1,
+            original: crate::ui::theme::current(),
+        });
         let backend = ratatui::backend::TestBackend::new(120, 30);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal.draw(|f| app.view(f)).unwrap();
@@ -10327,7 +10337,10 @@ mod tests {
     #[test]
     fn paste_into_selector_only_modal_is_swallowed_not_sent_to_terminal() {
         let mut app = app_with_sessions(1);
-        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal::default());
+        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal {
+            index: 0,
+            original: crate::ui::theme::current(),
+        });
 
         // A theme picker has no text field, but the paste must still be
         // consumed so it can't leak into the terminal behind the overlay.

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -508,9 +508,13 @@ pub struct SessionNameModal {
     pub name: TextInput,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ThemePickerModal {
     pub index: usize,
+    /// Palette active when the picker opened. The picker live-previews by
+    /// mutating the global palette as the selection moves, so cancelling
+    /// (`Esc`) restores this snapshot; only confirming (`Enter`) persists.
+    pub original: crate::session::ThemePalette,
 }
 
 /// Confirmation prompt for a destructive (hard) session delete, shown only when


### PR DESCRIPTION
## Summary

The theme picker live-previews by mutating the global palette as the selection moves (`set_active` on each `j`/`k`), but it never captured the palette that was active when the picker opened. Cancelling with `Esc` only skipped DB persistence — it left the previewed theme **stuck active** until the next explicit change.

## Fix

- Capture the active palette into a new `ThemePickerModal.original` field in `open_theme_picker`.
- On `Esc`, restore that snapshot via `theme::set_active` before closing. `Enter` still confirms + persists.

## Test

Adds `theme_picker_cancel_restores_previewed_theme` (acceptance): opens the picker, navigates to preview the next palette (asserts the global palette changed), then cancels and asserts the original palette is restored, the active theme is unchanged, and nothing is persisted to the DB. Complements the existing DB-only `theme_picker_esc_closes_without_persisting`.

Scoped to the theme-picker path only. `cargo fmt`, `clippy -D warnings`, and the full `nextest` suite (1411 tests) pass locally.

Closes thurbox task #8.