### PR TITLE
fix(cli): gate extension heartbeat + dedup task/automation/session CLI helpers

### DIFF
--- a/src/cli/action.rs
+++ b/src/cli/action.rs
@@ -1,0 +1,103 @@
+//! Shared helpers for the `task` and `automation` CLI surfaces, which both build
+//! an `AutomationAction` from `--session`/`--repo`/`--command` flags, label and
+//! serialize it, and spawn-or-reuse a headless session to deliver a prompt. Each
+//! command keeps only its type-specific wrappers (different return shapes and
+//! reuse-matching) on top of these primitives.
+//!
+//! tmux/spawn helpers are reached via fully-qualified `crate::agent::…` paths (no
+//! `use`) to keep the cli module free of an `agent` import — see
+//! tests/architecture_rules.rs::cli_module_isolation.
+
+use serde_json::{json, Value};
+
+use crate::session::{AutomationAction, SessionId};
+use crate::session_ops::SpawnRequest;
+use crate::storage::Database;
+
+/// Seconds to wait after a headless spawn before delivering the prompt, giving
+/// the agent CLI time to start.
+pub(crate) const BOOT_DELAY_SECS: u64 = 3;
+
+/// Human label for an action — `-` when there is none (a plain local todo).
+pub(crate) fn action_label(action: Option<&AutomationAction>) -> String {
+    match action {
+        None => "-".to_string(),
+        Some(AutomationAction::Send { .. }) => "send".to_string(),
+        Some(AutomationAction::Spawn { .. }) => "spawn".to_string(),
+        Some(AutomationAction::Exec { .. }) => "exec".to_string(),
+    }
+}
+
+/// Serialize an action to its JSON object — `Value::Null` when there is none.
+pub(crate) fn action_to_json(action: Option<&AutomationAction>) -> Value {
+    match action {
+        None => Value::Null,
+        Some(AutomationAction::Send { session_id }) => json!({
+            "kind": "send",
+            "session_id": session_id.to_string(),
+        }),
+        Some(AutomationAction::Spawn {
+            repo_path,
+            worktree_branch,
+            base_branch,
+            agent,
+            extra_repos,
+        }) => json!({
+            "kind": "spawn",
+            "repo_path": repo_path.to_string_lossy(),
+            "worktree_branch": worktree_branch,
+            "base_branch": base_branch,
+            "agent": agent,
+            "extra_repos": serde_json::to_value(extra_repos).unwrap_or(Value::Null),
+        }),
+        Some(AutomationAction::Exec { command }) => json!({
+            "kind": "exec",
+            "command": command,
+        }),
+    }
+}
+
+/// Parse + validate a `--session` UUID for a Send action: the session must
+/// exist. Shared by the task/automation `resolve_action` wrappers.
+pub(crate) fn resolve_send_target(db: &Database, s: &str) -> Result<SessionId, String> {
+    let session_id: SessionId = s
+        .parse()
+        .map_err(|_| format!("invalid session UUID: {s}"))?;
+    db.get_session_by_id(session_id)
+        .map_err(|e| format!("get_session_by_id: {e}"))?
+        .ok_or_else(|| format!("Session not found: {s}"))?;
+    Ok(session_id)
+}
+
+/// Why a [`spawn_and_deliver`] attempt didn't fully succeed. The split lets each
+/// caller preserve its own behavior: a spawn failure leaves no session, while a
+/// delivery failure still created one (callers that record a session id keep it).
+pub(crate) enum SpawnDeliverError {
+    /// The spawn itself failed; no session was created.
+    Spawn(String),
+    /// The session spawned but the delayed prompt delivery failed.
+    Deliver {
+        session_id: SessionId,
+        message: String,
+    },
+}
+
+/// Spawn a fresh headless session for `req` and deliver `prompt` once the agent
+/// boots (after [`BOOT_DELAY_SECS`]). Returns the new session id on success.
+pub(crate) fn spawn_and_deliver(
+    db: &Database,
+    name: &str,
+    req: SpawnRequest,
+    prompt: &str,
+) -> Result<SessionId, SpawnDeliverError> {
+    let session_id = crate::session_ops::spawn_session_headless(db, req)
+        .map_err(SpawnDeliverError::Spawn)?
+        .session_id;
+    crate::agent::tmux::send_prompt_after_delay(name, prompt, BOOT_DELAY_SECS).map_err(|e| {
+        SpawnDeliverError::Deliver {
+            session_id,
+            message: format!("spawned {name} but prompt delivery failed: {e}"),
+        }
+    })?;
+    Ok(session_id)
+}

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -7,6 +7,7 @@
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use crate::cli::action::{self, SpawnDeliverError};
 use crate::cli::output::{self, CommandOutput};
 use crate::session::automation::parse_trigger;
 use crate::session::{Automation, AutomationAction, AutomationRun, AutomationRunStatus, SessionId};
