### PR TITLE
fix(ui): prevent search-highlight panic; harden ui-review skill

### DIFF
--- a/.claude/skills/ui-review/scripts/capture.sh
+++ b/.claude/skills/ui-review/scripts/capture.sh
@@ -41,8 +41,13 @@ cd "$REPO_ROOT"
 # --- Args -------------------------------------------------------------------
 OUT_DIR=""
 DEMO_THEME="${DEMO_THEME:-doom}"
-WIDTH=1920
-HEIGHT=1080
+# Keep the viewport at/under ~1568px on the long edge: image inputs are
+# downscaled to that cap, so a 1920x1080 capture is resampled and the TUI's fine
+# detail (status glyphs, tree markers, swatches) blurs into illegibility for the
+# analyze phase. 1500x940 with FontSize 18 yields ~135 cols (>= the 120-col
+# threshold for the 3-panel layout) and renders 1:1, so text stays readable.
+WIDTH=1500
+HEIGHT=940
 while [ $# -gt 0 ]; do
     case "$1" in
         --theme)  DEMO_THEME="${2:?--theme needs a value}"; shift 2 ;;
@@ -94,23 +99,27 @@ if [ -z "$AGENTS" ]; then
     STUB=1
 fi
 
-# --- Isolated environment ----------------------------------------------------
-SANDBOX=$(mktemp -d "${TMPDIR:-/tmp}/thurbox-ui-review.XXXXXX")
-export HOME="$SANDBOX/home"
-export XDG_DATA_HOME="$SANDBOX/data"
-export XDG_CONFIG_HOME="$SANDBOX/config"
-export XDG_STATE_HOME="$SANDBOX/state"
-export XDG_CACHE_HOME="$SANDBOX/cache"
-export TMUX_TMPDIR="$SANDBOX/tmux"
+# --- Isolated environment (reuse the repo's single source of truth) ----------
+# Don't hand-roll isolation: scripts/dev/lib/sandbox-env.sh is the shared
+# dev-sandbox helper already used by the demo recorder + TUI smoke test.
+# `tbx_sandbox_init_full fresh` gives FULL hermetic isolation — a throwaway
+# mktemp root with fresh HOME + XDG_* — and crucially UNSETS any inherited
+# THURBOX_CONFIG_DIR / THURBOX_DATA_DIR. paths.rs honors those ahead of XDG, so an
+# inherited override (e.g. from a thurbox-dev direnv/sandbox shell) would silently
+# defeat XDG isolation and make the dev binary read/WRITE your REAL db + config.
+# `fresh` => the root is removed on teardown. Build the binaries BEFORE this (done
+# above) so cargo still resolves your real ~/.cargo before HOME is overridden.
+# shellcheck source=scripts/dev/lib/sandbox-env.sh
+# shellcheck disable=SC1091
+. "$REPO_ROOT/scripts/dev/lib/sandbox-env.sh"
+tbx_sandbox_init_full fresh
+
+SANDBOX="$TBX_SANDBOX_ROOT"
 CFG_DIR="$XDG_CONFIG_HOME/thurbox-dev"
 DB_FILE="$XDG_DATA_HOME/thurbox-dev/thurbox.db"
-mkdir -p "$HOME" "$CFG_DIR" "$XDG_DATA_HOME" "$XDG_STATE_HOME" \
-    "$XDG_CACHE_HOME" "$TMUX_TMPDIR"
+mkdir -p "$CFG_DIR" "$(dirname "$DB_FILE")"
 
-cleanup() {
-    tmux -L thurbox-dev kill-server >/dev/null 2>&1 || true
-    rm -rf "$SANDBOX"
-}
+cleanup() { tbx_sandbox_teardown; }
 trap cleanup EXIT INT TERM
 
 # --- Agent registry ----------------------------------------------------------
@@ -127,6 +136,18 @@ trap cleanup EXIT INT TERM
         done
     fi
 } > "$CFG_DIR/agents.toml"
