### PR TITLE
fix(ui): code-review scrollbar thumb reaches the bottom

### DIFF
--- a/src/ui/code_review.rs
+++ b/src/ui/code_review.rs
@@ -173,7 +173,12 @@ fn render_rows(
     }
     frame.render_widget(Paragraph::new(lines), content);
 
-    let geom = track.and_then(|t| scrollbar::render_into(frame, t, total, height, state.scroll));
+    // The view is selection-primary: the thumb tracks `selected` (which reaches
+    // the last row, `total - 1`), not `scroll` (which caps at `total - height`,
+    // so a thumb driven by it could never reach the bottom of the track). This
+    // also matches the drag mapping — `position_for_y` returns a `0..total`
+    // index that `apply_scrollbar_position` feeds straight to `cr_select_row`.
+    let geom = track.and_then(|t| scrollbar::render_into(frame, t, total, height, state.selected));
 
     let hitboxes = (start..end)
         .enumerate()


### PR DESCRIPTION
## Summary
- The code-review scrollbar thumb was "stuck halfway" and could never reach the bottom of the track.
- Root cause: the view is **selection-primary** (keyboard `cr_move`/`cr_home_end`, the wheel, and the scrollbar drag via `cr_select_row` all drive `state.selected`), but the rendered thumb was positioned from `state.scroll`. `scroll` caps at `total - height`, while ratatui's `Scrollbar` only puts the thumb at the bottom when `position == content_len - 1`.
- Fix: position the thumb from `state.selected` (reaches `total - 1` on the last row), consistent with the drag mapping (`position_for_y` → `cr_select_row`) and with the working `file_viewer` pane.

## Test plan
- Existing review/scrollbar unit tests pass (`cargo nextest run -E 'test(code_review) or test(scrollbar) or test(cr_)'`).
- Manual: open the code-review view (F7) on a diff longer than the viewport; drag the scrollbar / press `End` / scroll to the bottom — the thumb now travels the full track to the bottom.