### PR TITLE
feat(ui): fancier mouse-hover highlight (bg band + accent fill)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7670,10 +7670,10 @@ mod tests {
         assert_eq!(rp.focus, modals::RepoPickerFocus::Input);
     }
 
-    /// Hovering a footer button reverses its cells (a button-like hover),
-    /// distinct from the underline a list row gets.
+    /// Hovering a footer button brightens its fill to `accent_bright` (a
+    /// button-like hover), distinct from the background band a list row gets.
     #[test]
-    fn hovering_footer_button_reverses_it() {
+    fn hovering_footer_button_brightens_it() {
         let mut app = app_with_sessions(1);
         let backend = ratatui::backend::TestBackend::new(120, 30);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -7687,11 +7687,10 @@ mod tests {
         app.update(AppMessage::MouseMove { x: r.x, y: r.y });
         terminal.draw(|f| app.view(f)).unwrap();
         let buf = terminal.backend().buffer();
-        assert!(
-            buf[(r.x, r.y)]
-                .modifier
-                .contains(ratatui::style::Modifier::REVERSED),
-            "hovered footer button should be reversed"
+        assert_eq!(
+            buf[(r.x, r.y)].bg,
+            crate::ui::theme::Theme::accent_bright(),
+            "hovered footer button should brighten to accent_bright"
         );
     }
 
@@ -7930,9 +7929,9 @@ mod tests {
         assert!(rx.try_recv().is_err(), "legacy encoding must not forward");
     }
 
-    /// The hovered clickable row is underlined in the rendered frame.
+    /// The hovered clickable row gets a background band in the rendered frame.
     #[test]
-    fn hovered_session_row_is_underlined() {
+    fn hovered_session_row_gets_background_band() {
         let mut app = app_with_sessions(2);
         let backend = ratatui::backend::TestBackend::new(120, 30);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
@@ -7948,17 +7947,15 @@ mod tests {
         app.update(AppMessage::MouseMove { x: row.x, y: row.y });
         terminal.draw(|f| app.view(f)).unwrap();
 
+        let band = crate::ui::theme::Theme::selection_bg();
         let buffer = terminal.backend().buffer();
-        assert!(
-            buffer[(row.x, row.y)]
-                .modifier
-                .contains(ratatui::style::Modifier::UNDERLINED),
-            "hovered row cell must be underlined"
+        assert_eq!(
+            buffer[(row.x, row.y)].bg,
+            band,
+            "hovered row cell must get the selection_bg band"
         );
-        // A cell outside any clickable row stays plain.
-        assert!(!buffer[(0, 0)]
-            .modifier
-            .contains(ratatui::style::Modifier::UNDERLINED));
+        // A cell outside any clickable row keeps its non-band background.
+        assert_ne!(buffer[(0, 0)].bg, band);
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -6,7 +6,7 @@
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::Style,
     text::{Line, Span},
     widgets::Paragraph,
     Frame,
@@ -63,10 +63,12 @@ impl App {
         self.apply_selection_highlight(frame);
     }
 
-    /// Underline the clickable row under the mouse pointer (list panes and
-    /// selector-modal rows) so what a click would hit is visible before
-    /// clicking. Runs on the recorded click targets, after all rendering;
-    /// the selection highlight is applied later and wins on overlap.
+    /// Highlight the clickable element under the mouse pointer so what a click
+    /// would hit is visible before clicking. List/selector rows get a subtle
+    /// background band (the theme's `selection_bg`); buttons brighten their
+    /// fill to `accent_bright`. Runs on the recorded click targets, after all
+    /// rendering; the text selection highlight is applied later and wins on
+    /// overlap.
     fn apply_hover_highlight(&self, frame: &mut Frame) {
         let Some((hx, hy)) = self.mouse_hover else {
             return;
@@ -105,24 +107,25 @@ impl App {
         let Some(target) = hovered else {
             return;
         };
-        // Buttons (footer + modal) get a stronger, button-like hover — reverse
-        // the styled cell so an accent chip lights up — while list rows just
-        // underline to mark what a click would hit.
+        // Buttons (footer + modal) get a stronger, button-like hover — brighten
+        // their fill to the accent so the chip lights up — while list rows get a
+        // subtle background band to mark what a click would hit. Either way we
+        // tint the background only, leaving each cell's fg/modifiers intact.
         let is_button = matches!(
             target.action,
             ClickAction::Global(_) | ClickAction::ModalButton { .. }
         );
-        let hover_mod = if is_button {
-            Modifier::REVERSED
+        let hover_bg = if is_button {
+            Theme::accent_bright()
         } else {
-            Modifier::UNDERLINED
+            Theme::selection_bg()
         };
         let buf = frame.buffer_mut();
         let rect = target.rect;
         for y in rect.y..rect.y + rect.height {
             for x in rect.x..rect.x + rect.width {
                 if let Some(cell) = buf.cell_mut(ratatui::layout::Position::new(x, y)) {
-                    cell.modifier |= hover_mod;
+                    cell.set_bg(hover_bg);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Hovered list rows (sessions, tasks, automations, file tree, modal rows) now get a subtle **background band** from the theme's `selection_bg` instead of `Modifier::UNDERLINED`.
- Hovered buttons (footer pills, modal footer buttons) now **brighten their fill to `accent_bright`** instead of a raw `Modifier::REVERSED` swap.
- Both treatments tint the **background only**, leaving each cell's fg/modifiers intact (status dots, branch colours, bold all survive).
- Reuses existing per-theme colours — no new theme fields, works across all 9 presets + custom themes. The change is centralized in `App::apply_hover_highlight`.

## Test plan
- `cargo nextest run -E 'test(hover)'` — updated `hovering_footer_button_brightens_it` and `hovered_session_row_gets_background_band` pass.
- `cargo fmt --all --check` + `cargo clippy --all-targets --all-features -- -D warnings` clean (dropped now-unused `Modifier` import).
- Manual: hover rows (band appears) and footer pills (fill brightens); switch themes with `Ctrl+Y` to confirm band/fill track each preset.