### PR TITLE
feat(core): run agent sessions inside WSL distros

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,82 +449,107 @@ PATH` (as-is); `AutomationAction::Spawn` persists the list as JSON in the
 `NULL`/empty = single-repo, so old rows are byte-identical). The flow extension's
 `create-task.sh` forwards these flags (see `extensions/flow/FLOW.md`).
 
-## Remote SSH Sessions
+## Remote SSH & WSL Sessions
 
-Sessions can run on a **remote host** over SSH while the TUI runs
-locally. Remote hosts are declared as data in
-`~/.config/thurbox/hosts.toml` (seeded commented-out on first run,
-so a fresh install has zero remote hosts and behaves as before). The
-seeded file documents every field inline; the schema:
+Sessions can run on an **off-local host** while the TUI runs locally: a
+**remote machine over SSH**, or a **local WSL distro** (`wsl.exe`). A WSL
+distro is modeled as "SSH without the ssh" — the *only* difference is the
+launch prefix (`wsl.exe -d <distro>` vs `ssh <dest>`); tmux, git, the agent,
+and the worktrees all run **inside the distro** at native Linux paths, so
+everything downstream of the launcher (control-mode protocol, POSIX quoting,
+worktree layout) is identical to the SSH path — no `wslpath` translation. Hosts
+are declared as data in `~/.config/thurbox/hosts.toml` (seeded commented-out;
+fresh install = zero SSH hosts, behaves as before), **plus WSL distros are
+auto-discovered on Windows** (`wsl.exe -l -q`) with no config. The seeded file
+documents every field inline; the schema:
 
 ```toml
+# An SSH host (the default kind):
 [[hosts]]
 name = "devbox"               # required — backend id "ssh:devbox"; what --host expects
-destination = "me@devbox"     # required — ssh target ("user@host" or ~/.ssh/config alias)
+destination = "me@devbox"     # required for ssh — target ("user@host" or ~/.ssh/config alias)
 ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m", "-o", "ServerAliveInterval=15"]
                               # optional (default []) — extra ssh flags; no ~ expansion, use abs paths
-socket = "thurbox"            # optional (default "thurbox") — remote `tmux -L` socket
-session = "thurbox"           # optional (default "thurbox") — remote tmux session name
+socket = "thurbox"            # optional (default "thurbox") — host `tmux -L` socket
+session = "thurbox"           # optional (default "thurbox") — host tmux session name
 worktrees_dir = "/home/me/.local/share/thurbox/worktrees"
-                              # optional — abs remote worktrees dir
-                              # (default $HOME/.local/share/thurbox/worktrees, resolved over ssh)
-multiplexer = "tmux"          # optional (default "tmux") — set "psmux" for a Windows host
+                              # optional — abs worktrees dir on the host
+multiplexer = "tmux"          # optional (default "tmux") — set "psmux" for a Windows SSH host
+
+# A WSL distro (only needed to OVERRIDE auto-discovery, e.g. a custom worktrees_dir):
+[[hosts]]
+name = "ubuntu"               # → backend "wsl:ubuntu"; what --host expects
+kind = "wsl"                  # required to select the WSL transport
+distro = "Ubuntu-22.04"       # optional (default = name) — the wsl.exe distro name
 ```
 
 | Field | Req | Default | Purpose |
 |-------|-----|---------|---------|
-| `name` | yes | — | unique id; registers backend `ssh:<name>` |
-| `destination` | yes | — | ssh target, resolved via `~/.ssh/config` |
+| `name` | yes | — | unique id; registers backend `ssh:<name>` / `wsl:<name>` |
+| `kind` | no | `ssh` | transport: `ssh` (remote machine) or `wsl` (local distro) |
+| `destination` | ssh | — | ssh target, resolved via `~/.ssh/config` |
+| `distro` | no | `name` | WSL distro name (`kind = "wsl"` only) |
 | `ssh_opts` | no | `[]` | extra `ssh` flags (one token per element; no `~` expansion) |
-| `socket` | no | `thurbox` | remote `tmux -L` socket name |
-| `session` | no | `thurbox` | remote tmux session name |
-| `worktrees_dir` | no | `$HOME/.local/share/thurbox/worktrees` | abs remote worktrees dir |
-| `multiplexer` | no | `tmux` | remote multiplexer binary; `psmux` for a Windows host |
+| `socket` | no | `thurbox` | host `tmux -L` socket name |
+| `session` | no | `thurbox` | host tmux session name |
+| `worktrees_dir` | no | `$HOME/.local/share/thurbox/worktrees` | abs worktrees dir on the host/distro |
+| `multiplexer` | no | `tmux` | host multiplexer binary; `psmux` for a Windows SSH host |
 
 How it works: `TmuxBackend` is transport-neutral
 (`agent::transport::TmuxTransport`). The local backend launches
-`<mux> -L thurbox …`; a remote backend launches
-`ssh <dest> <mux> -L thurbox …`. The multiplexer binary (`agent::transport::DEFAULT_MUX`)
-is **`tmux` on Linux/macOS and `psmux` on Windows** — psmux is a native-Windows,
-drop-in tmux clone (ConPTY, no WSL) speaking the **same control-mode wire
-protocol** and pane-id (`%N`) / `-L` socket model, so the whole backend is
-parameterized by binary name rather than forked (a remote host can also pin
-`multiplexer = "psmux"`). The **control-mode** protocol
-(`control_mode.rs`) is byte-identical over either transport/binary, with one
+`<mux> -L thurbox …`; an SSH backend launches `ssh <dest> <mux> -L thurbox …`;
+a **WSL backend launches `wsl.exe -d <distro> tmux -L thurbox …`**
+(`TmuxTransport::Wsl`). `wsl.exe` joins + shell-interprets the trailing tokens
+exactly like `ssh`, so the same POSIX quoting (`shell::posix_quote`) and the
+byte-identical control-mode protocol (`control_mode.rs`) apply — only the
+one-time process launch differs. The local `DEFAULT_MUX` is **`tmux` on
+Linux/macOS and `psmux` on Windows** — psmux is a native-Windows, drop-in tmux
+clone (ConPTY, no WSL) speaking the **same control-mode wire protocol** and
+pane-id (`%N`) / `-L` socket model, so the whole backend is parameterized by
+binary name rather than forked (a remote SSH host can also pin
+`multiplexer = "psmux"`); a WSL distro runs `tmux` inside the distro. The
+control-mode protocol is byte-identical over either transport/binary, with one
 keystroke-encoding exception: psmux does **not** implement tmux's `send-keys
 -H` hex flag (given `-H 62` it injects the literal text "62", so typing `b`,
 Enter, Backspace, … were all broken on Windows). So `send_keys_commands`
-branches on `TmuxTransport::uses_psmux()` — tmux keeps the byte-exact `-H`
-hex path; psmux gets an equivalent encoding built from the primitives it
-*does* support (`send-keys -l` literal runs + `Enter`/`Tab`/`Escape`/`BSpace`/
-`C-<letter>` key-names), reconstructing the same byte stream the pane's PTY
-receives. Otherwise only the one-time process launch differs. Each host registers a backend
-named `ssh:<name>` (`TmuxBackend::from_host`, registered lazily in
-`main.rs`: a down host must not block startup, so
-`check_available`/`ensure_ready` are deferred to first use via
-`App::backend_for`).
+branches on `TmuxTransport::uses_psmux()` — tmux (incl. a WSL distro's tmux)
+keeps the byte-exact `-H` hex path; psmux gets an equivalent encoding built from
+the primitives it *does* support (`send-keys -l` literal runs +
+`Enter`/`Tab`/`Escape`/`BSpace`/`C-<letter>` key-names), reconstructing the same
+byte stream the pane's PTY receives. Each host registers a backend named
+`ssh:<name>` / `wsl:<name>` (`TmuxBackend::from_host`, registered lazily in
+`main.rs` from `host_config::load_all_with_warnings`: discovery/down hosts must
+not block startup, so `check_available`/`ensure_ready` are deferred to first use
+via `App::backend_for`).
 
-- **Data**: `session::HostDef`/`HostRegistry` (pure data, in
-  `session/` so both `agent` and `git` can use it). **Loading**:
-  `agent::host_config::load_or_seed()`.
-- **Selection**: `SessionConfig.backend` (`ssh:<host>` or `None` =
-  local). The TUI new-session flow shows a **host picker** first
-  (skipped when no hosts are configured); the chosen host runs git
-  worktree creation + branch listing on that host over SSH.
-- **Worktrees**: `git::*_on(host, …)` variants run `git` over
-  `ssh <dest> git -C <repo> …`. Remote worktrees live under the
-  host's `worktrees_dir` (or `$HOME/.local/share/thurbox/worktrees`
-  resolved + cached over ssh).
-- **Persistence/restore**: `backend_type` already round-trips in
-  SQLite; restore discovers windows **per backend** so remote
-  sessions re-adopt against their own host.
-- **Headless**: `thurbox-cli session create --host <name>` spawns
-  remotely (see below).
-- **Local e2e**: `scripts/dev/remote-ssh-test.sh up` spins a
-  throwaway Podman container (sshd + tmux + git) and `… test` runs
-  an isolated headless smoke test asserting a session lands on the
-  `ssh:podman` backend (state under `target/`, never touches your
-  real `~/.ssh`/`~/.config`).
+- **Data**: `session::HostDef` (with `kind: HostKind {Ssh, Wsl}`) /
+  `HostRegistry` (pure data, in `session/` so both `agent` and `git` can use
+  it); backend-name helpers `is_ssh_backend`/`is_wsl_backend`/
+  `is_remote_backend`. **Loading**: `agent::host_config::load_all{,_with_warnings}`
+  = configured hosts + `discover_wsl_hosts()` (deduped; a configured entry wins).
+- **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>` or `None`
+  = local). The TUI new-session flow shows a **host picker** first (skipped when
+  none configured/discovered); the chosen host runs git worktree creation +
+  branch listing on that host.
+- **Worktrees**: `git::*_on(host, …)` variants run `git` via the host launcher
+  (`git::host_launcher` → `ssh …` or `wsl.exe …`). Worktrees live under the
+  host's `worktrees_dir` (or `$HOME/.local/share/thurbox/worktrees` resolved +
+  cached per backend name — a WSL distro has no `destination`).
+- **Persistence/restore**: `backend_type` round-trips in SQLite; restore
+  discovers windows **per backend** so off-local sessions re-adopt against their
+  own host.
+- **Headless**: `thurbox-cli session create --host <name>` spawns on the host
+  (an SSH name or an auto-discovered WSL distro name).
+- **Caveats** (WSL inherits the SSH path): the headless `session delete --force`
+  teardown (`kill_window`/`git::remove_worktree`) is local-only — a `--force`
+  delete won't kill the in-distro window or remove the in-distro worktree (the
+  TUI's own teardown is backend-aware). `wsl.exe`'s exact arg-passing isn't
+  verified in CI (no WSL runner); the construction is unit-tested
+  (`transport::tests::wsl_*`, `git_command_wsl_*`).
+- **Local e2e**: `scripts/dev/remote-ssh-test.sh up` spins a throwaway Podman
+  container (sshd + tmux + git) and `… test` asserts a session lands on the
+  `ssh:podman` backend (state under `target/`, never touches your real
+  `~/.ssh`/`~/.config`).
 
 ## thurbox-cli
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -402,54 +402,76 @@ logs a warning and adoption proceeds with an empty seed.
 
 ---
 
