### PR TITLE
feat(ui): scannable keyword column in settings panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1720,9 +1720,11 @@ via the same `apply_live_settings` and toasts (noting a restart when
 `Settings::restart_only_differs` vs the global). The panel's own write calls
 `mark_settings_saved` so the poll doesn't re-toast it.
 
-`SettingsField` (in `app/modals.rs`) owns the field order, labels,
-descriptions (which avoid naming key chords, since those are rebindable),
-scalar-vs-bool/step logic (`adjust` with per-field clamping), and the
+`SettingsField` (in `app/modals.rs`) owns the field order, labels, short
+scannable keywords and descriptions (both avoid naming key chords, since those
+are rebindable; each row renders the bold `keyword` then the dimmed
+`description`, via the single `meta()` table so the parallel lookups never
+drift), scalar-vs-bool/step logic (`adjust` with per-field clamping), and the
 per-row live/restart marker (`restart_required`); the canonical
 live/restart comparison is `Settings::restart_only_differs`
 (`session/settings.rs`), reused by both the panel toast and the reload path.

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -1542,53 +1542,81 @@ impl SettingsField {
         SettingsField::AuditRetentionDays,
     ];
 
-    /// The field's `settings.toml` key and one-line help, in a single table so
-    /// the two parallel lookups never drift (and stay one match, not two).
-    /// The help avoids naming key chords — those are user-configurable, so a
-    /// hard-coded hint would drift from the actual binding.
-    fn meta(self) -> (&'static str, &'static str) {
+    /// The field's `settings.toml` key, a short scannable keyword, and one-line
+    /// help, in a single table so the three parallel lookups never drift (and
+    /// stay one match, not three). Both keyword and help avoid naming key chords
+    /// — those are user-configurable, so a hard-coded hint would drift from the
+    /// actual binding.
+    fn meta(self) -> (&'static str, &'static str, &'static str) {
         use SettingsField::*;
         match self {
-            FeatTasks => ("tasks", "Tasks panel and task search"),
-            FeatAutomations => ("automations", "Automations pane and schedule firing"),
-            FeatFileViewer => ("file_viewer", "File viewer column"),
-            FeatGlobalSearch => ("global_search", "Global search strip"),
-            FeatInfoPanel => ("info_panel", "Info panel column"),
-            FeatShellPane => ("shell_pane", "Per-session shell pane"),
-            FeatMouse => ("mouse", "Mouse: clicks, wheel, drag-select, hover"),
-            FeatNotifications => ("notifications", "OS desktop notifications on attention"),
-            FeatSoftDelete => ("soft_delete", "Soft-delete sessions with an undo window"),
-            FeatVersionCheck => ("version_check", "Check GitHub for updates (network call)"),
+            FeatTasks => ("tasks", "Tasks", "Tasks panel and task search"),
+            FeatAutomations => (
+                "automations",
+                "Automations",
+                "Automations pane and schedule firing",
+            ),
+            FeatFileViewer => ("file_viewer", "File viewer", "File viewer column"),
+            FeatGlobalSearch => ("global_search", "Global search", "Global search strip"),
+            FeatInfoPanel => ("info_panel", "Info panel", "Info panel column"),
+            FeatShellPane => ("shell_pane", "Shell pane", "Per-session shell pane"),
+            FeatMouse => ("mouse", "Mouse", "Mouse: clicks, wheel, drag-select, hover"),
+            FeatNotifications => (
+                "notifications",
+                "Notifications",
+                "OS desktop notifications on attention",
+            ),
+            FeatSoftDelete => (
+                "soft_delete",
+                "Soft delete",
+                "Soft-delete sessions with an undo window",
+            ),
+            FeatVersionCheck => (
+                "version_check",
+                "Version check",
+                "Check GitHub for updates (network call)",
+            ),
             FeatAutoUpdate => (
                 "auto_update",
+                "Auto-update",
                 "Silently self-update on launch (network call)",
             ),
             NotifAlsoOnWaiting => (
                 "also_on_waiting",
+                "Notify done",
                 "Also notify when a session finishes (Done)",
             ),
             NotifSuppressForActive => (
                 "suppress_for_active",
+                "Skip active",
                 "Skip the session you're already viewing",
             ),
-            NotifSound => ("sound", "Play the OS notification sound"),
+            NotifSound => ("sound", "Sound", "Play the OS notification sound"),
             NotifMinInterval => (
                 "min_interval_secs",
+                "Min interval",
                 "Min seconds between notifications per session",
             ),
             ScrollbackLines => (
                 "scrollback_lines",
+                "Scrollback",
                 "Terminal history lines kept per session",
             ),
             TwoPanelMinCols => (
                 "two_panel_min_cols",
+                "2-panel width",
                 "Min width (cols) to show the 2nd panel",
             ),
             ThreePanelMinCols => (
                 "three_panel_min_cols",
+                "3-panel width",
                 "Min width (cols) to show the 3rd panel",
             ),
-            AuditRetentionDays => ("audit_retention_days", "Days of audit-log history kept"),
+            AuditRetentionDays => (
+                "audit_retention_days",
+                "Audit days",
+                "Days of audit-log history kept",
+            ),
         }
     }
 
@@ -1597,9 +1625,15 @@ impl SettingsField {
         self.meta().0
     }
 
-    /// One-line help shown for the selected field in the panel footer.
-    pub fn description(self) -> &'static str {
+    /// A short, scannable keyword shown as the bold left column of each row.
+    pub fn keyword(self) -> &'static str {
         self.meta().1
+    }
+
+    /// One-line help shown next to the keyword (and for the selected field in
+    /// the panel footer context).
+    pub fn description(self) -> &'static str {
+        self.meta().2
     }
 
     /// Whether the field holds a boolean (toggled with Space/Enter) vs. a

