### PR TITLE
fix(core): launch remote agent sessions with host-adapted args and env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,15 +531,29 @@ clone (ConPTY, no WSL) speaking the **same control-mode wire protocol** and
 pane-id (`%N`) / `-L` socket model, so the whole backend is parameterized by
 binary name rather than forked (a remote SSH host can also pin
 `multiplexer = "psmux"`); a WSL distro runs `tmux` inside the distro. The
-control-mode protocol is byte-identical over either transport/binary, with one
-keystroke-encoding exception: psmux does **not** implement tmux's `send-keys
--H` hex flag (given `-H 62` it injects the literal text "62", so typing `b`,
-Enter, Backspace, … were all broken on Windows). So `send_keys_commands`
-branches on `TmuxTransport::uses_psmux()` — tmux (incl. a WSL distro's tmux)
-keeps the byte-exact `-H` hex path; psmux gets an equivalent encoding built from
-the primitives it *does* support (`send-keys -l` literal runs +
-`Enter`/`Tab`/`Escape`/`BSpace`/`C-<letter>` key-names), reconstructing the same
-byte stream the pane's PTY receives. Each host registers a backend named
+control-mode protocol is byte-identical over either transport/binary, with
+**psmux divergences** (all verified against psmux 3.3.6, each branched on
+`TmuxTransport::uses_psmux()`):
+
+- **`send-keys -H`** is not implemented (given `-H 62` it injects the literal
+  text "62", so typing `b`, Enter, Backspace, … were all broken on Windows).
+  `send_keys_commands` gives psmux an equivalent encoding built from the
+  primitives it *does* support (`send-keys -l` literal runs +
+  `Enter`/`Tab`/`Escape`/`BSpace`/`C-<letter>` key-names), reconstructing the
+  same byte stream the pane's PTY receives; tmux (incl. a WSL distro's tmux)
+  keeps the byte-exact `-H` hex path.
+- **`new-window` trailing tokens are not joined** — tmux joins them into one
+  shell command; psmux keeps only the *first* token and silently drops the
+  rest, so the agent launched with **no args**. And **`new-window -e` is
+  ignored** — env vars never reached the window's process (no
+  `THURBOX_SESSION` identity). `TmuxBackend::psmux_window_command` therefore
+  folds env + command into **one double-quoted token** of PowerShell
+  (`Set-Item Env:K 'v'; & 'claude' '--session-id' …` — psmux runs the token
+  via `powershell -NoLogo -Command`, whose Win32 command line strips unescaped
+  double quotes, hence single-quote inner / double-quote outer; backslash is
+  literal everywhere in psmux's parser, so `C:\` paths survive).
+
+Each host registers a backend named
 `ssh:<name>` / `wsl:<name>` (`TmuxBackend::from_host`, registered lazily in
 `main.rs` from `host_config::load_all_with_warnings`: discovery/down hosts must
 not block startup, so `check_available`/`ensure_ready` are deferred to first use
@@ -563,6 +577,21 @@ via `App::backend_for`).
   own host.
 - **Headless**: `thurbox-cli session create --host <name>` spawns on the host
   (an SSH name or an auto-discovered WSL distro name).
+- **Agent config on the host**: agent args referencing thurbox-managed config
+  by *local* path (the hooks extension's `--settings <config>/hooks/
+  claude.json`) would kill the remote agent on launch ("Settings file not
+  found"). `session_ops::spawn::adapt_agent_args_for_remote` (shared by
+  headless spawn and the TUI) rewrites them per host: on a POSIX remote the
+  home-anchored path is **translated to the remote home**, the file copied
+  there, and the arg substituted; on a psmux host / non-POSIX config root /
+  failed copy the **flag+path pair is stripped** so the agent launches clean.
+  Remote hooks can't signal either way (no `thurbox-cli` on the host, and it
+  would write the host's own DB, not the one the TUI reads) — remote sessions
+  stay `Idle` and rely on the output-quiescence fallbacks; a remote status
+  path is a named follow-up. The local-path env hints
+  (`THURBOX_METRICS_DIR`/`THURBOX_CONFIG_DIR`/`THURBOX_DATA_DIR`) are likewise
+  skipped for remote spawns (`inject_thurbox_env`); only the opaque identity
+  vars travel.
 - **Caveats** (WSL inherits the SSH path): the headless `session delete --force`
   teardown (`kill_window`/`git::remove_worktree`) is local-only — a `--force`
   delete won't kill the in-distro window or remove the in-distro worktree (the

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -697,6 +697,16 @@ impl Session {
         (Arc::clone(&self.backend), self.backend_id.clone())
     }
 
+    /// Replace the provider [`Self::restart`] rebuilds its launch args from.
+    ///
+    /// A session adopted at startup stores a provider built from the plain
+    /// registry def; a later restart must use a def resolved (and, for a remote
+    /// backend, arg-adapted) *now* — otherwise the relaunch would resurrect
+    /// local config paths the host can't see.
+    pub fn set_provider(&mut self, provider: Arc<dyn AgentProvider>) {
+        self.provider = provider;
+    }
+
     /// Restart the session: kill the old pane, spawn a fresh one with new config.
     ///
     /// Uses the agent's resume args (when defined) so it picks up the

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -726,7 +726,8 @@ impl TmuxBackend {
     /// appears to "not launch". `exec` replaces the wrapper so no extra process
     /// lingers. Local backends already inherit the user's interactive `PATH`, so
     /// they pass through unchanged — and so does a **psmux** remote (a Windows
-    /// SSH host), which has no `/bin/sh` to wrap with.
+    /// SSH host), which has no `/bin/sh` to wrap with (psmux windows are built by
+    /// [`psmux_window_command`] instead).
     ///
     /// Done here — not via tmux `default-command` — because that value round-trips
     /// through the remote transport's per-arg shell-quoting, where a `-l` flag's
@@ -738,6 +739,56 @@ impl TmuxBackend {
         } else {
             shell_cmd.to_string()
         }
+    }
+
+    /// Build the psmux `new-window` command token: one **double-quoted** string
+    /// holding a PowerShell command that sets the env vars and launches the
+    /// agent.
+    ///
+    /// psmux's control-mode parser diverges from tmux in three ways that this
+    /// encoding routes around (all verified against psmux 3.3.6):
+    /// - **Trailing tokens are not joined**: tmux joins multiple trailing
+    ///   `new-window` args into one shell command; psmux keeps only the first
+    ///   token and silently drops the rest — the agent launched with no args.
+    ///   So the whole command must be a single token.
+    /// - **`-e` is ignored**: env vars never reach the window's process. They
+    ///   are folded into the command itself (`Set-Item Env:K 'v'; …` — chosen
+    ///   over `$env:K` so the string stays `$`-free).
+    /// - **Quoting**: psmux runs the token via `powershell -NoLogo -Command
+    ///   <token>`, whose Win32 command line strips unescaped double quotes — so
+    ///   the *inner* PowerShell quoting must use single quotes (which Win32
+    ///   tokenization passes through). psmux's own tokenizer concatenates
+    ///   adjacent `'…'` segments (there is no escape that survives as a literal
+    ///   `'` inside them; backslash is literal everywhere, so `C:\` paths are
+    ///   safe) but passes `'` through **double-quoted** tokens untouched —
+    ///   hence single quotes inside, double quotes outside.
+    fn psmux_window_command(
+        command: &str,
+        args: &[String],
+        env: &HashMap<String, String>,
+    ) -> String {
+        // PowerShell single-quoting: '' is a literal ' inside '…'. That inner
+        // escape survives both outer layers (psmux passes ' through "…" tokens;
+        // Win32 tokenization ignores single quotes).
+        fn ps_quote(s: &str) -> String {
+            format!("'{}'", s.replace('\'', "''"))
+        }
+        let mut ps = String::new();
+        // Sort for a deterministic command (HashMap iteration order isn't).
+        let mut pairs: Vec<_> = env.iter().collect();
+        pairs.sort();
+        for (k, v) in pairs {
+            ps.push_str(&format!("Set-Item Env:{k} {}; ", ps_quote(v)));
+        }
+        ps.push_str(&format!("& {}", ps_quote(command)));
+        for a in args {
+            ps.push(' ');
+            ps.push_str(&ps_quote(a));
+        }
+        // The outer double quotes make this one psmux token. A raw `"` or
+        // newline inside would terminate the token / split the control-mode
+        // line early — there is no known escape, so neutralize them.
+        format!("\"{}\"", ps.replace(['"', '\n'], " "))
     }
 
     /// Run a closure with a reference to the active control mode, or bail if
