### PR TITLE
fix(core): harden remote status, spawn arg rewriting, and v39 migration

### DIFF
--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -208,7 +208,10 @@ fn flush_psmux_literal(pane_id: &str, literal: &mut Vec<u8>, cmds: &mut Vec<Stri
 /// backslash); any other backslash stays literal, so both are escaped here. A
 /// literal run never contains a newline (LF and CR map to key-names), but the
 /// control-mode line is `\n`-delimited, so newlines are replaced defensively.
-fn psmux_quote(s: &str) -> String {
+/// Also the argument encoding for any other psmux control-mode line (e.g.
+/// `new-window -c/-n` in [`super::tmux`]) — same tokenizer, so
+/// [`shell_escape`]'s POSIX `'\''` idiom would arrive mangled there too.
+pub(crate) fn psmux_quote(s: &str) -> String {
     format!(
         "\"{}\"",
         s.replace('\\', "\\\\")

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -854,20 +854,17 @@ impl TmuxBackend {
         args: &[String],
         env: &HashMap<String, String>,
     ) -> String {
-        fn ps_quote(s: &str) -> String {
-            format!("'{}'", s.replace('\'', "''"))
-        }
         let mut ps = String::new();
         // Sort for a deterministic command (HashMap iteration order isn't).
         let mut pairs: Vec<_> = env.iter().collect();
         pairs.sort();
         for (k, v) in pairs {
-            ps.push_str(&format!("Set-Item Env:{k} {}; ", ps_quote(v)));
+            ps.push_str(&format!("Set-Item Env:{k} {}; ", ps_single_quote(v)));
         }
-        ps.push_str(&format!("& {}", ps_quote(command)));
+        ps.push_str(&format!("& {}", ps_single_quote(command)));
         for a in args {
             ps.push(' ');
-            ps.push_str(&ps_quote(a));
+            ps.push_str(&ps_single_quote(a));
         }
         ps.replace(['"', '\n'], " ")
     }
@@ -1133,8 +1130,18 @@ impl SessionBackend for TmuxBackend {
             self.login_wrap_for_remote(&Self::build_shell_command(command, args))
         };
 
+        // psmux's tokenizer can't read POSIX `'\''` escapes (see
+        // `psmux_quote`), so its `-c`/`-n` values get the double-quote framing
+        // it does parse; tmux keeps the byte-identical single-quote path.
+        let quote_arg = |s: &str| {
+            if psmux {
+                control_mode::psmux_quote(s)
+            } else {
+                control_mode::shell_escape(s)
+            }
+        };
         let cwd_part = match cwd {
-            Some(dir) => format!(" -c {}", control_mode::shell_escape(&dir.to_string_lossy())),
+            Some(dir) => format!(" -c {}", quote_arg(&dir.to_string_lossy())),
             None => String::new(),
         };
         let env_part: String = if psmux {
@@ -1144,7 +1151,7 @@ impl SessionBackend for TmuxBackend {
                 .map(|(k, v)| format!(" -e {}", shell_escape(&format!("{k}={v}"))))
                 .collect()
         };
-        let escaped_window_name = shell_escape(window_name);
+        let escaped_window_name = quote_arg(window_name);
         let session = &self.session;
         let cmd = format!(
             "new-window -t {session} -n {escaped_window_name} -P -F '#{{pane_id}}'{cwd_part}{env_part} {shell_cmd}"
@@ -1314,10 +1321,14 @@ impl SessionBackend for TmuxBackend {
     }
 
     fn take_hook_state_events(&self) -> Vec<(String, String)> {
-        // Lock `control` directly — `with_control` errors before the control
-        // connection starts, and "no connection yet" is simply "no events".
+        // `try_lock`, not `lock`: this runs on the UI thread every tick, and a
+        // background restore thread holds `control` across `ControlMode::start`
+        // (an ssh connect + waited commands, up to tens of seconds on a slow
+        // host) — blocking here would stall the first frame ADR-P7 protects.
+        // A contended lock means no connection is serving events yet, and a
+        // skipped drain only defers queued events to the next tick.
         self.control
-            .lock()
+            .try_lock()
             .ok()
             .and_then(|guard| guard.as_ref().map(ControlMode::take_sub_events))
             .unwrap_or_default()
@@ -1475,7 +1486,8 @@ fn deferred_prompt_script(target: &str, text: &str) -> String {
 }
 
 /// Wrap `s` in a PowerShell single-quoted literal, doubling embedded quotes.
-#[cfg(windows)]
+/// Not `#[cfg(windows)]`: `psmux_window_powershell` quotes for a psmux *host*
+/// from any local OS.
 fn ps_single_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "''"))
 }
@@ -1524,9 +1536,9 @@ fn heartbeat_loop_command(cli_path: &Path) -> String {
 
 /// Windows: psmux runs a window command via `powershell -NoLogo -Command`, so
 /// the keeper loop is PowerShell — handed over as **one argv token**, dodging
-/// psmux's trailing-token handling entirely (same delivery as
-/// `psmux_window_powershell`, whose quoting rules the `ps_single_quote` here
-/// shares). This used to be a no-op ("no POSIX shell for the keeper loop"),
+/// psmux's trailing-token handling entirely (same delivery and
+/// `ps_single_quote` quoting as `psmux_window_powershell`). This used to be a
+/// no-op ("no POSIX shell for the keeper loop"),
 /// which silently degraded headless automation firing to TUI-only on Windows.
 #[cfg(windows)]
 fn heartbeat_loop_command(cli_path: &Path) -> String {

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -2065,9 +2065,11 @@ fn remote_hook_event_drives_session_status() {
     );
 }
 
-/// Events that don't resolve to a session (unknown pane — a shell/heartbeat
-/// window) or carry a non-allow-listed state (the value is remote-controlled
-/// free text) are dropped without touching the DB.
+/// Events that don't resolve to a session never touch the DB (an unknown pane
+/// is *parked* for the adoption retry — see
+/// `remote_hook_event_parked_until_session_adopted` — not applied), and a
+/// non-allow-listed state (the value is remote-controlled free text) is
+/// dropped outright.
 #[test]
 fn remote_hook_event_ignores_unmatched_and_invalid() {
     let backend = Arc::new(FakeBackend::stub());
@@ -2088,6 +2090,59 @@ fn remote_hook_event_ignores_unmatched_and_invalid() {
             .values()
             .all(|r| r.state.is_none()),
         "neither event may reach the hook columns"
+    );
+}
+
+/// An event for a pane no session claims *yet* is parked and re-applied once
+/// the session appears: the subscription's initial catch-up report lands while
+/// the background restore is still adopting that host's windows, and dropping
+/// it would lose e.g. a `done` set while the TUI was closed.
+#[test]
+fn remote_hook_event_parked_until_session_adopted() {
+    let backend = Arc::new(FakeBackend::stub());
+    let mut h = Harness::with_backend(STD_COLS, STD_ROWS, 1, backend.clone());
+    let id = h.app.sessions[0].info.id;
+
+    backend.push_hook_event("%5", "working");
+    h.app.refresh_session_statuses(); // no session owns %5 yet → parked
+
+    h.app.sessions[0].info.backend_id = Some("%5".into());
+    h.app.save_state();
+    h.app.refresh_session_statuses(); // nothing new pushed — the parked event applies
+
+    let rows = h.app.db.load_hook_states().unwrap();
+    assert_eq!(
+        rows.get(&id).and_then(|r| r.state.as_deref()),
+        Some("working"),
+        "the pre-adoption event must survive to the adopting tick"
+    );
+}
+
+/// Two transitions for one pane in a single drained batch (`working` then
+/// `done`, e.g. queued while the main thread stalled) must both land: deduping
+/// the second against the stale pre-batch cache would swallow the `done` and
+/// leave the session spinning on `working`.
+#[test]
+fn remote_hook_batch_applies_both_transitions() {
+    let backend = Arc::new(FakeBackend::stub());
+    let mut h = Harness::with_backend(STD_COLS, STD_ROWS, 1, backend.clone());
+    h.app.sessions[0].info.backend_id = Some("%5".into());
+    h.app.save_state();
+    let id = h.app.sessions[0].info.id;
+
+    // A previous turn ended `done`, absorbed into the cache.
+    backend.push_hook_event("%5", "done");
+    h.app.refresh_session_statuses();
+
+    backend.push_hook_event("%5", "working");
+    backend.push_hook_event("%5", "done");
+    h.app.refresh_session_statuses();
+
+    let rows = h.app.db.load_hook_states().unwrap();
+    assert_eq!(
+        rows.get(&id).and_then(|r| r.state.as_deref()),
+        Some("done"),
+        "the batch's final transition must not be swallowed by the stale cache"
     );
 }
 

--- a/src/app/code_review.rs
+++ b/src/app/code_review.rs
@@ -1576,8 +1576,9 @@ fn apply_textarea_key(ta: &mut TextArea, code: KeyCode, mods: KeyModifiers) {
 
 impl CodeReviewState {
     /// Longest diff-line body width (in chars) across every hunk of every file.
-    /// Bounds the horizontal scroll offset; computed on a keypress (not per
-    /// frame), so the O(total chars) scan is cheap.
+    /// Bounds the horizontal scroll offset. O(total chars), so callers keep it
+    /// off the hot path: it runs on an h-scroll keypress and in the renderer's
+    /// clamp only while `h_scroll > 0` — never on the default unscrolled frame.
     pub(crate) fn max_line_width(&self) -> usize {
         self.files
             .iter()

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1817,7 +1817,11 @@ impl App {
             return;
         }
         let expanded = paths::expand_tilde(&path);
-        if let Err(e) = self.db.upsert_repo_bookmark_kind("", &expanded, true) {
+        // Equivalent to a literal "" (the remote guard above means the wizard
+        // is local here), but keeps the `"" = local` encoding owned by
+        // `bookmark_host_key` alone.
+        let host = self.bookmark_host_key().to_string();
+        if let Err(e) = self.db.upsert_repo_bookmark_kind(&host, &expanded, true) {
             error!("Failed to save parent bookmark: {e}");
             self.set_error(format!("Failed to save parent bookmark: {e}"));
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -738,6 +738,13 @@ pub struct App {
     /// `data_version` observed at the last [`Self::cached_hook_states`] reload
     /// (`None` = never loaded, which forces the first load).
     hook_states_version: Option<i64>,
+    /// Remote hook events whose pane didn't match a session yet, kept for
+    /// retry: the subscription's initial catch-up report arrives while the
+    /// background restore is still discovering/adopting that host's windows,
+    /// so dropping unmatched events would lose e.g. a `done` set while the TUI
+    /// was closed. Entries carry their arrival time and expire (another
+    /// instance's panes never match). See [`Self::drain_remote_hook_events`].
+    pending_remote_hook_events: Vec<(String, String, String, std::time::Instant)>,
     /// When the last frame was painted, for the forced-redraw floor.
     last_draw_at: std::time::Instant,
     /// Cheap rolling signature of agent output across all sessions (sum of each
@@ -961,6 +968,7 @@ impl App {
             spinner_frame: 0,
             last_active_session_id: None,
             cached_hook_states: HashMap::new(),
+            pending_remote_hook_events: Vec::new(),
             hook_states_version: None,
             last_draw_at: std::time::Instant::now(),
             last_output_gen: 0,
@@ -4039,6 +4047,11 @@ impl App {
         // The value is remote-host-controlled free text: allow-list it (the
         // same states `session signal` accepts) and never interpolate it.
         const VALID_STATES: [&str; 4] = ["working", "blocked", "done", "idle"];
+        // Unmatched events are retried this long — comfortably past a slow
+        // host's background restore — then dropped (bounded below, so another
+        // instance's panes can't accumulate).
+        const PENDING_TTL: std::time::Duration = std::time::Duration::from_secs(120);
+        const PENDING_CAP: usize = 256;
         // Collect first: the registry borrow must end before &mut self below.
         let batches: Vec<(String, Vec<(String, String)>)> = self
             .backends
@@ -4046,42 +4059,60 @@ impl App {
             .map(|b| (b.name().to_string(), b.take_hook_state_events()))
             .filter(|(_, events)| !events.is_empty())
             .collect();
+        // Older pending retries first, so per-pane event order is preserved.
+        let now = std::time::Instant::now();
+        let mut queue = std::mem::take(&mut self.pending_remote_hook_events);
         for (backend_name, events) in batches {
             for (pane_id, state) in events {
-                if !VALID_STATES.contains(&state.as_str()) {
-                    continue;
+                queue.push((backend_name.clone(), pane_id, state, now));
+            }
+        }
+        // States applied *this drain*: the dedupe below must compare against
+        // the latest write, not `cached_hook_states` (only invalidated, not
+        // reloaded, mid-loop) — else the second event of a `working`→`done`
+        // batch that matches the stale cached value is swallowed.
+        let mut applied: HashMap<crate::session::SessionId, String> = HashMap::new();
+        for (backend_name, pane_id, state, arrived) in queue {
+            if !VALID_STATES.contains(&state.as_str()) {
+                continue;
+            }
+            let Some(id) = self
+                .sessions
+                .iter()
+                .find(|s| {
+                    s.backend_name() == backend_name
+                        && s.info.backend_id.as_deref() == Some(pane_id.as_str())
+                })
+                .map(|s| s.info.id)
+            else {
+                // No matching session *yet*: the subscription's initial report
+                // often lands before the background restore adopts the pane,
+                // so park the event for a later tick instead of losing it.
+                if now.duration_since(arrived) < PENDING_TTL
+                    && self.pending_remote_hook_events.len() < PENDING_CAP
+                {
+                    self.pending_remote_hook_events
+                        .push((backend_name, pane_id, state, arrived));
                 }
-                let Some(id) = self
-                    .sessions
-                    .iter()
-                    .find(|s| {
-                        s.backend_name() == backend_name
-                            && s.info.backend_id.as_deref() == Some(pane_id.as_str())
-                    })
-                    .map(|s| s.info.id)
-                else {
-                    // Not an agent pane (shell/heartbeat window) or a session
-                    // this instance doesn't hold — skip.
-                    continue;
-                };
-                // Dedupe against the cache: the subscription re-reports the
-                // current value on (re)connect, and re-stamping an already-
-                // acknowledged `done` would resurrect it as unseen and re-fire
-                // its OS notification on every TUI restart. Safe because
-                // done→done without an intervening `working` can't happen.
-                if self
-                    .cached_hook_states
+                continue;
+            };
+            // Dedupe against the current value: the subscription re-reports it
+            // on (re)connect, and re-stamping an already-acknowledged `done`
+            // would resurrect it as unseen and re-fire its OS notification on
+            // every TUI restart.
+            let current = applied.get(&id).map(String::as_str).or_else(|| {
+                self.cached_hook_states
                     .get(&id)
                     .and_then(|h| h.state.as_deref())
-                    == Some(state.as_str())
-                {
-                    continue;
-                }
-                if self.db.set_hook_state(id, &state).is_ok() {
-                    // Own-connection write: data_version won't move, force the
-                    // reload so this tick's derivation sees the exact row.
-                    self.invalidate_hook_state_cache();
-                }
+            });
+            if current == Some(state.as_str()) {
+                continue;
+            }
+            if self.db.set_hook_state(id, &state).is_ok() {
+                // Own-connection write: data_version won't move, force the
+                // reload so this tick's derivation sees the exact row.
+                self.invalidate_hook_state_cache();
+                applied.insert(id, state);
             }
         }
     }
@@ -5677,20 +5708,7 @@ fn resolve_process_cwd(
         })
         .collect();
 
-    // A remote session's symlink workspace is built on the *remote* host — a
-    // local workspace dir wouldn't exist there. Local sessions use the local
-    // builder as before.
-    let built = match host {
-        Some(h) => crate::git::ensure_remote_workspace(h, id, &pairs),
-        None => crate::workspace::ensure_workspace(id, &pairs).map_err(anyhow::Error::from),
-    };
-    match built {
-        Ok(ws) => Some(ws),
-        Err(e) => {
-            error!("Failed to build multi-repo workspace: {e}");
-            primary_cwd
-        }
-    }
+    crate::session_ops::spawn::build_multi_repo_workspace(host, id, &pairs).or(primary_cwd)
 }
 
 #[cfg(test)]

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -154,6 +154,11 @@ impl App {
         self.global_search.active = false;
         self.global_search.results.clear();
         self.global_search.query.clear();
+        // The snapshot predates any feature flag flipped while the strip was
+        // open (settings live-reload): re-enforce so the restore can't
+        // resurrect a panel/focus whose feature was just disabled. Runs after
+        // `active = false`, so its own close-search branch is a no-op.
+        self.enforce_feature_visibility();
         self.resize_sessions_to_content_area();
     }
 

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -680,8 +680,9 @@ impl App {
     /// in), and whether it's the active view. Packing mirrors `render_button_bar`
     /// (` label ` chip = label+2 wide, one-space gaps) so the recorded hitboxes
     /// match the pills `draw_central_tabs` paints. Shell/Review are gated by
-    /// their feature flags; cells stop before the right edge so they never run
-    /// into the right-aligned session-info title.
+    /// their feature flags; cells stop before the pane's right edge (they can
+    /// still paint over the right-aligned session-info title on a pane barely
+    /// wide enough for the pills — the tabs win, they're the interactive part).
     fn central_tab_cells(&self, area: Rect) -> Vec<CentralTabCell> {
         // No tabs on the empty "No Session" screen, or when the pane is too
         // narrow to hold even one.

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -153,53 +153,16 @@ fn worktree_path_for(host: Option<&HostDef>, repo_path: &Path, branch: &str) -> 
     }
 }
 
-/// Sanitize a workspace directory segment (the session id). Mirrors
-/// `workspace::sanitize_segment` so the remote workspace path matches the local
-/// one; `git` can't depend on `workspace`, so it is duplicated by construction.
-fn sanitize_workspace_segment(name: &str) -> String {
-    let cleaned: String = name
-        .trim()
-        .chars()
-        .map(|c| match c {
-            '/' | '\\' | ':' => '-',
-            c if c.is_whitespace() => '-',
-            c => c,
-        })
-        .collect();
-    cleaned.trim_matches(['.', '-']).to_string()
-}
-
-/// A unique, sanitized symlink name for a workspace member. Mirrors
-/// `workspace::unique_link_name`: collisions get a `-2`, `-3`, … suffix and an
-/// empty label falls back to `repo`.
-fn unique_link_name(name: &str, used: &mut HashSet<String>) -> String {
-    let sanitized = sanitize_workspace_segment(name);
-    let base = if sanitized.is_empty() {
-        "repo".to_string()
-    } else {
-        sanitized
-    };
-    if used.insert(base.clone()) {
-        return base;
-    }
-    let mut n = 2;
-    loop {
-        let candidate = format!("{base}-{n}");
-        if used.insert(candidate.clone()) {
-            return candidate;
-        }
-        n += 1;
-    }
-}
-
 /// Build a per-session **remote** symlink workspace on `host`: a directory
 /// holding one symlink per member (`<label> -> <remote member path>`), so a
 /// multi-repo remote session launches somewhere every repo is a visible subdir.
 ///
 /// This is the remote analogue of [`crate::workspace::ensure_workspace`], run
-/// over the host launcher (`ssh`/`wsl.exe`). All paths are POSIX (`/`-joined)
-/// because the host is always Linux, even when thurbox runs on Windows. Returns
-/// the remote workspace directory path.
+/// over the host launcher (`ssh`/`wsl.exe`). All paths are POSIX (`/`-joined):
+/// the `sh -c` script assumes a POSIX host, so on a Windows (`psmux`) SSH host
+/// it fails and callers fall back to the primary cwd (a multi-repo session
+/// there loses its workspace, with a logged error). Returns the remote
+/// workspace directory path.
 pub fn ensure_remote_workspace(
     host: &HostDef,
     id: &str,
@@ -212,7 +175,7 @@ pub fn ensure_remote_workspace(
     let mut script = format!("rm -rf {ws} && mkdir -p {ws}", ws = posix_quote(&ws));
     let mut used: HashSet<String> = HashSet::new();
     for (label, target) in members {
-        let name = unique_link_name(label, &mut used);
+        let name = crate::paths::unique_link_name(label, &mut used);
         let link = format!("{ws}/{name}");
         script.push_str(&format!(
             " && ln -s {target} {link}",
@@ -228,11 +191,10 @@ pub fn ensure_remote_workspace(
 /// The remote workspace directory for a session id on `host`, mirroring the
 /// local layout (`<thurbox data root>/workspaces/<sanitized id>`). Base:
 /// `<worktrees_dir>/..`, or `$HOME/.local/share/thurbox`. Sanitizes the id
-/// exactly like the local builder (`workspace::workspace_dir`) — `git` can't
-/// depend on `workspace`, so the scheme is mirrored here by construction (kept
-/// in sync via tests) — including its empty-id rejection: an empty segment
-/// would make the `rm -rf` in ensure/remove target the workspaces *root*,
-/// wiping every session's workspace on the host.
+/// with the same shared helper as the local builder
+/// (`workspace::workspace_dir`) — including its empty-id rejection: an empty
+/// segment would make the `rm -rf` in ensure/remove target the workspaces
+/// *root*, wiping every session's workspace on the host.
 pub(crate) fn remote_workspace_dir(host: &HostDef, id: &str) -> Result<String> {
     let base = match &host.worktrees_dir {
         Some(dir) => Path::new(dir)
@@ -241,7 +203,7 @@ pub(crate) fn remote_workspace_dir(host: &HostDef, id: &str) -> Result<String> {
             .unwrap_or_else(|| dir.clone()),
         None => format!("{}/.local/share/thurbox", remote_home(host)?),
     };
-    let segment = sanitize_workspace_segment(id);
+    let segment = crate::paths::sanitize_workspace_segment(id);
     anyhow::ensure!(!segment.is_empty(), "empty workspace id");
     Ok(format!("{base}/workspaces/{segment}"))
 }
@@ -308,14 +270,6 @@ fn host_shell_c(host: &HostDef, script: &str) -> Command {
     cmd
 }
 
-/// Copy a local file to the **same** absolute path on a remote `host`.
-/// See [`copy_bytes_to_remote`], which this reads the file into.
-pub fn copy_file_to_remote(host: &HostDef, local: &Path, remote_path: &str) -> Result<()> {
-    let bytes = std::fs::read(local)
-        .with_context(|| format!("failed to read local file {}", local.display()))?;
-    copy_bytes_to_remote(host, &bytes, remote_path)
-}
-
 /// Write `bytes` to `remote_path` on `host`, creating the parent directory.
 /// Streams the bytes over the host launcher's stdin into `cat > <path>`, so it
 /// is transport-neutral (ssh/wsl) and needs no `scp`/`\\wsl$` share. Used to
@@ -380,7 +334,10 @@ pub fn expand_remote_tilde(host: &HostDef, path: &str) -> Result<String> {
 /// with `--exec` so argv reaches `ls` verbatim (no `wsl.exe` `$`-substitution
 /// or shell re-splitting; over ssh each token is `posix_quote`d instead). `-p`
 /// appends a trailing `/` to directories, which is how they're identified
-/// without a shell loop.
+/// without a shell loop. Known gap: `-p` slashes only *real* directories, so
+/// a symlink to a directory is omitted — accepted, because the alternatives
+/// re-interpret the user-typed dir through a shell (`sh -c` loop; see the
+/// wsl list_dir test) or fail wholesale on a broken symlink (`ls -L`).
 ///
 /// This runs synchronously on the caller's (UI) thread, so the ssh variant
 /// adds `BatchMode=yes` + `ConnectTimeout=5` **after** the host's own
@@ -1885,32 +1842,6 @@ mod tests {
         let h = host("me@box", Some("/data/wt"));
         assert!(remote_workspace_dir(&h, "").is_err());
         assert!(remote_workspace_dir(&h, " .- ").is_err());
-    }
-
-    #[test]
-    fn sanitize_workspace_segment_matches_local_scheme() {
-        // Mirrors `workspace::sanitize_segment`: slashes/backslashes/colons and
-        // whitespace → `-`; leading/trailing `.`/`-` trimmed.
-        assert_eq!(sanitize_workspace_segment("feat/x"), "feat-x");
-        assert_eq!(sanitize_workspace_segment("a b:c\\d"), "a-b-c-d");
-        assert_eq!(sanitize_workspace_segment("--.hidden.--"), "hidden");
-        // A UUID (the real input) is unchanged.
-        assert_eq!(
-            sanitize_workspace_segment("d5715d35-9599-4507-9901-ef33b9476358"),
-            "d5715d35-9599-4507-9901-ef33b9476358"
-        );
-    }
-
-    #[test]
-    fn unique_link_name_dedups_with_dash_two_suffix() {
-        // Must match the local builder: first collision is `-2`, then `-3`, and
-        // an empty label falls back to `repo`.
-        let mut used = HashSet::new();
-        assert_eq!(unique_link_name("webapp", &mut used), "webapp");
-        assert_eq!(unique_link_name("webapp", &mut used), "webapp-2");
-        assert_eq!(unique_link_name("webapp", &mut used), "webapp-3");
-        assert_eq!(unique_link_name("", &mut used), "repo");
-        assert_eq!(unique_link_name("", &mut used), "repo-2");
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -530,6 +530,46 @@ pub fn complete_directory_path(input: &str) -> Option<String> {
     }
 }
 
+/// Reduce a display name / session id to a safe single path segment for a
+/// symlink-workspace link or directory name. Shared by the local
+/// (`workspace`) and remote (`git`) workspace builders so their layouts match
+/// by construction — neither may depend on the other.
+pub(crate) fn sanitize_workspace_segment(name: &str) -> String {
+    let cleaned: String = name
+        .trim()
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' => '-',
+            c if c.is_whitespace() => '-',
+            c => c,
+        })
+        .collect();
+    cleaned.trim_matches(['.', '-']).to_string()
+}
+
+/// Sanitize `name` and make it unique within `used` by appending `-2`, `-3`,
+/// …; an empty sanitized name falls back to `repo`. Same sharing rationale as
+/// [`sanitize_workspace_segment`].
+pub(crate) fn unique_link_name(name: &str, used: &mut std::collections::HashSet<String>) -> String {
+    let sanitized = sanitize_workspace_segment(name);
+    let base = if sanitized.is_empty() {
+        "repo".to_string()
+    } else {
+        sanitized
+    };
+    if used.insert(base.clone()) {
+        return base;
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{base}-{n}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1052,5 +1092,32 @@ mod tests {
         if let Some(s) = complete_directory_path("~/") {
             assert!(!s.starts_with('/'));
         }
+    }
+
+    #[test]
+    fn sanitize_workspace_segment_strips_separators_and_dots() {
+        // Slashes/backslashes/colons and whitespace → `-`; leading/trailing
+        // `.`/`-` trimmed.
+        assert_eq!(sanitize_workspace_segment("a/b\\c:d"), "a-b-c-d");
+        assert_eq!(sanitize_workspace_segment("  .git  "), "git");
+        assert_eq!(sanitize_workspace_segment("my repo"), "my-repo");
+        assert_eq!(sanitize_workspace_segment("--.hidden.--"), "hidden");
+        // A session-id UUID (the real workspace-dir input) is unchanged.
+        assert_eq!(
+            sanitize_workspace_segment("d5715d35-9599-4507-9901-ef33b9476358"),
+            "d5715d35-9599-4507-9901-ef33b9476358"
+        );
+    }
+
+    #[test]
+    fn unique_link_name_dedups_with_dash_two_suffix() {
+        // First collision is `-2`, then `-3`; an empty label falls back to
+        // `repo`.
+        let mut used = std::collections::HashSet::new();
+        assert_eq!(unique_link_name("webapp", &mut used), "webapp");
+        assert_eq!(unique_link_name("webapp", &mut used), "webapp-2");
+        assert_eq!(unique_link_name("webapp", &mut used), "webapp-3");
+        assert_eq!(unique_link_name("", &mut used), "repo");
+        assert_eq!(unique_link_name("", &mut used), "repo-2");
     }
 }

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -330,18 +330,30 @@ pub(crate) fn resolve_launch_cwd(
     if members.len() < 2 {
         return primary_cwd.to_path_buf();
     }
-    // A remote session's workspace must be built on the *remote* host — a local
-    // symlink dir wouldn't exist there. Local sessions use the local builder.
+    build_multi_repo_workspace(host, agent_session_id, &members)
+        .unwrap_or_else(|| primary_cwd.to_path_buf())
+}
+
+/// Build the per-session multi-repo symlink workspace — on the *remote* host
+/// when one is given (a local symlink dir wouldn't exist there), else with the
+/// local builder. `None` (error already logged) tells the caller to fall back
+/// to its primary cwd. Single home for the host branching + fallback policy,
+/// shared by [`resolve_launch_cwd`] and the TUI's `App::resolve_process_cwd`.
+pub(crate) fn build_multi_repo_workspace(
+    host: Option<&HostDef>,
+    agent_session_id: &str,
+    members: &[(String, PathBuf)],
+) -> Option<PathBuf> {
     let built = match host {
-        Some(h) => crate::git::ensure_remote_workspace(h, agent_session_id, &members),
-        None => crate::workspace::ensure_workspace(agent_session_id, &members)
+        Some(h) => crate::git::ensure_remote_workspace(h, agent_session_id, members),
+        None => crate::workspace::ensure_workspace(agent_session_id, members)
             .map_err(anyhow::Error::from),
     };
     match built {
-        Ok(ws) => ws,
+        Ok(ws) => Some(ws),
         Err(e) => {
             tracing::error!("Failed to build multi-repo workspace: {e}");
-            primary_cwd.to_path_buf()
+            None
         }
     }
 }
@@ -424,7 +436,13 @@ fn remote_config_root(host: &HostDef, config_root: &str) -> Option<String> {
         return Some(config_root.to_string());
     };
     let local_home = local_home.to_string_lossy().into_owned();
-    let Some(suffix) = config_root.strip_prefix(&local_home) else {
+    // Boundary-checked: home `/home/a` must not claim `/home/abc/…` (the
+    // stripped suffix would splice a garbage sibling path onto the remote
+    // home). Such a root is mirrored at its absolute path instead.
+    let Some(suffix) = config_root
+        .strip_prefix(&local_home)
+        .filter(|s| s.starts_with('/'))
+    else {
         return Some(config_root.to_string());
     };
     match crate::git::remote_home(host) {
@@ -440,6 +458,14 @@ fn remote_config_root(host: &HostDef, config_root: &str) -> Option<String> {
     }
 }
 
+/// True when `path` is `root` itself or a descendant — a plain
+/// `starts_with` would also claim sibling dirs sharing the prefix
+/// (`…/thurbox-backup` under root `…/thurbox`).
+fn path_under_root(path: &str, root: &str) -> bool {
+    path.strip_prefix(root)
+        .is_some_and(|rest| rest.is_empty() || rest.starts_with('/'))
+}
+
 /// Pure arg-rewriting core of [`adapt_agent_args_for_remote`]: every arg (or
 /// `--flag=value` value) under `config_root` is passed to `map`; `Some(new)`
 /// substitutes the path, `None` drops the arg **and** its preceding token when
@@ -451,12 +477,18 @@ fn rewrite_config_path_args(
 ) -> Vec<String> {
     let mut out: Vec<String> = Vec::with_capacity(args.len());
     for arg in args {
-        if arg.starts_with(config_root) {
+        if path_under_root(&arg, config_root) {
             match map(&arg) {
                 Some(new) => out.push(new),
                 None => {
                     tracing::warn!("dropping agent arg for remote spawn: {arg}");
-                    if out.last().is_some_and(|prev| prev.starts_with('-')) {
+                    // A `--flag=value` token is self-contained — never a
+                    // dangling flag for the dropped path — so popping it would
+                    // eat an unrelated (possibly already-rewritten) arg.
+                    if out
+                        .last()
+                        .is_some_and(|prev| prev.starts_with('-') && !prev.contains('='))
+                    {
                         out.pop();
                     }
                 }
@@ -466,7 +498,7 @@ fn rewrite_config_path_args(
         // `--flag=<path>` form: rewrite the value in place, or drop the whole
         // token (it is self-contained — nothing precedes it to pop).
         if let Some((flag, value)) = arg.split_once('=') {
-            if flag.starts_with('-') && value.starts_with(config_root) {
+            if flag.starts_with('-') && path_under_root(value, config_root) {
                 match map(value) {
                     Some(new) => out.push(format!("{flag}={new}")),
                     None => tracing::warn!("dropping agent arg for remote spawn: {arg}"),
@@ -650,6 +682,33 @@ mod tests {
         );
         let stripped = rewrite_config_path_args(args, "/cfg", |_| None);
         assert!(stripped.is_empty());
+    }
+
+    #[test]
+    fn rewrite_config_args_never_pops_a_self_contained_equals_token() {
+        // A `--flag=value` token before a stripped positional path is complete
+        // on its own — even when it was itself just rewritten — and must
+        // survive the pop that removes a dangling value-taking flag.
+        let args: Vec<String> = ["--settings=/cfg/a.json", "/cfg/b.json"]
+            .map(String::from)
+            .into();
+        let out = rewrite_config_path_args(args, "/cfg", |p| {
+            (p == "/cfg/a.json").then(|| format!("/rem{p}"))
+        });
+        assert_eq!(out, ["--settings=/rem/cfg/a.json"].map(String::from));
+    }
+
+    #[test]
+    fn rewrite_config_args_ignores_sibling_prefixed_paths() {
+        // `/cfg-backup` shares the `/cfg` string prefix but is not under the
+        // config root — it must pass through untouched, not be shipped/stripped.
+        let args: Vec<String> = ["--settings", "/cfg-backup/notes.md"]
+            .map(String::from)
+            .into();
+        let out = rewrite_config_path_args(args.clone(), "/cfg", |_| {
+            panic!("map must not be called for a sibling-prefixed path")
+        });
+        assert_eq!(out, args);
     }
 
     #[test]

--- a/src/storage/repo_bookmarks.rs
+++ b/src/storage/repo_bookmarks.rs
@@ -76,18 +76,6 @@ impl Database {
         Ok(())
     }
 
-    /// Touch a host's bookmark (update last_used_at) without incrementing
-    /// use_count.
-    pub fn touch_repo_bookmark(&self, host: &str, repo_path: &Path) -> rusqlite::Result<bool> {
-        let now = current_time_millis() as i64;
-        let path_str = repo_path.to_string_lossy().to_string();
-        let count = self.conn.execute(
-            "UPDATE repo_bookmarks SET last_used_at = ?1 WHERE host = ?2 AND repo_path = ?3",
-            params![now, host, path_str],
-        )?;
-        Ok(count > 0)
-    }
-
     /// Delete a host's repo bookmark. Returns true if it existed.
     pub fn delete_repo_bookmark(&self, host: &str, repo_path: &Path) -> rusqlite::Result<bool> {
         let path_str = repo_path.to_string_lossy().to_string();
@@ -192,22 +180,5 @@ mod tests {
         assert!(db.delete_repo_bookmark("", Path::new("/repo/a")).unwrap());
         assert!(!db.delete_repo_bookmark("", Path::new("/repo/a")).unwrap());
         assert!(db.list_repo_bookmarks("").unwrap().is_empty());
-    }
-
-    #[test]
-    fn touch_updates_last_used_at() {
-        let db = Database::open_in_memory().unwrap();
-
-        db.upsert_repo_bookmark("", Path::new("/repo/a")).unwrap();
-        let before = db.list_repo_bookmarks("").unwrap()[0].use_count;
-        assert!(db.touch_repo_bookmark("", Path::new("/repo/a")).unwrap());
-        let after = db.list_repo_bookmarks("").unwrap()[0].use_count;
-        assert_eq!(before, after);
-    }
-
-    #[test]
-    fn touch_nonexistent_returns_false() {
-        let db = Database::open_in_memory().unwrap();
-        assert!(!db.touch_repo_bookmark("", Path::new("/nope")).unwrap());
     }
 }

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1134,8 +1134,15 @@ fn migrate_v39_bookmark_host(conn: &Connection) -> rusqlite::Result<()> {
     if !table_exists(conn, "repo_bookmarks")? || column_exists(conn, "repo_bookmarks", "host")? {
         return Ok(());
     }
+    // Transactional (unlike the PRAGMA-toggling rebuilds above, nothing here
+    // forbids it): the version is only bumped after all steps, so a crash
+    // mid-rebuild would otherwise strand a `repo_bookmarks_v39` orphan that
+    // makes every re-run — and thus every DB open — fail. The DROP prefix
+    // additionally repairs an orphan left by a pre-fix binary.
     conn.execute_batch(
-        "CREATE TABLE repo_bookmarks_v39 (
+        "BEGIN;
+        DROP TABLE IF EXISTS repo_bookmarks_v39;
+        CREATE TABLE repo_bookmarks_v39 (
             host         TEXT NOT NULL DEFAULT '',
             repo_path    TEXT NOT NULL,
             label        TEXT,
@@ -1149,7 +1156,8 @@ fn migrate_v39_bookmark_host(conn: &Connection) -> rusqlite::Result<()> {
             SELECT '', repo_path, label, last_used_at, use_count, is_parent
             FROM repo_bookmarks;
         DROP TABLE repo_bookmarks;
-        ALTER TABLE repo_bookmarks_v39 RENAME TO repo_bookmarks;",
+        ALTER TABLE repo_bookmarks_v39 RENAME TO repo_bookmarks;
+        COMMIT;",
     )
 }
 
@@ -1402,6 +1410,38 @@ mod tests {
             )
             .unwrap();
         assert_eq!(version, SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn migrate_v39_recovers_from_a_crashed_prior_run() {
+        let conn = Connection::open_in_memory().unwrap();
+        // v38 state plus the orphan `repo_bookmarks_v39` a pre-fix binary could
+        // strand by crashing between its CREATE and the version bump. The
+        // re-run must repair it (DROP prefix), not fail with "table
+        // repo_bookmarks_v39 already exists" — which made the DB unopenable.
+        conn.execute_batch(
+            "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO metadata (key, value) VALUES ('schema_version', '38');
+             CREATE TABLE repo_bookmarks (
+                repo_path    TEXT PRIMARY KEY,
+                label        TEXT,
+                last_used_at INTEGER NOT NULL,
+                use_count    INTEGER NOT NULL DEFAULT 1,
+                is_parent    INTEGER NOT NULL DEFAULT 0
+             );
+             INSERT INTO repo_bookmarks (repo_path, last_used_at) VALUES ('/repo/a', 1);
+             CREATE TABLE repo_bookmarks_v39 (leftover TEXT);",
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        let (host, path): (String, String) = conn
+            .query_row("SELECT host, repo_path FROM repo_bookmarks", [], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })
+            .unwrap();
+        assert_eq!((host.as_str(), path.as_str()), ("", "/repo/a"));
     }
 
     #[test]

--- a/src/ui/code_review.rs
+++ b/src/ui/code_review.rs
@@ -193,15 +193,16 @@ fn render_rows(
 
     // Line-number column width from the largest number on screen.
     let num_w = line_number_width(state);
-    let gutter_w = num_w * 2 + 4; // "{old} {new} {sign} " — mirrors the gutter.
-    let avail = width.saturating_sub(gutter_w).max(1);
 
     // Final horizontal clamp: the app layer bounds `h_scroll` by the longest
     // line, but the exact body width is only known now — never scroll past what
     // the widest line can reveal. Wrapped/side-by-side layouts pin it to 0.
+    // Gated on an active scroll: `max_line_width` is an O(total chars) scan,
+    // so the default `h_scroll == 0` frame must not pay it on every repaint.
     if state.wrap || state.side_by_side {
         state.h_scroll = 0;
-    } else {
+    } else if state.h_scroll > 0 {
+        let avail = width.saturating_sub(gutter_width(num_w)).max(1);
         let max_h = state.max_line_width().saturating_sub(avail);
         state.h_scroll = state.h_scroll.min(max_h);
     }
@@ -221,12 +222,16 @@ fn render_rows(
         state.scroll = state.selected;
     }
 
-    // The active search query (lowercased) drives the in-row match highlight.
+    // The active search query drives the in-row match highlight — trimmed +
+    // lowercased exactly like `search_matches`, so a row the matcher counted
+    // never renders without its highlight (e.g. a query with a trailing space).
     let query = state
         .search
         .as_ref()
-        .map(|s| s.query.to_lowercase())
-        .filter(|q| !q.trim().is_empty());
+        .map(|s| s.query.trim().to_lowercase())
+        .filter(|q| !q.is_empty());
+
+    converge_wrap_scroll(state, width, num_w, height);
 
     // Build the windowed visual lines. When wrapping, the selected logical row's
     // first visual line must stay on screen: expand from `scroll` and, if the
@@ -482,7 +487,7 @@ fn unified_diff_line<'a>(
     let (sign, row_bg) = diff_row_bg(l.kind);
     let bg = row_bg_fn(row_bg, selected);
     let gutter = diff_gutter(l, num_w, sign);
-    let avail = width.saturating_sub(gutter.chars().count());
+    let avail = width.saturating_sub(gutter_width(num_w));
 
     let mut spans = vec![Span::styled(
         gutter,
@@ -511,7 +516,7 @@ fn unified_diff_line_wrapped<'a>(
     let (sign, row_bg) = diff_row_bg(l.kind);
     let bg = row_bg_fn(row_bg, selected);
     let gutter = diff_gutter(l, num_w, sign);
-    let gutter_w = gutter.chars().count();
+    let gutter_w = gutter_width(num_w);
     let avail = width.saturating_sub(gutter_w).max(1);
 
     let body_len = l.text.chars().count();
@@ -565,6 +570,60 @@ fn diff_gutter(l: &DiffLine, num_w: usize, sign: char) -> String {
     let old = l.old_no.map(|n| n.to_string()).unwrap_or_default();
     let new = l.new_no.map(|n| n.to_string()).unwrap_or_default();
     format!("{old:>num_w$} {new:>num_w$} {sign} ")
+}
+
+/// Cell width of [`diff_gutter`]'s output (two right-aligned numbers + three
+/// single-space/sign separators). The single encoding of the gutter layout —
+/// every consumer (h-scroll clamp, wrap chunking, continuation padding) derives
+/// from it, so a format change can't desync them from what is painted.
+fn gutter_width(num_w: usize) -> usize {
+    num_w * 2 + 4
+}
+
+/// With wrap on, a far jump (`G`, a scrollbar drag, a search step) can leave
+/// `scroll` many rows above the selection. Converge directly with a backward
+/// walk over visual-row counts — O(height) count-only passes — instead of
+/// letting `render_rows`' build loop advance one row per full-window rebuild
+/// (quadratic in the jump distance, a visible stall on a large diff). Lands
+/// on the smallest scroll ≥ the current one that keeps the selection's first
+/// visual row within `height`.
+fn converge_wrap_scroll(state: &mut CodeReviewState, width: usize, num_w: usize, height: usize) {
+    if !state.wrap || state.selected <= state.scroll {
+        return;
+    }
+    // Rows above the selection may fill at most height-1 visual rows, leaving
+    // one for the selection's first line (saturating: height 0 → selection).
+    let budget = height.saturating_sub(1);
+    let mut acc = 0usize;
+    let mut first = state.selected;
+    while first > state.scroll {
+        let c = visual_line_count(state, first - 1, width, num_w);
+        if acc + c > budget {
+            break;
+        }
+        acc += c;
+        first -= 1;
+    }
+    state.scroll = first;
+}
+
+/// How many visual rows logical row `i` occupies — the count-only mirror of
+/// [`row_visual_lines`] (wrap inflates only unified diff lines; every other
+/// row kind, and side-by-side, is exactly one). Must stay in lockstep with
+/// [`unified_diff_line_wrapped`]'s chunking so the wrap scroll walk in
+/// `render_rows` lands exactly where the build does.
+fn visual_line_count(state: &CodeReviewState, i: usize, width: usize, num_w: usize) -> usize {
+    if !state.wrap || state.side_by_side {
+        return 1;
+    }
+    match &state.rows[i] {
+        ReviewRow::Line(fi, hi, li) => {
+            let l = &state.files[*fi].hunks[*hi].lines[*li];
+            let avail = width.saturating_sub(gutter_width(num_w)).max(1);
+            l.text.chars().count().div_ceil(avail).max(1)
+        }
+        _ => 1,
+    }
 }
 
 /// Styled spans for a diff body windowed to `[start, start + avail)` chars,
@@ -1050,28 +1109,38 @@ fn render_footer(
     hits.into_iter().map(|h| (h, actions[h.index])).collect()
 }
 
-/// Byte offsets of every char inside a case-insensitive occurrence of `query`
-/// (already lowercased) within `text`. Non-overlapping, left-to-right. Feeds
-/// [`crate::ui::highlight::highlighted_spans_owned`] so search hits get the same
-/// accent+bold+underline emphasis as the fuzzy lists elsewhere in the app.
+/// Byte offsets of every source char inside a case-insensitive occurrence of
+/// `query` (already trimmed + lowercased) within `text`. Non-overlapping,
+/// left-to-right. The text is lowered char-by-char *including multi-char
+/// expansions* (`İ` → `i̇`), matching `search_matches`' `str::to_lowercase`
+/// row filter — a per-char equality would leave such matcher hits rendering
+/// with no highlight. Feeds
+/// [`crate::ui::highlight::highlighted_spans_owned`] so search hits get the
+/// same accent+bold+underline emphasis as the fuzzy lists elsewhere in the app.
 fn match_positions(text: &str, query: &str) -> Vec<usize> {
     if query.is_empty() {
         return Vec::new();
     }
-    let chars: Vec<(usize, char)> = text.char_indices().collect();
+    // (source byte offset, lowered char) — an expansion repeats its offset, so
+    // a window landing anywhere inside it still highlights the source char.
+    let lowered: Vec<(usize, char)> = text
+        .char_indices()
+        .flat_map(|(o, c)| c.to_lowercase().map(move |lc| (o, lc)))
+        .collect();
     let q: Vec<char> = query.chars().collect();
-    let (n, m) = (chars.len(), q.len());
+    let (n, m) = (lowered.len(), q.len());
     let mut positions = Vec::new();
     let mut i = 0;
     while i + m <= n {
-        let hit = (0..m).all(|k| chars[i + k].1.to_lowercase().eq(q[k].to_lowercase()));
-        if hit {
-            positions.extend((0..m).map(|k| chars[i + k].0));
+        if (0..m).all(|k| lowered[i + k].1 == q[k]) {
+            positions.extend((0..m).map(|k| lowered[i + k].0));
             i += m;
         } else {
             i += 1;
         }
     }
+    // Offsets are non-decreasing; expansions produce adjacent duplicates.
+    positions.dedup();
     positions
 }
 
@@ -1238,6 +1307,33 @@ mod tests {
         }
     }
 
+    /// A far jump under wrap (`G`-style: selection moved, scroll untouched)
+    /// converges in one pass: `converge_wrap_scroll` walks visual-row counts
+    /// backward from the selection instead of the build loop's
+    /// one-row-per-rebuild retry, and lands on the same invariant — the
+    /// selection's first visual row fits within the viewport height.
+    #[test]
+    fn converge_wrap_scroll_jumps_directly_to_the_selection() {
+        let mut state = demo_state_long();
+        state.wrap = true;
+        // Rows: FileHeader, HunkHeader, the 300-char line (row 2), then two
+        // short lines. At width 40 / num_w 2 the long line wraps to 10 visual
+        // rows, so with height 5 a selection on the last row (4) must scroll
+        // past it: rows 3+4 fill 2 of the 4 non-selection slots, row 2's 10
+        // don't fit → scroll = 3.
+        state.selected = state.rows.len() - 1;
+        state.scroll = 0;
+        converge_wrap_scroll(&mut state, 40, 2, 5);
+        assert_eq!(state.scroll, 3);
+
+        // A selection already in reach leaves scroll alone.
+        let mut near = demo_state_long();
+        near.wrap = true;
+        near.selected = 1;
+        converge_wrap_scroll(&mut near, 40, 2, 5);
+        assert_eq!(near.scroll, 0);
+    }
+
     /// Wrap expands a long line onto extra visual rows: several hitboxes share
     /// the same logical `index` (so a click on any wrapped row selects the whole
     /// line), and the tail of the line appears on a lower row.
@@ -1396,6 +1492,17 @@ mod tests {
         // No match → empty; empty query → empty.
         assert!(match_positions("abc", "z").is_empty());
         assert!(match_positions("abc", "").is_empty());
+    }
+
+    #[test]
+    fn match_positions_handles_multichar_lowercase_expansion() {
+        // `İ` (U+0130) lowers to two chars (`i` + U+0307). `search_matches`
+        // lowers rows with `str::to_lowercase`, so it counts this row as a hit
+        // for the lowered query — the highlighter must agree and mark the
+        // source char (one deduped offset, since both lowered chars share it).
+        let lowered = "\u{130}".to_lowercase(); // "i\u{307}"
+        let pos = match_positions("a\u{130}b", &lowered);
+        assert_eq!(pos, vec![1], "the single source char is highlighted once");
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -190,17 +190,6 @@ fn button_style(primary: bool) -> Style {
     }
 }
 
-/// Render a row of filled "pill" buttons (` label `, padded, on a solid accent
-/// or neutral selection fill) into the single-row `area`, returning one
-/// [`ButtonHit`] per *placed* button (index = position in `specs`). Buttons are
-/// separated by one space. When `right_align` is set the row is packed against
-/// the right edge of `area` (the convention for modal Save/Cancel and the global
-/// footer); otherwise it starts at the left edge.
-///
-/// Responsive by design: a button that would overflow `area` is dropped rather
-/// than wrapped or clipped mid-glyph, so a narrow footer simply shows fewer
-/// buttons. The solid fill (not brackets) is what marks each label as a
-/// clickable button.
 /// Paint a single filled pill button (` label `, padded, on the solid
 /// primary/secondary fill) into `rect` — the standalone form of the chips
 /// [`render_button_bar`] packs, for callers that own their own layout (e.g. the
@@ -220,6 +209,17 @@ pub fn render_pill(frame: &mut Frame, rect: Rect, label: &str, primary: bool) {
     );
 }
 
+/// Render a row of filled "pill" buttons (` label `, padded, on a solid accent
+/// or neutral selection fill) into the single-row `area`, returning one
+/// [`ButtonHit`] per *placed* button (index = position in `specs`). Buttons are
+/// separated by one space. When `right_align` is set the row is packed against
+/// the right edge of `area` (the convention for modal Save/Cancel and the global
+/// footer); otherwise it starts at the left edge.
+///
+/// Responsive by design: a button that would overflow `area` is dropped rather
+/// than wrapped or clipped mid-glyph, so a narrow footer simply shows fewer
+/// buttons. The solid fill (not brackets) is what marks each label as a
+/// clickable button.
 pub fn render_button_bar(
     frame: &mut Frame,
     area: Rect,
@@ -561,11 +561,6 @@ pub enum FocusLevel {
     Inactive,
 }
 
-/// Build a [`Block`] with tri-state focus styling.
-///
-/// Focus is communicated by colour (bright accent vs plain accent vs gray)
-/// rather than border weight — every level uses rounded borders for a
-/// softer, opencode-style chrome.
 /// The title text style for a pane at the given focus level — shared by
 /// [`focus_block`] and callers that render a pane title themselves (e.g. a
 /// right-aligned session-info title alongside the central-pane tab strip).
@@ -586,6 +581,11 @@ fn border_style_for(level: FocusLevel) -> Style {
     }
 }
 
+/// Build a [`Block`] with tri-state focus styling.
+///
+/// Focus is communicated by colour (bright accent vs plain accent vs gray)
+/// rather than border weight — every level uses rounded borders for a
+/// softer, opencode-style chrome.
 pub fn focus_block(title_text: &str, level: FocusLevel) -> Block<'_> {
     Block::default()
         .title(Line::from(Span::styled(title_text, title_style(level))))

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -33,7 +33,7 @@ fn workspace_dir(id: &str) -> io::Result<PathBuf> {
             "could not resolve workspaces directory",
         )
     })?;
-    let segment = sanitize_segment(id);
+    let segment = paths::sanitize_workspace_segment(id);
     if segment.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -56,7 +56,7 @@ pub fn ensure_workspace(id: &str, members: &[(String, PathBuf)]) -> io::Result<P
 
     let mut used: HashSet<String> = HashSet::new();
     for (name, target) in members {
-        let link_name = unique_link_name(name, &mut used);
+        let link_name = paths::unique_link_name(name, &mut used);
         let link_path = dir.join(&link_name);
         symlink(target, &link_path)?;
     }
@@ -135,43 +135,6 @@ fn symlink(target: &Path, link: &Path) -> io::Result<()> {
                 )))
             }
         }
-    }
-}
-
-/// Reduce a repo display name to a safe single path segment for a link name.
-fn sanitize_segment(name: &str) -> String {
-    let cleaned: String = name
-        .trim()
-        .chars()
-        .map(|c| match c {
-            '/' | '\\' | ':' => '-',
-            c if c.is_whitespace() => '-',
-            c => c,
-        })
-        .collect();
-    cleaned.trim_matches(['.', '-']).to_string()
-}
-
-/// Sanitize `name` and make it unique within `used` by appending `-2`, `-3`, …
-fn unique_link_name(name: &str, used: &mut HashSet<String>) -> String {
-    let base = {
-        let s = sanitize_segment(name);
-        if s.is_empty() {
-            "repo".to_string()
-        } else {
-            s
-        }
-    };
-    if used.insert(base.clone()) {
-        return base;
-    }
-    let mut n = 2;
-    loop {
-        let candidate = format!("{base}-{n}");
-        if used.insert(candidate.clone()) {
-            return candidate;
-        }
-        n += 1;
     }
 }
 
@@ -270,12 +233,5 @@ mod tests {
         let base = temp_base();
         let _g = TestPathGuard::new(&base);
         assert!(remove_workspace("never-made").is_ok());
-    }
-
-    #[test]
-    fn sanitize_strips_separators_and_dots() {
-        assert_eq!(sanitize_segment("a/b\\c:d"), "a-b-c-d");
-        assert_eq!(sanitize_segment("  .git  "), "git");
-        assert_eq!(sanitize_segment("my repo"), "my-repo");
     }
 }


### PR DESCRIPTION
## Summary

Fixes and cleanups from a review sweep of everything landed since v0.159.0:

- **DB integrity**: the v39 bookmark migration is now transactional with a `DROP TABLE IF EXISTS` prefix — a crash mid-rebuild (or an orphan `repo_bookmarks_v39` left by an already-shipped binary) can no longer make every subsequent DB open fail.
- **Remote status pipeline**: the per-tick hook-event drain uses `try_lock` so a slow host's background restore can't stall the UI thread (ADR-P7); events arriving before their session is adopted are parked and retried (capped, 120 s TTL) instead of dropped — so a `done` set while the TUI was closed survives restart; intra-batch dedup compares against the latest applied write, so a `working`→`done` pair in one batch can't leave the session spinning.
- **Remote spawn arg adaptation**: `rewrite_config_path_args` no longer pops a self-contained `--flag=value` token when stripping, and config-root/home prefix matches are boundary-checked (`~/.config/thurbox-backup` and `/home/abc` under home `/home/a` are left alone).
- **psmux**: `new-window -c`/`-n` values use the double-quote framing psmux's tokenizer parses (POSIX `'\''` arrives mangled on paths/names with apostrophes).
- **UI**: cancelling global search re-enforces feature visibility so the snapshot restore can't resurrect a feature-disabled panel; code review skips the O(chars) `max_line_width` scan on unscrolled frames, normalizes the search query identically for matcher and highlighter, converges wrap scroll in O(height), and derives every gutter consumer from one `gutter_width` helper.
- **Cleanups**: workspace sanitize/link-name helpers deduped into `paths`, the workspace build-or-fallback block into `session_ops`, psmux PowerShell quoting into `ps_single_quote`; dead `copy_file_to_remote` / `touch_repo_bookmark` removed; stale and spliced doc comments fixed.

## Test plan

- 5 new tests: park-and-retry + intra-batch drain acceptance tests, v39 crash-recovery migration test, `match_positions` multi-char-expansion test, `converge_wrap_scroll` unit test
- Full suite green post-rebase (1741 tests), clippy/fmt/deny/doc hooks all passed on commit
- CI checks pass