### PR TITLE
docs: reconcile CLAUDE.md/docs/website with source code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,7 +276,8 @@ Every push to `main` automatically triggers the release workflow:
    - Determines semantic version (feat→minor, fix/perf→patch)
    - Creates lightweight git tag: `v{version}` (e.g., v0.1.0)
    - Pushes tag to origin
-   - Builds binaries for 3 platforms (version passed via environment variable)
+   - Builds binaries for 4 platforms (3 Unix `.tar.gz` + 1 Windows `.zip`;
+     version passed via environment variable)
    - Generates changelog from commits
    - Publishes GitHub Release with binaries and release notes
 
@@ -293,10 +294,12 @@ Every push to `main` automatically triggers the release workflow:
 
 Each release includes:
 
-- Binaries for 3 platforms:
+- Binaries for 4 platforms:
   - `thurbox-v{ver}-x86_64-unknown-linux-gnu.tar.gz`
   - `thurbox-v{ver}-x86_64-unknown-linux-musl.tar.gz`
   - `thurbox-v{ver}-aarch64-apple-darwin.tar.gz`
+  - `thurbox-v{ver}-x86_64-pc-windows-msvc.zip` (the Windows artifact
+    extracted by `install.ps1` / packaged by Chocolatey)
 - `thurbox-v{ver}-checksums.txt` (SHA256 sums for verification)
 - Changelog with categorized commits
 
@@ -1289,7 +1292,7 @@ when the target session is the one in focus (`suppress_for_active`).
   the last delivery error; `--test` fires a sample notification
   *synchronously* (`notifications::send_blocking`, since the short-lived
   CLI has no dispatcher thread) so the user can confirm end-to-end.
-- **Click-to-focus** (dbus path only). The dbus action callback writes a
+- **Click-to-focus** (dbus + macOS `terminal-notifier` paths). The dbus action callback writes a
   session UUID to the SQLite `metadata` row keyed by
   [`PENDING_FOCUS_SESSION_ID_KEY`](src/session/mod.rs) (= the single
   source of truth shared by writer and reader). The TUI's
@@ -1297,10 +1300,14 @@ when the target session is the one in focus (`suppress_for_active`).
   `apply_pending_focus_request`) reads + deletes the row atomically
   (`Database::take_pending_focus_session_id`, a single
   `DELETE … RETURNING` statement) and switches `active_index` +
-  `InputFocus::Terminal`. The Windows-toast and macOS paths show the
-  banner but ignore clicks (a Windows toast can't call back into WSL;
-  modern macOS `UNUserNotificationCenter` actions need a signed app
-  bundle, which thurbox is not). **Terminal window-raising is
+  `InputFocus::Terminal`. On macOS the same row is written by
+  `terminal-notifier`'s `-execute` flag (which shells back into
+  `thurbox-cli session focus <id>`), so click-to-focus works whenever
+  `terminal-notifier` is installed. The Windows-toast path and macOS's
+  `osascript` fallback show the banner but ignore clicks (a Windows toast
+  can't call back into WSL; the `osascript`/`UNUserNotificationCenter`
+  action callbacks need a signed app bundle, which thurbox is not).
+  **Terminal window-raising is
   deliberately not implemented**: thurbox runs inside an arbitrary
   terminal emulator it doesn't own, and per-emulator window control is
   fragile (especially on Wayland). The session is pre-selected; the
@@ -1320,7 +1327,8 @@ when the target session is the one in focus (`suppress_for_active`).
 - **Code shape**. `src/notifications.rs` is the leaf side-effect layer
   (only knows `session` + `paths`) — a single background thread reads a
   per-process mpsc channel and dispatches over the resolved backend
-  (`notify-rust` for dbus/macOS, `powershell.exe` for the WSL toast). The
+  (`notify-rust` for dbus, `terminal-notifier`/`osascript` for macOS,
+  `powershell.exe` for the WSL toast). The
   notification body is bounded to 200 chars (`notify_state::truncate_body`)
   so a huge OSC message can't overflow the banner. The per-session
   bookkeeping (prior status, dedup timestamps) lives in
