### PR TITLE
feat(core): best-effort restore for force-deleted sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -572,9 +572,15 @@ window, remove worktrees + the symlink workspace, and disable
 when no TUI is running. Teardown is best-effort (failures land in
 the JSON report); the row is always soft-deleted last. A `--force`
 delete also stamps the `sessions.force_deleted` column (schema v37):
-the row still appears in the restore list **tagged `force-deleted`**,
-but `restore` refuses it (its worktrees + any uncommitted work are
-gone). A plain soft delete stays restorable.
+the row still appears in the restore list **tagged `force-deleted`** and
+is restorable **best-effort** — force-delete removes the worktree
+*directory* but not the git branch, so restore reattaches each surviving
+branch's committed work (`App::recreate_worktrees`); only uncommitted/
+untracked changes are gone. Because that recovery is lossy, the headless
+`session restore` **refuses a force-deleted row unless `--best-effort`**
+is passed (its JSON then carries `best_effort: true`); a plain soft delete
+restores with no flag. `restore_session` clears both `deleted_at` and
+`force_deleted`.
 
 The **TUI** `Ctrl+D` soft-deletes by default too (with a `Ctrl+Z` undo
 window). The `[features] soft_delete` flag (settings.toml, default
@@ -588,8 +594,12 @@ that can't be verified (remote host / git error → confirm to be safe;
 `App::assess_delete_risk` + `modals::DeleteRisk::from_stats` over
 `git::worktree_stats`). The modal itemizes what would be lost; a
 known-clean session is deleted with no prompt. A force-deleted session
-is then tagged + blocked in the restore list (above). The flag never
-changes `thurbox-cli session delete`, which stays soft unless `--force`.
+is then tagged in the restore list (above); restoring one via `Ctrl+U`
+(`Enter`) first asks for confirmation (`Modal::ConfirmRestore`, rendered
+by `ui::confirm_restore_modal`) since the recovery is best-effort
+(committed branch state only), then runs the normal restore path. The
+flag never changes `thurbox-cli session delete`, which stays soft unless
+`--force`.
 
 ### Parent sessions (lead/worker)
 

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -531,6 +531,50 @@ fn restore_sessions_modal_empty() {
     insta::assert_snapshot!(h.render());
 }
 
+#[test]
+fn force_deleted_restore_confirms_then_best_effort_restores() {
+    let mut h = Harness::standard(1);
+
+    // Persist the stub session, then force-delete it — the soft-deleted +
+    // force-deleted DB row a best-effort recovery acts on (no worktrees → no
+    // on-disk teardown needed).
+    let id = h.app.sessions[0].info.id;
+    let shared = h.app.session_to_shared(&h.app.sessions[0]);
+    h.app.db.upsert_session(&shared).unwrap();
+    crate::session_ops::delete_session_headless(&h.app.db, id, true).unwrap();
+    assert!(
+        h.app.db.get_deleted_session_by_id(id).unwrap().is_some(),
+        "row is soft-deleted + force-deleted"
+    );
+
+    // Ctrl+U lists it; Enter on a force-deleted row opens the confirm prompt
+    // rather than restoring immediately.
+    h.ctrl('u');
+    assert!(matches!(h.app.modal, modals::Modal::RestoreSessions(_)));
+    h.key(KeyCode::Enter, KeyModifiers::NONE);
+    assert!(
+        matches!(h.app.modal, modals::Modal::ConfirmRestore(_)),
+        "Enter on a force-deleted row asks for confirmation"
+    );
+    assert!(
+        h.app.db.get_deleted_session_by_id(id).unwrap().is_some(),
+        "nothing restored before confirmation"
+    );
+
+    // Confirm → `restore_session` clears `deleted_at` + `force_deleted`, so the
+    // row leaves the deleted list and is an active session again.
+    h.key(KeyCode::Enter, KeyModifiers::NONE);
+    assert!(!h.app.modal.is_open(), "confirm closes the prompt");
+    assert!(
+        h.app.db.get_deleted_session_by_id(id).unwrap().is_none(),
+        "the session is no longer in the deleted list"
+    );
+    assert!(
+        h.app.db.get_session_by_id(id).unwrap().is_some(),
+        "the row is an active session again"
+    );
+}
+
 // ── Delete + undo ────────────────────────────────────────────────────────────
 
 #[test]

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -297,6 +297,7 @@ impl App {
             Modal::RepoPicker(_) => self.handle_repo_picker_key(code, mods),
             Modal::TaskActionPicker(_) => self.handle_task_action_picker_key(code),
             Modal::ConfirmDelete(_) => self.handle_confirm_delete_key(code),
+            Modal::ConfirmRestore(_) => self.handle_confirm_restore_key(code),
             Modal::Settings(_) => self.handle_settings_key(code, mods),
             _ => return false,
         }
