### PR TITLE
feat(cli): add doctor command for runtime environment health check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -694,7 +694,12 @@ release — `--force` bypasses the up-to-date/dev-build guards; gated on
 `[features] auto_update`, off by default; the TUI also runs this silently on
 startup when the flag is on), `notify`
 (diagnose OS desktop notifications: prints the detected delivery backend
-and last error; `--test` fires a sample — see OS notifications below).
+and last error; `--test` fires a sample — see OS notifications below), `doctor`
+(aggregate runtime-environment health check: probes tmux ≥ 3.2 + git presence,
+each agent `command` on PATH (default-agent absence = error, others = warning),
+DB writability, and rolls up `config validate`; `--hosts` also probes each
+configured/discovered host for reachability concurrently. Reports only, never
+fixes; exits non-zero on any error-severity check so it works as a setup gate).
 Output is
 **human-readable by default** and switches to JSON automatically when stdout is
 piped (so `… | jq` keeps working); force a format with `--json` (compact),

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -639,6 +639,36 @@ impl TmuxBackend {
         Self::with_transport(transport, socket, session, host.backend_name())
     }
 
+    /// Probe the multiplexer over this backend's transport, returning its
+    /// trimmed `-V` banner (e.g. `"tmux 3.4"`) on success.
+    ///
+    /// `tmux -L <socket> -V` prints the version without connecting, and over the
+    /// SSH/WSL transport this verifies reachability + `tmux` presence at the same
+    /// time (see [`SessionBackend::check_available`], which is a thin `probe`
+    /// wrapper). The `>= 3.2` gate (`check_min_version`) only bites real tmux,
+    /// so a psmux host passes on its own banner. Doctor uses the returned string
+    /// for its per-check / per-host status line.
+    pub fn probe(&self) -> Result<String> {
+        let output = self
+            .transport
+            .tmux_command(&self.socket, &["-V"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("tmux is not installed or not in PATH")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("tmux -V failed: {}", stderr.trim());
+        }
+
+        let version_str = String::from_utf8_lossy(&output.stdout);
+        check_min_version(&version_str)?;
+        let version = version_str.trim().to_string();
+        debug!("multiplexer version: {version}");
+        Ok(version)
+    }
+
     /// Run a tmux command and return its stdout (used before control mode is available).
     fn tmux_output(&self, args: &[&str]) -> Result<String> {
         let output = self.run_tmux(args)?;
@@ -1105,25 +1135,7 @@ impl SessionBackend for TmuxBackend {
     }
 
     fn check_available(&self) -> Result<()> {
-        // `tmux -L <socket> -V` prints the version without connecting, and over
-        // the SSH transport this verifies remote connectivity at the same time.
-        let output = self
-            .transport
-            .tmux_command(&self.socket, &["-V"])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .context("tmux is not installed or not in PATH")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            bail!("tmux -V failed: {}", stderr.trim());
-        }
-
-        let version_str = String::from_utf8_lossy(&output.stdout);
-        check_min_version(&version_str)?;
-        debug!("multiplexer version: {}", version_str.trim());
-        Ok(())
+        self.probe().map(|_| ())
     }
 
     fn ensure_ready(&self) -> Result<()> {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -103,7 +103,10 @@ fn validate_keybindings() -> (Value, bool) {
 
 /// Validate every config file. Returns the full report plus the list of files
 /// that failed (empty = all valid).
-fn validate() -> (Value, Vec<String>) {
+///
+/// Exposed to the sibling `doctor` module so it folds config validity in as one
+/// check without re-parsing (see `cli::doctor`).
+pub(crate) fn validate() -> (Value, Vec<String>) {
     let (agents, agents_ok) = validate_toml::<crate::session::AgentRegistry>(
         crate::agent::agent_config::agents_config_path(),
         "agents.toml",

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,0 +1,536 @@
+//! `thurbox-cli doctor` — aggregate runtime-environment health check.
+//!
+//! `config validate` parses the config *files*; `doctor` probes the *runtime*:
+//! is `tmux` (>= 3.2) present, is `git` present, is each agent's `command` on
+//! PATH, does the database open writable, and (rolled up, not re-implemented)
+//! are the config files valid. With `--hosts` it also probes each configured /
+//! discovered host for reachability. It is the local counterpart of the e2e
+//! harnesses' `check` verb — a readiness probe you can run before ever
+//! launching a session.
+//!
+//! Doctor *reports*; it never installs tmux, seeds config, or edits PATH. It
+//! exits non-zero when any **error**-severity check fails (a usable CI/setup
+//! gate), zero when only warnings are present. Notification delivery is *not*
+//! re-probed here — that is `thurbox-cli notify`'s job; doctor emits a single
+//! advisory line pointing at it.
+//!
+//! The agent module's helpers (`TmuxBackend`, `host_config`, `agent_config`)
+//! are reached via fully-qualified paths (no `use crate::agent`) to keep the
+//! cli module free of an `agent` import — see
+//! tests/architecture_rules.rs::cli_module_isolation.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use clap::Args;
+use serde_json::{json, Value};
+
+use crate::storage::Database;
+
+use super::output::CommandOutput;
+
+/// Per-host reachability probe timeout. A dead box (or an SSH auth prompt)
+/// must not hang the whole command; host probes run concurrently, so wall time
+/// is bounded to roughly this regardless of host count.
+const HOST_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// `doctor` subcommand arguments.
+#[derive(Args, Debug)]
+pub struct DoctorArgs {
+    /// Also probe each configured/discovered host for reachability (SSH round
+    /// trip per host; off by default because it is slow and non-hermetic).
+    #[arg(long)]
+    pub hosts: bool,
+}
+
+/// Severity of a single check outcome.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Status {
+    /// Healthy.
+    Ok,
+    /// Degraded but non-fatal (e.g. a non-default agent's binary is absent).
+    Warn,
+    /// A problem that fails the command's exit code.
+    Error,
+}
+
+impl Status {
+    /// JSON/string form.
+    fn as_str(self) -> &'static str {
+        match self {
+            Status::Ok => "ok",
+            Status::Warn => "warn",
+            Status::Error => "error",
+        }
+    }
+
+    /// Leading glyph in the human rendering (mirrors `config validate`).
+    fn mark(self) -> &'static str {
+        match self {
+            Status::Ok => "✓",
+            Status::Warn => "·",
+            Status::Error => "✗",
+        }
+    }
+}
+
+/// One environment check's outcome.
+#[derive(Debug)]
+struct Check {
+    /// Stable identifier (`tmux`, `git`, `agent:claude`, `database`, `config`,
+    /// `host:ssh:devbox`).
+    id: String,
+    status: Status,
+    /// Short human-readable result (`3.4  ok`, `not found on PATH`, …).
+    detail: String,
+    /// Optional remediation pointer.
+    hint: Option<String>,
+}
+
+impl Check {
+    fn ok(id: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            status: Status::Ok,
+            detail: detail.into(),
+            hint: None,
+        }
+    }
+
+    fn new(
+        id: impl Into<String>,
+        status: Status,
+        detail: impl Into<String>,
+        hint: Option<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            status,
+            detail: detail.into(),
+            hint,
+        }
+    }
+
+    fn to_json(&self) -> Value {
+        json!({
+            "id": self.id,
+            "status": self.status.as_str(),
+            "detail": self.detail,
+            "hint": self.hint,
+        })
+    }
+}
+
+/// Run the `doctor` command. Reads the effective config (agents/hosts) and the
+/// already-open database; probes the local environment and, with `--hosts`, the
+/// configured host set.
+pub fn run(args: DoctorArgs, db: &Database) -> CommandOutput {
+    let mut checks = vec![check_tmux(), check_git()];
+    let agents = crate::agent::agent_config::load_or_seed();
+    checks.extend(agent_checks(&agents));
+    checks.push(check_database(db));
+    checks.push(check_config());
+    if args.hosts {
+        checks.extend(host_checks());
+    }
+
+    let healthy = healthy(&checks);
+    let headline = headline(&checks);
+    let advisory = notification_advisory();
+    let human = render(&checks, &headline, advisory.as_deref());
+
+    let report = json!({
+        "healthy": healthy,
+        "checks": checks.iter().map(Check::to_json).collect::<Vec<_>>(),
+        "advisory": advisory,
+        "summary": headline,
+    });
+
+    if healthy {
+        CommandOutput::new(report, human)
+    } else {
+        // Exit non-zero so `doctor` is usable as a CI/setup gate.
+        CommandOutput::failed(report, human, headline)
+    }
+}
+
+/// `tmux` (>= 3.2) present over the local transport.
+fn check_tmux() -> Check {
+    match crate::agent::tmux::TmuxBackend::local().probe() {
+        Ok(version) => Check::ok("tmux", format!("{version}  ok")),
+        Err(e) => Check::new(
+            "tmux",
+            Status::Error,
+            e.to_string(),
+            Some("install tmux >= 3.2 (thurbox's session backend requires it)".into()),
+        ),
+    }
+}
+
+/// `git` present (worktree creation shells out to it).
+fn check_git() -> Check {
+    // The cli module may not reference the `git` module (architecture rule), so
+    // probe the binary directly — a bare `git --version` needs no repo context.
+    match std::process::Command::new("git").arg("--version").output() {
+        Ok(out) if out.status.success() => {
+            let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            Check::ok("git", format!("{v}  ok"))
+        }
+        Ok(out) => Check::new(
+            "git",
+            Status::Error,
+            format!(
+                "git --version failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+            Some("install git".into()),
+        ),
+        Err(_) => Check::new(
+            "git",
+            Status::Error,
+            "not found on PATH",
+            Some("install git (thurbox creates worktrees with it)".into()),
+        ),
+    }
+}
+
+/// One `agent:<name>` check per registered agent: its `command` resolved on the
+/// local PATH. The default agent's absence is an **error** (the common first-run
+/// wall); a non-default agent's absence a **warning**. Remote-host agent
+/// presence isn't verified here (PATH differs per host).
+fn agent_checks(agents: &crate::session::AgentRegistry) -> Vec<Check> {
+    let default = agents.default_name();
+    agents
+        .agents
+        .iter()
+        .map(|a| {
+            let id = format!("agent:{}", a.name);
+            if crate::paths::which_on_path(&a.command) {
+                Check::ok(id, format!("{}  found", a.command))
+            } else if a.name == default {
+                Check::new(
+                    id,
+                    Status::Error,
+                    format!("{}: not found on PATH", a.command),
+                    Some(format!(
+                        "install `{}` or set a different `default` agent in agents.toml",
+                        a.command
+                    )),
+                )
+            } else {
+                Check::new(
+                    id,
+                    Status::Warn,
+                    format!("{}: not found on PATH (non-default)", a.command),
+                    None,
+                )
+            }
+        })
+        .collect()
+}
+
+/// The database opens writable and isn't held by another writer.
+fn check_database(db: &Database) -> Check {
+    match db.check_writable() {
+        Ok(()) => Check::ok("database", "writable  ok"),
+        Err(e) => Check::new(
+            "database",
+            Status::Error,
+            format!("not writable: {e}"),
+            Some("check filesystem permissions / free space for the thurbox data dir".into()),
+        ),
+    }
+}
+
+/// Roll up `config validate` as one check (delegated, never re-parsed).
+fn check_config() -> Check {
+    let (_, failed) = super::config::validate();
+    if failed.is_empty() {
+        Check::ok("config", "all files valid")
+    } else {
+        Check::new(
+            "config",
+            Status::Error,
+            format!("invalid: {}", failed.join(", ")),
+            Some("run `thurbox-cli config validate` for the per-file details".into()),
+        )
+    }
+}
+
+/// Probe every effective host (configured SSH/WSL + discovered WSL distros) for
+/// reachability, concurrently. Each host's `tmux -V` over its transport verifies
+/// connectivity + tmux presence + version in one shot; an unreachable or
+/// too-old host is an **error**. Only run under `--hosts`.
+fn host_checks() -> Vec<Check> {
+    let hosts = crate::agent::host_config::load_all();
+    if hosts.hosts.is_empty() {
+        return vec![Check::ok("hosts", "none configured")];
+    }
+
+    // Spawn one probe thread per host so wall time is bounded to the slowest
+    // (mirrors main.rs's background remote-restore), each reporting on its own
+    // channel we wait on with a timeout.
+    let probes: Vec<(String, mpsc::Receiver<Result<String, String>>)> = hosts
+        .hosts
+        .iter()
+        .cloned()
+        .map(|host| {
+            let backend_name = host.backend_name();
+            let (tx, rx) = mpsc::channel();
+            std::thread::spawn(move || {
+                let result = crate::agent::tmux::TmuxBackend::from_host(&host)
+                    .probe()
+                    .map_err(|e| e.to_string());
+                // Receiver may be gone if the caller already timed out; ignore.
+                let _ = tx.send(result);
+            });
+            (format!("host:{backend_name}"), rx)
+        })
+        .collect();
+
+    probes
+        .into_iter()
+        .map(|(id, rx)| match rx.recv_timeout(HOST_PROBE_TIMEOUT) {
+            Ok(Ok(version)) => Check::ok(id, format!("reachable  {version}")),
+            Ok(Err(e)) => Check::new(id, Status::Error, e, None),
+            Err(_) => Check::new(
+                id,
+                Status::Error,
+                format!("timed out after {}s", HOST_PROBE_TIMEOUT.as_secs()),
+                None,
+            ),
+        })
+        .collect()
+}
+
+/// A single advisory line pointing at `thurbox-cli notify` when notifications
+/// are enabled — doctor stays hands-off and never re-probes the delivery
+/// backend. `None` when the feature is off (nothing to advise).
+fn notification_advisory() -> Option<String> {
+    if crate::session::settings::global().features.notifications {
+        Some("Notifications are enabled — run `thurbox-cli notify` to diagnose delivery.".into())
+    } else {
+        None
+    }
+}
+
+/// Whether the environment is healthy: no **error**-severity checks. Warnings
+/// alone stay healthy (e.g. a non-default agent absent).
+fn healthy(checks: &[Check]) -> bool {
+    !checks.iter().any(|c| c.status == Status::Error)
+}
+
+/// One actionable summary line tailored to the outcome (mirrors notify's
+/// `diagnose_headline`).
+fn headline(checks: &[Check]) -> String {
+    let errors: Vec<&str> = checks
+        .iter()
+        .filter(|c| c.status == Status::Error)
+        .map(|c| c.id.as_str())
+        .collect();
+    let warns = checks.iter().filter(|c| c.status == Status::Warn).count();
+    if !errors.is_empty() {
+        return format!("{} problem(s): {}.", errors.len(), errors.join(", "));
+    }
+    if warns > 0 {
+        return format!("Environment healthy ({warns} warning(s)).");
+    }
+    "Environment healthy.".to_string()
+}
+
+/// Render the per-check status list plus headline and optional advisory,
+/// modeled on `config validate`'s `render_validate`.
+fn render(checks: &[Check], headline: &str, advisory: Option<&str>) -> String {
+    let mut lines = Vec::new();
+    for c in checks {
+        lines.push(format!("{} {}  {}", c.status.mark(), c.id, c.detail));
+        if let Some(hint) = &c.hint {
+            lines.push(format!("    → {hint}"));
+        }
+    }
+    lines.push(String::new());
+    lines.push(headline.to_string());
+    if let Some(a) = advisory {
+        lines.push(a.to_string());
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::TestPathGuard;
+
+    fn err(id: &str) -> Check {
+        Check::new(id, Status::Error, "boom", None)
+    }
+    fn warn(id: &str) -> Check {
+        Check::new(id, Status::Warn, "meh", None)
+    }
+
+    #[test]
+    fn healthy_only_when_no_errors() {
+        assert!(healthy(&[Check::ok("a", "ok"), warn("b")]));
+        assert!(!healthy(&[Check::ok("a", "ok"), err("b")]));
+        assert!(healthy(&[]));
+    }
+
+    #[test]
+    fn headline_names_error_checks() {
+        let h = headline(&[Check::ok("a", "ok"), err("tmux"), err("git")]);
+        assert!(h.contains("2 problem(s)"), "got: {h}");
+        assert!(h.contains("tmux") && h.contains("git"), "got: {h}");
+    }
+
+    #[test]
+    fn headline_counts_warnings_when_otherwise_healthy() {
+        let h = headline(&[Check::ok("a", "ok"), warn("agent:codex")]);
+        assert!(h.contains("healthy"), "got: {h}");
+        assert!(h.contains("1 warning"), "got: {h}");
+    }
+
+    #[test]
+    fn headline_is_plain_when_all_ok() {
+        assert_eq!(headline(&[Check::ok("a", "ok")]), "Environment healthy.");
+        // Empty is vacuously healthy too (no checks ran).
+        assert_eq!(headline(&[]), "Environment healthy.");
+    }
+
+    #[test]
+    fn status_string_and_glyph_mapping() {
+        assert_eq!(Status::Ok.as_str(), "ok");
+        assert_eq!(Status::Warn.as_str(), "warn");
+        assert_eq!(Status::Error.as_str(), "error");
+        assert_eq!(Status::Ok.mark(), "✓");
+        assert_eq!(Status::Warn.mark(), "·");
+        assert_eq!(Status::Error.mark(), "✗");
+    }
+
+    #[test]
+    fn render_lists_checks_marks_and_hints() {
+        let checks = vec![
+            Check::ok("tmux", "3.4  ok"),
+            Check::new(
+                "git",
+                Status::Error,
+                "not found on PATH",
+                Some("install git".into()),
+            ),
+        ];
+        let out = render(&checks, "1 problem(s): git.", Some("advisory line"));
+        assert!(out.contains("✓ tmux  3.4  ok"), "got:\n{out}");
+        assert!(out.contains("✗ git  not found on PATH"), "got:\n{out}");
+        assert!(out.contains("    → install git"), "got:\n{out}");
+        assert!(out.contains("1 problem(s): git."), "got:\n{out}");
+        assert!(out.contains("advisory line"), "got:\n{out}");
+    }
+
+    #[test]
+    fn render_without_advisory_omits_the_line() {
+        let out = render(
+            &[Check::ok("tmux", "3.4  ok")],
+            "Environment healthy.",
+            None,
+        );
+        assert!(out.ends_with("Environment healthy."), "got:\n{out}");
+        assert!(!out.contains("Notifications"), "got:\n{out}");
+    }
+
+    #[test]
+    fn notification_advisory_points_at_notify_when_enabled() {
+        // The default test-process settings have notifications enabled, so the
+        // advisory is present and points the user at `thurbox-cli notify`.
+        let a = notification_advisory().expect("advisory when notifications on");
+        assert!(a.contains("notify"), "got: {a}");
+    }
+
+    #[test]
+    fn agent_checks_default_absence_is_error_others_warn() {
+        // Two agents with commands that cannot exist on PATH; the default's
+        // absence is an error, the non-default's a warning.
+        let agent = |name: &str, command: &str| crate::session::AgentDef {
+            name: name.into(),
+            command: command.into(),
+            args: vec![],
+            resume_args: vec![],
+            fork_args: vec![],
+            new_session_args: vec![],
+            resume_latest: false,
+        };
+        let reg = crate::session::AgentRegistry {
+            config_version: None,
+            default: "primary".into(),
+            agents: vec![
+                agent("primary", "thurbox-doctor-missing-primary"),
+                agent("secondary", "thurbox-doctor-missing-secondary"),
+            ],
+        };
+        let checks = agent_checks(&reg);
+        assert_eq!(checks[0].id, "agent:primary");
+        assert_eq!(checks[0].status, Status::Error);
+        assert_eq!(checks[1].id, "agent:secondary");
+        assert_eq!(checks[1].status, Status::Warn);
+    }
+
+    #[test]
+    fn config_check_ok_on_fresh_environment() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let c = check_config();
+        assert_eq!(c.status, Status::Ok, "detail: {}", c.detail);
+    }
+
+    #[test]
+    fn config_check_errors_on_malformed_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let path = crate::agent::agent_config::agents_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "not toml {{{").unwrap();
+
+        let c = check_config();
+        assert_eq!(c.status, Status::Error);
+        assert!(c.detail.contains("agents.toml"), "got: {}", c.detail);
+    }
+
+    #[test]
+    fn database_check_ok_on_open_db() {
+        let db = Database::open_in_memory().unwrap();
+        assert_eq!(check_database(&db).status, Status::Ok);
+    }
+
+    #[test]
+    fn run_reports_expected_check_ids_and_shape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let db = Database::open_in_memory().unwrap();
+
+        // No --hosts: local checks only. Assert the report *shape* and that each
+        // fixed check id is present — not the concrete tmux/git pass, which
+        // depends on the host (may be absent on some CI runners).
+        let out = run(DoctorArgs { hosts: false }, &db);
+        assert!(out["healthy"].is_boolean());
+        let checks = out["checks"].as_array().expect("checks array");
+        assert!(!checks.is_empty());
+        for c in checks {
+            assert!(c["id"].is_string());
+            let status = c["status"].as_str().unwrap();
+            assert!(
+                matches!(status, "ok" | "warn" | "error"),
+                "unexpected status: {status}"
+            );
+            assert!(c["detail"].is_string());
+        }
+        let ids: Vec<&str> = checks.iter().filter_map(|c| c["id"].as_str()).collect();
+        for id in ["tmux", "git", "database", "config"] {
+            assert!(ids.contains(&id), "missing check `{id}` in {ids:?}");
+        }
+        // The default agent (claude) yields an `agent:claude` row.
+        assert!(
+            ids.iter().any(|id| id.starts_with("agent:")),
+            "expected at least one agent check in {ids:?}"
+        );
+        // No hosts configured in a fresh env, so no host:* rows appeared.
+        assert!(!ids.iter().any(|id| id.starts_with("host:")));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -16,6 +16,7 @@ use crate::storage::Database;
 pub mod action;
 pub mod automations;
 pub mod config;
+pub mod doctor;
 pub mod editor;
 pub mod extensions;
 pub mod identity;
@@ -102,6 +103,8 @@ pub enum Command {
     Update(update::UpdateArgs),
     /// Diagnose OS desktop notifications; `--test` fires a sample.
     Notify(notify::NotifyArgs),
+    /// Check the runtime environment (tmux, git, agents, database, config).
+    Doctor(doctor::DoctorArgs),
 }
 
 /// Build the additional-repo list for a multi-repo `Spawn` from the repeatable
@@ -154,6 +157,7 @@ pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
         Command::Version(args) => Ok(version::run(args)),
         Command::Update(args) => Ok(update::run(args)),
         Command::Notify(args) => Ok(notify::run(args)),
+        Command::Doctor(args) => Ok(doctor::run(args, db)),
     }?;
 
     println!("{}", format.render(&output));
