### PR TITLE
feat(ui): F-key-order footer/tab buttons and toggle-close theme/settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1613,15 +1613,15 @@ backend dependency stays visible at each call site.
   **Clickable buttons** reuse the same registry: `ui::render_button_bar`
   draws filled "pill" buttons (` Label ` on a solid accent/gray fill, no
   brackets) and returns `ui::ButtonHit`es. The bottom status-bar footer
-  renders Help/Tasks/Files/Shell/Review/Settings/Theme/Quit pills, each
-  suffixed with its live (rebindable) shortcut (`Help · F1`, an F-key
-  alternate where one exists, else the caret-ctrl chord `Quit · ^Q`). The
-  panel/pane toggles are feature-gated (Tasks/Files dropped when their panel
-  feature is off; the Shell/Review *view-toggle* pills are also dropped
-  *together* when the footer is too narrow to fit the full set
-  (`pill_block_width` vs the footer width) — so the essential
-  Settings/Theme/Quit pills never fall off). When the file viewer is open its
-  hints fill the space to their left.
+  renders Help/Info/Files/Theme/Tasks/Settings/Quit pills, ordered by F-key
+  (`Help · F1` … `Settings · F6`) with `Quit` last, each suffixed with its
+  live (rebindable) shortcut (an F-key alternate where one exists, else the
+  caret-ctrl chord `Quit · ^Q`). The panel toggles are feature-gated
+  (Info/Files/Tasks dropped when their panel feature is off; the same pills
+  are also dropped *together* when the footer is too narrow to fit the full
+  set (`pill_block_width` vs the footer width) — so the essential
+  Help/Theme/Settings/Quit pills never fall off). When the file viewer is open
+  its hints fill the space to their left.
   Pills are recorded as `ClickAction::Global(Action)` (a click runs
   `dispatch_action`, ignored while a modal is open). Every modal footer renders action buttons
   (Save/Cancel/Select/…) returned as `ui::ModalButtons` (each `ButtonHit`
@@ -1646,7 +1646,7 @@ backend dependency stays visible at each call site.
   `agent_picker_modal` drives the new-session flow.
 - **Central-pane tab strip.** The agent terminal, the per-session shell, and the
   code-review view share the central pane, surfaced as a clickable tab strip
-  (`Agent · Shell · F8 · Review · F7`) painted on the pane's **top border** by
+  (`Agent · Review · F7 · Shell · F8`) painted on the pane's **top border** by
   `App::draw_central_tabs`, which renders each tab as a filled **pill button**
   (`ui::render_pill`, the standalone form of the footer's `render_button_bar`
   chips) so it reads as clickable exactly like the Help/Tasks/… footer pills —

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -306,6 +306,13 @@ impl App {
     /// modal was open and consumed the key.
     pub(super) fn handle_modal_key_if_open(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
         use super::modals::Modal;
+        // Pressing a modal's own opener chord again dismisses it (toggle),
+        // mirroring the help overlay's F1-to-close. Routed as an `Esc` so each
+        // modal keeps its own dismissal semantics — the theme picker restores
+        // its live-preview original, the Settings panel discards its draft.
+        if self.modal_opener_pressed(code, mods) {
+            return self.handle_modal_key_if_open(KeyCode::Esc, KeyModifiers::NONE);
+        }
         match self.modal {
             Modal::RestoreSessions(_) => self.handle_restore_sessions_key(code),
             Modal::BranchSelector(_) => self.handle_branch_selector_key(code),
@@ -324,6 +331,22 @@ impl App {
             _ => return false,
         }
         true
+    }
+
+    /// Whether `code`/`mods` resolves to the action that *opens* the currently
+    /// open modal — i.e. the user re-pressed its toggle (e.g. `F4`/`Ctrl+Y`
+    /// with the theme picker open, `F6`/`Ctrl+,` with Settings open). Only the
+    /// self-toggling overlays opt in; the rest are dismissed only via `Esc`.
+    fn modal_opener_pressed(&self, code: KeyCode, mods: KeyModifiers) -> bool {
+        use super::modals::Modal;
+        let Some(action) = self.keybindings.lookup(code, mods) else {
+            return false;
+        };
+        match self.modal {
+            Modal::ThemePicker(_) => action == crate::session::Action::OpenThemePicker,
+            Modal::Settings(_) => action == crate::session::Action::OpenSettings,
+            _ => false,
+        }
     }
 
     /// Drive the Settings panel: edits a working copy, persists on `Ctrl+S`,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6850,6 +6850,29 @@ mod tests {
         assert_eq!(app.focus, InputFocus::SessionList);
     }
 
+    /// The theme picker's own opener chord (`F4`/`Ctrl+Y`) closes it when it's
+    /// already open, restoring the live-preview original like `Esc`.
+    #[test]
+    fn f4_toggles_theme_picker_closed() {
+        let mut app = app_with_sessions(1);
+        app.handle_key(KeyCode::F(4), KeyModifiers::NONE);
+        assert!(matches!(app.modal, modals::Modal::ThemePicker(_)));
+        // Re-pressing the opener dismisses it instead of being swallowed.
+        app.handle_key(KeyCode::F(4), KeyModifiers::NONE);
+        assert!(matches!(app.modal, modals::Modal::None));
+    }
+
+    /// The Settings panel's own opener chord (`F6`/`Ctrl+,`) closes it when it's
+    /// already open (discarding the draft, like `Esc`).
+    #[test]
+    fn f6_toggles_settings_closed() {
+        let mut app = app_with_sessions(1);
+        app.handle_key(KeyCode::F(6), KeyModifiers::NONE);
+        assert!(matches!(app.modal, modals::Modal::Settings(_)));
+        app.handle_key(KeyCode::F(6), KeyModifiers::NONE);
+        assert!(matches!(app.modal, modals::Modal::None));
+    }
+
     /// When the terminal is focused, readline/shell `Ctrl+<letter>` chords
     /// (here `Ctrl+W` = delete-word) defer to the PTY instead of running their
     /// thurbox command — but the same chord still works from the session list,

--- a/src/app/snapshots/thurbox__app__acceptance__automations_list_modal_empty.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__automations_list_modal_empty.snap
@@ -31,4 +31,4 @@ expression: h.render()
 ┌ Automations ──────────┐│                                                                         │
 │none                   ││                                                                         │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
- Sessions  0 session(s Help · F1 c Tasks · F5   Files · F3   Settings · F6   Theme · F4   Quit · ^Q
+ Sessions  Help · F1 s Info · F2 c Files · F3   Theme · F4   Tasks · F5   Settings · F6   Quit · ^Q

--- a/src/app/snapshots/thurbox__app__acceptance__empty_welcome_screen_renders.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__empty_welcome_screen_renders.snap
@@ -31,4 +31,4 @@ expression: h.render()
 ┌ Automations ──────────┐│                                                                         │
 │none                   ││                                                                         │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
- Sessions  0 session(s Help · F1 c Tasks · F5   Files · F3   Settings · F6   Theme · F4   Quit · ^Q
+ Sessions  Help · F1 s Info · F2 c Files · F3   Theme · F4   Tasks · F5   Settings · F6   Quit · ^Q

--- a/src/app/snapshots/thurbox__app__acceptance__help_overlay_lists_keybindings.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__help_overlay_lists_keybindings.snap
@@ -31,4 +31,4 @@ expression: h.render()
 ┌ Automations ──────────┐│                                                                         │
 │none                   ││                                                                         │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
- Sessions  0 session(s Help · F1 c Tasks · F5   Files · F3   Settings · F6   Theme · F4   Quit · ^Q
+ Sessions  Help · F1 s Info · F2 c Files · F3   Theme · F4   Tasks · F5   Settings · F6   Quit · ^Q

--- a/src/app/snapshots/thurbox__app__acceptance__restore_sessions_modal_empty.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__restore_sessions_modal_empty.snap
@@ -31,4 +31,4 @@ expression: h.render()
 ┌ Automations ──────────┐│                                                                         │
 │none                   ││                                                                         │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
- Sessions  0 session(s Help · F1 c Tasks · F5   Files · F3   Settings · F6   Theme · F4   Quit · ^Q
+ Sessions  Help · F1 s Info · F2 c Files · F3   Theme · F4   Tasks · F5   Settings · F6   Quit · ^Q

--- a/src/app/snapshots/thurbox__app__acceptance__theme_picker_lists_palettes.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__theme_picker_lists_palettes.snap
@@ -31,4 +31,4 @@ expression: h.render()
 ┌ Automations ──────────┐│                                                                         │
 │none                   ││                                                                         │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
- Sessions  0 session(s Help · F1 c Tasks · F5   Files · F3   Settings · F6   Theme · F4   Quit · ^Q
+ Sessions  Help · F1 s Info · F2 c Files · F3   Theme · F4   Tasks · F5   Settings · F6   Quit · ^Q

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -681,18 +681,19 @@ impl App {
         // Shell toggle returns to it — so it shows no hint.
         let mut specs: Vec<(CentralTab, &str, Option<crate::session::Action>)> =
             vec![(CentralTab::Agent, "Agent", None)];
-        if self.features.shell_pane {
-            specs.push((
-                CentralTab::Shell,
-                "Shell",
-                Some(crate::session::Action::ToggleShell),
-            ));
-        }
+        // Ordered by F-key (Review · F7 before Shell · F8) to match the footer.
         if self.features.code_review {
             specs.push((
                 CentralTab::Review,
                 "Review",
                 Some(crate::session::Action::ToggleReview),
+            ));
+        }
+        if self.features.shell_pane {
+            specs.push((
+                CentralTab::Shell,
+                "Shell",
+                Some(crate::session::Action::ToggleShell),
             ));
         }
 
@@ -780,8 +781,7 @@ impl App {
                 file_viewer_open: self.show_file_viewer,
                 tasks_enabled: self.features.tasks,
                 file_viewer_enabled: self.features.file_viewer,
-                shell_pane_enabled: self.features.shell_pane,
-                code_review_enabled: self.features.code_review,
+                info_panel_enabled: self.features.info_panel,
                 keybindings: &self.keybindings,
             },
         );

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -83,8 +83,7 @@ pub struct FooterState<'a> {
     /// Feature flags gating the panel buttons (hidden when off).
     pub tasks_enabled: bool,
     pub file_viewer_enabled: bool,
-    pub shell_pane_enabled: bool,
-    pub code_review_enabled: bool,
+    pub info_panel_enabled: bool,
     /// Live keybindings, so each footer pill can show its (rebindable) shortcut.
     pub keybindings: &'a KeyBindings,
 }
@@ -93,21 +92,22 @@ pub struct FooterState<'a> {
 /// dispatches. `render_footer` filters this by feature flags and returns the
 /// surviving `(ButtonHit, Action)` pairs so the click map can't drift from the
 /// render.
+///
+/// Ordered by F-key (`Help · F1`, `Info · F2`, … `Settings · F6`) with `Quit`
+/// last, so the row reads in the same order as the function-key alternates.
 const FOOTER_BUTTONS: &[(&str, Action)] = &[
     ("Help", Action::ToggleHelp),
-    ("Tasks", Action::FocusTasks),
+    ("Info", Action::ToggleInfoPanel),
     ("Files", Action::ToggleFileViewer),
-    ("Shell", Action::ToggleShell),
-    ("Review", Action::ToggleReview),
-    ("Settings", Action::OpenSettings),
     ("Theme", Action::OpenThemePicker),
+    ("Tasks", Action::FocusTasks),
+    ("Settings", Action::OpenSettings),
     ("Quit", Action::QuitApp),
 ];
 
 /// The footer buttons that survive the current feature flags, in render order.
-/// The panel/pane toggles (Tasks/Files/Shell/Review) are dropped when their
-/// feature is off (clicking a button that just toasts "disabled" would be
-/// noise).
+/// The panel toggles (Info/Files/Tasks) are dropped when their feature is off
+/// (clicking a button that just toasts "disabled" would be noise).
 fn footer_entries(flags: &FooterState<'_>) -> Vec<(&'static str, Action)> {
     FOOTER_BUTTONS
         .iter()
@@ -115,8 +115,7 @@ fn footer_entries(flags: &FooterState<'_>) -> Vec<(&'static str, Action)> {
         .filter(|(_, action)| match action {
             Action::FocusTasks => flags.tasks_enabled,
             Action::ToggleFileViewer => flags.file_viewer_enabled,
-            Action::ToggleShell => flags.shell_pane_enabled,
-            Action::ToggleReview => flags.code_review_enabled,
+            Action::ToggleInfoPanel => flags.info_panel_enabled,
             _ => true,
         })
         .collect()
@@ -135,12 +134,13 @@ fn pill_block_width(labels: &[String]) -> u16 {
 }
 
 /// Render the footer bar and return each clickable button's hitbox paired with
-/// the `Action` it dispatches, packed against the right edge. Tasks/Files are
-/// gated by their feature flags. The view-toggle pills (Shell/Review) are
-/// *optional*: when the full set would overflow the footer they're dropped
-/// first, so the essential Settings/Theme/Quit pills never fall off a narrow
-/// terminal. When the file viewer is open its navigation hints fill the space
-/// to the *left* of the buttons (right-aligned there) so both stay visible.
+/// the `Action` it dispatches, packed against the right edge. Info/Files/Tasks
+/// are gated by their feature flags, and the panel-toggle pills (Info/Files/
+/// Tasks) are *optional*: when the full set would overflow the footer they're
+/// dropped together, so the essential Help/Theme/Settings/Quit pills never fall
+/// off a narrow terminal. When the file viewer is open its navigation hints
+/// fill the space to the *left* of the buttons (right-aligned there) so both
+/// stay visible.
 pub fn render_footer(
     frame: &mut Frame,
     area: Rect,
@@ -168,11 +168,16 @@ pub fn render_footer(
             }
         })
         .collect();
-    // When the full set won't fit, drop *both* optional view-toggle pills
-    // together (so it's all-or-nothing, never a lone Shell or Review) rather
-    // than letting `render_button_bar` shed the rightmost essential pill.
+    // When the full set won't fit, drop the optional panel-toggle pills
+    // together (all-or-nothing) rather than letting `render_button_bar` shed
+    // the rightmost essential pill (Quit).
     if pill_block_width(&labels) > area.width {
-        let optional = |a: &Action| matches!(a, Action::ToggleShell | Action::ToggleReview);
+        let optional = |a: &Action| {
+            matches!(
+                a,
+                Action::ToggleInfoPanel | Action::ToggleFileViewer | Action::FocusTasks
+            )
+        };
         labels = entries
             .iter()
             .zip(&labels)
@@ -266,8 +271,8 @@ fn push_idle_counts<'a>(spans: &mut Vec<Span<'a>>, state: &FooterState<'a>) {
 
 fn push_shortcut_hints(spans: &mut Vec<Span<'_>>) {
     // Focus stays an informational hint (no single click target); the footer
-    // buttons (Help / Tasks / Files / Settings / Theme / Quit) are rendered as
-    // right-aligned clickable pills.
+    // buttons (Help / Info / Files / Theme / Tasks / Settings / Quit) are
+    // rendered as right-aligned clickable pills.
     let bold_key = Theme::keybind().add_modifier(Modifier::BOLD);
     let desc = Theme::keybind_desc();
     spans.extend([
@@ -370,8 +375,7 @@ mod tests {
             file_viewer_open,
             tasks_enabled: true,
             file_viewer_enabled: true,
-            shell_pane_enabled: true,
-            code_review_enabled: true,
+            info_panel_enabled: true,
             keybindings: test_keybindings(),
         }
     }
@@ -408,30 +412,29 @@ mod tests {
     fn footer_renders_all_buttons() {
         let (hits, line) = footer_render(false);
         for label in [
-            "Help", "Tasks", "Files", "Shell", "Review", "Settings", "Theme", "Quit",
+            "Help", "Info", "Files", "Theme", "Tasks", "Settings", "Quit",
         ] {
             assert!(line.contains(label), "missing {label} in footer: {line:?}");
         }
         // Each pill carries its live shortcut: an F-key alternate where one
-        // exists (Help · F1, Review · F7), else the caret-ctrl chord (Quit · ^Q).
-        for shortcut in ["F1", "F7", "F8", "^Q"] {
+        // exists (Help · F1, Info · F2), else the caret-ctrl chord (Quit · ^Q).
+        for shortcut in ["F1", "F2", "^Q"] {
             assert!(
                 line.contains(shortcut),
                 "missing shortcut {shortcut} in footer: {line:?}"
             );
         }
-        // Every button maps back to its Action, in render order — guards the
-        // index→action remapping in `render_footer`.
+        // Every button maps back to its Action, in render order (F-key order,
+        // Quit last) — guards the index→action remapping in `render_footer`.
         assert_eq!(
             hit_actions(&hits),
             vec![
                 Action::ToggleHelp,
-                Action::FocusTasks,
+                Action::ToggleInfoPanel,
                 Action::ToggleFileViewer,
-                Action::ToggleShell,
-                Action::ToggleReview,
-                Action::OpenSettings,
                 Action::OpenThemePicker,
+                Action::FocusTasks,
+                Action::OpenSettings,
                 Action::QuitApp,
             ]
         );
@@ -443,38 +446,41 @@ mod tests {
         let mut state = footer_state(false);
         state.tasks_enabled = false;
         state.file_viewer_enabled = false;
-        state.shell_pane_enabled = false;
-        state.code_review_enabled = false;
+        state.info_panel_enabled = false;
         let (hits, _) = render_footer_state(&state);
         assert_eq!(
             hit_actions(&hits),
             vec![
                 Action::ToggleHelp,
-                Action::OpenSettings,
                 Action::OpenThemePicker,
+                Action::OpenSettings,
                 Action::QuitApp,
             ],
             "only the non-panel buttons remain"
         );
     }
 
-    /// On a narrow footer the optional view-toggle pills (Shell/Review) drop as
-    /// a pair, but the essential Settings/Theme/Quit pills always survive.
+    /// On a narrow footer the optional panel-toggle pills (Info/Files/Tasks)
+    /// drop together, but the essential Help/Theme/Settings/Quit pills always
+    /// survive.
     #[test]
     fn footer_drops_view_toggles_when_narrow() {
         let state = footer_state(false);
-        let backend = TestBackend::new(100, 1);
+        let backend = TestBackend::new(70, 1);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut hits = Vec::new();
         terminal
-            .draw(|f| hits = render_footer(f, Rect::new(0, 0, 100, 1), &state))
+            .draw(|f| hits = render_footer(f, Rect::new(0, 0, 70, 1), &state))
             .unwrap();
         let actions = hit_actions(&hits);
         assert!(
-            !actions.contains(&Action::ToggleShell) && !actions.contains(&Action::ToggleReview),
-            "view-toggle pills drop together when the footer is too narrow: {actions:?}"
+            !actions.contains(&Action::ToggleInfoPanel)
+                && !actions.contains(&Action::ToggleFileViewer)
+                && !actions.contains(&Action::FocusTasks),
+            "panel-toggle pills drop together when the footer is too narrow: {actions:?}"
         );
         for essential in [
+            Action::ToggleHelp,
             Action::OpenSettings,
             Action::OpenThemePicker,
             Action::QuitApp,
@@ -508,7 +514,7 @@ mod tests {
         let (hits, line) = footer_render(true);
         assert_eq!(
             hits.len(),
-            8,
+            7,
             "buttons must remain when the file viewer is open"
         );
         assert!(line.contains("Quit"), "buttons still rendered: {line:?}");


### PR DESCRIPTION
## Summary

- Reorder the bottom footer pills by their function-key alternate (`Help·F1 … Settings·F6`) with `Quit` last; drop the `Shell`/`Review` pills and add an `Info` panel pill.
- Order the central-pane tab strip the same way — `Review·F7` before `Shell·F8`.
- Pressing a modal's own opener chord again now closes it: `F4`/`Ctrl+Y` toggles the theme picker, `F6`/`Ctrl+,` toggles Settings (mirroring the help overlay's `F1`-to-close). Routed as an `Esc` so each modal keeps its dismissal semantics (theme picker restores its live-preview original; Settings discards its draft).

## Test plan

- `cargo nextest run --all` — 1671 passed
- `cargo clippy --all-targets` — clean
- Updated footer unit tests + new `f4_toggles_theme_picker_closed` / `f6_toggles_settings_closed`; regenerated the 5 acceptance snapshots that pin the footer.
- CI checks pass