### PR TITLE
fix: infra quality cleanups (git/sync/notifications/agent/usage)

### DIFF
--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -339,16 +339,23 @@ impl ControlMode {
     ///
     /// Uses `try_send` so the reader thread never blocks: a full channel drops
     /// the chunk rather than stalling (which would deadlock `%pause` handling).
-    fn dispatch_output(pane_senders: &PaneSendersMapShared, pane_id: &str, data: Vec<u8>) {
+    fn dispatch_output(pane_senders: &PaneSendersMapShared, pane_id: &str, mut data: Vec<u8>) {
         let Ok(senders) = pane_senders.lock() else {
             return;
         };
         let Some(tx_vec) = senders.get(pane_id) else {
             return;
         };
-        // Broadcast output to all registered instances
-        for tx in tx_vec {
-            match tx.try_send(data.clone()) {
+        // Single-sender is the dominant case (one reader per pane): move `data`
+        // into it instead of cloning. Only fan-out (multiple registered
+        // instances) pays for a clone.
+        for (i, tx) in tx_vec.iter().enumerate() {
+            let chunk = if i + 1 == tx_vec.len() {
+                std::mem::take(&mut data)
+            } else {
+                data.clone()
+            };
+            match tx.try_send(chunk) {
                 Ok(()) => {}
                 Err(std::sync::mpsc::TrySendError::Full(_dropped)) => {
                     // Channel full — drop this chunk rather than blocking.
@@ -733,12 +740,14 @@ impl TmuxBackend {
             .control
             .lock()
             .map_err(|e| anyhow::anyhow!("control lock: {e}"))?;
-        *guard = None; // Drop dead ControlMode (triggers cleanup)
-        *guard = Some(ControlMode::start(
-            &self.transport,
-            &self.socket,
-            &self.session,
-        )?);
+        // Start the replacement *before* touching `guard`, and only store it on
+        // success. A failed `start()` propagates via `?` while the existing
+        // handle stays in place — so a retry reconnects cleanly instead of
+        // hitting `control = None` and reporting the misleading "call
+        // ensure_ready() first". Assigning `Some(fresh)` drops the dead
+        // ControlMode (its cleanup) as it replaces it.
+        let fresh = ControlMode::start(&self.transport, &self.socket, &self.session)?;
+        *guard = Some(fresh);
         debug!("Control mode reconnected successfully");
         Ok(())
     }
@@ -1512,48 +1521,26 @@ pub fn window_pane_pid(session_name: &str) -> Result<Option<u32>> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Read;
-
     use super::*;
     use crate::agent::control_mode::{
         decode_octal, format_send_keys, parse_notification, shell_escape,
     };
 
-    // --- shell_escape tests (verify re-export works) ---
-
+    // The control-mode primitives are re-exported through this module. Their
+    // behavior is covered exhaustively in `control_mode`'s own test module;
+    // this single smoke check just asserts the re-export path still resolves
+    // (the per-case bodies that used to be duplicated here added no coverage).
     #[test]
-    fn shell_escape_empty() {
-        assert_eq!(shell_escape(""), "''");
-    }
-
-    #[test]
-    fn shell_escape_simple() {
-        assert_eq!(shell_escape("hello"), "hello");
-    }
-
-    #[test]
-    fn shell_escape_path() {
-        assert_eq!(shell_escape("/home/user/repos/app"), "/home/user/repos/app");
-    }
-
-    #[test]
-    fn shell_escape_with_spaces() {
+    fn control_mode_reexports_resolve() {
         assert_eq!(shell_escape("hello world"), "'hello world'");
-    }
-
-    #[test]
-    fn shell_escape_with_quotes() {
-        assert_eq!(shell_escape("it's"), "'it'\\''s'");
-    }
-
-    #[test]
-    fn shell_escape_flag_value() {
-        assert_eq!(shell_escape("--permission-mode"), "--permission-mode");
-    }
-
-    #[test]
-    fn shell_escape_tool_pattern() {
-        assert_eq!(shell_escape("Read Bash(git:*)"), "'Read Bash(git:*)'");
+        assert_eq!(decode_octal("\\033"), vec![27]);
+        assert_eq!(format_send_keys("%1", b"A"), "send-keys -t %1 -H 41\n");
+        assert_eq!(
+            parse_notification("%pause %1"),
+            Notification::Pause {
+                pane_id: "%1".to_string()
+            }
+        );
     }
 
     // --- parse_tmux_version tests ---
@@ -1647,260 +1634,6 @@ mod tests {
         assert_eq!(cmd, "'/opt/My Agents/codex' --foo");
     }
 
-    // --- decode_octal tests (verify import works) ---
-
-    #[test]
-    fn decode_octal_esc() {
-        assert_eq!(decode_octal("\\033"), vec![27]); // ESC
-    }
-
-    #[test]
-    fn decode_octal_backslash() {
-        assert_eq!(decode_octal("\\134"), vec![b'\\']);
-    }
-
-    #[test]
-    fn decode_octal_newline() {
-        assert_eq!(decode_octal("\\012"), vec![b'\n']);
-    }
-
-    #[test]
-    fn decode_octal_passthrough() {
-        assert_eq!(decode_octal("hello"), b"hello");
-    }
-
-    #[test]
-    fn decode_octal_incomplete() {
-        assert_eq!(decode_octal("\\01"), b"\\01");
-    }
-
-    #[test]
-    fn decode_octal_non_octal_digits() {
-        assert_eq!(decode_octal("\\089"), b"\\089");
-    }
-
-    #[test]
-    fn decode_octal_mixed() {
-        assert_eq!(
-            decode_octal("A\\033[1mB"),
-            vec![b'A', 27, b'[', b'1', b'm', b'B']
-        );
-    }
-
-    #[test]
-    fn decode_octal_consecutive() {
-        assert_eq!(decode_octal("\\033\\033"), vec![27, 27]);
-    }
-
-    #[test]
-    fn decode_octal_empty() {
-        assert_eq!(decode_octal(""), b"");
-    }
-
-    #[test]
-    fn decode_octal_trailing_backslash() {
-        assert_eq!(decode_octal("a\\"), b"a\\");
-    }
-
-    #[test]
-    fn decode_octal_max_value() {
-        assert_eq!(decode_octal("\\377"), vec![0xFF]);
-    }
-
-    // --- parse_notification tests (verify import works) ---
-
-    #[test]
-    fn parse_output_notification() {
-        let n = parse_notification("%output %42 hello\\033[1m");
-        assert_eq!(
-            n,
-            Notification::Output {
-                pane_id: "%42".to_string(),
-                data: vec![b'h', b'e', b'l', b'l', b'o', 27, b'[', b'1', b'm'],
-            }
-        );
-    }
-
-    #[test]
-    fn parse_extended_output_notification() {
-        let n = parse_notification("%extended-output %2 0 : \\033[?2026hA\\033[?2026l");
-        assert_eq!(
-            n,
-            Notification::Output {
-                pane_id: "%2".to_string(),
-                data: vec![
-                    27, b'[', b'?', b'2', b'0', b'2', b'6', b'h', b'A', 27, b'[', b'?', b'2', b'0',
-                    b'2', b'6', b'l'
-                ],
-            }
-        );
-    }
-
-    #[test]
-    fn parse_begin_notification() {
-        assert_eq!(
-            parse_notification("%begin 1234567890 7 0"),
-            Notification::Begin
-        );
-    }
-
-    #[test]
-    fn parse_end_notification() {
-        assert_eq!(parse_notification("%end 1234567890 7 0"), Notification::End);
-    }
-
-    #[test]
-    fn parse_error_notification() {
-        assert_eq!(
-            parse_notification("%error 1234567890 3 0"),
-            Notification::Error
-        );
-    }
-
-    #[test]
-    fn parse_pause_notification() {
-        assert_eq!(
-            parse_notification("%pause %42"),
-            Notification::Pause {
-                pane_id: "%42".to_string()
-            }
-        );
-    }
-
-    #[test]
-    fn parse_other_notification() {
-        assert_eq!(
-            parse_notification("some random line"),
-            Notification::Other("some random line".to_string())
-        );
-    }
-
-    #[test]
-    fn parse_output_no_data() {
-        assert_eq!(
-            parse_notification("%output %42"),
-            Notification::Other("%output %42".to_string())
-        );
-    }
-
-    #[test]
-    fn parse_extended_output_no_colon_separator() {
-        assert_eq!(
-            parse_notification("%extended-output %2 0 data"),
-            Notification::Other("%extended-output %2 0 data".to_string())
-        );
-    }
-
-    #[test]
-    fn parse_output_empty_data() {
-        let n = parse_notification("%output %42 ");
-        assert_eq!(
-            n,
-            Notification::Output {
-                pane_id: "%42".to_string(),
-                data: vec![],
-            }
-        );
-    }
-
-    // --- format_send_keys tests (verify import works) ---
-
-    #[test]
-    fn format_send_keys_single_byte() {
-        assert_eq!(format_send_keys("%42", b"A"), "send-keys -t %42 -H 41\n");
-    }
-
-    #[test]
-    fn format_send_keys_multi_byte() {
-        assert_eq!(
-            format_send_keys("%42", b"ABC"),
-            "send-keys -t %42 -H 41 42 43\n"
-        );
-    }
-
-    #[test]
-    fn format_send_keys_empty() {
-        assert_eq!(format_send_keys("%42", &[]), "send-keys -t %42 -H\n");
-    }
-
-    #[test]
-    fn format_send_keys_escape_sequence() {
-        assert_eq!(
-            format_send_keys("%1", &[0x1b, b'[', b'A']),
-            "send-keys -t %1 -H 1b 5b 41\n"
-        );
-    }
-
-    // --- ControlModeReader tests (verify import works) ---
-
-    #[test]
-    fn control_mode_reader_data_delivery() {
-        let (tx, rx) = std::sync::mpsc::sync_channel(16);
-        let mut reader = ControlModeReader::new(rx);
-
-        tx.send(b"hello".to_vec()).unwrap();
-        let mut buf = [0u8; 16];
-        let n = reader.read(&mut buf).unwrap();
-        assert_eq!(&buf[..n], b"hello");
-    }
-
-    #[test]
-    fn control_mode_reader_eof_on_sender_drop() {
-        let (tx, rx) = std::sync::mpsc::sync_channel(16);
-        let mut reader = ControlModeReader::new(rx);
-
-        drop(tx);
-        let mut buf = [0u8; 16];
-        let n = reader.read(&mut buf).unwrap();
-        assert_eq!(n, 0); // EOF
-    }
-
-    #[test]
-    fn control_mode_reader_partial_reads() {
-        let (tx, rx) = std::sync::mpsc::sync_channel(16);
-        let mut reader = ControlModeReader::new(rx);
-
-        tx.send(b"hello world".to_vec()).unwrap();
-
-        let mut buf = [0u8; 5];
-        let n = reader.read(&mut buf).unwrap();
-        assert_eq!(&buf[..n], b"hello");
-
-        let n = reader.read(&mut buf).unwrap();
-        assert_eq!(&buf[..n], b" worl");
-
-        let n = reader.read(&mut buf).unwrap();
-        assert_eq!(&buf[..n], b"d");
-    }
-
-    #[test]
-    fn control_mode_reader_multiple_sends() {
-        let (tx, rx) = std::sync::mpsc::sync_channel(16);
-        let mut reader = ControlModeReader::new(rx);
-
-        tx.send(b"aaa".to_vec()).unwrap();
-        tx.send(b"bbb".to_vec()).unwrap();
-
-        let mut buf = [0u8; 16];
-        let n = reader.read(&mut buf).unwrap();
-        assert_eq!(&buf[..n], b"aaa");
-
-        let n = reader.read(&mut buf).unwrap();
-        assert_eq!(&buf[..n], b"bbb");
-    }
-
-    #[test]
-    fn control_mode_writer_is_send() {
-        fn assert_send<T: Send>() {}
-        assert_send::<ControlModeWriter>();
-    }
-
-    #[test]
-    fn control_mode_reader_is_send() {
-        fn assert_send<T: Send>() {}
-        assert_send::<ControlModeReader>();
-    }
-
     #[test]
     fn backend_default_has_no_control_mode() {
         let backend = LocalTmuxBackend::new();
@@ -1950,47 +1683,8 @@ mod tests {
         assert_eq!(backend.session, "sess-vm");
     }
 
-    #[test]
-    fn control_mode_reader_exact_size_buffer() {
-        let (tx, rx) = std::sync::mpsc::sync_channel(16);
-        let mut reader = ControlModeReader::new(rx);
-
-        tx.send(b"abc".to_vec()).unwrap();
-        let mut buf = [0u8; 3];
-        let n = reader.read(&mut buf).unwrap();
-        assert_eq!(n, 3);
-        assert_eq!(&buf[..n], b"abc");
-    }
-
-    #[test]
-    fn try_send_drops_when_channel_full() {
-        let (tx, _rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(1);
-
-        tx.send(b"first".to_vec()).unwrap();
-
-        match tx.try_send(b"second".to_vec()) {
-            Err(std::sync::mpsc::TrySendError::Full(_)) => {} // expected
-            other => panic!("Expected TrySendError::Full, got: {other:?}"),
-        }
-    }
-
     // Compile-time check: channel capacity must be large enough to buffer heavy output.
     const _: () = assert!(PANE_CHANNEL_CAPACITY >= 1024);
-
-    #[test]
-    fn parse_pause_notification_with_leading_percent() {
-        assert_eq!(
-            parse_notification("%pause %123"),
-            Notification::Pause {
-                pane_id: "%123".to_string()
-            }
-        );
-    }
-
-    #[test]
-    fn shell_escape_allows_equals_comma() {
-        assert_eq!(shell_escape("key=val,other"), "key=val,other");
-    }
 
     #[test]
     fn env_flag_simple_value() {
@@ -2014,19 +1708,6 @@ mod tests {
             .map(|(k, v)| format!(" -e {}", shell_escape(&format!("{k}={v}"))))
             .collect();
         assert_eq!(env_part, " -e 'MSG=hello world'");
-    }
-
-    #[test]
-    fn decode_octal_overflow_wraps() {
-        assert_eq!(decode_octal("\\400"), vec![0u8]);
-    }
-
-    #[test]
-    fn parse_extended_output_missing_pane_space() {
-        assert_eq!(
-            parse_notification("%extended-output %2 : data"),
-            Notification::Other("%extended-output %2 : data".to_string())
-        );
     }
 
     // --- window-name sanitization tests ---

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -860,7 +860,7 @@ pub fn worktree_is_dirty(cwd: &Path) -> bool {
 }
 
 /// Commits the worktree's HEAD is `(ahead, behind)` relative to its base ref,
-/// resolved by [`resolve_base_ref`] (upstream → `origin/HEAD` → `origin/main` →
+/// resolved by `resolve_base_ref` (upstream → `origin/HEAD` → `origin/main` →
 /// `origin/master`) — the same chain [`sync_worktree`] rebases onto, so the
 /// "behind" count is measured against the ref sync would use. Returns `(0, 0)`
 /// when no base can be resolved.

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -453,12 +453,22 @@ fn stable_repo_hash(input: &str) -> String {
     format!("{hash:016x}")
 }
 
+/// The two load-bearing path segments of the worktree layout: the stable
+/// repo-path hash and the sanitized branch name. Both the local
+/// ([`worktree_subpath`]) and remote ([`worktree_subpath_posix`]) variants
+/// derive their `<repo-hash>/<sanitized-branch>` tail from this, so the
+/// hash+sanitize logic lives in one place.
+fn worktree_segments(repo_path: &Path, branch: &str) -> (String, String) {
+    let repo_hash = stable_repo_hash(&repo_path.display().to_string());
+    let sanitized = branch.replace('/', "-");
+    (repo_hash, sanitized)
+}
+
 /// The deterministic `<base>/<repo-hash>/<sanitized-branch>` worktree layout,
 /// shared by local ([`worktree_path`]) and remote ([`worktree_path_for`])
 /// resolution so both produce identical sub-paths under their own base.
 fn worktree_subpath(base: PathBuf, repo_path: &Path, branch: &str) -> PathBuf {
-    let repo_hash = stable_repo_hash(&repo_path.display().to_string());
-    let sanitized = branch.replace('/', "-");
+    let (repo_hash, sanitized) = worktree_segments(repo_path, branch);
     base.join(repo_hash).join(sanitized)
 }
 
@@ -467,8 +477,7 @@ fn worktree_subpath(base: PathBuf, repo_path: &Path, branch: &str) -> PathBuf {
 /// separate from the `PathBuf` form because on Windows `PathBuf::join` inserts
 /// `\`, which the remote login shell would not accept.
 fn worktree_subpath_posix(base: &str, repo_path: &Path, branch: &str) -> String {
-    let repo_hash = stable_repo_hash(&repo_path.display().to_string());
-    let sanitized = branch.replace('/', "-");
+    let (repo_hash, sanitized) = worktree_segments(repo_path, branch);
     format!("{}/{repo_hash}/{sanitized}", base.trim_end_matches('/'))
 }
 
@@ -706,15 +715,17 @@ fn stash_with_retry(worktree_path: &Path) -> Result<bool> {
     anyhow::bail!("transient error persisted after retries: {last_err}")
 }
 
-/// Resolve the ref a worktree should be rebased onto during a sync.
+/// Resolve the base ref a worktree should be compared/rebased against.
 ///
 /// Prefers the branch's configured upstream (`@{upstream}`), then the remote's
 /// advertised default branch (`origin/HEAD`, e.g. `origin/main` or
 /// `origin/master` — whatever the repo actually uses), then the conventional
 /// `origin/main` / `origin/master`. Returns `None` when none resolve, so the
 /// caller can surface a clear error instead of blindly rebasing onto a
-/// possibly-missing `origin/main`.
-fn resolve_sync_base_ref(worktree_path: &Path) -> Option<String> {
+/// possibly-missing `origin/main`. Shared by [`sync_worktree`] (the rebase
+/// target) and [`ahead_behind`] (the comparison base) so the "behind" count is
+/// always measured against the ref sync would rebase onto.
+fn resolve_base_ref(worktree_path: &Path) -> Option<String> {
     // A branch with an explicit upstream rebases onto exactly that.
     if run_git_capture(
         &["rev-parse", "--verify", "--quiet", "@{upstream}"],
@@ -748,7 +759,7 @@ fn resolve_sync_base_ref(worktree_path: &Path) -> Option<String> {
 /// High-level sync: stash, fetch, rebase onto the base ref, pop stash.
 ///
 /// `base_ref` pins the ref to rebase onto; when `None` it is derived from the
-/// worktree via `resolve_sync_base_ref` (upstream → `origin/HEAD` →
+/// worktree via `resolve_base_ref` (upstream → `origin/HEAD` →
 /// `origin/main` → `origin/master`) rather than hardcoding `origin/main`.
 /// On conflict the rebase is aborted and any stash is restored.
 /// Retries `git stash` on transient index-lock errors.
@@ -775,7 +786,7 @@ pub fn sync_worktree(worktree_path: &Path, base_ref: Option<&str>) -> SyncResult
     // origin/main, …) reflect the just-fetched remote state.
     let base_ref = match base_ref
         .map(str::to_string)
-        .or_else(|| resolve_sync_base_ref(worktree_path))
+        .or_else(|| resolve_base_ref(worktree_path))
     {
         Some(r) => r,
         None => {
@@ -848,14 +859,13 @@ pub fn worktree_is_dirty(cwd: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// Commits the worktree's HEAD is `(ahead, behind)` relative to its upstream
-/// (`@{upstream}`), falling back to `origin/main` then `origin/master`.
-/// Returns `(0, 0)` when no base can be resolved.
+/// Commits the worktree's HEAD is `(ahead, behind)` relative to its base ref,
+/// resolved by [`resolve_base_ref`] (upstream → `origin/HEAD` → `origin/main` →
+/// `origin/master`) — the same chain [`sync_worktree`] rebases onto, so the
+/// "behind" count is measured against the ref sync would use. Returns `(0, 0)`
+/// when no base can be resolved.
 pub fn ahead_behind(cwd: &Path) -> (usize, usize) {
-    let base = ["@{upstream}", "origin/main", "origin/master"]
-        .into_iter()
-        .find(|r| run_git_capture(&["rev-parse", "--verify", "--quiet", r], cwd).is_some());
-    let Some(base) = base else {
+    let Some(base) = resolve_base_ref(cwd) else {
         return (0, 0);
     };
     // `--left-right --count <base>...HEAD` → "<behind>\t<ahead>".
@@ -1090,7 +1100,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_sync_base_ref_none_without_remote() {
+    fn resolve_base_ref_none_without_remote() {
         // A repo with no upstream and no remote refs resolves to no base ref,
         // so sync surfaces an error rather than rebasing onto a missing
         // `origin/main`.
@@ -1115,11 +1125,11 @@ mod tests {
         git(&["add", "."]);
         git(&["commit", "-qm", "init"]);
 
-        assert_eq!(resolve_sync_base_ref(repo), None);
+        assert_eq!(resolve_base_ref(repo), None);
     }
 
     #[test]
-    fn resolve_sync_base_ref_prefers_upstream() {
+    fn resolve_base_ref_prefers_upstream() {
         // A branch tracking an upstream resolves to `@{upstream}`, ahead of the
         // origin/HEAD and origin/main fallbacks.
         let tmp = tempfile::tempdir().unwrap();
@@ -1156,10 +1166,7 @@ mod tests {
         );
         run(&work, &["push", "-q", "-u", "origin", "HEAD"]);
 
-        assert_eq!(
-            resolve_sync_base_ref(&work),
-            Some("@{upstream}".to_string())
-        );
+        assert_eq!(resolve_base_ref(&work), Some("@{upstream}".to_string()));
     }
 
     #[test]

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -495,8 +495,6 @@ pub struct HostProbe {
     pub is_macos: bool,
     /// Compiled for `target_os = "windows"` (native Windows, not WSL).
     pub is_windows: bool,
-    /// Running under WSL (Microsoft kernel marker in `/proc/version`).
-    pub is_wsl: bool,
     /// A reachable freedesktop notification service on the session bus.
     pub has_dbus_service: bool,
     /// `powershell.exe` resolves on `PATH` (WSL interop available).
@@ -556,32 +554,18 @@ pub fn resolve_backend(configured: NotificationBackend, probe: HostProbe) -> Del
 }
 
 /// Gather host facts for [`detect_backend`]. The `cfg!` flags are
-/// compile-time; the dynamic probes (WSL marker, dbus service, powershell)
-/// are best-effort and never panic.
+/// compile-time; the dynamic probes (dbus service, powershell) are
+/// best-effort and never panic. WSL is not probed directly: routing keys off
+/// the absence of a dbus service plus the presence of `powershell.exe`, which
+/// is exactly the WSL case (and degrades correctly on any other host).
 pub fn probe_host() -> HostProbe {
     HostProbe {
         is_linux: cfg!(target_os = "linux"),
         is_macos: cfg!(target_os = "macos"),
         is_windows: cfg!(target_os = "windows"),
-        is_wsl: detect_wsl(),
         has_dbus_service: detect_dbus_service(),
         has_powershell: detect_powershell(),
     }
-}
-
-/// WSL is detected by the Microsoft marker the WSL kernel writes into
-/// `/proc/version` (e.g. "...microsoft-standard-WSL2..."). Pure check exposed
-/// for tests via [`proc_version_is_wsl`].
-fn detect_wsl() -> bool {
-    std::fs::read_to_string("/proc/version")
-        .map(|v| proc_version_is_wsl(&v))
-        .unwrap_or(false)
-}
-
-/// Pure WSL test over a `/proc/version` string.
-pub(crate) fn proc_version_is_wsl(proc_version: &str) -> bool {
-    let lower = proc_version.to_ascii_lowercase();
-    lower.contains("microsoft") || lower.contains("wsl")
 }
 
 /// Probe for a working freedesktop notification service. We deliberately do a
@@ -666,30 +650,22 @@ fn write_focus_request(session_id: SessionId) -> Result<(), Box<dyn std::error::
 mod tests {
     use super::*;
 
-    fn probe(
-        is_linux: bool,
-        is_macos: bool,
-        is_wsl: bool,
-        has_dbus: bool,
-        has_ps: bool,
-    ) -> HostProbe {
+    fn probe(is_linux: bool, is_macos: bool, has_dbus: bool, has_ps: bool) -> HostProbe {
         HostProbe {
             is_linux,
             is_macos,
             is_windows: false,
-            is_wsl,
             has_dbus_service: has_dbus,
             has_powershell: has_ps,
         }
     }
 
-    /// A native-Windows host facts struct (no WSL, no dbus, powershell present).
+    /// A native-Windows host facts struct (no dbus, powershell present).
     fn probe_windows() -> HostProbe {
         HostProbe {
             is_linux: false,
             is_macos: false,
             is_windows: true,
-            is_wsl: false,
             has_dbus_service: false,
             has_powershell: true,
         }
@@ -736,19 +712,8 @@ mod tests {
     }
 
     #[test]
-    fn proc_version_wsl_marker() {
-        assert!(proc_version_is_wsl(
-            "Linux version 6.6.0-microsoft-standard-WSL2 (gcc ...)"
-        ));
-        assert!(proc_version_is_wsl("... WSL ..."));
-        assert!(!proc_version_is_wsl(
-            "Linux version 6.6.0-arch1-1 (linux@archlinux) ..."
-        ));
-    }
-
-    #[test]
     fn auto_picks_dbus_on_normal_linux_desktop() {
-        let p = probe(true, false, false, true, false);
+        let p = probe(true, false, true, false);
         assert_eq!(
             resolve_backend(NotificationBackend::Auto, p),
             DeliveryBackend::Dbus
@@ -759,7 +724,7 @@ mod tests {
     fn auto_falls_back_to_windows_toast_under_wsl_without_dbus() {
         // The exact WSL failure case: linux + WSL marker + no dbus service,
         // but powershell.exe is reachable.
-        let p = probe(true, false, true, false, true);
+        let p = probe(true, false, false, true);
         assert_eq!(
             resolve_backend(NotificationBackend::Auto, p),
             DeliveryBackend::WindowsToast
@@ -768,7 +733,7 @@ mod tests {
 
     #[test]
     fn auto_under_wsl_without_powershell_reports_none() {
-        let p = probe(true, false, true, false, false);
+        let p = probe(true, false, false, false);
         assert_eq!(
             resolve_backend(NotificationBackend::Auto, p),
             DeliveryBackend::None
@@ -778,7 +743,7 @@ mod tests {
     #[test]
     fn auto_prefers_dbus_even_under_wsl_if_a_daemon_answers() {
         // A WSL setup that *does* run a notification daemon should still use it.
-        let p = probe(true, false, true, true, true);
+        let p = probe(true, false, true, true);
         assert_eq!(
             resolve_backend(NotificationBackend::Auto, p),
             DeliveryBackend::Dbus
@@ -787,7 +752,7 @@ mod tests {
 
     #[test]
     fn auto_picks_macos_banner() {
-        let p = probe(false, true, false, false, false);
+        let p = probe(false, true, false, false);
         assert_eq!(
             resolve_backend(NotificationBackend::Auto, p),
             DeliveryBackend::Macos
@@ -796,7 +761,7 @@ mod tests {
 
     #[test]
     fn off_always_disables() {
-        let p = probe(true, false, false, true, true);
+        let p = probe(true, false, true, true);
         assert_eq!(
             resolve_backend(NotificationBackend::Off, p),
             DeliveryBackend::None
@@ -806,17 +771,11 @@ mod tests {
     #[test]
     fn forced_dbus_requires_linux() {
         assert_eq!(
-            resolve_backend(
-                NotificationBackend::Dbus,
-                probe(true, false, false, false, false)
-            ),
+            resolve_backend(NotificationBackend::Dbus, probe(true, false, false, false)),
             DeliveryBackend::Dbus
         );
         assert_eq!(
-            resolve_backend(
-                NotificationBackend::Dbus,
-                probe(false, true, false, false, false)
-            ),
+            resolve_backend(NotificationBackend::Dbus, probe(false, true, false, false)),
             DeliveryBackend::None
         );
     }
@@ -826,14 +785,14 @@ mod tests {
         assert_eq!(
             resolve_backend(
                 NotificationBackend::Windows,
-                probe(true, false, true, false, true)
+                probe(true, false, false, true)
             ),
             DeliveryBackend::WindowsToast
         );
         assert_eq!(
             resolve_backend(
                 NotificationBackend::Windows,
-                probe(true, false, true, false, false)
+                probe(true, false, false, false)
             ),
             DeliveryBackend::None
         );

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -50,7 +50,7 @@ fn app_dir_name() -> &'static str {
 }
 
 /// The user's home directory: `$HOME` on Unix, `%USERPROFILE%` on Windows.
-fn home_dir() -> Option<PathBuf> {
+pub(crate) fn home_dir() -> Option<PathBuf> {
     let var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
     std::env::var_os(var).map(PathBuf::from)
 }

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -33,8 +33,6 @@ impl Database {
         let counter = self.get_session_counter()?;
 
         Ok(SharedState {
-            version: 1,
-            last_modified: crate::sync::current_time_millis(),
             session_counter: counter,
             sessions,
         })

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -99,9 +99,11 @@ impl Default for SyncState {
 pub struct PollResult {
     /// Delta between local and DB state (may be empty).
     pub delta: StateDelta,
-    /// Whether the database was modified externally (e.g. by the MCP server).
-    /// True even when the delta is empty, indicating that non-tracked state
-    /// (such as global roles or MCP servers) may have changed.
+    /// Whether the database was modified externally (another thurbox instance,
+    /// the headless CLI, or an automation tick). True even when the delta is
+    /// empty, indicating that state not carried by `delta` may have changed —
+    /// the active theme, session hook-states, automation/task/message rows, or
+    /// a pending-focus request.
     pub db_changed: bool,
 }
 

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -2,20 +2,11 @@ use std::path::PathBuf;
 
 use crate::session::SessionId;
 
-/// Current shared state format version.
-const SHARED_STATE_VERSION: u32 = 1;
-
 /// In-memory snapshot of shared state across all thurbox instances.
 ///
 /// Used for computing deltas between local and database state.
 #[derive(Debug, Clone)]
 pub struct SharedState {
-    /// Version of the shared state format.
-    pub version: u32,
-
-    /// Timestamp (millis since epoch) when this snapshot was taken.
-    pub last_modified: u64,
-
     /// Session counter for unique naming across instances.
     pub session_counter: usize,
 
@@ -27,8 +18,6 @@ impl SharedState {
     /// Create a new empty shared state.
     pub fn new() -> Self {
         Self {
-            version: SHARED_STATE_VERSION,
-            last_modified: current_time_millis(),
             session_counter: 0,
             sessions: Vec::new(),
         }
@@ -145,17 +134,14 @@ mod tests {
     #[test]
     fn new_shared_state_is_empty_and_valid() {
         let state = SharedState::new();
-        assert_eq!(state.version, SHARED_STATE_VERSION);
         assert_eq!(state.session_counter, 0);
         assert!(state.sessions.is_empty());
-        assert!(state.last_modified > 0);
     }
 
     #[test]
     fn default_state_equals_new() {
         let new_state = SharedState::new();
         let default_state = SharedState::default();
-        assert_eq!(new_state.version, default_state.version);
         assert_eq!(new_state.session_counter, default_state.session_counter);
     }
 

--- a/src/usage/mod.rs
+++ b/src/usage/mod.rs
@@ -106,8 +106,7 @@ fn claude_credentials_path() -> Option<PathBuf> {
             return Some(p);
         }
     }
-    let home = std::env::var_os("HOME")?;
-    let p = PathBuf::from(home)
+    let p = crate::paths::home_dir()?
         .join(".claude")
         .join(".credentials.json");
     p.exists().then_some(p)
@@ -275,8 +274,11 @@ const ANTIGRAVITY_QUOTA_URL: &str =
     "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota";
 
 fn antigravity_token() -> Option<String> {
-    let home = std::env::var_os("HOME")?;
-    let v = read_json_file(&PathBuf::from(home).join(".gemini").join("oauth_creds.json"))?;
+    let v = read_json_file(
+        &crate::paths::home_dir()?
+            .join(".gemini")
+            .join("oauth_creds.json"),
+    )?;
     let token = v.get("access_token").and_then(|x| x.as_str())?.to_string();
     (!token.contains('"') && !token.contains('\n')).then_some(token)
 }

--- a/tests/architecture_rules.rs
+++ b/tests/architecture_rules.rs
@@ -69,7 +69,9 @@ const MODULE_RULES: &[ModuleRules] = &[
     ModuleRules {
         name: "usage",
         allowed: &["session"],
-        allowed_path_only: &[],
+        // `paths::home_dir()` (fully-qualified, never `use`) to resolve agent
+        // credential files cross-platform ($HOME / %USERPROFILE%).
+        allowed_path_only: &["paths"],
     },
     // Headless session ops: no TUI state or PTY-attached backend. Talks to
     // tmux through the narrow helpers in `agent::tmux` via fully-qualified


### PR DESCRIPTION
Code-quality fixes from review of the git / sync / notifications / agent / usage modules. Surgical changes only; behavior is unchanged except where a finding explicitly calls for it.

## Findings fixed

1. **Base-ref fallback chain unified** — `src/git/mod.rs:863`. `ahead_behind` lacked the `origin/HEAD` step `resolve_sync_base_ref` had, so the "behind" count could be measured against a different base than sync rebases onto. Factored a single `resolve_base_ref(cwd)` (upstream → `origin/HEAD` → `origin/main` → `origin/master`) used by both `sync_worktree` and `ahead_behind`.

2. **`worktree_subpath` / `worktree_subpath_posix` deduped** — `src/git/mod.rs:459,469`. Both recomputed the load-bearing hash+sanitize; factored `worktree_segments(repo, branch) -> (hash, sanitized)`.

3. **Stale `db_changed` doc** — `src/sync/mod.rs:102`. Referenced a non-existent MCP server / global roles (tables dropped in v20); rewritten to name the real untracked writers (theme / hook-state / automation / task / message rows, pending-focus).

4. **Write-only `SharedState` versioning removed** — `src/sync/state.rs:14`. `version` / `last_modified` / `SHARED_STATE_VERSION` were written but only read in tests (no versioning protocol exists). Removed; updated the one construction site in `src/storage/sync.rs`.

5. **Unused `HostProbe::is_wsl`** — `src/notifications.rs:499`. Never consulted by `resolve_backend` (which routes off `has_dbus_service` + `has_powershell`). Dropped the field, `detect_wsl()`, and the now-orphaned `proc_version_is_wsl` helper + its test. WSL routing behavior unchanged.

6. **(perf) `dispatch_output` clone per sender** — `src/agent/tmux.rs:350`. Now moves the payload into the last (typically only) sender; fan-out still clones for earlier senders.

7. **`reconnect_control` left `control = None` on failed restart** — `src/agent/tmux.rs:731`. Now starts the replacement before touching the guard and only assigns on success, so a failed `start()` no longer reports the misleading "call ensure_ready() first" on later calls.

8. **~40 duplicated control-mode tests** — `src/agent/tmux.rs:1513`. They were imported from `control_mode.rs` (re-run, not redefined → zero added coverage). Deleted the verbatim duplicates; kept one re-export smoke check. Module-unique tests (parse_tmux_version, check_min_version, build_shell_command, sanitize_window_name, history_seed, env_flag, backend/from_host) were preserved.

9. **`usage` read `$HOME` directly** — `src/usage/mod.rs:109,278`. `None` on Windows → silent "not logged in". Exposed `paths::home_dir()` as `pub(crate)` and used it from both sites; allowed the `usage → paths` path-only dependency in `tests/architecture_rules.rs` (the only consequent change outside the listed scope).

## Verification

- `cargo fmt --all` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all` — 1545 passed, 0 failed