### PR TITLE
feat(core): add THURBOX_SOCKET override and a native Windows lab e2e

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,12 @@ one-off command), `clean`; Windows-only: `deploy`
 (cross-build + install to `C:\Tools\thurbox`), `run` (the deployed TUI over
 `ssh -t`), `test-suite` (nextest archive, mirrors `windows-test.sh`),
 `wsl-setup` / `wsl-check` (provision + verify a WSL distro as a thurbox
-target). Local state: `target/lab-test/` (gitignored).
+target), `native-test [agent]` (headless e2e of the **deployed** binaries
+natively on the host: `thurbox-cli.exe` creates a local psmux session —
+agent argv + `THURBOX_*` env asserted intact — and `thurbox.exe` boots
+inside a scoped psmux pane and must show/adopt it; isolated via the
+`THURBOX_SOCKET` env override, since psmux has no `TMUX_TMPDIR`-style
+socket-dir isolation). Local state: `target/lab-test/` (gitignored).
 
 ## Installation Script
 
@@ -545,13 +550,19 @@ control-mode protocol is byte-identical over either transport/binary, with
 - **`new-window` trailing tokens are not joined** — tmux joins them into one
   shell command; psmux keeps only the *first* token and silently drops the
   rest, so the agent launched with **no args**. And **`new-window -e` is
