### PR TITLE
feat(cli): coordinate same-repo PR merges in ci-shepherd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -883,7 +883,13 @@ sync, but the TUI editor never sets it.)
   (needs rebase — the normalized `rebase` signal from `provider.sh`, surfaced
   as the `REBASE` action flag by `scripts/classify.sh`; `dispatch-fix.sh
   --rebase` makes the worker rebase onto the base and force-push before
-  fixing). A `shepherd` session monitors via a
+  fixing). When **several PRs in one repo** are all REBASE-only,
+  `classify.sh` **serializes** them — only the lowest-numbered keeps the live
+  `REBASE` flag, the rest become `REBASE-QUEUED (behind #n)` and are held — so
+  the shepherd rebases one at a time (each merge advances the base for the next)
+  instead of force-pushing N branches that immediately re-invalidate each other,
+  clearing the stack in O(n) rebases instead of O(n²). A `shepherd` session
+  monitors via a
   `shepherd-tick` automation; fixers are thurbox **tasks** (`fix #<n>: …`) that
   self-report with the same `===RESULT===` sentinel as flow. It is
   **forge-agnostic**: the only thing baked in is **git**; *how* to talk to a
@@ -894,8 +900,15 @@ sync, but the TUI editor never sets it.)
   passes `--branch`/`--checkout-cmd`/`--feedback-cmd`/`--comment-cmd` to
   `dispatch-fix.sh`). Because thurbox's `--worktree` always runs `git worktree
   add -b` (which fails on an existing branch), `dispatch-fix.sh` adopts the
-  request branch itself (git-universal) into a shepherd-owned worktree. Spec:
-  `SHEPHERD.md`.
+  request branch itself (git-universal) into a shepherd-owned worktree. It is
+  also **session-aware**: the snapshot joins each request's head branch against
+  the live `thurbox-cli session list` (`scripts/link-sessions.sh`, pure +
+  bats-tested). A request whose branch already has a **non-fixer** thurbox
+  session (the user/another agent working it by hand) is **not** dispatched (two
+  worktrees would force-push the same branch) but is **monitored and folded into
+  the merge ordering** — the live session counts as that repo's active worker,
+  so the other same-repo requests queue behind it rather than the shepherd
+  standing the request down. Spec: `SHEPHERD.md`.
 - **`extensions/renovate/`** *(experimental)* — keeps local repos on up-to-date
   dependencies. A `renovate` session sweeps a `repos.md` watch list on a weekly
   `renovate-tick` automation and dispatches a `renovate-worker` per eligible

--- a/extensions/ci-shepherd/README.md
+++ b/extensions/ci-shepherd/README.md
@@ -91,6 +91,17 @@ extension list` / `status ci-shepherd` show what's active.
 - A fixer is a thurbox **task** named `fix #<n>: …`; its worker runs in an
   isolated worktree on the request branch and self-reports via a `===RESULT===`
   sentinel, pinging the shepherd the moment it finishes.
+- The shepherd stays out of your way without losing track: if you (or another
+  agent) already have a live thurbox session on a request's head branch, it
+  **won't** dispatch a duplicate fixer there (the two would fight over the same
+  branch) — instead it **monitors** that request and folds it into the merge
+  ordering, treating your session as that repo's active worker so the other
+  same-repo PRs queue behind it.
+- When several PRs in the **same repo** only need a rebase (branch protection
+  requires up-to-date branches), the shepherd rebases them **one at a time**
+  (lowest number first) instead of all at once — each merge advances the base
+  for the next, so the stack clears in O(n) rebases instead of O(n²) and merges
+  faster.
 
 ## How the fixer gets the request branch
 
@@ -113,8 +124,9 @@ branch; `clean` removes the worktree once the request is no longer actionable
 | `SHEPHERD.md` | The agent behavior spec (modes, actionability rules, output contract) |
 | `scripts/provider.sh` | The forge adapter layer — normalizes GitHub/GitLab/Bitbucket onto one contract (incl. the `rebase` behind/conflict signal, overridden by a git-local check) |
 | `scripts/rebase-check.sh` | Authoritative git-local behind/conflict check (`none`/`NEEDED`/`CONFLICT`) — fetched `origin/<base>` vs `origin/<head>`; unit-tested by `rebase-check.bats` |
