### PR TITLE
refactor: optimize in-code comments for LLM context

### DIFF
--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -41,8 +41,16 @@ Re-read all identified files from disk, then:
    - Ensure consistent formatting and code style with the
      rest of the project.
    - Structure code so it reads top-down.
-   - Let the code be self-documenting; only add comments for
-     non-obvious "why", never for "what".
+   - **Optimize comments aggressively** (full rubric: the
+     "Comments" section in `CLAUDE.md`). Let the code be
+     self-documenting: keep only comments that convey "why" /
+     rationale / non-obvious constraints / cross-references
+     (`ADR-*`, `schema vNN`, `see fn_x`). Cut restatements,
+     obvious trailing labels (`// list`, `// EOF`), and obvious
+     test-step narration — if an LLM could infer it from the
+     code, delete it. Tighten verbose doc comments, but never
+     delete a public doc that carries intra-doc links or
+     examples.
 
 Apply fixes, then summarize what was changed in Pass 1.
 
@@ -62,7 +70,13 @@ not rely on memory from Pass 1), then:
 3. **Logic review**: Look for contradictory logic, redundant
    conditions, unreachable branches, or mismatched
    assumptions between modules.
-4. **Import & dependency hygiene**: Ensure no circular
+4. **Comment accuracy**: Re-read every comment in the changed
+   files against the code it describes. Any comment that
+   describes a prior implementation, a wrong signature, or
+   behavior the code no longer has must be rewritten to match
+   or deleted. A stale comment is worse than none — it
+   anchors readers (and LLM agents) on the wrong intent.
+5. **Import & dependency hygiene**: Ensure no circular
    dependencies, unused imports, or misplaced
    responsibilities were introduced.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,31 @@ rumdl check .                        # Markdown lint (.rumdl.toml)
 rumdl fmt .                          # Markdown auto-fix
 ```
 
+## Comments
+
+Comments are context for the next reader — human or LLM agent. Each one must earn
+its tokens; a redundant or wrong comment makes agents *less* accurate, not more.
+
+- **Why, not what.** Explain rationale, tradeoffs, non-obvious constraints, and
+  invariants the code can't show. Never restate what the code plainly does.
+- **Accuracy is non-negotiable.** A stale comment (describes a prior impl, a wrong
+  signature, or behavior the code no longer has) is *worse than no comment* — it
+  anchors readers on the wrong intent. When you touch code, fix or delete the
+  comments around it; never leave one contradicting the code.
+- **Keep** design rationale, cross-references (`see fn_x`, `mirrors Y`), and
+  `ADR-*` / `schema vNN` anchors (they point at `docs/ARCHITECTURE.md` /
+  `docs/PERFORMANCE.md`). **Cut** restatements, obvious trailing labels (`// list`,
+  `// EOF`), and obvious test-step narration. If an LLM could infer it from the
+  code, it doesn't belong.
+- **Doc comments** (`///`/`//!`) document the public contract. Tighten verbose
+  ones, but never delete a doc that carries intra-doc links (`` [`Item`] ``) or a
+  ` ``` ` example without re-running `RUSTDOCFLAGS="-D warnings" cargo doc`
+  (CI fails on a broken link/example).
+- **Formatting is automatic** — `rustfmt` wraps comments at 80 cols
+  (`wrap_comments`); write content, let `cargo fmt` handle width.
+- This repo uses **no `TODO`/`FIXME`/`HACK` markers** and keeps **no commented-out
+  code** — track work in issues, delete dead code.
+
 ## Website Linting
 
 ```bash

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -210,8 +210,7 @@ const KNOWN_TOP_LEVEL_KEYS: [&str; 3] = ["config_version", "default", "agents"];
 /// that tells you to fix the file, while the TUI degrades gracefully so a
 /// single typo never strands you on the built-ins.
 fn parse_agents_toml(contents: &str) -> (AgentRegistry, Vec<String>) {
-    // A genuine syntax error can't be recovered per entry — there are no
-    // well-formed entries to keep — so fall back to built-ins as before.
+    // A genuine syntax error can't be recovered per entry — fall back to built-ins.
     let table: toml::Table = match contents.parse() {
         Ok(table) => table,
         Err(e) => {

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -772,9 +772,9 @@ impl Session {
     /// `cwd` is the directory the shell starts in — the caller passes the
     /// session's *launch* cwd (the multi-repo symlink workspace when there is
     /// one, so the shell lands where the agent does), falling back to the
-    /// primary repo (`info.cwd`) when `None`. Uses `$SHELL` (fallback `/bin/sh`)
-    /// as the command. The window name uses the `tbs-` prefix to distinguish
-    /// from the agent's `tb-` windows.
+    /// primary repo (`info.cwd`) when `None`. The command is the backend's
+    /// [`SessionBackend::default_shell`]. The window name uses the `tbs-` prefix
+    /// to distinguish from the agent's `tb-` windows.
     pub fn ensure_shell_pane(
         &mut self,
         rows: u16,
@@ -1143,7 +1143,6 @@ mod tests {
             },
         );
 
-        // No signal yet.
         assert_eq!(attention_at.load(Ordering::Relaxed), 0);
 
         // Terminal bell → attention, no message.

--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -13,8 +13,7 @@ use std::sync::{Arc, Mutex};
 /// bursts; chunks are dropped (not blocked) when full to keep the reader thread alive.
 pub const PANE_CHANNEL_CAPACITY: usize = 4096;
 
-/// Type alias for pane sender broadcast map.
-/// Maps pane IDs to vectors of sync senders for multi-instance output broadcast.
+/// Maps pane IDs to sync senders for multi-instance output broadcast.
 pub type PaneSendersMap = HashMap<String, Vec<SyncSender<Vec<u8>>>>;
 pub type PaneSendersMapShared = Arc<Mutex<PaneSendersMap>>;
 
@@ -312,7 +311,7 @@ mod tests {
 
     #[test]
     fn decode_octal_esc() {
-        assert_eq!(decode_octal("\\033"), vec![27]); // ESC
+        assert_eq!(decode_octal("\\033"), vec![27]);
     }
 
     #[test]
@@ -536,7 +535,7 @@ mod tests {
         drop(tx);
         let mut buf = [0u8; 16];
         let n = reader.read(&mut buf).unwrap();
-        assert_eq!(n, 0); // EOF
+        assert_eq!(n, 0);
     }
 
     #[test]
@@ -604,7 +603,7 @@ mod tests {
         tx.send(b"first".to_vec()).unwrap();
 
         match tx.try_send(b"second".to_vec()) {
-            Err(std::sync::mpsc::TrySendError::Full(_)) => {} // expected
+            Err(std::sync::mpsc::TrySendError::Full(_)) => {}
             other => panic!("Expected TrySendError::Full, got: {other:?}"),
         }
     }

--- a/src/agent/input.rs
+++ b/src/agent/input.rs
@@ -22,7 +22,6 @@ pub fn key_to_bytes(code: KeyCode, modifiers: KeyModifiers) -> Option<Vec<u8>> {
         return Some(bytes);
     }
 
-    // F-keys
     if let KeyCode::F(n) = code {
         return f_key_bytes(n, modifier_param);
     }
@@ -323,7 +322,6 @@ mod tests {
 
     #[test]
     fn alt_ctrl_letter() {
-        // Ctrl+Alt+C = ESC + 0x03
         assert_eq!(
             key_to_bytes(
                 KeyCode::Char('c'),

--- a/src/agent/json_merge.rs
+++ b/src/agent/json_merge.rs
@@ -175,8 +175,8 @@ mod tests {
         // Old payload merged schema A; later payload ships schema B. Prune by the
         // shared marker removes BOTH (no orphans), leaving only the user's entry.
         let mut doc = json!({"hooks": {"Stop": [{"command": "user"}]}});
-        merge(&mut doc, &json!({"hooks": {"OldEvent": [ours("done")]}})); // vA
-        merge(&mut doc, &json!({"hooks": {"NewEvent": [ours("done")]}})); // vB
+        merge(&mut doc, &json!({"hooks": {"OldEvent": [ours("done")]}}));
+        merge(&mut doc, &json!({"hooks": {"NewEvent": [ours("done")]}}));
         prune_marked(&mut doc, M);
         assert_eq!(doc, json!({"hooks": {"Stop": [{"command": "user"}]}}));
     }

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -154,7 +154,6 @@ mod tests {
             registry.get("extra-backend").unwrap().name(),
             "extra-backend"
         );
-        // Default is still local-tmux
         assert_eq!(registry.default_name(), "local-tmux");
     }
 

--- a/src/agent/self_update.rs
+++ b/src/agent/self_update.rs
@@ -454,7 +454,6 @@ cccc3333  thurbox-v0.114.0-aarch64-apple-darwin.tar.gz
             Ok(()) => {
                 // Compare is case-insensitive.
                 assert!(verify_sha256(&file, &empty.to_uppercase()).is_ok());
-                // A wrong digest is rejected.
                 let err = verify_sha256(&file, &"0".repeat(64)).unwrap_err();
                 assert!(err.contains("mismatch"), "got: {err}");
             }

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -219,7 +219,6 @@ pub fn save_settings(settings: &Settings) -> std::io::Result<()> {
     doc["three_panel_min_cols"] = value(i64::from(settings.three_panel_min_cols));
     doc["audit_retention_days"] = value(settings.audit_retention_days as i64);
 
-    // [features] table — create if missing.
     if !doc.contains_key("features") {
         doc["features"] = toml_edit::table();
     }
@@ -238,7 +237,6 @@ pub fn save_settings(settings: &Settings) -> std::io::Result<()> {
         set_table_bool(features, "auto_update", f.auto_update);
     }
 
-    // [notifications] table — create if missing.
     if !doc.contains_key("notifications") {
         doc["notifications"] = toml_edit::table();
     }

--- a/src/agent/themes_config.rs
+++ b/src/agent/themes_config.rs
@@ -252,7 +252,6 @@ mod tests {
             themes[0].palette.accent,
             ratatui::style::Color::Rgb(0xff, 0x00, 0xff)
         );
-        // Untouched colours inherit from the base.
         assert_eq!(
             themes[0].palette.text_primary,
             ThemePreset::CatppuccinMocha.palette().text_primary
@@ -281,7 +280,6 @@ mod tests {
         assert_eq!(themes[0].name, "ok");
         assert!(warnings.iter().any(|w| w.contains("shadows a built-in")));
         assert!(warnings.iter().any(|w| w.contains("not-a-colour")));
-        // The bad colour kept the base value.
         assert_eq!(
             themes[0].palette.accent,
             ThemePreset::Default.palette().accent

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -107,7 +107,6 @@ const MIN_TMUX_VERSION: (u32, u32) = (3, 2);
 /// Parse a `tmux -V` version string (e.g. `"tmux 3.4"`, `"tmux 3.3a"`) into a
 /// `(major, minor)` pair. Shared by the local and remote backends.
 fn parse_tmux_version(version_str: &str) -> Result<(u32, u32)> {
-    // Parse "tmux X.Y" or "tmux X.Ya" (e.g., "tmux 3.4" or "tmux 3.3a").
     let version_part = version_str.strip_prefix("tmux ").unwrap_or(version_str);
 
     let parts: Vec<&str> = version_part.split('.').collect();
@@ -288,14 +287,13 @@ impl ControlMode {
         loop {
             line_buf.clear();
             match reader.read_until(b'\n', &mut line_buf) {
-                Ok(0) => break, // EOF
+                Ok(0) => break,
                 Ok(_) => {}
                 Err(e) => {
                     debug!("Control reader I/O error: {e}");
                     break;
                 }
             }
-            // Strip trailing newline.
             if line_buf.last() == Some(&b'\n') {
                 line_buf.pop();
             }
@@ -358,9 +356,6 @@ impl ControlMode {
             match tx.try_send(chunk) {
                 Ok(()) => {}
                 Err(std::sync::mpsc::TrySendError::Full(_dropped)) => {
-                    // Channel full — drop this chunk rather than blocking.
-                    // The reader thread MUST stay unblocked to handle
-                    // %pause notifications and avoid deadlock.
                     debug!(pane_id = %pane_id, "Pane output channel full, dropping chunk");
                 }
                 Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {}
@@ -809,7 +804,6 @@ impl TmuxBackend {
                 .pane_senders
                 .lock()
                 .map_err(|e| anyhow::anyhow!("pane_senders lock: {e}"))?;
-            // Remove all senders for this pane (all instances lose the pane)
             senders.remove(pane_id);
             Ok(())
         })
@@ -1090,7 +1084,6 @@ impl SessionBackend for TmuxBackend {
             "resize-window -t {backend_id} -x {cols} -y {rows}"
         ))?;
 
-        // Then resize the pane within the window.
         self.ctrl_command(&format!("resize-pane -t {backend_id} -x {cols} -y {rows}"))?;
 
         Ok(())

--- a/src/agent/version_check.rs
+++ b/src/agent/version_check.rs
@@ -61,8 +61,8 @@ struct CachedCheck {
 /// - `latest` is empty / not parseable as newer, or
 /// - `latest` is not strictly greater than `current`.
 ///
-/// Otherwise returns a populated [`UpdateStatus`] with `update_available =
-/// true`. Pure: no IO, fully unit-testable.
+/// Otherwise returns a populated [`UpdateStatus`]. Pure: no IO, fully
+/// unit-testable.
 pub fn decide_update(current: &str, latest: &str) -> Option<UpdateStatus> {
     let current = current.trim();
     let latest = latest.trim().trim_start_matches('v');

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -290,13 +290,12 @@ fn theme_picker_lists_palettes() {
 #[test]
 fn ctrl_n_opens_repo_picker() {
     let mut h = Harness::standard(0);
-    h.render(); // first frame
+    h.render();
     h.ctrl('n'); // Ctrl+N → NewSession
     assert!(
         matches!(h.app.modal, modals::Modal::RepoPicker(_)),
         "Ctrl+N should open the repo picker (no hosts configured)"
     );
-    // Esc closes it again.
     h.key(KeyCode::Esc, KeyModifiers::NONE);
     assert!(!h.app.modal.is_open(), "Esc should dismiss the modal");
 }
@@ -387,7 +386,6 @@ fn settings_panel_live_toggle_applies_on_save() {
 
     h.ctrl(','); // OpenSettings — starts on the `tasks` field
     h.key(KeyCode::Char(' '), KeyModifiers::NONE); // toggle tasks off in the draft
-                                                   // Not applied until save.
     assert!(h.app.features.tasks, "draft edits don't apply until save");
 
     h.ctrl('s'); // Save
@@ -804,7 +802,7 @@ fn task_editor_creates_task_and_space_cycles_status() {
     h.key(KeyCode::Char('n'), KeyModifiers::NONE); // new-task editor
 
     for ch in "Demo task".chars() {
-        h.key(KeyCode::Char(ch), KeyModifiers::NONE); // type the title
+        h.key(KeyCode::Char(ch), KeyModifiers::NONE);
     }
     h.ctrl('s'); // save from any field
 

--- a/src/app/automation.rs
+++ b/src/app/automation.rs
@@ -17,12 +17,6 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use tracing::{debug, error, info};
 
 impl App {
-    /// Process due scheduled commands from the database (fallback).
-    ///
-    /// The primary dispatch is via `tmux run-shell -b -d` timers set at
-    /// scheduling time. This tick-loop catches commands whose tmux timer
-    /// failed or was never set (e.g., scheduled while Thurbox was down).
-    /// Throttled to once per second (~100 ticks at 10ms each).
     /// Fire any due automations. Called once per ~second from `tick()`; pass
     /// `force = true` for the one-shot startup catch-up pass (ignores cadence).
     pub(crate) fn process_automations(&mut self, force: bool) {

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -563,7 +563,6 @@ impl App {
         // actions in `handle_key` before this runs; everything else snaps to
         // the bottom and is forwarded to the PTY.
 
-        // Snap to bottom on any non-scroll key when scrolled up
         self.with_active_parser(|parser| {
             if parser.screen().scrollback() > 0 {
                 parser.screen_mut().set_scrollback(0);
@@ -1440,7 +1439,6 @@ impl App {
             return;
         };
         *wt = !*wt;
-        // Auto-select when toggling worktree on
         if *wt {
             if let Some(sel) = rp.selected.get_mut(real_idx) {
                 *sel = true;
@@ -1572,11 +1570,9 @@ impl App {
         rp: &mut super::modals::RepoPickerModal,
         expanded: &std::path::Path,
     ) -> bool {
-        // If the path is already represented, just select it (no duplicate row
-        // and no duplicate DB entry). A path already shown as a parent's child
-        // must NOT also be persisted as a standalone bookmark.
+        // If already represented, just select it (no duplicate row or DB entry).
         let Some(idx) = rp.bookmarks.iter().position(|p| p == expanded) else {
-            rp.push_row(expanded.to_path_buf(), true, false, false); // auto-select newly added
+            rp.push_row(expanded.to_path_buf(), true, false, false);
             return true;
         };
         let is_child = rp.is_child_row(idx);
@@ -1584,8 +1580,6 @@ impl App {
         if !is_header {
             rp.selected[idx] = true;
         }
-        // Only (re)persist standalone repos; children/headers are covered by
-        // their parent bookmark already.
         !is_child && !is_header
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -485,7 +485,7 @@ struct PendingDelete {
     created_at: std::time::Instant,
 }
 
-/// Result sent by a background container/VM restore thread on completion.
+/// The TEA model: owns all session/UI state and coordinates side effects.
 pub struct App {
     pub(crate) sessions: Vec<Session>,
     pub(crate) active_index: usize,
@@ -513,7 +513,6 @@ pub struct App {
     pub(crate) show_file_viewer: bool,
     pub(crate) file_viewer: crate::ui::file_viewer::FileViewerState,
     pub(crate) modal: modals::Modal,
-    // (Delete project, add project, edit project modal state is now in self.modal)
     /// In-progress new-session wizard (also drives fork/restart re-spawns).
     pub(crate) new_session: new_session_state::NewSessionWizardState,
     /// Inter-instance DB sync (polls for changes from other thurbox instances).
@@ -557,7 +556,6 @@ pub struct App {
     session_terminal_views: HashMap<SessionId, TerminalView>,
     /// Recently deleted session awaiting finalization or undo (Ctrl+Z).
     pending_delete: Option<PendingDelete>,
-    // (Restore sessions modal state is now in self.modal)
     /// Active text selection (click+drag), uses screen-absolute coordinates.
     pub(crate) text_selection: Option<Selection>,
     /// Scrollbars rendered this frame, with the scroll state each drives.
@@ -586,9 +584,9 @@ pub struct App {
     pub(crate) task_ui: task_state::TaskUiState,
     /// Global search strip (`Ctrl+/`): cross-scope search docked at the bottom.
     pub(crate) global_search: search::GlobalSearchState,
-    /// Currently active theme preset, cached so the header doesn't hit SQLite
-    /// every render. Kept in sync with `db.set_active_theme` writes.
-    /// Currently active theme (built-in preset or custom from themes.toml).
+    /// Currently active theme (built-in preset or custom from themes.toml),
+    /// cached so the header doesn't hit SQLite every render. Kept in sync with
+    /// `db.set_active_theme` writes.
     pub(crate) active_theme: crate::session::theme_config::ThemeEntry,
     /// User-customizable global keybindings. Loaded from
     /// `~/.config/thurbox/keybindings.json` on startup, falling back to defaults
@@ -786,7 +784,6 @@ impl App {
             tracing::warn!("{w}");
         }
 
-        // Load session counter from DB
         let session_counter = db.get_session_counter().unwrap_or(0);
 
         let mut sync_state = SyncState::new();
@@ -1467,21 +1464,20 @@ impl App {
             return;
         }
 
-        // Soft-delete in DB
         if let Err(e) = self.db.soft_delete_session(session_id) {
             error!("Failed to soft-delete session in DB: {e}");
         }
 
-        // Remove from the session list (do NOT kill backend or remove worktrees yet)
+        // Remove from the list only — do NOT kill the backend or remove
+        // worktrees yet (Ctrl+Z undo / Ctrl+U restore reuse them).
         let removed_session = self.sessions.remove(self.active_index);
         let session_name = removed_session.info.name.clone();
 
-        // Clean up terminal view state
         self.session_terminal_views.remove(&session_id);
 
         self.sync_active_session_to_project();
 
-        // Finalize any existing pending delete before storing the new one
+        // Finalize any existing pending delete before storing the new one.
         self.finalize_pending_delete();
 
         self.pending_delete = Some(PendingDelete {
@@ -1602,7 +1598,6 @@ impl App {
         self.set_status(StatusLevel::Success, format!("Restored '{session_name}'"));
     }
 
-    /// Open the restore deleted sessions modal (Ctrl+U).
     /// Open the theme picker, pre-selecting the currently active theme
     /// (built-in preset or custom from themes.toml).
     fn open_theme_picker(&mut self) {
@@ -3063,8 +3058,6 @@ impl App {
         }
     }
 
-    /// Sync `active_index` to the active project's first session, or invalidate
-    /// it when the project has no sessions.
     /// Clamp the active session index to the valid range after a session is removed.
     pub(crate) fn sync_active_session_to_project(&mut self) {
         if self.sessions.is_empty() {
@@ -3941,7 +3934,6 @@ impl App {
 
     /// Handle external state changes detected from other instances.
     fn handle_external_state_change(&mut self, delta: StateDelta) {
-        // Update session counter to avoid conflicts
         self.session_counter = self.session_counter.max(delta.counter_increment);
         self.apply_removed_sessions(delta.removed_sessions);
         self.apply_updated_sessions(delta.updated_sessions);
@@ -4002,7 +3994,6 @@ impl App {
             Vec<crate::agent::backend::DiscoveredSession>,
         > = HashMap::new();
         for shared_session in added {
-            // Skip if we already have this session
             if self.sessions.iter().any(|s| s.info.id == shared_session.id) {
                 continue;
             }
@@ -4206,7 +4197,6 @@ impl App {
     /// is bounded by the SQLite busy_timeout, after which upsert errors are
     /// logged and detach still runs.
     pub fn shutdown(mut self) {
-        // Finalize any pending delete before shutting down
         self.finalize_pending_delete();
         self.save_state();
         // Do NOT remove worktrees — they persist for resume.
@@ -4250,12 +4240,10 @@ impl App {
     /// (add/edit/delete) write to the DB at their point of change, avoiding
     /// race conditions where a blanket re-write overwrites another instance's edits.
     fn save_state(&self) {
-        // Sync session counter
         if let Err(e) = self.db.set_session_counter(self.session_counter) {
             error!("Failed to save session counter to DB: {e}");
         }
 
-        // Upsert all sessions
         for session in &self.sessions {
             let shared_session = self.session_to_shared(session);
             if let Err(e) = self.db.upsert_session(&shared_session) {
@@ -4300,7 +4288,7 @@ impl App {
             return None;
         }
 
-        // Only restore sessions that have a agent_session_id (resumable)
+        // Only sessions with an agent_session_id are resumable.
         let resumable: Vec<sync::SharedSession> = sessions
             .into_iter()
             .filter(|s| s.agent_session_id.is_some())
@@ -4944,11 +4932,8 @@ mod tests {
     use crate::agent::SessionBackend;
     use crate::session::{Automation, AutomationAction, AutomationRunStatus, AutomationSchedule};
 
-    // --- TextInput tests ---
-
     // --- Session switching tests ---
 
-    /// Stub backend that does nothing — for unit tests only.
     /// Inert backend for unit tests. `detached` counts `detach` calls so
     /// lifecycle tests can assert pane I/O teardown.
     #[derive(Default)]
@@ -5885,7 +5870,6 @@ mod tests {
 
     fn parser_with_scrollback() -> vt100::Parser {
         let mut parser = vt100::Parser::new(24, 80, 100);
-        // Fill screen and scrollback by writing many lines
         for i in 0..50 {
             parser.process(format!("line {i}\r\n").as_bytes());
         }
@@ -6111,7 +6095,6 @@ mod tests {
     #[test]
     fn any_key_clears_text_selection() {
         let mut app = app_with_sessions(1);
-        // Set up a fake selection
         app.text_selection = Some(Selection::new(
             TermPos { row: 0, col: 0 },
             PaneBounds::from_rect(ratatui::layout::Rect::new(0, 0, 80, 24)),

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -1,6 +1,5 @@
-// Modal state management for Thurbox TUI.
-// This module consolidates all modal-related state into type-safe enums,
-// replacing boolean flags with a single discriminated union.
+// Modal state management for Thurbox TUI: a single discriminated `Modal` enum
+// makes invalid states (two modals open at once) unrepresentable.
 
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -233,7 +232,7 @@ impl TextArea {
             if l == line {
                 return idx + col.min(len);
             }
-            idx += len + 1; // +1 for the consumed '\n'
+            idx += len + 1;
         }
         self.char_count()
     }
@@ -2113,7 +2112,6 @@ mod tests {
     #[test]
     fn test_text_input_with_unicode() {
         let mut input = TextInput::new();
-        // Test with multi-byte UTF-8 characters
         input.insert('ñ');
         input.insert('é');
         assert_eq!(input.cursor_pos(), 2);

--- a/src/app/notify_state.rs
+++ b/src/app/notify_state.rs
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn blocked_to_done_never_fires_even_with_also_on_done() {
-        // `also_on_done` fires only on the Working → Done edge; a Blocked → Done
+        // `also_on_waiting` fires only on the Working → Done edge; a Blocked → Done
         // slide is not a fresh completion worth re-notifying.
         let mut s = test_state(true, true, 0);
         let id = SessionId::default();

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,6 +1,5 @@
-// Safe state accessors for App struct.
-// This module provides bounds-safe accessors to replace direct array indexing,
-// preventing panics from out-of-bounds access.
+// Bounds-safe accessors for the active session, replacing direct array
+// indexing so an out-of-range `active_index` returns None instead of panicking.
 
 use crate::agent::Session;
 
@@ -8,13 +7,11 @@ use super::App;
 
 impl App {
     /// Get the currently active session, or None if index is out of bounds.
-    /// Replaces: `&self.sessions[self.active_index]`
     pub fn active_session(&self) -> Option<&Session> {
         self.sessions.get(self.active_index)
     }
 
     /// Get a mutable reference to the currently active session, or None if out of bounds.
-    /// Replaces: `&mut self.sessions[self.active_index]`
     pub fn active_session_mut(&mut self) -> Option<&mut Session> {
         self.sessions.get_mut(self.active_index)
     }
@@ -125,7 +122,6 @@ mod tests {
     fn active_session_returns_the_session_at_active_index() {
         let (mut app, _g, _t) = app_with_sessions(3);
 
-        // Default selection points at the first session.
         assert_eq!(
             app.active_session().map(|s| s.info.name.as_str()),
             Some("session-0")
@@ -158,7 +154,6 @@ mod tests {
         let (mut app, _g, _t) = app_with_sessions(2);
         app.active_index = 1;
 
-        // The mutable accessor reaches the same session and allows mutation.
         let session = app.active_session_mut().expect("session-1 is active");
         session.info.name = "renamed".to_string();
 
@@ -188,7 +183,6 @@ mod tests {
     fn has_active_session_reflects_index_validity() {
         let (mut app, _g, _t) = app_with_sessions(2);
 
-        // In-bounds index → valid.
         app.active_index = 0;
         assert!(app.has_active_session());
         app.active_index = 1;

--- a/src/app/sync_state.rs
+++ b/src/app/sync_state.rs
@@ -15,12 +15,10 @@ use crate::session::SessionId;
 /// a channel polled in `tick`.
 #[derive(Default)]
 pub(crate) struct WorktreeSyncState {
-    /// Whether a sync run is currently in flight.
     pub(crate) in_progress: bool,
-    /// Receives `(session_id, result)` from the background sync thread.
+    /// Receives results from the background sync thread.
     pub(crate) rx: Option<mpsc::Receiver<(SessionId, git::SyncResult)>>,
     /// Number of sessions the in-flight run is syncing.
     pub(crate) pending: usize,
-    /// Results collected so far for the in-flight run.
     pub(crate) completed: Vec<(SessionId, git::SyncResult)>,
 }

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -61,8 +61,6 @@ impl App {
     /// Deduplicated. Empty when nothing related is open right now. This is the
     /// single source of truth for both the details panel and the *open* key.
     pub(crate) fn task_related_session_indices(&self, task: &crate::session::Task) -> Vec<usize> {
-        // Persisted `Send` action target (CLI-authored), plus the in-memory link
-        // recorded when this task was triggered from the TUI this run.
         let send_target = match &task.action {
             Some(crate::session::AutomationAction::Send { session_id }) => Some(*session_id),
             _ => None,
@@ -268,17 +266,12 @@ impl App {
                 self.focus = InputFocus::SessionList;
                 self.task_ui.task_editor = None;
             }
-            // Open the central-pane editor for the selected task. On an empty
-            // panel, start a new task instead.
             KeyCode::Char('e') | KeyCode::Enter => self.enter_task_editor_or_new(count),
             // Scroll the full-screen preview (the list itself uses j/k).
             KeyCode::PageDown => self.scroll_task_preview(5),
             KeyCode::PageUp => self.scroll_task_preview(-5),
             KeyCode::Char(' ') => self.cycle_selected_task_status(),
-            // Open the trigger-time action picker (Send → session / Spawn new).
             KeyCode::Char('r') => self.open_selected_task_action_picker(),
-            // Jump to the task's related session terminal (the spawned
-            // `<title> · #<id>` window, or a persisted Send target).
             KeyCode::Char('o') => self.open_task_related_session(),
             KeyCode::Char('d') => self.delete_selected_task(),
             _ => {}

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -173,7 +173,6 @@ impl App {
             self.cached_session_order = Some((sig, order));
         }
 
-        // Build flat session list: all sessions, with tag names from projects
         let all_sessions: Vec<&SessionInfo> = self.sessions.iter().map(|s| &s.info).collect();
 
         // While the global-search strip is open, highlight the session list from
@@ -1604,8 +1603,6 @@ fn session_fuzzy(query: &str, info: &SessionInfo) -> Option<project_list::Sessio
 mod tests {
     use super::*;
 
-    // ── format_countdown tests ──
-
     #[test]
     fn format_countdown_zero() {
         assert_eq!(format_countdown(0), "due");
@@ -1633,8 +1630,6 @@ mod tests {
         assert_eq!(format_countdown(5_400_000), "in 1h 30m");
         assert_eq!(format_countdown(7_200_000), "in 2h");
     }
-
-    // ── truncate_str tests ──
 
     #[test]
     fn truncate_str_short() {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -30,8 +30,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             if failed.is_empty() {
                 Ok(CommandOutput::new(report, human))
             } else {
-                // Print the full report (human or JSON), then exit non-zero so
-                // this is usable as a dotfiles CI gate.
+                // Exit non-zero so this is usable as a dotfiles CI gate.
                 Ok(CommandOutput::failed(
                     report,
                     human,

--- a/src/cli/messages.rs
+++ b/src/cli/messages.rs
@@ -415,7 +415,6 @@ mod tests {
         assert_eq!(sent["enqueued"], true);
         assert_eq!(sent["woke"], false);
 
-        // Peek (unread) without consuming.
         let peek = run(
             Action::Inbox {
                 for_session: Some("flow".into()),
@@ -640,7 +639,6 @@ mod tests {
         .unwrap();
         send("second");
 
-        // Default peek shows only the unread one...
         let unread = run(
             Action::Inbox {
                 for_session: Some("flow".into()),
@@ -654,7 +652,6 @@ mod tests {
         assert_eq!(unread.as_array().unwrap().len(), 1);
         assert_eq!(unread[0]["body"], "second");
 
-        // ...--all shows both (read + unread).
         let all = run(
             Action::Inbox {
                 for_session: Some("flow".into()),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -186,7 +186,6 @@ mod tests {
 
         assert_eq!(extra.len(), 5);
 
-        // PATH@BASE — straightforward.
         assert_eq!(extra[0].repo_path, std::path::PathBuf::from("/srv/repo"));
         assert_eq!(extra[0].base_branch.as_deref(), Some("main"));
         assert!(extra[0].worktree);
@@ -198,16 +197,13 @@ mod tests {
         );
         assert_eq!(extra[1].base_branch.as_deref(), Some("develop"));
 
-        // No '@' — taken verbatim, no base.
         assert_eq!(extra[2].repo_path, std::path::PathBuf::from("/srv/plain"));
         assert_eq!(extra[2].base_branch, None);
 
-        // Empty path before '@' — the guard rejects the split and the token is
-        // taken verbatim (no base).
+        // Empty path before '@' — the guard rejects the split, token taken verbatim.
         assert_eq!(extra[3].repo_path, std::path::PathBuf::from("@onlybase"));
         assert_eq!(extra[3].base_branch, None);
 
-        // --add-dir is attached as-is, never a worktree.
         assert_eq!(extra[4].repo_path, std::path::PathBuf::from("/reference"));
         assert_eq!(extra[4].base_branch, None);
         assert!(!extra[4].worktree);
@@ -237,10 +233,8 @@ mod tests {
 
     #[test]
     fn parse_session_create_requires_name_and_repo() {
-        // Missing required args fails.
         assert!(Cli::try_parse_from(["thurbox-cli", "session", "create"]).is_err());
 
-        // Full happy path.
         let cli = Cli::try_parse_from([
             "thurbox-cli",
             "session",
@@ -325,8 +319,7 @@ mod tests {
         assert_eq!(uuid, "0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a");
         assert_eq!(text, "hello");
 
-        // Same subcommand, with the global `--text` flag set — the original
-        // collision-triggering invocation. Must still parse and set both.
+        // The original collision-triggering invocation: global `--text` flag set.
         let cli = Cli::try_parse_from([
             "thurbox-cli",
             "--text",
@@ -363,7 +356,6 @@ mod tests {
         };
         assert_eq!(uuid, "0f4dec1e-9d4b-4c4f-9d05-3a3a3a3a3a3a");
 
-        // No UUID arg fails.
         assert!(Cli::try_parse_from(["thurbox-cli", "session", "focus"]).is_err());
     }
 
@@ -486,7 +478,6 @@ mod tests {
             Cli::try_parse_from(["thurbox-cli", "task", "create"]).is_err(),
             "missing --title should fail"
         );
-        // A plain local todo needs only a title.
         let cli =
             Cli::try_parse_from(["thurbox-cli", "task", "create", "--title", "Fix bug"]).unwrap();
         let Command::Task {
@@ -703,7 +694,6 @@ mod tests {
         };
         assert!(query.is_none());
 
-        // `search` is an alias and accepts a filter query.
         let cli = Cli::try_parse_from(["thurbox-cli", "ext", "search", "deps"]).unwrap();
         let Command::Extension {
             action: extensions::Action::Available { query },

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -200,7 +200,6 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             let report = crate::session_ops::delete_session_headless(db, session.id, force)?;
             let mut human = format!("Deleted session '{}' ({})", session.name, session.id);
             if force {
-                // Aligned, two-space-indented detail under the header line.
                 let mut detail: Vec<(&str, String)> = vec![
                     ("killed window", report.killed_window.to_string()),
                     (
@@ -284,7 +283,6 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             let session = resolve(db, &uuid)?;
             let output = crate::agent::tmux::capture_pane_text(&session.name, lines)
                 .map_err(|e| format!("capture_pane_text: {e}"))?;
-            // The pane text itself is the useful human payload.
             let human = output.clone();
             Ok(CommandOutput::new(
                 json!({
@@ -437,7 +435,6 @@ mod tests {
         let v = run(Action::List { parent: None }, &db).unwrap();
         assert!(v.is_array(), "got {v}");
         assert_eq!(v.as_array().unwrap().len(), 0);
-        // The human rendering for an empty list is a friendly line, not a table.
         assert_eq!(v.human, "No active sessions.");
     }
 
@@ -672,14 +669,13 @@ mod tests {
 
     #[test]
     fn soft_delete_leaves_session_recoverable() {
-        // Bug #3: `session delete` without --force only soft-deletes the
-        // DB row, leaving pending scheduled commands and the metadata
-        // restorable.
+        // `session delete` without --force only soft-deletes the DB row,
+        // leaving its automations enabled and the session restorable.
         let db = db();
         let id = SessionId::default();
         let shared = SharedSession {
             id,
-            name: "Foo Bar".into(), // exercise bug #1 sanitization path too
+            name: "Foo Bar".into(),
             agent: "dev".into(),
             backend_id: String::new(),
             backend_type: "local-tmux".into(),

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -530,7 +530,6 @@ mod tests {
     #[test]
     fn create_and_edit_reject_blank_title() {
         let db = Database::open_in_memory().unwrap();
-        // Whitespace-only title is rejected at create.
         let err = run(
             Action::Create {
                 title: "   ".into(),
@@ -672,7 +671,6 @@ mod tests {
 
     #[test]
     fn create_blank_source_falls_back_to_local() {
-        // A whitespace-only --source is treated as "not given" → local.
         let db = Database::open_in_memory().unwrap();
         let out = run(create_action("plain", Some("   "), None, None), &db).unwrap();
         assert_eq!(out["source"], SOURCE_LOCAL);
@@ -699,7 +697,6 @@ mod tests {
             )
             .unwrap()
         };
-        // A real value re-points the source.
         assert_eq!(edit(Some("gitlab"))["source"], "gitlab");
         // A blank value is ignored (source is NOT NULL) — left unchanged.
         assert_eq!(edit(Some("  "))["source"], "gitlab");
@@ -720,7 +717,6 @@ mod tests {
         .unwrap();
         let id = created["id"].as_i64().unwrap();
 
-        // Edit re-points the external link and status.
         let edited = run(
             Action::Edit {
                 id,
@@ -736,13 +732,12 @@ mod tests {
         .unwrap();
         assert_eq!(edited["status"], "done");
         assert_eq!(edited["source"], "github"); // untouched (flag omitted)
-        assert_eq!(edited["external_id"], "42"); // untouched
+        assert_eq!(edited["external_id"], "42");
         assert_eq!(
             edited["external_url"],
             "https://example.com/issues/42#closed"
         );
 
-        // Passing an empty --external-url clears it to null.
         let cleared = run(
             Action::Edit {
                 id,

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -27,7 +27,6 @@ pub struct UpdateArgs {
 pub fn run(args: UpdateArgs) -> CommandOutput {
     let current = crate::agent::version_check::current_version();
 
-    // Auto-update is opt-in behind the feature flag.
     if !settings::global().features.auto_update {
         let hint = "update is disabled. Enable it by setting \
                     `[features] auto_update = true` in settings.toml.";

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -30,7 +30,6 @@ pub fn run(args: VersionArgs) -> CommandOutput {
         return CommandOutput::new(json!({ "version": current }), format!("thurbox {current}"));
     }
 
-    // --check is opt-in behind the feature flag.
     if !settings::global().features.version_check {
         let hint = "version --check is disabled. Enable it by setting \
                     `[features] version_check = true` in settings.toml.";

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -55,7 +55,7 @@ fn remote_home(host: &HostDef) -> Result<String> {
         }
     }
     let mut cmd = ssh_command(&host.destination, &host.ssh_opts);
-    // The remote shell expands $HOME; we pass it literally.
+    // Pass `$HOME` literally; the remote shell expands it.
     cmd.arg("echo").arg("$HOME");
     let output = cmd
         .stderr(Stdio::piped())
@@ -342,7 +342,6 @@ pub fn default_branch_on(
         }
     }
 
-    // Fallback: prefer "main", then "master"
     for candidate in ["main", "master"] {
         if local_branches.iter().any(|b| b == candidate) {
             return Some(candidate.to_string());
@@ -506,7 +505,6 @@ fn git_stash(worktree_path: &Path) -> Result<bool> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    // "No local changes to save" means nothing was stashed
     Ok(!stdout.contains("No local changes to save"))
 }
 
@@ -539,7 +537,6 @@ fn git_rebase_onto(worktree_path: &Path, base_ref: &str) -> Result<()> {
         .context("failed to run git rebase")?;
 
     if !output.status.success() {
-        // Abort the failed rebase
         let _ = Command::new("git")
             .args(["rebase", "--abort"])
             .current_dir(worktree_path)
@@ -643,7 +640,7 @@ fn try_remove_by_pid(lock_path: &Path) -> bool {
     };
 
     if Path::new(&format!("/proc/{pid}")).exists() {
-        return true; // process still alive
+        return true;
     }
 
     if std::fs::remove_file(lock_path).is_ok() {
@@ -984,10 +981,8 @@ mod tests {
 
         let _guard = TestPathGuard::new(tmp.path().join("data"));
 
-        // First fire: creates the branch + worktree.
         let p1 = create_or_attach_worktree(&repo, "feat/x", &base).expect("first creates");
         assert!(p1.exists());
-        // Second fire: branch + dir already exist — must reuse, not fail.
         let p2 = create_or_attach_worktree(&repo, "feat/x", &base).expect("second reuses");
         assert_eq!(p1, p2);
         // Worktree dir gone but branch remains: re-attach a worktree to it.
@@ -1075,7 +1070,6 @@ mod tests {
         let path_a = worktree_path(Path::new("/repo/a"), "main").unwrap();
         let path_b = worktree_path(Path::new("/repo/b"), "main").unwrap();
         assert_ne!(path_a, path_b);
-        // Both end with the same branch name
         assert_eq!(path_a.file_name(), path_b.file_name());
     }
 
@@ -1346,7 +1340,6 @@ mod tests {
     fn worktree_path_for_remote_uses_configured_dir() {
         let h = host("me@box", Some("/data/wt"));
         let path = worktree_path_for(Some(&h), Path::new("/srv/repo"), "feature/foo").unwrap();
-        // base / <repo-hash> / <sanitized-branch>
         let s = path.display().to_string();
         assert!(s.starts_with("/data/wt/"), "got {s}");
         assert!(s.ends_with("/feature-foo"), "got {s}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<()> {
     // covers config load, DB open, and session restore.
     let process_start = std::time::Instant::now();
 
-    // Set up panic hook that restores terminal before printing the panic
+    // Restore the terminal before the panic message prints (else it garbles).
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         restore_terminal();
@@ -185,7 +185,6 @@ async fn main() -> Result<()> {
     // tracing::warn above only reaches the log file the TUI hides.
     app.report_config_warnings(config_warnings);
 
-    // Load session state from DB and restore
     let t_phase = std::time::Instant::now();
     if let Some((sessions, counter)) = app.load_persisted_state_from_db() {
         app.restore_sessions(sessions, counter);
@@ -213,7 +212,6 @@ fn init_backends_and_config() -> Result<(
     thurbox::session::HostRegistry,
     Vec<String>,
 )> {
-    // Initialize session backends and agent provider.
     let local_tmux: Arc<dyn SessionBackend> = Arc::new(LocalTmuxBackend::new());
     local_tmux.check_available()?;
     local_tmux.ensure_ready()?;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -694,7 +694,6 @@ mod tests {
         let (tx, rx) = mpsc::channel::<Notification>();
         drop(rx);
         let sender = NotificationSender { tx };
-        // No receiver — silently dropped, no panic.
         sender.send(Notification {
             session_id: SessionId::default(),
             title: "t".into(),

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -475,7 +475,6 @@ pub fn complete_directory_path(input: &str) -> Option<String> {
         return None;
     }
 
-    // Expand tilde for filesystem operations
     let expanded = expand_tilde(input);
     let expanded_str = expanded.to_str().unwrap_or(input);
     let path = Path::new(expanded_str);
@@ -490,7 +489,6 @@ pub fn complete_directory_path(input: &str) -> Option<String> {
     let (parent, prefix) = if ends_with_sep {
         (path.to_path_buf(), String::new())
     } else {
-        // Split into parent + partial filename
         let parent = path.parent()?.to_path_buf();
         let file_name = path.file_name()?.to_str()?;
         (parent, file_name.to_string())
@@ -572,9 +570,7 @@ mod tests {
 
     #[test]
     fn default_strategy_is_xdg() {
-        reset_to_xdg(); // Ensure clean state
-                        // We can't easily test XDG without mocking env vars,
-                        // but we can verify the strategy exists.
+        reset_to_xdg();
         PATH_STRATEGY.with(|s| {
             assert_eq!(*s.borrow(), PathStrategy::Xdg);
         });
@@ -599,7 +595,6 @@ mod tests {
             let _guard = TestPathGuard::new(&base);
             assert_eq!(config_file(), Some(base.join("config.toml")));
         }
-        // After drop, should be reset to Xdg
         PATH_STRATEGY.with(|s| {
             assert_eq!(*s.borrow(), PathStrategy::Xdg);
         });
@@ -607,21 +602,17 @@ mod tests {
 
     #[test]
     fn thread_local_isolation() {
-        // Set override in main thread
         let base1 = PathBuf::from("/test/base1");
         set_test_dir(&base1);
 
         assert_eq!(config_file(), Some(base1.join("config.toml")));
 
-        // Spawn another thread and verify it has independent state
-        let handle = std::thread::spawn(|| {
-            // New thread should start with Xdg (default)
-            PATH_STRATEGY.with(|s| matches!(*s.borrow(), PathStrategy::Xdg))
-        });
+        // A fresh thread starts with the Xdg default, unaffected by this one.
+        let handle =
+            std::thread::spawn(|| PATH_STRATEGY.with(|s| matches!(*s.borrow(), PathStrategy::Xdg)));
 
         assert!(handle.join().unwrap());
 
-        // Main thread should still have override
         assert_eq!(config_file(), Some(base1.join("config.toml")));
 
         reset_to_xdg();
@@ -692,7 +683,6 @@ mod tests {
 
         reset_to_xdg();
 
-        // After reset, should use Xdg again
         PATH_STRATEGY.with(|s| {
             assert_eq!(*s.borrow(), PathStrategy::Xdg);
         });
@@ -703,7 +693,6 @@ mod tests {
         let base = PathBuf::from("/persistent");
         set_test_dir(&base);
 
-        // Multiple calls should use the same override
         for _ in 0..3 {
             assert_eq!(config_file(), Some(base.join("config.toml")));
         }
@@ -725,12 +714,9 @@ mod tests {
                 assert_eq!(config_file(), Some(base2.join("config.toml")));
             }
 
-            // After inner guard drops, should still use base2's strategy
-            // (because nested set_test_dir overwrites the strategy)
             PATH_STRATEGY.with(|s| matches!(*s.borrow(), PathStrategy::Xdg));
         }
 
-        // After outer guard drops, should be Xdg
         PATH_STRATEGY.with(|s| {
             assert_eq!(*s.borrow(), PathStrategy::Xdg);
         });
@@ -834,8 +820,6 @@ mod tests {
 
     #[test]
     fn complete_directory_path_with_real_dir() {
-        // Build the scenario from a real temp dir so it's platform-independent
-        // (no reliance on `/tmp` existing).
         let temp = tempfile::TempDir::new().unwrap();
         std::fs::create_dir(temp.path().join("uniquedir")).unwrap();
         let input = format!("{}/uniqued", temp.path().display());
@@ -844,8 +828,7 @@ mod tests {
 
     #[test]
     fn complete_directory_path_trailing_slash() {
-        // A real directory with a trailing slash lists children — result depends
-        // on contents, but it must not panic.
+        // A real directory with a trailing slash lists children — must not panic.
         let temp = tempfile::TempDir::new().unwrap();
         let result = complete_directory_path(&format!("{}/", temp.path().display()));
         assert!(result.is_some() || result.is_none());
@@ -853,8 +836,6 @@ mod tests {
 
     #[test]
     fn complete_directory_path_exact_match() {
-        // An existing directory path (no trailing slash) completes with the
-        // separator the function appends.
         let temp = tempfile::TempDir::new().unwrap();
         let inner = temp.path().join("exact");
         std::fs::create_dir(&inner).unwrap();
@@ -864,9 +845,8 @@ mod tests {
 
     #[test]
     fn complete_directory_path_root() {
-        // "/" is a valid directory — shouldn't panic
+        // "/" is a valid directory — shouldn't panic.
         let result = complete_directory_path("/");
-        // Root has children, so we expect Some or None depending on common prefix
         assert!(result.is_some() || result.is_none());
     }
 
@@ -875,23 +855,19 @@ mod tests {
         let temp = tempfile::TempDir::new().unwrap();
         let base = temp.path();
 
-        // Create two subdirectories with a common prefix
         std::fs::create_dir(base.join("project_alpha")).unwrap();
         std::fs::create_dir(base.join("project_beta")).unwrap();
         std::fs::create_dir(base.join("other")).unwrap();
 
-        // Completing "project_" should find common prefix "project_"
+        // Two matches, no completion beyond the typed prefix → None.
         let input = format!("{}/project_", base.display());
         let result = complete_directory_path(&input);
-        // Two matches: project_alpha, project_beta — common prefix beyond typed is empty
         assert_eq!(result, None);
 
-        // Completing "project_a" should complete to "project_alpha/"
         let input = format!("{}/project_a", base.display());
         let result = complete_directory_path(&input);
         assert_eq!(result, Some("lpha/".to_string()));
 
-        // Completing "oth" should complete to "other/"
         let input = format!("{}/oth", base.display());
         let result = complete_directory_path(&input);
         assert_eq!(result, Some("er/".to_string()));
@@ -905,7 +881,6 @@ mod tests {
         std::fs::create_dir(base.join(".hidden")).unwrap();
         std::fs::create_dir(base.join("visible")).unwrap();
 
-        // Without dot prefix, hidden dirs are skipped
         let input = format!("{}/", base.display());
         let result = complete_directory_path(&input);
         assert_eq!(result, Some("visible/".to_string()));
@@ -919,7 +894,6 @@ mod tests {
         std::fs::create_dir(base.join(".hidden")).unwrap();
         std::fs::create_dir(base.join("visible")).unwrap();
 
-        // With dot prefix, hidden dirs are included
         let input = format!("{}/.hid", base.display());
         let result = complete_directory_path(&input);
         assert_eq!(result, Some("den/".to_string()));
@@ -933,7 +907,6 @@ mod tests {
         std::fs::write(base.join("readme.md"), "content").unwrap();
         std::fs::create_dir(base.join("src")).unwrap();
 
-        // Only directories should match, not files
         let input = format!("{}/rea", base.display());
         let result = complete_directory_path(&input);
         assert_eq!(result, None);
@@ -1007,7 +980,7 @@ mod tests {
 
     #[test]
     fn expand_tilde_other_user() {
-        // ~otheruser should NOT be expanded — only ~ and ~/ are handled
+        // ~otheruser is NOT expanded — only ~ and ~/ are handled.
         assert_eq!(expand_tilde("~otheruser"), PathBuf::from("~otheruser"));
     }
 
@@ -1037,7 +1010,6 @@ mod tests {
         let base = temp.path();
         std::fs::create_dir(base.join("mydir")).unwrap();
 
-        // Use expanded path to simulate what tilde expansion produces
         let input = format!("{}/my", base.display());
         let result = complete_directory_path(&input);
         assert_eq!(result, Some("dir/".to_string()));
@@ -1045,8 +1017,7 @@ mod tests {
 
     #[test]
     fn complete_directory_path_tilde_trailing_slash() {
-        // "~/" should produce completions from the home directory
-        // The result (if any) should be a relative suffix, not start with '/'
+        // "~/" completions are relative suffixes, never absolute.
         if let Some(s) = complete_directory_path("~/") {
             assert!(!s.starts_with('/'));
         }

--- a/src/session/agent_def.rs
+++ b/src/session/agent_def.rs
@@ -19,9 +19,9 @@ const ID_PLACEHOLDER: &str = "{id}";
 /// One coding-agent CLI definition.
 ///
 /// Each `*_args` group is appended to the final argument list **only** when its
-/// driving value is present (a model is selected, the session is being resumed,
-/// etc.), with `{model}` / `{id}` substituted token-by-token. This avoids any
-/// "unresolved placeholder" heuristics: a group with no value is simply omitted.
+/// driving value is present (the session is being resumed/forked, etc.), with
+/// `{id}` substituted token-by-token. This avoids any "unresolved placeholder"
+/// heuristics: a group with no value is simply omitted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentDef {
     /// Display + lookup name (e.g. `"claude"`). Unique within a registry.

--- a/src/session/automation.rs
+++ b/src/session/automation.rs
@@ -332,7 +332,7 @@ pub fn parse_duration(s: &str) -> Option<u64> {
 /// unit, or arithmetic overflow.
 fn duration_token_ms(digits: &str, unit: char) -> Option<u64> {
     if digits.is_empty() {
-        return None; // unit with no preceding number
+        return None;
     }
     let n: u64 = digits.parse().ok()?;
     let unit_ms: u64 = match unit.to_ascii_lowercase() {

--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -472,17 +472,15 @@ prompt = "tick"
                 command: command.map(str::to_string),
             }
         };
-        // Valid: a pure send, or a pure exec.
         assert!(auto(Some("flow"), Some("tick"), None).validate().is_ok());
         assert!(auto(None, None, Some("sync.sh")).validate().is_ok());
-        // Invalid: both flavours (exec would silently win, dropping the send fields).
+        // Both flavours set: exec would silently win, dropping the send fields.
         assert!(auto(Some("flow"), Some("tick"), Some("sync.sh"))
             .validate()
             .is_err());
         assert!(auto(None, Some("tick"), Some("sync.sh"))
             .validate()
             .is_err());
-        // Invalid: neither flavour.
         assert!(auto(None, None, None).validate().is_err());
         assert!(auto(None, Some("tick"), None).validate().is_err());
     }
@@ -550,7 +548,6 @@ prompt = "tick"
 
     #[test]
     fn config_merge_source_path_defaults_to_dest_filename() {
-        // Explicit source wins.
         let explicit = ConfigMerge {
             path: "~/.gemini/settings.json".into(),
             source: Some("gemini-hooks.json".into()),

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -377,7 +377,6 @@ mod tests {
                 .unwrap();
         assert!(s.notifications.also_on_waiting);
         assert_eq!(s.notifications.min_interval_secs, 30);
-        // Untouched fields stay on defaults.
         assert!(s.notifications.suppress_for_active);
         assert!(s.notifications.sound);
     }

--- a/src/session/task.rs
+++ b/src/session/task.rs
@@ -6,9 +6,10 @@
 //! git worktree — and prompts it (`Spawn`). A task with no action is a plain
 //! local todo (triggering is a no-op until it is connected to an agent).
 //!
-//! The `source`/`external_id`/`external_url` fields scaffold future sync with
-//! external issue trackers (Jira, GitHub Issues, …); local tasks use
-//! `source = "local"` and leave the external fields empty.
+//! The `source`/`external_id`/`external_url` fields back bidirectional sync with
+//! external issue trackers (Jira, GitHub Issues, …) via the task-integration
+//! extensions; local tasks use `source = "local"` and leave the external fields
+//! empty.
 //!
 //! This module is pure data (no local crate imports beyond `super`), matching
 //! the architecture rule for `session`. Persistence lives in `storage::tasks`;
@@ -81,8 +82,8 @@ pub struct Task {
     pub status: TaskStatus,
     /// How the task connects to an agent. `None` = an unconnected local todo.
     pub action: Option<AutomationAction>,
-    /// Origin of the task (`"local"` or an external tracker name). Scaffolding
-    /// for future external sync.
+    /// Origin of the task (`"local"` or an external tracker name); the
+    /// `(source, external_id)` pair is the external-sync dedup key.
     pub source: String,
     /// Identifier in the external tracker, when `source` is not `"local"`.
     pub external_id: Option<String>,
@@ -249,14 +250,12 @@ mod tests {
         assert!(prompt.contains("Thurbox task #42"));
         assert!(prompt.contains("# Wire up SSH backend"));
         assert!(prompt.contains("Implement `SshTmuxBackend`."));
-        // Self-service context: how to read more and how to close it out.
         assert!(prompt.contains("thurbox-cli task show 42"));
         assert!(prompt.contains("thurbox-cli task edit 42 --status done"));
     }
 
     #[test]
     fn spawn_session_name_keeps_the_title_verbatim() {
-        // The human title is preserved (casing + spacing), tagged with the id.
         assert_eq!(
             sample_task(None).spawn_session_name(),
             "Wire up SSH backend · #42"
@@ -267,7 +266,6 @@ mod tests {
     fn spawn_session_name_collapses_whitespace() {
         let mut task = sample_task(None);
         task.title = "  Fix   TUI\tcrash  ".to_string();
-        // Internal runs collapse to single spaces; ends are trimmed.
         assert_eq!(task.spawn_session_name(), "Fix TUI crash · #42");
     }
 
@@ -303,13 +301,12 @@ mod tests {
     #[test]
     fn matches_spawn_session_accepts_current_and_legacy_names() {
         let task = sample_task(None);
-        // Current convention: trailing " · #<id>" tag.
         assert!(task.matches_spawn_session("Wire up SSH backend · #42"));
         assert!(task.matches_spawn_session("Some since-edited title · #42"));
         // Legacy forms still relink after a restart.
         assert!(task.matches_spawn_session("task-42-wire-up-ssh-backend"));
-        assert!(task.matches_spawn_session("task-42")); // legacy bare convention
-                                                        // Different task ids never match — including the tricky #4 vs #42 boundary.
+        assert!(task.matches_spawn_session("task-42"));
+        // Different task ids never match — including the tricky #4 vs #42 boundary.
         assert!(!task.matches_spawn_session("Wire up SSH backend · #421"));
         assert!(!task.matches_spawn_session("Wire up SSH backend · #4"));
         assert!(!task.matches_spawn_session("task-421"));

--- a/src/session/theme_config.rs
+++ b/src/session/theme_config.rs
@@ -1,17 +1,12 @@
 //! Theme palettes for the Thurbox TUI.
 //!
-//! A `ThemePalette` is the runtime, swappable counterpart to the static colour
-//! constants that used to live in `src/ui/theme.rs`. Widgets read the active
+//! A `ThemePalette` is the runtime, swappable palette. Widgets read the active
 //! palette via `crate::ui::theme::current()`; users pick one via the theme
 //! picker modal or by setting `active_theme` in the SQLite metadata table.
 
 use ratatui::style::Color;
 
 /// Colour values + glyph preferences for the entire TUI.
-///
-/// Field names match the former `Theme::*` constants one-to-one so the
-/// existing widget code translates cleanly to function calls
-/// (`Theme::accent()` etc.).
 ///
 /// Palettes are never persisted directly — only the preset *name* is stored
 /// in the SQLite `metadata.active_theme` row. The runtime palette is

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -198,9 +198,7 @@ mod tests {
         assert!(report.removed_worktrees.is_empty());
         assert_eq!(report.disabled_automations, 0);
 
-        // Row is soft-deleted.
         assert!(db.get_session_by_id(id).unwrap().is_none());
-        // The automation is still enabled.
         assert!(db.get_automation(auto).unwrap().unwrap().enabled);
     }
 

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -1458,19 +1458,16 @@ prompt = "tick"
         let target = src.path().to_string_lossy().to_string();
         let report = install_extension(&db, &target, None, false).unwrap();
 
-        // Files laid down under home.
         assert!(home.join("FLOW.md").exists());
         assert!(home.join("scripts/do.sh").exists());
         assert!(home.join("repos.md").exists());
         // {home} substituted in the settings template.
         let settings = std::fs::read_to_string(home.join(".claude/settings.json")).unwrap();
         assert_eq!(settings, format!("perm {}/x", home.display()));
-        // Symlink created.
         assert!(std::fs::symlink_metadata(home.join("CLAUDE.md"))
             .unwrap()
             .file_type()
             .is_symlink());
-        // executable bit set.
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -1481,7 +1478,6 @@ prompt = "tick"
             assert_eq!(mode & 0o100, 0o100, "do.sh should be executable");
         }
 
-        // Agent registered, manifest written + active, automation created.
         assert_eq!(report.agents_added, ["flow"]);
         let reg = crate::agent::agent_config::load_or_seed();
         assert_eq!(reg.get("flow").unwrap().args, ["--model", "haiku"]);

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -245,12 +245,10 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn run_exec_command_reports_success_and_failure() {
-        // A zero-exit command → Success, with stdout captured.
         let (status, detail) = run_exec_command("printf hello");
         assert_eq!(status, AutomationRunStatus::Success);
         assert!(detail.contains("hello"), "got {detail}");
 
-        // A non-zero exit → Error, with the exit code in the detail.
         let (status, detail) = run_exec_command("exit 3");
         assert_eq!(status, AutomationRunStatus::Error);
         assert!(detail.contains('3'), "got {detail}");
@@ -298,7 +296,6 @@ mod tests {
             .env
             .get(crate::paths::DATA_DIR_OVERRIDE_ENV)
             .expect("data dir injected");
-        // They match the parents of the resolved config/db files.
         assert_eq!(
             Some(std::path::Path::new(cfg_dir)),
             crate::paths::config_file()
@@ -377,10 +374,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let mut env = HashMap::new();
         env.insert("CLAUDE_CONFIG_DIR".into(), tmp.path().display().to_string());
-        // No transcript yet -> no resume.
         assert_eq!(resume_trigger_for(&claude, "missing", &env), None);
 
-        // With a transcript -> resume by the pinned id.
         let sid = "11111111-2222-3333-4444-555555555555";
         let proj = tmp.path().join("projects").join("-slug");
         std::fs::create_dir_all(&proj).unwrap();

--- a/src/storage/automations.rs
+++ b/src/storage/automations.rs
@@ -542,7 +542,6 @@ mod tests {
         let id = db
             .create_automation(&send_automation("x", Some(100)))
             .unwrap();
-        // expected != stored next_run_at → no claim, no mutation.
         assert!(!db.claim_due_automation(id, 999, Some(5000), 200).unwrap());
         let got = db.get_automation(id).unwrap().unwrap();
         assert_eq!(got.next_run_at, Some(100));
@@ -574,7 +573,6 @@ mod tests {
             .unwrap();
         let runs = db.list_automation_runs(id, 10).unwrap();
         assert_eq!(runs.len(), 2);
-        // Newest first.
         assert_eq!(runs[0].status, AutomationRunStatus::Skipped);
     }
 

--- a/src/storage/repo_bookmarks.rs
+++ b/src/storage/repo_bookmarks.rs
@@ -170,7 +170,6 @@ mod tests {
         let before = db.list_repo_bookmarks().unwrap()[0].use_count;
         assert!(db.touch_repo_bookmark(Path::new("/repo/a")).unwrap());
         let after = db.list_repo_bookmarks().unwrap()[0].use_count;
-        // touch doesn't increment use_count
         assert_eq!(before, after);
     }
 

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -187,7 +187,6 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
         ",
     )?;
 
-    // Seed metadata if not present
     conn.execute(
         "INSERT OR IGNORE INTO metadata (key, value) VALUES ('schema_version', ?1)",
         [SCHEMA_VERSION.to_string()],
@@ -772,7 +771,6 @@ fn migrate_v20_profiles(conn: &Connection) -> rusqlite::Result<()> {
 /// removed from the product — the agent picks its own model now. The
 /// drop is guarded so a re-run (column already gone) is a no-op.
 fn migrate_v21_drop_model(conn: &Connection) -> rusqlite::Result<()> {
-    // Already gone (re-run) is a no-op; a real failure propagates.
     drop_column_if_present(conn, "sessions", "model")
 }
 
@@ -871,9 +869,7 @@ fn migrate_v24_automations(conn: &Connection) -> rusqlite::Result<()> {
 }
 
 /// v24 → v25: add the `tasks` table (todo list with agent-action linkage).
-///
-/// Idempotent CREATE: fresh v25 databases already have the table from
-/// `initialize`; existing v24 databases get it here. No data backfill.
+/// Idempotent CREATE; no data backfill.
 fn migrate_v25_tasks(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS tasks (
@@ -1564,7 +1560,7 @@ mod tests {
     fn schema_is_idempotent() {
         let conn = Connection::open_in_memory().unwrap();
         initialize(&conn).unwrap();
-        initialize(&conn).unwrap(); // Should not error
+        initialize(&conn).unwrap();
     }
 
     #[test]

--- a/src/storage/sessions.rs
+++ b/src/storage/sessions.rs
@@ -200,14 +200,12 @@ impl Database {
             let (session, worktree) = row?;
             if let Some(last) = sessions.last_mut() {
                 if last.id == session.id {
-                    // Same session — just append the worktree
                     if let Some(wt) = worktree {
                         last.worktrees.push(wt);
                     }
                     continue;
                 }
             }
-            // New session
             let mut s = session;
             if let Some(wt) = worktree {
                 s.worktrees.push(wt);

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -257,11 +257,10 @@ mod tests {
     #[test]
     fn pending_focus_session_id_round_trip() {
         let db = Database::open_in_memory().unwrap();
-        // Nothing pending initially.
         assert_eq!(db.take_pending_focus_session_id().unwrap(), None);
 
-        // The notifications module writes via raw SQL using the same key
-        // (`FOCUS_REQUEST_KEY`); this mirrors what the click handler does.
+        // The notifications click handler writes via raw SQL using the same
+        // `PENDING_FOCUS_SESSION_ID_KEY`; this mirrors that.
         db.conn
             .execute(
                 "INSERT INTO metadata (key, value) VALUES (?1, ?2)",

--- a/src/storage/sync.rs
+++ b/src/storage/sync.rs
@@ -134,7 +134,6 @@ mod tests {
 
         let _ = db1.has_external_changes().unwrap();
 
-        // db2 makes a change
         let session = make_session("S1");
         db2.upsert_session(&session).unwrap();
 

--- a/src/storage/worktrees.rs
+++ b/src/storage/worktrees.rs
@@ -18,13 +18,11 @@ impl Database {
         let now = current_time_millis() as i64;
         let sid = session_id.to_string();
 
-        // Delete existing active rows for this session
         self.conn.execute(
             "DELETE FROM worktrees WHERE session_id = ?1 AND deleted_at IS NULL",
             params![sid],
         )?;
 
-        // Insert all new rows
         for wt in worktrees {
             self.conn.execute(
                 "INSERT INTO worktrees (session_id, repo_path, worktree_path, branch, created_at, deleted_at) \

--- a/src/sync/delta.rs
+++ b/src/sync/delta.rs
@@ -48,21 +48,18 @@ impl StateDelta {
 
         let mut delta = StateDelta::default();
 
-        // Sessions: Added (in new but not in old)
         for (id, session) in &new_session_map {
             if !old_session_map.contains_key(id) {
                 delta.added_sessions.push((*session).clone());
             }
         }
 
-        // Sessions: Removed (in old but not in new or tombstoned in new)
         for id in old_session_map.keys() {
             if !new_session_map.contains_key(id) {
                 delta.removed_sessions.push(*id);
             }
         }
 
-        // Sessions: Updated (in both but key fields changed)
         for (id, new_session) in &new_session_map {
             if let Some(old_session) = old_session_map.get(id) {
                 if session_changed(old_session, new_session) {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -168,19 +168,12 @@ mod tests {
     fn should_poll_respects_interval() {
         let mut sync = SyncState::with_interval(Duration::from_millis(100));
 
-        // First check should not poll (too soon)
         assert!(!sync.should_poll());
 
-        // Wait for interval to pass
         std::thread::sleep(Duration::from_millis(110));
-
-        // Now should poll
         assert!(sync.should_poll());
 
-        // Update poll time
         sync.last_poll_time = Instant::now();
-
-        // Should not poll again immediately
         assert!(!sync.should_poll());
     }
 

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -54,7 +54,6 @@ pub struct SharedSession {
     /// The underlying agent session ID (if started).
     pub agent_session_id: Option<String>,
 
-    /// Working directory (if specified).
     pub cwd: Option<PathBuf>,
 
     /// Extra directories (beyond `cwd`) this session spans. When a session has
@@ -63,7 +62,6 @@ pub struct SharedSession {
     /// not just those with an `--add-dir`-style flag — can reach them.
     pub additional_dirs: Vec<PathBuf>,
 
-    /// Worktree information (if session uses git worktrees).
     pub worktrees: Vec<SharedWorktree>,
 
     /// Backend ID of the companion shell pane (if spawned).
@@ -92,10 +90,8 @@ pub struct SharedWorktree {
     /// Path to the git repository root.
     pub repo_path: PathBuf,
 
-    /// Path to the git worktree.
     pub worktree_path: PathBuf,
 
-    /// Branch name for this worktree.
     pub branch: String,
 }
 

--- a/src/ui/automation_detail.rs
+++ b/src/ui/automation_detail.rs
@@ -127,7 +127,6 @@ fn run_line<'a>(run: &AutomationRunRow<'_>, is_selected: bool) -> Line<'a> {
             format!("{pointer}{glyph} {word:<7}"),
             Style::default().fg(color).add_modifier(Modifier::BOLD),
         ),
-        // Absolute clock time, then the relative age.
         Span::styled(
             format!("{:<11} ", run.at),
             Style::default().fg(Theme::text_secondary()),

--- a/src/ui/automation_editor_modal.rs
+++ b/src/ui/automation_editor_modal.rs
@@ -110,9 +110,9 @@ pub fn render_automation_editor_modal(
 ) -> (Vec<super::RowHitbox>, super::ModalButtons) {
     let frame_area = frame.area();
     let fields = &state.visible_fields;
-    // One row per field + status + preview + spacing inside the modal frame.
-    // The multi-line Prompt field spans more than one row, so grow the height by
-    // its wrapped row count (the old `+ 5` already counted Prompt as one row).
+    // Height = one row per field + 5 (status/preview/spacing); the multi-line
+    // Prompt field grows it by its wrapped row count beyond the one already
+    // counted in the per-field tally.
     let extra = if fields.contains(&AutomationField::Prompt) {
         // Inner text width of the 60%-wide overlay (minus the 1-col borders).
         let inner_w = (frame_area.width * 60 / 100).saturating_sub(2);
@@ -629,9 +629,7 @@ mod tests {
 
     #[test]
     fn wrapped_cursor_maps_logical_col_to_display() {
-        // start
         assert_eq!(wrapped_cursor(0, 10, 1), (0, 0));
-        // mid-row
         assert_eq!(wrapped_cursor(5, 10, 1), (0, 5));
         // exactly on a wrap boundary moves to the next row's start
         assert_eq!(wrapped_cursor(10, 10, 2), (1, 0));

--- a/src/ui/automations_list_modal.rs
+++ b/src/ui/automations_list_modal.rs
@@ -120,7 +120,6 @@ mod tests {
 
     #[test]
     fn truncate_adds_ellipsis_when_over_width() {
-        // 7 chars, max 6 → keep 3 chars + "..." = 6 chars total.
         let out = truncate("abcdefg", 6);
         assert_eq!(out, "abc...");
         assert_eq!(out.chars().count(), 6);

--- a/src/ui/branch_selector_modal.rs
+++ b/src/ui/branch_selector_modal.rs
@@ -24,14 +24,11 @@ pub fn render_branch_selector_modal(
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Min(1),    // Branch list
-            Constraint::Length(1), // Footer
-        ])
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
         .split(inner);
 
-    // Windowed around the selection with a scrollbar when more branches than
-    // fit (the modal caps at 15 visible).
+    // render_selector_rows windows these around the selection (with a scrollbar)
+    // when there are more than the 15-line cap fit.
     let lines: Vec<Line<'_>> = state
         .branches
         .iter()
@@ -55,7 +52,7 @@ mod tests {
         let height = |n: usize| (n.min(15) + 4) as u16;
         assert_eq!(height(1), 5);
         assert_eq!(height(15), 19);
-        assert_eq!(height(30), 19); // capped
+        assert_eq!(height(30), 19);
         assert_eq!(height(0), 4);
     }
 

--- a/src/ui/confirm_delete_modal.rs
+++ b/src/ui/confirm_delete_modal.rs
@@ -29,10 +29,10 @@ pub fn render_confirm_delete_modal(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1), // Prompt
-            Constraint::Length(1), // Spacer
-            Constraint::Length(1), // Warning
-            Constraint::Min(1),    // Footer
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(1),
         ])
         .split(inner);
 

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -252,7 +252,6 @@ impl FileViewerState {
     /// the global search to jump to a file/dir result. Best-effort: silently
     /// no-ops if `target` isn't under any current root.
     pub fn reveal_path(&mut self, target: &Path) {
-        // Find the root that contains `target`, then expand each ancestor dir.
         for root_idx in 0..self.roots.len() {
             let root_path = self.roots[root_idx].path.clone();
             let Ok(rel) = target.strip_prefix(&root_path) else {
@@ -385,7 +384,6 @@ impl FileViewerState {
                 return;
             }
         }
-        // Else: move selection up one level (parent)
         if index_path.len() > 1 {
             let parent_path = &index_path[..index_path.len() - 1];
             let new_rows = self.flatten();
@@ -414,7 +412,6 @@ fn push_flat(
     is_root: bool,
 ) {
     let label = if is_root {
-        // Show a shortened path for roots (last 2 components)
         short_root_label(&node.path)
     } else {
         node.path

--- a/src/ui/global_search.rs
+++ b/src/ui/global_search.rs
@@ -39,7 +39,6 @@ pub(crate) fn render_global_search(frame: &mut Frame, area: Rect, state: &Global
         return;
     }
 
-    // Query line, per-scope summary, the result list (flexible), then key hints.
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/src/ui/highlight.rs
+++ b/src/ui/highlight.rs
@@ -177,7 +177,6 @@ mod tests {
     fn owned_variant_matches_borrowed() {
         let owned = highlighted_spans_owned("foo-bar", &[0, 4], Style::default());
         assert_eq!(texts(&owned), vec!["f", "oo-", "b", "ar"]);
-        // Empty positions → one span.
         let owned = highlighted_spans_owned("hi", &[], Style::default());
         assert_eq!(texts(&owned), vec!["hi"]);
     }
@@ -186,7 +185,6 @@ mod tests {
     fn out_of_range_positions_are_ignored() {
         let spans = highlighted_spans("ab", &[99], Style::default());
         assert_eq!(texts(&spans), vec!["ab"]);
-        // The owned variant ignores them the same way.
         let owned = highlighted_spans_owned("ab", &[99], Style::default());
         assert_eq!(texts(&owned), vec!["ab"]);
     }
@@ -200,9 +198,7 @@ mod tests {
         let text = "abc…";
         assert!(!text.is_char_boundary(4));
         let spans = highlighted_spans(text, &[0, 4], Style::default());
-        // 'a' highlighted, the mid-char position dropped, remainder plain.
         assert_eq!(texts(&spans), vec!["a", "bc…"]);
-        // Owned variant is robust the same way.
         let owned = highlighted_spans_owned(text, &[0, 4], Style::default());
         assert_eq!(texts(&owned), vec!["a", "bc…"]);
     }
@@ -213,11 +209,9 @@ mod tests {
         // Selected wins regardless of dimmed.
         assert_eq!(row_base_style(true, true, normal), Theme::selected_item());
         assert_eq!(row_base_style(true, false, normal), Theme::selected_item());
-        // Dimmed (but not selected) is the muted+DIM style, not `normal`.
         let dimmed = row_base_style(false, true, normal);
         assert_eq!(dimmed.fg, Some(Theme::text_muted()));
         assert!(dimmed.add_modifier.contains(Modifier::DIM));
-        // Otherwise the caller's resting style passes through unchanged.
         assert_eq!(row_base_style(false, false, normal), normal);
     }
 }

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -47,40 +47,31 @@ pub fn render_info_panel(
 
     let mut lines = Vec::new();
 
-    // ── Session section (most relevant: "what am I looking at") ──
     append_session_section(&mut lines, info, parent_name);
-
-    // ── Repos ──
     append_repos_section(&mut lines, info);
 
-    // ── Git change summary (real git state of the worktree) ──
     if let Some(ref git) = info.git_stats {
         append_git_section(&mut lines, git);
     }
 
-    // ── Session CPU/RAM ──
     if let Some(m) = metrics {
         append_session_resources(&mut lines, m, inner_width);
     }
 
-    // ── Agent section (Claude CLI metrics) ──
     if let Some(ref metrics) = info.agent_metrics {
         append_agent_section(&mut lines, metrics, inner_width);
     }
 
-    // ── Usage / rate-limits (account-level, the `/usage` equivalent) ──
     if let Some(u) = usage {
         if !u.is_empty() {
             append_usage_section(&mut lines, u, inner_width);
         }
     }
 
-    // ── System Resources section (global CPU/RAM) ──
     if let Some(m) = metrics {
         append_system_section(&mut lines, m, inner_width);
     }
 
-    // ── Automations section ──
     append_automations_section(&mut lines, automations, inner_width);
 
     let paragraph = Paragraph::new(lines)
@@ -700,7 +691,7 @@ mod tests {
         assert!(header.contains("CPU"));
         assert!(header.contains("0%"));
         let bar: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
-        // bar_width = 20 - 2 = 18, all empty
+        // bar_width = 20 - 2 = 18
         assert!(bar.contains(&"░".repeat(18)));
         assert!(!bar.contains('█'));
     }
@@ -711,7 +702,7 @@ mod tests {
         let header: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(header.contains("100%"));
         let bar: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
-        // bar_width = 18, all filled
+        // bar_width = 18
         assert!(bar.contains(&"█".repeat(18)));
         assert!(!bar.contains('░'));
     }
@@ -750,9 +741,9 @@ mod tests {
         let inner_width = 16;
         let lines = render_gauge_lines("CPU", 42.0, None, inner_width);
         let bar: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
-        // bar should be [<filled><empty>] with total bar_width = inner_width - 2
         let bar_content_len = bar.chars().count();
-        assert_eq!(bar_content_len, inner_width); // [ + bar_width + ]
+        // [ + bar_width + ] == inner_width
+        assert_eq!(bar_content_len, inner_width);
     }
 
     // ── separator tests ──

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -122,7 +122,7 @@ fn three_panel_layout(
     show_automations_pane: bool,
     automation_count: usize,
 ) -> PanelAreas {
-    let mut constraints: Vec<Constraint> = vec![Constraint::Percentage(18)]; // list
+    let mut constraints: Vec<Constraint> = vec![Constraint::Percentage(18)];
     if show_info_panel {
         constraints.push(Constraint::Percentage(15));
     }
@@ -306,7 +306,6 @@ mod tests {
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_some());
         assert!(areas.file_viewer.is_some());
-        // file viewer should be to the right of terminal
         let term = areas.terminal;
         let fv = areas.file_viewer.unwrap();
         assert!(fv.x >= term.x + term.width);
@@ -319,7 +318,6 @@ mod tests {
         assert!(areas.info_panel.is_none());
         assert!(areas.tasks_panel.is_some());
         assert!(areas.file_viewer.is_none());
-        // Tasks panel sits to the right of the terminal.
         let term = areas.terminal;
         let tp = areas.tasks_panel.unwrap();
         assert!(tp.x >= term.x + term.width);
@@ -331,7 +329,6 @@ mod tests {
         let term = areas.terminal;
         let tp = areas.tasks_panel.expect("tasks panel shown");
         let fv = areas.file_viewer.expect("file viewer shown");
-        // Order: terminal → tasks → file viewer (both on the right).
         assert!(tp.x >= term.x + term.width, "tasks right of terminal");
         assert!(fv.x >= tp.x + tp.width, "file viewer right of tasks");
     }
@@ -451,7 +448,6 @@ mod tests {
         let areas = compute_layout(area(100, 30), false, false, false, false, true, 2);
         let sessions = areas.left_panel.unwrap();
         let autos = areas.automations_panel.expect("automations pane shown");
-        // Same column, automations stacked beneath the session list.
         assert_eq!(sessions.x, autos.x);
         assert_eq!(sessions.width, autos.width);
         assert_eq!(autos.y, sessions.y + sessions.height);

--- a/src/ui/links.rs
+++ b/src/ui/links.rs
@@ -231,7 +231,7 @@ mod tests {
         let rows = vec!["• https://example.com".to_string()];
         let links = detect_urls(&rows);
         assert_eq!(links.len(), 1);
-        assert_eq!(links[0].start_col, 2); // char position, not byte position
+        assert_eq!(links[0].start_col, 2);
         assert_eq!(links[0].end_col, 21);
         assert_eq!(url_at_position(&links, 0, 2), Some("https://example.com"));
         assert_eq!(url_at_position(&links, 0, 1), None);

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -282,15 +282,12 @@ mod tests {
             .all(|s| s.style.add_modifier.contains(Modifier::BOLD)
                 && s.style.fg == Some(Theme::border_focused())));
 
-        // Bold span exists somewhere in the paragraph.
         assert!(lines.iter().any(|l| l.spans.iter().any(
             |s| s.content.as_ref() == "bold" && s.style.add_modifier.contains(Modifier::BOLD)
         )));
 
-        // Bullets are rendered with a marker.
         assert!(texts.iter().any(|t| t == "• one"));
         assert!(texts.iter().any(|t| t == "• two"));
-        // Code-block content is preserved.
         assert!(texts.iter().any(|t| t == "code"));
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -216,7 +216,7 @@ pub fn render_button_bar(
             rect,
         );
         hits.push(ButtonHit { rect, index });
-        x += width + 1; // advance past the button + separator
+        x += width + 1;
     }
     hits
 }

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -110,7 +110,7 @@ fn group_display(info: &SessionInfo) -> String {
 ///
 /// The order is intentionally a pure function of *manual order*
 /// (`display_order`, set by the user via move up/down) and *stable insertion
-/// order* — never of status or live recency. A status change (→`Attention`,
+/// order* — never of status or live recency. A status change (→`Blocked`,
 /// →`Idle`) only recolors the dot; rows stay exactly where the user put them.
 pub struct SessionOrder {
     /// Input indices in render order.
@@ -857,17 +857,6 @@ const AGENT_STATUS_SEPARATOR: &str = "  ";
 /// Minimum columns the inline agent status needs to be worth showing.
 const AGENT_STATUS_MIN_WIDTH: usize = 4;
 
-/// Build the single line of a session entry:
-/// `<status-dot> [└] [↳] [☁] [⑂] <name> [<agent-status>]`.
-///
-/// The active row is signalled by the list's highlight background, so no extra
-/// pointer glyph is needed. A child session nested under its parent (`depth >
-/// 0`) gets a muted `└` tree prefix; a child whose parent renders in another
-/// repo group gets a `↳` mark instead. Remote (`ssh:<host>`) sessions get a
-/// `☁` mark and sessions running in a git worktree get a `⑂` mark, all between
-/// the status dot and the name. The agent-reported status (see
-/// [`agent_status_text`]) is appended after the name, truncated with `…` to
-/// fit `inner_width`.
 /// Style for the session name span.
 fn name_span_style(is_active: bool, is_dimmed: bool) -> Style {
     if is_dimmed {
@@ -1089,7 +1078,6 @@ mod tests {
     fn highlighted_spans_basic() {
         let style = Style::default().fg(Theme::text_primary());
         let spans = build_highlighted_spans("foo-bar", &[0, 4], style);
-        // Should produce: "f" (highlighted), "oo-" (normal), "b" (highlighted), "ar" (normal)
         assert_eq!(spans.len(), 4);
         assert_eq!(spans[0].content, "f");
         assert_eq!(spans[1].content, "oo-");
@@ -1141,7 +1129,6 @@ mod tests {
         let style = Style::default().fg(Theme::text_primary());
         let mut spans = vec![Span::raw("prefix ")];
         append_name_spans(&mut spans, "foo-bar", Some(&[0, 4]), style);
-        // prefix + "f" (highlighted) + "oo-" (normal) + "b" (highlighted) + "ar" (normal)
         assert_eq!(spans.len(), 5);
         assert_eq!(spans[0].content, "prefix ");
         assert_eq!(spans[1].content, "f");
@@ -1494,7 +1481,7 @@ mod tests {
 
     #[test]
     fn status_never_reorders_groups() {
-        // Manual order wins: an Attention session recolors its dot but never
+        // Manual order wins: a Blocked session recolors its dot but never
         // bubbles its group. Groups stay in label order ("infra" < "webapp").
         let waiting = info_repo("infra-1", "infra", SessionStatus::Done);
         let attn = info_repo("web-attn", "webapp", SessionStatus::Blocked);
@@ -1539,7 +1526,7 @@ mod tests {
         let sessions = vec![&a, &b, &c];
         assert_eq!(order_names(&sessions), vec!["a", "b", "c"]);
 
-        // Flip a→Attention and b→Idle: order is unchanged.
+        // Flip a→Blocked and b→Idle: order is unchanged.
         let a2 = info_repo("a", "webapp", SessionStatus::Blocked);
         let b2 = info_repo("b", "webapp", SessionStatus::Idle);
         let flipped = vec![&a2, &b2, &c];
@@ -1869,7 +1856,7 @@ mod tests {
         let worker = info_child("worker", "webapp", SessionStatus::Blocked, &lead);
         let busy = info_repo("busy", "infra", SessionStatus::Working);
         let sessions = vec![&busy, &lead, &worker];
-        // The child's Attention status doesn't bubble its group: groups stay
+        // The child's Blocked status doesn't bubble its group: groups stay
         // in label order ("infra" < "webapp"); the child stays nested.
         assert_eq!(
             order_names_depths(&sessions),

--- a/src/ui/repo_picker_modal.rs
+++ b/src/ui/repo_picker_modal.rs
@@ -64,33 +64,29 @@ pub fn render_repo_picker_modal(
 
     let mut constraints = Vec::new();
     if state.search_active {
-        constraints.push(Constraint::Length(3)); // Search bar
+        constraints.push(Constraint::Length(3));
     }
-    constraints.push(Constraint::Length(list_height)); // Bookmark list
-    constraints.push(Constraint::Length(3)); // Path input
-    constraints.push(Constraint::Min(1)); // Footer
+    constraints.push(Constraint::Length(list_height));
+    constraints.push(Constraint::Length(3));
+    constraints.push(Constraint::Min(1));
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints(constraints)
         .split(inner);
 
-    // Assign named chunk areas based on whether search bar is visible.
     let (search_area, list_area, input_area, footer_area) = if state.search_active {
         (Some(chunks[0]), chunks[1], chunks[2], chunks[3])
     } else {
         (None, chunks[0], chunks[1], chunks[2])
     };
 
-    // Search bar (when active)
     if let Some(area) = search_area {
         render_search_bar(frame, area, state);
     }
 
-    // Bookmark list with checkboxes
     let hitboxes = render_bookmark_list(frame, list_area, state);
 
-    // Path input
     render_text_field_with_suggestion(
         frame,
         input_area,
@@ -406,9 +402,7 @@ mod tests {
     fn highlighted_spans_accents_matched_characters() {
         let base = Style::default();
         let spans = highlighted_spans("ll", "", "hello", base);
-        // Whole display text is preserved across the interleaved spans.
         assert_eq!(span_text(&spans), "hello");
-        // Exactly the two matched 'l' characters are accented.
         assert_eq!(accent_chars(&spans), "ll");
     }
 

--- a/src/ui/scrollbar.rs
+++ b/src/ui/scrollbar.rs
@@ -144,7 +144,6 @@ mod tests {
     #[test]
     fn position_for_y_endpoints() {
         let g = geom(5, 10, 100);
-        // Top of the track maps to 0, bottom maps to the last index.
         assert_eq!(g.position_for_y(5), 0);
         assert_eq!(g.position_for_y(14), 99);
     }
@@ -152,14 +151,12 @@ mod tests {
     #[test]
     fn position_for_y_midpoint() {
         let g = geom(0, 11, 101);
-        // Exact middle row → exact middle position.
         assert_eq!(g.position_for_y(5), 50);
     }
 
     #[test]
     fn position_for_y_clamps_out_of_range() {
         let g = geom(5, 10, 100);
-        // Above the track clamps to 0, below clamps to the max.
         assert_eq!(g.position_for_y(0), 0);
         assert_eq!(g.position_for_y(255), 99);
     }
@@ -188,7 +185,6 @@ mod tests {
     fn reserve_track_splits_when_overflowing() {
         let area = Rect::new(4, 2, 20, 10);
         let (content, track) = reserve_track(area, 100, 10);
-        // Content loses its rightmost column; the track claims it.
         assert_eq!(content, Rect::new(4, 2, 19, 10));
         assert_eq!(track, Some(Rect::new(23, 2, 1, 10)));
     }

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -211,18 +211,14 @@ mod tests {
             dragging: false,
             pane: test_pane(),
         };
-        // First row: col >= 5
         assert!(sel.contains(1, 5));
         assert!(sel.contains(1, 80));
         assert!(!sel.contains(1, 4));
-        // Middle row: all cols
         assert!(sel.contains(2, 0));
         assert!(sel.contains(2, 999));
-        // Last row: col <= 10
         assert!(sel.contains(3, 0));
         assert!(sel.contains(3, 10));
         assert!(!sel.contains(3, 11));
-        // Outside rows
         assert!(!sel.contains(0, 5));
         assert!(!sel.contains(4, 5));
     }
@@ -328,7 +324,6 @@ mod tests {
 
         highlight_buffer(&mut buf, &sel, style);
 
-        // Cells 2..5 should have the style, others should not
         assert_eq!(buf.cell(Position::new(1, 0)).unwrap().fg, Color::Reset);
         assert_eq!(buf.cell(Position::new(2, 0)).unwrap().fg, Color::Red);
         assert_eq!(buf.cell(Position::new(4, 0)).unwrap().fg, Color::Red);
@@ -361,8 +356,8 @@ mod tests {
     fn pane_bounds_clamp() {
         let pane = PaneBounds::from_rect(Rect::new(10, 5, 20, 10));
         assert_eq!(pane.clamp(15, 8), (15, 8)); // inside
-        assert_eq!(pane.clamp(5, 3), (10, 5)); // top-left
-        assert_eq!(pane.clamp(50, 20), (29, 14)); // bottom-right
+        assert_eq!(pane.clamp(5, 3), (10, 5)); // clamped to top-left
+        assert_eq!(pane.clamp(50, 20), (29, 14)); // clamped to bottom-right
     }
 
     #[test]

--- a/src/ui/session_name_modal.rs
+++ b/src/ui/session_name_modal.rs
@@ -21,10 +21,7 @@ pub fn render_session_name_modal(
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(3), // Name field
-            Constraint::Min(1),    // Footer
-        ])
+        .constraints([Constraint::Length(3), Constraint::Min(1)])
         .split(inner);
 
     super::render_text_field(frame, chunks[0], "Name", state.name, state.cursor, true);

--- a/src/ui/settings_modal.rs
+++ b/src/ui/settings_modal.rs
@@ -246,7 +246,6 @@ fn field_line<'a>(
 ) -> Line<'a> {
     let active = field == m.field;
 
-    // ── Left: pointer + description ─────────────────────────────────────────
     let pointer = if active { "▸ " } else { "  " };
     let desc_style = if active {
         Style::default()
@@ -256,7 +255,6 @@ fn field_line<'a>(
         Style::default().fg(Theme::text_secondary())
     };
 
-    // ── Right: value column + a reserved 2-col marker column ────────────────
     let value = m.value_string(field);
     let value_str = value_text(m, field);
     let value_style = if field.is_scalar() {

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -121,7 +121,6 @@ pub fn render_footer(
 
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 
-    // Buttons always sit on the far right.
     let hits = super::render_button_bar(frame, area, &FOOTER_BUTTONS, true);
 
     // File-viewer hints fill whatever room is left of the buttons.

--- a/src/ui/task_detail.rs
+++ b/src/ui/task_detail.rs
@@ -117,7 +117,6 @@ pub fn render_task_detail(
         return None;
     }
 
-    // Split: fixed metadata rows on top, the rendered markdown below.
     let meta_h = (meta_lines.len() as u16 + 1).min(inner.height);
     let parts = Layout::default()
         .direction(Direction::Vertical)

--- a/src/ui/task_editor_modal.rs
+++ b/src/ui/task_editor_modal.rs
@@ -66,8 +66,8 @@ pub fn render_task_editor_into(
     frame.render_widget(Paragraph::new(editor_lines(state)), inner);
 
     // Row layout (matches `editor_lines`): Title=1 row, Description=1 header +
-    // one row per newline-separated line, Status=1 row. Build a hitbox per
-    // field, clipped to the inner area.
+    // one row per newline-separated line, Status=1 row. Hitboxes are clipped to
+    // the inner area.
     let desc_rows = 1 + state.description.split('\n').count() as u16;
     let mut y = 0u16;
     let mut hits = Vec::new();

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -58,7 +58,6 @@ pub fn render_terminal(
         .block(block)
         .style(Style::default().fg(Theme::text_primary()).bg(Color::Reset));
 
-    // Hide cursor when scrolled up
     if scroll_offset > 0 {
         let mut cursor = Cursor::default();
         cursor.hide();
@@ -67,7 +66,6 @@ pub fn render_terminal(
 
     frame.render_widget(pseudo_term, area);
 
-    // Render scrollbar when there's scrollback content.
     if total_scrollback == 0 {
         return None;
     }
@@ -100,7 +98,6 @@ pub fn render_empty_terminal(frame: &mut Frame, area: Rect) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    // Centered hint box
     let box_width: u16 = 33;
     let box_height: u16 = 6;
 

--- a/src/ui/worktree_name_modal.rs
+++ b/src/ui/worktree_name_modal.rs
@@ -23,10 +23,7 @@ pub fn render_worktree_name_modal(
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(3), // Name field
-            Constraint::Min(1),    // Footer
-        ])
+        .constraints([Constraint::Length(3), Constraint::Min(1)])
         .split(inner);
 
     super::render_text_field(

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -108,7 +108,7 @@ fn symlink(target: &Path, link: &Path) -> io::Result<()> {
     match std::os::windows::fs::symlink_dir(target, link) {
         Ok(()) => Ok(()),
         Err(_) => {
-            // `mklink` is a cmd.exe builtin; `/J` makes a directory junction.
+            // `mklink` is a cmd.exe builtin, so it runs via `cmd /C`.
             let status = std::process::Command::new("cmd")
                 .args(["/C", "mklink", "/J"])
                 .arg(link)
@@ -253,7 +253,6 @@ mod tests {
 
         remove_workspace("s").unwrap();
         assert!(!ws.exists());
-        // Target survived.
         assert!(repo.join("file.txt").exists());
     }
 


### PR DESCRIPTION
## Summary

Aggressive, LLM-context-oriented cleanup of in-code comments across the whole
`src/` tree, plus a standing policy so it doesn't re-accumulate. Comments are
context for the next reader (human or agent): each retained one should convey
intent the code itself can't, and a **stale comment is worse than none** (it
anchors an LLM on the wrong intent).

Applied directly via a multi-agent workflow (one agent per file), then gated on a
full whole-crate verify.

### Comment edits (122/122 files, net −221 lines in `src/`)

- **Cut 182** noise comments (restatements, obvious trailing labels, obvious
  test-step narration).
- **Rewrote 24** verbose comments into tight "why" statements.
- **Fixed 13 stale comments** that contradicted the code — the highest-value
  changes. Examples:
  - `Attention` → `Blocked` in 4 comments (renamed `SessionStatus` variant).
  - `also_on_done` → `also_on_waiting` (wrong field name) in `notify_state`.
  - Deleted a doc describing the removed `tmux run-shell` timer dispatch.
  - `$SHELL`/`/bin/sh` → `SessionBackend::default_shell` in `backend`.
- **Kept 2,455** high-signal comments untouched (rationale, ADR/`schema vNN`
  cross-refs, invariants, public-API docs).

No code, signatures, or string/char literals changed — comment-only.

### Ongoing hygiene

- `CLAUDE.md` — new **"## Comments"** section codifying the rubric.
- `.claude/commands/refactor.md` — Pass 1 cites the rubric with the aggressive cut
  list; Pass 2 adds a dedicated comment-accuracy/stale step.

## Test plan

- `cargo fmt --all --check` ✅
- `cargo build --all-targets` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` ✅ (no broken
  intra-doc links / examples)
- `cargo nextest run --all` ✅ 1551 passed
- `git diff` confirmed comment-only (no non-comment hunks)