-## ADR-13: Remote sessions via an SSH tmux transport
+## ADR-13: Off-local sessions via an SSH / WSL tmux transport
 
-**Choice**: Run agent sessions on a remote host by launching the
-same tmux control-mode protocol over SSH. `LocalTmuxBackend` is
+**Choice**: Run agent sessions on a remote host (over SSH) or in a
+local WSL distro (via `wsl.exe`) by launching the same tmux
+control-mode protocol behind a launch prefix. `LocalTmuxBackend` is
 generalized into `TmuxBackend { transport, socket, session, name }`
-where `transport: TmuxTransport` is either `Local` (a bare
-`Command::new("tmux")`) or `Ssh { destination, ssh_opts, mux }`
-(`ssh <dest> <mux> …`, where `mux` is the remote multiplexer binary —
-`tmux` by default, or `psmux` for a Windows host). The transport's *only* job is to build the
-`Command`; everything downstream — the control-mode reader/writer
-threads, pane registration, `send-keys`/`%output` — is byte-for-byte
-identical (`control_mode.rs` was already transport-agnostic).
+where `transport: TmuxTransport` is `Local` (a bare
+`Command::new("tmux")`), `Ssh { destination, ssh_opts, mux }`
+(`ssh <dest> <mux> …`), or `Wsl { distro, mux }`
+(`wsl.exe -d <distro> <mux> …`). `mux` is the host multiplexer binary
+(`tmux` by default, or `psmux` for a Windows SSH host; a WSL distro
+runs `tmux`). The transport's *only* job is to build the `Command`;
+everything downstream — the control-mode reader/writer threads, pane
+registration, `send-keys`/`%output` — is byte-for-byte identical
+(`control_mode.rs` was already transport-agnostic). The SSH and WSL
+arms share `TmuxTransport::prefixed`, since both join + shell-interpret
+the trailing POSIX-quoted tokens identically; only the launcher prefix
+differs.
 
-Remote hosts are declared as data in `~/.config/thurbox/hosts.toml`
-(`session::HostDef`/`HostRegistry`, loaded by
-`agent::host_config::load_or_seed`), each registered as a backend
-named `ssh:<host>` via `TmuxBackend::from_host`.
+Hosts are declared as data in `~/.config/thurbox/hosts.toml`
+(`session::HostDef { kind: HostKind {Ssh, Wsl}, … }`/`HostRegistry`),
+and WSL distros are additionally **auto-discovered** on Windows
+(`agent::host_config::discover_wsl_hosts` via `wsl.exe -l -q`). The
+combined set is loaded by `agent::host_config::load_all`, each
+registered as a backend named `ssh:<host>` / `wsl:<distro>` via
+`TmuxBackend::from_host`.
 
-**Why**: The local-vs-remote difference is exactly one line (how the
-tmux process is launched). The per-session control commands travel
-over the stdin pipe, not ssh argv, so only the one-time
-`attach-session` launch crosses the ssh boundary. Relying on the
-system `ssh` binary + `~/.ssh/config` keeps auth/keys/multiplexing
-out of thurbox (ControlMaster/ControlPersist + ServerAliveInterval
-are recommended in the seeded `ssh_opts`).
+**Why WSL = "SSH without the ssh"**: `wsl.exe` runs `tmux`, `git`, the
+agent, and the worktrees all *inside* the distro at native Linux paths,
+so there's no Windows↔Linux path translation (`wslpath`) and the
+worktree layout matches the SSH path exactly. Modeling WSL as a host
+kind (rather than a per-session "run in WSL" flag wrapping a native
+psmux pane) reuses the entire remote-host subsystem — picker,
+persistence/restore, `git::*_on`, headless `--host` — for free.
+
+**Why** (general): The local-vs-off-local difference is exactly one
+line (how the tmux process is launched). The per-session control
+commands travel over the stdin pipe, not the launcher argv, so only the
+one-time `attach-session` launch crosses the boundary. SSH relies on
+the system `ssh` binary + `~/.ssh/config` for auth/keys/multiplexing;
+WSL needs no credentials at all.
 
 **Key design decisions**:
 
-- **Lazy registration**: SSH backends are registered but *not*
+- **Lazy registration**: off-local backends are registered but *not*
   connected at startup (`check_available`/`ensure_ready` deferred to
-  first use via `App::backend_for`), so a down host never blocks the
-  TUI.
-- **Selection**: `SessionConfig.backend` (`ssh:<host>` or `None`).
-  The TUI shows a host picker as the first new-session step (skipped
-  when no hosts are configured); `thurbox-cli session create --host`
-  is the headless equivalent.
-- **Persistence/restore**: `backend_type` already round-trips in
-  SQLite; restore was changed to discover windows **per backend** so
-  remote sessions re-adopt against their own host's tmux.
-- **Remote worktrees**: `git::*_on(host, …)` variants run
-  `ssh <dest> git -C <repo> …`. Remote worktree paths resolve under
-  the host's `worktrees_dir` (or `$HOME/.local/share/thurbox/…`
-  resolved + cached over ssh).
+  first use via `App::backend_for`), so a down host (or slow WSL
+  discovery) never blocks the TUI.
+- **Auto-discovery**: WSL distros appear with zero config; an explicit
+  `kind = "wsl"` entry of the same name wins (for overrides like
+  `worktrees_dir`). `discover_wsl_hosts` decodes `wsl.exe`'s UTF-16LE
+  output and is a no-op off Windows / without `wsl.exe`.
+- **Selection**: `SessionConfig.backend` (`ssh:<host>` / `wsl:<distro>`
+  or `None`); `is_remote_backend` covers both. The TUI shows a host
+  picker as the first new-session step (skipped when none configured/
+  discovered); `thurbox-cli session create --host` is the headless
+  equivalent.
+- **Persistence/restore**: `backend_type` round-trips in SQLite;
+  restore discovers windows **per backend** so off-local sessions
+  re-adopt against their own host's tmux.
+- **Off-local worktrees**: `git::*_on(host, …)` run git via
+  `git::host_launcher` (`ssh …` or `wsl.exe …`). Worktree paths resolve
+  under the host's `worktrees_dir` (or `$HOME/.local/share/thurbox/…`
+  resolved + cached, keyed by backend name since a WSL host has no
+  `destination`).
 
-**Module placement**: `HostDef`/`HostRegistry` live in `session/`
-(the dependency sink) so both `agent` (builds the backend) and `git`
-(runs git over SSH) can depend on them without violating the
-module-isolation rules.
+**Module placement**: `HostDef`/`HostRegistry`/`HostKind` live in
+`session/` (the dependency sink) so both `agent` (builds the backend)
+and `git` (runs git on the host) can depend on them without violating
+the module-isolation rules.
 
 **Riskiest area**: SSH reconnect on a flapping link — `reconnect_control`
 reopens the ssh connection; ControlMaster + keepalives mitigate

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -15,7 +15,7 @@ development checkout never touches your real setup.
 | File | Format | Edited by | Read | Purpose |
 |------|--------|-----------|------|---------|
 | `~/.config/thurbox/agents.toml` | TOML | you | **live** (mtime poll) | coding-agent CLI definitions |
-| `~/.config/thurbox/hosts.toml` | TOML | you | startup | remote SSH hosts |
+| `~/.config/thurbox/hosts.toml` | TOML | you | startup | remote SSH hosts + local WSL distros |
 | `~/.config/thurbox/settings.toml` | TOML | you + `Ctrl+,` panel | **live** (feature flags) / startup (rest) | tuning knobs + feature flags |
 | `~/.config/thurbox/themes.toml` | TOML | you | startup | custom theme palettes |
 | `~/.config/thurbox/keybindings.json` | JSON | F1 editor (or you) | **live** (mtime poll) | key chord overrides |
