### PR TITLE
docs: compare thurbox vs parallel-agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,52 @@ adds:
   worktree; `Ctrl+S` syncs them with their base branch and asks the
   agent to resolve rebase conflicts automatically.
 
+## Comparison
+
+Lots of tools now "run coding agents in parallel, each in its own git
+worktree". They mostly differ on what's underneath: whether the session
+backend is **real tmux** or a re-implemented multiplexer, whether the UI is a
+lightweight **TUI** or an Electron/native app, whether they launch the
+**unmodified vendor CLI** or their own model, and whether one session can span
+several repos. Thurbox optimizes the boring-but-load-bearing end of that list.
+
+| Tool | Interface | Session backend | Agents | Multi-repo session | Platforms | Remote / SSH | License |
+|------|-----------|-----------------|--------|--------------------|-----------|--------------|---------|
+| **Thurbox** | TUI | **Real tmux** (+ psmux on Windows) | **Any CLI** — data in `agents.toml` | **✓** (one session, many repos) | Linux · macOS · Windows | **✓** (SSH hosts) | MIT |
+| [Conductor](https://www.conductor.build/) | Native GUI | App-managed PTY | Claude, Codex, Cursor | ✗ | macOS only | ✗ | Free (closed source) |
+| [Herdr](https://herdr.dev/) | TUI | **Own** multiplexer (Rust) | Claude, Codex, Gemini | ✗ | Linux · macOS | Runs on a remote box | AGPL-3.0 |
+| [1Code](https://github.com/21st-dev/1code) | Desktop GUI | App-managed PTY | Claude, Codex | ✗ | macOS | Cloud agents | Apache-2.0 |
+| [Orca](https://www.onorca.dev/) | Desktop GUI (Electron) | App-managed PTY | Claude, Codex, Gemini, Cursor + 30 more | ✗ | macOS · Windows · Linux | Remote Orca servers | MIT |
+| [Claude Squad](https://github.com/smtg-ai/claude-squad) | TUI | **Real tmux** | Claude, Codex, OpenCode, Aider, Amp | ✗ | Linux · macOS (no Windows) | ✗ | AGPL-3.0 |
+| [Vibe Kanban](https://github.com/BloopAI/vibe-kanban) | Web (kanban) | App-managed PTY | Claude, Codex, Cursor, Gemini + more | ✗ | Cross-platform | ✗ | Apache-2.0 (community-maintained) |
+| [Cursor](https://cursor.com/) | IDE + cloud | App-managed (its **own** models) | Composer + frontier models | ✗ | macOS · Windows · Linux | Cloud VMs + SSH | Proprietary (paid) |
+
+What makes Thurbox different (some of these are shared — the combination is the
+point):
+
+- **Real tmux, not a re-implemented multiplexer.** Sessions live in the same
+  battle-tested mux that already survives crashes, restarts, and reboots —
+  reattach from any terminal with `tmux -L thurbox attach`. A custom multiplexer
+  is one more thing that can lose your session. (Of the tools above, only Claude
+  Squad shares this.)
+- **A TUI, not an Electron app.** Tiny footprint; runs in a plain terminal,
+  over SSH, on a headless server — no desktop, no GPU, no per-window browser.
+- **Launches the unmodified vendor CLI.** Thurbox knows nothing about the
+  agent's model, prompts, or tools — it just runs `command + args` — so you get
+  the newest agent features the day the CLI ships them, with no wrapper in the
+  way (vs Cursor, which runs its own models).
+- **Any agent CLI as data** (`~/.config/thurbox/agents.toml`) — add your own with
+  no recompile; Thurbox is deliberately agent-neutral.
+- **Multi-repo sessions.** One session can span several repos at once (a
+  per-session symlink workspace), not just one worktree per task.
+
+On top of that, Thurbox is the only entry here that is terminal-native **and**
+runs on Windows **and** over SSH, and it ships a full headless CLI
+(`thurbox-cli`) plus cron-like automations to drive and schedule fleets of
+agents with no GUI at all. The GUI tools trade footprint and that scriptability
+for click-to-review visual diffs and a gentler on-ramp. Feature accuracy as of
+June 2026; check each project for the latest.
+
 ## Features
 
 <table>

--- a/website/_includes/sidebar.njk
+++ b/website/_includes/sidebar.njk
@@ -1,7 +1,8 @@
 {%- set sections = [
   { heading: "Getting Started", links: [
     { slug: "installation", href: "installation.html", label: "Installation" },
-    { slug: "recipes", href: "recipes.html", label: "Recipes" }
+    { slug: "recipes", href: "recipes.html", label: "Recipes" },
+    { slug: "comparison", href: "comparison.html", label: "Comparison" }
   ]},
   { heading: "Features", links: [
     { href: "features.html#session-orchestration", label: "Sessions" },

--- a/website/docs/comparison.html
+++ b/website/docs/comparison.html
@@ -1,0 +1,187 @@
+---
+layout: docs.njk
+title: 'Comparison — Thurbox Docs'
+description: 'How Thurbox compares to other parallel coding-agent tools (Conductor, Herdr, 1Code, Orca, Claude Squad, Vibe Kanban, Cursor): real tmux vs custom multiplexer, TUI vs Electron, native vendor CLI vs own models, and multi-repo sessions.'
+currentPage: 'comparison'
+breadcrumb: 'Comparison'
+---
+<h1>Comparison</h1>
+          <p>
+            Lots of tools now &ldquo;run coding agents in parallel, each in its own git
+            worktree.&rdquo; They mostly differ on what&rsquo;s underneath: whether the session
+            backend is
+            <strong>real tmux</strong>
+            or a re-implemented multiplexer, whether the UI is a lightweight
+            <strong>TUI</strong>
+            or an Electron/native app, whether they launch the
+            <strong>unmodified vendor CLI</strong>
+            or their own model, and whether one session can span several repos. Thurbox optimizes
+            the boring-but-load-bearing end of that list.
+          </p>
+
+          <table>
+            <thead>
+              <tr>
+                <th>Tool</th>
+                <th>Interface</th>
+                <th>Session backend</th>
+                <th>Agents</th>
+                <th>Multi-repo session</th>
+                <th>Platforms</th>
+                <th>Remote / SSH</th>
+                <th>License</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>Thurbox</strong></td>
+                <td>TUI</td>
+                <td><strong>Real tmux</strong> (+ psmux on Windows)</td>
+                <td>
+                  <strong>Any CLI</strong>
+                  &mdash; data in
+                  <code>agents.toml</code>
+                </td>
+                <td><strong>&#x2713;</strong> (one session, many repos)</td>
+                <td>Linux &middot; macOS &middot; Windows</td>
+                <td><strong>&#x2713;</strong> (SSH hosts)</td>
+                <td>MIT</td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="https://www.conductor.build/" target="_blank" rel="noopener">Conductor</a>
+                </td>
+                <td>Native GUI</td>
+                <td>App-managed PTY</td>
+                <td>Claude, Codex, Cursor</td>
+                <td>&#x2717;</td>
+                <td>macOS only</td>
+                <td>&#x2717;</td>
+                <td>Free (closed source)</td>
+              </tr>
+              <tr>
+                <td><a href="https://herdr.dev/" target="_blank" rel="noopener">Herdr</a></td>
+                <td>TUI</td>
+                <td><strong>Own</strong> multiplexer (Rust)</td>
+                <td>Claude, Codex, Gemini</td>
+                <td>&#x2717;</td>
+                <td>Linux &middot; macOS</td>
+                <td>Runs on a remote box</td>
+                <td>AGPL-3.0</td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="https://github.com/21st-dev/1code" target="_blank" rel="noopener">1Code</a>
+                </td>
+                <td>Desktop GUI</td>
+                <td>App-managed PTY</td>
+                <td>Claude, Codex</td>
+                <td>&#x2717;</td>
+                <td>macOS</td>
+                <td>Cloud agents</td>
+                <td>Apache-2.0</td>
+              </tr>
+              <tr>
+                <td><a href="https://www.onorca.dev/" target="_blank" rel="noopener">Orca</a></td>
+                <td>Desktop GUI (Electron)</td>
+                <td>App-managed PTY</td>
+                <td>Claude, Codex, Gemini, Cursor + 30 more</td>
+                <td>&#x2717;</td>
+                <td>macOS &middot; Windows &middot; Linux</td>
+                <td>Remote Orca servers</td>
+                <td>MIT</td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="https://github.com/smtg-ai/claude-squad" target="_blank" rel="noopener">Claude Squad</a>
+                </td>
+                <td>TUI</td>
+                <td><strong>Real tmux</strong></td>
+                <td>Claude, Codex, OpenCode, Aider, Amp</td>
+                <td>&#x2717;</td>
+                <td>Linux &middot; macOS (no Windows)</td>
+                <td>&#x2717;</td>
+                <td>AGPL-3.0</td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="https://github.com/BloopAI/vibe-kanban" target="_blank" rel="noopener">Vibe Kanban</a>
+                </td>
+                <td>Web (kanban)</td>
+                <td>App-managed PTY</td>
+                <td>Claude, Codex, Cursor, Gemini + more</td>
+                <td>&#x2717;</td>
+                <td>Cross-platform</td>
+                <td>&#x2717;</td>
+                <td>Apache-2.0 (community-maintained)</td>
+              </tr>
+              <tr>
+                <td><a href="https://cursor.com/" target="_blank" rel="noopener">Cursor</a></td>
+                <td>IDE + cloud</td>
+                <td>App-managed (its <strong>own</strong> models)</td>
+                <td>Composer + frontier models</td>
+                <td>&#x2717;</td>
+                <td>macOS &middot; Windows &middot; Linux</td>
+                <td>Cloud VMs + SSH</td>
+                <td>Proprietary (paid)</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h2 id="what-makes-thurbox-different">
+            What makes Thurbox different
+            <a href="#what-makes-thurbox-different" class="heading-anchor">#</a>
+          </h2>
+          <p>Some of these are shared &mdash; the combination is the point.</p>
+          <ul>
+            <li>
+              <strong>Real tmux, not a re-implemented multiplexer.</strong>
+              Sessions live in the same battle-tested mux that already survives crashes, restarts,
+              and reboots &mdash; reattach from any terminal with
+              <code>tmux -L thurbox attach</code>
+              . A custom multiplexer is one more thing that can lose your session. (Of the tools
+              above, only Claude Squad shares this.)
+            </li>
+            <li>
+              <strong>A TUI, not an Electron app.</strong>
+              Tiny footprint; runs in a plain terminal, over SSH, on a headless server &mdash; no
+              desktop, no GPU, no per-window browser.
+            </li>
+            <li>
+              <strong>Launches the unmodified vendor CLI.</strong>
+              Thurbox knows nothing about the agent&rsquo;s model, prompts, or tools &mdash; it just
+              runs
+              <code>command + args</code>
+              &mdash; so you get the newest agent features the day the CLI ships them, with no
+              wrapper in the way (vs Cursor, which runs its own models).
+            </li>
+            <li>
+              <strong>Any agent CLI as data</strong>
+              (
+              <code>~/.config/thurbox/agents.toml</code>
+              ) &mdash; add your own with no recompile; Thurbox is deliberately agent-neutral.
+            </li>
+            <li>
+              <strong>Multi-repo sessions.</strong>
+              One session can span several repos at once (a per-session symlink workspace), not just
+              one worktree per task.
+            </li>
+          </ul>
+          <p>
+            On top of that, Thurbox is the only entry here that is terminal-native
+            <strong>and</strong>
+            runs on Windows
+            <strong>and</strong>
+            over SSH, and it ships a full headless CLI (
+            <code>thurbox-cli</code>
+            ) plus cron-like automations to drive and schedule fleets of agents with no GUI at all.
+            The GUI tools trade footprint and that scriptability for click-to-review visual diffs and
+            a gentler on-ramp.
+          </p>
+          <div class="info-box">
+            <p>
+              <strong>Note:</strong>
+              Feature accuracy as of June 2026; these projects move fast, so check each one for the
+              latest.
+            </p>
+          </div>

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -25,6 +25,16 @@ currentPage: 'index'
                 <p>Per-session coding agents, worktrees, automations, and the responsive UI.</p>
               </div>
             </a>
+            <a href="comparison.html" class="docs-hub-card">
+              <div class="card">
+                <div class="card-icon">&#x2696;</div>
+                <h3>Comparison</h3>
+                <p>
+                  How Thurbox stacks up against other parallel coding-agent tools: real tmux, TUI
+                  footprint, native vendor CLI, and multi-repo sessions.
+                </p>
+              </div>
+            </a>
             <a href="extensions.html" class="docs-hub-card">
               <div class="card">
                 <div class="card-icon">&#x1f9e9;</div>


### PR DESCRIPTION
Add a Comparison section to the README and a mirrored website docs page
(website/docs/comparison.html, wired into the sidebar nav + docs hub).

The table is organized around Thurbox's load-bearing differentiators
rather than generic feature checkboxes: session backend (real tmux vs a
re-implemented multiplexer), interface footprint (TUI vs Electron),
agent execution (unmodified vendor CLI vs an app's own models), and
multi-repo-per-session support. Compares against Conductor, Herdr,
1Code, Orca, Claude Squad, Vibe Kanban, and Cursor.

Honest about shared traits (Claude Squad also uses real tmux; Herdr is
also a TUI) — the positioning is the combination, not any single axis.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RHtrcAG4wP5F9k3WVkfdza