### PR TITLE
fix(core): make WSL/remote agent sessions launch correctly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,10 +519,13 @@ How it works: `TmuxBackend` is transport-neutral
 (`agent::transport::TmuxTransport`). The local backend launches
 `<mux> -L thurbox …`; an SSH backend launches `ssh <dest> <mux> -L thurbox …`;
 a **WSL backend launches `wsl.exe -d <distro> tmux -L thurbox …`**
-(`TmuxTransport::Wsl`). `wsl.exe` joins + shell-interprets the trailing tokens
-exactly like `ssh`, so the same POSIX quoting (`shell::posix_quote`) and the
-byte-identical control-mode protocol (`control_mode.rs`) apply — only the
-one-time process launch differs. The local `DEFAULT_MUX` is **`tmux` on
+(`TmuxTransport::Wsl`). `wsl.exe` forwards whitespace-free tokens to the
+in-distro shell like `ssh` does, so the same POSIX quoting
+(`shell::posix_quote`) and the byte-identical control-mode protocol
+(`control_mode.rs`) apply — only the one-time process launch differs. (An arg
+*containing whitespace* is preserved as one word, so multi-word `sh -c` scripts
+go through `wsl.exe --exec` instead — see `shell::wsl_command` /
+`git::host_shell_c`.) The local `DEFAULT_MUX` is **`tmux` on
 Linux/macOS and `psmux` on Windows** — psmux is a native-Windows, drop-in tmux
 clone (ConPTY, no WSL) speaking the **same control-mode wire protocol** and
 pane-id (`%N`) / `-L` socket model, so the whole backend is parameterized by

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -171,8 +171,11 @@ not applicable.
 1. **Host picker** — choose where the session runs: `local`, or any
    remote SSH host defined in `hosts.toml`. Skipped entirely when no
    remote hosts are configured (preserving the local-only flow). For
-   a remote host the repo picker opens to a typed remote path and the
-   worktree + tmux window are created on that host over SSH.
+   a remote host the repo picker shows the repos previously used *on
+   that host* (bookmarks are host-scoped, schema v39); new paths are
+   typed (with `Tab` completing against the remote filesystem, `~`
+   resolving to the remote home, and existence verified on Enter) and
+   the worktree + tmux window are created on that host over SSH.
 2. **Repo picker** — fuzzy-searchable list of bookmarked repo
    paths. `Space` toggles selection, `w` marks the selected repo
    as a worktree base, `d` deletes the bookmark, and a path-input
@@ -328,9 +331,11 @@ For **SSH**, thurbox shells out to the system `ssh` binary, so
 authentication, keys, and connection multiplexing come from your
 `~/.ssh/config` — thurbox never handles credentials. A **WSL distro**
 is reached with `wsl.exe -d <distro>` (no credentials, no network);