@@ -14,10 +15,6 @@ use crate::session_ops::SpawnRequest;
 use crate::storage::automations::NewAutomation;
 use crate::storage::Database;
 use crate::sync::current_time_millis;
-
-/// Seconds to wait after a headless spawn before delivering the automation's
-/// prompt, giving the agent CLI time to start.
-const BOOT_DELAY_SECS: u64 = 3;
 
 #[derive(Subcommand, Debug)]
 pub enum Action {
@@ -369,7 +366,7 @@ fn render_automation_list(autos: &[Automation]) -> String {
                 if a.enabled { "on" } else { "off" }.to_string(),
                 a.name.clone(),
                 a.schedule.kind().to_string(),
-                automation_action_label(&a.action),
+                action::action_label(Some(&a.action)),
             ]
         })
         .collect();
@@ -387,7 +384,7 @@ fn render_automation_detail(a: &Automation) -> String {
             format!("{} ({})", a.schedule.kind(), a.schedule.spec()),
         ),
         ("timezone", output::dash(a.timezone.as_deref())),
-        ("action", automation_action_label(&a.action)),
+        ("action", action::action_label(Some(&a.action))),
         ("prompt", a.prompt.clone()),
     ];
     output::kv(&pairs)
@@ -418,15 +415,6 @@ fn render_tick(v: &Value) -> String {
     let skipped = count("skipped");
     let healed = count("healed");
     format!("Tick: {fired} fired, {skipped} skipped, {healed} extension(s) healed.")
-}
-
-/// Human label for an automation's send/spawn action.
-fn automation_action_label(action: &AutomationAction) -> String {
-    match action {
-        AutomationAction::Send { .. } => "send".to_string(),
-        AutomationAction::Spawn { .. } => "spawn".to_string(),
-        AutomationAction::Exec { .. } => "exec".to_string(),
-    }
 }
 
 /// Fire every due automation headlessly: claim (atomic CAS, so this is safe to
