### PR TITLE
fix(core): mark_session_seen deleted_at guard + notifications doc fix

### DIFF
--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,7 +1,8 @@
 //! OS desktop notifications for the "agent needs you" event.
 //!
 //! Sends a notification when a session transitions into an attention-needing
-//! state (`Attention` always, plus `Waiting` when opted in). Delivery picks a
+//! state (`Blocked` always, plus the finished `Done` edge when opted in via
+//! `also_on_waiting`). Delivery picks a
 //! **backend** at startup ([`detect_backend`]):
 //!
 //! - **dbus** (`org.freedesktop.Notifications`) on a normal Linux desktop.

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -407,7 +407,7 @@ impl Database {
     /// every tick.
     pub fn mark_session_seen(&self, id: SessionId, at_least: i64) -> rusqlite::Result<()> {
         self.conn.execute(
-            "UPDATE sessions SET seen_at = ?1 WHERE id = ?2",
+            "UPDATE sessions SET seen_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
             params![at_least, id.to_string()],
         )?;
         Ok(())


### PR DESCRIPTION
Completes two review findings (#19, #21) that earlier sessions marked done without producing any code. Both verified locally: fmt, `cargo check`, `cargo doc -D warnings`, and the storage test pass.