### PR TITLE
perf(core): cache session-status reads, gated on data_version

Stop re

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,9 +106,13 @@ atomic); `refresh_session_statuses` marks dirty on a status change; the floor
 covers time-driven UI (clock/metrics/cursor blink). Idle paints drop ~100 fps →
 ~4 fps with input/output latency unchanged. The session-list ordering is cached
 keyed by a content signature (`App::session_order_signature`), rebuilt only when
-its grouping/nesting inputs change. Launch with `THURBOX_PERF_LOG=1` to log one
-`first_frame_ms` startup line to `thurbox.log`. Full rationale +
-intentionally-skipped optimizations: `docs/PERFORMANCE.md`.
+its grouping/nesting inputs change. The per-tick session-status read is likewise
+cached (`App::cached_hook_states`), reloaded only when `PRAGMA data_version`
+moves — so an idle `tick` no longer rescans the `sessions` table (ADR-P6). Launch
+with `THURBOX_PERF_LOG=1` to log a `startup` line (phase breakdown +
+`first_frame_ms`, plus `restore_discover`/`restore_adopt`/`adopt_split`) to
+`thurbox.log`. Full rationale + intentionally-skipped optimizations:
+`docs/PERFORMANCE.md`.
 
 ### Windows test environment (VM)
 
@@ -1154,9 +1158,14 @@ frame; the static `icon()` is used in non-animated contexts (info panel).
   fresh spawn seeds **nothing** — a never-reported session is `Idle`, and the
   agent's hooks drive it from there (so an idle, just-booted agent doesn't look
   stuck working).
-- **Derivation.** `App::refresh_session_statuses` (`src/app/mod.rs`) reads
-  all hook rows once per tick: exited → `Idle`; else the persisted state
-  (`working`/`blocked`; `idle`/none → `Idle`). `done` shows as `Done` (blue)
+- **Derivation.** `App::refresh_session_statuses` (`src/app/mod.rs`) derives
+  each session's status every tick from the hook rows — exited → `Idle`; else
+  the persisted state (`working`/`blocked`; `idle`/none → `Idle`). The rows are
+  **cached** (`App::cached_hook_states`) and reloaded from the DB only when
+  `PRAGMA data_version` moves (an external `session signal`), not on every tick;
+  same-connection writes (`seen_at`, restart's `clear_hook_state`) are applied
+  write-through / via `invalidate_hook_state_cache` (see `docs/PERFORMANCE.md`
+  ADR-P6). `done` shows as `Done` (blue)
   **whether focused or not** — so a turn you're watching visibly completes — and
   becomes `Idle` only when you **move focus off it** (acknowledge it): the focus
   change vs. `last_active_session_id` marks the just-left `done` session `seen`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -201,7 +201,10 @@ all editing UI — there is no need for a human-editable config file.
 Every connection sets a **5 s busy_timeout** (the DB is shared by
 the TUI, `thurbox-cli`, and the automation heartbeat; writes are
 short single-row upserts, so a bounded wait beats an immediate
-`SQLITE_BUSY` error or an unbounded freeze). The append-only
+`SQLITE_BUSY` error or an unbounded freeze) plus the WAL-friendly
+performance pragmas `synchronous = NORMAL`, `cache_size`, `mmap_size`,
+and `temp_store = MEMORY` (`storage::schema::initialize`; rationale in
+`docs/PERFORMANCE.md` ADR-P6). The append-only
 **audit log is pruned to 90 days** on `Database::open` — entries
 are debugging breadcrumbs, not compliance data, and unbounded
 growth would bloat the database over months of use.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -74,6 +74,17 @@ wall-clock-free `u64` counters bumped at the render/tick hot paths:
 | `ordered_sessions_rebuilds` | session-list order rebuilt vs. served from cache |
 | `parser_locks_render` | central pane locked a vt100 parser to render (one per terminal frame) |
 | `automation_entries_built` | automations-pane entry list built |
+| `hook_state_loads` | `refresh_session_statuses` actually reloaded the persisted hook columns (`load_hook_states`) — gated on a `data_version` change (ADR-P6), so it stays flat while idle |
+| `external_poll_checks` / `external_poll_reloads` | `poll_external_changes` ran its cheap `PRAGMA data_version` check / found a change and did a full shared-state reload |
+
+`hook_state_loads` is the regression gate for ADR-P6: it climbs once at startup
+and then only when an external `session signal` commits, instead of ~1 per tick.
+`external_poll_reloads` stays 0 with no other writer. Tick-driven counters are
+asserted in the `#[test]` units in `super::tests`
+(`perf_hook_states_cached_across_idle_ticks`,
+`perf_hook_states_reload_on_external_change`,
+`perf_external_poll_never_reloads_without_external_writes`), not the render-path
+acceptance harness (which skips `tick`).
 
 The acceptance harness (`src/app/acceptance.rs`) asserts on
 `App::perf_counters()` — e.g. *idle iterations skip the paint*, *the session
@@ -156,9 +167,26 @@ won't pay off.
 (ADR-P2). Heavier measurement is **opt-in and local**:
 
 - **Time-to-first-frame**: launch with `THURBOX_PERF_LOG=1`; `run_loop` logs one
-  `first_frame_ms=…` line (covering config load, DB open, and session restore)
-  to `~/.local/share/thurbox/thurbox.log`. Off by default — never affects normal
-  runs or the smoke test.
+  `startup …` line to `~/.local/share/thurbox/thurbox.log` with a **phase
+  breakdown** that sums to roughly `first_frame_ms` —
+  `config_init_ms` (config-file loads + local backend ready), `db_open_ms`,
+  `extension_heal_ms` (self-heal + built-in hooks wiring + agents reload),
+  `restore_ms` (session restore), and `first_frame_ms` (total to first paint).
+  When restore is the long pole, the same flag also emits per-backend
+  `restore_discover` lines (`discover_ms`) and per-session `restore_adopt` lines
+  (`adopt_ms`) so the *sequential* restore can be attributed. Note `restore_adopt`
+  covers both restore paths — **adopt** (a live tmux pane is re-attached) and
+  **respawn** (no live pane matched, so a fresh agent is launched); on a cold
+  socket (e.g. after a reboot) every session respawns. For the adopt path, an
+  `adopt_split` line (in `TmuxBackend::adopt`) further breaks `adopt_ms` into
+  `capture_ms` (the independent `tmux capture-pane` subprocess — the only part
+  that could run in parallel across sessions) and `connect_ms` (the
+  control-mode attach). This split is the deciding measurement for parallelizing
+  restore: the control-mode connection is serialized by a single mutex held
+  across each command's full round-trip (`TmuxBackend::with_control`), so
+  `connect_ms` is inherently sequential and only `capture_ms` can be overlapped.
+  Off by default — never affects normal runs or the smoke test; the timing reads
+  are gated on the flag so there is zero overhead otherwise.
 - **Binary size**: the non-gating `binary-size` CI job
   (`.github/workflows/ci.yml`) builds `--release` and records `thurbox` /
   `thurbox-cli` sizes to the job summary + an artifact. It is intentionally
