### PR TITLE
feat(ui): clickable view-toggle buttons + central-pane tab strip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1613,10 +1613,17 @@ backend dependency stays visible at each call site.
   **Clickable buttons** reuse the same registry: `ui::render_button_bar`
   draws filled "pill" buttons (` Label ` on a solid accent/gray fill, no
   brackets) and returns `ui::ButtonHit`es. The bottom status-bar footer
-  renders Help/Settings/Theme/Quit pills (always shown — when the file
-  viewer is open its hints fill the space to their left), recorded as
-  `ClickAction::Global(Action)` (a click runs `dispatch_action`, ignored
-  while a modal is open). Every modal footer renders action buttons
+  renders Help/Tasks/Files/Shell/Review/Settings/Theme/Quit pills, each
+  suffixed with its live (rebindable) shortcut (`Help · F1`, an F-key
+  alternate where one exists, else the caret-ctrl chord `Quit · ^Q`). The
+  panel/pane toggles are feature-gated (Tasks/Files dropped when their panel
+  feature is off; the Shell/Review *view-toggle* pills are also dropped
+  *together* when the footer is too narrow to fit the full set
+  (`pill_block_width` vs the footer width) — so the essential
+  Settings/Theme/Quit pills never fall off). When the file viewer is open its
+  hints fill the space to their left.
+  Pills are recorded as `ClickAction::Global(Action)` (a click runs
+  `dispatch_action`, ignored while a modal is open). Every modal footer renders action buttons
   (Save/Cancel/Select/…) returned as `ui::ModalButtons` (each `ButtonHit`
   paired with the key it replays) and recorded as
   `ClickAction::ModalButton { code, mods }`; `handle_modal_click` replays
@@ -1637,6 +1644,33 @@ backend dependency stays visible at each call site.
   `[features] mouse` in settings.toml — disabled, mouse capture is
   never enabled and the terminal keeps native mouse behavior.
   `agent_picker_modal` drives the new-session flow.
+- **Central-pane tab strip.** The agent terminal, the per-session shell, and the
+  code-review view share the central pane, surfaced as a clickable tab strip
+  (`Agent · Shell · F8 · Review · F7`) painted on the pane's **top border** by
+  `App::draw_central_tabs`, which renders each tab as a filled **pill button**
+  (`ui::render_pill`, the standalone form of the footer's `render_button_bar`
+  chips) so it reads as clickable exactly like the Help/Tasks/… footer pills —
+  the active view is the accent-filled "primary" pill, the rest neutral
+  "secondary" pills (hover reverses the fill via the shared `is_button` path).
+  Each tab carries its toggle's live shortcut hint, preferring the **F-key**
+  alternate
+  (`tab_shortcut`) — a focused agent terminal passes `Ctrl+<letter>` chords
+  through to the CLI (`Ctrl+X` is emacs's prefix key, so it never reaches
+  `ToggleReview`), whereas the F-key dispatches in every pane. Agent has no
+  dedicated key (the Shell toggle returns to it), so it shows no hint.
+  Shell/Review tabs are gated by their feature
+  flags. `central_tab_cells` lays out the on-border hitboxes (recorded as
+  `ClickAction::CentralTab(CentralTab::{Agent,Shell,Review})` **before** the
+  pane's whole-rect focus fallback so a tab click wins); a click runs
+  `App::select_central_tab`, which *selects* the view (closing any open review
+  when switching to Agent/Shell, opening it for Review) — distinct from the
+  keyboard `Ctrl+T`/`Ctrl+X` *toggles*. So the central pane's session-info title
+  (`terminal_view`/`code_review`) is **right-aligned** (via `title_top` +
+  `ui::title_style`) to leave the border's left free for the tabs. The F-keys
+  switch views from **any** view: `ToggleShell` is a `review_escape_chord` (so an
+  open review lets F8 fall through to the global binding instead of swallowing
+  it), and `toggle_shell_view` is review-aware — with a review open it closes it
+  and lands on the shell, mirroring the Shell tab.
 - **`cli/`** — `thurbox-cli` subcommand dispatch (headless
   session ops + scheduling + editor command).
 

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -316,6 +316,25 @@ impl Harness {
         });
         self
     }
+
+    /// Render, then click the central-pane tab strip's cell for `tab` (returns
+    /// false when no such tab was rendered, e.g. its feature is off).
+    fn click_central_tab(&mut self, tab: CentralTab) -> bool {
+        self.render();
+        let rect = self.app.click_targets.iter().find_map(|t| match t.action {
+            ClickAction::CentralTab(found) if found == tab => Some(t.rect),
+            _ => None,
+        });
+        let Some(rect) = rect else {
+            return false;
+        };
+        self.app.update(AppMessage::MouseClick {
+            x: rect.x + 1,
+            y: rect.y,
+            modifiers: KeyModifiers::NONE,
+        });
+        true
+    }
 }
 
 // ── Snapshot tests: stable, deterministic screens ────────────────────────────