@@ -1797,7 +1805,7 @@ below the commented examples). The modal edits a working-copy `draft` and
 applies **only on `Ctrl+S`** (`Esc` discards — there is no live preview).
 
 Feature flags that gate UI panels (`tasks`, `file_viewer`, `info_panel`,
-`global_search`, `shell_pane`, `soft_delete`) are read from `App.features`
+`global_search`, `shell_pane`, `code_review`, `soft_delete`) are read from `App.features`
 every frame, so `submit_settings_panel` copies the draft's flags into
 `self.features` (via `App::apply_live_settings`) and they take effect
 immediately. Everything else is read once at startup from the write-once

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -408,8 +408,9 @@ logs a warning and adoption proceeds with an empty seed.
 same tmux control-mode protocol over SSH. `LocalTmuxBackend` is
 generalized into `TmuxBackend { transport, socket, session, name }`
 where `transport: TmuxTransport` is either `Local` (a bare
-`Command::new("tmux")`) or `Ssh { destination, ssh_opts }`
-(`ssh <dest> tmux …`). The transport's *only* job is to build the
+`Command::new("tmux")`) or `Ssh { destination, ssh_opts, mux }`
+(`ssh <dest> <mux> …`, where `mux` is the remote multiplexer binary —
+`tmux` by default, or `psmux` for a Windows host). The transport's *only* job is to build the
 `Command`; everything downstream — the control-mode reader/writer
 threads, pane registration, `send-keys`/`%output` — is byte-for-byte
 identical (`control_mode.rs` was already transport-agnostic).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -36,8 +36,8 @@ backends register at startup) and `themes.toml` need a restart.
 opens a **Settings panel** listing every knob. It writes the file back
 **preserving its comments**, and feature flags that gate UI panels apply
 **live** on save; the rest (`mouse`, `notifications`, `automations`,
-`version_check`, the four editable `[notifications]` knobs, and the
-scalars) take effect on the next launch — the panel marks those rows
+`version_check`, `auto_update`, the four editable `[notifications]` knobs,
+and the scalars) take effect on the next launch — the panel marks those rows
 with `⟳` and toasts a restart note. The panel exposes only the four
 editable notification knobs (`also_on_waiting`, `suppress_for_active`,
 `sound`, `min_interval_secs`); `[notifications] backend` is **not** in
@@ -198,9 +198,12 @@ min_interval_secs   = 5        # per-session floor between notifications
 
 Turn major TUI features off entirely. All default to `true` **except
 `version_check` and `auto_update`, which default to `false`** (both
-reach the network, so they are opt-in). Like the rest of settings.toml,
-changes need a
-restart. A disabled feature's pane never renders, its keybinding shows
+reach the network, so they are opt-in). The UI-panel flags
+(`tasks`, `file_viewer`, `info_panel`, `global_search`, `shell_pane`,
+`code_review`, `soft_delete`) apply **live** on save; the rest
+(`automations`, `mouse`, `notifications`, `version_check`, `auto_update`)
+take effect on the next launch.
+A disabled feature's pane never renders, its keybinding shows
 a status toast instead of acting, and its global-search scope returns
 no results. Data is never touched, so re-enabling a flag is lossless.
 

--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -129,13 +129,11 @@ onThisPage:
             : the TUI polls their mtime (~1/s) and applies edits with a confirmation toast &mdash;
             no restart. For
             <code>settings.toml</code>
-            the feature flags and
+            the UI-panel feature flags apply immediately; the
             <code>[notifications]</code>
-            knobs apply immediately; the write-once scalars (plus
-            <code>version_check</code>
-            /
-            <code>auto_update</code>
-            ) take effect on the next launch and the toast says so.
+            knobs, the
+            <code>automations</code>/<code>mouse</code>/<code>notifications</code>/<code>version_check</code>/<code>auto_update</code>
+            feature flags, and the write-once scalars take effect on the next launch and the toast says so.
             <code>hosts.toml</code>
             and
             <code>themes.toml</code>
@@ -317,13 +315,11 @@ resume_latest = false       # true = id-less "resume last session in cwd"</code>
             switches, seeded fully commented-out (defaults apply when absent). Only knobs a user
             plausibly wants are exposed; internals stay hardcoded. The file is
             <strong>live-reloaded</strong>
-            via mtime poll: the feature flags and
+            via mtime poll: the UI-panel feature flags apply immediately, while the
             <code>[notifications]</code>