@@ -186,11 +214,58 @@ regressions without flakiness or new dependencies.
 
 ---
 
+## ADR-P6: Reload the session-status hooks only on a `data_version` change
+
+**Choice**: `refresh_session_statuses` (`src/app/mod.rs`) used to run
+`Database::load_hook_states` — an indexed scan of the `sessions` table — on
+*every* tick (~100×/s) to derive each session's status. It now caches the hook
+rows (`App::cached_hook_states`) and reloads them only when the DB's
+`PRAGMA data_version` moves since the last load (`App::hook_states_version`).
+The pragma is an in-memory counter read (no table access), so the per-tick cost
+drops from a full scan + row mapping + UUID parsing + HashMap build to a single
+integer compare. The per-tick *derivation* (spinner, the output-quiescence
+`working → Idle` fallback, done/seen logic) still runs every tick against the
+cache, so status latency is unchanged. `load_hook_states` itself uses
+`prepare_cached` so the reload, when it happens, skips the SQL re-parse.
+
+Two writers don't move *this* connection's `data_version`, so they're handled
+explicitly: the deferred `seen_at` marks are applied **write-through** into the
+cache (otherwise a just-acknowledged `done` session would re-derive to `Done`
+next tick), and the restart path's `clear_hook_state` calls
+`App::invalidate_hook_state_cache` (forces a reload). External
+`thurbox-cli session signal` writes come from another connection and *do* bump
+`data_version`, so they're picked up on the next tick as before.
+
+Alongside this, `Database::initialize` (`src/storage/schema.rs`) sets the
+WAL-friendly performance pragmas `synchronous = NORMAL`, `cache_size = -8000`
+(8 MB), `mmap_size = 64 MB`, and `temp_store = MEMORY`.
+
+**Why**: ADR-P1 made *rendering* demand-driven, but `tick` still ran every
+≤10 ms and re-scanned the sessions table for hook state each time — pure waste
+on the overwhelmingly common idle tick where nothing signalled. The
+content-derived `data_version` gate is self-invalidating for cross-process
+writes (the common case) and can't miss them; the two same-connection writers
+are few and explicitly handled.
+
+**Rejected**:
+
+- *Tie the reload to the 250 ms sync poll* (`poll_external_changes`) — would add
+  up to 250 ms of latency to a status change (blocked/working/done), a visible
+  regression; the dedicated per-tick `data_version` read keeps ~10 ms latency.
+- *A second `has_external_changes`-style cursor* — that method mutates the
+  shared `last_data_version` used by the sync poll; reusing it would make the
+  two consumers steal each other's change edges. A read-only `data_version()`
+  avoids the coupling.
+
+---
+
 ## Quick reference
 
 | I want to… | Do this |
 | --- | --- |
