### PR TITLE
docs(config): fix stale OS-notifications trigger in CONFIG.md

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -290,13 +290,21 @@ shown and you update extensions by hand.
 
 ### `[notifications]` — OS notification settings
 
-Surfaces an OS notification when a session crosses into a state that
-needs the user's attention (the agent rang the terminal bell or emitted
-an OSC 9 / OSC 777 message — usually because it's waiting on an answer
-or has finished a task). The notification body is the agent's last OSC
-message when present (truncated to 200 chars), otherwise `Waiting for
-input`. **Only fires while the TUI is open** — the agent terminal parser
-is what sees the bell, and it doesn't run when thurbox isn't.
+Surfaces an OS notification when a session **transitions into a state
+that needs your attention**. The trigger is the hooks-driven
+[session status](#session-status) (reported by the agent's hooks, *not*
+the terminal bell / output): the notification fires when a session crosses
+into `Blocked` (the agent needs input or approval) and, with
+`also_on_waiting = true`, also when it finishes a turn (`Working → Done`).
+The edge is observed once per tick in `refresh_session_statuses` — the
+same place the session-list status icon is computed, so the banner can
+never drift from the list — then deduped per session (`min_interval_secs`)
+and skipped for the session you're currently viewing (`suppress_for_active`).
+The notification body is the agent's last OSC 9 / OSC 777 message when
+present (truncated to 200 chars), otherwise `Waiting for input` — the OSC
+message is kept only for the body text, no longer for the trigger.
+**Only fires while the TUI is open** — the dispatcher thread runs only
+inside the TUI, so a headless `automation tick` never notifies.
 
 **Delivery backend** (`backend`, default `auto`) is detected at startup:
 


### PR DESCRIPTION
## What

The `[notifications]` section in `docs/CONFIG.md` opened by framing the
trigger as the terminal **bell / OSC 9 / OSC 777** signal. That framing is
stale: notification dispatch now fires on the **hooks-driven
`SessionStatus` transition** — the same model already documented by the
adjacent "Session status" section and the `also_on_waiting` table row.

This rewrites the opening paragraph to match the code:

- Trigger is the hooks-reported status (`session signal --state …`), not
  the bell/output: fires into `Blocked` always, and into `Done` on the
  `Working → Done` edge when `also_on_waiting = true`.
- The edge is observed once per tick in `refresh_session_statuses` /
  `dispatch_status_notifications`, deduped per session (`min_interval_secs`)
  and suppressed for the focused session (`suppress_for_active`).
- The OSC 9/777 message is kept only for the notification **body** text
  (truncated to 200 chars, else `Waiting for input`), no longer for the
  trigger.
- Fixed the "only fires while the TUI is open" rationale: it's the
  dispatcher thread, not a bell-watching parser.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓ (clean)
- `cargo nextest run --all` ✓ (1476 passed, 0 failed)
- Markdown verified by hand (rumdl not installed locally): no over-length
  prose, no trailing whitespace, no hard tabs.

Docs-only change; no code touched.

Resolves task #15.