### PR TITLE
test(core): add Pester tests for install.ps1 pure helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,29 @@ jobs:
       - name: Run install script tests
         run: bats scripts/install.bats
 
+  install-script-ps:
+    name: Install Script Tests (PowerShell)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # pwsh is preinstalled on GitHub-hosted runners. The install.ps1 helpers
+      # are platform-independent (the tests set PROCESSOR_ARCHITECTURE
+      # themselves), so they run on ubuntu rather than needing a windows runner.
+      - name: Run install.ps1 helper tests (Pester)
+        shell: pwsh
+        run: |
+          $mod = Get-Module -ListAvailable Pester |
+            Sort-Object Version -Descending | Select-Object -First 1
+          if (-not $mod -or $mod.Version.Major -lt 5) {
+            Install-Module Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          }
+          Import-Module Pester -MinimumVersion 5.0.0
+          $cfg = New-PesterConfiguration
+          $cfg.Run.Path = 'scripts/install.Tests.ps1'
+          $cfg.Run.Exit = $true
+          $cfg.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $cfg
+
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest
@@ -263,6 +286,7 @@ jobs:
       - conventional-commits
       - markdown-lint
       - install-script
+      - install-script-ps
       - shellcheck
       - website-lint
       - sonarqube

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,9 @@ ARM64 Windows installs the x86_64 build (runs under x64 emulation).
 - Pure helpers (`Get-Target`, `Get-ExpectedChecksum`) are guarded by
   `$env:THURBOX_PS_TEST` so the file can be dot-sourced for testing without
   running the installer
+- Tested by `scripts/install.Tests.ps1` (Pester 5; CI `install-script-ps` job,
+  run with `pwsh` on ubuntu since the helpers are platform-independent) —
+  the PowerShell mirror of `install.bats`
 
 ## Linting & Formatting
 

