### PR TITLE
feat(ui): true paired side-by-side diff in code review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1508,10 +1508,20 @@ code_review`.
   (`App::handle_review_files_key`, captured before the global lookup like the diff
   pane). While open it owns the central pane; `Esc`/`Ctrl+X` (or `F7`) close it.
   Rendered by `ui::code_review`, reusing `scrollbar`/`focus_block`/
-  `render_button_bar`/theme. **Unified or side-by-side** diff layout, toggled with
-  `v` / the footer button (`side_by_side`). **Mouse-first** (no vim modal): click a
-  diff line to select/comment, click footer buttons, drag the scrollbar,
-  wheel-scroll. **tuicr nav keys**: `j`/`k` + arrows, PageUp/Down + `Ctrl+D`/`U`,
+  `render_button_bar`/theme. **Unified or true paired side-by-side** diff layout,
+  toggled with `v` / the footer button (`side_by_side`). Side-by-side is
+  GitHub-style paired: a deletion (left) and its aligned addition (right) share
+  **one** screen row (positional `del[k] ↔ add[k]` alignment via the pure
+  `session::review::pair_hunk`; unpaired remainders get a blank half-cell). The
+  pairing is a rendering concern only — `ReviewRow::Line` stays row-granular, so
+  a paired row is still one selectable unit and every `match` on it is unchanged;
+  the row build (`push_file_rows`) just emits one row per pair (the addition
+  folds into its deletion's row) when `side_by_side`. Which side a comment
+  attaches to is resolved at compose time (`CodeReviewState::selected_anchor`):
+  keyboard defaults to New (the addition), a mouse click uses the column it hit
+  (`App::cr_click_row` → `click_side`; left = Old, right = New). **Mouse-first**
+  (no vim modal): click a diff line to select/comment, click footer buttons, drag
+  the scrollbar, wheel-scroll. **tuicr nav keys**: `j`/`k` + arrows, PageUp/Down + `Ctrl+D`/`U`,
   `g`/`G`, `{`/`}` (or Tab) next/prev file, `[`/`]` next/prev hunk. Every footer
   button is labelled with its key (`Comment·c`, `Send→Agent·e`, `Find·/`, …) so
   the shortcuts are discoverable; the changed-files column shows a nav-key legend.
@@ -1601,12 +1611,14 @@ code_review`.
   the compiled review into the session's agent as a prompt to address it — the
   review → agent → re-review loop, the orchestrator-native equivalent of submit.
 - **v1 follow-ups** (named, not silently dropped): range/multi-line comments,
-  *true* paired side-by-side (v1's side-by-side is split-column — one source line
-  per row, context on both sides, add/del on their own side), async diff build for
+  token-level intra-line word diffs on a paired row (v1 aligns whole lines
+  positionally, not sub-line), async diff build for
   huge repos (v1 builds synchronously on toggle), grammar-aware syntax
   highlighting (v1's lexer is heuristic + language-agnostic), horizontal
   scroll + wrap in the **side-by-side** layout (v1 supports them in unified
-  only), auto-revealing a horizontally-scrolled-off search match, and
+  only; paired rows pin `h_scroll = 0`), per-side search-match highlighting in
+  side-by-side (v1 navigates but doesn't substring-highlight paired rows),
+  auto-revealing a horizontally-scrolled-off search match, and
   search-match highlight across a wrap-boundary seam.
 
 ## Demo Video

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -620,10 +620,18 @@ reviewed-marks never collide across repos. Each repo resolves its own base
 branch); the commit target lists commits across all repos, repo-tagged.
 
 **Why unified *and* side-by-side?** tuicr offers both (its `diff_view`);
-`v` toggles them. v1's side-by-side is split-column (one source line per
-row — context on both sides, additions/deletions on their own side) so
-selection + comment anchoring (1 row = 1 line) stay intact; true paired
-side-by-side is a follow-up.
+`v` toggles them. The side-by-side layout is **true paired** — a deletion
+(left) and its aligned addition (right) sit on the *same* screen row
+(positional `del[k] ↔ add[k]` alignment, `session::review::pair_hunk`),
+so a modified block reads as N rows instead of the 2N a stacked layout
+takes. The core invariant is preserved: a paired row is still **one
+selectable unit** (the pairing is a rendering concern; `ReviewRow::Line`
+stays row-granular), and which side a comment attaches to is resolved at
+compose time — keyboard defaults to New (the addition), a mouse click uses
+the column it hit (left = Old, right = New). Alignment is positional
+(dependency-free, matching the heuristic syntax highlighter); token-level
+intra-line word diffs, and horizontal-scroll/wrap parity in the paired
+layout, are follow-ups.
 
 **Why syntax highlighting?** Plain diffs are hard to skim. A small,
 dependency-free lexer (`ui::syntax`) colours comments / strings / numbers

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -1722,6 +1722,7 @@ fn open_minimal_review(h: &mut Harness) {
             scroll: 0,
             compose: None,
             side_by_side: false,
+            click_side: None,
             h_scroll: 0,
             wrap: false,
             target: crate::app::code_review::ReviewTarget::Working,
@@ -2026,6 +2027,65 @@ fn clicking_review_row_focuses_the_pane() {
         h.app.focus,
         InputFocus::CodeReview,
         "clicking a diff row focuses the review pane"
+    );
+}
+
+/// A click in the paired side-by-side layout records which column (old | new)
+/// it hit, so a follow-up comment attaches to that side; a later column-less
+/// select (scrollbar drag) clears it.
+#[test]
+fn side_by_side_click_records_column_side() {
+    use crate::session::review::Side;
+    let mut h = Harness::new(STD_COLS, STD_ROWS, 1);
+    let sid = h.app.sessions[0].info.id;
+    let mut cr = crate::app::code_review::CodeReviewState::for_test(sid, 1);
+    cr.side_by_side = true;
+    cr.rebuild_rows();
+    h.app.code_reviews.insert(sid, cr);
+    h.app.focus = InputFocus::CodeReview;
+    h.render();
+    let r = h
+        .app
+        .click_targets
+        .iter()
+        .find(|t| matches!(t.action, ClickAction::ReviewRow(_)))
+        .map(|t| t.rect)
+        .expect("review diff rows recorded as click targets");
+
+    // Right column → the New side is recorded for that row.
+    h.app.update(AppMessage::MouseClick {
+        x: r.x + r.width - 1,
+        y: r.y,
+        modifiers: KeyModifiers::NONE,
+    });
+    assert!(
+        matches!(
+            h.app.active_review().unwrap().click_side,
+            Some((_, Side::New))
+        ),
+        "a right-column click records the New side"
+    );
+
+    // Left column → the Old side.
+    h.app.update(AppMessage::MouseClick {
+        x: r.x,
+        y: r.y,
+        modifiers: KeyModifiers::NONE,
+    });
+    assert!(
+        matches!(
+            h.app.active_review().unwrap().click_side,
+            Some((_, Side::Old))
+        ),
+        "a left-column click records the Old side"
+    );
+
+    // A column-less select (scrollbar drag / cr_select_row) clears it.
+    let sel = h.app.active_review().unwrap().selected;
+    h.app.cr_select_row(sel);
+    assert!(
+        h.app.active_review().unwrap().click_side.is_none(),
+        "a column-less select clears the recorded click side"
     );
 }
 

