### PR TITLE
refactor(ui): dedup block-cursor + row-hitbox helpers, borrow cached order

### DIFF
--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -242,8 +242,8 @@ impl App {
                 session_list_state: &mut self.session_list_state,
                 session_match_positions: &ordered.match_positions,
                 session_search_active,
-                headers: &ordered.headers,
-                depths: &ordered.depths,
+                headers: ordered.headers,
+                depths: ordered.depths,
                 spinner,
             },
         );

--- a/src/ui/automation_editor_modal.rs
+++ b/src/ui/automation_editor_modal.rs
@@ -451,24 +451,8 @@ fn wrapped_cursor(col: usize, wrap_w: usize, n_rows: usize) -> (usize, usize) {
 
 /// One indented prompt row with a block cursor drawn at char index `caret`.
 fn prompt_cursor_row<'a>(chunk: &[char], caret: usize, text_style: Style) -> Line<'a> {
-    let caret = caret.min(chunk.len());
     let mut spans = vec![Span::raw("    ")];
-    let before: String = chunk[..caret].iter().collect();
-    if !before.is_empty() {
-        spans.push(Span::styled(before, text_style));
-    }
-    let cursor_char = chunk
-        .get(caret)
-        .map(|c| c.to_string())
-        .unwrap_or_else(|| " ".to_string());
-    spans.push(Span::styled(cursor_char, Theme::cursor()));
-    let after: String = chunk
-        .get(caret + 1..)
-        .map(|s| s.iter().collect())
-        .unwrap_or_default();
-    if !after.is_empty() {
-        spans.push(Span::styled(after, text_style));
-    }
+    super::push_block_cursor(&mut spans, chunk, caret, text_style);
     Line::from(spans)
 }
 

--- a/src/ui/automation_editor_modal.rs
+++ b/src/ui/automation_editor_modal.rs
@@ -49,7 +49,7 @@ pub struct AutomationEditorState<'a> {
 
 impl<'a> AutomationEditorState<'a> {
     /// Borrow view data from an editor modal. Shared by the centered-overlay and
-    /// in-pane render paths so the 18-field projection lives in one place.
+    /// in-pane render paths so the field projection lives in one place.
     pub fn from_modal(
         m: &'a crate::app::modals::AutomationEditorModal,
         preview: &'a str,

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -711,13 +711,7 @@ fn render_tree(
 
     // One hitbox per visible tree row; `rows_area` already excludes the
     // reserved scrollbar column, so row clicks never overlap the track.
-    let hitboxes = (start..end)
-        .enumerate()
-        .map(|(line, i)| super::RowHitbox {
-            rect: Rect::new(rows_area.x, rows_area.y + line as u16, rows_area.width, 1),
-            index: i,
-        })
-        .collect();
+    let hitboxes = super::windowed_row_hitboxes(rows_area, start, end);
 
     let geom = track
         .and_then(|track| scrollbar::render_into(frame, track, rows.len(), height, state.selected));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -97,13 +97,7 @@ pub fn render_selector_rows(
     let (start, end) = file_viewer::visible_window(total, selected, height);
     let visible: Vec<Line<'_>> = lines.into_iter().skip(start).take(end - start).collect();
     frame.render_widget(Paragraph::new(visible), rows_area);
-    let hitboxes = (start..end)
-        .enumerate()
-        .map(|(line, i)| RowHitbox {
-            rect: Rect::new(rows_area.x, rows_area.y + line as u16, rows_area.width, 1),
-            index: i,
-        })
-        .collect();
+    let hitboxes = windowed_row_hitboxes(rows_area, start, end);
     let geom = track.and_then(|t| scrollbar::render_into(frame, t, total, height, selected));
     (hitboxes, geom)
 }
@@ -395,6 +389,38 @@ pub fn editor_field_line_with_cursor<'a>(
     Line::from(spans)
 }
 
+/// Push a block-cursor text run into `spans`: the text before the caret styled
+/// with `style`, the character under the caret in [`Theme::cursor`] (a single
+/// space when the caret sits at end-of-text), then the text after it in `style`.
+///
+/// The single source of truth for the editor block-cursor split — every editor
+/// (and the scroll-windowing path) wraps this rather than re-deriving the
+/// `caret + 1..` slice (an easy off-by-one).
+pub(crate) fn push_block_cursor<'a>(
+    spans: &mut Vec<Span<'a>>,
+    chars: &[char],
+    caret: usize,
+    style: Style,
+) {
+    let caret = caret.min(chars.len());
+    let before: String = chars[..caret].iter().collect();
+    if !before.is_empty() {
+        spans.push(Span::styled(before, style));
+    }
+    let cursor_char = chars
+        .get(caret)
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| " ".to_string());
+    spans.push(Span::styled(cursor_char, Theme::cursor()));
+    let after: String = chars
+        .get(caret + 1..)
+        .map(|s| s.iter().collect())
+        .unwrap_or_default();
+    if !after.is_empty() {
+        spans.push(Span::styled(after, style));
+    }
+}
+
 /// Append `value` to `spans` with a real block cursor drawn at the caret
 /// position so horizontal movement inside the text is visible. Falls back to a
 /// trailing block when no cursor is supplied (preserves the prior end-of-line
@@ -406,23 +432,8 @@ fn push_value_with_cursor<'a>(
     value_style: Style,
 ) {
     let chars: Vec<char> = value.chars().collect();
-    let caret = cursor.unwrap_or(chars.len()).min(chars.len());
-
-    let before: String = chars[..caret].iter().collect();
-    if !before.is_empty() {
-        spans.push(Span::styled(before, value_style));
-    }
-    let cursor_char = chars
-        .get(caret)
-        .map(|c| c.to_string())
-        .unwrap_or_else(|| " ".to_string());
-    spans.push(Span::styled(cursor_char, Theme::cursor()));
-    if caret < chars.len() {
-        let after: String = chars[caret + 1..].iter().collect();
-        if !after.is_empty() {
-            spans.push(Span::styled(after, value_style));
-        }
-    }
+    let caret = cursor.unwrap_or(chars.len());
+    push_block_cursor(spans, &chars, caret, value_style);
 }
 
 /// Build a footer/hint [`Line`] from `(key, description)` pairs, styling keys
