### PR TITLE
docs(core): correct ADR-12 backend type to TmuxBackend over transport

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -321,10 +321,13 @@ code.
 
 ## ADR-12: Local tmux as default backend
 
-**Choice**: The first `SessionBackend` implementation is
-`LocalTmuxBackend`, using a dedicated tmux server
+**Choice**: The default `SessionBackend` is `TmuxBackend`
+parameterized over its `Local` transport (`TmuxTransport::Local`)
+and registered as `local-tmux`, using a dedicated tmux server
 (`tmux -L thurbox`) with session name `thurbox`. All I/O goes
-through tmux control mode (`-C`).
+through tmux control mode (`-C`). (The transport abstraction that
+also enables remote SSH backends is ADR-13; here the choice is
+simply that the out-of-the-box backend runs tmux locally.)
 
 **Why**: tmux provides session persistence (survives crashes),
 multi-instance support (multiple thurbox processes can independently


### PR DESCRIPTION
## Summary

ADR-12 in `docs/ARCHITECTURE.md` named the backend type `LocalTmuxBackend`, which no longer exists as a real struct — it survives only as a backward-compat type alias (`src/agent/tmux.rs`). The canonical type is `TmuxBackend` parameterized over `TmuxTransport` (`Local`/`Ssh`).

This updates the ADR-12 *Choice* prose to the current design: the default `SessionBackend` is `TmuxBackend` over `TmuxTransport::Local`, registered as `local-tmux`. A parenthetical points at ADR-13 for the transport abstraction that also enables remote SSH backends.

The edit also makes ADR-12 internally consistent — its body already referenced `TmuxBackend::adopt`, contradicting the old `LocalTmuxBackend` opening.

## Scope

Docs only (`docs/ARCHITECTURE.md`); no code change.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all` — 1410 passed, 0 failed

Closes task #27.