### PR TITLE
ci: run the suite on merge_group for the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,20 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # The merge queue re-runs the full suite against the temporary
+  # `gh-readonly-queue/*` branch (PR rebased onto main). Without this trigger the
+  # required "All Checks" gate never reports on a queued PR and it stalls until
+  # the queue's check timeout, so the queue *needs* this to merge anything.
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
 # Cancel a superseded run when a new commit is pushed to the same PR, so rapid
-# re-pushes don't pile up parallel runs of the (heavy) Rust matrix.
+# re-pushes don't pile up parallel runs of the (heavy) Rust matrix. Each merge
+# queue entry gets a distinct `github.ref`, so queued runs never cancel each
+# other.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -24,16 +31,24 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      rust: ${{ steps.filter.outputs.rust }}
-      shell: ${{ steps.filter.outputs.shell }}
-      markdown: ${{ steps.filter.outputs.markdown }}
-      website: ${{ steps.filter.outputs.website }}
-      install_sh: ${{ steps.filter.outputs.install_sh }}
-      install_ps: ${{ steps.filter.outputs.install_ps }}
+      rust: ${{ steps.filter.outputs.rust || steps.all.outputs.all }}
+      shell: ${{ steps.filter.outputs.shell || steps.all.outputs.all }}
+      markdown: ${{ steps.filter.outputs.markdown || steps.all.outputs.all }}
+      website: ${{ steps.filter.outputs.website || steps.all.outputs.all }}
+      install_sh: ${{ steps.filter.outputs.install_sh || steps.all.outputs.all }}
+      install_ps: ${{ steps.filter.outputs.install_ps || steps.all.outputs.all }}
     steps:
+      # A merge queue entry already contains exactly the PR's changes; validate
+      # the whole suite against it rather than diffing (paths-filter has no PR
+      # base on a `merge_group` event). Every filter output falls back to this.
+      - id: all
+        if: github.event_name == 'merge_group'
+        run: echo "all=true" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        if: github.event_name == 'pull_request'
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
+        if: github.event_name == 'pull_request'
         with:
           # Every filter includes `.github/workflows/ci.yml` so editing the
           # workflow re-runs all jobs — any job's definition may have changed.


### PR DESCRIPTION
Prerequisite for enabling a **merge queue** on `main` (linear history is already enforced).

## Why
The `protect-main-branch` ruleset requires the **All Checks** status check. A merge queue validates each PR against a temporary `gh-readonly-queue/*` branch via the `merge_group` event. CI currently only triggers on `pull_request`, so without this change queued PRs would get **no status report** and stall until the queue's check timeout — merges would break, not speed up.

## Change
- Add a `merge_group` trigger to `ci.yml`.
- On a merge group the `changes` job skips `paths-filter` (there is no PR base to diff) and runs the **full** suite against the queued branch. `conventional-commits` stays `pull_request`-only (skipped ⇒ success).

## Next step (after this merges)
Enable the merge queue on the `protect-main-branch` ruleset with the **rebase** merge method (matches the repo's rebase-only, signed, linear-history policy).