### PR TITLE
ci: skip irrelevant jobs per PR via path filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,68 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Cancel a superseded run when a new commit is pushed to the same PR, so rapid
+# re-pushes don't pile up parallel runs of the (heavy) Rust matrix.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Classify the PR diff into file-category outputs the other jobs gate on, so a
+  # docs-only (or shell-only, website-only, …) PR skips the irrelevant jobs.
+  # Job-level `if:` (not workflow-level `paths-ignore:`) is required so the
+  # always-run `all-checks` gate still reports a status — a skipped job reports
+  # `skipped`, which `all-checks` treats as success.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      shell: ${{ steps.filter.outputs.shell }}
+      markdown: ${{ steps.filter.outputs.markdown }}
+      website: ${{ steps.filter.outputs.website }}
+      install_sh: ${{ steps.filter.outputs.install_sh }}
+      install_ps: ${{ steps.filter.outputs.install_ps }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          # Each filter includes `.github/workflows/ci.yml` where relevant so a
+          # CI edit re-runs the broad jobs it could affect.
+          filters: |
+            rust:
+              - 'src/**'
+              - 'tests/**'
+              - 'build.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.config/nextest.toml'
+              - 'deny.toml'
+              - 'sonar-project.properties'
+              - '.github/workflows/ci.yml'
+            shell:
+              - '**/*.sh'
+              - '.shellcheckrc'
+              - '.github/workflows/ci.yml'
+            markdown:
+              - '**/*.md'
+              - '.rumdl.toml'
+            website:
+              - 'website/**'
+              - 'package.json'
+              - 'package-lock.json'
+            install_sh:
+              - 'scripts/install.sh'
+              - 'scripts/install.bats'
+            install_ps:
+              - 'scripts/install.ps1'
+              - 'scripts/install.Tests.ps1'
+
   check:
     name: Check
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -20,6 +79,8 @@ jobs:
 
   fmt:
     name: Rustfmt
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -30,6 +91,8 @@ jobs:
 
   clippy:
     name: Clippy
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -41,6 +104,8 @@ jobs:
 
   nextest:
     name: Nextest
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -53,6 +118,8 @@ jobs:
 
   windows:
     name: Windows (check + clippy)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -75,6 +142,8 @@ jobs:
 
   architecture:
     name: Architecture Rules
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -84,6 +153,8 @@ jobs:
 
   tui-smoke:
     name: TUI Smoke Test
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -96,6 +167,8 @@ jobs:
 
   acceptance:
     name: Acceptance Tests
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -109,6 +182,8 @@ jobs:
 
   deny:
     name: Cargo Deny
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -124,6 +199,8 @@ jobs:
 
   docs:
     name: Documentation
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -148,6 +225,8 @@ jobs:
 
   markdown-lint:
     name: Markdown Lint
+    needs: changes
+    if: needs.changes.outputs.markdown == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -158,6 +237,8 @@ jobs:
 
   install-script:
     name: Install Script Tests
+    needs: changes
+    if: needs.changes.outputs.install_sh == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -168,6 +249,8 @@ jobs:
 
   install-script-ps:
     name: Install Script Tests (PowerShell)
+    needs: changes
+    if: needs.changes.outputs.install_ps == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -191,6 +274,8 @@ jobs:
 
   shellcheck:
     name: ShellCheck
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -201,6 +286,8 @@ jobs:
 
   website-lint:
     name: Website Lint
+    needs: changes
+    if: needs.changes.outputs.website == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -218,6 +305,8 @@ jobs:
 
   sonarqube:
     name: SonarQube
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -238,6 +327,8 @@ jobs:
   # See docs/PERFORMANCE.md (memory / binary size).
   binary-size:
     name: Binary Size
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -273,6 +364,7 @@ jobs:
     name: All Checks
     if: always()
     needs:
+      - changes
       - check
       - fmt
       - clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
-          # Each filter includes `.github/workflows/ci.yml` where relevant so a
-          # CI edit re-runs the broad jobs it could affect.
+          # Every filter includes `.github/workflows/ci.yml` so editing the
+          # workflow re-runs all jobs — any job's definition may have changed.
           filters: |
             rust:
               - 'src/**'
@@ -55,16 +55,20 @@ jobs:
             markdown:
               - '**/*.md'
               - '.rumdl.toml'
+              - '.github/workflows/ci.yml'
             website:
               - 'website/**'
               - 'package.json'
               - 'package-lock.json'
+              - '.github/workflows/ci.yml'
             install_sh:
               - 'scripts/install.sh'
               - 'scripts/install.bats'
+              - '.github/workflows/ci.yml'
             install_ps:
               - 'scripts/install.ps1'
               - 'scripts/install.Tests.ps1'
+              - '.github/workflows/ci.yml'
 
   check:
     name: Check


### PR DESCRIPTION
Add a `changes` detection job (dorny/paths-filter) that classifies the PR
diff into file categories, and gate every CI job on the relevant category so
a docs-only, shell-only, or website-only PR no longer retriggers the full
Rust build/test matrix.

- Rust jobs (check/fmt/clippy/nextest/windows/architecture/tui-smoke/
  acceptance/deny/docs/sonarqube/binary-size) run only on Rust-affecting
  changes (src, tests, Cargo.*, build.rs, deny.toml, nextest/sonar config).
- shellcheck on *.sh, markdown-lint on *.md, website-lint on website/**,
  install-script(-ps) on their respective installers.
- conventional-commits stays always-on (commit-message check).
- all-checks stays an always-run gate; skipped jobs report `skipped`, which
  it treats as success, so branch protection on `all-checks` is unaffected.

Also add a cancel-in-progress concurrency group keyed to the PR so a new
push cancels the superseded run.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Veqpxe5tmne7phFkuSWRBC