### PR TITLE
feat(config): add GitHub Copilot CLI as a built-in agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,7 +350,7 @@ Enforced by cocogitto via pre-commit hooks.
 
 The set of launchable coding agents is declared **as data** in
 `~/.config/thurbox/agents.toml`, seeded with built-ins
-(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `vibe`) on first run.
+(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`) on first run.
 Each `[[agents]]` entry is an `AgentDef`:
 
 ```toml
@@ -383,17 +383,19 @@ your own `[[agents]]` entry to support any CLI — no recompile.
 **Session id pinning vs. `resume_latest`.** thurbox generates the
 `agent_session_id` (a UUID) and only `claude` accepts it at creation
 (`--session-id {id}`), so only claude can resume/fork by that exact id.
-The other built-ins (`codex`, `opencode`, `antigravity`, `aider`) can't pin
-or report their id, so they set `resume_latest = true` with **id-less**
-resume/fork flags (no `{id}` token): the agent resolves "the last
+The other built-ins (`codex`, `opencode`, `antigravity`, `aider`, `copilot`)
+can't pin or report their id, so they set `resume_latest = true` with
+**id-less** resume/fork flags (no `{id}` token): the agent resolves "the last
 session in *this* directory" itself (`codex resume --last`, `opencode
---continue`, `agy --continue`, `aider --restore-chat-history`).
+--continue`, `agy --continue`, `aider --restore-chat-history`, `copilot
+--continue`).
 This works because restart reuses the session's cwd and a single-repo
 fork reuses the parent's cwd. `resume_latest` only changes *when* the
 resume group fires (see `session_ops::resume_trigger_for`): for these
 agents restart always triggers resume; for claude it still defers to an
 on-disk transcript check. Caveats: agents without `fork_args`
-(`antigravity`, `aider` — neither CLI forks) start fresh on `Ctrl+F`; and a
+(`antigravity`, `aider`, `copilot` — none of these CLIs fork) start fresh on
+`Ctrl+F`; and a
 **multi-repo** fork of a cwd-scoped agent lands in a fresh symlink
 workspace, so `--last`/`--continue` finds no parent session (multi-repo
 *restart* still resumes, since it keeps the same workspace dir).
@@ -1043,7 +1045,11 @@ the old `-c notify=…` done-only override — a reversible write into `hooks.js
 never `config.toml`), an `[[external_files]]` drops an opencode plugin into
 `~/.config/opencode/plugin/` (idle/working/blocked/done) and a managed
 `~/.vibe/hooks.toml` for Mistral `vibe` (working/blocked/done; **experimental**,
-refused if a user file already exists), and a `[[config_merges]]` deep-merges
+refused if a user file already exists), an `[[external_files]]` drops a managed
+`~/.copilot/hooks/thurbox-status.json` for GitHub Copilot CLI (`copilot`)
+(idle/working/blocked/done; **experimental**, copilot's own hook schema —
+`notification` matched to `permission_prompt` drives blocked; ships both
+`bash`+`powershell` commands), and a `[[config_merges]]` deep-merges
 hook entries into `antigravity`'s shared `~/.gemini/settings.json`
 (idle/working/blocked/done; `agy` adopted claude's hook schema, verified
 against agy 1.0.9 — `PreToolUse` drives working, `Notification` blocked, see

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ adds:
   repo(s) and branch, each running the agent you chose.
 - **Any agent** — a session runs one coding-agent CLI selected at
   creation time. Built-ins (claude, codex, antigravity, opencode,
-  aider, vibe) are seeded into `~/.config/thurbox/agents.toml`; add your
+  aider, copilot, vibe) are seeded into `~/.config/thurbox/agents.toml`; add your
   own without recompiling.
 - **Git worktree isolation** — each session can spawn on a fresh
   worktree; `Ctrl+S` syncs them with their base branch and asks the
@@ -365,7 +365,7 @@ switched live with `Ctrl+Y` (or `F4`) and persisted across restarts.
   stable identity.
 - **[Agent definitions](#agents)** — every launchable agent is declared as
   data in `agents.toml` (seeded with claude, codex, antigravity, opencode,
-  aider, vibe); add your own with no recompile.
+  aider, copilot, vibe); add your own with no recompile.
 - **[Git worktree isolation](#common-workflows)** — spawn a session on a
   fresh worktree branch; `Ctrl+S` syncs them with their base branch and asks
   the agent to resolve rebase conflicts.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -606,7 +606,7 @@ trivially testable. Composite styles (e.g., `focused_title()`) are
 at creation time; each agent runs with its own default config.
 Agents are described as **data** in `~/.config/thurbox/agents.toml`
 (sibling of any other config), seeded with built-ins (claude,
-codex, antigravity, opencode, aider, vibe) on first run via
+codex, antigravity, opencode, aider, copilot, vibe) on first run via
 `agent::agent_config::load_or_seed`. An `AgentDef` carries a
 `command`, `args` (always passed — bake in flags like a model
 here if you want), and argument-template groups (`resume_args`,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -93,8 +93,8 @@ way), making it usable as a dotfiles CI gate.
 ## agents.toml
 
 Declares the launchable coding agents. Seeded with the built-ins
-(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `vibe`) on first
-run; edit or add `[[agents]]` entries to support any CLI — no
+(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`) on
+first run; edit or add `[[agents]]` entries to support any CLI — no
 recompile. A malformed `[[agents]]` entry is skipped (with a toast
 naming it) and the rest still load; only a document-level syntax error
 falls back to the built-ins. Either way the error is shown.