@@ -843,6 +847,21 @@ mod tests {
             panic!("expected Notify");
         };
         assert!(args.test);
+    }
+
+    #[test]
+    fn parse_doctor_with_and_without_hosts() {
+        let cli = Cli::try_parse_from(["thurbox-cli", "doctor"]).unwrap();
+        let Command::Doctor(args) = cli.command else {
+            panic!("expected Doctor");
+        };
+        assert!(!args.hosts);
+
+        let cli = Cli::try_parse_from(["thurbox-cli", "doctor", "--hosts"]).unwrap();
+        let Command::Doctor(args) = cli.command else {
+            panic!("expected Doctor");
+        };
+        assert!(args.hosts);
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -165,6 +165,15 @@ impl Database {
         &self.conn
     }
 
+    /// Confirm the database is writable and not held by another writer.
+    ///
+    /// `BEGIN IMMEDIATE` takes the reserved write lock immediately (failing on a
+    /// read-only file or a busy DB), then `ROLLBACK` releases it having mutated
+    /// nothing — a genuine writability probe used by `thurbox-cli doctor`.
+    pub fn check_writable(&self) -> rusqlite::Result<()> {
+        self.conn.execute_batch("BEGIN IMMEDIATE; ROLLBACK;")
+    }
+
     /// Open an in-memory database (for testing).
     pub fn open_in_memory() -> rusqlite::Result<Self> {
         let conn = Connection::open_in_memory()?;


### PR DESCRIPTION
## Summary

Adds `thurbox-cli doctor` — an aggregate runtime-environment health check that answers the first-run question "why won't my session launch?", complementing `config validate` (which only parses the config *files*). Closes thurbeen/thurbox#747 (task #64).

**Local checks (always run):**
- `tmux` present and >= 3.2 (reuses `check_min_version` via a new `TmuxBackend::probe` returning the `-V` banner; `check_available` now delegates to it)
- `git` present
- `agent:<name>` per registered agent — `command` resolved on PATH; the **default** agent's absence is an **error**, a non-default agent's a **warning**
- `database` writable (new `Database::check_writable`, a `BEGIN IMMEDIATE`/`ROLLBACK` probe)
- `config` validity rolled up from the existing `config::validate()` (delegated, never re-parsed)

**Host checks (`--hosts`, opt-in):** probes each configured/discovered host for reachability, concurrently (one thread per host, 10s per-host timeout) — `tmux -V` over the transport verifies connectivity + tmux presence + version in one shot. An unreachable/too-old host is an error.

Reports only — never installs, seeds, or edits anything. Exits non-zero on any error-severity check so it works as a CI/setup gate (warnings alone stay green). Notification delivery is delegated to `thurbox-cli notify` (one advisory line, not re-probed). Human/JSON/exit-code follow the `config validate` precedent.

## Test plan

- 20 new unit tests (status/glyph mapping, healthy/headline/render logic, per-check builders, `run` shape, arg parsing) — all green
- Full pre-commit suite passed (fmt, clippy `-D warnings`, nextest, architecture rules, deny, doc, rumdl)
- Manually exercised: `doctor` (human + JSON + exit 0 healthy) and `doctor --hosts` (probed real configured hosts, returned versions)