### PR TITLE
feat(ui): clearer remote-session marker in session list

### DIFF
--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -119,12 +119,12 @@ fn append_session_section<'a>(
             ),
         ]));
     }
-    // Remote host (ssh:<host>); omitted entirely for local sessions.
+    // Remote host (ssh:/wsl:); omitted entirely for local sessions.
     if let Some(host) = info.remote_host.as_deref() {
         lines.push(Line::from(vec![
             Span::styled("Host:  ", Theme::label()),
             Span::styled(
-                format!("\u{2601} {host}"),
+                format!("\u{21c5} {host}"),
                 Style::default().fg(Theme::accent()),
             ),
         ]));

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -878,11 +878,12 @@ fn push_prefix_marks(
         spans.push(Span::styled("\u{21b3} ", tree_style));
     }
 
-    // Remote (ssh:<host>) sessions get a cloud mark so it's clear at a glance
-    // the agent runs on another machine. Sits right after the status dot.
+    // Remote (ssh:/wsl:) sessions get a remote-link mark so it's clear at a
+    // glance the agent runs on another machine. Sits right after the status
+    // dot; two trailing spaces keep it off the session name.
     if info.remote_host.is_some() {
         spans.push(Span::styled(
-            "\u{2601} ",
+            "\u{21c5}  ",
             mark_style(is_dimmed, Theme::accent),
         ));
     }
@@ -1323,14 +1324,14 @@ mod tests {
         let mut s = info("remote");
         s.remote_host = Some("devbox".to_string());
         let line = build_session_line(&s, None, false, false, 0, false, WIDE, "◐");
-        assert!(line_text(&line).contains('\u{2601}'));
+        assert!(line_text(&line).contains('\u{21c5}'));
     }
 
     #[test]
     fn line_no_remote_glyph_for_local_session() {
         let s = info("local");
         let line = build_session_line(&s, None, false, false, 0, false, WIDE, "◐");
-        assert!(!line_text(&line).contains('\u{2601}'));
+        assert!(!line_text(&line).contains('\u{21c5}'));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Swap the cloud glyph (☁) for a remote-link glyph (⇅) on remote sessions in the session list. A cloud read as "cloud provider", which is misleading — these are just SSH hosts / local WSL distros.
- Add two-space separation between the marker and the session name so it no longer crowds the name.
- Apply the same glyph at both render sites — the session-list prefix mark (`src/ui/project_list.rs`) and the info-panel `Host:` row (`src/ui/info_panel.rs`) — and correct the nearby comments from `ssh:<host>` to `ssh:/wsl:` (the marker covers WSL sessions too).

Result: the list shows `○ ⇅  my-session` and the F2 info panel shows `Host: ⇅ devbox`.

## Test plan

- `cargo build --bin thurbox` — compiles clean.
- `cargo nextest run --all` — full suite green (1742 passed), including the two updated `line_shows_remote_glyph…` / `line_no_remote_glyph…` assertions.
- Manual eyeball via `scripts/dev/sandbox.sh` (configured SSH/WSL host) or the podman e2e (`scripts/dev/remote-ssh-test.sh up` + a session on `ssh:podman`): confirm the list and info panel render the new glyph with a clear gap.