+
+# --- Keybindings override (VHS can't type Ctrl+, or F-keys) ------------------
+# Remap the two actions whose default chords VHS cannot emit to free, typeable
+# Ctrl+<letter> chords so the tape can open them. The rendered panels are
+# identical regardless of which key opens them.
+#   GlobalSearch: default Ctrl+/ -> Ctrl+A   OpenSettings: default Ctrl+, -> Ctrl+X
+cat > "$CFG_DIR/keybindings.json" <<'EOF'
+{
+  "GlobalSearch": ["ctrl+a"],
+  "OpenSettings": ["ctrl+x"]
+}
+EOF
 
 # --- Throwaway sample repo (so the file viewer shows a realistic tree) --------
 DEMO_REPO="$SANDBOX/sample-project"
@@ -166,6 +187,26 @@ log "Seeding sessions for:$AGENTS"
 for a in $AGENTS; do
     "$CLI_BIN" session create --name "$a" --repo-path "$DEMO_REPO" --agent "$a" >/dev/null
 done
+
+# Isolation tripwire: at this point (CLI-only, no TUI yet) the sandbox DB must
+# hold EXACTLY the sessions we just seeded, all rooted under $SANDBOX. If the
+# count is off or any cwd escapes the sandbox, isolation has broken — abort
+# LOUDLY rather than read/pollute the caller's real thurbox database.
+# shellcheck disable=SC2086 # $AGENTS is a space-separated list, split on purpose
+want=$(printf '%s\n' $AGENTS | grep -c .)
+got=$(sqlite3 "$DB_FILE" "SELECT count(*) FROM sessions WHERE deleted_at IS NULL" 2>/dev/null || echo "?")
+escaped=$(sqlite3 "$DB_FILE" \
+    "SELECT cwd FROM sessions WHERE deleted_at IS NULL AND cwd NOT LIKE '$SANDBOX%'" \
+    2>/dev/null || true)
+if [ "$got" != "$want" ] || [ -n "$escaped" ]; then
+    die "sandbox isolation breach — refusing to continue.
+  DB:       $DB_FILE
+  expected: $want session(s), all under $SANDBOX
+  found:    $got session(s)${escaped:+, incl. cwd(s) OUTSIDE the sandbox:
+$escaped}
+This means THURBOX_DATA_DIR/THURBOX_CONFIG_DIR (or similar) pointed the dev
+binary at your real data. Aborting before any further writes."
+fi
 
 log "Seeding tasks + an automation"
 "$CLI_BIN" task create --title "Write integration tests" >/dev/null 2>&1 || true
@@ -225,6 +266,9 @@ emit() { # file label screen keys
 08-theme-picker.png|Theme picker|theme|Ctrl+Y
 09-repo-picker.png|New-session / repo picker|new-session|Ctrl+N
 10-keybindings.png|Keybindings help + editor|keybindings|Ctrl+G
+11-settings-panel.png|Settings panel|settings|Ctrl+,
+12-automation-editor.png|Automation editor (multi-line prompt)|automation-editor|Ctrl+P then Enter
+13-task-editor.png|Task editor (in-pane)|task-editor|Ctrl+W then Enter
 MANIFEST
     printf '\n]\n'
 } > "$OUT_DIR/manifest.json"

--- a/.claude/skills/ui-review/tapes/screenshots.tape
+++ b/.claude/skills/ui-review/tapes/screenshots.tape
@@ -8,7 +8,9 @@
 # VHS has no function-key commands, so this uses thurbox's Ctrl aliases:
 #   Ctrl+B = info panel, Ctrl+E = file viewer, Ctrl+W = tasks, Ctrl+P = automations,
 #   Ctrl+A = global search, Ctrl+Y = theme picker, Ctrl+N = new session,
