### PR TITLE
feat(ui): copy the status-bar message with Ctrl+C or a click

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1840,7 +1840,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 |-----|--------|----------|
 | `Ctrl+Q` | Quit (detach sessions) | **Q**uit |
 | `Ctrl+N` | New session (opens repo picker) | **N**ew |
-| `Ctrl+C` | Copy selection / SIGINT (terminal) | **C**opy |
+| `Ctrl+C` | Copy selection, else status message; SIGINT in a focused terminal | **C**opy |
 | `Ctrl+V` | Paste from clipboard | Paste |
 | `Ctrl+P` | Automations (list/new/edit/toggle/run/delete) | **P**rogram |
 | `Ctrl+W` / `F5` | Toggle tasks panel (todo list) | Work items |

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -1164,6 +1164,67 @@ fn global_search_returns_results_for_a_session_query() {
     );
 }
 
+#[test]
+fn ctrl_c_in_a_focused_terminal_preserves_sigint_over_status_copy() {
+    // Ctrl+C copies the status message only in non-PTY panes. In a focused
+    // terminal it must still fall through to SIGINT — so the status-copy path is
+    // skipped and the shown message is left untouched (deterministic: no
+    // clipboard call). The status row stays reachable by mouse click there.
+    let mut h = Harness::standard(1);
+    h.app.focus = InputFocus::Terminal;
+    h.app.set_error("boom");
+
+    h.ctrl('c'); // Copy — no selection, terminal-focused → SIGINT, not a copy
+
+    let msg = h.app.status_message.as_ref().expect("message still shown");
+    assert_eq!(
+        msg.text, "boom",
+        "terminal Ctrl+C leaves the status message intact (SIGINT, no copy)"
+    );
+}
+
+#[test]
+fn ctrl_c_outside_a_terminal_copies_the_status_message() {
+    // In a non-PTY pane Ctrl+C (no selection) runs the status-copy path. Every
+    // branch of `copy_status_to_clipboard` overwrites the toast (copied /
+    // unavailable / write-error), so the original message no longer stands —
+    // deterministic regardless of whether a clipboard exists on the runner.
+    let mut h = Harness::standard(1);
+    h.app.focus = InputFocus::SessionList;
+    h.app.set_error("boom");
+
+    h.ctrl('c'); // Copy — no selection, non-terminal → copy the status message
+
+    let msg = h
+        .app
+        .status_message
+        .as_ref()
+        .expect("a toast is still shown");
+    assert_ne!(
+        msg.text, "boom",
+        "the copy path fired and replaced the original message with its result"
+    );
+}
+
+#[test]
+fn status_message_row_records_a_click_to_copy_target() {
+    // The status row is click-to-copy: whenever a message is shown, its rect is
+    // registered as a `CopyStatus` hitbox so a mouse click pulls the text out.
+    let mut h = Harness::standard(1);
+    h.app.set_info("something worth copying");
+    h.render();
+
+    let has_target = h
+        .app
+        .click_targets
+        .iter()
+        .any(|t| matches!(t.action, ClickAction::CopyStatus));
+    assert!(
+        has_target,
+        "a shown status message registers a CopyStatus click target"
+    );
+}
+
 // ── Spawn-dependent flows (fake backend, real Tokio I/O wiring) ───────────────
 
 #[tokio::test]

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1139,11 +1139,13 @@ impl App {
         Some(consumed)
     }
 
-    /// Clipboard actions (Copy/Paste). Copy only consumes the key when there's a
-    /// selection; otherwise it yields (false) so the terminal can send SIGINT.
-    /// Paste is normally intercepted earlier (so it reaches modal text inputs);
-    /// this path covers the plain-terminal case. Returns `Some(consumed)` when
-    /// `action` is one of these, else `None`.
+    /// Clipboard actions (Copy/Paste). Copy prefers the active selection; with no
+    /// selection it copies the current status-bar message — except in a focused
+    /// terminal (agent or shell), where it yields (false) so the PTY still gets
+    /// SIGINT and the status row stays click-to-copy. Paste is normally
+    /// intercepted earlier (so it reaches modal text inputs); this path covers
+    /// the plain-terminal case. Returns `Some(consumed)` when `action` is one of
+    /// these, else `None`.
     fn dispatch_clipboard_action(&mut self, action: crate::session::Action) -> Option<bool> {
         use crate::session::Action;
         let consumed = match action {
@@ -1151,8 +1153,16 @@ impl App {
                 if self.text_selection.is_some() {
                     self.copy_selection_to_clipboard();
                     true
+                } else if !matches!(self.focus, InputFocus::Terminal)
+                    && self.status_message.is_some()
+                {
+                    // A non-PTY pane: Ctrl+C has no other meaning, so copy the
+                    // status message. In a focused terminal we fall through to
+                    // SIGINT (below) instead.
+                    self.copy_status_to_clipboard();
+                    true
                 } else {
-                    false // no selection → let the terminal send SIGINT
+                    false // terminal → SIGINT; elsewhere with no status → no-op
                 }
             }
             Action::Paste => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -477,6 +477,9 @@ pub(crate) enum ClickAction {
     /// Select a central-pane view from the tab strip in the pane's top border
     /// (Agent / Shell / Review). Dispatched by `activate_click_target`.
     CentralTab(CentralTab),
+    /// Copy the current status-bar message to the clipboard (click the status
+    /// row). Dispatched by `activate_click_target`.
+    CopyStatus,
 }
 
 /// One clickable region rendered this frame: its rect plus what a click on it
@@ -2616,6 +2619,10 @@ impl App {
                 self.select_central_tab(tab);
                 true
             }
+            ClickAction::CopyStatus => {
+                self.copy_status_to_clipboard();
+                true
+            }
         }
     }
 