@@ -981,16 +1032,27 @@ impl SessionBackend for TmuxBackend {
         rows: u16,
         cols: u16,
     ) -> Result<SpawnedSession> {
-        let shell_cmd = self.login_wrap_for_remote(&Self::build_shell_command(command, args));
+        // psmux can't take the command as joined trailing tokens nor env via
+        // `-e` (see `psmux_window_command`); everything is folded into one
+        // token there. tmux keeps the byte-identical multi-token + `-e` path.
+        let psmux = self.transport.uses_psmux();
+        let shell_cmd = if psmux {
+            Self::psmux_window_command(command, args, env)
+        } else {
+            self.login_wrap_for_remote(&Self::build_shell_command(command, args))
+        };
 
         let cwd_part = match cwd {
             Some(dir) => format!(" -c {}", control_mode::shell_escape(&dir.to_string_lossy())),
             None => String::new(),
         };
-        let env_part: String = env
-            .iter()
-            .map(|(k, v)| format!(" -e {}", shell_escape(&format!("{k}={v}"))))
-            .collect();
+        let env_part: String = if psmux {
+            String::new()
+        } else {
+            env.iter()
+                .map(|(k, v)| format!(" -e {}", shell_escape(&format!("{k}={v}"))))
+                .collect()
+        };
         let escaped_window_name = shell_escape(window_name);
         let session = &self.session;
         let cmd = format!(
@@ -1724,6 +1786,44 @@ mod tests {
         // Local backends inherit the user's interactive PATH — no wrap needed.
         let backend = TmuxBackend::local();
         assert_eq!(backend.login_wrap_for_remote("claude"), "claude");
+    }
+
+    // --- psmux_window_command tests ---
+    // psmux keeps only the FIRST trailing new-window token (tmux joins them) and
+    // ignores `-e` entirely, so the whole launch — env included — must be one
+    // double-quoted token of PowerShell (verified against psmux 3.3.6).
+
+    #[test]
+    fn psmux_window_command_is_one_double_quoted_token() {
+        let args = vec!["--session-id".to_string(), "abc-123".to_string()];
+        let cmd = TmuxBackend::psmux_window_command("claude", &args, &HashMap::new());
+        assert_eq!(cmd, "\"& 'claude' '--session-id' 'abc-123'\"");
+    }
+
+    #[test]
+    fn psmux_window_command_folds_env_as_set_item() {
+        // `Set-Item Env:K 'v'` (not `$env:K`) keeps the string `$`-free; sorted
+        // for determinism. Values with spaces survive the PS single quotes.
+        let mut env = HashMap::new();
+        env.insert("THURBOX_SESSION".to_string(), "id-1".to_string());
+        env.insert("B".to_string(), "x y".to_string());
+        let cmd = TmuxBackend::psmux_window_command("claude", &[], &env);
+        assert_eq!(
+            cmd,
+            "\"Set-Item Env:B 'x y'; Set-Item Env:THURBOX_SESSION 'id-1'; & 'claude'\""
+        );
+    }
+
+    #[test]
+    fn psmux_window_command_escapes_and_sanitizes() {
+        // A literal ' doubles (PowerShell escaping); a raw " or newline would
+        // terminate the outer token / split the control-mode line, so both are
+        // neutralized to spaces. Backslash paths pass through untouched (psmux
+        // treats backslash literally everywhere).
+        let args = vec!["it's".to_string(), "say \"hi\"\nnow".to_string()];
+        let cmd =
+            TmuxBackend::psmux_window_command("C:\\Tools\\claude.exe", &args, &HashMap::new());
+        assert_eq!(cmd, "\"& 'C:\\Tools\\claude.exe' 'it''s' 'say  hi  now'\"");
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1158,8 +1158,28 @@ impl App {
     /// config by looking its agent up in the registry. Falls back to the
     /// registry default, then to the built-in default, so a stale/unknown agent
     /// name never breaks spawning.
+    ///
+    /// For **adoption** (attaching to an already-running window). Paths that
+    /// launch a new process use `launch_provider_for`, which also adapts the
+    /// def's args for a remote host.
     pub fn provider_for(&self, config: &SessionConfig) -> Arc<dyn crate::agent::AgentProvider> {
         Arc::new(GenericProvider::new(self.agent_def_for(&config.agent)))
+    }
+
+    /// [`Self::provider_for`], plus remote arg adaptation: when `config` targets
+    /// a remote (SSH/WSL) backend, the def's args that reference thurbox-managed
+    /// config files by *local* path (claude's hooks `--settings …`) are rewritten
+    /// for the host — materialized at a home-translated remote path, or stripped
+    /// when no remote path can work — because an unresolvable path kills the
+    /// agent on launch ("Settings file not found"). Shares the headless spawn's
+    /// implementation; used by every path that launches a new agent process
+    /// (spawn, restore, respawn-on-restore).
+    fn launch_provider_for(&self, config: &SessionConfig) -> Arc<dyn crate::agent::AgentProvider> {
+        let mut def = self.agent_def_for(&config.agent);
+        if let Some(h) = self.host_for_backend(config.backend.as_deref()) {
+            def.args = crate::session_ops::spawn::adapt_agent_args_for_remote(h, def.args);
+        }
+        Arc::new(GenericProvider::new(def))
     }
 
     /// Resolve the [`AgentDef`] for an agent name via the same fallback chain as
@@ -1411,6 +1431,10 @@ impl App {
         // Keep the same thurbox identity across a restart so injected env stays
         // stable (`THURBOX_SESSION`).
         let session_id = session.info.id;
+        // Preserve a remote backend on the config — set *before* env injection
+        // (which skips the local-path dir vars for remote sessions) and used to
+        // adapt the relaunch args for the host.
+        let backend_type = session.backend_name().to_string();
         // Rebuild the process cwd: the primary repo for a single-repo session,
         // or the (idempotently rebuilt) symlink workspace for a multi-repo one.
         let cwd = self.session_process_cwd(&session.info);
@@ -1422,6 +1446,7 @@ impl App {
             cwd,
             agent,
             fork_session_id: None,
+            backend: crate::session::is_remote_backend(&backend_type).then_some(backend_type),
             ..SessionConfig::default()
         };
         // `Session::restart` replaces the session env wholesale, so re-inject the
@@ -1439,12 +1464,17 @@ impl App {
     /// Execute the actual restart with the finalized config.
     fn do_restart(&mut self, config: SessionConfig) {
         let (rows, cols) = self.content_area_size();
+        // Resolve the relaunch provider from the *current* registry (and adapt
+        // its args for a remote backend) before restarting — the provider the
+        // session stored at spawn/adopt time may predate both.
+        let provider = self.launch_provider_for(&config);
         let Some(session) = self.active_session_mut() else {
             // The active session vanished (e.g. deleted by a concurrent CLI
             // command) before the restart fired — degrade to a no-op.
             self.new_session.restart = false;
             return;
         };
+        session.set_provider(provider);
         let session_id = session.info.id;
         match session.restart(&config, rows, cols) {
             Ok(()) => {
@@ -1923,18 +1953,13 @@ impl App {
             deleted.agent_session_id.clone(),
             deleted.agent,
             cwd,
+            &deleted.backend_type,
         );
         config.resume_session_id = deleted.agent_session_id;
-        // Preserve the persisted backend so a restored off-local
-        // (`ssh:<host>` / `wsl:<distro>`) session keeps its backend name on the
-        // config; local sessions stay `None`.
-        if crate::session::is_remote_backend(&deleted.backend_type) {
-            config.backend = Some(deleted.backend_type.clone());
-        }
 
         let session_name = deleted.name.clone();
         let (rows, cols) = self.content_area_size();
-        let provider = self.provider_for(&config);
+        let provider = self.launch_provider_for(&config);
 
         match Session::spawn(
             session_name.clone(),
@@ -3334,17 +3359,7 @@ impl App {
             }
         };
 
-        let provider = self.provider_for(&config);
-
-        // On a remote host, materialize any thurbox-managed config file the
-        // agent args reference by its *local* path (e.g. claude's hooks
-        // `--settings <config>/hooks/claude.json`) at the same path on the
-        // remote, so the agent doesn't fail to launch ("Settings file not
-        // found"). Best-effort; shares the headless spawn's implementation.
-        if let Some(h) = spawn_host.as_ref() {
-            let args = crate::agent::AgentProvider::build_args(provider.as_ref(), &config);
-            crate::session_ops::spawn::materialize_agent_config_on_remote(h, &args);
-        }
+        let provider = self.launch_provider_for(&config);
 
         Some(SpawnInputs {
             config,
@@ -4604,12 +4619,18 @@ impl App {
         agent_session_id: Option<String>,
         agent: String,
         cwd: Option<PathBuf>,
+        backend_type: &str,
     ) -> SessionConfig {
         let mut config = SessionConfig {
             agent_session_id: agent_session_id.clone(),
             session_id: Some(id),
             cwd,
             agent,
+            // Preserve a persisted off-local (`ssh:<host>` / `wsl:<distro>`)
+            // backend — set *before* env injection, which skips the local-path
+            // dir vars for remote sessions. Local stays `None`.
+            backend: crate::session::is_remote_backend(backend_type)
+                .then(|| backend_type.to_string()),
             ..SessionConfig::default()
         };
         // `THURBOX_SESSION` (derived from `session_id`) is the identity that
@@ -4650,11 +4671,12 @@ impl App {
             Some(agent_sid.clone()),
             shared_session.agent.clone(),
             cwd,
+            &shared_session.backend_type,
         );
         let def = self.agent_def_for(&config.agent);
         config.resume_session_id =
             crate::session_ops::resume_trigger_for(&def, agent_sid, &config.env);
-        let provider = self.provider_for(&config);
+        let provider = self.launch_provider_for(&config);
 
         if let Ok(mut spawned) = Session::spawn(
             shared_session.name.clone(),
@@ -5032,6 +5054,11 @@ impl App {
         // restarts: `do_spawn_session` upserts in place (no soft-delete + new-row
         // churn), and `THURBOX_SESSION` is re-injected with the same id. Any
         // cached id / queued message addressed to this session stays valid.
+        // Preserving a remote `backend` keeps the respawn on its own host —
+        // without it `do_spawn_session` would silently relaunch the session on
+        // the local tmux, pointed at worktree paths that only exist remotely.
+        let backend = crate::session::is_remote_backend(&shared.backend_type)
+            .then(|| shared.backend_type.clone());
         let mut config = SessionConfig {
             session_id: Some(shared.id),
             resume_session_id: None,
@@ -5039,6 +5066,7 @@ impl App {
             cwd: shared.cwd,
             agent,
             fork_session_id: None,
+            backend,
             ..SessionConfig::default()
         };
         let def = self.agent_def_for(&config.agent);
@@ -5758,9 +5786,15 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let _guard = crate::paths::TestPathGuard::new(tmp.path());
         let id = crate::session::SessionId::default();
-        let config =
-            App::restored_session_config(id, Some("agent-conv-uuid".into()), "claude".into(), None);
+        let config = App::restored_session_config(
+            id,
+            Some("agent-conv-uuid".into()),
+            "claude".into(),
+            None,
+            "local-tmux",
+        );
         assert_eq!(config.session_id, Some(id));
+        assert_eq!(config.backend, None, "local backend stays None");
         assert_eq!(
             config.env.get("THURBOX_SESSION"),
             Some(&id.to_string()),
@@ -5784,8 +5818,31 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let _guard = crate::paths::TestPathGuard::new(tmp.path());
         let id = crate::session::SessionId::default();
-        let config = App::restored_session_config(id, None, "codex".into(), None);
+        let config = App::restored_session_config(id, None, "codex".into(), None, "local-tmux");
         assert_eq!(config.env.get("THURBOX_SESSION"), Some(&id.to_string()));
+    }
+
+    #[test]
+    fn restored_session_config_remote_backend_carries_and_skips_local_dirs() {
+        // A restored off-local session must set `backend` *before* env injection
+        // so the local-path dir vars are skipped (they don't exist on the host)
+        // — and so the relaunch provider adapts the def's args for the host.
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+        let id = crate::session::SessionId::default();
+        let config = App::restored_session_config(
+            id,
+            Some("agent-conv-uuid".into()),
+            "claude".into(),
+            None,
+            "ssh:devbox",
+        );
+        assert_eq!(config.backend.as_deref(), Some("ssh:devbox"));
+        assert!(config.env.contains_key("THURBOX_SESSION"));
+        assert!(!config
+            .env
+            .contains_key(crate::paths::CONFIG_DIR_OVERRIDE_ENV));
+        assert!(!config.env.contains_key(crate::paths::DATA_DIR_OVERRIDE_ENV));
     }
 
     #[test]

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -189,6 +189,12 @@ fn build_agent_invocation(
 ///   so the agent's `thurbox-cli` (its status hook) targets the same DB the TUI
 ///   reads regardless of XDG / PATH / a stale tmux-server env.
 ///
+/// The three *path* vars are **local-only**: a remote (SSH/WSL) session skips
+/// them — the local dirs don't exist on the host, and a remote `thurbox-cli`
+/// pinned to them would resolve garbage instead of its own defaults. The
+/// identity vars (`THURBOX_SESSION`/`THURBOX_SESSION_ID`/`THURBOX_TASK`) are
+/// opaque and travel everywhere.
+///
 /// Kept in sync with `App::build_spawn_inputs` so headless and TUI sessions look
 /// identical to the spawned process (modulo `THURBOX_TASK` as noted above).
 ///
@@ -210,6 +216,13 @@ pub(crate) fn inject_thurbox_env(
         config
             .env
             .insert("THURBOX_TASK".into(), task_id.to_string());
+    }
+    if config
+        .backend
+        .as_deref()
+        .is_some_and(crate::session::is_remote_backend)
+    {
+        return;
     }
     if let Some(dir) = crate::paths::metrics_directory() {
         config
@@ -308,6 +321,28 @@ mod tests {
                 .as_deref()
                 .and_then(|p| p.parent())
         );
+    }
+
+    #[test]
+    fn inject_env_skips_local_path_dirs_for_remote_backend() {
+        // The metrics/config/data dirs are *local* paths — meaningless on an
+        // SSH/WSL host, and a remote `thurbox-cli` pinned to them would resolve
+        // garbage. Identity vars still travel.
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+        let mut config = SessionConfig {
+            session_id: Some(SessionId::default()),
+            backend: Some("ssh:devbox".into()),
+            ..SessionConfig::default()
+        };
+        inject_thurbox_env(&mut config, "agent-conv-uuid", None);
+        assert!(config.env.contains_key("THURBOX_SESSION"));
+        assert!(config.env.contains_key("THURBOX_SESSION_ID"));
+        assert!(!config.env.contains_key("THURBOX_METRICS_DIR"));
+        assert!(!config
+            .env
+            .contains_key(crate::paths::CONFIG_DIR_OVERRIDE_ENV));
+        assert!(!config.env.contains_key(crate::paths::DATA_DIR_OVERRIDE_ENV));
     }
 
     #[test]

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -69,12 +69,23 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
 
     // Resolve the agent definition once; `agent_name` is derived from it so the
     // persisted name always matches the def that's actually launched.
-    let agent_def = super::resolve_agent_def(req.agent.as_deref());
+    let mut agent_def = super::resolve_agent_def(req.agent.as_deref());
     let agent_name = agent_def.name.clone();
 
     // Resolve the optional remote host. `backend_type` is `local-tmux` or
     // `ssh:<host>`; `host` is the matching HostDef for remote git/tmux ops.
     let (backend_type, host) = resolve_host(req.host.as_deref())?;
+
+    // The def's `args` may reference thurbox-managed config files by their
+    // *local* absolute path (e.g. claude's hooks `--settings <config>/hooks/
+    // claude.json`), which the agent errors on when the path doesn't exist on
+    // the host ("Settings file not found" → the pane dies instantly). Rewrite
+    // them for the host: materialize the file remotely (translating a
+    // home-anchored path to the remote home) or, when that's impossible, strip
+    // the flag so the agent at least launches.
+    if let Some(h) = host.as_ref() {
+        agent_def.args = adapt_agent_args_for_remote(h, agent_def.args);
+    }
     let (primary_cwd, worktrees, additional_dirs) = resolve_dirs(&req, host.as_ref())?;
 
     let agent_session_id = req
@@ -110,15 +121,6 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     super::inject_thurbox_env(&mut config, &agent_session_id, req.task_id);
 
     let (command, args) = super::build_agent_invocation(&agent_def, &config);
-
-    // The agent's args may reference thurbox-managed config files by their
-    // *local* absolute path (e.g. claude's hooks `--settings <config>/hooks/
-    // claude.json`). On a remote host that path doesn't exist, so the agent
-    // errors on launch ("Settings file not found"). Materialize each such file
-    // at the same path on the remote before launching.
-    if let Some(h) = host.as_ref() {
-        materialize_agent_config_on_remote(h, &args);
-    }
 
     // Remote spawns drive the SSH backend's control mode to learn the real pane
     // id; local spawns leave `backend_id` empty for the TUI to resolve by name.
@@ -344,89 +346,134 @@ pub(crate) fn resolve_launch_cwd(
     }
 }
 
-/// Copy any thurbox-managed config files referenced in the agent `args` (by
-/// their *local* absolute path) to the same path on the remote `host`, so an
-/// agent launched with e.g. `--settings <config>/hooks/claude.json` finds the
-/// file there. Best-effort: a copy failure is logged, not fatal — the agent
-/// still launches (the hooks just won't fire), and we never block a spawn on it.
+/// Adapt agent `args` that reference thurbox-managed config files (by their
+/// *local* absolute path) for a spawn on the remote `host`, returning the args
+/// to actually launch with. An agent handed a path that doesn't exist on the
+/// host errors out and the pane dies instantly (claude: "Settings file not
+/// found"), so an unresolvable path must never reach the remote launch:
 ///
-/// Scope is deliberately narrow: only existing local **files under the thurbox
-/// config dir** are copied, so we never ship an arbitrary path an agent's own
-/// args happen to contain (a repo path, a user file, …). And the mirror is
-/// only attempted when the remote would resolve the *same absolute path* — the
-/// agent's arg is not rewritten (args are rebuilt from the `AgentDef` at every
-/// spawn), so a path the remote can't reproduce byte-for-byte is skipped with
-/// a warning rather than materialized somewhere the agent won't look:
-/// - a non-POSIX (Windows `C:\…`) local config root can never resolve on the
-///   POSIX remote;
-/// - a `psmux` host is native Windows — no POSIX shell to copy with, and no
-///   local-POSIX path to resolve;
-/// - a home-anchored config root only matches when local and remote `$HOME`
-///   agree (the common same-user WSL/devbox case).
+/// - **Translate + materialize** (POSIX remotes): rewrite a home-anchored
+///   config path onto the *remote* home (identity when the homes agree), copy
+///   the local file to that remote path, and substitute the rewritten arg.
+/// - **Strip as fallback**: on a `psmux` host (native Windows — no POSIX side
+///   to copy to and hook commands are `sh` syntax anyway), a non-POSIX local
+///   config root, a config path outside the local home that a home-translation
+///   can't map, or a failed remote copy/home lookup, drop the path **and its
+///   preceding flag** (e.g. the whole `--settings <path>` pair) with a warning
+///   so the agent launches clean instead of dead.
 ///
-/// Shared by the headless spawn and the TUI (`App::build_spawn_inputs`) so both
-/// paths give a remote session the same agent config.
-pub(crate) fn materialize_agent_config_on_remote(host: &HostDef, args: &[String]) {
+/// Scope is deliberately narrow: only paths under the **thurbox config dir**
+/// are touched (and only existing local files are copied), so an arbitrary
+/// path in the agent's own args — a repo path, a user file — is never
+/// rewritten or shipped. Remote hooks still can't *signal* (no `thurbox-cli`
+/// on the host, and it would write to the host's own DB); they fail soft.
+///
+/// Shared by the headless spawn and the TUI (`App::build_spawn_inputs`) so
+/// both paths launch a remote session with the same args.
+pub(crate) fn adapt_agent_args_for_remote(host: &HostDef, args: Vec<String>) -> Vec<String> {
     let Some(config_root) = crate::paths::config_file()
         .and_then(|p| p.parent().map(|d| d.to_string_lossy().into_owned()))
     else {
-        return;
+        return args;
     };
-    if !config_root.starts_with('/') || host.mux() == "psmux" {
-        return;
-    }
-    if !remote_resolves_local_path(host, &config_root) {
-        return;
-    }
-    for arg in args {
-        // Only absolute paths under the thurbox config dir that exist as local
-        // files are candidates.
-        if !arg.starts_with(&config_root) {
-            continue;
-        }
-        let local = std::path::Path::new(arg);
+    // Resolve the translation target lazily (one ssh round-trip) and at most
+    // once; `None` = strip mode.
+    let mut remote_root: Option<Option<String>> = None;
+    rewrite_config_path_args(args, &config_root, |local_path| {
+        let root = remote_root
+            .get_or_insert_with(|| remote_config_root(host, &config_root))
+            .clone()?;
+        let remote_path = format!("{root}{}", &local_path[config_root.len()..]);
+        let local = std::path::Path::new(local_path);
         if !local.is_file() {
-            continue;
+            return None;
         }
-        if let Err(e) = crate::git::copy_file_to_remote(host, local, arg) {
+        match crate::git::copy_file_to_remote(host, local, &remote_path) {
+            Ok(()) => Some(remote_path),
+            Err(e) => {
+                tracing::warn!(
+                    "failed to materialize agent config {local_path} on host '{}': {e:#}",
+                    host.name
+                );
+                None
+            }
+        }
+    })
+}
+
+/// Where the local thurbox config root lands on `host`, or `None` when no
+/// remote location can hold it (→ strip the args instead):
+/// - a non-POSIX (Windows `C:\…`) local root or a `psmux` host can't take a
+///   POSIX copy at all;
+/// - a home-anchored root translates onto the **remote** home (identity when
+///   local and remote `$HOME` agree — the common same-user WSL/devbox case);
+/// - a root outside the local home is mirrored at the same absolute path.
+fn remote_config_root(host: &HostDef, config_root: &str) -> Option<String> {
+    if !config_root.starts_with('/') || host.mux() == "psmux" {
+        tracing::warn!(
+            "stripping local agent-config args for host '{}': no POSIX path for the \
+             thurbox config dir there",
+            host.name
+        );
+        return None;
+    }
+    let Some(local_home) = crate::paths::home_dir() else {
+        return Some(config_root.to_string());
+    };
+    let local_home = local_home.to_string_lossy().into_owned();
+    let Some(suffix) = config_root.strip_prefix(&local_home) else {
+        return Some(config_root.to_string());
+    };
+    match crate::git::remote_home(host) {
+        Ok(remote_home) => Some(format!("{remote_home}{suffix}")),
+        Err(e) => {
             tracing::warn!(
-                "failed to materialize agent config {arg} on host '{}': {e:#}",
+                "stripping local agent-config args for host '{}': cannot resolve remote \
+                 home: {e:#}",
                 host.name
             );
+            None
         }
     }
 }
 
-/// Whether `host` would resolve `path` at the same absolute location as the
-/// local machine. Only home-anchored paths can differ: they match exactly when
-/// the local and remote `$HOME` agree (the common same-user WSL/devbox case).
-/// A mismatch (or an unresolvable remote home) is logged and returns `false`.
-fn remote_resolves_local_path(host: &HostDef, path: &str) -> bool {
-    let Some(local_home) = crate::paths::home_dir() else {
-        return true;
-    };
-    let local_home = local_home.to_string_lossy().into_owned();
-    if !path.starts_with(&local_home) {
-        return true;
-    }
-    match crate::git::remote_home(host) {
-        Ok(remote_home) if remote_home == local_home => true,
-        Ok(remote_home) => {
-            tracing::warn!(
-                "not materializing agent config on host '{}': local home {local_home} != \
-                 remote home {remote_home}, so the agent's local-path args can't resolve there",
-                host.name
-            );
-            false
+/// Pure arg-rewriting core of [`adapt_agent_args_for_remote`]: every arg (or
+/// `--flag=value` value) under `config_root` is passed to `map`; `Some(new)`
+/// substitutes the path, `None` drops the arg **and** its preceding token when
+/// that token is a flag (so a `--settings <path>` pair vanishes together).
+fn rewrite_config_path_args(
+    args: Vec<String>,
+    config_root: &str,
+    mut map: impl FnMut(&str) -> Option<String>,
+) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(args.len());
+    for arg in args {
+        if arg.starts_with(config_root) {
+            match map(&arg) {
+                Some(new) => out.push(new),
+                None => {
+                    tracing::warn!("dropping agent arg for remote spawn: {arg}");
+                    if out.last().is_some_and(|prev| prev.starts_with('-')) {
+                        out.pop();
+                    }
+                }
+            }
+            continue;
         }
-        Err(e) => {
-            tracing::warn!(
-                "not materializing agent config on host '{}': cannot resolve remote home: {e:#}",
-                host.name
-            );
-            false
+        // `--flag=<path>` form: rewrite the value in place, or drop the whole
+        // token (it is self-contained — nothing precedes it to pop).
+        if let Some((flag, value)) = arg.split_once('=') {
+            if flag.starts_with('-') && value.starts_with(config_root) {
+                match map(value) {
+                    Some(new) => out.push(format!("{flag}={new}")),
+                    None => tracing::warn!("dropping agent arg for remote spawn: {arg}"),
+                }
+                continue;
+            }
         }
+        out.push(arg);
     }
+    out
 }
 
 /// A human-friendly label for a member directory in the symlink workspace:
@@ -534,6 +581,83 @@ mod tests {
         };
         db.upsert_session(&parent).unwrap();
         assert!(validate_parent_session(&db, Some(parent.id)).is_ok());
+    }
+
+    #[test]
+    fn adapt_agent_args_is_identity_without_config_paths() {
+        // No arg references the thurbox config dir → args pass through
+        // untouched and, because the remote root is resolved lazily, no ssh
+        // round-trip is attempted (the host here doesn't exist).
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let host = HostDef {
+            name: "nonexistent-host".into(),
+            destination: "user@nonexistent-host".into(),
+            ..Default::default()
+        };
+        let args: Vec<String> = ["--session-id", "abc", "--model", "opus"]
+            .map(String::from)
+            .into();
+        assert_eq!(adapt_agent_args_for_remote(&host, args.clone()), args);
+    }
+
+    #[test]
+    fn rewrite_config_args_substitutes_translated_path() {
+        let args: Vec<String> = ["--settings", "/home/a/.config/thurbox/hooks/claude.json"]
+            .map(String::from)
+            .into();
+        let out = rewrite_config_path_args(args, "/home/a/.config/thurbox", |p| {
+            Some(p.replace("/home/a/", "/home/b/"))
+        });
+        assert_eq!(
+            out,
+            ["--settings", "/home/b/.config/thurbox/hooks/claude.json"].map(String::from)
+        );
+    }
+
+    #[test]
+    fn rewrite_config_args_strips_flag_and_path_pair() {
+        // When no remote path can work, the path AND its `--settings` flag must
+        // both vanish — leaving a dangling flag would eat the next arg.
+        let args: Vec<String> = [
+            "--verbose",
+            "--settings",
+            "/home/a/.config/thurbox/hooks/claude.json",
+            "--session-id",
+            "x",
+        ]
+        .map(String::from)
+        .into();
+        let out = rewrite_config_path_args(args, "/home/a/.config/thurbox", |_| None);
+        assert_eq!(out, ["--verbose", "--session-id", "x"].map(String::from));
+    }
+
+    #[test]
+    fn rewrite_config_args_handles_equals_form_and_positional() {
+        // `--flag=<path>` rewrites in place / drops as one token; a positional
+        // config path (no preceding flag) drops alone.
+        let args: Vec<String> = ["--settings=/cfg/hooks/x.json", "/cfg/seed.toml"]
+            .map(String::from)
+            .into();
+        let rewritten =
+            rewrite_config_path_args(args.clone(), "/cfg", |p| Some(format!("/rem{p}")));
+        assert_eq!(
+            rewritten,
+            ["--settings=/rem/cfg/hooks/x.json", "/rem/cfg/seed.toml"].map(String::from)
+        );
+        let stripped = rewrite_config_path_args(args, "/cfg", |_| None);
+        assert!(stripped.is_empty());
+    }
+
+    #[test]
+    fn rewrite_config_args_leaves_unrelated_args_untouched() {
+        let args: Vec<String> = ["--model", "opus", "--add-dir", "/home/a/repo"]
+            .map(String::from)
+            .into();
+        let out = rewrite_config_path_args(args.clone(), "/home/a/.config/thurbox", |_| {
+            panic!("map must not be called for non-config args")
+        });
+        assert_eq!(out, args);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remote (SSH) claude sessions died on arrival: the hooks extension's `--settings <local path>` can't resolve on the host. Agent args referencing thurbox-managed config are now **adapted per host** — translated to the remote home and materialized there on POSIX remotes, stripped (flag+path pair) on psmux/Windows hosts or when the copy fails — on every launch path (spawn, restore, respawn, `Ctrl+R` restart).
- psmux (Windows) sessions launched the agent with **no args and no env**: its control-mode `new-window` keeps only the first trailing token and ignores `-e`. The launch is now folded into one double-quoted PowerShell token (`Set-Item Env:K 'v'; & 'claude' …`), verified against psmux 3.3.6 on a real Windows host — `--session-id` pinning and `THURBOX_SESSION` identity work on Windows remotes for the first time.
- `inject_thurbox_env` no longer leaks local-only path vars (`THURBOX_METRICS_DIR`/`CONFIG_DIR`/`DATA_DIR`) into remote sessions, and a stale remote session no longer silently respawns on the local tmux.

## Test plan

- CI checks pass (1718 tests, incl. new coverage for arg rewriting/stripping, psmux token quoting/env folding, remote env skip)
- Verified live against real hosts: linux-host (ssh+tmux — settings materialized at translated path, claude boots with hooks) and win-host (ssh+psmux — argv + identity env delivered, claude boots)

https://claude.ai/code/session_015PTHu7pNyZZUFJrvZmCU4y