### PR TITLE
fix(core): make WSL/remote agent sessions launch correctly

### DIFF
--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -682,9 +682,17 @@ impl TmuxBackend {
     }
 
     /// The shell tmux should use for `default-command`. Local uses the user's
-    /// `$SHELL`; a remote backend uses a POSIX shell that is guaranteed to exist
-    /// on the remote host. Not used on Windows (psmux keeps its native default
-    /// shell — see [`apply_session_config`](Self::apply_session_config)).
+    /// `$SHELL`; a remote backend uses a POSIX shell guaranteed to exist on the
+    /// remote host. Not used on Windows (psmux keeps its native default shell —
+    /// see [`apply_session_config`](Self::apply_session_config)).
+    ///
+    /// The value must be a single, space-free token: it round-trips through the
+    /// remote transport's per-argument shell-quoting (`ssh`/`wsl.exe`), where a
+    /// space would be re-split by the remote shell into extra `set-option` args.
+    /// The login-shell `PATH` fix for remote agents (e.g. `claude` under
+    /// `~/.local/bin`) is applied at the *window command* instead — see
+    /// [`build_shell_command`](Self::build_shell_command) /
+    /// [`login_wrap_for_remote`](Self::login_wrap_for_remote).
     #[cfg(not(windows))]
     fn config_shell(&self) -> String {
         if self.transport.is_remote() {
@@ -708,6 +716,29 @@ impl TmuxBackend {
             parts.push(control_mode::shell_escape(arg));
         }
         parts.join(" ")
+    }
+
+    /// Wrap a window command in a **login** shell for a remote/WSL backend so the
+    /// user's profile `PATH` is present. Agents are commonly installed under
+    /// `~/.local/bin` (e.g. `claude`), which the login profile adds to `PATH`; a
+    /// non-login shell skips those files, so the agent binary isn't found, the
+    /// window command exits 1, and the pane dies instantly — the remote session
+    /// appears to "not launch". `exec` replaces the wrapper so no extra process
+    /// lingers. Local backends already inherit the user's interactive `PATH`, so
+    /// they pass through unchanged.
+    ///
+    /// Done here — not via tmux `default-command` — because that value round-trips
+    /// through the remote transport's per-arg shell-quoting, where a `-l` flag's
+    /// space would be re-split into a stray `set-option` argument.
+    fn login_wrap_for_remote(&self, shell_cmd: &str) -> String {
+        if self.transport.is_remote() {
+            // `exec` replaces the login shell with the agent (after the profile
+            // has set PATH), so no wrapper process lingers under the pane.
+            let inner = control_mode::shell_escape(&format!("exec {shell_cmd}"));
+            format!("/bin/sh -lc {inner}")
+        } else {
+            shell_cmd.to_string()
+        }
     }
 
     /// Run a closure with a reference to the active control mode, or bail if
@@ -951,7 +982,7 @@ impl SessionBackend for TmuxBackend {
         rows: u16,
         cols: u16,
     ) -> Result<SpawnedSession> {
-        let shell_cmd = Self::build_shell_command(command, args);
+        let shell_cmd = self.login_wrap_for_remote(&Self::build_shell_command(command, args));
 
         let cwd_part = match cwd {
             Some(dir) => format!(" -c {}", control_mode::shell_escape(&dir.to_string_lossy())),
@@ -1677,6 +1708,23 @@ mod tests {
         ));
         assert_eq!(backend.socket, TMUX_SOCKET);
         assert_eq!(backend.session, TMUX_SESSION);
+    }
+
+    #[test]
+    fn login_wrap_wraps_remote_command_in_login_shell() {
+        // Remote/WSL: the window command runs under a login shell so the user's
+        // profile PATH (e.g. `~/.local/bin/claude`) is present, or the agent
+        // binary isn't found and the pane dies instantly.
+        let backend = TmuxBackend::from_host(&crate::session::HostDef::wsl("Ubuntu"));
+        let wrapped = backend.login_wrap_for_remote("claude --resume x");
+        assert_eq!(wrapped, "/bin/sh -lc 'exec claude --resume x'");
+    }
+
+    #[test]
+    fn login_wrap_is_noop_for_local() {
+        // Local backends inherit the user's interactive PATH — no wrap needed.
+        let backend = TmuxBackend::local();
+        assert_eq!(backend.login_wrap_for_remote("claude"), "claude");
     }
 
     #[test]

--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -211,6 +211,10 @@ mod tests {
             [
                 "-d",
                 "Ubuntu",
+                // `--cd /` pins a valid landing dir so wsl.exe doesn't inherit
+                // the caller's cwd (which may not exist on the target distro).
+                "--cd",
+                "/",
                 "tmux",
                 "-L",
                 "thurbox",

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -39,6 +39,44 @@ fn is_ctrl_letter_chord(code: KeyCode, mods: KeyModifiers) -> bool {
     mods == KeyModifiers::CONTROL && matches!(code, KeyCode::Char(c) if c.is_ascii_alphabetic())
 }
 
+/// The directory-completion suffix to append after `prefix`, given the candidate
+/// directory `names` in the parent (as returned by `git::list_dir_on`). Mirrors
+/// `paths::complete_directory_path` for the remote case:
+/// - no match, or an ambiguous prefix with nothing more shared → `None`;
+/// - a single match → the remaining chars **plus a trailing `/`** (so the next
+///   `Tab` descends into it);
+/// - several matches → their longest common prefix beyond `prefix`.
+///
+/// Pure (no I/O) so the completion logic is unit-tested without a remote host.
+fn dir_completion_suffix(names: &[String], prefix: &str) -> Option<String> {
+    let matches: Vec<&str> = names
+        .iter()
+        .map(String::as_str)
+        .filter(|n| n.starts_with(prefix))
+        .collect();
+    let first = matches.first()?;
+    // Longest common prefix of the matches. It always extends `prefix` (a valid
+    // char boundary), so slicing the byte count back into `first` is safe.
+    let common_len = matches[1..].iter().fold(first.len(), |end, m| {
+        first
+            .bytes()
+            .zip(m.bytes())
+            .take(end)
+            .take_while(|(a, b)| a == b)
+            .count()
+    });
+    let beyond = first.get(prefix.len()..common_len)?;
+    if beyond.is_empty() && matches.len() > 1 {
+        return None; // ambiguous with nothing new to add
+    }
+    let suffix = if matches.len() == 1 {
+        format!("{beyond}/")
+    } else {
+        beyond.to_string()
+    };
+    (!suffix.is_empty()).then_some(suffix)
+}
+
 impl App {
     /// Main key handler dispatcher.
     ///
@@ -1609,6 +1647,20 @@ impl App {
                 return;
             }
             KeyCode::Tab => {
+                // Remote targets have no per-keystroke suggestion (that would
+                // fire an ssh/wsl round-trip on every character); compute one on
+                // demand here by listing the remote directory.
+                if self.new_session.backend.is_some() {
+                    let value = rp.path_input.value().to_string();
+                    if let Some(sug) = self.remote_path_completion(&value) {
+                        if let super::modals::Modal::RepoPicker(ref mut rp) = self.modal {
+                            for c in sug.chars() {
+                                rp.path_input.insert(c);
+                            }
+                        }
+                    }
+                    return;
+                }
                 if let Some(suggestion) = rp.path_suggestion.take() {
                     for c in suggestion.chars() {
                         rp.path_input.insert(c);
@@ -1720,10 +1772,32 @@ impl App {
         self.refresh_repo_picker_rows();
     }
 
+    /// Compute a remote directory completion for the repo-picker path input by
+    /// listing the parent directory on the selected host over ssh/wsl. Returns
+    /// the suffix to append (mirroring `paths::complete_directory_path`), or
+    /// `None`. Only called on an explicit `Tab` so it doesn't run per keystroke.
+    fn remote_path_completion(&self, input: &str) -> Option<String> {
+        let host = self.host_for_backend(self.new_session.backend.as_deref())?;
+        // Need at least one `/` to know which remote dir to list.
+        let (parent, prefix) = input.rsplit_once('/')?;
+        let parent = if parent.is_empty() { "/" } else { parent };
+        let entries = crate::git::list_dir_on(host, parent).ok()?;
+        dir_completion_suffix(&entries, prefix)
+    }
+
     pub(super) fn update_repo_picker_path_suggestion(&mut self) {
+        // For a remote target (SSH host or WSL distro) the path lives on the
+        // *remote* filesystem, so completing against the local one would suggest
+        // the wrong directories entirely. Suppress the local-filesystem
+        // suggestion in that case — the path is typed as a plain remote path.
+        let remote = self.new_session.backend.is_some();
         let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
             return;
         };
+        if remote {
+            rp.path_suggestion = None;
+            return;
+        }
         let value = rp.path_input.value().to_string();
         let at_end = rp.path_input.cursor_pos() == value.chars().count();
         if at_end && !value.is_empty() {
@@ -1852,8 +1926,57 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_ctrl_letter_chord, session_name_to_branch};
+    use super::{dir_completion_suffix, is_ctrl_letter_chord, session_name_to_branch};
     use crossterm::event::{KeyCode, KeyModifiers};
+
+    fn names(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn dir_completion_single_match_appends_trailing_slash() {
+        // One match → complete the rest and descend on the next Tab.
+        let dirs = names(&["repositories", "downloads"]);
+        assert_eq!(
+            dir_completion_suffix(&dirs, "rep"),
+            Some("ositories/".to_string())
+        );
+    }
+
+    #[test]
+    fn dir_completion_multi_match_uses_common_prefix() {
+        // Several matches → their longest common prefix beyond the typed prefix,
+        // no trailing slash (still ambiguous).
+        let dirs = names(&["adaptfy-landing", "adaptfy-landing-infra", "ai-ml"]);
+        assert_eq!(
+            dir_completion_suffix(&dirs, "adaptfy"),
+            Some("-landing".to_string())
+        );
+    }
+
+    #[test]
+    fn dir_completion_ambiguous_with_no_shared_extension_is_none() {
+        // Two matches that share nothing past the prefix → nothing to add.
+        let dirs = names(&["ai-ml", "ai-infra"]);
+        assert_eq!(dir_completion_suffix(&dirs, "ai-"), None);
+    }
+
+    #[test]
+    fn dir_completion_no_match_is_none() {
+        let dirs = names(&["repositories", "downloads"]);
+        assert_eq!(dir_completion_suffix(&dirs, "zzz"), None);
+        assert_eq!(dir_completion_suffix(&[], "any"), None);
+    }
+
+    #[test]
+    fn dir_completion_exact_match_alone_still_descends() {
+        // Prefix already equals the only entry → append just the slash.
+        let dirs = names(&["repositories"]);
+        assert_eq!(
+            dir_completion_suffix(&dirs, "repositories"),
+            Some("/".to_string())
+        );
+    }
 
     #[test]
     fn ctrl_letter_chord_detects_readline_namespace() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1385,7 +1385,7 @@ impl App {
         let session_id = session.info.id;
         // Rebuild the process cwd: the primary repo for a single-repo session,
         // or the (idempotently rebuilt) symlink workspace for a multi-repo one.
-        let cwd = session_process_cwd(&session.info);
+        let cwd = self.session_process_cwd(&session.info);
 
         let mut config = SessionConfig {
             resume_session_id: None,
@@ -2074,11 +2074,20 @@ impl App {
         let session_id = session.info.id;
         if session.shell_pane.is_none() {
             let (rows, cols) = self.content_area_size();
+            // Resolve the launch cwd (host-aware for remote workspaces) before
+            // taking the mutable session borrow; the immutable borrow of
+            // `self.sessions` ends with this block.
+            let shell_cwd = {
+                let idx = self.active_index;
+                match self.sessions.get(idx) {
+                    Some(s) => self.session_process_cwd(&s.info),
+                    None => None,
+                }
+            };
             let Some(session) = self.active_session_mut() else {
                 // Active session removed concurrently — nothing to switch to.
                 return;
             };
-            let shell_cwd = session_process_cwd(&session.info);
             if let Err(e) = session.ensure_shell_pane(rows, cols, shell_cwd.as_deref()) {
                 error!("Failed to create shell pane: {e}");
                 self.set_error(format!("Failed to create shell: {e:#}"));
@@ -3128,6 +3137,23 @@ impl App {
         self.hosts.get_by_backend(backend?)
     }
 
+    /// The launch cwd for an *existing* session, derived from its persisted
+    /// `SessionInfo`: the multi-repo symlink workspace (built on the session's
+    /// host, remote or local), or the primary repo when single-repo. Used by the
+    /// restart and shell-pane paths, which must agree on the cwd so the shell
+    /// lands exactly where the agent runs.
+    fn session_process_cwd(&self, info: &SessionInfo) -> Option<PathBuf> {
+        // `remote_host` is the bare host name (`None` = local).
+        let host = info.remote_host.as_deref().and_then(|n| self.hosts.get(n));
+        resolve_process_cwd(
+            info.agent_session_id.as_deref(),
+            info.cwd.clone(),
+            &info.worktrees,
+            &info.additional_dirs,
+            host,
+        )
+    }
+
     /// Resolve the backend for a *persisted* session by its `backend_type`, or
     /// `None` when this instance cannot manage it.
     ///
@@ -3213,11 +3239,13 @@ impl App {
         // gathers every member dir; `info.cwd` keeps the primary repo (restored
         // after spawn). Single-repo sessions are unchanged.
         let primary_cwd = config.cwd.clone();
+        let spawn_host = self.host_for_backend(config.backend.as_deref()).cloned();
         config.cwd = resolve_process_cwd(
             config.agent_session_id.as_deref(),
             primary_cwd.clone(),
             worktrees,
             additional_dirs,
+            spawn_host.as_ref(),
         );
 
         let backend = match self.backend_for(&config) {
@@ -3230,6 +3258,17 @@ impl App {
         };
 
         let provider = self.provider_for(&config);
+
+        // On a remote host, materialize any thurbox-managed config file the
+        // agent args reference by its *local* path (e.g. claude's hooks
+        // `--settings <config>/hooks/claude.json`) at the same path on the
+        // remote, so the agent doesn't fail to launch ("Settings file not
+        // found"). Best-effort; shares the headless spawn's implementation.
+        if let Some(h) = spawn_host.as_ref() {
+            let args = crate::agent::AgentProvider::build_args(provider.as_ref(), &config);
+            crate::session_ops::spawn::materialize_agent_config_on_remote(h, &args);
+        }
+
         Some(SpawnInputs {
             config,
             primary_cwd,
@@ -5260,6 +5299,7 @@ fn resolve_process_cwd(
     primary_cwd: Option<PathBuf>,
     worktrees: &[WorktreeInfo],
     additional_dirs: &[PathBuf],
+    host: Option<&crate::session::HostDef>,
 ) -> Option<PathBuf> {
     let members = session_member_dirs(primary_cwd.as_deref(), worktrees, additional_dirs);
     if members.len() < 2 {
@@ -5279,26 +5319,20 @@ fn resolve_process_cwd(
         })
         .collect();
 
-    match crate::workspace::ensure_workspace(id, &pairs) {
+    // A remote session's symlink workspace is built on the *remote* host — a
+    // local workspace dir wouldn't exist there. Local sessions use the local
+    // builder as before.
+    let built = match host {
+        Some(h) => crate::git::ensure_remote_workspace(h, id, &pairs),
+        None => crate::workspace::ensure_workspace(id, &pairs).map_err(anyhow::Error::from),
+    };
+    match built {
         Ok(ws) => Some(ws),
         Err(e) => {
             error!("Failed to build multi-repo workspace: {e}");
             primary_cwd
         }
     }
-}
-
-/// The launch cwd for an *existing* session, derived from its persisted
-/// `SessionInfo`: the multi-repo symlink workspace, or the primary repo when
-/// single-repo. Used by the restart and shell-pane paths, which must agree on
-/// the cwd so the companion shell lands exactly where the agent runs.
-fn session_process_cwd(info: &SessionInfo) -> Option<PathBuf> {
-    resolve_process_cwd(
-        info.agent_session_id.as_deref(),
-        info.cwd.clone(),
-        &info.worktrees,
-        &info.additional_dirs,
-    )
 }
 
 #[cfg(test)]
@@ -9542,7 +9576,7 @@ mod tests {
     #[test]
     fn process_cwd_single_member_is_primary() {
         let cwd = PathBuf::from("/src/only");
-        let out = resolve_process_cwd(Some("id-1"), Some(cwd.clone()), &[], &[]);
+        let out = resolve_process_cwd(Some("id-1"), Some(cwd.clone()), &[], &[], None);
         assert_eq!(out, Some(cwd));
     }
 
@@ -9562,6 +9596,7 @@ mod tests {
             Some(primary.clone()),
             &[],
             std::slice::from_ref(&other),
+            None,
         )
         .unwrap();
 
@@ -9583,6 +9618,7 @@ mod tests {
             Some(primary.clone()),
             &[],
             std::slice::from_ref(&other),
+            None,
         );
         assert_eq!(out, Some(primary));
     }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Mutex, OnceLock};
@@ -151,6 +151,209 @@ fn worktree_path_for(host: Option<&HostDef>, repo_path: &Path, branch: &str) -> 
             )))
         }
     }
+}
+
+/// Sanitize a workspace directory segment (the session id). Mirrors
+/// `workspace::sanitize_segment` so the remote workspace path matches the local
+/// one; `git` can't depend on `workspace`, so it is duplicated by construction.
+fn sanitize_workspace_segment(name: &str) -> String {
+    let cleaned: String = name
+        .trim()
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' => '-',
+            c if c.is_whitespace() => '-',
+            c => c,
+        })
+        .collect();
+    cleaned.trim_matches(['.', '-']).to_string()
+}
+
+/// A unique, sanitized symlink name for a workspace member. Mirrors
+/// `workspace::unique_link_name`: collisions get a `-2`, `-3`, … suffix and an
+/// empty label falls back to `repo`.
+fn unique_link_name(name: &str, used: &mut HashSet<String>) -> String {
+    let base = {
+        let s = sanitize_workspace_segment(name);
+        if s.is_empty() {
+            "repo".to_string()
+        } else {
+            s
+        }
+    };
+    if used.insert(base.clone()) {
+        return base;
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{base}-{n}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
+/// Build a per-session **remote** symlink workspace on `host`: a directory
+/// holding one symlink per member (`<label> -> <remote member path>`), so a
+/// multi-repo remote session launches somewhere every repo is a visible subdir.
+///
+/// This is the remote analogue of [`crate::workspace::ensure_workspace`], run
+/// over the host launcher (`ssh`/`wsl.exe`). All paths are POSIX (`/`-joined)
+/// because the host is always Linux, even when thurbox runs on Windows. Returns
+/// the remote workspace directory path.
+pub fn ensure_remote_workspace(
+    host: &HostDef,
+    id: &str,
+    members: &[(String, PathBuf)],
+) -> Result<PathBuf> {
+    // Base: `<worktrees_dir>/..`/thurbox root, or `$HOME/.local/share/thurbox`.
+    let base = match &host.worktrees_dir {
+        Some(dir) => Path::new(dir)
+            .parent()
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|| dir.clone()),
+        None => format!("{}/.local/share/thurbox", remote_home(host)?),
+    };
+    // Sanitize the id + link names exactly like the local builder
+    // (`workspace::ensure_workspace`) so a session's remote workspace has the
+    // same layout as a local one — `git` can't depend on `workspace`, so the
+    // scheme is mirrored here by construction (kept in sync via tests).
+    let ws = format!("{base}/workspaces/{}", sanitize_workspace_segment(id));
+
+    // Fresh dir, then one symlink per member, de-duplicating names with a `-2`,
+    // `-3`, … suffix (matching the local builder).
+    let mut script = format!("rm -rf {ws} && mkdir -p {ws}", ws = posix_quote(&ws));
+    let mut used: HashSet<String> = HashSet::new();
+    for (label, target) in members {
+        let name = unique_link_name(label, &mut used);
+        let link = format!("{ws}/{name}");
+        script.push_str(&format!(
+            " && ln -s {target} {link}",
+            target = posix_quote(&target.to_string_lossy()),
+            link = posix_quote(&link),
+        ));
+    }
+
+    let output = host_shell_c(host, &script)
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to build remote multi-repo workspace")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("remote workspace build failed: {}", stderr.trim());
+    }
+    Ok(PathBuf::from(ws))
+}
+
+/// Build a `<launcher> sh -c <script>` [`Command`] for a host, correct for each
+/// transport's argument handling.
+///
+/// The two launchers disagree on how trailing args reach the in-host shell:
+/// - **`wsl.exe`** passes each `Command` arg through as a *separate* process
+///   argument, so the multi-statement `script` must be a single **unquoted**
+///   arg (`wsl.exe … sh -c "<script>"`). Wrapping it in POSIX quotes would make
+///   the in-distro shell treat the quoted blob as one command word ("not
+///   found").
+/// - **`ssh`** space-joins its trailing args into one string the remote login
+///   shell re-splits, so the `script` must be POSIX-quoted to survive as a
+///   single `sh -c` argument (mirroring [`git_command`]).
+fn host_shell_c(host: &HostDef, script: &str) -> Command {
+    let mut cmd = host_launcher(host);
+    if host.is_wsl() {
+        cmd.arg("sh").arg("-c").arg(script);
+    } else {
+        cmd.arg(posix_quote("sh"))
+            .arg(posix_quote("-c"))
+            .arg(posix_quote(script));
+    }
+    cmd
+}
+
+/// Copy a local file to the **same** absolute path on a remote `host`, creating
+/// the parent directory. Streams the file's bytes over the host launcher's
+/// stdin into `cat > <path>`, so it is transport-neutral (ssh/wsl) and needs no
+/// `scp`/`\\wsl$` share. Used to materialize thurbox-managed agent config (e.g.
+/// the hooks `--settings claude.json`) on the remote so the agent — launched
+/// with a `--settings <path>` that thurbox generated against the *local* config
+/// dir — finds the file at that path on the remote too.
+pub fn copy_file_to_remote(host: &HostDef, local: &Path, remote_path: &str) -> Result<()> {
+    use std::io::Write;
+
+    let bytes = std::fs::read(local)
+        .with_context(|| format!("failed to read local file {}", local.display()))?;
+
+    let parent = Path::new(remote_path)
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "/".to_string());
+    // `mkdir -p <dir> && cat > <file>`: stdin is the file body. Both transports
+    // pass stdin straight through to the in-host shell.
+    let script = format!(
+        "mkdir -p {dir} && cat > {file}",
+        dir = posix_quote(&parent),
+        file = posix_quote(remote_path),
+    );
+
+    let mut child = host_shell_c(host, &script)
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("failed to spawn remote file-copy")?;
+    child
+        .stdin
+        .take()
+        .context("remote file-copy stdin unavailable")?
+        .write_all(&bytes)
+        .context("failed to stream file to remote")?;
+    let output = child
+        .wait_with_output()
+        .context("failed to wait on remote file-copy")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("remote file-copy failed: {}", stderr.trim());
+    }
+    Ok(())
+}
+
+/// List immediate sub-directory **names** of `dir` on `host` over the host
+/// launcher. Hidden (`.`-prefixed) entries are skipped and output is sorted.
+/// Used by the repo picker's remote path completion.
+///
+/// Runs `ls -1p <dir>` — a **variable-free** command on purpose: `wsl.exe`
+/// strips `$var` expansions that appear *inside* a single `sh -c '<script>'`
+/// argument (a shell `for`/`case` loop over `$d` silently yields empty names),
+/// so a script-based lister is unusable over the WSL transport. `-p` appends a
+/// trailing `/` to directories, which is how they're identified without a loop.
+pub fn list_dir_on(host: &HostDef, dir: &str) -> Result<Vec<String>> {
+    // `ls -1p <dir>`: one entry per line, dirs suffixed with `/`. `ls`, `-1p`
+    // and the dir are separate argv tokens (no `$` inside a `-c` string), so
+    // this survives wsl.exe's argument handling.
+    let mut cmd = host_launcher(host);
+    for tok in ["ls", "-1p", dir] {
+        cmd.arg(if host.is_wsl() {
+            tok.to_string()
+        } else {
+            posix_quote(tok)
+        });
+    }
+    let output = cmd
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to list remote directory")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("remote dir listing failed: {}", stderr.trim());
+    }
+    let mut names: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        // Only directories (trailing `/`), skipping hidden entries.
+        .filter_map(|line| line.strip_suffix('/'))
+        .filter(|name| !name.is_empty() && !name.starts_with('.'))
+        .map(String::from)
+        .collect();
+    names.sort();
+    Ok(names)
 }
 
 /// Global cache for repo display names (path → name).
@@ -1483,6 +1686,10 @@ mod tests {
             [
                 "-d",
                 "Ubuntu",
+                // Neutral landing dir so wsl.exe doesn't inherit the caller's
+                // cwd and fail to chdir on the target distro.
+                "--cd",
+                "/",
                 "git",
                 "-C",
                 "/home/me/repo",
@@ -1493,6 +1700,92 @@ mod tests {
             ]
         );
         assert_eq!(cmd.get_current_dir(), None);
+    }
+
+    #[test]
+    fn host_shell_c_wsl_passes_script_unquoted() {
+        // WSL: the multi-statement script must be a single *unquoted* arg, else
+        // the in-distro shell treats the quoted blob as one command word.
+        let h = HostDef::wsl("Ubuntu");
+        let cmd = host_shell_c(&h, "mkdir -p /a && ln -s /b /a/b");
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "wsl.exe");
+        assert_eq!(
+            args,
+            [
+                "-d",
+                "Ubuntu",
+                "--cd",
+                "/",
+                "sh",
+                "-c",
+                "mkdir -p /a && ln -s /b /a/b"
+            ]
+        );
+    }
+
+    #[test]
+    fn host_shell_c_ssh_posix_quotes_script() {
+        // SSH space-joins its trailing args, so the script must be POSIX-quoted
+        // to survive as a single `sh -c` argument.
+        let h = host("me@box", None);
+        let cmd = host_shell_c(&h, "mkdir -p /a && ln -s /b /a/b");
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "ssh");
+        // The script arg is single-quoted as a whole.
+        assert!(
+            args.iter().any(|a| a == "'mkdir -p /a && ln -s /b /a/b'"),
+            "script should be posix-quoted for ssh; got {args:?}"
+        );
+    }
+
+    #[test]
+    fn list_dir_on_wsl_uses_variable_free_ls() {
+        // Must be `ls -1p <dir>` as separate argv tokens — NOT an `sh -c`
+        // script — because wsl.exe strips `$var` inside a `-c` string, which
+        // would break any loop-based lister.
+        let h = HostDef::wsl("Ubuntu");
+        let mut cmd = host_launcher(&h);
+        for tok in ["ls", "-1p", "/home/me/repos"] {
+            cmd.arg(tok);
+        }
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "wsl.exe");
+        assert_eq!(
+            args,
+            ["-d", "Ubuntu", "--cd", "/", "ls", "-1p", "/home/me/repos"]
+        );
+        // No `sh -c` (the broken form) anywhere.
+        assert!(
+            !args.iter().any(|a| a == "-c"),
+            "must not use sh -c: {args:?}"
+        );
+    }
+
+    #[test]
+    fn sanitize_workspace_segment_matches_local_scheme() {
+        // Mirrors `workspace::sanitize_segment`: slashes/backslashes/colons and
+        // whitespace → `-`; leading/trailing `.`/`-` trimmed.
+        assert_eq!(sanitize_workspace_segment("feat/x"), "feat-x");
+        assert_eq!(sanitize_workspace_segment("a b:c\\d"), "a-b-c-d");
+        assert_eq!(sanitize_workspace_segment("--.hidden.--"), "hidden");
+        // A UUID (the real input) is unchanged.
+        assert_eq!(
+            sanitize_workspace_segment("d5715d35-9599-4507-9901-ef33b9476358"),
+            "d5715d35-9599-4507-9901-ef33b9476358"
+        );
+    }
+
+    #[test]
+    fn unique_link_name_dedups_with_dash_two_suffix() {
+        // Must match the local builder: first collision is `-2`, then `-3`, and
+        // an empty label falls back to `repo`.
+        let mut used = HashSet::new();
+        assert_eq!(unique_link_name("webapp", &mut used), "webapp");
+        assert_eq!(unique_link_name("webapp", &mut used), "webapp-2");
+        assert_eq!(unique_link_name("webapp", &mut used), "webapp-3");
+        assert_eq!(unique_link_name("", &mut used), "repo");
+        assert_eq!(unique_link_name("", &mut used), "repo-2");
     }
 
     #[test]

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -52,11 +52,14 @@ fn build_restart_plan(session: &SharedSession) -> Result<RestartPlan, String> {
     // workspace, gathering every member dir; a single-repo session keeps the
     // primary repo. Only resolve when there is a primary cwd to anchor on.
     if let Some(primary) = session.cwd.clone() {
+        // The headless restart path is local-only (`spawn_window`), so the
+        // workspace is built locally; remote restart isn't wired here.
         config.cwd = Some(super::spawn::resolve_launch_cwd(
             &agent_session_id,
             &primary,
             &session.worktrees,
             &session.additional_dirs,
+            None,
         ));
     }
 

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -92,6 +92,7 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         &primary_cwd,
         &worktrees,
         &additional_dirs,
+        host.as_ref(),
     );
 
     // Mint the thurbox SessionId up front so it can be injected into the
@@ -109,6 +110,15 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     super::inject_thurbox_env(&mut config, &agent_session_id, req.task_id);
 
     let (command, args) = super::build_agent_invocation(&agent_def, &config);
+
+    // The agent's args may reference thurbox-managed config files by their
+    // *local* absolute path (e.g. claude's hooks `--settings <config>/hooks/
+    // claude.json`). On a remote host that path doesn't exist, so the agent
+    // errors on launch ("Settings file not found"). Materialize each such file
+    // at the same path on the remote before launching.
+    if let Some(h) = host.as_ref() {
+        materialize_agent_config_on_remote(h, &args);
+    }
 
     // Remote spawns drive the SSH backend's control mode to learn the real pane
     // id; local spawns leave `backend_id` empty for the TUI to resolve by name.
@@ -301,6 +311,7 @@ pub(crate) fn resolve_launch_cwd(
     primary_cwd: &std::path::Path,
     worktrees: &[SharedWorktree],
     additional_dirs: &[PathBuf],
+    host: Option<&HostDef>,
 ) -> PathBuf {
     let mut members: Vec<(String, PathBuf)> = Vec::new();
     if worktrees.is_empty() {
@@ -317,11 +328,55 @@ pub(crate) fn resolve_launch_cwd(
     if members.len() < 2 {
         return primary_cwd.to_path_buf();
     }
-    match crate::workspace::ensure_workspace(agent_session_id, &members) {
+    // A remote session's workspace must be built on the *remote* host — a local
+    // symlink dir wouldn't exist there. Local sessions use the local builder.
+    let built = match host {
+        Some(h) => crate::git::ensure_remote_workspace(h, agent_session_id, &members),
+        None => crate::workspace::ensure_workspace(agent_session_id, &members)
+            .map_err(anyhow::Error::from),
+    };
+    match built {
         Ok(ws) => ws,
         Err(e) => {
             tracing::error!("Failed to build multi-repo workspace: {e}");
             primary_cwd.to_path_buf()
+        }
+    }
+}
+
+/// Copy any thurbox-managed config files referenced in the agent `args` (by
+/// their *local* absolute path) to the same path on the remote `host`, so an
+/// agent launched with e.g. `--settings <config>/hooks/claude.json` finds the
+/// file there. Best-effort: a copy failure is logged, not fatal — the agent
+/// still launches (the hooks just won't fire), and we never block a spawn on it.
+///
+/// Scope is deliberately narrow: only existing local **files under the thurbox
+/// config dir** are copied, so we never ship an arbitrary path an agent's own
+/// args happen to contain (a repo path, a user file, …).
+///
+/// Shared by the headless spawn and the TUI (`App::build_spawn_inputs`) so both
+/// paths give a remote session the same agent config.
+pub(crate) fn materialize_agent_config_on_remote(host: &HostDef, args: &[String]) {
+    let Some(config_root) = crate::paths::config_file()
+        .and_then(|p| p.parent().map(|d| d.to_string_lossy().into_owned()))
+    else {
+        return;
+    };
+    for arg in args {
+        // Only absolute paths under the thurbox config dir that exist as local
+        // files are candidates.
+        if !arg.starts_with(&config_root) {
+            continue;
+        }
+        let local = std::path::Path::new(arg);
+        if !local.is_file() {
+            continue;
+        }
+        if let Err(e) = crate::git::copy_file_to_remote(host, local, arg) {
+            tracing::warn!(
+                "failed to materialize agent config {arg} on host '{}': {e:#}",
+                host.name
+            );
         }
     }
 }
@@ -546,7 +601,7 @@ mod tests {
     fn resolve_launch_cwd_single_member_is_primary() {
         let primary = PathBuf::from("/tmp/primary");
         // No worktrees, no extra dirs → 1 member → primary cwd, no workspace.
-        let got = resolve_launch_cwd("sid-1", &primary, &[], &[]);
+        let got = resolve_launch_cwd("sid-1", &primary, &[], &[], None);
         assert_eq!(got, primary);
     }
 
@@ -558,7 +613,7 @@ mod tests {
         std::fs::create_dir_all(&primary).unwrap();
         let extra = temp.path().join("extra");
         std::fs::create_dir_all(&extra).unwrap();
-        let got = resolve_launch_cwd("sid-multi", &primary, &[], &[extra]);
+        let got = resolve_launch_cwd("sid-multi", &primary, &[], &[extra], None);
         // Two members → a symlink workspace, not the primary itself.
         assert_ne!(got, primary);
         assert!(got.join("primary").exists() || got.exists());

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -48,9 +48,20 @@ pub fn ssh_command(destination: &str, ssh_opts: &[String]) -> Command {
 /// identically. No `--` separator is used (none of thurbox's commands start
 /// with a `-`, matching the SSH path which also omits it), so distros are
 /// reached uniformly on every supported `wsl.exe`.
+///
+/// `--cd /` pins the launched process's working directory to a path that exists
+/// on *every* distro. Without it, `wsl.exe` inherits the **caller's** current
+/// directory and tries to `chdir` to the same path inside the target distro —
+/// which fails when thurbox itself runs inside another WSL distro (the caller's
+/// cwd, e.g. `/home/me/repo`, doesn't exist on the target). That failure prints
+/// a `WSL Relay ERROR: CreateProcessCommon chdir(...) failed` on stderr and
+/// corrupts the tmux control-mode handshake, so the agent window never launches.
+/// `/` is a neutral landing dir: every caller overrides the real working dir
+/// anyway (`git -C <path>`, tmux `new-window -c <path>`).
 pub fn wsl_command(distro: &str) -> Command {
     let mut cmd = Command::new("wsl.exe");
     cmd.arg("-d").arg(distro);
+    cmd.arg("--cd").arg("/");
     cmd
 }
 
@@ -84,13 +95,15 @@ mod tests {
     }
 
     #[test]
-    fn wsl_command_sets_program_and_distro() {
+    fn wsl_command_sets_program_distro_and_neutral_cwd() {
         let cmd = wsl_command("Ubuntu");
         assert_eq!(cmd.get_program().to_string_lossy(), "wsl.exe");
         let args: Vec<String> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
-        assert_eq!(args, ["-d", "Ubuntu"]);
+        // `--cd /` pins a valid landing dir so wsl.exe doesn't inherit (and fail
+        // to chdir to) the caller's cwd when thurbox runs inside another distro.
+        assert_eq!(args, ["-d", "Ubuntu", "--cd", "/"]);
     }
 }


### PR DESCRIPTION
## Summary

Fixes remote agent sessions running on a WSL distro (or SSH host) that is reached from **inside another WSL distro** — the common thurbox-in-WSL setup. Several failures along the launch path are addressed:

- **`wsl.exe` inherited the caller's cwd** → it tried to `chdir` to a path that does not exist on the target distro, printing `WSL Relay ERROR: chdir(...) failed` and corrupting the tmux control-mode handshake so the agent window never launched. `wsl_command` now passes `--cd /` (a neutral landing dir; every caller overrides the real cwd via `git -C` / tmux `-c`).
- **Agent ran in a non-login shell without `~/.local/bin` on PATH** → `claude` (installed under `~/.local/bin`) was not found, the window command exited 1, and the pane died instantly. The remote window command is now wrapped in a login shell (`/bin/sh -lc 'exec …'`).
- **Hooks `--settings <local path>` did not exist on the remote** → the agent errored `Settings file not found`. thurbox-managed config files referenced in the agent args (under the local config dir) are now materialized on the remote at the same path before launch (transport-neutral, streamed over stdin).
- **Multi-repo symlink workspace was built locally** and its local path handed to the remote. It is now built **on the remote host** (`ensure_remote_workspace`), with the host threaded through `resolve_process_cwd` / `resolve_launch_cwd`; naming mirrors the local builder.
- **Repo picker leaked local paths for a remote target** → local filesystem completion is suppressed for a remote target, and `Tab` now completes against the **remote** filesystem (`list_dir_on`, a variable-free `ls -1p` because `wsl.exe` strips `$var` inside `sh -c`).

## Test plan

- `cargo nextest run --all` — 1686 passing (7 new unit tests: login-shell wrap, remote `sh -c` quoting per transport, variable-free `ls`, workspace-name parity with the local builder, directory-completion suffix logic).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test --test architecture_rules` — 12/12.
- Verified end-to-end against a real WSL setup (distro A → distro B): single- and multi-repo sessions launch with Claude Code running in the correct folder, hooks settings materialized, `Tab` completes remote directories.