### PR TITLE
feat(core): auto-detect installed agent CLIs for seeding and picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,6 +451,33 @@ workspace, so `--last`/`--continue` finds no parent session (multi-repo
 A session stores only its **agent name**; there are no
 per-session model/permission/prompt/tool knobs.
 
+**Installed-agent detection** (agent-neutral, no schema change). A single
+primitive `agent::preflight::command_on_path(command)` asks the OS whether an
+`AgentDef`'s opaque `command` string resolves to a runnable executable (walks
+`$PATH`, plus `PATHEXT` on Windows; a shell function / missing `$PATH` degrades
+to "assume present", so it's advisory only). It informs two point-in-time
+moments — it never special-cases any agent, and a custom `[[agents]]` entry is
+probed for free:
+
+- **Seed-time** (`render_seed`, first-run only, non-destructive). The seed still
+  writes **all seven** built-ins as a complete reference, but the `default`
+  becomes the first built-in, in canonical order, whose `command` is installed
+  (falling back to `claude` on a bare machine), and each un-installed built-in
+  gets a `# not found on PATH at seed time` comment above its `name` line. The
+  document still parses to the seven built-ins and passes strict `config
+  validate` (comments are ignored). Seeding only runs when `agents.toml` is
+  absent, so an edited file is never rewritten and the comments never refresh —
+  the picker carries the live truth.
+- **Pick-time** (`finish_prepare_spawn` → `agent_picker_modal`). Because `$PATH`
+  can change between runs, availability is recomputed when the picker opens:
+  each `AgentChoice` carries `available`, un-installed rows render **dimmed** with
+  a `(not installed)` marker but stay **selectable** (a shell rc may resolve the
+  binary the probe can't see), and the initial selection moves to the first
+  available agent (`initial_selection`) without reordering the list. A
+  **remote-host** session marks every agent available (no dimming) — the local
+  `$PATH` says nothing about the host. This is display only; it does not block a
+  spawn (the spawn-time binary guard is a separate concern).
+
 ### Multi-repo sessions (symlink workspace)
 
 A session can span several repositories (the repo picker allows

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -8,7 +8,7 @@
 
 use std::path::PathBuf;
 
-use crate::session::{AgentDef, AgentRegistry};
+use crate::session::{AgentDef, AgentRegistry, DEFAULT_AGENT_NAME};
 
 /// Built-in agent definitions, also used to seed `agents.toml` on first run.
 ///
@@ -183,8 +183,67 @@ pub fn load_or_seed_with_warnings() -> (AgentRegistry, Vec<String>) {
     }
 }
 
+/// Comment stamped on the line above a built-in whose `command` wasn't runnable
+/// at seed time. It's a point-in-time hint only — the picker carries live truth
+/// — and is only ever written on first run (see [`render_seed`]).
+const NOT_FOUND_NOTE: &str = "# not found on PATH at seed time";
+
+/// Build the first-run `agents.toml` contents, tailored to the machine: pick a
+/// `default` agent that's actually installed and annotate the built-ins that
+/// aren't. All seven entries are kept (the file stays a complete, editable
+/// reference); `is_available` is the point-in-time PATH probe.
+///
+/// - **`default`** becomes the first built-in, in canonical order, whose
+///   `command` is available — falling back to `"claude"` when none are (today's
+///   behavior on a bare machine), so the file always names a real entry.
+/// - Each un-installed built-in gets a [`NOT_FOUND_NOTE`] comment above its
+///   `name = "…"` line. Comments are ignored by the parser, so the document
+///   still yields exactly the seven built-ins.
+///
+/// Pure over `is_available` so it can be unit-tested without touching the OS.
+fn render_seed(is_available: impl Fn(&str) -> bool) -> String {
+    // Canonical (name, command) order comes straight from the parsed seed, so
+    // this never hard-codes any agent identity in Rust.
+    let builtins = builtin_registry();
+
+    let default = builtins
+        .agents
+        .iter()
+        .find(|a| is_available(&a.command))
+        .map(|a| a.name.as_str())
+        .unwrap_or(DEFAULT_AGENT_NAME);
+
+    let mut out = BUILTIN_AGENTS_TOML.to_string();
+
+    // The const already names DEFAULT_AGENT_NAME, so only a different pick needs
+    // a rewrite (keeps the all-installed seed byte-identical to the const).
+    if default != DEFAULT_AGENT_NAME {
+        out = out.replacen(
+            &format!("default = \"{DEFAULT_AGENT_NAME}\"\n"),
+            &format!("default = \"{default}\"\n"),
+            1,
+        );
+    }
+
+    for agent in &builtins.agents {
+        if is_available(&agent.command) {
+            continue;
+        }
+        // Names are unique across the whole seed (the commented examples use
+        // distinct names like `claude-opus`), so this targets the real entry.
+        let name_line = format!("name = \"{}\"\n", agent.name);
+        let annotated = format!("{NOT_FOUND_NOTE}\n{name_line}");
+        out = out.replacen(&name_line, &annotated, 1);
+    }
+
+    out
+}
+
 /// Write the bundled agents.toml on first run, degrading to the built-in
-/// registry (with a warning) if the dir or file can't be created.
+/// registry (with a warning) if the dir or file can't be created. The seeded
+/// contents are tailored to the machine (see [`render_seed`]): the `default` is
+/// the first installed built-in and un-installed built-ins are annotated. The
+/// returned registry mirrors the file so callers see the chosen default.
 fn seed_agents_toml(path: &std::path::Path) -> (AgentRegistry, Vec<String>) {
     if let Some(parent) = path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
@@ -194,14 +253,17 @@ fn seed_agents_toml(path: &std::path::Path) -> (AgentRegistry, Vec<String>) {
             );
         }
     }
-    if let Err(e) = std::fs::write(path, BUILTIN_AGENTS_TOML) {
+    let contents = render_seed(super::preflight::command_on_path);
+    if let Err(e) = std::fs::write(path, &contents) {
         return (
             builtin_registry(),
             vec![format!("Failed to seed agents.toml: {e}")],
         );
     }
     tracing::info!(path = %path.display(), "Seeded agents.toml with built-in agents");
-    (builtin_registry(), Vec::new())
+    // Parse what we just wrote so the in-memory default matches the file (the
+    // dynamic default lives in the annotated document, not the const).
+    parse_agents_toml(&contents)
 }
 
 /// Top-level keys read directly by the resilient parser; anything else at the
@@ -437,13 +499,116 @@ mod tests {
         let path = agents_config_path().unwrap();
         assert!(!path.exists());
 
+        // The seeded `default` is machine-dependent now (first installed
+        // built-in, else claude), so assert it's a real registered built-in
+        // rather than pinning "claude" — render_seed's own tests cover the
+        // selection logic deterministically.
         let reg = load_or_seed();
-        assert_eq!(reg.default, "claude");
         assert!(path.exists(), "agents.toml should have been seeded");
+        assert!(
+            reg.get(&reg.default).is_some(),
+            "seeded default must name a registered agent: {}",
+            reg.default
+        );
+        assert_eq!(reg.agents.len(), 7, "all seven built-ins stay seeded");
 
         // Second call reads the seeded file and yields the same registry.
         let reg2 = load_or_seed();
         assert_eq!(reg, reg2);
+    }
+
+    #[test]
+    fn render_seed_bare_machine_keeps_claude_default_and_annotates_all() {
+        // Nothing installed: default falls back to claude (today's behavior),
+        // and every built-in is flagged, but the document still parses to 7.
+        let seed = render_seed(|_| false);
+        let (reg, warnings) = parse_agents_toml(&seed);
+        assert!(
+            warnings.is_empty(),
+            "annotated seed parses clean: {warnings:?}"
+        );
+        assert_eq!(reg.default, "claude");
+        assert_eq!(reg.agents.len(), 7);
+        // Every real entry carries the not-found note above its name line.
+        for name in [
+            "claude",
+            "codex",
+            "antigravity",
+            "opencode",
+            "aider",
+            "copilot",
+            "vibe",
+        ] {
+            assert!(
+                seed.contains(&format!("{NOT_FOUND_NOTE}\nname = \"{name}\"\n")),
+                "{name} should be annotated as not-found"
+            );
+        }
+    }
+
+    #[test]
+    fn render_seed_picks_first_installed_and_only_annotates_missing() {
+        // Only `codex` present: it becomes the default and is NOT annotated;
+        // the rest are annotated. Canonical order puts claude first, but claude
+        // isn't installed, so codex wins.
+        let seed = render_seed(|command| command == "codex");
+        let (reg, _) = parse_agents_toml(&seed);
+        assert_eq!(reg.default, "codex");
+        assert_eq!(reg.agents.len(), 7);
+        assert!(
+            seed.contains("default = \"codex\"\n"),
+            "default line must be rewritten to codex"
+        );
+        assert!(
+            !seed.contains(&format!("{NOT_FOUND_NOTE}\nname = \"codex\"\n")),
+            "an installed agent must not be annotated"
+        );
+        assert!(
+            seed.contains(&format!("{NOT_FOUND_NOTE}\nname = \"claude\"\n")),
+            "an un-installed agent must be annotated"
+        );
+    }
+
+    #[test]
+    fn render_seed_keeps_claude_default_line_when_claude_installed() {
+        // claude installed (canonical first) ⇒ default stays claude, and the
+        // default line is left byte-identical to the const (no rewrite needed).
+        let seed = render_seed(|command| command == "claude");
+        assert!(seed.contains("default = \"claude\"\n"));
+        let (reg, _) = parse_agents_toml(&seed);
+        assert_eq!(reg.default, "claude");
+        assert!(
+            !seed.contains(&format!("{NOT_FOUND_NOTE}\nname = \"claude\"\n")),
+            "claude is installed, must not be annotated"
+        );
+        assert!(
+            seed.contains(&format!("{NOT_FOUND_NOTE}\nname = \"codex\"\n")),
+            "codex is not installed, must be annotated"
+        );
+    }
+
+    #[test]
+    fn render_seed_all_installed_is_byte_identical_to_const() {
+        // When everything is present there's nothing to annotate or rewrite, so
+        // the seed matches the pristine const exactly.
+        let seed = render_seed(|_| true);
+        assert_eq!(seed, BUILTIN_AGENTS_TOML);
+    }
+
+    #[test]
+    fn render_seed_probes_command_not_name() {
+        // antigravity's command (`agy`) differs from its display name — the
+        // probe must key on the command, and the default/annotation resolve
+        // back to the *name*. This guards the command-vs-name mapping.
+        let seed = render_seed(|command| command == "agy");
+        let (reg, _) = parse_agents_toml(&seed);
+        assert_eq!(reg.default, "antigravity");
+        assert!(
+            !seed.contains(&format!("{NOT_FOUND_NOTE}\nname = \"antigravity\"\n")),
+            "antigravity's command is installed, so it must not be annotated"
+        );
+        // A sibling whose command is absent is still annotated.
+        assert!(seed.contains(&format!("{NOT_FOUND_NOTE}\nname = \"claude\"\n")));
     }
 
     #[test]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,6 +6,7 @@ pub mod generic;
 pub mod host_config;
 pub mod input;
 pub mod json_merge;
+pub mod preflight;
 pub mod provider;
 pub mod registry;
 pub mod self_update;

--- a/src/agent/preflight.rs
+++ b/src/agent/preflight.rs
@@ -1,0 +1,235 @@
+//! Best-effort "is this command runnable?" detection.
+//!
+//! A single, agent-neutral primitive that asks the OS whether an
+//! [`AgentDef`](crate::session::AgentDef)'s opaque `command` string resolves to
+//! an executable. It walks `$PATH` exactly as a shell would (plus `PATHEXT` on
+//! Windows), so it never bakes any agent's name or flags into the binary.
+//!
+//! It powers two point-in-time observations: the seed-time default/annotation
+//! choice ([`crate::agent::agent_config`]) and the pick-time picker dimming
+//! (`finish_prepare_spawn`). Both re-probe each time — a PATH walk is
+//! microseconds — so a freshly-installed agent is picked up on the next run
+//! without any caching.
+//!
+//! Detection is deliberately advisory: a shell function / alias / rc-resolved
+//! command can false-negative here, so callers use it to *inform* display and
+//! seeding, never to hard-block (the spawn-time guard that can block is a
+//! separate concern).
+
+/// Whether `command` resolves to a runnable executable using the process's
+/// current environment (`PATH`, and `PATHEXT` on Windows).
+///
+/// Returns `true` when the command can't be conclusively ruled out — an
+/// unreadable/absent `PATH` degrades to "assume present" so detection never
+/// makes the caller *more* pessimistic than reality.
+pub fn command_on_path(command: &str) -> bool {
+    let path = std::env::var_os("PATH");
+    // On non-Windows, `pathext` is unused; on Windows it drives the extension
+    // probe. Reading it unconditionally keeps the pure inner fn signature flat.
+    let pathext = std::env::var_os("PATHEXT");
+    command_on_path_in(command, path.as_deref(), pathext.as_deref())
+}
+
+/// Pure core of [`command_on_path`], parameterized on the `PATH` / `PATHEXT`
+/// values so it can be tested hermetically without mutating process env.
+fn command_on_path_in(
+    command: &str,
+    path_var: Option<&std::ffi::OsStr>,
+    pathext: Option<&std::ffi::OsStr>,
+) -> bool {
+    if command.is_empty() {
+        return false;
+    }
+
+    // A command carrying a path separator is resolved directly, not via PATH —
+    // mirroring how the shell treats `./x` or `/usr/bin/x`.
+    if has_path_separator(command) {
+        return is_executable_file(std::path::Path::new(command), pathext);
+    }
+
+    // No PATH to walk: we can't prove absence, so assume present (advisory).
+    let Some(path_var) = path_var else {
+        return true;
+    };
+
+    std::env::split_paths(path_var).any(|dir| {
+        // Skip the empty entries some PATHs carry (a leading/trailing `:`).
+        !dir.as_os_str().is_empty() && is_executable_file(&dir.join(command), pathext)
+    })
+}
+
+/// Whether `path` (a fully-formed candidate) is an executable file. On Windows,
+/// also try each `PATHEXT` extension when the bare path doesn't already resolve.
+fn is_executable_file(path: &std::path::Path, pathext: Option<&std::ffi::OsStr>) -> bool {
+    if is_runnable(path) {
+        return true;
+    }
+    if cfg!(windows) {
+        for ext in windows_pathext(pathext) {
+            // Extensions in PATHEXT include the leading dot (".EXE").
+            let mut candidate = path.as_os_str().to_owned();
+            candidate.push(&ext);
+            if is_runnable(std::path::Path::new(&candidate)) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Whether `path` exists as a regular file that a shell could launch. A
+/// metadata error (missing / unreadable) or a non-file is *not* runnable; on
+/// Unix an execute bit is also required, while Windows has no such bit so a
+/// regular file suffices (PATHEXT is applied by the caller).
+fn is_runnable(path: &std::path::Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Any execute bit (user/group/other) makes it runnable enough for a
+        // shell to launch it.
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        // No executable bit on Windows: existence as a regular file (already
+        // checked, with PATHEXT applied upstream) is the runnable signal.
+        true
+    }
+}
+
+/// The Windows executable extensions to try, from `PATHEXT`, falling back to a
+/// sensible default set when the var is missing/empty.
+fn windows_pathext(pathext: Option<&std::ffi::OsStr>) -> Vec<std::ffi::OsString> {
+    let raw = pathext
+        .map(|s| s.to_string_lossy().into_owned())
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".to_string());
+    raw.split(';')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(std::ffi::OsString::from)
+        .collect()
+}
+
+/// Whether the command string carries a path separator (so it should be
+/// resolved as a path, not looked up in `PATH`). Backslash counts on Windows.
+fn has_path_separator(command: &str) -> bool {
+    command.contains('/') || (cfg!(windows) && command.contains('\\'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    /// Create an executable file `name` inside `dir`.
+    fn write_exe(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        p
+    }
+
+    #[test]
+    fn found_when_present_on_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        write_exe(dir.path(), "my-agent");
+        let path = dir.path().as_os_str();
+        assert!(command_on_path_in("my-agent", Some(path), None));
+    }
+
+    #[test]
+    fn missing_when_absent_from_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().as_os_str();
+        assert!(!command_on_path_in("nope-not-here", Some(path), None));
+    }
+
+    #[test]
+    fn empty_command_is_never_found() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(!command_on_path_in("", Some(dir.path().as_os_str()), None));
+    }
+
+    #[test]
+    fn absent_path_var_assumes_present() {
+        // Advisory posture: with no PATH to walk we can't prove absence.
+        assert!(command_on_path_in("anything", None, None));
+    }
+
+    #[test]
+    fn empty_path_entries_are_skipped() {
+        let dir = tempfile::TempDir::new().unwrap();
+        write_exe(dir.path(), "agent");
+        // A PATH with empty segments (leading/trailing separators) must still
+        // find the real dir and not treat "" as the cwd match.
+        let sep = if cfg!(windows) { ";" } else { ":" };
+        let joined = format!("{sep}{}{sep}", dir.path().display());
+        assert!(command_on_path_in("agent", Some(OsStr::new(&joined)), None));
+        assert!(!command_on_path_in(
+            "ghost",
+            Some(OsStr::new(&joined)),
+            None
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_containing_command_checks_directly() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let exe = write_exe(dir.path(), "direct");
+        let as_path = exe.to_str().unwrap();
+        // An absolute/relative path is resolved directly, ignoring PATH.
+        assert!(command_on_path_in(as_path, None, None));
+        let missing = dir.path().join("gone");
+        assert!(!command_on_path_in(missing.to_str().unwrap(), None, None));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_executable_file_is_not_runnable() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = dir.path().join("data");
+        std::fs::write(&p, b"x").unwrap(); // no +x bit
+        assert!(!command_on_path_in(
+            "data",
+            Some(dir.path().as_os_str()),
+            None
+        ));
+    }
+
+    // `windows_pathext` is pure and compiled on every platform (the caller
+    // gates it behind `cfg!(windows)`, not the fn), so its parsing is testable
+    // regardless of host OS.
+
+    #[test]
+    fn windows_pathext_falls_back_to_defaults() {
+        assert_eq!(
+            windows_pathext(None),
+            [".COM", ".EXE", ".BAT", ".CMD"].map(std::ffi::OsString::from)
+        );
+        // Blank/whitespace-only PATHEXT also uses the defaults.
+        assert_eq!(
+            windows_pathext(Some(OsStr::new("   "))),
+            [".COM", ".EXE", ".BAT", ".CMD"].map(std::ffi::OsString::from)
+        );
+    }
+
+    #[test]
+    fn windows_pathext_parses_trims_and_skips_empties() {
+        assert_eq!(
+            windows_pathext(Some(OsStr::new(".EXE; .CMD ;;.PS1"))),
+            [".EXE", ".CMD", ".PS1"].map(std::ffi::OsString::from)
+        );
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1437,16 +1437,28 @@ impl App {
         }
 
         let default = self.agents.default_name();
-        let selected_index = names.iter().position(|n| *n == default).unwrap_or(0);
-        let choices = self
+        let default_index = names.iter().position(|n| *n == default).unwrap_or(0);
+        // A local PATH probe is meaningless for a remote host (the binary lives
+        // on the host), so mark every agent available there — no false dimming.
+        let remote = config
+            .backend
+            .as_deref()
+            .map(crate::session::is_remote_backend)
+            .unwrap_or(false);
+        let choices: Vec<_> = self
             .agents
             .agents
             .iter()
             .map(|a| crate::ui::agent_picker_modal::AgentChoice {
                 name: a.name.clone(),
                 command: a.command.clone(),
+                available: remote || crate::agent::preflight::command_on_path(&a.command),
             })
             .collect();
+        // Registry order is preserved; only the starting cursor moves to the
+        // first available agent when the default itself isn't installed.
+        let selected_index =
+            crate::ui::agent_picker_modal::initial_selection(&choices, default_index);
         self.new_session.spawn_name = Some(name);
         self.new_session.spawn_config = Some(config);
         self.new_session.spawn_worktrees = worktrees;

--- a/src/ui/agent_picker_modal.rs
+++ b/src/ui/agent_picker_modal.rs
@@ -1,19 +1,51 @@
 use ratatui::{
     layout::{Constraint, Direction, Layout},
-    text::Line,
+    text::{Line, Span},
     Frame,
 };
 
+use super::theme::Theme;
 use super::{
     centered_fixed_height_rect, render_modal_frame, render_selector_footer, render_selector_rows,
     selector_line,
 };
 
 /// One selectable agent row: display name + the CLI command it launches.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct AgentChoice {
     pub name: String,
     pub command: String,
+    /// Whether the launch `command` was found on PATH when the picker opened.
+    /// Un-installed agents render dimmed + marked but stay selectable (advisory
+    /// only — a shell rc could resolve the binary the probe can't see). Always
+    /// `true` for remote-host sessions, where the local PATH says nothing.
+    pub available: bool,
+}
+
+impl Default for AgentChoice {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            command: String::new(),
+            // A choice with no availability signal is treated as present, so
+            // the picker never dims by accident.
+            available: true,
+        }
+    }
+}
+
+/// Pick the initial selection: keep the registry default when it's available,
+/// else the first available choice, else fall back to the default index (so an
+/// all-un-installed list still lands somewhere sensible). Registry order is
+/// never changed — only where the cursor starts.
+pub fn initial_selection(choices: &[AgentChoice], default_index: usize) -> usize {
+    if choices.get(default_index).is_some_and(|c| c.available) {
+        return default_index;
+    }
+    choices
+        .iter()
+        .position(|c| c.available)
+        .unwrap_or(default_index)
 }
 
 #[derive(Debug, Clone, Default)]
@@ -46,11 +78,90 @@ pub fn render_agent_picker_modal(
             } else {
                 format!("{}  ({})", c.name, c.command)
             };
-            selector_line(&label, i == state.selected_index)
+            let selected = i == state.selected_index;
+            if c.available {
+                selector_line(&label, selected)
+            } else {
+                unavailable_line(&label, selected)
+            }
         })
         .collect();
 
     let buttons = render_selector_footer(frame, chunks[1]);
     let hits = render_selector_rows(frame, chunks[0], lines, state.selected_index);
     (hits, buttons)
+}
+
+/// Render an un-installed agent row: the standard selection prefix (so the
+/// cursor stays visible) plus a muted label and a trailing ` (not installed)`
+/// marker. Kept selectable on purpose — dimming is advisory.
+fn unavailable_line<'a>(label: &str, selected: bool) -> Line<'a> {
+    let prefix = if selected { "▸ " } else { "  " };
+    let style = Theme::normal_item().fg(Theme::text_muted());
+    Line::from(Span::styled(
+        format!("{prefix}{label} (not installed)"),
+        style,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn choice(name: &str, available: bool) -> AgentChoice {
+        AgentChoice {
+            name: name.into(),
+            command: name.into(),
+            available,
+        }
+    }
+
+    #[test]
+    fn initial_selection_keeps_available_default() {
+        let choices = vec![choice("claude", true), choice("codex", true)];
+        assert_eq!(initial_selection(&choices, 0), 0);
+        assert_eq!(initial_selection(&choices, 1), 1);
+    }
+
+    #[test]
+    fn initial_selection_moves_off_unavailable_default() {
+        // Default is claude (index 0) but it's not installed; codex is.
+        let choices = vec![choice("claude", false), choice("codex", true)];
+        assert_eq!(initial_selection(&choices, 0), 1);
+    }
+
+    #[test]
+    fn initial_selection_falls_back_when_none_available() {
+        let choices = vec![choice("claude", false), choice("codex", false)];
+        assert_eq!(initial_selection(&choices, 0), 0);
+        assert_eq!(initial_selection(&choices, 1), 1);
+    }
+
+    #[test]
+    fn initial_selection_empty_is_default_index() {
+        assert_eq!(initial_selection(&[], 3), 3);
+    }
+
+    /// Concatenate a line's span contents for assertions.
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn unavailable_line_marks_and_prefixes() {
+        // Selected row keeps the ▸ cursor and carries the advisory marker.
+        let selected = line_text(&unavailable_line("codex  (codex)", true));
+        assert!(
+            selected.starts_with("▸ "),
+            "selected keeps cursor: {selected}"
+        );
+        assert!(
+            selected.contains("codex  (codex)") && selected.ends_with("(not installed)"),
+            "label + marker present: {selected}"
+        );
+        // Unselected row uses the blank prefix, still marked.
+        let unselected = line_text(&unavailable_line("vibe", false));
+        assert!(unselected.starts_with("  "));
+        assert!(unselected.ends_with("(not installed)"));
+    }
 }


### PR DESCRIPTION
## Summary

Auto-detect which agent CLIs are installed and use that to (a) seed a sensible `default` in `agents.toml`, (b) annotate un-installed built-ins, and (c) dim un-installed agents in the new-session picker — all agent-neutral (detection operates only on the opaque `command` string; no `AgentDef` schema change, no migration).

- **Detection primitive** — new `agent::preflight::command_on_path` walks `PATH` (plus `PATHEXT` on Windows), resolves path-containing commands directly, and stays advisory (missing `PATH` / shell functions degrade to "assume present").
- **Seed-time** (`render_seed`, first-run only, non-destructive) — still writes all seven built-ins as a complete reference, but `default` becomes the first installed built-in in canonical order (falling back to `claude` on a bare machine), and un-installed entries get a `# not found on PATH at seed time` comment. The annotated file still parses to the seven built-ins and passes strict `config validate`.
- **Pick-time** — un-installed agents render dimmed with a `(not installed)` marker but stay selectable; the initial cursor moves to the first installed agent without reordering. Remote-host sessions skip local probing (local `PATH` says nothing about the host).

Implements phases 1–3 of thurbeen/thurbox#755. The spawn-time binary guard (thurbeen/thurbox#745) is intentionally left to its own PR; only the shared `command_on_path` primitive overlaps.

## Test plan

- `cargo nextest run --all` — 1766 tests pass (incl. new `preflight`, `render_seed`, `initial_selection`, and picker-render tests, plus `architecture_rules`).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `rumdl` — all clean.
- End-to-end through the real `thurbox-cli`: only-`codex` PATH → `default = "codex"` with the other six annotated; empty PATH → falls back to `default = "claude"`, all seven annotated; `config validate` reports the seed valid.
- All 17 pre-commit hooks pass; commit SSH-signed.