@@ -327,6 +328,25 @@ impl App {
                 let session_id = cd.session_id;
                 self.modal.close();
                 self.confirm_hard_delete_session(session_id);
+            }
+            KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
+                self.modal.close();
+            }
+            _ => {}
+        }
+    }
+
+    /// Drive the best-effort restore confirmation for a force-deleted session:
+    /// `Enter`/`y` restores (committed branch state only), `Esc`/`n` cancels.
+    fn handle_confirm_restore_key(&mut self, code: KeyCode) {
+        let super::modals::Modal::ConfirmRestore(ref cr) = self.modal else {
+            return;
+        };
+        match code {
+            KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
+                let deleted = cr.deleted.clone();
+                self.modal.close();
+                self.restore_deleted_session(deleted);
             }
             KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
                 self.modal.close();
@@ -609,8 +629,17 @@ impl App {
                 if rs.index >= rs.list.len() && rs.index > 0 {
                     rs.index -= 1;
                 }
-                self.modal.close();
-                self.restore_deleted_session(deleted);
+                // A force-deleted session lost its uncommitted work; confirm the
+                // best-effort recovery first. Plain soft-deletes restore directly.
+                if deleted.force_deleted {
+                    self.modal =
+                        super::modals::Modal::ConfirmRestore(super::modals::ConfirmRestoreModal {
+                            deleted,
+                        });
+                } else {
+                    self.modal.close();
+                    self.restore_deleted_session(deleted);
+                }
             }
             _ => {}
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1727,16 +1727,15 @@ impl App {
     }
 
     /// Restore a soft-deleted session: un-delete in DB, recreate worktrees, and spawn.
+    ///
+    /// Works for force-deleted sessions too, on a best-effort basis: force-delete
+    /// removed the worktree directory but not the git branch, so
+    /// [`Self::recreate_worktrees`] reattaches each branch that still exists
+    /// (uncommitted work was lost on delete). `restore_session` also clears the
+    /// `force_deleted` flag. The TUI gates this behind a confirm modal.
     fn restore_deleted_session(&mut self, deleted: DeletedSessionInfo) {
-        // A force-deleted session had its worktrees + tmux window torn down (and
-        // any uncommitted work lost), so there's nothing coherent to restore.
-        if deleted.force_deleted {
-            self.set_error(format!(
-                "'{}' was force-deleted; its worktrees were removed and it can't be restored",
-                deleted.name
-            ));
-            return;
-        }
+        let was_force_deleted = deleted.force_deleted;
+        let wanted_worktrees = deleted.worktrees.len();
 
         if let Err(e) = self.db.restore_session(deleted.id) {
             error!("Failed to restore session in DB: {e}");
@@ -1745,6 +1744,7 @@ impl App {
         }
 
         let worktree_infos = Self::recreate_worktrees(&deleted.worktrees);
+        let recovered_worktrees = worktree_infos.len();
         let cwd = worktree_infos
             .first()
             .map(|wt| wt.worktree_path.clone())
@@ -1803,7 +1803,21 @@ impl App {
 
                 self.save_state();
 
-                self.set_status(StatusLevel::Success, format!("Restored '{session_name}'"));
+                if was_force_deleted {
+                    // Recovery is lossy: note it, and flag any worktree whose
+                    // branch was gone (so couldn't be reattached).
+                    let mut msg =
+                        format!("Restored '{session_name}' (best-effort: uncommitted work lost");
+                    if recovered_worktrees < wanted_worktrees {
+                        msg.push_str(&format!(
+                            ", {recovered_worktrees} of {wanted_worktrees} worktrees recovered"
+                        ));
+                    }
+                    msg.push(')');
+                    self.set_status(StatusLevel::Info, msg);
+                } else {
+                    self.set_status(StatusLevel::Success, format!("Restored '{session_name}'"));
+                }
             }
             Err(e) => {
                 error!("Failed to spawn restored session: {e}");

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -604,6 +604,16 @@ pub struct ConfirmDeleteModal {
     pub risk: DeleteRisk,
 }
 
+/// Confirmation prompt for a **best-effort** restore of a force-deleted session.
+/// Force-delete tore down the worktree directory + tmux window (and any
+/// uncommitted work), but the git branch — and its committed history — survives,
+/// so restore can reattach it. This modal warns that only committed state is
+/// recovered, then restores the carried session on confirm.
+#[derive(Debug, Clone)]
+pub struct ConfirmRestoreModal {
+    pub deleted: DeletedSessionInfo,
+}
+
 // ── RestoreSessionsModal ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Default)]
@@ -1807,6 +1817,7 @@ pub enum Modal {
     ThemePicker(ThemePickerModal),
     TaskActionPicker(TaskActionPickerModal),
     ConfirmDelete(ConfirmDeleteModal),
+    ConfirmRestore(ConfirmRestoreModal),
     Settings(SettingsModal),
 }
 

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -690,6 +690,16 @@ impl App {
             );
         }
 
+        // Best-effort restore confirmation (a force-deleted session)
+        if let super::modals::Modal::ConfirmRestore(ref cr) = self.modal {
+            return crate::ui::confirm_restore_modal::render_confirm_restore_modal(
+                frame,
+                &crate::ui::confirm_restore_modal::ConfirmRestoreState {
+                    session_name: &cr.deleted.name,
+                },
+            );
+        }
+
         Vec::new()
     }
 

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -78,6 +78,10 @@ pub enum Action {
     Restore {
         /// Session UUID.
         uuid: String,
+        /// Recover a force-deleted session best-effort: only committed branch
+        /// state comes back (uncommitted/untracked work was lost on delete).
+        #[arg(long)]
+        best_effort: bool,
     },
     /// Restart a session in-place (kills the window, re-spawns with --resume).
     Restart {
@@ -232,7 +236,7 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 human,
             ))
         }
-        Action::Restore { uuid } => {
+        Action::Restore { uuid, best_effort } => {
             let id: SessionId = uuid
                 .parse()
                 .map_err(|_| format!("Invalid session UUID: {uuid}"))?;
@@ -240,21 +244,35 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 .get_deleted_session_by_id(id)
                 .map_err(|e| format!("get_deleted_session_by_id: {e}"))?
                 .ok_or_else(|| format!("Deleted session not found: {uuid}"))?;
-            if deleted.force_deleted {
+            // A force-deleted session lost its uncommitted work; restoring it only
+            // recovers committed branch state, so require an explicit opt-in.
+            if deleted.force_deleted && !best_effort {
                 return Err(format!(
-                    "Session '{}' was force-deleted; its worktrees were removed and it can't be restored",
+                    "Session '{}' was force-deleted; pass --best-effort to recover committed work (uncommitted/untracked changes are gone)",
                     deleted.name
                 ));
             }
+            // `restore_session` clears `deleted_at` and `force_deleted`; a running
+            // TUI re-creates worktrees + the tmux window on its next sync.
             db.restore_session(deleted.id)
                 .map_err(|e| format!("restore_session: {e}"))?;
+            let best_effort_recovery = deleted.force_deleted;
+            let human = if best_effort_recovery {
+                format!(
+                    "Restored session '{}' ({}) — best-effort: uncommitted work was not recovered",
+                    deleted.name, deleted.id
+                )
+            } else {
+                format!("Restored session '{}' ({})", deleted.name, deleted.id)
+            };
             Ok(CommandOutput::new(
                 json!({
                     "restored": true,
                     "id": deleted.id.to_string(),
                     "name": deleted.name,
+                    "best_effort": best_effort_recovery,
                 }),
-                format!("Restored session '{}' ({})", deleted.name, deleted.id),
+                human,
             ))
         }
         Action::Restart { uuid } => {
@@ -726,11 +744,55 @@ mod tests {
         let restored = run(
             Action::Restore {
                 uuid: id.to_string(),
+                best_effort: false,
             },
             &db,
         )
         .unwrap();
         assert_eq!(restored["restored"], true);
+        assert_eq!(restored["best_effort"], false);
+        assert!(db.get_session_by_id(id).unwrap().is_some());
+    }
+
+    #[test]
+    fn restore_force_deleted_requires_best_effort_flag() {
+        let db = db();
+        let shared = make_test_session("forced");
+        let id = shared.id;
+        db.upsert_session(&shared).unwrap();
+
+        // Force-delete marks the row force_deleted; restore must then opt in.
+        run(
+            Action::Delete {
+                uuid: id.to_string(),
+                force: true,
+            },
+            &db,
+        )
+        .unwrap();
+
+        let err = run(
+            Action::Restore {
+                uuid: id.to_string(),
+                best_effort: false,
+            },
+            &db,
+        )
+        .unwrap_err();
+        assert!(err.contains("--best-effort"), "{err}");
+        // Still soft-deleted (refused).
+        assert!(db.get_deleted_session_by_id(id).unwrap().is_some());
+
+        let restored = run(
+            Action::Restore {
+                uuid: id.to_string(),
+                best_effort: true,
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(restored["restored"], true);
+        assert_eq!(restored["best_effort"], true);
         assert!(db.get_session_by_id(id).unwrap().is_some());
     }
 }

--- a/src/ui/confirm_delete_modal.rs
+++ b/src/ui/confirm_delete_modal.rs
@@ -1,13 +1,9 @@
 use ratatui::{
-    layout::{Constraint, Direction, Layout},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::Paragraph,
     Frame,
 };
 
-use super::centered_fixed_height_rect;
-use super::render_modal_frame_danger;
 use super::theme::Theme;
 use crate::app::modals::DeleteRisk;
 
@@ -103,32 +99,17 @@ pub fn render_confirm_delete_modal(
         Style::default().fg(Theme::danger()),
     )));
 
-    // Outer height: the body lines + a blank spacer + the footer row (2), plus
-    // the top/bottom border (2).
-    let height = body.len() as u16 + 2 + 2;
-    let area = centered_fixed_height_rect(MODAL_WIDTH_PCT, height, frame.area());
-    let inner = render_modal_frame_danger(frame, area, "Delete session");
-
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(body.len() as u16),
-            Constraint::Length(1), // blank spacer
-            Constraint::Length(1), // footer
-        ])
-        .split(inner);
-
-    frame.render_widget(Paragraph::new(body), chunks[0]);
-
-    super::render_action_footer(
+    super::render_confirm_modal(
         frame,
-        chunks[2],
+        MODAL_WIDTH_PCT,
+        "Delete session",
+        true,
+        body,
         (
             "Delete",
             crossterm::event::KeyCode::Enter,
             crossterm::event::KeyModifiers::NONE,
         ),
-        "Cancel",
     )
 }
 

--- a/src/ui/confirm_restore_modal.rs
+++ b/src/ui/confirm_restore_modal.rs
@@ -1,0 +1,89 @@
+use ratatui::{
+    style::{Modifier, Style},
+    text::{Line, Span},
+    Frame,
+};
+
+use super::theme::Theme;
+
+const MODAL_WIDTH_PCT: u16 = 60;
+
+pub struct ConfirmRestoreState<'a> {
+    pub session_name: &'a str,
+}
+
+/// Render the best-effort restore confirmation prompt for a force-deleted
+/// session. Force-delete removed the worktree directory + tmux window (and any
+/// uncommitted work), but the git branch and its committed history survive, so
+/// restore reattaches what's left. This warns that only committed state comes
+/// back before acting.
+pub fn render_confirm_restore_modal(
+    frame: &mut Frame,
+    state: &ConfirmRestoreState<'_>,
+) -> super::ModalButtons {
+    let body: Vec<Line> = vec![
+        Line::from(vec![
+            Span::raw("Restore force-deleted "),
+            Span::styled(
+                format!("'{}'", state.session_name),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("?"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "This is best-effort: committed work on the branch is reattached,",
+            Style::default().fg(Theme::text_secondary()),
+        )),
+        Line::from(Span::styled(
+            "but uncommitted and untracked changes were lost on delete.",
+            Style::default().fg(Theme::danger()),
+        )),
+    ];
+
+    super::render_confirm_modal(
+        frame,
+        MODAL_WIDTH_PCT,
+        "Restore session",
+        false,
+        body,
+        (
+            "Restore",
+            crossterm::event::KeyCode::Enter,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn rendered_text(name: &str) -> String {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_confirm_restore_modal(frame, &ConfirmRestoreState { session_name: name });
+            })
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn warns_about_lost_work_and_shows_footer() {
+        let out = rendered_text("my-session");
+        assert!(out.contains("my-session"), "{out}");
+        assert!(out.contains("best-effort"), "{out}");
+        assert!(out.contains("uncommitted"), "{out}");
+        assert!(out.contains("Restore"), "{out}");
+        assert!(out.contains("Cancel"), "{out}");
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ pub mod automations_list_modal;
 pub mod automations_panel;
 pub mod branch_selector_modal;
 pub mod confirm_delete_modal;
+pub mod confirm_restore_modal;
 pub mod file_viewer;
 pub mod global_search;
 pub mod highlight;
@@ -570,6 +571,45 @@ pub fn render_modal_frame_danger(frame: &mut Frame, area: Rect, title: &str) -> 
     let inner = block.inner(area);
     frame.render_widget(block, area);
     inner
+}
+
+/// Render a centered yes/no confirmation modal: the `body` lines, a blank
+/// spacer, and an action footer (`confirm` label/key + a `Cancel` button).
+/// `danger` picks the red-bordered frame. Returns the footer buttons. Shared by
+/// the delete / restore confirmations so their scaffold reads identically.
+pub fn render_confirm_modal(
+    frame: &mut Frame,
+    width_pct: u16,
+    title: &str,
+    danger: bool,
+    body: Vec<Line>,
+    confirm: (
+        &str,
+        crossterm::event::KeyCode,
+        crossterm::event::KeyModifiers,
+    ),
+) -> ModalButtons {
+    // Outer height: the body lines + a blank spacer + the footer row, plus the
+    // top/bottom border (2).
+    let height = body.len() as u16 + 2 + 2;
+    let area = centered_fixed_height_rect(width_pct, height, frame.area());
+    let inner = if danger {
+        render_modal_frame_danger(frame, area, title)
+    } else {
+        render_modal_frame(frame, area, title)
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(body.len() as u16),
+            Constraint::Length(1), // blank spacer
+            Constraint::Length(1), // footer
+        ])
+        .split(inner);
+
+    frame.render_widget(Paragraph::new(body), chunks[0]);
+    render_action_footer(frame, chunks[2], confirm, "Cancel")
 }
 
 /// Set up a list modal with dim overlay, styled border, and list + footer split.

--- a/src/ui/restore_sessions_modal.rs
+++ b/src/ui/restore_sessions_modal.rs
@@ -58,7 +58,8 @@ pub fn render_restore_sessions_modal(
                 " {} ({}) {}{} ",
                 entry.name, entry.agent, entry.deleted_ago, wt_indicator
             );
-            // A force-deleted row is dimmed (it can't be restored) and tagged.
+            // A force-deleted row is dimmed + tagged: it restores best-effort
+            // (committed branch state only — uncommitted work was lost on delete).
             let base_style = if selected {
                 Theme::selected_item()
             } else if entry.force_deleted {


### PR DESCRIPTION
## Summary

- Force-delete removes the worktree *directory* but not the git branch, so a force-deleted session's **committed work survives**. Allow restoring it best-effort instead of refusing outright.
- **TUI**: `Enter` on a force-deleted row in the restore list (`Ctrl+U`) opens a new `ConfirmRestore` modal warning that uncommitted/untracked work is gone, then runs the normal restore path. The success toast notes it was best-effort and how many worktrees were recovered.
- **CLI**: `session restore` refuses a force-deleted row unless `--best-effort` is passed; the JSON then carries `best_effort: true`.
- No schema change: `recreate_worktrees` already reattaches only surviving branches, and `restore_session` already clears the `force_deleted` flag.

## Test plan

- `cargo nextest run --all` — full suite (1571 tests) green, including:
  - `confirm_restore_modal::warns_about_lost_work_and_shows_footer` (render test)
  - `cli::sessions::tests::restore_force_deleted_requires_best_effort_flag` (flag gating)
  - `app::acceptance::force_deleted_restore_confirms_then_best_effort_restores` (Ctrl+U → confirm → restore + DB state)
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Manual (sandbox): create a worktree session, `session delete --force`, confirm plain `session restore` is refused and `--best-effort` recovers the branch's committed work with the worktree dir recreated.