### PR TITLE
feat(cli): hint to install terminal-notifier for macOS click-to-focus

### DIFF
--- a/src/cli/notify.rs
+++ b/src/cli/notify.rs
@@ -46,6 +46,10 @@ pub fn run(args: NotifyArgs) -> CommandOutput {
         ("deliverable", yes_no(backend.is_deliverable())),
         ("click-to-focus", yes_no(backend.supports_click_to_focus())),
     ];
+    // Only meaningful on the macOS backend; elsewhere the field is absent.
+    if let Some(present) = terminal_notifier_present(backend) {
+        pairs.push(("terminal-notifier", yes_no(present)));
+    }
     if let Some(err) = &last_error {
         pairs.push(("last_error", err.clone()));
     }
@@ -61,6 +65,7 @@ pub fn run(args: NotifyArgs) -> CommandOutput {
             "resolved_backend": backend.label(),
             "deliverable": backend.is_deliverable(),
             "click_to_focus": backend.supports_click_to_focus(),
+            "terminal_notifier": terminal_notifier_present(backend),
             "last_error": last_error,
             "summary": headline,
         }),
@@ -91,11 +96,12 @@ fn run_test(feature_on: bool, backend: DeliveryBackend) -> CommandOutput {
 
     match notifications::send_blocking(&n, backend) {
         Ok(()) => {
-            let msg = format!(
+            let mut msg = format!(
                 "Sent a test notification via {}. If you don't see it, check your OS \
                  notification settings.",
                 backend.label()
             );
+            append_macos_hint(&mut msg, backend);
             CommandOutput::new(
                 json!({
                     "feature_enabled": true,
@@ -138,10 +144,47 @@ fn diagnose_headline(feature_on: bool, backend: DeliveryBackend) -> String {
             backend.label()
         );
     }
-    format!(
+    let mut headline = format!(
         "Notifications enabled — delivering via {}. Run `thurbox-cli notify --test` to confirm.",
         backend.label()
-    )
+    );
+    append_macos_hint(&mut headline, backend);
+    headline
+}
+
+/// The one-line, actionable nudge shown on the macOS backend when
+/// `terminal-notifier` is absent: describes what's degraded (Script Editor
+/// attribution, dead clicks) and the one-command fix. Text sourced from the
+/// `notifications` module doc.
+const MACOS_TERMINAL_NOTIFIER_HINT: &str =
+    "On macOS these banners are attributed to \"Script Editor\" and clicking them does nothing — \
+     run `brew install terminal-notifier` to enable click-to-focus and native branding.";
+
+/// Append [`MACOS_TERMINAL_NOTIFIER_HINT`] to `msg` (space-separated) when the
+/// macOS backend is degraded — i.e. active but without `terminal-notifier`.
+/// Shared by the default diagnostic and the `--test` success message so the
+/// nudge reads identically from either entry point.
+fn append_macos_hint(msg: &mut String, backend: DeliveryBackend) {
+    if macos_hint_applies(backend) {
+        msg.push(' ');
+        msg.push_str(MACOS_TERMINAL_NOTIFIER_HINT);
+    }
+}
+
+/// True when the macOS backend is active but `terminal-notifier` is missing, so
+/// the degraded-notification hint applies. Keys off
+/// [`DeliveryBackend::supports_click_to_focus`], which already encodes exactly
+/// "macOS + terminal-notifier present" (and is `false` for `Macos` on non-macOS
+/// builds), so the branch stays cross-platform-compilable.
+fn macos_hint_applies(backend: DeliveryBackend) -> bool {
+    matches!(backend, DeliveryBackend::Macos) && !backend.supports_click_to_focus()
+}
+
+/// Whether `terminal-notifier` is available, but only for the macOS backend —
+/// `None` (field omitted) on every other backend, where the notion is
+/// irrelevant.
+fn terminal_notifier_present(backend: DeliveryBackend) -> Option<bool> {
+    matches!(backend, DeliveryBackend::Macos).then(|| backend.supports_click_to_focus())
 }
 
 fn on_off(b: bool) -> String {
@@ -194,5 +237,70 @@ mod tests {
     fn headline_confirms_a_working_backend() {
         let h = diagnose_headline(true, DeliveryBackend::Dbus);
         assert!(h.contains("delivering via"), "got: {h}");
+    }
+
+    #[test]
+    fn hint_names_the_fix() {
+        assert!(MACOS_TERMINAL_NOTIFIER_HINT.contains("brew install"));
+        assert!(MACOS_TERMINAL_NOTIFIER_HINT.contains("terminal-notifier"));
+        assert!(MACOS_TERMINAL_NOTIFIER_HINT.contains("Script Editor"));
+    }
+
+    #[test]
+    fn headline_hints_terminal_notifier_on_macos_without_it() {
+        let h = diagnose_headline(true, DeliveryBackend::Macos);
+        // Deterministic on non-macOS builds (Macos → no click-to-focus, so the
+        // hint fires); on macOS it adapts to whether the tool is installed.
+        if DeliveryBackend::Macos.supports_click_to_focus() {
+            assert!(h.contains("delivering via"), "got: {h}");
+            assert!(!h.contains("brew install"), "no hint when present: {h}");
+        } else {
+            assert!(h.contains("delivering via"), "still confirms delivery: {h}");
+            assert!(h.contains("terminal-notifier"), "got: {h}");
+            assert!(h.contains("brew install"), "got: {h}");
+        }
+    }
+
+    #[test]
+    fn non_macos_headlines_omit_the_macos_hint() {
+        for b in [
+            DeliveryBackend::Dbus,
+            DeliveryBackend::WindowsToast,
+            DeliveryBackend::None,
+        ] {
+            let h = diagnose_headline(true, b);
+            assert!(!h.contains("terminal-notifier"), "{b:?} leaked hint: {h}");
+        }
+    }
+
+    #[test]
+    fn terminal_notifier_field_only_for_macos() {
+        assert!(terminal_notifier_present(DeliveryBackend::Dbus).is_none());
+        assert!(terminal_notifier_present(DeliveryBackend::None).is_none());
+        // Present (Some) on the macOS backend, value tracking availability.
+        let macos = terminal_notifier_present(DeliveryBackend::Macos);
+        assert_eq!(
+            macos,
+            Some(DeliveryBackend::Macos.supports_click_to_focus())
+        );
+    }
+
+    #[test]
+    fn append_macos_hint_appends_only_when_degraded() {
+        // Non-macOS backends never get the hint; the base string is untouched.
+        let mut s = "base".to_string();
+        append_macos_hint(&mut s, DeliveryBackend::Dbus);
+        assert_eq!(s, "base");
+
+        // On the macOS backend the hint fires only without terminal-notifier,
+        // and when it does it preserves the base plus a single-space separator.
+        // This is the only direct coverage of the append shared by `run_test`.
+        let mut s = "base".to_string();
+        append_macos_hint(&mut s, DeliveryBackend::Macos);
+        if DeliveryBackend::Macos.supports_click_to_focus() {
+            assert_eq!(s, "base", "no hint when terminal-notifier is present");
+        } else {
+            assert_eq!(s, format!("base {MACOS_TERMINAL_NOTIFIER_HINT}"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Makes macOS notification click-to-focus **discoverable** via `thurbox-cli notify`. When the resolved backend is macOS but `terminal-notifier` is absent, thurbox silently falls back to `osascript`, which shows banners attributed to "Script Editor" whose clicks do nothing — and nothing told the user this is a one-command fix.

- `diagnose_headline` now appends a one-line hint on the degraded macOS path: what's degraded (Script Editor attribution, dead clicks) + the fix (`brew install terminal-notifier` for click-to-focus and native branding).
- `run_test` mirrors the same hint on its success message (shared `append_macos_hint` helper), so `--test` nudges too.
- Adds a `terminal_notifier` field to the JSON payload (present only on the macOS backend; `null` elsewhere, mirroring the existing `last_error` shape).

Purely additive / diagnostic-only — **no delivery-behavior change**. Keys off the existing macOS-correct `DeliveryBackend::supports_click_to_focus()` predicate, so no new public surface and the branch stays cross-platform-compilable/testable.

Closes Thurbeen/thurbox#753 (thurbox task #58).

## Test plan

- 6 new/updated unit tests in `cli::notify::tests` (hint text, macOS with/without terminal-notifier branch, non-macOS non-leakage, JSON-field gating, `append_macos_hint` concatenation contract) — all green.
- Full pre-commit suite passed (fmt, clippy `-D warnings`, `cargo check`, nextest, architecture rules, cargo-deny, cargo-doc, conventional-commit).
- CI checks pass.