@@ -1201,6 +1220,113 @@ async fn ctrl_t_opens_shell_pane_on_spawnable_backend() {
         h.app.session_terminal_views.get(&id),
         Some(&TerminalView::Shell),
         "the active session now shows its shell view"
+    );
+}
+
+#[tokio::test]
+async fn central_tab_strip_switches_agent_and_shell_views() {
+    // The top-border tab strip is mouse-driven: clicking Shell flips to the
+    // shell view (spawning the pane), clicking Agent flips back.
+    let mut h = Harness::spawnable(1);
+    let id = h.app.sessions[0].info.id;
+    assert_eq!(h.app.active_central_tab(), CentralTab::Agent);
+
+    assert!(h.click_central_tab(CentralTab::Shell), "Shell tab rendered");
+    assert!(
+        h.app.sessions[0].shell_pane.is_some(),
+        "clicking Shell spawned the shell pane"
+    );
+    assert_eq!(
+        h.app.session_terminal_views.get(&id),
+        Some(&TerminalView::Shell),
+        "clicking Shell selects the shell view"
+    );
+    assert_eq!(h.app.active_central_tab(), CentralTab::Shell);
+
+    assert!(h.click_central_tab(CentralTab::Agent), "Agent tab rendered");
+    assert_eq!(
+        h.app.session_terminal_views.get(&id),
+        Some(&TerminalView::Claude),
+        "clicking Agent returns to the agent view"
+    );
+    assert_eq!(h.app.active_central_tab(), CentralTab::Agent);
+}
+
+#[tokio::test]
+async fn f8_leaves_open_review_for_the_shell() {
+    // With a review overlaying the central pane, F8 (ToggleShell) must reach the
+    // global binding (the review's key capture lets it fall through) and land on
+    // the shell — not silently flip the hidden terminal view behind the review.
+    let mut h = Harness::spawnable(1);
+    let sid = h.app.active_session_id().unwrap();
+    h.app
+        .code_reviews
+        .insert(sid, super::code_review::CodeReviewState::for_test(sid, 2));
+    h.app.focus = InputFocus::CodeReview;
+    assert_eq!(h.app.active_central_tab(), CentralTab::Review);
+
+    h.func(8); // F8 = ToggleShell
+
+    assert!(
+        h.app.active_review().is_none(),
+        "F8 closes the open review instead of being swallowed"
+    );
+    assert_eq!(
+        h.app.active_central_tab(),
+        CentralTab::Shell,
+        "F8 lands on the shell view"
+    );
+    assert_eq!(
+        h.app.focus,
+        InputFocus::Terminal,
+        "focus moves out of the (now closed) review to the terminal"
+    );
+    assert!(
+        h.app.sessions[0].shell_pane.is_some(),
+        "the shell pane was spawned"
+    );
+}
+
+#[tokio::test]
+async fn central_tab_strip_renders_labels_and_shortcuts() {
+    // The strip paints Agent/Shell/Review with each toggle's shortcut hint in
+    // the pane's top border (Agent has no dedicated key, so no hint).
+    let mut h = Harness::spawnable(1);
+    let screen = h.render();
+    // The tab strip is the pane border row carrying the Review toggle hint `F7`
+    // (anchored on it to avoid the "…Agent Orchestrator" header banner). The
+    // F-key form is shown, not `^X`, since a focused terminal passes Ctrl chords
+    // through to the agent.
+    let top = screen.lines().find(|l| l.contains("F7")).unwrap_or("");
+    for needle in ["Agent", "Shell", "F8", "Review", "F7"] {
+        assert!(
+            top.contains(needle),
+            "central tab strip missing {needle:?}: {top:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn central_tab_strip_omits_feature_gated_tabs() {
+    // Shell/Review tabs are gated by their feature flags; Agent always shows.
+    let mut h = Harness::spawnable(1);
+    h.app.features.shell_pane = false;
+    h.app.features.code_review = false;
+    h.render();
+
+    let tabs: Vec<CentralTab> = h
+        .app
+        .click_targets
+        .iter()
+        .filter_map(|t| match t.action {
+            ClickAction::CentralTab(tab) => Some(tab),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        tabs,
+        vec![CentralTab::Agent],
+        "only the Agent tab survives when Shell/Review features are off"
     );
 }
 

--- a/src/app/code_review.rs
+++ b/src/app/code_review.rs
@@ -1166,6 +1166,10 @@ impl App {
                     | crate::session::Action::FocusBackward
                     | crate::session::Action::QuitApp
                     | crate::session::Action::ToggleReview
+                    // The sibling central-pane view: `ToggleShell` (F8) leaves
+                    // the review straight to the shell, mirroring how the
+                    // Shell tab does — so the F-keys switch views from anywhere.
+                    | crate::session::Action::ToggleShell
                     | crate::session::Action::ToggleHelp
                     | crate::session::Action::OpenSettings
                     | crate::session::Action::OpenThemePicker

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -431,6 +431,9 @@ pub(crate) enum ClickAction {
     /// Jump the diff to the changed-file at this diff-file index (clicked in the
     /// changed-files list).
     ReviewFile(usize),
+    /// Select a central-pane view from the tab strip in the pane's top border
+    /// (Agent / Shell / Review). Dispatched by `activate_click_target`.
+    CentralTab(CentralTab),
 }
 
 /// One clickable region rendered this frame: its rect plus what a click on it
@@ -504,6 +507,17 @@ pub enum InputFocus {
 pub(crate) enum TerminalView {
     Claude,
     Shell,
+}
+
+/// The three mutually-exclusive central-pane views, surfaced as a clickable tab
+/// strip in the pane's top border. `Agent`/`Shell` map to [`TerminalView`];
+/// `Review` is the native code-review overlay. A tab click *selects* the view
+/// (see `App::select_central_tab`), unlike the keyboard toggles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CentralTab {
+    Agent,
+    Shell,
+    Review,
 }
 
 /// Holds a recently deleted session for undo (Ctrl+Z) support.
@@ -1974,44 +1988,106 @@ impl App {
     /// Toggle the terminal view between Claude and Shell for the active session.
     /// Lazily spawns the shell pane on first toggle.
     pub(crate) fn toggle_shell_view(&mut self) {
+        // A review overlays the central pane; F8/Ctrl+T leaves it straight to
+        // the shell (the user's "back to shell" expectation, same as the Shell
+        // tab) rather than silently flipping the hidden terminal view behind the
+        // review.
+        if self.active_review().is_some() {
+            self.select_central_tab(CentralTab::Shell);
+            return;
+        }
+        match self.active_terminal_view() {
+            TerminalView::Claude => self.show_shell_view(),
+            TerminalView::Shell => self.show_agent_view(),
+        }
+    }
+
+    /// Switch the active session's terminal view back to the agent CLI.
+    fn show_agent_view(&mut self) {
+        if let Some(sid) = self.active_session_id() {
+            self.session_terminal_views
+                .insert(sid, TerminalView::Claude);
+        }
+    }
+
+    /// Switch the active session's terminal view to its shell, creating the
+    /// shell pane on first use. Started in the same launch cwd as the agent (the
+    /// multi-repo workspace when there is one), so switching lands you there.
+    fn show_shell_view(&mut self) {
         let Some(session) = self.sessions.get(self.active_index) else {
             return;
         };
         let session_id = session.info.id;
-        let needs_shell = session.shell_pane.is_none();
+        if session.shell_pane.is_none() {
+            let (rows, cols) = self.content_area_size();
+            let Some(session) = self.active_session_mut() else {
+                // Active session removed concurrently — nothing to switch to.
+                return;
+            };
+            let shell_cwd = session_process_cwd(&session.info);
+            if let Err(e) = session.ensure_shell_pane(rows, cols, shell_cwd.as_deref()) {
+                error!("Failed to create shell pane: {e}");
+                self.set_error(format!("Failed to create shell: {e:#}"));
+                return;
+            }
+            self.save_state();
+        }
+        self.session_terminal_views
+            .insert(session_id, TerminalView::Shell);
+    }
 
-        let current = self
-            .session_terminal_views
-            .get(&session_id)
-            .copied()
-            .unwrap_or(TerminalView::Claude);
-
-        match current {
-            TerminalView::Claude => {
-                // Lazily create the shell pane if it doesn't exist. Start it in
-                // the same launch cwd as the agent (the multi-repo workspace when
-                // there is one), so switching to the terminal lands you there.
-                if needs_shell {
-                    let (rows, cols) = self.content_area_size();
-                    let Some(session) = self.active_session_mut() else {
-                        // Active session removed concurrently — nothing to toggle.
-                        return;
-                    };
-                    let shell_cwd = session_process_cwd(&session.info);
-                    if let Err(e) = session.ensure_shell_pane(rows, cols, shell_cwd.as_deref()) {
-                        error!("Failed to create shell pane: {e}");
-                        self.set_error(format!("Failed to create shell: {e:#}"));
-                        return;
-                    }
-                    self.save_state();
+    /// Select a central-pane view from the top-border tab strip. Unlike the
+    /// keyboard toggles this *selects* `tab` unambiguously: switching to
+    /// Agent/Shell closes any open review first, and Review opens the review if
+    /// it isn't already. Feature-gated tabs aren't rendered, so a click on a
+    /// disabled view can't arrive here.
+    pub(crate) fn select_central_tab(&mut self, tab: CentralTab) {
+        match tab {
+            CentralTab::Agent => {
+                if self.active_review().is_some() {
+                    self.close_code_review();
                 }
-                self.session_terminal_views
-                    .insert(session_id, TerminalView::Shell);
+                self.show_agent_view();
+                self.focus_central_terminal();
             }
-            TerminalView::Shell => {
-                self.session_terminal_views
-                    .insert(session_id, TerminalView::Claude);
+            CentralTab::Shell => {
+                if self.active_review().is_some() {
+                    self.close_code_review();
+                }
+                self.show_shell_view();
+                self.focus_central_terminal();
             }
+            CentralTab::Review => {
+                if self.active_review().is_none() {
+                    self.toggle_code_review();
+                }
+                // `toggle_code_review` can fail to open (e.g. no worktree); only
+                // grab focus when a review is actually present.
+                if self.active_review().is_some() && self.focus != InputFocus::CodeReview {
+                    self.focus = InputFocus::CodeReview;
+                    self.on_focus_changed();
+                }
+            }
+        }
+    }
+
+    /// Focus the central terminal pane (shared by the Agent/Shell tab clicks).
+    fn focus_central_terminal(&mut self) {
+        if self.focus != InputFocus::Terminal {
+            self.focus = InputFocus::Terminal;
+            self.on_focus_changed();
+        }
+    }
+
+    /// The central-pane tab currently shown: Review wins (it overlays the pane),
+    /// else the per-session terminal view.
+    pub(crate) fn active_central_tab(&self) -> CentralTab {
+        if self.active_review().is_some() {
+            CentralTab::Review
+        } else if self.active_terminal_view() == TerminalView::Shell {
+            CentralTab::Shell
+        } else {
+            CentralTab::Agent
         }
     }
 
@@ -2352,6 +2428,10 @@ impl App {
             ClickAction::ReviewFile(fi) => {
                 self.focus = InputFocus::ReviewFiles;
                 self.cr_jump_to_file(fi);
+                true
+            }
+            ClickAction::CentralTab(tab) => {
+                self.select_central_tab(tab);
                 true
             }
         }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -22,8 +22,22 @@ use crate::ui::{
     terminal_view, theme_picker_modal, worktree_name_modal,
 };
 
-use super::{App, ClickAction, ClickTarget, InputFocus, ScrollTarget, ScrollbarHit, TerminalView};
+use super::{
+    App, CentralTab, ClickAction, ClickTarget, InputFocus, ScrollTarget, ScrollbarHit, TerminalView,
+};
 use crate::ui::scrollbar::ScrollbarGeom;
+
+/// One laid-out central-pane tab (Agent/Shell/Review) on the pane's top border:
+/// its on-border rect (click target + paint position), the display label (with
+/// any shortcut baked in, e.g. `"Review · F7"`), and whether it's the active
+/// view. Rendered as a filled pill via `ui::render_pill`, exactly like the
+/// footer buttons, so it reads as clickable.
+struct CentralTabCell {
+    tab: CentralTab,
+    rect: Rect,
+    label: String,
+    active: bool,
+}
 
 impl App {
     pub fn view(&mut self, frame: &mut Frame) {
@@ -104,6 +118,7 @@ impl App {
                         | ClickAction::SelectFileRow(_)
                         | ClickAction::Global(_)
                         | ClickAction::ReviewButton(_)
+                        | ClickAction::CentralTab(_)
                         | ClickAction::PaneField { .. }
                 )
             };
@@ -122,7 +137,10 @@ impl App {
         // fg/modifiers intact.
         let is_button = matches!(
             target.action,
-            ClickAction::Global(_) | ClickAction::ModalButton { .. } | ClickAction::ReviewButton(_)
+            ClickAction::Global(_)
+                | ClickAction::ModalButton { .. }
+                | ClickAction::ReviewButton(_)
+                | ClickAction::CentralTab(_)
         );
         let hover_bg = if is_button {
             Theme::accent_bright()
@@ -546,15 +564,24 @@ impl App {
             return;
         }
 
-        // The native code-review view takes over the central pane whenever the
-        // active session has one open — persisted per session like the shell
-        // view, so it survives session switches.
+        // Agent terminal / shell / code-review all share the central pane and a
+        // clickable tab strip in its top border. Record the tab click targets
+        // *before* the pane renders its own whole-rect focus fallback, so a tab
+        // click wins over a plain pane-focus click. The review overlay takes the
+        // pane whenever the active session has one open (persisted per session
+        // like the shell view, so it survives session switches).
+        let tabs = self.central_tab_cells(terminal);
+        for cell in &tabs {
+            self.record_click(cell.rect, ClickAction::CentralTab(cell.tab));
+        }
         if self.active_review().is_some() {
             self.render_code_review_pane(frame, terminal);
-            return;
+        } else {
+            self.render_terminal_pane(frame, terminal);
         }
-
-        self.render_terminal_pane(frame, terminal);
+        // Drawn last so it overlays the pane's top border (the right-aligned
+        // session-info title leaves the left free for the tabs).
+        self.draw_central_tabs(frame, &tabs);
     }
 
     /// Render the open code-review view into the central pane (dimmed when not
@@ -635,6 +662,84 @@ impl App {
         self.record_scrollbar(geom, ScrollTarget::Terminal);
     }
 
+    /// Lay out the central-pane tab strip (Agent / Shell / Review) along the top
+    /// border of `area` as filled pill buttons. Each cell carries its on-border
+    /// rect (click target + paint position), its display label (shortcut baked
+    /// in), and whether it's the active view. Packing mirrors `render_button_bar`
+    /// (` label ` chip = label+2 wide, one-space gaps) so the recorded hitboxes
+    /// match the pills `draw_central_tabs` paints. Shell/Review are gated by
+    /// their feature flags; cells stop before the right edge so they never run
+    /// into the right-aligned session-info title.
+    fn central_tab_cells(&self, area: Rect) -> Vec<CentralTabCell> {
+        // No tabs on the empty "No Session" screen, or when the pane is too
+        // narrow to hold even one.
+        if area.width < 6 || area.height == 0 || self.sessions.get(self.active_index).is_none() {
+            return Vec::new();
+        }
+        let active = self.active_central_tab();
+        // (tab, name, action-for-shortcut). Agent has no dedicated key — the
+        // Shell toggle returns to it — so it shows no hint.
+        let mut specs: Vec<(CentralTab, &str, Option<crate::session::Action>)> =
+            vec![(CentralTab::Agent, "Agent", None)];
+        if self.features.shell_pane {
+            specs.push((
+                CentralTab::Shell,
+                "Shell",
+                Some(crate::session::Action::ToggleShell),
+            ));
+        }
+        if self.features.code_review {
+            specs.push((
+                CentralTab::Review,
+                "Review",
+                Some(crate::session::Action::ToggleReview),
+            ));
+        }
+
+        // Pack pills left-to-right starting one cell in from the rounded corner,
+        // separated by a one-space gap (which shows the border between chips),
+        // matching `render_button_bar`.
+        let mut x = area.x + 1;
+        let limit = area.x + area.width.saturating_sub(1);
+        let mut cells = Vec::with_capacity(specs.len());
+        for (i, (tab, name, action)) in specs.into_iter().enumerate() {
+            let gap = u16::from(i > 0);
+            let shortcut = action
+                .and_then(|a| crate::session::compact_shortcut(self.keybindings.chords_for(a)));
+            let label = match shortcut {
+                Some(sc) => format!("{name} · {sc}"),
+                None => name.to_string(),
+            };
+            // Pill width = ` label ` (label + one pad cell each side), per
+            // `ui::button_width` for a hint-less `ButtonSpec`.
+            let width = label.chars().count() as u16 + 2;
+            if x + gap + width > limit {
+                break; // out of room — drop the rest rather than overrun the title
+            }
+            x += gap;
+            cells.push(CentralTabCell {
+                tab,
+                rect: Rect::new(x, area.y, width, 1),
+                label,
+                active: tab == active,
+            });
+            x += width;
+        }
+        cells
+    }
+
+    /// Paint the central-pane tab strip onto the top border row as filled pill
+    /// buttons (same look as the footer Help/Tasks/… pills, so they read as
+    /// clickable). The active view is the accent-filled "primary" pill; the rest
+    /// are neutral "secondary" pills. One-space gaps between them leave the
+    /// pane's border showing, and the right-aligned session-info title is
+    /// untouched.
+    fn draw_central_tabs(&self, frame: &mut Frame, cells: &[CentralTabCell]) {
+        for cell in cells {
+            crate::ui::render_pill(frame, cell.rect, &cell.label, cell.active);
+        }
+    }
+
     /// Render the bottom status-bar footer.
     fn render_footer(&mut self, frame: &mut Frame, footer: Rect) {
         let is_shell_view = self.active_terminal_view() == TerminalView::Shell;
@@ -675,6 +780,8 @@ impl App {
                 file_viewer_open: self.show_file_viewer,
                 tasks_enabled: self.features.tasks,
                 file_viewer_enabled: self.features.file_viewer,
+                shell_pane_enabled: self.features.shell_pane,
+                code_review_enabled: self.features.code_review,
                 keybindings: &self.keybindings,
             },
         );

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -735,6 +735,23 @@ impl KeyChord {
         parts.join("+")
     }
 
+    /// A compact one-token label for tight UI (footer pills, central-pane tabs):
+    /// `ctrl+<letter>` as `^X`, a bare F-key as `F7`, else the full
+    /// [`display`](Self::display) notation.
+    pub fn compact(&self) -> String {
+        if self.mods == KeyModifiers::CONTROL {
+            if let KeyCode::Char(c) = self.code {
+                return format!("^{}", c.to_ascii_uppercase());
+            }
+        }
+        if let KeyCode::F(n) = self.code {
+            if self.mods.is_empty() {
+                return format!("F{n}");
+            }
+        }
+        self.display()
+    }
+
     /// Parse `"ctrl+n"`, `"f1"`, `"shift+pageup"`, `"cmd+j"`. Case-insensitive.
     /// `cmd`/`super`/`command`/`win` all mean the SUPER modifier (`cmd` is the
     /// canonical display form).
@@ -798,6 +815,20 @@ impl KeyChord {
 /// at the same time.
 pub fn contexts_overlap(a: KeyContext, b: KeyContext) -> bool {
     a == KeyContext::Global || b == KeyContext::Global || a == b
+}
+
+/// The compact shortcut hint for an action's bound `chords`, preferring a bare
+/// **F-key** alternate over the primary chord — the F-key fits a tight footer
+/// and dispatches even from a focused terminal (where a `Ctrl+<letter>` is
+/// passed through to the agent CLI). Falls back to the first chord's
+/// [`compact`](KeyChord::compact) form; `None` when there is no binding. Shared
+/// by the footer pills and the central-pane tab strip so they never drift.
+pub fn compact_shortcut(chords: &[KeyChord]) -> Option<String> {
+    chords
+        .iter()
+        .find(|c| matches!(c.code, KeyCode::F(_)) && c.mods.is_empty())
+        .or_else(|| chords.first())
+        .map(KeyChord::compact)
 }
 
 /// A user-editable map from `Action` to one or more chords.
@@ -1697,5 +1728,37 @@ mod tests {
                 Some(Action::FileViewerPrevMatch)
             );
         }
+    }
+
+    #[test]
+    fn compact_renders_ctrl_fkey_and_fallback() {
+        assert_eq!(KeyChord::ctrl('x').compact(), "^X");
+        assert_eq!(KeyChord::function(7).compact(), "F7");
+        // Non-ctrl, non-F-key falls back to the full display notation.
+        assert_eq!(
+            KeyChord {
+                mods: KeyModifiers::NONE,
+                code: KeyCode::Enter,
+            }
+            .compact(),
+            "enter"
+        );
+    }
+
+    #[test]
+    fn compact_shortcut_prefers_the_f_key_alternate() {
+        // ToggleReview is bound to [Ctrl+X, F7]; the hint must surface F7 (it
+        // dispatches from a focused terminal where Ctrl+X is passed through).
+        assert_eq!(
+            compact_shortcut(KeyBindings::default().chords_for(Action::ToggleReview)),
+            Some("F7".to_string())
+        );
+        // QuitApp has no F-key, so it falls back to the primary chord's caret.
+        assert_eq!(
+            compact_shortcut(KeyBindings::default().chords_for(Action::QuitApp)),
+            Some("^Q".to_string())
+        );
+        // No binding → no hint.
+        assert_eq!(compact_shortcut(&[]), None);
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -22,7 +22,7 @@ pub use host_def::{
     is_remote_backend, is_ssh_backend, is_wsl_backend, HostDef, HostKind, HostRegistry,
     SSH_BACKEND_PREFIX, WSL_BACKEND_PREFIX,
 };
-pub use keybindings::{Action, KeyBindings, KeyChord, KeyContext};
+pub use keybindings::{compact_shortcut, Action, KeyBindings, KeyChord, KeyContext};
 pub use message::SessionMessage;
 pub use review::{
     parse_unified_diff, Classification, CommentAnchor, DiffFile, DiffHunk, DiffLine, DiffLineKind,

--- a/src/ui/code_review.rs
+++ b/src/ui/code_review.rs
@@ -55,7 +55,10 @@ pub(crate) fn render(
     let (add, del) = state.totals();
     let target = state.target.label(&state.repos, &state.commits);
     let title = format!(" Code review · {target}  +{add} -{del} ");
-    let block = focus_block(&title, level);
+    // Right-aligned so the app-layer central-pane tab strip (Agent/Shell/Review)
+    // overlaid on the left of this top border has room.
+    let block = focus_block("", level)
+        .title_top(Line::from(Span::styled(title, crate::ui::title_style(level))).right_aligned());
     let inner = block.inner(area);
     frame.render_widget(block, area);
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -201,6 +201,25 @@ fn button_style(primary: bool) -> Style {
 /// than wrapped or clipped mid-glyph, so a narrow footer simply shows fewer
 /// buttons. The solid fill (not brackets) is what marks each label as a
 /// clickable button.
+/// Paint a single filled pill button (` label `, padded, on the solid
+/// primary/secondary fill) into `rect` — the standalone form of the chips
+/// [`render_button_bar`] packs, for callers that own their own layout (e.g. the
+/// central-pane tab strip painted on the pane border). `rect.width` should be
+/// the label width plus the two padding cells (` label `) so the fill spans the
+/// chip.
+pub fn render_pill(frame: &mut Frame, rect: Rect, label: &str, primary: bool) {
+    if rect.width == 0 || rect.height == 0 {
+        return;
+    }
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            format!(" {label} "),
+            button_style(primary),
+        ))),
+        rect,
+    );
+}
+
 pub fn render_button_bar(
     frame: &mut Frame,
     area: Rect,
@@ -509,30 +528,32 @@ pub enum FocusLevel {
 /// Focus is communicated by colour (bright accent vs plain accent vs gray)
 /// rather than border weight — every level uses rounded borders for a
 /// softer, opencode-style chrome.
-pub fn focus_block(title_text: &str, level: FocusLevel) -> Block<'_> {
+/// The title text style for a pane at the given focus level — shared by
+/// [`focus_block`] and callers that render a pane title themselves (e.g. a
+/// right-aligned session-info title alongside the central-pane tab strip).
+pub fn title_style(level: FocusLevel) -> Style {
     match level {
-        FocusLevel::Focused => Block::default()
-            .title(Line::from(Span::styled(title_text, Theme::focused_title())))
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Theme::accent_bright())),
-        FocusLevel::Active => Block::default()
-            .title(Line::from(Span::styled(
-                title_text,
-                Style::default().fg(Theme::accent()),
-            )))
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Theme::accent())),
-        FocusLevel::Inactive => Block::default()
-            .title(Line::from(Span::styled(
-                title_text,
-                Theme::unfocused_title(),
-            )))
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Theme::border_unfocused())),
+        FocusLevel::Focused => Theme::focused_title(),
+        FocusLevel::Active => Style::default().fg(Theme::accent()),
+        FocusLevel::Inactive => Theme::unfocused_title(),
     }
+}
+
+/// The border style for a pane at the given focus level.
+fn border_style_for(level: FocusLevel) -> Style {
+    match level {
+        FocusLevel::Focused => Style::default().fg(Theme::accent_bright()),
+        FocusLevel::Active => Style::default().fg(Theme::accent()),
+        FocusLevel::Inactive => Style::default().fg(Theme::border_unfocused()),
+    }
+}
+
+pub fn focus_block(title_text: &str, level: FocusLevel) -> Block<'_> {
+    Block::default()
+        .title(Line::from(Span::styled(title_text, title_style(level))))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(border_style_for(level))
 }
 
 /// Build a [`Block`] with focused or unfocused styling (backward compat).

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -6,11 +6,9 @@ use ratatui::{
     Frame,
 };
 
-use crossterm::event::{KeyCode, KeyModifiers};
-
 use super::theme::Theme;
 use crate::app::{StatusLevel, StatusMessage};
-use crate::session::{Action, KeyBindings, KeyChord};
+use crate::session::{Action, KeyBindings};
 
 fn brand_style() -> Style {
     Style::default()
@@ -85,6 +83,8 @@ pub struct FooterState<'a> {
     /// Feature flags gating the panel buttons (hidden when off).
     pub tasks_enabled: bool,
     pub file_viewer_enabled: bool,
+    pub shell_pane_enabled: bool,
+    pub code_review_enabled: bool,
     /// Live keybindings, so each footer pill can show its (rebindable) shortcut.
     pub keybindings: &'a KeyBindings,
 }
@@ -97,55 +97,50 @@ const FOOTER_BUTTONS: &[(&str, Action)] = &[
     ("Help", Action::ToggleHelp),
     ("Tasks", Action::FocusTasks),
     ("Files", Action::ToggleFileViewer),
+    ("Shell", Action::ToggleShell),
+    ("Review", Action::ToggleReview),
     ("Settings", Action::OpenSettings),
     ("Theme", Action::OpenThemePicker),
     ("Quit", Action::QuitApp),
 ];
 
 /// The footer buttons that survive the current feature flags, in render order.
-/// Tasks/Files are dropped when their panel feature is off (clicking a button
-/// that just toasts "disabled" would be noise).
-fn footer_entries(tasks_enabled: bool, file_viewer_enabled: bool) -> Vec<(&'static str, Action)> {
+/// The panel/pane toggles (Tasks/Files/Shell/Review) are dropped when their
+/// feature is off (clicking a button that just toasts "disabled" would be
+/// noise).
+fn footer_entries(flags: &FooterState<'_>) -> Vec<(&'static str, Action)> {
     FOOTER_BUTTONS
         .iter()
         .copied()
         .filter(|(_, action)| match action {
-            Action::FocusTasks => tasks_enabled,
-            Action::ToggleFileViewer => file_viewer_enabled,
+            Action::FocusTasks => flags.tasks_enabled,
+            Action::ToggleFileViewer => flags.file_viewer_enabled,
+            Action::ToggleShell => flags.shell_pane_enabled,
+            Action::ToggleReview => flags.code_review_enabled,
             _ => true,
         })
         .collect()
 }
 
-/// Compact shortcut hint for a footer pill. Prefers an F-key alternate (`F1`)
-/// since it's the narrowest in the tight footer, else the first chord in caret
-/// form (`^Q`). `None` when the action has no binding.
-fn footer_shortcut(chords: &[KeyChord]) -> Option<String> {
-    chords
-        .iter()
-        .find_map(|c| match c.code {
-            KeyCode::F(n) if c.mods.is_empty() => Some(format!("F{n}")),
-            _ => None,
-        })
-        .or_else(|| chords.first().map(caret_form))
-}
-
-/// Render a chord compactly for the footer: `ctrl+<char>` → `^Q` / `^,`;
-/// anything else falls back to the full `KeyChord::display()` notation.
-fn caret_form(chord: &KeyChord) -> String {
-    if chord.mods == KeyModifiers::CONTROL {
-        if let KeyCode::Char(c) = chord.code {
-            return format!("^{}", c.to_ascii_uppercase());
-        }
+/// Total width of the footer pill block: each pill is ` label ` (the label plus
+/// the two padding spaces) and pills are joined by a single-space separator.
+/// Mirrors `render_button_bar`'s packing so the responsive trim below agrees
+/// with what actually renders.
+fn pill_block_width(labels: &[String]) -> u16 {
+    if labels.is_empty() {
+        return 0;
     }
-    chord.display()
+    let pills: u16 = labels.iter().map(|l| l.chars().count() as u16 + 2).sum();
+    pills + labels.len() as u16 - 1
 }
 
 /// Render the footer bar and return each clickable button's hitbox paired with
 /// the `Action` it dispatches, packed against the right edge. Tasks/Files are
-/// gated by their feature flags. When the file viewer is open its navigation
-/// hints fill the space to the *left* of the buttons (right-aligned there) so
-/// both stay visible.
+/// gated by their feature flags. The view-toggle pills (Shell/Review) are
+/// *optional*: when the full set would overflow the footer they're dropped
+/// first, so the essential Settings/Theme/Quit pills never fall off a narrow
+/// terminal. When the file viewer is open its navigation hints fill the space
+/// to the *left* of the buttons (right-aligned there) so both stay visible.
 pub fn render_footer(
     frame: &mut Frame,
     area: Rect,
@@ -160,18 +155,32 @@ pub fn render_footer(
 
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 
-    let entries = footer_entries(state.tasks_enabled, state.file_viewer_enabled);
+    let mut entries = footer_entries(state);
     // Suffix each pill with its live shortcut (`Help · F1`); own the strings so
-    // the borrowed `ButtonSpec`s can reference them.
-    let labels: Vec<String> = entries
+    // the borrowed `ButtonSpec`s can reference them. Kept index-aligned with
+    // `entries` through the responsive trim below.
+    let mut labels: Vec<String> = entries
         .iter()
-        .map(
-            |(label, action)| match footer_shortcut(state.keybindings.chords_for(*action)) {
+        .map(|(label, action)| {
+            match crate::session::compact_shortcut(state.keybindings.chords_for(*action)) {
                 Some(sc) => format!("{label} · {sc}"),
                 None => label.to_string(),
-            },
-        )
+            }
+        })
         .collect();
+    // When the full set won't fit, drop *both* optional view-toggle pills
+    // together (so it's all-or-nothing, never a lone Shell or Review) rather
+    // than letting `render_button_bar` shed the rightmost essential pill.
+    if pill_block_width(&labels) > area.width {
+        let optional = |a: &Action| matches!(a, Action::ToggleShell | Action::ToggleReview);
+        labels = entries
+            .iter()
+            .zip(&labels)
+            .filter(|((_, a), _)| !optional(a))
+            .map(|(_, l)| l.clone())
+            .collect();
+        entries.retain(|(_, a)| !optional(a));
+    }
     let specs: Vec<super::ButtonSpec<'_>> = labels
         .iter()
         .map(|l| super::ButtonSpec::secondary(l))
@@ -361,6 +370,8 @@ mod tests {
             file_viewer_open,
             tasks_enabled: true,
             file_viewer_enabled: true,
+            shell_pane_enabled: true,
+            code_review_enabled: true,
             keybindings: test_keybindings(),
         }
     }
@@ -396,12 +407,14 @@ mod tests {
     #[test]
     fn footer_renders_all_buttons() {
         let (hits, line) = footer_render(false);
-        for label in ["Help", "Tasks", "Files", "Settings", "Theme", "Quit"] {
+        for label in [
+            "Help", "Tasks", "Files", "Shell", "Review", "Settings", "Theme", "Quit",
+        ] {
             assert!(line.contains(label), "missing {label} in footer: {line:?}");
         }
         // Each pill carries its live shortcut: an F-key alternate where one
-        // exists (Help · F1), else the caret-ctrl chord (Quit · ^Q).
-        for shortcut in ["F1", "^Q"] {
+        // exists (Help · F1, Review · F7), else the caret-ctrl chord (Quit · ^Q).
+        for shortcut in ["F1", "F7", "F8", "^Q"] {
             assert!(
                 line.contains(shortcut),
                 "missing shortcut {shortcut} in footer: {line:?}"
@@ -415,6 +428,8 @@ mod tests {
                 Action::ToggleHelp,
                 Action::FocusTasks,
                 Action::ToggleFileViewer,
+                Action::ToggleShell,
+                Action::ToggleReview,
                 Action::OpenSettings,
                 Action::OpenThemePicker,
                 Action::QuitApp,
@@ -422,12 +437,14 @@ mod tests {
         );
     }
 
-    /// Tasks/Files buttons are dropped when their feature is off.
+    /// The panel/pane-toggle buttons are dropped when their feature is off.
     #[test]
     fn footer_hides_panel_buttons_when_features_off() {
         let mut state = footer_state(false);
         state.tasks_enabled = false;
         state.file_viewer_enabled = false;
+        state.shell_pane_enabled = false;
+        state.code_review_enabled = false;
         let (hits, _) = render_footer_state(&state);
         assert_eq!(
             hit_actions(&hits),
@@ -439,6 +456,34 @@ mod tests {
             ],
             "only the non-panel buttons remain"
         );
+    }
+
+    /// On a narrow footer the optional view-toggle pills (Shell/Review) drop as
+    /// a pair, but the essential Settings/Theme/Quit pills always survive.
+    #[test]
+    fn footer_drops_view_toggles_when_narrow() {
+        let state = footer_state(false);
+        let backend = TestBackend::new(100, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut hits = Vec::new();
+        terminal
+            .draw(|f| hits = render_footer(f, Rect::new(0, 0, 100, 1), &state))
+            .unwrap();
+        let actions = hit_actions(&hits);
+        assert!(
+            !actions.contains(&Action::ToggleShell) && !actions.contains(&Action::ToggleReview),
+            "view-toggle pills drop together when the footer is too narrow: {actions:?}"
+        );
+        for essential in [
+            Action::OpenSettings,
+            Action::OpenThemePicker,
+            Action::QuitApp,
+        ] {
+            assert!(
+                actions.contains(&essential),
+                "essential pill {essential:?} must survive a narrow footer: {actions:?}"
+            );
+        }
     }
 
     /// The two panel buttons gate independently — a swapped flag in
@@ -463,7 +508,7 @@ mod tests {
         let (hits, line) = footer_render(true);
         assert_eq!(
             hits.len(),
-            6,
+            8,
             "buttons must remain when the file viewer is open"
         );
         assert!(line.contains("Quit"), "buttons still rendered: {line:?}");

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -1,6 +1,7 @@
 use ratatui::{
     layout::{Margin, Rect},
     style::{Color, Style},
+    text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
     Frame,
 };
@@ -52,7 +53,11 @@ pub fn render_terminal(
         }
     };
 
-    let block = focus_block(&title, level);
+    // The session-info title is right-aligned so the central-pane tab strip
+    // (Agent/Shell/Review), overlaid on the left of this same top border by the
+    // app layer, has room.
+    let block = focus_block("", level)
+        .title_top(Line::from(Span::styled(title, super::title_style(level))).right_aligned());
 
     let mut pseudo_term = PseudoTerminal::new(parser.screen())
         .block(block)
@@ -88,7 +93,6 @@ pub fn render_terminal(
 
 pub fn render_empty_terminal(frame: &mut Frame, area: Rect) {
     use ratatui::layout::{Alignment, Constraint, Direction, Layout};
-    use ratatui::text::{Line, Span};
 
     let block = Block::default()
         .title(" No Session ")


### PR DESCRIPTION
## Summary

Make the shell-pane and code-review toggles discoverable and clickable, and let the F-keys switch the central-pane view from anywhere.

- **Footer**: adds **Shell** / **Review** pills next to Help/Tasks/Files, each showing its live shortcut. They're feature-gated and responsively dropped together on a narrow footer so the essential Settings/Theme/Quit pills never fall off.
- **Central-pane tab strip**: an `Agent · Shell · F8 · Review · F7` strip painted on the pane's top border, rendered as **filled pill buttons** (`ui::render_pill`, same style as the footer) so it clearly reads as clickable. The active view is the accent "primary" pill. Clicking a tab selects that view (closing/opening the review as needed); the session-info title is right-aligned to make room.
- **Shortcut hints prefer the F-key form (F8/F7)**: a focused agent terminal passes `Ctrl+<letter>` through to the CLI (`Ctrl+X` is emacs's prefix key), so only the F-key dispatches there. Consolidated into the shared `keybindings::compact_shortcut` used by both surfaces.
- **F8/F7 switch views from any view**, including **leaving an open review for the shell** — `ToggleShell` is now a review escape chord and `toggle_shell_view` is review-aware.

## Test plan

- New acceptance tests: footer narrow-drop, tab switching, feature-gating, label/shortcut rendering, and F8-from-open-review.
- New unit tests for `compact_shortcut` / `KeyChord::compact`.
- Full lib suite (1635 tests) + clippy clean.