### PR TITLE
docs: add thurbox logo (shell box + worker tree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<p align="center">
-  <img src="./website/assets/logo.svg" alt="thurbox" width="340">
-</p>
-
 # Thurbox
+
+<div align="center">
+  <img src="./website/assets/logo.svg" alt="thurbox" width="340">
+</div>
 
 Run any coding-agent CLI in persistent terminal sessions.
 Thurbox is a multi-session TUI orchestrator that launches

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="./website/assets/logo.svg" alt="thurbox" width="340">
+</p>
+
 # Thurbox
 
 Run any coding-agent CLI in persistent terminal sessions.

--- a/website/_includes/base.njk
+++ b/website/_includes/base.njk
@@ -32,7 +32,7 @@ hasOwnMain: false
     <a class="skip-link" href="#main-content">Skip to content</a>
     <nav class="nav{% if navScrolled %} scrolled{% endif %}" id="nav">
       <!-- prettier-ignore -->
-      <a href="{{ root }}/index.html" class="nav-brand">thur<span>box</span></a>
+      <a href="{{ root }}/index.html" class="nav-brand"><img src="{{ root }}/assets/logo-mark.svg" alt="" class="nav-brand-mark" width="26" height="26" />thur<span>box</span></a>
       <button class="hamburger" id="hamburger" aria-label="Toggle menu">
         <span></span>
         <span></span>

--- a/website/assets/favicon.svg
+++ b/website/assets/favicon.svg
@@ -1,5 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="#1a080a"/>
-  <rect x="2" y="2" width="28" height="28" rx="4" fill="none" stroke="#ff5c54" stroke-width="1"/>
-  <text x="6" y="21" font-family="monospace" font-size="14" font-weight="bold" fill="#6eff6e">$_</text>
+  <rect width="32" height="32" rx="7" fill="#1a080a"/>
+  <rect x="1.5" y="1.5" width="29" height="29" rx="5.5" fill="none" stroke="#ff5c54" stroke-width="1.5"/>
+  <text x="5" y="18" font-family="monospace" font-size="13" font-weight="bold" fill="#6eff6e">$</text>
+  <rect x="16" y="11.5" width="8" height="4" rx="0.8" fill="#6eff6e"/>
+  <circle cx="9" cy="24" r="2.1" fill="#6eff6e"/>
+  <circle cx="16" cy="24" r="2.1" fill="#ffb627"/>
+  <circle cx="23" cy="24" r="2.1" fill="#ff5c54"/>
 </svg>

--- a/website/assets/logo-mark.svg
+++ b/website/assets/logo-mark.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="thurbox logo mark">
+  <!-- shell box: the "box" of thur-box with a shell prompt -->
+  <rect x="6" y="7" width="52" height="27" rx="8" fill="#1a080a"/>
+  <rect x="7.25" y="8.25" width="49.5" height="24.5" rx="6.75" fill="none" stroke="#ff5c54" stroke-width="2.5"/>
+  <text x="13" y="28" font-family="'JetBrains Mono','DejaVu Sans Mono',monospace" font-size="15" font-weight="700" fill="#6eff6e">$</text>
+  <rect x="31" y="20.5" width="12" height="5.5" rx="1" fill="#6eff6e"/>
+  <!-- orchestration tree -->
+  <g stroke="#ff5c54" stroke-width="1.8" fill="none" stroke-linecap="round">
+    <path d="M32 34 V40"/>
+    <path d="M14 40 H50"/>
+    <path d="M14 40 V44"/>
+    <path d="M32 40 V44"/>
+    <path d="M50 40 V44"/>
+  </g>
+  <!-- worker session nodes (done / working / blocked) -->
+  <circle cx="14" cy="50" r="5" fill="#1a080a" stroke="#6eff6e" stroke-width="2.2"/>
+  <circle cx="32" cy="50" r="5" fill="#1a080a" stroke="#ffb627" stroke-width="2.2"/>
+  <circle cx="50" cy="50" r="5" fill="#1a080a" stroke="#ff5c54" stroke-width="2.2"/>
+</svg>

--- a/website/assets/logo.svg
+++ b/website/assets/logo.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 252 64" role="img" aria-label="thurbox">
+  <!-- mark: shell box orchestrating a worker tree -->
+  <g>
+    <rect x="6" y="7" width="52" height="27" rx="8" fill="#1a080a"/>
+    <rect x="7.25" y="8.25" width="49.5" height="24.5" rx="6.75" fill="none" stroke="#ff5c54" stroke-width="2.5"/>
+    <text x="13" y="28" font-family="'JetBrains Mono','DejaVu Sans Mono',monospace" font-size="15" font-weight="700" fill="#6eff6e">$</text>
+    <rect x="31" y="20.5" width="12" height="5.5" rx="1" fill="#6eff6e"/>
+    <g stroke="#ff5c54" stroke-width="1.8" fill="none" stroke-linecap="round">
+      <path d="M32 34 V40"/>
+      <path d="M14 40 H50"/>
+      <path d="M14 40 V44"/>
+      <path d="M32 40 V44"/>
+      <path d="M50 40 V44"/>
+    </g>
+    <circle cx="14" cy="50" r="5" fill="#1a080a" stroke="#6eff6e" stroke-width="2.2"/>
+    <circle cx="32" cy="50" r="5" fill="#1a080a" stroke="#ffb627" stroke-width="2.2"/>
+    <circle cx="50" cy="50" r="5" fill="#1a080a" stroke="#ff5c54" stroke-width="2.2"/>
+  </g>
+  <!-- wordmark -->
+  <text x="76" y="44" font-family="'JetBrains Mono','DejaVu Sans Mono',monospace" font-size="34" font-weight="700" letter-spacing="-1">
+    <tspan fill="#f5e6e0">thur</tspan><tspan fill="#ff5c54">box</tspan>
+  </text>
+  <!-- trailing cursor echoing the shell -->
+  <rect x="234" y="22" width="11" height="26" rx="1.5" fill="#6eff6e"/>
+</svg>

--- a/website/css/components.css
+++ b/website/css/components.css
@@ -23,12 +23,21 @@
 }
 
 .nav-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   font-family: var(--font-display);
   font-size: 0.95rem;
   font-weight: 400;
   text-transform: uppercase;
   color: var(--text-primary);
   letter-spacing: 0.02em;
+}
+
+.nav-brand-mark {
+  display: block;
+  width: 26px;
+  height: 26px;
 }
 
 .nav-brand span {


### PR DESCRIPTION
## Summary

- New SVG visual identity built on thurbox's existing terminal/Doom palette (`#1a080a` / `#ff5c54` / `#6eff6e`): a **shell terminal box orchestrating a worker-session tree** — box + shell + orchestration in one mark.
- `website/assets/logo.svg` — horizontal lockup: mark + `thur`(cream)`box`(red) wordmark + trailing green cursor.
- `website/assets/logo-mark.svg` — standalone square mark; worker nodes colored by session status (green=done, yellow=working, red=blocked).
- `website/assets/favicon.svg` — refreshed to match, distilled to box + shell + 3 status dots so it stays legible at 16px.
- `README.md` — centered logo at the top.
- Website nav (`base.njk` + `components.css`) — mark icon beside the wordmark; favicon already referenced (same path, auto-upgraded).

## Test plan

- [x] All three SVGs validate as well-formed XML.
- [x] Rasterized with `rsvg-convert` at 16/26/128/256/520px — mark, lockup, nav icon, and favicon all render cleanly.
- [x] Wordmark "box" red matches the site's existing `--cyan` (`#ff5c54`) so nav text and logo stay color-consistent.
- [x] `prettier --check` passes on `components.css`.