### PR TITLE
fix(ui): close hard-delete modal immediately, tear down worktree in background

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1496,21 +1496,32 @@ impl App {
     }
 
     /// Hard-delete a session after the confirmation prompt (soft_delete off):
-    /// tear down the tmux window, worktrees, symlink workspace, and pending
-    /// send automations, then drop the live session. There is no Ctrl+Z undo
-    /// (the row stays restorable via Ctrl+U, which re-spawns fresh) — the
-    /// confirmation modal is the safety net instead.
+    /// soft-delete the row + disable pending sends on the UI thread (fast
+    /// SQLite writes) so the modal closes and the row vanishes immediately,
+    /// then defer the slow tmux `kill-window` + `git worktree remove` +
+    /// symlink-workspace cleanup to a background task. There is no Ctrl+Z
+    /// undo (the row stays restorable via Ctrl+U, which re-spawns fresh) —
+    /// the confirmation modal is the safety net instead.
     fn confirm_hard_delete_session(&mut self, session_id: SessionId) {
         let Some(idx) = self.sessions.iter().position(|s| s.info.id == session_id) else {
             return;
         };
 
-        // Reuse the headless teardown so the destructive logic stays in one
-        // place. Best-effort: failures are logged, never abort the delete.
-        if let Err(e) =
-            crate::session_ops::delete::delete_session_headless(&self.db, session_id, true)
-        {
-            error!("Hard-delete of session {session_id} failed: {e}");
+        // Snapshot the shared row before the soft-delete so the background
+        // teardown still has the window name + worktrees + agent_session_id.
+        let shared = match self.db.get_session_by_id(session_id) {
+            Ok(opt) => opt,
+            Err(e) => {
+                error!("Hard-delete lookup for session {session_id} failed: {e}");
+                None
+            }
+        };
+
+        if let Err(e) = self.db.disable_send_automations_for_session(session_id) {
+            error!("Failed to disable pending sends for session {session_id}: {e}");
+        }
+        if let Err(e) = self.db.soft_delete_session(session_id) {
+            error!("Failed to soft-delete session {session_id}: {e}");
         }
 
         let removed_session = self.sessions.remove(idx);
@@ -1522,9 +1533,16 @@ impl App {
         }
         self.sync_active_session_to_project();
 
-        // Drop the live PTY connection (the tmux window was already killed by
-        // the teardown above).
+        // Drop the live PTY connection; the tmux window itself is killed by
+        // the background teardown below.
         removed_session.kill();
+
+        if let Some(shared) = shared {
+            tokio::task::spawn_blocking(move || {
+                let mut report = crate::session_ops::delete::ForceDeleteReport::default();
+                crate::session_ops::delete::teardown_runtime_resources(&shared, &mut report);
+            });
+        }
 
         self.set_status(
             StatusLevel::Info,

--- a/src/session_ops/delete.rs
+++ b/src/session_ops/delete.rs
@@ -36,7 +36,10 @@ pub fn delete_session_headless(
     let mut report = ForceDeleteReport::default();
 
     if force {
-        force_teardown(db, session_id, &session, &mut report)?;
+        teardown_runtime_resources(&session, &mut report);
+        report.disabled_automations = db
+            .disable_send_automations_for_session(session_id)
+            .map_err(|e| format!("disable_send_automations_for_session: {e}"))?;
     }
 
     db.soft_delete_session(session_id)
@@ -45,16 +48,16 @@ pub fn delete_session_headless(
     Ok(report)
 }
 
-/// Tear down a session's runtime resources for a force-delete: kill the tmux
-/// window, remove worktrees + the symlink workspace, and disable any pending
-/// `Send` automations. Best-effort cleanup is recorded in `report`; only the
-/// automation-disable failure (a DB error) aborts.
-fn force_teardown(
-    db: &Database,
-    session_id: SessionId,
+/// Tear down a session's slow runtime resources: kill the tmux window, remove
+/// worktrees + the symlink workspace. Touches no SQLite — safe to call from a
+/// background thread after the row has been soft-deleted on the UI thread, so
+/// the TUI's hard-delete confirmation can close without blocking on a remote
+/// `kill-window` or a `git worktree remove`. Best-effort: failures are logged
+/// into `report` (or `tracing::warn`), never abort.
+pub fn teardown_runtime_resources(
     session: &crate::sync::SharedSession,
     report: &mut ForceDeleteReport,
-) -> Result<(), String> {
+) {
     // Capture the pane's OS pid *before* the kill so we can reap the pane's child
     // process below. Windows refuses to remove a directory that is a live
     // process's cwd, and a session's agent runs with cwd = its worktree /
@@ -93,12 +96,6 @@ fn force_teardown(
             tracing::warn!("remove_workspace({asid}) failed: {e}");
         }
     }
-
-    report.disabled_automations = db
-        .disable_send_automations_for_session(session_id)
-        .map_err(|e| format!("disable_send_automations_for_session: {e}"))?;
-
-    Ok(())
 }
 
 /// Wait (≈5s) for a killed pane's child process to exit, force-terminating it as


### PR DESCRIPTION
## Summary

- Confirming the hard-delete prompt ran `delete_session_headless` synchronously, so the modal kept rendering until tmux `kill-window` + every `git worktree remove` + symlink-workspace cleanup returned — visibly hanging on remote hosts and large worktrees.
- Split the slow runtime teardown into a public, DB-free `teardown_runtime_resources` (`src/session_ops/delete.rs`) and run it from `confirm_hard_delete_session` (`src/app/mod.rs:1503`) via `tokio::task::spawn_blocking`. Only the fast SQLite writes (soft-delete + disable pending sends) and the UI/PTY drop stay on the UI thread, so the next paint shows the row gone.
- Headless `delete_session_headless` keeps its existing ordering (runtime → automation disable → soft-delete), so `thurbox-cli session delete --force` behavior is unchanged.

## Test plan

- [x] `cargo check --all`
- [x] `cargo nextest run -E 'test(delete)'` (35 passed)
- [ ] Manually disable `[features] soft_delete`, confirm hard-delete in the TUI, verify the modal closes the moment Enter is pressed and the worktree is gone shortly after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)