### PR TITLE
fix(core): stop psmux mangling typed quotes and arm the heartbeat on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -546,7 +546,12 @@ control-mode protocol is byte-identical over either transport/binary, with
   primitives it *does* support (`send-keys -l` literal runs +
   `Enter`/`Tab`/`Escape`/`BSpace`/`C-<letter>` key-names), reconstructing the
   same byte stream the pane's PTY receives; tmux (incl. a WSL distro's tmux)
-  keeps the byte-exact `-H` hex path.
+  keeps the byte-exact `-H` hex path. Literal runs go out as `-l -N 1 "…"`
+  (double-quoted, `\"`/`\\` escaped): psmux's send-coalescing pass re-quotes
+  literals with a POSIX `'\''` escape its own parser can't read back, so any
+  `'` typed arrived in the pane as `\` (`it's` → `it\s`) — the `-N` flag makes
+  psmux's coalescing decoder bail, and its direct handler reads the
+  double-quote framing correctly (`flush_psmux_literal` / `psmux_quote`).
 - **`new-window` trailing tokens are not joined** — tmux joins them into one
   shell command; psmux keeps only the *first* token and silently drops the
   rest, so the agent launched with **no args**. And **`new-window -e` is

--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -149,9 +149,19 @@ fn psmux_key_name(b: u8) -> Option<String> {
     })
 }
 
