### PR TITLE
fix(core): resolve remaining HOME reads via paths::home_dir()

### DIFF
--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -2123,8 +2123,8 @@ impl App {
     fn spawn_repo_picker_no_repos(&mut self) {
         let mut config = SessionConfig::default();
         if self.new_session.backend.is_none() {
-            if let Some(home) = std::env::var_os("HOME") {
-                config.cwd = Some(std::path::PathBuf::from(home));
+            if let Some(home) = crate::paths::home_dir() {
+                config.cwd = Some(home);
             }
         }
         self.spawn_session_with_config(&config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,7 @@ fn fallback_database_path() -> std::path::PathBuf {
             }
             #[cfg(not(windows))]
             {
-                let mut p = std::path::PathBuf::from(std::env::var_os("HOME").unwrap_or_default());
+                let mut p = thurbox::paths::home_dir().unwrap_or_default();
                 p.push(".local");
                 p.push("share");
                 p

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -50,7 +50,7 @@ fn app_dir_name() -> &'static str {
 }
 
 /// The user's home directory: `$HOME` on Unix, `%USERPROFILE%` on Windows.
-pub(crate) fn home_dir() -> Option<PathBuf> {
+pub fn home_dir() -> Option<PathBuf> {
     let var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
     std::env::var_os(var).map(PathBuf::from)
 }


### PR DESCRIPTION
## Summary

Two sites read the `HOME` env var directly instead of the platform-aware
`paths::home_dir()` helper, so they silently misbehaved on Windows (where
`HOME` is unset → empty/`None` path). Routed both through `paths::home_dir()`,
which falls back to `USERPROFILE` on Windows.

- `src/main.rs` (`fallback_database_path`, non-Windows branch): build the base
  `PathBuf` from `paths::home_dir().unwrap_or_default()` instead of
  `std::env::var_os("HOME").unwrap_or_default()`.
- `src/app/key_handlers.rs` (`spawn_repo_picker_no_repos`): take the cwd from
  `crate::paths::home_dir()` instead of `std::env::var_os("HOME")`.
- `src/paths.rs`: `home_dir()` is now `pub` so the binary crate can reach it
  (`pub(crate)` wouldn't cross the lib/bin boundary).

Each call site's existing semantics are preserved.

## Test plan

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all` — 1589 passed