### PR TITLE
fix(core): stop wsl.exe chdir mangling from breaking worktree spawns

### DIFF
--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -207,23 +207,19 @@ mod tests {
         let cmd = t.tmux_command("thurbox", &["has-session", "-t", "thurbox"]);
         let (prog, args) = program_and_args(&cmd);
         assert_eq!(prog, "wsl.exe");
-        assert_eq!(
-            args,
-            [
-                "-d",
-                "Ubuntu",
-                "tmux",
-                "-L",
-                "thurbox",
-                "has-session",
-                "-t",
-                "thurbox",
-            ]
-        );
-        // A Unix caller pins the child cwd to `/` (see `shell::wsl_command`)
-        // so wsl.exe doesn't inherit a caller cwd missing from the distro.
+        // A Unix caller passes `--cd /` (see `shell::wsl_command`) so wsl.exe
+        // doesn't inherit a caller cwd missing from — or mangled into — the
+        // target distro.
         #[cfg(unix)]
-        assert_eq!(cmd.get_current_dir(), Some(std::path::Path::new("/")));
+        let prefix: &[&str] = &["-d", "Ubuntu", "--cd", "/"];
+        #[cfg(not(unix))]
+        let prefix: &[&str] = &["-d", "Ubuntu"];
+        let expected: Vec<&str> = prefix
+            .iter()
+            .copied()
+            .chain(["tmux", "-L", "thurbox", "has-session", "-t", "thurbox"])
+            .collect();
+        assert_eq!(args, expected);
     }
 
     #[test]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1712,25 +1712,20 @@ mod tests {
         );
         let (prog, args) = program_and_args(&cmd);
         assert_eq!(prog, "wsl.exe");
-        assert_eq!(
-            args,
-            [
-                "-d",
-                "Ubuntu",
-                "git",
-                "-C",
-                "/home/me/repo",
-                "worktree",
-                "add",
-                "-b",
-                "x",
-            ]
-        );
-        // A Unix caller pins the child cwd to `/` so wsl.exe doesn't inherit
-        // (and fail to chdir to) a caller cwd missing from the target distro.
+        // A Unix caller passes `--cd /` so wsl.exe doesn't inherit (or mangle,
+        // via a prefix-sibling distro name) a caller cwd missing from the
+        // target distro — see `shell::wsl_command`.
         #[cfg(unix)]
-        assert_eq!(cmd.get_current_dir(), Some(Path::new("/")));
-        #[cfg(windows)]
+        let prefix: &[&str] = &["-d", "Ubuntu", "--cd", "/"];
+        #[cfg(not(unix))]
+        let prefix: &[&str] = &["-d", "Ubuntu"];
+        let expected: Vec<&str> = prefix
+            .iter()
+            .copied()
+            .chain(["git", "-C", "/home/me/repo", "worktree", "add", "-b", "x"])
+            .collect();
+        assert_eq!(args, expected);
+        // The child cwd is left to the OS default; `--cd` is the control.
         assert_eq!(cmd.get_current_dir(), None);
     }
 
@@ -1744,17 +1739,16 @@ mod tests {
         let cmd = host_shell_c(&h, "mkdir -p /a && ln -s /b /a/b");
         let (prog, args) = program_and_args(&cmd);
         assert_eq!(prog, "wsl.exe");
-        assert_eq!(
-            args,
-            [
-                "-d",
-                "Ubuntu",
-                "-e",
-                "sh",
-                "-c",
-                "mkdir -p /a && ln -s /b /a/b"
-            ]
-        );
+        #[cfg(unix)]
+        let prefix: &[&str] = &["-d", "Ubuntu", "--cd", "/"];
+        #[cfg(not(unix))]
+        let prefix: &[&str] = &["-d", "Ubuntu"];
+        let expected: Vec<&str> = prefix
+            .iter()
+            .copied()
+            .chain(["-e", "sh", "-c", "mkdir -p /a && ln -s /b /a/b"])
+            .collect();
+        assert_eq!(args, expected);
     }
 
     #[test]