-/// Emit the pending printable run as one or more `send-keys -l` commands and
-/// clear it. Long runs are split at `SEND_KEYS_CHUNK_BYTES` (on char boundaries)
-/// so no control-mode line gets over-long.
+/// Emit the pending printable run as one or more `send-keys -l -N 1` commands
+/// and clear it. Long runs are split at `SEND_KEYS_CHUNK_BYTES` (on char
+/// boundaries) so no control-mode line gets over-long.
+///
+/// The `-N 1` is load-bearing, not a stray repeat count. psmux's control-mode
+/// reader runs every line through a send-coalescing pass
+/// (`coalesce_send_commands` in psmux) that decodes each send's bytes and
+/// re-emits them re-quoted with the POSIX `'\''` escape — which psmux's own
+/// tokenizer cannot read back, so any `'` in the text arrived in the pane as
+/// `\` (`it's` was typed as `it\s`), regardless of how the client framed it.
+/// The decoder bails on a `-N` flag, letting the original line reach the
+/// direct send-keys handler, whose single parse handles the double-quote
+/// framing of [`psmux_quote`] correctly. Verified against psmux 3.3.6.
 fn flush_psmux_literal(pane_id: &str, literal: &mut Vec<u8>, cmds: &mut Vec<String>) {
     if literal.is_empty() {
         return;
@@ -159,7 +169,7 @@ fn flush_psmux_literal(pane_id: &str, literal: &mut Vec<u8>, cmds: &mut Vec<Stri
     let text = String::from_utf8_lossy(literal).into_owned();
     let emit = |chunk: &str, cmds: &mut Vec<String>| {
         cmds.push(format!(
-            "send-keys -t {pane_id} -l {}\n",
+            "send-keys -t {pane_id} -l -N 1 {}\n",
             psmux_quote(chunk)
         ));
     };
@@ -177,13 +187,21 @@ fn flush_psmux_literal(pane_id: &str, literal: &mut Vec<u8>, cmds: &mut Vec<Stri
     literal.clear();
 }
 
-/// Single-quote `s` for a psmux `send-keys -l` argument. Always quotes (even a
-/// bare word) so a leading `-` is never read as a flag; embedded single quotes
-/// use the POSIX `'\''` break. A literal run never contains a newline (both LF
-/// and CR map to key-names, not literal text), but the control-mode line is
-/// `\n`-delimited, so newlines are replaced with spaces defensively.
+/// Double-quote `s` for a psmux `send-keys -l` argument. Always quotes (even a
+/// bare word) so a leading `-` is never read as a flag. Double quotes — not
+/// POSIX single quotes — because psmux's tokenizer has no working escape for a
+/// `'` inside `'…'`, but inside `"…"` it passes `'` through untouched and
+/// reads exactly two escapes: `\"` (literal quote) and `\\` (literal
+/// backslash); any other backslash stays literal, so both are escaped here. A
+/// literal run never contains a newline (LF and CR map to key-names), but the
+/// control-mode line is `\n`-delimited, so newlines are replaced defensively.
 fn psmux_quote(s: &str) -> String {
-    format!("'{}'", s.replace('\n', " ").replace('\'', "'\\''"))
+    format!(
+        "\"{}\"",
+        s.replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', " ")
+    )
 }
 
 /// Per-pane writer that sends input via control-mode `send-keys` through the
@@ -686,7 +704,7 @@ mod tests {
         // Typing `b` must inject `b`, not the literal text "62".
         assert_eq!(
             send_keys_commands("%1", b"b", true),
-            vec!["send-keys -t %1 -l 'b'\n".to_string()]
+            vec!["send-keys -t %1 -l -N 1 \"b\"\n".to_string()]
         );
     }
 
@@ -694,7 +712,7 @@ mod tests {
     fn psmux_printable_run_is_one_literal_command() {
         assert_eq!(
             send_keys_commands("%1", b"hello world", true),
-            vec!["send-keys -t %1 -l 'hello world'\n".to_string()]
+            vec!["send-keys -t %1 -l -N 1 \"hello world\"\n".to_string()]
         );
     }
 
@@ -746,16 +764,30 @@ mod tests {
             send_keys_commands("%1", b"\x1b[A", true),
             vec![
                 "send-keys -t %1 Escape\n".to_string(),
-                "send-keys -t %1 -l '[A'\n".to_string(),
+                "send-keys -t %1 -l -N 1 \"[A\"\n".to_string(),
             ]
         );
     }
 
     #[test]
-    fn psmux_literal_single_quote_is_escaped() {
+    fn psmux_literal_single_quote_survives() {
+        // Regression: psmux's send-coalescing re-quoted literals with the
+        // POSIX `'\''` escape its own parser can't read back, so `it's` was
+        // typed into the pane as `it\s`. The `-N 1` opts out of coalescing and
+        // the double-quote framing passes `'` through untouched.
         assert_eq!(
             send_keys_commands("%1", b"it's", true),
-            vec!["send-keys -t %1 -l 'it'\\''s'\n".to_string()]
+            vec!["send-keys -t %1 -l -N 1 \"it's\"\n".to_string()]
+        );
+    }
+
+    #[test]
+    fn psmux_literal_escapes_backslash_and_double_quote() {
+        // psmux's double-quote tokenizer reads exactly `\"` and `\\`; both
+        // must be escaped so Windows paths and quoted text round-trip.
+        assert_eq!(
+            send_keys_commands("%1", br#"say "hi" C:\p"#, true),
+            vec!["send-keys -t %1 -l -N 1 \"say \\\"hi\\\" C:\\\\p\"\n".to_string()]
         );
     }
 
@@ -765,7 +797,7 @@ mod tests {
         assert_eq!(
             send_keys_commands("%1", b"ls\r", true),
             vec![
-                "send-keys -t %1 -l 'ls'\n".to_string(),
+                "send-keys -t %1 -l -N 1 \"ls\"\n".to_string(),
                 "send-keys -t %1 Enter\n".to_string(),
             ]
         );
@@ -779,9 +811,9 @@ mod tests {
             send_keys_commands("%1", b"\x1b[200~hi\x1b[201~", true),
             vec![
                 "send-keys -t %1 Escape\n".to_string(),
-                "send-keys -t %1 -l '[200~hi'\n".to_string(),
+                "send-keys -t %1 -l -N 1 \"[200~hi\"\n".to_string(),
                 "send-keys -t %1 Escape\n".to_string(),
-                "send-keys -t %1 -l '[201~'\n".to_string(),
+                "send-keys -t %1 -l -N 1 \"[201~\"\n".to_string(),
             ]
         );
     }
@@ -790,7 +822,7 @@ mod tests {
     fn psmux_utf8_char_goes_to_literal() {
         assert_eq!(
             send_keys_commands("%1", "é".as_bytes(), true),
-            vec!["send-keys -t %1 -l 'é'\n".to_string()]
+            vec!["send-keys -t %1 -l -N 1 \"é\"\n".to_string()]
         );
     }
 
@@ -804,8 +836,8 @@ mod tests {
         for cmd in &cmds {
             let inner = cmd
                 .trim_end()
-                .strip_prefix("send-keys -t %1 -l '")
-                .and_then(|s| s.strip_suffix('\''))
+                .strip_prefix("send-keys -t %1 -l -N 1 \"")
+                .and_then(|s| s.strip_suffix('"'))
                 .expect("literal command shape");
             text.push_str(inner);
         }

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -1288,12 +1288,10 @@ pub fn send_prompt_now(session_name: &str, text: &str) -> Result<()> {
 
 /// Window name for the headless automation heartbeat keeper. Deliberately NOT
 /// `tb-` prefixed so [`LocalTmuxBackend::discover`] ignores it — it is
-/// infrastructure, not a session. (Windows has no keeper window in v1.)
-#[cfg(not(windows))]
+/// infrastructure, not a session.
 const HEARTBEAT_WINDOW: &str = "automation-heartbeat";
 
 /// How often the heartbeat keeper invokes `automation tick`.
-#[cfg(not(windows))]
 const HEARTBEAT_INTERVAL_SECS: u64 = 60;
 
 /// List the window names in the thurbox tmux session (empty if the server is
@@ -1388,20 +1386,12 @@ fn ps_single_quote(s: &str) -> String {
 /// automations work with no other sessions. Idempotent — a no-op when the
 /// keeper already exists. `cli_path` is the absolute path to `thurbox-cli`.
 ///
-/// On Windows this is currently a no-op: the keeper's loop relies on a POSIX
-/// shell that psmux's `run-shell` does not provide, so headless automation
-/// firing degrades to TUI-only on Windows in v1 (see the Windows parity notes).
-#[cfg(not(windows))]
 pub fn ensure_automation_heartbeat(cli_path: &Path) -> Result<()> {
     TmuxBackend::local().ensure_session_configured()?;
     if list_window_names().iter().any(|w| w == HEARTBEAT_WINDOW) {
         return Ok(());
     }
-    // The loop body runs via the server's shell, so escape the CLI path.
-    let cli = shell_escape(&cli_path.display().to_string());
-    let loop_cmd = format!(
-        "while true; do {cli} automation tick >/dev/null 2>&1; sleep {HEARTBEAT_INTERVAL_SECS}; done"
-    );
+    let loop_cmd = heartbeat_loop_command(cli_path);
     let status = local_mux_command(&[
         "new-window",
         "-d",
@@ -1420,13 +1410,28 @@ pub fn ensure_automation_heartbeat(cli_path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Windows: the headless heartbeat keeper is not available in v1 (no POSIX
-/// shell for the keeper loop under psmux). Automations still fire from the TUI;
-/// this is a no-op so callers don't treat the absence as an error.
+/// The keeper's loop, as the window command. It runs via the server's shell,
+/// so the CLI path is escaped for it.
+#[cfg(not(windows))]
+fn heartbeat_loop_command(cli_path: &Path) -> String {
+    let cli = shell_escape(&cli_path.display().to_string());
+    format!(
+        "while true; do {cli} automation tick >/dev/null 2>&1; sleep {HEARTBEAT_INTERVAL_SECS}; done"
+    )
+}
+
+/// Windows: psmux runs a window command via `powershell -NoLogo -Command`, so
+/// the keeper loop is PowerShell — handed over as **one argv token**, dodging
+/// psmux's trailing-token handling entirely (same delivery as
+/// `psmux_window_powershell`, whose quoting rules the `ps_single_quote` here
+/// shares). This used to be a no-op ("no POSIX shell for the keeper loop"),
+/// which silently degraded headless automation firing to TUI-only on Windows.
 #[cfg(windows)]
-pub fn ensure_automation_heartbeat(_cli_path: &Path) -> Result<()> {
-    debug!("Automation heartbeat keeper is not supported on Windows (TUI-only firing)");
-    Ok(())
+fn heartbeat_loop_command(cli_path: &Path) -> String {
+    let cli = ps_single_quote(&cli_path.display().to_string());
+    format!(
+        "while ($true) {{ & {cli} automation tick *> $null; Start-Sleep {HEARTBEAT_INTERVAL_SECS} }}"
+    )
 }
 
 /// Resolve the path to the `thurbox-cli` binary that sits next to the currently


### PR DESCRIPTION
## Summary

- **Quote corruption fixed**: any `'` typed or pasted into a psmux-backed session arrived as `\` (`it's` → `it\s`). Root cause is in psmux itself — its control-mode send-coalescing decodes each `send-keys`, re-quotes with a POSIX `'\''` escape, and re-parses with a tokenizer that can't read it back. Literal runs now go out as `send-keys -l -N 1 "…"` (double-quoted, `\"`/`\\` escaped): `-N` makes psmux's coalescing decoder bail, and its direct handler parses the double-quote framing correctly. Verified live: `it's "q" C:\p` reaches the pane byte-intact.
- **Headless automations now fire on Windows**: the heartbeat keeper was a documented no-op ("no POSIX shell for the loop"). The loop is now PowerShell handed to psmux as one argv token, so schedules fire with the TUI closed. Verified live: `automation create` arms the keeper on a scoped socket; `automation tick` runs clean headless.

## Test plan

- CI checks pass (1720 tests; psmux encoding expectations updated + new quote/escape coverage)
- Verified on a real Windows 11 host with the deployed binaries; Windows cross-compile checked (`x86_64-pc-windows-gnu`)

https://claude.ai/code/session_015PTHu7pNyZZUFJrvZmCU4y