-            knobs apply immediately, while the write-once scalars (plus
-            <code>version_check</code>
-            /
-            <code>auto_update</code>
-            ) take effect on the next launch.
+            knobs, the
+            <code>automations</code>/<code>mouse</code>/<code>notifications</code>/<code>version_check</code>/<code>auto_update</code>
+            feature flags, and the write-once scalars take effect on the next launch.
           </p>
           <div class="info-box">
             <p>
@@ -381,9 +377,10 @@ resume_latest = false       # true = id-less "resume last session in cwd"</code>
           </table>
           <p>
             A complete <code>settings.toml</code> showing every knob at its default &mdash; copy
-            this and uncomment what you want to change (feature flags and
-            <code>[notifications]</code> apply live; the write-once scalars take effect on the next
-            launch):
+            this and uncomment what you want to change (the UI-panel feature flags apply live; the
+            <code>[notifications]</code> knobs, the
+            <code>automations</code>/<code>mouse</code>/<code>notifications</code>/<code>version_check</code>/<code>auto_update</code>
+            flags, and the write-once scalars take effect on the next launch):
           </p>
           <pre data-title="settings.toml"><code class="language-toml">config_version = 1
 
@@ -419,10 +416,13 @@ min_interval_secs   = 5        # per-session floor between notifications</code><
             Turn major TUI features off entirely. All default to
             <code>true</code>
             <strong>except <code>version_check</code> and <code>auto_update</code>, which default to <code>false</code></strong>
-            (both reach the network, so they are opt-in). Feature-flag changes are
-            <strong>live-reloaded</strong> &mdash; they take effect immediately, no restart (only the
-            write-once scalars and <code>version_check</code>/<code>auto_update</code> wait for the
-            next launch). A disabled feature's pane never renders, its keybinding shows a status
+            (both reach the network, so they are opt-in). The UI-panel feature flags
+            (<code>tasks</code>, <code>file_viewer</code>, <code>info_panel</code>,
+            <code>global_search</code>, <code>shell_pane</code>, <code>code_review</code>,
+            <code>soft_delete</code>) are <strong>live-reloaded</strong> &mdash; they take effect
+            immediately, no restart. The rest (<code>automations</code>, <code>mouse</code>,
+            <code>notifications</code>, <code>version_check</code>, <code>auto_update</code>) and the
+            write-once scalars wait for the next launch. A disabled feature's pane never renders, its keybinding shows a status
             toast instead of acting, and its global-search scope returns no results. Data is never
             touched, so re-enabling a flag is lossless.
           </p>

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -23,9 +23,12 @@ onThisPage:
           <p>
             When the terminal panel is focused,
             <strong>all keys are forwarded to the PTY</strong>
-            except those with a
+            except most keys with a
             <code>Ctrl</code>
-            modifier (intercepted as global commands) and
+            modifier (intercepted as global commands &mdash; though a handful that collide with
+            readline, such as
+            <code>Ctrl+B/D/E/F/O/P/R/S/U/W</code>, defer to the agent CLI; see
+            <strong>Terminal passthrough</strong> below) and
             <code>Shift+arrow/page</code>
             /
             <code>Alt+page</code>


### PR DESCRIPTION
## Summary

Source-grounded audit of the documentation surface (a fan-out of verification agents cross-checking CLAUDE.md / docs/ / website/ against the actual code) found and fixed 13 confirmed drift points:

- **CLAUDE.md** — release ships **4** platform artifacts (added the Windows `.zip`), not 3; macOS notifications now use `terminal-notifier`/`osascript` (click-to-focus works via `terminal-notifier -execute`), not dbus-only; added `code_review` to the live UI-panel feature-flag list.
- **docs/CONFIG.md** — added `auto_update` to the restart-only set; replaced the blanket "`[features]` changes need a restart" with the correct live-vs-restart split.
- **docs/ARCHITECTURE.md** — `TmuxTransport::Ssh` carries a third field (`mux`) for psmux/Windows-remote support.
- **website/docs/configuration.html** — `[notifications]` knobs and the `automations`/`mouse`/`notifications`/`version_check`/`auto_update` flags are restart-only, not live (3 spots reconciled).
- **website/docs/keybindings.html** — qualified the terminal-passthrough intro (`Ctrl+B/D/E/F/O/P/R/S/U/W` defer to the agent CLI).

Docs-only; no code or behavior changes.

## Test plan

- CI checks pass (rumdl markdown lint + website lint)
- `rumdl check` passes locally on all changed markdown