### PR TITLE
feat(ui): add Ctrl+X shortcut for code review and show it in the demo

### DIFF
--- a/.claude/skills/ui-review/scripts/capture.sh
+++ b/.claude/skills/ui-review/scripts/capture.sh
@@ -141,8 +141,9 @@ trap cleanup EXIT INT TERM
 # Remap the actions whose default chords VHS cannot emit to free, typeable
 # Ctrl+<letter> chords so the tape can open them. The rendered panels are
 # identical regardless of which key opens them.
-#   GlobalSearch: Ctrl+/ -> Ctrl+A   OpenSettings: Ctrl+, -> Ctrl+X
-#   ToggleReview: F7     -> Ctrl+R   (code-review view)
+#   GlobalSearch: Ctrl+/    -> Ctrl+A   OpenSettings: Ctrl+, -> Ctrl+X
+#   ToggleReview: Ctrl+X/F7 -> Ctrl+R   (code-review view; remapping it here also
+#                                        frees its default Ctrl+X for OpenSettings)
 cat > "$CFG_DIR/keybindings.json" <<'EOF'
 {
   "GlobalSearch": ["ctrl+a"],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1350,8 +1350,10 @@ Thurbox has a **built-in, natively-rendered** code-review view (no external
 binary, no nested TUI) — a tuicr-like GitHub-style continuous diff with
 classified comments and a review summary. It targets the active session's
 worktree (`<base>..HEAD`), which maps cleanly onto thurbox's model (every
-session is a worktree on a branch forked from a base). Toggle with `F7`
-(rebindable `Action::ToggleReview`), like the shell pane; gated by `[features]
+session is a worktree on a branch forked from a base). Toggle with `Ctrl+X`
+(`F7` alternate; rebindable `Action::ToggleReview`), like the shell pane —
+`Ctrl+X` is in `terminal_passthrough` (the emacs prefix key), so in a focused
+terminal it reaches the agent and `F7` opens the review. Gated by `[features]
 code_review`.
 
 - **Surface (tuicr-like).** A continuous diff stream in the central pane (its own
@@ -1368,7 +1370,7 @@ code_review`.
   into the diff at the selected file (the file viewer's "open"), `r`/`R` toggle
   the file/hunk reviewed mark, and `Esc` closes the review
   (`App::handle_review_files_key`, captured before the global lookup like the diff
-  pane). While open it owns the central pane; `Esc`/`F7` close it.
+  pane). While open it owns the central pane; `Esc`/`Ctrl+X` (or `F7`) close it.
   Rendered by `ui::code_review`, reusing `scrollbar`/`focus_block`/
   `render_button_bar`/theme. **Unified or side-by-side** diff layout, toggled with
   `v` / the footer button (`side_by_side`). **Mouse-first** (no vim modal): click a
@@ -1463,8 +1465,12 @@ overrides `HOME`, so agents boot with fresh history/config (no
 past conversations leak); CLIs that authenticate via the system
 keyring stay logged in but show no account email on screen. The
 tapes exercise the session list, info panel (`Ctrl+B`), file
-viewer (`Ctrl+E`), theme picker, session-creation flow, and the
-Automations pane over the seeded sessions and sample tree.
+viewer (`Ctrl+E`), native code review (`Ctrl+X`, the default
+`ToggleReview` chord; `F7` alternate), theme picker, session-creation flow, and the
+Automations pane over the seeded sessions and sample tree. The hero
+`agents` demo also opens the code-review view, so it seeds the same
+worktree-with-a-committed-diff session the dedicated `code-review`
+clip uses.
 
 It runs fully isolated from your real environment — a dev build
 (`0.0.0-dev` → `dev_build` cfg) uses the `thurbox-dev` socket and
