### PR TITLE
fix(ui): never highlight repo-group header with its session row

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8718,12 +8718,23 @@ mod tests {
         app.update(AppMessage::MouseMove { x: row.x, y: row.y });
         terminal.draw(|f| app.view(f)).unwrap();
 
+        // The first session's hitbox spans its prepended repo-group header plus
+        // the session line; the tint must land on the session line (the bottom
+        // row) and spare the header. `row.y` is the header row for a group's
+        // first session.
+        let session_y = row.y + row.height - 1;
         let band = crate::ui::theme::Theme::selection_bg();
         let buffer = terminal.backend().buffer();
         assert_eq!(
+            buffer[(row.x, session_y)].bg,
+            band,
+            "hovered session line must get the selection_bg band"
+        );
+        // The repo-group header above the session line is never tinted.
+        assert_ne!(
             buffer[(row.x, row.y)].bg,
             band,
-            "hovered row cell must get the selection_bg band"
+            "repo-group header must not get the hover band"
         );
         // A cell outside any clickable row keeps its non-band background.
         assert_ne!(buffer[(0, 0)].bg, band);

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -39,6 +39,21 @@ struct CentralTabCell {
     active: bool,
 }
 
+/// The rect to paint a hover tint over, given a click target's hitbox.
+///
+/// A session row's hitbox spans a prepended repo-group header line plus the
+/// session line itself (2 rows for a group's first session), so tinting the
+/// whole rect would bleed onto the header. The header is always first and the
+/// session line always last, so a multi-line session hitbox tints only its last
+/// row. Every other target (single-line rows, buttons) tints its full rect.
+fn hover_tint_rect(hitbox: Rect, is_session: bool) -> Rect {
+    if is_session && hitbox.height > 1 {
+        Rect::new(hitbox.x, hitbox.y + hitbox.height - 1, hitbox.width, 1)
+    } else {
+        hitbox
+    }
+}
+
 impl App {
     pub fn view(&mut self, frame: &mut Frame) {
         self.metrics.bump(|p| &mut p.frames_rendered);
@@ -152,7 +167,8 @@ impl App {
             Theme::selection_bg()
         };
         let buf = frame.buffer_mut();
-        let rect = target.rect;
+        let is_session = matches!(target.action, ClickAction::SelectSession(_));
+        let rect = hover_tint_rect(target.rect, is_session);
         for y in rect.y..rect.y + rect.height {
             for x in rect.x..rect.x + rect.width {
                 if let Some(cell) = buf.cell_mut(ratatui::layout::Position::new(x, y)) {
@@ -1851,5 +1867,28 @@ mod tests {
     #[test]
     fn truncate_str_empty() {
         assert_eq!(truncate_str("", 5), "");
+    }
+
+    // --- hover_tint_rect (repo-group header must never be tinted) ---
+
+    #[test]
+    fn hover_tint_skips_group_header_on_multiline_session() {
+        // A group's first session is a 2-row hitbox (header + session line);
+        // the tint must land on the bottom row only, sparing the header.
+        let hitbox = Rect::new(1, 5, 28, 2);
+        assert_eq!(hover_tint_rect(hitbox, true), Rect::new(1, 6, 28, 1));
+    }
+
+    #[test]
+    fn hover_tint_covers_single_line_session() {
+        let hitbox = Rect::new(1, 7, 28, 1);
+        assert_eq!(hover_tint_rect(hitbox, true), hitbox);
+    }
+
+    #[test]
+    fn hover_tint_covers_full_rect_for_non_session_targets() {
+        // Buttons / other rows keep their whole rect even when multi-line.
+        let hitbox = Rect::new(1, 5, 28, 2);
+        assert_eq!(hover_tint_rect(hitbox, false), hitbox);
     }
 }

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -637,12 +637,9 @@ fn render_session_section(
     // Available width inside the block (subtract 2 for borders)
     let inner_width = area.width.saturating_sub(2) as usize;
 
-    // Header row that each row belongs to, so a group's header highlights
-    // whenever *any* of its members is the active row — not just the first.
+    // The header row each row belongs to, used to roll each group's members up
+    // to a single status dot on the header below.
     let group_of = header_group_of(headers);
-    let active_group = show_selection
-        .then(|| group_of.get(active_index).copied())
-        .flatten();
 
     // Roll each repo group up to its most-urgent member status, keyed by the
     // group's header row index, so the header shows a single dot you can scan.
@@ -690,15 +687,11 @@ fn render_session_section(
             )];
 
             // Prepend a subtle repo-group header above the first session of
-            // each group. The header is highlighted when the active row lives
-            // anywhere in its group.
+            // each group. The header carries the group's rolled-up status dot
+            // but never reflects selection (that stays on the session rows).
             if let Some(Some(label)) = headers.get(i) {
-                let selected = active_group == Some(i);
                 let rollup = group_rollup.get(&i).copied().unwrap_or(info.status);
-                item_lines.insert(
-                    0,
-                    group_header_line(label, rollup, inner_width, selected, spinner),
-                );
+                item_lines.insert(0, group_header_line(label, rollup, inner_width, spinner));
             }
 
             item_heights.push(item_lines.len() as u16);
@@ -711,7 +704,7 @@ fn render_session_section(
     // because `highlight_style` patches the whole item area, which for a row
     // that carries a prepended repo-group header would bleed the background up
     // onto that header. Painting it in the row keeps the highlight to the
-    // session line only; the header gets a text-colour change instead.
+    // session line only; the header stays muted regardless of selection.
     let list = List::new(items).block(block);
 
     list_state.select(show_selection.then_some(active_index));
@@ -765,9 +758,8 @@ fn render_empty_sessions(frame: &mut Frame, area: Rect, block: ratatui::widgets:
 }
 
 /// For each row, the index of the group header row it belongs to. Lets a group's
-/// header highlight whenever *any* member row is the active one, not just the
-/// group's first row. Rows before the first header map to row 0, which is
-/// harmless since those rows carry no header.
+/// members roll up to a single status dot on their header. Rows before the first
+/// header map to row 0, which is harmless since those rows carry no header.
 fn header_group_of(headers: &[Option<String>]) -> Vec<usize> {
     let mut out = Vec::with_capacity(headers.len());
     let mut current = 0;
@@ -781,23 +773,16 @@ fn header_group_of(headers: &[Option<String>]) -> Vec<usize> {
 }
 
 /// A full-width repo-group header: `● ── label ──────────`. The leading dot is
-/// the group's rolled-up most-urgent status; the label is muted by default and
-/// switches to an accent text colour (no background) when the active row is in
-/// its group, so the selection background stays on the session row alone.
+/// the group's rolled-up most-urgent status; the label is always muted. The
+/// header never reflects selection — highlighting belongs to the session rows
+/// alone, so selecting a group's first row must not light up its header.
 fn group_header_line(
     label: &str,
     rollup: SessionStatus,
     inner_width: usize,
-    selected: bool,
     spinner: &str,
 ) -> Line<'static> {
-    // Active group: a text-colour change only (accent + bold), never the full
-    // selection background — that belongs to the session row, not its header.
-    let style = if selected {
-        Theme::selected_item()
-    } else {
-        Style::default().fg(Theme::text_muted())
-    };
+    let style = Style::default().fg(Theme::text_muted());
     let dot = format!("{} ", super::status_glyph(rollup, spinner));
     let mut text = format!("\u{2500}\u{2500} {label} ");
     let used = dot.chars().count() + text.chars().count();
@@ -1419,20 +1404,13 @@ mod tests {
     }
 
     #[test]
-    fn selected_group_header_changes_text_colour_without_background() {
-        let line = group_header_line("repo", SessionStatus::Idle, WIDE, true, "◐");
-        // No background tint anywhere — only a text-colour change on the label.
-        assert!(line.spans.iter().all(|sp| sp.style.bg.is_none()));
-        let label = &line.spans[1];
-        assert_eq!(label.style.fg, Some(Theme::accent()));
-        assert!(label.style.add_modifier.contains(Modifier::BOLD));
-    }
-
-    #[test]
-    fn unselected_group_header_is_muted_without_background() {
-        let line = group_header_line("repo", SessionStatus::Idle, WIDE, false, "◐");
+    fn group_header_is_always_muted_without_background() {
+        // The header never reflects selection: selecting a group's first row
+        // must not light up its header. Always muted, never a background tint.
+        let line = group_header_line("repo", SessionStatus::Idle, WIDE, "◐");
         assert!(line.spans.iter().all(|sp| sp.style.bg.is_none()));
         assert_eq!(line.spans[1].style.fg, Some(Theme::text_muted()));
+        assert!(!line.spans[1].style.add_modifier.contains(Modifier::BOLD));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The repo-group header renders above each group's first session and shares that session row's hitbox (a 2-line item). Selecting or hovering that first row was bleeding the highlight onto the header, while other rows in the group were not — the header should never be highlighted.
- **Keyboard selection:** removed the header's active-group accent/bold styling; `group_header_line` now always renders muted and no longer takes a `selected` flag.
- **Mouse hover:** `apply_hover_highlight` painted the tint over the whole hitbox; extracted a pure `hover_tint_rect` helper that restricts a multi-line session row's tint to its own (bottom) line, sparing the prepended header.
- Refreshed the stale comments that still described the removed highlight behavior.

## Test plan

- `cargo build --bin thurbox` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- New unit tests: `hover_tint_rect` (multi-line session skips header, single-line covers fully, non-session covers full rect); reworked `group_header_is_always_muted_without_background`
- `cargo nextest run` for `project_list` + `app::view` — 91/91 pass
- Manual: select/hover a group's first session — header stays muted