### PR TITLE
feat(ui): add find-in-diff search to the code-review view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1409,8 +1409,27 @@ code_review`.
   diff line to select/comment, click footer buttons, drag the scrollbar,
   wheel-scroll. **tuicr nav keys**: `j`/`k` + arrows, PageUp/Down + `Ctrl+D`/`U`,
   `g`/`G`, `{`/`}` (or Tab) next/prev file, `[`/`]` next/prev hunk. Every footer
-  button is labelled with its key (`Comment·c`, `Send→Agent·e`, …) so the
-  shortcuts are discoverable; the changed-files column shows a nav-key legend.
+  button is labelled with its key (`Comment·c`, `Send→Agent·e`, `Find·/`, …) so
+  the shortcuts are discoverable; the changed-files column shows a nav-key legend.
+- **Find in diff (`/`).** A `/`-triggered find sub-mode (also the `Find·/` footer
+  button, and `/` from the changed-files pane) searches every visible row's text
+  — file paths, hunk headings, diff line bodies, comment bodies (case-insensitive
+  literal substring) — via the pure `CodeReviewState::{row_text,search_matches}`.
+  It **mirrors the file viewer's find**: a bar at the top of the diff shows the
+  `/`-prefixed query, the match position / count, and key hints; typing is
+  incremental (the selection jumps to the first match live); while typing,
+  `Enter`/`↓`/`Ctrl+N` step to the next match and `↑`/`Ctrl+P` the previous (all
+  staying in the input), `Tab` commits (the bar stays for highlighting), and after
+  committing `n`/`N` step matches relative to the cursor (`cr_search_step` scans
+  from the selection + wraps, like the file viewer's `next_match`). `Esc` clears
+  the search (a second `Esc` closes the review). Matched runs are highlighted in
+  place with the shared `ui::highlight` accent+underline emphasis (on a matched
+  diff line the literal hit replaces syntax colour for that line). State is
+  `CodeReviewState::search: Option<ReviewSearch>` (the displayed position is
+  derived from the selection, not stored), captured before the global keybinding
+  lookup like compose / the target picker. Side-by-side diff rows navigate but
+  aren't substring-highlighted (a v1 follow-up); folded (reviewed) files
+  contribute only their header to the search until expanded.
 - **Colours.** Dedicated theme keys `diff_added`/`diff_removed` (line fg) and
   `diff_added_bg`/`diff_removed_bg` (a subtle full-row tint) — added to
   `ThemePalette` (all 15 presets derive them; bg blended toward `app_bg` via

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -1419,6 +1419,7 @@ fn open_minimal_review(h: &mut Harness) {
             commits: Vec::new(),
             host: None,
             target_picker: None,
+            search: None,
         },
     );
     h.app.focus = InputFocus::CodeReview;
@@ -1444,6 +1445,83 @@ fn review_toggle_key_closes_open_review() {
         InputFocus::CodeReview,
         "focus leaves the review when it closes"
     );
+}
+
+/// `/` opens find-in-diff (file-viewer pattern): typing jumps to the first
+/// match, `Tab` commits, `n`/`N` step matches relative to the cursor, and `Esc`
+/// clears the search before it closes the review.
+#[test]
+fn review_search_flow_finds_navigates_and_clears() {
+    let mut h = Harness::new(STD_COLS, STD_ROWS, 1);
+    let sid = h.app.sessions[0].info.id;
+    // Two files: src/f0.rs, src/f1.rs (each one added line).
+    h.app.code_reviews.insert(
+        sid,
+        crate::app::code_review::CodeReviewState::for_test(sid, 2),
+    );
+    h.app.focus = InputFocus::CodeReview;
+
+    // `/` enters the search sub-mode (capturing keys).
+    h.key(KeyCode::Char('/'), KeyModifiers::NONE);
+    assert!(h
+        .app
+        .active_review()
+        .and_then(|cr| cr.search.as_ref())
+        .is_some_and(|s| s.editing));
+
+    // Type ".rs" → matches both file headers; selection jumps to the first.
+    for c in ['.', 'r', 's'] {
+        h.key(KeyCode::Char(c), KeyModifiers::NONE);
+    }
+    let (first, second) = {
+        let cr = h.app.active_review().unwrap();
+        let s = cr.search.as_ref().unwrap();
+        assert_eq!(s.matches.len(), 2, "both file headers match '.rs'");
+        assert_eq!(cr.selected, s.matches[0], "jumps to the first match");
+        (s.matches[0], s.matches[1])
+    };
+
+    // Enter (while typing) steps to the next match without leaving the input.
+    h.key(KeyCode::Enter, KeyModifiers::NONE);
+    assert_eq!(h.app.active_review().unwrap().selected, second);
+    assert!(
+        h.app
+            .active_review()
+            .unwrap()
+            .search
+            .as_ref()
+            .unwrap()
+            .editing
+    );
+
+    // Tab commits: still open, no longer editing.
+    h.key(KeyCode::Tab, KeyModifiers::NONE);
+    assert!(h
+        .app
+        .active_review()
+        .and_then(|cr| cr.search.as_ref())
+        .is_some_and(|s| !s.editing));
+
+    // `n`/`N` step matches relative to the cursor (wrapping).
+    h.key(KeyCode::Char('n'), KeyModifiers::NONE);
+    assert_eq!(
+        h.app.active_review().unwrap().selected,
+        first,
+        "n from the last match wraps to the first"
+    );
+    h.key(KeyCode::Char('N'), KeyModifiers::NONE);
+    assert_eq!(
+        h.app.active_review().unwrap().selected,
+        second,
+        "N from the first match wraps to the last"
+    );
+
+    // Esc clears the search but keeps the review open; a second Esc closes it.
+    h.key(KeyCode::Esc, KeyModifiers::NONE);
+    assert!(h.app.active_review().is_some());
+    assert!(h.app.active_review().unwrap().search.is_none());
+    h.key(KeyCode::Esc, KeyModifiers::NONE);
+    assert!(h.app.active_review().is_none());
 }
 
 /// A review is per-session like the shell view: switching to another session

--- a/src/app/code_review.rs
+++ b/src/app/code_review.rs
@@ -71,6 +71,8 @@ pub(crate) enum ReviewButton {
     ToggleView,
     /// Open the review-target picker (branch / working / per-commit).
     Target,
+    /// Open the find-in-diff search.
+    Find,
 }
 
 /// One rendered row in the flattened review view (diff + interleaved comments +
@@ -93,6 +95,24 @@ impl ReviewRow {
     pub(crate) fn is_selectable(&self) -> bool {
         !matches!(self, ReviewRow::Info(_))
     }
+}
+
+/// In-review text search (the `/`-triggered find-in-diff sub-mode), mirroring
+/// the file viewer's find. Matches rows whose text — file paths, hunk headers,
+/// diff line bodies, and comment bodies — contains the query (case-insensitive).
+/// While [`Self::editing`] every key edits the query (the selection jumps to the
+/// first match as you type); `Enter`/`↓`/`Ctrl+N` step to the next match, `↑`/
+/// `Ctrl+P` the previous, and `Tab` commits — after which the bar stays for
+/// highlighting and `n`/`N` step matches just like the file viewer.
+pub(crate) struct ReviewSearch {
+    /// The query being typed (append-only editing, like the file viewer).
+    pub query: String,
+    /// Whether the query line is still being typed (captures all keys).
+    pub editing: bool,
+    /// Matching row indices (into [`CodeReviewState::rows`]), in row order. The
+    /// "current" position shown in the bar is derived from the selection, so
+    /// `n`/`N` always step relative to where the cursor actually is.
+    pub matches: Vec<usize>,
 }
 
 /// In-progress comment composition (an in-view sub-mode of the review).
@@ -139,6 +159,8 @@ pub(crate) struct CodeReviewState {
     pub host: Option<HostDef>,
     /// The open target picker, if any.
     pub target_picker: Option<TargetPickerState>,
+    /// The open find-in-diff search, if any (see [`ReviewSearch`]).
+    pub search: Option<ReviewSearch>,
 }
 
 impl ReviewTarget {
@@ -268,6 +290,10 @@ impl CodeReviewState {
         if self.selected >= self.rows.len() {
             self.selected = self.rows.len().saturating_sub(1);
         }
+        // Row indices shifted (a fold toggle, a new comment) — refresh any open
+        // search's match set so `n`/`N` and the highlight stay anchored to live
+        // rows. Selection is left where the caller put it.
+        self.refresh_search_matches();
     }
 
     /// Append one file's rows: the header, then (unless folded) its file-level
@@ -303,6 +329,60 @@ impl CodeReviewState {
         let add = self.files.iter().map(DiffFile::added_count).sum();
         let del = self.files.iter().map(DiffFile::deleted_count).sum();
         (add, del)
+    }
+
+    /// The searchable text of a row: the file path, the hunk section heading,
+    /// the diff line body, or the comment body. Drives both `/` search matching
+    /// and the in-row match highlight, so the two never disagree about what a
+    /// row "contains".
+    pub(crate) fn row_text(&self, row: &ReviewRow) -> Option<String> {
+        match row {
+            ReviewRow::FileHeader(fi) => self.files.get(*fi).map(|f| f.path.clone()),
+            ReviewRow::HunkHeader(fi, hi) => self
+                .files
+                .get(*fi)
+                .and_then(|f| f.hunks.get(*hi))
+                .map(|h| h.header.clone()),
+            ReviewRow::Line(fi, hi, li) => self
+                .files
+                .get(*fi)
+                .and_then(|f| f.hunks.get(*hi))
+                .and_then(|h| h.lines.get(*li))
+                .map(|l| l.text.clone()),
+            ReviewRow::Comment(id) | ReviewRow::Summary(id) => {
+                self.comment(*id).map(|c| c.body.clone())
+            }
+            ReviewRow::SummaryHeader | ReviewRow::Info(_) => None,
+        }
+    }
+
+    /// Row indices (into [`Self::rows`], in order) whose [`Self::row_text`]
+    /// contains `query` case-insensitively. Empty/whitespace query → no matches.
+    /// Pure so the search is unit-testable independent of [`App`].
+    pub(crate) fn search_matches(&self, query: &str) -> Vec<usize> {
+        let q = query.trim().to_lowercase();
+        if q.is_empty() {
+            return Vec::new();
+        }
+        (0..self.rows.len())
+            .filter(|&i| {
+                self.row_text(&self.rows[i])
+                    .is_some_and(|t| t.to_lowercase().contains(&q))
+            })
+            .collect()
+    }
+
+    /// Refresh the open search's match set against the current [`Self::rows`]
+    /// (no-op when no search is open). Called after the query changes and after
+    /// the rows are rebuilt so `n`/`N` + the highlight stay anchored to live rows.
+    pub(crate) fn refresh_search_matches(&mut self) {
+        let Some(query) = self.search.as_ref().map(|s| s.query.clone()) else {
+            return;
+        };
+        let matches = self.search_matches(&query);
+        if let Some(s) = self.search.as_mut() {
+            s.matches = matches;
+        }
     }
 }
 
@@ -410,6 +490,7 @@ impl App {
             commits,
             host,
             target_picker: None,
+            search: None,
         };
         // Install the bare state for this session, then load comments + marks +
         // build rows through the single shared path (`reload_review_data`).
@@ -662,11 +743,129 @@ impl App {
         }
     }
 
-    /// Rows that fit in the diff viewport (excluding the title + footer chrome).
+    /// Rows that fit in the diff viewport (excluding the title + footer chrome,
+    /// and the search bar when it is open).
     fn code_review_viewport(&self) -> usize {
-        // Central pane height minus the block border (2) and the footer bar (1).
+        // Central pane height minus the block border (2) and the footer bar (1),
+        // minus the search bar's row when a search is open.
         let (rows, _) = self.content_area_size();
-        (rows as usize).saturating_sub(3)
+        let search = usize::from(self.active_review().is_some_and(|cr| cr.search.is_some()));
+        (rows as usize).saturating_sub(3 + search)
+    }
+
+    // ── Search ───────────────────────────────────────────────────────────────
+
+    /// Open the find-in-diff search (`/`), capturing keystrokes into the query
+    /// until `Tab`/`Esc`. A fresh query starts empty.
+    pub(crate) fn cr_start_search(&mut self) {
+        if let Some(cr) = self.active_review_mut() {
+            cr.search = Some(ReviewSearch {
+                query: String::new(),
+                editing: true,
+                matches: Vec::new(),
+            });
+        }
+    }
+
+    /// Close the search entirely (drops the query + highlights).
+    pub(crate) fn cr_close_search(&mut self) {
+        if let Some(cr) = self.active_review_mut() {
+            cr.search = None;
+        }
+    }
+
+    /// `Tab`: commit the query — stop editing but keep the search open so the
+    /// matches stay highlighted and `n`/`N` step. An empty query just closes it
+    /// (mirrors the file viewer hiding its bar on an empty commit).
+    fn cr_commit_search(&mut self) {
+        let Some(cr) = self.active_review_mut() else {
+            return;
+        };
+        match cr.search.as_mut() {
+            Some(s) if s.query.trim().is_empty() => cr.search = None,
+            Some(s) => s.editing = false,
+            None => {}
+        }
+    }
+
+    /// Edit the query (append a char or backspace), then re-match and jump the
+    /// selection to the first match — the file viewer's incremental search.
+    fn cr_edit_search(&mut self, push: Option<char>) {
+        if let Some(cr) = self.active_review_mut() {
+            if let Some(s) = cr.search.as_mut() {
+                match push {
+                    Some(c) => s.query.push(c),
+                    None => {
+                        s.query.pop();
+                    }
+                }
+            }
+            cr.refresh_search_matches();
+        }
+        self.cr_jump_first_match();
+    }
+
+    /// Move the selection to the first match, if any.
+    fn cr_jump_first_match(&mut self) {
+        if let Some(cr) = self.active_review_mut() {
+            if let Some(&first) = cr.search.as_ref().and_then(|s| s.matches.first()) {
+                cr.selected = first;
+                cr.ensure_visible();
+            }
+        }
+    }
+
+    /// Step to the next/previous match (`n`/`N`, `Enter`/arrows while typing),
+    /// scanning from the current selection and wrapping — so it always moves
+    /// relative to the cursor, exactly like the file viewer's `next_match`.
+    pub(crate) fn cr_search_step(&mut self, forward: bool) {
+        let Some(cr) = self.active_review_mut() else {
+            return;
+        };
+        let Some(s) = cr.search.as_ref() else {
+            return;
+        };
+        if s.matches.is_empty() {
+            return;
+        }
+        let next = if forward {
+            // First match strictly after the selection, else wrap to the first.
+            s.matches
+                .iter()
+                .find(|&&i| i > cr.selected)
+                .copied()
+                .or_else(|| s.matches.first().copied())
+        } else {
+            // Last match strictly before the selection, else wrap to the last.
+            s.matches
+                .iter()
+                .rev()
+                .find(|&&i| i < cr.selected)
+                .copied()
+                .or_else(|| s.matches.last().copied())
+        };
+        if let Some(sel) = next {
+            cr.selected = sel;
+            cr.ensure_visible();
+        }
+    }
+
+    /// Key handling while the search query line is being typed, mirroring the
+    /// file viewer: `Enter`/`↓`/`Ctrl+N` next match, `↑`/`Ctrl+P` previous (all
+    /// stay in the input), `Tab` commits, `Esc` cancels, `Backspace`/chars edit.
+    fn handle_review_search_key(&mut self, code: KeyCode, mods: KeyModifiers) {
+        let ctrl = mods.contains(KeyModifiers::CONTROL);
+        match code {
+            KeyCode::Esc => self.cr_close_search(),
+            KeyCode::Enter | KeyCode::Down => self.cr_search_step(true),
+            KeyCode::Up => self.cr_search_step(false),
+            KeyCode::Tab => self.cr_commit_search(),
+            KeyCode::Char('n') if ctrl => self.cr_search_step(true),
+            KeyCode::Char('p') if ctrl => self.cr_search_step(false),
+            KeyCode::Backspace => self.cr_edit_search(None),
+            KeyCode::Char(c) if !ctrl => self.cr_edit_search(Some(c)),
+            _ => {}
+        }
     }
 
     // ── Comments ─────────────────────────────────────────────────────────────
@@ -948,6 +1147,7 @@ impl App {
             ReviewButton::CycleClass => self.cr_compose_cycle_class(true),
             ReviewButton::ToggleView => self.cr_toggle_side_by_side(),
             ReviewButton::Target => self.cr_open_target_picker(),
+            ReviewButton::Find => self.cr_start_search(),
         }
     }
 
@@ -1001,6 +1201,14 @@ impl App {
             self.handle_review_compose_key(code, mods);
             return true;
         }
+        // The search query line, while being typed, captures all keys.
+        let searching = self
+            .active_review()
+            .is_some_and(|cr| cr.search.as_ref().is_some_and(|s| s.editing));
+        if searching {
+            self.handle_review_search_key(code, mods);
+            return true;
+        }
 
         let ctrl = mods.contains(KeyModifiers::CONTROL);
         // Ctrl+D / Ctrl+U half-page (pager convention). Handled before the guard
@@ -1020,7 +1228,15 @@ impl App {
             return true;
         }
         match code {
+            // Esc clears an active (confirmed) search before closing the review,
+            // so a stray `/` is one keystroke to undo.
+            KeyCode::Esc if self.active_review().is_some_and(|cr| cr.search.is_some()) => {
+                self.cr_close_search()
+            }
             KeyCode::Esc => self.close_code_review(),
+            KeyCode::Char('/') => self.cr_start_search(),
+            KeyCode::Char('n') => self.cr_search_step(true),
+            KeyCode::Char('N') => self.cr_search_step(false),
             KeyCode::Down | KeyCode::Char('j') => self.cr_move(1),
             KeyCode::Up | KeyCode::Char('k') => self.cr_move(-1),
             KeyCode::PageDown => self.cr_page(true),
@@ -1103,6 +1319,12 @@ impl App {
             }
             KeyCode::Char('r') => self.cr_toggle_reviewed(false),
             KeyCode::Char('R') => self.cr_toggle_reviewed(true),
+            // `/` searches the diff: open the find sub-mode and drop into the
+            // diff pane, which the search input owns.
+            KeyCode::Char('/') => {
+                self.cr_start_search();
+                self.focus = InputFocus::CodeReview;
+            }
             _ => {}
         }
         true
@@ -1345,6 +1567,7 @@ impl CodeReviewState {
             commits: Vec::new(),
             host: None,
             target_picker: None,
+            search: None,
         };
         s.rebuild_rows();
         s
@@ -1409,6 +1632,7 @@ mod tests {
             commits: Vec::new(),
             host: None,
             target_picker: None,
+            search: None,
         };
         s.rebuild_rows();
         s
@@ -1742,6 +1966,74 @@ mod tests {
         let orphan = vec![line_comment(9, "gone.rs", 1, Classification::Note, "n")];
         let md = review_markdown(&[sample_file()], &orphan).unwrap();
         assert!(!md.contains("gone.rs"), "orphan file omitted: {md}");
+    }
+
+    #[test]
+    fn search_matches_diff_text_paths_and_comments() {
+        // sample_file: src/foo.rs with a "ctx" context line + an "added" line.
+        let s = state_with(
+            vec![sample_file()],
+            vec![line_comment(
+                1,
+                "src/foo.rs",
+                2,
+                Classification::Note,
+                "look here",
+            )],
+        );
+        // Diff line body.
+        let added: Vec<String> = s
+            .search_matches("added")
+            .iter()
+            .filter_map(|&i| s.row_text(&s.rows[i]))
+            .collect();
+        assert!(added.iter().any(|t| t == "added"));
+        // File path (case-insensitive).
+        assert!(!s.search_matches("FOO.RS").is_empty());
+        // Comment body.
+        assert!(s
+            .search_matches("look")
+            .iter()
+            .any(|&i| matches!(s.rows[i], ReviewRow::Comment(1))));
+        // No matches for absent text, and an empty/whitespace query matches nothing.
+        assert!(s.search_matches("zzz-nope").is_empty());
+        assert!(s.search_matches("   ").is_empty());
+    }
+
+    #[test]
+    fn refresh_search_matches_reanchors_after_rebuild() {
+        // A reviewed file folds to just its header on rebuild, so a match that
+        // lived on a now-hidden line must drop out of the refreshed match set.
+        let mut s = state_with(vec![sample_file()], vec![]);
+        s.search = Some(ReviewSearch {
+            query: "added".to_string(),
+            editing: false,
+            matches: Vec::new(),
+        });
+        s.refresh_search_matches();
+        assert_eq!(
+            s.search.as_ref().unwrap().matches.len(),
+            1,
+            "the 'added' diff line matches while the file is expanded"
+        );
+
+        // Folding the file (mark reviewed) hides its lines; rebuild must refresh
+        // the matches so none point at a vanished row.
+        s.reviewed_files.insert("src/foo.rs".into());
+        s.rebuild_rows();
+        assert!(
+            s.search.as_ref().unwrap().matches.is_empty(),
+            "the hidden line no longer matches after the file folds"
+        );
+    }
+
+    #[test]
+    fn search_matches_are_in_row_order() {
+        let s = state_with(vec![sample_file()], vec![]);
+        // "ctx" and "added" both contain no shared substring; query "d" hits the
+        // "added" line. Ensure indices are ascending.
+        let m = s.search_matches("d");
+        assert!(m.windows(2).all(|w| w[0] < w[1]));
     }
 
     #[test]

--- a/src/ui/code_review.rs
+++ b/src/ui/code_review.rs
@@ -67,9 +67,20 @@ pub(crate) fn render(
         };
     }
 
-    // Footer (buttons) is always the last row; the diff uses the rest.
+    // Footer (buttons) is always the last row; the diff uses the rest. A search
+    // bar, when open, takes the top row of what's left.
     let footer = Rect::new(inner.x, inner.y + inner.height - 1, inner.width, 1);
-    let diff_area = Rect::new(inner.x, inner.y, inner.width, inner.height - 1);
+    let mut diff_area = Rect::new(inner.x, inner.y, inner.width, inner.height - 1);
+    if state.search.is_some() && diff_area.height > 1 {
+        let search_row = Rect::new(diff_area.x, diff_area.y, diff_area.width, 1);
+        diff_area = Rect::new(
+            diff_area.x,
+            diff_area.y + 1,
+            diff_area.width,
+            diff_area.height - 1,
+        );
+        render_search_bar(frame, search_row, state);
+    }
 
     let composing = state.compose.is_some();
     // The target picker, when open, replaces the diff body (keyboard-driven).
@@ -167,9 +178,22 @@ fn render_rows(
     // Line-number column width from the largest number on screen.
     let num_w = line_number_width(state);
 
+    // The active search query (lowercased) drives the in-row match highlight.
+    let query = state
+        .search
+        .as_ref()
+        .map(|s| s.query.to_lowercase())
+        .filter(|q| !q.trim().is_empty());
+
     let mut lines: Vec<Line> = Vec::with_capacity(end - start);
     for i in start..end {
-        lines.push(row_line(state, i, content.width as usize, num_w));
+        lines.push(row_line(
+            state,
+            i,
+            content.width as usize,
+            num_w,
+            query.as_deref(),
+        ));
     }
     frame.render_widget(Paragraph::new(lines), content);
 
@@ -202,8 +226,15 @@ fn line_number_width(state: &CodeReviewState) -> usize {
     max.to_string().len().max(2)
 }
 
-/// Build the styled `Line` for row `i`.
-fn row_line<'a>(state: &CodeReviewState, i: usize, width: usize, num_w: usize) -> Line<'a> {
+/// Build the styled `Line` for row `i`. `query` (lowercased, non-empty) is the
+/// active find-in-diff search, used to highlight literal match runs in the row.
+fn row_line<'a>(
+    state: &CodeReviewState,
+    i: usize,
+    width: usize,
+    num_w: usize,
+    query: Option<&str>,
+) -> Line<'a> {
     let selected = i == state.selected;
     let sel_style = |base: Style| {
         if selected {
@@ -214,19 +245,21 @@ fn row_line<'a>(state: &CodeReviewState, i: usize, width: usize, num_w: usize) -
     };
 
     match &state.rows[i] {
-        ReviewRow::FileHeader(fi) => file_header_line(state, *fi, width, &sel_style),
-        ReviewRow::HunkHeader(fi, hi) => hunk_header_line(state, *fi, *hi, width, &sel_style),
+        ReviewRow::FileHeader(fi) => file_header_line(state, *fi, width, query, &sel_style),
+        ReviewRow::HunkHeader(fi, hi) => {
+            hunk_header_line(state, *fi, *hi, width, query, &sel_style)
+        }
         ReviewRow::Line(fi, hi, li) => {
             let f = &state.files[*fi];
             let l = &f.hunks[*hi].lines[*li];
             if state.side_by_side {
                 side_by_side_line(l, width, num_w, &sel_style)
             } else {
-                unified_diff_line(f, l, width, num_w, selected, &sel_style)
+                unified_diff_line(f, l, width, num_w, selected, query, &sel_style)
             }
         }
         ReviewRow::Comment(id) | ReviewRow::Summary(id) => {
-            comment_line(state, *id, width, sel_style)
+            comment_line(state, *id, width, query, sel_style)
         }
         ReviewRow::SummaryHeader => Line::from(Span::styled(
             truncate("── Review summary (s to add) ──", width),
@@ -250,6 +283,7 @@ fn file_header_line<'a>(
     state: &CodeReviewState,
     fi: usize,
     width: usize,
+    query: Option<&str>,
     sel_style: &impl Fn(Style) -> Style,
 ) -> Line<'a> {
     let f = &state.files[fi];
@@ -293,10 +327,12 @@ fn file_header_line<'a>(
                     .add_modifier(Modifier::BOLD),
             ),
         ),
-        Span::styled(mid, sel_style(header)),
+    ];
+    spans.extend(highlight_text(mid, sel_style(header), query));
+    spans.extend([
         Span::styled(adds, sel_style(Style::default().fg(Theme::diff_added()))),
         Span::styled(dels, sel_style(Style::default().fg(Theme::diff_removed()))),
-    ];
+    ]);
     if !mark.is_empty() {
         spans.push(Span::styled(
             mark.to_string(),
@@ -314,6 +350,7 @@ fn hunk_header_line<'a>(
     fi: usize,
     hi: usize,
     width: usize,
+    query: Option<&str>,
     sel_style: &impl Fn(Style) -> Style,
 ) -> Line<'a> {
     let f = &state.files[fi];
@@ -331,14 +368,12 @@ fn hunk_header_line<'a>(
         "  @@ -{},{} +{},{} @@ {}{}",
         h.old_start, old_span, h.new_start, new_span, h.header, mark
     );
-    Line::from(Span::styled(
-        truncate(&text, width),
-        sel_style(
-            Style::default()
-                .fg(Theme::accent())
-                .add_modifier(Modifier::DIM),
-        ),
-    ))
+    let base = sel_style(
+        Style::default()
+            .fg(Theme::accent())
+            .add_modifier(Modifier::DIM),
+    );
+    Line::from(highlight_text(truncate(&text, width), base, query))
 }
 
 /// A unified-diff line: a `old new ±` gutter plus the syntax-highlighted body,
@@ -350,6 +385,7 @@ fn unified_diff_line<'a>(
     width: usize,
     num_w: usize,
     selected: bool,
+    query: Option<&str>,
     sel_style: &impl Fn(Style) -> Style,
 ) -> Line<'a> {
     let (sign, row_bg) = match l.kind {
@@ -371,18 +407,33 @@ fn unified_diff_line<'a>(
         gutter,
         sel_style(bg(Style::default().fg(Theme::text_muted()))),
     )];
-    let lang = crate::ui::syntax::lang_for(&f.path);
+    // When a search query hits this line, highlight the literal matches over the
+    // plain text (search clarity wins over syntax colour on the matched line);
+    // otherwise render the syntax-highlighted tokens as usual.
+    let truncated: String = l.text.chars().take(avail).collect();
+    let positions = query
+        .map(|q| match_positions(&truncated, q))
+        .unwrap_or_default();
     let mut used = 0usize;
-    for (tok, tcolor) in crate::ui::syntax::highlight(&l.text, &lang) {
-        if used >= avail {
-            break;
-        }
-        let tok: String = tok.chars().take(avail - used).collect();
-        used += tok.chars().count();
-        spans.push(Span::styled(
-            tok,
-            sel_style(bg(Style::default().fg(tcolor))),
+    if !positions.is_empty() {
+        used = truncated.chars().count();
+        let base = sel_style(bg(Style::default().fg(Theme::text_primary())));
+        spans.extend(crate::ui::highlight::highlighted_spans_owned(
+            &truncated, &positions, base,
         ));
+    } else {
+        let lang = crate::ui::syntax::lang_for(&f.path);
+        for (tok, tcolor) in crate::ui::syntax::highlight(&l.text, &lang) {
+            if used >= avail {
+                break;
+            }
+            let tok: String = tok.chars().take(avail - used).collect();
+            used += tok.chars().count();
+            spans.push(Span::styled(
+                tok,
+                sel_style(bg(Style::default().fg(tcolor))),
+            ));
+        }
     }
     // Pad so the row tint fills the full width.
     if used < avail {
@@ -398,6 +449,7 @@ fn comment_line<'a>(
     state: &CodeReviewState,
     id: i64,
     width: usize,
+    query: Option<&str>,
     sel_style: impl Fn(Style) -> Style,
 ) -> Line<'a> {
     let Some(c) = state.comment(id) else {
@@ -414,20 +466,20 @@ fn comment_line<'a>(
         &format!("{first}{more}"),
         width.saturating_sub(badge.chars().count()),
     );
-    Line::from(vec![
-        Span::styled(
-            badge,
-            sel_style(
-                Style::default()
-                    .fg(class_color(c.classification))
-                    .add_modifier(Modifier::BOLD),
-            ),
+    let mut spans = vec![Span::styled(
+        badge,
+        sel_style(
+            Style::default()
+                .fg(class_color(c.classification))
+                .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(
-            body,
-            sel_style(Style::default().fg(Theme::text_secondary())),
-        ),
-    ])
+    )];
+    spans.extend(highlight_text(
+        body,
+        sel_style(Style::default().fg(Theme::text_secondary())),
+        query,
+    ));
+    Line::from(spans)
 }
 
 /// Render one diff line as two side-by-side cells (old | new). One source line
@@ -516,7 +568,7 @@ pub(crate) fn render_files_list(
     let hint_row = Rect::new(inner.x, inner.y + inner.height - 1, inner.width, 1);
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            truncate(" ↑↓ move · ↵ open · r seen", inner.width as usize),
+            truncate(" ↑↓ move · ↵ open · r seen · / find", inner.width as usize),
             Style::default().fg(Theme::text_muted()),
         ))),
         hint_row,
@@ -779,6 +831,7 @@ fn render_footer(
                 ButtonSpec::primary("Comment").with_hint("·c"),
                 ButtonSpec::primary("Send→Agent").with_hint("·e"),
                 ButtonSpec::secondary("Close").with_hint("·esc"),
+                ButtonSpec::secondary("Find").with_hint("·/"),
                 ButtonSpec::secondary("File").with_hint("·f"),
                 ButtonSpec::secondary("Summary").with_hint("·s"),
                 ButtonSpec::secondary("Reviewed").with_hint("·r"),
@@ -790,6 +843,7 @@ fn render_footer(
                 ReviewButton::Comment,
                 ReviewButton::SendToAgent,
                 ReviewButton::Close,
+                ReviewButton::Find,
                 ReviewButton::FileComment,
                 ReviewButton::Summary,
                 ReviewButton::MarkReviewed,
@@ -801,6 +855,85 @@ fn render_footer(
     };
     let hits = render_button_bar(frame, area, &specs, false);
     hits.into_iter().map(|h| (h, actions[h.index])).collect()
+}
+
+/// Byte offsets of every char inside a case-insensitive occurrence of `query`
+/// (already lowercased) within `text`. Non-overlapping, left-to-right. Feeds
+/// [`crate::ui::highlight::highlighted_spans_owned`] so search hits get the same
+/// accent+bold+underline emphasis as the fuzzy lists elsewhere in the app.
+fn match_positions(text: &str, query: &str) -> Vec<usize> {
+    if query.is_empty() {
+        return Vec::new();
+    }
+    let chars: Vec<(usize, char)> = text.char_indices().collect();
+    let q: Vec<char> = query.chars().collect();
+    let (n, m) = (chars.len(), q.len());
+    let mut positions = Vec::new();
+    let mut i = 0;
+    while i + m <= n {
+        let hit = (0..m).all(|k| chars[i + k].1.to_lowercase().eq(q[k].to_lowercase()));
+        if hit {
+            positions.extend((0..m).map(|k| chars[i + k].0));
+            i += m;
+        } else {
+            i += 1;
+        }
+    }
+    positions
+}
+
+/// Spans for `text` styled with `base`, with literal `query` hits highlighted
+/// when `query` (lowercased, non-empty) is set and matches; otherwise a single
+/// plain span. Owned so the spans can outlive a per-row `String`.
+fn highlight_text(text: String, base: Style, query: Option<&str>) -> Vec<Span<'static>> {
+    if let Some(q) = query {
+        let positions = match_positions(&text, q);
+        if !positions.is_empty() {
+            return crate::ui::highlight::highlighted_spans_owned(&text, &positions, base);
+        }
+    }
+    vec![Span::styled(text, base)]
+}
+
+/// Render the find-in-diff search bar (the top row of the diff area while a
+/// search is open): the `/`-prefixed query (with a caret while typing) plus the
+/// match position/count and key hints, so the shortcut stays discoverable.
+fn render_search_bar(frame: &mut Frame, area: Rect, state: &CodeReviewState) {
+    let Some(s) = state.search.as_ref() else {
+        return;
+    };
+    let style = Style::default().fg(Theme::search_bar());
+    let total = s.matches.len();
+    // The "current" position is derived from the selection (like the file
+    // viewer's `current_match_index`), so it stays correct after `n`/`N` or a
+    // plain `j`/`k` move; 0 when the cursor isn't on a match.
+    let current = s
+        .matches
+        .iter()
+        .position(|&i| i == state.selected)
+        .map(|p| p + 1)
+        .unwrap_or(0);
+    let count = if s.query.trim().is_empty() {
+        String::new()
+    } else if total == 0 {
+        "  no matches".to_string()
+    } else {
+        format!("  {current}/{total}")
+    };
+    let caret = if s.editing { "█" } else { "" };
+    let hint = if s.editing {
+        "   ↵/↓ next · ↑ prev · tab done · esc cancel"
+    } else {
+        "   n next · N prev · esc clear"
+    };
+    let text = format!("/{}{caret}{count}{hint}", s.query);
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            truncate(&text, area.width as usize),
+            style,
+        ))),
+        area,
+    );
 }
 
 /// Truncate `s` to `width` display columns (char-based; good enough for the
@@ -876,6 +1009,7 @@ mod tests {
             commits: Vec::new(),
             host: None,
             target_picker: None,
+            search: None,
         };
         s.rebuild_rows();
         s
@@ -973,6 +1107,46 @@ mod tests {
         assert_eq!(file_indices.len(), 3);
         assert!(
             file_indices.contains(&0) && file_indices.contains(&1) && file_indices.contains(&2)
+        );
+    }
+
+    #[test]
+    fn match_positions_finds_case_insensitive_runs() {
+        // "Foo bar foo" with query "foo" → two non-overlapping matches, each
+        // contributing one byte offset per char (3 chars → 3 offsets).
+        let pos = match_positions("Foo bar foo", "foo");
+        assert_eq!(pos, vec![0, 1, 2, 8, 9, 10]);
+        // No match → empty; empty query → empty.
+        assert!(match_positions("abc", "z").is_empty());
+        assert!(match_positions("abc", "").is_empty());
+    }
+
+    #[test]
+    fn renders_search_bar_and_highlights_match() {
+        let mut state = demo_state();
+        state.search = Some(crate::app::code_review::ReviewSearch {
+            query: "ctx".to_string(),
+            editing: true,
+            matches: state.search_matches("ctx"),
+        });
+        let mut term = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        term.draw(|f| {
+            let area = Rect::new(0, 0, 80, 20);
+            let _ = render(f, area, &mut state, FocusLevel::Focused);
+        })
+        .unwrap();
+        // The search bar prints the `/`-prefixed query somewhere on screen.
+        let buf = term.backend().buffer();
+        let mut screen = String::new();
+        for y in 0..20 {
+            for x in 0..80 {
+                screen.push_str(buf[(x, y)].symbol());
+            }
+            screen.push('\n');
+        }
+        assert!(
+            screen.contains("/ctx"),
+            "search bar shows the query: {screen}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds a `/`-triggered **find-in-diff** to the native code-review view (`Ctrl+X`/`F7`): searches every visible row — file paths, hunk headings, diff line bodies, and comment bodies — case-insensitively, and highlights matches in place via the shared `ui::highlight` emphasis.
- **Mirrors the file viewer's find**: incremental jump-to-first while typing; `Enter`/`↓`/`Ctrl+N` next, `↑`/`Ctrl+P` prev, `Tab` commits, then `n`/`N` step matches relative to the cursor; `Esc` clears (a second `Esc` closes the review).
- Shortcut is clearly surfaced: a `Find·/` footer button, a `/ find` hint in the changed-files legend, and the search bar's own key hints.
- State is `CodeReviewState::search`, captured before the global keybinding lookup like compose / the target picker; the displayed match position is derived from the selection.

## Test plan

- `cargo nextest run --all` (1660 tests pass), `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt --all --check`, `rumdl check` all clean.
- New unit tests for `search_matches`/`match_positions`/match ordering/`refresh_search_matches`, a render test for the bar + highlight, and an end-to-end acceptance test driving `/` → type → `Enter`/`Tab` → `n`/`N` → `Esc`.
- CI checks pass