--- a/scripts/install.Tests.ps1
+++ b/scripts/install.Tests.ps1
@@ -1,0 +1,156 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Pester tests for scripts/install.ps1.
+
+.DESCRIPTION
+    Mirrors the coverage style of scripts/install.bats: structural assertions
+    (the helpers exist, the source is ASCII-only / BOM-free / parses) plus
+    behavioral tests for the two pure helpers exposed for testing -
+    Get-Target and Get-ExpectedChecksum.
+
+    install.ps1 guards the installer behind $env:THURBOX_PS_TEST, so dot-sourcing
+    it here defines every function without running Invoke-Install.
+
+.EXAMPLE
+    Invoke-Pester -Path scripts/install.Tests.ps1
+
+.NOTES
+    Requires Pester 5+. The helpers are platform-independent (Get-Target only
+    reads $env:PROCESSOR_ARCHITECTURE, which the tests set explicitly), so this
+    runs on any OS where PowerShell is available - not just native Windows.
+#>
+
+BeforeAll {
+    $script:ScriptPath = Join-Path $PSScriptRoot 'install.ps1'
+    $env:THURBOX_PS_TEST = '1'
+    # Dot-source so the helper functions land in this scope; the
+    # THURBOX_PS_TEST guard keeps Invoke-Install from firing.
+    . $script:ScriptPath
+}
+
+AfterAll {
+    Remove-Item Env:\THURBOX_PS_TEST -ErrorAction SilentlyContinue
+}
+
+Describe 'install.ps1 source' {
+    It 'exists' {
+        Test-Path $script:ScriptPath | Should -BeTrue
+    }
+
+    It 'has valid PowerShell syntax' {
+        $tokens = $null
+        $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile(
+            $script:ScriptPath, [ref]$tokens, [ref]$errors) | Out-Null
+        $errors | Should -BeNullOrEmpty
+    }
+
+    It 'is ASCII-only (survives irm | iex on Windows PowerShell 5.1)' {
+        $bytes = [System.IO.File]::ReadAllBytes($script:ScriptPath)
+        ($bytes | Where-Object { $_ -gt 127 } | Measure-Object).Count | Should -Be 0
+    }
+
+    It 'has no UTF-8 BOM' {
+        $bytes = [System.IO.File]::ReadAllBytes($script:ScriptPath)
+        ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) |
+            Should -BeFalse
+    }
+
+    It 'guards the installer behind $env:THURBOX_PS_TEST' {
+        (Get-Content $script:ScriptPath -Raw) | Should -Match 'THURBOX_PS_TEST'
+    }
+
+    It 'defines the <Name> function' -ForEach @(
+        @{ Name = 'Get-Target' }
+        @{ Name = 'Get-LatestVersion' }
+        @{ Name = 'Get-ExpectedChecksum' }
+        @{ Name = 'Add-ToUserPath' }
+        @{ Name = 'Invoke-Install' }
+        @{ Name = 'Show-Banner' }
+    ) {
+        Get-Command -Name $Name -CommandType Function -ErrorAction SilentlyContinue |
+            Should -Not -BeNullOrEmpty
+    }
+}
+
+Describe 'Get-Target' {
+    BeforeAll {
+        $script:SavedArch = $env:PROCESSOR_ARCHITECTURE
+    }
+
+    AfterAll {
+        $env:PROCESSOR_ARCHITECTURE = $script:SavedArch
+    }
+
+    It 'maps AMD64 to the x86_64 MSVC target' {
+        $env:PROCESSOR_ARCHITECTURE = 'AMD64'
+        Get-Target | Should -Be 'x86_64-pc-windows-msvc'
+    }
+
+    It 'maps ARM64 to the x86_64 build (runs under emulation)' {
+        $env:PROCESSOR_ARCHITECTURE = 'ARM64'
+        Get-Target | Should -Be 'x86_64-pc-windows-msvc'
+    }
+
+    It 'rejects 32-bit Windows' {
+        $env:PROCESSOR_ARCHITECTURE = 'x86'
+        { Get-Target } | Should -Throw '*32-bit*'
+    }
+
+    It 'rejects an unknown architecture' {
+        $env:PROCESSOR_ARCHITECTURE = 'SPARC'
+        { Get-Target } | Should -Throw '*Unsupported architecture*'
+    }
+}
+
+Describe 'Get-ExpectedChecksum' {
+    BeforeAll {
+        $script:Archive = 'thurbox-v1.2.3-x86_64-pc-windows-msvc.zip'
+        $script:Hash    = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    }
+
+    BeforeEach {
+        $script:Checksums = New-TemporaryFile
+    }
+
+    AfterEach {
+        Remove-Item $script:Checksums -ErrorAction SilentlyContinue
+    }
+
+    It 'returns the hash for the matching archive' {
+        Set-Content -Path $script:Checksums -Value "$script:Hash  $script:Archive"
+        Get-ExpectedChecksum -ChecksumFile $script:Checksums -ArchiveName $script:Archive |
+            Should -Be $script:Hash
+    }
+
+    It 'lowercases an uppercase hash' {
+        $upper = $script:Hash.ToUpper()
+        Set-Content -Path $script:Checksums -Value "$upper  $script:Archive"
+        Get-ExpectedChecksum -ChecksumFile $script:Checksums -ArchiveName $script:Archive |
+            Should -Be $script:Hash
+    }
+
+    It 'accepts the sha256sum binary marker (asterisk before the name)' {
+        Set-Content -Path $script:Checksums -Value "$script:Hash *$script:Archive"
+        Get-ExpectedChecksum -ChecksumFile $script:Checksums -ArchiveName $script:Archive |
+            Should -Be $script:Hash
+    }
+
+    It 'selects the correct line among several entries' {
+        $other = 'a' * 64
+        Set-Content -Path $script:Checksums -Value @(
+            "$other  thurbox-v1.2.3-x86_64-unknown-linux-musl.tar.gz"
+            "$script:Hash  $script:Archive"
+            "$other  thurbox-v1.2.3-aarch64-apple-darwin.tar.gz"
+        )
+        Get-ExpectedChecksum -ChecksumFile $script:Checksums -ArchiveName $script:Archive |
+            Should -Be $script:Hash
+    }
+
+    It 'throws when the archive is absent from the checksums file' {
+        Set-Content -Path $script:Checksums -Value "$script:Hash  some-other-file.zip"
+        { Get-ExpectedChecksum -ChecksumFile $script:Checksums -ArchiveName $script:Archive } |
+            Should -Throw "*$script:Archive*"
+    }
+}


### PR DESCRIPTION
## What

Adds automated tests for `scripts/install.ps1`'s dot-sourceable pure helpers (`Get-Target` / `Get-ExpectedChecksum`), which previously had **zero** coverage despite exposing the `$env:THURBOX_PS_TEST` test hook. Closes the gap with the Linux/macOS installer, which is covered by `scripts/install.bats`.

## Changes

- **`scripts/install.Tests.ps1`** (new) — Pester 5 suite mirroring `install.bats`:
  - Structural guards: file parses, ASCII-only, no UTF-8 BOM, `THURBOX_PS_TEST` guard present, helper functions defined.
  - `Get-Target`: AMD64 → x86_64 MSVC target, ARM64 → x86_64 (emulation), rejects `x86` and unknown arches.
  - `Get-ExpectedChecksum`: matching hash, lowercasing, sha256sum `*` binary marker, correct line among many, throws when absent.
- **`.github/workflows/ci.yml`** — new `install-script-ps` job running the suite via preinstalled `pwsh` on `ubuntu-latest` (the helpers are platform-independent — tests set `PROCESSOR_ARCHITECTURE` themselves), added to `all-checks.needs`.
- **`CLAUDE.md`** — documents the new test file under the install.ps1 specifics.

## Notes

- Pre-commit stays unchanged: the existing bats hook needs no PowerShell, whereas Pester needs `pwsh` which isn't guaranteed on every dev box — so the Pester suite is CI-only, consistent with the task's "wire into CI if practical" guidance.
- Local verification: `cargo clippy --all-targets --all-features -- -D warnings` and `cargo nextest run --all` (1410 passed) are green; the change touches no Rust.