### PR TITLE
fix(ui): highlight code-review footer buttons and restyle for consistency

### DIFF
--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -1486,6 +1486,32 @@ fn review_persists_per_session_across_switches() {
     );
 }
 
+/// Hovering a code-review footer button brightens its fill to `accent_bright`,
+/// exactly like the global footer and modal buttons. Regression: review footer
+/// buttons (recorded as `ClickAction::ReviewButton`) were left out of the hover
+/// highlight, so they never lit up under the pointer.
+#[test]
+fn hovering_review_footer_button_brightens_it() {
+    let mut h = Harness::new(STD_COLS, STD_ROWS, 1);
+    open_minimal_review(&mut h);
+    h.render();
+    let r = h
+        .app
+        .click_targets
+        .iter()
+        .find(|t| matches!(t.action, ClickAction::ReviewButton(_)))
+        .map(|t| t.rect)
+        .expect("review footer buttons recorded");
+    h.app.update(AppMessage::MouseMove { x: r.x, y: r.y });
+    h.render();
+    let buf = h.terminal.backend().buffer();
+    assert_eq!(
+        buf[(r.x, r.y)].bg,
+        crate::ui::theme::Theme::accent_bright(),
+        "hovered review footer button should brighten to accent_bright"
+    );
+}
+
 /// Global overlay/panel toggles fall through the review's key capture so they
 /// stay reachable while a review is open (regression: the capture handler
 /// swallowed them). The review itself stays open.

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -103,6 +103,7 @@ impl App {
                         | ClickAction::SelectAutomation(_)
                         | ClickAction::SelectFileRow(_)
                         | ClickAction::Global(_)
+                        | ClickAction::ReviewButton(_)
                         | ClickAction::PaneField { .. }
                 )
             };
