### PR TITLE
feat(core): live hooks-driven status for remote sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -601,13 +601,28 @@ via `App::backend_for`).
   home-anchored path is **translated to the remote home**, the file copied
   there, and the arg substituted; on a psmux host / non-POSIX config root /
   failed copy the **flag+path pair is stripped** so the agent launches clean.
-  Remote hooks can't signal either way (no `thurbox-cli` on the host, and it
-  would write the host's own DB, not the one the TUI reads) — remote sessions
-  stay `Idle` and rely on the output-quiescence fallbacks; a remote status
-  path is a named follow-up. The local-path env hints
+  The local-path env hints
   (`THURBOX_METRICS_DIR`/`THURBOX_CONFIG_DIR`/`THURBOX_DATA_DIR`) are likewise
   skipped for remote spawns (`inject_thurbox_env`); only the opaque identity
   vars travel.
+- **Remote session status** (hooks-driven, like local): `thurbox-cli session
+  signal` can't work from a host (no CLI there; it would write the host's own
+  DB), so the materialized hook file's commands are **rewritten**
+  (`builtin_hooks::rewrite_hook_signals_for_remote`) to set a tmux **pane user
+  option** instead — `tmux set-option -p @thurbox_state <s>` needs no socket,
+  pane id, or identity inside a pane. The local TUI's persistent control-mode
+  connection subscribes once per connection (`refresh-client -B
+  'thurbox-status:%*:#{@thurbox_state}'`, armed in `ControlMode::start` so
+  reconnects re-arm; tmux ≥ 3.2 = the existing floor) and receives
+  `%subscription-changed` pushes (≤1/s), queued on the connection and drained
+  each tick by `App::drain_remote_hook_events` into the same `set_hook_state`
+  columns local signals use — so Done→seen acknowledgment, OS notifications,
+  rollups, and the stuck-`working` fallback are shared. Events are matched by
+  **backend name + pane id** (pane ids collide across hosts), allow-listed
+  (remote-controlled text), and deduped against the cache (a reconnect
+  re-report must not resurrect an acknowledged `done`). Carve-outs: psmux
+  remotes (no subscriptions; hooks stripped) and non-claude agents (their hook
+  configs aren't materialized remotely) stay Idle-only.
 - **Caveats** (WSL inherits the SSH path): the headless `session delete --force`
   teardown (`kill_window`/`git::remove_worktree`) is local-only — a `--force`
   delete won't kill the in-distro window or remove the in-distro worktree (the
@@ -1320,6 +1335,10 @@ frame; the static `icon()` is used in non-animated contexts (info panel).
   `THURBOX_SESSION_ID`), so a hook passes no id. It writes the persisted
   state and the TUI picks it up via `PRAGMA data_version` — works headless.
   (`idle` = agent at rest, e.g. a boot-time hook; `done` = a turn just finished.)
+  **Remote** sessions use a different callback with the same downstream:
+  the materialized hook file sets a tmux pane user option instead, delivered
+  over the control-mode subscription into the same hook columns (see the
+  Remote-session-status bullet in the Remote SSH & WSL section).
 - **Persistence.** `sessions.hook_state` / `hook_state_at` / `seen_at`
   (schema **v34**), with targeted-UPDATE accessors `set_hook_state` /
   `mark_session_seen` / `load_hook_states` (`storage/sessions.rs`).

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -226,6 +226,18 @@ pub trait SessionBackend: Send + Sync {
 
     /// Return the PID of the process running in a backend pane.
     fn pane_pid(&self, backend_id: &str) -> Result<Option<u32>>;
+
+    /// Drain queued `(backend_id, hook-state)` events reported by a remote
+    /// agent's hooks (a tmux pane user option pushed over the control-mode
+    /// subscription — see [`crate::session::REMOTE_HOOK_STATE_OPTION`]).
+    ///
+    /// Poll-style shared state (like the `TermSignals` atomics): the app tick
+    /// drains this and persists each state exactly as a local
+    /// `thurbox-cli session signal` would have. Default: no events — only the
+    /// tmux backend produces them.
+    fn take_hook_state_events(&self) -> Vec<(String, String)> {
+        Vec::new()
+    }
 }
 
 /// Internal bundle of I/O handles before wiring.

--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -26,11 +26,24 @@ pub struct CommandResponse {
 /// Parsed notification from the tmux control mode protocol.
 #[derive(Debug, PartialEq)]
 pub enum Notification {
-    Output { pane_id: String, data: Vec<u8> },
+    Output {
+        pane_id: String,
+        data: Vec<u8>,
+    },
     Begin,
     End,
     Error,
-    Pause { pane_id: String },
+    Pause {
+        pane_id: String,
+    },
+    /// A `refresh-client -B` format subscription reported a changed value
+    /// (tmux >= 3.2). Carries the remote hook state for
+    /// [`crate::session::REMOTE_HOOK_SUBSCRIPTION`].
+    SubscriptionChanged {
+        name: String,
+        pane_id: String,
+        value: String,
+    },
     Other(String),
 }
 
@@ -310,7 +323,55 @@ pub fn parse_notification(line: &str) -> Notification {
         };
     }
 