-#   Ctrl+G = keybindings help, Ctrl+J = next session.
+#   Ctrl+G = keybindings help, Ctrl+J = next session, Ctrl+X = settings.
+# Ctrl+A (global search) and Ctrl+X (settings) are remapped by capture.sh via a
+# seeded keybindings.json, because VHS cannot type their real chords (Ctrl+/, Ctrl+,).
 
 # VHS still requires at least one Output; we use a throwaway one and rely on
 # Screenshot for the real artifacts.
@@ -34,12 +36,21 @@ Sleep 3s
 # 01 — default view: session list + terminal
 Screenshot "__SHOT_DIR__/01-session-list.png"
 
-# 02 — select a different session
+# 02 — select a different session (terminal still focused)
 Ctrl+J
 Sleep 1500ms
 Screenshot "__SHOT_DIR__/02-second-session.png"
 
-# 03 — info panel
+# Focus the session list. The panel-toggle chords below (Ctrl+B/E/W/P) are
+# terminal-PASSTHROUGH actions: while a session terminal is focused they are
+# forwarded to the agent CLI instead of running the thurbox command, so they
+# must be issued from the session list. Ctrl+H (focus previous pane) is NOT a
+# passthrough, so it reliably moves focus Terminal -> session list. Each toggle
+# below returns focus to the session list when closed, so one Ctrl+H suffices.
+Ctrl+H
+Sleep 700ms
+
+# 03 — info panel (toggle leaves focus on the session list)
 Ctrl+B
 Sleep 1500ms
 Screenshot "__SHOT_DIR__/03-info-panel.png"
@@ -96,6 +107,34 @@ Sleep 1500ms
 Screenshot "__SHOT_DIR__/10-keybindings.png"
 Escape
 Sleep 500ms
+
+# 11 — settings panel. Default chord is Ctrl+, / F6, neither typeable by VHS;
+# capture.sh remaps OpenSettings -> Ctrl+X for the tape.
+Ctrl+X
+Sleep 1500ms
+Screenshot "__SHOT_DIR__/11-settings-panel.png"
+Escape
+Sleep 700ms
+
+# 12 — automation editor (multi-line wrapping prompt + modal button footer).
+# Ctrl+P opens the automations list; Enter edits the seeded "nightly-triage".
+Ctrl+P
+Sleep 900ms
+Enter
+Sleep 1500ms
+Screenshot "__SHOT_DIR__/12-automation-editor.png"
+Escape
+Sleep 700ms
+
+# 13 — task editor (in-pane, central-pane). Ctrl+W focuses the tasks panel;
+# Enter opens the editor for the selected task.
+Ctrl+W
+Sleep 900ms
+Enter
+Sleep 1500ms
+Screenshot "__SHOT_DIR__/13-task-editor.png"
+Escape
+Sleep 700ms
 
 # Quit cleanly.
 Ctrl+Q

