### PR TITLE
feat(ui): show keyboard shortcut on each footer button

### DIFF
--- a/src/app/snapshots/thurbox__app__acceptance__automations_list_modal_empty.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__automations_list_modal_empty.snap
@@ -31,4 +31,4 @@ expression: h.render()
 ┌ Automations ──────────┐│                                                                         │
 │none                   ││                                                                         │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
- Sessions  0 session(s)  ^H/^L Focus                 Help   Tasks   Files   Settings   Theme   Quit
+ Sessions  0 session(s Help · F1 c Tasks · F5   Files · F3   Settings · F6   Theme · F4   Quit · ^Q

--- a/src/app/snapshots/thurbox__app__acceptance__empty_welcome_screen_renders.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__empty_welcome_screen_renders.snap
@@ -31,4 +31,4 @@ expression: h.render()
 ┌ Automations ──────────┐│                                                                         │
 │none                   ││                                                                         │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
- Sessions  0 session(s)  ^H/^L Focus                 Help   Tasks   Files   Settings   Theme   Quit
+ Sessions  0 session(s Help · F1 c Tasks · F5   Files · F3   Settings · F6   Theme · F4   Quit · ^Q

--- a/src/app/snapshots/thurbox__app__acceptance__help_overlay_lists_keybindings.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__help_overlay_lists_keybindings.snap
@@ -31,4 +31,4 @@ expression: h.render()
 ┌ Automations ──────────┐│                                                                         │
 │none                   ││                                                                         │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
- Sessions  0 session(s)  ^H/^L Focus                 Help   Tasks   Files   Settings   Theme   Quit
+ Sessions  0 session(s Help · F1 c Tasks · F5   Files · F3   Settings · F6   Theme · F4   Quit · ^Q

--- a/src/app/snapshots/thurbox__app__acceptance__restore_sessions_modal_empty.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__restore_sessions_modal_empty.snap
@@ -31,4 +31,4 @@ expression: h.render()
 ┌ Automations ──────────┐│                                                                         │
 │none                   ││                                                                         │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
- Sessions  0 session(s)  ^H/^L Focus                 Help   Tasks   Files   Settings   Theme   Quit
+ Sessions  0 session(s Help · F1 c Tasks · F5   Files · F3   Settings · F6   Theme · F4   Quit · ^Q

--- a/src/app/snapshots/thurbox__app__acceptance__theme_picker_lists_palettes.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__theme_picker_lists_palettes.snap
@@ -31,4 +31,4 @@ expression: h.render()
 ┌ Automations ──────────┐│                                                                         │
 │none                   ││                                                                         │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
- Sessions  0 session(s)  ^H/^L Focus                 Help   Tasks   Files   Settings   Theme   Quit
+ Sessions  0 session(s Help · F1 c Tasks · F5   Files · F3   Settings · F6   Theme · F4   Quit · ^Q

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -605,6 +605,7 @@ impl App {
                 file_viewer_open: self.show_file_viewer,
                 tasks_enabled: self.features.tasks,
                 file_viewer_enabled: self.features.file_viewer,
+                keybindings: &self.keybindings,
             },
         );
         // The renderer pairs each surviving button with its Action, so the

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -6,9 +6,11 @@ use ratatui::{
     Frame,
 };
 
+use crossterm::event::{KeyCode, KeyModifiers};
+
 use super::theme::Theme;
 use crate::app::{StatusLevel, StatusMessage};
-use crate::session::Action;
+use crate::session::{Action, KeyBindings, KeyChord};
 
 fn brand_style() -> Style {
     Style::default()
@@ -83,6 +85,8 @@ pub struct FooterState<'a> {
     /// Feature flags gating the panel buttons (hidden when off).
     pub tasks_enabled: bool,
     pub file_viewer_enabled: bool,
+    /// Live keybindings, so each footer pill can show its (rebindable) shortcut.
+    pub keybindings: &'a KeyBindings,
 }
 
 /// The clickable footer buttons, in render order, paired with the `Action` each
@@ -113,6 +117,30 @@ fn footer_entries(tasks_enabled: bool, file_viewer_enabled: bool) -> Vec<(&'stat
         .collect()
 }
 
+/// Compact shortcut hint for a footer pill. Prefers an F-key alternate (`F1`)
+/// since it's the narrowest in the tight footer, else the first chord in caret
+/// form (`^Q`). `None` when the action has no binding.
+fn footer_shortcut(chords: &[KeyChord]) -> Option<String> {
+    chords
+        .iter()
+        .find_map(|c| match c.code {
+            KeyCode::F(n) if c.mods.is_empty() => Some(format!("F{n}")),
+            _ => None,
+        })
+        .or_else(|| chords.first().map(caret_form))
+}
+
+/// Render a chord compactly for the footer: `ctrl+<char>` → `^Q` / `^,`;
+/// anything else falls back to the full `KeyChord::display()` notation.
+fn caret_form(chord: &KeyChord) -> String {
+    if chord.mods == KeyModifiers::CONTROL {
+        if let KeyCode::Char(c) = chord.code {
+            return format!("^{}", c.to_ascii_uppercase());
+        }
+    }
+    chord.display()
+}
+
 /// Render the footer bar and return each clickable button's hitbox paired with
 /// the `Action` it dispatches, packed against the right edge. Tasks/Files are
 /// gated by their feature flags. When the file viewer is open its navigation
@@ -133,9 +161,20 @@ pub fn render_footer(
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 
     let entries = footer_entries(state.tasks_enabled, state.file_viewer_enabled);
-    let specs: Vec<super::ButtonSpec<'_>> = entries
+    // Suffix each pill with its live shortcut (`Help · F1`); own the strings so
+    // the borrowed `ButtonSpec`s can reference them.
+    let labels: Vec<String> = entries
         .iter()
-        .map(|(label, _)| super::ButtonSpec::secondary(label))
+        .map(
+            |(label, action)| match footer_shortcut(state.keybindings.chords_for(*action)) {
+                Some(sc) => format!("{label} · {sc}"),
+                None => label.to_string(),
+            },
+        )
+        .collect();
+    let specs: Vec<super::ButtonSpec<'_>> = labels
+        .iter()
+        .map(|l| super::ButtonSpec::secondary(l))
         .collect();
     let hits = super::render_button_bar(frame, area, &specs, true);
 
@@ -306,6 +345,11 @@ mod tests {
         );
     }
 
+    fn test_keybindings() -> &'static KeyBindings {
+        static KB: std::sync::OnceLock<KeyBindings> = std::sync::OnceLock::new();
+        KB.get_or_init(KeyBindings::default)
+    }
+
     fn footer_state(file_viewer_open: bool) -> FooterState<'static> {
         FooterState {
             session_count: 1,
@@ -317,6 +361,7 @@ mod tests {
             file_viewer_open,
             tasks_enabled: true,
             file_viewer_enabled: true,
+            keybindings: test_keybindings(),
         }
     }
 
@@ -353,6 +398,14 @@ mod tests {
         let (hits, line) = footer_render(false);
         for label in ["Help", "Tasks", "Files", "Settings", "Theme", "Quit"] {
             assert!(line.contains(label), "missing {label} in footer: {line:?}");
+        }
+        // Each pill carries its live shortcut: an F-key alternate where one
+        // exists (Help · F1), else the caret-ctrl chord (Quit · ^Q).
+        for shortcut in ["F1", "^Q"] {
+            assert!(
+                line.contains(shortcut),
+                "missing shortcut {shortcut} in footer: {line:?}"
+            );
         }
         // Every button maps back to its Action, in render order — guards the
         // index→action remapping in `render_footer`.


### PR DESCRIPTION
## Summary

- Footer pills now show their keyboard shortcut: `Help · F1`, `Tasks · F5`, `Files · F3`, `Settings · F6`, `Theme · F4`, `Quit · ^Q`.
- The shortcut is looked up **live** from the user's keybindings (rebindable), preferring the F-key alternate and falling back to caret-ctrl notation (`^Q`) — consistent with the existing `^H/^L Focus` hint.
- No change to `ButtonSpec` / `render_button_bar` / the `ButtonHit → Action` click map: the combined `Label · <shortcut>` string flows through the existing pill-rendering path.

## Test plan

- `cargo nextest run --lib` (1543 tests pass).
- New unit assertion in `footer_renders_all_buttons` checks the rendered footer contains `F1` and `^Q`.
- Regenerated the 5 acceptance snapshots that render the footer.
- `cargo clippy --all-targets --all-features -D warnings` clean.

Note: wider pills consume more of the right-aligned footer row, so at very narrow widths they overlap the left status text (pre-existing right-aligned-overlap behavior); fits comfortably at ≥120 cols.