@@ -796,34 +807,24 @@ fn push_cursor_spans(
     has_left_overflow: bool,
     suggestion_text: &str,
 ) {
-    let before: String = chars[content_start..cursor].iter().collect();
-    let cursor_char = if cursor < chars.len() {
-        chars[cursor].to_string()
-    } else {
-        " ".to_string()
-    };
-    let after_start = (cursor + 1).min(chars.len());
-    let after_end = visible_end.min(chars.len());
-    let after: String = chars[after_start..after_end].iter().collect();
-    let after_len = after.len();
-
-    if !before.is_empty() {
-        spans.push(Span::styled(
-            before,
-            Style::default().fg(Theme::text_primary()),
-        ));
-    }
-    spans.push(Span::styled(cursor_char, Theme::cursor()));
-    if !after.is_empty() {
-        spans.push(Span::styled(
-            after,
-            Style::default().fg(Theme::text_primary()),
-        ));
-    }
+    let window = &chars[content_start..visible_end];
+    let caret = cursor - content_start;
+    push_block_cursor(
+        spans,
+        window,
+        caret,
+        Style::default().fg(Theme::text_primary()),
+    );
 
     if suggestion_text.is_empty() {
         return;
     }
+    // Byte length of the rendered "after" text, used to budget the suggestion
+    // tail against the remaining visible width.
+    let after_len = window
+        .get(caret + 1..)
+        .map(|s| s.iter().collect::<String>().len())
+        .unwrap_or(0);
     let used = if has_left_overflow { 1 } else { 0 }
         + (cursor - content_start)
         + 1 // cursor block

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -155,18 +155,16 @@ pub fn compute_session_order(sessions: &[&SessionInfo]) -> SessionOrder {
 
     // Groups: by lowest member manual order, then label for determinism.
     // Moves renumber all sessions densely in render order, so a group's
-    // minimum reproduces the group order the user last saw.
-    groups.sort_by(|a, b| {
-        let key = |g: &Group| {
-            let order = g
-                .members
-                .iter()
-                .map(|&i| sort_key(i).0)
-                .min()
-                .unwrap_or(i64::MAX);
-            (order, g.label.clone().unwrap_or_default())
-        };
-        key(a).cmp(&key(b))
+    // minimum reproduces the group order the user last saw. `sort_by_cached_key`
+    // computes each group's key once rather than per pairwise comparison.
+    groups.sort_by_cached_key(|g| {
+        let order = g
+            .members
+            .iter()
+            .map(|&i| sort_key(i).0)
+            .min()
+            .unwrap_or(i64::MAX);
+        (order, g.label.clone().unwrap_or_default())
     });
 
     let mut order = Vec::with_capacity(sessions.len());
@@ -438,36 +436,28 @@ pub struct OrderedSessions<'a> {
     pub match_positions: Vec<Option<SessionMatch>>,
     pub active_index: usize,
     /// Parallel to `sessions`: `Some(label)` on each repo group's first row,
-    /// used to render a subtle header above it. `None` elsewhere.
-    pub headers: Vec<Option<String>>,
+    /// used to render a subtle header above it. `None` elsewhere. Borrowed from
+    /// the source [`SessionOrder`] (never cloned — the order is render-stable).
+    pub headers: &'a [Option<String>],
     /// Parallel to `sessions`: tree depth within the repo group
-    /// (see [`SessionOrder::depths`]).
-    pub depths: Vec<u8>,
+    /// (see [`SessionOrder::depths`]). Borrowed from the source [`SessionOrder`].
+    pub depths: &'a [u8],
 }
 
 impl<'a> OrderedSessions<'a> {
-    /// Reorder the parallel arrays into render order, remapping `active_index`
-    /// and `match_positions` to follow it.
-    pub fn new(
-        sessions: &[&'a SessionInfo],
-        match_positions: &[Option<SessionMatch>],
-        active_index: usize,
-    ) -> Self {
-        let order = compute_session_order(sessions);
-        Self::from_order(sessions, &order, match_positions, active_index)
-    }
-
-    /// As [`Self::new`], but reuses a previously computed [`SessionOrder`]
-    /// instead of recomputing it. The order is a pure function of the session
-    /// set's grouping/nesting inputs (`repo_display_names`, `display_order`,
-    /// `id`, `parent_session_id`) — never status — so the caller can cache it
-    /// keyed by a content signature and skip the grouping/sort/nest work on
-    /// frames where none of those changed (see `App::render_left_panel`). The
-    /// per-frame remap of refs / match positions / `active_index` still runs,
-    /// since those vary independently of the order.
+    /// Reorder the parallel arrays into render order against a previously
+    /// computed [`SessionOrder`], remapping `active_index` and `match_positions`
+    /// to follow it. The order is a pure function of the session set's
+    /// grouping/nesting inputs (`repo_display_names`, `display_order`, `id`,
+    /// `parent_session_id`) — never status — so the caller can cache it keyed by
+    /// a content signature and skip the grouping/sort/nest work on frames where
+    /// none of those changed (see `App::render_left_panel`). The per-frame remap
+    /// of refs / match positions / `active_index` still runs, since those vary
+    /// independently of the order; `headers`/`depths` are *borrowed* from the
+    /// cached `order` rather than cloned each frame.
     pub fn from_order(
         sessions: &[&'a SessionInfo],
-        order: &SessionOrder,
+        order: &'a SessionOrder,
         match_positions: &[Option<SessionMatch>],
         active_index: usize,
     ) -> Self {
@@ -487,8 +477,8 @@ impl<'a> OrderedSessions<'a> {
             sessions: ordered_sessions,
             match_positions: ordered_matches,
             active_index: new_active,
-            headers: order.headers.clone(),
-            depths: order.depths.clone(),
+            headers: &order.headers,
+            depths: &order.depths,
         }
     }
 }
@@ -1029,7 +1019,8 @@ mod tests {
         let matches: Vec<Option<SessionMatch>> = vec![None, None];
         // active_index points at the first input session; the manually ordered
         // one renders above it and active_index is remapped to follow it.
-        let ordered = OrderedSessions::new(&sessions, &matches, 0);
+        let order = compute_session_order(&sessions);
+        let ordered = OrderedSessions::from_order(&sessions, &order, &matches, 0);
         assert_eq!(ordered.sessions[0].name, "moved");
         assert_eq!(ordered.sessions[1].name, "first");
         assert_eq!(ordered.active_index, 1);
@@ -1247,9 +1238,13 @@ mod tests {
         let n1 = info("n1");
         let n2 = info("n2");
         let sessions = vec![&n1, &n2];
-        let ordered = OrderedSessions::new(&sessions, &[None, None], 0);
+        let order = compute_session_order(&sessions);
+        let ordered = OrderedSessions::from_order(&sessions, &order, &[None, None], 0);
         // Single "(no repo)" group: header on row 0, none after.
-        assert_eq!(ordered.headers, vec![Some("(no repo)".to_string()), None]);
+        assert_eq!(
+            ordered.headers.to_vec(),
+            vec![Some("(no repo)".to_string()), None]
+        );
     }
 
     #[test]
@@ -1265,7 +1260,8 @@ mod tests {
         terminal
             .draw(|f| {
                 let sessions = vec![&n1, &n2];
-                let ordered = OrderedSessions::new(&sessions, &[None, None], 0);
+                let order = compute_session_order(&sessions);
+                let ordered = OrderedSessions::from_order(&sessions, &order, &[None, None], 0);
                 hitboxes = render_left_panel(
                     f,
                     Rect::new(0, 0, 30, 12),
@@ -1277,8 +1273,8 @@ mod tests {
                         session_list_state: &mut list_state,
                         session_match_positions: &ordered.match_positions,
                         session_search_active: false,
-                        headers: &ordered.headers,
-                        depths: &ordered.depths,
+                        headers: ordered.headers,
+                        depths: ordered.depths,
                         spinner: "◐",
                     },
                 );
@@ -1294,7 +1290,8 @@ mod tests {
     #[test]
     fn ordered_sessions_empty_input() {
         let sessions: Vec<&SessionInfo> = vec![];
-        let ordered = OrderedSessions::new(&sessions, &[], 0);
+        let order = compute_session_order(&sessions);
+        let ordered = OrderedSessions::from_order(&sessions, &order, &[], 0);
         assert!(ordered.sessions.is_empty());
         assert_eq!(ordered.active_index, 0);
         assert!(ordered.headers.is_empty());

--- a/src/ui/task_editor_modal.rs
+++ b/src/ui/task_editor_modal.rs
@@ -175,24 +175,8 @@ fn description_text_rows<'a>(
 /// Render one description row with a block cursor drawn at `cur_col`.
 fn description_cursor_line<'a>(text: &str, cur_col: usize, text_style: Style) -> Line<'a> {
     let chars: Vec<char> = text.chars().collect();
-    let caret = cur_col.min(chars.len());
     let mut spans = vec![Span::raw("    ")];
-    let before: String = chars[..caret].iter().collect();
-    if !before.is_empty() {
-        spans.push(Span::styled(before, text_style));
-    }
-    let cursor_char = chars
-        .get(caret)
-        .map(|c| c.to_string())
-        .unwrap_or_else(|| " ".to_string());
-    spans.push(Span::styled(cursor_char, Theme::cursor()));
-    let after: String = chars
-        .get(caret + 1..)
-        .map(|s| s.iter().collect())
-        .unwrap_or_default();
-    if !after.is_empty() {
-        spans.push(Span::styled(after, text_style));
-    }
+    super::push_block_cursor(&mut spans, &chars, cur_col, text_style);
     Line::from(spans)
 }
 


### PR DESCRIPTION
Code-quality fixes for `src/ui/` from the W4 review brief. Surgical — no behavior change except where a finding called for it; render output is preserved.

## Findings fixed

1. **Block-cursor span split reimplemented ~5×** — `src/ui/mod.rs:402` & `:789`, `src/ui/automation_editor_modal.rs:453`, `src/ui/task_editor_modal.rs:176`. Extracted a shared `push_block_cursor(spans, chars, caret, style)` helper in `ui/mod.rs` (single source of truth for the before / cursor-char / after split + the `caret + 1..` off-by-one) and wrapped it from every site, including the scroll-windowing `push_cursor_spans` path (`global_search.rs:137` left alone per the brief — different shape).

2. **Hand-rolled windowed row-hitbox loops** — `src/ui/file_viewer.rs:715` & `src/ui/mod.rs:100`. Replaced both with the existing `windowed_row_hitboxes` helper.

3. **(perf) `OrderedSessions::from_order` cloned cached vecs every frame** — `src/ui/project_list.rs:490`. `headers`/`depths` are now borrowed slices (`&[Option<String>]` / `&[u8]`) tied to the cached `SessionOrder`'s lifetime instead of cloned each frame. The test-only `OrderedSessions::new` (which delegated to `from_order` over a *local* order, incompatible with borrowing) was dropped; its 4 callers now build the order explicitly via `compute_session_order`.

4. **(perf) Group comparator cloned label per comparison** — `src/ui/project_list.rs:167`. Switched `sort_by` → `sort_by_cached_key` so each group's key is computed once.

5. **Stale brittle doc count** — `src/ui/automation_editor_modal.rs:52`. Dropped the hard-coded "18-field projection" (the struct has 21 fields now) so the doc can't drift again.

Also pruned the now-redundant comments in the touched functions (per the brief's conservative comment policy).

## Verification
- `cargo fmt --all` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all` — 1589 passed, 0 failed