+    if let Some(n) = parse_subscription_changed(line) {
+        return n;
+    }
+
     Notification::Other(line.to_string())
+}
+
+/// Parse a `%subscription-changed` notification (tmux >= 3.2 format
+/// subscriptions, armed via `refresh-client -B`).
+///
+/// Wire format (tmux man page): `%subscription-changed name session-id
+/// window-id window-index pane-id ... : value` — "any arguments after pane-id
+/// up until a single ':' are for future use and should be ignored". Parsed
+/// positionally (name = token 0, pane id = token 4, validated) with the value
+/// being everything after the first ` : ` separator past the pane token,
+/// verbatim — it may legally be empty or contain spaces/colons. Any shape
+/// violation returns `None` (→ `Notification::Other`); wire data never
+/// panics.
+fn parse_subscription_changed(line: &str) -> Option<Notification> {
+    let rest = line.strip_prefix("%subscription-changed ")?;
+    let mut tokens = rest.splitn(6, ' ');
+    let name = tokens.next()?.to_string();
+    // session-id, window-id, window-index — positional, unused.
+    for _ in 0..3 {
+        tokens.next()?;
+    }
+    let pane_id = tokens.next()?.to_string();
+    if !is_valid_pane_id(&pane_id) {
+        return None;
+    }
+    // Whatever follows the pane id: `[future-use tokens ]: value`.
+    let tail = tokens.next().unwrap_or("");
+    let value = if let Some(v) = tail.strip_prefix(": ") {
+        v.to_string()
+    } else if tail == ":" {
+        String::new()
+    } else if let Some(idx) = tail.find(" : ") {
+        tail[idx + 3..].to_string()
+    } else if tail.ends_with(" :") {
+        // Future-use tokens then an empty value ("a b :").
+        String::new()
+    } else {
+        return None;
+    };
+    Some(Notification::SubscriptionChanged {
+        name,
+        pane_id,
+        value,
+    })
 }
 
 /// A tmux pane id is `%<digits>`. Pane ids are interpolated unquoted into
@@ -608,6 +669,83 @@ mod tests {
             parse_notification("%extended-output %2 : data"),
             Notification::Other("%extended-output %2 : data".to_string())
         );