-| `scripts/classify.sh` | Pure request → action-flag classifier (`CHANGES-REQ`/`CI-FAIL`/`REBASE`/…); unit-tested by `classify.bats` |
-| `scripts/shepherd-snapshot.sh` | One-call view: watched requests (with action flags) + fixer tasks/sessions/worktrees |
+| `scripts/classify.sh` | Pure request → action-flag classifier (`CHANGES-REQ`/`CI-FAIL`/`REBASE`/`REBASE-QUEUED`/…), incl. per-repo rebase serialization; unit-tested by `classify.bats` |
+| `scripts/link-sessions.sh` | Pure (requests × sessions) head-branch join — flags requests already worked by a live, non-fixer thurbox session; unit-tested by `link-sessions.bats` |
+| `scripts/shepherd-snapshot.sh` | One-call view: watched requests (with action flags + live-session links) + fixer tasks/sessions/worktrees |
 | `scripts/dispatch-fix.sh` | Prepare a request-branch worktree + create and run the fixer task |
 | `scripts/parse-result.sh` | Extract the worker `===RESULT===` sentinel |
 | `extension.toml` | Declarative install + runtime manifest (`thurbox-cli extension install` reads this) |

--- a/extensions/ci-shepherd/SHEPHERD.md
+++ b/extensions/ci-shepherd/SHEPHERD.md
@@ -73,13 +73,53 @@ sessions. The relevant forge client must be authenticated (`gh auth status` /
 `glab auth status` / Bitbucket `BB_TOKEN`); if a repo shows a provider error,
 surface it once under "Needs you" and move on.
 
+**Live-session links.** Right under a request's classify line the snapshot may
+print a `⮑ #<n> head=<branch> already has a live session: <name> <id>` line.
+That means a thurbox session **other than a fixer** (not `shepherd`, not a
+`task-*` / `… · #<id>` worker) is already on that request's head branch — the
+user, or another agent, is working it by hand. **This is a worker, not a
+blocker.** Don't dispatch your own fixer (you'd duplicate the work and race
+their force-push), but don't park it either: **monitor it and fold it into the
+merge ordering**. The live session counts as that repo's active worker exactly
+like one of your in-flight fixers — so it holds the repo's rebase slot (see
+*Rebase serialization*): keep the **other** same-repo requests queued behind it,
+and report it as **in progress**, not under "Needs you" (it's advancing, the
+user is on it). You're sequencing merges, not standing down.
+
 **Action flags** (precedence, highest first): `draft` (skip) → `CHANGES-REQ` →
-`CI-FAIL` → `REBASE` → `ok`. **`REBASE`** means the request is **behind its
-target branch** (`rebase=NEEDED`) or has **diverged into conflict**
+`CI-FAIL` → `REBASE` → `REBASE-QUEUED` → `ok`. **`REBASE`** means the request is
+**behind its target branch** (`rebase=NEEDED`) or has **diverged into conflict**
 (`rebase=CONFLICT`) — branch protection ("require branches up to date") blocks
 the merge until it's rebased. CI-FAIL outranks REBASE on purpose: clear red
 checks first, since the rebase re-runs CI and is the last gate before a clean
 request can merge. The per-request line shows `rebase=NEEDED|CONFLICT|none`.
+
+**`REBASE-QUEUED`** is a `REBASE` request that must **wait its turn** (see
+*Rebase serialization* below): another REBASE request in the same repo goes
+first, so this one is **not** dispatched yet — its line carries
+`(queued behind #<n>)`. Treat it as **not actionable** this tick.
+
+**Rebase serialization (per repo) — the merge accelerator.** With "require
+branches up to date" protection on, REBASE-only requests in the same repo
+mutually invalidate each other: rebase them all at once and whichever merges
+first knocks the rest back out of date, so you burn O(n²) rebases + CI runs and
+nothing converges. `classify.sh` therefore lets **only the lowest-numbered**
+REBASE request in a repo keep the live `REBASE` flag (it's the oldest → most
+likely already reviewed → closest to merge); every other REBASE request becomes
+`REBASE-QUEUED`. Dispatch only the active one; once it merges, the next tick
+promotes the next-lowest. The result is one rebase at a time per repo, O(n)
+total, merging fastest. CI-FAIL / CHANGES-REQ requests are **not** queued — they
+need independent work and dispatch in parallel; a request joins the rebase queue
+only once it is REBASE-only.
+
+The classify queue orders by **number** because it's pure (no session
+knowledge). The **active rebase slot** is held by whatever is *already working*
+that repo — a live session (the `⮑` link) or your own in-flight rebase fixer —
+even if that isn't the lowest number. So when a same-repo request already has a
+worker, treat **it** as the active rebase and keep the rest `REBASE-QUEUED`
+behind it, rather than dispatching a second rebase that would race the worker.
+Only when **no** same-repo request is being worked do you dispatch the
+lowest-numbered `REBASE` to open the slot.
 
 The `rebase` signal is **git-local and authoritative**: the snapshot fetches
 `origin` and tests each request's head against its base directly
