### PR TITLE
feat(ui): file viewer diff/review pane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1184,6 +1184,44 @@ global_search` in settings.toml; scopes whose feature is disabled
   (session list, tasks panel) were removed in favour of it. The file
   viewer's `/` (in-file text search) is unrelated and stays.
 
+## File viewer diff/review pane (`Ctrl+E`)
+
+The file viewer (`Ctrl+E`/`F3`, rightmost 20% column at width ≥ 120) is a
+**git-aware diff/review pane**, not just a tree. It annotates the worktree
+tree with the session's changes vs its base ref and shows a color-coded
+unified diff in the central pane.
+
+- **Changed-file glyphs.** Each tracked change gets an `M`/`A`/`D`/`R`/`?`
+  glyph and a status-colored, bold name in the tree, so changed files stand
+  out from unchanged siblings (`ui::file_viewer::build_row_line` +
+  `diff_status_color`). The `Files` block title carries a rollup —
+  ` Files · Δ origin/main 4f +120 -18 ` — so the comparison base is explicit
+  (`diff_header_title`).
+- **Inline diff.** When the file viewer is focused and the selection is a
+  changed file, the **central pane** renders that file's unified diff vs
+  base, colored by line kind (added=green, removed=red, hunk=accent,
+  context/meta=muted) — `ui::diff_view::render_diff`, dispatched from
+  `App::render_central_pane` (mirrors how `InputFocus::TaskList` repurposes
+  the central pane). `PageUp`/`PageDown` scroll it
+  (`App::diff_preview_scroll`). `Enter`/`FileViewerExpand` still opens the
+  real file in `$EDITOR`.
+- **Base ref.** Derived (not persisted) by `git::resolve_base_ref`
+  (`@{upstream}` → `origin/HEAD` → `origin/main` → `origin/master`) — the
+  **same** chain `Ctrl+S` sync rebases onto and `ahead_behind` measures
+  against, so the diff, the "behind" count, and sync never drift. A worktree
+  with no resolvable base shows the plain tree (no glyphs).
+- **Data flow (respects `ui ✗ git`).** Diff types are pure data in
+  `session::diff` (`DiffStatus`/`FileChange`/`WorktreeDiff` +
+  `DiffLine`/`DiffLineKind`/`FileDiff`). `git::changed_files` /
+  `git::file_diff` *produce* them; `App` computes off the render path (a
+  `worktree_diff` `BackgroundTask` on the `GIT_REFRESH_TICKS` cadence, like
+  `git_stats`, cached in `App::cached_diff`; the per-file diff is lazily
+  computed on selection change into `App::cached_file_diff` via
+  `ensure_selected_file_diff`); `ui` only *renders* the `session`-owned
+  types and never references `git`. v1 is **local-only** (remote `ssh:<host>`
+  sessions skip the diff) and diffs the **primary** worktree; multi-repo +
+  remote diff are follow-ups. Full design: `docs/proposals/files-diff-review-pane.md`.
+
 ## Session status (hooks-driven)
 
 The session list shows, at a glance, which agents are blocked, working,

--- a/docs/proposals/files-diff-review-pane.md
+++ b/docs/proposals/files-diff-review-pane.md
@@ -1,0 +1,409 @@
+# Proposal: File viewer → diff/review pane
+
+**Status:** Draft (design only — not implemented)
+**Author:** (proposal)
+**Scope:** Turn the read-only file tree (`Ctrl+E` / `F3`) into a
+glance-able **diff/review pane** that answers *"what did this agent
+change?"* without leaving thurbox.
+
+---
+
+## 1. Motivation
+
+The file viewer today is a read-only directory tree. It walks the
+session's worktree(s) + `additional_dirs` (`expected_root_paths`,
+`src/ui/file_viewer.rs`), lazily expands directories, supports a `/`
+substring search, and opens a file in `$EDITOR` on `Enter`
+(`App::file_viewer_expand` → `open_file_in_editor`,
+`src/app/key_handlers.rs:1632`). It never shells out to git and shows
+nothing about *what changed*.
+
+Meanwhile thurbox's whole value proposition is *multiple agents editing
+code in parallel worktrees*. The single most common question a user has
+when they switch to a session is **"what did this agent just do?"** —
+and answering it means leaving thurbox for `git diff`, a terminal, or an
+editor. The data is already computed for an unrelated feature: the info
+panel shows `GitStats { files_changed, insertions, deletions, dirty,
+ahead, behind }` via `git::worktree_stats` (`src/git/mod.rs:874`). We
+surface the *counts* but not the *content*.
+
+**Goal:** make the file viewer default to a diff-first view of the
+session's worktree, mark changed files with status glyphs so they float
+to the top, and let the user read a syntax-/diff-colored hunk inline.
+
+---
+
+## 2. Grounding: what exists today (verified against the code)
+
+Every claim below was read out of the tree on this branch.
+
+### 2.1 File viewer (`src/ui/file_viewer.rs`)
+
+- `FileNode { path, is_dir, expanded, children: Option<Vec<FileNode>> }`
+  (≈ line 25) — lazy tree node.
+- `FileViewerState { roots: Vec<FileNode>, selected, search_active,
+  search_query, search_cursor }` (≈ line 80) — the persistent state, held
+  on `App` as `file_viewer` (`src/app/mod.rs:509`).
+- `FlatRow { index_path, depth, label, is_dir, expanded }` (≈ line 72) —
+  the flattened render row.
+- `rebuild_from_session(&SessionInfo)` (≈ line 290) populates `roots`
+  from `expected_root_paths` (worktrees → additional_dirs → cwd fallback).
+- `read_dir_sorted` (≈ line 581): dirs-first, dotfiles skipped,
+  case-insensitive name sort. **This sort is where status-based float-to-top
+  ordering would hook in.**
+- `render_file_viewer(frame, area, &FileViewerState, focus) ->
+  (Option<ScrollbarGeom>, Vec<RowHitbox>)` (≈ line 616); per-row spans
+  built in `build_row_line` (≈ line 749) — **this is where glyphs/colors
+  attach.**
+- `selected_file_with_root() -> Option<(PathBuf, PathBuf)>` (≈ line 235)
+  and `activate() -> Activation::Open(PathBuf)` (≈ line 351) drive opening.
+- `enumerate_paths()` (≈ line 542) feeds global search.
+- **No syntax highlighting today.** Rows are colored only by search-match
+  state.
+
+### 2.2 App wiring
+
+- `show_file_viewer: bool` (`src/app/mod.rs:508`); toggled by
+  `act_toggle_file_viewer` (`src/app/key_handlers.rs:1590`), which rebuilds
+  for the active session and resizes.
+- `InputFocus::FileViewer` (`src/app/mod.rs:466`); part of the focus ring
+  (`SessionList → Terminal → FileViewer → TaskList`, `focus_ring` in
+  `key_handlers.rs`).
+- Render hook: `App::render_file_viewer` (`src/app/view.rs:437`) lazily
+  rebuilds via `needs_rebuild_for` and records scrollbar + row click
+  targets (`ScrollTarget::FileViewer`, `ClickAction::SelectFileRow`).
+- Keybindings: `ToggleFileViewer` (Ctrl+E / F3); scoped nav actions
+  `FileViewerDown/Up/Collapse/Expand/Search/NextMatch/PrevMatch` under
+  `KeyContext::FileViewer` (`src/session/keybindings.rs:71`).
+- Layout: `PanelAreas::file_viewer: Option<Rect>`, rightmost ~20% column,
+  only at width ≥ 120 (`src/ui/layout.rs`).
+
+### 2.3 Git plumbing
+
+- `git::worktree_stats(cwd) -> Option<GitStats>` (`src/git/mod.rs:874`).
+  **Important nuance:** its file/line counts come from `git diff --numstat
+  HEAD` — i.e. **uncommitted working-tree changes vs HEAD**, *not* vs the
+  base branch. Only the `ahead/behind` pair (`ahead_behind`, line 854) is
+  base-relative, via `rev-list --left-right --count`.
+- The base ref is **not persisted anywhere per worktree.** It is *derived
+  on demand* by `resolve_sync_base_ref(worktree_path)` (`src/git/mod.rs:709`,
+  private): `@{upstream}` → `origin/HEAD` → `origin/main` → `origin/master`,
+  else `None`. `ahead_behind` (line 854) does its own inline version of the
+  same fallback chain.
+- `git_command(host, cwd, args)` (≈ line 14) builds `git -C <cwd> …`
+  locally or `ssh <dest> git -C <cwd> …` for `ssh:<host>` backends.
+  `run_git_capture(args, cwd)` (line 806) is the local stdout helper
+  (**no host variant yet** — see Risk R4).
+- `WorktreeInfo { repo_path, worktree_path, branch }`
+  (`src/session/mod.rs:47`); `SessionInfo.worktrees: Vec<WorktreeInfo>`
+  and `SessionInfo.git_stats: Option<GitStats>` (line 218).
+- `worktree_branch`/`base_branch` *are* persisted, but only for an
+  `AutomationAction::Spawn` row (schema columns in `storage/tasks.rs`) —
+  not on a live `SessionInfo`/`WorktreeInfo`. So at runtime we have the
+  worktree's *current* branch but must derive its *base*.
+
+### 2.4 Markdown renderer (`src/ui/markdown.rs`)
+
+- `render_markdown(src: &str) -> Vec<Line<'static>>` (line 20), used by
+  `ui/task_detail.rs:129`. Handles headings, emphasis, lists, blockquotes,
+  links, fenced code blocks — but **code blocks are merely dimmed, no
+  syntax/diff coloring.** Backed by `pulldown_cmark` only; the project
+  pulls in **no** `syntect` / `tree-sitter` / `two-face` (verified in
+  `Cargo.toml`).
+
+### 2.5 Architecture constraint (hard rule)
+
+`tests/architecture_rules.rs` allows `ui` to import only `session`, `app`,
+`fuzzy`, `paths` — **`ui` may not reference `git` in any form** (not even a
+fully-qualified `crate::git::…` path; `allowed_path_only` is empty for
+`ui`). `git` may import `session`, `paths`, `shell`. Therefore **all git
+work happens in `app`/`git`; `ui` only renders pre-computed view-model
+data handed to it.** This mirrors the existing `git_stats` flow: `app`
+computes off-thread, stows the result on `SessionInfo`, `ui` reads it.
+
+---
+
+## 3. Design
+
+### 3.1 UX
+
+**Default to diff.** When the pane opens (`Ctrl+E`/`F3`) for a session
+that has a resolvable base and any changes, it opens in **Changes mode**
+instead of the full tree. The pane has two modes, toggled with a new
+scoped key (proposed `t` = "tree", rebindable
+`Action::FileViewerToggleMode`):
+
+| Mode | Shows |
+|------|-------|
+| **Changes** (default when changes exist) | A flat, status-sorted list of changed files vs base, each prefixed with a status glyph and `+a/-d` line deltas. |
+| **Tree** (today's behavior) | The full worktree tree, now *annotated* with the same status glyphs. |
+
+Falling back: if the base can't be resolved or there are zero changes,
+the pane opens in **Tree** mode (today's behavior) with a one-line header
+note (`no base branch` / `no changes vs <base>`), so nothing regresses
+for non-git or pristine sessions.
+
+**Header line.** Both modes show a compact header:
+`Δ <base> · 4 files +120 −18` (base ref short name + rollup, reusing the
+`GitStats` numbers). This makes the comparison point explicit — important
+because the base is *derived*, not chosen by the user (§3.4).
+
+**Status glyphs** (new `git_glyph`/`git_color` in `ui`, fed pre-computed
+status — see §3.3):
+
+| Status | Glyph | Color (theme field) |
+|--------|-------|---------------------|
+| Modified | `M` | `status_working` (yellow) |
+| Added | `A` | `status_idle` (green) |
+| Deleted | `D` | `status_blocked` (red) |
+| Renamed | `R` | accent |
+| Untracked | `?` | muted |
+
+Reuse the existing theme palette (`status_working`/`status_blocked`/
+`status_idle`) rather than inventing new theme fields, to keep the patch
+small; a follow-up can add dedicated `diff_added`/`diff_removed` fields.
+
+**Float to top.** In Tree mode, `read_dir_sorted` is extended so that,
+when status data is present, entries are key-sorted by *(has-changes-desc,
+dirs-first, name)* — a changed file/dir sorts above unchanged siblings,
+and a directory that *contains* a change is marked and floats up so the
+path to a change is visible without hunting. In Changes mode the list is
+already only changed files, sorted by status then path.
+
+**Inline hunk preview.** `Enter` (or `FileViewerExpand`) on a changed
+file no longer only shells to `$EDITOR`. Instead the **central pane**
+shows a read-only, scrollable **diff view** of that file vs base — exactly
+the way the tasks panel takes over the central pane with a markdown
+preview (`view::render_task_workspace`, `ui/task_detail.rs`). The diff is
+rendered with per-line coloring (added = green, removed = red, hunk
+header = accent, context = muted). `PageUp`/`PageDown` scroll it (new
+`App::diff_preview_scroll`, mirroring `task_preview_scroll`). A second
+`Enter` (or a dedicated `o`/`Action::OpenInEditor`-style key) opens the
+real file in `$EDITOR` **at the first changed line** (§3.5). `Esc`/`Ctrl+H`
+returns to the pane.
+
+**Where the diff renders.** Two options were considered:
+
+- *(A — recommended)* Diff in the **central pane** when the file viewer is
+  focused, mirroring how `InputFocus::TaskList` repurposes the central
+  pane. Most screen real estate, consistent with an existing pattern, and
+  keeps the narrow 20% file-viewer column for the file list.
+- *(B)* Diff **inside** the 20% file-viewer column under the list. Rejected
+  for v1: 20% width can't show a useful unified diff.
+
+### 3.2 Affected modules (per CLAUDE.md architecture)
+
+```text
+session  + DiffStatus enum, FileChange struct, FileDiff struct (pure data)
+git      + changed_files(cwd, base) , file_diff(cwd, base, path),
+           resolve_base_ref (promote resolve_sync_base_ref to pub)
+app      + diff cache (BackgroundTask), base-ref resolution, mode state,
+           central-pane diff render dispatch, open-at-line
+ui       + render the diff view + status glyphs from PRE-COMPUTED data only
+```
+
+- **`session/`** (pure data, no deps): add the view-model types so both
+  `git` (producer) and `ui` (consumer) can name them without crossing the
+  `ui ✗ git` boundary — same trick `GitStats` uses (it lives in `session`,
+  produced by `git`, rendered by `ui`).
+  - `enum DiffStatus { Modified, Added, Deleted, Renamed, Untracked }`
+  - `struct FileChange { path: PathBuf, status: DiffStatus, insertions:
+    usize, deletions: usize }`
+  - `struct WorktreeDiff { base_ref: String, files: Vec<FileChange> }`
+  - `struct FileDiff { path, base_ref, lines: Vec<DiffLine> }` where
+    `DiffLine { kind: DiffLineKind, text: String }` and
+    `DiffLineKind { Added, Removed, Context, Hunk, Meta }`. Keeping the
+    parsed line model in `session` means `ui` colors by `kind` and never
+    parses a diff (and never imports git).
+- **`git/`**: add producers.
+  - `pub fn changed_files(cwd: &Path, base: &str) -> Vec<FileChange>` —
+    `git diff --numstat -z <base>` + `git diff --name-status -z <base>`
+    (or one `--numstat --name-status` pass), parsed into `FileChange`.
+    Untracked files come from `git status --porcelain` (the existing
+    `worktree_is_dirty` already runs this). Reuse `parse_numstat`'s shape
+    (line 826).
+  - `pub fn file_diff(cwd: &Path, base: &str, path: &Path) -> FileDiff` —
+    `git diff <base> -- <path>`, parsed line-by-line into `DiffLine`s.
+  - `pub fn resolve_base_ref(cwd: &Path) -> Option<String>` — **promote the
+    existing private `resolve_sync_base_ref` to public** (rename for the
+    broader use), so diff and sync share one base-resolution policy and can
+    never drift. The Ctrl+S sync path keeps calling it.
+  - Add `*_on(host, …)` variants later (Risk R4); v1 may scope diff to
+    local sessions.
+- **`app/`**: the bridge (allowed to import everything).
+  - New `BackgroundTask`-style cache `diff: BackgroundTask<(SessionId,
+    Option<WorktreeDiff>)>` next to the existing `git_stats` task
+    (`src/app/mod.rs:524`), refreshed on the same cadence
+    (`GIT_REFRESH_TICKS ≈ 500`) and on session switch / file-viewer open.
+    Store the resolved `WorktreeDiff` on `App` (or on `SessionInfo`
+    alongside `git_stats`).
+  - Lazily compute `FileDiff` for the *selected* changed file only (cheap;
+    one `git diff -- <path>`), cached by `(session, path, base, mtime)`.
+  - Mode state: `file_viewer_mode: FileViewerMode { Changes, Tree }` on
+    `App` (or inside `FileViewerState`).
+  - Dispatch: when `InputFocus::FileViewer` and the selection is a changed
+    file, `view.rs` renders the diff in the central pane.
+- **`ui/`**: pure rendering only.
+  - `file_viewer::build_row_line` gains an optional `&[FileChange]` (or a
+    `path → DiffStatus` map) param to prefix glyphs/colors. Defaulted/None
+    keeps current behavior.
+  - New `ui/diff_view.rs`: `render_diff(frame, area, &FileDiff, focus,
+    scroll)` — colors each `DiffLine` by `kind`. Pure; receives only
+    `session`-owned data. (We deliberately do **not** route the diff
+    through `render_markdown`: it can't color +/- lines — §2.4 — and a
+    purpose-built renderer is simpler and faster than faking a fenced code
+    block.)
+
+### 3.3 Data flow (no rule violations)
+
+```text
+tick (≈ every 5s) / session-switch / Ctrl+E
+  └─ app: spawn off-thread  git::changed_files(wt, base)         ─┐
+                            base = git::resolve_base_ref(wt)      │  git layer
+  └─ result (SessionId, WorktreeDiff) → cached on App/SessionInfo ┘
+selection moves to a changed file
+  └─ app: git::file_diff(wt, base, path) (lazy, cached)
+view(model)
+  └─ ui::file_viewer::render_file_viewer(.., Some(&changes))   ← glyphs
+  └─ ui::diff_view::render_diff(.., &file_diff, ..)            ← central pane
+```
+
+`ui` only ever sees `session`-owned `WorktreeDiff`/`FileDiff`; `git`
+calls happen exclusively on `app`/`git` threads. This is byte-for-byte
+the `git_stats` pattern that already passes `architecture_rules.rs`.
+
+### 3.4 The base-branch question (the crux)
+
+The task framing assumes "base branch is tracked per worktree." **It is
+not** (§2.3): at runtime we only have `WorktreeInfo.branch` (the worktree's
+*own* branch), and the base is *derived* by `resolve_sync_base_ref`. Three
+consequences:
+
+1. **v1 derives the base** the same way sync does, and shows it in the
+   header so the user knows the comparison point. This is zero new
+   persistence and consistent with Ctrl+S.
+2. **Edge case — no upstream/origin:** a worktree off a *local* base
+   branch with no remote resolves to `None`. v1 falls back to Tree mode
+   with a `no base branch` note (and could offer a future "diff vs HEAD"
+   secondary mode reusing the existing `--numstat HEAD` path).
+3. **Future — persist the base.** The clean fix is to store the base on
+   the worktree at creation: `create_worktree(repo, new_branch,
+   base_branch)` *already receives* the base (`src/git/mod.rs:229`) — it's
+   just dropped after the `git worktree add`. A follow-up adds a
+   `base_branch` column to the session/worktree persistence and threads it
+   into `WorktreeInfo`, making the diff base exact rather than derived.
+   Out of scope for v1 (schema migration); called out as the principled
+   end-state.
+
+### 3.5 Syntax-awareness and open-at-line
+
+- **Diff coloring** (v1): per-line by `DiffLineKind` — green/red/accent/
+  muted. No language grammar needed; ships in the first cut.
+- **Syntax highlighting of code within the diff** (future): the project
+  has *no* highlighter dependency today (§2.4). Adding `syntect` (or
+  `two-face`) pulls in a sizable dep + theme handling and touches
+  `cargo deny` policy. Proposed as an opt-in follow-up gated behind a
+  `[features] syntax_highlight` flag, applied as a second styling pass over
+  the `Context`/`Added`/`Removed` line bodies. Explicitly **not** in v1.
+- **Open at a specific line:** `git diff` hunk headers (`@@ -a,b +c,d @@`)
+  give the new-file line of the first change. `open_file_in_editor` already
+  shells to `$EDITOR`; extend it to pass a `+<line>` argument (e.g.
+  `${EDITOR} +<line> <file>` — vim/nvim/nano/VS Code-`--goto` styles
+  differ, so gate on a small editor-flavor map or honor a
+  `THURBOX_EDITOR_LINE_FMT`). Modest, isolated change in `app`.
+
+---
+
+## 4. Phased implementation plan
+
+**Phase 0 — git producers + data types (no UI).**
+Add `DiffStatus`/`FileChange`/`WorktreeDiff`/`FileDiff`/`DiffLine` to
+`session/`. Add `git::changed_files`, `git::file_diff`, promote
+`resolve_base_ref` to public. Unit-test the parsers with fixture strings
+(mirrors the existing `parse_numstat` tests at `git/mod.rs:~895`). No
+behavior change yet. *Lowest risk; fully testable headless.*
+
+**Phase 1 — status glyphs in Tree mode.**
+Thread a `path → DiffStatus` map from the new `app` diff cache into
+`build_row_line`; render glyphs + colors. Extend `read_dir_sorted` to
+float changed entries. The pane still opens as a tree — purely additive.
+
+**Phase 2 — Changes mode + header + default.**
+Add `FileViewerMode`, the header line, the `t` toggle, and make `Ctrl+E`
+default to Changes when a base resolves and changes exist (else Tree).
+Update the F1 help + CLAUDE.md "Architecture / file viewer" notes.
+
+**Phase 3 — inline diff in the central pane.**
+`ui/diff_view.rs` + `view.rs` dispatch when a changed file is selected.
+Lazy `file_diff` cache, `diff_preview_scroll`, `PageUp`/`PageDown`.
+insta snapshot of a small fixed diff (the acceptance harness renders to a
+`TestBackend`; see `src/app/acceptance.rs`).
+
+**Phase 4 — open-at-line.**
+Extend `open_file_in_editor` with the first-changed-line jump.
+
+**Phase 5 (follow-up, separate PR) — persisted base + syntax highlight.**
+Persist `base_branch` on the worktree (schema migration) for an exact
+base; optional `syntect` behind `[features] syntax_highlight`; remote
+`*_on(host)` diff variants.
+
+Phases 0–4 are the proposal's v1. Each phase is independently shippable
+and leaves the pane working.
+
+---
+
+## 5. Testing
+
+- **Parsers (Phase 0):** unit tests on `changed_files`/`file_diff` over
+  canned `git diff` output, alongside the existing `parse_numstat` tests.
+- **Glyph/sort (Phase 1):** pure tests on the extended `read_dir_sorted`
+  comparator and `build_row_line` span output (no git needed — feed a
+  synthetic status map).
+- **Acceptance (Phases 2–3):** drive the in-process `Harness`
+  (`src/app/acceptance.rs`) — open the pane, assert mode/header state, and
+  insta-snapshot the diff render for a fixed `FileDiff` fixture (avoid live
+  git in the snapshot to keep it deterministic).
+- **Architecture:** `cargo test --test architecture_rules` must stay green
+  — proves `ui` never gained a `git` reference.
+
+---
+
+## 6. Risks & mitigations
+
+- **R1 — base ref ambiguity.** Derived base can surprise (e.g. a stacked
+  branch whose `@{upstream}` is another feature branch). *Mitigation:*
+  always show the resolved base in the header; Phase 5 persists an exact
+  base. Reusing one `resolve_base_ref` for both diff and sync keeps the
+  surprise consistent with existing Ctrl+S behavior.
+- **R2 — performance.** `git diff` per tick on a large worktree could
+  stall. *Mitigation:* run in the existing off-thread `BackgroundTask` on
+  the `GIT_REFRESH_TICKS` cadence (never on the render path), exactly like
+  `git_stats`; lazy `file_diff` only for the selected file; cap rendered
+  diff lines (a `DIFF_LINE_CAP`, mirroring global search's
+  `CONTENT_LINE_CAP`).
+- **R3 — architecture regression.** Easy to accidentally `use crate::git`
+  from `ui`. *Mitigation:* all diff types live in `session`; the
+  `architecture_rules` test fails the build if violated.
+- **R4 — remote (`ssh:<host>`) sessions.** `run_git_capture` has no host
+  variant, so v1 diff is **local-only**; remote sessions fall back to Tree
+  mode with a note. *Mitigation:* Phase 5 adds `changed_files_on` /
+  `file_diff_on` using `git_command(host, …)` (which already supports SSH).
+- **R5 — narrow terminals.** The pane only exists at width ≥ 120, and the
+  central-pane diff needs room. *Mitigation:* reuse the existing layout
+  gating; below threshold the feature is simply unavailable (as the file
+  viewer already is).
+- **R6 — binary / huge files.** `git diff` on a binary yields `Binary
+  files differ`. *Mitigation:* detect and render a one-line placeholder;
+  `parse_numstat` already treats binaries as `-\t-` (line 826).
+- **R7 — scope creep into a full review tool** (comments, staging,
+  approvals). *Mitigation:* v1 is strictly read-only "what changed";
+  anything write-side is explicitly out of scope.
+
+---
+
+## 7. Out of scope (v1)
+
+Staging/committing from the pane, inline review comments, side-by-side
+(split) diff, word-level intra-line diff, syntax highlighting of code
+bodies, remote-session diff, and persisting an exact base branch — all
+deferred to follow-ups (§4 Phase 5).

--- a/docs/proposals/files-diff-review-pane.md
+++ b/docs/proposals/files-diff-review-pane.md
@@ -1,6 +1,8 @@
 # Proposal: File viewer → diff/review pane
 
-**Status:** Draft (design only — not implemented)
+**Status:** Phases 0–3 implemented (diff data + producers, status glyphs,
+inline central-pane diff). Phases 4 (open-at-line) and 5 (review
+comments/notes → agent loop) are follow-ups.
 **Author:** (proposal)
 **Scope:** Turn the read-only file tree (`Ctrl+E` / `F3`) into a
 glance-able **diff/review pane** that answers *"what did this agent

--- a/docs/proposals/files-diff-review-pane.md
+++ b/docs/proposals/files-diff-review-pane.md
@@ -4,7 +4,9 @@
 **Author:** (proposal)
 **Scope:** Turn the read-only file tree (`Ctrl+E` / `F3`) into a
 glance-able **diff/review pane** that answers *"what did this agent
-change?"* without leaving thurbox.
+change?"* — and lets you leave **review comments/notes** on the diff that
+are handed back to the session's agent so it can proceed with the required
+changes, all without leaving thurbox.
 
 ---
 
@@ -26,6 +28,15 @@ editor. The data is already computed for an unrelated feature: the info
 panel shows `GitStats { files_changed, insertions, deletions, dirty,
 ahead, behind }` via `git::worktree_stats` (`src/git/mod.rs:874`). We
 surface the *counts* but not the *content*.
+
+And once you can *see* the diff, the natural next move is to *act* on it:
+jot a note on a line ("handle the None case here"), then have the agent
+that wrote the code pick it up and fix it. thurbox already has the rail
+for that — the inter-session **message queue** (`thurbox-cli message
+send`) durably delivers a payload into a running agent and wakes it
+(`src/cli/messages.rs`, `agent::tmux::send_prompt_now`). The review pane
+is where those comments get authored and anchored to a file/line; the
+mailbox is how they reach the agent. See §3.6.
 
 **Goal:** make the file viewer default to a diff-first view of the
 session's worktree, mark changed files with status glyphs so they float
@@ -312,6 +323,144 @@ consequences:
   differ, so gate on a small editor-flavor map or honor a
   `THURBOX_EDITOR_LINE_FMT`). Modest, isolated change in `app`.
 
+### 3.6 Review comments / notes → agent action loop
+
+This is the part that turns the pane from *read* into *review*: leave a
+note on the diff, hand it to the agent that wrote the code, let it proceed
+with the change. Modeled on the GitHub flow — **draft many comments, then
+submit the review as one batch** — rather than firing a separate agent
+wake per keystroke.
+
+#### 3.6.1 UX
+
+- **Anchored comment.** With a file's diff open in the central pane
+  (§3.1), move the cursor to a line and press `c`
+  (`Action::AddReviewComment`, scoped to `KeyContext::FileViewer`). A small
+  multi-line input (reuse `modals::TextArea`, the same widget the task
+  editor uses) opens; type the note, `Ctrl+S`/`Enter` saves it anchored to
+  that `(file, line)`. The commented line gets a gutter marker (`▌` +
+  accent) and a count badge on the file row in the list.
+- **File-level / general note.** `C` (shift) on a file row, or on the
+  Changes-mode header, creates a comment with **no line anchor** — a
+  file-wide or session-wide "note" (covers the user's "add notes" ask
+  distinct from line comments; both are the same record with `line:
+  Option<u32>`).
+- **Manage drafts.** A comment marker is selectable; `c` re-opens it to
+  edit, `d` deletes it. Drafts **persist across restarts** (table, §3.6.3)
+  so a review survives a TUI restart or being picked up from a headless
+  `thurbox-cli` session — they are *pending* until submitted.
+- **Submit review.** A pane action `s` (`Action::SubmitReview`, or a
+  footer "Submit review (N)" pill button) composes **all pending comments
+  for the session** into one structured prompt, delivers it to the
+  session's agent, wakes it, and marks the comments `submitted`. A toast
+  reports `sent 4 comments → <agent>`. Submitted comments drop their
+  "pending" styling and move to a collapsed "Submitted" group (history),
+  so you can see what you already asked for.
+- **Round-trip.** Because delivery rides the mailbox (§3.6.4), the agent's
+  reply (`message reply …`, kind `result`) lands back in thurbox exactly
+  like flow/shepherd worker replies do today — no new return channel.
+
+#### 3.6.2 The composed prompt
+
+`ReviewComment`s are rendered into one agent-readable block by a pure
+`Task::agent_prompt`-style builder (`ReviewBundle::agent_prompt`), e.g.:
+
+```text
+Code review on <base>..<branch>. Please address these comments, make the
+changes in this worktree, and reply when done:
+
+  src/foo.rs:42   handle the None case here instead of unwrapping
+  src/bar.rs:10   rename `x` — unclear what it holds
+  (general)       add a test covering the empty-input path
+
+Run `thurbox-cli message reply <id> --kind result --body "…"` when finished.
+```
+
+The line anchors come straight from the diff the user was reading (the
+new-file line of each `DiffLine`), so the agent gets exact coordinates,
+not prose. The trailing self-service hint mirrors `Task::agent_prompt`'s
+existing "how to close this out" footer.
+
+#### 3.6.3 Persistence (drafts need their own store)
+
+The mailbox is **delivery-only** (exactly-once, drained-and-gone) — it
+can't hold an editable draft set. So comments get a dedicated table,
+mirroring `tasks`/`session_messages`:
+
+- `session/` (pure data): `struct ReviewComment { id: i64, session_id:
+  SessionId, path: PathBuf, line: Option<u32>, side: DiffSide, body:
+  String, base_ref: String, created_at: u64, submitted_at: Option<u64> }`
+  where `enum DiffSide { Old, New }` (anchor on the deletion or addition
+  side; v1 defaults to `New`). `line: None` = file/general note.
+- `storage/` (new schema version, next after the current head): a
+  `review_comments` table + an index on `(session_id) WHERE submitted_at
+  IS NULL` (the "pending" query), soft-delete optional. CRUD
+  `create_review_comment` / `list_review_comments(session, pending_only)` /
+  `update_review_comment` / `delete_review_comment` /
+  `mark_review_comments_submitted(ids)` — a direct analogue of
+  `storage/messages.rs` + `storage/tasks.rs`. Audited like tasks.
+
+Note this *also* fixes the diff base needing to be exact: each comment
+snapshots `base_ref` at authoring time, so a comment stays meaningful even
+if the derived base later moves.
+
+#### 3.6.4 Delivery (reuse the mailbox, no new transport)
+
+Submit composes the bundle and reuses the **existing** path end-to-end —
+nothing new in `agent`/`tmux`:
+
+```text
+SubmitReview
+  ├─ app: bundle = ReviewBundle::agent_prompt(pending comments)
+  ├─ db.enqueue_message(NewMessage { to_session_id: session, kind:"review",
+  │                                  body: bundle, from_task_id: None })   (durable)
+  ├─ app.send_prompt_to_session(session, bundle, 0)   (TUI: bracketed-paste + Enter)
+  │     └─ headless equiv: agent::tmux::send_prompt_now(name, bundle)
+  ├─ db.mark_review_comments_submitted(ids)
+  └─ toast "sent N comments → <agent>"
+```
+
+- `enqueue_message` (`storage/messages.rs:93`) gives durable, capped,
+  exactly-once delivery; the agent drains with `thurbox-cli message inbox
+  --claim` (kind `review`) — **no agent-side change needed**, it already
+  reads its mailbox in the flow/shepherd loops.
+- `send_prompt_to_session` (`src/app/mod.rs:4841`) is the TUI nudge that
+  pastes the bundle into the live pane (bracketed-paste safe, so the
+  multi-line body never submits early — same property `task_agent_prompt`
+  relies on). Headless callers use `send_prompt_now`
+  (`agent::tmux.rs:1139`).
+- `kind = "review"` is just a convention string (validation only bounds
+  length, `session/message.rs:54`), consistent with the agent-neutral
+  mailbox — no enum change.
+
+#### 3.6.5 CLI symmetry (optional, Phase 6)
+
+For headless/agent parity, add `thurbox-cli review add --session <id>
+--path <p> [--line N] --body <text>` / `review list` / `review submit
+--session <id>`, wrapping the same `storage` CRUD + the
+`enqueue_message`/wake used by `message send`. This lets a *worker* agent
+itself drop a review note on a peer (e.g. a lead reviewing a worker's
+branch) — the same way flow/shepherd already script the mailbox. Not
+required for the TUI feature; listed so the design stays
+CLI-complete (ADR-style: the binary learns a generic verb, extensions
+compose it).
+
+#### 3.6.6 Module impact (incremental over §3.2)
+
+```text
+session  + ReviewComment, DiffSide, ReviewBundle::agent_prompt (pure data)
+storage  + review_comments table + CRUD (new schema version)
+app      + draft state, add/edit/delete-at-line handlers, SubmitReview
+           (compose → enqueue_message → send_prompt_to_session → mark)
+ui       + comment gutter markers + count badges + the TextArea input,
+           all from PRE-COMPUTED ReviewComment data (never touches git/db)
+cli      + `review` subcommand (Phase 6, optional)
+```
+
+Still inside the architecture rules: `ui` renders `session`-owned
+`ReviewComment`s handed to it by `app`; all DB/mailbox work is in
+`app`/`storage`/`cli`.
+
 ---
 
 ## 4. Phased implementation plan
@@ -342,13 +491,25 @@ insta snapshot of a small fixed diff (the acceptance harness renders to a
 **Phase 4 — open-at-line.**
 Extend `open_file_in_editor` with the first-changed-line jump.
 
-**Phase 5 (follow-up, separate PR) — persisted base + syntax highlight.**
-Persist `base_branch` on the worktree (schema migration) for an exact
-base; optional `syntect` behind `[features] syntax_highlight`; remote
-`*_on(host)` diff variants.
+**Phase 5 — review comments / notes → agent (§3.6).**
+`ReviewComment`/`DiffSide`/`ReviewBundle` in `session/`; the
+`review_comments` table + CRUD in `storage/` (new schema version); draft
+add/edit/delete-at-line handlers, the `TextArea` input + gutter markers in
+`app`/`ui`; `SubmitReview` composing the bundle and delivering via the
+existing `enqueue_message` + `send_prompt_to_session` path. This is the
+"proceed with required changes" loop and depends only on Phase 3 (a
+readable diff to anchor against). Gated by `[features] tasks`-style flag if
+desired.
 
-Phases 0–4 are the proposal's v1. Each phase is independently shippable
-and leaves the pane working.
+**Phase 6 (follow-up, separate PR) — CLI parity + persisted base + syntax
+highlight.** `thurbox-cli review add/list/submit` (§3.6.5); persist
+`base_branch` on the worktree (schema migration) for an exact base;
+optional `syntect` behind `[features] syntax_highlight`; remote
+`*_on(host)` diff + delivery variants.
+
+Phases 0–5 are the proposal's v1 (3–4 are the diff pane; 5 adds the review
+loop). Each phase is independently shippable and leaves the pane working;
+Phases 0–4 ship value even if 5 slips.
 
 ---
 
@@ -363,8 +524,12 @@ and leaves the pane working.
   (`src/app/acceptance.rs`) — open the pane, assert mode/header state, and
   insta-snapshot the diff render for a fixed `FileDiff` fixture (avoid live
   git in the snapshot to keep it deterministic).
-- **Architecture:** `cargo test --test architecture_rules` must stay green
-  — proves `ui` never gained a `git` reference.
+- **Review comments (Phase 5):** pure tests on `ReviewBundle::agent_prompt`
+  (deterministic prompt from a fixed comment set) and the `review_comments`
+  CRUD (round-trip, pending filter, `mark_submitted`) — the `storage` test
+  pattern already used for `tasks`/`messages`. An acceptance test drives
+  add-comment → SubmitReview and asserts a `review` message was enqueued
+  for the session (`list_messages`) and the drafts flipped to submitted.
 
 ---
 
@@ -395,15 +560,39 @@ and leaves the pane working.
 - **R6 — binary / huge files.** `git diff` on a binary yields `Binary
   files differ`. *Mitigation:* detect and render a one-line placeholder;
   `parse_numstat` already treats binaries as `-\t-` (line 826).
-- **R7 — scope creep into a full review tool** (comments, staging,
-  approvals). *Mitigation:* v1 is strictly read-only "what changed";
-  anything write-side is explicitly out of scope.
+- **R7 — comment anchor drift.** A line-anchored comment can go stale if
+  the agent edits the file before reading it (line N no longer means the
+  same thing). *Mitigation:* the composed prompt carries the `base_ref` +
+  the surrounding diff context, not a bare line number, so the agent
+  resolves the anchor against content; the agent is told to *address the
+  intent*, not blindly edit line N. v1 doesn't attempt live anchor
+  re-mapping (a known hard problem) — comments are a one-shot review
+  payload, not a persistent annotation pinned through subsequent edits.
+- **R8 — wake races / dropped delivery.** A wake nudge is best-effort
+  (`enqueue_and_wake` doesn't fail the send if the pane is busy). *Mitigation:*
+  the message is durably enqueued *before* the wake (exactly-once
+  `claim_messages`), and submitting arms the automation heartbeat
+  (`arm_heartbeat`) so a missed wake is still drained headless — identical
+  to how flow/shepherd already guarantee delivery.
+- **R9 — review write-state in the diff cache.** Pending comments must not
+  be blown away by the periodic diff refresh. *Mitigation:* comments live in
+  their own `review_comments` table keyed by `(session, path, line)`, fully
+  decoupled from the ephemeral `WorktreeDiff` cache; a diff refresh
+  re-renders markers from the table, never the reverse.
+- **R10 — scope creep into a full forge review tool** (approvals, threaded
+  replies, resolve/unresolve, suggested-change patches). *Mitigation:* v1
+  is author-note → deliver-to-agent → agent-replies; richer review state is
+  explicitly deferred.
 
 ---
 
 ## 7. Out of scope (v1)
 
-Staging/committing from the pane, inline review comments, side-by-side
-(split) diff, word-level intra-line diff, syntax highlighting of code
-bodies, remote-session diff, and persisting an exact base branch — all
-deferred to follow-ups (§4 Phase 5).
+Staging/committing from the pane, side-by-side (split) diff, word-level
+intra-line diff, syntax highlighting of code bodies, remote-session diff,
+persisting an exact base branch, `thurbox-cli review` parity, and
+forge-grade review state (approve/request-changes, threaded/resolvable
+comments, suggested-change patches, live anchor re-mapping across edits) —
+all deferred to follow-ups (§4 Phases 5–6). Note **review comments/notes
+are now in scope** (§3.6, Phase 5) — they were deferred in the first draft
+of this proposal and pulled in on request.

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -554,9 +554,16 @@ impl App {
     fn handle_file_viewer_nav_key(&mut self, code: KeyCode) {
         // Navigation/search/expand keys are rebindable `FileViewer`-scoped
         // actions, resolved by the context lookup in `handle_key` before this
-        // runs. Only the fixed "Esc clears an active query" shortcut remains.
-        if matches!(code, KeyCode::Esc) && !self.file_viewer.search_query.is_empty() {
-            self.file_viewer.end_search();
+        // runs. PageUp/PageDown scroll the central-pane diff (when a changed
+        // file is selected); only the fixed "Esc clears an active query"
+        // shortcut otherwise remains.
+        match code {
+            KeyCode::PageDown => self.scroll_diff_preview(10),
+            KeyCode::PageUp => self.scroll_diff_preview(-10),
+            KeyCode::Esc if !self.file_viewer.search_query.is_empty() => {
+                self.file_viewer.end_search();
+            }
+            _ => {}
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -535,6 +535,14 @@ pub struct App {
     /// root, changes)`. The root is the worktree path the diff's relative paths
     /// resolve against, so the file tree can map an absolute node path → status.
     cached_diff: Option<(SessionId, PathBuf, crate::session::WorktreeDiff)>,
+    /// Lazily-computed unified diff of the file currently selected in the file
+    /// viewer: `(session, absolute file path, diff)`. Recomputed only when the
+    /// selection moves to a different changed file (one `git diff -- <file>`),
+    /// then rendered in the central pane. `None` when the selection isn't a
+    /// changed file.
+    cached_file_diff: Option<(SessionId, PathBuf, crate::session::FileDiff)>,
+    /// Vertical scroll offset (in lines) of the central-pane diff view.
+    diff_preview_scroll: u16,
     /// Cached update-check result, rendered as the header "update available"
     /// badge. `Some` only when `[features] version_check` is on and a newer
     /// release is known (from the on-disk cache). Read off the network — see
@@ -832,6 +840,8 @@ impl App {
             git_stats: background::BackgroundTask::default(),
             worktree_diff: background::BackgroundTask::default(),
             cached_diff: None,
+            cached_file_diff: None,
+            diff_preview_scroll: 0,
             // Seed the badge from the cache (no network); refreshed on first
             // tick if the flag is on and the cache is stale.
             update_status: if crate::session::settings::global().features.version_check {
@@ -3870,6 +3880,83 @@ impl App {
             .as_ref()
             .filter(|(sid, _, _)| *sid == active_id)
             .map(|(_, _, diff)| diff)
+    }
+
+    /// Ensure `cached_file_diff` matches the file viewer's currently-selected
+    /// file. Computes one `git diff -- <file>` only when the selection moved to
+    /// a different *changed* file; a cheap no-op otherwise. Clears the cache
+    /// (and resets scroll) when the selection isn't a changed file. Called from
+    /// the render path — the git call fires on selection change, not per frame.
+    pub(crate) fn ensure_selected_file_diff(&mut self) {
+        let Some(active) = self.sessions.get(self.active_index) else {
+            self.clear_file_diff();
+            return;
+        };
+        let session_id = active.info.id;
+
+        let Some((file, _root)) = self.file_viewer.selected_file_with_root() else {
+            self.clear_file_diff();
+            return;
+        };
+        // The selection must be a changed file under the current diff's root.
+        let Some((sid, root, diff)) = self.cached_diff.as_ref() else {
+            self.clear_file_diff();
+            return;
+        };
+        if *sid != session_id {
+            self.clear_file_diff();
+            return;
+        }
+        let Ok(rel) = file.strip_prefix(root) else {
+            self.clear_file_diff();
+            return;
+        };
+        if diff.status_of(rel).is_none() {
+            self.clear_file_diff();
+            return;
+        }
+
+        // Already cached for this exact file? Then nothing to do.
+        if let Some((csid, cpath, _)) = &self.cached_file_diff {
+            if *csid == session_id && cpath == &file {
+                return;
+            }
+        }
+
+        let base = diff.base_ref.clone();
+        let root = root.clone();
+        let rel = rel.to_path_buf();
+        let fd = crate::git::file_diff(&root, &base, &rel);
+        self.cached_file_diff = Some((session_id, file, fd));
+        self.diff_preview_scroll = 0;
+    }
+
+    fn clear_file_diff(&mut self) {
+        if self.cached_file_diff.is_some() {
+            self.cached_file_diff = None;
+            self.diff_preview_scroll = 0;
+        }
+    }
+
+    /// The diff to render in the central pane for the active session's current
+    /// file-viewer selection, if it's a changed file.
+    pub(crate) fn selected_file_diff(&self) -> Option<&crate::session::FileDiff> {
+        let active_id = self.sessions.get(self.active_index)?.info.id;
+        self.cached_file_diff
+            .as_ref()
+            .filter(|(sid, _, _)| *sid == active_id)
+            .map(|(_, _, fd)| fd)
+    }
+
+    /// Current central-pane diff scroll offset (lines).
+    pub(crate) fn diff_preview_scroll(&self) -> u16 {
+        self.diff_preview_scroll
+    }
+
+    /// Scroll the central-pane diff by `delta` lines (clamped at the top).
+    pub(crate) fn scroll_diff_preview(&mut self, delta: i32) {
+        let next = self.diff_preview_scroll as i32 + delta;
+        self.diff_preview_scroll = next.max(0) as u16;
     }
 
     /// Kick off a background system-metrics refresh.
@@ -9724,6 +9811,35 @@ mod tests {
         app.poll_git_stats();
 
         assert!(!app.git_stats.in_progress());
+    }
+
+    #[test]
+    fn worktree_diff_caches_and_filters_by_active_session() {
+        use crate::session::{DiffStatus, FileChange, WorktreeDiff};
+        let mut app = app_with_sessions(2);
+        let sid0 = app.sessions[0].info.id;
+
+        let diff = WorktreeDiff {
+            base_ref: "origin/main".into(),
+            files: vec![FileChange {
+                path: "a.rs".into(),
+                status: DiffStatus::Modified,
+                insertions: 2,
+                deletions: 1,
+            }],
+        };
+        let tx = app.worktree_diff.start();
+        tx.send((sid0, Some((PathBuf::from("/wt"), diff.clone()))))
+            .unwrap();
+        app.poll_worktree_diff();
+        assert!(!app.worktree_diff.in_progress());
+
+        // Session 0 is active → the diff is surfaced.
+        app.active_index = 0;
+        assert_eq!(app.active_worktree_diff(), Some(&diff));
+        // Switching to a different session hides the (other session's) diff.
+        app.active_index = 1;
+        assert_eq!(app.active_worktree_diff(), None);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -526,6 +526,15 @@ pub struct App {
     metrics_refresh: background::BackgroundTask<MetricsRefresh>,
     /// Background active-session git-stats refresh, polled each tick.
     git_stats: background::BackgroundTask<(SessionId, Option<crate::session::GitStats>)>,
+    /// Background active-session worktree-diff refresh (changed files vs the
+    /// resolved base ref), feeding the file-viewer diff pane. Polled each tick;
+    /// computed off the render path like `git_stats`.
+    worktree_diff:
+        background::BackgroundTask<(SessionId, Option<(PathBuf, crate::session::WorktreeDiff)>)>,
+    /// Applied result of the latest `worktree_diff` refresh: `(session, diff
+    /// root, changes)`. The root is the worktree path the diff's relative paths
+    /// resolve against, so the file tree can map an absolute node path → status.
+    cached_diff: Option<(SessionId, PathBuf, crate::session::WorktreeDiff)>,
     /// Cached update-check result, rendered as the header "update available"
     /// badge. `Some` only when `[features] version_check` is on and a newer
     /// release is known (from the on-disk cache). Read off the network — see
@@ -821,6 +830,8 @@ impl App {
             metrics: metrics_state::MetricsState::new(),
             metrics_refresh: background::BackgroundTask::default(),
             git_stats: background::BackgroundTask::default(),
+            worktree_diff: background::BackgroundTask::default(),
+            cached_diff: None,
             // Seed the badge from the cache (no network); refreshed on first
             // tick if the flag is on and the cache is stale.
             update_status: if crate::session::settings::global().features.version_check {
@@ -3470,12 +3481,14 @@ impl App {
     fn tick_background_refreshes(&mut self) {
         self.poll_metrics_refresh();
         self.poll_git_stats();
+        self.poll_worktree_diff();
 
         if self.metrics.tick_count % METRICS_REFRESH_TICKS == 0 {
             self.start_metrics_refresh();
         }
         if self.metrics.tick_count % GIT_REFRESH_TICKS == 0 {
             self.start_git_stats_refresh();
+            self.start_worktree_diff_refresh();
         }
         if self.metrics.tick_count % CONFIG_RELOAD_TICKS == 0 {
             self.poll_config_reload();
@@ -3803,6 +3816,60 @@ impl App {
                 session.info.git_stats = stats;
             }
         }
+    }
+
+    /// Kick off a background worktree-diff refresh for the active session — the
+    /// changed-files-vs-base list that drives the file-viewer diff pane. Runs
+    /// `git` on a blocking task; the result is applied in
+    /// [`Self::poll_worktree_diff`]. Only computed while the file viewer is open
+    /// (the only consumer), and one refresh at a time.
+    fn start_worktree_diff_refresh(&mut self) {
+        if !self.show_file_viewer || self.worktree_diff.in_progress() {
+            return;
+        }
+        let Some(session) = self.sessions.get(self.active_index) else {
+            return;
+        };
+        // v1 diffs the primary worktree (or cwd); multi-repo diff is a follow-up.
+        // Remote (`ssh:<host>`) sessions have no local worktree to diff — skip.
+        if session.info.remote_host.is_some() {
+            return;
+        }
+        let session_id = session.info.id;
+        let Some(root) = session
+            .info
+            .worktrees
+            .first()
+            .map(|wt| wt.worktree_path.clone())
+            .or_else(|| session.info.cwd.clone())
+        else {
+            return;
+        };
+
+        let tx = self.worktree_diff.start();
+        tokio::task::spawn_blocking(move || {
+            let payload = crate::git::resolve_base_ref(&root)
+                .map(|base| (root.clone(), crate::git::changed_files(&root, &base)));
+            let _ = tx.send((session_id, payload));
+        });
+    }
+
+    /// Apply a completed background worktree-diff refresh, if one has finished.
+    fn poll_worktree_diff(&mut self) {
+        if let background::TaskPoll::Done((session_id, payload)) = self.worktree_diff.poll() {
+            self.cached_diff = payload.map(|(root, diff)| (session_id, root, diff));
+        }
+    }
+
+    /// The active session's cached worktree diff, if it matches the current
+    /// selection. Handed to the file viewer so changed files get status glyphs;
+    /// `None` clears them (different session, no base, or not yet computed).
+    pub(crate) fn active_worktree_diff(&self) -> Option<&crate::session::WorktreeDiff> {
+        let active_id = self.sessions.get(self.active_index)?.info.id;
+        self.cached_diff
+            .as_ref()
+            .filter(|(sid, _, _)| *sid == active_id)
+            .map(|(_, _, diff)| diff)
     }
 
     /// Kick off a background system-metrics refresh.
@@ -4309,6 +4376,10 @@ impl App {
         } else {
             self.file_viewer.clear();
         }
+        // Drop any prior session's diff and recompute promptly so glyphs don't
+        // lag the cadence; `active_worktree_diff` filters stale results anyway.
+        self.cached_diff = None;
+        self.start_worktree_diff_refresh();
     }
 
     /// Set status bar message with the given severity level.

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -451,8 +451,9 @@ impl App {
             InputFocus::FileViewer => crate::ui::FocusLevel::Focused,
             _ => crate::ui::FocusLevel::Inactive,
         };
+        let changes = self.active_worktree_diff();
         let (geom, rows) =
-            file_viewer::render_file_viewer(frame, fv_area, &self.file_viewer, fv_focus);
+            file_viewer::render_file_viewer(frame, fv_area, &self.file_viewer, fv_focus, changes);
         self.record_scrollbar(geom, ScrollTarget::FileViewer);
         self.record_row_clicks(
             rows,

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -498,6 +498,24 @@ impl App {
             self.record_scrollbar(geom, ScrollTarget::TaskPreview);
             return;
         }
+        // In the file-viewer context, when the selection is a changed file the
+        // central pane shows that file's color-coded diff vs the base ref.
+        if self.focus == InputFocus::FileViewer {
+            self.ensure_selected_file_diff();
+            if self.selected_file_diff().is_some() {
+                let scroll = self.diff_preview_scroll();
+                if let Some(fd) = self.selected_file_diff() {
+                    crate::ui::diff_view::render_diff(
+                        frame,
+                        terminal,
+                        fd,
+                        scroll,
+                        crate::ui::FocusLevel::Active,
+                    );
+                }
+                return;
+            }
+        }
         // While the global-search strip previews a task result, mirror that in
         // the central pane (focus stays in the strip, so the normal task-context
         // branch above doesn't fire).

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -932,11 +932,7 @@ fn parse_name_status(out: &str) -> Vec<(crate::session::DiffStatus, String)> {
 /// Classify each line of a unified diff into a [`DiffLine`] so the UI only
 /// colors by kind. Metadata (`diff --git`, `index`, `---`/`+++`, …) is checked
 /// before the `+`/`-` body cases since `+++`/`---` start with those bytes.
-fn parse_unified_diff(
-    out: &str,
-    path: &Path,
-    base: &str,
-) -> crate::session::FileDiff {
+fn parse_unified_diff(out: &str, path: &Path, base: &str) -> crate::session::FileDiff {
     use crate::session::{DiffLine, DiffLineKind, FileDiff};
     let mut lines = Vec::new();
     let mut binary = false;
@@ -1041,8 +1037,11 @@ pub fn changed_files(cwd: &Path, base: &str) -> crate::session::WorktreeDiff {
         }
     }
 
-    diff.files
-        .sort_by(|a, b| status_rank(a.status).cmp(&status_rank(b.status)).then_with(|| a.path.cmp(&b.path)));
+    diff.files.sort_by(|a, b| {
+        status_rank(a.status)
+            .cmp(&status_rank(b.status))
+            .then_with(|| a.path.cmp(&b.path))
+    });
     diff
 }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -721,8 +721,10 @@ fn stash_with_retry(worktree_path: &Path) -> Result<bool> {
 /// caller can surface a clear error instead of blindly rebasing onto a
 /// possibly-missing `origin/main`. Shared by [`sync_worktree`] (the rebase
 /// target) and [`ahead_behind`] (the comparison base) so the "behind" count is
-/// always measured against the ref sync would rebase onto.
-fn resolve_base_ref(worktree_path: &Path) -> Option<String> {
+/// always measured against the ref sync would rebase onto. Also the base the
+/// file-viewer diff pane compares against, so the diff, the "behind" count, and
+/// what `Ctrl+S` would rebase onto can never drift apart.
+pub fn resolve_base_ref(worktree_path: &Path) -> Option<String> {
     // A branch with an explicit upstream rebases onto exactly that.
     if run_git_capture(
         &["rev-parse", "--verify", "--quiet", "@{upstream}"],
@@ -893,10 +895,263 @@ pub fn worktree_stats(cwd: &Path) -> Option<crate::session::GitStats> {
     })
 }
 
+/// Status rank for floating changed files: tracked edits first, untracked last.
+fn status_rank(s: crate::session::DiffStatus) -> u8 {
+    use crate::session::DiffStatus::*;
+    match s {
+        Modified => 0,
+        Added => 1,
+        Deleted => 2,
+        Renamed => 3,
+        Untracked => 4,
+    }
+}
+
+/// Parse `git diff --name-status` into `(status, path)` pairs. Rename/copy rows
+/// (`R100\told\tnew`) keep the new (destination) path.
+fn parse_name_status(out: &str) -> Vec<(crate::session::DiffStatus, String)> {
+    let mut v = Vec::new();
+    for line in out.lines() {
+        let mut cols = line.split('\t');
+        let Some(code) = cols.next() else { continue };
+        let letter = code.chars().next().unwrap_or(' ');
+        let Some(status) = crate::session::DiffStatus::from_code(letter) else {
+            continue;
+        };
+        // `.next()` already consumed the code column; the new path is the last
+        // remaining column (handles both `M\tfile` and `R100\told\tnew`).
+        let path = cols.next_back().unwrap_or("");
+        if path.is_empty() {
+            continue;
+        }
+        v.push((status, path.to_string()));
+    }
+    v
+}
+
+/// Classify each line of a unified diff into a [`DiffLine`] so the UI only
+/// colors by kind. Metadata (`diff --git`, `index`, `---`/`+++`, …) is checked
+/// before the `+`/`-` body cases since `+++`/`---` start with those bytes.
+fn parse_unified_diff(
+    out: &str,
+    path: &Path,
+    base: &str,
+) -> crate::session::FileDiff {
+    use crate::session::{DiffLine, DiffLineKind, FileDiff};
+    let mut lines = Vec::new();
+    let mut binary = false;
+    for line in out.lines() {
+        let kind = if line.starts_with("@@") {
+            DiffLineKind::Hunk
+        } else if line.starts_with("Binary files") {
+            binary = true;
+            DiffLineKind::Meta
+        } else if line.starts_with("+++")
+            || line.starts_with("---")
+            || line.starts_with("diff ")
+            || line.starts_with("index ")
+            || line.starts_with("new file")
+            || line.starts_with("deleted file")
+            || line.starts_with("old mode")
+            || line.starts_with("new mode")
+            || line.starts_with("rename ")
+            || line.starts_with("copy ")
+            || line.starts_with("similarity ")
+            || line.starts_with("dissimilarity ")
+            || line.starts_with("GIT binary patch")
+            || line.starts_with('\\')
+        {
+            DiffLineKind::Meta
+        } else if line.starts_with('+') {
+            DiffLineKind::Added
+        } else if line.starts_with('-') {
+            DiffLineKind::Removed
+        } else {
+            DiffLineKind::Context
+        };
+        lines.push(DiffLine {
+            kind,
+            text: line.to_string(),
+        });
+    }
+    FileDiff {
+        path: path.to_path_buf(),
+        base_ref: base.to_string(),
+        lines,
+        binary,
+    }
+}
+
+/// Changed files in `cwd`'s worktree vs `base`, for the diff/review pane.
+///
+/// Merges `git diff --numstat <base>` (line counts) with `--name-status
+/// <base>` (status letters), then appends untracked files (`?? …` from `status
+/// --porcelain`) since those aren't part of a `diff <base>`. Results are sorted
+/// most-significant-status-then-path so changed files float to the top. Returns
+/// an empty [`WorktreeDiff`] (with `base_ref` set) when `cwd` isn't a worktree.
+pub fn changed_files(cwd: &Path, base: &str) -> crate::session::WorktreeDiff {
+    use crate::session::{DiffStatus, FileChange, WorktreeDiff};
+    let mut diff = WorktreeDiff {
+        base_ref: base.to_string(),
+        files: Vec::new(),
+    };
+    if run_git_capture(&["rev-parse", "--is-inside-work-tree"], cwd).is_none() {
+        return diff;
+    }
+
+    // Per-path (insertions, deletions).
+    let numstat = run_git_capture(&["diff", "--numstat", base], cwd).unwrap_or_default();
+    let mut counts: HashMap<String, (usize, usize)> = HashMap::new();
+    for line in numstat.lines() {
+        let mut cols = line.split('\t');
+        let added = cols.next();
+        let deleted = cols.next();
+        if let Some(path) = cols.next() {
+            let ins = added.and_then(|s| s.parse().ok()).unwrap_or(0);
+            let del = deleted.and_then(|s| s.parse().ok()).unwrap_or(0);
+            counts.insert(path.to_string(), (ins, del));
+        }
+    }
+
+    // Status letter per path (authoritative for status).
+    let name_status = run_git_capture(&["diff", "--name-status", base], cwd).unwrap_or_default();
+    for (status, path) in parse_name_status(&name_status) {
+        let (insertions, deletions) = counts.get(&path).copied().unwrap_or((0, 0));
+        diff.files.push(FileChange {
+            path: PathBuf::from(&path),
+            status,
+            insertions,
+            deletions,
+        });
+    }
+
+    // Untracked files aren't in `diff <base>`; surface them as additions.
+    let status = run_git_capture(&["status", "--porcelain"], cwd).unwrap_or_default();
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("?? ") {
+            let p = rest.trim();
+            if !p.is_empty() {
+                diff.files.push(FileChange {
+                    path: PathBuf::from(p),
+                    status: DiffStatus::Untracked,
+                    insertions: 0,
+                    deletions: 0,
+                });
+            }
+        }
+    }
+
+    diff.files
+        .sort_by(|a, b| status_rank(a.status).cmp(&status_rank(b.status)).then_with(|| a.path.cmp(&b.path)));
+    diff
+}
+
+/// Unified diff of a single file vs `base`, parsed into classified lines.
+///
+/// For a tracked change this is `git diff <base> -- <path>`. An untracked file
+/// has no `<base>` side, so its current contents are synthesized as all-added
+/// lines (portable; avoids a `/dev/null` `--no-index` that differs on Windows).
+pub fn file_diff(cwd: &Path, base: &str, path: &Path) -> crate::session::FileDiff {
+    use crate::session::{DiffLine, DiffLineKind, FileDiff};
+    let path_str = path.to_string_lossy();
+    let out = run_git_capture(&["diff", base, "--", &path_str], cwd).unwrap_or_default();
+    if !out.trim().is_empty() {
+        return parse_unified_diff(&out, path, base);
+    }
+
+    // Empty diff: either no change, or an untracked file. Synthesize an
+    // all-added view from the file's current contents when it exists.
+    let abs = cwd.join(path);
+    if let Ok(contents) = std::fs::read_to_string(&abs) {
+        let mut lines = vec![DiffLine {
+            kind: DiffLineKind::Meta,
+            text: format!("untracked file ({} lines)", contents.lines().count()),
+        }];
+        if !contents.is_empty() {
+            lines.push(DiffLine {
+                kind: DiffLineKind::Hunk,
+                text: format!("@@ -0,0 +1,{} @@", contents.lines().count()),
+            });
+        }
+        for l in contents.lines() {
+            lines.push(DiffLine {
+                kind: DiffLineKind::Added,
+                text: format!("+{l}"),
+            });
+        }
+        return FileDiff {
+            path: path.to_path_buf(),
+            base_ref: base.to_string(),
+            lines,
+            binary: false,
+        };
+    }
+
+    FileDiff {
+        path: path.to_path_buf(),
+        base_ref: base.to_string(),
+        lines: Vec::new(),
+        binary: false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::paths::TestPathGuard;
+
+    #[test]
+    fn parse_name_status_handles_renames() {
+        use crate::session::DiffStatus;
+        let v = parse_name_status("M\tsrc/a.rs\nA\tsrc/b.rs\nR100\tsrc/old.rs\tsrc/new.rs\n");
+        assert_eq!(
+            v,
+            vec![
+                (DiffStatus::Modified, "src/a.rs".to_string()),
+                (DiffStatus::Added, "src/b.rs".to_string()),
+                (DiffStatus::Renamed, "src/new.rs".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_unified_diff_classifies_lines() {
+        use crate::session::DiffLineKind;
+        let raw = "diff --git a/x.rs b/x.rs\n\
+                   index 111..222 100644\n\
+                   --- a/x.rs\n\
+                   +++ b/x.rs\n\
+                   @@ -1,2 +1,2 @@\n\
+                    ctx\n\
+                   -gone\n\
+                   +added\n";
+        let fd = parse_unified_diff(raw, Path::new("x.rs"), "origin/main");
+        let kinds: Vec<_> = fd.lines.iter().map(|l| l.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                DiffLineKind::Meta,    // diff --git
+                DiffLineKind::Meta,    // index
+                DiffLineKind::Meta,    // ---
+                DiffLineKind::Meta,    // +++
+                DiffLineKind::Hunk,    // @@
+                DiffLineKind::Context, //  ctx
+                DiffLineKind::Removed, // -gone
+                DiffLineKind::Added,   // +added
+            ]
+        );
+        assert!(!fd.binary);
+    }
+
+    #[test]
+    fn parse_unified_diff_detects_binary() {
+        let fd = parse_unified_diff(
+            "diff --git a/img.png b/img.png\nBinary files a/img.png and b/img.png differ\n",
+            Path::new("img.png"),
+            "origin/main",
+        );
+        assert!(fd.binary);
+    }
 
     #[test]
     fn parse_numstat_sums_changes() {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1153,6 +1153,77 @@ mod tests {
     }
 
     #[test]
+    fn changed_files_and_file_diff_end_to_end() {
+        use crate::session::DiffStatus;
+        let tmp = tempfile::tempdir().unwrap();
+        let work = tmp.path().join("work");
+        let run = |dir: &Path, args: &[&str]| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .expect("run git");
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        std::fs::create_dir_all(&work).unwrap();
+        run(&work, &["init", "-q"]);
+        run(&work, &["config", "user.email", "t@example.com"]);
+        run(&work, &["config", "user.name", "t"]);
+        // Base commit on `main` with two files.
+        run(&work, &["checkout", "-q", "-b", "main"]);
+        std::fs::write(work.join("keep.txt"), "one\ntwo\n").unwrap();
+        std::fs::write(work.join("gone.txt"), "bye\n").unwrap();
+        run(&work, &["add", "."]);
+        run(&work, &["commit", "-qm", "base"]);
+
+        // Diverge on a feature branch: modify, delete, add (committed), + untracked.
+        run(&work, &["checkout", "-q", "-b", "feat"]);
+        std::fs::write(work.join("keep.txt"), "one\ntwo\nthree\n").unwrap();
+        std::fs::remove_file(work.join("gone.txt")).unwrap();
+        std::fs::write(work.join("added.txt"), "new\n").unwrap();
+        run(&work, &["add", "keep.txt", "gone.txt", "added.txt"]);
+        run(&work, &["commit", "-qm", "work"]);
+        std::fs::write(work.join("scratch.txt"), "untracked\n").unwrap();
+
+        let diff = changed_files(&work, "main");
+        let by = |p: &str| {
+            diff.files
+                .iter()
+                .find(|f| f.path.as_path() == std::path::Path::new(p))
+                .map(|f| f.status)
+        };
+        assert_eq!(by("keep.txt"), Some(DiffStatus::Modified));
+        assert_eq!(by("gone.txt"), Some(DiffStatus::Deleted));
+        assert_eq!(by("added.txt"), Some(DiffStatus::Added));
+        assert_eq!(by("scratch.txt"), Some(DiffStatus::Untracked));
+
+        // The modified file's unified diff has the added line, colored as Added.
+        let fd = file_diff(&work, "main", std::path::Path::new("keep.txt"));
+        assert!(!fd.binary);
+        assert!(
+            fd.lines
+                .iter()
+                .any(|l| l.kind == crate::session::DiffLineKind::Added && l.text.contains("three")),
+            "expected an added 'three' line in {:?}",
+            fd.lines
+        );
+
+        // An untracked file synthesizes an all-added view from its contents.
+        let untracked = file_diff(&work, "main", std::path::Path::new("scratch.txt"));
+        assert!(
+            untracked
+                .lines
+                .iter()
+                .any(|l| l.kind == crate::session::DiffLineKind::Added
+                    && l.text.contains("untracked"))
+        );
+    }
+
+    #[test]
     fn parse_numstat_sums_changes() {
         let (files, ins, dels) = parse_numstat("1\t2\tfile.rs\n3\t4\tother.rs\n-\t-\tbin.png\n");
         assert_eq!(files, 3);

--- a/src/session/diff.rs
+++ b/src/session/diff.rs
@@ -1,0 +1,226 @@
+//! Pure data types for the file-viewer diff/review pane.
+//!
+//! These live in `session` (the dependency-free data layer) so the `git`
+//! module can *produce* them and the `ui` module can *render* them without
+//! `ui` ever referencing `git` — the same split [`GitStats`] uses. `ui` colors
+//! a diff purely by [`DiffLineKind`]; it never parses a diff itself.
+//!
+//! [`GitStats`]: crate::session::GitStats
+
+use std::path::PathBuf;
+
+/// Git change status of a file in a worktree diff vs its base ref.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffStatus {
+    Modified,
+    Added,
+    Deleted,
+    Renamed,
+    /// Present in the worktree but not tracked by git.
+    Untracked,
+}
+
+impl DiffStatus {
+    /// Single-character marker shown in the file tree / changes list.
+    pub fn glyph(self) -> char {
+        match self {
+            DiffStatus::Modified => 'M',
+            DiffStatus::Added => 'A',
+            DiffStatus::Deleted => 'D',
+            DiffStatus::Renamed => 'R',
+            DiffStatus::Untracked => '?',
+        }
+    }
+
+    /// Parse git's porcelain status letter (from `--name-status` /
+    /// `status --porcelain`). Returns `None` for unrecognized codes.
+    pub fn from_code(code: char) -> Option<Self> {
+        match code {
+            'M' => Some(DiffStatus::Modified),
+            'A' => Some(DiffStatus::Added),
+            'D' => Some(DiffStatus::Deleted),
+            'R' => Some(DiffStatus::Renamed),
+            'C' => Some(DiffStatus::Added), // copy → treat as added
+            'T' => Some(DiffStatus::Modified), // type-change → modified
+            '?' => Some(DiffStatus::Untracked),
+            _ => None,
+        }
+    }
+}
+
+/// One changed file in a worktree diff vs a base ref. Line counts come from
+/// `git diff --numstat`; a binary file reports `0/0`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileChange {
+    pub path: PathBuf,
+    pub status: DiffStatus,
+    pub insertions: usize,
+    pub deletions: usize,
+}
+
+/// The set of changes in a worktree vs a resolved base ref, computed by the
+/// app/git layer off the render path and cached for the file viewer.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WorktreeDiff {
+    /// The base ref the diff was taken against (e.g. `origin/main`). Shown in
+    /// the pane header so the comparison point is explicit.
+    pub base_ref: String,
+    /// Changed files, ordered most-significant-status first by the producer.
+    pub files: Vec<FileChange>,
+}
+
+impl WorktreeDiff {
+    /// Total `(files, insertions, deletions)` rollup for the header line.
+    pub fn totals(&self) -> (usize, usize, usize) {
+        let (mut ins, mut del) = (0usize, 0usize);
+        for f in &self.files {
+            ins += f.insertions;
+            del += f.deletions;
+        }
+        (self.files.len(), ins, del)
+    }
+
+    /// Status of a specific path, if it changed. Used to annotate tree rows.
+    pub fn status_of(&self, path: &std::path::Path) -> Option<DiffStatus> {
+        self.files
+            .iter()
+            .find(|f| f.path == path)
+            .map(|f| f.status)
+    }
+}
+
+/// Kind of a single line in a rendered unified diff. The `ui` layer maps each
+/// to a color (added=green, removed=red, hunk=accent, context/meta=muted).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffLineKind {
+    Added,
+    Removed,
+    Context,
+    /// A `@@ -a,b +c,d @@` hunk header.
+    Hunk,
+    /// `diff --git`, `index`, `---`/`+++`, `Binary files …` etc.
+    Meta,
+}
+
+/// One line of a rendered file diff, already classified so `ui` only colors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffLine {
+    pub kind: DiffLineKind,
+    pub text: String,
+}
+
+/// A single file's unified diff vs the base ref, parsed into classified lines.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileDiff {
+    pub path: PathBuf,
+    pub base_ref: String,
+    pub lines: Vec<DiffLine>,
+    /// True when git reported a binary file (no textual hunks available).
+    pub binary: bool,
+}
+
+impl FileDiff {
+    /// New-file line number of the first added/context line after a hunk
+    /// header — the position to jump an editor to. `None` when no hunk is
+    /// present (e.g. a binary or empty diff).
+    pub fn first_changed_line(&self) -> Option<u32> {
+        let mut new_line: Option<u32> = None;
+        for l in &self.lines {
+            match l.kind {
+                DiffLineKind::Hunk => {
+                    new_line = parse_hunk_new_start(&l.text);
+                }
+                DiffLineKind::Added => {
+                    if let Some(n) = new_line {
+                        return Some(n);
+                    }
+                }
+                DiffLineKind::Context => {
+                    if let Some(n) = new_line.as_mut() {
+                        *n += 1;
+                    }
+                }
+                DiffLineKind::Removed | DiffLineKind::Meta => {}
+            }
+        }
+        // No added line found: fall back to the first hunk's start.
+        self.lines
+            .iter()
+            .find(|l| l.kind == DiffLineKind::Hunk)
+            .and_then(|l| parse_hunk_new_start(&l.text))
+    }
+}
+
+/// Extract the new-file start line from a hunk header `@@ -a,b +c,d @@`.
+fn parse_hunk_new_start(header: &str) -> Option<u32> {
+    let plus = header.split('+').nth(1)?;
+    let num: String = plus.chars().take_while(|c| c.is_ascii_digit()).collect();
+    num.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_glyph_and_code_roundtrip() {
+        for s in [
+            DiffStatus::Modified,
+            DiffStatus::Added,
+            DiffStatus::Deleted,
+            DiffStatus::Renamed,
+            DiffStatus::Untracked,
+        ] {
+            assert_eq!(DiffStatus::from_code(s.glyph()), Some(s));
+        }
+        assert_eq!(DiffStatus::from_code('X'), None);
+    }
+
+    #[test]
+    fn worktree_diff_totals() {
+        let d = WorktreeDiff {
+            base_ref: "origin/main".into(),
+            files: vec![
+                FileChange {
+                    path: "a.rs".into(),
+                    status: DiffStatus::Modified,
+                    insertions: 3,
+                    deletions: 1,
+                },
+                FileChange {
+                    path: "b.rs".into(),
+                    status: DiffStatus::Added,
+                    insertions: 10,
+                    deletions: 0,
+                },
+            ],
+        };
+        assert_eq!(d.totals(), (2, 13, 1));
+        assert_eq!(d.status_of(std::path::Path::new("a.rs")), Some(DiffStatus::Modified));
+        assert_eq!(d.status_of(std::path::Path::new("missing")), None);
+    }
+
+    #[test]
+    fn hunk_new_start_parses() {
+        assert_eq!(parse_hunk_new_start("@@ -1,2 +3,4 @@ fn foo()"), Some(3));
+        assert_eq!(parse_hunk_new_start("@@ -0,0 +1 @@"), Some(1));
+        assert_eq!(parse_hunk_new_start("not a hunk"), None);
+    }
+
+    #[test]
+    fn first_changed_line_walks_context() {
+        let fd = FileDiff {
+            path: "x.rs".into(),
+            base_ref: "origin/main".into(),
+            binary: false,
+            lines: vec![
+                DiffLine { kind: DiffLineKind::Meta, text: "diff --git".into() },
+                DiffLine { kind: DiffLineKind::Hunk, text: "@@ -10,3 +10,4 @@".into() },
+                DiffLine { kind: DiffLineKind::Context, text: " ctx".into() },
+                DiffLine { kind: DiffLineKind::Added, text: "+new".into() },
+            ],
+        };
+        // hunk new-start 10, one context line → added at 11.
+        assert_eq!(fd.first_changed_line(), Some(11));
+    }
+}

--- a/src/session/diff.rs
+++ b/src/session/diff.rs
@@ -82,10 +82,7 @@ impl WorktreeDiff {
 
     /// Status of a specific path, if it changed. Used to annotate tree rows.
     pub fn status_of(&self, path: &std::path::Path) -> Option<DiffStatus> {
-        self.files
-            .iter()
-            .find(|f| f.path == path)
-            .map(|f| f.status)
+        self.files.iter().find(|f| f.path == path).map(|f| f.status)
     }
 }
 
@@ -196,7 +193,10 @@ mod tests {
             ],
         };
         assert_eq!(d.totals(), (2, 13, 1));
-        assert_eq!(d.status_of(std::path::Path::new("a.rs")), Some(DiffStatus::Modified));
+        assert_eq!(
+            d.status_of(std::path::Path::new("a.rs")),
+            Some(DiffStatus::Modified)
+        );
         assert_eq!(d.status_of(std::path::Path::new("missing")), None);
     }
 
@@ -214,10 +214,22 @@ mod tests {
             base_ref: "origin/main".into(),
             binary: false,
             lines: vec![
-                DiffLine { kind: DiffLineKind::Meta, text: "diff --git".into() },
-                DiffLine { kind: DiffLineKind::Hunk, text: "@@ -10,3 +10,4 @@".into() },
-                DiffLine { kind: DiffLineKind::Context, text: " ctx".into() },
-                DiffLine { kind: DiffLineKind::Added, text: "+new".into() },
+                DiffLine {
+                    kind: DiffLineKind::Meta,
+                    text: "diff --git".into(),
+                },
+                DiffLine {
+                    kind: DiffLineKind::Hunk,
+                    text: "@@ -10,3 +10,4 @@".into(),
+                },
+                DiffLine {
+                    kind: DiffLineKind::Context,
+                    text: " ctx".into(),
+                },
+                DiffLine {
+                    kind: DiffLineKind::Added,
+                    text: "+new".into(),
+                },
             ],
         };
         // hunk new-start 10, one context line → added at 11.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_def;
 pub mod automation;
+pub mod diff;
 pub mod extension_def;
 pub mod host_def;
 pub mod keybindings;
@@ -13,6 +14,7 @@ pub use automation::{
     parse_hhmm, preset_to_cron, Automation, AutomationAction, AutomationRun, AutomationRunStatus,
     AutomationSchedule, ExtraRepo, SchedulePreset,
 };
+pub use diff::{DiffLine, DiffLineKind, DiffStatus, FileChange, FileDiff, WorktreeDiff};
 pub use extension_def::{
     AgentPatch, ConfigMerge, ExtensionAutomation, ExtensionDef, ExtensionFile, ExtensionSession,
     ExtensionSymlink, ExternalFile,

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -1,0 +1,132 @@
+//! Central-pane unified-diff renderer for the file-viewer review pane.
+//!
+//! Pure rendering: receives a [`FileDiff`] (already parsed + classified by the
+//! `git` layer into [`DiffLineKind`]s) and colors each line. It never parses a
+//! diff or touches `git` — the `ui ✗ git` architecture rule holds.
+
+use ratatui::{
+    layout::{Alignment, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::scrollbar;
+use super::{focus_block, theme::Theme, FocusLevel};
+use crate::session::{DiffLine, DiffLineKind, FileDiff};
+
+/// Render `diff` into `area` as a scrollable, color-coded unified diff.
+/// `scroll` is the top line offset (clamped here so an over-scroll past the end
+/// snaps to the last page).
+pub fn render_diff(frame: &mut Frame, area: Rect, diff: &FileDiff, scroll: u16, focus: FocusLevel) {
+    let title = diff_title(diff);
+    let block = focus_block(&title, focus);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.height == 0 || inner.width == 0 {
+        return;
+    }
+
+    if diff.binary {
+        let p = Paragraph::new(Line::from(Span::styled(
+            "binary file — no textual diff",
+            Style::default().fg(Theme::text_muted()),
+        )))
+        .alignment(Alignment::Center);
+        frame.render_widget(p, inner);
+        return;
+    }
+
+    if diff.lines.is_empty() {
+        let p = Paragraph::new(Line::from(Span::styled(
+            "no changes",
+            Style::default().fg(Theme::text_muted()),
+        )))
+        .alignment(Alignment::Center);
+        frame.render_widget(p, inner);
+        return;
+    }
+
+    let total = diff.lines.len();
+    let height = inner.height as usize;
+    let max_scroll = total.saturating_sub(height);
+    let start = (scroll as usize).min(max_scroll);
+    let end = (start + height).min(total);
+
+    let (rows_area, track) = scrollbar::reserve_track(inner, total, height);
+    let lines: Vec<Line> = diff.lines[start..end].iter().map(style_line).collect();
+    frame.render_widget(Paragraph::new(lines), rows_area);
+
+    if let Some(track) = track {
+        scrollbar::render_into(frame, track, total, height, start);
+    }
+}
+
+/// Block title: `<path> · Δ <base>`.
+fn diff_title(diff: &FileDiff) -> String {
+    let name = diff
+        .path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| diff.path.to_string_lossy().into_owned());
+    let base = diff
+        .base_ref
+        .strip_prefix("refs/remotes/")
+        .or_else(|| diff.base_ref.strip_prefix("refs/heads/"))
+        .unwrap_or(&diff.base_ref);
+    format!(" {name} · Δ {base} ")
+}
+
+/// Color one diff line by its kind: added=green, removed=red, hunk=accent
+/// (bold), context=normal, metadata=muted.
+fn style_line(line: &DiffLine) -> Line<'static> {
+    let (color, bold) = match line.kind {
+        DiffLineKind::Added => (Theme::status_idle(), false),
+        DiffLineKind::Removed => (Theme::status_blocked(), false),
+        DiffLineKind::Hunk => (Theme::accent(), true),
+        DiffLineKind::Context => (Theme::text_primary(), false),
+        DiffLineKind::Meta => (Theme::text_muted(), false),
+    };
+    let mut style = Style::default().fg(color);
+    if bold {
+        style = style.add_modifier(Modifier::BOLD);
+    }
+    Line::from(Span::styled(line.text.clone(), style))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(kind: DiffLineKind, text: &str) -> DiffLine {
+        DiffLine {
+            kind,
+            text: text.into(),
+        }
+    }
+
+    #[test]
+    fn title_shortens_base_and_uses_basename() {
+        let fd = FileDiff {
+            path: "src/app/mod.rs".into(),
+            base_ref: "refs/remotes/origin/main".into(),
+            lines: vec![],
+            binary: false,
+        };
+        assert_eq!(diff_title(&fd), " mod.rs · Δ origin/main ");
+    }
+
+    #[test]
+    fn style_line_colors_by_kind() {
+        // Added is green (status_idle), removed is red (status_blocked).
+        let added = style_line(&line(DiffLineKind::Added, "+x"));
+        let removed = style_line(&line(DiffLineKind::Removed, "-y"));
+        assert_eq!(added.spans[0].style.fg, Some(Theme::status_idle()));
+        assert_eq!(removed.spans[0].style.fg, Some(Theme::status_blocked()));
+        // Hunk header is bold accent.
+        let hunk = style_line(&line(DiffLineKind::Hunk, "@@ -1 +1 @@"));
+        assert_eq!(hunk.spans[0].style.fg, Some(Theme::accent()));
+        assert!(hunk.spans[0].style.add_modifier.contains(Modifier::BOLD));
+    }
+}

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -720,7 +720,12 @@ fn render_tree(
         .iter()
         .enumerate()
         .map(|(i, row)| {
-            build_row_line(row, start + i == state.selected, query_lc.as_deref(), changes)
+            build_row_line(
+                row,
+                start + i == state.selected,
+                query_lc.as_deref(),
+                changes,
+            )
         })
         .collect();
     frame.render_widget(Paragraph::new(lines), rows_area);
@@ -1168,5 +1173,59 @@ mod tests {
         st.clear();
         assert_eq!(st.roots.len(), 0);
         assert_eq!(st.selected, 0);
+    }
+
+    #[test]
+    fn diff_header_title_summarizes_changes() {
+        use crate::session::{DiffStatus, FileChange, WorktreeDiff};
+        let d = WorktreeDiff {
+            base_ref: "refs/remotes/origin/main".into(),
+            files: vec![FileChange {
+                path: "a.rs".into(),
+                status: DiffStatus::Modified,
+                insertions: 4,
+                deletions: 1,
+            }],
+        };
+        assert_eq!(
+            diff_header_title(Some(&d)),
+            " Files · Δ origin/main 1f +4 -1 "
+        );
+        // No changes / no diff → plain title.
+        assert_eq!(diff_header_title(None), " Files ");
+        let empty = WorktreeDiff::default();
+        assert_eq!(diff_header_title(Some(&empty)), " Files ");
+    }
+
+    #[test]
+    fn build_row_line_prefixes_status_glyph_for_changed_file() {
+        use crate::session::{DiffStatus, FileChange, WorktreeDiff};
+        let row = FlatRow {
+            index_path: vec![0, 0],
+            depth: 1,
+            label: "a.rs".into(),
+            is_dir: false,
+            expanded: false,
+            path: PathBuf::from("/wt/a.rs"),
+        };
+        let changes = WorktreeDiff {
+            base_ref: "origin/main".into(),
+            files: vec![FileChange {
+                path: "/wt/a.rs".into(),
+                status: DiffStatus::Modified,
+                insertions: 1,
+                deletions: 0,
+            }],
+        };
+        let line = build_row_line(&row, false, None, Some(&changes));
+        // Spans: indent+marker, "M ", label.
+        let joined: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(joined.contains("M "), "expected a status glyph: {joined:?}");
+        assert!(joined.contains("a.rs"));
+
+        // A directory or an unchanged file gets no glyph.
+        let plain = build_row_line(&row, false, None, None);
+        let joined2: String = plain.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(!joined2.contains("M "));
     }
 }

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -18,7 +18,17 @@ use ratatui::{
 
 use super::scrollbar::{self, ScrollbarGeom};
 use super::{focus_block, theme::Theme, FocusLevel};
-use crate::session::SessionInfo;
+use crate::session::{DiffStatus, SessionInfo, WorktreeDiff};
+
+/// Theme color for a file's git-change status glyph/name in the tree.
+pub(crate) fn diff_status_color(status: DiffStatus) -> ratatui::style::Color {
+    match status {
+        DiffStatus::Modified => Theme::status_working(),
+        DiffStatus::Added | DiffStatus::Untracked => Theme::status_idle(),
+        DiffStatus::Deleted => Theme::status_blocked(),
+        DiffStatus::Renamed => Theme::accent(),
+    }
+}
 
 /// One node in the tree. `children = None` means "not yet expanded"; an
 /// empty `Some(vec![])` means "expanded but empty".
@@ -75,6 +85,8 @@ struct FlatRow {
     label: String,
     is_dir: bool,
     expanded: bool,
+    /// Absolute filesystem path of this node, for git-status lookup.
+    path: PathBuf,
 }
 
 pub struct FileViewerState {
@@ -425,6 +437,7 @@ fn push_flat(
         label,
         is_dir: node.is_dir,
         expanded: node.expanded,
+        path: node.path.clone(),
     });
     if node.is_dir && node.expanded {
         if let Some(children) = &node.children {
@@ -615,8 +628,9 @@ pub fn render_file_viewer(
     area: Rect,
     state: &FileViewerState,
     focus: FocusLevel,
+    changes: Option<&WorktreeDiff>,
 ) -> (Option<ScrollbarGeom>, Vec<super::RowHitbox>) {
-    let inner = render_chrome(frame, area, state, focus);
+    let inner = render_chrome(frame, area, state, focus, changes);
 
     if inner.height == 0 || inner.width == 0 {
         return (None, Vec::new());
@@ -631,7 +645,7 @@ pub fn render_file_viewer(
         return (None, Vec::new());
     }
 
-    render_tree(frame, inner, state)
+    render_tree(frame, inner, state, changes)
 }
 
 /// Lay out the viewer chrome — the bordered `Files` block plus the optional
@@ -641,6 +655,7 @@ fn render_chrome(
     area: Rect,
     state: &FileViewerState,
     focus: FocusLevel,
+    changes: Option<&WorktreeDiff>,
 ) -> Rect {
     use ratatui::layout::{Constraint, Direction, Layout};
 
@@ -656,7 +671,8 @@ fn render_chrome(
         .split(area);
     let list_outer = chunks[0];
 
-    let block = focus_block(" Files ", focus);
+    let title = diff_header_title(changes);
+    let block = focus_block(&title, focus);
     let inner = block.inner(list_outer);
     frame.render_widget(block, list_outer);
 
@@ -681,6 +697,7 @@ fn render_tree(
     frame: &mut Frame,
     list_area: Rect,
     state: &FileViewerState,
+    changes: Option<&WorktreeDiff>,
 ) -> (Option<ScrollbarGeom>, Vec<super::RowHitbox>) {
     let rows = state.flatten();
     let height = list_area.height as usize;
@@ -702,7 +719,9 @@ fn render_tree(
     let lines: Vec<Line> = rows[start..end]
         .iter()
         .enumerate()
-        .map(|(i, row)| build_row_line(row, start + i == state.selected, query_lc.as_deref()))
+        .map(|(i, row)| {
+            build_row_line(row, start + i == state.selected, query_lc.as_deref(), changes)
+        })
         .collect();
     frame.render_widget(Paragraph::new(lines), rows_area);
 
@@ -737,17 +756,35 @@ fn row_label_color(is_match: bool, is_dir: bool) -> ratatui::style::Color {
     }
 }
 
-fn build_row_line(row: &FlatRow, selected: bool, query_lc: Option<&str>) -> Line<'static> {
+fn build_row_line(
+    row: &FlatRow,
+    selected: bool,
+    query_lc: Option<&str>,
+    changes: Option<&WorktreeDiff>,
+) -> Line<'static> {
     let indent = "  ".repeat(row.depth);
     let marker = row_marker(row);
     let is_match = query_lc
         .map(|q| row.label.to_lowercase().contains(q))
         .unwrap_or(true);
 
+    // Git-change status for this exact file (directories aren't annotated).
+    let status = if row.is_dir {
+        None
+    } else {
+        changes.and_then(|c| c.status_of(&row.path))
+    };
+
     let label_style = if selected {
         Style::default()
             .bg(Theme::selection_bg())
             .fg(Theme::selection_fg())
+            .add_modifier(Modifier::BOLD)
+    } else if let Some(s) = status {
+        // A changed file's name takes its status color and bolds, so it
+        // stands out against unchanged siblings even before you read the glyph.
+        Style::default()
+            .fg(diff_status_color(s))
             .add_modifier(Modifier::BOLD)
     } else {
         let mut s = Style::default().fg(row_label_color(is_match, row.is_dir));
@@ -764,10 +801,45 @@ fn build_row_line(row: &FlatRow, selected: bool, query_lc: Option<&str>) -> Line
         Style::default().fg(Theme::text_muted())
     };
 
-    Line::from(vec![
-        Span::styled(format!("{indent}{marker}"), prefix_style),
-        Span::styled(row.label.clone(), label_style),
-    ])
+    let mut spans = vec![Span::styled(format!("{indent}{marker}"), prefix_style)];
+    // Status glyph between the tree marker and the name (e.g. `M `).
+    if let Some(s) = status {
+        let glyph_style = if selected {
+            Style::default()
+                .bg(Theme::selection_bg())
+                .fg(Theme::selection_fg())
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+                .fg(diff_status_color(s))
+                .add_modifier(Modifier::BOLD)
+        };
+        spans.push(Span::styled(format!("{} ", s.glyph()), glyph_style));
+    }
+    spans.push(Span::styled(row.label.clone(), label_style));
+    Line::from(spans)
+}
+
+/// Block title for the tree, showing the diff base + rollup when changes exist
+/// (e.g. ` Files · Δ origin/main 4 ±  +120 −18 `), else plain ` Files `.
+fn diff_header_title(changes: Option<&WorktreeDiff>) -> String {
+    match changes {
+        Some(d) if !d.files.is_empty() => {
+            let (files, ins, del) = d.totals();
+            let base = short_ref(&d.base_ref);
+            format!(" Files · Δ {base} {files}f +{ins} -{del} ")
+        }
+        _ => " Files ".to_string(),
+    }
+}
+
+/// Trim a long ref for the header (`refs/remotes/origin/main` → `origin/main`,
+/// `@{upstream}` stays as-is).
+fn short_ref(base: &str) -> String {
+    base.strip_prefix("refs/remotes/")
+        .or_else(|| base.strip_prefix("refs/heads/"))
+        .unwrap_or(base)
+        .to_string()
 }
 
 fn render_search_bar(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,6 +6,7 @@ pub mod automations_panel;
 pub mod branch_selector_modal;
 pub mod confirm_delete_modal;
 pub mod confirm_restore_modal;
+pub mod diff_view;
 pub mod file_viewer;
 pub mod global_search;
 pub mod highlight;


### PR DESCRIPTION
## What

Turns the read-only file viewer (\`Ctrl+E\`/\`F3\`) into a git-aware **diff/review pane** that answers *"what did this agent change?"* without leaving thurbox. Implements **Phases 0–3** of the design in \`docs/proposals/files-diff-review-pane.md\`.

## What's in this PR

- **Phase 0 — data + producers.** New pure-data \`session::diff\` types (\`DiffStatus\`/\`FileChange\`/\`WorktreeDiff\` + \`DiffLine\`/\`DiffLineKind\`/\`FileDiff\`); \`git::changed_files\` / \`git::file_diff\` producers; \`resolve_base_ref\` promoted to \`pub\` so the diff, the "behind" count, and \`Ctrl+S\` sync all share one base-resolution policy.
- **Phase 1 — status glyphs.** \`M\`/\`A\`/\`D\`/\`R\`/\`?\` markers + status-colored bold names in the tree, and a diff summary in the \`Files\` title (\` Files · Δ origin/main 4f +120 -18 \`).
- **Phase 3 — inline diff.** When the file viewer is focused and a changed file is selected, the **central pane** shows that file's color-coded unified diff (added=green, removed=red, hunk=accent), \`PageUp\`/\`PageDown\` to scroll. \`Enter\` still opens the real file in \`\$EDITOR\`.

## Architecture

Respects the \`ui ✗ git\` rule: diff types live in \`session\`, \`git\` produces them, \`App\` computes off the render path (a \`worktree_diff\` \`BackgroundTask\` on the \`GIT_REFRESH_TICKS\` cadence like \`git_stats\`; per-file diff lazily computed on selection change), and \`ui\` only renders the \`session\`-owned types. \`cargo test --test architecture_rules\` stays green.

## Tests

- \`session::diff\` unit tests (glyph/code round-trip, totals, hunk-line parsing).
- \`git\` parser tests (\`--name-status\` renames, unified-diff classification, binary detection) **+ an end-to-end test against a real temp repo** (Modified/Deleted/Added/Untracked + file-diff content + untracked synthesis).
- \`ui\` tests (header summary, glyph rows, diff line coloring).
- \`app\` test: worktree-diff cache filters by active session.
- Full \`cargo nextest run --all\` green except one pre-existing tmux-server contention flake (\`session_ops::extensions::uninstall_reverses_install\`, passes in isolation, untouched by this PR).

## Scope / follow-ups

v1 is **local-only** (remote \`ssh:<host>\` sessions skip the diff) and diffs the **primary** worktree. Deferred to follow-ups (per the proposal): a flat "Changes mode" + default, **Phase 4** open-at-line, **Phase 5** review comments/notes → agent loop, multi-repo + remote diff, and syntax highlighting.

Proposal doc updated with implementation status.