-since `wsl.exe` joins + shell-interprets its trailing tokens just like
-`ssh`, the *same* tmux control-mode protocol, POSIX quoting, and
-worktree layout apply — only the launch prefix differs. So off-local
+`wsl.exe` forwards whitespace-free tokens to the in-distro shell like
+`ssh` does, so the *same* tmux control-mode protocol, POSIX quoting,
+and worktree layout apply — only the launch prefix differs (multi-word
+`sh -c` scripts go through `wsl.exe --exec`, which hands argv over
+verbatim; see `shell::wsl_command`). So off-local
 sessions get identical persistence, multi-instance sharing, and
 restore-on-startup as local ones; the worktree and agent process live
 on the remote host / inside the distro (a WSL distro's worktrees stay

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -733,8 +733,6 @@ impl TmuxBackend {
     /// space would be re-split into a stray `set-option` argument.
     fn login_wrap_for_remote(&self, shell_cmd: &str) -> String {
         if self.transport.is_remote() && !self.transport.uses_psmux() {
-            // `exec` replaces the login shell with the agent (after the profile
-            // has set PATH), so no wrapper process lingers under the pane.
             let inner = control_mode::shell_escape(&format!("exec {shell_cmd}"));
             format!("/bin/sh -lc {inner}")
         } else {

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -682,9 +682,17 @@ impl TmuxBackend {
     }
 
     /// The shell tmux should use for `default-command`. Local uses the user's
-    /// `$SHELL`; a remote backend uses a POSIX shell that is guaranteed to exist
-    /// on the remote host. Not used on Windows (psmux keeps its native default
-    /// shell — see [`apply_session_config`](Self::apply_session_config)).
+    /// `$SHELL`; a remote backend uses a POSIX shell guaranteed to exist on the
+    /// remote host. Not used on Windows (psmux keeps its native default shell —
+    /// see [`apply_session_config`](Self::apply_session_config)).
+    ///
+    /// The value must be a single, space-free token: it round-trips through the
+    /// remote transport's per-argument shell-quoting (`ssh`/`wsl.exe`), where a
+    /// space would be re-split by the remote shell into extra `set-option` args.
+    /// The login-shell `PATH` fix for remote agents (e.g. `claude` under
+    /// `~/.local/bin`) is applied at the *window command* instead — see
+    /// [`build_shell_command`](Self::build_shell_command) /
+    /// [`login_wrap_for_remote`](Self::login_wrap_for_remote).
     #[cfg(not(windows))]
     fn config_shell(&self) -> String {
         if self.transport.is_remote() {
@@ -708,6 +716,30 @@ impl TmuxBackend {
             parts.push(control_mode::shell_escape(arg));
         }
         parts.join(" ")
+    }
+
+    /// Wrap a window command in a **login** shell for a remote/WSL backend so the
+    /// user's profile `PATH` is present. Agents are commonly installed under
+    /// `~/.local/bin` (e.g. `claude`), which the login profile adds to `PATH`; a
+    /// non-login shell skips those files, so the agent binary isn't found, the
+    /// window command exits 1, and the pane dies instantly — the remote session
+    /// appears to "not launch". `exec` replaces the wrapper so no extra process
+    /// lingers. Local backends already inherit the user's interactive `PATH`, so
+    /// they pass through unchanged — and so does a **psmux** remote (a Windows
+    /// SSH host), which has no `/bin/sh` to wrap with.
+    ///
+    /// Done here — not via tmux `default-command` — because that value round-trips
+    /// through the remote transport's per-arg shell-quoting, where a `-l` flag's
+    /// space would be re-split into a stray `set-option` argument.
+    fn login_wrap_for_remote(&self, shell_cmd: &str) -> String {
+        if self.transport.is_remote() && !self.transport.uses_psmux() {
+            // `exec` replaces the login shell with the agent (after the profile
+            // has set PATH), so no wrapper process lingers under the pane.
+            let inner = control_mode::shell_escape(&format!("exec {shell_cmd}"));
+            format!("/bin/sh -lc {inner}")
+        } else {
+            shell_cmd.to_string()
+        }
     }
 
     /// Run a closure with a reference to the active control mode, or bail if
@@ -951,7 +983,7 @@ impl SessionBackend for TmuxBackend {
         rows: u16,
         cols: u16,
     ) -> Result<SpawnedSession> {
-        let shell_cmd = Self::build_shell_command(command, args);
+        let shell_cmd = self.login_wrap_for_remote(&Self::build_shell_command(command, args));
 
         let cwd_part = match cwd {
             Some(dir) => format!(" -c {}", control_mode::shell_escape(&dir.to_string_lossy())),
@@ -1677,6 +1709,37 @@ mod tests {
         ));
         assert_eq!(backend.socket, TMUX_SOCKET);
         assert_eq!(backend.session, TMUX_SESSION);
+    }
+
+    #[test]
+    fn login_wrap_wraps_remote_command_in_login_shell() {
+        // Remote/WSL: the window command runs under a login shell so the user's
+        // profile PATH (e.g. `~/.local/bin/claude`) is present, or the agent
+        // binary isn't found and the pane dies instantly.
+        let backend = TmuxBackend::from_host(&crate::session::HostDef::wsl("Ubuntu"));
+        let wrapped = backend.login_wrap_for_remote("claude --resume x");
+        assert_eq!(wrapped, "/bin/sh -lc 'exec claude --resume x'");
+    }
+
+    #[test]
+    fn login_wrap_is_noop_for_local() {
+        // Local backends inherit the user's interactive PATH — no wrap needed.
+        let backend = TmuxBackend::local();
+        assert_eq!(backend.login_wrap_for_remote("claude"), "claude");
+    }
+
+    #[test]
+    fn login_wrap_is_noop_for_psmux_remote() {
+        // A Windows SSH host (multiplexer = "psmux") has no `/bin/sh`; wrapping
+        // would replace the agent command with one that can't start at all.
+        let host = crate::session::HostDef {
+            name: "winbox".into(),
+            destination: "me@winbox".into(),
+            multiplexer: Some("psmux".into()),
+            ..Default::default()
+        };
+        let backend = TmuxBackend::from_host(&host);
+        assert_eq!(backend.login_wrap_for_remote("claude"), "claude");
     }
 
     #[test]

--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -219,6 +219,10 @@ mod tests {
                 "thurbox",
             ]
         );
+        // A Unix caller pins the child cwd to `/` (see `shell::wsl_command`)
+        // so wsl.exe doesn't inherit a caller cwd missing from the distro.
+        #[cfg(unix)]
+        assert_eq!(cmd.get_current_dir(), Some(std::path::Path::new("/")));
     }
 
     #[test]

--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -34,10 +34,11 @@ pub enum TmuxTransport {
         mux: String,
     },
     /// Run the multiplexer inside a local WSL distro via `wsl.exe -d <distro>`.
-    /// This is the SSH variant minus the network: `wsl.exe` joins and
-    /// shell-interprets the trailing tokens exactly like `ssh`, so the same
-    /// control-mode protocol and POSIX quoting apply. `mux` is the in-distro
-    /// multiplexer binary (`tmux`).
+    /// This is the SSH variant minus the network: `wsl.exe` forwards the
+    /// whitespace-free tokens used here to the in-distro shell like `ssh` does
+    /// (see [`crate::shell::wsl_command`] for the exact forwarding model), so
+    /// the same control-mode protocol and POSIX quoting apply. `mux` is the
+    /// in-distro multiplexer binary (`tmux`).
     Wsl { distro: String, mux: String },
 }
 

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1628,8 +1628,10 @@ impl App {
             return;
         }
 
-        let host_key = self.new_session.backend.clone().unwrap_or_default();
-        if let Err(e) = self.db.delete_repo_bookmark(&host_key, &path) {
+        if let Err(e) = self
+            .db
+            .delete_repo_bookmark(self.bookmark_host_key(), &path)
+        {
             error!("Failed to delete repo bookmark: {e}");
         }
 
@@ -1753,8 +1755,10 @@ impl App {
         };
         let persist = Self::repo_picker_select_or_add_row(rp, &expanded);
         if persist {
-            let host_key = self.new_session.backend.clone().unwrap_or_default();
-            if let Err(e) = self.db.upsert_repo_bookmark(&host_key, &expanded) {
+            if let Err(e) = self
+                .db
+                .upsert_repo_bookmark(self.bookmark_host_key(), &expanded)
+            {
                 error!("Failed to save repo bookmark: {e}");
                 self.set_error(format!("Failed to save repo bookmark: {e}"));
             }
@@ -1899,9 +1903,8 @@ impl App {
         let (worktree_repos, normal_repos) = Self::partition_selected_repos(rp);
 
         // Touch all selected bookmarks so they stay sorted by recency.
-        let host_key = self.new_session.backend.clone().unwrap_or_default();
         for repo in worktree_repos.iter().chain(normal_repos.iter()) {
-            if let Err(e) = self.db.upsert_repo_bookmark(&host_key, repo) {
+            if let Err(e) = self.db.upsert_repo_bookmark(self.bookmark_host_key(), repo) {
                 error!("Failed to touch repo bookmark: {e}");
             }
         }
@@ -2041,8 +2044,8 @@ mod tests {
         // LCP lands mid-char and must be floored, not sliced (panic) or
         // dropped (no completion for a valid shared prefix).
         let dirs = names(&["répo-a", "rêpo-b"]);
-        assert_eq!(dir_completion_suffix(&dirs, "r"), None); // nothing whole shared
-                                                             // Diverging *after* a multibyte char keeps the full shared run.
+        assert_eq!(dir_completion_suffix(&dirs, "r"), None);
+        // Diverging *after* a multibyte char keeps the full shared run.
         let dirs = names(&["été-x", "été-y"]);
         assert_eq!(dir_completion_suffix(&dirs, "é"), Some("té-".to_string()));
     }

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -39,6 +39,53 @@ fn is_ctrl_letter_chord(code: KeyCode, mods: KeyModifiers) -> bool {
     mods == KeyModifiers::CONTROL && matches!(code, KeyCode::Char(c) if c.is_ascii_alphabetic())
 }
 
+/// The directory-completion suffix to append after `prefix`, given the candidate
+/// directory `names` in the parent (as returned by `git::list_dir_on`). Mirrors
+/// `paths::complete_directory_path` for the remote case:
+/// - hidden (`.`-prefixed) names are offered only to a `.`-prefix (like the
+///   local completer's `matching_dir_names`);
+/// - no match, or an ambiguous prefix with nothing more shared → `None`;
+/// - a single match → the remaining chars **plus a trailing `/`** (so the next
+///   `Tab` descends into it);
+/// - several matches → their longest common prefix beyond `prefix`.
+///
+/// Pure (no I/O) so the completion logic is unit-tested without a remote host.
+fn dir_completion_suffix(names: &[String], prefix: &str) -> Option<String> {
+    let show_hidden = prefix.starts_with('.');
+    let matches: Vec<&str> = names
+        .iter()
+        .map(String::as_str)
+        .filter(|n| show_hidden || !n.starts_with('.'))
+        .filter(|n| n.starts_with(prefix))
+        .collect();
+    let first = matches.first()?;
+    // Longest common prefix of the matches, floored to a char boundary of
+    // `first` (a byte-wise LCP can land mid-char when names diverge inside a
+    // multibyte char). It always covers at least `prefix` — itself a valid
+    // boundary — so slicing back into `first` is safe.
+    let mut common_len = matches[1..].iter().fold(first.len(), |end, m| {
+        first
+            .bytes()
+            .zip(m.bytes())
+            .take(end)
+            .take_while(|(a, b)| a == b)
+            .count()
+    });
+    while !first.is_char_boundary(common_len) {
+        common_len -= 1;
+    }
+    let beyond = first.get(prefix.len()..common_len)?;
+    if beyond.is_empty() && matches.len() > 1 {
+        return None; // ambiguous with nothing new to add
+    }
+    let suffix = if matches.len() == 1 {
+        format!("{beyond}/")
+    } else {
+        beyond.to_string()
+    };
+    (!suffix.is_empty()).then_some(suffix)
+}
+
 impl App {
     /// Main key handler dispatcher.
     ///
@@ -445,10 +492,13 @@ impl App {
                 self.send_task_to_session(task_id, &title, status, session_id);
             }
             TaskActionChoice::SpawnNew => {
-                // Reuse the normal new-session flow; the prompt is
-                // delivered + the task advanced when the spawn lands.
+                // Reuse the normal new-session flow (host picker included);
+                // the prompt is delivered + the task advanced when the spawn
+                // lands. Going through the wizard entry also clears a backend
+                // left over from a previously cancelled remote flow, which
+                // would otherwise silently make this picker remote.
                 self.task_ui.pending_task_prompt = Some((task_id, title));
-                self.open_repo_picker();
+                self.start_new_session();
             }
         }
     }
@@ -1609,6 +1659,30 @@ impl App {
                 return;
             }
             KeyCode::Tab => {
+                // Remote targets have no per-keystroke suggestion (that would
+                // fire an ssh/wsl round-trip on every character); compute one on
+                // demand here by listing the remote directory. Mirrors the local
+                // branch below: completion only applies with the cursor at the
+                // end (inserting mid-string would garble the path), and a Tab
+                // with nothing to complete moves focus to the list.
+                if self.new_session.backend.is_some() {
+                    let value = rp.path_input.value().to_string();
+                    let at_end = rp.path_input.cursor_pos() == value.chars().count();
+                    let sug = at_end
+                        .then(|| self.remote_path_completion(&value))
+                        .flatten();
+                    if let super::modals::Modal::RepoPicker(ref mut rp) = self.modal {
+                        match sug {
+                            Some(sug) => {
+                                for c in sug.chars() {
+                                    rp.path_input.insert(c);
+                                }
+                            }
+                            None => rp.focus = super::modals::RepoPickerFocus::List,
+                        }
+                    }
+                    return;
+                }
                 if let Some(suggestion) = rp.path_suggestion.take() {
                     for c in suggestion.chars() {
                         rp.path_input.insert(c);
@@ -1720,10 +1794,32 @@ impl App {
         self.refresh_repo_picker_rows();
     }
 
+    /// Compute a remote directory completion for the repo-picker path input by
+    /// listing the parent directory on the selected host over ssh/wsl. Returns
+    /// the suffix to append (mirroring `paths::complete_directory_path`), or
+    /// `None`. Only called on an explicit `Tab` so it doesn't run per keystroke.
+    fn remote_path_completion(&self, input: &str) -> Option<String> {
+        let host = self.host_for_backend(self.new_session.backend.as_deref())?;
+        // Need at least one `/` to know which remote dir to list.
+        let (parent, prefix) = input.rsplit_once('/')?;
+        let parent = if parent.is_empty() { "/" } else { parent };
+        let entries = crate::git::list_dir_on(host, parent).ok()?;
+        dir_completion_suffix(&entries, prefix)
+    }
+
     pub(super) fn update_repo_picker_path_suggestion(&mut self) {
+        // For a remote target (SSH host or WSL distro) the path lives on the
+        // *remote* filesystem, so completing against the local one would suggest
+        // the wrong directories entirely. Suppress the local-filesystem
+        // suggestion in that case — the path is typed as a plain remote path.
+        let remote = self.new_session.backend.is_some();
         let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
             return;
         };
+        if remote {
+            rp.path_suggestion = None;
+            return;
+        }
         let value = rp.path_input.value().to_string();
         let at_end = rp.path_input.cursor_pos() == value.chars().count();
         if at_end && !value.is_empty() {
@@ -1852,8 +1948,82 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_ctrl_letter_chord, session_name_to_branch};
+    use super::{dir_completion_suffix, is_ctrl_letter_chord, session_name_to_branch};
     use crossterm::event::{KeyCode, KeyModifiers};
+
+    fn names(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn dir_completion_single_match_appends_trailing_slash() {
+        // One match → complete the rest and descend on the next Tab.
+        let dirs = names(&["repositories", "downloads"]);
+        assert_eq!(
+            dir_completion_suffix(&dirs, "rep"),
+            Some("ositories/".to_string())
+        );
+    }
+
+    #[test]
+    fn dir_completion_multi_match_uses_common_prefix() {
+        // Several matches → their longest common prefix beyond the typed prefix,
+        // no trailing slash (still ambiguous).
+        let dirs = names(&["adaptfy-landing", "adaptfy-landing-infra", "ai-ml"]);
+        assert_eq!(
+            dir_completion_suffix(&dirs, "adaptfy"),
+            Some("-landing".to_string())
+        );
+    }
+
+    #[test]
+    fn dir_completion_ambiguous_with_no_shared_extension_is_none() {
+        // Two matches that share nothing past the prefix → nothing to add.
+        let dirs = names(&["ai-ml", "ai-infra"]);
+        assert_eq!(dir_completion_suffix(&dirs, "ai-"), None);
+    }
+
+    #[test]
+    fn dir_completion_no_match_is_none() {
+        let dirs = names(&["repositories", "downloads"]);
+        assert_eq!(dir_completion_suffix(&dirs, "zzz"), None);
+        assert_eq!(dir_completion_suffix(&[], "any"), None);
+    }
+
+    #[test]
+    fn dir_completion_hidden_dirs_only_offered_to_dot_prefix() {
+        // Mirrors the local completer: hidden entries never match a plain
+        // prefix (including the empty one), but a `.`-prefix reaches them.
+        let dirs = names(&[".config", ".cache", "repos"]);
+        assert_eq!(dir_completion_suffix(&dirs, ""), Some("repos/".to_string()));
+        assert_eq!(
+            dir_completion_suffix(&dirs, ".co"),
+            Some("nfig/".to_string())
+        );
+        assert_eq!(dir_completion_suffix(&dirs, "."), Some("c".to_string()));
+    }
+
+    #[test]
+    fn dir_completion_multibyte_divergence_floors_to_char_boundary() {
+        // "répo-a" vs "rêpo-b" diverge inside the 2-byte é/ê — the byte-wise
+        // LCP lands mid-char and must be floored, not sliced (panic) or
+        // dropped (no completion for a valid shared prefix).
+        let dirs = names(&["répo-a", "rêpo-b"]);
+        assert_eq!(dir_completion_suffix(&dirs, "r"), None); // nothing whole shared
+                                                             // Diverging *after* a multibyte char keeps the full shared run.
+        let dirs = names(&["été-x", "été-y"]);
+        assert_eq!(dir_completion_suffix(&dirs, "é"), Some("té-".to_string()));
+    }
+
+    #[test]
+    fn dir_completion_exact_match_alone_still_descends() {
+        // Prefix already equals the only entry → append just the slash.
+        let dirs = names(&["repositories"]);
+        assert_eq!(
+            dir_completion_suffix(&dirs, "repositories"),
+            Some("/".to_string())
+        );
+    }
 
     #[test]
     fn ctrl_letter_chord_detects_readline_namespace() {

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1628,7 +1628,8 @@ impl App {
             return;
         }
 
-        if let Err(e) = self.db.delete_repo_bookmark(&path) {
+        let host_key = self.new_session.backend.clone().unwrap_or_default();
+        if let Err(e) = self.db.delete_repo_bookmark(&host_key, &path) {
             error!("Failed to delete repo bookmark: {e}");
         }
 
@@ -1712,11 +1713,16 @@ impl App {
     }
 
     /// Commit the typed path in the repo-picker input: add or re-select the
-    /// bookmark, persist it, clear the input, and refresh the filter.
+    /// bookmark, persist it (scoped to the target host), clear the input, and
+    /// refresh the filter.
     fn repo_picker_commit_path_input(&mut self) {
-        // For a remote target the path is a remote path: don't expand `~`
-        // against the local home, and don't persist it as a local bookmark.
-        let remote = self.new_session.backend.is_some();
+        // A remote path expands `~` against the *remote* home (never the local
+        // one) and is verified to exist on the host before it's accepted —
+        // catching a typo here beats failing minutes later at branch listing
+        // or worktree creation. One ssh/wsl round-trip, on explicit Enter only.
+        let remote_host = self
+            .host_for_backend(self.new_session.backend.as_deref())
+            .cloned();
         let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
             return;
         };
@@ -1725,14 +1731,30 @@ impl App {
             self.recompute_repo_filter();
             return;
         }
-        let expanded = if remote {
-            std::path::PathBuf::from(&path)
-        } else {
-            paths::expand_tilde(&path)
+        let expanded = match &remote_host {
+            Some(host) => {
+                let expanded = match crate::git::expand_remote_tilde(host, &path) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        self.set_error(format!("Cannot resolve ~ on '{}': {e:#}", host.name));
+                        return;
+                    }
+                };
+                if crate::git::list_dir_on(host, &expanded).is_err() {
+                    self.set_error(format!("Path not found on '{}': {expanded}", host.name));
+                    return;
+                }
+                std::path::PathBuf::from(expanded)
+            }
+            None => paths::expand_tilde(&path),
+        };
+        let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
+            return;
         };
         let persist = Self::repo_picker_select_or_add_row(rp, &expanded);
-        if persist && !remote {
-            if let Err(e) = self.db.upsert_repo_bookmark(&expanded) {
+        if persist {
+            let host_key = self.new_session.backend.clone().unwrap_or_default();
+            if let Err(e) = self.db.upsert_repo_bookmark(&host_key, &expanded) {
                 error!("Failed to save repo bookmark: {e}");
                 self.set_error(format!("Failed to save repo bookmark: {e}"));
             }
@@ -1769,7 +1791,16 @@ impl App {
     /// Import the typed path as a *parent* folder: persist it as a parent
     /// bookmark, then rebuild the list (re-scanning its git sub-directories).
     /// The parent itself is not added as a selectable repo — its children are.
+    /// Local targets only: the child scan walks the local filesystem, so a
+    /// remote parent would import the wrong machine's repos.
     fn repo_picker_import_parent(&mut self) {
+        if self.new_session.backend.is_some() {
+            self.set_status(
+                super::StatusLevel::Info,
+                "Parent import scans the local filesystem — add remote repos by path instead",
+            );
+            return;
+        }
         let super::modals::Modal::RepoPicker(ref mut rp) = self.modal else {
             return;
         };
@@ -1782,7 +1813,7 @@ impl App {
             return;
         }
         let expanded = paths::expand_tilde(&path);
-        if let Err(e) = self.db.upsert_repo_bookmark_kind(&expanded, true) {
+        if let Err(e) = self.db.upsert_repo_bookmark_kind("", &expanded, true) {
             error!("Failed to save parent bookmark: {e}");
             self.set_error(format!("Failed to save parent bookmark: {e}"));
         }
@@ -1868,8 +1899,9 @@ impl App {
         let (worktree_repos, normal_repos) = Self::partition_selected_repos(rp);
 
         // Touch all selected bookmarks so they stay sorted by recency.
+        let host_key = self.new_session.backend.clone().unwrap_or_default();
         for repo in worktree_repos.iter().chain(normal_repos.iter()) {
-            if let Err(e) = self.db.upsert_repo_bookmark(repo) {
+            if let Err(e) = self.db.upsert_repo_bookmark(&host_key, repo) {
                 error!("Failed to touch repo bookmark: {e}");
             }
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -150,7 +150,30 @@ fn create_worktrees(
 ) -> Result<Vec<WorktreeInfo>, String> {
     let mut worktree_infos: Vec<WorktreeInfo> = Vec::new();
     for repo_path in repo_paths {
-        match git::create_worktree_on(host, repo_path, new_branch, base_branch) {
+        // Multi-repo spawn: the chosen base comes from the *primary* repo's
+        // branch list and may not exist in an extra repo. Fall back to that
+        // repo's own default branch — mirroring the headless `--add-repo
+        // PATH[@BASE]` model where each repo resolves its own base — instead
+        // of failing (and rolling back) the whole spawn.
+        let repo_base = if git::branch_exists_on(host, repo_path, base_branch) {
+            base_branch.to_string()
+        } else {
+            let branches = git::list_branches_on(host, repo_path).unwrap_or_default();
+            match git::default_branch_on(host, repo_path, &branches) {
+                Some(fallback) => {
+                    tracing::info!(
+                        "base '{base_branch}' not found in {}; forking its worktree \
+                         from the repo's default branch '{fallback}'",
+                        repo_path.display()
+                    );
+                    fallback
+                }
+                // No resolvable default: keep the original base so the error
+                // below names the branch the user actually picked.
+                None => base_branch.to_string(),
+            }
+        };
+        match git::create_worktree_on(host, repo_path, new_branch, &repo_base) {
             Ok(worktree_path) => worktree_infos.push(WorktreeInfo {
                 repo_path: repo_path.clone(),
                 worktree_path,
@@ -1188,30 +1211,29 @@ impl App {
 
     /// Open the repo picker modal for creating a new session.
     ///
-    /// Loads bookmarks from the database, pre-selects repos from the active
-    /// project (if any), and shows the repo picker modal. For a remote target
-    /// (`new_session.backend` set) local bookmarks don't apply, so the picker opens
-    /// empty with the path input focused for a typed remote path.
+    /// Loads the target host's bookmarks from the database (bookmarks are
+    /// host-scoped — a remote target shows the repos previously used *on that
+    /// host*, never local paths) and shows the repo picker modal. A remote
+    /// target with no bookmarks yet opens with the path input focused for a
+    /// typed remote path; once it has history it opens on the list like a
+    /// local target.
     pub(crate) fn open_repo_picker(&mut self) {
-        // Local bookmarks point at local paths, so they're meaningless for a
-        // remote target: open the picker empty with the path input focused.
         let remote = self.new_session.backend.is_some();
-        let bookmarks = if remote {
-            Vec::new()
-        } else {
-            self.load_repo_bookmarks()
-        };
+        let bookmarks = self.load_repo_bookmarks();
+        let empty = bookmarks.is_empty();
         let mut rp = modals::RepoPickerModal::default();
         Self::rebuild_repo_picker_rows(&mut rp, bookmarks);
-        if remote {
+        if remote && empty {
             rp.focus = modals::RepoPickerFocus::Input;
         }
         self.modal = modals::Modal::RepoPicker(rp);
     }
 
-    /// Load persisted repo bookmarks, logging (and swallowing) any DB error.
+    /// Load persisted repo bookmarks for the new-session wizard's current
+    /// target host (`""` = local), logging (and swallowing) any DB error.
     fn load_repo_bookmarks(&self) -> Vec<crate::storage::repo_bookmarks::RepoBookmark> {
-        match self.db.list_repo_bookmarks() {
+        let host_key = self.new_session.backend.as_deref().unwrap_or_default();
+        match self.db.list_repo_bookmarks(host_key) {
             Ok(b) => b,
             Err(e) => {
                 tracing::error!("Failed to load repo bookmarks: {e}");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1229,11 +1229,17 @@ impl App {
         self.modal = modals::Modal::RepoPicker(rp);
     }
 
+    /// The host-scope key for repo bookmarks: the new-session wizard's target
+    /// backend name (`ssh:<name>` / `wsl:<name>`), or `""` for local — the
+    /// `repo_bookmarks.host` column (schema v39).
+    pub(super) fn bookmark_host_key(&self) -> &str {
+        self.new_session.backend.as_deref().unwrap_or_default()
+    }
+
     /// Load persisted repo bookmarks for the new-session wizard's current
-    /// target host (`""` = local), logging (and swallowing) any DB error.
+    /// target host, logging (and swallowing) any DB error.
     fn load_repo_bookmarks(&self) -> Vec<crate::storage::repo_bookmarks::RepoBookmark> {
-        let host_key = self.new_session.backend.as_deref().unwrap_or_default();
-        match self.db.list_repo_bookmarks(host_key) {
+        match self.db.list_repo_bookmarks(self.bookmark_host_key()) {
             Ok(b) => b,
             Err(e) => {
                 tracing::error!("Failed to load repo bookmarks: {e}");
@@ -9642,6 +9648,63 @@ mod tests {
         assert_eq!(members.len(), 2);
         assert_eq!(members[0].1, PathBuf::from("/src/primary"));
         assert_eq!(members[1].1, PathBuf::from("/src/other"));
+    }
+
+    /// Init a real git repo at `dir` on branch `main` with one commit.
+    fn init_repo(dir: &std::path::Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        let git = |args: &[&str]| {
+            let ok = crate::git::git_program()
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .expect("run git")
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed in {}", dir.display());
+        };
+        git(&["init", "-q", "-b", "main"]);
+        git(&["config", "user.email", "t@example.com"]);
+        git(&["config", "user.name", "t"]);
+        std::fs::write(dir.join("file.txt"), "hi").unwrap();
+        git(&["add", "."]);
+        git(&["commit", "-qm", "init"]);
+    }
+
+    #[test]
+    fn create_worktrees_falls_back_to_extra_repos_default_branch() {
+        // The chosen base exists only in the primary repo; the extra repo must
+        // fork from its own default branch instead of failing the whole spawn.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path().join("data"));
+        let primary = tmp.path().join("primary");
+        let extra = tmp.path().join("extra");
+        init_repo(&primary);
+        init_repo(&extra);
+        let ok = crate::git::git_program()
+            .args(["branch", "feat-base"])
+            .current_dir(&primary)
+            .output()
+            .unwrap()
+            .status
+            .success();
+        assert!(ok, "creating feat-base in primary failed");
+
+        let infos = create_worktrees(
+            None,
+            &[primary.clone(), extra.clone()],
+            "wt-branch",
+            "feat-base",
+        )
+        .expect("both worktrees created");
+
+        assert_eq!(infos.len(), 2);
+        for info in &infos {
+            assert!(info.worktree_path.exists());
+            assert_eq!(info.branch, "wt-branch");
+        }
+        assert_eq!(infos[0].repo_path, primary);
+        assert_eq!(infos[1].repo_path, extra);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1385,7 +1385,7 @@ impl App {
         let session_id = session.info.id;
         // Rebuild the process cwd: the primary repo for a single-repo session,
         // or the (idempotently rebuilt) symlink workspace for a multi-repo one.
-        let cwd = session_process_cwd(&session.info);
+        let cwd = self.session_process_cwd(&session.info);
 
         let mut config = SessionConfig {
             resume_session_id: None,
@@ -1740,6 +1740,26 @@ impl App {
                     let _ = std::fs::remove_file(metrics_dir.join(format!("{sid}.json")));
                 }
                 let _ = crate::workspace::remove_workspace(sid);
+                // A remote session's workspace lives on its host (see
+                // `git::ensure_remote_workspace`) — tear it down there too, or
+                // it leaks forever. Gated on multi-repo so a single-repo delete
+                // never pays an ssh/wsl round-trip (no workspace exists).
+                let info = &pending.session.info;
+                let multi = session_member_dirs(
+                    info.cwd.as_deref(),
+                    &info.worktrees,
+                    &info.additional_dirs,
+                )
+                .len()
+                    >= 2;
+                if multi {
+                    if let Some(host) = info.remote_host.as_deref().and_then(|n| self.hosts.get(n))
+                    {
+                        if let Err(e) = crate::git::remove_remote_workspace(host, sid) {
+                            warn!("failed to remove remote workspace for {sid}: {e:#}");
+                        }
+                    }
+                }
             }
             pending.session.kill();
         }
@@ -2074,11 +2094,22 @@ impl App {
         let session_id = session.info.id;
         if session.shell_pane.is_none() {
             let (rows, cols) = self.content_area_size();
+            // Resolve the launch cwd (host-aware for remote workspaces) before
+            // taking the mutable session borrow; the immutable borrow of
+            // `self.sessions` ends with this block. The *non-building* variant:
+            // the agent is running in the workspace, and the ensure-style
+            // rebuild would rm -rf its cwd out from under it.
+            let shell_cwd = {
+                let idx = self.active_index;
+                match self.sessions.get(idx) {
+                    Some(s) => self.session_process_cwd_existing(&s.info),
+                    None => None,
+                }
+            };
             let Some(session) = self.active_session_mut() else {
                 // Active session removed concurrently — nothing to switch to.
                 return;
             };
-            let shell_cwd = session_process_cwd(&session.info);
             if let Err(e) = session.ensure_shell_pane(rows, cols, shell_cwd.as_deref()) {
                 error!("Failed to create shell pane: {e}");
                 self.set_error(format!("Failed to create shell: {e:#}"));
@@ -3128,6 +3159,50 @@ impl App {
         self.hosts.get_by_backend(backend?)
     }
 
+    /// The launch cwd for an *existing* session, derived from its persisted
+    /// `SessionInfo`: the multi-repo symlink workspace ((re)built on the
+    /// session's host, remote or local), or the primary repo when single-repo.
+    /// Used by the restart path — the agent is about to relaunch, so the
+    /// destructive workspace rebuild is safe there.
+    fn session_process_cwd(&self, info: &SessionInfo) -> Option<PathBuf> {
+        // `remote_host` is the bare host name (`None` = local).
+        let host = info.remote_host.as_deref().and_then(|n| self.hosts.get(n));
+        resolve_process_cwd(
+            info.agent_session_id.as_deref(),
+            info.cwd.clone(),
+            &info.worktrees,
+            &info.additional_dirs,
+            host,
+        )
+    }
+
+    /// Like [`session_process_cwd`](Self::session_process_cwd) but **never
+    /// (re)builds** the workspace — it derives the same deterministic path
+    /// without touching the filesystem. For callers that resolve the cwd of a
+    /// session whose agent is *still running* there (the shell pane): the
+    /// ensure-style rebuild is `rm -rf` + recreate, which would delete the
+    /// running agent's cwd inode out from under it.
+    fn session_process_cwd_existing(&self, info: &SessionInfo) -> Option<PathBuf> {
+        let members =
+            session_member_dirs(info.cwd.as_deref(), &info.worktrees, &info.additional_dirs);
+        if members.len() < 2 {
+            return info.cwd.clone();
+        }
+        let Some(id) = info.agent_session_id.as_deref() else {
+            return info.cwd.clone();
+        };
+        let host = info.remote_host.as_deref().and_then(|n| self.hosts.get(n));
+        let path = match host {
+            // Only network cost is the (cached) remote `$HOME` lookup.
+            Some(h) => crate::git::remote_workspace_dir(h, id)
+                .map(PathBuf::from)
+                .map_err(|e| error!("Failed to resolve remote workspace path: {e:#}")),
+            None => crate::workspace::workspace_path(id)
+                .map_err(|e| error!("Failed to resolve workspace path: {e}")),
+        };
+        path.ok().or_else(|| info.cwd.clone())
+    }
+
     /// Resolve the backend for a *persisted* session by its `backend_type`, or
     /// `None` when this instance cannot manage it.
     ///
@@ -3213,11 +3288,13 @@ impl App {
         // gathers every member dir; `info.cwd` keeps the primary repo (restored
         // after spawn). Single-repo sessions are unchanged.
         let primary_cwd = config.cwd.clone();
+        let spawn_host = self.host_for_backend(config.backend.as_deref()).cloned();
         config.cwd = resolve_process_cwd(
             config.agent_session_id.as_deref(),
             primary_cwd.clone(),
             worktrees,
             additional_dirs,
+            spawn_host.as_ref(),
         );
 
         let backend = match self.backend_for(&config) {
@@ -3230,6 +3307,17 @@ impl App {
         };
 
         let provider = self.provider_for(&config);
+
+        // On a remote host, materialize any thurbox-managed config file the
+        // agent args reference by its *local* path (e.g. claude's hooks
+        // `--settings <config>/hooks/claude.json`) at the same path on the
+        // remote, so the agent doesn't fail to launch ("Settings file not
+        // found"). Best-effort; shares the headless spawn's implementation.
+        if let Some(h) = spawn_host.as_ref() {
+            let args = crate::agent::AgentProvider::build_args(provider.as_ref(), &config);
+            crate::session_ops::spawn::materialize_agent_config_on_remote(h, &args);
+        }
+
         Some(SpawnInputs {
             config,
             primary_cwd,
@@ -5260,6 +5348,7 @@ fn resolve_process_cwd(
     primary_cwd: Option<PathBuf>,
     worktrees: &[WorktreeInfo],
     additional_dirs: &[PathBuf],
+    host: Option<&crate::session::HostDef>,
 ) -> Option<PathBuf> {
     let members = session_member_dirs(primary_cwd.as_deref(), worktrees, additional_dirs);
     if members.len() < 2 {
@@ -5279,26 +5368,20 @@ fn resolve_process_cwd(
         })
         .collect();
 
-    match crate::workspace::ensure_workspace(id, &pairs) {
+    // A remote session's symlink workspace is built on the *remote* host — a
+    // local workspace dir wouldn't exist there. Local sessions use the local
+    // builder as before.
+    let built = match host {
+        Some(h) => crate::git::ensure_remote_workspace(h, id, &pairs),
+        None => crate::workspace::ensure_workspace(id, &pairs).map_err(anyhow::Error::from),
+    };
+    match built {
         Ok(ws) => Some(ws),
         Err(e) => {
             error!("Failed to build multi-repo workspace: {e}");
             primary_cwd
         }
     }
-}
-
-/// The launch cwd for an *existing* session, derived from its persisted
-/// `SessionInfo`: the multi-repo symlink workspace, or the primary repo when
-/// single-repo. Used by the restart and shell-pane paths, which must agree on
-/// the cwd so the companion shell lands exactly where the agent runs.
-fn session_process_cwd(info: &SessionInfo) -> Option<PathBuf> {
-    resolve_process_cwd(
-        info.agent_session_id.as_deref(),
-        info.cwd.clone(),
-        &info.worktrees,
-        &info.additional_dirs,
-    )
 }
 
 #[cfg(test)]
@@ -9542,7 +9625,7 @@ mod tests {
     #[test]
     fn process_cwd_single_member_is_primary() {
         let cwd = PathBuf::from("/src/only");
-        let out = resolve_process_cwd(Some("id-1"), Some(cwd.clone()), &[], &[]);
+        let out = resolve_process_cwd(Some("id-1"), Some(cwd.clone()), &[], &[], None);
         assert_eq!(out, Some(cwd));
     }
 
@@ -9562,6 +9645,7 @@ mod tests {
             Some(primary.clone()),
             &[],
             std::slice::from_ref(&other),
+            None,
         )
         .unwrap();
 
@@ -9583,6 +9667,7 @@ mod tests {
             Some(primary.clone()),
             &[],
             std::slice::from_ref(&other),
+            None,
         );
         assert_eq!(out, Some(primary));
     }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -1089,6 +1089,9 @@ impl App {
                 search_active: rp.focus == super::modals::RepoPickerFocus::Search
                     || !rp.search_input.value().is_empty(),
                 filtered_indices: &rp.filtered_indices,
+                host: self
+                    .host_for_backend(self.new_session.backend.as_deref())
+                    .map(|h| h.name.as_str()),
             },
         )
     }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -173,13 +173,11 @@ fn sanitize_workspace_segment(name: &str) -> String {
 /// `workspace::unique_link_name`: collisions get a `-2`, `-3`, … suffix and an
 /// empty label falls back to `repo`.
 fn unique_link_name(name: &str, used: &mut HashSet<String>) -> String {
-    let base = {
-        let s = sanitize_workspace_segment(name);
-        if s.is_empty() {
-            "repo".to_string()
-        } else {
-            s
-        }
+    let sanitized = sanitize_workspace_segment(name);
+    let base = if sanitized.is_empty() {
+        "repo".to_string()
+    } else {
+        sanitized
     };
     if used.insert(base.clone()) {
         return base;
@@ -223,14 +221,7 @@ pub fn ensure_remote_workspace(
         ));
     }
 
-    let output = host_shell_c(host, &script)
-        .stderr(Stdio::piped())
-        .output()
-        .context("failed to build remote multi-repo workspace")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("remote workspace build failed: {}", stderr.trim());
-    }
+    run_host_script(host, &script, "workspace build")?;
     Ok(PathBuf::from(ws))
 }
 
@@ -262,15 +253,32 @@ pub(crate) fn remote_workspace_dir(host: &HostDef, id: &str) -> Result<String> {
 /// workspace is not an error (`rm -rf` on a missing path succeeds).
 pub fn remove_remote_workspace(host: &HostDef, id: &str) -> Result<()> {
     let ws = remote_workspace_dir(host, id)?;
-    let output = host_shell_c(host, &format!("rm -rf {}", posix_quote(&ws)))
+    run_host_script(
+        host,
+        &format!("rm -rf {}", posix_quote(&ws)),
+        "workspace removal",
+    )
+}
+
+/// Map a finished remote command to `Ok(stdout)`, or an error carrying the
+/// trimmed remote stderr when it exited non-zero. Shared by every remote
+/// helper below so their failures read uniformly.
+fn remote_output_or_stderr(output: std::process::Output, action: &str) -> Result<Vec<u8>> {
+    if output.status.success() {
+        return Ok(output.stdout);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    anyhow::bail!("remote {action} failed: {}", stderr.trim())
+}
+
+/// Run `script` on `host` via [`host_shell_c`], discarding stdout. See
+/// [`remote_output_or_stderr`] for the failure shape.
+fn run_host_script(host: &HostDef, script: &str, action: &str) -> Result<()> {
+    let output = host_shell_c(host, script)
         .stderr(Stdio::piped())
         .output()
-        .context("failed to remove remote workspace")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("remote workspace removal failed: {}", stderr.trim());
-    }
-    Ok(())
+        .with_context(|| format!("failed to run remote {action}"))?;
+    remote_output_or_stderr(output, action).map(|_| ())
 }
 
 /// Build a `<launcher> sh -c <script>` [`Command`] for a host, correct for each
@@ -339,11 +347,7 @@ pub fn copy_file_to_remote(host: &HostDef, local: &Path, remote_path: &str) -> R
     let output = child
         .wait_with_output()
         .context("failed to wait on remote file-copy")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("remote file-copy failed: {}", stderr.trim());
-    }
-    Ok(())
+    remote_output_or_stderr(output, "file-copy").map(|_| ())
 }
 
 /// Expand a leading `~` in a remote path against the host's `$HOME`. Remote
@@ -361,11 +365,11 @@ pub fn expand_remote_tilde(host: &HostDef, path: &str) -> Result<String> {
 }
 
 /// List immediate sub-directory **names** of `dir` on `host` over the host
-/// launcher, sorted. Hidden (`.`-prefixed) entries are *included* — the caller
-/// filters by the prefix it is completing (mirroring the local completer,
-/// which offers hidden dirs only to a `.`-prefix). A leading `~` is expanded
-/// against the host's `$HOME`. Used by the repo picker's remote path
-/// completion.
+/// launcher, sorted. Hidden (`.`-prefixed) entries are *included* — the
+/// completion layer decides their visibility (`dir_completion_suffix` offers
+/// them only to a `.`-prefix, mirroring the local completer). A leading `~`
+/// is expanded against the host's `$HOME`. Used by the repo picker's remote
+/// path completion.
 ///
 /// Runs `ls -1p <dir>` — a **variable-free** command on purpose, and over WSL
 /// with `--exec` so argv reaches `ls` verbatim (no `wsl.exe` `$`-substitution
@@ -380,10 +384,29 @@ pub fn expand_remote_tilde(host: &HostDef, path: &str) -> Result<String> {
 /// password-prompting host instead of freezing the TUI indefinitely.
 pub fn list_dir_on(host: &HostDef, dir: &str) -> Result<Vec<String>> {
     let dir = expand_remote_tilde(host, dir)?;
-    let mut cmd = if host.is_wsl() {
+    let output = list_dir_command(host, &dir)
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to list remote directory")?;
+    let stdout = remote_output_or_stderr(output, "dir listing")?;
+    let mut names: Vec<String> = String::from_utf8_lossy(&stdout)
+        .lines()
+        .filter_map(|line| line.strip_suffix('/'))
+        .filter(|name| !name.is_empty())
+        .map(String::from)
+        .collect();
+    names.sort();
+    Ok(names)
+}
+
+/// The `ls -1p <dir>` launcher [`list_dir_on`] runs (`dir` already
+/// tilde-expanded). Split out so the per-transport construction is testable
+/// without a live host.
+fn list_dir_command(host: &HostDef, dir: &str) -> Command {
+    if host.is_wsl() {
         let mut cmd = host_launcher(host);
         cmd.arg("-e");
-        for tok in ["ls", "-1p", &dir] {
+        for tok in ["ls", "-1p", dir] {
             cmd.arg(tok);
         }
         cmd
@@ -395,28 +418,11 @@ pub fn list_dir_on(host: &HostDef, dir: &str) -> Result<Vec<String>> {
                 .map(|s| s.to_string()),
         );
         let mut cmd = crate::shell::ssh_command(&host.destination, &opts);
-        for tok in ["ls", "-1p", &dir] {
+        for tok in ["ls", "-1p", dir] {
             cmd.arg(posix_quote(tok));
         }
         cmd
-    };
-    let output = cmd
-        .stderr(Stdio::piped())
-        .output()
-        .context("failed to list remote directory")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("remote dir listing failed: {}", stderr.trim());
     }
-    let mut names: Vec<String> = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        // Only directories (trailing `/`).
-        .filter_map(|line| line.strip_suffix('/'))
-        .filter(|name| !name.is_empty())
-        .map(String::from)
-        .collect();
-    names.sort();
-    Ok(names)
 }
 
 /// Global cache for repo display names (path → name).
@@ -1805,16 +1811,12 @@ mod tests {
     }
 
     #[test]
-    fn list_dir_on_wsl_uses_variable_free_exec_ls() {
+    fn list_dir_command_wsl_uses_variable_free_exec_ls() {
         // Must be `--exec ls -1p <dir>` as separate argv tokens — NOT an
         // `sh -c` script — so no wsl.exe `$`-substitution or shell
         // re-interpretation can touch the user-typed dir.
         let h = HostDef::wsl("Ubuntu");
-        let mut cmd = host_launcher(&h);
-        cmd.arg("-e");
-        for tok in ["ls", "-1p", "/home/me/repos"] {
-            cmd.arg(tok);
-        }
+        let cmd = list_dir_command(&h, "/home/me/repos");
         let (prog, args) = program_and_args(&cmd);
         assert_eq!(prog, "wsl.exe");
         assert_eq!(args, ["-d", "Ubuntu", "-e", "ls", "-1p", "/home/me/repos"]);
@@ -1826,7 +1828,7 @@ mod tests {
     }
 
     #[test]
-    fn list_dir_on_ssh_adds_noninteractive_opts_after_user_opts() {
+    fn list_dir_command_ssh_adds_noninteractive_opts_after_user_opts() {
         // Completion runs synchronously on the UI thread: BatchMode +
         // ConnectTimeout make an unreachable/password host fail fast instead
         // of freezing the TUI. They come AFTER the host's own ssh_opts — ssh
@@ -1837,20 +1839,17 @@ mod tests {
             ssh_opts: vec!["-o".into(), "ConnectTimeout=30".into()],
             ..Default::default()
         };
-        // Reconstruct the launcher exactly as list_dir_on's ssh branch does.
-        let mut opts = h.ssh_opts.clone();
-        opts.extend(
-            ["-o", "BatchMode=yes", "-o", "ConnectTimeout=5"]
-                .iter()
-                .map(|s| s.to_string()),
-        );
-        let cmd = crate::shell::ssh_command(&h.destination, &opts);
+        let cmd = list_dir_command(&h, "/srv/repos");
         let (prog, args) = program_and_args(&cmd);
         assert_eq!(prog, "ssh");
         let user_pos = args.iter().position(|a| a == "ConnectTimeout=30");
         let ours_pos = args.iter().position(|a| a == "ConnectTimeout=5");
         assert!(user_pos.unwrap() < ours_pos.unwrap());
         assert!(args.iter().any(|a| a == "BatchMode=yes"));
+        // The listing itself follows the destination, each token quoted for
+        // the remote shell's re-split (no-ops for these safe tokens).
+        let dest = args.iter().position(|a| a == "me@box").unwrap();
+        assert_eq!(&args[dest + 1..], ["ls", "-1p", "/srv/repos"]);
     }
 
     #[test]
@@ -1863,6 +1862,24 @@ mod tests {
             "/home/me/repos"
         );
         assert_eq!(expand_remote_tilde(&h, "/data/~x").unwrap(), "/data/~x");
+    }
+
+    #[test]
+    fn remote_workspace_dir_derives_base_from_worktrees_dir() {
+        // With a configured worktrees_dir the path is pure (no host round-trip):
+        // base = its parent, mirroring the local `<data root>/workspaces` layout.
+        let h = host("me@box", Some("/data/wt"));
+        let ws = remote_workspace_dir(&h, "abc-123").unwrap();
+        assert_eq!(ws, "/data/workspaces/abc-123");
+    }
+
+    #[test]
+    fn remote_workspace_dir_rejects_empty_id() {
+        // An empty sanitized segment would make ensure/remove `rm -rf` the
+        // workspaces *root* — must error like the local builder.
+        let h = host("me@box", Some("/data/wt"));
+        assert!(remote_workspace_dir(&h, "").is_err());
+        assert!(remote_workspace_dir(&h, " .- ").is_err());
     }
 
     #[test]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Mutex, OnceLock};
@@ -102,7 +102,7 @@ fn remote_home_cache() -> &'static Mutex<HashMap<String, String>> {
 
 /// Resolve the `$HOME` directory on a host (over SSH or inside a WSL distro),
 /// caching the result.
-fn remote_home(host: &HostDef) -> Result<String> {
+pub(crate) fn remote_home(host: &HostDef) -> Result<String> {
     let key = host.backend_name();
     if let Ok(guard) = remote_home_cache().lock() {
         if let Some(home) = guard.get(&key) {
@@ -151,6 +151,272 @@ fn worktree_path_for(host: Option<&HostDef>, repo_path: &Path, branch: &str) -> 
             )))
         }
     }
+}
+
+/// Sanitize a workspace directory segment (the session id). Mirrors
+/// `workspace::sanitize_segment` so the remote workspace path matches the local
+/// one; `git` can't depend on `workspace`, so it is duplicated by construction.
+fn sanitize_workspace_segment(name: &str) -> String {
+    let cleaned: String = name
+        .trim()
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' => '-',
+            c if c.is_whitespace() => '-',
+            c => c,
+        })
+        .collect();
+    cleaned.trim_matches(['.', '-']).to_string()
+}
+
+/// A unique, sanitized symlink name for a workspace member. Mirrors
+/// `workspace::unique_link_name`: collisions get a `-2`, `-3`, … suffix and an
+/// empty label falls back to `repo`.
+fn unique_link_name(name: &str, used: &mut HashSet<String>) -> String {
+    let base = {
+        let s = sanitize_workspace_segment(name);
+        if s.is_empty() {
+            "repo".to_string()
+        } else {
+            s
+        }
+    };
+    if used.insert(base.clone()) {
+        return base;
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{base}-{n}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
+/// Build a per-session **remote** symlink workspace on `host`: a directory
+/// holding one symlink per member (`<label> -> <remote member path>`), so a
+/// multi-repo remote session launches somewhere every repo is a visible subdir.
+///
+/// This is the remote analogue of [`crate::workspace::ensure_workspace`], run
+/// over the host launcher (`ssh`/`wsl.exe`). All paths are POSIX (`/`-joined)
+/// because the host is always Linux, even when thurbox runs on Windows. Returns
+/// the remote workspace directory path.
+pub fn ensure_remote_workspace(
+    host: &HostDef,
+    id: &str,
+    members: &[(String, PathBuf)],
+) -> Result<PathBuf> {
+    let ws = remote_workspace_dir(host, id)?;
+
+    // Fresh dir, then one symlink per member, de-duplicating names with a `-2`,
+    // `-3`, … suffix (matching the local builder).
+    let mut script = format!("rm -rf {ws} && mkdir -p {ws}", ws = posix_quote(&ws));
+    let mut used: HashSet<String> = HashSet::new();
+    for (label, target) in members {
+        let name = unique_link_name(label, &mut used);
+        let link = format!("{ws}/{name}");
+        script.push_str(&format!(
+            " && ln -s {target} {link}",
+            target = posix_quote(&target.to_string_lossy()),
+            link = posix_quote(&link),
+        ));
+    }
+
+    let output = host_shell_c(host, &script)
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to build remote multi-repo workspace")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("remote workspace build failed: {}", stderr.trim());
+    }
+    Ok(PathBuf::from(ws))
+}
+
+/// The remote workspace directory for a session id on `host`, mirroring the
+/// local layout (`<thurbox data root>/workspaces/<sanitized id>`). Base:
+/// `<worktrees_dir>/..`, or `$HOME/.local/share/thurbox`. Sanitizes the id
+/// exactly like the local builder (`workspace::workspace_dir`) — `git` can't
+/// depend on `workspace`, so the scheme is mirrored here by construction (kept
+/// in sync via tests) — including its empty-id rejection: an empty segment
+/// would make the `rm -rf` in ensure/remove target the workspaces *root*,
+/// wiping every session's workspace on the host.
+pub(crate) fn remote_workspace_dir(host: &HostDef, id: &str) -> Result<String> {
+    let base = match &host.worktrees_dir {
+        Some(dir) => Path::new(dir)
+            .parent()
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|| dir.clone()),
+        None => format!("{}/.local/share/thurbox", remote_home(host)?),
+    };
+    let segment = sanitize_workspace_segment(id);
+    anyhow::ensure!(!segment.is_empty(), "empty workspace id");
+    Ok(format!("{base}/workspaces/{segment}"))
+}
+
+/// Remove the remote symlink workspace for a session id on `host` — the
+/// teardown counterpart of [`ensure_remote_workspace`], the remote analogue of
+/// [`crate::workspace::remove_workspace`]. Only the workspace dir (symlinks) is
+/// removed; the repos the links point at are untouched, and a missing
+/// workspace is not an error (`rm -rf` on a missing path succeeds).
+pub fn remove_remote_workspace(host: &HostDef, id: &str) -> Result<()> {
+    let ws = remote_workspace_dir(host, id)?;
+    let output = host_shell_c(host, &format!("rm -rf {}", posix_quote(&ws)))
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to remove remote workspace")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("remote workspace removal failed: {}", stderr.trim());
+    }
+    Ok(())
+}
+
+/// Build a `<launcher> sh -c <script>` [`Command`] for a host, correct for each
+/// transport's argument handling.
+///
+/// The two launchers disagree on how trailing args reach the in-host shell:
+/// - **`wsl.exe`** gets `--exec` (`-e`), which bypasses `wsl.exe`'s own
+///   command-line processing entirely: argv reaches the in-distro process
+///   verbatim, so the multi-statement `script` travels as one **unquoted** arg
+///   and `sh -c` parses the `posix_quote`d paths inside it exactly like the
+///   ssh path. Without `-e`, `wsl.exe` mangles the script — it substitutes
+///   `$…` even inside a preserved argument (single quotes don't protect it),
+///   and pre-quoting the script makes the in-distro shell treat the quoted
+///   blob as one command word ("not found").
+/// - **`ssh`** space-joins its trailing args into one string the remote login
+///   shell re-splits, so the `script` must be POSIX-quoted to survive as a
+///   single `sh -c` argument (mirroring [`git_command`]).
+fn host_shell_c(host: &HostDef, script: &str) -> Command {
+    let mut cmd = host_launcher(host);
+    if host.is_wsl() {
+        cmd.arg("-e").arg("sh").arg("-c").arg(script);
+    } else {
+        cmd.arg(posix_quote("sh"))
+            .arg(posix_quote("-c"))
+            .arg(posix_quote(script));
+    }
+    cmd
+}
+
+/// Copy a local file to the **same** absolute path on a remote `host`, creating
+/// the parent directory. Streams the file's bytes over the host launcher's
+/// stdin into `cat > <path>`, so it is transport-neutral (ssh/wsl) and needs no
+/// `scp`/`\\wsl$` share. Used to materialize thurbox-managed agent config (e.g.
+/// the hooks `--settings claude.json`) on the remote so the agent — launched
+/// with a `--settings <path>` that thurbox generated against the *local* config
+/// dir — finds the file at that path on the remote too.
+pub fn copy_file_to_remote(host: &HostDef, local: &Path, remote_path: &str) -> Result<()> {
+    use std::io::Write;
+
+    let bytes = std::fs::read(local)
+        .with_context(|| format!("failed to read local file {}", local.display()))?;
+
+    let parent = Path::new(remote_path)
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "/".to_string());
+    // `mkdir -p <dir> && cat > <file>`: stdin is the file body. Both transports
+    // pass stdin straight through to the in-host shell.
+    let script = format!(
+        "mkdir -p {dir} && cat > {file}",
+        dir = posix_quote(&parent),
+        file = posix_quote(remote_path),
+    );
+
+    let mut child = host_shell_c(host, &script)
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("failed to spawn remote file-copy")?;
+    child
+        .stdin
+        .take()
+        .context("remote file-copy stdin unavailable")?
+        .write_all(&bytes)
+        .context("failed to stream file to remote")?;
+    let output = child
+        .wait_with_output()
+        .context("failed to wait on remote file-copy")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("remote file-copy failed: {}", stderr.trim());
+    }
+    Ok(())
+}
+
+/// Expand a leading `~` in a remote path against the host's `$HOME`. Remote
+/// paths are never expanded against the *local* home (they're different
+/// filesystems), so this is the only `~` handling a remote path gets. A path
+/// with no `~` prefix passes through unchanged.
+pub fn expand_remote_tilde(host: &HostDef, path: &str) -> Result<String> {
+    if path == "~" {
+        return remote_home(host);
+    }
+    match path.strip_prefix("~/") {
+        Some(rest) => Ok(format!("{}/{}", remote_home(host)?, rest)),
+        None => Ok(path.to_string()),
+    }
+}
+
+/// List immediate sub-directory **names** of `dir` on `host` over the host
+/// launcher, sorted. Hidden (`.`-prefixed) entries are *included* — the caller
+/// filters by the prefix it is completing (mirroring the local completer,
+/// which offers hidden dirs only to a `.`-prefix). A leading `~` is expanded
+/// against the host's `$HOME`. Used by the repo picker's remote path
+/// completion.
+///
+/// Runs `ls -1p <dir>` — a **variable-free** command on purpose, and over WSL
+/// with `--exec` so argv reaches `ls` verbatim (no `wsl.exe` `$`-substitution
+/// or shell re-splitting; over ssh each token is `posix_quote`d instead). `-p`
+/// appends a trailing `/` to directories, which is how they're identified
+/// without a shell loop.
+///
+/// This runs synchronously on the caller's (UI) thread, so the ssh variant
+/// adds `BatchMode=yes` + `ConnectTimeout=5` **after** the host's own
+/// `ssh_opts` (ssh honors the first occurrence of an option, so a user
+/// setting wins): completion fails fast on an unreachable or
+/// password-prompting host instead of freezing the TUI indefinitely.
+pub fn list_dir_on(host: &HostDef, dir: &str) -> Result<Vec<String>> {
+    let dir = expand_remote_tilde(host, dir)?;
+    let mut cmd = if host.is_wsl() {
+        let mut cmd = host_launcher(host);
+        cmd.arg("-e");
+        for tok in ["ls", "-1p", &dir] {
+            cmd.arg(tok);
+        }
+        cmd
+    } else {
+        let mut opts = host.ssh_opts.clone();
+        opts.extend(
+            ["-o", "BatchMode=yes", "-o", "ConnectTimeout=5"]
+                .iter()
+                .map(|s| s.to_string()),
+        );
+        let mut cmd = crate::shell::ssh_command(&host.destination, &opts);
+        for tok in ["ls", "-1p", &dir] {
+            cmd.arg(posix_quote(tok));
+        }
+        cmd
+    };
+    let output = cmd
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to list remote directory")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("remote dir listing failed: {}", stderr.trim());
+    }
+    let mut names: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        // Only directories (trailing `/`).
+        .filter_map(|line| line.strip_suffix('/'))
+        .filter(|name| !name.is_empty())
+        .map(String::from)
+        .collect();
+    names.sort();
+    Ok(names)
 }
 
 /// Global cache for repo display names (path → name).
@@ -1492,7 +1758,137 @@ mod tests {
                 "x",
             ]
         );
+        // A Unix caller pins the child cwd to `/` so wsl.exe doesn't inherit
+        // (and fail to chdir to) a caller cwd missing from the target distro.
+        #[cfg(unix)]
+        assert_eq!(cmd.get_current_dir(), Some(Path::new("/")));
+        #[cfg(windows)]
         assert_eq!(cmd.get_current_dir(), None);
+    }
+
+    #[test]
+    fn host_shell_c_wsl_passes_script_unquoted_via_exec() {
+        // WSL: `--exec` hands argv to the in-distro process verbatim, so the
+        // multi-statement script travels as a single *unquoted* arg. Without
+        // it, wsl.exe substitutes `$…` inside the script and a pre-quoted
+        // script arrives as one literal command word ("not found").
+        let h = HostDef::wsl("Ubuntu");
+        let cmd = host_shell_c(&h, "mkdir -p /a && ln -s /b /a/b");
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "wsl.exe");
+        assert_eq!(
+            args,
+            [
+                "-d",
+                "Ubuntu",
+                "-e",
+                "sh",
+                "-c",
+                "mkdir -p /a && ln -s /b /a/b"
+            ]
+        );
+    }
+
+    #[test]
+    fn host_shell_c_ssh_posix_quotes_script() {
+        // SSH space-joins its trailing args, so the script must be POSIX-quoted
+        // to survive as a single `sh -c` argument.
+        let h = host("me@box", None);
+        let cmd = host_shell_c(&h, "mkdir -p /a && ln -s /b /a/b");
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "ssh");
+        // The script arg is single-quoted as a whole.
+        assert!(
+            args.iter().any(|a| a == "'mkdir -p /a && ln -s /b /a/b'"),
+            "script should be posix-quoted for ssh; got {args:?}"
+        );
+    }
+
+    #[test]
+    fn list_dir_on_wsl_uses_variable_free_exec_ls() {
+        // Must be `--exec ls -1p <dir>` as separate argv tokens — NOT an
+        // `sh -c` script — so no wsl.exe `$`-substitution or shell
+        // re-interpretation can touch the user-typed dir.
+        let h = HostDef::wsl("Ubuntu");
+        let mut cmd = host_launcher(&h);
+        cmd.arg("-e");
+        for tok in ["ls", "-1p", "/home/me/repos"] {
+            cmd.arg(tok);
+        }
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "wsl.exe");
+        assert_eq!(args, ["-d", "Ubuntu", "-e", "ls", "-1p", "/home/me/repos"]);
+        // No `sh -c` (the broken form) anywhere.
+        assert!(
+            !args.iter().any(|a| a == "-c"),
+            "must not use sh -c: {args:?}"
+        );
+    }
+
+    #[test]
+    fn list_dir_on_ssh_adds_noninteractive_opts_after_user_opts() {
+        // Completion runs synchronously on the UI thread: BatchMode +
+        // ConnectTimeout make an unreachable/password host fail fast instead
+        // of freezing the TUI. They come AFTER the host's own ssh_opts — ssh
+        // honors the first occurrence, so a user setting wins.
+        let h = HostDef {
+            name: "box".into(),
+            destination: "me@box".into(),
+            ssh_opts: vec!["-o".into(), "ConnectTimeout=30".into()],
+            ..Default::default()
+        };
+        // Reconstruct the launcher exactly as list_dir_on's ssh branch does.
+        let mut opts = h.ssh_opts.clone();
+        opts.extend(
+            ["-o", "BatchMode=yes", "-o", "ConnectTimeout=5"]
+                .iter()
+                .map(|s| s.to_string()),
+        );
+        let cmd = crate::shell::ssh_command(&h.destination, &opts);
+        let (prog, args) = program_and_args(&cmd);
+        assert_eq!(prog, "ssh");
+        let user_pos = args.iter().position(|a| a == "ConnectTimeout=30");
+        let ours_pos = args.iter().position(|a| a == "ConnectTimeout=5");
+        assert!(user_pos.unwrap() < ours_pos.unwrap());
+        assert!(args.iter().any(|a| a == "BatchMode=yes"));
+    }
+
+    #[test]
+    fn expand_remote_tilde_passes_plain_paths_through() {
+        // No `~` prefix → no remote round-trip, byte-identical passthrough
+        // (including a mid-path `~`, which is not a home reference).
+        let h = HostDef::wsl("Ubuntu");
+        assert_eq!(
+            expand_remote_tilde(&h, "/home/me/repos").unwrap(),
+            "/home/me/repos"
+        );
+        assert_eq!(expand_remote_tilde(&h, "/data/~x").unwrap(), "/data/~x");
+    }
+
+    #[test]
+    fn sanitize_workspace_segment_matches_local_scheme() {
+        // Mirrors `workspace::sanitize_segment`: slashes/backslashes/colons and
+        // whitespace → `-`; leading/trailing `.`/`-` trimmed.
+        assert_eq!(sanitize_workspace_segment("feat/x"), "feat-x");
+        assert_eq!(sanitize_workspace_segment("a b:c\\d"), "a-b-c-d");
+        assert_eq!(sanitize_workspace_segment("--.hidden.--"), "hidden");
+        // A UUID (the real input) is unchanged.
+        assert_eq!(
+            sanitize_workspace_segment("d5715d35-9599-4507-9901-ef33b9476358"),
+            "d5715d35-9599-4507-9901-ef33b9476358"
+        );
+    }
+
+    #[test]
+    fn unique_link_name_dedups_with_dash_two_suffix() {
+        // Must match the local builder: first collision is `-2`, then `-3`, and
+        // an empty label falls back to `repo`.
+        let mut used = HashSet::new();
+        assert_eq!(unique_link_name("webapp", &mut used), "webapp");
+        assert_eq!(unique_link_name("webapp", &mut used), "webapp-2");
+        assert_eq!(unique_link_name("webapp", &mut used), "webapp-3");
+        assert_eq!(unique_link_name("", &mut used), "repo");
+        assert_eq!(unique_link_name("", &mut used), "repo-2");
     }
 
     #[test]

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -52,8 +52,9 @@ fn build_restart_plan(session: &SharedSession) -> Result<RestartPlan, String> {
     // workspace, gathering every member dir; a single-repo session keeps the
     // primary repo. Only resolve when there is a primary cwd to anchor on.
     if let Some(primary) = session.cwd.clone() {
-        // The headless restart path is local-only (`spawn_window`), so the
-        // workspace is built locally; remote restart isn't wired here.
+        // The headless restart path is local-only (`spawn_window`; remote
+        // sessions are refused up front in `restart_session_headless`), so
+        // the workspace is always built locally.
         config.cwd = Some(super::spawn::resolve_launch_cwd(
             &agent_session_id,
             &primary,

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -52,11 +52,14 @@ fn build_restart_plan(session: &SharedSession) -> Result<RestartPlan, String> {
     // workspace, gathering every member dir; a single-repo session keeps the
     // primary repo. Only resolve when there is a primary cwd to anchor on.
     if let Some(primary) = session.cwd.clone() {
+        // The headless restart path is local-only (`spawn_window`), so the
+        // workspace is built locally; remote restart isn't wired here.
         config.cwd = Some(super::spawn::resolve_launch_cwd(
             &agent_session_id,
             &primary,
             &session.worktrees,
             &session.additional_dirs,
+            None,
         ));
     }
 
@@ -85,6 +88,17 @@ pub fn restart_session_headless(db: &Database, session_id: SessionId) -> Result<
         .get_session_by_id(session_id)
         .map_err(|e| format!("Failed to load session: {e}"))?
         .ok_or_else(|| format!("Session not found: {session_id}"))?;
+
+    // The kill/spawn below drive the *local* tmux only. Silently "restarting"
+    // a remote session would leave its real window running on the host and
+    // spawn a stray local one (with a locally-built workspace), so refuse.
+    if crate::session::is_remote_backend(&session.backend_type) {
+        return Err(format!(
+            "Session '{}' runs on remote backend '{}'; headless restart is \
+             local-only — restart it from the TUI instead",
+            session.name, session.backend_type
+        ));
+    }
 
     let plan = build_restart_plan(&session)?;
 

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -92,6 +92,7 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
         &primary_cwd,
         &worktrees,
         &additional_dirs,
+        host.as_ref(),
     );
 
     // Mint the thurbox SessionId up front so it can be injected into the
@@ -109,6 +110,15 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     super::inject_thurbox_env(&mut config, &agent_session_id, req.task_id);
 
     let (command, args) = super::build_agent_invocation(&agent_def, &config);
+
+    // The agent's args may reference thurbox-managed config files by their
+    // *local* absolute path (e.g. claude's hooks `--settings <config>/hooks/
+    // claude.json`). On a remote host that path doesn't exist, so the agent
+    // errors on launch ("Settings file not found"). Materialize each such file
+    // at the same path on the remote before launching.
+    if let Some(h) = host.as_ref() {
+        materialize_agent_config_on_remote(h, &args);
+    }
 
     // Remote spawns drive the SSH backend's control mode to learn the real pane
     // id; local spawns leave `backend_id` empty for the TUI to resolve by name.
@@ -301,6 +311,7 @@ pub(crate) fn resolve_launch_cwd(
     primary_cwd: &std::path::Path,
     worktrees: &[SharedWorktree],
     additional_dirs: &[PathBuf],
+    host: Option<&HostDef>,
 ) -> PathBuf {
     let mut members: Vec<(String, PathBuf)> = Vec::new();
     if worktrees.is_empty() {
@@ -317,11 +328,95 @@ pub(crate) fn resolve_launch_cwd(
     if members.len() < 2 {
         return primary_cwd.to_path_buf();
     }
-    match crate::workspace::ensure_workspace(agent_session_id, &members) {
+    // A remote session's workspace must be built on the *remote* host — a local
+    // symlink dir wouldn't exist there. Local sessions use the local builder.
+    let built = match host {
+        Some(h) => crate::git::ensure_remote_workspace(h, agent_session_id, &members),
+        None => crate::workspace::ensure_workspace(agent_session_id, &members)
+            .map_err(anyhow::Error::from),
+    };
+    match built {
         Ok(ws) => ws,
         Err(e) => {
             tracing::error!("Failed to build multi-repo workspace: {e}");
             primary_cwd.to_path_buf()
+        }
+    }
+}
+
+/// Copy any thurbox-managed config files referenced in the agent `args` (by
+/// their *local* absolute path) to the same path on the remote `host`, so an
+/// agent launched with e.g. `--settings <config>/hooks/claude.json` finds the
+/// file there. Best-effort: a copy failure is logged, not fatal — the agent
+/// still launches (the hooks just won't fire), and we never block a spawn on it.
+///
+/// Scope is deliberately narrow: only existing local **files under the thurbox
+/// config dir** are copied, so we never ship an arbitrary path an agent's own
+/// args happen to contain (a repo path, a user file, …). And the mirror is
+/// only attempted when the remote would resolve the *same absolute path* — the
+/// agent's arg is not rewritten (args are rebuilt from the `AgentDef` at every
+/// spawn), so a path the remote can't reproduce byte-for-byte is skipped with
+/// a warning rather than materialized somewhere the agent won't look:
+/// - a non-POSIX (Windows `C:\…`) local config root can never resolve on the
+///   POSIX remote;
+/// - a `psmux` host is native Windows — no POSIX shell to copy with, and no
+///   local-POSIX path to resolve;
+/// - a home-anchored config root only matches when local and remote `$HOME`
+///   agree (the common same-user WSL/devbox case).
+///
+/// Shared by the headless spawn and the TUI (`App::build_spawn_inputs`) so both
+/// paths give a remote session the same agent config.
+pub(crate) fn materialize_agent_config_on_remote(host: &HostDef, args: &[String]) {
+    let Some(config_root) = crate::paths::config_file()
+        .and_then(|p| p.parent().map(|d| d.to_string_lossy().into_owned()))
+    else {
+        return;
+    };
+    if !config_root.starts_with('/') || host.mux() == "psmux" {
+        return;
+    }
+    // A config root under the local home requires the remote home to match,
+    // or the mirrored path (and the agent's arg) can't resolve there.
+    if let Some(local_home) = crate::paths::home_dir() {
+        let local_home = local_home.to_string_lossy().into_owned();
+        if config_root.starts_with(&local_home) {
+            match crate::git::remote_home(host) {
+                Ok(remote_home) if remote_home != local_home => {
+                    tracing::warn!(
+                        "not materializing agent config on host '{}': local home \
+                         {local_home} != remote home {remote_home}, so the agent's \
+                         local-path args can't resolve there",
+                        host.name
+                    );
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "not materializing agent config on host '{}': cannot resolve \
+                         remote home: {e:#}",
+                        host.name
+                    );
+                    return;
+                }
+                Ok(_) => {}
+            }
+        }
+    }
+    for arg in args {
+        // Only absolute paths under the thurbox config dir that exist as local
+        // files are candidates.
+        if !arg.starts_with(&config_root) {
+            continue;
+        }
+        let local = std::path::Path::new(arg);
+        if !local.is_file() {
+            continue;
+        }
+        if let Err(e) = crate::git::copy_file_to_remote(host, local, arg) {
+            tracing::warn!(
+                "failed to materialize agent config {arg} on host '{}': {e:#}",
+                host.name
+            );
         }
     }
 }
@@ -546,7 +641,7 @@ mod tests {
     fn resolve_launch_cwd_single_member_is_primary() {
         let primary = PathBuf::from("/tmp/primary");
         // No worktrees, no extra dirs → 1 member → primary cwd, no workspace.
-        let got = resolve_launch_cwd("sid-1", &primary, &[], &[]);
+        let got = resolve_launch_cwd("sid-1", &primary, &[], &[], None);
         assert_eq!(got, primary);
     }
 
@@ -558,7 +653,7 @@ mod tests {
         std::fs::create_dir_all(&primary).unwrap();
         let extra = temp.path().join("extra");
         std::fs::create_dir_all(&extra).unwrap();
-        let got = resolve_launch_cwd("sid-multi", &primary, &[], &[extra]);
+        let got = resolve_launch_cwd("sid-multi", &primary, &[], &[extra], None);
         // Two members → a symlink workspace, not the primary itself.
         assert_ne!(got, primary);
         assert!(got.join("primary").exists() || got.exists());

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -375,32 +375,8 @@ pub(crate) fn materialize_agent_config_on_remote(host: &HostDef, args: &[String]
     if !config_root.starts_with('/') || host.mux() == "psmux" {
         return;
     }
-    // A config root under the local home requires the remote home to match,
-    // or the mirrored path (and the agent's arg) can't resolve there.
-    if let Some(local_home) = crate::paths::home_dir() {
-        let local_home = local_home.to_string_lossy().into_owned();
-        if config_root.starts_with(&local_home) {
-            match crate::git::remote_home(host) {
-                Ok(remote_home) if remote_home != local_home => {
-                    tracing::warn!(
-                        "not materializing agent config on host '{}': local home \
-                         {local_home} != remote home {remote_home}, so the agent's \
-                         local-path args can't resolve there",
-                        host.name
-                    );
-                    return;
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "not materializing agent config on host '{}': cannot resolve \
-                         remote home: {e:#}",
-                        host.name
-                    );
-                    return;
-                }
-                Ok(_) => {}
-            }
-        }
+    if !remote_resolves_local_path(host, &config_root) {
+        return;
     }
     for arg in args {
         // Only absolute paths under the thurbox config dir that exist as local
@@ -417,6 +393,38 @@ pub(crate) fn materialize_agent_config_on_remote(host: &HostDef, args: &[String]
                 "failed to materialize agent config {arg} on host '{}': {e:#}",
                 host.name
             );
+        }
+    }
+}
+
+/// Whether `host` would resolve `path` at the same absolute location as the
+/// local machine. Only home-anchored paths can differ: they match exactly when
+/// the local and remote `$HOME` agree (the common same-user WSL/devbox case).
+/// A mismatch (or an unresolvable remote home) is logged and returns `false`.
+fn remote_resolves_local_path(host: &HostDef, path: &str) -> bool {
+    let Some(local_home) = crate::paths::home_dir() else {
+        return true;
+    };
+    let local_home = local_home.to_string_lossy().into_owned();
+    if !path.starts_with(&local_home) {
+        return true;
+    }
+    match crate::git::remote_home(host) {
+        Ok(remote_home) if remote_home == local_home => true,
+        Ok(remote_home) => {
+            tracing::warn!(
+                "not materializing agent config on host '{}': local home {local_home} != \
+                 remote home {remote_home}, so the agent's local-path args can't resolve there",
+                host.name
+            );
+            false
+        }
+        Err(e) => {
+            tracing::warn!(
+                "not materializing agent config on host '{}': cannot resolve remote home: {e:#}",
+                host.name
+            );
+            false
         }
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -42,8 +42,9 @@ pub fn ssh_command(destination: &str, ssh_opts: &[String]) -> Command {
 ///
 /// This is the WSL analogue of [`ssh_command`], but `wsl.exe`'s argument
 /// forwarding is subtly different from ssh's plain space-join (observed against
-/// current `wsl.exe`; it only bypasses the shell entirely with `-e`/`--exec`,
-/// which we don't pass):
+/// current `wsl.exe`; callers that need argv to arrive verbatim bypass the
+/// shell entirely by appending `-e`/`--exec` — see `git::host_shell_c` /
+/// `git::list_dir_on`):
 ///
 /// - a **whitespace-free** token reaches the in-distro shell for interpretation
 ///   exactly like over ssh — POSIX-quote it the same way (the shell strips the

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -40,17 +40,41 @@ pub fn ssh_command(destination: &str, ssh_opts: &[String]) -> Command {
 /// Build a `wsl.exe -d <distro>` [`Command`], ready for the caller to append
 /// the in-distro command and its arguments.
 ///
-/// This is the WSL analogue of [`ssh_command`]: `wsl.exe` joins the trailing
-/// arguments with spaces and runs them through the distro's default login
-/// shell (it only bypasses the shell with `-e`/`--exec`, which we don't pass),
-/// exactly like `ssh <dest> <command>`. So callers append the *same*
-/// POSIX-quoted tokens they would for SSH — the in-distro shell re-splits them
-/// identically. No `--` separator is used (none of thurbox's commands start
-/// with a `-`, matching the SSH path which also omits it), so distros are
-/// reached uniformly on every supported `wsl.exe`.
+/// This is the WSL analogue of [`ssh_command`], but `wsl.exe`'s argument
+/// forwarding is subtly different from ssh's plain space-join (observed against
+/// current `wsl.exe`; it only bypasses the shell entirely with `-e`/`--exec`,
+/// which we don't pass):
+///
+/// - a **whitespace-free** token reaches the in-distro shell for interpretation
+///   exactly like over ssh — POSIX-quote it the same way (the shell strips the
+///   quotes; metacharacters like `%(…)` survive);
+/// - an argument **containing whitespace** is preserved as a single word — do
+///   *not* pre-quote a multi-word `sh -c` script for WSL, or the quotes arrive
+///   literally and the shell treats the whole blob as one command name (see
+///   `git::host_shell_c`, which branches on this).
+///
+/// No `--` separator is used (none of thurbox's commands start with a `-`,
+/// matching the SSH path which also omits it).
+///
+/// `wsl.exe` inherits the **caller's** current directory and tries to `chdir`
+/// to the same path inside the target distro — which fails when thurbox itself
+/// runs inside *another* WSL distro (the caller's cwd, e.g. `/home/me/repo`,
+/// doesn't exist on the target). That failure prints a `WSL Relay ERROR:
+/// CreateProcessCommon chdir(...) failed` on stderr and corrupts the tmux
+/// control-mode handshake, so the agent window never launches. So on a Unix
+/// caller the child's cwd is pinned to `/` — a landing dir every distro has —
+/// which is safe because every caller overrides the real working dir anyway
+/// (`git -C <path>`, tmux `new-window -c <path>`). Pinning the *caller* cwd
+/// (rather than passing `--cd /`) works on every `wsl.exe`; `--cd` is absent
+/// from the Windows 10 inbox build, which aborts on unknown flags. A native
+/// Windows caller keeps the inherit behavior (its `C:\…` cwd maps to
+/// `/mnt/c/…` under default automount; there is no universally-valid Windows
+/// pin, and `--cd` would trade this edge case for a hard legacy failure).
 pub fn wsl_command(distro: &str) -> Command {
     let mut cmd = Command::new("wsl.exe");
     cmd.arg("-d").arg(distro);
+    #[cfg(unix)]
+    cmd.current_dir("/");
     cmd
 }
 
@@ -84,7 +108,7 @@ mod tests {
     }
 
     #[test]
-    fn wsl_command_sets_program_and_distro() {
+    fn wsl_command_sets_program_distro_and_neutral_cwd() {
         let cmd = wsl_command("Ubuntu");
         assert_eq!(cmd.get_program().to_string_lossy(), "wsl.exe");
         let args: Vec<String> = cmd
@@ -92,5 +116,13 @@ mod tests {
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
         assert_eq!(args, ["-d", "Ubuntu"]);
+        // A Unix caller pins its cwd to `/` so wsl.exe doesn't inherit (and
+        // fail to chdir to) a caller cwd that doesn't exist in the target
+        // distro. Done via the child cwd — not `--cd`, which legacy wsl.exe
+        // rejects.
+        #[cfg(unix)]
+        assert_eq!(cmd.get_current_dir(), Some(std::path::Path::new("/")));
+        #[cfg(windows)]
+        assert_eq!(cmd.get_current_dir(), None);
     }
 }

--- a/src/storage/repo_bookmarks.rs
+++ b/src/storage/repo_bookmarks.rs
@@ -6,7 +6,9 @@ use crate::sync::current_time_millis;
 
 use super::Database;
 
-/// A bookmarked/recently-used repo path.
+/// A bookmarked/recently-used repo path, scoped to the host whose filesystem
+/// it lives on (`""` = local, else the backend name `ssh:<name>` /
+/// `wsl:<name>`) so a remote target gets its own bookmark memory.
 #[derive(Debug, Clone)]
 pub struct RepoBookmark {
     pub repo_path: PathBuf,
@@ -20,15 +22,16 @@ pub struct RepoBookmark {
 }
 
 impl Database {
-    /// List all repo bookmarks, sorted by last_used_at descending (most recent first).
-    pub fn list_repo_bookmarks(&self) -> rusqlite::Result<Vec<RepoBookmark>> {
+    /// List a host's repo bookmarks (`""` = local), sorted by last_used_at
+    /// descending (most recent first).
+    pub fn list_repo_bookmarks(&self, host: &str) -> rusqlite::Result<Vec<RepoBookmark>> {
         let mut stmt = self.conn.prepare(
             "SELECT repo_path, label, last_used_at, use_count, is_parent \
-             FROM repo_bookmarks ORDER BY last_used_at DESC",
+             FROM repo_bookmarks WHERE host = ?1 ORDER BY last_used_at DESC",
         )?;
 
         let bookmarks = stmt
-            .query_map([], |row| {
+            .query_map([host], |row| {
                 let path: String = row.get(0)?;
                 Ok(RepoBookmark {
                     repo_path: PathBuf::from(path),
@@ -43,50 +46,54 @@ impl Database {
         Ok(bookmarks)
     }
 
-    /// Add or update a repo bookmark. Increments use_count and updates last_used_at.
-    pub fn upsert_repo_bookmark(&self, repo_path: &Path) -> rusqlite::Result<()> {
-        self.upsert_repo_bookmark_kind(repo_path, false)
+    /// Add or update a host's repo bookmark (`""` = local). Increments
+    /// use_count and updates last_used_at.
+    pub fn upsert_repo_bookmark(&self, host: &str, repo_path: &Path) -> rusqlite::Result<()> {
+        self.upsert_repo_bookmark_kind(host, repo_path, false)
     }
 
-    /// Add or update a repo bookmark, setting whether it is a parent folder.
-    /// Increments use_count and updates last_used_at; `is_parent` is set on both
-    /// insert and conflict so the kind can be flipped by re-importing a path.
+    /// Add or update a host's repo bookmark, setting whether it is a parent
+    /// folder. Increments use_count and updates last_used_at; `is_parent` is
+    /// set on both insert and conflict so the kind can be flipped by
+    /// re-importing a path.
     pub fn upsert_repo_bookmark_kind(
         &self,
+        host: &str,
         repo_path: &Path,
         is_parent: bool,
     ) -> rusqlite::Result<()> {
         let now = current_time_millis() as i64;
         let path_str = repo_path.to_string_lossy().to_string();
         self.conn.execute(
-            "INSERT INTO repo_bookmarks (repo_path, last_used_at, use_count, is_parent) \
-             VALUES (?1, ?2, 1, ?3) \
-             ON CONFLICT(repo_path) DO UPDATE SET \
+            "INSERT INTO repo_bookmarks (host, repo_path, last_used_at, use_count, is_parent) \
+             VALUES (?1, ?2, ?3, 1, ?4) \
+             ON CONFLICT(host, repo_path) DO UPDATE SET \
                  last_used_at = excluded.last_used_at, \
                  use_count = use_count + 1, \
                  is_parent = excluded.is_parent",
-            params![path_str, now, is_parent as i64],
+            params![host, path_str, now, is_parent as i64],
         )?;
         Ok(())
     }
 
-    /// Touch a bookmark (update last_used_at) without incrementing use_count.
-    pub fn touch_repo_bookmark(&self, repo_path: &Path) -> rusqlite::Result<bool> {
+    /// Touch a host's bookmark (update last_used_at) without incrementing
+    /// use_count.
+    pub fn touch_repo_bookmark(&self, host: &str, repo_path: &Path) -> rusqlite::Result<bool> {
         let now = current_time_millis() as i64;
         let path_str = repo_path.to_string_lossy().to_string();
         let count = self.conn.execute(
-            "UPDATE repo_bookmarks SET last_used_at = ?1 WHERE repo_path = ?2",
-            params![now, path_str],
+            "UPDATE repo_bookmarks SET last_used_at = ?1 WHERE host = ?2 AND repo_path = ?3",
+            params![now, host, path_str],
         )?;
         Ok(count > 0)
     }
 
-    /// Delete a repo bookmark. Returns true if it existed.
-    pub fn delete_repo_bookmark(&self, repo_path: &Path) -> rusqlite::Result<bool> {
+    /// Delete a host's repo bookmark. Returns true if it existed.
+    pub fn delete_repo_bookmark(&self, host: &str, repo_path: &Path) -> rusqlite::Result<bool> {
         let path_str = repo_path.to_string_lossy().to_string();
         let count = self.conn.execute(
-            "DELETE FROM repo_bookmarks WHERE repo_path = ?1",
-            params![path_str],
+            "DELETE FROM repo_bookmarks WHERE host = ?1 AND repo_path = ?2",
+            params![host, path_str],
         )?;
         Ok(count > 0)
     }
@@ -99,7 +106,7 @@ mod tests {
     #[test]
     fn list_repo_bookmarks_empty() {
         let db = Database::open_in_memory().unwrap();
-        let bookmarks = db.list_repo_bookmarks().unwrap();
+        let bookmarks = db.list_repo_bookmarks("").unwrap();
         assert!(bookmarks.is_empty());
     }
 
@@ -107,10 +114,10 @@ mod tests {
     fn upsert_and_list_repo_bookmarks() {
         let db = Database::open_in_memory().unwrap();
 
-        db.upsert_repo_bookmark(Path::new("/repo/a")).unwrap();
-        db.upsert_repo_bookmark(Path::new("/repo/b")).unwrap();
+        db.upsert_repo_bookmark("", Path::new("/repo/a")).unwrap();
+        db.upsert_repo_bookmark("", Path::new("/repo/b")).unwrap();
 
-        let bookmarks = db.list_repo_bookmarks().unwrap();
+        let bookmarks = db.list_repo_bookmarks("").unwrap();
         assert_eq!(bookmarks.len(), 2);
         let paths: Vec<&Path> = bookmarks.iter().map(|b| b.repo_path.as_path()).collect();
         assert!(paths.contains(&Path::new("/repo/a")));
@@ -119,14 +126,39 @@ mod tests {
     }
 
     #[test]
+    fn bookmarks_are_scoped_per_host() {
+        // The same path on two hosts is two independent bookmarks, and each
+        // host's list only shows its own — the point of the (host, repo_path)
+        // key: a remote target gets its own memory, never local paths.
+        let db = Database::open_in_memory().unwrap();
+
+        db.upsert_repo_bookmark("", Path::new("/repo/a")).unwrap();
+        db.upsert_repo_bookmark("ssh:devbox", Path::new("/repo/a"))
+            .unwrap();
+        db.upsert_repo_bookmark("ssh:devbox", Path::new("/srv/remote"))
+            .unwrap();
+
+        let local = db.list_repo_bookmarks("").unwrap();
+        assert_eq!(local.len(), 1);
+        let remote = db.list_repo_bookmarks("ssh:devbox").unwrap();
+        assert_eq!(remote.len(), 2);
+
+        // Deleting on one host leaves the other host's row alone.
+        assert!(db
+            .delete_repo_bookmark("ssh:devbox", Path::new("/repo/a"))
+            .unwrap());
+        assert_eq!(db.list_repo_bookmarks("").unwrap().len(), 1);
+    }
+
+    #[test]
     fn parent_bookmark_round_trips() {
         let db = Database::open_in_memory().unwrap();
 
-        db.upsert_repo_bookmark(Path::new("/repo/a")).unwrap();
-        db.upsert_repo_bookmark_kind(Path::new("/parent/x"), true)
+        db.upsert_repo_bookmark("", Path::new("/repo/a")).unwrap();
+        db.upsert_repo_bookmark_kind("", Path::new("/parent/x"), true)
             .unwrap();
 
-        let bookmarks = db.list_repo_bookmarks().unwrap();
+        let bookmarks = db.list_repo_bookmarks("").unwrap();
         let parent = bookmarks
             .iter()
             .find(|b| b.repo_path == Path::new("/parent/x"))
@@ -143,11 +175,11 @@ mod tests {
     fn upsert_increments_use_count() {
         let db = Database::open_in_memory().unwrap();
 
-        db.upsert_repo_bookmark(Path::new("/repo/a")).unwrap();
-        db.upsert_repo_bookmark(Path::new("/repo/a")).unwrap();
-        db.upsert_repo_bookmark(Path::new("/repo/a")).unwrap();
+        db.upsert_repo_bookmark("", Path::new("/repo/a")).unwrap();
+        db.upsert_repo_bookmark("", Path::new("/repo/a")).unwrap();
+        db.upsert_repo_bookmark("", Path::new("/repo/a")).unwrap();
 
-        let bookmarks = db.list_repo_bookmarks().unwrap();
+        let bookmarks = db.list_repo_bookmarks("").unwrap();
         assert_eq!(bookmarks.len(), 1);
         assert_eq!(bookmarks[0].use_count, 3);
     }
@@ -156,26 +188,26 @@ mod tests {
     fn delete_repo_bookmark() {
         let db = Database::open_in_memory().unwrap();
 
-        db.upsert_repo_bookmark(Path::new("/repo/a")).unwrap();
-        assert!(db.delete_repo_bookmark(Path::new("/repo/a")).unwrap());
-        assert!(!db.delete_repo_bookmark(Path::new("/repo/a")).unwrap());
-        assert!(db.list_repo_bookmarks().unwrap().is_empty());
+        db.upsert_repo_bookmark("", Path::new("/repo/a")).unwrap();
+        assert!(db.delete_repo_bookmark("", Path::new("/repo/a")).unwrap());
+        assert!(!db.delete_repo_bookmark("", Path::new("/repo/a")).unwrap());
+        assert!(db.list_repo_bookmarks("").unwrap().is_empty());
     }
 
     #[test]
     fn touch_updates_last_used_at() {
         let db = Database::open_in_memory().unwrap();
 
-        db.upsert_repo_bookmark(Path::new("/repo/a")).unwrap();
-        let before = db.list_repo_bookmarks().unwrap()[0].use_count;
-        assert!(db.touch_repo_bookmark(Path::new("/repo/a")).unwrap());
-        let after = db.list_repo_bookmarks().unwrap()[0].use_count;
+        db.upsert_repo_bookmark("", Path::new("/repo/a")).unwrap();
+        let before = db.list_repo_bookmarks("").unwrap()[0].use_count;
+        assert!(db.touch_repo_bookmark("", Path::new("/repo/a")).unwrap());
+        let after = db.list_repo_bookmarks("").unwrap()[0].use_count;
         assert_eq!(before, after);
     }
 
     #[test]
     fn touch_nonexistent_returns_false() {
         let db = Database::open_in_memory().unwrap();
-        assert!(!db.touch_repo_bookmark(Path::new("/nope")).unwrap());
+        assert!(!db.touch_repo_bookmark("", Path::new("/nope")).unwrap());
     }
 }

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1352,6 +1352,59 @@ mod tests {
     }
 
     #[test]
+    fn migrate_from_v38_rebuilds_repo_bookmarks_with_host_key() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Minimal v38 state: the pre-v39 repo_bookmarks shape with one row.
+        conn.execute_batch(
+            "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO metadata (key, value) VALUES ('schema_version', '38');
+             CREATE TABLE repo_bookmarks (
+                repo_path    TEXT PRIMARY KEY,
+                label        TEXT,
+                last_used_at INTEGER NOT NULL,
+                use_count    INTEGER NOT NULL DEFAULT 1,
+                is_parent    INTEGER NOT NULL DEFAULT 0
+             );
+             INSERT INTO repo_bookmarks (repo_path, last_used_at, use_count, is_parent)
+             VALUES ('/repo/a', 1, 3, 1);",
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        // The existing row migrated as local ('') with its fields intact.
+        let (host, count, is_parent): (String, i64, i64) = conn
+            .query_row(
+                "SELECT host, use_count, is_parent FROM repo_bookmarks \
+                 WHERE repo_path = '/repo/a'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(host, "");
+        assert_eq!(count, 3);
+        assert_eq!(is_parent, 1);
+
+        // The rebuilt (host, repo_path) key allows the same path on another
+        // host — the whole point of the rebuild.
+        conn.execute(
+            "INSERT INTO repo_bookmarks (host, repo_path, last_used_at) \
+             VALUES ('ssh:devbox', '/repo/a', 2)",
+            [],
+        )
+        .unwrap();
+
+        let version: String = conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
     fn migrate_from_v26_adds_is_parent_column() {
         let conn = Connection::open_in_memory().unwrap();
         // Minimal v26 state: a repo_bookmarks table without the is_parent column.

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -14,9 +14,11 @@ use rusqlite::Connection;
 /// v37 adds `force_deleted` to `sessions` (a hard delete tore down its
 /// worktrees/tmux, so it can't be restored — the restore list tags + blocks it);
 /// v38 adds `base_branch` to `sessions` plus the `review_comments` /
-/// `review_marks` tables (the native code-review view).
+/// `review_marks` tables (the native code-review view); v39 scopes
+/// `repo_bookmarks` to a `host` (`''` = local), giving remote targets the
+/// same bookmark memory as local ones.
 /// Gaps in the step table are fine (there is no v18 step either).
-pub const SCHEMA_VERSION: u32 = 38;
+pub const SCHEMA_VERSION: u32 = 39;
 
 /// A single migration step: applied when the stored version is below `target`.
 type MigrationStep = (u32, fn(&Connection) -> rusqlite::Result<()>);
@@ -168,11 +170,13 @@ pub fn initialize(conn: &Connection) -> rusqlite::Result<()> {
             ON automation_runs(automation_id, started_at);
 
         CREATE TABLE IF NOT EXISTS repo_bookmarks (
-            repo_path    TEXT PRIMARY KEY,
+            host         TEXT NOT NULL DEFAULT '',
+            repo_path    TEXT NOT NULL,
             label        TEXT,
             last_used_at INTEGER NOT NULL,
             use_count    INTEGER NOT NULL DEFAULT 1,
-            is_parent    INTEGER NOT NULL DEFAULT 0
+            is_parent    INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (host, repo_path)
         );
 
         CREATE TABLE IF NOT EXISTS tasks (
@@ -281,6 +285,7 @@ fn migrate(conn: &Connection) -> rusqlite::Result<()> {
         (36, migrate_v36_action_command),
         (37, migrate_v37_force_deleted),
         (38, migrate_v38_code_review),
+        (39, migrate_v39_bookmark_host),
     ];
 
     for &(target, step) in steps {
@@ -1116,6 +1121,36 @@ fn migrate_v38_code_review(conn: &Connection) -> rusqlite::Result<()> {
         );",
     )?;
     Ok(())
+}
+
+/// v38 → v39: scope repo bookmarks to the **host** they live on. A remote
+/// (SSH/WSL) target previously had no bookmark memory at all — the picker
+/// opened empty — because a bookmark row couldn't say whose filesystem its
+/// path belongs to. The primary key becomes `(host, repo_path)` (`''` =
+/// local, else the backend name `ssh:<name>` / `wsl:<name>`), which needs a
+/// table rebuild (SQLite can't alter a primary key). Existing rows migrate as
+/// local. Guarded on the `host` column so a re-run is a no-op.
+fn migrate_v39_bookmark_host(conn: &Connection) -> rusqlite::Result<()> {
+    if !table_exists(conn, "repo_bookmarks")? || column_exists(conn, "repo_bookmarks", "host")? {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "CREATE TABLE repo_bookmarks_v39 (
+            host         TEXT NOT NULL DEFAULT '',
+            repo_path    TEXT NOT NULL,
+            label        TEXT,
+            last_used_at INTEGER NOT NULL,
+            use_count    INTEGER NOT NULL DEFAULT 1,
+            is_parent    INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (host, repo_path)
+        );
+        INSERT INTO repo_bookmarks_v39
+            (host, repo_path, label, last_used_at, use_count, is_parent)
+            SELECT '', repo_path, label, last_used_at, use_count, is_parent
+            FROM repo_bookmarks;
+        DROP TABLE repo_bookmarks;
+        ALTER TABLE repo_bookmarks_v39 RENAME TO repo_bookmarks;",
+    )
 }
 
 #[cfg(test)]

--- a/src/ui/repo_picker_modal.rs
+++ b/src/ui/repo_picker_modal.rs
@@ -33,6 +33,10 @@ pub struct RepoPickerState<'a> {
     pub search_cursor: usize,
     pub search_active: bool,
     pub filtered_indices: &'a [usize],
+    /// The target host's name for an off-local session (`None` = local).
+    /// Shown in the list title so it's unambiguous whose filesystem the
+    /// repos (and the typed path) belong to.
+    pub host: Option<&'a str>,
 }
 
 /// The clickable sub-areas of the repo picker that focus an editable field:
@@ -151,7 +155,10 @@ fn render_bookmark_list(
         Theme::border_unfocused()
     };
 
-    let title = format!(" Repos ({}) ", state.bookmarks.len());
+    let title = match state.host {
+        Some(host) => format!(" Repos on {host} ({}) ", state.bookmarks.len()),
+        None => format!(" Repos ({}) ", state.bookmarks.len()),
+    };
 
     let list_block = Block::default()
         .title(title)
@@ -443,6 +450,7 @@ mod tests {
             search_cursor: 0,
             search_active: false,
             filtered_indices: EMPTY_IDX,
+            host: None,
         }
     }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -64,6 +64,15 @@ pub fn ensure_workspace(id: &str, members: &[(String, PathBuf)]) -> io::Result<P
     Ok(dir)
 }
 
+/// The workspace directory path for `id` **without building or touching it** —
+/// for callers that need where an existing workspace lives while an agent is
+/// still running in it (e.g. the companion shell pane): the destructive
+/// rebuild in [`ensure_workspace`] would delete the running agent's cwd inode
+/// out from under it.
+pub fn workspace_path(id: &str) -> io::Result<PathBuf> {
+    workspace_dir(id)
+}
+
 /// Remove the workspace directory for `id`, if present. Only the symlinks are
 /// removed; the directories they point at are untouched. A missing workspace is
 /// not an error.


### PR DESCRIPTION
Remote sessions on a WSL distro (or SSH host) reached from inside
another distro failed in several ways. Fix the launch path end to end:

- wsl_command pins a Unix caller's cwd to `/` so wsl.exe doesn't
  inherit a cwd that doesn't exist on the target distro (which
  corrupted the tmux control-mode handshake so the agent window never
  launched). Done via the child cwd, not `--cd`, which legacy
  (Windows 10 inbox) wsl.exe rejects as an unknown flag.
- Wrap the remote window command in a login shell (/bin/sh -lc 'exec …')
  so the user's profile PATH is present; agents under ~/.local/bin
  (e.g. claude) are found instead of exiting 1 and killing the pane.
  psmux (Windows SSH) hosts are exempt — they have no /bin/sh.
- Materialize thurbox-managed agent config referenced by local path
  (claude's hooks --settings <config>/hooks/claude.json) onto the
  remote at the same path, so the agent doesn't error 'Settings file
  not found'. Skipped with a warning when the remote can't resolve
  that path byte-for-byte (Windows-local config root, psmux host, or
  mismatched local/remote $HOME) instead of writing garbage.
- Build the multi-repo symlink workspace on the remote host instead of
  locally, and thread the host through resolve_process_cwd /
  resolve_launch_cwd. Mirror the local workspace naming scheme,
  including its empty-id guard (an empty segment would rm -rf the
  workspaces root). Tear the remote workspace down on hard delete
  (remove_remote_workspace) so it doesn't leak on the host, and give
  the shell pane a non-building path resolver so opening it can't
  rm -rf the workspace the running agent is cwd'd in. Headless restart
  of a remote session is refused explicitly (it only drives the local
  tmux; a silent local respawn left the remote window running).
- Remote scripts run via `wsl.exe --exec sh -c '<script>'`: --exec
  hands argv to the distro verbatim, so no wsl.exe $-substitution or
  arg mangling can corrupt posix-quoted paths (ssh keeps the quoted
  space-join path). shell.rs documents the observed wsl.exe forwarding
  model the two transports' quoting derives from.
- Repo picker: suppress local filesystem path completion for a remote
  target, and complete against the remote filesystem on Tab
  (variable-free `ls -1p` over --exec). `~` expands against the remote
  $HOME, hidden dirs complete only from a `.` prefix (mirroring the
  local completer), completion applies only with the cursor at the
  end, Tab with nothing to complete moves focus to the list (as
  locally), and the ssh listing uses BatchMode + ConnectTimeout so an
  unreachable host fails fast instead of freezing the TUI. Task-spawn
  now enters through the wizard (host picker included) so a backend
  left over from a cancelled remote flow can't leak into its picker.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AzJDys3buYZdbaQNF6wsuJ