@@ -1645,7 +1651,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+W` / `F5` | Toggle tasks panel (todo list) | Work items |
 | `Ctrl+/` | Global search (sessions/tasks/automations/files) | **/** = search |
 | `Ctrl+T` / `F8` | Toggle shell pane | **T**erminal |
-| `F7` | Toggle native code-review view | Review |
+| `Ctrl+X` / `F7` | Toggle native code-review view | Review |
 | `Ctrl+H` | Focus previous pane (cycle backward) | Vim: **h** = left |
 | `Ctrl+J` | Select next session | Vim: **j** = down |
 | `Ctrl+K` | Select previous session | Vim: **k** = up |
@@ -1673,7 +1679,7 @@ own scrollback, e.g. Terminal.app/iTerm2).
 
 These defaults can be overridden two ways, both writing the same
 `~/.config/thurbox/keybindings.json` (an `Action` name → one or more
-chord strings, e.g. `{ "QuitApp": ["ctrl+x"] }`):
+chord strings, e.g. `{ "QuitApp": ["ctrl+a"] }`):
 
 - **Interactively** from the F1 panel, which is a live editor rather
   than a read-only overlay. `j`/`k` select an action, `Enter`/`r`
@@ -1718,11 +1724,12 @@ kill-line, `Ctrl+R` = reverse-search, `Ctrl+D` = EOF, …). So when a session
 **terminal is focused**, the actions flagged by `Action::terminal_passthrough`
 (`ToggleInfoPanel`/`DeleteSession`/`ToggleFileViewer`/
 `ForkSession`/`OpenInEditor`/`OpenAutomations`/`RestartSession`/`StartSync`/
-`OpenRestoreSessions`/`FocusTasks`) **defer to the agent CLI** instead of
-running the thurbox command — `handle_key` skips `dispatch_action` and falls
-through to `handle_terminal_key`, which forwards the bytes to the PTY. The
+`OpenRestoreSessions`/`FocusTasks`/`ToggleReview`) **defer to the agent CLI**
+instead of running the thurbox command — `handle_key` skips `dispatch_action`
+and falls through to `handle_terminal_key`, which forwards the bytes to the PTY
+(so e.g. `Ctrl+X` reaches emacs's prefix key in a focused terminal). The
 thurbox command stays reachable from the **session list** (and via its `F`-key
-alternate where one exists — `F2`/`F3`/`F5`). The deferral is gated on the
+alternate where one exists — `F2`/`F3`/`F5`/`F7`). The deferral is gated on the
 bound chord still being a bare `Ctrl+<letter>` (`is_ctrl_letter_chord`), so
 rebinding a passthrough action to a non-conflicting key keeps it working in the
 terminal. Navigation / app-control chords (`Ctrl+H/J/K/L` focus + session nav,

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ point):
   scrollbars, plus drag-to-select — a gentler on-ramp than most TUIs, while
   staying fully keyboard-first (and toggleable via `[features] mouse`).
 - **Native code review, in the terminal.** A built-in, GitHub-style diff
-  reviewer (`F7`) — browse the branch, a commit, or working changes in a folder
+  reviewer (`Ctrl+X`) — browse the branch, a commit, or working changes in a folder
   tree, leave classified comments, fold reviewed files, then send the review
   back to the agent to address. The click-to-review visual diff that used to be
   a GUI-only perk, without leaving the TUI.
@@ -290,7 +290,7 @@ result; `Esc` restores exactly what you had.
 
 ### Code Review
 
-A native, GitHub-style diff reviewer (`F7`) — no external tool. Browse the
+A native, GitHub-style diff reviewer (`Ctrl+X`, `F7` alternate) — no external tool. Browse the
 branch (`<base>..HEAD`), a single commit, or the uncommitted changes; the
 changed files show as a **folder tree** with colored statuses, and the diff is
 syntax-highlighted. Leave classified comments (issue / suggestion / note /
@@ -623,7 +623,7 @@ repos? Add `--add-repo PATH@main` (its own worktree per repo) or
 | `Ctrl+/` | Global search (sessions/tasks/automations/files) | **/** = search |
 | `Ctrl+W` / `F5` | Toggle tasks panel (todo list) | **W**ork items |
 | `Ctrl+T` | Toggle shell pane | **T**erminal |
-| `F7` | Toggle code-review pane (native diff reviewer) | Review |
+| `Ctrl+X` / `F7` | Toggle code-review pane (native diff reviewer) | Review |
 | `Ctrl+H` | Focus previous pane (cycle backward) | Vim: **h** = left |
 | `Ctrl+J` | Select next session | Vim: **j** = down |
 | `Ctrl+K` | Select previous session | Vim: **k** = up |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -215,7 +215,7 @@ no results. Data is never touched, so re-enabling a flag is lossless.
 | `global_search` | `true` | global search strip (`Ctrl+/`) |
 | `info_panel` | `true` | info panel column (`F2`) |
 | `shell_pane` | `true` | per-session shell toggle (`Ctrl+T`) |
-| `code_review` | `true` | native code-review view (diff + comments, `F7`) |
+| `code_review` | `true` | native code-review view (diff + comments, `Ctrl+X`) |
 | `mouse` | `true` | mouse capture: clicks, wheel, drag-select, hover, scrollbars |
 | `notifications` | `true` | OS desktop notifications when a session needs attention |
 | `soft_delete` | `true` | TUI `Ctrl+D` soft-deletes (Ctrl+Z undo); off = hard delete after a confirmation prompt |
@@ -416,7 +416,7 @@ effect).
 Maps `Action` names to one or more chord strings:
 
 ```json