--- a/src/app/code_review.rs
+++ b/src/app/code_review.rs
@@ -15,7 +15,7 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use std::path::{Path, PathBuf};
 
 use crate::session::review::{
-    parse_unified_diff, Classification, CommentAnchor, DiffFile, ReviewComment, Side,
+    pair_hunk, parse_unified_diff, Classification, CommentAnchor, DiffFile, ReviewComment, Side,
 };
 use crate::session::{HostDef, SessionId};
 
@@ -152,8 +152,17 @@ pub(crate) struct CodeReviewState {
     pub selected: usize,
     pub scroll: usize,
     pub compose: Option<ComposeState>,
-    /// Side-by-side (old | new) vs unified diff layout. Toggled with `v`.
+    /// Side-by-side (old | new) vs unified diff layout. Toggled with `v`. In
+    /// this layout a deletion and its aligned addition share one selectable row
+    /// (see [`crate::session::review::pair_hunk`]); comments still anchor to a
+    /// single side.
     pub side_by_side: bool,
+    /// The side a mouse click landed on, scoped to the row it selected
+    /// (`(row, side)`). Lets a click on the old/new column of a paired
+    /// side-by-side row steer a subsequent comment to that side; any keyboard
+    /// move changes `selected` so the stale entry no longer matches and the
+    /// anchor falls back to its default (New). `None` = keyboard-driven.
+    pub click_side: Option<(usize, Side)>,
     /// Horizontal column offset of the diff body (the line-number gutter stays
     /// pinned). Slides long lines into view; toggled with `Left`/`Right`.
     /// Ignored while `wrap` is on and in the side-by-side layout.
@@ -267,6 +276,76 @@ impl CodeReviewState {
         }
     }
 
+    /// The comment anchor for the selected row, if it can carry one (a diff line
+    /// or a file/hunk header). `file_level` forces a file anchor even on a line.
+    ///
+    /// On a line row the side is resolved so a paired side-by-side row (a
+    /// deletion aligned with an addition) anchors sensibly: a mouse click that
+    /// hit a specific column ([`Self::click_side`], scoped to this row) wins when
+    /// that side exists; otherwise it defaults to New (the addition), falling
+    /// back to Old for a pure deletion — matching the unified layout's
+    /// prefer-new rule. Pure so the side logic is unit-testable without an
+    /// [`App`].
+    pub(crate) fn selected_anchor(&self, file_level: bool) -> Option<CommentAnchor> {
+        match self.rows.get(self.selected)? {
+            ReviewRow::Line(fi, hi, li) => {
+                let file = self.files.get(*fi)?;
+                if file_level {
+                    return Some(CommentAnchor::File {
+                        file: file.path.clone(),
+                    });
+                }
+                let hunk = file.hunks.get(*hi)?;
+                // Resolve the old-side / new-side DiffLines this row stands for.
+                // Unified: a single line, treated as whichever side it carries.
+                // Paired side-by-side: the whole SidePair (a deletion aligned
+                // with an addition), so both sides may be present.
+                let (old_line, new_line) = if self.side_by_side {
+                    let pair = pair_hunk(hunk)
+                        .into_iter()
+                        .find(|p| p.old == Some(*li) || p.new == Some(*li))?;
+                    (
+                        pair.old.and_then(|i| hunk.lines.get(i)),
+                        pair.new.and_then(|i| hunk.lines.get(i)),
+                    )
+                } else {
+                    let line = hunk.lines.get(*li)?;
+                    (
+                        line.old_no.is_some().then_some(line),
+                        line.new_no.is_some().then_some(line),
+                    )
+                };
+                let want = self
+                    .click_side
+                    .filter(|(row, _)| *row == self.selected)
+                    .map(|(_, s)| s);
+                let (side, line) = match want {
+                    Some(Side::Old) if old_line.is_some() => (Side::Old, old_line),
+                    Some(Side::New) if new_line.is_some() => (Side::New, new_line),
+                    _ if new_line.is_some() => (Side::New, new_line),
+                    _ => (Side::Old, old_line),
+                };
+                let line = line?;
+                let ln = match side {
+                    Side::New => line.new_no?,
+                    Side::Old => line.old_no?,
+                };
+                Some(CommentAnchor::Line {
+                    file: file.path.clone(),
+                    side,
+                    line: ln,
+                })
+            }
+            ReviewRow::FileHeader(fi) | ReviewRow::HunkHeader(fi, _) => {
+                let file = self.files.get(*fi)?;
+                Some(CommentAnchor::File {
+                    file: file.path.clone(),
+                })
+            }
+            _ => None,
+        }
+    }
+
     /// Whether `path`'s diff is folded (collapsed to just its header). A file
     /// folds once reviewed; [`Self::fold_override`] flips that per file so the
     /// user can peek at a reviewed file (or collapse an unreviewed one) without