@@ -1781,7 +1775,16 @@ mod tests {
         let cmd = list_dir_command(&h, "/home/me/repos");
         let (prog, args) = program_and_args(&cmd);
         assert_eq!(prog, "wsl.exe");
-        assert_eq!(args, ["-d", "Ubuntu", "-e", "ls", "-1p", "/home/me/repos"]);
+        #[cfg(unix)]
+        let prefix: &[&str] = &["-d", "Ubuntu", "--cd", "/"];
+        #[cfg(not(unix))]
+        let prefix: &[&str] = &["-d", "Ubuntu"];
+        let expected: Vec<&str> = prefix
+            .iter()
+            .copied()
+            .chain(["-e", "ls", "-1p", "/home/me/repos"])
+            .collect();
+        assert_eq!(args, expected);
         // No `sh -c` (the broken form) anywhere.
         assert!(
             !args.iter().any(|a| a == "-c"),

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -62,12 +62,19 @@ pub fn ssh_command(destination: &str, ssh_opts: &[String]) -> Command {
 /// runs inside *another* WSL distro (the caller's cwd, e.g. `/home/me/repo`,
 /// doesn't exist on the target). That failure prints a `WSL Relay ERROR:
 /// CreateProcessCommon chdir(...) failed` on stderr and corrupts the tmux
-/// control-mode handshake, so the agent window never launches. So on a Unix
-/// caller the child's cwd is pinned to `/` — a landing dir every distro has —
+/// control-mode handshake, so the agent window never launches.
+///
+/// A Unix caller therefore passes `--cd /` (a landing dir every distro has),
 /// which is safe because every caller overrides the real working dir anyway
-/// (`git -C <path>`, tmux `new-window -c <path>`). Pinning the *caller* cwd
-/// (rather than passing `--cd /`) works on every `wsl.exe`; `--cd` is absent
-/// from the Windows 10 inbox build, which aborts on unknown flags. A native
+/// (`git -C <path>`, tmux `new-window -c <path>`). We use `--cd /` rather than
+/// only pinning the child's `current_dir("/")`: when the caller distro's name
+/// is a **prefix of a sibling distro** (e.g. calling into `MagicDebian` from a
+/// host that also has `MagicDebianPerso`), `wsl.exe`'s cwd back-translation
+/// mangles the pinned path into `<sibling-suffix>` + cwd — producing
+/// `chdir(Perso/home/…)` — so `current_dir("/")` alone does *not* suppress the
+/// error. `--cd /` bypasses that translation entirely. `--cd` is a Store/WSL2
+/// flag; the Unix-caller case is always WSL2 (thurbox is running inside a
+/// distro), so the legacy Windows-10-inbox concern doesn't apply here. A native
 /// Windows caller keeps the inherit behavior (its `C:\…` cwd maps to
 /// `/mnt/c/…` under default automount; there is no universally-valid Windows
 /// pin, and `--cd` would trade this edge case for a hard legacy failure).
@@ -75,7 +82,7 @@ pub fn wsl_command(distro: &str) -> Command {
     let mut cmd = Command::new("wsl.exe");
     cmd.arg("-d").arg(distro);
     #[cfg(unix)]
-    cmd.current_dir("/");
+    cmd.arg("--cd").arg("/");
     cmd
 }
 
@@ -116,14 +123,17 @@ mod tests {
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
-        assert_eq!(args, ["-d", "Ubuntu"]);
-        // A Unix caller pins its cwd to `/` so wsl.exe doesn't inherit (and
-        // fail to chdir to) a caller cwd that doesn't exist in the target
-        // distro. Done via the child cwd — not `--cd`, which legacy wsl.exe
-        // rejects.
+        // A Unix caller passes `--cd /` so wsl.exe doesn't inherit (and fail to
+        // chdir to) a caller cwd that doesn't exist in the target distro.
+        // Pinning only the child cwd is insufficient — wsl.exe back-translates
+        // it through the caller-distro name and, with a prefix-sibling distro,
+        // yields a mangled `chdir(<suffix>/…)`; `--cd /` bypasses that.
         #[cfg(unix)]
-        assert_eq!(cmd.get_current_dir(), Some(std::path::Path::new("/")));
+        assert_eq!(args, ["-d", "Ubuntu", "--cd", "/"]);
         #[cfg(windows)]
+        assert_eq!(args, ["-d", "Ubuntu"]);
+        // The child cwd is left to the OS default; the translation control is
+        // the `--cd` flag, not the caller's process cwd.
         assert_eq!(cmd.get_current_dir(), None);
     }
 }


### PR DESCRIPTION
## Summary

- WSL worktree sessions silently failed to appear when two local distros share a name prefix (e.g. `MagicDebian` and `MagicDebianPerso`).
- Root cause: `shell::wsl_command` pinned the child cwd to `/` to avoid `wsl.exe` chdir'ing into a caller path missing from the target distro. But `wsl.exe` back-translates that pinned cwd through the caller distro name, and a prefix-sibling confuses it into a mangled `chdir(Perso/home/…)` that still fails — corrupting the tmux control-mode handshake, so `git worktree add` returns garbled output, no worktree row is persisted, and the session never renders.
- Fix: pass `--cd /` (a WSL2 flag that bypasses cwd back-translation) instead of the ineffective `current_dir("/")` pin, gated to Unix callers (the only case that hits this bug, and always WSL2 — so the legacy Windows-10-inbox `--cd` concern doesn't apply).
- Updated the `wsl_command` doc comment explaining the prefix-sibling trap, and the arg-list assertions in `shell.rs`, `agent/transport.rs`, and `git/mod.rs`.

## Test plan

- [x] Reproduced the `chdir(Perso/…)` error on a real `MagicDebian`/`MagicDebianPerso` host; confirmed `--cd /` eliminates it.
- [x] Ran a real `git worktree add -b … main` for a repo on `MagicDebian` through the fixed command shape — clean, no error, worktree created and torn down.
- [x] `cargo nextest run --all` — 1741 passed, 0 failed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --check`, architecture rules — pass.