### PR TITLE
feat(core): surface send automations that skip a dead target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -857,6 +857,21 @@ extension manifest (`[[automations]]` with a `command` field instead of
 `session_ref`/`prompt`). `Task.action` shares the enum but tasks never carry an
 `Exec` (it's automation-only).
 
+Only **Send** has a live-target precondition, so it's the only action that can
+*miss*. When a `Send` fires against a target that isn't a running session, the
+run is recorded `Skipped` (as before) and, in the TUI, an error toast surfaces
+it (`Automation "<name>": <reason>` — otherwise the miss is buried in the
+per-automation run-history panel). The two miss modes are distinguished by the
+run detail and drive different follow-up (identically in the TUI
+`App::fire_send_automation` and the headless `cli::automations::fire_send`): a
+*transient* miss — the session row still exists but its tmux window isn't
+adopted yet (`target session not running`) — leaves the automation **enabled**
+(it may be restored); a *permanent* miss — the row is gone / soft- or
+force-deleted (`target session no longer exists`) — **auto-disables** the
+automation via `disable_send_automations_for_session` (the same primitive
+force-delete uses), since it can never succeed again. `Spawn`/`Exec` have no
+such precondition and are unaffected.
+
 Automations fire even when the TUI is closed: a tmux heartbeat
 keeper window (`automation-heartbeat`, armed on TUI startup and on
 `automation create`) loops `automation tick` every 60 s and keeps

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -2233,3 +2233,54 @@ fn remote_hook_event_dedupes_repeated_state() {
         "an identical re-report must not re-stamp state_at"
     );
 }
+
+#[test]
+fn send_automation_at_a_dead_target_toasts_and_disables() {
+    use crate::session::{AutomationAction, AutomationRunStatus, AutomationSchedule};
+    // No live session, and the target row doesn't exist in the DB either — a
+    // permanent miss: the send can never land, so firing it must surface a
+    // warning toast AND auto-disable the automation instead of skipping silently
+    // forever.
+    let mut h = Harness::standard(0);
+    let id = h
+        .app
+        .db
+        .create_automation(&crate::storage::automations::NewAutomation {
+            name: "dead-nudge".into(),
+            enabled: true,
+            schedule: AutomationSchedule::Cron {
+                expr: "0 9 * * *".into(),
+            },
+            timezone: None,
+            action: AutomationAction::Send {
+                session_id: crate::session::SessionId::default(),
+            },
+            prompt: "ping".into(),
+            // Already due so `process_automations` picks it up this pass.
+            next_run_at: Some(1),
+        })
+        .unwrap();
+
+    h.app.process_automations(true);
+
+    // Toast surfaces the miss, naming the automation.
+    let msg = h.app.status_message.as_ref().expect("a toast was raised");
+    assert!(
+        matches!(msg.level, StatusLevel::Error),
+        "warned as an error"
+    );
+    assert!(msg.text.contains("dead-nudge"), "names it: {}", msg.text);
+
+    // The automation is auto-disabled (its target is gone for good).
+    let after = h.app.db.get_automation(id).unwrap().unwrap();
+    assert!(
+        !after.enabled,
+        "a permanently-missing target disables the send"
+    );
+
+    // The run is still recorded, tagged with the shared gone-for-good detail.
+    let runs = h.app.db.list_automation_runs(id, 10).unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].status, AutomationRunStatus::Skipped);
+    assert_eq!(runs[0].detail, crate::session::SEND_TARGET_GONE);
+}

--- a/src/app/automation.rs
+++ b/src/app/automation.rs
@@ -12,9 +12,10 @@ use super::view;
 use super::{App, InputFocus, StatusLevel};
 use crate::session::{
     Automation, AutomationAction, AutomationRunStatus, AutomationSchedule, SessionId,
+    SEND_TARGET_GONE, SEND_TARGET_NOT_RUNNING,
 };
 use crossterm::event::{KeyCode, KeyModifiers};
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 impl App {
     /// Fire any due automations. Called once per ~second from `tick()`; pass
@@ -65,6 +66,24 @@ impl App {
             {
                 error!("Failed to record run for automation {}: {e}", auto.id);
             }
+            // A `send` that misses its target is a real delivery failure, not a
+            // silent no-op: surface it as a toast (the run is otherwise only
+            // visible in the per-automation run-history panel). `Spawn`/`Exec`
+            // have no live-target precondition, so this is `send`-specific.
+            if matches!(auto.action, AutomationAction::Send { .. })
+                && matches!(
+                    status,
+                    AutomationRunStatus::Skipped | AutomationRunStatus::Error
+                )
+            {
+                self.set_status(
+                    StatusLevel::Error,
+                    format!("Automation \"{}\": {detail}", auto.name),
+                );
+                // A skip may have auto-disabled the automation (target gone for
+                // good) — refresh so the pane/list reflects it.
+                self.refresh_automations();
+            }
         }
     }
 
