### PR TITLE
docs: note Chocolatey package pending moderator approval

### DIFF
--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -8,6 +8,14 @@ from the GitHub Release and shims them onto your `PATH`.
 choco install thurbox
 ```
 
+> **Status: pending moderation.** The package has been pushed to the Chocolatey
+> community repository but has **not yet been approved by the moderators**, so
+> `choco install thurbox` will not resolve it from the community feed until it
+> goes live. This is expected for a new package (see
+> [Moderation](#automated-publishing-ci) below); until then, install with
+> [`scripts/install.ps1`](../../scripts/install.ps1) or pack/install the local
+> template (see [Test locally](#test-locally)).
+
 The canonical package source lives here:
 [`thurbox.nuspec`](thurbox.nuspec) (metadata) plus
 [`tools/chocolateyinstall.ps1`](tools/chocolateyinstall.ps1) (downloads the


### PR DESCRIPTION
Add a status callout to the Chocolatey packaging README stating the
package has been pushed but not yet approved by the community-repo
moderators, so `choco install thurbox` won't resolve it from the feed
yet. Points users at the PowerShell installer / local template in the
meantime.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C75D4evLLWSzHsxLr5Rx2H