@@ -462,8 +450,8 @@ fn tick(db: &Database) -> Result<Value, String> {
             .claim_due_automation(auto.id, auto.next_run_at.unwrap_or(0), next, now)
             .map_err(|e| format!("claim_due_automation: {e}"))?;
         if !claimed {
-            // Another firer (TUI / concurrent tick) won the claim. The CLI
-            // logs at WARN by default, so report it in the JSON too.
+            // Another firer (TUI / concurrent tick) won the claim. This logs at
+            // debug! (invisible at the default level), so report it in the JSON too.
             tracing::debug!(
                 automation_id = auto.id,
                 "automation claim lost to a concurrent firer"
@@ -597,24 +585,18 @@ fn fire_spawn(
         task_id: None,
         extra_repos: extra_repos.to_vec(),
     };
-    match crate::session_ops::spawn_session_headless(db, req) {
-        Ok(result) => {
-            let session_id = Some(result.session_id);
-            match crate::agent::tmux::send_prompt_after_delay(&name, &auto.prompt, BOOT_DELAY_SECS)
-            {
-                Ok(()) => (
-                    AutomationRunStatus::Success,
-                    format!("spawned {name}"),
-                    session_id,
-                ),
-                Err(e) => (
-                    AutomationRunStatus::Error,
-                    format!("spawned {name} but prompt delivery failed: {e}"),
-                    session_id,
-                ),
-            }
-        }
-        Err(e) => (AutomationRunStatus::Error, e, None),
+    match action::spawn_and_deliver(db, &name, req, &auto.prompt) {
+        Ok(session_id) => (
+            AutomationRunStatus::Success,
+            format!("spawned {name}"),
+            Some(session_id),
+        ),
+        // A spawned-but-undelivered run still records its session id.
+        Err(SpawnDeliverError::Deliver {
+            session_id,
+            message,
+        }) => (AutomationRunStatus::Error, message, Some(session_id)),
+        Err(SpawnDeliverError::Spawn(e)) => (AutomationRunStatus::Error, e, None),
     }
 }
 
@@ -651,15 +633,9 @@ fn resolve_action(
             Err("specify either --session (send) or --repo (spawn), not both".into())
         }
         (None, None) => Err("specify --session (send), --repo (spawn), or --command (exec)".into()),
-        (Some(s), None) => {
-            let session_id: SessionId = s
-                .parse()
-                .map_err(|_| format!("invalid session UUID: {s}"))?;
-            db.get_session_by_id(session_id)
-                .map_err(|e| format!("get_session_by_id: {e}"))?
-                .ok_or_else(|| format!("Session not found: {s}"))?;
-            Ok(AutomationAction::Send { session_id })
-        }
+        (Some(s), None) => Ok(AutomationAction::Send {
+            session_id: action::resolve_send_target(db, &s)?,
+        }),
         (None, Some(r)) => Ok(AutomationAction::Spawn {
             repo_path: r.into(),
             worktree_branch: worktree,
@@ -671,30 +647,7 @@ fn resolve_action(
 }
 
 fn automation_to_json(a: &Automation) -> Value {
-    let action = match &a.action {
-        AutomationAction::Send { session_id } => json!({
-            "kind": "send",
-            "session_id": session_id.to_string(),
-        }),
-        AutomationAction::Spawn {
-            repo_path,
-            worktree_branch,
-            base_branch,
-            agent,
-            extra_repos,
-        } => json!({
-            "kind": "spawn",
-            "repo_path": repo_path.to_string_lossy(),
-            "worktree_branch": worktree_branch,
-            "base_branch": base_branch,
-            "agent": agent,
-            "extra_repos": serde_json::to_value(extra_repos).unwrap_or(Value::Null),
-        }),
-        AutomationAction::Exec { command } => json!({
-            "kind": "exec",
-            "command": command,
-        }),
-    };
+    let action = action::action_to_json(Some(&a.action));
     json!({
         "id": a.id,
         "name": a.name,
@@ -771,19 +724,19 @@ mod tests {
     #[test]
     fn action_label_distinguishes_send_and_spawn() {
         assert_eq!(
-            automation_action_label(&AutomationAction::Send {
+            action::action_label(Some(&AutomationAction::Send {
                 session_id: SessionId::default(),
-            }),
+            })),
             "send"
         );
         assert_eq!(
-            automation_action_label(&AutomationAction::Spawn {
+            action::action_label(Some(&AutomationAction::Spawn {
                 repo_path: "/x".into(),
                 worktree_branch: None,
                 base_branch: None,
                 agent: None,
                 extra_repos: Vec::new(),
-            }),
+            })),
             "spawn"
         );
     }

--- a/src/cli/extensions.rs
+++ b/src/cli/extensions.rs
@@ -9,6 +9,7 @@
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use crate::cli::automations::arm_heartbeat;
 use crate::cli::output::{self, CommandOutput};
 use crate::session::ExtensionDef;
 use crate::storage::Database;
@@ -408,15 +409,6 @@ fn load_manifest(name: &str) -> Result<ExtensionDef, String> {
              (it writes ~/.config/thurbox/extensions/{name}.toml)."
         )
     })
-}
-
-/// Best-effort: ensure the tmux heartbeat keeper runs so the extension's
-/// automations fire even when no TUI is attached. Non-fatal on failure.
-fn arm_heartbeat() {
-    let cli = crate::agent::tmux::resolve_cli_binary();
-    if let Err(e) = crate::agent::tmux::ensure_automation_heartbeat(&cli) {
-        eprintln!("warning: failed to arm automation heartbeat: {e}");
-    }
 }
 
 /// Build the `extension available` result: every official extension with its

--- a/src/cli/identity.rs
+++ b/src/cli/identity.rs
@@ -1,0 +1,45 @@
+//! Resolve the thurbox session a CLI invocation is running *inside*, from the
+//! env vars thurbox injects at spawn. Shared by `message` (provenance) and
+//! `session signal` (the hook callback's identity).
+
+use crate::session::SessionId;
+use crate::storage::Database;
+use crate::sync::SharedSession;
+
+/// The calling session, resolved from the `THURBOX_SESSION` env var thurbox
+/// injects at spawn (the registry key). `None` when not running inside a thurbox
+/// session, or the id no longer maps to a live row. DB errors are swallowed to
+/// `None` (provenance is best-effort).
+pub(crate) fn calling_session(db: &Database) -> Option<SharedSession> {
+    let raw = std::env::var("THURBOX_SESSION").ok()?;
+    let id: SessionId = raw.parse().ok()?;
+    db.get_session_by_id(id).ok().flatten()
+}
+
+/// The calling session resolved from `$THURBOX_SESSION`, falling back to a lookup
+/// by the agent conversation id in `$THURBOX_SESSION_ID` (the env fallback for
+/// agents whose hooks don't inherit `$THURBOX_SESSION`). `Ok(None)` when neither
+/// resolves. Unlike [`calling_session`], DB errors are surfaced.
+pub(crate) fn calling_session_or_by_agent_id(
+    db: &Database,
+) -> Result<Option<SharedSession>, String> {
+    if let Ok(raw) = std::env::var("THURBOX_SESSION") {
+        if let Ok(id) = raw.parse::<SessionId>() {
+            if let Some(s) = db
+                .get_session_by_id(id)
+                .map_err(|e| format!("get_session_by_id: {e}"))?
+            {
+                return Ok(Some(s));
+            }
+        }
+    }
+    if let Ok(agent_sid) = std::env::var("THURBOX_SESSION_ID") {
+        if let Some(s) = db
+            .get_session_by_agent_session_id(&agent_sid)
+            .map_err(|e| format!("get_session_by_agent_session_id: {e}"))?
+        {
+            return Ok(Some(s));
+        }
+    }
+    Ok(None)
+}

--- a/src/cli/messages.rs
+++ b/src/cli/messages.rs
@@ -7,6 +7,7 @@
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use crate::cli::identity::calling_session;
 use crate::cli::output::{self, CommandOutput};
 use crate::session::{SessionId, SessionMessage};
 use crate::storage::messages::{NewMessage, DEFAULT_RETENTION_DAYS};
@@ -324,15 +325,6 @@ fn enqueue_and_wake(
         }),
         human,
     ))
-}
-
-/// The calling session, resolved from the `THURBOX_SESSION` env var thurbox
-/// injects at spawn (the registry key). `None` when not running inside a thurbox
-/// session, or the id no longer maps to a live row.
-fn calling_session(db: &Database) -> Option<SharedSession> {
-    let raw = std::env::var("THURBOX_SESSION").ok()?;
-    let id: SessionId = raw.parse().ok()?;
-    db.get_session_by_id(id).ok().flatten()
 }
 
 /// The calling session's id from `THURBOX_SESSION` (used for provenance).

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,10 +13,12 @@ use clap::{Parser, Subcommand};
 
 use crate::storage::Database;
 
+pub mod action;
 pub mod automations;
 pub mod config;
 pub mod editor;
 pub mod extensions;
+pub mod identity;
 pub mod messages;
 pub mod notify;
 pub mod output;

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -334,25 +334,8 @@ fn resolve_signal_target(db: &Database, session: Option<&str>) -> Result<SharedS
     if let Some(uuid) = session {
         return resolve(db, uuid);
     }
-    if let Ok(raw) = std::env::var("THURBOX_SESSION") {
-        if let Ok(id) = raw.parse::<SessionId>() {
-            if let Some(s) = db
-                .get_session_by_id(id)
-                .map_err(|e| format!("get_session_by_id: {e}"))?
-            {
-                return Ok(s);
-            }
-        }
-    }
-    if let Ok(agent_sid) = std::env::var("THURBOX_SESSION_ID") {
-        if let Some(s) = db
-            .get_session_by_agent_session_id(&agent_sid)
-            .map_err(|e| format!("get_session_by_agent_session_id: {e}"))?
-        {
-            return Ok(s);
-        }
-    }
-    Err("not inside a thurbox session; pass --session <uuid>".into())
+    crate::cli::identity::calling_session_or_by_agent_id(db)?
+        .ok_or_else(|| "not inside a thurbox session; pass --session <uuid>".into())
 }
 
 /// Render the session list as an aligned table (or a friendly empty line).

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -8,15 +8,12 @@
 use clap::Subcommand;
 use serde_json::{json, Value};
 
+use crate::cli::action::{self, SpawnDeliverError};
 use crate::cli::output::{self, CommandOutput};
-use crate::session::{AutomationAction, SessionId, Task, TaskStatus, SOURCE_LOCAL};
+use crate::session::{AutomationAction, Task, TaskStatus, SOURCE_LOCAL};
 use crate::session_ops::SpawnRequest;
 use crate::storage::tasks::NewTask;
 use crate::storage::Database;
-
-/// Seconds to wait after a headless spawn before delivering the task's title,
-/// giving the agent CLI time to start.
-const BOOT_DELAY_SECS: u64 = 3;
 
 #[derive(Subcommand, Debug)]
 pub enum Action {
@@ -237,7 +234,7 @@ fn render_task_list(tasks: &[Task]) -> String {
                 t.id.to_string(),
                 status_glyph(t.status),
                 t.title.clone(),
-                task_action_label(&t.action),
+                action::action_label(t.action.as_ref()),
             ]
         })
         .collect();
