### PR TITLE
docs: clarify hooks extension config file locations and coexistence

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -357,9 +357,32 @@ no id. A finished turn shows `Done` (blue) — for the session you're watching t
 
 The hooks are wired up automatically by the built-in **hooks** extension
 (auto-activated on first run). Opt out with `thurbox-cli extension deactivate
-hooks`. See `extensions/hooks/README.md`. The status colours are tunable theme
-keys (`status_working` / `status_blocked` / `status_done` / `status_idle` /
-`status_error` — see `themes.toml`).
+hooks`. The status colours are tunable theme keys (`status_working` /
+`status_blocked` / `status_done` / `status_idle` / `status_error` — see
+`themes.toml`).
+
+The wiring is applied **only to agents thurbox launches** — it never edits your
+own global agent config (e.g. your personal `~/.claude/settings.json`). thurbox's
+managed hook config lives per agent, applied by injecting a flag into
+`agents.toml` or by a reversible merge into / managed file in the agent's own
+config dir:
+
+| Agent | On-disk location | How it's applied |
+|-------|------------------|------------------|
+| claude | `~/.config/thurbox/hooks/claude.json` | `--settings` flag (claude merges it with your own settings) |
+| aider | — (no file) | `--notifications-command` flag |
+| opencode | `~/.config/opencode/plugin/thurbox-status.js` | managed plugin file |
+| codex | `~/.codex/hooks.json` | reversible JSON-merge of thurbox's entries |
+| vibe | `~/.vibe/hooks.toml` | managed file (refused if you already have one) |
+| antigravity | `~/.gemini/settings.json` | reversible JSON-merge of thurbox's entries |
+
+The home dir is `~/.config/thurbox/hooks` on a release build and
+`~/.config/thurbox-dev/hooks` on a dev build. Because claude *merges* the
+`--settings` file, your own hooks still fire inside a thurbox session — both run.
+Hand-edits to a managed file are rewritten from the embedded payload on the next
+TUI start / heartbeat tick; to customize, deactivate the extension and wire the
+hook yourself, or edit the payload under `extensions/hooks/` and reinstall. Full
+per-agent detail: `extensions/hooks/README.md`.
 
 ## themes.toml
 

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -80,6 +80,37 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
   fail-open no-op. If a future `agy` changes the hook schema, edit
   `antigravity-hooks.json` (no code change).
 
+## Where the config lives
+
+The wiring is applied **only to agents thurbox launches** — it never edits your
+own global agent config (e.g. your personal `~/.claude/settings.json`). For
+claude the managed hooks file is passed with `--settings`, which claude **merges
+on top of** your own settings: inside a thurbox session both your hooks and
+thurbox's fire, while a plain `claude` outside thurbox sees only your own. The
+other agents are wired by a reversible merge into — or a managed file dropped in
+— their own config dir.
+
+| Agent | On-disk location | How it's applied |
+|-------|------------------|------------------|
+| claude | `~/.config/thurbox/hooks/claude.json` | `--settings` flag on the `claude` agent (claude merges it) |
+| aider | — (no file) | `--notifications-command` flag on the `aider` agent |
+| opencode | `~/.config/opencode/plugin/thurbox-status.js` | managed plugin file (`requires_dir`) |
+| codex | `~/.codex/hooks.json` | reversible JSON-merge of our entries |
+| vibe | `~/.vibe/hooks.toml` | managed file (refused if you already have one) |
+| antigravity | `~/.gemini/settings.json` | reversible JSON-merge of our entries |
+
+The home dir is `~/.config/thurbox/hooks` for a release build and
+`~/.config/thurbox-dev/hooks` for a dev build, so the two stay isolated.
+
+**Inspect or customize.** To see exactly what thurbox installed, read the file
+for the agent above (e.g. `cat ~/.config/thurbox/hooks/claude.json`). The
+injected `--settings` / `--notifications-command` flags themselves live in the
+`claude` / `aider` entries of `~/.config/thurbox/agents.toml`. You can hand-edit
+a managed file, but self-heal rewrites it from the embedded payload on the next
+TUI start / heartbeat tick — so to keep a change, either deactivate the extension
+(`thurbox-cli extension deactivate hooks`) and wire the hook yourself, or edit
+the payload source under `extensions/hooks/` and reinstall.
+
 ## Mechanism
 
 This extension exercises two extension-manifest capabilities (see

--- a/website/docs/agent-hooks.html
+++ b/website/docs/agent-hooks.html
@@ -9,6 +9,7 @@ onThisPage:
   - { id: 'states', label: 'The five states' }
   - { id: 'coverage', label: 'Per-agent coverage' }
   - { id: 'wiring', label: 'How each agent is wired' }
+  - { id: 'config', label: 'Where the config lives' }
   - { id: 'optout', label: 'Opt out' }
   - { id: 'files', label: 'Files' }
 ---
@@ -316,6 +317,106 @@ onThisPage:
             <code>session signal</code>
             marker.
           </p>
+
+          <h2 id="config">
+            Where the config lives
+            <a href="#config" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            The wiring is applied
+            <strong>only to agents Thurbox launches</strong>
+            &mdash; it never edits your own global agent config (e.g. your personal
+            <code>~/.claude/settings.json</code>
+            ). For claude the managed hooks file is passed with
+            <code>--settings</code>
+            , which claude
+            <strong>merges on top of</strong>
+            your own settings: inside a Thurbox session both your hooks and Thurbox's fire, while a
+            plain
+            <code>claude</code>
+            outside Thurbox sees only your own. The other agents are wired by a reversible merge
+            into &mdash; or a managed file dropped in &mdash; their own config dir.
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Agent</th>
+                <th>On-disk location</th>
+                <th>How it's applied</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>claude</td>
+                <td><code>~/.config/thurbox/hooks/claude.json</code></td>
+                <td>
+                  <code>--settings</code>
+                  flag on the
+                  <code>claude</code>
+                  agent (claude merges it)
+                </td>
+              </tr>
+              <tr>
+                <td>aider</td>
+                <td>&mdash; (no file)</td>
+                <td>
+                  <code>--notifications-command</code>
+                  flag on the
+                  <code>aider</code>
+                  agent
+                </td>
+              </tr>
+              <tr>
+                <td>opencode</td>
+                <td><code>~/.config/opencode/plugin/thurbox-status.js</code></td>
+                <td>managed plugin file</td>
+              </tr>
+              <tr>
+                <td>codex</td>
+                <td><code>~/.codex/hooks.json</code></td>
+                <td>reversible JSON-merge of our entries</td>
+              </tr>
+              <tr>
+                <td>vibe</td>
+                <td><code>~/.vibe/hooks.toml</code></td>
+                <td>managed file (refused if you already have one)</td>
+              </tr>
+              <tr>
+                <td>antigravity</td>
+                <td><code>~/.gemini/settings.json</code></td>
+                <td>reversible JSON-merge of our entries</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            The home dir is
+            <code>~/.config/thurbox/hooks</code>
+            for a release build and
+            <code>~/.config/thurbox-dev/hooks</code>
+            for a dev build, so the two stay isolated.
+          </p>
+          <div class="info-box">
+            <p>
+              <strong>Inspect or customize.</strong>
+              To see exactly what Thurbox installed, read the file for the agent above (e.g.
+              <code>cat ~/.config/thurbox/hooks/claude.json</code>
+              ). The injected
+              <code>--settings</code>
+              /
+              <code>--notifications-command</code>
+              flags themselves live in the
+              <code>claude</code>
+              /
+              <code>aider</code>
+              entries of
+              <code>~/.config/thurbox/agents.toml</code>
+              . You can hand-edit a managed file, but self-heal rewrites it from the embedded payload
+              on the next TUI start / heartbeat tick &mdash; so to keep a change, either deactivate
+              the extension and wire the hook yourself, or edit the payload source under
+              <code>extensions/hooks/</code>
+              and reinstall.
+            </p>
+          </div>
 
           <h2 id="optout">
             Opt out


### PR DESCRIPTION
## Summary

- Document **where the built-in hooks extension's managed config lives per agent** (claude `~/.config/thurbox/hooks/claude.json`, codex `~/.codex/hooks.json`, antigravity `~/.gemini/settings.json`, opencode plugin dir, vibe `~/.vibe/hooks.toml`, aider flag-only).
- Clarify that the wiring applies **only to thurbox-launched sessions** and **coexists** with the user's own agent config (claude *merges* the `--settings` file) rather than replacing it — the point of confusion this fills.
- Add inspect/customize guidance (how to read the files, where the injected flags live in `agents.toml`, self-heal behavior on hand-edits).

Surfaces updated: `extensions/hooks/README.md` (new "Where the config lives" section), `website/docs/agent-hooks.html` (mirrored section + onThisPage nav entry), `docs/CONFIG.md` (expanded Session status section).

Docs-only; no code changes.

## Test plan

- `rumdl check` passes on the two markdown files
- HTML section matches the file's native indentation style (not reformatted)
- CI checks pass