### PR TITLE
feat(ui): click a Settings boolean row to toggle it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1464,7 +1464,9 @@ backend dependency stays visible at each call site.
   that key through the modal's own handler so a click matches the keyboard
   path. **Clicking a field** selects it: editor modals (Settings / Automation)
   ship per-field hitboxes recorded as `ClickAction::ModalField(i)` (→
-  `select_modal_field`, sets the active field like Tab/↑↓); the in-pane
+  `select_modal_field`, sets the active field like Tab/↑↓) — and in **Settings**
+  a click on a boolean row also **toggles** it (its whole point is the on/off
+  switch; scalar rows only select, so a stray click never changes a number); the in-pane
   automation/task editors record `ClickAction::PaneField { focus, index }` (→
   focus the editor + `select_pane_field`); the repo picker records
   `ClickAction::RepoFocus(..)` for its path-input / search sub-fields. Hovering

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -290,6 +290,32 @@ impl Harness {
         }
         out
     }
+
+    /// Click the open Settings panel's row for `field`. Renders first so this
+    /// frame's `ModalField` hitboxes exist, locates the one carrying `field`'s
+    /// `ORDER` index, and dispatches a click at its left edge.
+    fn click_settings_field(&mut self, field: modals::SettingsField) -> &mut Self {
+        self.render();
+        let index = modals::SettingsField::ORDER
+            .iter()
+            .position(|f| *f == field)
+            .expect("field in ORDER");
+        let rect = self
+            .app
+            .click_targets
+            .iter()
+            .find_map(|t| match t.action {
+                ClickAction::ModalField(i) if i == index => Some(t.rect),
+                _ => None,
+            })
+            .expect("settings field hitbox recorded");
+        self.app.update(AppMessage::MouseClick {
+            x: rect.x + 1,
+            y: rect.y,
+            modifiers: KeyModifiers::NONE,
+        });
+        self
+    }
 }
 
 // ── Snapshot tests: stable, deterministic screens ────────────────────────────
@@ -430,6 +456,61 @@ fn settings_panel_live_toggle_applies_on_save() {
     assert!(
         !h.app.features.tasks,
         "a live feature flag applies immediately on save"
+    );
+}
+
+#[test]
+fn settings_panel_click_toggles_boolean_field() {
+    let mut h = Harness::standard(1);
+    assert!(h.app.features.mouse, "mouse on by default");
+    assert!(h.app.features.info_panel, "info_panel default on");
+
+    h.ctrl(','); // OpenSettings — opens on the `tasks` field
+                 // Click a *different* field than the one focused on open, so the click must
+                 // both select the row and toggle its boolean.
+    h.click_settings_field(modals::SettingsField::FeatInfoPanel);
+
+    let modals::Modal::Settings(s) = &h.app.modal else {
+        panic!("settings panel still open after the click");
+    };
+    assert_eq!(
+        s.field,
+        modals::SettingsField::FeatInfoPanel,
+        "the click selected the clicked row"
+    );
+    assert!(
+        !s.draft.features.info_panel,
+        "the click also toggled the boolean off in the draft"
+    );
+    assert!(
+        h.app.features.info_panel,
+        "draft edits don't apply until save"
+    );
+}
+
+#[test]
+fn settings_panel_click_does_not_change_scalar() {
+    let mut h = Harness::standard(1);
+    h.ctrl(','); // OpenSettings
+    h.render();
+    let before = match &h.app.modal {
+        modals::Modal::Settings(s) => s.draft.scrollback_lines,
+        _ => unreachable!(),
+    };
+
+    h.click_settings_field(modals::SettingsField::ScrollbackLines);
+
+    let modals::Modal::Settings(s) = &h.app.modal else {
+        panic!("settings panel still open");
+    };
+    assert_eq!(
+        s.field,
+        modals::SettingsField::ScrollbackLines,
+        "the click selected the scalar row"
+    );
+    assert_eq!(
+        s.draft.scrollback_lines, before,
+        "a click never steps a scalar value — only selects it"
     );
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2093,12 +2093,20 @@ impl App {
         }
 
         // Editor-field clicks select that field (no key replay — the user then
-        // adjusts/types with the keyboard, exactly as after Tab/↑↓).
+        // adjusts/types with the keyboard, exactly as after Tab/↑↓). The one
+        // exception is a Settings boolean row, whose whole point is the on/off
+        // switch: clicking it both selects and toggles it (scalar rows just
+        // select, so a stray click can't silently change a numeric value).
         if let Some(index) = self.click_targets.iter().find_map(|t| match t.action {
             ClickAction::ModalField(i) if t.rect.contains(pos) => Some(i),
             _ => None,
         }) {
             self.select_modal_field(index);
+            if let modals::Modal::Settings(s) = &mut self.modal {
+                if !s.field.is_scalar() {
+                    s.toggle();
+                }
+            }
             return;
         }
 

--- a/src/ui/settings_modal.rs
+++ b/src/ui/settings_modal.rs
@@ -182,7 +182,7 @@ fn footer_lines<'a>(state: &SettingsModalState<'_>) -> Vec<Line<'a>> {
     footer.push(key_hint_line(&[
         ("Tab/↑↓", " move  "),
         ("←→", " adjust  "),
-        ("Space", " toggle"),
+        ("Space/click", " toggle"),
     ]));
     footer
 }


### PR DESCRIPTION
## Summary

- Clicking a boolean row in the Settings panel (`Ctrl+,`) now **selects and toggles** it in one click — previously a field click only selected it.
- The toggle reuses the same `SettingsModal::toggle()` the `Space`/`Enter` keyboard path calls, so a click is identical to the keypress (draft-only until `Ctrl+S`).
- Scalar rows (scrollback lines, panel widths, etc.) still only **select** on click, so a stray click can never silently change a numeric value — adjust those with `←/→` or the wheel.
- Footer hint updated to `Space/click  toggle`; gated by the existing `[features] mouse` flag.

## Test plan

- `cargo nextest run -E 'test(settings_panel)'` — added `settings_panel_click_toggles_boolean_field` (click selects + toggles a boolean, draft-only until save) and `settings_panel_click_does_not_change_scalar` (click selects a scalar without stepping it). All 6 settings tests pass.
- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt`; `rumdl check` clean.