@@ -250,7 +247,7 @@ fn render_task_detail(t: &Task) -> String {
         ("id", t.id.to_string()),
         ("title", t.title.clone()),
         ("status", t.status.as_str().to_string()),
-        ("action", task_action_label(&t.action)),
+        ("action", action::action_label(t.action.as_ref())),
         ("source", t.source.clone()),
     ];
     if let Some(url) = &t.external_url {
@@ -287,17 +284,6 @@ fn status_glyph(status: TaskStatus) -> String {
         TaskStatus::Todo => "☐ todo".to_string(),
         TaskStatus::InProgress => "◐ in-progress".to_string(),
         TaskStatus::Done => "☑ done".to_string(),
-    }
-}
-
-/// Human label for a task's optional agent action.
-fn task_action_label(action: &Option<AutomationAction>) -> String {
-    match action {
-        None => "-".to_string(),
-        Some(AutomationAction::Send { .. }) => "send".to_string(),
-        Some(AutomationAction::Spawn { .. }) => "spawn".to_string(),
-        // Exec is an automation-only action; tasks never carry one.
-        Some(AutomationAction::Exec { .. }) => "exec".to_string(),
     }
 }
 
@@ -361,9 +347,11 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
                 task_id: Some(task.id),
                 extra_repos: extra_repos.clone(),
             };