@@ -2998,6 +3005,33 @@ impl App {
         self.text_selection = None;
         self.selected_text_cache = None;
         self.set_status(StatusLevel::Info, "Copied to clipboard");
+    }
+
+    /// Copy the current status-bar message (info / error / …) to the clipboard.
+    /// Reachable via `Copy` (Ctrl+C, outside a focused terminal) or by clicking
+    /// the status row — so a stray error/path can be pulled out of the TUI to
+    /// paste elsewhere. A no-op (no toast) when nothing is shown.
+    fn copy_status_to_clipboard(&mut self) {
+        let Some(text) = self
+            .status_message
+            .as_ref()
+            .map(|m| m.text.clone())
+            .filter(|t| !t.is_empty())
+        else {
+            return; // nothing shown → no-op (no "copied" toast to overwrite it)
+        };
+
+        let Some(clipboard) = &mut self.clipboard else {
+            self.set_error("Clipboard not available");
+            return;
+        };
+
+        if let Err(e) = clipboard.set_text(&text) {
+            self.set_error(format!("Clipboard write failed: {e}"));
+            return;
+        }
+
+        self.set_status(StatusLevel::Info, "Status message copied to clipboard");
     }
 
     /// Wrap text in bracketed paste escape sequences and send it to the

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -91,6 +91,12 @@ impl App {
         }
         if let Some(status_area) = areas.status_message {
             status_bar::render_status_message_row(frame, status_area, &self.footer_state());
+            // Click the status row to copy its message (the row is only carved
+            // when there's something to show). Recorded only when a real message
+            // is present, not the transient sync spinner.
+            if self.status_message.is_some() {
+                self.record_click(status_area, ClickAction::CopyStatus);
+            }
         }
         self.render_footer(frame, areas.footer);
         self.render_modals(frame);
@@ -139,6 +145,7 @@ impl App {
                         | ClickAction::ReviewTarget(_)
                         | ClickAction::CentralTab(_)
                         | ClickAction::PaneField { .. }
+                        | ClickAction::CopyStatus
                 )
             };
             reachable && t.rect.contains(pos)

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -53,8 +53,9 @@ pub enum Action {
     GlobalSearch,
     /// Open the Settings panel (view/edit settings.toml in the TUI).
     OpenSettings,
-    /// Copy the active mouse selection (falls through to terminal SIGINT when
-    /// there is no selection).
+    /// Copy the active mouse selection. With no selection it copies the current
+    /// status-bar message instead — except in a focused terminal, where it falls
+    /// through to SIGINT (the status row stays click-to-copy there).
     Copy,
     /// Paste the clipboard into the focused text input / terminal.
     Paste,
@@ -216,7 +217,7 @@ impl Action {
             Action::FocusTasks => "Tasks",
             Action::GlobalSearch => "Global search",
             Action::OpenSettings => "Settings",
-            Action::Copy => "Copy selection",
+            Action::Copy => "Copy selection / status",
             Action::Paste => "Paste",
             Action::SessionListNext => "Next item",
             Action::SessionListPrev => "Previous item",


### PR DESCRIPTION
## Summary

- With no active mouse selection, `Ctrl+C` now copies the current status/error message to the clipboard from any non-terminal pane.
- In a **focused terminal** (agent or shell), `Ctrl+C` still falls through to SIGINT — so interrupting an agent is unchanged.
- The status row is also **click-to-copy**, so the message can be grabbed by mouse even while a terminal is focused.

## Test plan

- New acceptance tests: terminal `Ctrl+C` preserves SIGINT (status untouched), non-terminal `Ctrl+C` runs the copy path, and the status row registers a click-to-copy hitbox.
- CI checks pass (fmt, clippy, nextest, architecture, deny, doc, markdown).