@@ -321,12 +400,38 @@ impl CodeReviewState {
         }
         for (hi, hunk) in file.hunks.iter().enumerate() {
             rows.push(ReviewRow::HunkHeader(fi, hi));
-            for (li, line) in hunk.lines.iter().enumerate() {
-                rows.push(ReviewRow::Line(fi, hi, li));
-                // Line comments anchored to this line (either side).
-                for c in &self.comments {
-                    if c.anchor.anchors_line(&file.path, line.old_no, line.new_no) {
-                        rows.push(ReviewRow::Comment(c.id));
+            if self.side_by_side {
+                // Paired layout: a deletion and its aligned addition share one
+                // selectable row, keyed by the old (or, if absent, the new) line
+                // — the renderer re-derives the pair from the same `pair_hunk`.
+                // Comments for either side interleave after the shared row.
+                for pair in pair_hunk(hunk) {
+                    let rep = pair.old.or(pair.new).expect("a pair has ≥1 side");
+                    rows.push(ReviewRow::Line(fi, hi, rep));
+                    let mut prev = None;
+                    for li in [pair.old, pair.new].into_iter().flatten() {
+                        // A context pair points both sides at the same line;
+                        // don't interleave its comments twice.
+                        if Some(li) == prev {
+                            continue;
+                        }
+                        prev = Some(li);
+                        let line = &hunk.lines[li];
+                        for c in &self.comments {
+                            if c.anchor.anchors_line(&file.path, line.old_no, line.new_no) {
+                                rows.push(ReviewRow::Comment(c.id));
+                            }
+                        }
+                    }
+                }
+            } else {
+                for (li, line) in hunk.lines.iter().enumerate() {
+                    rows.push(ReviewRow::Line(fi, hi, li));
+                    // Line comments anchored to this line (either side).
+                    for c in &self.comments {
+                        if c.anchor.anchors_line(&file.path, line.old_no, line.new_no) {
+                            rows.push(ReviewRow::Comment(c.id));
+                        }
                     }
                 }
             }
@@ -495,6 +600,7 @@ impl App {
             scroll: 0,
             compose: None,
             side_by_side: false,
+            click_side: None,
             h_scroll: 0,
             wrap: false,
             target,
@@ -665,7 +771,10 @@ impl App {
         }
     }
 
-    /// Toggle the unified ↔ side-by-side diff layout (tuicr's `diff_view`).
+    /// Toggle the unified ↔ paired side-by-side diff layout (tuicr's
+    /// `diff_view`). The two layouts have different row sets — side-by-side
+    /// merges each aligned deletion+addition into one row — so the rows are
+    /// rebuilt; `rebuild_rows` clamps the selection if it fell off the end.
     pub(crate) fn cr_toggle_side_by_side(&mut self) {
         if let Some(cr) = self.active_review_mut() {
             cr.side_by_side = !cr.side_by_side;
@@ -674,6 +783,9 @@ impl App {
             if cr.side_by_side {
                 cr.h_scroll = 0;
             }
+            cr.click_side = None;
+            cr.rebuild_rows();
+            cr.ensure_visible();
         }
     }
 
@@ -789,11 +901,35 @@ impl App {
         }
     }
 
-    /// Set the selection directly (a click), if the row is selectable.
+    /// Set the selection directly (a column-less click / scrollbar drag), if the
+    /// row is selectable. Clears any recorded click side (no column context).
     pub(crate) fn cr_select_row(&mut self, idx: usize) {
         if let Some(cr) = self.active_review_mut() {
             if cr.rows.get(idx).is_some_and(ReviewRow::is_selectable) {
                 cr.selected = idx;
+                cr.click_side = None;
+                cr.ensure_visible();
+            }
+        }
+    }
+
+    /// Select a row from a mouse click, recording which column (old | new) the
+    /// click hit so a follow-up comment on a paired side-by-side row attaches to
+    /// that side. `rel_x` is the click offset within the `width`-wide row; the
+    /// paired layout splits at its center separator. In the unified layout the
+    /// column carries no side, so nothing is recorded.
+    pub(crate) fn cr_click_row(&mut self, idx: usize, rel_x: u16, width: u16) {
+        if let Some(cr) = self.active_review_mut() {
+            if cr.rows.get(idx).is_some_and(ReviewRow::is_selectable) {
+                cr.selected = idx;
+                cr.click_side = cr.side_by_side.then(|| {
+                    let side = if rel_x < width / 2 {
+                        Side::Old
+                    } else {
+                        Side::New
+                    };
+                    (idx, side)
+                });
                 cr.ensure_visible();
             }
         }
@@ -928,36 +1064,7 @@ impl App {
 
     /// The anchor for a line/file comment on the current selection, if any.
     fn cr_selected_anchor(&self, file_level: bool) -> Option<CommentAnchor> {
-        let cr = self.active_review()?;
-        match cr.rows.get(cr.selected)? {
-            ReviewRow::Line(fi, hi, li) => {
-                let file = cr.files.get(*fi)?;
-                if file_level {
-                    return Some(CommentAnchor::File {
-                        file: file.path.clone(),
-                    });
-                }
-                let line = file.hunks.get(*hi)?.lines.get(*li)?;
-                // Prefer the new side; fall back to the old side for deletions.
-                let (side, ln) = match (line.new_no, line.old_no) {
-                    (Some(n), _) => (Side::New, n),
-                    (None, Some(o)) => (Side::Old, o),
-                    _ => return None,
-                };
-                Some(CommentAnchor::Line {
-                    file: file.path.clone(),
-                    side,
-                    line: ln,
-                })
-            }
-            ReviewRow::FileHeader(fi) | ReviewRow::HunkHeader(fi, _) => {
-                let file = cr.files.get(*fi)?;
-                Some(CommentAnchor::File {
-                    file: file.path.clone(),
-                })
-            }
-            _ => None,
-        }
+        self.active_review()?.selected_anchor(file_level)
     }
 
     /// Begin composing a comment at the selected line (or the file).
@@ -1643,6 +1750,7 @@ impl CodeReviewState {
             scroll: 0,
             compose: None,
             side_by_side: false,
+            click_side: None,
             h_scroll: 0,
             wrap: false,
             target: ReviewTarget::Branch,
@@ -1710,6 +1818,7 @@ mod tests {
             scroll: 0,
             compose: None,
             side_by_side: false,
+            click_side: None,
             h_scroll: 0,
             wrap: false,
             target: ReviewTarget::Branch,
@@ -1720,6 +1829,53 @@ mod tests {
         };
         s.rebuild_rows();
         s
+    }
+
+    /// A file with one change block: 1 context, 2 deletions, 2 additions —
+    /// enough to exercise the paired side-by-side pairing (del[k] ↔ add[k]).
+    fn change_block_file() -> DiffFile {
+        DiffFile {
+            path: "src/foo.rs".into(),
+            old_path: None,
+            status: FileStatus::Modified,
+            hunks: vec![DiffHunk {
+                old_start: 1,
+                new_start: 1,
+                header: String::new(),
+                lines: vec![
+                    DiffLine {
+                        kind: DiffLineKind::Context,
+                        old_no: Some(1),
+                        new_no: Some(1),
+                        text: "ctx".into(),
+                    },
+                    DiffLine {
+                        kind: DiffLineKind::Del,
+                        old_no: Some(2),
+                        new_no: None,
+                        text: "old a".into(),
+                    },
+                    DiffLine {
+                        kind: DiffLineKind::Del,
+                        old_no: Some(3),
+                        new_no: None,
+                        text: "old b".into(),
+                    },
+                    DiffLine {
+                        kind: DiffLineKind::Add,
+                        old_no: None,
+                        new_no: Some(2),
+                        text: "new a".into(),
+                    },
+                    DiffLine {
+                        kind: DiffLineKind::Add,
+                        old_no: None,
+                        new_no: Some(3),
+                        text: "new b".into(),
+                    },
+                ],
+            }],
+        }
     }
 
     #[test]
@@ -1800,6 +1956,154 @@ mod tests {
             .position(|r| matches!(r, ReviewRow::Line(0, 0, 1)))
             .unwrap();
         assert!(matches!(s.rows[line_pos + 1], ReviewRow::Comment(7)));
+    }
+
+    /// The paired side-by-side layout collapses an aligned deletion+addition
+    /// into ONE selectable row, so a change block of 2 del + 2 add (+1 context)
+    /// yields 3 `Line` rows, not 5 — while the enum stays row-granular.
+    #[test]
+    fn side_by_side_merges_aligned_del_add_into_one_row() {
+        let mut s = state_with(vec![change_block_file()], vec![]);
+        let unified_lines = s
+            .rows
+            .iter()
+            .filter(|r| matches!(r, ReviewRow::Line(..)))
+            .count();
+        assert_eq!(unified_lines, 5, "unified: one row per diff line");
+
+        s.side_by_side = true;
+        s.rebuild_rows();
+        let paired: Vec<_> = s
+            .rows
+            .iter()
+            .filter_map(|r| match r {
+                ReviewRow::Line(_, _, li) => Some(*li),
+                _ => None,
+            })
+            .collect();
+        // Context (li 0), then del[0]↔add[0] (rep = del li 1), del[1]↔add[1]
+        // (rep = del li 2). The addition lines (3, 4) fold into their pair.
+        assert_eq!(paired, vec![0, 1, 2]);
+    }
+
+    /// A comment on either side of a paired row interleaves right after the
+    /// shared row — the addition (New) folds into its deletion's row, so its
+    /// comment still appears there.
+    #[test]
+    fn side_by_side_interleaves_comment_on_folded_addition() {
+        // Comment anchored to the New side, new line 2 (the first addition,
+        // which pairs with the first deletion).
+        let comment = ReviewComment {
+            id: 9,
+            session_id: SessionId::default(),
+            anchor: CommentAnchor::Line {
+                file: "src/foo.rs".into(),
+                side: Side::New,
+                line: 2,
+            },
+            classification: Classification::Note,
+            body: "look here".into(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        let mut s = state_with(vec![change_block_file()], vec![comment]);
+        s.side_by_side = true;
+        s.rebuild_rows();
+        // The paired row's representative is the deletion (li 1); the comment
+        // sits on the very next row even though its anchor is the addition.
+        let pos = s
+            .rows
+            .iter()
+            .position(|r| matches!(r, ReviewRow::Line(0, 0, 1)))
+            .unwrap();
+        assert!(matches!(s.rows[pos + 1], ReviewRow::Comment(9)));
+    }
+
+    /// A paired change row (a deletion aligned with an addition) anchors a
+    /// keyboard comment to the New side by default, and to the clicked column
+    /// when a mouse click recorded one for that exact row.
+    #[test]
+    fn paired_row_anchor_defaults_new_and_honors_click_side() {
+        let mut s = state_with(vec![change_block_file()], vec![]);
+        s.side_by_side = true;
+        s.rebuild_rows();
+        // Select the first paired change row (rep = deletion li 1).
+        s.selected = s
+            .rows
+            .iter()
+            .position(|r| matches!(r, ReviewRow::Line(0, 0, 1)))
+            .unwrap();
+
+        // Keyboard default: the New (addition) side, new line 2.
+        assert_eq!(
+            s.selected_anchor(false),
+            Some(CommentAnchor::Line {
+                file: "src/foo.rs".into(),
+                side: Side::New,
+                line: 2,
+            })
+        );
+
+        // A left-column click on this row steers it to the Old (deletion) side.
+        s.click_side = Some((s.selected, Side::Old));
+        assert_eq!(
+            s.selected_anchor(false),
+            Some(CommentAnchor::Line {
+                file: "src/foo.rs".into(),
+                side: Side::Old,
+                line: 2,
+            })
+        );
+
+        // A stale click side for a *different* row is ignored (falls back to
+        // the New default).
+        s.click_side = Some((s.selected + 999, Side::Old));
+        assert!(matches!(
+            s.selected_anchor(false),
+            Some(CommentAnchor::Line {
+                side: Side::New,
+                ..
+            })
+        ));
+    }
+
+    /// A pure-deletion row (no aligned addition) still anchors to the Old side
+    /// in the paired layout, even if a click asked for New.
+    #[test]
+    fn paired_deletion_only_row_anchors_old() {
+        let file = DiffFile {
+            path: "src/foo.rs".into(),
+            old_path: None,
+            status: FileStatus::Modified,
+            hunks: vec![DiffHunk {
+                old_start: 1,
+                new_start: 1,
+                header: String::new(),
+                lines: vec![DiffLine {
+                    kind: DiffLineKind::Del,
+                    old_no: Some(1),
+                    new_no: None,
+                    text: "gone".into(),
+                }],
+            }],
+        };
+        let mut s = state_with(vec![file], vec![]);
+        s.side_by_side = true;
+        s.rebuild_rows();
+        s.selected = s
+            .rows
+            .iter()
+            .position(|r| matches!(r, ReviewRow::Line(..)))
+            .unwrap();
+        s.click_side = Some((s.selected, Side::New));
+        assert_eq!(
+            s.selected_anchor(false),
+            Some(CommentAnchor::Line {
+                file: "src/foo.rs".into(),
+                side: Side::Old,
+                line: 1,
+            })
+        );
     }
 
     fn repo(label: &str, base: &str) -> ReviewRepo {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2326,12 +2326,19 @@ impl App {
         // consumed click stops here; session-list and terminal clicks fall
         // through so the same press still arms text selection.
         let pos = Position::new(x, y);
-        if let Some(action) = self
+        if let Some((action, rect)) = self
             .click_targets
             .iter()
             .find(|t| t.rect.contains(pos))
-            .map(|t| t.action)
+            .map(|t| (t.action, t.rect))
         {
+            // A diff-row click carries its column so a paired side-by-side row
+            // can steer a follow-up comment to the old/new side it hit.
+            if let ClickAction::ReviewRow(i) = action {
+                self.focus = InputFocus::CodeReview;
+                self.cr_click_row(i, x.saturating_sub(rect.x), rect.width);
+                return;
+            }
             if self.activate_click_target(action) {
                 return;
             }

--- a/src/session/review.rs
+++ b/src/session/review.rs
@@ -404,6 +404,64 @@ fn parse_start(s: &str) -> u32 {
         .unwrap_or(0)
 }
 
+// ── Side-by-side pairing ─────────────────────────────────────────────────────
+
+/// One visual row of the paired (true side-by-side) layout: the old-side and
+/// new-side line indices within a hunk (`None` = a blank half-cell). A context
+/// line pairs with itself (`old == new`); within a change block a deletion and
+/// an addition align positionally (`del[k] ↔ add[k]`), and any uneven remainder
+/// is left half-blank. Every hunk line appears in exactly one [`SidePair`] on
+/// exactly one side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SidePair {
+    pub old: Option<usize>,
+    pub new: Option<usize>,
+}
+
+/// Collapse a hunk into paired side-by-side rows (see [`SidePair`]). Positional
+/// alignment — cheap, deterministic, and dependency-free (matching the
+/// heuristic, language-agnostic stance already taken for syntax highlighting).
+/// Pure so the row builder ([`crate::app`]) and the renderer ([`crate::ui`])
+/// derive the exact same pairing and never disagree on which lines share a row.
+pub fn pair_hunk(hunk: &DiffHunk) -> Vec<SidePair> {
+    let lines = &hunk.lines;
+    let mut pairs = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        match lines[i].kind {
+            DiffLineKind::Context => {
+                pairs.push(SidePair {
+                    old: Some(i),
+                    new: Some(i),
+                });
+                i += 1;
+            }
+            // A change block: the run of deletions, then the run of additions
+            // immediately after it (git emits `-` lines before `+` within a
+            // contiguous change). Align them positionally.
+            _ => {
+                let del_start = i;
+                while i < lines.len() && lines[i].kind == DiffLineKind::Del {
+                    i += 1;
+                }
+                let del_len = i - del_start;
+                let add_start = i;
+                while i < lines.len() && lines[i].kind == DiffLineKind::Add {
+                    i += 1;
+                }
+                let add_len = i - add_start;
+                for k in 0..del_len.max(add_len) {
+                    pairs.push(SidePair {
+                        old: (k < del_len).then_some(del_start + k),
+                        new: (k < add_len).then_some(add_start + k),
+                    });
+                }
+            }
+        }
+    }
+    pairs
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -635,5 +693,167 @@ index 1..2 100644
     #[test]
     fn empty_input_yields_no_files() {
         assert!(parse_unified_diff("").is_empty());
+    }
+
+    /// Build a hunk from a compact `kind` list (`c`/`-`/`+`) for pairing tests.
+    fn hunk_of(kinds: &str) -> DiffHunk {
+        let (mut o, mut n) = (1u32, 1u32);
+        let lines = kinds
+            .chars()
+            .map(|ch| {
+                let (kind, old, new) = match ch {
+                    '-' => {
+                        let l = (DiffLineKind::Del, Some(o), None);
+                        o += 1;
+                        l
+                    }
+                    '+' => {
+                        let l = (DiffLineKind::Add, None, Some(n));
+                        n += 1;
+                        l
+                    }
+                    _ => {
+                        let l = (DiffLineKind::Context, Some(o), Some(n));
+                        o += 1;
+                        n += 1;
+                        l
+                    }
+                };
+                DiffLine {
+                    kind,
+                    old_no: old,
+                    new_no: new,
+                    text: ch.to_string(),
+                }
+            })
+            .collect();
+        DiffHunk {
+            old_start: 1,
+            new_start: 1,
+            header: String::new(),
+            lines,
+        }
+    }
+
+    #[test]
+    fn pairs_context_with_itself() {
+        // Two context lines → two rows, each showing the same line on both sides.
+        let pairs = pair_hunk(&hunk_of("cc"));
+        assert_eq!(
+            pairs,
+            vec![
+                SidePair {
+                    old: Some(0),
+                    new: Some(0)
+                },
+                SidePair {
+                    old: Some(1),
+                    new: Some(1)
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn pairs_even_change_block_positionally() {
+        // `c - - + + c` → context, then del[0]↔add[0], del[1]↔add[1], context.
+        let pairs = pair_hunk(&hunk_of("c--++c"));
+        assert_eq!(
+            pairs,
+            vec![
+                SidePair {
+                    old: Some(0),
+                    new: Some(0)
+                },
+                SidePair {
+                    old: Some(1),
+                    new: Some(3)
+                },
+                SidePair {
+                    old: Some(2),
+                    new: Some(4)
+                },
+                SidePair {
+                    old: Some(5),
+                    new: Some(5)
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn uneven_block_leaves_remainder_half_blank() {
+        // 3 deletions, 1 addition: del[0]↔add[0], then two del-only rows.
+        let pairs = pair_hunk(&hunk_of("---+"));
+        assert_eq!(
+            pairs,
+            vec![
+                SidePair {
+                    old: Some(0),
+                    new: Some(3)
+                },
+                SidePair {
+                    old: Some(1),
+                    new: None
+                },
+                SidePair {
+                    old: Some(2),
+                    new: None
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn pure_additions_and_deletions_pair_against_blanks() {
+        // Pure additions: every row is new-only (old blank).
+        assert_eq!(
+            pair_hunk(&hunk_of("++")),
+            vec![
+                SidePair {
+                    old: None,
+                    new: Some(0)
+                },
+                SidePair {
+                    old: None,
+                    new: Some(1)
+                },
+            ]
+        );
+        // Pure deletions: every row is old-only (new blank).
+        assert_eq!(
+            pair_hunk(&hunk_of("--")),
+            vec![
+                SidePair {
+                    old: Some(0),
+                    new: None
+                },
+                SidePair {
+                    old: Some(1),
+                    new: None
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn every_line_appears_in_exactly_one_pair() {
+        let hunk = hunk_of("c--++c-+c");
+        let pairs = pair_hunk(&hunk);
+        let mut seen = std::collections::HashSet::new();
+        for p in &pairs {
+            // A context pair references the same line on both sides (old == new);
+            // an add/del pair references two distinct lines. Count distinct.
+            let distinct: std::collections::HashSet<usize> =
+                [p.old, p.new].into_iter().flatten().collect();
+            for li in distinct {
+                assert!(seen.insert(li), "line {li} placed twice");
+            }
+        }
+        assert_eq!(
+            seen.len(),
+            hunk.lines.len(),
+            "every hunk line is placed exactly once"
+        );
     }
 }

--- a/src/ui/code_review.rs
+++ b/src/ui/code_review.rs
@@ -9,7 +9,9 @@ use ratatui::widgets::{Clear, Paragraph};
 use ratatui::Frame;
 
 use crate::app::code_review::{CodeReviewState, ComposeState, ReviewButton, ReviewRow};
-use crate::session::review::{Classification, CommentAnchor, DiffFile, DiffLine, DiffLineKind};
+use crate::session::review::{
+    pair_hunk, Classification, CommentAnchor, DiffFile, DiffHunk, DiffLine, DiffLineKind, SidePair,
+};
 use crate::ui::scrollbar::{self, ScrollbarGeom};
 use crate::ui::theme::Theme;
 use crate::ui::{focus_block, render_button_bar, ButtonSpec, FocusLevel, RowHitbox};
@@ -194,6 +196,12 @@ fn render_rows(
     // Line-number column width from the largest number on screen.
     let num_w = line_number_width(state);
 
+    // Wrapping is a unified-only concern: the paired side-by-side layout is
+    // always one screen row per logical row (its horizontal-scroll/wrap parity
+    // is a named follow-up). Collapse the two flags into one local so the scroll
+    // math below treats side-by-side exactly like unwrapped unified.
+    let wrap = state.wrap && !state.side_by_side;
+
     // Final horizontal clamp: the app layer bounds `h_scroll` by the longest
     // line, but the exact body width is only known now — never scroll past what
     // the widest line can reveal. Wrapped/side-by-side layouts pin it to 0.
@@ -210,7 +218,7 @@ fn render_rows(
     // Clamp scroll so the selection stays visible (the nav layer set a lower
     // bound; here we enforce the upper edge given the known height). With wrap
     // off, one logical row = one visual row, so the original math holds.
-    if !state.wrap {
+    if !wrap {
         if state.selected >= state.scroll + height {
             state.scroll = state.selected + 1 - height;
         }
@@ -231,7 +239,9 @@ fn render_rows(
         .map(|s| s.query.trim().to_lowercase())
         .filter(|q| !q.is_empty());
 
-    converge_wrap_scroll(state, width, num_w, height);
+    if wrap {
+        converge_wrap_scroll(state, width, num_w, height);
+    }
 
     // Build the windowed visual lines. When wrapping, the selected logical row's
     // first visual line must stay on screen: expand from `scroll` and, if the
@@ -255,7 +265,7 @@ fn render_rows(
                 num_w,
                 query.as_deref(),
                 state.h_scroll,
-                state.wrap,
+                wrap,
             ) {
                 lines.push(line);
                 logical.push(i);
@@ -263,9 +273,8 @@ fn render_rows(
         }
         // Selection off the bottom (only possible when wrapping inflates rows):
         // scroll down one logical row and rebuild.
-        let overflows = state.wrap
-            && selected_first.map_or(true, |f| f >= height)
-            && state.scroll < state.selected;
+        let overflows =
+            wrap && selected_first.map_or(true, |f| f >= height) && state.scroll < state.selected;
         if overflows {
             state.scroll += 1;
             continue;
@@ -339,12 +348,14 @@ fn row_visual_lines<'a>(
         }
         ReviewRow::Line(fi, hi, li) => {
             let f = &state.files[*fi];
-            let l = &f.hunks[*hi].lines[*li];
+            let hunk = &f.hunks[*hi];
             if state.side_by_side {
-                vec![side_by_side_line(l, width, num_w, &sel_style)]
+                vec![paired_diff_line(hunk, *li, width, num_w, &sel_style)]
             } else if wrap {
+                let l = &hunk.lines[*li];
                 unified_diff_line_wrapped(f, l, width, num_w, selected, query, &sel_style)
             } else {
+                let l = &hunk.lines[*li];
                 vec![unified_diff_line(
                     f, l, width, num_w, selected, h_scroll, query, &sel_style,
                 )]
@@ -730,16 +741,31 @@ fn comment_line<'a>(
     Line::from(spans)
 }
 
-/// Render one diff line as two side-by-side cells (old | new). One source line
-/// per screen row: context appears in both cells, a deletion only on the left,
-/// an addition only on the right — so selection + comment anchoring (1 row = 1
-/// line) are unchanged.
-fn side_by_side_line<'a>(
-    l: &DiffLine,
+/// Render one paired side-by-side row: the old-side cell `│` the new-side cell.
+/// True GitHub-style pairing — a deletion (left) and its aligned addition
+/// (right) sit on the *same* screen row (see
+/// [`crate::session::review::pair_hunk`]). `li` is the row's representative line
+/// index; the [`SidePair`] it belongs to supplies both sides (a blank half-cell
+/// where a side is absent). The selection + comment anchor stay 1 row = 1
+/// selectable unit; which side a comment attaches to is resolved at compose
+/// time. Plain add/remove tinting (no syntax highlighting), matching the
+/// unified body's gutter-sign convention.
+fn paired_diff_line<'a>(
+    hunk: &DiffHunk,
+    li: usize,
     width: usize,
     num_w: usize,
     sel_style: &impl Fn(Style) -> Style,
 ) -> Line<'a> {
+    // Re-derive the pair this row stands for from the same pure pairing the row
+    // builder used, so the two never disagree on which lines share the row.
+    let pair = pair_hunk(hunk)
+        .into_iter()
+        .find(|p| p.old == Some(li) || p.new == Some(li))
+        .unwrap_or(SidePair {
+            old: Some(li),
+            new: None,
+        });
     let half = width.saturating_sub(1) / 2;
     let prim = || Style::default().fg(Theme::text_primary());
     let removed = || {
@@ -752,27 +778,29 @@ fn side_by_side_line<'a>(
             .fg(Theme::diff_added())
             .bg(Theme::diff_added_bg())
     };
-    // (cell text, cell style) for each side; the changed side carries its tint
-    // (sel_style overrides bg when the row is selected).
-    let (left, lstyle, right, rstyle) = match l.kind {
-        DiffLineKind::Context => (
+    // Each cell tints only when it carries a change (a context line pairs with
+    // itself and stays plain on both sides); sel_style overrides bg on select.
+    let (left, lstyle) = match pair.old.map(|i| &hunk.lines[i]) {
+        Some(l) => (
             half_cell(l.old_no, &l.text, num_w, half),
-            prim(),
+            if l.kind == DiffLineKind::Del {
+                removed()
+            } else {
+                prim()
+            },
+        ),
+        None => (half_cell(None, "", num_w, half), prim()),
+    };
+    let (right, rstyle) = match pair.new.map(|i| &hunk.lines[i]) {
+        Some(l) => (
             half_cell(l.new_no, &l.text, num_w, half),
-            prim(),
+            if l.kind == DiffLineKind::Add {
+                added()
+            } else {
+                prim()
+            },
         ),
-        DiffLineKind::Del => (
-            half_cell(l.old_no, &l.text, num_w, half),
-            removed(),
-            half_cell(None, "", num_w, half),
-            prim(),
-        ),
-        DiffLineKind::Add => (
-            half_cell(None, "", num_w, half),
-            prim(),
-            half_cell(l.new_no, &l.text, num_w, half),
-            added(),
-        ),
+        None => (half_cell(None, "", num_w, half), prim()),
     };
     Line::from(vec![
         Span::styled(left, sel_style(lstyle)),
@@ -1060,7 +1088,7 @@ fn render_footer(
     // so it stays discoverable. The non-composing bar leads with the essential
     // actions (Comment, Send→Agent, Close) so they survive a narrow footer —
     // `render_button_bar` drops overflow from the right and marks it with `…`.
-    let view_label = if side_by_side { "Unified" } else { "Split" };
+    let view_label = if side_by_side { "Unified" } else { "Side" };
     let wrap_label = if wrap { "NoWrap" } else { "Wrap" };
     let (specs, actions): (Vec<ButtonSpec>, Vec<ReviewButton>) = if composing {
         (
@@ -1267,6 +1295,7 @@ mod tests {
             scroll: 0,
             compose: None,
             side_by_side: false,
+            click_side: None,
             h_scroll: 0,
             wrap: false,
             target: crate::app::code_review::ReviewTarget::Branch,
@@ -1305,6 +1334,33 @@ mod tests {
                 .unwrap();
             }
         }
+    }
+
+    /// True paired side-by-side draws a deletion and its aligned addition on the
+    /// SAME screen row: one line shows the old body left, the new body right,
+    /// split by the `│` separator — the density win over v1's split-column.
+    #[test]
+    fn paired_side_by_side_shows_both_sides_on_one_row() {
+        let mut state = demo_state();
+        state.side_by_side = true;
+        state.rebuild_rows();
+        let mut term = Terminal::new(TestBackend::new(60, 20)).unwrap();
+        term.draw(|f| {
+            let _ = render(f, Rect::new(0, 0, 60, 20), &mut state, FocusLevel::Focused);
+        })
+        .unwrap();
+        let buf = term.backend().buffer();
+        let mut paired_row = false;
+        for y in 0..20 {
+            let row: String = (0..60).map(|x| buf[(x, y)].symbol()).collect();
+            if row.contains("old") && row.contains("new") && row.contains('│') {
+                paired_row = true;
+            }
+        }
+        assert!(
+            paired_row,
+            "the deletion (old) and addition (new) render on one paired row"
+        );
     }
 
     /// A far jump under wrap (`G`-style: selection moved, scroll untouched)


### PR DESCRIPTION
## Summary

Replaces the v1 split-column side-by-side layout in the native code-review view (`Ctrl+X` / `F7`) with **true GitHub-style paired rows**: a deletion (left) and its aligned addition (right) now share one screen row, so a modified block reads as N rows instead of 2N. Closes thurbeen/thurbox#748 (task #63).

- **Pairing pass** (`session::review::pair_hunk`, pure + unit-tested): positional `del[k] ↔ add[k]` alignment within each change block; context lines pair with themselves; uneven remainders get a blank half-cell. Every hunk line lands in exactly one pair.
- **Invariant preserved**: `ReviewRow::Line` stays row-granular, so a paired row is still one selectable unit and every `match` on it is unchanged. The row build emits one row per pair (the addition folds into its deletion's row); the renderer and anchor logic re-derive the same pairing.
- **Comment side** resolved at compose time: keyboard defaults to New (the addition); a mouse click uses the column it hit (left = Old, right = New), via a row-scoped `click_side`.
- Split-column layout removed entirely (`v` now toggles Unified ↔ Paired); side-by-side keeps `h_scroll = 0` (horizontal-scroll/wrap parity remains a named follow-up). Docs (`CLAUDE.md`, `docs/FEATURES.md`) updated.

## Test plan

- `session::review` pairing unit tests (context / even / uneven / pure-add / pure-del / every-line-once)
- `app::code_review` tests: row-merge, comment interleave on folded addition, anchor default-New + click-side + stale-row + deletion-only
- `app::acceptance` test: mouse column → recorded side, cleared by column-less select
- `ui::code_review` render test: both sides drawn on one paired row
- Full pre-commit suite (fmt, clippy `-D warnings`, nextest, cargo-deny, cargo-doc, rumdl, conventional-commit) passed locally; visually eyeballed the rendered paired layout
- CI checks pass

🤖 Manual review requested — auto-merge intentionally NOT enabled.