### PR TITLE
refactor: group dev e2e harnesses under e2e/, share a common lib (#740 Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,9 @@ Windows VM, `real-host.sh` = a machine you own) sharing one sourced library,
 extractor (**no `python3`**), the `hosts_block` `[[hosts]]` emitter, and the
 `session create → get → assert` core (`e2e_create_and_get`/`e2e_assert`). The TUI
 smoke test lives at `scripts/dev/smoke/tui-smoke.sh`. `scripts/dev/README.md` is
-the newcomer index (which script for which job). Thin compatibility shims remain
-at the old flat paths (`remote-ssh-test.sh`/`windows-test.sh`/`lab-test.sh`/
-`tui-smoke-test.sh`) and forward to the new locations.
+the newcomer index (which script for which job) and carries the old→new path
+map (the flat `remote-ssh-test.sh`/`windows-test.sh`/`lab-test.sh`/
+`tui-smoke-test.sh` names were renamed, not kept as shims).
 
 ## Performance (render loop)
 

--- a/scripts/dev/README.md
+++ b/scripts/dev/README.md
@@ -52,8 +52,8 @@ Every e2e harness ends on a single line: `PASS <message>` (green, exit 0) or
 
 ## Moved paths
 
-These entrypoints were renamed; thin shims at the old paths still forward (and
-print a note). Update references to the new paths:
+These entrypoints were renamed (the old flat paths no longer exist). Update any
+references:
 
 | Old | New |
 |---|---|

--- a/scripts/dev/lab-test.sh
+++ b/scripts/dev/lab-test.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# Moved: scripts/dev/lab-test.sh → scripts/dev/e2e/real-host.sh
-# Thin compatibility shim (kept for muscle memory / external notes).
-# See scripts/dev/README.md.
-set -euo pipefail
-here="$(cd "$(dirname "$0")" && pwd)"
-printf '\033[1;33mnote:\033[0m lab-test.sh moved to e2e/real-host.sh — please update your reference.\n' >&2
-exec "$here/e2e/real-host.sh" "$@"

--- a/scripts/dev/lib/sandbox-env.sh
+++ b/scripts/dev/lib/sandbox-env.sh
@@ -16,7 +16,7 @@
 #                           Used by the demo recorder + TUI smoke test.
 #
 # Source it (don't execute) AFTER setting REPO_ROOT (or TBX_REPO_ROOT). Written
-# in POSIX sh so both bash callers (sandbox.sh, tui-smoke-test.sh) and the
+# in POSIX sh so both bash callers (sandbox.sh, smoke/tui-smoke.sh) and the
 # /usr/bin/env sh caller (record.sh) can source it. Both flavors prepend the
 # repo's target/debug to PATH so an agent hook's `thurbox-cli` resolves to *this*
 # dev binary (and writes to the sandbox DB the dev TUI reads).

--- a/scripts/dev/remote-ssh-test.sh
+++ b/scripts/dev/remote-ssh-test.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# Moved: scripts/dev/remote-ssh-test.sh → scripts/dev/e2e/linux-container.sh
-# Thin compatibility shim (kept for muscle memory / external notes).
-# See scripts/dev/README.md.
-set -euo pipefail
-here="$(cd "$(dirname "$0")" && pwd)"
-printf '\033[1;33mnote:\033[0m remote-ssh-test.sh moved to e2e/linux-container.sh — please update your reference.\n' >&2
-exec "$here/e2e/linux-container.sh" "$@"

--- a/scripts/dev/tui-smoke-test.sh
+++ b/scripts/dev/tui-smoke-test.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# Moved: scripts/dev/tui-smoke-test.sh → scripts/dev/smoke/tui-smoke.sh
-# Thin compatibility shim (kept for muscle memory / external notes).
-# See scripts/dev/README.md.
-set -euo pipefail
-here="$(cd "$(dirname "$0")" && pwd)"
-printf '\033[1;33mnote:\033[0m tui-smoke-test.sh moved to smoke/tui-smoke.sh — please update your reference.\n' >&2
-exec "$here/smoke/tui-smoke.sh" "$@"

--- a/scripts/dev/windows-test.sh
+++ b/scripts/dev/windows-test.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# Moved: scripts/dev/windows-test.sh → scripts/dev/e2e/windows-vm.sh
-# Thin compatibility shim (kept for muscle memory / external notes).
-# See scripts/dev/README.md.
-set -euo pipefail
-here="$(cd "$(dirname "$0")" && pwd)"
-printf '\033[1;33mnote:\033[0m windows-test.sh moved to e2e/windows-vm.sh — please update your reference.\n' >&2
-exec "$here/e2e/windows-vm.sh" "$@"


### PR DESCRIPTION
## What & why

Phase 1 of the `scripts/dev` refactor from #740: make the dev/test harnesses **legible and DRY** for newcomers, with **zero behaviour/CI changes**. No change to *what* any harness tests or the isolation model (`thurbox-dev` socket, scoped `THURBOX_*_DIR`, private `-L` sockets, `target/*-test` state dirs) — this is a legibility/de-dup pass.

## Changes

**Regroup + rename** — the session-backend e2e family now reads as a set, named by the *host it targets*:

| Old | New |
|---|---|
| `scripts/dev/remote-ssh-test.sh` | `scripts/dev/e2e/linux-container.sh` |
| `scripts/dev/windows-test.sh` | `scripts/dev/e2e/windows-vm.sh` |
| `scripts/dev/lab-test.sh` | `scripts/dev/e2e/real-host.sh` |
| `scripts/dev/tui-smoke-test.sh` | `scripts/dev/smoke/tui-smoke.sh` |

**Extract `scripts/dev/e2e/lib/e2e-common.sh`** — one source of truth for what the trio copied: colour logging, a single **PASS/FAIL result contract** (`pass`/`fail`, `E2E_JSON=1` for a machine-readable line), the parameterized `[[hosts]]` emitter, and the shared **create → get → assert** core (`e2e_create_and_get` / `e2e_assert`).

**Drop the `python3` dependency** — JSON is parsed in-shell via a small `json_field` sed extractor for `thurbox-cli`'s flat `--json` objects (a #740 success criterion).

**Add `scripts/dev/README.md`** — the newcomer index (which script for which job) + the old→new path map.

**No shims** — the old flat paths were removed outright (the branch isn't merged, so nothing external depends on them yet).

**References updated in lockstep** — `justfile` (`smoke`/`lab`), `.github/workflows/ci.yml` (the `tui-smoke` `run:` path + the windows-vm comment), `CLAUDE.md`, `CONTRIBUTING.md`, `docs/DEVELOPMENT.md`, `docs/PERFORMANCE.md`.

## Verification

- `shellcheck` clean over every tracked `*.sh` (run exactly as CI does)
- `rumdl` clean over all touched docs
- `bash -n` on every script; entrypoints dispatch correctly
- Unit checks of `json_field`, the `FAILS` dynamic-scoping counter, and the full `create → read → assert` wiring with a stubbed CLI
- Repo-wide sweep confirms no live reference to the old paths remains (only the intentional rename-map)

The e2e provisioning stays per-script and the assertion core is shared — Phase 2 (porting that core to a Rust `xtask`) remains the optional follow-up in #740, to evaluate only if the bash library keeps fighting the native-Windows quoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01519f54iCpA32yFqNiMauQ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01519f54iCpA32yFqNiMauQ8)_