@@ -75,23 +94,7 @@ impl App {
         auto: &Automation,
     ) -> (AutomationRunStatus, String, Option<SessionId>) {
         match &auto.action {
-            AutomationAction::Send { session_id } => {
-                if self.sessions.iter().any(|s| s.info.id == *session_id) {
-                    self.send_prompt_to_session(*session_id, &auto.prompt, 0);
-                    info!("Automation {} sent prompt to {}", auto.id, session_id);
-                    (
-                        AutomationRunStatus::Success,
-                        format!("sent to {session_id}"),
-                        Some(*session_id),
-                    )
-                } else {
-                    (
-                        AutomationRunStatus::Skipped,
-                        "target session not running".to_string(),
-                        None,
-                    )
-                }
-            }
+            AutomationAction::Send { session_id } => self.fire_send_automation(auto, *session_id),
             AutomationAction::Spawn {
                 repo_path,
                 worktree_branch,
@@ -120,6 +123,52 @@ impl App {
                 let (status, detail) = crate::session_ops::run_exec_command(command);
                 (status, detail, None)
             }
+        }
+    }
+
+    /// Execute a `Send` automation: type the prompt into the target session's
+    /// live pane. When the target isn't a running session, distinguish a
+    /// *transient* miss (the row still exists but its window isn't adopted yet —
+    /// stay enabled, it may be restored) from a *permanent* one (the row is
+    /// gone / soft- / force-deleted — disable the automation so it stops
+    /// silently retrying, mirroring force-delete's `disable_send_automations_for_session`).
+    fn fire_send_automation(
+        &mut self,
+        auto: &Automation,
+        session_id: SessionId,
+    ) -> (AutomationRunStatus, String, Option<SessionId>) {
+        if self.sessions.iter().any(|s| s.info.id == session_id) {
+            self.send_prompt_to_session(session_id, &auto.prompt, 0);
+            info!("Automation {} sent prompt to {}", auto.id, session_id);
+            return (
+                AutomationRunStatus::Success,
+                format!("sent to {session_id}"),
+                Some(session_id),
+            );
+        }
+        // Not live. `get_session_name` filters `deleted_at IS NULL`, so `None`
+        // means the target row is gone for good.
+        match self.db.get_session_name(session_id) {
+            Ok(Some(_)) => (
+                AutomationRunStatus::Skipped,
+                SEND_TARGET_NOT_RUNNING.to_string(),
+                None,
+            ),
+            Ok(None) => {
+                if let Err(e) = self.db.disable_send_automations_for_session(session_id) {
+                    warn!("disable_send_automations_for_session: {e}");
+                }
+                (
+                    AutomationRunStatus::Skipped,
+                    SEND_TARGET_GONE.to_string(),
+                    None,
+                )
+            }
+            Err(e) => (
+                AutomationRunStatus::Error,
+                format!("get_session_name: {e}"),
+                None,
+            ),
         }
     }
 

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -10,7 +10,10 @@ use serde_json::{json, Value};
 use crate::cli::action::{self, SpawnDeliverError};
 use crate::cli::output::{self, CommandOutput};
 use crate::session::automation::parse_trigger;
-use crate::session::{Automation, AutomationAction, AutomationRun, AutomationRunStatus, SessionId};
+use crate::session::{
+    Automation, AutomationAction, AutomationRun, AutomationRunStatus, SessionId, SEND_TARGET_GONE,
+    SEND_TARGET_NOT_RUNNING,
+};
 use crate::session_ops::SpawnRequest;
 use crate::storage::automations::NewAutomation;
 use crate::storage::Database;
@@ -521,11 +524,18 @@ fn fire_send(
     let name = match db.get_session_name(session_id) {
         Ok(Some(name)) => name,
         Ok(None) => {
+            // The target row is gone (missing / soft- / force-deleted). This
+            // `send` can never succeed again, so disable it — the same
+            // treatment `disable_send_automations_for_session` applies on
+            // force-delete — instead of silently skipping on every fire.
+            if let Err(e) = db.disable_send_automations_for_session(session_id) {
+                tracing::warn!("disable_send_automations_for_session: {e}");
+            }
             return (
                 AutomationRunStatus::Skipped,
-                "target session not found".into(),
+                SEND_TARGET_GONE.to_string(),
                 None,
-            )
+            );
         }
         Err(e) => {
             return (
@@ -538,7 +548,7 @@ fn fire_send(
     if !crate::agent::tmux::window_exists(&name) {
         return (
             AutomationRunStatus::Skipped,
-            "target session not running".into(),
+            SEND_TARGET_NOT_RUNNING.to_string(),
             None,
         );
     }
@@ -898,5 +908,37 @@ mod tests {
             ..run
         };
         assert_eq!(run_to_json(&run)["related_session_id"], Value::Null);
+    }
+
+    #[test]
+    fn fire_send_disables_automation_when_target_row_is_gone() {
+        let db = Database::open_in_memory().unwrap();
+        let target = SessionId::default();
+        // A `send` automation whose target session was never created (or was
+        // deleted): the row is gone, so the fire can never succeed again.
+        let id = db
+            .create_automation(&crate::storage::automations::NewAutomation {
+                name: "nudge".into(),
+                enabled: true,
+                schedule: crate::session::AutomationSchedule::Cron {
+                    expr: "0 9 * * *".into(),
+                },
+                timezone: None,
+                action: AutomationAction::Send { session_id: target },
+                prompt: "hi".into(),
+                next_run_at: Some(1),
+            })
+            .unwrap();
+        let auto = db.get_automation(id).unwrap().unwrap();
+
+        let (status, detail, related) = fire_send(&db, &auto, target);
+
+        assert_eq!(status, AutomationRunStatus::Skipped);
+        assert_eq!(detail, SEND_TARGET_GONE);
+        assert!(related.is_none());
+        // The automation is now disabled so it stops silently retrying.
+        let after = db.get_automation(id).unwrap().unwrap();
+        assert!(!after.enabled);
+        assert_eq!(after.next_run_at, None);
     }
 }

--- a/src/session/automation.rs
+++ b/src/session/automation.rs
@@ -165,6 +165,17 @@ impl AutomationAction {
     }
 }
 
+/// Run-detail for a `Send` whose target isn't running but whose session row
+/// still exists (not adopted yet / restartable) — a *transient* miss that
+/// leaves the automation enabled. Shared by the TUI (`App::fire_send_automation`)
+/// and headless (`cli::fire_send`) paths so the two stay byte-identical.
+pub const SEND_TARGET_NOT_RUNNING: &str = "target session not running";
+
+/// Run-detail for a `Send` whose target row is gone for good (missing / soft- or
+/// force-deleted) — a *permanent* miss that auto-disables the automation. Shared
+/// by both firing paths (see [`SEND_TARGET_NOT_RUNNING`]).
+pub const SEND_TARGET_GONE: &str = "target session no longer exists (automation disabled)";
+
 /// Outcome of a single automation fire, kept for history.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AutomationRunStatus {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -12,7 +12,7 @@ pub mod theme_config;
 pub use agent_def::{AgentDef, AgentRegistry};
 pub use automation::{
     parse_hhmm, preset_to_cron, Automation, AutomationAction, AutomationRun, AutomationRunStatus,
-    AutomationSchedule, ExtraRepo, SchedulePreset,
+    AutomationSchedule, ExtraRepo, SchedulePreset, SEND_TARGET_GONE, SEND_TARGET_NOT_RUNNING,
 };
 pub use extension_def::{
     AgentPatch, ConfigMerge, ExtensionAutomation, ExtensionDef, ExtensionFile, ExtensionSession,


### PR DESCRIPTION
## Summary

A `send` automation firing at a non-running session used to record a silent `skipped` run — no toast, no notification — so a queued relay/reminder never landed and the user got no signal. This surfaces the miss and, where possible, self-corrects:

- **TUI toast** on a `send` skip/error naming the automation (`Automation "<name>": <reason>`). The run is otherwise only visible in the per-automation run-history panel.
- **Distinguishes the two miss modes** via `get_session_name` (which filters `deleted_at IS NULL`):
  - *transient* — row present, tmux window not adopted yet (`target session not running`) → stays **enabled** (may be restored).
  - *permanent* — row missing / soft- or force-deleted (`target session no longer exists`) → **auto-disables** the automation via the existing `disable_send_automations_for_session` primitive (same treatment force-delete applies), so it stops retrying forever.
- Applied **identically** in the TUI (`App::fire_send_automation`) and the headless tick (`cli::fire_send`) via shared run-detail constants (`SEND_TARGET_NOT_RUNNING` / `SEND_TARGET_GONE`).

`Spawn`/`Exec` have no live-target precondition and are unaffected. Deferred (out of scope): OS desktop notification for headless misses, edge-triggered cadence, a persistent per-automation "last run failed" marker, retry/backoff.

Closes thurbeen/thurbox#746

## Test plan

- New `cli::automations::tests::fire_send_disables_automation_when_target_row_is_gone` — a gone-for-good target returns `Skipped` and auto-disables the automation.
- New `app::acceptance::send_automation_at_a_dead_target_toasts_and_disables` — end-to-end through `process_automations`: warning toast raised + automation disabled + run recorded with the shared detail.
- `cargo build`, full `cargo nextest`, `cargo clippy -D warnings`, `cargo fmt`, `rumdl`, `architecture_rules` all pass (pre-commit + pre-push hooks green, signed commit).