-  ignored** — env vars never reached the window's process (no
-  `THURBOX_SESSION` identity). `TmuxBackend::psmux_window_command` therefore
-  folds env + command into **one double-quoted token** of PowerShell
+  ignored** (on the argv path too) — env vars never reached the window's
+  process (no `THURBOX_SESSION` identity). `TmuxBackend::psmux_window_powershell`
+  therefore folds env + command into **one token** of PowerShell
   (`Set-Item Env:K 'v'; & 'claude' '--session-id' …` — psmux runs the token
   via `powershell -NoLogo -Command`, whose Win32 command line strips unescaped
-  double quotes, hence single-quote inner / double-quote outer; backslash is
-  literal everywhere in psmux's parser, so `C:\` paths survive).
+  double quotes, hence PowerShell single-quoting throughout; backslash is
+  literal everywhere in psmux's parser, so `C:\` paths survive). Control-mode
+  spawns (`psmux_window_command`) frame it in double quotes — psmux's
+  tokenizer concatenates adjacent `'…'` segments but passes `'` through `"…"`
+  tokens — and the headless local `spawn_window` passes it as a single argv
+  arg. The local socket honors the `THURBOX_SOCKET` env override
+  (`local_socket()`) so test/sandbox tooling can scope an instance on Windows,
+  where every `-L <name>` resolves machine-wide (no `TMUX_TMPDIR`).
 
 Each host registers a backend named
 `ssh:<name>` / `wsl:<name>` (`TmuxBackend::from_host`, registered lazily in

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -627,6 +627,7 @@ User-set (read by thurbox):
 | `VISUAL`, then `EDITOR` | `Ctrl+O` editor when `editor_command` is unset |
 | `SHELL` | the `Ctrl+T` companion shell pane (fallback `/bin/sh`) |
 | `RUST_LOG` | log filter for `thurbox.log` |
+| `THURBOX_SOCKET` | overrides the **local** multiplexer socket name (default `thurbox`; dev builds `thurbox-dev`). For test/sandbox tooling: Unix scoping uses `TMUX_TMPDIR`, but psmux (Windows) resolves every `-L <name>` machine-wide, so this is the only way to fully scope an instance there. Remote hosts are unaffected (socket from `hosts.toml`). Empty = unset. |
 
 Set **by** thurbox into every spawned agent process (not user-set;
 `session_ops::inject_thurbox_env` / `App::build_spawn_inputs`). An

--- a/scripts/dev/lab-test.sh
+++ b/scripts/dev/lab-test.sh
@@ -32,6 +32,11 @@
 #   run             run the deployed thurbox.exe interactively over `ssh -t`
 #                   (native-Windows manual testing; WSL distros appear in its
 #                   host picker)
+#   native-test [agent]  headless e2e of the DEPLOYED binaries on the host:
+#                   thurbox-cli.exe creates a local psmux session (agent argv +
+#                   THURBOX_* env asserted intact) and thurbox.exe boots to a
+#                   frame that shows it. Scoped via THURBOX_SOCKET (needs a
+#                   deploy of a build that supports it). Default agent: claude
 #   test-suite      run the full nextest suite on the host (cross-built
 #                   archive; installs cargo-nextest.exe there if missing)
 #   wsl-setup [distro]   install WSL + <distro> (default Debian) and provision
@@ -427,6 +432,83 @@ cmd_run() {
   exec ssh -t "$DEST" "C:/Tools/thurbox/thurbox.exe"
 }
 
+# Native e2e of the DEPLOYED binaries, entirely on the host: thurbox-cli.exe
+# creates a local (psmux) session whose agent must come up with its argv and
+# THURBOX_* env intact, then thurbox.exe boots inside a scoped psmux pane and
+# must adopt that session. Fully isolated via THURBOX_SOCKET (the deployed
+# build must support it) + THURBOX_CONFIG_DIR/THURBOX_DATA_DIR under LAB_DIR —
+# psmux has no TMUX_TMPDIR-style socket-dir isolation, so the env override is
+# the only thing keeping this off the machine's real thurbox/thurbox-dev
+# servers.
+cmd_native_test() {
+  require_windows
+  ssh_host 'powershell -NoProfile -Command "Test-Path C:/Tools/thurbox/thurbox-cli.exe"' 2> /dev/null \
+    | grep -qi true || die "thurbox-cli.exe not deployed — run '$0 $DEST deploy' first"
+  local agent="${1:-claude}"
+  log "native e2e on $DEST: agent '$agent', scoped socket $LAB_SOCKET, state $LAB_DIR/native"
+  run_ps "$LAB_DIR" "$LAB_SOCKET" "$agent" <<'EOF'
+param([string]$LabDir, [string]$Socket, [string]$Agent)
+$ErrorActionPreference = 'Stop'
+$cli = 'C:/Tools/thurbox/thurbox-cli.exe'
+$tui = 'C:/Tools/thurbox/thurbox.exe'
+$name = 'lab-native'
+$fails = 0
+function Assert([bool]$ok, [string]$what) {
+  if ($ok) { Write-Output "  ok   $what" } else { Write-Output "  FAIL $what"; $script:fails++ }
+}
+
+# Scoped env for every thurbox child below. THURBOX_SOCKET keeps the whole run
+# off the machine's real psmux servers.
+$env:THURBOX_SOCKET = $Socket
+$env:THURBOX_CONFIG_DIR = "$LabDir/native/config"
+$env:THURBOX_DATA_DIR = "$LabDir/native/data"
+
+psmux -L $Socket kill-server 2>$null
+Remove-Item -Recurse -Force "$LabDir/native" -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path "$LabDir/native/repo" | Out-Null
+git -C "$LabDir/native/repo" init -qb main
+git -C "$LabDir/native/repo" config user.email test@thurbox
+git -C "$LabDir/native/repo" config user.name thurbox-lab
+git -C "$LabDir/native/repo" commit -qm init --allow-empty
+
+Write-Output "== thurbox-cli session create (local psmux backend) =="
+$out = & $cli --json session create --name $name --repo-path "$LabDir/native/repo" --agent $Agent 2>&1 | Out-String
+if ($LASTEXITCODE -ne 0) { Write-Output $out; Write-Output "FAIL session create exited $LASTEXITCODE"; exit 1 }
+$json = $out | ConvertFrom-Json
+Assert ($json.name -eq $name) "session created (id $($json.id))"
+Start-Sleep 8
+
+# The scoped server (NOT thurbox-dev) must own the agent window, alive.
+$panes = (psmux -L $Socket list-panes -a -F '#{window_name} #{pane_dead}') -join "`n"
+Assert ($panes -match "tb-$name 0") "agent window alive on scoped socket ($Socket)"
+
+# The window process must carry the folded env + argv (psmux drops -e and
+# joined tokens; the deployed build must route around both).
+$procs = (Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -match 'Set-Item Env:THURBOX_SESSION' }).CommandLine -join "`n"
+Assert ($procs -match [regex]::Escape($json.id)) "THURBOX_SESSION env folded into the window command"
+Assert ($procs -match "'$Agent'") "agent argv delivered ($Agent)"
+
+$list = & $cli --json session list | Out-String | ConvertFrom-Json
+Assert (@($list | Where-Object { $_.name -eq $name }).Count -eq 1) "thurbox-cli session list sees the session"
+
+Write-Output "== thurbox.exe TUI boot (inside a scoped psmux pane) =="
+# psmux targets are session-qualified; the session name is the deployed
+# build's compile-time default, so discover it instead of hardcoding.
+$sess = (psmux -L $Socket list-sessions -F '#{session_name}' | Select-Object -First 1)
+# Window command is one argv token: env + exec. The pane gives the TUI a ConPTY.
+$boot = "Set-Item Env:THURBOX_SOCKET '$Socket'; Set-Item Env:THURBOX_CONFIG_DIR '$LabDir/native/config'; Set-Item Env:THURBOX_DATA_DIR '$LabDir/native/data'; & '$tui'"
+psmux -L $Socket new-window -d -t "${sess}:" -n lab-tui $boot
+Start-Sleep 8
+$frame = (psmux -L $Socket capture-pane -p -t "${sess}:lab-tui") -join "`n"
+Assert ($frame -match 'lab-native') "TUI booted and shows/adopted the session"
+
+psmux -L $Socket kill-server 2>$null
+if ($fails -gt 0) { Write-Output "NATIVE-TEST FAILURES: $fails"; exit 1 }
+Write-Output "NATIVE-TEST OK"
+EOF
+  printf '\033[1;32mPASS\033[0m native thurbox (dev) runs correctly on %s\n' "$DEST"
+}
+
 cmd_test_suite() {
   require_windows
   require_win_target
@@ -591,6 +673,7 @@ case "$VERB" in
   clean)      cmd_clean ;;
   deploy)     cmd_deploy ;;
   run)        cmd_run ;;