-{ "QuitApp": ["ctrl+x"], "OpenThemePicker": ["ctrl+y", "f4"] }
+{ "QuitApp": ["ctrl+a"], "OpenThemePicker": ["ctrl+y", "f4"] }
 ```
 
 - Preferred editing path is the **F1 panel** (live capture, conflict

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -373,7 +373,7 @@ applicable: `h/j/k/l` for navigation, semantic letters for actions
 | `Ctrl+W` / `F5` | Global | Toggle tasks panel (todo list) | Work items |
 | `Ctrl+/` | Global | Global search across every scope | **/** = search |
 | `Ctrl+T` / `F8` | Global | Toggle shell pane alongside the agent session | **T**erminal |
-| `F7` | Global | Toggle the native code-review view | Review |
+| `Ctrl+X` / `F7` | Global | Toggle the native code-review view | Review |
 | `Ctrl+H` | Global | Focus previous pane (cycle backward) | Vim: **h** = left |
 | `Ctrl+J` | Global | Select next session | Vim: **j** = down |
 | `Ctrl+K` | Global | Select previous session | Vim: **k** = up |
@@ -433,7 +433,7 @@ action's defaults, and `Shift+D` resets every action at once (removing the
 override file). If the chord conflicts it is reassigned from the other action
 and a status toast reports the move. Changes persist immediately to
 `~/.config/thurbox/keybindings.json` (`Action` name → chord strings, e.g.
-`{ "QuitApp": ["ctrl+x"] }`) and take effect on the next keystroke — no
+`{ "QuitApp": ["ctrl+a"] }`) and take effect on the next keystroke — no
 restart. The file can also be hand-edited directly.
 
 **Context-scoped keys.** Each action belongs to a scope — `Global`,
@@ -556,7 +556,7 @@ editor of choice can open them as a workspace.
 
 ## Code Review (native)
 
-Thurbox ships a **native, built-in** tuicr-like review view (`F7`): a
+Thurbox ships a **native, built-in** tuicr-like review view (`Ctrl+X`, `F7` alternate): a
 GitHub-style continuous diff of the active session's worktree
 (`<base>..HEAD`) with classified comments (issue / suggestion / note /
 praise), per-file/hunk "reviewed" marks, and a review summary — rendered

--- a/scripts/demo/agents.tape
+++ b/scripts/demo/agents.tape
@@ -4,8 +4,9 @@
 # the dev binary, sets up an isolated environment, seeds one session per real
 # agent CLI, and exports $THURBOX_BIN. See that script for context.
 #
-# VHS has no function-key commands, so this uses the Ctrl aliases added for the
-# panel toggles: Ctrl+B = info panel, Ctrl+E = file viewer.
+# VHS has no function-key commands, so this uses the Ctrl aliases of the panel
+# toggles: Ctrl+B = info panel, Ctrl+E = file viewer, Ctrl+X = code review (its
+# default primary chord; F7 is the alternate VHS can't send).
 
 Output docs/media/thurbox-demo.gif
 Output docs/media/thurbox-demo.mp4
@@ -64,6 +65,42 @@ Sleep 800ms
 Ctrl+E
 Sleep 600ms
 Ctrl+B
+Sleep 1200ms
+
+# --- Native code review ------------------------------------------------------
+# After antigravity (the 4th agent) the next session down is "review" — a
+# worktree on a branch with a real committed diff (seeded by record.sh). Select
+# it (focus stays on the session list, not the terminal — Ctrl+X is in
+# terminal_passthrough, so opening from a focused terminal would forward the
+# chord to the agent), then open the built-in code-review view (Ctrl+X, default
+# ToggleReview): a GitHub-style continuous diff in the centre, the changed-files
+# list on the right, an action bar across the bottom — no external binary.
+Ctrl+J
+Sleep 1s
+Ctrl+X
+Sleep 2500ms
+
+# Scroll the diff — added lines (green) read clearly and the changed-files list
+# tracks the current file.
+Type "j"
+Sleep 500ms
+Type "j"
+Sleep 500ms
+Type "j"
+Sleep 1000ms
+
+# `}` jumps to the next changed file; the files list highlight follows.
+Type "}"
+Sleep 1400ms
+
+# `v` toggles side-by-side (old | new), then back to unified.
+Type "v"
+Sleep 2200ms
+Type "v"
+Sleep 1400ms
+
+# Esc closes the review, back to the session list.
+Escape
 Sleep 1200ms
 
 # --- Session-creation workflow -----------------------------------------------

--- a/scripts/demo/code-review.tape
+++ b/scripts/demo/code-review.tape
@@ -6,8 +6,9 @@
 # vars this tape relies on ($THURBOX_BIN).
 #
 # Requires: vhs (charmbracelet/vhs) + ffmpeg + ttyd. VHS has no function-key
-# commands, so the review toggle (F7 by default) is rebound to Ctrl+X by the
-# runner's keybindings.json; everything else is Ctrl chords + plain keys.
+# commands, so the review toggle is opened with its default primary chord Ctrl+X
+# (F7 is the alternate VHS can't send); everything else is Ctrl chords + plain
+# keys.
 
 Output docs/media/code-review-demo.gif
 Output docs/media/code-review-demo.mp4
@@ -28,11 +29,15 @@ Sleep 2s
 Show
 
 # The worktree "review" session is seeded LAST, so restore leaves it selected on
-# launch with its terminal focused. Ctrl+X (rebound ToggleReview) opens the
+# launch with its terminal focused. Ctrl+X is in terminal_passthrough (the emacs
+# prefix key), so from a focused terminal it is forwarded to the agent — focus
+# the session list first (Ctrl+H), then Ctrl+X (default ToggleReview) opens the
 # native code-review view: a continuous diff of the branch (<base>..HEAD) in the
 # centre, the changed-files list in the right column, an action bar across the
 # bottom.
 Sleep 2500ms
+Ctrl+H
+Sleep 600ms
 Ctrl+X
 Sleep 2600ms
 

--- a/scripts/demo/record.sh
+++ b/scripts/demo/record.sh
@@ -163,10 +163,12 @@ trap cleanup EXIT INT TERM
 # The search.tape opens the strip with Ctrl+A — an unambiguous chord every
 # terminal sends — so seed a keybindings.json that maps it. Only GlobalSearch is
 # overridden; every other action keeps its built-in default.
-# The code-review view toggles with F7 by default, which VHS also can't send, so
-# it is rebound to Ctrl+X for the code-review tape. Both overrides are harmless
-# for the other tapes.
-printf '{\n  "GlobalSearch": ["ctrl+a"],\n  "ToggleReview": ["ctrl+x"]\n}\n' \
+# The code-review view needs no override: its default primary chord is Ctrl+X
+# (F7 alternate, which VHS can't send), so the agents/code-review tapes open it
+# with a plain Ctrl+X. Because Ctrl+X is in terminal_passthrough (the emacs
+# prefix key), those tapes open the review from the session list, not a focused
+# terminal, where the chord would be forwarded to the agent instead.
+printf '{\n  "GlobalSearch": ["ctrl+a"]\n}\n' \
     > "$CFG_DIR/keybindings.json"
 
 # --- A throwaway sample repo so the file viewer shows a realistic tree --------
@@ -299,15 +301,16 @@ for a in $AGENTS; do
 done
 
 # --- Code-review demo: a worktree session with a real committed diff ---------
-# The review view diffs <base>..HEAD of a session's worktree, so the code-review
-# tape needs a session whose branch actually has changes. Create it LAST so
-# restore leaves it selected on launch (finish_adopted_session makes the
-# last-restored session active), on a worktree off the sample repo, then commit a
-# small multi-file change into that worktree so the Branch target shows a
-# colourful diff. Gated on the code-review tape so other clips stay fast /
-# unchanged.
+# The review view diffs <base>..HEAD of a session's worktree, so any tape that
+# opens the code-review view needs a session whose branch actually has changes.
+# Both the dedicated `code-review` clip and the hero `agents` demo (which now
+# showcases the review feature) use it. Create it LAST so restore leaves it
+# selected on launch (finish_adopted_session makes the last-restored session
+# active), on a worktree off the sample repo, then commit a small multi-file
+# change into that worktree so the Branch target shows a colourful diff. Gated on
+# those two tapes so the remaining clips stay fast / unchanged.
 # shellcheck disable=SC2086 # $TAPES is a space-separated list, split on purpose
-if printf '%s ' $TAPES | grep -Eq '(^| )code-review( |$)'; then
+if printf '%s ' $TAPES | grep -Eq '(^| )(code-review|agents)( |$)'; then
     echo "==> Seeding a worktree review session with a committed diff"
     review_agent=$(printf '%s\n' $AGENTS | head -n1)
     "$CLI_BIN" session create --name "review" --repo-path "$DEMO_REPO" \

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6547,12 +6547,12 @@ mod tests {
         let mut app = app_with_sessions(0);
         app.handle_key(KeyCode::F(1), KeyModifiers::NONE); // open help (selected = 0)
         app.handle_key(KeyCode::Char('r'), KeyModifiers::NONE); // begin capture
-        app.handle_key(KeyCode::Char('x'), KeyModifiers::CONTROL); // bind ctrl+x
+        app.handle_key(KeyCode::Char('a'), KeyModifiers::CONTROL); // bind ctrl+a (free)
 
         let action = crate::session::Action::rebindable_in_order()[0];
         assert_eq!(
             app.keybindings
-                .lookup(KeyCode::Char('x'), KeyModifiers::CONTROL),
+                .lookup(KeyCode::Char('a'), KeyModifiers::CONTROL),
             Some(action)
         );
         let modals::Modal::Help(ref h) = app.modal else {
@@ -6569,13 +6569,15 @@ mod tests {
         app.handle_key(KeyCode::Esc, KeyModifiers::NONE); // cancel capture
 
         // Still in the help modal, no longer capturing, and nothing was bound.
+        // Ctrl+A is the probe because it is unbound by default (Ctrl+X is now
+        // ToggleReview's default chord).
         let modals::Modal::Help(ref h) = app.modal else {
             panic!("Esc during capture should not close the help modal");
         };
         assert!(!h.capturing);
         assert_eq!(
             app.keybindings
-                .lookup(KeyCode::Char('x'), KeyModifiers::CONTROL),
+                .lookup(KeyCode::Char('a'), KeyModifiers::CONTROL),
             None
         );
     }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -335,7 +335,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let _g = TestPathGuard::new(tmp.path());
         crate::storage::keybindings::save_keybindings_json(
-            r#"{ "QuitApp": ["ctrl+x"], "NewSession": ["ctrl+x"] }"#,
+            r#"{ "QuitApp": ["ctrl+a"], "NewSession": ["ctrl+a"] }"#,
         )
         .unwrap();
 

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -326,6 +326,11 @@ impl Action {
     /// rarely used and the convenient shell toggle wins. It also carries an `F8`
     /// alternate, so this is a considered choice — do not "fix" it by adding it
     /// here.
+    ///
+    /// `Ctrl+X` (`ToggleReview`) **is** in the list: it is the emacs/readline
+    /// *prefix* key (`C-x C-e` edits the command line, `C-x C-s` saves, …), so
+    /// deferring it keeps that prefix working for the inner agent/shell. `F7` is
+    /// its in-terminal alternate.
     pub fn terminal_passthrough(self) -> bool {
         matches!(
             self,
@@ -338,7 +343,8 @@ impl Action {
                 | Action::RestartSession    // Ctrl+R — reverse search
                 | Action::StartSync         // Ctrl+S — forward search / XOFF
                 | Action::OpenRestoreSessions // Ctrl+U — kill line
-                | Action::FocusTasks // Ctrl+W — delete word    (F5 alt)
+                | Action::FocusTasks        // Ctrl+W — delete word      (F5 alt)
+                | Action::ToggleReview // Ctrl+X — emacs prefix (C-x …)  (F7 alt)
         )
     }
 
@@ -374,9 +380,13 @@ impl Action {
             // one; F1–F7 are taken). Stays a shell toggle in the terminal — see
             // the `terminal_passthrough` exception note.
             Action::ToggleShell => vec![KeyChord::ctrl('t'), KeyChord::function(8)],
-            // F7 — the Ctrl+<letter> namespace is full and F-keys never collide
-            // with the PTY's readline chords. Fully rebindable.
-            Action::ToggleReview => vec![KeyChord::function(7)],
+            // Ctrl+X primary, F7 alternate — consistent with the other panel
+            // toggles. Ctrl+X is the emacs/readline *prefix* key (`C-x C-e`,
+            // `C-x C-s`, …), so it is in `terminal_passthrough`: it forwards to
+            // the agent in a focused terminal/shell pane (emacs `C-x` unaffected)
+            // and toggles the review only from non-terminal panes. F7 is the
+            // in-terminal escape hatch. Fully rebindable.
+            Action::ToggleReview => vec![KeyChord::ctrl('x'), KeyChord::function(7)],
             Action::ForkSession => vec![KeyChord::ctrl('f')],
             Action::RestartSession => vec![KeyChord::ctrl('r')],
             Action::UndoDelete => vec![KeyChord::ctrl('z')],
@@ -1057,6 +1067,7 @@ mod tests {
             Action::StartSync,           // Ctrl+S
             Action::OpenRestoreSessions, // Ctrl+U
             Action::FocusTasks,          // Ctrl+W
+            Action::ToggleReview,        // Ctrl+X — emacs prefix
         ] {
             assert!(
                 action.terminal_passthrough(),
@@ -1122,6 +1133,22 @@ mod tests {
     }
 
     #[test]
+    fn toggle_review_has_dual_ctrl_x_and_f7_chord() {
+        // Ctrl+X primary (in terminal_passthrough — the emacs prefix key), F7
+        // alternate. Mirrors the other panel toggles.
+        let kb = KeyBindings::default();
+        assert_eq!(
+            kb.lookup(KeyCode::Char('x'), KeyModifiers::CONTROL),
+            Some(Action::ToggleReview)
+        );
+        assert_eq!(
+            kb.lookup(KeyCode::F(7), KeyModifiers::NONE),
+            Some(Action::ToggleReview)
+        );
+        assert!(Action::ToggleReview.terminal_passthrough());
+    }
+
+    #[test]
     fn lookup_finds_default_chord() {
         let kb = KeyBindings::default();
         assert_eq!(
@@ -1136,8 +1163,10 @@ mod tests {
 
     #[test]
     fn lookup_returns_none_for_unbound_chord() {
+        // Ctrl+A is unbound by default (it is a readline editing chord, not a
+        // thurbox action), so it is the neutral "free chord" for fixtures.
         let kb = KeyBindings::default();
-        assert_eq!(kb.lookup(KeyCode::Char('x'), KeyModifiers::CONTROL), None);
+        assert_eq!(kb.lookup(KeyCode::Char('a'), KeyModifiers::CONTROL), None);
     }
 
     #[test]
@@ -1183,23 +1212,23 @@ mod tests {
 
     #[test]
     fn from_json_falls_back_for_missing_actions() {
-        let json = r#"{ "QuitApp": ["ctrl+x"] }"#;
+        let json = r#"{ "QuitApp": ["ctrl+a"] }"#;
         let kb = KeyBindings::from_json(json).unwrap();
-        assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('x')));
+        assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('a')));
         // Unmodified actions retain defaults.
         assert_eq!(kb.chord_for(Action::NewSession), Some(&KeyChord::ctrl('n')));
     }
 
     #[test]
     fn from_json_ignores_unknown_actions_and_invalid_chords() {
-        let json = r#"{ "QuitApp": ["nonsense", "ctrl+x"], "BogusAction": ["ctrl+y"] }"#;
+        let json = r#"{ "QuitApp": ["nonsense", "ctrl+a"], "BogusAction": ["ctrl+y"] }"#;
         let kb = KeyBindings::from_json(json).unwrap();
-        assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('x')));
+        assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('a')));
     }
 
     #[test]
     fn from_json_with_warnings_reports_skipped_entries() {
-        let json = r#"{ "QuitApp": ["nonsense", "ctrl+x"], "BogusAction": ["ctrl+y"] }"#;
+        let json = r#"{ "QuitApp": ["nonsense", "ctrl+a"], "BogusAction": ["ctrl+y"] }"#;
         let (_, warnings) = KeyBindings::from_json_with_warnings(json).unwrap();
         assert!(
             warnings.iter().any(|w| w.contains("BogusAction")),
@@ -1214,22 +1243,22 @@ mod tests {
     #[test]
     fn from_json_with_warnings_reports_chord_conflicts() {
         // Two global actions on the same chord: one nondeterministically wins.
-        let json = r#"{ "QuitApp": ["ctrl+x"], "NewSession": ["ctrl+x"] }"#;
+        let json = r#"{ "QuitApp": ["ctrl+a"], "NewSession": ["ctrl+a"] }"#;
         let (_, warnings) = KeyBindings::from_json_with_warnings(json).unwrap();
         assert!(
             warnings
                 .iter()
-                .any(|w| w.contains("ctrl+x") && w.contains("bound to both")),
+                .any(|w| w.contains("ctrl+a") && w.contains("bound to both")),
             "conflict must be reported: {warnings:?}"
         );
     }
 
     #[test]
     fn from_json_with_warnings_is_quiet_for_valid_input() {
-        let json = r#"{ "QuitApp": ["ctrl+x"] }"#;
+        let json = r#"{ "QuitApp": ["ctrl+a"] }"#;
         let (kb, warnings) = KeyBindings::from_json_with_warnings(json).unwrap();
         assert!(warnings.is_empty(), "got: {warnings:?}");
-        assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('x')));
+        assert_eq!(kb.chord_for(Action::QuitApp), Some(&KeyChord::ctrl('a')));
     }
 
     #[test]
@@ -1330,11 +1359,12 @@ mod tests {
     #[test]
     fn rebind_replaces_all_chords() {
         let mut kb = KeyBindings::default();
-        let chord = KeyChord::ctrl('x');
+        // ctrl+a is free by default, so the rebind steals from no one.
+        let chord = KeyChord::ctrl('a');
         assert_eq!(kb.rebind(Action::ToggleHelp, chord), None);
         assert_eq!(kb.chords_for(Action::ToggleHelp), &[chord]);
         assert_eq!(
-            kb.lookup(KeyCode::Char('x'), KeyModifiers::CONTROL),
+            kb.lookup(KeyCode::Char('a'), KeyModifiers::CONTROL),
             Some(Action::ToggleHelp)
         );
         // The old dual F-key fallback is gone after a single-chord rebind.
@@ -1458,8 +1488,10 @@ mod tests {
         // scopes overlap (e.g. a global and a session-list action). The lookup
         // must pick a stable winner regardless of HashMap iteration order.
         let mut kb = KeyBindings::default();
-        let chord = KeyChord::ctrl('x');
-        // Bind ctrl+x to a global action and a session-list action directly in
+        // Ctrl+A is unbound by default, so it has no other claimants to muddy
+        // the overlap test (Ctrl+X is now ToggleReview's default).
+        let chord = KeyChord::ctrl('a');
+        // Bind ctrl+a to a global action and a session-list action directly in
         // the map, bypassing `rebind`'s conflict resolution.
         kb.map.insert(Action::ToggleHelp, vec![chord]); // global
         kb.map.insert(Action::SessionListNext, vec![chord]); // scoped
@@ -1468,7 +1500,7 @@ mod tests {
         assert_eq!(
             kb.lookup_in(
                 KeyContext::SessionList,
-                KeyCode::Char('x'),
+                KeyCode::Char('a'),
                 KeyModifiers::CONTROL
             ),
             Some(Action::SessionListNext)
@@ -1477,7 +1509,7 @@ mod tests {
         assert_eq!(
             kb.lookup_in(
                 KeyContext::Terminal,
-                KeyCode::Char('x'),
+                KeyCode::Char('a'),
                 KeyModifiers::CONTROL
             ),
             Some(Action::ToggleHelp)
@@ -1487,7 +1519,7 @@ mod tests {
             assert_eq!(
                 kb.lookup_in(
                     KeyContext::SessionList,
-                    KeyCode::Char('x'),
+                    KeyCode::Char('a'),
                     KeyModifiers::CONTROL
                 ),
                 Some(Action::SessionListNext)

--- a/src/storage/keybindings.rs
+++ b/src/storage/keybindings.rs
@@ -61,7 +61,7 @@ mod tests {
     fn save_then_load_round_trip() {
         let tmp = tempfile::tempdir().unwrap();
         let _g = TestPathGuard::new(tmp.path());
-        let body = r#"{"QuitApp": ["ctrl+x"]}"#;
+        let body = r#"{"QuitApp": ["ctrl+a"]}"#;
         save_keybindings_json(body).unwrap();
         assert_eq!(load_keybindings_json().unwrap().as_deref(), Some(body));
     }

--- a/website/css/landing.css
+++ b/website/css/landing.css
@@ -128,7 +128,7 @@
 }
 
 .hero-demo {
-  max-width: 900px;
+  max-width: 1100px;
   margin: 0 auto;
 }
 

--- a/website/docs/comparison.html
+++ b/website/docs/comparison.html
@@ -195,7 +195,7 @@ breadcrumb: 'Comparison'
             <li>
               <strong>Native code review, in the terminal.</strong>
               A built-in, GitHub-style diff reviewer (
-              <code>F7</code>
+              <code>Ctrl+X</code>
               ) &mdash; browse the branch, a commit, or working changes in a folder tree, leave
               classified comments, fold reviewed files, then send the review back to the agent to
               address. The click-to-review visual diff that used to be a GUI-only perk, without

--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -470,7 +470,7 @@ min_interval_secs   = 5        # per-session floor between notifications</code><
               <tr>
                 <td><code>code_review</code></td>
                 <td><code>true</code></td>
-                <td>native code-review view (diff + comments, <code>F7</code>)</td>
+                <td>native code-review view (diff + comments, <code>Ctrl+X</code>)</td>
               </tr>
               <tr>
                 <td><code>mouse</code></td>
@@ -657,7 +657,7 @@ app_bg = "reset"             # keep the terminal's native background</code></pre
             <a href="#keybindings-json" class="heading-anchor">#</a>
           </h2>
           <p>Maps <code>Action</code> names to one or more chord strings:</p>
-          <pre data-title="keybindings.json"><code class="language-json">{ "QuitApp": ["ctrl+x"], "OpenThemePicker": ["ctrl+y", "f4"] }</code></pre>
+          <pre data-title="keybindings.json"><code class="language-json">{ "QuitApp": ["ctrl+a"], "OpenThemePicker": ["ctrl+y", "f4"] }</code></pre>
           <ul>
             <li>
               The preferred editing path is the

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -642,15 +642,15 @@ ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m"]
             </div>
             <figcaption>
               A native, GitHub-style review pane &mdash;
-              <code>F7</code>
+              <code>Ctrl+X</code>
               , no external tool.
             </figcaption>
           </figure>
           <p>
             Every session is a git worktree on a branch forked from a base, so &ldquo;review what
             this agent built&rdquo; maps cleanly onto the session model. Press
-            <code>F7</code>
-            to open a native diff reviewer in the central pane &mdash; rendered by Thurbox itself,
+            <code>Ctrl+X</code>
+            (or <code>F7</code>) to open a native diff reviewer in the central pane &mdash; rendered by Thurbox itself,
             with no external binary.
           </p>
           <ul>

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -122,7 +122,7 @@ onThisPage:
                 </td>
               </tr>
               <tr>
-                <td><code>F7</code></td>
+                <td><code>Ctrl+X</code> / <code>F7</code></td>
                 <td>Toggle code-review pane (native diff reviewer)</td>
                 <td>Review</td>
               </tr>

--- a/website/index.html
+++ b/website/index.html
@@ -345,7 +345,7 @@ cargo build --release</code></pre>
               <h3>Code Review</h3>
               <p>
                 A native, GitHub-style diff reviewer (
-                <code>F7</code>
+                <code>Ctrl+X</code>
                 ) &mdash; no external tool. Browse the branch, a commit, or working changes in a
                 <strong>folder tree</strong>
                 , leave classified comments, fold reviewed files, then
@@ -499,7 +499,7 @@ Ctrl+O  Open repos in editor</pre>
         <div class="feature-showcase">
           <div class="feature-row">
             <div class="feature-row-text">
-              <p class="feature-row-eyebrow">F7</p>
+              <p class="feature-row-eyebrow">Ctrl+X</p>
               <h3>Code review</h3>
               <p>
                 A native, GitHub-style diff reviewer &mdash; no external tool. Browse the branch, a


### PR DESCRIPTION
## Summary

- Add `Ctrl+X` as the default primary chord for the native code-review view (`F7` stays as alternate), making it consistent with the other panel toggles. It's added to `terminal_passthrough` (the emacs/readline prefix key), so in a focused terminal/shell pane it's forwarded to the agent — only toggling the review from non-terminal panes, keeping emacs `C-x` unaffected.
- Migrate the "free example chord" in keybinding fixtures/docs from `ctrl+x` to `ctrl+a`, since `ctrl+x` is now a real default.
- Hero demo and website now showcase the code-review view; the hero demo video is enlarged on the landing page.

## Test plan

- `cargo nextest run --all` (1629 passing)
- New unit tests: `toggle_review_has_dual_ctrl_x_and_f7_chord`, passthrough coverage for `ToggleReview`
- CI checks pass