--- a/src/ui/highlight.rs
+++ b/src/ui/highlight.rs
@@ -49,12 +49,21 @@ fn highlight_style(base_style: Style) -> Style {
 /// Split `text` into highlighted/plain runs at the matched byte `positions`
 /// (UTF-8 offsets, as returned by [`crate::fuzzy::fuzzy_match`]). Out-of-range
 /// positions stop the scan; the trailing remainder is emitted as a plain run.
+///
+/// A position is skipped when it doesn't land on a char boundary of `text`. The
+/// match offsets are computed against the *full* label, but callers may pass a
+/// truncated one (e.g. a row clipped to the column width with a trailing `…`),
+/// so an offset can fall inside a multi-byte char that only exists in the
+/// truncated string. Slicing there would panic, so such positions are dropped.
 fn segments(text: &str, positions: &[usize]) -> Vec<Segment> {
     let mut segments = Vec::new();
     let mut last_end = 0;
     for &byte_pos in positions {
         if byte_pos > text.len() {
             break;
+        }
+        if !text.is_char_boundary(byte_pos) {
+            continue;
         }
         if let Some(ch) = text[byte_pos..].chars().next() {
             let char_len = ch.len_utf8();
@@ -180,6 +189,22 @@ mod tests {
         // The owned variant ignores them the same way.
         let owned = highlighted_spans_owned("ab", &[99], Style::default());
         assert_eq!(texts(&owned), vec!["ab"]);
+    }
+
+    #[test]
+    fn position_inside_a_multibyte_char_does_not_panic() {
+        // Regression: match offsets are computed on the full label but the
+        // caller passes a truncated one ending in '…' (a 3-byte char). A
+        // position landing *inside* the ellipsis must be dropped, not sliced.
+        // "abc…" => bytes: a=0 b=1 c=2 '…'=3..6, len 6. Position 4/5 is mid-'…'.
+        let text = "abc…";
+        assert!(!text.is_char_boundary(4));
+        let spans = highlighted_spans(text, &[0, 4], Style::default());
+        // 'a' highlighted, the mid-char position dropped, remainder plain.
+        assert_eq!(texts(&spans), vec!["a", "bc…"]);
+        // Owned variant is robust the same way.
+        let owned = highlighted_spans_owned(text, &[0, 4], Style::default());
+        assert_eq!(texts(&owned), vec!["a", "bc…"]);
     }
 
     #[test]


### PR DESCRIPTION
## What

Ran a UI/UX review of the thurbox TUI (driving the real TUI via the `ui-review` skill). The review surfaced one real crash, which is fixed here, plus several fixes to the review tooling itself. **No website/report publishing is included** (per request).

## The bug (the headline fix)

Global search **panicked the entire TUI**:

```
thread 'main' panicked at src/ui/highlight.rs:59:31:
start byte index 23 is not a char boundary; it is inside '…' (bytes 21..24 of string)
```

`segments()` sliced a row label at a fuzzy-match byte offset without checking it landed on a UTF-8 char boundary. Match offsets are computed against the **full** label, but callers pass the **truncated** one (e.g. the tasks panel's `Write integration tes…`), so an offset can index *inside* the multi-byte `…` that only exists after truncation → slice panic → crash.

- Guard each offset with `str::is_char_boundary` before slicing; drop misaligned positions.
- Regression test for the exact case (a position inside a trailing `…`).
- Only reproduces when a matched row is narrow enough to truncate — which is why it hadn't shown up before.

## Tooling fixes (`.claude/skills/ui-review`)

While running the review, the capture script had to be hardened — these are real correctness fixes:

1. **Sandbox isolation breach (most important).** The script isolated via `XDG_*`, but `paths.rs` lets `THURBOX_DATA_DIR`/`THURBOX_CONFIG_DIR` (exported by the dev-sandbox/direnv pattern) win over `XDG_*`. A capture run therefore **read and wrote the caller's real thurbox DB**. Now it reuses the repo's own `tbx_sandbox_init_full` helper (which unsets those overrides) and adds a post-seed tripwire that aborts if any seeded session escapes the sandbox.
2. **Wrong screens captured.** The panel-toggle chords (`Ctrl+B/E/W/P`) are terminal-passthrough, so fired from the launch (terminal) focus they were forwarded to the agent CLI and 6/13 screenshots captured the terminal instead. Focus the session list first; also added Settings / automation-editor / task-editor captures (the recently-shipped features).
3. **Illegible screenshots.** Dropped the viewport to 1500x940 so it renders at/under the image-input downscale cap. The previous 1920x1080 blurred glyphs/tree-markers/swatches into illegibility — which had caused several false findings.

## Review outcome

Apart from the crash, the TUI is well-built and consistent: status uses shape+colour (colour-blind safe), search highlighting is underline+bold (not colour-only), empty states teach the relevant key, and the editor/modal vocabulary is consistent. Findings JSON + screenshots are in `target/ui-review/` (gitignored).

## Test plan

- `cargo nextest run` (ui + search subset, 315 tests) — pass, incl. new regression test
- `cargo fmt --check`, `cargo clippy` — clean
- Re-ran the capture end-to-end: global search now highlights truncated rows without panicking; all 13 screens render correctly in a fully isolated sandbox.

Please do **not** auto-merge.