+  native-test) cmd_native_test "$@" ;;
   test-suite) cmd_test_suite ;;
   wsl-setup)  cmd_wsl_setup "$@" ;;
   wsl-check)  cmd_wsl_check "$@" ;;

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -24,6 +24,25 @@ const TMUX_SOCKET: &str = if cfg!(dev_build) {
     "thurbox"
 };
 
+/// Env var overriding the **local** multiplexer socket name.
+///
+/// Unix test/sandbox tooling scopes the socket by pointing `TMUX_TMPDIR` at a
+/// private directory, but psmux (native Windows) has no socket-directory
+/// concept — every `-L <name>` resolves machine-wide, so without this override
+/// a scoped test on Windows would share (and could tear down) the user's real
+/// `thurbox`/`thurbox-dev` server. Remote hosts are unaffected (their socket
+/// comes from `hosts.toml`).
+pub const SOCKET_OVERRIDE_ENV: &str = "THURBOX_SOCKET";
+
+/// The local multiplexer socket name: [`SOCKET_OVERRIDE_ENV`] when set and
+/// non-empty, else the compile-time default.
+fn local_socket() -> String {
+    std::env::var(SOCKET_OVERRIDE_ENV)
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| TMUX_SOCKET.to_string())
+}
+
 /// tmux session name used to group all thurbox windows.
 /// Dev builds use "thurbox-dev" to avoid interfering with an installed release binary.
 const TMUX_SESSION: &str = if cfg!(dev_build) {
@@ -39,7 +58,7 @@ const TMUX_SESSION: &str = if cfg!(dev_build) {
 /// Windows) and socket instead of hardcoding `tmux` at each call site.
 fn local_mux_command(args: &[&str]) -> Command {
     let mut cmd = Command::new(DEFAULT_MUX);
-    cmd.arg("-L").arg(TMUX_SOCKET).args(args);
+    cmd.arg("-L").arg(local_socket()).args(args);
     // Strip nesting env so these one-shots target thurbox's own socket even when
     // thurbox is launched inside a tmux/psmux pane (see `strip_mux_nesting_env`).
     crate::agent::transport::strip_mux_nesting_env(&mut cmd);
@@ -504,7 +523,7 @@ impl TmuxBackend {
     pub fn local() -> Self {
         Self {
             transport: TmuxTransport::Local,
-            socket: TMUX_SOCKET.to_string(),
+            socket: local_socket(),
             session: TMUX_SESSION.to_string(),
             name: "local-tmux".to_string(),
             control: Mutex::new(None),
@@ -741,35 +760,35 @@ impl TmuxBackend {
         }
     }
 
-    /// Build the psmux `new-window` command token: one **double-quoted** string
-    /// holding a PowerShell command that sets the env vars and launches the
-    /// agent.
+    /// Build the PowerShell command a psmux window runs: set the env vars, then
+    /// launch the agent.
     ///
-    /// psmux's control-mode parser diverges from tmux in three ways that this
-    /// encoding routes around (all verified against psmux 3.3.6):
-    /// - **Trailing tokens are not joined**: tmux joins multiple trailing
-    ///   `new-window` args into one shell command; psmux keeps only the first
-    ///   token and silently drops the rest — the agent launched with no args.
-    ///   So the whole command must be a single token.
-    /// - **`-e` is ignored**: env vars never reach the window's process. They
-    ///   are folded into the command itself (`Set-Item Env:K 'v'; …` — chosen
-    ///   over `$env:K` so the string stays `$`-free).
-    /// - **Quoting**: psmux runs the token via `powershell -NoLogo -Command
-    ///   <token>`, whose Win32 command line strips unescaped double quotes — so
-    ///   the *inner* PowerShell quoting must use single quotes (which Win32
-    ///   tokenization passes through). psmux's own tokenizer concatenates
-    ///   adjacent `'…'` segments (there is no escape that survives as a literal
-    ///   `'` inside them; backslash is literal everywhere, so `C:\` paths are
-    ///   safe) but passes `'` through **double-quoted** tokens untouched —
-    ///   hence single quotes inside, double quotes outside.
-    fn psmux_window_command(
+    /// psmux ignores `new-window -e` — env vars never reach the window's
+    /// process — so they are folded into the command itself (`Set-Item Env:K
+    /// 'v'; …`, chosen over `$env:K` so the string stays `$`-free). psmux runs
+    /// the window command via `powershell -NoLogo -Command <string>`, whose
+    /// Win32 command line strips unescaped double quotes — so all quoting is
+    /// PowerShell **single** quotes (`''` = literal `'`), which Win32
+    /// tokenization passes through. A raw `"` or newline would break the outer
+    /// framing on either delivery path (below) with no escape that survives,
+    /// so both are neutralized to spaces.
+    ///
+    /// Two callers deliver this string as **one unit** (verified against psmux
+    /// 3.3.6; both needed because psmux drops what tmux would keep):
+    /// - [`psmux_window_command`](Self::psmux_window_command) wraps it in
+    ///   double quotes for a control-mode `new-window` line, whose parser keeps
+    ///   only the *first* trailing token (tmux joins them) — the agent launched
+    ///   with no args. psmux's tokenizer concatenates adjacent `'…'` segments
+    ///   but passes `'` through `"…"` tokens untouched (backslash is literal
+    ///   everywhere, so `C:\` paths are safe) — hence single quotes inside,
+    ///   double quotes outside.
+    /// - [`spawn_window`] passes it verbatim as a single argv token (the argv
+    ///   path joins trailing tokens fine, but still ignores `-e`).
+    fn psmux_window_powershell(
         command: &str,
         args: &[String],
         env: &HashMap<String, String>,
     ) -> String {
-        // PowerShell single-quoting: '' is a literal ' inside '…'. That inner
-        // escape survives both outer layers (psmux passes ' through "…" tokens;
-        // Win32 tokenization ignores single quotes).
         fn ps_quote(s: &str) -> String {
             format!("'{}'", s.replace('\'', "''"))
         }
@@ -785,10 +804,17 @@ impl TmuxBackend {
             ps.push(' ');
             ps.push_str(&ps_quote(a));
         }
-        // The outer double quotes make this one psmux token. A raw `"` or
-        // newline inside would terminate the token / split the control-mode
-        // line early — there is no known escape, so neutralize them.
-        format!("\"{}\"", ps.replace(['"', '\n'], " "))
+        ps.replace(['"', '\n'], " ")
+    }
+
+    /// [`psmux_window_powershell`](Self::psmux_window_powershell) framed as one
+    /// **double-quoted** control-mode token for a `new-window` line.
+    fn psmux_window_command(
+        command: &str,
+        args: &[String],
+        env: &HashMap<String, String>,
+    ) -> String {
+        format!("\"{}\"", Self::psmux_window_powershell(command, args, env))
     }
 
     /// Run a closure with a reference to the active control mode, or bail if
@@ -1322,13 +1348,14 @@ pub fn send_prompt_after_delay(session_name: &str, text: &str, delay_secs: u64) 
 #[cfg(not(windows))]
 fn deferred_prompt_script(target: &str, text: &str) -> String {
     let escaped_target = shell_escape(target);
+    let socket = local_socket();
     // Bracketed-paste wrap (see `bracketed_paste`) so multi-line prompts don't
     // submit early; `-l` makes the multiplexer deliver the bytes literally.
     let escaped_text = shell_escape(&bracketed_paste(text));
     format!(
-        "{DEFAULT_MUX} -L {TMUX_SOCKET} send-keys -t {escaped_target} -l {escaped_text}; \
+        "{DEFAULT_MUX} -L {socket} send-keys -t {escaped_target} -l {escaped_text}; \
          sleep 0.2; \
-         {DEFAULT_MUX} -L {TMUX_SOCKET} send-keys -t {escaped_target} Enter"
+         {DEFAULT_MUX} -L {socket} send-keys -t {escaped_target} Enter"
     )
 }
 
@@ -1338,11 +1365,12 @@ fn deferred_prompt_script(target: &str, text: &str) -> String {
 #[cfg(windows)]
 fn deferred_prompt_script(target: &str, text: &str) -> String {
     let t = ps_single_quote(target);
+    let socket = local_socket();
     let body = ps_single_quote(&bracketed_paste(text));
     format!(
-        "powershell -NoProfile -Command \"{DEFAULT_MUX} -L {TMUX_SOCKET} send-keys -t {t} -l {body}; \
+        "powershell -NoProfile -Command \"{DEFAULT_MUX} -L {socket} send-keys -t {t} -l {body}; \
          Start-Sleep -Milliseconds 200; \
-         {DEFAULT_MUX} -L {TMUX_SOCKET} send-keys -t {t} Enter\""
+         {DEFAULT_MUX} -L {socket} send-keys -t {t} Enter\""
     )
 }
 
@@ -1506,14 +1534,21 @@ pub fn spawn_window(
     if let Some(dir) = cwd {
         tmux.args(["-c", &dir.to_string_lossy()]);
     }
-    for (k, v) in env {
-        tmux.args(["-e", &format!("{k}={v}")]);
-    }
-    // Pass the command + args as a single argv list. tmux treats trailing args
-    // as the command to run inside the window.
-    tmux.arg(command);
-    for a in args {
-        tmux.arg(a);
+    if cfg!(windows) {
+        // psmux (the local mux on Windows) ignores `-e`, so the env must be
+        // folded into the window command itself; delivered as a single argv
+        // token (see `psmux_window_powershell`).
+        tmux.arg(TmuxBackend::psmux_window_powershell(command, args, env));
+    } else {
+        for (k, v) in env {
+            tmux.args(["-e", &format!("{k}={v}")]);
+        }
+        // Pass the command + args as a single argv list. tmux treats trailing
+        // args as the command to run inside the window.
+        tmux.arg(command);
+        for a in args {
+            tmux.arg(a);
+        }
     }
 
     let output = tmux
@@ -1769,6 +1804,21 @@ mod tests {
         ));
         assert_eq!(backend.socket, TMUX_SOCKET);
         assert_eq!(backend.session, TMUX_SESSION);
+    }
+
+    #[test]
+    fn local_socket_honors_env_override() {
+        // nextest runs one process per test, so env mutation can't race other
+        // tests reading `local_socket()`.
+        std::env::set_var(SOCKET_OVERRIDE_ENV, "thurbox-lab-test");
+        assert_eq!(local_socket(), "thurbox-lab-test");
+        assert_eq!(TmuxBackend::local().socket, "thurbox-lab-test");
+        // Empty counts as unset — a sandbox script exporting `THURBOX_SOCKET=`
+        // must not produce `-L ''`.
+        std::env::set_var(SOCKET_OVERRIDE_ENV, "");
+        assert_eq!(local_socket(), TMUX_SOCKET);
+        std::env::remove_var(SOCKET_OVERRIDE_ENV);
+        assert_eq!(local_socket(), TMUX_SOCKET);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **`THURBOX_SOCKET` env override** for the local multiplexer socket (`local_socket()`). Unix test tooling scopes instances via `TMUX_TMPDIR`, but psmux resolves every `-L <name>` machine-wide — a scoped test on Windows would share (and could tear down) the user's real `thurbox`/`thurbox-dev` server. Remote hosts unaffected (`hosts.toml` socket). Documented in `docs/CONFIG.md`.
- **Headless local spawns on Windows keep their env**: psmux ignores `new-window -e` on the argv path too, so `thurbox-cli session create` run natively on Windows lost `THURBOX_SESSION` identity. The psmux builder is split into `psmux_window_powershell` (folded env+argv, PowerShell single-quoting) + the control-mode double-quoted framing; `spawn_window` now passes the folded string as one argv token.
- **`lab-test.sh native-test [agent]`**: headless e2e of the *deployed* binaries entirely on a Windows host — `thurbox-cli.exe` creates a local psmux session (agent window alive; folded env + argv asserted on the real process) and `thurbox.exe` boots inside a scoped psmux pane and must show/adopt it. Fully isolated via `THURBOX_SOCKET` + `THURBOX_CONFIG_DIR`/`THURBOX_DATA_DIR`.

## Test plan

- CI checks pass (1719 local tests incl. new `local_socket` / builder-split coverage)
- Verified on a real Windows 11 host: `deploy` → `native-test` passes all assertions with the claude agent; full cross-built nextest suite passes there (1701/1701)

https://claude.ai/code/session_015PTHu7pNyZZUFJrvZmCU4y