### PR TITLE
docs: add code_review feature flag to website config table

### DIFF
--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -466,6 +466,11 @@ min_interval_secs   = 5        # per-session floor between notifications</code><
                 <td>per-session shell toggle (<code>Ctrl+T</code>)</td>
               </tr>
               <tr>
+                <td><code>code_review</code></td>
+                <td><code>true</code></td>
+                <td>native code-review view (diff + comments, <code>F7</code>)</td>
+              </tr>
+              <tr>
                 <td><code>mouse</code></td>
                 <td><code>true</code></td>
                 <td>mouse capture: clicks, wheel, drag-select, hover, scrollbars</td>


### PR DESCRIPTION
## Summary

- The website Configuration page listed `code_review` in the `settings.toml` seed block but **omitted it from the `[features]` reference table**, leaving the table out of sync with its own seed and with `docs/CONFIG.md`.
- Added the missing `code_review` row after `shell_pane`, matching the canonical flag order. The website table now lists all 12 feature flags, identical to `docs/CONFIG.md`.

## Test plan

- `npm run build:website` succeeds (eleventy build clean).
- `npx htmlhint _site/docs/configuration.html` passes with no errors.
- Verified the website table and `docs/CONFIG.md` table now enumerate the same 12 flags (`tasks`, `automations`, `file_viewer`, `global_search`, `info_panel`, `shell_pane`, `code_review`, `mouse`, `notifications`, `soft_delete`, `version_check`, `auto_update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3wajnnim3JHQ7yKiJmCcW)_