@@ -93,11 +133,19 @@ The forge's own value is kept only as a fallback for heads that aren't on
 1. **Dispatch** a fixer for every request that is actionable AND has no live
    fixer:
    - **Actionable**: flag is `CI-FAIL`, `CHANGES-REQ`, or `REBASE`, and not
-     `draft`.
+     `draft`. **`REBASE-QUEUED` is NOT actionable** — it's waiting on the active
+     rebase in its repo (see *Rebase serialization*); leave it for a later tick.
    - **Already handled**: a `fix #<n>` task exists for that repo+number that is
      not `done` → skip (a worker is on it). If the task is `done` but the
      request is STILL actionable, the previous fix didn't land it →
      re-dispatch and flag under "Needs you".
+   - **Worked by a live session**: the snapshot printed a `⮑ … already has a
+     live session` line for this request → someone is working its branch by
+     hand. Do **not** dispatch (you'd duplicate the work and race their
+     force-push), but **don't park it** — it's an active worker. **Monitor** it
+     (track its CI/rebase state across ticks) and treat it as its repo's active
+     rebase, so the other same-repo requests stay `REBASE-QUEUED` behind it (see
+     *Rebase serialization*). Report it as **in progress**, not "Needs you".
    - **Capacity**: at most **3** running fixer sessions total. Over capacity →
      leave it for the next tick.
    - Dispatch. **Built-in forge** (the snapshot listed it) — one call:
@@ -140,7 +188,14 @@ The forge's own value is kept only as a fallback for heads that aren't on
        permission prompt, or a question addressed to the user → "Needs you".
      - Exit 2 → malformed; treat as still working, flag if it repeats.
 
-3. Output: if nothing needs the user, reply EXACTLY
+3. **Monitor each live-session request** (the `⮑` links) the same way — but you
+   own none of these, so just watch state, never touch the worktree: note its
+   flag (still `CI-FAIL`/`REBASE`, or now `ok`/merged), and keep its same-repo
+   followers `REBASE-QUEUED` behind it. Surface it only if it's stuck (its
+   session vanished while the request is still actionable → the hand-off
+   stalled; "Needs you") — otherwise it's silent in-progress.
+
+4. Output: if nothing needs the user, reply EXACTLY
    `tick: all quiet (N fixing, M actionable)` — nothing else. Otherwise emit
    ONLY the Needs-you bullets + footer.
 
@@ -149,9 +204,14 @@ The forge's own value is kept only as a fallback for heads that aren't on
 One screen max:
 
 - **Fixing**: `#task #n <repo> [worker] (age)`
+- **In progress (live session)**: `#n <repo> — <session> [CI-FAIL|REBASE|ok]` —
+  worked by hand, you're monitoring + ordering around it; omit the line if none.
 - **Actionable, unassigned**: `#n <repo> — CI-FAIL|CHANGES-REQ|REBASE`
+- **Queued behind a rebase**: `#n <repo> — REBASE-QUEUED (behind #m)` — fine, just
+  waiting their turn; omit the line if none.
 - **Needs you**: true blockers only (a worker's question, a request that keeps
-  failing after a fix, a provider auth error)
+  failing after a fix, a provider auth error, a live-session request that
+  stalled — its session vanished while the request is still actionable)
 - Footer.
 
 ## CLEAN

--- a/extensions/ci-shepherd/extension.toml
+++ b/extensions/ci-shepherd/extension.toml
@@ -55,6 +55,10 @@ path = "scripts/classify.sh"
 executable = true
 
 [[files]]
