### PR TITLE
test(core): exercise real App state accessors in state.rs

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -32,63 +32,179 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn test_option_get_with_valid_index() {
-        let vec = [1, 2, 3];
-        let idx = 1;
-        assert_eq!(vec.get(idx), Some(&2));
+    use super::App;
+    use crate::agent::backend::SpawnedSession;
+    use crate::agent::{AgentProvider, BackendRegistry, GenericProvider, Session, SessionBackend};
+    use crate::storage::Database;
+    use std::path::Path;
+    use std::sync::Arc;
+
+    /// Inert backend so a real [`App`] can be built without touching tmux.
+    struct StubBackend;
+    impl SessionBackend for StubBackend {
+        fn name(&self) -> &str {
+            "stub"
+        }
+        fn check_available(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn ensure_ready(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn spawn(
+            &self,
+            _: &str,
+            _: &str,
+            _: &[String],
+            _: Option<&Path>,
+            _: &std::collections::HashMap<String, String>,
+            _: u16,
+            _: u16,
+        ) -> anyhow::Result<SpawnedSession> {
+            anyhow::bail!("stub backend does not spawn")
+        }
+        fn adopt(
+            &self,
+            _: &str,
+            _: u16,
+            _: u16,
+        ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
+            anyhow::bail!("stub backend does not adopt")
+        }
+        fn discover(&self) -> anyhow::Result<Vec<crate::agent::backend::DiscoveredSession>> {
+            Ok(vec![])
+        }
+        fn resize(&self, _: &str, _: u16, _: u16) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn is_dead(&self, _: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        fn kill(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn detach(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn pane_pid(&self, _: &str) -> anyhow::Result<Option<u32>> {
+            Ok(None)
+        }
+    }
+
+    /// Build a real [`App`] seeded with `count` stub sessions (`active_index` at
+    /// 0 when non-empty), hermetic via a [`TestPathGuard`] tempdir the caller
+    /// must keep alive for the `App`'s lifetime.
+    fn app_with_sessions(count: usize) -> (App, crate::paths::TestPathGuard, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let guard = crate::paths::TestPathGuard::new(tmp.path());
+        let backend: Arc<dyn SessionBackend> = Arc::new(StubBackend);
+        let provider: Arc<dyn AgentProvider> = Arc::new(GenericProvider::new(
+            crate::agent::agent_config::builtin_registry()
+                .default_agent()
+                .unwrap()
+                .clone(),
+        ));
+        let mut app = App::new(
+            24,
+            120,
+            BackendRegistry::new(Arc::clone(&backend)),
+            crate::agent::agent_config::builtin_registry(),
+            Database::open_in_memory().unwrap(),
+        );
+        for i in 0..count {
+            app.sessions
+                .push(Session::stub(&format!("session-{i}"), &backend, &provider));
+        }
+        if count > 0 {
+            app.active_index = 0;
+        }
+        (app, guard, tmp)
     }
 
     #[test]
-    fn test_option_get_with_out_of_bounds() {
-        let vec: [i32; 3] = [1, 2, 3];
-        let idx = 10;
-        assert!(vec.get(idx).is_none());
+    fn active_session_returns_the_session_at_active_index() {
+        let (mut app, _g, _t) = app_with_sessions(3);
+
+        // Default selection points at the first session.
+        assert_eq!(
+            app.active_session().map(|s| s.info.name.as_str()),
+            Some("session-0")
+        );
+
+        app.active_index = 2;
+        assert_eq!(
+            app.active_session().map(|s| s.info.name.as_str()),
+            Some("session-2")
+        );
     }
 
     #[test]
-    fn test_has_active_logic_when_valid() {
-        let index = 2;
-        let len = 5;
-        assert!(index < len);
+    fn active_session_is_none_when_no_sessions() {
+        let (app, _g, _t) = app_with_sessions(0);
+        assert!(app.active_session().is_none());
     }
 
     #[test]
-    fn test_has_active_logic_when_invalid() {
-        let index = 5;
-        let len = 5;
-        assert!(index >= len);
+    fn active_session_is_none_when_index_out_of_bounds() {
+        let (mut app, _g, _t) = app_with_sessions(2);
+        // An index past the end must not panic — the accessor guards it.
+        app.active_index = 5;
+        assert!(app.active_session().is_none());
+        assert!(!app.has_active_session());
     }
 
     #[test]
-    fn test_accessor_return_type_is_option() {
-        let values: [&str; 2] = ["a", "b"];
-        let valid_get: Option<&&str> = values.first();
-        let invalid_get: Option<&&str> = values.get(10);
+    fn active_session_mut_yields_the_active_session() {
+        let (mut app, _g, _t) = app_with_sessions(2);
+        app.active_index = 1;
 
-        assert!(valid_get.is_some());
-        assert!(invalid_get.is_none());
+        // The mutable accessor reaches the same session and allows mutation.
+        let session = app.active_session_mut().expect("session-1 is active");
+        session.info.name = "renamed".to_string();
+
+        assert_eq!(
+            app.active_session().map(|s| s.info.name.as_str()),
+            Some("renamed")
+        );
     }
 
     #[test]
-    fn test_has_active_session_empty_collection() {
-        let index = 0;
-        let len = 0;
-        assert!(index >= len);
+    fn active_session_mut_is_none_when_index_out_of_bounds() {
+        let (mut app, _g, _t) = app_with_sessions(1);
+        app.active_index = 9;
+        assert!(app.active_session_mut().is_none());
     }
 
     #[test]
-    fn test_accessor_semantics() {
-        let collection: [i32; 3] = [10, 20, 30];
+    fn session_count_tracks_the_session_list() {
+        let (app0, _g0, _t0) = app_with_sessions(0);
+        assert_eq!(app0.session_count(), 0);
 
-        let result_valid = collection.get(1);
-        assert!(result_valid.is_some());
-        assert_eq!(result_valid, Some(&20));
+        let (app3, _g3, _t3) = app_with_sessions(3);
+        assert_eq!(app3.session_count(), 3);
+    }
 
-        let result_invalid = collection.get(100);
-        assert!(result_invalid.is_none());
+    #[test]
+    fn has_active_session_reflects_index_validity() {
+        let (mut app, _g, _t) = app_with_sessions(2);
 
-        let result_zero = collection.first();
-        assert_eq!(result_zero, Some(&10));
+        // In-bounds index → valid.
+        app.active_index = 0;
+        assert!(app.has_active_session());
+        app.active_index = 1;
+        assert!(app.has_active_session());
+
+        // Index equal to len (one past the last) and beyond → invalid.
+        app.active_index = 2;
+        assert!(!app.has_active_session());
+        app.active_index = 100;
+        assert!(!app.has_active_session());
+    }
+
+    #[test]
+    fn has_active_session_is_false_for_empty_app() {
+        let (app, _g, _t) = app_with_sessions(0);
+        assert!(!app.has_active_session());
+        assert_eq!(app.session_count(), 0);
     }
 }


### PR DESCRIPTION
## What

The unit tests in `src/app/state.rs` asserted standard-library slice behavior (`[1,2,3].get(i)`, `idx < len`) rather than the `App` accessor logic they claimed to cover — hollow tests that would still pass if the accessors were deleted.

## Change

Rewrite them to build a **real `App`** on an inert stub `SessionBackend` + in-memory `Database` (hermetic via `TestPathGuard`) and exercise the actual accessors and state transitions:

- `active_session()` / `active_session_mut()` — return the session at `active_index`, `None` when empty or out-of-bounds; the `_mut` variant's mutation is observed back through the shared accessor.
- `session_count()` — tracks the session list (0 and N).
- `has_active_session()` — true for in-bounds indices, false at `len` (one-past-the-end), beyond, and for an empty app.

Scoped strictly to the test module of `src/app/state.rs`; no production code changed.

## Verification

- `cargo nextest run --all` → 1411 passed
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --all`

Closes Thurbox task #28.