### PR TITLE
fix(core): storage-quality fixes (atomic upsert, JSON dirs, shared action codec, v34 ALTER)

### DIFF
--- a/src/storage/automations.rs
+++ b/src/storage/automations.rs
@@ -4,8 +4,6 @@
 //! `(action_kind, …)` with the action-specific columns. The `next_run_at`
 //! column is the dispatcher's scan key — see `app::process_automations`.
 
-use std::path::PathBuf;
-
 use rusqlite::{params, OptionalExtension};
 
 use crate::session::{
@@ -32,7 +30,7 @@ impl Database {
     pub fn create_automation(&self, new: &NewAutomation) -> rusqlite::Result<i64> {
         let now = current_time_millis() as i64;
         let (target_session, repo_path, worktree_branch, base_branch, agent, extra, command) =
-            action_columns(&new.action);
+            super::action_to_columns(&new.action);
         self.conn.execute(
             "INSERT INTO automations
                 (name, enabled, schedule_kind, schedule_spec, timezone,
@@ -96,7 +94,7 @@ impl Database {
     /// Replace an automation's definition (everything except id/created_at).
     pub fn update_automation(&self, auto: &Automation) -> rusqlite::Result<()> {
         let (target_session, repo_path, worktree_branch, base_branch, agent, extra, command) =
-            action_columns(&auto.action);
+            super::action_to_columns(&auto.action);
         let now = current_time_millis() as i64;
         self.conn.execute(
             "UPDATE automations SET
@@ -302,63 +300,20 @@ const COLS: &str = "id, name, enabled, schedule_kind, schedule_spec, timezone, \
     prompt, created_at, updated_at, last_run_at, next_run_at, action_extra_repos, \
     action_command";
 
-/// Decompose an action into its persisted columns. The extra-repo element is the
-/// JSON-encoded extra-repo list (`None` for single-repo spawns / `Send`); the
-/// final element is the shell command (`Some` only for `Exec`).
-type ActionColumns = (
-    Option<String>, // target_session
-    Option<String>, // repo_path
-    Option<String>, // worktree_branch
-    Option<String>, // base_branch
-    Option<String>, // agent
-    Option<String>, // action_extra_repos (JSON)
-    Option<String>, // action_command
-);
-
-fn action_columns(action: &AutomationAction) -> ActionColumns {
-    match action {
-        AutomationAction::Send { session_id } => (
-            Some(session_id.to_string()),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ),
-        AutomationAction::Spawn {
-            repo_path,
-            worktree_branch,
-            base_branch,
-            agent,
-            extra_repos,
-        } => (
-            None,
-            Some(repo_path.to_string_lossy().into_owned()),
-            worktree_branch.clone(),
-            base_branch.clone(),
-            agent.clone(),
-            super::extra_repos_to_json(extra_repos),
-            None,
-        ),
-        AutomationAction::Exec { command } => {
-            (None, None, None, None, None, None, Some(command.clone()))
-        }
-    }
-}
-
 fn map_automation(row: &rusqlite::Row) -> rusqlite::Result<Automation> {
     let id: i64 = row.get(0)?;
     let schedule_kind: String = row.get(3)?;
     let schedule_spec: String = row.get(4)?;
     let action_kind: String = row.get(6)?;
-    let target_session: Option<String> = row.get(7)?;
-    let repo_path: Option<String> = row.get(8)?;
-    let worktree_branch: Option<String> = row.get(9)?;
-    let base_branch: Option<String> = row.get(10)?;
-    let agent: Option<String> = row.get(11)?;
-    let extra_repos_json: Option<String> = row.get(17)?;
-    let action_command: Option<String> = row.get(18)?;
+    let cols: super::ActionColumns = (
+        row.get(7)?,
+        row.get(8)?,
+        row.get(9)?,
+        row.get(10)?,
+        row.get(11)?,
+        row.get(17)?,
+        row.get(18)?,
+    );
 
     let schedule =
         AutomationSchedule::from_parts(&schedule_kind, &schedule_spec).ok_or_else(|| {
@@ -369,24 +324,7 @@ fn map_automation(row: &rusqlite::Row) -> rusqlite::Result<Automation> {
             )
         })?;
 
-    let action = match action_kind.as_str() {
-        "send" => AutomationAction::Send {
-            session_id: target_session
-                .unwrap_or_default()
-                .parse()
-                .unwrap_or_default(),
-        },
-        "exec" => AutomationAction::Exec {
-            command: action_command.unwrap_or_default(),
-        },
-        _ => AutomationAction::Spawn {
-            repo_path: PathBuf::from(repo_path.unwrap_or_default()),
-            worktree_branch,
-            base_branch,
-            agent,
-            extra_repos: super::extra_repos_from_json(extra_repos_json),
-        },
-    };
+    let action = super::action_from_columns(&action_kind, cols);
 
     Ok(Automation {
         id,
@@ -405,6 +343,8 @@ fn map_automation(row: &rusqlite::Row) -> rusqlite::Result<Automation> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
     fn send_automation(name: &str, next: Option<u64>) -> NewAutomation {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -23,10 +23,12 @@ pub mod sync;
 pub mod tasks;
 mod worktrees;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
 use uuid::Uuid;
+
+use crate::session::AutomationAction;
 
 /// Serialize a `Spawn` action's extra-repo list for the `action_extra_repos`
 /// column. An empty list (the single-repo common case) stores `NULL`, so old
@@ -46,6 +48,80 @@ pub(super) fn extra_repos_from_json(raw: Option<String>) -> Vec<crate::session::
     raw.filter(|s| !s.is_empty())
         .and_then(|s| serde_json::from_str(&s).ok())
         .unwrap_or_default()
+}
+
+/// The action-specific columns an [`AutomationAction`] is stored as, shared by
+/// the `tasks` and `automations` tables (both carry an identical group). The
+/// `action_kind` discriminant is stored separately (`AutomationAction::kind`).
+pub(super) type ActionColumns = (
+    Option<String>, // target_session
+    Option<String>, // repo_path
+    Option<String>, // worktree_branch
+    Option<String>, // base_branch
+    Option<String>, // agent
+    Option<String>, // action_extra_repos (JSON)
+    Option<String>, // action_command
+);
+
+/// Encode an action into its persisted columns (sans the `action_kind`
+/// discriminant, which the caller derives via [`AutomationAction::kind`]).
+pub(super) fn action_to_columns(action: &AutomationAction) -> ActionColumns {
+    match action {
+        AutomationAction::Send { session_id } => (
+            Some(session_id.to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        AutomationAction::Spawn {
+            repo_path,
+            worktree_branch,
+            base_branch,
+            agent,
+            extra_repos,
+        } => (
+            None,
+            Some(repo_path.to_string_lossy().into_owned()),
+            worktree_branch.clone(),
+            base_branch.clone(),
+            agent.clone(),
+            extra_repos_to_json(extra_repos),
+            None,
+        ),
+        AutomationAction::Exec { command } => {
+            (None, None, None, None, None, None, Some(command.clone()))
+        }
+    }
+}
+
+/// Reconstruct an action from its `action_kind` discriminant + persisted
+/// columns. An unrecognized `kind` decodes to `Spawn` (the automations
+/// catch-all); callers that allow an action-less row (tasks) gate this on a
+/// non-NULL `action_kind` themselves.
+pub(super) fn action_from_columns(kind: &str, cols: ActionColumns) -> AutomationAction {
+    let (target_session, repo_path, worktree_branch, base_branch, agent, extra_repos_json, command) =
+        cols;
+    match kind {
+        "send" => AutomationAction::Send {
+            session_id: target_session
+                .unwrap_or_default()
+                .parse()
+                .unwrap_or_default(),
+        },
+        "exec" => AutomationAction::Exec {
+            command: command.unwrap_or_default(),
+        },
+        _ => AutomationAction::Spawn {
+            repo_path: PathBuf::from(repo_path.unwrap_or_default()),
+            worktree_branch,
+            base_branch,
+            agent,
+            extra_repos: extra_repos_from_json(extra_repos_json),
+        },
+    }
 }
 
 /// SQLite-backed database for application state.

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -999,13 +999,12 @@ fn migrate_v33_action_extra_repos(conn: &Connection) -> rusqlite::Result<()> {
 /// identically to the pre-hooks behaviour.
 ///
 /// Fresh v34 databases already have the columns from `initialize` and skip this
-/// step; existing databases get them via the ALTERs. `let _` swallows the
-/// "duplicate column" error so a re-run is a no-op.
+/// step; existing databases get them via the ALTERs, guarded so a re-run is a
+/// no-op.
 fn migrate_v34_hook_status(conn: &Connection) -> rusqlite::Result<()> {
-    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN hook_state TEXT", []);
-    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN hook_state_at INTEGER", []);
-    let _ = conn.execute("ALTER TABLE sessions ADD COLUMN seen_at INTEGER", []);
-    Ok(())
+    add_column_if_absent(conn, "sessions", "hook_state", "TEXT")?;
+    add_column_if_absent(conn, "sessions", "hook_state_at", "INTEGER")?;
+    add_column_if_absent(conn, "sessions", "seen_at", "INTEGER")
 }
 
 /// v34 → v35: index `tasks(source, external_id)` for external-tracker sync.

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 
 use crate::session::SessionId;
 use crate::sync::{current_time_millis, SharedSession, SharedWorktree};
@@ -40,50 +40,63 @@ pub struct DeletedSessionInfo {
 
 impl Database {
     /// Insert or update a session.
+    ///
+    /// Deliberately a single atomic `INSERT … ON CONFLICT(id) DO UPDATE` and
+    /// never lists the hook columns (`hook_state`/`hook_state_at`/`seen_at`), so
+    /// the TUI's full-row write-back can't clobber a state a headless hook just
+    /// set (see [`set_hook_state`](Self::set_hook_state)). `created_at` is set
+    /// only on insert; a conflict revives a soft-deleted row (`deleted_at =
+    /// NULL`). The pre-write existence check decides only the audit label and
+    /// can't make the write race — the UPSERT handles both cases regardless.
     pub fn upsert_session(&self, session: &SharedSession) -> rusqlite::Result<()> {
         let now = current_time_millis() as i64;
         let id_str = session.id.to_string();
 
-        let existing: Option<String> = self
+        let existed = self
             .conn
             .query_row(
-                "SELECT id FROM sessions WHERE id = ?1",
+                "SELECT 1 FROM sessions WHERE id = ?1",
                 params![id_str],
-                |row| row.get(0),
+                |_| Ok(()),
             )
-            .ok();
+            .optional()?
+            .is_some();
 
-        let additional_dirs_str: String = session
-            .additional_dirs
-            .iter()
-            .map(|p| p.display().to_string())
-            .collect::<Vec<_>>()
-            .join("\n");
+        self.conn.execute(
+            "INSERT INTO sessions (id, name, agent, backend_id, backend_type, \
+             agent_session_id, cwd, additional_dirs, shell_backend_id, \
+             parent_session_id, display_order, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12) \
+             ON CONFLICT(id) DO UPDATE SET \
+                 name = excluded.name, agent = excluded.agent, \
+                 backend_id = excluded.backend_id, \
+                 backend_type = excluded.backend_type, \
+                 agent_session_id = excluded.agent_session_id, \
+                 cwd = excluded.cwd, additional_dirs = excluded.additional_dirs, \
+                 shell_backend_id = excluded.shell_backend_id, \
+                 parent_session_id = excluded.parent_session_id, \
+                 display_order = excluded.display_order, \
+                 updated_at = excluded.updated_at, deleted_at = NULL",
+            params![
+                id_str,
+                session.name,
+                session.agent,
+                session.backend_id,
+                session.backend_type,
+                session.agent_session_id,
+                session
+                    .cwd
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().into_owned()),
+                additional_dirs_to_db(&session.additional_dirs),
+                session.shell_backend_id,
+                session.parent_session_id.map(|id| id.to_string()),
+                session.display_order,
+                now,
+            ],
+        )?;
 
-        if existing.is_some() {
-            self.conn.execute(
-                "UPDATE sessions SET name = ?1, agent = ?2, \
-                 backend_id = ?3, backend_type = ?4, agent_session_id = ?5, \
-                 cwd = ?6, additional_dirs = ?7, shell_backend_id = ?8, \
-                 parent_session_id = ?9, display_order = ?10, updated_at = ?11, \
-                 deleted_at = NULL \
-                 WHERE id = ?12",
-                params![
-                    session.name,
-                    session.agent,
-                    session.backend_id,
-                    session.backend_type,
-                    session.agent_session_id,
-                    session.cwd.as_ref().map(|p| p.display().to_string()),
-                    additional_dirs_str,
-                    session.shell_backend_id,
-                    session.parent_session_id.map(|id| id.to_string()),
-                    session.display_order,
-                    now,
-                    id_str,
-                ],
-            )?;
-
+        if existed {
             self.log_audit(
                 EntityType::Session,
                 &id_str,
@@ -93,28 +106,6 @@ impl Database {
                 None,
             )?;
         } else {
-            self.conn.execute(
-                "INSERT INTO sessions (id, name, agent, backend_id, backend_type, \
-                 agent_session_id, cwd, additional_dirs, shell_backend_id, \
-                 parent_session_id, display_order, created_at, updated_at) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-                params![
-                    id_str,
-                    session.name,
-                    session.agent,
-                    session.backend_id,
-                    session.backend_type,
-                    session.agent_session_id,
-                    session.cwd.as_ref().map(|p| p.display().to_string()),
-                    additional_dirs_str,
-                    session.shell_backend_id,
-                    session.parent_session_id.map(|id| id.to_string()),
-                    session.display_order,
-                    now,
-                    now,
-                ],
-            )?;
-
             self.log_audit(
                 EntityType::Session,
                 &id_str,
@@ -125,7 +116,6 @@ impl Database {
             )?;
         }
 
-        // Upsert worktrees if present
         if !session.worktrees.is_empty() {
             self.upsert_worktrees(session.id, &session.worktrees)?;
         }
@@ -461,6 +451,34 @@ impl Database {
     }
 }
 
+/// Encode a session's `additional_dirs` for the column: a JSON array of path
+/// strings (empty list → `''`, satisfying the `NOT NULL` column). JSON keeps a
+/// path containing a newline from round-tripping as two separate dirs, which the
+/// previous `\n`-joined encoding could not.
+fn additional_dirs_to_db(dirs: &[PathBuf]) -> String {
+    if dirs.is_empty() {
+        return String::new();
+    }
+    let strs: Vec<String> = dirs
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    // A `Vec<String>` always serializes; the fallback is unreachable.
+    serde_json::to_string(&strs).unwrap_or_default()
+}
+
+/// Decode the `additional_dirs` column. New rows store a JSON array; legacy rows
+/// are newline-delimited, so a failed JSON parse falls back to splitting on `\n`.
+fn additional_dirs_from_db(raw: &str) -> Vec<PathBuf> {
+    if raw.is_empty() {
+        return Vec::new();
+    }
+    match serde_json::from_str::<Vec<String>>(raw) {
+        Ok(list) => list.into_iter().map(PathBuf::from).collect(),
+        Err(_) => raw.split('\n').map(PathBuf::from).collect(),
+    }
+}
+
 /// Build an optional [`SharedWorktree`] from the three nullable worktree
 /// columns of a joined row. Returns `None` unless all three are present.
 fn worktree_from_cols(
@@ -493,11 +511,7 @@ fn row_to_shared_session(
     let wt_path: Option<String> = row.get(12)?;
     let wt_branch: Option<String> = row.get(13)?;
 
-    let additional_dirs: Vec<PathBuf> = if dirs_str.is_empty() {
-        Vec::new()
-    } else {
-        dirs_str.split('\n').map(PathBuf::from).collect()
-    };
+    let additional_dirs = additional_dirs_from_db(&dirs_str);
 
     let worktree = worktree_from_cols(wt_repo, wt_path, wt_branch);
 
@@ -760,6 +774,37 @@ mod tests {
 
         let sessions = db.list_active_sessions().unwrap();
         assert_eq!(sessions[0].additional_dirs.len(), 2);
+    }
+
+    #[test]
+    fn additional_dirs_with_newline_roundtrips_as_one_dir() {
+        // A path containing a newline must survive as a single dir — the old
+        // `\n`-joined encoding split it into two.
+        let db = Database::open_in_memory().unwrap();
+        let mut session = make_session("Session 1");
+        let weird = PathBuf::from("/home/user/odd\nname");
+        session.additional_dirs = vec![weird.clone()];
+
+        db.upsert_session(&session).unwrap();
+
+        let sessions = db.list_active_sessions().unwrap();
+        assert_eq!(sessions[0].additional_dirs, vec![weird]);
+    }
+
+    #[test]
+    fn additional_dirs_reads_legacy_newline_rows() {
+        // Rows written before the JSON encoding are newline-delimited; they must
+        // still decode (best-effort, no migration).
+        let dirs = additional_dirs_from_db("/a\n/b\n/c");
+        assert_eq!(
+            dirs,
+            vec![
+                PathBuf::from("/a"),
+                PathBuf::from("/b"),
+                PathBuf::from("/c")
+            ]
+        );
+        assert!(additional_dirs_from_db("").is_empty());
     }
 
     #[test]

--- a/src/storage/tasks.rs
+++ b/src/storage/tasks.rs
@@ -6,8 +6,6 @@
 //! via `deleted_at` mirrors sessions/worktrees. Mutations are recorded in the
 //! audit log under [`EntityType::Task`].
 
-use std::path::PathBuf;
-
 use rusqlite::{params, OptionalExtension};
 
 use crate::session::{AutomationAction, Task, TaskStatus, SOURCE_LOCAL};
@@ -48,16 +46,12 @@ impl Database {
     /// Insert a new task, returning its row id.
     pub fn create_task(&self, new: &NewTask) -> rusqlite::Result<i64> {
         let now = current_time_millis() as i64;
-        let (
-            action_kind,
-            target_session,
-            repo_path,
-            worktree_branch,
-            base_branch,
-            agent,
-            extra,
-            command,
-        ) = action_columns(new.action.as_ref());
+        let action_kind = new.action.as_ref().map(|a| a.kind());
+        let (target_session, repo_path, worktree_branch, base_branch, agent, extra, command) = new
+            .action
+            .as_ref()
+            .map(super::action_to_columns)
+            .unwrap_or_default();
         self.conn.execute(
             "INSERT INTO tasks
                 (title, status, action_kind, target_session, repo_path,
@@ -139,16 +133,12 @@ impl Database {
 
     /// Replace a task's definition (everything except id/created_at/deleted_at).
     pub fn update_task(&self, task: &Task) -> rusqlite::Result<()> {
-        let (
-            action_kind,
-            target_session,
-            repo_path,
-            worktree_branch,
-            base_branch,
-            agent,
-            extra,
-            command,
-        ) = action_columns(task.action.as_ref());
+        let action_kind = task.action.as_ref().map(|a| a.kind());
+        let (target_session, repo_path, worktree_branch, base_branch, agent, extra, command) = task
+            .action
+            .as_ref()
+            .map(super::action_to_columns)
+            .unwrap_or_default();
         let now = current_time_millis() as i64;
         self.conn.execute(
             "UPDATE tasks SET
@@ -234,93 +224,24 @@ const COLS: &str = "id, title, status, action_kind, target_session, repo_path, \
     created_at, updated_at, deleted_at, description, action_extra_repos, \
     action_command";
 
-/// Decompose an optional action into its persisted columns. All `None` when the
-/// task is unconnected (`action_kind` is then NULL). The final element is the
-/// JSON-encoded extra-repo list (`None` for single-repo spawns / non-spawns).
-type ActionColumns = (
-    Option<String>, // action_kind
-    Option<String>, // target_session
-    Option<String>, // repo_path
-    Option<String>, // worktree_branch
-    Option<String>, // base_branch
-    Option<String>, // agent
-    Option<String>, // action_extra_repos (JSON)
-    Option<String>, // action_command
-);
-
-fn action_columns(action: Option<&AutomationAction>) -> ActionColumns {
-    match action {
-        None => (None, None, None, None, None, None, None, None),
-        Some(AutomationAction::Send { session_id }) => (
-            Some("send".to_string()),
-            Some(session_id.to_string()),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ),
-        Some(AutomationAction::Spawn {
-            repo_path,
-            worktree_branch,
-            base_branch,
-            agent,
-            extra_repos,
-        }) => (
-            Some("spawn".to_string()),
-            None,
-            Some(repo_path.to_string_lossy().into_owned()),
-            worktree_branch.clone(),
-            base_branch.clone(),
-            agent.clone(),
-            super::extra_repos_to_json(extra_repos),
-            None,
-        ),
-        // Exec is an automation-only action; a task never carries one in
-        // practice, but the shared enum means we round-trip it for completeness.
-        Some(AutomationAction::Exec { command }) => (
-            Some("exec".to_string()),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(command.clone()),
-        ),
-    }
-}
-
 fn map_task(row: &rusqlite::Row) -> rusqlite::Result<Task> {
     let action_kind: Option<String> = row.get(3)?;
-    let target_session: Option<String> = row.get(4)?;
-    let repo_path: Option<String> = row.get(5)?;
-    let worktree_branch: Option<String> = row.get(6)?;
-    let base_branch: Option<String> = row.get(7)?;
-    let agent: Option<String> = row.get(8)?;
-    let extra_repos_json: Option<String> = row.get(16)?;
-    let action_command: Option<String> = row.get(17)?;
+    let cols: super::ActionColumns = (
+        row.get(4)?,
+        row.get(5)?,
+        row.get(6)?,
+        row.get(7)?,
+        row.get(8)?,
+        row.get(16)?,
+        row.get(17)?,
+    );
 
-    let action = match action_kind.as_deref() {
-        Some("send") => Some(AutomationAction::Send {
-            session_id: target_session
-                .unwrap_or_default()
-                .parse()
-                .unwrap_or_default(),
-        }),
-        Some("spawn") => Some(AutomationAction::Spawn {
-            repo_path: PathBuf::from(repo_path.unwrap_or_default()),
-            worktree_branch,
-            base_branch,
-            agent,
-            extra_repos: super::extra_repos_from_json(extra_repos_json),
-        }),
-        Some("exec") => Some(AutomationAction::Exec {
-            command: action_command.unwrap_or_default(),
-        }),
-        _ => None,
-    };
+    // An action-less local todo has a NULL `action_kind`; only a present
+    // discriminant decodes to an action (Exec round-trips even though the TUI
+    // never authors one onto a task).
+    let action = action_kind
+        .as_deref()
+        .map(|kind| super::action_from_columns(kind, cols));
 
     Ok(Task {
         id: row.get(0)?,
@@ -339,6 +260,8 @@ fn map_task(row: &rusqlite::Row) -> rusqlite::Result<Task> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
     use crate::session::SessionId;
 


### PR DESCRIPTION
Fixes the storage-quality findings from the code review. Scope: `src/storage/` only.

## Findings fixed

1. **(HIGH) `migrate_v34` swallowed ALTER errors** — `src/storage/schema.rs:1004`.
   Replaced the banned `let _ = conn.execute("ALTER …")` pattern with the existing
   `add_column_if_absent` helper for the three hook columns (`hook_state`,
   `hook_state_at`, `seen_at`), matching migrations v33/v36. A failed ALTER no
   longer stays hidden while `SCHEMA_VERSION` advances and `load_hook_states`
   later queries missing columns.

2. **`upsert_session` non-atomic + swallowed read error** — `src/storage/sessions.rs:43`.
   Rewrote the write as a single atomic `INSERT … ON CONFLICT(id) DO UPDATE SET …`
   (the native UPSERT idiom from `settings.rs`/`repo_bookmarks.rs`). The pre-write
   existence check now uses `.optional()?` (errors propagate) and only chooses the
   audit label — it can't make the write race. The invariant that `upsert_session`
   **never** writes the hook columns is preserved and now documented.

3. **`additional_dirs` newline-delimited** — `src/storage/sessions.rs:56`.
   Now stored as a JSON array of path strings (like the sibling
   `action_extra_repos` column), so a path containing a newline round-trips as one
   dir. Reads fall back to the legacy `\n` split for existing rows, so no migration
   is needed. Added regression tests for the newline round-trip and legacy decode.

4. **Duplicated action codec across the two action-bearing tables** —
   `src/storage/tasks.rs:240` and `src/storage/automations.rs:308`.
   Factored a single `action_to_columns` / `action_from_columns` codec into
   `src/storage/mod.rs` (alongside the shared `extra_repos_*_json` helpers) and
   call it from both. Behavior unchanged: automations decode an unknown kind to
   `Spawn` as before, and tasks still gate on a non-NULL `action_kind` so an
   action-less todo decodes to `None`.

## Comments
Pruned a few restating/noise comments in the touched files; kept the rationale,
invariant, and gotcha comments (notably the `upsert_session`-never-writes-the-hook-columns
note, now expanded).

## Verification
`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and
`cargo nextest run --all` (1591 tests) all pass.