@@ -55,7 +55,7 @@ the right knob:
 | I want to… | Edit | Section |
 |------------|------|---------|
 | Add a coding agent, pin a model, change resume/fork flags | `agents.toml` | [agents.toml](#agentstoml) |
-| Run sessions on a remote machine over SSH | `hosts.toml` | [hosts.toml](#hoststoml) |
+| Run sessions on a remote machine over SSH, or in a local WSL distro | `hosts.toml` | [hosts.toml](#hoststoml) |
 | Turn a whole TUI feature on/off (tasks, mouse, notifications…) | `settings.toml` `[features]` | [`[features]`](#features--whole-feature-switches) |
 | Tune scrollback, panel breakpoints, audit retention | `settings.toml` | [settings.toml](#settingstoml) |
 | Change when/how OS notifications fire | `settings.toml` `[notifications]` | [`[notifications]`](#notifications--os-notification-settings) |
@@ -127,24 +127,35 @@ to exactly the seven built-ins.
 
 ## hosts.toml
 
-Declares remote SSH hosts; each `[[hosts]]` entry registers a session
-backend named `ssh:<name>`. Seeded fully commented-out (fresh installs
-are local-only). Malformed file → zero remote hosts, error shown.
+Declares off-local hosts — **remote SSH machines** and **local WSL
+distros**. Each `[[hosts]]` entry registers a session backend named
+`ssh:<name>` (default kind) or `wsl:<name>`. Seeded fully commented-out
+(fresh installs are local-only for SSH). Malformed file → zero
+configured hosts, error shown.
 
 | Field | Required | Default | Purpose |
 |-------|----------|---------|---------|
-| `name` | yes | — | backend id `ssh:<name>`; what `--host` expects |
-| `destination` | yes | — | ssh target (`user@host` or `~/.ssh/config` alias) |
-| `ssh_opts` | no | `[]` | extra ssh flags, one token per element |
-| `socket` | no | `thurbox` | remote `tmux -L` socket |
-| `session` | no | `thurbox` | remote tmux session name |
-| `worktrees_dir` | no | remote `$HOME/.local/share/thurbox/worktrees` | absolute remote worktrees dir |
-| `multiplexer` | no | `tmux` | remote multiplexer binary; set to `psmux` for a Windows host |
+| `name` | yes | — | backend id `ssh:<name>` / `wsl:<name>`; what `--host` expects |
+| `kind` | no | `ssh` | transport: `ssh` (remote machine) or `wsl` (local distro) |
+| `destination` | for ssh | — | ssh target (`user@host` or `~/.ssh/config` alias) |
+| `distro` | no | `name` | WSL distro name (`kind = "wsl"` only) |
+| `ssh_opts` | no | `[]` | extra ssh flags, one token per element (ssh only) |
+| `socket` | no | `thurbox` | host `tmux -L` socket |
+| `session` | no | `thurbox` | host tmux session name |
+| `worktrees_dir` | no | host `$HOME/.local/share/thurbox/worktrees` | absolute worktrees dir on the host/distro |
+| `multiplexer` | no | `tmux` | host multiplexer binary; set to `psmux` for a Windows SSH host |
 
-Auth comes entirely from your `~/.ssh/config`; thurbox never handles
-credentials. Host changes require a restart (the registry is read once
-and the remote `$HOME` is cached per destination for the process
-lifetime).
+**SSH** auth comes entirely from your `~/.ssh/config`; thurbox never
+handles credentials. **WSL** distros are reached with
+`wsl.exe -d <distro>` and need no config entry at all — on Windows they
+are **auto-discovered** (`wsl.exe -l -q`) and appear in the host picker
+and `--host` automatically; add a `kind = "wsl"` entry only to override
+a default (e.g. `worktrees_dir`). For both kinds, tmux, git, the agent,
+and worktrees all run **on the host / inside the distro** at native
+paths (a WSL distro's worktrees live in its own Linux filesystem, not on
+`/mnt/c`); the distro needs `tmux` >= 3.2 and `git`. Host changes
+require a restart (the registry is read once and each host's `$HOME` is
+cached for the process lifetime).
 
 ## settings.toml
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -286,42 +286,57 @@ fork_args = ["fork", "--last"]
 resume_latest = true
 ```
 
-### Remote SSH sessions
+### Remote SSH & WSL sessions
 
-Like agents, remote hosts are **data**. A session can run on a
-remote machine over SSH while the TUI stays local. Hosts are
-declared in `~/.config/thurbox/hosts.toml` (seeded commented-out, so
-a fresh install has none and behaves exactly as before):
+Like agents, off-local hosts are **data**. A session can run on a
+remote machine over SSH, or inside a local **WSL distro**, while the
+TUI stays local. Hosts are declared in
+`~/.config/thurbox/hosts.toml` (seeded commented-out, so a fresh
+install has none and behaves exactly as before) — **and WSL distros
+are auto-discovered on Windows** (`wsl.exe -l -q`), so they need no
+entry at all:
 
 ```toml
 [[hosts]]
 name = "devbox"            # selectable as backend "ssh:devbox"
 destination = "me@devbox"  # resolved via ~/.ssh/config
 ssh_opts = ["-o", "ControlMaster=auto", "-o", "ControlPersist=10m"]
+
+# Only needed to override an auto-discovered WSL distro's defaults:
+[[hosts]]
+name = "ubuntu"            # selectable as backend "wsl:ubuntu"
+kind = "wsl"
+distro = "Ubuntu-22.04"    # defaults to `name`
 ```
 
-Each `[[hosts]]` entry (`session::HostDef`) has two required fields
-and four optional ones — the seeded `hosts.toml` documents each
-inline:
+Each `[[hosts]]` entry (`session::HostDef`) — the seeded `hosts.toml`
+documents each field inline:
 
 | Field | Required | Default | Meaning |
 |-------|----------|---------|---------|
-| `name` | yes | — | unique id; registers the backend `ssh:<name>` and is what `--host` expects |
-| `destination` | yes | — | ssh target (`user@host` or a `~/.ssh/config` alias) |
+| `name` | yes | — | unique id; registers the backend `ssh:<name>` / `wsl:<name>` and is what `--host` expects |
+| `kind` | no | `ssh` | transport: `ssh` (remote machine) or `wsl` (local distro) |
+| `destination` | for ssh | — | ssh target (`user@host` or a `~/.ssh/config` alias) |
+| `distro` | no | `name` | WSL distro name (`kind = "wsl"` only) |
 | `ssh_opts` | no | `[]` | extra `ssh` flags, one token per array element; no `~` expansion (use absolute paths) |
-| `socket` | no | `thurbox` | remote `tmux -L` socket name |
-| `session` | no | `thurbox` | remote tmux session name |
-| `worktrees_dir` | no | `$HOME/.local/share/thurbox/worktrees` | absolute remote dir for git worktrees |
+| `socket` | no | `thurbox` | host `tmux -L` socket name |
+| `session` | no | `thurbox` | host tmux session name |
+| `worktrees_dir` | no | `$HOME/.local/share/thurbox/worktrees` | absolute dir on the host/distro for git worktrees |
 
-Each host becomes a session backend named `ssh:<name>`. Thurbox
-shells out to the system `ssh` binary, so authentication, keys, and
-connection multiplexing come from your `~/.ssh/config` — thurbox
-never handles credentials. The same tmux control-mode protocol runs
-over the SSH pipe, so remote sessions get identical persistence,
-multi-instance sharing, and restore-on-startup as local ones; the
-worktree and agent process live on the remote host. In the session
-list a remote session is marked with a `☁` glyph (and the info panel
-shows its `Host:`), mirroring the worktree `⑂` mark.
+Each host becomes a session backend named `ssh:<name>` / `wsl:<name>`.
+For **SSH**, thurbox shells out to the system `ssh` binary, so
+authentication, keys, and connection multiplexing come from your
+`~/.ssh/config` — thurbox never handles credentials. A **WSL distro**
+is reached with `wsl.exe -d <distro>` (no credentials, no network);
+since `wsl.exe` joins + shell-interprets its trailing tokens just like
+`ssh`, the *same* tmux control-mode protocol, POSIX quoting, and
+worktree layout apply — only the launch prefix differs. So off-local
+sessions get identical persistence, multi-instance sharing, and
+restore-on-startup as local ones; the worktree and agent process live
+on the remote host / inside the distro (a WSL distro's worktrees stay
+in its own Linux filesystem, not on `/mnt/c`). In the session list an
+off-local session is marked with a `☁` glyph (and the info panel shows
+its `Host:`), mirroring the worktree `⑂` mark.
 
 **Why a config file rather than ad-hoc destinations?** Named hosts
 give the picker stable, readable entries and let `backend_type`

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -318,13 +318,13 @@ impl ShellPane {
     }
 }
 
-/// The bare remote host name for a session's backend (e.g. `devbox` for an
-/// `ssh:devbox` backend), or `None` for local backends. Drives the session
-/// list's remote indicator.
+/// The bare host name for a session's off-local backend (e.g. `devbox` for an
+/// `ssh:devbox` backend, `Ubuntu` for a `wsl:Ubuntu` backend), or `None` for
+/// local backends. Drives the session list's remote indicator.
 fn remote_host_from_backend(backend: &Arc<dyn SessionBackend>) -> Option<String> {
-    backend
-        .name()
-        .strip_prefix(crate::session::SSH_BACKEND_PREFIX)
+    let name = backend.name();
+    name.strip_prefix(crate::session::SSH_BACKEND_PREFIX)
+        .or_else(|| name.strip_prefix(crate::session::WSL_BACKEND_PREFIX))
         .map(str::to_string)
 }
 
@@ -1069,19 +1069,20 @@ mod tests {
     }
 
     #[test]
-    fn remote_host_from_backend_strips_ssh_prefix() {
+    fn remote_host_from_backend_strips_ssh_and_wsl_prefixes() {
         let host = crate::session::HostDef {
             name: "devbox".into(),
             destination: "me@devbox".into(),
-            socket: None,
-            session: None,
-            ssh_opts: vec![],
-            worktrees_dir: None,
-            multiplexer: None,
+            ..Default::default()
         };
         let ssh: Arc<dyn SessionBackend> =
             Arc::new(crate::agent::tmux::TmuxBackend::from_host(&host));
         assert_eq!(remote_host_from_backend(&ssh).as_deref(), Some("devbox"));
+
+        let wsl: Arc<dyn SessionBackend> = Arc::new(crate::agent::tmux::TmuxBackend::from_host(
+            &crate::session::HostDef::wsl("Ubuntu"),
+        ));
+        assert_eq!(remote_host_from_backend(&wsl).as_deref(), Some("Ubuntu"));
 
         let local: Arc<dyn SessionBackend> = Arc::new(crate::agent::tmux::TmuxBackend::local());
         assert_eq!(remote_host_from_backend(&local), None);

--- a/src/agent/host_config.rs
+++ b/src/agent/host_config.rs
@@ -7,28 +7,37 @@
 //! and behaves exactly as before. If the file exists but cannot be read or
 //! parsed, we fall back to an empty registry rather than failing to start.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
+use std::process::Command;
 
-use crate::session::HostRegistry;
+use crate::session::{HostDef, HostRegistry};
 
 /// Seed contents for `hosts.toml` on first run: full field documentation plus a
 /// commented-out example, but no active hosts.
-pub const SEED_HOSTS_TOML: &str = r#"# Thurbox remote SSH hosts  —  ~/.config/thurbox/hosts.toml
+pub const SEED_HOSTS_TOML: &str = r#"# Thurbox hosts  —  ~/.config/thurbox/hosts.toml
 #
-# Each [[hosts]] entry describes a remote machine thurbox can run agent sessions
-# on, over SSH. A host named "<name>" registers a session backend called
-# "ssh:<name>", offered in the new-session host picker (TUI) and selectable with
+# Each [[hosts]] entry describes an off-local target thurbox can run agent
+# sessions on: a remote machine over SSH, or a local WSL distro. A host named
+# "<name>" registers a session backend ("ssh:<name>" or "wsl:<name>"), offered
+# in the new-session host picker (TUI) and selectable with
 # `thurbox-cli session create --host <name>`. The agent process, its tmux
-# window, and any git worktrees all live on the remote host; only the TUI runs
-# locally.
+# window, and any git worktrees all live on the host (or inside the distro);
+# only the TUI runs locally.
 #
-# thurbox shells out to the system `ssh` binary, so authentication, keys, and
-# connection details all come from your ~/.ssh/config — thurbox never handles
-# credentials itself. The remote host needs `tmux` >= 3.2 and `git`.
+# SSH hosts: thurbox shells out to the system `ssh` binary, so authentication,
+# keys, and connection details all come from your ~/.ssh/config — thurbox never
+# handles credentials itself. The remote host needs `tmux` >= 3.2 and `git`.
 #
-# This file starts empty (every entry below is commented out), so a fresh
-# install registers zero remote hosts and behaves exactly like a local-only
-# setup. Uncomment and edit an entry to add a host.
+# WSL distros are AUTO-DISCOVERED on Windows (via `wsl.exe -l -q`) and appear in
+# the host picker with NO config here — only add a [[hosts]] entry with
+# kind = "wsl" when you want to override defaults (e.g. worktrees_dir). The
+# distro needs `tmux` >= 3.2 and `git` installed inside it; worktrees live in
+# the distro's own Linux filesystem (fast), not on /mnt/c.
+#
+# This file starts empty (every entry below is commented out): a fresh install
+# registers zero SSH hosts (WSL distros still auto-discover) and otherwise
+# behaves like a local-only setup. Uncomment and edit an entry to add one.
 #
 # Unknown keys are reported on startup (and fail `thurbox-cli config
 # validate`) but don't break the load.
@@ -36,38 +45,45 @@ pub const SEED_HOSTS_TOML: &str = r#"# Thurbox remote SSH hosts  —  ~/.config/
 # Fields per [[hosts]] entry:
 #
 #   name           (string, required)
-#       Short, unique identifier. Registers the backend as "ssh:<name>" and is
-#       the value `--host` expects. Example: "devbox".
+#       Short, unique identifier. Registers the backend as "ssh:<name>" /
+#       "wsl:<name>" and is the value `--host` expects. Example: "devbox".
 #
-#   destination    (string, required)
+#   kind           (string, optional, default: "ssh")
+#       Transport: "ssh" (a remote machine) or "wsl" (a local WSL distro).
+#
+#   destination    (string, required for kind = "ssh")
 #       SSH target passed straight to `ssh`. Either "user@host" or a Host alias
-#       defined in your ~/.ssh/config. Example: "me@devbox".
+#       defined in your ~/.ssh/config. Example: "me@devbox". Ignored for WSL.
 #
-#   ssh_opts       (array of strings, optional, default: [])
+#   distro         (string, optional; kind = "wsl" only)
+#       WSL distro name (as `wsl.exe -l -q` reports it). Defaults to `name`.
+#
+#   ssh_opts       (array of strings, optional, default: []; ssh only)
 #       Extra flags inserted before the destination, one token per array
 #       element (e.g. "-p" then "2222"). thurbox does NOT expand `~`, so use
 #       absolute paths for things like `-i <keyfile>`.
 #
 #   socket         (string, optional, default: "thurbox")
-#       Remote `tmux -L` socket name. Override only to avoid colliding with
-#       another thurbox/tmux server on the same remote host.
+#       Host `tmux -L` socket name. Override only to avoid colliding with
+#       another thurbox/tmux server on the same host.
 #
 #   session        (string, optional, default: "thurbox")
-#       Remote tmux session name that groups thurbox's windows.
+#       Host tmux session name that groups thurbox's windows.
 #
 #   worktrees_dir  (string, optional)
-#       Absolute remote directory under which git worktrees are created. When
-#       unset, thurbox uses $HOME/.local/share/thurbox/worktrees on the remote
-#       (the remote $HOME is resolved over ssh on first use).
+#       Absolute directory (on the host / inside the distro) under which git
+#       worktrees are created. When unset, thurbox uses
+#       $HOME/.local/share/thurbox/worktrees there ($HOME resolved on first use).
 #
 #   multiplexer    (string, optional, default: "tmux")
-#       Remote multiplexer binary. Set to "psmux" when the remote host is a
-#       Windows machine (psmux speaks the same control-mode wire protocol).
+#       Multiplexer binary on the host. Set to "psmux" when an SSH host is a
+#       Windows machine (psmux speaks the same control-mode wire protocol);
+#       WSL distros use "tmux".
 #
 config_version = 1
 
 # ──────────────────────────────────────────────────────────────────────────
-# Minimal host — the two required fields are enough (uncomment and edit)
+# Minimal SSH host — the two required fields are enough (uncomment and edit)
 # ──────────────────────────────────────────────────────────────────────────
 #
 # Relies on your ~/.ssh/config for auth and connection tuning. Registers the
@@ -78,7 +94,7 @@ config_version = 1
 # destination = "me@laptop"     # "user@host" or a ~/.ssh/config Host alias
 #
 # ──────────────────────────────────────────────────────────────────────────
-# Fully annotated host — every optional field, shown with its default
+# Fully annotated SSH host — every optional field, shown with its default
 # ──────────────────────────────────────────────────────────────────────────
 #
 # [[hosts]]
@@ -95,6 +111,17 @@ config_version = 1
 # # session = "thurbox"         # remote tmux session grouping thurbox windows
 # # worktrees_dir = "/home/me/.local/share/thurbox/worktrees"  # abs remote path
 # # multiplexer = "tmux"        # set to "psmux" for a Windows remote host
+#
+# ──────────────────────────────────────────────────────────────────────────
+# WSL distro — only needed to OVERRIDE auto-discovery (distros appear with no
+# entry here). Use this to pin a custom worktrees_dir or distro name.
+# ──────────────────────────────────────────────────────────────────────────
+#
+# [[hosts]]
+# name = "ubuntu"               # → backend "wsl:ubuntu", value for --host
+# kind = "wsl"
+# distro = "Ubuntu-22.04"       # the wsl.exe distro name (defaults to `name`)
+# # worktrees_dir = "/home/me/.local/share/thurbox/worktrees"  # abs path in WSL
 "#;
 
 /// Path to the remote-host config file: `~/.config/thurbox/hosts.toml`
@@ -168,9 +195,177 @@ pub fn load_or_seed_with_warnings() -> (HostRegistry, Vec<String>) {
     }
 }
 
+/// Load configured hosts (`hosts.toml`) and append auto-discovered local WSL
+/// distros, returning user-facing warnings. This is what the TUI and the
+/// headless `--host` resolver use so WSL distros are selectable with zero
+/// config; the discovered set never overrides an explicitly configured host of
+/// the same name.
+pub fn load_all_with_warnings() -> (HostRegistry, Vec<String>) {
+    let (mut reg, warnings) = load_or_seed_with_warnings();
+    augment_with_wsl(&mut reg);
+    (reg, warnings)
+}
+
+/// [`load_all_with_warnings`] for headless callers: logs the warnings instead
+/// of surfacing them in the UI.
+pub fn load_all() -> HostRegistry {
+    let (reg, warnings) = load_all_with_warnings();
+    for w in &warnings {
+        tracing::warn!("{w}");
+    }
+    reg
+}
+
+/// Append auto-discovered WSL distros to `reg`, skipping any whose name already
+/// matches a configured host (so a hand-written `hosts.toml` entry for a distro
+/// — e.g. with a custom `worktrees_dir` — wins over the bare discovered one).
+fn augment_with_wsl(reg: &mut HostRegistry) {
+    let configured: HashSet<&str> = reg.hosts.iter().map(|h| h.name.as_str()).collect();
+    let discovered: Vec<HostDef> = discover_wsl_hosts()
+        .into_iter()
+        .filter(|h| !configured.contains(h.name.as_str()))
+        .collect();
+    reg.hosts.extend(discovered);
+}
+
+/// Infrastructure distros `wsl.exe -l -q` reports that aren't interactive
+/// shells — filtered out of auto-discovery (matched case-insensitively).
+const WSL_INFRA_DISTROS: &[&str] = &["docker-desktop", "docker-desktop-data"];
+
+/// Auto-discover installed WSL distros as [`HostDef`]s (kind
+/// [`HostKind::Wsl`](crate::session::HostKind::Wsl)).
+///
+/// Runs `wsl.exe -l -q` and parses its output. Returns empty when `wsl.exe`
+/// isn't available (any non-Windows host, or Windows without WSL) or the
+/// command fails — discovery is strictly best-effort and never blocks startup.
+pub(crate) fn discover_wsl_hosts() -> Vec<HostDef> {
+    if !wsl_exe_available() {
+        return Vec::new();
+    }
+    let output = match Command::new("wsl.exe").arg("-l").arg("-q").output() {
+        Ok(o) if o.status.success() => o,
+        Ok(o) => {
+            tracing::debug!(
+                status = ?o.status,
+                "wsl.exe -l -q failed; no WSL distros auto-discovered"
+            );
+            return Vec::new();
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "could not run wsl.exe; no WSL distros auto-discovered");
+            return Vec::new();
+        }
+    };
+    parse_wsl_distros(&output.stdout)
+        .into_iter()
+        .map(HostDef::wsl)
+        .collect()
+}
+
+/// Whether `wsl.exe` can be invoked: always attempted on Windows; elsewhere
+/// only when it resolves on `PATH` (WSL interop exposes it inside a distro, so
+/// thurbox running in one WSL distro can still reach its siblings).
+fn wsl_exe_available() -> bool {
+    cfg!(windows) || crate::paths::which_on_path("wsl.exe")
+}
+
+/// Parse `wsl.exe -l -q` output into distro names.
+///
+/// `wsl.exe` emits **UTF-16LE** on Windows (decoded by [`decode_wsl_output`]);
+/// each line is one distro name. Blank lines, the UTF-8/16 BOM, infrastructure
+/// distros ([`WSL_INFRA_DISTROS`]), and surrounding whitespace are stripped.
+/// Pure + unit-tested so the decoding/filtering is verified without a live
+/// `wsl.exe`.
+pub(crate) fn parse_wsl_distros(bytes: &[u8]) -> Vec<String> {
+    decode_wsl_output(bytes)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .filter(|l| !WSL_INFRA_DISTROS.contains(&l.to_ascii_lowercase().as_str()))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Decode `wsl.exe` console output, which is UTF-16LE on Windows. Detected by
+/// the characteristic interleaved NUL high-bytes of ASCII text; any other
+/// producer is decoded as UTF-8. The BOM and stray NULs are stripped.
+fn decode_wsl_output(bytes: &[u8]) -> String {
+    let sample = bytes.chunks_exact(2).take(8);
+    let sampled = sample.clone().count();
+    let utf16_like = sampled > 0 && sample.filter(|c| c[1] == 0).count() * 2 > sampled;
+    let decoded = if utf16_like {
+        let units: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        String::from_utf16_lossy(&units)
+    } else {
+        String::from_utf8_lossy(bytes).into_owned()
+    };
+    decoded.replace(['\u{feff}', '\u{0}'], "")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a UTF-16LE byte buffer the way `wsl.exe` emits it.
+    fn utf16le(s: &str) -> Vec<u8> {
+        s.encode_utf16().flat_map(u16::to_le_bytes).collect()
+    }
+
+    #[test]
+    fn parse_wsl_distros_decodes_utf16le() {
+        let bytes = utf16le("Ubuntu\r\nDebian\r\n");
+        assert_eq!(parse_wsl_distros(&bytes), ["Ubuntu", "Debian"]);
+    }
+
+    #[test]
+    fn parse_wsl_distros_handles_bom_blank_lines_and_utf8() {
+        // UTF-16LE with a leading BOM and a trailing blank line.
+        let bytes = utf16le("\u{feff}Ubuntu-22.04\r\n\r\n");
+        assert_eq!(parse_wsl_distros(&bytes), ["Ubuntu-22.04"]);
+        // A UTF-8 producer (non-Windows mock) still parses.
+        assert_eq!(parse_wsl_distros(b"Alpine\nFedora\n"), ["Alpine", "Fedora"]);
+    }
+
+    #[test]
+    fn parse_wsl_distros_filters_infra_distros() {
+        let bytes = utf16le("Ubuntu\r\ndocker-desktop\r\ndocker-desktop-data\r\n");
+        assert_eq!(parse_wsl_distros(&bytes), ["Ubuntu"]);
+    }
+
+    #[test]
+    fn parse_wsl_distros_empty_input_yields_no_distros() {
+        assert!(parse_wsl_distros(&[]).is_empty());
+        assert!(parse_wsl_distros(&utf16le("")).is_empty());
+        assert!(parse_wsl_distros(&utf16le("\r\n  \r\n")).is_empty());
+    }
+
+    #[test]
+    fn augment_with_wsl_keeps_configured_entries() {
+        // A configured host named "Ubuntu" must not be duplicated by discovery.
+        // (discover_wsl_hosts() returns empty off-Windows here, but the dedup
+        // logic is exercised directly.)
+        let mut reg = HostRegistry {
+            config_version: None,
+            hosts: vec![HostDef {
+                name: "Ubuntu".into(),
+                kind: crate::session::HostKind::Wsl,
+                worktrees_dir: Some("/custom/wt".into()),
+                ..Default::default()
+            }],
+        };
+        let before = reg.hosts.len();
+        augment_with_wsl(&mut reg);
+        // The configured Ubuntu survives untouched; on a non-WSL host nothing
+        // else is added.
+        assert_eq!(
+            reg.get("Ubuntu").unwrap().worktrees_dir.as_deref(),
+            Some("/custom/wt")
+        );
+        assert!(reg.hosts.len() >= before);
+    }
 
     #[test]
     fn seed_toml_parses_to_empty_registry() {
@@ -182,7 +377,7 @@ mod tests {
     /// (the empty-registry test above proves they don't register).
     #[test]
     fn seed_toml_documents_minimal_and_full_examples() {
-        for marker in ["Minimal host", "Fully annotated host"] {
+        for marker in ["Minimal SSH host", "Fully annotated SSH host", "WSL distro"] {
             assert!(
                 SEED_HOSTS_TOML.contains(marker),
                 "hosts.toml seed must include the '{marker}' example"
@@ -197,7 +392,9 @@ mod tests {
     fn seed_toml_documents_every_host_field() {
         for field in [
             "name",
+            "kind",
             "destination",
+            "distro",
             "ssh_opts",
             "socket",
             "session",

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -527,8 +527,9 @@ impl TmuxBackend {
         }
     }
 
-    /// Build a remote tmux backend that runs `tmux` over SSH on `host`. The
-    /// backend is named `ssh:<host.name>` and uses the same socket/session
+    /// Build an off-local tmux backend for `host` — `tmux` over SSH for an SSH
+    /// host, or `tmux` inside a WSL distro via `wsl.exe`. The backend is named
+    /// `ssh:<host.name>` / `wsl:<host.name>` and uses the same socket/session
     /// names as the local backend unless the host overrides them.
     pub fn from_host(host: &crate::session::HostDef) -> Self {
         let socket = host
@@ -539,16 +540,19 @@ impl TmuxBackend {
             .session
             .clone()
             .unwrap_or_else(|| TMUX_SESSION.to_string());
-        Self::with_transport(
+        let transport = if host.is_wsl() {
+            TmuxTransport::Wsl {
+                distro: host.distro_name(),
+                mux: host.mux(),
+            }
+        } else {
             TmuxTransport::Ssh {
                 destination: host.destination.clone(),
                 ssh_opts: host.ssh_opts.clone(),
                 mux: host.mux(),
-            },
-            socket,
-            session,
-            host.backend_name(),
-        )
+            }
+        };
+        Self::with_transport(transport, socket, session, host.backend_name())
     }
 
     /// Run a tmux command and return its stdout (used before control mode is available).
@@ -1650,16 +1654,27 @@ mod tests {
         let host = crate::session::HostDef {
             name: "devbox".into(),
             destination: "me@devbox".into(),
-            socket: None,
-            session: None,
             ssh_opts: vec!["-o".into(), "ControlMaster=auto".into()],
-            worktrees_dir: None,
-            multiplexer: None,
+            ..Default::default()
         };
         let backend = TmuxBackend::from_host(&host);
         assert_eq!(backend.name(), "ssh:devbox");
         assert!(backend.transport.is_remote());
         // Falls back to the default socket/session when the host omits them.
+        assert_eq!(backend.socket, TMUX_SOCKET);
+        assert_eq!(backend.session, TMUX_SESSION);
+    }
+
+    #[test]
+    fn from_host_builds_named_wsl_backend() {
+        let host = crate::session::HostDef::wsl("Ubuntu");
+        let backend = TmuxBackend::from_host(&host);
+        assert_eq!(backend.name(), "wsl:Ubuntu");
+        assert!(backend.transport.is_remote());
+        assert!(matches!(
+            backend.transport,
+            TmuxTransport::Wsl { ref distro, .. } if distro == "Ubuntu"
+        ));
         assert_eq!(backend.socket, TMUX_SOCKET);
         assert_eq!(backend.session, TMUX_SESSION);
     }
@@ -1671,9 +1686,7 @@ mod tests {
             destination: "vm".into(),
             socket: Some("tb-vm".into()),
             session: Some("sess-vm".into()),
-            ssh_opts: vec![],
-            worktrees_dir: None,
-            multiplexer: None,
+            ..Default::default()
         };
         let backend = TmuxBackend::from_host(&host);
         assert_eq!(backend.socket, "tb-vm");

--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -10,14 +10,15 @@
 
 use std::process::Command;
 
-use crate::shell::{posix_quote, ssh_command};
+use crate::shell::{posix_quote, ssh_command, wsl_command};
 
 /// The local multiplexer binary: `psmux` on Windows (a native, drop-in tmux
 /// replacement with an identical control-mode wire protocol), `tmux` elsewhere.
 /// psmux also installs `tmux`/`pmux` aliases, but `psmux` is the canonical name.
 pub const DEFAULT_MUX: &str = if cfg!(windows) { "psmux" } else { "tmux" };
 
-/// How to launch the multiplexer for a backend: directly, or wrapped in `ssh`.
+/// How to launch the multiplexer for a backend: directly, wrapped in `ssh`, or
+/// inside a local WSL distro via `wsl.exe`.
 #[derive(Debug, Clone)]
 pub enum TmuxTransport {
     /// Run the multiplexer ([`DEFAULT_MUX`]) on the local machine.
@@ -32,6 +33,12 @@ pub enum TmuxTransport {
         ssh_opts: Vec<String>,
         mux: String,
     },
+    /// Run the multiplexer inside a local WSL distro via `wsl.exe -d <distro>`.
+    /// This is the SSH variant minus the network: `wsl.exe` joins and
+    /// shell-interprets the trailing tokens exactly like `ssh`, so the same
+    /// control-mode protocol and POSIX quoting apply. `mux` is the in-distro
+    /// multiplexer binary (`tmux`).
+    Wsl { distro: String, mux: String },
 }
 
 /// Environment variables a tmux/psmux server reads to resolve a *nested*
@@ -81,32 +88,43 @@ impl TmuxTransport {
                 destination,
                 ssh_opts,
                 mux,
-            } => {
-                let mut cmd = ssh_command(destination, ssh_opts);
-                cmd.arg(posix_quote(mux));
-                cmd.arg(posix_quote("-L"));
-                cmd.arg(posix_quote(socket));
-                for a in args {
-                    cmd.arg(posix_quote(a));
-                }
-                cmd
+            } => Self::prefixed(ssh_command(destination, ssh_opts), mux, socket, args),
+            TmuxTransport::Wsl { distro, mux } => {
+                Self::prefixed(wsl_command(distro), mux, socket, args)
             }
         };
         strip_mux_nesting_env(&mut cmd);
         cmd
     }
 
-    /// Whether this transport reaches tmux over SSH.
+    /// Append `<mux> -L <socket> <args…>` to a launcher command (`ssh …` or
+    /// `wsl.exe …`), POSIX-quoting each token so the host's login shell
+    /// re-splits them intact. Shared by the SSH and WSL arms, which differ only
+    /// in the launcher prefix.
+    fn prefixed(mut cmd: Command, mux: &str, socket: &str, args: &[&str]) -> Command {
+        cmd.arg(posix_quote(mux));
+        cmd.arg(posix_quote("-L"));
+        cmd.arg(posix_quote(socket));
+        for a in args {
+            cmd.arg(posix_quote(a));
+        }
+        cmd
+    }
+
+    /// Whether this transport reaches the multiplexer through a launch prefix
+    /// (SSH or WSL) rather than running it directly on the local machine.
     pub fn is_remote(&self) -> bool {
-        matches!(self, TmuxTransport::Ssh { .. })
+        matches!(self, TmuxTransport::Ssh { .. } | TmuxTransport::Wsl { .. })
     }
 
     /// The multiplexer binary this transport launches: [`DEFAULT_MUX`] locally,
-    /// or the per-host `multiplexer` for an SSH host.
+    /// or the per-host `multiplexer` for an SSH host / WSL distro (`tmux` for a
+    /// distro, so [`uses_psmux`](Self::uses_psmux) is `false` and the in-distro
+    /// tmux keeps the `-H` hex keystroke path).
     pub fn mux(&self) -> &str {
         match self {
             TmuxTransport::Local => DEFAULT_MUX,
-            TmuxTransport::Ssh { mux, .. } => mux,
+            TmuxTransport::Ssh { mux, .. } | TmuxTransport::Wsl { mux, .. } => mux,
         }
     }
 
@@ -180,6 +198,30 @@ mod tests {
     }
 
     #[test]
+    fn wsl_wraps_mux_with_distro() {
+        let t = TmuxTransport::Wsl {
+            distro: "Ubuntu".into(),
+            mux: "tmux".into(),
+        };
+        let cmd = t.tmux_command("thurbox", &["has-session", "-t", "thurbox"]);
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "wsl.exe");
+        assert_eq!(
+            args,
+            [
+                "-d",
+                "Ubuntu",
+                "tmux",
+                "-L",
+                "thurbox",
+                "has-session",
+                "-t",
+                "thurbox",
+            ]
+        );
+    }
+
+    #[test]
     fn tmux_command_strips_nesting_env() {
         let cmd = TmuxTransport::Local.tmux_command("thurbox", &["has-session"]);
         // Removed vars surface in get_envs() as (key, None).
@@ -211,6 +253,14 @@ mod tests {
             mux: "tmux".into(),
         }
         .uses_psmux());
+        // A WSL distro runs Linux `tmux`, which supports the `-H` hex flag, so
+        // it must NOT take the psmux keystroke-encoding path.
+        let wsl = TmuxTransport::Wsl {
+            distro: "Ubuntu".into(),
+            mux: "tmux".into(),
+        };
+        assert_eq!(wsl.mux(), "tmux");
+        assert!(!wsl.uses_psmux());
     }
 
     #[test]
@@ -219,6 +269,11 @@ mod tests {
         assert!(TmuxTransport::Ssh {
             destination: "h".into(),
             ssh_opts: vec![],
+            mux: "tmux".into(),
+        }
+        .is_remote());
+        assert!(TmuxTransport::Wsl {
+            distro: "Ubuntu".into(),
             mux: "tmux".into(),
         }
         .is_remote());

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1089,7 +1089,8 @@ impl App {
 
     /// Entry point for the new-session wizard.
     ///
-    /// When remote hosts are configured (`hosts.toml`), first shows the host
+    /// When any off-local host is available — a configured SSH/WSL host
+    /// (`hosts.toml`) or an auto-discovered WSL distro — first shows the host
     /// picker so the user can choose where the session runs; otherwise goes
     /// straight to the repo picker (preserving the local-only UX).
     pub(crate) fn start_new_session(&mut self) {
@@ -1107,7 +1108,7 @@ impl App {
         }];
         for host in &self.hosts.hosts {
             choices.push(crate::ui::host_picker_modal::HostChoice {
-                label: format!("{}  ({})", host.name, host.destination),
+                label: format!("{}  ({})", host.name, host.picker_detail()),
                 backend: host.backend_name(),
             });
         }
@@ -1808,9 +1809,10 @@ impl App {
             cwd,
         );
         config.resume_session_id = deleted.agent_session_id;
-        // Preserve the persisted backend so a restored remote (`ssh:<host>`)
-        // session keeps its backend name on the config; local sessions stay `None`.
-        if crate::session::is_ssh_backend(&deleted.backend_type) {
+        // Preserve the persisted backend so a restored off-local
+        // (`ssh:<host>` / `wsl:<distro>`) session keeps its backend name on the
+        // config; local sessions stay `None`.
+        if crate::session::is_remote_backend(&deleted.backend_type) {
             config.backend = Some(deleted.backend_type.clone());
         }
 
@@ -2982,20 +2984,22 @@ impl App {
         &self,
         backend: Option<&str>,
     ) -> Option<&crate::session::HostDef> {
-        // `get_by_backend` already returns `None` for non-`ssh:` names.
+        // `get_by_backend` returns `None` for local (`non-ssh:`/`non-wsl:`)
+        // names.
         self.hosts.get_by_backend(backend?)
     }
 
     /// Resolve the backend for a *persisted* session by its `backend_type`, or
     /// `None` when this instance cannot manage it.
     ///
-    /// An unknown `ssh:<host>` backend (e.g. a host this instance hasn't loaded
-    /// from `hosts.toml`, or another instance configured) is **skipped** rather
-    /// than falling back to local — adopting a remote session on the local
-    /// backend would corrupt its `backend_type` and risk a pane-id collision
-    /// (tmux numbers panes `%N` per server, so a remote `%1` can match an
-    /// unrelated local `%1`). Legacy/local values (empty, `tmux`, `local-tmux`)
-    /// still fall back to the default local backend.
+    /// An unknown off-local backend (`ssh:<host>` / `wsl:<distro>` — e.g. a host
+    /// this instance hasn't loaded from `hosts.toml`, a distro not present here,
+    /// or one another instance configured) is **skipped** rather than falling
+    /// back to local — adopting an off-local session on the local backend would
+    /// corrupt its `backend_type` and risk a pane-id collision (tmux numbers
+    /// panes `%N` per server, so a remote `%1` can match an unrelated local
+    /// `%1`). Legacy/local values (empty, `tmux`, `local-tmux`) still fall back
+    /// to the default local backend.
     pub(crate) fn resolve_persisted_backend(
         &self,
         backend_type: &str,
@@ -3003,7 +3007,7 @@ impl App {
         if let Some(b) = self.backends.get(backend_type) {
             return Some(b.clone());
         }
-        if crate::session::is_ssh_backend(backend_type) {
+        if crate::session::is_remote_backend(backend_type) {
             return None;
         }
         Some(self.backends.default_backend().clone())
@@ -5859,42 +5863,42 @@ mod tests {
         let mut app = app_with_sessions(0);
         app.set_hosts(crate::session::HostRegistry {
             config_version: None,
-            hosts: vec![crate::session::HostDef {
-                name: "devbox".into(),
-                destination: "me@devbox".into(),
-                socket: None,
-                session: None,
-                ssh_opts: vec![],
-                worktrees_dir: None,
-                multiplexer: None,
-            }],
+            hosts: vec![
+                crate::session::HostDef {
+                    name: "devbox".into(),
+                    destination: "me@devbox".into(),
+                    ..Default::default()
+                },
+                crate::session::HostDef::wsl("Ubuntu"),
+            ],
         });
         app.start_new_session();
         match app.modal {
             modals::Modal::HostPicker(ref hp) => {
-                // "local" first, then each ssh host.
-                assert_eq!(hp.choices.len(), 2);
+                // "local" first, then each off-local host (ssh + wsl).
+                assert_eq!(hp.choices.len(), 3);
                 assert_eq!(hp.choices[0].backend, "");
                 assert_eq!(hp.choices[1].backend, "ssh:devbox");
+                assert_eq!(hp.choices[2].backend, "wsl:Ubuntu");
+                assert!(hp.choices[2].label.contains("WSL"));
             }
             ref other => panic!("expected host picker, got {other:?}"),
         }
     }
 
     #[test]
-    fn host_for_backend_resolves_ssh_only() {
+    fn host_for_backend_resolves_ssh_and_wsl() {
         let mut app = app_with_sessions(0);
         app.set_hosts(crate::session::HostRegistry {
             config_version: None,
-            hosts: vec![crate::session::HostDef {
-                name: "devbox".into(),
-                destination: "me@devbox".into(),
-                socket: None,
-                session: None,
-                ssh_opts: vec![],
-                worktrees_dir: None,
-                multiplexer: None,
-            }],
+            hosts: vec![
+                crate::session::HostDef {
+                    name: "devbox".into(),
+                    destination: "me@devbox".into(),
+                    ..Default::default()
+                },
+                crate::session::HostDef::wsl("Ubuntu"),
+            ],
         });
         assert!(app.host_for_backend(None).is_none());
         assert!(app.host_for_backend(Some("local-tmux")).is_none());
@@ -5904,6 +5908,7 @@ mod tests {
                 .destination,
             "me@devbox"
         );
+        assert!(app.host_for_backend(Some("wsl:Ubuntu")).unwrap().is_wsl());
         assert!(app.host_for_backend(Some("ssh:unknown")).is_none());
     }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -235,7 +235,10 @@ fn render_show(report: &Value) -> String {
 
 fn show(db: &Database) -> Result<Value, String> {
     let agents = crate::agent::agent_config::load_or_seed();
-    let hosts = crate::agent::host_config::load_or_seed();
+    // The *effective* host set: configured SSH/WSL hosts plus auto-discovered
+    // WSL distros — matching what `--host` and the TUI picker actually offer
+    // (`config validate` stays file-only).
+    let hosts = crate::agent::host_config::load_all();
     let settings = crate::session::settings::global();
     let (custom_themes, _) = crate::agent::themes_config::load_or_seed_with_warnings();
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -9,13 +9,27 @@ use tracing::warn;
 
 use crate::paths;
 use crate::session::HostDef;
-use crate::shell::{posix_quote, ssh_command};
+use crate::shell::{posix_quote, ssh_command, wsl_command};
 
-/// Build a `git` [`Command`] targeting `cwd`, run either locally or over SSH.
+/// Build the launcher [`Command`] for an off-local host: `ssh <opts> <dest>`
+/// for an SSH host, or `wsl.exe -d <distro>` for a WSL distro. Both join and
+/// shell-interpret the trailing tokens identically, so callers append the same
+/// POSIX-quoted command afterward.
+fn host_launcher(h: &HostDef) -> Command {
+    if h.is_wsl() {
+        wsl_command(&h.distro_name())
+    } else {
+        ssh_command(&h.destination, &h.ssh_opts)
+    }
+}
+
+/// Build a `git` [`Command`] targeting `cwd`, run locally, over SSH, or inside
+/// a WSL distro.
 ///
-/// For the remote variant the command becomes
-/// `ssh <opts> <dest> git -C <cwd> <args…>`, with each remote token
-/// shell-escaped so it survives the remote login shell's re-splitting.
+/// For an off-local host the command becomes
+/// `<launcher> git -C <cwd> <args…>` (launcher = `ssh <opts> <dest>` or
+/// `wsl.exe -d <distro>`), with each token shell-escaped so it survives the
+/// host login shell's re-splitting.
 fn git_command(host: Option<&HostDef>, cwd: &Path, args: &[&str]) -> Command {
     match host {
         None => {
@@ -25,7 +39,7 @@ fn git_command(host: Option<&HostDef>, cwd: &Path, args: &[&str]) -> Command {
             cmd
         }
         Some(h) => {
-            let mut cmd = ssh_command(&h.destination, &h.ssh_opts);
+            let mut cmd = host_launcher(h);
             cmd.arg(posix_quote("git"));
             cmd.arg(posix_quote("-C"));
             cmd.arg(posix_quote(&cwd.to_string_lossy()));
@@ -37,40 +51,44 @@ fn git_command(host: Option<&HostDef>, cwd: &Path, args: &[&str]) -> Command {
     }
 }
 
-/// Cache of resolved remote `$HOME` directories, keyed by ssh destination, so
-/// we only pay one round-trip per host. Entries live for the process lifetime:
-/// `hosts.toml` is read once at startup, so repointing a destination at a
-/// different machine requires a restart anyway — the cache can never be
-/// staler than the host config it derives from.
+/// Cache of resolved host `$HOME` directories, keyed by the host's backend name
+/// (`ssh:<name>` / `wsl:<name>`), so we only pay one round-trip per host. A WSL
+/// host has no `destination`, so the backend name — unique per host — is the
+/// stable key for both kinds. Entries live for the process lifetime:
+/// `hosts.toml` is read once at startup, so repointing a host requires a
+/// restart anyway — the cache can never be staler than the config it derives
+/// from.
 fn remote_home_cache() -> &'static Mutex<HashMap<String, String>> {
     static CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Resolve the remote `$HOME` for a host, caching the result.
+/// Resolve the `$HOME` directory on a host (over SSH or inside a WSL distro),
+/// caching the result.
 fn remote_home(host: &HostDef) -> Result<String> {
+    let key = host.backend_name();
     if let Ok(guard) = remote_home_cache().lock() {
-        if let Some(home) = guard.get(&host.destination) {
+        if let Some(home) = guard.get(&key) {
             return Ok(home.clone());
         }
     }
-    let mut cmd = ssh_command(&host.destination, &host.ssh_opts);
-    // Pass `$HOME` literally; the remote shell expands it.
+    let mut cmd = host_launcher(host);
+    // Pass `$HOME` literally; the host login shell expands it.
     cmd.arg("echo").arg("$HOME");
     let output = cmd
         .stderr(Stdio::piped())
         .output()
-        .context("failed to resolve remote $HOME over ssh")?;
+        .context("failed to resolve host $HOME")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("ssh echo $HOME failed: {}", stderr.trim());
+        anyhow::bail!("`echo $HOME` on {key} failed: {}", stderr.trim());
     }
     let home = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if home.is_empty() {
-        anyhow::bail!("remote $HOME resolved empty for {}", host.destination);
+        anyhow::bail!("$HOME resolved empty for {key}");
     }
     if let Ok(mut guard) = remote_home_cache().lock() {
-        guard.insert(host.destination.clone(), home.clone());
+        guard.insert(key, home.clone());
     }
     Ok(home)
 }
@@ -1343,11 +1361,9 @@ mod tests {
         HostDef {
             name: "h".into(),
             destination: dest.into(),
-            socket: None,
-            session: None,
             ssh_opts: vec!["-o".into(), "ControlMaster=auto".into()],
             worktrees_dir: wt_dir.map(|s| s.to_string()),
-            multiplexer: None,
+            ..Default::default()
         }
     }
 
@@ -1395,6 +1411,33 @@ mod tests {
             ]
         );
         // No local current_dir is set for the remote variant.
+        assert_eq!(cmd.get_current_dir(), None);
+    }
+
+    #[test]
+    fn git_command_wsl_wraps_in_wsl_exe() {
+        let h = HostDef::wsl("Ubuntu");
+        let cmd = git_command(
+            Some(&h),
+            Path::new("/home/me/repo"),
+            &["worktree", "add", "-b", "x"],
+        );
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "wsl.exe");
+        assert_eq!(
+            args,
+            [
+                "-d",
+                "Ubuntu",
+                "git",
+                "-C",
+                "/home/me/repo",
+                "worktree",
+                "add",
+                "-b",
+                "x",
+            ]
+        );
         assert_eq!(cmd.get_current_dir(), None);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,14 +224,15 @@ fn init_backends_and_config() -> Result<(
         thurbox::agent::settings_config::load_or_seed_with_warnings();
     thurbox::session::settings::init(settings);
 
-    // Register one SSH backend per configured remote host
-    // (~/.config/thurbox/hosts.toml). These are registered lazily: a down or
+    // Register one backend per off-local host: each configured SSH host in
+    // ~/.config/thurbox/hosts.toml, plus every auto-discovered local WSL distro
+    // (`wsl.exe -l -q`, Windows only). These are registered lazily: a down or
     // slow host must not block TUI startup, so check_available()/ensure_ready()
     // are deferred to first spawn/restore (see App::backend_for).
-    let (hosts, host_warnings) = thurbox::agent::host_config::load_or_seed_with_warnings();
+    let (hosts, host_warnings) = thurbox::agent::host_config::load_all_with_warnings();
     config_warnings.extend(host_warnings);
     for host in &hosts.hosts {
-        tracing::debug!(host = %host.name, dest = %host.destination, "Registering SSH backend");
+        tracing::debug!(host = %host.name, backend = %host.backend_name(), "Registering backend");
         backends.register(Arc::new(TmuxBackend::from_host(host)));
     }
 

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -297,7 +297,7 @@ fn dispatch_macos(n: &Notification) -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(target_os = "macos")]
 fn terminal_notifier_available() -> bool {
     static AVAILABLE: OnceLock<bool> = OnceLock::new();
-    *AVAILABLE.get_or_init(|| which_on_path("terminal-notifier"))
+    *AVAILABLE.get_or_init(|| crate::paths::which_on_path("terminal-notifier"))
 }
 
 #[cfg(target_os = "macos")]
@@ -604,15 +604,7 @@ fn detect_dbus_service() -> bool {
 
 /// `powershell.exe` on `PATH` (WSL interop). Cheap PATH scan; no process spawn.
 fn detect_powershell() -> bool {
-    which_on_path("powershell.exe")
-}
-
-/// Minimal `PATH` lookup (avoids pulling in a `which` crate for one probe).
-fn which_on_path(exe: &str) -> bool {
-    let Ok(path) = std::env::var("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&path).any(|dir| dir.join(exe).exists())
+    crate::paths::which_on_path("powershell.exe")
 }
 
 /// SQLite `metadata` key the click handler writes to. The TUI's

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -55,6 +55,16 @@ pub fn home_dir() -> Option<PathBuf> {
     std::env::var_os(var).map(PathBuf::from)
 }
 
+/// Whether `exe` resolves on `PATH`. A minimal lookup that avoids pulling in a
+/// `which` crate for a one-off probe (used to detect optional helper binaries
+/// like `wsl.exe` / `powershell.exe`); cheap PATH scan, no process spawn.
+pub fn which_on_path(exe: &str) -> bool {
+    let Ok(path) = std::env::var("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(exe).exists())
+}
+
 /// Base directory for config files. `$XDG_CONFIG_HOME` wins on every platform
 /// (some users set it on Windows too); otherwise `%APPDATA%` on Windows,
 /// `$HOME/.config` on Unix.
@@ -535,6 +545,27 @@ mod tests {
             display_path(Path::new("/home/user/Repositories/thurbox")),
             "thurbox"
         );
+    }
+
+    #[test]
+    fn which_on_path_finds_present_and_rejects_absent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // `which_on_path` checks for the file verbatim (no `.exe` munging), so a
+        // plain marker filename resolves identically on every platform.
+        let marker = "tbx_which_probe_marker";
+        std::fs::write(dir.path().join(marker), b"").unwrap();
+
+        let saved = std::env::var_os("PATH");
+        std::env::set_var("PATH", dir.path());
+        let found = which_on_path(marker);
+        let missing = which_on_path("tbx_which_probe_absent");
+        match saved {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+
+        assert!(found, "marker on PATH should be found");
+        assert!(!missing, "a name not on PATH should not be found");
     }
 
     #[test]

--- a/src/session/host_def.rs
+++ b/src/session/host_def.rs
@@ -1,11 +1,18 @@
-//! Remote-host definitions — pure data describing SSH targets thurbox can run
-//! sessions on.
+//! Remote-host definitions — pure data describing the off-local targets
+//! thurbox can run sessions on: SSH machines and local WSL distros.
 //!
 //! Loaded from `~/.config/thurbox/hosts.toml` by
-//! [`crate::agent::host_config`]. Kept here in `session` (the dependency sink)
-//! so both `agent` (which builds the SSH tmux backend) and `git` (which runs
-//! `git` over SSH for remote worktrees) can depend on the same type without
-//! crossing the module-isolation rules.
+//! [`crate::agent::host_config`] (and, for WSL, auto-discovered there too).
+//! Kept here in `session` (the dependency sink) so both `agent` (which builds
+//! the tmux backend) and `git` (which runs `git` on the host for remote
+//! worktrees) can depend on the same type without crossing the
+//! module-isolation rules.
+//!
+//! A WSL distro is modeled as "SSH without the ssh": the only difference from
+//! a remote host is the launch prefix (`wsl.exe -d <distro>` instead of
+//! `ssh <dest>`). tmux, git, the agent, and the worktrees all run *inside* the
+//! distro at native Linux paths, so everything downstream of the launcher is
+//! identical to the SSH path.
 
 use serde::{Deserialize, Serialize};
 
@@ -13,48 +20,122 @@ use serde::{Deserialize, Serialize};
 /// (and persisted in `backend_type`) as `ssh:devbox`.
 pub const SSH_BACKEND_PREFIX: &str = "ssh:";
 
+/// The backend-name prefix for WSL distros. A distro named `Ubuntu` is
+/// registered (and persisted in `backend_type`) as `wsl:Ubuntu`.
+pub const WSL_BACKEND_PREFIX: &str = "wsl:";
+
 /// Whether a backend name refers to a remote SSH host (`ssh:<name>`).
 pub fn is_ssh_backend(backend_name: &str) -> bool {
     backend_name.starts_with(SSH_BACKEND_PREFIX)
 }
 
-/// A single remote host reachable over SSH.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Whether a backend name refers to a WSL distro (`wsl:<distro>`).
+pub fn is_wsl_backend(backend_name: &str) -> bool {
+    backend_name.starts_with(WSL_BACKEND_PREFIX)
+}
+
+/// Whether a backend name refers to any off-local host (SSH or WSL) — i.e. one
+/// that needs a launch prefix and runs git/worktrees somewhere other than the
+/// local filesystem. Local backends (`""`, `tmux`, `local-tmux`) are not.
+pub fn is_remote_backend(backend_name: &str) -> bool {
+    is_ssh_backend(backend_name) || is_wsl_backend(backend_name)
+}
+
+/// How thurbox reaches a host: over SSH, or into a local WSL distro.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum HostKind {
+    /// A remote machine reached with `ssh <destination>`.
+    #[default]
+    Ssh,
+    /// A local Windows Subsystem for Linux distro reached with
+    /// `wsl.exe -d <distro>`.
+    Wsl,
+}
+
+/// A single off-local host: an SSH machine or a local WSL distro.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct HostDef {
-    /// Short, unique name. The backend is registered as `ssh:<name>`.
+    /// Short, unique name. The backend is registered as `ssh:<name>` or
+    /// `wsl:<name>` depending on [`kind`](Self::kind).
     pub name: String,
+    /// Transport kind: SSH (default) or WSL.
+    #[serde(default)]
+    pub kind: HostKind,
     /// SSH destination (e.g. `me@devbox`), resolved via the user's
-    /// `~/.ssh/config`.
+    /// `~/.ssh/config`. Required for [`HostKind::Ssh`]; ignored for WSL.
+    #[serde(default)]
     pub destination: String,
-    /// Optional override for the remote `tmux -L` socket name. Defaults to the
+    /// WSL distro name (e.g. `Ubuntu`). Defaults to [`name`](Self::name) when
+    /// unset. Ignored for [`HostKind::Ssh`].
+    #[serde(default)]
+    pub distro: Option<String>,
+    /// Optional override for the host's `tmux -L` socket name. Defaults to the
     /// same socket thurbox uses locally.
     #[serde(default)]
     pub socket: Option<String>,
-    /// Optional override for the remote tmux session name.
+    /// Optional override for the host's tmux session name.
     #[serde(default)]
     pub session: Option<String>,
     /// Extra `ssh` flags inserted before the destination (e.g.
-    /// `["-o", "ControlMaster=auto"]`).
+    /// `["-o", "ControlMaster=auto"]`). SSH-only.
     #[serde(default)]
     pub ssh_opts: Vec<String>,
-    /// Optional absolute remote directory under which git worktrees are
-    /// created. When unset, the remote `$HOME/.local/share/thurbox/worktrees`
-    /// is resolved at spawn time.
+    /// Optional absolute directory (inside the host / distro) under which git
+    /// worktrees are created. When unset, the host's
+    /// `$HOME/.local/share/thurbox/worktrees` is resolved at spawn time.
     #[serde(default)]
     pub worktrees_dir: Option<String>,
-    /// Optional remote multiplexer binary. Defaults to `tmux`; set to `psmux`
-    /// for a Windows host (psmux speaks the same control-mode wire protocol).
+    /// Optional multiplexer binary on the host. Defaults to `tmux` (the WSL
+    /// distro and a Unix SSH host both run `tmux`); set to `psmux` for a
+    /// Windows SSH host (psmux speaks the same control-mode wire protocol).
     #[serde(default)]
     pub multiplexer: Option<String>,
 }
 
 impl HostDef {
-    /// The backend name this host registers under: `ssh:<name>`.
-    pub fn backend_name(&self) -> String {
-        format!("{SSH_BACKEND_PREFIX}{}", self.name)
+    /// Construct an auto-discovered WSL host for `distro` with all defaults.
+    pub fn wsl(distro: impl Into<String>) -> Self {
+        let distro = distro.into();
+        Self {
+            name: distro.clone(),
+            kind: HostKind::Wsl,
+            distro: Some(distro),
+            ..Self::default()
+        }
     }
 
-    /// The remote multiplexer binary for this host (`tmux` unless overridden).
+    /// Whether this host is a WSL distro.
+    pub fn is_wsl(&self) -> bool {
+        self.kind == HostKind::Wsl
+    }
+
+    /// The WSL distro name (the explicit `distro` field, else the host `name`).
+    /// Only meaningful for [`HostKind::Wsl`].
+    pub fn distro_name(&self) -> String {
+        self.distro.clone().unwrap_or_else(|| self.name.clone())
+    }
+
+    /// The backend name this host registers under: `ssh:<name>` or
+    /// `wsl:<name>`.
+    pub fn backend_name(&self) -> String {
+        let prefix = match self.kind {
+            HostKind::Ssh => SSH_BACKEND_PREFIX,
+            HostKind::Wsl => WSL_BACKEND_PREFIX,
+        };
+        format!("{prefix}{}", self.name)
+    }
+
+    /// A short detail string for the host picker (the SSH destination, or
+    /// `WSL` for a distro).
+    pub fn picker_detail(&self) -> String {
+        match self.kind {
+            HostKind::Ssh => self.destination.clone(),
+            HostKind::Wsl => "WSL".to_string(),
+        }
+    }
+
+    /// The host's multiplexer binary (`tmux` unless overridden).
     pub fn mux(&self) -> String {
         self.multiplexer
             .clone()
@@ -81,9 +162,11 @@ impl HostRegistry {
         self.hosts.iter().find(|h| h.name == name)
     }
 
-    /// Look up a host by its `ssh:<name>` backend name.
+    /// Look up a host by its `ssh:<name>` or `wsl:<name>` backend name.
     pub fn get_by_backend(&self, backend_name: &str) -> Option<&HostDef> {
-        let bare = backend_name.strip_prefix(SSH_BACKEND_PREFIX)?;
+        let bare = backend_name
+            .strip_prefix(SSH_BACKEND_PREFIX)
+            .or_else(|| backend_name.strip_prefix(WSL_BACKEND_PREFIX))?;
         self.get(bare)
     }
 
@@ -107,33 +190,96 @@ mod tests {
         let h = HostDef {
             name: "devbox".into(),
             destination: "me@devbox".into(),
-            socket: None,
-            session: None,
-            ssh_opts: vec![],
-            worktrees_dir: None,
-            multiplexer: None,
+            ..Default::default()
         };
         assert_eq!(h.backend_name(), "ssh:devbox");
+    }
+
+    #[test]
+    fn wsl_constructor_and_backend_name() {
+        let h = HostDef::wsl("Ubuntu");
+        assert!(h.is_wsl());
+        assert_eq!(h.kind, HostKind::Wsl);
+        assert_eq!(h.distro_name(), "Ubuntu");
+        assert_eq!(h.backend_name(), "wsl:Ubuntu");
+        assert_eq!(h.picker_detail(), "WSL");
+        // WSL distros run `tmux` inside the distro, same as a Unix SSH host.
+        assert_eq!(h.mux(), "tmux");
+
+        // An SSH host (the default kind) keeps the ssh prefix and is not WSL.
+        let ssh = HostDef {
+            name: "devbox".into(),
+            destination: "me@devbox".into(),
+            ..Default::default()
+        };
+        assert!(!ssh.is_wsl());
+        assert_eq!(ssh.picker_detail(), "me@devbox");
+    }
+
+    #[test]
+    fn distro_name_falls_back_to_host_name() {
+        let h = HostDef {
+            name: "work".into(),
+            kind: HostKind::Wsl,
+            distro: None,
+            ..Default::default()
+        };
+        assert_eq!(h.distro_name(), "work");
+    }
+
+    #[test]
+    fn backend_predicates_classify_prefixes() {
+        assert!(is_ssh_backend("ssh:devbox"));
+        assert!(!is_ssh_backend("wsl:Ubuntu"));
+        assert!(is_wsl_backend("wsl:Ubuntu"));
+        assert!(!is_wsl_backend("ssh:devbox"));
+        assert!(is_remote_backend("ssh:devbox"));
+        assert!(is_remote_backend("wsl:Ubuntu"));
+        assert!(!is_remote_backend("local-tmux"));
+        assert!(!is_remote_backend(""));
     }
 
     #[test]
     fn registry_lookup_by_name_and_backend() {
         let reg = HostRegistry {
             config_version: None,
-            hosts: vec![HostDef {
-                name: "devbox".into(),
-                destination: "me@devbox".into(),
-                socket: None,
-                session: None,
-                ssh_opts: vec![],
-                worktrees_dir: None,
-                multiplexer: None,
-            }],
+            hosts: vec![
+                HostDef {
+                    name: "devbox".into(),
+                    destination: "me@devbox".into(),
+                    ..Default::default()
+                },
+                HostDef::wsl("Ubuntu"),
+            ],
         };
         assert_eq!(reg.get("devbox").unwrap().destination, "me@devbox");
         assert_eq!(reg.get_by_backend("ssh:devbox").unwrap().name, "devbox");
+        assert_eq!(reg.get_by_backend("wsl:Ubuntu").unwrap().name, "Ubuntu");
         assert!(reg.get_by_backend("devbox").is_none());
         assert!(reg.get_by_backend("local-tmux").is_none());
+    }
+
+    #[test]
+    fn parses_wsl_host_from_toml() {
+        let toml = r#"
+[[hosts]]
+name = "Ubuntu"
+kind = "wsl"
+
+[[hosts]]
+name = "custom"
+kind = "wsl"
+distro = "Debian"
+worktrees_dir = "/home/me/wt"
+"#;
+        let reg: HostRegistry = toml::from_str(toml).unwrap();
+        let u = reg.get("Ubuntu").unwrap();
+        assert!(u.is_wsl());
+        assert_eq!(u.distro_name(), "Ubuntu");
+        assert_eq!(u.backend_name(), "wsl:Ubuntu");
+        let c = reg.get("custom").unwrap();
+        assert_eq!(c.distro_name(), "Debian");
+        assert_eq!(c.worktrees_dir.as_deref(), Some("/home/me/wt"));
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -18,7 +18,10 @@ pub use extension_def::{
     AgentPatch, ConfigMerge, ExtensionAutomation, ExtensionDef, ExtensionFile, ExtensionSession,
     ExtensionSymlink, ExternalFile,
 };
-pub use host_def::{is_ssh_backend, HostDef, HostRegistry, SSH_BACKEND_PREFIX};
+pub use host_def::{
+    is_remote_backend, is_ssh_backend, is_wsl_backend, HostDef, HostKind, HostRegistry,
+    SSH_BACKEND_PREFIX, WSL_BACKEND_PREFIX,
+};
 pub use keybindings::{Action, KeyBindings, KeyChord, KeyContext};
 pub use message::SessionMessage;
 pub use review::{

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -336,19 +336,21 @@ fn dir_label(path: &std::path::Path) -> String {
 
 /// Resolve `--host` to `(backend_type, host)`.
 ///
-/// `None`/empty → the local backend. A named host must exist in `hosts.toml`,
-/// otherwise an error is returned listing the available hosts.
+/// `None`/empty → the local backend. A named host must exist in `hosts.toml`
+/// **or** be an auto-discovered local WSL distro, otherwise an error is
+/// returned listing the available hosts.
 fn resolve_host(host_name: Option<&str>) -> Result<(String, Option<HostDef>), String> {
     let Some(name) = host_name.filter(|n| !n.is_empty()) else {
         return Ok((LOCAL_TMUX_BACKEND_TYPE.to_string(), None));
     };
-    let registry = crate::agent::host_config::load_or_seed();
+    let registry = crate::agent::host_config::load_all();
     match registry.get(name) {
         Some(h) => Ok((h.backend_name(), Some(h.clone()))),
         None => {
             let available = registry.names().join(", ");
             Err(format!(
-                "Unknown host '{name}'. Configure it in hosts.toml. Available: [{available}]"
+                "Unknown host '{name}'. Configure it in hosts.toml (or check the \
+                 WSL distro name). Available: [{available}]"
             ))
         }
     }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -37,6 +37,23 @@ pub fn ssh_command(destination: &str, ssh_opts: &[String]) -> Command {
     cmd
 }
 
+/// Build a `wsl.exe -d <distro>` [`Command`], ready for the caller to append
+/// the in-distro command and its arguments.
+///
+/// This is the WSL analogue of [`ssh_command`]: `wsl.exe` joins the trailing
+/// arguments with spaces and runs them through the distro's default login
+/// shell (it only bypasses the shell with `-e`/`--exec`, which we don't pass),
+/// exactly like `ssh <dest> <command>`. So callers append the *same*
+/// POSIX-quoted tokens they would for SSH — the in-distro shell re-splits them
+/// identically. No `--` separator is used (none of thurbox's commands start
+/// with a `-`, matching the SSH path which also omits it), so distros are
+/// reached uniformly on every supported `wsl.exe`.
+pub fn wsl_command(distro: &str) -> Command {
+    let mut cmd = Command::new("wsl.exe");
+    cmd.arg("-d").arg(distro);
+    cmd
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +81,16 @@ mod tests {
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
         assert_eq!(args, ["-p", "2222", "me@box"]);
+    }
+
+    #[test]
+    fn wsl_command_sets_program_and_distro() {
+        let cmd = wsl_command("Ubuntu");
+        assert_eq!(cmd.get_program().to_string_lossy(), "wsl.exe");
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, ["-d", "Ubuntu"]);
     }
 }


### PR DESCRIPTION
## Summary

Adds **WSL as a session backend** so thurbox running on native Windows can launch agent sessions *inside* a WSL distro. A distro is modeled as **"SSH without the ssh"** — the only difference from a remote host is the launch prefix (`wsl.exe -d <distro>` instead of `ssh <dest>`). tmux, git, the agent, and the worktrees all run inside the distro at native Linux paths, so the control-mode protocol, POSIX quoting, and worktree layout are identical to the existing SSH path (no `wslpath` translation).

- `HostDef` gains `kind: HostKind {Ssh, Wsl}` + `distro`; backends register as `ssh:<name>` or `wsl:<distro>`.
- New `TmuxTransport::Wsl` and `shell::wsl_command`; git + `$HOME` resolution route through a shared host launcher.
- **Auto-discovery**: WSL distros are enumerated on Windows via `wsl.exe -l -q` (UTF-16LE-aware parser) and appear in the host picker and `--host` with zero config; an explicit `hosts.toml` entry (`kind = "wsl"`) overrides a discovered distro.
- Worktrees live in the distro's own Linux filesystem (not `/mnt/c`).
- `which_on_path` centralized into `paths` (de-dups the copy in `notifications`).
- Docs updated: CLAUDE.md, ADR-13, CONFIG.md, FEATURES.md.

## Test plan

- 1643 unit tests pass; new tests cover `wsl_command`, `TmuxTransport::Wsl`, `from_host` WSL, `git_command` WSL, `HostDef` kind/predicates/TOML parsing, `parse_wsl_distros` (UTF-16/BOM/UTF-8/infra-filter/empty), discovery dedup, the host picker, and `paths::which_on_path`.
- `clippy` clean, architecture rules pass, cross-compiles for `x86_64-pc-windows-gnu`.
- ⚠️ Command *construction* is unit-tested, but a **live `wsl.exe` round-trip needs on-Windows verification** — there is no WSL runner in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)