### PR TITLE
fix(core): app-layer quality fixes (agent-neutral toasts, dedup, error surfacing)

### DIFF
--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -1098,3 +1098,19 @@ fn perf_idle_iterations_skip_the_paint() {
     assert_eq!(skipped, 4, "idle iterations skip the expensive draw");
     assert_eq!(h.app.perf_counters().redraws_skipped, 4);
 }
+
+/// `dispatch_action` partitions `Action` across several sub-dispatchers whose
+/// final arm (`dispatch_scoped_pane_action`) is `unreachable!()`. A new `Action`
+/// variant that isn't wired into any dispatcher would therefore panic at runtime
+/// instead of failing to compile — this exercises every variant through the real
+/// dispatch path so an unrouted action fails the suite loudly. A fresh harness
+/// per action keeps the routing decision independent of accumulated side effects.
+#[tokio::test]
+async fn every_action_is_routed_by_dispatch_action() {
+    for &action in crate::session::Action::all() {
+        let mut h = Harness::standard(1);
+        // The assertion is simply that this does not hit the `unreachable!()` in
+        // `dispatch_scoped_pane_action` (or otherwise panic).
+        let _ = h.app.dispatch_action(action);
+    }
+}

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1671,7 +1671,7 @@ impl App {
     }
 
     /// `Enter` on the theme picker: activate the selected entry and persist it