@@ -123,7 +123,7 @@ The seeded file also ships two commented, copy-pasteable templates
 below the built-ins — **Add your own agent** (every field annotated)
 and **Pin a model** (a `claude-opus` variant baking `--model opus`
 into `args`). Both stay commented, so a fresh install still resolves
-to exactly the six built-ins.
+to exactly the seven built-ins.
 
 ## hosts.toml
 

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -66,6 +66,16 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
   `vibe-hooks.toml` (no code change). And if you already maintain your own
   `~/.vibe/hooks.toml`, the write is **refused** (no managed marker) so it's never
   clobbered — vibe simply goes unreported rather than broken.
+- **copilot** *(experimental)* — GitHub Copilot CLI (the `copilot` command) loads
+  hooks from its own dir, `~/.copilot/hooks/*.json`. We drop a managed standalone
+  file in (an `[[external_files]]`, guarded by `requires_dir`, only when copilot is
+  installed), so your other hook files are never touched. Events (copilot's own
+  schema): `sessionStart` → idle, `userPromptSubmitted`/`preToolUse` → working,
+  `agentStop` → done, and `notification` matched to `permission_prompt` → blocked
+  (so an `agent_idle`/`shell_completed` notification doesn't flip the dot red).
+  Both `bash` and `powershell` commands are shipped, so status works on Windows
+  too. **Caveat:** if a future `copilot` changes the hook schema, edit
+  `copilot-hooks.json` (no code change).
 - **antigravity** — antigravity (the `agy` CLI, the Gemini CLI successor) loads
   hooks only from its shared `~/.gemini/settings.json`, so we **JSON-merge** our
   entries in (a `[[config_merges]]`, guarded by `requires_dir`) without clobbering
@@ -97,6 +107,7 @@ other agents are wired by a reversible merge into — or a managed file dropped 
 | opencode | `~/.config/opencode/plugin/thurbox-status.js` | managed plugin file (`requires_dir`) |
 | codex | `~/.codex/hooks.json` | reversible JSON-merge of our entries |
 | vibe | `~/.vibe/hooks.toml` | managed file (refused if you already have one) |
+| copilot | `~/.copilot/hooks/thurbox-status.json` | managed standalone file (`requires_dir`) |
 | antigravity | `~/.gemini/settings.json` | reversible JSON-merge of our entries |
 
 The home dir is `~/.config/thurbox/hooks` for a release build and

--- a/extensions/hooks/copilot-hooks.json
+++ b/extensions/hooks/copilot-hooks.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "thurbox-cli session signal --state idle || true  # managed by thurbox `extension install` — do not edit",
+        "powershell": "thurbox-cli session signal --state idle 2>$null; exit 0  # managed by thurbox `extension install`",
+        "timeoutSec": 10
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "thurbox-cli session signal --state working || true",
+        "powershell": "thurbox-cli session signal --state working 2>$null; exit 0",
+        "timeoutSec": 10
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "thurbox-cli session signal --state working || true",
+        "powershell": "thurbox-cli session signal --state working 2>$null; exit 0",
+        "timeoutSec": 10
+      }
+    ],
+    "notification": [
+      {
+        "type": "command",
+        "matcher": "permission_prompt",
+        "bash": "thurbox-cli session signal --state blocked || true",
+        "powershell": "thurbox-cli session signal --state blocked 2>$null; exit 0",
+        "timeoutSec": 10
+      }
+    ],
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "thurbox-cli session signal --state done || true",
+        "powershell": "thurbox-cli session signal --state done 2>$null; exit 0",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}

