### PR TITLE
ci: speed up Windows CI (parallelize + Defender exclusion + drop redundant check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,26 +120,53 @@ jobs:
           tool: cargo-nextest
       - run: cargo nextest run --all --profile ci
 
-  windows:
-    name: Windows (check + clippy)
+  # Native-Windows gate (psmux backend selection, known-folder paths, toast
+  # notifications, junction workspaces), split into two parallel jobs so the heavy
+  # Windows compile isn't serialized: clippy-driver and rustc don't share
+  # artifacts, so a single job ran two back-to-back full builds (~9 min). The
+  # separate `cargo check` pass was dropped — `clippy -D warnings` already
+  # type-checks, so it covers the compile gate. Each job excludes the build dirs
+  # from Defender real-time scanning, the dominant Windows-runner overhead (it
+  # scans every .rlib/.exe cargo writes). The local dockur VM
+  # (scripts/dev/windows-test.sh test-suite) runs the same suite from a
+  # cross-built nextest archive; these jobs are the automated mirror.
+  windows-clippy:
+    name: Windows (clippy)
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Exclude build dirs from Defender real-time scanning
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+          Add-MpPreference -ExclusionPath "$env:USERPROFILE\.cargo"
+          Add-MpPreference -ExclusionPath "$env:USERPROFILE\.rustup"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  windows-test:
+    name: Windows (tests)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Exclude build dirs from Defender real-time scanning
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+          Add-MpPreference -ExclusionPath "$env:USERPROFILE\.cargo"
+          Add-MpPreference -ExclusionPath "$env:USERPROFILE\.rustup"
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
         with:
           tool: cargo-nextest
-      # Native-Windows gate: compile (psmux backend selection, known-folder paths,
-      # toast notifications, junction workspaces) AND run the full test suite. The
-      # local dockur VM (scripts/dev/windows-test.sh test-suite) runs the same
-      # suite from a cross-built nextest archive; this job is the automated mirror.
-      - run: cargo check --all --all-targets
-      - run: cargo clippy --all-targets --all-features -- -D warnings
       # --no-fail-fast: surface every native-Windows test failure in one run
       # (the `ci` profile is fail-fast); easier to triage runner-specific issues.
       - run: cargo nextest run --all --profile ci --no-fail-fast
@@ -375,7 +402,8 @@ jobs:
       - nextest
       - acceptance
       - architecture
-      - windows
+      - windows-clippy
+      - windows-test
       - tui-smoke
       - deny
       - docs


### PR DESCRIPTION
## Summary

The `Windows (check + clippy)` job was the sole CI critical-path bottleneck — **~560s** in the last successful run, 2.3× the next slowest job, while everything else finishes in under 4 min. It ran **three** full compile passes back-to-back on a single crate (`cargo check` → `cargo clippy` → `cargo nextest`).

This PR:

- **Splits it into two parallel jobs** (`Windows (clippy)` + `Windows (tests)`). clippy-driver and rustc don't share compiled artifacts, so the single job was effectively two serial full builds; running them in parallel (sharing the `Swatinem/rust-cache` dependency cache) roughly halves wall-clock.
- **Drops the redundant `cargo check` pass** — `clippy -D warnings` already type-checks, so it covers the compile gate with no loss of coverage.
- **Excludes the build dirs from Windows Defender real-time scanning** (workspace, `~/.cargo`, `~/.rustup`) — Defender scans every `.rlib`/`.exe` cargo writes and is the dominant `windows-latest` overhead for Rust builds (~20–40%).
- Updates the `all-checks` aggregate gate to depend on the two new job names.

Expected: Windows off the critical path, ~9 min → ~4–5 min.

## Notes

- Branch protection should require the **`All Checks`** aggregate job (not the individual `Windows (check + clippy)` name). If the old job name was individually required, that rule needs updating to the new names — flagging so a maintainer can confirm.
- The flags `--all` / `--all-features` are technically no-ops here (single crate, no `[features]`), but kept for consistency with the Linux jobs.

## Test plan

- CI runs this workflow on the PR; confirm both `Windows (clippy)` and `Windows (tests)` pass and total Windows wall-clock drops.