+    }
+
+    // --- %subscription-changed parsing tests ---
+    // Wire shape (tmux man page): `%subscription-changed name session-id
+    // window-id window-index pane-id ... : value` — args between pane-id and
+    // the ':' are documented future-use; the value may be empty or contain
+    // spaces/colons.
+
+    #[test]
+    fn subscription_changed_parses_canonical_line() {
+        assert_eq!(
+            parse_notification("%subscription-changed thurbox-status $1 @5 2 %7 : done"),
+            Notification::SubscriptionChanged {
+                name: "thurbox-status".into(),
+                pane_id: "%7".into(),
+                value: "done".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn subscription_changed_ignores_future_use_args() {
+        assert_eq!(
+            parse_notification(
+                "%subscription-changed thurbox-status $1 @5 2 %7 extra stuff : working"
+            ),
+            Notification::SubscriptionChanged {
+                name: "thurbox-status".into(),
+                pane_id: "%7".into(),
+                value: "working".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn subscription_changed_empty_value_variants() {
+        for line in [
+            "%subscription-changed s $1 @5 2 %7 :",
+            "%subscription-changed s $1 @5 2 %7 : ",
+            "%subscription-changed s $1 @5 2 %7 future :",
+        ] {
+            match parse_notification(line) {
+                Notification::SubscriptionChanged { value, .. } => {
+                    assert_eq!(value, "", "line: {line}")
+                }
+                other => panic!("expected SubscriptionChanged for {line}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn subscription_changed_value_keeps_spaces_and_colons() {
+        assert_eq!(
+            parse_notification("%subscription-changed s $1 @5 2 %7 : a b : c"),
+            Notification::SubscriptionChanged {
+                name: "s".into(),
+                pane_id: "%7".into(),
+                value: "a b : c".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn subscription_changed_malformed_falls_to_other() {
+        // Invalid pane token / missing separator / truncated — wire data must
+        // never panic, it degrades to Other.
+        for line in [
+            "%subscription-changed s $1 @5 2 pane7 : done",
+            "%subscription-changed s $1 @5 2 %7 done",
+            "%subscription-changed s $1 @5",
+            "%subscription-changed",
+        ] {
+            assert!(
+                matches!(parse_notification(line), Notification::Other(_)),
+                "line: {line}"
+            );
+        }
     }
 
     // --- format_send_keys tests ---

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -220,9 +220,20 @@ struct ControlMode {
     pane_senders: PaneSendersMapShared,
     /// FIFO queue of response channels — one per `send_command()` call, in order.
     response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
+    /// `(pane_id, state)` pairs from `%subscription-changed` notifications
+    /// (remote hook status — see [`crate::session::REMOTE_HOOK_STATE_OPTION`]),
+    /// pushed by the reader thread and drained by the app tick via
+    /// [`Self::take_sub_events`]. Bounded (drop-oldest): a short-lived
+    /// connection (e.g. a headless spawn's) has no drainer.
+    sub_events: Arc<Mutex<VecDeque<(String, String)>>>,
     reader_handle: Mutex<Option<JoinHandle<()>>>,
     child: Mutex<Child>,
 }
+
+/// Cap on queued subscription events. Status transitions are rare and the
+/// queue is drained every TUI tick — the cap only guards an undrained
+/// connection against unbounded growth.
+const SUB_EVENTS_CAP: usize = 256;
 
 impl ControlMode {
     /// Start a control mode connection to the thurbox tmux session over the
@@ -252,15 +263,24 @@ impl ControlMode {
             Arc::new(Mutex::new(std::collections::HashMap::new()));
         let response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>> =
             Arc::new(Mutex::new(VecDeque::new()));
+        let sub_events: Arc<Mutex<VecDeque<(String, String)>>> =
+            Arc::new(Mutex::new(VecDeque::new()));
 
         let reader_stdin = Arc::clone(&stdin);
         let reader_pane_senders = Arc::clone(&pane_senders);
         let reader_queue = Arc::clone(&response_queue);
+        let reader_sub_events = Arc::clone(&sub_events);
 
         let reader_handle = std::thread::Builder::new()
             .name("tmux-control-reader".into())
             .spawn(move || {
-                Self::reader_thread(stdout, reader_stdin, reader_pane_senders, reader_queue);
+                Self::reader_thread(
+                    stdout,
+                    reader_stdin,
+                    reader_pane_senders,
+                    reader_queue,
+                    reader_sub_events,
+                );
             })
             .context("Failed to spawn control reader thread")?;
 
@@ -268,6 +288,7 @@ impl ControlMode {
             stdin,
             pane_senders,
             response_queue,
+            sub_events,
             reader_handle: Mutex::new(Some(reader_handle)),
             child: Mutex::new(child),
         };
@@ -280,6 +301,24 @@ impl ControlMode {
 
         // Enable flow control (pause-after=5 seconds of buffered output).
         control.send_command("refresh-client -f pause-after=5")?;
+
+        // Subscribe to the remote-hook status option of every pane of the
+        // attached session (tmux pushes `%subscription-changed` on change) —
+        // how an off-local agent's hooks reach the local status derivation.
+        // tmux-only (psmux has no format subscriptions) and best-effort: a
+        // refusal must not brick the whole backend, status just stays dark.
+        // Armed here — not per pane — so `reconnect_control` re-arms for free
+        // and panes created later are covered (`%*` is session-scoped).
+        if !transport.uses_psmux() {
+            let arm = format!(
+                "refresh-client -B '{}:%*:#{{{}}}'",
+                crate::session::REMOTE_HOOK_SUBSCRIPTION,
+                crate::session::REMOTE_HOOK_STATE_OPTION,
+            );
+            if let Err(e) = control.send_command(&arm) {
+                warn!("failed to arm the remote-hook status subscription: {e:#}");
+            }
+        }
 
         Ok(control)
     }
@@ -297,6 +336,7 @@ impl ControlMode {
         stdin: Arc<Mutex<ChildStdin>>,
         pane_senders: PaneSendersMapShared,
         response_queue: Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
+        sub_events: Arc<Mutex<VecDeque<(String, String)>>>,
     ) {
         let mut reader = BufReader::new(stdout);
         // Accumulates response lines for the current in-flight command.
@@ -336,6 +376,23 @@ impl ControlMode {
                 }
                 Notification::Pause { pane_id } => {
                     Self::resume_pane(&stdin, &pane_id);
+                }
+                // Consumed even mid-%begin block: tmux never interleaves
+                // notifications inside response bodies, so this can't eat a
+                // response line. Empty value = the pane option is unset.
+                Notification::SubscriptionChanged {
+                    name,
+                    pane_id,
+                    value,
+                } => {
+                    if name == crate::session::REMOTE_HOOK_SUBSCRIPTION && !value.is_empty() {
+                        if let Ok(mut events) = sub_events.lock() {
+                            if events.len() >= SUB_EVENTS_CAP {
+                                events.pop_front();
+                            }
+                            events.push_back((pane_id, value));
+                        }
+                    }
                 }
                 Notification::Other(text) => {
                     if let Some(ref mut lines) = collecting {
@@ -396,6 +453,14 @@ impl ControlMode {
                 let _ = tx.send(CommandResponse { lines, is_error });
             }
         }
+    }
+
+    /// Drain the queued `(pane_id, state)` remote-hook status events.
+    fn take_sub_events(&self) -> Vec<(String, String)> {
+        self.sub_events
+            .lock()
+            .map(|mut events| events.drain(..).collect())
+            .unwrap_or_default()
     }
 
     /// Respond to a `%pause` by asking tmux to resume output for the pane.
@@ -1246,6 +1311,16 @@ impl SessionBackend for TmuxBackend {
             "display-message -t {backend_id} -p '#{{pane_pid}}'"
         ))?;
         Ok(result.trim().parse().ok())
+    }
+
+    fn take_hook_state_events(&self) -> Vec<(String, String)> {
+        // Lock `control` directly — `with_control` errors before the control
+        // connection starts, and "no connection yet" is simply "no events".
+        self.control
+            .lock()
+            .ok()
+            .and_then(|guard| guard.as_ref().map(ControlMode::take_sub_events))
+            .unwrap_or_default()
     }
 }
 

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -75,17 +75,35 @@ fn init_git_repo(dir: &Path, dirty: bool) {
 /// tests must be `#[tokio::test]`.
 struct FakeBackend {
     spawnable: bool,
+    /// Pushable remote-hook status events, drained by
+    /// [`SessionBackend::take_hook_state_events`] — lets a test drive the
+    /// remote-session status path without a control-mode connection.
+    hook_events: std::sync::Mutex<Vec<(String, String)>>,
 }
 
 impl FakeBackend {
     /// Inert: spawning/adopting fails.
     fn stub() -> Self {
-        Self { spawnable: false }
+        Self {
+            spawnable: false,
+            hook_events: std::sync::Mutex::new(Vec::new()),
+        }
     }
 
     /// Spawnable: `spawn`/`adopt` succeed with no-op I/O.
     fn spawnable() -> Self {
-        Self { spawnable: true }
+        Self {
+            spawnable: true,
+            hook_events: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Queue a `(pane_id, state)` event for the next drain.
+    fn push_hook_event(&self, pane_id: &str, state: &str) {
+        self.hook_events
+            .lock()
+            .unwrap()
+            .push((pane_id.to_string(), state.to_string()));
     }
 }
 
@@ -145,6 +163,9 @@ impl SessionBackend for FakeBackend {
     }
     fn pane_pid(&self, _: &str) -> anyhow::Result<Option<u32>> {
         Ok(None)
+    }
+    fn take_hook_state_events(&self) -> Vec<(String, String)> {
+        std::mem::take(&mut self.hook_events.lock().unwrap())
     }
 }
 
@@ -1965,5 +1986,90 @@ fn info_panel_toggles_while_review_is_open() {
     assert!(
         h.app.active_review().is_some(),
         "toggling the info panel leaves the review open"
+    );
+}
+
+// ── Remote-hook status events (control-mode subscription → hook columns) ──────
+
+/// The backend queued a remote-hook event for a session's pane: one refresh
+/// drains it into the hook columns and the derived status reflects it — the
+/// remote analogue of a local `thurbox-cli session signal`.
+#[test]
+fn remote_hook_event_drives_session_status() {
+    let backend = Arc::new(FakeBackend::stub());
+    let mut h = Harness::with_backend(STD_COLS, STD_ROWS, 2, backend.clone());
+    h.app.sessions[0].info.backend_id = Some("%5".into());
+    h.app.sessions[1].info.backend_id = Some("%9".into());
+    h.app.save_state(); // hook columns update persisted rows
+
+    backend.push_hook_event("%5", "working");
+    h.app.refresh_session_statuses();
+
+    // Stub sessions have fresh output, so `working` isn't quiescence-demoted.
+    assert_eq!(h.app.sessions[0].info.status, SessionStatus::Working);
+    assert_eq!(
+        h.app.sessions[1].info.status,
+        SessionStatus::Idle,
+        "the other session is untouched"
+    );
+    let rows = h.app.db.load_hook_states().unwrap();
+    assert_eq!(
+        rows.get(&h.app.sessions[0].info.id)
+            .and_then(|r| r.state.as_deref()),
+        Some("working"),
+        "the event is persisted through set_hook_state"
+    );
+}
+
+/// Events that don't resolve to a session (unknown pane — a shell/heartbeat
+/// window) or carry a non-allow-listed state (the value is remote-controlled
+/// free text) are dropped without touching the DB.
+#[test]
+fn remote_hook_event_ignores_unmatched_and_invalid() {
+    let backend = Arc::new(FakeBackend::stub());
+    let mut h = Harness::with_backend(STD_COLS, STD_ROWS, 1, backend.clone());
+    h.app.sessions[0].info.backend_id = Some("%5".into());
+    h.app.save_state();
+
+    backend.push_hook_event("%99", "working"); // no such pane
+    backend.push_hook_event("%5", "rm -rf /"); // not an allowed state
+    h.app.refresh_session_statuses();
+
+    assert_eq!(h.app.sessions[0].info.status, SessionStatus::Idle);
+    assert!(
+        h.app
+            .db
+            .load_hook_states()
+            .unwrap()
+            .values()
+            .all(|r| r.state.is_none()),
+        "neither event may reach the hook columns"
+    );
+}
+
+/// A re-report of the current state (the subscription re-sends the pane
+/// option's value on reconnect/TUI restart) must not re-stamp `state_at` —
+/// otherwise an already-acknowledged `done` resurrects as unseen and re-fires
+/// its OS notification on every restart.
+#[test]
+fn remote_hook_event_dedupes_repeated_state() {
+    let backend = Arc::new(FakeBackend::stub());
+    let mut h = Harness::with_backend(STD_COLS, STD_ROWS, 1, backend.clone());
+    h.app.sessions[0].info.backend_id = Some("%5".into());
+    h.app.save_state();
+    let id = h.app.sessions[0].info.id;
+
+    backend.push_hook_event("%5", "done");
+    h.app.refresh_session_statuses();
+    let first_at = h.app.db.load_hook_states().unwrap()[&id].state_at;
+    assert!(first_at.is_some());
+
+    std::thread::sleep(std::time::Duration::from_millis(5));
+    backend.push_hook_event("%5", "done");
+    h.app.refresh_session_statuses();
+    let second_at = h.app.db.load_hook_states().unwrap()[&id].state_at;
+    assert_eq!(
+        first_at, second_at,
+        "an identical re-report must not re-stamp state_at"
     );
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3906,12 +3906,17 @@ impl App {
     /// Recompute each session's status/activity/notification for this tick.
     ///
     /// Status is **hooks-driven**: agents report `working`/`blocked`/`done` via
-    /// `thurbox-cli session signal`, persisted in `sessions` and read here in one
-    /// batch (see [`derive_session_status`]). A `done` session stays `Done` until
-    /// the user moves focus *off* it (acknowledged → `Idle`). The OSC terminal
-    /// title is still captured for the live activity line, but no longer drives
-    /// status.
+    /// `thurbox-cli session signal` (local sessions) or a tmux pane user option
+    /// pushed over the control-mode subscription (remote sessions — drained
+    /// below into the same hook columns), persisted in `sessions` and read here
+    /// in one batch (see [`derive_session_status`]). A `done` session stays
+    /// `Done` until the user moves focus *off* it (acknowledged → `Idle`). The
+    /// OSC terminal title is still captured for the live activity line, but no
+    /// longer drives status.
     fn refresh_session_statuses(&mut self) {
+        // Before the data_version gate, so a persisted remote event reloads the
+        // cache in this same tick.
+        self.drain_remote_hook_events();
         self.metrics.bump(|p| &mut p.status_refreshes);
         let active_index = self.active_index;
         // Reload the persisted hook columns only when the DB actually changed —
@@ -3982,6 +3987,68 @@ impl App {
     /// `data_version`, so the version gate wouldn't otherwise notice them.
     fn invalidate_hook_state_cache(&mut self) {
         self.hook_states_version = None;
+    }
+
+    /// Drain remote-hook status events from every backend and persist them,
+    /// exactly as `thurbox-cli session signal` would have done locally.
+    ///
+    /// A remote agent's hooks set a tmux pane user option; the backend's
+    /// control-mode subscription queues `(pane_id, state)` pairs (see
+    /// [`crate::agent::backend::SessionBackend::take_hook_state_events`]).
+    /// Each is resolved to a session by **backend name + pane id** — pane ids
+    /// collide across hosts — and written through [`set_hook_state`]
+    /// (`crate::storage`), so the whole derivation downstream (Done→seen
+    /// acknowledgment, OS notifications, rollups, the stuck-working fallback)
+    /// is shared with local sessions.
+    fn drain_remote_hook_events(&mut self) {
+        // The value is remote-host-controlled free text: allow-list it (the
+        // same states `session signal` accepts) and never interpolate it.
+        const VALID_STATES: [&str; 4] = ["working", "blocked", "done", "idle"];
+        // Collect first: the registry borrow must end before &mut self below.
+        let batches: Vec<(String, Vec<(String, String)>)> = self
+            .backends
+            .all_backends()
+            .map(|b| (b.name().to_string(), b.take_hook_state_events()))
+            .filter(|(_, events)| !events.is_empty())
+            .collect();
+        for (backend_name, events) in batches {
+            for (pane_id, state) in events {
+                if !VALID_STATES.contains(&state.as_str()) {
+                    continue;
+                }
+                let Some(id) = self
+                    .sessions
+                    .iter()
+                    .find(|s| {
+                        s.backend_name() == backend_name
+                            && s.info.backend_id.as_deref() == Some(pane_id.as_str())
+                    })
+                    .map(|s| s.info.id)
+                else {
+                    // Not an agent pane (shell/heartbeat window) or a session
+                    // this instance doesn't hold — skip.
+                    continue;
+                };
+                // Dedupe against the cache: the subscription re-reports the
+                // current value on (re)connect, and re-stamping an already-
+                // acknowledged `done` would resurrect it as unseen and re-fire
+                // its OS notification on every TUI restart. Safe because
+                // done→done without an intervening `working` can't happen.
+                if self
+                    .cached_hook_states
+                    .get(&id)
+                    .and_then(|h| h.state.as_deref())
+                    == Some(state.as_str())
+                {
+                    continue;
+                }
+                if self.db.set_hook_state(id, &state).is_ok() {
+                    // Own-connection write: data_version won't move, force the
+                    // reload so this tick's derivation sees the exact row.
+                    self.invalidate_hook_state_cache();
+                }
+            }
+        }
     }
 
     /// If the just-left session (`last_active_session_id`) is an unseen `done`,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -308,18 +308,23 @@ fn host_shell_c(host: &HostDef, script: &str) -> Command {
     cmd
 }
 
-/// Copy a local file to the **same** absolute path on a remote `host`, creating
-/// the parent directory. Streams the file's bytes over the host launcher's
-/// stdin into `cat > <path>`, so it is transport-neutral (ssh/wsl) and needs no
-/// `scp`/`\\wsl$` share. Used to materialize thurbox-managed agent config (e.g.
-/// the hooks `--settings claude.json`) on the remote so the agent — launched
-/// with a `--settings <path>` that thurbox generated against the *local* config
-/// dir — finds the file at that path on the remote too.
+/// Copy a local file to the **same** absolute path on a remote `host`.
+/// See [`copy_bytes_to_remote`], which this reads the file into.
 pub fn copy_file_to_remote(host: &HostDef, local: &Path, remote_path: &str) -> Result<()> {
-    use std::io::Write;
-
     let bytes = std::fs::read(local)
         .with_context(|| format!("failed to read local file {}", local.display()))?;
+    copy_bytes_to_remote(host, &bytes, remote_path)
+}
+
+/// Write `bytes` to `remote_path` on `host`, creating the parent directory.
+/// Streams the bytes over the host launcher's stdin into `cat > <path>`, so it
+/// is transport-neutral (ssh/wsl) and needs no `scp`/`\\wsl$` share. Used to
+/// materialize thurbox-managed agent config (e.g. the hooks `--settings
+/// claude.json`, with its commands rewritten for the host) on the remote so
+/// the agent — launched with a `--settings <path>` that thurbox generated
+/// against the *local* config dir — finds the file at that path there too.
+pub fn copy_bytes_to_remote(host: &HostDef, bytes: &[u8], remote_path: &str) -> Result<()> {
+    use std::io::Write;
 
     let parent = Path::new(remote_path)
         .parent()
@@ -342,7 +347,7 @@ pub fn copy_file_to_remote(host: &HostDef, local: &Path, remote_path: &str) -> R
         .stdin
         .take()
         .context("remote file-copy stdin unavailable")?
-        .write_all(&bytes)
+        .write_all(bytes)
         .context("failed to stream file to remote")?;
     let output = child
         .wait_with_output()

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -51,6 +51,22 @@ pub const DEFAULT_AGENT_NAME: &str = "claude";
 /// without crossing module boundaries.
 pub const PENDING_FOCUS_SESSION_ID_KEY: &str = "pending_focus_session_id";
 
+/// tmux **pane user option** a remote agent's hooks set to report status
+/// (`tmux set-option -p @thurbox_state <working|blocked|done|idle>`). The
+/// remote-side replacement for `thurbox-cli session signal`, which can't work
+/// off-local (no CLI on the host, and it would write the host's own DB). The
+/// local TUI receives changes over its control-mode connection via a format
+/// subscription (see [`REMOTE_HOOK_SUBSCRIPTION`]). Defined in the pure-data
+/// layer so `agent` (subscription) and `session_ops` (hook-command rewrite)
+/// share one source of truth.
+pub const REMOTE_HOOK_STATE_OPTION: &str = "@thurbox_state";
+
+/// Name of the control-mode format subscription
+/// (`refresh-client -B <name>:%*:#{@thurbox_state}`) that pushes
+/// [`REMOTE_HOOK_STATE_OPTION`] changes as `%subscription-changed`
+/// notifications for every pane of the attached session.
+pub const REMOTE_HOOK_SUBSCRIPTION: &str = "thurbox-status";
+
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
     pub repo_path: PathBuf,

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -1,6 +1,9 @@
 //! The built-in **hooks** extension: wires each coding agent's lifecycle hooks
 //! to `thurbox-cli session signal` so sessions report `working`/`blocked`/`done`
-//! back to thurbox (see the hooks-driven `SessionStatus`).
+//! back to thurbox (see the hooks-driven `SessionStatus`). For **remote**
+//! sessions the same hook file is shipped with its commands rewritten to a tmux
+//! pane user option (`rewrite_hook_signals_for_remote`) — the local TUI
+//! receives those over its control-mode subscription.
 //!
 //! Unlike user extensions (which are fetched from a source on demand, ADR-20),
 //! this one ships **embedded** in the binary and is **auto-activated by default**
@@ -28,6 +31,35 @@ const ANTIGRAVITY_HOOKS: &str = include_str!("../../extensions/hooks/antigravity
 const CODEX_HOOKS: &str = include_str!("../../extensions/hooks/codex-hooks.json");
 const VIBE_HOOKS: &str = include_str!("../../extensions/hooks/vibe-hooks.toml");
 const COPILOT_HOOKS: &str = include_str!("../../extensions/hooks/copilot-hooks.json");
+
+/// Marker prefix of every thurbox-managed hook command; the state word
+/// (`working`/`blocked`/`done`/`idle`) follows it directly.
+const SIGNAL_MARKER: &str = "thurbox-cli session signal --state ";
+
+/// Rewrite thurbox-managed hook commands for a **remote (real-tmux) host**:
+/// `thurbox-cli session signal --state <s>` →
+/// `tmux set-option -p @thurbox_state <s>`.
+///
+/// `thurbox-cli` can't signal from a remote host (it isn't installed there,
+/// and it would write the host's own DB — never the one the local TUI reads).
+/// A tmux **pane user option** can: inside a pane `set-option -p` needs no
+/// socket, pane id, or identity (`$TMUX`/`$TMUX_PANE` are in the pane env),
+/// and the local TUI's control-mode connection receives changes through its
+/// [`crate::session::REMOTE_HOOK_SUBSCRIPTION`] format subscription. Applied
+/// by the spawn-time materialization (`adapt_agent_args_for_remote`) to every
+/// config file it ships. Prefix-replace keeps the state word and whatever
+/// trails it (`|| true`, `;; esac; true`) intact; the replacement contains no
+/// `"`/`\`, so a byte-level replace on JSON text is safe. Idempotent, and a
+/// no-op for marker-free content.
+pub(crate) fn rewrite_hook_signals_for_remote(contents: &str) -> String {
+    contents.replace(
+        SIGNAL_MARKER,
+        &format!(
+            "tmux set-option -p {} ",
+            crate::session::REMOTE_HOOK_STATE_OPTION
+        ),
+    )
+}
 
 /// The hooks extension's home, under this build's resolved config dir
 /// (`~/.config/thurbox/hooks` for a release build, `~/.config/thurbox-dev/hooks`
@@ -122,6 +154,63 @@ pub fn ensure_builtin_hooks_extension(db: &Database) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- rewrite_hook_signals_for_remote tests ---
+
+    #[test]
+    fn remote_rewrite_replaces_every_signal_command() {
+        let rewritten = rewrite_hook_signals_for_remote(CLAUDE_SETTINGS);
+        // No local CLI reference survives, every state maps to the pane option.
+        assert!(!rewritten.contains("thurbox-cli"));
+        for state in ["idle", "working", "blocked", "done"] {
+            assert!(
+                rewritten.contains(&format!("tmux set-option -p @thurbox_state {state}")),
+                "missing rewritten {state} command"
+            );
+        }
+        // The surrounding hook shape (`|| true`, the blocked `case`) survives
+        // the prefix replace, and the result is still valid JSON with all five
+        // hook events.
+        assert!(rewritten.contains("tmux set-option -p @thurbox_state idle || true"));
+        assert!(rewritten.contains("tmux set-option -p @thurbox_state blocked ;;"));
+        let json: serde_json::Value = serde_json::from_str(&rewritten).expect("still valid JSON");
+        let hooks = json.get("hooks").and_then(|h| h.as_object()).unwrap();
+        for event in [
+            "SessionStart",
+            "UserPromptSubmit",
+            "PreToolUse",
+            "Notification",
+            "Stop",
+        ] {
+            assert!(hooks.contains_key(event), "missing hook event {event}");
+        }
+    }
+
+    #[test]
+    fn remote_rewrite_is_idempotent_and_passes_through() {
+        let once = rewrite_hook_signals_for_remote(CLAUDE_SETTINGS);
+        assert_eq!(rewrite_hook_signals_for_remote(&once), once);
+        let unrelated = "default = \"claude\"\n[[agents]]\nname = \"claude\"\n";
+        assert_eq!(rewrite_hook_signals_for_remote(unrelated), unrelated);
+    }
+
+    #[test]
+    fn signal_marker_matches_shipped_hook_commands() {
+        // Guard: a future edit to the hook asset that drifts from the marker
+        // (e.g. reordering flags) would silently break the remote rewrite.
+        // Every `session signal` occurrence in the claude asset must carry the
+        // exact marker prefix.
+        let occurrences = CLAUDE_SETTINGS.matches("session signal").count();
+        assert_eq!(
+            CLAUDE_SETTINGS.matches(SIGNAL_MARKER).count(),
+            occurrences,
+            "a `session signal` command in claude.json doesn't match SIGNAL_MARKER"
+        );
+        assert_eq!(
+            occurrences, 5,
+            "claude.json hook count changed — review the rewrite"
+        );
+    }
 
     #[test]
     fn embedded_assets_are_present() {

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -365,8 +365,12 @@ pub(crate) fn resolve_launch_cwd(
 /// Scope is deliberately narrow: only paths under the **thurbox config dir**
 /// are touched (and only existing local files are copied), so an arbitrary
 /// path in the agent's own args — a repo path, a user file — is never
-/// rewritten or shipped. Remote hooks still can't *signal* (no `thurbox-cli`
-/// on the host, and it would write to the host's own DB); they fail soft.
+/// rewritten or shipped. Each shipped file also has its thurbox-managed hook
+/// commands rewritten for the host
+/// ([`super::builtin_hooks::rewrite_hook_signals_for_remote`]): the local
+/// `thurbox-cli session signal` can't work there, but a tmux pane user option
+/// can — the local TUI receives it over its control-mode subscription, so
+/// remote sessions get live hooks-driven status.
 ///
 /// Shared by the headless spawn and the TUI (`App::build_spawn_inputs`) so
 /// both paths launch a remote session with the same args.
@@ -384,11 +388,10 @@ pub(crate) fn adapt_agent_args_for_remote(host: &HostDef, args: Vec<String>) -> 
             .get_or_insert_with(|| remote_config_root(host, &config_root))
             .clone()?;
         let remote_path = format!("{root}{}", &local_path[config_root.len()..]);
-        let local = std::path::Path::new(local_path);
-        if !local.is_file() {
-            return None;
-        }
-        match crate::git::copy_file_to_remote(host, local, &remote_path) {
+        // Read failure (missing/unreadable/non-file) → strip, as before.
+        let contents = std::fs::read_to_string(local_path).ok()?;
+        let contents = super::builtin_hooks::rewrite_hook_signals_for_remote(&contents);
+        match crate::git::copy_bytes_to_remote(host, contents.as_bytes(), &remote_path) {
             Ok(()) => Some(remote_path),
             Err(e) => {
                 tracing::warn!(


### PR DESCRIPTION
## Summary

- Remote (ssh/wsl) sessions finally get **live Working/Blocked/Done status** — previously stuck at Idle because hooks ran `thurbox-cli session signal`, which can't exist (or reach the right DB) on the host.
- **Remote side**: the materialized hooks `claude.json` gets its commands rewritten to `tmux set-option -p @thurbox_state <s>` (no socket/pane-id/identity needed inside a pane), shipped via the new `git::copy_bytes_to_remote`.
- **Local side**: each control-mode connection arms one `refresh-client -B 'thurbox-status:%*:…'` format subscription at start (tmux ≥ 3.2 — the existing floor; psmux excluded; reconnects re-arm free); `%subscription-changed` notifications are parsed positionally into a bounded queue.
- **App**: `SessionBackend::take_hook_state_events` (poll-style, default empty) drains per tick; events resolve by backend name + pane id, are allow-listed, deduped against the cache (no Done re-flash on reconnect), and written through the same `set_hook_state` path — so seen-acknowledgment, OS notifications, rollups, and the quiescence fallback are all shared with local sessions.

## Test plan

- CI passes (1731 tests: `%subscription-changed` wire parsing, hook-command rewrite incl. a marker-drift guard, App drain via a pushable FakeBackend — match/skip/allow-list/dedupe)
- Verified live on linux-host (tmux 3.5a): rewritten hook file on the host; synthetic pane-option events drive the TUI through Working (spinner) / Done / Blocked, including a session created after the subscription armed; silent-pane `working` still demotes via the quiescence guard

https://claude.ai/code/session_015PTHu7pNyZZUFJrvZmCU4y