### PR TITLE
chore: preflight-check jq in demo record.sh

### DIFF
--- a/scripts/demo/record.sh
+++ b/scripts/demo/record.sh
@@ -33,7 +33,7 @@
 #     have running.
 #   * XDG_{DATA,CONFIG,STATE,CACHE}_HOME point at a throwaway dir.
 #
-# Requirements: cargo, git, tmux, vhs (+ ffmpeg + ttyd) and whichever agent CLIs
+# Requirements: cargo, git, tmux, sqlite3, jq, vhs (+ ffmpeg + ttyd) and whichever agent CLIs
 # you want to feature (claude / opencode / codex / antigravity). Missing agents are
 # skipped with a warning.
 #
@@ -72,7 +72,7 @@ done
 
 # --- Preflight: required tools ----------------------------------------------
 missing=
-for tool in cargo git tmux vhs sqlite3; do
+for tool in cargo git tmux vhs sqlite3 jq; do
     command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
 done
 if [ -n "$missing" ]; then


### PR DESCRIPTION
## Summary

`scripts/demo/record.sh` shells out to `jq` — unconditionally when seeding the claude config (`~/.claude.json`), and conditionally for the gemini `trustedFolders.json` map — but `jq` was missing from the required-tool preflight loop. A machine without `jq` therefore failed **late** with a confusing error mid-run, after the expensive build/setup, instead of failing fast.

## Changes

- Add `jq` to the preflight `command -v` check so a missing `jq` fails immediately with the existing clear "missing required tool(s)" message, matching the other dev scripts.
- Align the header `Requirements:` comment with the tools actually enforced by the preflight (it was also missing `sqlite3`).

## Testing

- `shellcheck scripts/demo/record.sh` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all` — 1410 passed

Closes task #29.