-| Measure startup | `THURBOX_PERF_LOG=1 thurbox`, read `first_frame_ms` in `thurbox.log` |
+| Measure startup | `THURBOX_PERF_LOG=1 thurbox`, read the `startup` line in `thurbox.log` |
+| Break down startup time | Read the `startup` phase fields (`config_init_ms`/`db_open_ms`/`extension_heal_ms`/`restore_ms`) + the `restore_discover`/`restore_adopt` lines |
+| Verify the status-hook cache (ADR-P6) | `cargo nextest run -E 'test(perf_hook_states)'`; `hook_state_loads` stays flat while idle, +1 per external `session signal` |
 | See binary size | Check the `Binary Size` CI job summary, or `cargo bloat --release --crates` |
 | Profile CPU | `cargo flamegraph --profile release-with-debug --bin thurbox` |
 | Verify no perf regression | `cargo nextest run -E 'test(perf_)'` |

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -977,13 +977,31 @@ impl SessionBackend for TmuxBackend {
         if !control_mode::is_valid_pane_id(backend_id) {
             bail!("refusing to adopt invalid pane id: {backend_id:?}");
         }
+        // Opt-in split timing (THURBOX_PERF_LOG): `capture_history_seed` is an
+        // independent `tmux capture-pane` subprocess (parallelizable), while
+        // `connect_pane` drives the serialized control-mode connection. Knowing
+        // their ratio decides whether parallelizing the capture half is worth it.
+        let perf_log = std::env::var_os("THURBOX_PERF_LOG").is_some();
+
         // Capture before connecting so seeded history can't duplicate live
         // output. Best-effort: adoption must survive a failed capture.
+        let capture_start = perf_log.then(std::time::Instant::now);
         let seed = self.capture_history_seed(backend_id).unwrap_or_else(|e| {
             warn!("Failed to capture history for pane {backend_id}: {e}");
             Vec::new()
         });
+        let capture_ms = capture_start.map(|s| s.elapsed().as_millis() as u64);
+
+        let connect_start = perf_log.then(std::time::Instant::now);
         let connected = self.connect_pane(backend_id, rows, cols)?;
+        if let (Some(capture_ms), Some(start)) = (capture_ms, connect_start) {
+            tracing::info!(
+                pane = %backend_id,
+                capture_ms,
+                connect_ms = start.elapsed().as_millis() as u64,
+                "adopt_split"
+            );
+        }
         if seed.is_empty() {
             return Ok(connected);
         }

--- a/src/app/metrics_state.rs
+++ b/src/app/metrics_state.rs
@@ -34,6 +34,18 @@ pub(crate) struct PerfCounters {
     /// Times the automations-pane entry list was built (once per render of the
     /// pane; cheap for the typical handful of automations).
     pub(crate) automation_entries_built: u64,
+    /// Times `refresh_session_statuses` actually reloaded the persisted hook
+    /// columns from the DB (`Database::load_hook_states`). Gated on a
+    /// `data_version` change (ADR-P6), so it stays flat while idle and ticks up
+    /// once per external `session signal` — not once per tick.
+    pub(crate) hook_state_loads: u64,
+    /// Times `poll_external_changes` ran its cheap `PRAGMA data_version` check
+    /// (throttled to the poll interval, not per tick).
+    pub(crate) external_poll_checks: u64,
+    /// Subset of `external_poll_checks` where the version actually changed and a
+    /// full shared-state reload ran. The ratio of reloads to checks shows how
+    /// often the poll does real work vs. spins.
+    pub(crate) external_poll_reloads: u64,
 }
 
 /// CPU/RAM metrics collection plus the app-wide tick counter that paces the

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -613,6 +613,16 @@ pub struct App {
     /// moves off a `done` session, that session is marked "seen" (→ `Idle`), so
     /// the blue `Done` state stays visible until you actually switch away.
     last_active_session_id: Option<crate::session::SessionId>,
+    /// Cached persisted hook-status rows (`session signal` state). Reloaded only
+    /// when the DB's `data_version` moves (an *external* signal), not on every
+    /// tick — the per-tick `data_version` read is far cheaper than the
+    /// sessions-table scan it replaces. This process's own `seen_at` writes
+    /// don't bump our `data_version`, so they're applied write-through in
+    /// [`Self::refresh_session_statuses`]. See `docs/PERFORMANCE.md`.
+    cached_hook_states: HashMap<crate::session::SessionId, crate::storage::HookRow>,
+    /// `data_version` observed at the last [`Self::cached_hook_states`] reload
+    /// (`None` = never loaded, which forces the first load).
+    hook_states_version: Option<i64>,
     /// When the last frame was painted, for the forced-redraw floor.
     last_draw_at: std::time::Instant,
     /// Cheap rolling signature of agent output across all sessions (sum of each
@@ -834,6 +844,8 @@ impl App {
             needs_redraw: true,
             spinner_frame: 0,
             last_active_session_id: None,
+            cached_hook_states: HashMap::new(),
+            hook_states_version: None,
             last_draw_at: std::time::Instant::now(),
             last_output_gen: 0,
             cached_session_order: None,
@@ -1291,6 +1303,9 @@ impl App {
                 // resumed agent may not re-fire its boot hook). Mirrors the
                 // headless `restart_session_headless` path.
                 let _ = self.db.clear_hook_state(session_id);
+                // Our own write doesn't move this connection's `data_version`,
+                // so force the status cache to reload and pick up the cleared row.
+                self.invalidate_hook_state_cache();
                 self.save_state();
                 self.set_status(StatusLevel::Info, "Session restarted");
             }
@@ -3399,8 +3414,18 @@ impl App {
     fn refresh_session_statuses(&mut self) {
         self.metrics.bump(|p| &mut p.status_refreshes);
         let active_index = self.active_index;
-        // One indexed scan per tick for the persisted hook columns.
-        let hooks = self.db.load_hook_states().unwrap_or_default();
+        // Reload the persisted hook columns only when the DB actually changed —
+        // an *external* `session signal` bumps `data_version`, but our own
+        // `seen_at` writes (below) do not — otherwise reuse the cached map. This
+        // replaces a full sessions-table scan on every (~10 ms) tick with a
+        // cheap in-memory `PRAGMA data_version` read on idle ticks. See
+        // `docs/PERFORMANCE.md`.
+        let version = self.db.data_version().ok();
+        if self.hook_states_version.is_none() || version != self.hook_states_version {
+            self.metrics.bump(|p| &mut p.hook_state_loads);
+            self.cached_hook_states = self.db.load_hook_states().unwrap_or_default();
+            self.hook_states_version = version;
+        }
         // "Seen" writes are deferred past the &mut self.sessions borrow below.
         let mut seen_writes: Vec<(crate::session::SessionId, i64)> = Vec::new();
 
@@ -3411,7 +3436,9 @@ impl App {
         // an unseen `done`.
         let active_id = self.sessions.get(active_index).map(|s| s.info.id);
         if active_id != self.last_active_session_id {
-            if let Some((prev, state_at)) = self.unseen_done_on_focus_leave(&hooks) {
+            if let Some((prev, state_at)) =
+                self.unseen_done_on_focus_leave(&self.cached_hook_states)
+            {
                 seen_writes.push((prev, state_at));
             }
             self.last_active_session_id = active_id;
@@ -3420,13 +3447,23 @@ impl App {
         // Track whether any visible field changed so a quiet transition (no new
         // output, so the output detector won't catch it) still repaints promptly
         // instead of waiting for the forced-redraw floor.
-        let changed = Self::apply_session_status_fields(&mut self.sessions, &hooks, &seen_writes);
+        let changed = Self::apply_session_status_fields(
+            &mut self.sessions,
+            &self.cached_hook_states,
+            &seen_writes,
+        );
 
-        // Persist the seen marks now that the sessions borrow is released. Done
-        // only on the transition (guarded above by `seen_at < state_at`), so the
-        // focused session doesn't bump `data_version` every tick.
+        // Persist the seen marks now that the sessions borrow is released, and
+        // mirror them into the cache write-through: our own write doesn't move
+        // `data_version`, so without this the next tick would reload nothing and
+        // re-derive the just-acknowledged `done` session back to `Done`.
+        // Guarded above by `seen_at < state_at`, so the focused session doesn't
+        // bump `data_version` every tick.
         for (id, state_at) in seen_writes {
             let _ = self.db.mark_session_seen(id, state_at);
+            if let Some(hook) = self.cached_hook_states.get_mut(&id) {
+                hook.seen_at = Some(state_at);
+            }
         }
 
         // Advance the spinner unconditionally (it must tick every call, not just
@@ -3437,6 +3474,14 @@ impl App {
             self.request_redraw();
         }
         self.dispatch_status_notifications();
+    }
+
+    /// Force [`Self::cached_hook_states`] to reload on the next status refresh.
+    /// Needed after this process writes hook columns on its *own* DB connection
+    /// (e.g. clearing state on restart): such writes don't move our connection's
+    /// `data_version`, so the version gate wouldn't otherwise notice them.
+    fn invalidate_hook_state_cache(&mut self) {
+        self.hook_states_version = None;
     }
 
     /// If the just-left session (`last_active_session_id`) is an unseen `done`,
@@ -3552,13 +3597,19 @@ impl App {
     /// and apply any theme change / session delta they produced.
     fn poll_external_changes(&mut self) {
         let Ok(Some(result)) = sync::poll_for_changes(&mut self.sync_state, &mut self.db) else {
-            // Even with no broader DB change, a notification click may have
-            // landed: it writes a single row and the sync layer doesn't
-            // distinguish, so we always check.
+            // Throttled (or errored): no `data_version` check ran this tick, so
+            // it isn't counted. Even with no broader DB change, a notification
+            // click may have landed: it writes a single row and the sync layer
+            // doesn't distinguish, so we always check.
             self.apply_pending_focus_request();
             return;
         };
+        // A `Some` result means the cheap `PRAGMA data_version` check actually
+        // ran; `db_changed` further means it found a change and did the full
+        // shared-state reload.
+        self.metrics.bump(|p| &mut p.external_poll_checks);
         if result.db_changed {
+            self.metrics.bump(|p| &mut p.external_poll_reloads);
             self.apply_external_theme_change();
             self.apply_pending_focus_request();
         }
@@ -4272,6 +4323,12 @@ impl App {
     /// startup.
     pub fn restore_sessions(&mut self, sessions: Vec<sync::SharedSession>, session_counter: usize) {
         self.session_counter = session_counter;
+        // Opt-in startup-restore breakdown (THURBOX_PERF_LOG). Restore is
+        // sequential — backends are discovered one by one and each session is
+        // adopted with a blocking `capture_pane_text` — so per-backend
+        // discover and per-session adopt timings show whether (and how much)
+        // parallelizing this would pay off. Read once here, never per tick.
+        let perf_log = std::env::var_os("THURBOX_PERF_LOG").is_some();
 
         // Only sessions with an agent_session_id are resumable.
         let resumable: Vec<sync::SharedSession> = sessions
@@ -4279,14 +4336,23 @@ impl App {
             .filter(|s| s.agent_session_id.is_some())
             .collect();
 
-        let discovered_by_backend = self.discover_windows_by_backend(&resumable);
+        let discovered_by_backend = self.discover_windows_by_backend(&resumable, perf_log);
 
         for shared in resumable {
             let discovered = discovered_by_backend
                 .get(&shared.backend_type)
                 .cloned()
                 .unwrap_or_default();
+            let adopt_start = perf_log.then(std::time::Instant::now);
+            let name = perf_log.then(|| shared.name.clone());
             self.restore_single_session(shared, &discovered);
+            if let (Some(start), Some(name)) = (adopt_start, name) {
+                tracing::info!(
+                    session = %name,
+                    adopt_ms = start.elapsed().as_millis() as u64,
+                    "restore_adopt"
+                );
+            }
         }
 
         // Claim ownership of restored sessions in the shared state
@@ -4302,6 +4368,7 @@ impl App {
     fn discover_windows_by_backend(
         &self,
         resumable: &[sync::SharedSession],
+        perf_log: bool,
     ) -> HashMap<String, Vec<crate::agent::backend::DiscoveredSession>> {
         let mut discovered_by_backend: HashMap<
             String,
@@ -4311,7 +4378,16 @@ impl App {
             if discovered_by_backend.contains_key(&shared.backend_type) {
                 continue;
             }
+            let discover_start = perf_log.then(std::time::Instant::now);
             let disc = self.discover_windows_for_backend(&shared.backend_type);
+            if let Some(start) = discover_start {
+                tracing::info!(
+                    backend = %shared.backend_type,
+                    windows = disc.len() as u64,
+                    discover_ms = start.elapsed().as_millis() as u64,
+                    "restore_discover"
+                );
+            }
             discovered_by_backend.insert(shared.backend_type.clone(), disc);
         }
         discovered_by_backend
@@ -6410,6 +6486,15 @@ mod tests {
         shared.id
     }
 
+    /// Simulate an external `session signal`: write the hook state, then
+    /// invalidate the status cache the way a real out-of-process signal would
+    /// (its commit bumps this connection's `data_version`). The tests share one
+    /// in-memory connection, so the bump must be emulated explicitly.
+    fn signal_hook(app: &mut App, id: crate::session::SessionId, state: &str) {
+        app.db.set_hook_state(id, state).unwrap();
+        app.invalidate_hook_state_cache();
+    }
+
     #[test]
     fn restored_session_config_injects_identity_env() {
         // Regression: a restored/undeleted session must carry `THURBOX_SESSION`
@@ -6545,7 +6630,7 @@ mod tests {
             ("working", SessionStatus::Working),
             ("blocked", SessionStatus::Blocked),
         ] {
-            app.db.set_hook_state(id, state).unwrap();
+            signal_hook(&mut app, id, state);
             app.refresh_session_statuses();
             assert_eq!(
                 app.sessions[0].info.status, expected,
@@ -6562,7 +6647,7 @@ mod tests {
         // falls back to Idle. While output is still fresh it stays Working.
         let mut app = app_with_sessions(1);
         let id = persist_session(&app, 0);
-        app.db.set_hook_state(id, "working").unwrap();
+        signal_hook(&mut app, id, "working");
 
         // Fresh output → genuinely working.
         app.refresh_session_statuses();
@@ -6592,7 +6677,7 @@ mod tests {
         // you should see the blue "done" for the session you're watching.
         app.active_index = 1;
         app.refresh_session_statuses(); // focus moves to 1 (baseline update)
-        app.db.set_hook_state(id1, "done").unwrap();
+        signal_hook(&mut app, id1, "done");
         app.refresh_session_statuses();
         assert_eq!(
             app.sessions[1].info.status,
@@ -6613,13 +6698,54 @@ mod tests {
     }
 
     #[test]
+    fn refresh_seen_done_stays_idle_without_reload() {
+        // Regression for the status-cache write-through (ADR-P6): once a `done`
+        // session is acknowledged (focus left → seen), it must stay Idle on
+        // later ticks even when nothing reloads the cache. Marking it seen is a
+        // same-connection write that does NOT bump `data_version`, so without
+        // mirroring `seen_at` into the cached row the next derive would see a
+        // stale `seen_at < state_at` and flip it back to Done.
+        let mut app = app_with_sessions(2);
+        persist_session(&app, 0);
+        let id1 = persist_session(&app, 1);
+        app.active_index = 0;
+        app.refresh_session_statuses(); // baseline focus on 0
+
+        app.active_index = 1;
+        app.refresh_session_statuses(); // focus → 1
+        signal_hook(&mut app, id1, "done");
+        app.refresh_session_statuses();
+        assert_eq!(app.sessions[1].info.status, SessionStatus::Done);
+
+        // Acknowledge by leaving focus: seen_at written + mirrored into cache.
+        app.active_index = 0;
+        app.refresh_session_statuses();
+        assert_eq!(app.sessions[1].info.status, SessionStatus::Idle);
+
+        // A further refresh with no external change must NOT reload the cache,
+        // yet the session stays Idle (proves the write-through, not a reload).
+        let loads_before = app.perf_counters().hook_state_loads;
+        app.refresh_session_statuses();
+        assert_eq!(
+            app.perf_counters().hook_state_loads,
+            loads_before,
+            "no external change ⇒ no cache reload on the follow-up tick"
+        );
+        assert_eq!(
+            app.sessions[1].info.status,
+            SessionStatus::Idle,
+            "an acknowledged done session must stay Idle via the seen_at write-through"
+        );
+    }
+
+    #[test]
     fn refresh_done_unfocused_shows_done() {
         // A background session that finishes shows Done (blue) until visited.
         let mut app = app_with_sessions(2);
         persist_session(&app, 0);
         let id1 = persist_session(&app, 1);
         app.active_index = 0;
-        app.db.set_hook_state(id1, "done").unwrap();
+        signal_hook(&mut app, id1, "done");
         app.refresh_session_statuses();
         assert_eq!(app.sessions[1].info.status, SessionStatus::Done);
     }
@@ -6633,7 +6759,7 @@ mod tests {
         assert!(!app.should_redraw(), "quiescent after a redraw");
 
         // An external hook write must make the next refresh repaint.
-        app.db.set_hook_state(id, "blocked").unwrap();
+        signal_hook(&mut app, id, "blocked");
         app.refresh_session_statuses();
         assert!(
             app.should_redraw(),
@@ -6645,7 +6771,7 @@ mod tests {
     fn working_session_animates_spinner_and_repaints() {
         let mut app = app_with_sessions(1);
         let id = persist_session(&app, 0);
-        app.db.set_hook_state(id, "working").unwrap();
+        signal_hook(&mut app, id, "working");
 
         // Advance enough ticks to cross a spinner-frame boundary and confirm the
         // frame moves and the UI is marked dirty (so the live list animates).
@@ -6678,7 +6804,7 @@ mod tests {
         let mut app = app_with_sessions(2);
         let id0 = persist_session(&app, 0);
         let id1 = persist_session(&app, 1);
-        app.db.set_hook_state(id0, "working").unwrap();
+        signal_hook(&mut app, id0, "working");
 
         app.metrics.tick_count = 0;
         app.refresh_session_statuses();
@@ -6686,7 +6812,7 @@ mod tests {
 
         // Cross a spinner-frame boundary AND change session 1's status together.
         app.metrics.tick_count = SPINNER_TICKS_PER_FRAME;
-        app.db.set_hook_state(id1, "blocked").unwrap();
+        signal_hook(&mut app, id1, "blocked");
         app.refresh_session_statuses();
 
         assert_eq!(app.sessions[1].info.status, SessionStatus::Blocked);
@@ -6716,7 +6842,7 @@ mod tests {
     fn refresh_exited_session_is_idle_regardless_of_hook() {
         let mut app = app_with_sessions(1);
         let id = persist_session(&app, 0);
-        app.db.set_hook_state(id, "blocked").unwrap();
+        signal_hook(&mut app, id, "blocked");
         app.sessions[0].mark_exited_for_test();
         app.refresh_session_statuses();
         assert_eq!(app.sessions[0].info.status, SessionStatus::Idle);
@@ -10290,6 +10416,76 @@ mod tests {
         assert_eq!(app.metrics.tick_count, 1);
         app.tick();
         assert_eq!(app.metrics.tick_count, 2);
+    }
+
+    #[test]
+    fn perf_hook_states_cached_across_idle_ticks() {
+        // `refresh_session_statuses` reloads the persisted hook columns only
+        // when the DB's `data_version` moves. With no external writer, the first
+        // tick loads and every subsequent idle tick reuses the cache — so the
+        // expensive sessions-table scan no longer runs ~100×/s. See
+        // docs/PERFORMANCE.md (ADR-P2).
+        let mut app = App::new(24, 80, stub_backend(), stub_agents(), test_db());
+        assert_eq!(app.perf_counters().hook_state_loads, 0);
+        for _ in 0..5 {
+            app.tick();
+        }
+        assert_eq!(
+            app.perf_counters().hook_state_loads,
+            1,
+            "only the first tick loads; idle ticks reuse the cache"
+        );
+    }
+
+    #[test]
+    fn perf_hook_states_reload_on_external_change() {
+        // An *external* `session signal` commits on another connection, bumping
+        // this connection's `data_version` — which must invalidate the cache and
+        // trigger exactly one fresh load. A file-backed DB is required so a
+        // second connection shares the same database.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let db = Database::open(tmp.path()).unwrap();
+        let mut app = App::new(24, 80, stub_backend(), stub_agents(), db);
+
+        app.tick();
+        let after_first = app.perf_counters().hook_state_loads;
+        assert_eq!(after_first, 1);
+
+        // No external write yet: another idle tick stays cached.
+        app.tick();
+        assert_eq!(app.perf_counters().hook_state_loads, 1);
+
+        // A different connection commits → `data_version` moves.
+        let db2 = Database::open(tmp.path()).unwrap();
+        db2.set_session_counter(7).unwrap();
+
+        app.tick();
+        assert_eq!(
+            app.perf_counters().hook_state_loads,
+            2,
+            "an external commit must invalidate the cache exactly once"
+        );
+    }
+
+    #[test]
+    fn perf_external_poll_never_reloads_without_external_writes() {
+        // With no *other* connection writing, `PRAGMA data_version` never moves,
+        // so the cheap poll never escalates to a full shared-state reload. The
+        // ratio of reloads to checks is the "is the poll doing real work?"
+        // signal; here it must be zero.
+        let mut app = App::new(24, 80, stub_backend(), stub_agents(), test_db());
+        for _ in 0..8 {
+            app.tick();
+        }
+        assert_eq!(
+            app.perf_counters().external_poll_reloads,
+            0,
+            "no external writes ⇒ no shared-state reload"
+        );
+        assert!(
+            app.perf_counters().external_poll_reloads <= app.perf_counters().external_poll_checks,
+            "reloads are a subset of checks"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,12 +106,25 @@ async fn main() -> Result<()> {
         .with_ansi(false)
         .init();
 
+    // Coarse, always-cheap startup phase marks (a handful of one-shot
+    // `Instant::now()` calls, never in a loop). The breakdown is only *emitted*
+    // when THURBOX_PERF_LOG is set; capturing it unconditionally keeps the code
+    // simple at no measurable cost. See docs/PERFORMANCE.md (ADR-P5).
+    let mut startup = StartupTimings::default();
+
     // Initialize session backends, load every config file, and open the DB.
     // `agents` is reloaded after the extension heal below (which may patch
     // agents.toml), so the initial copy here is only used for its warnings.
+    let t_phase = std::time::Instant::now();
     let (backends, _agents, hosts, mut config_warnings) = init_backends_and_config()?;
+    startup.config_init_ms = t_phase.elapsed().as_millis();
+
+    let t_phase = std::time::Instant::now();
     let db = open_database();
+    startup.db_open_ms = t_phase.elapsed().as_millis();
     activate_persisted_theme(&db);
+
+    let t_phase = std::time::Instant::now();
 
     // Self-heal active extensions: re-create any session/automation a managed
     // extension declares but that has since been deleted. Runs before the
@@ -144,6 +157,7 @@ async fn main() -> Result<()> {
     // (otherwise a freshly-seeded profile would spawn agents without their hooks
     // and statuses would be stuck until the next launch).
     let agents = thurbox::agent::agent_config::load_or_seed();
+    startup.extension_heal_ms = t_phase.elapsed().as_millis();
 
     // Silent auto-update (opt-in via [features] auto_update). Kicked off on a
     // background thread *before* the TUI starts so a slow download never blocks
@@ -172,13 +186,15 @@ async fn main() -> Result<()> {
     app.report_config_warnings(config_warnings);
 
     // Load session state from DB and restore
+    let t_phase = std::time::Instant::now();
     if let Some((sessions, counter)) = app.load_persisted_state_from_db() {
         app.restore_sessions(sessions, counter);
     }
+    startup.restore_ms = t_phase.elapsed().as_millis();
 
     arm_automation_heartbeat();
 
-    let res = run_loop(&mut terminal, &mut app, process_start).await;
+    let res = run_loop(&mut terminal, &mut app, process_start, startup).await;
 
     app.shutdown();
     // `_terminal_guard` restores the terminal as it drops here (and on any early
@@ -368,15 +384,33 @@ fn run_auto_update(tx: &std::sync::mpsc::Sender<String>) {
     }
 }
 
+/// Coarse one-shot startup phase durations (milliseconds), captured in `main`
+/// and logged once after the first paint when `THURBOX_PERF_LOG` is set. The
+/// phases sum to roughly `first_frame_ms`, so a slow boot can be attributed to
+/// config/backend init, DB open, extension heal, or session restore rather than
+/// guessed at. See docs/PERFORMANCE.md (ADR-P5).
+#[derive(Default, Clone, Copy)]
+struct StartupTimings {
+    /// `init_backends_and_config`: config-file loads + local backend ready.
+    config_init_ms: u128,
+    /// `Database::open` (schema migrations included).
+    db_open_ms: u128,
+    /// Extension self-heal + built-in hooks wiring + agents.toml reload.
+    extension_heal_ms: u128,
+    /// `load_persisted_state_from_db` + `restore_sessions` (sequential adopt).
+    restore_ms: u128,
+}
+
 async fn run_loop(
     terminal: &mut ratatui::DefaultTerminal,
     app: &mut App,
     process_start: std::time::Instant,
+    startup: StartupTimings,
 ) -> Result<()> {
     // Opt-in (THURBOX_PERF_LOG) time-to-first-frame measurement: logged once,
     // right after the first paint, so it never affects normal runs or the smoke
-    // test. Read `~/.local/share/thurbox/thurbox.log` for the `first_frame_ms`
-    // line. See docs/PERFORMANCE.md.
+    // test. Read `~/.local/share/thurbox/thurbox.log` for the `startup` line
+    // (phase breakdown + `first_frame_ms`). See docs/PERFORMANCE.md.
     let perf_log = std::env::var_os("THURBOX_PERF_LOG").is_some();
     let mut first_frame_logged = false;
 
@@ -390,7 +424,14 @@ async fn run_loop(
             app.mark_redrawn();
 
             if perf_log && !first_frame_logged {
-                tracing::info!(first_frame_ms = process_start.elapsed().as_millis() as u64);
+                tracing::info!(
+                    config_init_ms = startup.config_init_ms as u64,
+                    db_open_ms = startup.db_open_ms as u64,
+                    extension_heal_ms = startup.extension_heal_ms as u64,
+                    restore_ms = startup.restore_ms as u64,
+                    first_frame_ms = process_start.elapsed().as_millis() as u64,
+                    "startup"
+                );
                 first_frame_logged = true;
             }
         } else {

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -28,6 +28,22 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
     conn.busy_timeout(BUSY_TIMEOUT)?;
     conn.execute_batch("PRAGMA journal_mode = WAL;")?;
     conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+    // Performance pragmas (safe under WAL):
+    // - `synchronous = NORMAL` is the WAL-recommended setting: a crash can't
+    //   corrupt the DB, only lose the last few un-checkpointed commits — fine
+    //   for this advisory session/automation state, and it avoids an fsync per
+    //   commit.
+    // - `cache_size = -8000` gives each connection an 8 MB page cache (negative
+    //   = KiB), comfortably holding the small working set in memory.
+    // - `mmap_size` memory-maps reads, skipping a copy through the page cache
+    //   for the read-heavy polling workload.
+    // - `temp_store = MEMORY` keeps transient indexes/sorts off disk.
+    conn.execute_batch(
+        "PRAGMA synchronous = NORMAL;
+         PRAGMA cache_size = -8000;
+         PRAGMA mmap_size = 67108864;
+         PRAGMA temp_store = MEMORY;",
+    )?;
 
     conn.execute_batch(
         "

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -427,9 +427,14 @@ impl Database {
     }
 
     /// Load the hook-status columns for every active session in one indexed
-    /// scan, keyed by id. Called once per tick by the TUI to derive statuses.
+    /// scan, keyed by id. The TUI derives statuses from this but reloads only
+    /// when `data_version` moves (see `App::refresh_session_statuses`), so it
+    /// is not run on every tick.
     pub fn load_hook_states(&self) -> rusqlite::Result<HashMap<SessionId, HookRow>> {
-        let mut stmt = self.conn.prepare(
+        // `prepare_cached` keeps the compiled statement across reloads — this is
+        // a hot query (the TUI's status refresh), so skipping the re-parse on
+        // every reload is worthwhile.
+        let mut stmt = self.conn.prepare_cached(
             "SELECT id, hook_state, hook_state_at, seen_at \
              FROM sessions WHERE deleted_at IS NULL",
         )?;

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -5,9 +5,7 @@ use super::Database;
 impl Database {
     /// Check if another instance has modified the database since our last check.
     pub fn has_external_changes(&mut self) -> rusqlite::Result<bool> {
-        let current: i64 = self
-            .conn
-            .query_row("PRAGMA data_version", [], |row| row.get(0))?;
+        let current = self.data_version()?;
 
         if current != self.last_data_version {
             self.last_data_version = current;
@@ -15,6 +13,18 @@ impl Database {
         } else {
             Ok(false)
         }
+    }
+
+    /// Read `PRAGMA data_version` without advancing the
+    /// [`Self::has_external_changes`] cursor. The value changes whenever
+    /// *another* connection commits (never for this connection's own writes),
+    /// so a caller can cheaply gate a per-tick cache reload on it — independent
+    /// of, and without disturbing, the sync poll's own change tracking. The
+    /// pragma reads an in-memory counter (no table access), so it is far cheaper
+    /// than re-running a query.
+    pub fn data_version(&self) -> rusqlite::Result<i64> {
+        self.conn
+            .query_row("PRAGMA data_version", [], |row| row.get(0))
     }
 
     /// Build a SharedState snapshot from the current database contents.

--- a/website/css/docs.css
+++ b/website/css/docs.css
@@ -300,3 +300,38 @@ h3:hover .heading-anchor {
     grid-template-columns: repeat(3, 1fr);
   }
 }
+
+/* ---- Performance charts (inline SVG) ---- */
+.perf-figure {
+  margin: var(--space-xl) 0;
+}
+
+.perf-figure svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 660px;
+}
+
+.perf-figure .perf-axis {
+  fill: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.perf-figure .perf-value {
+  fill: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.perf-figure .perf-grid {
+  stroke: var(--border-light);
+  stroke-width: 1;
+}
+
+.perf-figure figcaption {
+  margin-top: var(--space-sm);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}

--- a/website/docs/performance.html
+++ b/website/docs/performance.html
@@ -8,6 +8,7 @@ onThisPage:
   - { id: 'rendering', label: 'Demand-Driven Rendering' }
   - { id: 'counters', label: 'Perf Counters' }
   - { id: 'caching', label: 'Session-Order Cache' }
+  - { id: 'status-cache', label: 'Session-Status Cache' }
   - { id: 'not-optimized', label: 'Deliberately Not Optimized' }
   - { id: 'measuring', label: 'Measuring Performance' }
 ---
@@ -88,6 +89,14 @@ onThisPage:
       <td><code>status_refreshes</code> / <code>automation_entries_built</code></td>
       <td>per-tick status pass, automations-pane builds</td>
     </tr>
+    <tr>
+      <td><code>hook_state_loads</code></td>
+      <td>the session-status rows were actually reloaded from the DB (gated on a <code>data_version</code> change &mdash; stays flat while idle)</td>
+    </tr>
+    <tr>
+      <td><code>external_poll_checks</code> / <code>external_poll_reloads</code></td>
+      <td>the cross-instance <code>PRAGMA data_version</code> poll ran / found a change and reloaded shared state</td>
+    </tr>
   </tbody>
 </table>
 
@@ -108,6 +117,68 @@ onThisPage:
   order alters the hash, so there is no manual &ldquo;mark dirty&rdquo; call site to forget. This
   matters most while an agent streams output and the screen repaints every frame.
 </p>
+
+<h2 id="status-cache">
+  Session-Status Cache
+  <a href="#status-cache" class="heading-anchor">#</a>
+</h2>
+<p>
+  Session status (working / blocked / done / idle) is driven by agent hooks persisted in SQLite.
+  Deriving it used to re-scan the <code>sessions</code> table on <em>every</em> tick (~100&times;/s),
+  even on an idle screen where nothing changed. The rows are now <strong>cached</strong> and reloaded
+  only when the database's <code>PRAGMA data_version</code> moves &mdash; a single in-memory counter
+  read, far cheaper than an indexed scan plus row mapping. The per-tick <em>derivation</em> (the
+  Working spinner, the output-quiescence fallback, the done/seen logic) still runs every tick against
+  the cache, so status latency is unchanged.
+</p>
+<p>
+  An external <code>thurbox-cli session signal</code> commits on another connection, which bumps
+  <code>data_version</code> and is picked up on the next tick. The two writes that don't move
+  <em>this</em> connection's version &mdash; marking a <code>done</code> session
+  <code>seen</code>, and clearing state on restart &mdash; are handled explicitly (write-through and
+  cache invalidation), so the cache can never serve a stale status. The
+  <code>hook_state_loads</code> counter proves it: flat while idle, +1 per external signal.
+</p>
+
+<figure class="perf-figure">
+  <svg viewBox="0 0 660 250" role="img" aria-labelledby="idle-title idle-desc">
+    <title id="idle-title">Idle work per second, before vs. after</title>
+    <desc id="idle-desc">
+      On a fully idle screen, frame paints drop from about 100 to 4 per second, and session-status
+      table scans drop from about 100 to near zero per second.
+    </desc>
+    <!-- gridlines + y-axis -->
+    <line class="perf-grid" x1="56" y1="40" x2="620" y2="40" />
+    <line class="perf-grid" x1="56" y1="120" x2="620" y2="120" />
+    <line class="perf-grid" x1="56" y1="200" x2="620" y2="200" />
+    <text class="perf-axis" x="48" y="44" text-anchor="end">100</text>
+    <text class="perf-axis" x="48" y="124" text-anchor="end">50</text>
+    <text class="perf-axis" x="48" y="204" text-anchor="end">0</text>
+    <!-- legend -->
+    <rect x="430" y="6" width="12" height="12" fill="var(--text-muted)" />
+    <text class="perf-axis" x="448" y="16">before</text>
+    <rect x="520" y="6" width="12" height="12" fill="var(--green)" />
+    <text class="perf-axis" x="538" y="16">after (idle)</text>
+    <!-- group 1: frame paints -->
+    <rect x="120" y="40" width="80" height="160" fill="var(--text-muted)" />
+    <rect x="220" y="194" width="80" height="6" fill="var(--green)" />
+    <text class="perf-value" x="160" y="34" text-anchor="middle">100</text>
+    <text class="perf-value" x="260" y="188" text-anchor="middle">~4</text>
+    <text class="perf-axis" x="210" y="222" text-anchor="middle">frame paints / s</text>
+    <!-- group 2: status scans -->
+    <rect x="400" y="40" width="80" height="160" fill="var(--text-muted)" />
+    <rect x="500" y="197" width="80" height="3" fill="var(--green)" />
+    <text class="perf-value" x="440" y="34" text-anchor="middle">100</text>
+    <text class="perf-value" x="540" y="191" text-anchor="middle">&#8776;0</text>
+    <text class="perf-axis" x="490" y="222" text-anchor="middle">DB status scans / s</text>
+  </svg>
+  <figcaption>
+    Idle-screen work per second. Demand-driven rendering (ADR-P1) takes paints from ~100&nbsp;fps to
+    the 4&nbsp;fps forced-redraw floor; the session-status cache (ADR-P6) takes the per-tick
+    <code>sessions</code>-table scan to near zero. Input and output latency are unchanged &mdash; the
+    loop still wakes every &le;10&nbsp;ms, it just does less.
+  </figcaption>
+</figure>
 
 <h2 id="not-optimized">
   Deliberately Not Optimized
@@ -141,8 +212,12 @@ onThisPage:
 </p>
 <ul>
   <li>
-    <strong>Startup</strong> &mdash; launch with <code>THURBOX_PERF_LOG=1</code>; one
-    <code>first_frame_ms</code> line is logged to <code>thurbox.log</code>.
+    <strong>Startup</strong> &mdash; launch with <code>THURBOX_PERF_LOG=1</code>; a
+    <code>startup</code> line is logged to <code>thurbox.log</code> with a phase breakdown
+    (<code>config_init_ms</code> / <code>db_open_ms</code> / <code>extension_heal_ms</code> /
+    <code>restore_ms</code>) that sums to <code>first_frame_ms</code>, plus per-backend
+    <code>restore_discover</code> and per-session <code>restore_adopt</code> / <code>adopt_split</code>
+    lines when session restore is the long pole.
   </li>
   <li>
     <strong>Binary size</strong> &mdash; a non-gating CI job records the release
@@ -155,3 +230,39 @@ onThisPage:
     neither is a project dependency.
   </li>
 </ul>
+<figure class="perf-figure">
+  <svg viewBox="0 0 660 210" role="img" aria-labelledby="startup-title startup-desc">
+    <title id="startup-title">Startup time to first frame, by phase</title>
+    <desc id="startup-desc">
+      A representative cold start restoring five sessions reaches the first frame in about 226
+      milliseconds; session restore is roughly 71 percent of it, while config load, database open,
+      and extension heal are a few milliseconds each.
+    </desc>
+    <!-- stacked bar: config | db | heal | restore | init+paint -->
+    <rect x="20" y="30" width="82" height="40" fill="var(--yellow)" />
+    <rect x="102" y="30" width="3" height="40" fill="var(--purple)" />
+    <rect x="105" y="30" width="5" height="40" fill="var(--cyan)" />
+    <rect x="110" y="30" width="439" height="40" fill="var(--blue)" />
+    <rect x="549" y="30" width="91" height="40" fill="var(--text-muted)" />
+    <text class="perf-value" x="329" y="55" text-anchor="middle" fill="var(--bg-primary)">
+      restore &#8776; 71%
+    </text>
+    <!-- legend -->
+    <rect x="20" y="96" width="11" height="11" fill="var(--yellow)" />
+    <text class="perf-axis" x="37" y="105">config load &#8212; 30 ms</text>
+    <rect x="20" y="114" width="11" height="11" fill="var(--purple)" />
+    <text class="perf-axis" x="37" y="123">db open &#8212; 1 ms</text>
+    <rect x="20" y="132" width="11" height="11" fill="var(--cyan)" />
+    <text class="perf-axis" x="37" y="141">extension heal &#8212; 2 ms</text>
+    <rect x="20" y="150" width="11" height="11" fill="var(--blue)" />
+    <text class="perf-axis" x="37" y="159">session restore &#8212; 160 ms</text>
+    <rect x="20" y="168" width="11" height="11" fill="var(--text-muted)" />
+    <text class="perf-axis" x="37" y="177">init + first paint &#8212; 33 ms</text>
+  </svg>
+  <figcaption>
+    Where startup time goes, from a real <code>THURBOX_PERF_LOG=1</code> run restoring five sessions
+    (~226&nbsp;ms to first frame). The breakdown is what motivated measuring restore before any
+    parallelization &mdash; and what showed it is bounded by tmux's serialized control-mode
+    connection rather than by parallelizable work. Numbers vary with session count and scrollback.
+  </figcaption>
+</figure>


### PR DESCRIPTION
## Summary

Automated PR from publish skill.

## Test plan

- CI checks pass