-    /// as the active theme (a persistence failure is logged, not surfaced).
+    /// as the active theme.
     fn commit_theme_selection(
         &mut self,
         entries: Vec<crate::session::theme_config::ThemeEntry>,
@@ -1683,6 +1683,7 @@ impl App {
         crate::ui::theme::set_active(entry.palette.clone());
         if let Err(e) = self.db.set_active_theme(&entry.name) {
             tracing::error!("Failed to persist active theme: {e}");
+            self.set_error(format!("Failed to persist theme: {e}"));
         }
         self.active_theme = entry;
     }
@@ -1983,6 +1984,7 @@ impl App {
         if persist && !remote {
             if let Err(e) = self.db.upsert_repo_bookmark(&expanded) {
                 error!("Failed to save repo bookmark: {e}");
+                self.set_error(format!("Failed to save repo bookmark: {e}"));
             }
         }
         let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
@@ -2036,6 +2038,7 @@ impl App {
         let expanded = paths::expand_tilde(&path);
         if let Err(e) = self.db.upsert_repo_bookmark_kind(&expanded, true) {
             error!("Failed to save parent bookmark: {e}");
+            self.set_error(format!("Failed to save parent bookmark: {e}"));
         }
         if let super::modals::Modal::RepoPicker(ref mut rp) = self.modal {
             rp.path_input.clear();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -111,6 +111,9 @@ struct PendingSessionSpawn {
     /// A task-initiated spawn's `(task_id, title)`, captured at kickoff so the
     /// prompt is delivered + the task advanced when the session comes up.
     task_prompt: Option<(i64, String)>,
+    /// Agent name for the spawn, captured so a failure toast names the real
+    /// agent (codex/aider/…) rather than hardcoding "claude".
+    agent: String,
 }
 
 /// Continuation for a backgrounded worktree-creation: the wizard inputs needed
@@ -2049,50 +2052,16 @@ impl App {
 
     /// Move the open modal's selection to `row` (a row index recorded by this
     /// frame's renderer, so it is always in bounds) and return the key that
-    /// activates a row there: `Enter` for the selectors and the F1 editor,
-    /// `Space` for the repo picker — where a row's action is toggle/fold and
-    /// `Enter` would confirm the whole modal on a misclick.
+    /// activates a row there (see [`modals::Modal::list_selection`]).
     fn select_modal_row(&mut self, row: usize) -> Option<KeyCode> {
-        match &mut self.modal {
-            modals::Modal::Help(h) => {
-                h.selected = row;
-                Some(KeyCode::Enter)
-            }
-            modals::Modal::ThemePicker(tp) => {
-                tp.index = row;
-                Some(KeyCode::Enter)
-            }
-            modals::Modal::AgentPicker(ap) => {
-                ap.selected_index = row;
-                Some(KeyCode::Enter)
-            }
-            modals::Modal::HostPicker(hp) => {
-                hp.selected_index = row;
-                Some(KeyCode::Enter)
-            }
-            modals::Modal::BranchSelector(bs) => {
-                bs.index = row;
-                Some(KeyCode::Enter)
-            }
-            modals::Modal::TaskActionPicker(p) => {
-                p.selected = row;
-                Some(KeyCode::Enter)
-            }
-            modals::Modal::AutomationsList(al) => {
-                al.index = row;
-                Some(KeyCode::Enter)
-            }
-            modals::Modal::RestoreSessions(rs) => {
-                rs.index = row;
-                Some(KeyCode::Enter)
-            }
-            modals::Modal::RepoPicker(rp) => {
-                rp.focus = modals::RepoPickerFocus::List;
-                rp.list_index = row;
-                Some(KeyCode::Char(' '))
-            }
-            _ => None,
+        // The repo picker routes keys by its internal focus; a row click always
+        // means the list (mirrors the keyboard path), so force it before moving.
+        if let modals::Modal::RepoPicker(ref mut rp) = self.modal {
+            rp.focus = modals::RepoPickerFocus::List;
         }
+        let (index, activation_key) = self.modal.list_selection()?;
+        *index = row;
+        Some(activation_key)
     }
 
     /// Select the index-th field of the active editor modal (its position in
@@ -2358,19 +2327,10 @@ impl App {
     }
 
     /// The open modal's current selection index, when it has a selectable list.
-    fn modal_selected_index(&self) -> Option<usize> {
-        match &self.modal {
-            modals::Modal::Help(h) => Some(h.selected),
-            modals::Modal::ThemePicker(tp) => Some(tp.index),
-            modals::Modal::AgentPicker(ap) => Some(ap.selected_index),
-            modals::Modal::HostPicker(hp) => Some(hp.selected_index),
-            modals::Modal::BranchSelector(bs) => Some(bs.index),
-            modals::Modal::TaskActionPicker(p) => Some(p.selected),
-            modals::Modal::AutomationsList(al) => Some(al.index),
-            modals::Modal::RestoreSessions(rs) => Some(rs.index),
-            modals::Modal::RepoPicker(rp) => Some(rp.list_index),
-            _ => None,
-        }
+    /// Shares [`modals::Modal::list_selection`] with [`Self::select_modal_row`]
+    /// (hence `&mut self`) so the two can't drift onto different modal sets.
+    fn modal_selected_index(&mut self) -> Option<usize> {
+        self.modal.list_selection().map(|(index, _)| *index)
     }
 
     /// Route a mouse-wheel tick to whichever pane is under the cursor, so the
@@ -2906,9 +2866,10 @@ impl App {
         if config.agent.is_empty() {
             config.agent = self.agents.default_name();
         }
-        if config.agent_session_id.is_none() {
-            config.agent_session_id = Some(uuid::Uuid::new_v4().to_string());
-        }
+        let agent_session_id = config
+            .agent_session_id
+            .get_or_insert_with(|| uuid::Uuid::new_v4().to_string())
+            .clone();
         // Mint the thurbox SessionId up front (unless a respawn supplied one) so
         // it can be injected as `THURBOX_SESSION` before launch and `Session::spawn`
         // reuses it. Stable across restarts.
@@ -2916,45 +2877,10 @@ impl App {
             config.session_id = Some(SessionId::default());
         }
 
-        // Inject identity + statusline env vars (kept in sync with the headless
-        // `session_ops::inject_thurbox_env`). `THURBOX_SESSION` is the thurbox
-        // session key (read by the mailbox CLI); `THURBOX_SESSION_ID` is the
-        // agent's conversation id (read by the metrics script) — kept distinct.
-        // `THURBOX_TASK` is not set here: TUI task spawns track the task↔session
-        // link in-memory (`task_session_links`); only the headless `task run`
-        // path auto-tags messages with it.
-        if let Some(id) = config.session_id {
-            config.env.insert("THURBOX_SESSION".into(), id.to_string());
-        }
-        if let Some(ref sid) = config.agent_session_id {
-            config.env.insert("THURBOX_SESSION_ID".into(), sid.clone());
-        }
-        if let Some(metrics_dir) = crate::paths::metrics_directory() {
-            config.env.insert(
-                "THURBOX_METRICS_DIR".into(),
-                metrics_dir.to_string_lossy().into(),
-            );
-        }
-        // Pin the agent's `thurbox-cli` (status hook) to this thurbox's resolved
-        // config/data dirs, so a `session signal` lands in the DB the TUI reads
-        // regardless of XDG / PATH / stale tmux-server env. Mirrors
-        // `session_ops::inject_thurbox_env`.
-        if let Some(dir) =
-            crate::paths::config_file().and_then(|p| p.parent().map(|d| d.to_path_buf()))
-        {
-            config.env.insert(
-                crate::paths::CONFIG_DIR_OVERRIDE_ENV.into(),
-                dir.to_string_lossy().into(),
-            );
-        }
-        if let Some(dir) =
-            crate::paths::database_file().and_then(|p| p.parent().map(|d| d.to_path_buf()))
-        {
-            config.env.insert(
-                crate::paths::DATA_DIR_OVERRIDE_ENV.into(),
-                dir.to_string_lossy().into(),
-            );
-        }
+        // Inject identity + statusline env vars. `THURBOX_TASK` is left unset: TUI
+        // task spawns track the task↔session link in-memory (`task_session_links`),
+        // so only the headless `task run` path auto-tags messages with it.
+        crate::session_ops::inject_thurbox_env(&mut config, &agent_session_id, None);
 
         // For a multi-repo session, launch the agent in a symlink workspace that
         // gathers every member dir; `info.cwd` keeps the primary repo (restored
@@ -3076,7 +3002,7 @@ impl App {
             }
             Err(e) => {
                 error!("Failed to spawn session: {e}");
-                self.set_error(format!("Failed to start claude: {e:#}"));
+                self.set_error(format!("Failed to start {}: {e:#}", inputs.config.agent));
             }
         }
     }
@@ -3113,6 +3039,7 @@ impl App {
             cols,
         } = inputs;
 
+        let agent = config.agent.clone();
         let tx = self.session_spawn.start();
         self.pending_session_spawn = Some(PendingSessionSpawn {
             primary_cwd,
@@ -3120,6 +3047,7 @@ impl App {
             additional_dirs,
             parent_session_id,
             task_prompt,
+            agent,
         });
         self.set_status(StatusLevel::Info, format!("Spawning {name}…"));
 
@@ -3156,7 +3084,7 @@ impl App {
             ),
             Err(e) => {
                 error!("Failed to spawn session: {e}");
-                self.set_error(format!("Failed to start claude: {e}"));
+                self.set_error(format!("Failed to start {}: {e}", pending.agent));
             }
         }
     }
@@ -11062,6 +10990,7 @@ mod tests {
             additional_dirs: vec![],
             parent_session_id: None,
             task_prompt: None,
+            agent: "codex".into(),
         });
 
         app.poll_session_spawn();
@@ -11069,6 +10998,8 @@ mod tests {
         let msg = app.status_message.as_ref().unwrap();
         assert_eq!(msg.level, StatusLevel::Error);
         assert!(msg.text.contains("tmux exploded"));
+        // The toast names the real agent, not a hardcoded "claude".
+        assert!(msg.text.contains("codex"), "got {}", msg.text);
         assert!(app.sessions.is_empty());
         assert!(!app.session_spawn.in_progress());
         assert!(app.pending_session_spawn.is_none());
@@ -11084,6 +11015,7 @@ mod tests {
             additional_dirs: vec![],
             parent_session_id: None,
             task_prompt: None,
+            agent: "claude".into(),
         });
 
         app.poll_session_spawn();

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -430,6 +430,30 @@ fn apply_ctrl_line_edit(field: &mut impl LineEdit, code: KeyCode, mods: KeyModif
     true
 }
 
+/// Apply a key to a multi-line [`TextArea`] field: `Enter` inserts a newline,
+/// `Up`/`Down` move within the text, and the rest edit / move the cursor.
+/// Returns `true` when the key was consumed. `Esc` (cancel) and `Tab`/`BackTab`
+/// (field navigation) are deliberately *not* handled here — they belong to the
+/// owning editor — and `Ctrl` chords should be routed through
+/// [`apply_ctrl_line_edit`] first. Shared by the automation `Prompt` and task
+/// `Description` fields so their editing behavior can't drift apart.
+fn handle_textarea_key(area: &mut TextArea, code: KeyCode) -> bool {
+    match code {
+        KeyCode::Enter => area.insert_newline(),
+        KeyCode::Up => area.move_up(),
+        KeyCode::Down => area.move_down(),
+        KeyCode::Char(c) => area.insert(c),
+        KeyCode::Backspace => area.backspace(),
+        KeyCode::Delete => area.delete(),
+        KeyCode::Left => area.move_left(),
+        KeyCode::Right => area.move_right(),
+        KeyCode::Home => area.home(),
+        KeyCode::End => area.end(),
+        _ => return false,
+    }
+    true
+}
+
 /// Apply a text-editing key (insert/backspace/delete/cursor move + readline
 /// `Ctrl+W`/`Ctrl+U`) to the currently focused field, if any. Returns `true`
 /// when `code`+`mods` was a text-editing key (whether or not a field was
@@ -833,17 +857,9 @@ impl AutomationEditorModal {
                 KeyCode::Esc => return EditorOutcome::Cancel,
                 KeyCode::Tab => self.next_field(),
                 KeyCode::BackTab => self.prev_field(),
-                KeyCode::Enter => self.prompt.insert_newline(),
-                KeyCode::Up => self.prompt.move_up(),
-                KeyCode::Down => self.prompt.move_down(),
-                KeyCode::Char(c) => self.prompt.insert(c),
-                KeyCode::Backspace => self.prompt.backspace(),
-                KeyCode::Delete => self.prompt.delete(),
-                KeyCode::Left => self.prompt.move_left(),
-                KeyCode::Right => self.prompt.move_right(),
-                KeyCode::Home => self.prompt.home(),
-                KeyCode::End => self.prompt.end(),
-                _ => {}
+                _ => {
+                    handle_textarea_key(&mut self.prompt, code);
+                }
             }
             return EditorOutcome::Continue;
         }
@@ -1364,17 +1380,9 @@ impl TaskEditorModal {
                 KeyCode::Esc => return EditorOutcome::Cancel,
                 KeyCode::Tab => self.next_field(),
                 KeyCode::BackTab => self.prev_field(),
-                KeyCode::Enter => self.description.insert_newline(),
-                KeyCode::Up => self.description.move_up(),
-                KeyCode::Down => self.description.move_down(),
-                KeyCode::Char(c) => self.description.insert(c),
-                KeyCode::Backspace => self.description.backspace(),
-                KeyCode::Delete => self.description.delete(),
-                KeyCode::Left => self.description.move_left(),
-                KeyCode::Right => self.description.move_right(),
-                KeyCode::Home => self.description.home(),
-                KeyCode::End => self.description.end(),
-                _ => {}
+                _ => {
+                    handle_textarea_key(&mut self.description, code);
+                }
             }
             return EditorOutcome::Continue;
         }
@@ -1548,17 +1556,21 @@ impl SettingsField {
     /// flags that gate UI panels (read from `App.features` every frame) apply
     /// live; everything else is read once at startup from `settings::global()`,
     /// which is a write-once value that can't be re-applied in-process.
+    ///
+    /// Derived from the canonical
+    /// [`crate::session::settings::Settings::restart_only_differs`] rather than
+    /// a second hand-maintained list: flip just this field on a default draft
+    /// and ask whether that single change registers as restart-only. So the UI
+    /// `⟳` marker can never disagree with the toast/reload partition.
     pub fn restart_required(self) -> bool {
-        use SettingsField::*;
-        !matches!(
-            self,
-            FeatTasks
-                | FeatFileViewer
-                | FeatGlobalSearch
-                | FeatInfoPanel
-                | FeatShellPane
-                | FeatSoftDelete
-        )
+        let mut modal = SettingsModal::new(crate::session::settings::Settings::default());
+        modal.field = self;
+        if self.is_scalar() {
+            modal.adjust(1);
+        } else {
+            modal.toggle();
+        }
+        modal.restart_required_changed()
     }
 }
 
@@ -1751,6 +1763,29 @@ impl Modal {
 
     pub fn is_open(&self) -> bool {
         !matches!(self, Modal::None)
+    }
+
+    /// For a modal with a selectable list, a mutable handle to its selection
+    /// cursor plus the key a row-click replays to activate that row (`Enter` for
+    /// the selectors and the F1 editor, `Space` for the repo picker — where a
+    /// row's action is toggle/fold and `Enter` would confirm the whole modal on
+    /// a misclick). This is the **single** match over the selector modals, so the
+    /// read path (`App::modal_selected_index`) and the write path
+    /// (`App::select_modal_row`) can never drift onto different modal sets — a new
+    /// selectable modal is wired into both at once by adding one arm here.
+    pub(super) fn list_selection(&mut self) -> Option<(&mut usize, KeyCode)> {
+        match self {
+            Modal::Help(h) => Some((&mut h.selected, KeyCode::Enter)),
+            Modal::ThemePicker(tp) => Some((&mut tp.index, KeyCode::Enter)),
+            Modal::AgentPicker(ap) => Some((&mut ap.selected_index, KeyCode::Enter)),
+            Modal::HostPicker(hp) => Some((&mut hp.selected_index, KeyCode::Enter)),
+            Modal::BranchSelector(bs) => Some((&mut bs.index, KeyCode::Enter)),
+            Modal::TaskActionPicker(p) => Some((&mut p.selected, KeyCode::Enter)),
+            Modal::AutomationsList(al) => Some((&mut al.index, KeyCode::Enter)),
+            Modal::RestoreSessions(rs) => Some((&mut rs.index, KeyCode::Enter)),
+            Modal::RepoPicker(rp) => Some((&mut rp.list_index, KeyCode::Char(' '))),
+            _ => None,
+        }
     }
 }
 
@@ -2253,6 +2288,46 @@ mod tests {
         modal.toggle_action();
         assert_eq!(modal.action, AutomationActionKind::Send);
         assert!(!modal.visible_fields().contains(&AutomationField::Repo));
+    }
+
+    #[test]
+    fn visible_fields_track_trigger_kind() {
+        use AutomationField::*;
+        let fields = |trigger| {
+            AutomationEditorModal {
+                trigger_kind: trigger,
+                action: AutomationActionKind::Send,
+                ..Default::default()
+            }
+            .visible_fields()
+        };
+        // A one-shot delay never shows a wall-clock timezone field.
+        assert_eq!(
+            fields(TriggerKind::Once),
+            vec![Name, Trigger, Delay, Action, Target, Prompt]
+        );
+        assert!(!fields(TriggerKind::Once).contains(&Timezone));
+        // Wall-clock schedules carry a timezone and their time steppers.
+        assert_eq!(
+            fields(TriggerKind::Hourly),
+            vec![Name, Trigger, Minute, Timezone, Action, Target, Prompt]
+        );
+        assert_eq!(
+            fields(TriggerKind::Daily),
+            vec![Name, Trigger, Hour, Minute, Timezone, Action, Target, Prompt]
+        );
+        assert_eq!(
+            fields(TriggerKind::Weekdays),
+            vec![Name, Trigger, Hour, Minute, Timezone, Action, Target, Prompt]
+        );
+        assert_eq!(
+            fields(TriggerKind::Weekly),
+            vec![Name, Trigger, Weekday, Hour, Minute, Timezone, Action, Target, Prompt]
+        );
+        assert_eq!(
+            fields(TriggerKind::Cron),
+            vec![Name, Trigger, CronExpr, Timezone, Action, Target, Prompt]
+        );
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -1179,23 +1179,16 @@ fn repo_display_name(repo_path: &std::path::Path) -> String {
         .unwrap_or_else(|| repo_path.to_string_lossy().into_owned())
 }
 
-/// A task's agent action, decomposed into display-ready pieces. `target` is the
-/// short session id (Send) or the `repo[#branch]` (Spawn); `None` is a plain
-/// local todo. Lets the two label styles (details panel vs. panel summary) share
-/// one match over [`AutomationAction`](crate::session::AutomationAction).
-enum TaskActionParts {
-    Local,
-    Send { target: String },
-    Spawn { target: String },
-}
-
-fn task_action_parts(task: &crate::session::Task) -> TaskActionParts {
+/// One-line description of a task's agent linkage for the details panel.
+fn task_linkage(task: &crate::session::Task) -> String {
     use crate::session::AutomationAction;
     match &task.action {
-        None => TaskActionParts::Local,
-        Some(AutomationAction::Send { session_id }) => TaskActionParts::Send {
-            target: short_session_id(session_id),
-        },
+        // `None`, and the automation-only `Exec` (a task never carries one), are
+        // plain local todos with no agent linkage to show.
+        None | Some(AutomationAction::Exec { .. }) => "local todo".to_string(),
+        Some(AutomationAction::Send { session_id }) => {
+            format!("send → {}", short_session_id(session_id))
+        }
         Some(AutomationAction::Spawn {
             repo_path,
             worktree_branch,
@@ -1206,20 +1199,8 @@ fn task_action_parts(task: &crate::session::Task) -> TaskActionParts {
                 Some(b) => format!("{repo}#{b}"),
                 None => repo,
             };
-            TaskActionParts::Spawn { target }
+            format!("spawn → {target}")
         }
-        // Exec is an automation-only action; a task never carries one, so it has
-        // no agent linkage to show.
-        Some(AutomationAction::Exec { .. }) => TaskActionParts::Local,
-    }
-}
-
-/// One-line description of a task's agent linkage for the details panel.
-fn task_linkage(task: &crate::session::Task) -> String {
-    match task_action_parts(task) {
-        TaskActionParts::Local => "local todo".to_string(),
-        TaskActionParts::Send { target } => format!("send → {target}"),
-        TaskActionParts::Spawn { target } => format!("spawn → {target}"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use crossterm::event::{
     self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
     Event, KeyEventKind, KeyboardEnhancementFlags, MouseButton, MouseEventKind,
@@ -120,7 +120,7 @@ async fn main() -> Result<()> {
     startup.config_init_ms = t_phase.elapsed().as_millis();
 
     let t_phase = std::time::Instant::now();
-    let db = open_database();
+    let db = open_database()?;
     startup.db_open_ms = t_phase.elapsed().as_millis();
     activate_persisted_theme(&db);
 
@@ -257,9 +257,10 @@ fn init_backends_and_config() -> Result<(
 
 /// Open the SQLite database for persistent state, falling back to the default
 /// XDG location (dev vs. prod build) when the path can't be resolved.
-fn open_database() -> Database {
+fn open_database() -> Result<Database> {
     let db_path = thurbox::paths::database_file().unwrap_or_else(fallback_database_path);
-    Database::open(&db_path).expect("Failed to open database")
+    Database::open(&db_path)
+        .with_context(|| format!("failed to open database at {}", db_path.display()))
 }
 
 /// Degenerate-fallback database path, used only when

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -445,6 +445,76 @@ mod tests {
     }
 
     #[test]
+    fn every_feature_flag_is_classified_restart_or_live() {
+        // Destructuring WITHOUT `..` makes a newly-added feature flag fail to
+        // compile here until it is explicitly classified below — the safety net
+        // that stops a startup-wired flag from defaulting to "applies live" by
+        // omission in `restart_only_differs` (which would wrongly toast "applied
+        // live"). Each binding is consumed by `cases`, so none goes unused.
+        let FeatureFlags {
+            tasks,
+            automations,
+            file_viewer,
+            global_search,
+            info_panel,
+            shell_pane,
+            mouse,
+            notifications,
+            soft_delete,
+            version_check,
+            auto_update,
+        } = FeatureFlags::default();
+        // Consume every binding so the no-`..` destructure above stays a hard
+        // compile-time guard (an unused binding would otherwise be the only
+        // warning, not an error).
+        let _ = (
+            tasks,
+            automations,
+            file_viewer,
+            global_search,
+            info_panel,
+            shell_pane,
+            mouse,
+            notifications,
+            soft_delete,
+            version_check,
+            auto_update,
+        );
+
+        // `live` flags gate UI panels read from `App.features` every frame, so
+        // flipping one is NOT a restart-only difference; the rest are read once
+        // at startup and MUST register as one.
+        let live: [fn(&mut FeatureFlags); 6] = [
+            |f| f.tasks = !f.tasks,
+            |f| f.file_viewer = !f.file_viewer,
+            |f| f.global_search = !f.global_search,
+            |f| f.info_panel = !f.info_panel,
+            |f| f.shell_pane = !f.shell_pane,
+            |f| f.soft_delete = !f.soft_delete,
+        ];
+        let restart: [fn(&mut FeatureFlags); 5] = [
+            |f| f.automations = !f.automations,
+            |f| f.mouse = !f.mouse,
+            |f| f.notifications = !f.notifications,
+            |f| f.version_check = !f.version_check,
+            |f| f.auto_update = !f.auto_update,
+        ];
+
+        let base = Settings::default();
+        let check = |flip: fn(&mut FeatureFlags), expect_restart: bool| {
+            let mut other = base.clone();
+            flip(&mut other.features);
+            assert_eq!(
+                base.restart_only_differs(&other),
+                expect_restart,
+                "a feature flag's restart classification disagrees with restart_only_differs",
+            );
+        };
+        live.into_iter().for_each(|flip| check(flip, false));
+        restart.into_iter().for_each(|flip| check(flip, true));
+    }
+
+    #[test]
     fn global_defaults_when_uninitialized() {
         // Note: other tests may have init()'d already; both paths are default.
         assert_eq!(global().two_panel_min_cols, 80);

--- a/src/ui/automation_editor_modal.rs
+++ b/src/ui/automation_editor_modal.rs
@@ -47,8 +47,8 @@ pub struct AutomationEditorState<'a> {
     pub focused: bool,
     /// The fields shown for the current trigger kind + action, in display and
     /// navigation order. Projected from the single source of truth
-    /// ([`crate::app::modals::AutomationEditorModal::visible_fields`]) so render
-    /// order can't drift from the modal's cursor-navigation order.
+    /// (`AutomationEditorModal::visible_fields`) so render order can't drift from
+    /// the modal's cursor-navigation order.
     pub visible_fields: Vec<AutomationField>,
 }
 

--- a/src/ui/automation_editor_modal.rs
+++ b/src/ui/automation_editor_modal.rs
@@ -45,6 +45,11 @@ pub struct AutomationEditorState<'a> {
     /// preview), the active-field cursor/highlight is suppressed and the border
     /// is drawn unfocused.
     pub focused: bool,
+    /// The fields shown for the current trigger kind + action, in display and
+    /// navigation order. Projected from the single source of truth
+    /// ([`crate::app::modals::AutomationEditorModal::visible_fields`]) so render
+    /// order can't drift from the modal's cursor-navigation order.
+    pub visible_fields: Vec<AutomationField>,
 }
 
 impl<'a> AutomationEditorState<'a> {
@@ -77,35 +82,9 @@ impl<'a> AutomationEditorState<'a> {
             target_session: m.selected_target().map(|(_, name)| name.as_str()),
             preview,
             focused,
+            visible_fields: m.visible_fields(),
         }
     }
-}
-
-/// Fields shown for the current trigger kind + action, in order. Mirrors
-/// `AutomationEditorModal::visible_fields`.
-fn visible_fields(trigger: TriggerKind, action: AutomationActionKind) -> Vec<AutomationField> {
-    use AutomationField::*;
-    let mut fields = vec![Name, Trigger];
-    match trigger {
-        TriggerKind::Once => fields.push(Delay),
-        TriggerKind::Hourly => fields.push(Minute),
-        TriggerKind::Daily | TriggerKind::Weekdays => fields.extend([Hour, Minute]),
-        TriggerKind::Weekly => fields.extend([Weekday, Hour, Minute]),
-        TriggerKind::Cron => fields.push(CronExpr),
-    }
-    if trigger != TriggerKind::Once {
-        fields.push(Timezone);
-    }
-    fields.push(Action);
-    match action {
-        AutomationActionKind::Send => fields.push(Target),
-        AutomationActionKind::Spawn => fields.extend([Repo, Worktree, Agent]),
-        AutomationActionKind::Exec => fields.push(Command),
-    }
-    if action != AutomationActionKind::Exec {
-        fields.push(Prompt);
-    }
-    fields
 }
 
 /// One click hitbox per visible field, given each field's `(index, display_row,
@@ -130,7 +109,7 @@ pub fn render_automation_editor_modal(
     state: &AutomationEditorState<'_>,
 ) -> (Vec<super::RowHitbox>, super::ModalButtons) {
     let frame_area = frame.area();
-    let fields = visible_fields(state.trigger_kind, state.action);
+    let fields = &state.visible_fields;
     // One row per field + status + preview + spacing inside the modal frame.
     // The multi-line Prompt field spans more than one row, so grow the height by
     // its wrapped row count (the old `+ 5` already counted Prompt as one row).
@@ -253,11 +232,11 @@ fn editor_body_lines<'a>(
     state: &AutomationEditorState<'a>,
     width: u16,
 ) -> (Vec<Line<'a>>, Option<usize>, Vec<(usize, usize)>) {
-    let fields = visible_fields(state.trigger_kind, state.action);
+    let fields = &state.visible_fields;
     let mut lines: Vec<Line> = Vec::new();
     let mut active_row = None;
     let mut field_spans = Vec::with_capacity(fields.len());
-    for f in &fields {
+    for f in fields {
         let start = lines.len();
         let active = *f == state.field && state.focused;
         // The multi-line prompt expands into a label row + wrapped text rows;
@@ -597,63 +576,13 @@ mod tests {
             target_session: None,
             preview: "",
             focused: true,
+            // Matches the fixture's Daily + Send trigger/action. The field-order
+            // logic itself is tested against the canonical
+            // `AutomationEditorModal::visible_fields` in `app::modals`.
+            visible_fields: vec![
+                Name, Trigger, Hour, Minute, Timezone, Action, Target, Prompt,
+            ],
         }
-    }
-
-    #[test]
-    fn visible_fields_once_has_delay_and_no_timezone() {
-        let f = visible_fields(TriggerKind::Once, AutomationActionKind::Send);
-        assert_eq!(f, vec![Name, Trigger, Delay, Action, Target, Prompt]);
-        assert!(!f.contains(&Timezone), "Once never shows a timezone field");
-    }
-
-    #[test]
-    fn visible_fields_schedule_kinds_carry_timezone_and_time_steppers() {
-        assert_eq!(
-            visible_fields(TriggerKind::Hourly, AutomationActionKind::Send),
-            vec![Name, Trigger, Minute, Timezone, Action, Target, Prompt]
-        );
-        assert_eq!(
-            visible_fields(TriggerKind::Daily, AutomationActionKind::Send),
-            vec![Name, Trigger, Hour, Minute, Timezone, Action, Target, Prompt]
-        );
-        assert_eq!(
-            visible_fields(TriggerKind::Weekdays, AutomationActionKind::Send),
-            vec![Name, Trigger, Hour, Minute, Timezone, Action, Target, Prompt]
-        );
-        assert_eq!(
-            visible_fields(TriggerKind::Weekly, AutomationActionKind::Send),
-            vec![Name, Trigger, Weekday, Hour, Minute, Timezone, Action, Target, Prompt]
-        );
-    }
-
-    #[test]
-    fn visible_fields_cron_shows_cron_expr() {
-        let f = visible_fields(TriggerKind::Cron, AutomationActionKind::Send);
-        assert_eq!(
-            f,
-            vec![Name, Trigger, CronExpr, Timezone, Action, Target, Prompt]
-        );
-    }
-
-    #[test]
-    fn visible_fields_action_shapes_the_tail() {
-        // Send → Target + Prompt.
-        let send = visible_fields(TriggerKind::Daily, AutomationActionKind::Send);
-        assert_eq!(&send[send.len() - 2..], &[Target, Prompt]);
-
-        // Spawn → Repo/Worktree/Agent + Prompt.
-        let spawn = visible_fields(TriggerKind::Daily, AutomationActionKind::Spawn);
-        assert_eq!(&spawn[spawn.len() - 4..], &[Repo, Worktree, Agent, Prompt]);
-
-        // Exec → Command and NO Prompt.
-        let exec = visible_fields(TriggerKind::Daily, AutomationActionKind::Exec);
-        assert!(exec.contains(&Command));
-        assert!(
-            !exec.contains(&Prompt),
-            "Exec runs a shell command, never a prompt"
-        );
-        assert_eq!(*exec.last().unwrap(), Command);
     }
 
     #[test]


### PR DESCRIPTION
Code-quality fixes for `src/app/` + `src/main.rs` (worker W3), from a review of the codebase. Each finding is listed with its `file:line` and how it was addressed. Behavior is unchanged except where a finding explicitly calls for it (the two error-surfacing fixes and the agent-neutral toasts).

## Fixes

1. **Agent-neutral spawn-failure toasts** — `src/app/mod.rs:3079`, `:3159`. A failed `codex`/`aider`/… launch showed "Failed to start claude". Both the sync and async spawn paths now interpolate the real agent name (`inputs.config.agent` / a new `PendingSessionSpawn.agent` captured at kickoff).

2. **`build_spawn_inputs` dedupe** — `src/app/mod.rs:2919`. Replaced the hand-rolled `THURBOX_*` env injection (which had drifted from the helper) with a call to `session_ops::inject_thurbox_env`, keeping only the workspace-cwd resolution inline. Env output is equivalent (verified against the restore/restart paths that already use the helper).

3. **Parallel modal-selection matches** — `src/app/mod.rs:2361` (`modal_selected_index`) and `:2055` (`select_modal_row`). Collapsed both onto a single `Modal::list_selection` match (returns a `&mut` cursor + the row's activation key), so a new selector modal is wired into the read and write paths at once. The repo-picker focus quirk stays in `select_modal_row`.

4. **`dispatch_action` exhaustiveness** — `src/app/key_handlers.rs:1297`. `dispatch_scoped_pane_action` ends in `unreachable!()`, so a new unrouted `Action` would panic at runtime. Added `every_action_is_routed_by_dispatch_action` (in `acceptance.rs`) driving every `Action::all()` variant through `dispatch_action`, which fails loudly if any falls through.

5. **Silent persist failures** — `src/app/key_handlers.rs:1684` (theme), `:1985`, `:2038` (repo bookmarks). The `Err` arms were `tracing::error!`-only; they now also call `self.set_error(…)`, matching `persist_keybindings`.

6. **`visible_fields` duplicated modal↔renderer** — canonical `AutomationEditorModal::visible_fields` (`src/app/modals.rs`), mirrored in `src/ui/automation_editor_modal.rs:86`. The ui state now carries `visible_fields` projected from the single source via `from_modal`; the ui-side recomputation + its mirror tests are deleted (trigger-kind coverage moved onto the canonical method's tests in `app/modals.rs`).

7. **`restart_only_differs` hand-partitioned + duplicated** — `src/session/settings.rs:225` (canonical) and `src/app/modals.rs:1551` (`SettingsField::restart_required`). `restart_required` now derives from the canonical classifier (flip the field on a default draft → `restart_only_differs`). Added a per-field test in `settings.rs` that destructures `FeatureFlags` without `..`, so a new startup-wired flag must be explicitly classified rather than silently treated as "applies live".

8. **`TextArea` key-handling duplicated** — `src/app/modals.rs` automation Prompt (~`:832`) and task Description (~`:1357`). Extracted a shared `handle_textarea_key(&mut TextArea, …)` (mirroring `apply_ctrl_line_edit`), called from both.

9. **`TaskActionParts` single-consumer indirection + wrong doc** — `src/app/view.rs:1186`. Its doc claimed a second "panel summary" caller that doesn't exist. Inlined the match into `task_linkage()` and deleted the enum + builder.

10. **`main.rs` startup `.expect()` panic** — `src/main.rs:262`. `open_database()` now returns `Result<Database>` and is propagated with `?` + `.context(…)`, like every other startup step. (The home-dir handling at `main.rs:291` was left untouched per the brief.)

Also pruned the one now-stale comment in a touched region (the "persistence failure is logged, not surfaced" note on `commit_theme_selection`); the module's rich rationale comments were kept.

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all` — 1588 passed, 0 failed