-            crate::session_ops::spawn_session_headless(db, req)?;
-            crate::agent::tmux::send_prompt_after_delay(&name, &prompt, BOOT_DELAY_SECS)
-                .map_err(|e| format!("spawned {name} but prompt delivery failed: {e}"))?;
+            action::spawn_and_deliver(db, &name, req, &prompt).map_err(|e| match e {
+                SpawnDeliverError::Spawn(msg) | SpawnDeliverError::Deliver { message: msg, .. } => {
+                    msg
+                }
+            })?;
             mark_in_progress(db, task)?;
             Ok(json!({ "spawned": name, "id": task.id }))
         }
@@ -441,15 +429,9 @@ fn resolve_action(
         (Some(_), None) if !extra_repos.is_empty() => {
             Err("--add-repo/--add-dir apply to --repo (spawn), not --session (send)".into())
         }
-        (Some(s), None) => {
-            let session_id: SessionId = s
-                .parse()
-                .map_err(|_| format!("invalid session UUID: {s}"))?;
-            db.get_session_by_id(session_id)
-                .map_err(|e| format!("get_session_by_id: {e}"))?
-                .ok_or_else(|| format!("Session not found: {s}"))?;
-            Ok(Some(AutomationAction::Send { session_id }))
-        }
+        (Some(s), None) => Ok(Some(AutomationAction::Send {
+            session_id: action::resolve_send_target(db, &s)?,
+        })),
         (None, Some(r)) => Ok(Some(AutomationAction::Spawn {
             repo_path: r.into(),
             worktree_branch: worktree,
@@ -461,31 +443,7 @@ fn resolve_action(
 }
 
 fn task_to_json(t: &Task) -> Value {
-    let action = match &t.action {
-        None => Value::Null,
-        Some(AutomationAction::Send { session_id }) => json!({
-            "kind": "send",
-            "session_id": session_id.to_string(),
-        }),
-        Some(AutomationAction::Spawn {
-            repo_path,
-            worktree_branch,
-            base_branch,
-            agent,
-            extra_repos,
-        }) => json!({
-            "kind": "spawn",
-            "repo_path": repo_path.to_string_lossy(),
-            "worktree_branch": worktree_branch,
-            "base_branch": base_branch,
-            "agent": agent,
-            "extra_repos": serde_json::to_value(extra_repos).unwrap_or(Value::Null),
-        }),
-        Some(AutomationAction::Exec { command }) => json!({
-            "kind": "exec",
-            "command": command,
-        }),
-    };
+    let action = action::action_to_json(t.action.as_ref());
     json!({
         "id": t.id,
         "title": t.title,
@@ -503,6 +461,7 @@ fn task_to_json(t: &Task) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::SessionId;
 
     /// Minimal local task for render tests.
     fn task(id: i64, title: &str, status: TaskStatus, action: Option<AutomationAction>) -> Task {
@@ -530,15 +489,15 @@ mod tests {
 
     #[test]
     fn action_label_distinguishes_send_spawn_and_none() {
-        assert_eq!(task_action_label(&None), "-");
+        assert_eq!(action::action_label(None), "-");
         assert_eq!(
-            task_action_label(&Some(AutomationAction::Send {
+            action::action_label(Some(&AutomationAction::Send {
                 session_id: SessionId::default(),
             })),
             "send"
         );
         assert_eq!(
-            task_action_label(&Some(AutomationAction::Spawn {
+            action::action_label(Some(&AutomationAction::Spawn {
                 repo_path: "/x".into(),
                 worktree_branch: None,
                 base_branch: None,


### PR DESCRIPTION
Fixes a batch of code-quality findings from a review of `src/cli/`. All
behavior-preserving except finding 1 (a contract bug). Each fix below lists its
`file:line` from the review.

## Fixes

1. **Duplicate `arm_heartbeat()` bypassed the `[features] automations` gate** —
   `src/cli/extensions.rs:415`. A private `arm_heartbeat()` copy omitted the
   feature gate that `cli::automations::arm_heartbeat()` enforces, so 6 extension
   ops (install/update/update-all/reinstall/activate) spawned a tmux keeper
   window even when automations are disabled — violating the documented
   no-op-when-disabled contract. Deleted the copy; all sites now call the gated
   `cli::automations::arm_heartbeat()`.

2. **Inverted log-level comment** — `src/cli/automations.rs:465`. The comment
   claimed the CLI "logs at WARN" but the call is `tracing::debug!` (invisible at
   the default level). Reworded to match (`debug!`, surfaced via JSON), keeping
   the JSON-surfacing rationale.

3. **`AutomationAction → JSON` match duplicated** — `src/cli/tasks.rs:463` and
   `src/cli/automations.rs:673`. Factored a single
   `action::action_to_json(Option<&AutomationAction>)` helper used by both
   (`Value::Null` for the task `None` case, never hit for the required automation
   action).

4. **`resolve_action` / `*_action_label` / spawn-or-reuse duplicated** —
   `src/cli/automations.rs:629` and `src/cli/tasks.rs`. Factored into the new
   `src/cli/action.rs`: `BOOT_DELAY_SECS`, `action_label`, `resolve_send_target`
   (the `--session` UUID parse + existence check), and `spawn_and_deliver` (the
   spawn-then-deliver-after-boot core with the shared `spawned … but prompt
   delivery failed` error). A `SpawnDeliverError` enum lets each caller keep its
   own shape: automations records the session id on a delivery failure, tasks
   propagates the error string. Reuse-matching stays type-specific (different per
   surface), so only the genuinely shared core moved.

5. **`THURBOX_SESSION` resolution implemented twice** — `src/cli/messages.rs:332`
   and `src/cli/sessions.rs:333`. Factored `calling_session(db)` and
   `calling_session_or_by_agent_id(db)` into the new `src/cli/identity.rs`. Each
   call site keeps its prior semantics: `message` swallows DB errors to `None`
   and never falls back to the agent id; `session signal` surfaces DB errors and
   does fall back via `$THURBOX_SESSION_ID`.

Also pruned the now-stale doc-comments on the deleted helpers per the
comment-reduction policy (only in touched files).

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all` — 1589 passed, 0 failed (incl. `architecture_rules`;
  the new `cli` submodules reach `crate::agent::tmux` via fully-qualified paths
  only, per the cli isolation rule).