--- a/extensions/hooks/extension.toml
+++ b/extensions/hooks/extension.toml
@@ -82,6 +82,24 @@ path = "~/.vibe/hooks.toml"
 source = "vibe-hooks.toml"
 requires_dir = "~/.vibe"
 
+# GitHub Copilot CLI (the `copilot` command) loads hooks from its own dir,
+# ~/.copilot/hooks/*.json (each file loaded alphabetically), so we drop a managed
+# standalone file in — never touching the user's other hook files. Guarded by
+# requires_dir so it's a no-op when copilot isn't installed; the hooks/ subdir is
+# created automatically. Events (copilot's own schema, see
+# https://docs.github.com/en/copilot/reference/hooks-configuration):
+# sessionStart → idle, userPromptSubmitted/preToolUse → working, agentStop →
+# done, and notification (matched to `permission_prompt`) → blocked. Both `bash`
+# and `powershell` commands are shipped so status works on Windows too. The
+# `session signal` JSON output carries none of copilot's decision keys
+# (permissionDecision/decision/additionalContext), so it never affects the
+# preToolUse/agentStop fail-open flow. If a future copilot changes the schema,
+# edit copilot-hooks.json (no code change).
+[[external_files]]
+path = "~/.copilot/hooks/thurbox-status.json"
+source = "copilot-hooks.json"
+requires_dir = "~/.copilot"
+
 # antigravity (the `agy` CLI, the Gemini CLI successor) loads hooks only from its
 # shared ~/.gemini/settings.json, which we must NOT clobber — so we JSON-merge our
 # entries in (reversibly; uninstall prunes exactly ours, leaving the user's

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -76,6 +76,15 @@ command = "aider"
 resume_args = ["--restore-chat-history"]
 resume_latest = true
 
+# GitHub Copilot CLI (the `copilot` command) resumes the most recent session in
+# the launch directory via `--continue`; it can't pin or report a session id and
+# has no fork (Ctrl+F falls back to a fresh session).
+[[agents]]
+name = "copilot"
+command = "copilot"
+resume_args = ["--continue"]
+resume_latest = true
+
 [[agents]]
 name = "vibe"
 command = "vibe"