@@ -111,13 +112,17 @@ impl App {
         let Some(target) = hovered else {
             return;
         };
-        // Buttons (footer + modal) get a stronger, button-like hover — brighten
-        // their fill to the accent so the chip lights up — while list rows get a
-        // subtle background band to mark what a click would hit. Either way we
-        // tint the background only, leaving each cell's fg/modifiers intact.
+        // Buttons (footer + modal + code-review) get a stronger, button-like
+        // hover — brighten their fill to the accent so the chip lights up — while
+        // list rows get a subtle background band to mark what a click would hit.
+        // For a button we also force the fg to `inverted_fg` so the brightened
+        // chip stays legible regardless of the resting style (primary's accent
+        // fill and the neutral selection-filled secondary chip carry different fg
+        // colours); for rows we tint only the background, leaving each cell's
+        // fg/modifiers intact.
         let is_button = matches!(
             target.action,
-            ClickAction::Global(_) | ClickAction::ModalButton { .. }
+            ClickAction::Global(_) | ClickAction::ModalButton { .. } | ClickAction::ReviewButton(_)
         );
         let hover_bg = if is_button {
             Theme::accent_bright()
@@ -130,6 +135,9 @@ impl App {
             for x in rect.x..rect.x + rect.width {
                 if let Some(cell) = buf.cell_mut(ratatui::layout::Position::new(x, y)) {
                     cell.set_bg(hover_bg);
+                    if is_button {
+                        cell.set_fg(Theme::inverted_fg());
+                    }
                 }
             }
         }

--- a/src/ui/code_review.rs
+++ b/src/ui/code_review.rs
@@ -755,19 +755,17 @@ fn render_footer(
     composing: bool,
     side_by_side: bool,
 ) -> Vec<(crate::ui::ButtonHit, ReviewButton)> {
-    // Labels carry their keyboard shortcut (`label·key`) so every button is also
-    // a discoverable shortcut.
-    let view_label = if side_by_side {
-        "Unified·v"
-    } else {
-        "Split·v"
-    };
+    // Each button carries its keyboard shortcut as a dimmed hint (`label·key`)
+    // so it stays discoverable. The non-composing bar leads with the essential
+    // actions (Comment, Send→Agent, Close) so they survive a narrow footer —
+    // `render_button_bar` drops overflow from the right and marks it with `…`.
+    let view_label = if side_by_side { "Unified" } else { "Split" };
     let (specs, actions): (Vec<ButtonSpec>, Vec<ReviewButton>) = if composing {
         (
             vec![
-                ButtonSpec::primary("Save·^S"),
-                ButtonSpec::secondary("Cancel·esc"),
-                ButtonSpec::secondary("Class·tab"),
+                ButtonSpec::primary("Save").with_hint("·^S"),
+                ButtonSpec::secondary("Cancel").with_hint("·esc"),
+                ButtonSpec::secondary("Class").with_hint("·tab"),
             ],
             vec![
                 ReviewButton::Save,
@@ -778,26 +776,26 @@ fn render_footer(
     } else {
         (
             vec![
-                ButtonSpec::primary("Comment·c"),
-                ButtonSpec::secondary("File·f"),
-                ButtonSpec::secondary("Summary·s"),
-                ButtonSpec::secondary("Reviewed·r"),
-                ButtonSpec::secondary("Target·t"),
-                ButtonSpec::secondary(view_label),
-                ButtonSpec::secondary("Copy·y"),
-                ButtonSpec::primary("Send→Agent·e"),
-                ButtonSpec::secondary("Close·esc"),
+                ButtonSpec::primary("Comment").with_hint("·c"),
+                ButtonSpec::primary("Send→Agent").with_hint("·e"),
+                ButtonSpec::secondary("Close").with_hint("·esc"),
+                ButtonSpec::secondary("File").with_hint("·f"),
+                ButtonSpec::secondary("Summary").with_hint("·s"),
+                ButtonSpec::secondary("Reviewed").with_hint("·r"),
+                ButtonSpec::secondary("Target").with_hint("·t"),
+                ButtonSpec::secondary(view_label).with_hint("·v"),
+                ButtonSpec::secondary("Copy").with_hint("·y"),
             ],
             vec![
                 ReviewButton::Comment,
+                ReviewButton::SendToAgent,
+                ReviewButton::Close,
                 ReviewButton::FileComment,
                 ReviewButton::Summary,
                 ReviewButton::MarkReviewed,
                 ReviewButton::Target,
                 ReviewButton::ToggleView,
                 ReviewButton::Copy,
-                ReviewButton::SendToAgent,
-                ReviewButton::Close,
             ],
         )
     };
@@ -897,6 +895,36 @@ mod tests {
             })
             .unwrap();
         }
+    }
+
+    #[test]
+    fn footer_leads_with_essentials_and_marks_overflow_when_narrow() {
+        // 40 cols fits exactly Comment·c (11) + Send→Agent·e (14) + Close·esc
+        // (11) with separators (11+1+14+1+11 = 38); the rest overflow.
+        let mut term = Terminal::new(TestBackend::new(40, 1)).unwrap();
+        let mut actions = Vec::new();
+        term.draw(|f| {
+            actions = render_footer(f, Rect::new(0, 0, 40, 1), false, false)
+                .into_iter()
+                .map(|(_, a)| a)
+                .collect();
+        })
+        .unwrap();
+        assert_eq!(
+            actions,
+            vec![
+                ReviewButton::Comment,
+                ReviewButton::SendToAgent,
+                ReviewButton::Close,
+            ],
+            "the essential actions lead and survive a narrow footer"
+        );
+        let buf = term.backend().buffer();
+        let row: String = (0..40).map(|x| buf[(x, 0)].symbol()).collect();
+        assert!(
+            row.contains('…'),
+            "dropped buttons are marked with an ellipsis"
+        );
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -105,14 +105,17 @@ pub fn render_selector_rows(
     (hitboxes, geom)
 }
 
-/// One button to render in a [`render_button_bar`] row: its visible `label`
-/// and whether it is the primary/affirmative action (an accent-filled pill vs a
-/// muted gray pill). Pure presentation — the app layer maps the rendered
-/// hitbox's index back to an action/key.
+/// One button to render in a [`render_button_bar`] row: its visible `label`,
+/// whether it is the primary/affirmative action (an accent-filled pill vs the
+/// neutral selection-filled pill), and an optional `hint` — a keyboard shortcut
+/// suffix (e.g. `·c`) rendered dimmed within the same chip so the key reads as a
+/// subordinate annotation, not part of the label. Pure presentation — the app
+/// layer maps the rendered hitbox's index back to an action/key.
 #[derive(Debug, Clone, Copy)]
 pub struct ButtonSpec<'a> {
     pub label: &'a str,
     pub primary: bool,
+    pub hint: Option<&'a str>,
 }
 
 impl<'a> ButtonSpec<'a> {
@@ -120,6 +123,7 @@ impl<'a> ButtonSpec<'a> {
         Self {
             label,
             primary: true,
+            hint: None,
         }
     }
 
@@ -127,7 +131,14 @@ impl<'a> ButtonSpec<'a> {
         Self {
             label,
             primary: false,
+            hint: None,
         }
+    }
+
+    /// Attach a dimmed keyboard-shortcut suffix to this button (e.g. `"·c"`).
+    pub fn with_hint(mut self, hint: &'a str) -> Self {
+        self.hint = Some(hint);
+        self
     }
 }
 
@@ -149,16 +160,22 @@ pub type ModalButtons = Vec<(
     crossterm::event::KeyModifiers,
 )>;
 
-/// Width (display columns) the button for `label` occupies when rendered as a
-/// pill chip (one space of padding on each side: ` label `).
-fn button_width(label: &str) -> u16 {
-    label.chars().count() as u16 + 2
+/// Width (display columns) a button occupies when rendered as a pill chip: the
+/// label plus its optional hint suffix, with one space of padding on each side
+/// (` label·key `).
+fn button_width(spec: &ButtonSpec<'_>) -> u16 {
+    let hint = spec.hint.map_or(0, |h| h.chars().count());
+    (spec.label.chars().count() + hint) as u16 + 2
 }
 
 /// The resting fill style for a button — a filled "pill" chip. Primary actions
-/// use the accent colour (a focused-badge look); secondary actions a muted gray
-/// fill. The space-padded label on a solid background reads as a button without
-/// brackets, and the fill is what the hover highlight reverses.
+/// use the accent colour (a focused-badge look); secondary actions the
+/// neutral, contrast-tuned selection pair (`selection_fg` on `selection_bg`),
+/// which every palette guarantees is legible — unlike the old `inverted_fg` on
+/// `text_muted`, where `inverted_fg` tracks the app background and so collapsed
+/// to dark-on-dark (dark themes) / light-on-light (light themes) over the muted
+/// mid-gray. The space-padded label on a solid background reads as a button
+/// without brackets, and the fill is what the hover highlight brightens.
 fn button_style(primary: bool) -> Style {
     if primary {
         Style::default()
@@ -167,18 +184,18 @@ fn button_style(primary: bool) -> Style {
             .add_modifier(ratatui::style::Modifier::BOLD)
     } else {
         Style::default()
-            .fg(Theme::inverted_fg())
-            .bg(Theme::text_muted())
+            .fg(Theme::selection_fg())
+            .bg(Theme::selection_bg())
             .add_modifier(ratatui::style::Modifier::BOLD)
     }
 }
 
 /// Render a row of filled "pill" buttons (` label `, padded, on a solid accent
-/// or gray fill) into the single-row `area`, returning one [`ButtonHit`] per
-/// *placed* button (index = position in `specs`). Buttons are separated by one
-/// space. When `right_align` is set the row is packed against the right edge of
-/// `area` (the convention for modal Save/Cancel and the global footer);
-/// otherwise it starts at the left edge.
+/// or neutral selection fill) into the single-row `area`, returning one
+/// [`ButtonHit`] per *placed* button (index = position in `specs`). Buttons are
+/// separated by one space. When `right_align` is set the row is packed against
+/// the right edge of `area` (the convention for modal Save/Cancel and the global
+/// footer); otherwise it starts at the left edge.
 ///
 /// Responsive by design: a button that would overflow `area` is dropped rather
 /// than wrapped or clipped mid-glyph, so a narrow footer simply shows fewer
@@ -194,8 +211,8 @@ pub fn render_button_bar(
         return Vec::new();
     }
     // Total width of every button plus single-space separators.
-    let total: u16 = specs.iter().map(|s| button_width(s.label)).sum::<u16>()
-        + specs.len().saturating_sub(1) as u16;
+    let total: u16 =
+        specs.iter().map(button_width).sum::<u16>() + specs.len().saturating_sub(1) as u16;
 
     let mut x = if right_align && total <= area.width {
         area.x + area.width - total
@@ -205,21 +222,46 @@ pub fn render_button_bar(
     let limit = area.x + area.width;
 
     let mut hits = Vec::with_capacity(specs.len());
+    let mut dropped = false;
     for (index, spec) in specs.iter().enumerate() {
-        let width = button_width(spec.label);
+        let width = button_width(spec);
         if x + width > limit {
-            break; // out of room — drop the rest rather than corrupt the row
+            dropped = true; // out of room — drop the rest rather than corrupt the row
+            break;
         }
         let rect = Rect::new(x, area.y, width, 1);
-        frame.render_widget(
-            Paragraph::new(Line::from(Span::styled(
-                format!(" {} ", spec.label),
-                button_style(spec.primary),
-            ))),
-            rect,
-        );
+        let base = button_style(spec.primary);
+        // The chip is ` label ` (no hint) or ` label·key ` with the hint dimmed
+        // on the same fill so the shortcut reads as a subordinate annotation.
+        let line = match spec.hint {
+            Some(hint) => Line::from(vec![
+                Span::styled(format!(" {}", spec.label), base),
+                Span::styled(
+                    format!("{hint} "),
+                    base.add_modifier(ratatui::style::Modifier::DIM),
+                ),
+            ]),
+            None => Line::from(Span::styled(format!(" {} ", spec.label), base)),
+        };
+        frame.render_widget(Paragraph::new(line), rect);
         hits.push(ButtonHit { rect, index });
         x += width + 1;
+    }
+    // When a left-aligned bar (the review/global footer) drops buttons, mark the
+    // overflow with a muted `…` in the leftover space so the hidden actions are
+    // discoverable rather than silently gone. Right-aligned modal footers pack
+    // one or two buttons and effectively never overflow, so they keep their
+    // clean trailing edge.
+    if dropped && !right_align && x < limit {
+        let avail = limit - x;
+        let marker = if avail >= 3 { " … " } else { "…" };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                marker,
+                Style::default().fg(Theme::text_muted()),
+            ))),
+            Rect::new(x, area.y, avail.min(marker.chars().count() as u16), 1),
+        );
     }
     hits
 }
@@ -1003,6 +1045,66 @@ mod tests {
                 assert_eq!(hits[0].index, 0);
             })
             .unwrap();
+    }
+
+    #[test]
+    fn render_button_bar_left_overflow_shows_ellipsis() {
+        let backend = ratatui::backend::TestBackend::new(40, 1);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                // " Save " = 6 fits; " Cancel " = 8 needs 6+1+8 = 15 > 12, so it
+                // is dropped, leaving room for the ` … ` overflow marker.
+                let area = Rect::new(0, 0, 12, 1);
+                let specs = [ButtonSpec::primary("Save"), ButtonSpec::secondary("Cancel")];
+                let hits = render_button_bar(f, area, &specs, false);
+                assert_eq!(hits.len(), 1);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        let row: String = (0..12).map(|x| buf[(x, 0)].symbol()).collect();
+        assert!(
+            row.contains('…'),
+            "left-aligned overflow marks dropped buttons with an ellipsis, got {row:?}"
+        );
+    }
+
+    #[test]
+    fn render_button_bar_right_overflow_has_no_ellipsis() {
+        let backend = ratatui::backend::TestBackend::new(40, 1);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, 12, 1);
+                let specs = [ButtonSpec::primary("Save"), ButtonSpec::secondary("Cancel")];
+                let _ = render_button_bar(f, area, &specs, true);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        let row: String = (0..12).map(|x| buf[(x, 0)].symbol()).collect();
+        assert!(
+            !row.contains('…'),
+            "right-aligned modal footers don't draw the overflow marker, got {row:?}"
+        );
+    }
+
+    #[test]
+    fn button_with_hint_widens_chip_and_renders_suffix() {
+        let backend = ratatui::backend::TestBackend::new(40, 1);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, 40, 1);
+                let specs = [ButtonSpec::primary("Comment").with_hint("·c")];
+                let hits = render_button_bar(f, area, &specs, false);
+                assert_eq!(hits.len(), 1);
+                // " Comment·c ": label 7 + hint 2 + 2 padding = 11 cols.
+                assert_eq!(hits[0].rect.width, 11);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        let row: String = (0..11).map(|x| buf[(x, 0)].symbol()).collect();
+        assert_eq!(row, " Comment·c ");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix the native **code-review** footer buttons never lighting up on hover: they are recorded as `ClickAction::ReviewButton`, which was missing from `apply_hover_highlight`'s `reachable` filter and `is_button` check. They now brighten like the global footer / modal buttons, and hover forces the fg to `inverted_fg` so the brightened chip stays legible.
- Restyle secondary button chips to the contrast-tuned `selection_fg`/`selection_bg` pair instead of `inverted_fg` on `text_muted` (which collapsed to dark-on-dark / light-on-light because `inverted_fg` tracks the app background). Shared by the global footer and modal footers, so the contrast fix applies app-wide and across all 9 themes.
- Add a muted `…` overflow marker for left-aligned button bars, reorder the review footer so the essentials (Comment, Send→Agent, Close) survive a narrow width, and render each pill's keyboard shortcut as a dimmed hint.

## Test plan

- New tests: review-button hover highlight, button-bar overflow marker (left shows `…`, right does not), hint-widened chip, and narrow-footer ordering/overflow.
- `cargo nextest run --all` (1623 passing), `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt` clean.
- CI checks pass.