### PR TITLE
docs: note Windows support is experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ VERSION=v0.1.0 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/mai
 
 **Windows (PowerShell):**
 
+> [!NOTE]
+> Windows support is **experimental** for now. The core works (psmux as the
+> multiplexer, a native ConPTY backend, WSL distros as remote hosts), but it
+> sees less testing than Linux/macOS — expect rough edges and please report
+> issues.
+
 ```powershell
 irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex
 ```

--- a/packaging/chocolatey/thurbox.nuspec
+++ b/packaging/chocolatey/thurbox.nuspec
@@ -36,6 +36,9 @@ thurbox is a TUI for orchestrating multiple coding-agent CLI sessions
 Sessions survive crashes/restarts because the multiplexer keeps the processes
 alive.
 
+**Note:** Windows support is experimental for now — it sees less testing than
+Linux/macOS, so expect rough edges and please report issues.
+
 This package installs the prebuilt x86_64 Windows release binaries
 (`thurbox.exe` + `thurbox-cli.exe`) from the official GitHub Release and shims
 them onto your PATH.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -184,6 +184,8 @@ function Invoke-Install {
         Write-Warn "Added $InstallDir to your user PATH - restart your terminal for it to take effect."
     }
 
+    Write-Warn 'Windows support is experimental for now - expect rough edges and please report issues.'
+
     Write-Host "`nNext steps" -ForegroundColor Magenta
     Write-Step '* Install psmux (the Windows multiplexer): https://github.com/psmux/psmux'
     Write-Step '* Install a coding-agent CLI (claude, codex, antigravity, opencode, aider, ...)'

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -52,6 +52,15 @@ onThisPage:
           <pre data-wrap><code class="language-bash">VERSION=v0.1.0 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
 
           <h3>Windows (PowerShell)</h3>
+          <div class="info-box warning">
+            <p>
+              <strong>Experimental.</strong>
+              Windows support is experimental for now &mdash; the core works
+              (psmux as the multiplexer, a native ConPTY backend, WSL distros as
+              remote hosts), but it sees less testing than Linux/macOS. Expect
+              rough edges and please report issues.
+            </p>
+          </div>
           <p>
             On native Windows the install script is PowerShell. It installs to
             <code>%LOCALAPPDATA%\Programs\thurbox</code>


### PR DESCRIPTION
## Summary

- Add an "experimental" notice for Windows support across the user-facing surfaces: README (Windows install section), the PowerShell installer output, the website installation docs, and the Chocolatey package description.
- The notice clarifies the core works (psmux multiplexer, native ConPTY backend, WSL distros as remote hosts) but sees less testing than Linux/macOS — expect rough edges, please report issues.

## Test plan

- Docs/packaging only; CI checks pass