### PR TITLE
fix(core): session + session_ops quality fixes (W5)

### DIFF
--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -198,6 +198,32 @@ pub struct ExtensionAutomation {
     pub command: Option<String>,
 }
 
+impl ExtensionAutomation {
+    /// Reject the invalid flavour combinations the 3-`Option` shape allows but
+    /// the `send`-xor-`exec` model forbids: setting `command` *and* a send field
+    /// (downstream `command` silently wins, dropping the send fields), or
+    /// setting neither. Mirrors [`crate::session::message::validate_kind_body`];
+    /// called where the manifest is turned into resources
+    /// ([`crate::session_ops::ensure_extension`]).
+    pub fn validate(&self) -> Result<(), String> {
+        let has_send_fields = self.session_ref.is_some() || self.prompt.is_some();
+        if self.command.is_some() && has_send_fields {
+            return Err(format!(
+                "automation '{}' sets both `command` (exec) and send fields \
+                 (`session_ref`/`prompt`); set exactly one flavour",
+                self.name
+            ));
+        }
+        if self.command.is_none() && self.session_ref.is_none() {
+            return Err(format!(
+                "automation '{}' has neither a `command` nor a `session_ref`",
+                self.name
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// A full extension manifest: the resources to ensure when the extension is
 /// active. One manifest per `extension.toml` file.
 ///
@@ -433,6 +459,32 @@ prompt = "tick"
         assert_eq!(def.automations[0].session_ref.as_deref(), Some("flow"));
         assert_eq!(def.automations[0].prompt.as_deref(), Some("tick"));
         assert!(!def.is_empty());
+    }
+
+    #[test]
+    fn automation_validate_rejects_invalid_flavours() {
+        let auto = |session_ref: Option<&str>, prompt: Option<&str>, command: Option<&str>| {
+            ExtensionAutomation {
+                name: "a".into(),
+                trigger: "hourly".into(),
+                session_ref: session_ref.map(str::to_string),
+                prompt: prompt.map(str::to_string),
+                command: command.map(str::to_string),
+            }
+        };
+        // Valid: a pure send, or a pure exec.
+        assert!(auto(Some("flow"), Some("tick"), None).validate().is_ok());
+        assert!(auto(None, None, Some("sync.sh")).validate().is_ok());
+        // Invalid: both flavours (exec would silently win, dropping the send fields).
+        assert!(auto(Some("flow"), Some("tick"), Some("sync.sh"))
+            .validate()
+            .is_err());
+        assert!(auto(None, Some("tick"), Some("sync.sh"))
+            .validate()
+            .is_err());
+        // Invalid: neither flavour.
+        assert!(auto(None, None, None).validate().is_err());
+        assert!(auto(None, Some("tick"), None).validate().is_err());
     }
 
     #[test]

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -691,6 +691,12 @@ impl KeyBindings {
     /// active in `context` — i.e. global actions plus those scoped to
     /// `context`. The keypress is normalized first so Shift+letter encodings
     /// match regardless of how the terminal delivered them.
+    ///
+    /// When a hand-edited config binds one chord to several overlapping actions
+    /// the match is resolved **deterministically**: a context-scoped action
+    /// wins over a global one (more specific intent), ties broken by the
+    /// earliest position in [`Action::all`]. Iterating the `HashMap` and
+    /// returning the first hit would otherwise pick nondeterministically.
     pub fn lookup_in(
         &self,
         context: KeyContext,
@@ -698,6 +704,17 @@ impl KeyBindings {
         mods: KeyModifiers,
     ) -> Option<Action> {
         let target = KeyChord::normalized(mods, code);
+        // Lower sort key wins: scoped (0) before global (1), then earliest in
+        // `Action::all()`.
+        let sort_key = |action: &Action| -> (u8, usize) {
+            let is_global = (action.context() == KeyContext::Global) as u8;
+            let idx = Action::all()
+                .iter()
+                .position(|a| a == action)
+                .unwrap_or(usize::MAX);
+            (is_global, idx)
+        };
+        let mut best: Option<Action> = None;
         for (action, chords) in &self.map {
             let ctx = action.context();
             if ctx != KeyContext::Global && ctx != context {
@@ -707,10 +724,16 @@ impl KeyBindings {
                 .iter()
                 .any(|c| c.code == target.code && c.mods == target.mods)
             {
-                return Some(*action);
+                let wins = match best {
+                    None => true,
+                    Some(b) => sort_key(action) < sort_key(&b),
+                };
+                if wins {
+                    best = Some(*action);
+                }
             }
         }
-        None
+        best
     }
 
     /// Replace all chords for `action` with the single `chord`. If the chord
@@ -1224,6 +1247,49 @@ mod tests {
             ),
             Some(Action::QuitApp)
         );
+    }
+
+    #[test]
+    fn lookup_in_resolves_overlapping_bindings_deterministically() {
+        // A hand-edited config can bind one chord to several actions whose
+        // scopes overlap (e.g. a global and a session-list action). The lookup
+        // must pick a stable winner regardless of HashMap iteration order.
+        let mut kb = KeyBindings::default();
+        let chord = KeyChord::ctrl('x');
+        // Bind ctrl+x to a global action and a session-list action directly in
+        // the map, bypassing `rebind`'s conflict resolution.
+        kb.map.insert(Action::ToggleHelp, vec![chord]); // global
+        kb.map.insert(Action::SessionListNext, vec![chord]); // scoped
+
+        // In the session list both match; the scoped action wins over global.
+        assert_eq!(
+            kb.lookup_in(
+                KeyContext::SessionList,
+                KeyCode::Char('x'),
+                KeyModifiers::CONTROL
+            ),
+            Some(Action::SessionListNext)
+        );
+        // Outside its scope only the global action is eligible.
+        assert_eq!(
+            kb.lookup_in(
+                KeyContext::Terminal,
+                KeyCode::Char('x'),
+                KeyModifiers::CONTROL
+            ),
+            Some(Action::ToggleHelp)
+        );
+        // Repeated lookups never flip (no nondeterminism).
+        for _ in 0..50 {
+            assert_eq!(
+                kb.lookup_in(
+                    KeyContext::SessionList,
+                    KeyCode::Char('x'),
+                    KeyModifiers::CONTROL
+                ),
+                Some(Action::SessionListNext)
+            );
+        }
     }
 
     #[test]

--- a/src/session/theme_config.rs
+++ b/src/session/theme_config.rs
@@ -307,6 +307,13 @@ fn apply_color(
 }
 
 impl CustomThemeDef {
+    /// Number of per-colour override fields wired into [`Self::resolve`]'s
+    /// `fields` array. Tied to the array's length at compile time; a test
+    /// (`override_array_covers_every_color_field`) asserts it matches the
+    /// struct's colour-field count, so a forgotten row can't silently make a
+    /// colour un-overridable.
+    const COLOR_OVERRIDE_COUNT: usize = 26;
+
     /// Materialise the theme: base preset palette + overrides. Unparsable
     /// colours and an unknown base degrade to warnings, never to a hard
     /// failure — a half-styled theme beats no theme.
@@ -327,7 +334,7 @@ impl CustomThemeDef {
             palette.nerd_font_enabled = nerd;
         }
 
-        let fields: [(&str, &Option<String>, &mut Color); 26] = [
+        let fields: [(&str, &Option<String>, &mut Color); Self::COLOR_OVERRIDE_COUNT] = [
             ("accent", &self.accent, &mut palette.accent),
             (
                 "accent_bright",
@@ -893,5 +900,43 @@ mod tests {
             "Catppuccin Mocha"
         );
         assert_eq!(ThemePreset::TokyoNight.display_name(), "Tokyo Night");
+    }
+
+    #[test]
+    fn all_enumerates_every_preset_variant() {
+        // Exhaustive match: adding a variant fails to compile until it's listed
+        // here, and the EXPECTED guard ensures `all()` was also updated. Mirrors
+        // keybindings.rs's `all_enumerates_every_action_variant`.
+        fn classify(p: ThemePreset) -> u8 {
+            match p {
+                ThemePreset::Default => 0,
+                ThemePreset::CatppuccinMocha => 0,
+                ThemePreset::TokyoNight => 0,
+                ThemePreset::GruvboxDark => 0,
+                ThemePreset::CatppuccinLatte => 0,
+                ThemePreset::TokyoNightDay => 0,
+                ThemePreset::GruvboxLight => 0,
+                ThemePreset::SolarizedLight => 0,
+                ThemePreset::Doom => 0,
+            }
+        }
+        const EXPECTED: usize = 9;
+        assert_eq!(ThemePreset::all().len(), EXPECTED);
+        for p in ThemePreset::all() {
+            classify(*p);
+        }
+    }
+
+    #[test]
+    fn override_array_covers_every_color_field() {
+        // Count the struct's colour-override fields (total serialized fields
+        // minus the five non-colour meta fields) and assert it equals the
+        // `fields` array length. A new `Option<String>` colour added to the
+        // struct but not to `resolve()`'s array would be silently
+        // un-overridable; this catches the omission.
+        let json = serde_json::to_value(CustomThemeDef::default()).unwrap();
+        let total = json.as_object().unwrap().len();
+        const META_FIELDS: usize = 5; // name, display_name, base, light, nerd_font
+        assert_eq!(total - META_FIELDS, CustomThemeDef::COLOR_OVERRIDE_COUNT);
     }
 }

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -25,7 +25,7 @@ use std::path::{Path, PathBuf};
 
 use crate::session::automation::parse_trigger;
 use crate::session::extension_def::HOME_TOKEN;
-use crate::session::{AutomationAction, ExtensionAutomation, ExtensionDef, SessionId};
+use crate::session::{Automation, AutomationAction, ExtensionAutomation, ExtensionDef, SessionId};
 use crate::storage::automations::NewAutomation;
 use crate::storage::Database;
 use crate::sync::current_time_millis;
@@ -691,9 +691,6 @@ pub fn uninstall_extension(
     Ok(report)
 }
 
-/// Refuse to recursively delete obviously-dangerous paths (root, `$HOME`
-/// itself, or a shallow path) — a guard before `remove_dir_all` on a
-/// manifest-supplied home.
 /// Remove a directory tree. On Windows a just-written payload file can be held
 /// transiently by the search indexer / antivirus, so `remove_dir_all` fails with
 /// `ERROR_SHARING_VIOLATION` (os error 32); retry with a short backoff until the
@@ -724,6 +721,9 @@ fn remove_dir_all_resilient(path: &Path) -> std::io::Result<()> {
     }
 }
 
+/// Refuse to recursively delete obviously-dangerous paths (root, `$HOME`
+/// itself, or a shallow path) — a guard before `remove_dir_all` on a
+/// manifest-supplied home.
 fn guard_removable_dir(path: &Path) -> Result<(), String> {
     let depth = path
         .components()
@@ -862,14 +862,25 @@ pub fn ensure_extension(db: &Database, def: &ExtensionDef) -> Result<EnsureRepor
     let mut report = EnsureReport::default();
     let mut session_ids: HashMap<String, SessionId> = HashMap::new();
 
+    // Snapshot existing rows once instead of re-listing per declared resource:
+    // self-heal runs this on every heartbeat tick. Declared names are unique, so
+    // a pre-loop snapshot is correct for the existence lookups below.
+    let existing_sessions: HashMap<String, SessionId> = db
+        .list_active_sessions()
+        .map_err(|e| format!("list_active_sessions: {e}"))?
+        .into_iter()
+        .map(|row| (row.name, row.id))
+        .collect();
+    let existing_automations: HashMap<String, Automation> = db
+        .list_automations()
+        .map_err(|e| format!("list_automations: {e}"))?
+        .into_iter()
+        .map(|row| (row.name.clone(), row))
+        .collect();
+
     for sess in &def.sessions {
-        let existing = db
-            .list_active_sessions()
-            .map_err(|e| format!("list_active_sessions: {e}"))?
-            .into_iter()
-            .find(|row| row.name == sess.name);
-        let id = match existing {
-            Some(row) => row.id,
+        let id = match existing_sessions.get(&sess.name) {
+            Some(id) => *id,
             None => {
                 let result = super::spawn_session_headless(
                     db,
@@ -894,6 +905,7 @@ pub fn ensure_extension(db: &Database, def: &ExtensionDef) -> Result<EnsureRepor
     }
 
     for auto in &def.automations {
+        auto.validate()?;
         // An exec automation has no session; a send one resolves its target.
         let target = if auto.command.is_some() {
             None
@@ -911,7 +923,13 @@ pub fn ensure_extension(db: &Database, def: &ExtensionDef) -> Result<EnsureRepor
                 )
             })?)
         };
-        ensure_automation(db, auto, target, &mut report)?;
+        ensure_automation(
+            db,
+            auto,
+            target,
+            existing_automations.get(&auto.name),
+            &mut report,
+        )?;
     }
 
     Ok(report)
@@ -925,6 +943,7 @@ fn ensure_automation(
     db: &Database,
     auto: &ExtensionAutomation,
     target: Option<SessionId>,
+    existing: Option<&Automation>,
     report: &mut EnsureReport,
 ) -> Result<(), String> {
     // Desired action: a command wins (exec); otherwise send to the target.
@@ -940,15 +959,11 @@ fn ensure_automation(
             ))
         }
     };
-    let existing = db
-        .list_automations()
-        .map_err(|e| format!("list_automations: {e}"))?
-        .into_iter()
-        .find(|row| row.name == auto.name);
-    if let Some(mut row) = existing {
+    if let Some(row) = existing {
         // Re-link a send automation whose target session was recreated (a new id).
         if let (AutomationAction::Send { session_id }, Some(t)) = (&row.action, target) {
             if *session_id != t {
+                let mut row = row.clone();
                 row.action = AutomationAction::Send { session_id: t };
                 db.update_automation(&row)
                     .map_err(|e| format!("update_automation: {e}"))?;
@@ -998,28 +1013,29 @@ pub fn deactivate_extension(
 ) -> Result<DeactivateReport, String> {
     let mut report = DeactivateReport::default();
 
+    // Snapshot existing rows once rather than re-listing per declared resource.
+    let automation_ids: HashMap<String, i64> = db
+        .list_automations()
+        .map_err(|e| format!("list_automations: {e}"))?
+        .into_iter()
+        .map(|row| (row.name, row.id))
+        .collect();
     for auto in &def.automations {
-        let id = db
-            .list_automations()
-            .map_err(|e| format!("list_automations: {e}"))?
-            .into_iter()
-            .find(|row| row.name == auto.name)
-            .map(|row| row.id);
-        if let Some(id) = id {
+        if let Some(&id) = automation_ids.get(&auto.name) {
             db.delete_automation(id)
                 .map_err(|e| format!("delete_automation: {e}"))?;
             report.automations_deleted.push(auto.name.clone());
         }
     }
 
+    let session_ids: HashMap<String, SessionId> = db
+        .list_active_sessions()
+        .map_err(|e| format!("list_active_sessions: {e}"))?
+        .into_iter()
+        .map(|row| (row.name, row.id))
+        .collect();
     for sess in &def.sessions {
-        let id = db
-            .list_active_sessions()
-            .map_err(|e| format!("list_active_sessions: {e}"))?
-            .into_iter()
-            .find(|row| row.name == sess.name)
-            .map(|row| row.id);
-        if let Some(id) = id {
+        if let Some(&id) = session_ids.get(&sess.name) {
             super::delete_session_headless(db, id, force)?;
             report.sessions_deleted.push(sess.name.clone());
         }

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -42,16 +42,21 @@ pub fn run_exec_command(command: &str) -> (AutomationRunStatus, String) {
         Ok(out) => out,
         Err(e) => return (AutomationRunStatus::Error, format!("spawn failed: {e}")),
     };
-    // Keep the last ~500 chars of each stream.
+    // Keep the last 500 chars of each stream. Single pass via a capped ring so a
+    // huge stream isn't walked twice (count + skip) or materialized in full.
+    const TAIL_CHARS: usize = 500;
     let tail = |s: &[u8]| -> String {
         let t = String::from_utf8_lossy(s);
         let t = t.trim();
-        let n = t.chars().count();
-        if n > 500 {
-            t.chars().skip(n - 500).collect()
-        } else {
-            t.to_string()
+        let mut ring: std::collections::VecDeque<char> =
+            std::collections::VecDeque::with_capacity(TAIL_CHARS + 1);
+        for c in t.chars() {
+            if ring.len() == TAIL_CHARS {
+                ring.pop_front();
+            }
+            ring.push_back(c);
         }
+        ring.into_iter().collect()
     };
     let stdout = tail(&out.stdout);
     let stderr = tail(&out.stderr);
@@ -125,13 +130,16 @@ pub(crate) fn resume_trigger_for(
     resume_id_if_transcript_exists(agent_session_id, env)
 }
 
-/// Resolve the [`AgentDef`](crate::session::AgentDef) for an agent name from
-/// the on-disk registry, mirroring [`build_agent_invocation`]'s fallback chain
-/// (named agent → registry default → built-in default).
-pub(crate) fn resolve_agent_def(agent: &str) -> crate::session::AgentDef {
+/// Resolve the [`AgentDef`](crate::session::AgentDef) for a requested agent name
+/// from the on-disk registry. The single source of truth for the agent fallback
+/// chain (requested name → registry default → built-in default), so spawn and
+/// restart agree on both the launched def *and* its `.name` without re-running
+/// the seed. `None`/empty falls straight through to the registry default.
+pub(crate) fn resolve_agent_def(requested: Option<&str>) -> crate::session::AgentDef {
     let registry = crate::agent::agent_config::load_or_seed();
-    registry
-        .get(agent)
+    requested
+        .filter(|n| !n.is_empty())
+        .and_then(|n| registry.get(n))
         .or_else(|| registry.default_agent())
         .cloned()
         .unwrap_or_else(|| {
@@ -142,14 +150,16 @@ pub(crate) fn resolve_agent_def(agent: &str) -> crate::session::AgentDef {
         })
 }
 
-/// Build the `(command, args)` invocation for the agent named by
-/// `config.agent`, looked up in the on-disk agent registry (falling back to
-/// the registry default, then to the built-in default).
+/// Build the `(command, args)` invocation for an already-resolved [`AgentDef`].
 ///
-/// Centralised here so headless spawn and restart agree on the args.
-fn build_agent_invocation(config: &SessionConfig) -> (String, Vec<String>) {
-    let def = resolve_agent_def(&config.agent);
-    let provider = crate::agent::GenericProvider::new(def);
+/// Centralised here so headless spawn and restart agree on the args, and so the
+/// `AgentDef` is resolved exactly once per operation (callers pass the def they
+/// already resolved rather than re-running [`resolve_agent_def`]).
+fn build_agent_invocation(
+    def: &crate::session::AgentDef,
+    config: &SessionConfig,
+) -> (String, Vec<String>) {
+    let provider = crate::agent::GenericProvider::new(def.clone());
     // Reach the provider trait methods via fully-qualified call syntax so this
     // module imports nothing from the agent module (architecture rule:
     // session_ops must stay free of agent-layer imports).

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -45,7 +45,7 @@ fn build_restart_plan(session: &SharedSession) -> Result<RestartPlan, String> {
         ..SessionConfig::default()
     };
     super::inject_thurbox_env(&mut config, &agent_session_id, None);
-    let def = super::resolve_agent_def(&config.agent);
+    let def = super::resolve_agent_def(Some(&config.agent));
     config.resume_session_id = super::resume_trigger_for(&def, &agent_session_id, &config.env);
 
     // A multi-repo session (≥2 members) launches in its per-session symlink
@@ -60,7 +60,7 @@ fn build_restart_plan(session: &SharedSession) -> Result<RestartPlan, String> {
         ));
     }
 
-    let (command, args) = super::build_agent_invocation(&config);
+    let (command, args) = super::build_agent_invocation(&def, &config);
 
     Ok(RestartPlan {
         window_name: session.name.clone(),

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use crate::session::{ExtraRepo, HostDef, SessionConfig, SessionId, DEFAULT_AGENT_NAME};
+use crate::session::{ExtraRepo, HostDef, SessionConfig, SessionId};
 use crate::storage::Database;
 use crate::sync::{SharedSession, SharedWorktree};
 
@@ -64,10 +64,13 @@ pub struct SpawnResult {
 /// Spawn a new session inside `tmux -L thurbox`, persisting its state to the
 /// shared SQLite database.
 pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnResult, String> {
-    validate_session_name(&req.name)?;
+    crate::paths::validate_safe_name(&req.name)?;
     validate_parent_session(db, req.parent_session_id)?;
 
-    let agent_name = resolve_agent_name(req.agent.as_deref());
+    // Resolve the agent definition once; `agent_name` is derived from it so the
+    // persisted name always matches the def that's actually launched.
+    let agent_def = super::resolve_agent_def(req.agent.as_deref());
+    let agent_name = agent_def.name.clone();
 
     // Resolve the optional remote host. `backend_type` is `local-tmux` or
     // `ssh:<host>`; `host` is the matching HostDef for remote git/tmux ops.
@@ -105,7 +108,7 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     };
     super::inject_thurbox_env(&mut config, &agent_session_id, req.task_id);
 
-    let (command, args) = super::build_agent_invocation(&config);
+    let (command, args) = super::build_agent_invocation(&agent_def, &config);
 
     // Remote spawns drive the SSH backend's control mode to learn the real pane
     // id; local spawns leave `backend_id` empty for the TUI to resolve by name.
@@ -189,11 +192,6 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     })
 }
 
-/// Validate a session name. Delegates to the shared `paths::validate_safe_name`.
-fn validate_session_name(name: &str) -> Result<(), String> {
-    crate::paths::validate_safe_name(name)
-}
-
 /// Validate that the requested parent session, if any, exists and is active.
 /// Runs before any side effects (worktree creation, tmux spawn).
 fn validate_parent_session(db: &Database, parent: Option<SessionId>) -> Result<(), String> {
@@ -204,21 +202,6 @@ fn validate_parent_session(db: &Database, parent: Option<SessionId>) -> Result<(
         Ok(Some(_)) => Ok(()),
         Ok(None) => Err(format!("Parent session not found: {parent}")),
         Err(e) => Err(format!("get_session_by_id: {e}")),
-    }
-}
-
-/// Resolve the agent name: explicit request wins, otherwise the registry's
-/// default agent, otherwise the built-in default.
-fn resolve_agent_name(requested: Option<&str>) -> String {
-    if let Some(name) = requested.filter(|n| !n.is_empty()) {
-        return name.to_string();
-    }
-    let registry = crate::agent::agent_config::load_or_seed();
-    let name = registry.default_name();
-    if name.is_empty() {
-        DEFAULT_AGENT_NAME.to_string()
-    } else {
-        name
     }
 }
 
@@ -364,6 +347,7 @@ fn resolve_host(host_name: Option<&str>) -> Result<(String, Option<HostDef>), St
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::DEFAULT_AGENT_NAME;
     use crate::storage::Database;
 
     fn empty_db() -> Database {
@@ -438,9 +422,24 @@ mod tests {
     }
 
     #[test]
-    fn resolve_agent_name_uses_explicit() {
-        assert_eq!(resolve_agent_name(Some("codex")), "codex");
-        assert_eq!(resolve_agent_name(Some("")), DEFAULT_AGENT_NAME);
+    fn resolve_agent_def_derives_name_with_fallback() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        // An explicit, seeded agent wins and its name round-trips.
+        assert_eq!(super::super::resolve_agent_def(Some("codex")).name, "codex");
+        // Empty/None/unknown fall back to the registry default.
+        assert_eq!(
+            super::super::resolve_agent_def(Some("")).name,
+            DEFAULT_AGENT_NAME
+        );
+        assert_eq!(
+            super::super::resolve_agent_def(None).name,
+            DEFAULT_AGENT_NAME
+        );
+        assert_eq!(
+            super::super::resolve_agent_def(Some("no-such-agent")).name,
+            DEFAULT_AGENT_NAME
+        );
     }
 
     #[test]


### PR DESCRIPTION
Code-quality fixes from review of `src/session/` and `src/session_ops/` (worker W5). No behavior change except where a finding explicitly calls for it (deterministic keybinding resolution, validation of invalid extension-automation combos, and an agent name now derived from the resolved def).

## Findings fixed

1. **Theme override array has no compile-time link to the struct** — `src/session/theme_config.rs:330`. Tied the `[…; 26]` array length to a named `CustomThemeDef::COLOR_OVERRIDE_COUNT` const and added `override_array_covers_every_color_field`, which counts the struct's colour fields via serde so a forgotten array row (a silently un-overridable colour) fails the test.
2. **`ThemePreset` variants restated without a guard** — `src/session/theme_config.rs:98`. Added `all_enumerates_every_preset_variant` (exhaustive match + length guard) mirroring keybindings.rs's `all_enumerates_every_action_variant`.
3. **`ExtensionAutomation` models a sum type as 3 Options** — `src/session/extension_def.rs:181`. Added `validate()` (mirroring `SessionMessage::validate_kind_body`) rejecting the "both" (command + send fields) and "neither" combos, and call it in `ensure_extension` so the invalid combo is rejected instead of silently dropping the send fields.
4. **`lookup_in` returned first HashMap match (nondeterministic)** — `src/session/keybindings.rs:701`. Now collects matches and picks a stable winner: a context-scoped action beats a global one, ties broken by earliest position in `Action::all()`. Added a test.
5. **`resolve_agent_name` / `resolve_agent_def` each re-ran the fallback + `load_or_seed()`** — `src/session_ops/spawn.rs:212`, `src/session_ops/mod.rs:131`. `load_or_seed` ran twice per spawn with divergent tails. `resolve_agent_def` now owns the whole fallback chain (`Option<&str>` → named/default/builtin); spawn & restart resolve the def once and derive `.name` from it (the persisted name now always matches the launched def). `build_agent_invocation` takes the already-resolved `AgentDef`.
6. **`validate_session_name` was a no-value passthrough** — `src/session_ops/spawn.rs:193`. Inlined `paths::validate_safe_name(&req.name)?` and deleted the wrapper.
7. **Misattached doc comment** — `src/session_ops/extensions.rs:694`. `guard_removable_dir`'s doc was attached above `remove_dir_all_resilient`; moved it down to `guard_removable_dir`.
8. **(perf) `ensure`/`deactivate` listed per resource each tick** — `src/session_ops/extensions.rs:866`. Hoisted the `list_active_sessions()`/`list_automations()` calls out of the loops into name→row maps (self-heal runs this every heartbeat tick).
9. **(perf) `tail()` walked output twice** — `src/session_ops/mod.rs:46`. `chars().count()` then `skip` → single pass via a capped ring buffer.

## Verification
`cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo nextest run --all` (1593 tests) all green.