--- a/src/ui/settings_modal.rs
+++ b/src/ui/settings_modal.rs
@@ -201,6 +201,13 @@ fn build_rows<'a>(
         .map(|f| value_text(m, *f).chars().count())
         .max()
         .unwrap_or(3);
+    // Width of the keyword column: the widest keyword, so the descriptions that
+    // follow all start at the same column.
+    let keyword_width = SettingsField::ORDER
+        .iter()
+        .map(|f| f.keyword().chars().count())
+        .max()
+        .unwrap_or(0);
 
     let mut rows: Vec<(Line<'a>, Option<SettingsField>)> = Vec::new();
     for (section_idx, (title, fields)) in SECTIONS.iter().enumerate() {
@@ -219,7 +226,10 @@ fn build_rows<'a>(
             None,
         ));
         for field in *fields {
-            rows.push((field_line(m, *field, width, value_width), Some(*field)));
+            rows.push((
+                field_line(m, *field, width, keyword_width, value_width),
+                Some(*field),
+            ));
         }
     }
     rows
@@ -237,22 +247,35 @@ fn value_text(m: &crate::app::modals::SettingsModal, field: SettingsField) -> St
 }
 
 /// One field row laid out in fixed columns so values and markers align:
-/// `▸ <description> … <value right-justified in value_width><⟳ marker>`.
+/// `▸ <keyword (bold)> <description (dimmed)> … <value right-justified in
+/// value_width><⟳ marker>`. The bold keyword carries the "what" at a glance; the
+/// dimmer description is the supporting detail.
 fn field_line<'a>(
     m: &crate::app::modals::SettingsModal,
     field: SettingsField,
     width: usize,
+    keyword_width: usize,
     value_width: usize,
 ) -> Line<'a> {
     let active = field == m.field;
 
     let pointer = if active { "▸ " } else { "  " };
-    let desc_style = if active {
+    // Keyword: bold, brighter than the description so the hierarchy reads
+    // keyword > description.
+    let keyword_style = if active {
         Style::default()
             .fg(Theme::accent_bright())
             .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Theme::text_secondary())
+        Style::default()
+            .fg(Theme::text_secondary())
+            .add_modifier(Modifier::BOLD)
+    };
+    // Description: non-bold and dimmer, recedes behind the keyword.
+    let desc_style = if active {
+        Style::default().fg(Theme::accent())
+    } else {
+        Style::default().fg(Theme::text_muted())
     };
 
     let value = m.value_string(field);
@@ -278,21 +301,31 @@ fn field_line<'a>(
         "  "
     };
 
-    // Columns: pointer(2) + desc + pad + value(value_width) + marker(2).
+    // Columns: pointer(2) + keyword(keyword_width) + gap(1) + desc + pad +
+    // value(value_width) + marker(2). The keyword is padded to a fixed width so
+    // every description starts in the same column.
+    let keyword = field.keyword();
+    let keyword_pad = keyword_width.saturating_sub(keyword.chars().count());
+    let keyword_block = keyword_width + 1; // +1 gap after the keyword
     let right_block = value_width + marker.chars().count();
     let mut desc = field.description().to_string();
-    let left_budget = width.saturating_sub(2 + right_block + 1); // +1 minimum gap
+    // +1 minimum gap before the value column.
+    let left_budget = width.saturating_sub(2 + keyword_block + right_block + 1);
     if desc.chars().count() > left_budget {
         desc = desc.chars().take(left_budget.saturating_sub(1)).collect();
         desc.push('…');
     }
     let pad = width
-        .saturating_sub(2 + desc.chars().count() + right_block)
+        .saturating_sub(2 + keyword_block + desc.chars().count() + right_block)
         .max(1);
     let value_pad = value_width.saturating_sub(value_str.chars().count());
 
     Line::from(vec![
-        Span::styled(format!("{pointer}{desc}"), desc_style),
+        Span::styled(
+            format!("{pointer}{keyword}{}", " ".repeat(keyword_pad + 1)),
+            keyword_style,
+        ),
+        Span::styled(desc, desc_style),
         Span::raw(" ".repeat(pad + value_pad)),
         Span::styled(value_str, value_style),
         Span::styled(marker, Style::default().fg(Theme::text_muted())),


### PR DESCRIPTION
## Summary
- Settings rows previously showed only a long sentence, with the `settings.toml` key tucked away in the footer — hard to tell at a glance what each row controls.
- Add a short **bold keyword** as a fixed left column, with the existing description following **dimmed** on the same row (hierarchy reads keyword > description).
- Extend `SettingsField::meta()` to a `(key, keyword, description)` 3-tuple so the parallel lookups stay one match and never drift; add a `keyword()` accessor.
- Renderer computes a `keyword_width` column the same way it already computes `value_width`; value/marker right-alignment and modal width (66) are unchanged.

Example:
```
▸ Tasks         Tasks panel and task search                 on
  Automations   Automations pane and schedule firing        on ⟳
  Mouse         Mouse: clicks, wheel, drag-select, h…       on ⟳
  2-panel width Min width (cols) to show the 2nd pan…   ‹ 80 › ⟳
```

## Test plan
- `cargo build --bin thurbox` — clean
- `cargo clippy` — clean
- `cargo nextest run -E 'test(settings)'` — 55 pass
- `cargo nextest run -E 'test(acceptance)'` — 50 pass (incl. `screen.contains("Tasks panel")`)
- Visual render verified: keyword column aligned, descriptions truncate cleanly, values right-aligned with `⟳` markers