### PR TITLE
feat(ui): rebindable automations/tasks panes; coherent shortcuts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1630,7 +1630,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+P` | Automations (list/new/edit/toggle/run/delete) | **P**rogram |
 | `Ctrl+W` / `F5` | Toggle tasks panel (todo list) | Work items |
 | `Ctrl+/` | Global search (sessions/tasks/automations/files) | **/** = search |
-| `Ctrl+T` | Toggle shell pane | **T**erminal |
+| `Ctrl+T` / `F8` | Toggle shell pane | **T**erminal |
 | `F7` | Toggle native code-review view | Review |
 | `Ctrl+H` | Focus previous pane (cycle backward) | Vim: **h** = left |
 | `Ctrl+J` | Select next session | Vim: **j** = down |
@@ -1683,10 +1683,11 @@ chord strings, e.g. `{ "QuitApp": ["ctrl+x"] }`):
   (mtime poll — see `docs/CONFIG.md`).
 
 **Context-scoped bindings.** Each `Action` has a `KeyContext` (`Global`,
-`SessionList`, `FileViewer`, `Terminal`). Global actions are active
-everywhere; scoped actions fire only while their pane is focused, so a
-single-letter key like `j` can drive both the file viewer and the session
-list (and the terminal still forwards it to the PTY). `handle_key` resolves
+`SessionList`, `Automations`, `Tasks`, `FileViewer`, `Terminal`). Global
+actions are active everywhere; scoped actions fire only while their pane is
+focused, so a single-letter key like `j` can drive the file viewer, session
+list, automations pane, and tasks pane independently (and the terminal still
+forwards it to the PTY). `handle_key` resolves
 keys via `KeyBindings::lookup_in(App::focus_key_context(), …)`, dispatched
 through `dispatch_action`. Conflict detection (`KeyBindings::rebind`) only
 steals a chord between actions whose scopes overlap (`contexts_overlap`) —
@@ -1729,8 +1730,10 @@ falls through to normal cursor handling.
 
 A few stateful keys stay literal (the F1 panel lists them under
 **Fixed (not rebindable)**): modal selectors (j/k/Enter/Esc), the
-automations/tasks panes, the file-viewer **search sub-mode**, and the
-terminal's catch-all PTY forwarding.
+automation **run-history** sub-mode, the file-viewer **search sub-mode**, and
+the terminal's catch-all PTY forwarding. The automations and tasks panes
+themselves are **rebindable** scoped contexts (`KeyContext::Automations` /
+`KeyContext::Tasks`), mirroring the session list.
 
 ### macOS
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -372,7 +372,7 @@ applicable: `h/j/k/l` for navigation, semantic letters for actions
 | `Ctrl+P` | Global | Automations (scheduled agent runs) | **P**rogram |
 | `Ctrl+W` / `F5` | Global | Toggle tasks panel (todo list) | Work items |
 | `Ctrl+/` | Global | Global search across every scope | **/** = search |
-| `Ctrl+T` | Global | Toggle shell pane alongside the agent session | **T**erminal |
+| `Ctrl+T` / `F8` | Global | Toggle shell pane alongside the agent session | **T**erminal |
 | `F7` | Global | Toggle the native code-review view | Review |
 | `Ctrl+H` | Global | Focus previous pane (cycle backward) | Vim: **h** = left |
 | `Ctrl+J` | Global | Select next session | Vim: **j** = down |
@@ -437,14 +437,15 @@ and a status toast reports the move. Changes persist immediately to
 restart. The file can also be hand-edited directly.
 
 **Context-scoped keys.** Each action belongs to a scope — `Global`,
-`SessionList`, `FileViewer`, or `Terminal`. Global actions fire anywhere;
-scoped actions fire only while their pane is focused, so the same single-letter
-key (e.g. `j`) can drive both the file viewer and the session list while the
-terminal still forwards it to the shell. Conflicts are only flagged between
-actions whose scopes overlap. A handful of stateful keys stay fixed (shown in
-the F1 panel under *Fixed (not rebindable)*): modal selectors
-(`j`/`k`/`Enter`/`Esc`), the automations/tasks panes, the file-viewer search
-sub-mode, and the terminal's catch-all PTY forwarding.
+`SessionList`, `Automations`, `Tasks`, `FileViewer`, or `Terminal`. Global
+actions fire anywhere; scoped actions fire only while their pane is focused, so
+the same single-letter key (e.g. `j`) can drive the file viewer, session list,
+automations pane, and tasks pane independently while the terminal still forwards
+it to the shell. Conflicts are only flagged between actions whose scopes
+overlap. A handful of stateful keys stay fixed (shown in the F1 panel under
+*Fixed (not rebindable)*): modal selectors (`j`/`k`/`Enter`/`Esc`), the
+automation run-history sub-mode, the file-viewer search sub-mode, and the
+terminal's catch-all PTY forwarding.
 
 **Readline editing in modal text fields.** Thurbox's own text inputs
 (session / branch name, repo-picker path & search, automation editor,
@@ -1756,9 +1757,16 @@ the terminal keeps its native mouse behavior.
 
 ## Shell Pane Toggle
 
-`Ctrl+T` toggles between the agent session and a shell pane
+`Ctrl+T` (or `F8`) toggles between the agent session and a shell pane
 (plain bash/zsh) for the active session. The shell runs in a
 separate tmux pane alongside the agent pane.
+
+Unlike the other readline-shadowing `Ctrl+<letter>` chords (`Ctrl+B`/`D`/`E`/
+`F`/`O`/`P`/`R`/`S`/`U`/`W`), `Ctrl+T` is **not** passed through to the agent PTY
+when a terminal is focused: it still toggles the shell. This is a deliberate
+exception — readline's transpose-chars (`Ctrl+T`) is rarely used, and the
+convenient shell toggle wins. `F8` is the equivalent alternate, matching the
+other panel toggles' F-keys.
 
 - **Status bar**: Shows "Shell" label when viewing the shell pane.
 - **Per-session state**: Each session tracks its own `TerminalView`

--- a/src/app/automation.rs
+++ b/src/app/automation.rs
@@ -639,28 +639,40 @@ impl App {
         true
     }
 
-    /// Handle keys while the automations pane is focused: navigate and drive the
-    /// same toggle/run/edit/delete actions as the Ctrl+P modal. (Ctrl+N to
-    /// create is handled globally in `dispatch_action`, so it works here too,
-    /// including on an empty pane.)
-    pub(crate) fn handle_automations_pane_key(&mut self, code: KeyCode) {
+    /// Fallback for keys the automations pane doesn't bind. All navigation and
+    /// actions resolve through the keybinding lookup (`KeyContext::Automations`)
+    /// → [`Self::dispatch_automations_pane_action`]; nothing unbound is handled
+    /// here (the pane has no `Esc` behavior).
+    pub(crate) fn handle_automations_pane_key(&mut self, _code: KeyCode) {}
+
+    /// Run an `Automations`-scoped action resolved from the keybinding lookup.
+    /// The circular-nav glue (j past the last automation loops to the session
+    /// list, k at the top hands focus back) lives in the reused move helpers, so
+    /// rebinding a key never changes that behavior. Returns `true` (consumed).
+    ///
+    /// `New`/`Open`/`Next`/`Prev` work on an empty pane (count == 0) — the
+    /// helpers handle that — while toggle/run/delete are no-ops without a row.
+    pub(crate) fn dispatch_automations_pane_action(
+        &mut self,
+        action: crate::session::Action,
+    ) -> bool {
+        use crate::session::Action;
         let count = self.automation_ui.cached_automations.len();
-        match code {
-            // Creating works regardless of whether the pane has entries.
-            KeyCode::Char('n') => self.new_automation_in_pane(),
-            // `k`/Up at the top row (or empty pane) flows focus back up into the
-            // session list; `j`/Down past the last loops to the top of it — so
-            // the left column behaves as one circular vertical list.
-            KeyCode::Char('k') | KeyCode::Up => self.automations_pane_move_up(count),
-            KeyCode::Char('j') | KeyCode::Down => self.automations_pane_move_down(count),
-            // `Enter`/`e` focuses the central-pane editor (like `Enter` on a
-            // session focuses its terminal); on an empty pane it starts a new
-            // automation.
-            KeyCode::Enter | KeyCode::Char('e') => self.enter_automation_editor_in_pane(count),
-            // Remaining nav/actions are no-ops on an empty pane.
-            _ if count > 0 => self.dispatch_automation_pane_action(code, count),
+        match action {
+            Action::AutomationsNew => self.new_automation_in_pane(),
+            Action::AutomationsPrev => self.automations_pane_move_up(count),
+            Action::AutomationsNext => self.automations_pane_move_down(count),
+            Action::AutomationsOpen => self.enter_automation_editor_in_pane(count),
+            // Toggle / run / delete act on the row under the cursor — no-ops on
+            // an empty pane.
+            Action::AutomationsToggle | Action::AutomationsRun | Action::AutomationsDelete
+                if count > 0 =>
+            {
+                self.run_selected_automation_action(action, count)
+            }
             _ => {}
         }
+        true
     }
 
     /// `Enter`/`e` in the automations pane: open the editor for the selection,
@@ -674,15 +686,31 @@ impl App {
         self.refresh_selected_automation_runs();
     }
 
-    /// Clamp the selection and run the toggle/run/delete action for the row
-    /// under the cursor (caller guarantees a non-empty pane).
-    fn dispatch_automation_pane_action(&mut self, code: KeyCode, count: usize) {
+    /// Clamp the selection and toggle/run/delete the automation under the cursor
+    /// (caller guarantees a non-empty pane).
+    fn run_selected_automation_action(&mut self, action: crate::session::Action, count: usize) {
+        use crate::session::Action;
         if self.automation_ui.automation_panel_index >= count {
             self.automation_ui.automation_panel_index = count - 1;
         }
         let id =
             self.automation_ui.cached_automations[self.automation_ui.automation_panel_index].id;
-        self.handle_automation_pane_action(code, id);
+        match action {
+            Action::AutomationsToggle => {
+                self.toggle_automation_by_id(id);
+                self.sync_automation_editor();
+            }
+            Action::AutomationsRun => self.run_automation_by_id(id),
+            Action::AutomationsDelete => {
+                self.delete_automation_by_id(id);
+                let new_count = self.automation_ui.cached_automations.len();
+                if new_count > 0 && self.automation_ui.automation_panel_index >= new_count {
+                    self.automation_ui.automation_panel_index = new_count - 1;
+                }
+                self.refresh_automation_view();
+            }
+            _ => {}
+        }
     }
 
     /// `k`/Up in the automations pane: step up, or hand focus back to the
@@ -707,26 +735,6 @@ impl App {
             self.automation_ui.automation_panel_index += 1;
         }
         self.refresh_automation_view();
-    }
-
-    /// Toggle / run / delete the selected automation (`Space`/`r`/`d`).
-    fn handle_automation_pane_action(&mut self, code: KeyCode, id: i64) {
-        match code {
-            KeyCode::Char(' ') => {
-                self.toggle_automation_by_id(id);
-                self.sync_automation_editor();
-            }
-            KeyCode::Char('r') => self.run_automation_by_id(id),
-            KeyCode::Char('d') => {
-                self.delete_automation_by_id(id);
-                let new_count = self.automation_ui.cached_automations.len();
-                if new_count > 0 && self.automation_ui.automation_panel_index >= new_count {
-                    self.automation_ui.automation_panel_index = new_count - 1;
-                }
-                self.refresh_automation_view();
-            }
-            _ => {}
-        }
     }
 
     /// Handle keys while editing the scoped automation in the central pane.

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -166,8 +166,12 @@ impl App {
         use crate::session::KeyContext;
         match self.focus {
             InputFocus::SessionList => KeyContext::SessionList,
+            InputFocus::Automations => KeyContext::Automations,
+            InputFocus::TaskList => KeyContext::Tasks,
             InputFocus::FileViewer if !self.file_viewer.search_active => KeyContext::FileViewer,
             InputFocus::Terminal => KeyContext::Terminal,
+            // The editor / run-history focuses are capture sub-modes handled
+            // before the lookup, so they stay on Global here.
             _ => KeyContext::Global,
         }
     }
@@ -1108,6 +1112,23 @@ impl App {
     fn dispatch_scoped_pane_action(&mut self, action: crate::session::Action) -> bool {
         use crate::session::Action;
         match action {
+            Action::AutomationsNew
+            | Action::AutomationsNext
+            | Action::AutomationsPrev
+            | Action::AutomationsOpen
+            | Action::AutomationsToggle
+            | Action::AutomationsRun
+            | Action::AutomationsDelete => self.dispatch_automations_pane_action(action),
+            Action::TasksNew
+            | Action::TasksNext
+            | Action::TasksPrev
+            | Action::TasksOpen
+            | Action::TasksCycleStatus
+            | Action::TasksRun
+            | Action::TasksOpenRelated
+            | Action::TasksDelete
+            | Action::TasksPreviewDown
+            | Action::TasksPreviewUp => self.dispatch_tasks_pane_action(action),
             Action::FileViewerDown
             | Action::FileViewerUp
             | Action::FileViewerCollapse
@@ -1186,12 +1207,10 @@ impl App {
                 true
             }
             InputFocus::Automations => {
-                self.handle_automations_pane_key(KeyCode::Char('d'));
-                true
+                self.dispatch_automations_pane_action(crate::session::Action::AutomationsDelete)
             }
             InputFocus::TaskList => {
-                self.handle_task_list_key(KeyCode::Char('d'));
-                true
+                self.dispatch_tasks_pane_action(crate::session::Action::TasksDelete)
             }
             InputFocus::AutomationEditor
             | InputFocus::AutomationRunHistory

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6234,16 +6234,18 @@ mod tests {
 
         // j/k navigate within the pane; past either end they loop out into the
         // session list (the column is circular).
+        // Keys route through the real pipeline: focus = Automations scopes the
+        // lookup to `KeyContext::Automations`, resolving j/k to the pane actions.
         app.automation_ui.cached_automations = vec![make(1, "a"), make(2, "b")];
         app.focus = InputFocus::Automations;
         app.automation_ui.automation_panel_index = 0;
-        app.handle_automations_pane_key(KeyCode::Char('j'));
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE);
         assert_eq!(app.automation_ui.automation_panel_index, 1);
-        app.handle_automations_pane_key(KeyCode::Char('k'));
+        app.handle_key(KeyCode::Char('k'), KeyModifiers::NONE);
         assert_eq!(app.automation_ui.automation_panel_index, 0);
         // j past the last automation loops out to the session list.
         app.automation_ui.automation_panel_index = 1;
-        app.handle_automations_pane_key(KeyCode::Char('j'));
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE);
         assert_eq!(app.focus, InputFocus::SessionList);
     }
 
@@ -6276,9 +6278,9 @@ mod tests {
         assert_eq!(app.automation_ui.automation_panel_index, 0);
 
         // Down past the last automation loops to the TOP session.
-        app.handle_automations_pane_key(KeyCode::Char('j')); // a → b
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE); // a → b
         assert_eq!(app.automation_ui.automation_panel_index, 1);
-        app.handle_automations_pane_key(KeyCode::Char('j')); // past last → top session
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE); // past last → top session
         assert_eq!(app.focus, InputFocus::SessionList);
         assert_eq!(app.active_index, 0, "looped to first session");
 
@@ -6292,7 +6294,7 @@ mod tests {
 
         // And k at the top automation hands back up to the last session.
         app.automation_ui.automation_panel_index = 0;
-        app.handle_automations_pane_key(KeyCode::Char('k'));
+        app.handle_key(KeyCode::Char('k'), KeyModifiers::NONE);
         assert_eq!(app.focus, InputFocus::SessionList);
         assert_eq!(app.active_index, 1, "back to last session");
     }
@@ -6527,7 +6529,7 @@ mod tests {
 
         // `j` past the end clamps to the last rebindable action.
         let last = crate::session::Action::rebindable_in_order().len() - 1;
-        for _ in 0..50 {
+        for _ in 0..(last + 5) {
             app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE);
         }
         let modals::Modal::Help(ref h) = app.modal else {
@@ -6676,8 +6678,18 @@ mod tests {
         assert_eq!(app.focus_key_context(), KeyContext::Global);
         app.file_viewer.search_active = false;
 
-        // Automations / tasks / editors are not a scoped keybinding context.
+        // The automations and tasks panes are their own scoped contexts, so
+        // single letters (j/k/n/r/d/…) resolve there without leaking to the PTY.
         app.focus = InputFocus::Automations;
+        assert_eq!(app.focus_key_context(), KeyContext::Automations);
+        app.focus = InputFocus::TaskList;
+        assert_eq!(app.focus_key_context(), KeyContext::Tasks);
+
+        // The in-pane editors / run-history are capture sub-modes handled before
+        // the lookup, so they stay on Global.
+        app.focus = InputFocus::AutomationEditor;
+        assert_eq!(app.focus_key_context(), KeyContext::Global);
+        app.focus = InputFocus::TaskEditor;
         assert_eq!(app.focus_key_context(), KeyContext::Global);
     }
 

--- a/src/app/snapshots/thurbox__app__acceptance__help_overlay_lists_keybindings.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__help_overlay_lists_keybindings.snap
@@ -12,7 +12,7 @@ expression: h.render()
 │                   │› ctrl+h          Focus previous pane                    █│                   │
 │                   │  ctrl+l          Focus next pane                        █│                   │
 │                   │  ctrl+j          Next session                           █│                   │
-│                   │  ctrl+k          Previous session                       █│                   │
+│                   │  ctrl+k          Previous session                       ║│                   │
 │                   │                                                         ║│                   │
 │                   │Sessions                                                 ║│                   │
 │                   │  ctrl+n          New session                            ║│                   │

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -237,45 +237,48 @@ impl App {
         }
     }
 
-    /// Handle keys while the tasks panel is focused: `j`/`k` select (and preview
-    /// the selected task in the central pane), `PageUp`/`PageDown` scroll that
-    /// preview, `n` create, `e`/`Enter` open the central-pane editor, `Space`
-    /// cycles status, `r` opens the trigger-time action picker, `d` deletes,
-    /// `Esc` leaves. Searching is handled by the global `Ctrl+/`.
+    /// Fallback for keys the tasks panel doesn't bind. Navigation and actions
+    /// resolve through the keybinding lookup (`KeyContext::Tasks`) →
+    /// [`Self::dispatch_tasks_pane_action`]; only the unbound `Esc` (leave the
+    /// panel) is handled here.
     pub(crate) fn handle_task_list_key(&mut self, code: KeyCode) {
-        // Creating works regardless of whether the panel has entries.
-        if matches!(code, KeyCode::Char('n')) {
-            self.new_task_in_pane();
-            return;
+        if matches!(code, KeyCode::Esc) {
+            self.focus = InputFocus::SessionList;
+            self.task_ui.task_editor = None;
         }
+    }
 
+    /// Run a `Tasks`-scoped action resolved from the keybinding lookup: `j`/`k`
+    /// select (and preview the task in the central pane), `PageUp`/`PageDown`
+    /// scroll that preview, `n` create, `e`/`Enter` open the editor, `Space`
+    /// cycles status, `r` opens the trigger-time action picker, `o` opens the
+    /// related session, `d` deletes. Returns `true` (consumed). Creating /
+    /// opening work on an empty panel (count == 0).
+    pub(crate) fn dispatch_tasks_pane_action(&mut self, action: crate::session::Action) -> bool {
+        use crate::session::Action;
         let count = self.task_ui.filtered_task_indices.len();
-        match code {
-            KeyCode::Char('j') | KeyCode::Down
-                if count > 0 && self.task_ui.task_panel_index + 1 < count =>
-            {
-                self.task_ui.task_panel_index += 1;
-                self.refresh_task_view();
+        match action {
+            Action::TasksNew => self.new_task_in_pane(),
+            Action::TasksNext => {
+                if count > 0 && self.task_ui.task_panel_index + 1 < count {
+                    self.task_ui.task_panel_index += 1;
+                    self.refresh_task_view();
+                }
             }
-            KeyCode::Char('j') | KeyCode::Down => {}
-            KeyCode::Char('k') | KeyCode::Up => {
+            Action::TasksPrev => {
                 self.task_ui.task_panel_index = self.task_ui.task_panel_index.saturating_sub(1);
                 self.refresh_task_view();
             }
-            KeyCode::Esc => {
-                self.focus = InputFocus::SessionList;
-                self.task_ui.task_editor = None;
-            }
-            KeyCode::Char('e') | KeyCode::Enter => self.enter_task_editor_or_new(count),
-            // Scroll the full-screen preview (the list itself uses j/k).
-            KeyCode::PageDown => self.scroll_task_preview(5),
-            KeyCode::PageUp => self.scroll_task_preview(-5),
-            KeyCode::Char(' ') => self.cycle_selected_task_status(),
-            KeyCode::Char('r') => self.open_selected_task_action_picker(),
-            KeyCode::Char('o') => self.open_task_related_session(),
-            KeyCode::Char('d') => self.delete_selected_task(),
+            Action::TasksOpen => self.enter_task_editor_or_new(count),
+            Action::TasksPreviewDown => self.scroll_task_preview(5),
+            Action::TasksPreviewUp => self.scroll_task_preview(-5),
+            Action::TasksCycleStatus => self.cycle_selected_task_status(),
+            Action::TasksRun => self.open_selected_task_action_picker(),
+            Action::TasksOpenRelated => self.open_task_related_session(),
+            Action::TasksDelete => self.delete_selected_task(),
             _ => {}
         }
+        true
     }
 
     /// `e`/`Enter` on the tasks panel: open the central-pane editor for the

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -1401,28 +1401,11 @@ fn render_help_overlay(
     ));
     help_lines.push(help_line(
         "j/k/Enter/Esc".into(),
-        "Automations & tasks panes, and modal selectors",
+        "Modal selectors & automation run-history (the automations/tasks panes are rebindable above)",
     ));
     help_lines.push(help_line(
-        "n / e".into(),
-        "Tasks: new task / edit selected (central-pane editor)",
-    ));
-    help_lines.push(help_line(
-        "r".into(),
-        "Tasks: run — Send to a session or Spawn a new one",
-    ));
-    help_lines.push(help_line(
-        "Space".into(),
-        "Tasks: cycle status (todo → in progress → done)",
-    ));
-    help_lines.push(help_line("d".into(), "Tasks: delete selected"));
-    help_lines.push(help_line(
-        "PgUp/PgDn".into(),
-        "Tasks: scroll the description preview",
-    ));
-    help_lines.push(help_line(
-        "j/k {} []".into(),
-        "Code review: move · {}/[] jump file/hunk · g/G top/bottom · v split view",
+        "j/k {}/[]".into(),
+        "Code review: move · { } prev/next file · [ ] prev/next hunk · g/G top/bottom · v split view",
     ));
     help_lines.push(help_line(
         "c/f/s".into(),

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -69,6 +69,32 @@ pub enum Action {
     /// Sort sessions alphabetically by name within each repo group, preserving
     /// group order and parent/child nesting (children sort among siblings).
     SessionListSortAlphabetically,
+    // ── Automations pane (scoped) ───────────────────────────────────────
+    AutomationsNew,
+    AutomationsNext,
+    AutomationsPrev,
+    /// Open the central-pane editor for the selected automation.
+    AutomationsOpen,
+    /// Toggle the selected automation enabled/disabled.
+    AutomationsToggle,
+    /// Run the selected automation now.
+    AutomationsRun,
+    AutomationsDelete,
+    // ── Tasks pane (scoped) ─────────────────────────────────────────────
+    TasksNew,
+    TasksNext,
+    TasksPrev,
+    /// Open the central-pane editor for the selected task.
+    TasksOpen,
+    /// Cycle the selected task's status (Todo → InProgress → Done).
+    TasksCycleStatus,
+    /// Open the trigger-time action picker (Send → session / Spawn new).
+    TasksRun,
+    /// Open the selected task's related session.
+    TasksOpenRelated,
+    TasksDelete,
+    TasksPreviewDown,
+    TasksPreviewUp,
     // ── File viewer (scoped) ────────────────────────────────────────────
     FileViewerDown,
     FileViewerUp,
@@ -92,6 +118,8 @@ pub enum Action {
 pub enum KeyContext {
     Global,
     SessionList,
+    Automations,
+    Tasks,
     FileViewer,
     Terminal,
 }
@@ -131,6 +159,23 @@ impl Action {
             Action::SessionListMoveDown,
             Action::SessionListMoveUp,
             Action::SessionListSortAlphabetically,
+            Action::AutomationsNew,
+            Action::AutomationsNext,
+            Action::AutomationsPrev,
+            Action::AutomationsOpen,
+            Action::AutomationsToggle,
+            Action::AutomationsRun,
+            Action::AutomationsDelete,
+            Action::TasksNew,
+            Action::TasksNext,
+            Action::TasksPrev,
+            Action::TasksOpen,
+            Action::TasksCycleStatus,
+            Action::TasksRun,
+            Action::TasksOpenRelated,
+            Action::TasksDelete,
+            Action::TasksPreviewDown,
+            Action::TasksPreviewUp,
             Action::FileViewerDown,
             Action::FileViewerUp,
             Action::FileViewerCollapse,
@@ -179,6 +224,23 @@ impl Action {
             Action::SessionListMoveDown => "Move session down",
             Action::SessionListMoveUp => "Move session up",
             Action::SessionListSortAlphabetically => "Sort sessions A→Z",
+            Action::AutomationsNew => "New automation",
+            Action::AutomationsNext => "Next item",
+            Action::AutomationsPrev => "Previous item",
+            Action::AutomationsOpen => "Edit automation",
+            Action::AutomationsToggle => "Toggle enabled",
+            Action::AutomationsRun => "Run now",
+            Action::AutomationsDelete => "Delete automation",
+            Action::TasksNew => "New task",
+            Action::TasksNext => "Next item",
+            Action::TasksPrev => "Previous item",
+            Action::TasksOpen => "Edit task",
+            Action::TasksCycleStatus => "Cycle status",
+            Action::TasksRun => "Run (Send / Spawn)",
+            Action::TasksOpenRelated => "Open related session",
+            Action::TasksDelete => "Delete task",
+            Action::TasksPreviewDown => "Scroll preview down",
+            Action::TasksPreviewUp => "Scroll preview up",
             Action::FileViewerDown => "Move down",
             Action::FileViewerUp => "Move up",
             Action::FileViewerCollapse => "Collapse / parent",
@@ -206,6 +268,23 @@ impl Action {
             | Action::SessionListMoveDown
             | Action::SessionListMoveUp
             | Action::SessionListSortAlphabetically => KeyContext::SessionList,
+            Action::AutomationsNew
+            | Action::AutomationsNext
+            | Action::AutomationsPrev
+            | Action::AutomationsOpen
+            | Action::AutomationsToggle
+            | Action::AutomationsRun
+            | Action::AutomationsDelete => KeyContext::Automations,
+            Action::TasksNew
+            | Action::TasksNext
+            | Action::TasksPrev
+            | Action::TasksOpen
+            | Action::TasksCycleStatus
+            | Action::TasksRun
+            | Action::TasksOpenRelated
+            | Action::TasksDelete
+            | Action::TasksPreviewDown
+            | Action::TasksPreviewUp => KeyContext::Tasks,
             Action::FileViewerDown
             | Action::FileViewerUp
             | Action::FileViewerCollapse
@@ -241,6 +320,12 @@ impl Action {
     /// `Ctrl+Q` quit, `Ctrl+N` new, …) are deliberately **not** deferred: they
     /// are the keyboard escape route out of the terminal, so they must keep
     /// working there even though some collide with readline.
+    ///
+    /// `Ctrl+T` (`ToggleShell`) is a deliberate exception that is **not** in
+    /// this list even though it shadows readline's transpose-chars: transpose is
+    /// rarely used and the convenient shell toggle wins. It also carries an `F8`
+    /// alternate, so this is a considered choice — do not "fix" it by adding it
+    /// here.
     pub fn terminal_passthrough(self) -> bool {
         matches!(
             self,
@@ -285,7 +370,10 @@ impl Action {
             Action::OpenInEditor => vec![KeyChord::ctrl('o')],
             Action::OpenAutomations => vec![KeyChord::ctrl('p')],
             Action::StartSync => vec![KeyChord::ctrl('s')],
-            Action::ToggleShell => vec![KeyChord::ctrl('t')],
+            // Ctrl+T primary, F8 alternate (the only panel toggle that lacked
+            // one; F1–F7 are taken). Stays a shell toggle in the terminal — see
+            // the `terminal_passthrough` exception note.
+            Action::ToggleShell => vec![KeyChord::ctrl('t'), KeyChord::function(8)],
             // F7 — the Ctrl+<letter> namespace is full and F-keys never collide
             // with the PTY's readline chords. Fully rebindable.
             Action::ToggleReview => vec![KeyChord::function(7)],
@@ -338,6 +426,26 @@ impl Action {
             Action::SessionListSortAlphabetically => {
                 vec![KeyChord::normalized(KeyModifiers::NONE, KeyCode::Char('S'))]
             }
+            // Automations pane (scoped) — same letters as the session list,
+            // safe because the context lookup keeps them apart.
+            Action::AutomationsNew => vec![KeyChord::plain('n')],
+            Action::AutomationsNext => vec![KeyChord::plain('j'), KeyChord::key(KeyCode::Down)],
+            Action::AutomationsPrev => vec![KeyChord::plain('k'), KeyChord::key(KeyCode::Up)],
+            Action::AutomationsOpen => vec![KeyChord::key(KeyCode::Enter), KeyChord::plain('e')],
+            Action::AutomationsToggle => vec![KeyChord::plain(' ')],
+            Action::AutomationsRun => vec![KeyChord::plain('r')],
+            Action::AutomationsDelete => vec![KeyChord::plain('d')],
+            // Tasks pane (scoped).
+            Action::TasksNew => vec![KeyChord::plain('n')],
+            Action::TasksNext => vec![KeyChord::plain('j'), KeyChord::key(KeyCode::Down)],
+            Action::TasksPrev => vec![KeyChord::plain('k'), KeyChord::key(KeyCode::Up)],
+            Action::TasksOpen => vec![KeyChord::key(KeyCode::Enter), KeyChord::plain('e')],
+            Action::TasksCycleStatus => vec![KeyChord::plain(' ')],
+            Action::TasksRun => vec![KeyChord::plain('r')],
+            Action::TasksOpenRelated => vec![KeyChord::plain('o')],
+            Action::TasksDelete => vec![KeyChord::plain('d')],
+            Action::TasksPreviewDown => vec![KeyChord::key(KeyCode::PageDown)],
+            Action::TasksPreviewUp => vec![KeyChord::key(KeyCode::PageUp)],
             Action::FileViewerDown => vec![KeyChord::plain('j'), KeyChord::key(KeyCode::Down)],
             Action::FileViewerUp => vec![KeyChord::plain('k'), KeyChord::key(KeyCode::Up)],
             Action::FileViewerCollapse => vec![KeyChord::plain('h'), KeyChord::key(KeyCode::Left)],
@@ -447,6 +555,33 @@ pub fn help_sections() -> Vec<(&'static str, Vec<Action>)> {
                 SessionListMoveDown,
                 SessionListMoveUp,
                 SessionListSortAlphabetically,
+            ],
+        ),
+        (
+            "Automations (when focused)",
+            vec![
+                AutomationsNew,
+                AutomationsNext,
+                AutomationsPrev,
+                AutomationsOpen,
+                AutomationsToggle,
+                AutomationsRun,
+                AutomationsDelete,
+            ],
+        ),
+        (
+            "Tasks (when focused)",
+            vec![
+                TasksNew,
+                TasksNext,
+                TasksPrev,
+                TasksOpen,
+                TasksCycleStatus,
+                TasksRun,
+                TasksOpenRelated,
+                TasksDelete,
+                TasksPreviewDown,
+                TasksPreviewUp,
             ],
         ),
         (
@@ -972,6 +1107,21 @@ mod tests {
     }
 
     #[test]
+    fn toggle_shell_has_dual_ctrl_and_f8_chord() {
+        // Ctrl+T is the only panel toggle that historically lacked an F-key
+        // alternate; F8 was the first free function key.
+        let kb = KeyBindings::default();
+        assert_eq!(
+            kb.lookup(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            Some(Action::ToggleShell)
+        );
+        assert_eq!(
+            kb.lookup(KeyCode::F(8), KeyModifiers::NONE),
+            Some(Action::ToggleShell)
+        );
+    }
+
+    #[test]
     fn lookup_finds_default_chord() {
         let kb = KeyBindings::default();
         assert_eq!(
@@ -1138,6 +1288,23 @@ mod tests {
                 Action::SessionListMoveDown => 0,
                 Action::SessionListMoveUp => 0,
                 Action::SessionListSortAlphabetically => 0,
+                Action::AutomationsNew => 0,
+                Action::AutomationsNext => 0,
+                Action::AutomationsPrev => 0,
+                Action::AutomationsOpen => 0,
+                Action::AutomationsToggle => 0,
+                Action::AutomationsRun => 0,
+                Action::AutomationsDelete => 0,
+                Action::TasksNew => 0,
+                Action::TasksNext => 0,
+                Action::TasksPrev => 0,
+                Action::TasksOpen => 0,
+                Action::TasksCycleStatus => 0,
+                Action::TasksRun => 0,
+                Action::TasksOpenRelated => 0,
+                Action::TasksDelete => 0,
+                Action::TasksPreviewDown => 0,
+                Action::TasksPreviewUp => 0,
                 Action::FileViewerDown => 0,
                 Action::FileViewerUp => 0,
                 Action::FileViewerCollapse => 0,
@@ -1153,7 +1320,7 @@ mod tests {
         }
         // The listed variants must equal Action::all().len(). If you add
         // a variant, update both `Action::all()` and the match above.
-        const EXPECTED: usize = 42;
+        const EXPECTED: usize = 59;
         assert_eq!(Action::all().len(), EXPECTED);
         for a in Action::all() {
             classify(*a);
@@ -1241,6 +1408,33 @@ mod tests {
                 KeyModifiers::NONE
             ),
             Some(Action::SessionListNext)
+        );
+        // The same `j` drives the automations and tasks panes, each scoped to
+        // its own context — no collision with the session list / file viewer.
+        assert_eq!(
+            kb.lookup_in(
+                KeyContext::Automations,
+                KeyCode::Char('j'),
+                KeyModifiers::NONE
+            ),
+            Some(Action::AutomationsNext)
+        );
+        assert_eq!(
+            kb.lookup_in(KeyContext::Tasks, KeyCode::Char('j'), KeyModifiers::NONE),
+            Some(Action::TasksNext)
+        );
+        // A bare letter unique to one pane resolves only there.
+        assert_eq!(
+            kb.lookup_in(KeyContext::Tasks, KeyCode::Char('o'), KeyModifiers::NONE),
+            Some(Action::TasksOpenRelated)
+        );
+        assert_eq!(
+            kb.lookup_in(
+                KeyContext::SessionList,
+                KeyCode::Char('o'),
+                KeyModifiers::NONE
+            ),
+            None
         );
         // The terminal never resolves `j` — it forwards it to the PTY.
         assert_eq!(


### PR DESCRIPTION
## Summary

A keyboard-shortcut coherence pass — three fixes that align the bindings with the system's own rules:

- **Automations & tasks panes are now rebindable.** They were the only focusable panes that hardcoded their keys (`j`/`k`/`n`/`e`/`r`/`d`/`Space`/`o`/`PgUp`/`PgDn`) and listed them under F1 → *Fixed (not rebindable)*, unlike the session list. Added `KeyContext::Automations`/`Tasks` plus 17 scoped `Action`s (current keys as defaults), wired through the existing `lookup_in`/`dispatch_action` machinery. The circular-nav glue (j past the last automation → top of the session list) stays in the reused move helpers — only the key→action mapping moved — so rebinding never changes the wrap behavior.
- **`Ctrl+T` (ToggleShell) gained its missing `F8` alternate** — it was the only panel toggle without one (F1–F7 are taken). It deliberately stays a shell toggle in a focused terminal (not passed through to the agent like the other readline `Ctrl+<letter>` chords); transpose-chars is rarely used and the toggle wins. Documented as an intentional exception so it isn't "fixed" later.
- **Code-review nav help text** — the ambiguous `"{}/[] jump file/hunk"` now spells out `{ }` prev/next file and `[ ]` prev/next hunk.

Docs (`CLAUDE.md`, `docs/FEATURES.md`) reconciled: new scopes, the `F8` alternate, the passthrough-exception note, and the trimmed *Fixed-keys* block. A follow-up refactor folds the automations row-action dispatch into a single `Action`-based helper (no more `Action → KeyCode → Action` round-trip).

## Test plan

- `cargo build` clean; full lib suite (1585 tests) + integration + `architecture_rules` green.
- New focused tests: `j` resolving to distinct actions across SessionList/Automations/Tasks/FileViewer (and `None` in Terminal), `o` scoped only to Tasks, the `F8` ↔ ToggleShell dual chord, and the circular-nav loop driven through the real `handle_key` pipeline.
- Regenerated the F1 help snapshot; `cargo fmt` + `clippy -D warnings` clean; doc lines within the 100-col limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTfxFQ64FFN4oHCzU9bYvt)_