### PR TITLE
feat(ui): click to choose code-review target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1544,10 +1544,12 @@ code_review`.
   whole branch (`<base>..HEAD`, the default), the **uncommitted working changes**
   (`git diff HEAD`), or a **single commit** (`git show`) — mirroring tuicr's
   `-r`/`-w`/commit targets. An in-view picker lists Working, Branch, and each
-  commit in `<base>..HEAD` (`git log`); selecting one recomputes the diff
-  (`ReviewTarget`, `build_target_diff`, `git::{diff_working_on,show_commit_on,
-  list_commits_on}`). A session with no resolvable base defaults to the
-  working-changes target.
+  commit in `<base>..HEAD` (`git log`); selecting one (keyboard ↑/↓/Enter **or a
+  mouse click** on the entry — `render_target_picker` returns a `RowHitbox` per
+  entry, recorded as `ClickAction::ReviewTarget(i)` → `App::cr_select_target`)
+  recomputes the diff (`ReviewTarget`, `build_target_diff`,
+  `git::{diff_working_on,show_commit_on, list_commits_on}`). A session with no
+  resolvable base defaults to the working-changes target.
 - **Multi-repo sessions.** A multi-repo session reviews **all** its worktrees at
   once: the diff is built per repo and concatenated, with each file path
   namespaced `"<repo>/<path>"` so files, comments, and "reviewed" marks stay

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -1968,6 +1968,50 @@ fn clicking_review_row_focuses_the_pane() {
     );
 }
 
+/// The review-target picker is mouse-driven too: clicking one of its entries
+/// switches the diff to that target, mirroring the keyboard Enter path.
+#[test]
+fn clicking_review_target_entry_switches_target() {
+    use crate::app::code_review::ReviewTarget;
+    let mut h = Harness::new(STD_COLS, STD_ROWS, 1);
+    let sid = h.app.sessions[0].info.id;
+    h.app.code_reviews.insert(
+        sid,
+        crate::app::code_review::CodeReviewState::for_test(sid, 2),
+    );
+    h.app.focus = InputFocus::CodeReview;
+    // The picker opens on Branch (the for_test default); it offers Working +
+    // Branch entries.
+    h.app.cr_open_target_picker();
+    assert_eq!(h.app.active_review().unwrap().target, ReviewTarget::Branch);
+    h.render();
+
+    // Find the "Working" entry's hitbox (index 0) and click it.
+    let r = h
+        .app
+        .click_targets
+        .iter()
+        .find(|t| matches!(t.action, ClickAction::ReviewTarget(0)))
+        .map(|t| t.rect)
+        .expect("target-picker entries recorded as click targets");
+    h.app.update(AppMessage::MouseClick {
+        x: r.x,
+        y: r.y,
+        modifiers: KeyModifiers::NONE,
+    });
+
+    let cr = h.app.active_review().unwrap();
+    assert_eq!(
+        cr.target,
+        ReviewTarget::Working,
+        "clicking a target-picker entry switches the diff to that target"
+    );
+    assert!(
+        cr.target_picker.is_none(),
+        "selecting a target closes the picker"
+    );
+}
+
 /// Global overlay/panel toggles fall through the review's key capture so they
 /// stay reachable while a review is open (regression: the capture handler
 /// swallowed them). The review itself stays open.

--- a/src/app/code_review.rs
+++ b/src/app/code_review.rs
@@ -743,6 +743,18 @@ impl App {
         }
     }
 
+    /// Apply the target-picker entry at `idx` (a click), mirroring the keyboard
+    /// Enter path. Out-of-range indices are ignored.
+    pub(crate) fn cr_select_target(&mut self, idx: usize) {
+        let chosen = self
+            .active_review()
+            .and_then(|cr| cr.target_picker.as_ref())
+            .and_then(|picker| picker.entries.get(idx).cloned());
+        if let Some(target) = chosen {
+            self.cr_set_target(target);
+        }
+    }
+
     /// Key handling while the target picker is open.
     fn handle_target_picker_key(&mut self, code: KeyCode) {
         let chosen = {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -471,6 +471,9 @@ pub(crate) enum ClickAction {
     /// Jump the diff to the changed-file at this diff-file index (clicked in the
     /// changed-files list).
     ReviewFile(usize),
+    /// Select the review-target-picker entry at this index (clicked while the
+    /// picker is open).
+    ReviewTarget(usize),
     /// Select a central-pane view from the tab strip in the pane's top border
     /// (Agent / Shell / Review). Dispatched by `activate_click_target`.
     CentralTab(CentralTab),
@@ -2594,6 +2597,11 @@ impl App {
             ClickAction::ReviewFile(fi) => {
                 self.focus = InputFocus::ReviewFiles;
                 self.cr_jump_to_file(fi);
+                true
+            }
+            ClickAction::ReviewTarget(i) => {
+                self.focus = InputFocus::CodeReview;
+                self.cr_select_target(i);
                 true
             }
             ClickAction::CentralTab(tab) => {

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -121,6 +121,7 @@ impl App {
                         | ClickAction::SelectFileRow(_)
                         | ClickAction::Global(_)
                         | ClickAction::ReviewButton(_)
+                        | ClickAction::ReviewTarget(_)
                         | ClickAction::CentralTab(_)
                         | ClickAction::PaneField { .. }
                 )
@@ -611,6 +612,9 @@ impl App {
         // focus fallback.
         for h in hits.rows {
             self.record_click(h.rect, ClickAction::ReviewRow(h.index));
+        }
+        for h in hits.targets {
+            self.record_click(h.rect, ClickAction::ReviewTarget(h.index));
         }
         for (h, action) in hits.buttons {
             self.record_click(h.rect, ClickAction::ReviewButton(action));

--- a/src/ui/code_review.rs
+++ b/src/ui/code_review.rs
@@ -19,6 +19,9 @@ use crate::ui::{focus_block, render_button_bar, ButtonSpec, FocusLevel, RowHitbo
 pub(crate) struct CodeReviewHits {
     /// One hitbox per visible diff/comment row (index = row in `state.rows`).
     pub rows: Vec<RowHitbox>,
+    /// One hitbox per visible target-picker entry (index = entry in the
+    /// picker); empty unless the target picker is open.
+    pub targets: Vec<RowHitbox>,
     /// Footer buttons paired with the action each triggers.
     pub buttons: Vec<(crate::ui::ButtonHit, ReviewButton)>,
     pub scrollbar: Option<ScrollbarGeom>,
@@ -65,6 +68,7 @@ pub(crate) fn render(
     if inner.height == 0 || inner.width == 0 {
         return CodeReviewHits {
             rows: Vec::new(),
+            targets: Vec::new(),
             buttons: Vec::new(),
             scrollbar: None,
         };
@@ -86,9 +90,11 @@ pub(crate) fn render(
     }
 
     let composing = state.compose.is_some();
-    // The target picker, when open, replaces the diff body (keyboard-driven).
+    // The target picker, when open, replaces the diff body. Its entries are
+    // clickable (`targets`), on top of the keyboard-driven ↑/↓/Enter path.
+    let mut targets = Vec::new();
     let hits = if state.target_picker.is_some() {
-        render_target_picker(frame, diff_area, state);
+        targets = render_target_picker(frame, diff_area, state);
         (Vec::new(), None)
     } else {
         render_rows(frame, diff_area, state)
@@ -109,20 +115,26 @@ pub(crate) fn render(
 
     CodeReviewHits {
         rows: hits.0,
+        targets,
         buttons,
         scrollbar: hits.1,
     }
 }
 
 /// Render the review-target picker (branch / working / per-commit) into `area`.
-fn render_target_picker(frame: &mut Frame, area: Rect, state: &CodeReviewState) {
+///
+/// Returns one [`RowHitbox`] per rendered entry (`index` = entry position in
+/// `picker.entries`) so a click selects that target, matching the keyboard
+/// ↑/↓/Enter path.
+fn render_target_picker(frame: &mut Frame, area: Rect, state: &CodeReviewState) -> Vec<RowHitbox> {
     let Some(picker) = state.target_picker.as_ref() else {
-        return;
+        return Vec::new();
     };
     let mut lines: Vec<Line> = vec![Line::from(Span::styled(
-        " Review target  (↑/↓ select · Enter · Esc)",
+        " Review target  (↑/↓ select · Enter · Esc · or click)",
         Style::default().fg(Theme::text_muted()),
     ))];
+    let mut hits = Vec::new();
     let height = area.height as usize;
     for (i, target) in picker
         .entries
@@ -141,12 +153,18 @@ fn render_target_picker(frame: &mut Frame, area: Rect, state: &CodeReviewState) 
         } else {
             Style::default().fg(Theme::text_primary())
         };
+        // Row 0 is the header line; entry `i` renders on the next row down.
+        hits.push(RowHitbox {
+            rect: Rect::new(area.x, area.y + 1 + i as u16, area.width, 1),
+            index: i,
+        });
         lines.push(Line::from(Span::styled(
             truncate(&format!("{marker}{label}"), area.width as usize),
             style,
         )));
     }
     frame.render_widget(Paragraph::new(lines), area);
+    hits
 }
 
 /// Render the windowed diff/comment rows + scrollbar. Returns row hitboxes


### PR DESCRIPTION
## Summary

- The native code-review target picker (`t` / the Target footer button) was keyboard-only (↑/↓/Enter). Its entries are now **clickable** with the mouse.
- `render_target_picker` returns one `RowHitbox` per rendered entry; the app records these as `ClickAction::ReviewTarget(i)` and applies the selection via `App::cr_select_target`, funnelling into the same `cr_set_target` path as the keyboard Enter, so a click recomputes the diff and closes the picker.
- Hover on a picker entry now gets the list-row highlight; the picker hint reads `… · Esc · or click`.

## Test plan

- New acceptance test `clicking_review_target_entry_switches_target` drives a real click on the "Working" entry and asserts the target switches + the picker closes.
- CI checks pass