### PR TITLE
fix(ui): cover all TUI assets with their feature flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1907,7 +1907,12 @@ Feature flags that gate UI panels (`tasks`, `file_viewer`, `info_panel`,
 `global_search`, `shell_pane`, `code_review`, `soft_delete`) are read from `App.features`
 every frame, so `submit_settings_panel` copies the draft's flags into
 `self.features` (via `App::apply_live_settings`) and they take effect
-immediately. Everything else is read once at startup from the write-once
+immediately. `apply_live_settings` also runs `enforce_feature_visibility`,
+which tears down any surface a now-disabled live flag left open (the `show_*`
+panel toggles, a session's open shell view, an open code review) and moves
+focus off it — otherwise the panel would keep rendering with its tab/footer
+affordance gone. Each branch only forces the *hidden* state, so re-enabling a
+flag never re-opens anything. Everything else is read once at startup from the write-once
 `settings::global()` `OnceLock` (which can't be re-applied in-process):
 those rows are marked `⟳`, and a save that changes one toasts "some changes
 apply after restart".

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -1310,25 +1310,79 @@ async fn central_tab_strip_renders_labels_and_shortcuts() {
 
 #[tokio::test]
 async fn central_tab_strip_omits_feature_gated_tabs() {
-    // Shell/Review tabs are gated by their feature flags; Agent always shows.
+    // Shell/Review tabs are gated by their feature flags. With both off, only
+    // the Agent pill would remain — a tab strip you can't switch away from — so
+    // the whole strip is suppressed rather than advertising a lone dead tab.
     let mut h = Harness::spawnable(1);
+    let collect_tabs = |app: &super::App| -> Vec<CentralTab> {
+        app.click_targets
+            .iter()
+            .filter_map(|t| match t.action {
+                ClickAction::CentralTab(tab) => Some(tab),
+                _ => None,
+            })
+            .collect()
+    };
+
+    // Only one alternate view gated off → the strip stays (Agent + the other).
+    h.app.features.shell_pane = false;
+    h.app.features.code_review = true;
+    h.render();
+    assert_eq!(
+        collect_tabs(&h.app),
+        vec![CentralTab::Agent, CentralTab::Review],
+        "Review survives when only Shell is gated off"
+    );
+
+    // Both alternate views gated off → no tab strip at all.
     h.app.features.shell_pane = false;
     h.app.features.code_review = false;
     h.render();
+    assert!(
+        collect_tabs(&h.app).is_empty(),
+        "the lone Agent tab is dropped when Shell and Review are both off"
+    );
+}
 
-    let tabs: Vec<CentralTab> = h
-        .app
-        .click_targets
-        .iter()
-        .filter_map(|t| match t.action {
-            ClickAction::CentralTab(tab) => Some(tab),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(
-        tabs,
-        vec![CentralTab::Agent],
-        "only the Agent tab survives when Shell/Review features are off"
+/// The F2 info panel lists upcoming automation runs. When the `automations`
+/// feature is off the TUI never fires those schedules (and the pane is hidden),
+/// so the info panel must not surface them either — even though the cache is
+/// still loaded from the DB.
+#[tokio::test]
+async fn info_panel_hides_automations_when_feature_off() {
+    use crate::session::{Automation, AutomationAction, AutomationSchedule};
+    let mut h = Harness::spawnable(1);
+    h.app.show_info_panel = true;
+    let far_future = crate::sync::current_time_millis() + 3_600_000;
+    h.app.automation_ui.cached_automations = vec![Automation {
+        id: 1,
+        name: "infopanelnightly".into(),
+        enabled: true,
+        schedule: AutomationSchedule::Once { at: 0 },
+        timezone: None,
+        action: AutomationAction::Send {
+            session_id: SessionId::default(),
+        },
+        prompt: "p".into(),
+        created_at: 0,
+        updated_at: 0,
+        last_run_at: None,
+        next_run_at: Some(far_future),
+    }];
+
+    // Feature on: the info panel's automations section lists it.
+    h.app.features.automations = true;
+    assert!(
+        h.render().contains("infopanelnightly"),
+        "info panel surfaces the upcoming automation when the feature is on"
+    );
+
+    // Feature off: the pane is hidden *and* the info-panel section is dropped,
+    // so the automation appears nowhere.
+    h.app.features.automations = false;
+    assert!(
+        !h.render().contains("infopanelnightly"),
+        "info panel must not surface automations when the feature is off"
     );
 }
 
@@ -1504,6 +1558,49 @@ fn perf_idle_iterations_skip_the_paint() {
     assert_eq!(requested, 1, "only the initial dirty frame paints");
     assert_eq!(skipped, 4, "idle iterations skip the expensive draw");
     assert_eq!(h.app.perf_counters().redraws_skipped, 4);
+}
+
+/// Disabling a live feature flag at runtime tears down whatever panel/view it
+/// had left open (otherwise the panel keeps rendering with its tab/footer
+/// affordance gone). Covers the `apply_live_settings` → `enforce_feature_visibility`
+/// path the settings panel and config-reload both run.
+#[tokio::test]
+async fn disabling_a_live_feature_tears_down_its_open_surfaces() {
+    let mut h = Harness::spawnable(1);
+    let sid = h.app.sessions[0].info.id;
+
+    // Open every live-gated surface, and park focus on the file viewer.
+    h.app.show_info_panel = true;
+    h.app.show_file_viewer = true;
+    h.app.show_tasks_panel = true;
+    h.app
+        .session_terminal_views
+        .insert(sid, TerminalView::Shell);
+    open_minimal_review(&mut h);
+    h.app.focus = InputFocus::FileViewer;
+
+    // Flip the live UI feature flags off and re-apply (as the settings panel does).
+    let mut settings = crate::session::settings::Settings::default();
+    settings.features.info_panel = false;
+    settings.features.file_viewer = false;
+    settings.features.tasks = false;
+    settings.features.shell_pane = false;
+    settings.features.code_review = false;
+    h.app.apply_live_settings(&settings);
+
+    assert!(!h.app.show_info_panel, "info panel hidden");
+    assert!(!h.app.show_file_viewer, "file viewer hidden");
+    assert!(!h.app.show_tasks_panel, "tasks panel hidden");
+    assert_eq!(
+        h.app.session_terminal_views.get(&sid).copied(),
+        Some(TerminalView::Claude),
+        "shell view reverted to the agent view"
+    );
+    assert!(h.app.code_reviews.is_empty(), "open review closed");
+    assert!(
+        matches!(h.app.focus, InputFocus::SessionList),
+        "focus moved off the now-hidden file viewer"
+    );
 }
 
 /// `dispatch_action` partitions `Action` across several sub-dispatchers whose

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1021,7 +1021,61 @@ impl App {
     /// the settings panel's save path and the live-reload poll.
     pub(crate) fn apply_live_settings(&mut self, settings: &crate::session::settings::Settings) {
         self.features = settings.features;
+        self.enforce_feature_visibility();
         self.resize_sessions_to_content_area();
+    }
+
+    /// Tear down any panel/view/focus that a now-disabled live feature flag
+    /// leaves stranded. The open-state booleans (`show_*`), the per-session
+    /// shell views, and the open code reviews are all opt-in toggles that
+    /// survive a flag flip, so without this a feature disabled at runtime would
+    /// keep rendering its panel even though its tab/footer affordance is gone.
+    /// Each branch only forces the *hidden* state, so it's idempotent and never
+    /// re-opens anything when a flag is turned back on.
+    fn enforce_feature_visibility(&mut self) {
+        if !self.features.info_panel {
+            self.show_info_panel = false;
+        }
+        if !self.features.file_viewer {
+            self.show_file_viewer = false;
+            if self.focus == InputFocus::FileViewer {
+                self.focus = InputFocus::SessionList;
+            }
+        }
+        if !self.features.tasks {
+            self.show_tasks_panel = false;
+            if matches!(self.focus, InputFocus::TaskList | InputFocus::TaskEditor) {
+                self.focus = InputFocus::SessionList;
+            }
+        }
+        if !self.features.automations
+            && matches!(
+                self.focus,
+                InputFocus::Automations
+                    | InputFocus::AutomationEditor
+                    | InputFocus::AutomationRunHistory
+            )
+        {
+            self.focus = InputFocus::SessionList;
+        }
+        if !self.features.global_search && self.global_search.active {
+            self.close_global_search();
+        }
+        if !self.features.shell_pane {
+            // Flip every session showing its shell back to the agent view (the
+            // Shell tab/toggle is gone, so there's no way back otherwise).
+            for view in self.session_terminal_views.values_mut() {
+                if *view == TerminalView::Shell {
+                    *view = TerminalView::Claude;
+                }
+            }
+        }
+        if !self.features.code_review && !self.code_reviews.is_empty() {
+            self.code_reviews.clear();
+            if matches!(self.focus, InputFocus::CodeReview | InputFocus::ReviewFiles) {
+                self.focus = InputFocus::Terminal;
+            }
+        }
     }
 
     /// Record the current `settings.toml` mtime so the next reload poll doesn't

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -354,10 +354,15 @@ impl App {
         };
         let now = crate::sync::current_time_millis();
         let agent_usage = self.usage.get(&info.agent);
+        // Skip the upcoming-automations section entirely when the feature is
+        // off: the TUI won't fire those schedules, so advertising their
+        // countdowns here (the cache is loaded from the DB regardless) would
+        // surface a disabled feature. Mirrors the footer badge being zeroed.
         let automation_entries: Vec<info_panel::AutomationEntry> = self
             .automation_ui
             .cached_automations
             .iter()
+            .filter(|_| self.features.automations)
             .filter(|a| a.enabled && a.next_run_at.is_some())
             .map(|a| {
                 let remaining = a.next_run_at.unwrap_or(now).saturating_sub(now);
@@ -695,6 +700,12 @@ impl App {
                 "Shell",
                 Some(crate::session::Action::ToggleShell),
             ));
+        }
+        // With both Shell and Review gated off there's only the Agent pill left
+        // — a tab strip you can't switch away from. Drop it entirely so a
+        // single non-functional tab doesn't advertise views that are disabled.
+        if specs.len() < 2 {
+            return Vec::new();
         }
 
         // Pack pills left-to-right starting one cell in from the rounded corner,


### PR DESCRIPTION
Three surfaces still advertised features whose flag was off:

- The F2 info panel listed upcoming automation runs even with
  `automations` disabled (the cache loads from the DB regardless).
  Gate the section, mirroring the footer badge being zeroed.
- The central-pane tab strip painted a lone "Agent" pill when both
  `shell_pane` and `code_review` were off — a tab strip you can't
  switch away from. Suppress the strip when no alternate view survives.
- `apply_live_settings` swapped the flags but never tore down panels
  already open when a live flag flipped off, so a runtime-disabled
  feature kept rendering its panel with its tab/footer affordance gone.
  Add `enforce_feature_visibility`: hide the `show_*` panels, revert
  open shell views, close open code reviews, and move focus off any
  now-hidden pane. Idempotent — only ever forces the hidden state.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QspkQUUKmmiQVnf2qGVRdy