+path = "scripts/link-sessions.sh"
+executable = true
+
+[[files]]
 path = "scripts/rebase-check.sh"
 executable = true
 

--- a/extensions/ci-shepherd/scripts/classify.bats
+++ b/extensions/ci-shepherd/scripts/classify.bats
@@ -77,3 +77,45 @@ classify() { req "$@" | "$SCRIPT"; }
   [ "$status" -eq 0 ]
   [[ "$output" == *"(no open requests)"* ]]
 }
+
+# --- Rebase serialization (per repo): one REBASE active, the rest queued ------
+
+# A multi-request array: each arg is "number,rebase[,ci]" (review/draft default
+# to none/false). Used to exercise the cross-request rebase ordering.
+many() {
+  printf '%s\n' "$@" | jq -R 'split(",") |
+    { number: (.[0] | tonumber), title: "t", branch: "b\(.[0])", draft: false,
+      review: "none", ci: (.[2] // "OK"), rebase: .[1] }' | jq -sc '.'
+}
+
+@test "a lone REBASE request keeps the active flag (no queue)" {
+  run bash -c "echo '$(many 3,NEEDED)' | '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"#3  [REBASE]"* ]]
+  [[ "$output" != *"REBASE-QUEUED"* ]]
+}
+
+@test "two same-repo REBASE requests serialize: lowest number is active" {
+  run bash -c "echo '$(many 5,NEEDED 2,CONFLICT)' | '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"#2  [REBASE]"* ]]
+  [[ "$output" == *"#5  [REBASE-QUEUED]"* ]]
+  [[ "$output" == *"queued behind #2"* ]]
+}
+
+@test "rebase ordering is numeric, not lexical (#9 before #10)" {
+  run bash -c "echo '$(many 10,NEEDED 9,NEEDED)' | '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"#9  [REBASE]"* ]]
+  [[ "$output" == *"#10  [REBASE-QUEUED]"* ]]
+  [[ "$output" == *"queued behind #9"* ]]
+}
+
+@test "CI-FAIL is never queued; only REBASE requests serialize among themselves" {
+  run bash -c "echo '$(many 1,NEEDED,FAIL 4,NEEDED 7,NEEDED)' | '$SCRIPT'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"#1  [CI-FAIL]"* ]]
+  [[ "$output" == *"#4  [REBASE]"* ]]
+  [[ "$output" == *"#7  [REBASE-QUEUED]"* ]]
+  [[ "$output" == *"queued behind #4"* ]]
+}

--- a/extensions/ci-shepherd/scripts/classify.sh
+++ b/extensions/ci-shepherd/scripts/classify.sh
@@ -4,29 +4,52 @@
 # Reads a normalized request JSON array (the provider.sh `list` shape) on stdin
 # and prints one formatted line per request with its derived action flag. Kept
 # separate from shepherd-snapshot.sh so the flag precedence is unit-testable
-# (`bats classify.bats`) without a live forge.
+# (`bats classify.bats`) without a live forge. The input array is one repo's
+# open requests, so the rebase ordering below is naturally scoped per repo.
 #
 # Flag precedence (highest first):
-#   draft        — work in progress, never actionable
-#   CHANGES-REQ  — a reviewer asked for changes
-#   CI-FAIL      — checks are red
-#   REBASE       — behind the target branch / diverged (rebase.NEEDED|CONFLICT);
-#                  branch protection blocks the merge until it's brought up to date
-#   ok           — nothing to do
+#   draft          — work in progress, never actionable
+#   CHANGES-REQ    — a reviewer asked for changes
+#   CI-FAIL        — checks are red
+#   REBASE         — behind the target branch / diverged (rebase.NEEDED|CONFLICT);
+#                    branch protection blocks the merge until it's brought up to date
+#   REBASE-QUEUED  — same as REBASE, but another REBASE request in this repo goes
+#                    first (see "Rebase serialization" below) — hold, don't dispatch
+#   ok             — nothing to do
 #
 # CI-FAIL outranks REBASE on purpose: fix the red checks first; a rebase re-runs
 # CI anyway, so it's the last gate before a clean PR can merge.
+#
+# Rebase serialization (per repo): when "require branches up to date" protection
+# is on, REBASE-only requests in the same repo mutually invalidate each other —
+# rebasing them all at once means whichever merges first knocks the rest back out
+# of date, so you pay O(n^2) rebases + CI runs. To merge them fastest we rebase
+# ONE at a time: the lowest-numbered REBASE request (oldest, most likely already
+# reviewed = closest to merge) keeps the actionable `REBASE` flag; every other
+# REBASE request is demoted to `REBASE-QUEUED` and held until the active one
+# merges and the next tick advances the queue. CI-FAIL / CHANGES-REQ requests are
+# never queued — they need independent work and dispatch in parallel; they join
+# the rebase queue only once they become REBASE-only.
 
 set -euo pipefail
 
 jq -r '
   if length == 0 then "  (no open requests)" else
-  .[] |
-  ((.rebase // "none")) as $rb |
-  (if .draft then "draft"
-   elif .review == "CHANGES_REQUESTED" then "CHANGES-REQ"
-   elif .ci == "FAIL" then "CI-FAIL"
-   elif $rb == "NEEDED" or $rb == "CONFLICT" then "REBASE"
-   else "ok" end) as $flag |
-  "  #\(.number)  [\($flag)]  \(.title)  (head=\(.branch), CI=\(.ci), review=\(.review), rebase=\($rb))"
+  # Attach the derived flag to every request first, so the rebase queue can be
+  # computed across the whole repo before any line is printed.
+  [ .[]
+    | . + { _rb: (.rebase // "none") }
+    | . + { _flag:
+        (if .draft then "draft"
+         elif .review == "CHANGES_REQUESTED" then "CHANGES-REQ"
+         elif .ci == "FAIL" then "CI-FAIL"
+         elif ._rb == "NEEDED" or ._rb == "CONFLICT" then "REBASE"
+         else "ok" end) }
+  ] as $reqs
+  # The active rebase target: the lowest-numbered REBASE request merges first.
+  | ( [ $reqs[] | select(._flag == "REBASE") | .number ] | sort | first ) as $rb_next
+  | $reqs[]
+  | ( ._flag == "REBASE" and .number != $rb_next ) as $queued
+  | "  #\(.number)  [\(if $queued then "REBASE-QUEUED" else ._flag end)]  \(.title)  (head=\(.branch), CI=\(.ci), review=\(.review), rebase=\(._rb))"
+    + ( if $queued then "  (queued behind #\($rb_next))" else "" end )
   end'

--- a/extensions/ci-shepherd/scripts/link-sessions.bats
+++ b/extensions/ci-shepherd/scripts/link-sessions.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# Tests for link-sessions.sh — the pure (requests × sessions) head-branch join.
+# They feed crafted normalized-request JSON on stdin and a crafted session-list
+# JSON file as $1, so they run anywhere bats + jq are installed, with no live
+# forge or tmux:
+#   bats extensions/ci-shepherd/scripts/link-sessions.bats
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/link-sessions.sh"
+  SESS="${BATS_TEST_TMPDIR}/sessions.json"
+}
+
+# A one-element request array on branch $1 (default feat/x).
+req() {
+  jq -nc --arg b "${1:-feat/x}" '[ { number: 7, title: "t", branch: $b } ]'
+}
+
+# Write a session-list JSON file: each arg is "name:branch". The branch is the
+# text after the LAST colon, so a session name may itself contain colons
+# (e.g. "fix #7: red CI · #42:feat/x" → name "fix #7: red CI · #42", branch
+# "feat/x"). A worktree with an empty branch is written as branch "".
+sessions() {
+  local out='[]' name branch
+  for spec in "$@"; do
+    name="${spec%:*}"; branch="${spec##*:}"
+    out="$(printf '%s' "$out" | jq -c --arg n "$name" --arg b "$branch" \
+      '. + [{ name: $n, id: "id-\($n)", cwd: "/repo", worktrees: [{ branch: $b }] }]')"
+  done
+  printf '%s' "$out" > "$SESS"
+}
+
+@test "syntax is valid" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "a user session on the head branch is flagged" {
+  sessions "mywork:feat/x"
+  run bash -c "'$SCRIPT' '$SESS' <<<'$(req feat/x)'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"#7"* ]]
+  [[ "$output" == *"head=feat/x"* ]]
+  [[ "$output" == *"mywork"* ]]
+}
+
+@test "no session on the branch prints nothing" {
+  sessions "other:feat/unrelated"
+  run bash -c "'$SCRIPT' '$SESS' <<<'$(req feat/x)'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "the shepherd's own fixer session is excluded (task- prefix)" {
+  sessions "task-42-fix:feat/x"
+  run bash -c "'$SCRIPT' '$SESS' <<<'$(req feat/x)'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "a current-style worker session (· #id) is excluded" {
+  sessions "fix #7: red CI · #42:feat/x"
+  run bash -c "'$SCRIPT' '$SESS' <<<'$(req feat/x)'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "the shepherd monitor session is excluded" {
+  sessions "shepherd:feat/x"
+  run bash -c "'$SCRIPT' '$SESS' <<<'$(req feat/x)'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "a session merely containing 'task' (not the task- prefix) still matches" {
+  sessions "refactor-tasks:feat/x"
+  run bash -c "'$SCRIPT' '$SESS' <<<'$(req feat/x)'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"refactor-tasks"* ]]
+}
+
+@test "a multi-repo session matches on a non-first worktree branch" {
+  printf '%s' '[{"name":"multi","id":"id-m","cwd":"/repo",
+    "worktrees":[{"branch":"other"},{"branch":"feat/x"}]}]' > "$SESS"
+  run bash -c "'$SCRIPT' '$SESS' <<<'$(req feat/x)'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"multi"* ]]
+}
+
+@test "no sessions file (default /dev/null) is safe" {
+  run bash -c "'$SCRIPT' <<<'$(req feat/x)'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "a request with no branch is skipped, not matched" {
+  sessions "mywork:" # empty branch on the session too
+  run bash -c "echo '[{\"number\":9,\"title\":\"t\",\"branch\":\"\"}]' | '$SCRIPT' '$SESS'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/extensions/ci-shepherd/scripts/link-sessions.sh
+++ b/extensions/ci-shepherd/scripts/link-sessions.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# link-sessions.sh — flag change requests that already have a *live, non-fixer*
+# thurbox session on their head branch.
+#
+# The shepherd dispatches a fixer per actionable request, but a PR/MR may
+# already be getting hands-on work in another thurbox session — one the user
+# (or another agent) opened on that branch. That session is a *worker*, not a
+# blocker: the shepherd shouldn't dispatch a duplicate fixer (two worktrees
+# force-pushing one branch would clobber each other), but it should keep
+# *monitoring* the request and fold it into the per-repo merge ordering (the
+# live session holds that repo's rebase slot). This join surfaces the overlap
+# so the shepherd can do that instead of dispatching over it.
+#
+# Reads the normalized request JSON array (the provider.sh `list` shape) on
+# stdin and takes the `thurbox-cli session list --json` array as $1 (a file
+# path; default /dev/null = no sessions). Prints one line per (request,
+# session) overlap, nothing when there is none:
+#   "  ⮑ #<n> head=<branch> already has a live session: <name>  <id>  cwd=<cwd>"
+#
+# Kept separate from shepherd-snapshot.sh so the match logic is unit-testable
+# (`bats link-sessions.bats`) without a live forge or running tmux.
+#
+# Fixer/shepherd sessions are *excluded* (shepherd, task-*, "… · #<id>"): those
+# ARE the shepherd's own dispatch result, already tracked via the `fix #<n>`
+# tasks — counting them would flag every dispatched PR. The point is to spot
+# OTHER work on the branch.
+
+set -euo pipefail
+
+SESS_FILE="${1:-/dev/null}"
+
+jq -r --slurpfile sess "$SESS_FILE" '
+  ($sess[0] // []) as $sessions
+  | .[]
+  | . as $req
+  | ($req.branch // "") as $head
+  | select($head != "")
+  | $sessions[]
+  | select((.name == "shepherd"
+            or (.name | startswith("task-"))
+            or (.name | test(" · #[0-9]+$"))) | not)
+  | select(any((.worktrees // [])[]; .branch == $head))
+  | "  ⮑ #\($req.number) head=\($head) already has a live session: " +
+    "\(.name)  \(.id)  cwd=\(.cwd // "?")"
+'

--- a/extensions/ci-shepherd/scripts/shepherd-snapshot.sh
+++ b/extensions/ci-shepherd/scripts/shepherd-snapshot.sh
@@ -18,6 +18,12 @@ WT_DIR="$HOME_DIR/worktrees"
 
 trim() { printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'; }
 
+# Snapshot the live session list ONCE so each request can be cross-referenced
+# against any thurbox session already working on its head branch (link-sessions.sh).
+SESS_FILE="$(mktemp -t shepherd-sessions.XXXXXX)"
+trap 'rm -f "$SESS_FILE"' EXIT
+thurbox-cli session list --json 2>/dev/null > "$SESS_FILE" || echo '[]' > "$SESS_FILE"
+
 echo "## change requests (watched repos)"
 if [ ! -f "$REPOS_MD" ]; then
   echo "  (no repos.md — add your repos to $REPOS_MD)"
@@ -50,6 +56,9 @@ else
           || { echo "  (provider error: $(printf '%s' "$CRS" | head -1))"; continue; }
         printf '%s' "$CRS" | "$HERE/classify.sh" 2>/dev/null \
           || echo "  (could not parse provider output)"
+        # Flag any request whose head branch already has a live, non-fixer
+        # thurbox session — hands-on work the shepherd must not race.
+        printf '%s' "$CRS" | "$HERE/link-sessions.sh" "$SESS_FILE" 2>/dev/null || true
       done
 fi
 
@@ -69,11 +78,11 @@ echo
 echo "## sessions (shepherd / workers)"
 # Worker sessions are named "<title> · #<id>" (current) or "task-<id>[-…]"
 # (legacy) — mirror flow-snapshot.sh / Task::matches_spawn_session.
-thurbox-cli session list --json 2>/dev/null | jq -r '
+jq -r '
   .[] | select(.name == "shepherd"
                or (.name | startswith("task-"))
                or (.name | test(" · #[0-9]+$"))) |
-  "  \(.name)  \(.id)  agent=\(.agent)  cwd=\(.cwd)"' 2>/dev/null || true
+  "  \(.name)  \(.id)  agent=\(.agent)  cwd=\(.cwd)"' "$SESS_FILE" 2>/dev/null || true
 
 echo
 echo "## fixer worktrees ($WT_DIR)"


### PR DESCRIPTION
## Summary

Teach ci-shepherd to **sequence multiple change requests in the same repo** so
they merge faster, instead of racing or churning. Two coordinated changes:

### Live-session awareness — monitor & order, don't duplicate
`scripts/link-sessions.sh` (pure, bats-tested) joins each request's head branch
against the live `thurbox-cli session list`. A request already worked by a
**non-fixer** thurbox session (you, or another agent, by hand) is **not**
dispatched — a second worktree force-pushing the same branch would clobber it —
but it is **not parked** either. The shepherd **monitors** it and folds it into
the merge ordering, treating that session as the repo's active worker so the
other same-repo requests queue behind it.

### Per-repo rebase serialization — O(n) instead of O(n²)
Under "require branches up to date" protection, REBASE-only PRs in one repo
mutually invalidate: rebasing all at once means each merge knocks the rest back
out of date. `scripts/classify.sh` now lets only the **lowest-numbered** REBASE
request keep the live `REBASE` flag; the rest become `REBASE-QUEUED (behind #n)`
and are held until the active one merges and the next tick promotes the queue.
The active rebase slot is held by whatever already works that repo — a live
session **or** an in-flight fixer. `CI-FAIL` / `CHANGES-REQ` are never queued
(independent work, dispatch in parallel).

### Also
- `SHEPHERD.md`: `REBASE-QUEUED` flag, serialization + slot rules, live-session
  monitoring, REPORT "in progress (live session)" category.
- Docs: `README.md`, `CLAUDE.md`.

## Test plan
- `scripts/link-sessions.bats` (10 cases: match, exclusions for shepherd/fixer
  sessions, multi-repo worktree, empty/`/dev/null` safety).
- `scripts/classify.bats` (rebase serialization: lowest-active, numeric order,
  CI-FAIL never queued).
- ShellCheck clean on all three scripts; markdown within the 100-char limit.
- CI checks pass.