@@ -353,6 +362,7 @@ mod tests {
         assert!(reg.get("antigravity").is_some());
         assert!(reg.get("opencode").is_some());
         assert!(reg.get("aider").is_some());
+        assert!(reg.get("copilot").is_some());
         assert!(reg.get("vibe").is_some());
 
         // Claude pins a thurbox id and resumes/forks by it.
@@ -370,8 +380,9 @@ mod tests {
         assert_eq!(opencode.fork_args, ["--continue", "--fork"]);
         assert!(opencode.resume_latest);
 
-        // antigravity/aider resume their latest session but have no fork group.
-        for name in ["antigravity", "aider"] {
+        // antigravity/aider/copilot resume their latest session but have no
+        // fork group.
+        for name in ["antigravity", "aider", "copilot"] {
             let a = reg.get(name).unwrap();
             assert!(a.resume_latest, "{name} should resume latest");
             assert!(!a.resume_args.is_empty(), "{name} needs resume_args");
@@ -380,7 +391,7 @@ mod tests {
 
         // No non-claude resume/fork token may carry a {id} placeholder — these
         // agents can't be addressed by a thurbox-known id.
-        for name in ["codex", "antigravity", "opencode", "aider"] {
+        for name in ["codex", "antigravity", "opencode", "aider", "copilot"] {
             let a = reg.get(name).unwrap();
             assert!(
                 !a.resume_args
@@ -394,7 +405,7 @@ mod tests {
 
     /// The seed must carry copy-pasteable examples (add-your-own-agent +
     /// pin-a-model) but keep them commented, so parsing still yields exactly
-    /// the six built-ins — a fresh install boots on pure defaults.
+    /// the seven built-ins — a fresh install boots on pure defaults.
     #[test]
     fn seed_documents_examples_yet_stays_builtin_only() {
         for marker in [
@@ -411,7 +422,7 @@ mod tests {
         // Examples are commented, so the seed parses to just the built-ins.
         let reg = builtin_registry();
         assert_eq!(reg.default, "claude");
-        assert_eq!(reg.agents.len(), 6, "examples must stay commented out");
+        assert_eq!(reg.agents.len(), 7, "examples must stay commented out");
         assert!(
             reg.get("claude-opus").is_none(),
             "example must not register"
@@ -478,7 +489,7 @@ mod tests {
     fn one_malformed_entry_is_skipped_and_the_rest_survive() {
         // The real-world footgun: `args` given a bare string instead of an
         // array. Previously this failed the whole document and stranded the
-        // user on the six built-ins; now only the bad entry is dropped.
+        // user on the built-ins; now only the bad entry is dropped.
         let toml = r#"
 default = "claude"
 

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -27,6 +27,7 @@ const OPENCODE_PLUGIN: &str = include_str!("../../extensions/hooks/opencode-stat
 const ANTIGRAVITY_HOOKS: &str = include_str!("../../extensions/hooks/antigravity-hooks.json");
 const CODEX_HOOKS: &str = include_str!("../../extensions/hooks/codex-hooks.json");
 const VIBE_HOOKS: &str = include_str!("../../extensions/hooks/vibe-hooks.toml");
+const COPILOT_HOOKS: &str = include_str!("../../extensions/hooks/copilot-hooks.json");
 
 /// The hooks extension's home, under this build's resolved config dir
 /// (`~/.config/thurbox/hooks` for a release build, `~/.config/thurbox-dev/hooks`
@@ -53,6 +54,7 @@ fn materialize_source() -> Result<PathBuf, String> {
         ("antigravity-hooks.json", ANTIGRAVITY_HOOKS),
         ("codex-hooks.json", CODEX_HOOKS),
         ("vibe-hooks.toml", VIBE_HOOKS),
+        ("copilot-hooks.json", COPILOT_HOOKS),
     ];
     for (name, contents) in writes {
         let path = dir.join(name);
@@ -134,6 +136,10 @@ mod tests {
         // marker (external-file uninstall, see `is_user_modified`).
         assert!(VIBE_HOOKS.contains("thurbox-cli session signal"));
         assert!(VIBE_HOOKS.contains("thurbox `extension install`"));
+        // The copilot payload carries the signal command and the managed marker
+        // (external-file uninstall, see `is_user_modified`).
+        assert!(COPILOT_HOOKS.contains("thurbox-cli session signal"));
+        assert!(COPILOT_HOOKS.contains("thurbox `extension install`"));
     }
 
     #[test]
@@ -209,6 +215,33 @@ mod tests {
         assert!(payload["hooks"]["BeforeTool"].is_null());
         assert!(payload["hooks"]["AfterAgent"].is_null());
         assert!(ANTIGRAVITY_HOOKS.contains("thurbox-cli session signal"));
+
+        // copilot drops a managed standalone file into ~/.copilot/hooks/ (guarded
+        // by requires_dir; the hooks/ subdir is created on write).
+        let copilot = def
+            .external_files
+            .iter()
+            .find(|f| f.path.contains(".copilot"))
+            .expect("copilot external file present");
+        assert_eq!(copilot.source_path(), "copilot-hooks.json");
+        assert_eq!(copilot.requires_dir.as_deref(), Some("~/.copilot"));
+
+        // The copilot payload is valid JSON using copilot's own event schema, so a
+        // typo can't ship a file copilot would reject.
+        let copilot_payload: serde_json::Value =
+            serde_json::from_str(COPILOT_HOOKS).expect("copilot payload is valid JSON");
+        for event in [
+            "sessionStart",
+            "userPromptSubmitted",
+            "preToolUse",
+            "notification",
+            "agentStop",
+        ] {
+            assert!(
+                copilot_payload["hooks"][event].is_array(),
+                "copilot hook event {event} missing"
+            );
+        }
     }
 
     #[test]

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -76,9 +76,10 @@ fn build_restart_plan(session: &SharedSession) -> Result<RestartPlan, String> {
 ///
 /// For the `claude` agent, uses its resume group when a transcript for the
 /// session id exists on disk, otherwise pins the same id for a fresh start.
-/// For `resume_latest` agents (codex, opencode, antigravity, aider) it resumes the
-/// latest session in the (unchanged) launch directory. Other agents degrade to
-/// "start fresh" (the live tmux process is what carries state across restarts).
+/// For `resume_latest` agents (codex, opencode, antigravity, aider, copilot) it
+/// resumes the latest session in the (unchanged) launch directory. Other agents
+/// degrade to "start fresh" (the live tmux process is what carries state across
+/// restarts).
 pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<(), String> {
     let session = db
         .get_session_by_id(session_id)

--- a/website/docs/agent-hooks.html
+++ b/website/docs/agent-hooks.html
@@ -1,7 +1,7 @@
 ---
 layout: docs.njk
 title: 'Agent hooks — Thurbox Docs'
-description: 'The built-in hooks extension: wire each coding agent CLI lifecycle hook to thurbox-cli session signal so every session reports working/blocked/done/idle. Per-agent coverage matrix for claude, codex, antigravity, opencode, aider, and vibe.'
+description: 'The built-in hooks extension: wire each coding agent CLI lifecycle hook to thurbox-cli session signal so every session reports working/blocked/done/idle. Per-agent coverage matrix for claude, codex, antigravity, opencode, aider, copilot, and vibe.'
 currentPage: 'agent-hooks'
 breadcrumb: 'Agent hooks'
 onThisPage:
@@ -181,6 +181,13 @@ onThisPage:
                 <td>&mdash;</td>
               </tr>
               <tr>
+                <td>copilot <sup>*</sup></td>
+                <td>&#x2713;</td>
+                <td>&#x2713;</td>
+                <td>&#x2713;</td>
+                <td>&#x2713;</td>
+              </tr>
+              <tr>
                 <td>vibe <sup>*</sup></td>
                 <td>&mdash;</td>
                 <td>&#x2713;</td>
@@ -192,7 +199,7 @@ onThisPage:
           <p>
             <sup>*</sup>
             <strong>Experimental</strong>
-            &mdash; the hook schema for codex and vibe is newer or not exhaustively
+            &mdash; the hook schema for codex, copilot, and vibe is newer or not exhaustively
             verified against the live CLI. If event names differ, the fix is a one-file edit to the
             extension payload (no code change), and an unrecognized hook is a fail-open no-op
             (
@@ -304,6 +311,30 @@ onThisPage:
               <strong>refused</strong>
               (never clobbered) &mdash; vibe simply goes unreported.
             </li>
+            <li>
+              <strong>copilot</strong>
+              <em>(experimental)</em>
+              &mdash; GitHub Copilot CLI loads hooks from its own
+              <code>~/.copilot/hooks/</code>
+              dir, so Thurbox drops a managed standalone file in (only when copilot is installed),
+              never touching your other hook files.
+              <code>sessionStart</code>
+              &rarr; idle,
+              <code>userPromptSubmitted</code>
+              /
+              <code>preToolUse</code>
+              &rarr; working,
+              <code>agentStop</code>
+              &rarr; done, and
+              <code>notification</code>
+              matched to
+              <code>permission_prompt</code>
+              &rarr; blocked. Both
+              <code>bash</code>
+              and
+              <code>powershell</code>
+              commands ship, so status works on Windows too.
+            </li>
           </ul>
           <p>
             These use three manifest capabilities &mdash;
@@ -382,6 +413,11 @@ onThisPage:
                 <td>managed file (refused if you already have one)</td>
               </tr>
               <tr>
+                <td>copilot</td>
+                <td><code>~/.copilot/hooks/thurbox-status.json</code></td>
+                <td>managed standalone file</td>
+              </tr>
+              <tr>
                 <td>antigravity</td>
                 <td><code>~/.gemini/settings.json</code></td>
                 <td>reversible JSON-merge of our entries</td>
@@ -458,5 +494,7 @@ thurbox-cli extension activate hooks     # re-enable it</code></pre>
             <code>opencode-status.js</code>
             ,
             <code>vibe-hooks.toml</code>
+            ,
+            <code>copilot-hooks.json</code>
             ).
           </p>

--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -216,6 +216,8 @@ thurbox-cli config show       # effective config + where each value came from</c
             ,
             <code>aider</code>
             ,
+            <code>copilot</code>
+            ,
             <code>vibe</code>
             ) on first run; edit or add
             <code>[[agents]]</code>

--- a/website/docs/faq.html
+++ b/website/docs/faq.html
@@ -14,10 +14,10 @@ breadcrumb: 'FAQ'
 <h2 id="what-is-thurbox">What is Thurbox?</h2>
 <p>
   Thurbox is a multi-session TUI orchestrator that runs any coding-agent CLI
-  — Claude Code, Codex, Antigravity, opencode, aider, Vibe, or any CLI you
-  define — inside persistent tmux panes. Sessions, agents, and git worktrees
-  are first-class citizens, and sessions survive crashes, restarts, and
-  reboots because tmux keeps the processes alive.
+  — Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe,
+  or any CLI you define — inside persistent tmux panes. Sessions, agents, and
+  git worktrees are first-class citizens, and sessions survive crashes,
+  restarts, and reboots because tmux keeps the processes alive.
 </p>
 
 <h2 id="how-different">
@@ -37,9 +37,10 @@ breadcrumb: 'FAQ'
 <h2 id="supported-agents">Which coding agents does Thurbox support?</h2>
 <p>
   Thurbox is agent-neutral. It ships built-in definitions for Claude Code,
-  Codex, Antigravity, opencode, aider, and Vibe, and you can add any other CLI
-  by editing agents.toml — no recompile required. Thurbox only knows how to
-  launch each CLI with the right command and arguments; it never touches the
+  Codex, Antigravity, opencode, aider, GitHub Copilot CLI, and Vibe, and you can
+  add any other CLI by editing agents.toml — no recompile required. Thurbox only
+  knows how to launch each CLI with the right command and arguments; it never
+  touches the
   agent's model, prompts, or permissions.
 </p>
 
@@ -93,7 +94,7 @@ breadcrumb: 'FAQ'
         "name": "What is Thurbox?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Thurbox is a multi-session TUI orchestrator that runs any coding-agent CLI — Claude Code, Codex, Antigravity, opencode, aider, Vibe, or any CLI you define — inside persistent tmux panes. Sessions, agents, and git worktrees are first-class citizens, and sessions survive crashes, restarts, and reboots because tmux keeps the processes alive."
+          "text": "Thurbox is a multi-session TUI orchestrator that runs any coding-agent CLI — Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, or any CLI you define — inside persistent tmux panes. Sessions, agents, and git worktrees are first-class citizens, and sessions survive crashes, restarts, and reboots because tmux keeps the processes alive."
         }
       },
       {
@@ -109,7 +110,7 @@ breadcrumb: 'FAQ'
         "name": "Which coding agents does Thurbox support?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Thurbox is agent-neutral. It ships built-in definitions for Claude Code, Codex, Antigravity, opencode, aider, and Vibe, and you can add any other CLI by editing agents.toml — no recompile required. Thurbox only knows how to launch each CLI with the right command and arguments; it never touches the agent's model, prompts, or permissions."
+          "text": "Thurbox is agent-neutral. It ships built-in definitions for Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, and Vibe, and you can add any other CLI by editing agents.toml — no recompile required. Thurbox only knows how to launch each CLI with the right command and arguments; it never touches the agent's model, prompts, or permissions."
         }
       },
       {

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -41,8 +41,9 @@ breadcrumb: 'Features'
           </figure>
           <p>
             Run multiple coding-agent CLIs side-by-side, each in its own tmux pane. A session runs
-            one agent (Claude Code, Codex, Antigravity, opencode, aider, Vibe, or your own), each
-            with its own default config. Sessions persist across crashes, restarts, and even
+            one agent (Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, or
+            your own), each with its own default config. Sessions persist across crashes, restarts,
+            and even
             multiple concurrent Thurbox instances &mdash; tmux keeps them alive in the background.
           </p>
           <ul>

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -210,7 +210,8 @@ cargo build --release</code></pre>
                   >
                     claude
                   </a>
-                  , codex, antigravity, opencode, aider, or vibe &mdash; whichever agents you plan to run
+                  , codex, antigravity, opencode, aider, copilot, or vibe &mdash; whichever agents you
+                  plan to run
                 </td>
               </tr>
               <tr>

--- a/website/index.html
+++ b/website/index.html
@@ -1,7 +1,7 @@
 ---
 layout: base.njk
 title: 'Thurbox — TUI Agentic IDE'
-description: 'Thurbox runs any coding-agent CLI (Claude Code, Codex, Antigravity, opencode, aider, Vibe) in persistent tmux panes — sessions, agents, and git worktrees as first-class citizens.'
+description: 'Thurbox runs any coding-agent CLI (Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe) in persistent tmux panes — sessions, agents, and git worktrees as first-class citizens.'
 root: '.'
 extraCss: ['landing.css']
 footer: true
@@ -15,8 +15,8 @@ footer: true
           Agentic IDE
         </h1>
         <p class="subtitle">
-          Run Claude Code, Codex, Antigravity, opencode, aider, Vibe — or any CLI you define — side by
-          side in persistent tmux panes that survive crashes and restarts.
+          Run Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe — or any CLI
+          you define — side by side in persistent tmux panes that survive crashes and restarts.
         </p>
         <p class="agent-support">
           Built-in agent support for
@@ -44,6 +44,11 @@ footer: true
             <!-- prettier-ignore -->
             <svg class="agent-logo" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M3 5.8 4.8 4 12.3 11.5 4.8 19 3 17.2 8.7 11.5Z M11 17h9v2.4h-9z"/></svg>
             aider
+          </span>
+          <span>
+            <!-- prettier-ignore -->
+            <svg class="agent-logo" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M23.922 16.997C23.061 18.492 18.063 22.02 12 22.02 5.937 22.02.939 18.492.078 16.997A.641.641 0 0 1 0 16.741v-2.869a.883.883 0 0 1 .053-.22c.372-.935 1.347-2.292 2.605-2.656.167-.429.414-1.055.644-1.517a10.098 10.098 0 0 1-.052-1.086c0-1.331.282-2.499 1.132-3.368.397-.406.89-.717 1.474-.952C7.255 2.937 9.248 1.98 11.978 1.98c2.731 0 4.767.957 6.166 2.093.584.235 1.077.546 1.474.952.85.869 1.132 2.037 1.132 3.368 0 .368-.014.733-.052 1.086.23.462.477 1.088.644 1.517 1.258.364 2.233 1.721 2.605 2.656a.841.841 0 0 1 .053.22v2.869a.641.641 0 0 1-.078.256Zm-11.75-5.992h-.344a4.359 4.359 0 0 1-.355.508c-.77.947-1.918 1.492-3.508 1.492-1.725 0-2.989-.359-3.782-1.259a2.137 2.137 0 0 1-.085-.104L4 11.746v6.585c1.435.779 4.514 2.179 8 2.179 3.486 0 6.565-1.4 8-2.179v-6.585l-.098-.104s-.033.045-.085.104c-.793.9-2.057 1.259-3.782 1.259-1.59 0-2.738-.545-3.508-1.492a4.359 4.359 0 0 1-.355-.508Zm2.328 3.25c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm-5 0c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm3.313-6.185c.136 1.057.403 1.913.878 2.497.442.544 1.134.938 2.344.938 1.573 0 2.292-.337 2.657-.751.384-.435.558-1.15.558-2.361 0-1.14-.243-1.847-.705-2.319-.477-.488-1.319-.862-2.824-1.025-1.487-.161-2.192.138-2.533.529-.269.307-.437.808-.438 1.578v.021c0 .265.021.562.063.893Zm-1.626 0c.042-.331.063-.628.063-.894v-.02c-.001-.77-.169-1.271-.438-1.578-.341-.391-1.046-.69-2.533-.529-1.505.163-2.347.537-2.824 1.025-.462.472-.705 1.179-.705 2.319 0 1.211.175 1.926.558 2.361.365.414 1.084.751 2.657.751 1.21 0 1.902-.394 2.344-.938.475-.584.742-1.44.878-2.497Z"/></svg>
+            Copilot
           </span>
           <span>
             <!-- prettier-ignore -->
@@ -276,7 +281,8 @@ cargo build --release</code></pre>
               <h3>Any Coding Agent</h3>
               <p>
                 A session runs one agent of your choice &mdash; Claude Code, Codex, Antigravity,
-                opencode, aider, Vibe, or any CLI you describe. Each agent runs with its own default
+                opencode, aider, GitHub Copilot CLI, Vibe, or any CLI you describe. Each agent runs
+                with its own default
                 config. Mix different agents across the sidebar.
               </p>
             </div>
@@ -758,7 +764,7 @@ Ctrl+O  Open repos in editor</pre>
                 <a href="https://github.com/anthropics/claude-code" target="_blank" rel="noopener">
                   claude
                 </a>
-                , codex, antigravity, opencode, aider, or vibe
+                , codex, antigravity, opencode, aider, copilot, or vibe
               </li>
               <li>
                 <strong>git</strong>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -1,8 +1,9 @@
 # Thurbox
 
 > Thurbox is a multi-session TUI orchestrator that runs any coding-agent CLI
-> — Claude Code, Codex, Antigravity, opencode, aider, Vibe, or any CLI you
-> define — inside persistent tmux panes. Sessions, agents, and git worktrees
+> — Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe,
+> or any CLI you define — inside persistent tmux panes. Sessions, agents, and
+> git worktrees
 > are first-class citizens, and sessions survive crashes, restarts, and
 > reboots because tmux keeps the agent processes alive. It is written in Rust,
 > open source under the MIT license, and runs on Linux, macOS, and Windows


### PR DESCRIPTION
## Summary

- Add `copilot` (GitHub Copilot CLI) as a built-in agent in the seeded `agents.toml` — resumes the most recent session in the launch directory via `--continue` (`resume_latest`), no fork, mirroring antigravity/aider.
- Wire live session status via the built-in hooks extension: a managed `~/.copilot/hooks/thurbox-status.json` maps `sessionStart`→idle, `userPromptSubmitted`/`preToolUse`→working, `agentStop`→done, and `notification[permission_prompt]`→blocked. Ships both `bash` and `powershell` commands (Windows-friendly).
- Update agent enumerations and hooks coverage across docs (CLAUDE.md, README, CONFIG, ARCHITECTURE) and the website (homepage chip + prose, faq, features, installation, configuration, agent-hooks, llms.txt).

## Test plan

- `cargo nextest` (agent_config, builtin_hooks, extension, restart): all pass
- `cargo clippy --all-targets --all-features -D warnings`: clean
- `cargo fmt --check`, architecture_rules, rumdl, website lints: clean
- CI checks pass