### PR TITLE
feat(core): derive a distinct Exited status for dead panes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1337,7 +1337,7 @@ or done. `SessionStatus` (`src/session/mod.rs`) has five states driven by
 | `Blocked` | red | `◆` | agent needs input or approval |
 | `Done` | blue | `●` (filled) | a turn just finished; shown until you switch away |
 | `Idle` | green | `○` (hollow) | acknowledged (you moved off a Done), never active, or at rest |
-| `Error` | red | `✗` | reserved for a crashed agent — **not derived yet** (no exit-code signal; exited → `Idle`) |
+| `Error` | red | `✗` | the agent process exited abnormally (crash / missing binary / interrupted mid-turn); rendered "Exited". A graceful exit after a clean `done`/`idle` edge stays `Idle` instead. No real exit *code* yet (`has_exited()` is boolean) |
 
 The live session list **animates** the `Working` spinner (`ui::SPINNER_FRAMES`,
 `App::spinner_frame` advanced from `tick_count`, ~8 fps, repaints forced only
@@ -1365,7 +1365,9 @@ frame; the static `icon()` is used in non-animated contexts (info panel).
   agent's hooks drive it from there (so an idle, just-booted agent doesn't look
   stuck working).
 - **Derivation.** `App::refresh_session_statuses` (`src/app/mod.rs`) derives
-  each session's status every tick from the hook rows — exited → `Idle`; else
+  each session's status every tick from the hook rows — an exited pane maps to
+  `Error` (crash: exited while `working`/`blocked` or with no hook edge) or
+  `Idle` (graceful: exited after a clean `done`/`idle` edge); a live pane uses
   the persisted state (`working`/`blocked`; `idle`/none → `Idle`). The rows are
   **cached** (`App::cached_hook_states`) and reloaded from the DB only when
   `PRAGMA data_version` moves (an external `session signal`), not on every tick;
@@ -1386,8 +1388,10 @@ frame; the static `icon()` is used in non-animated contexts (info panel).
   treated as `Idle`. TUI agents animate their progress line (Claude's
   `(Xs · esc to interrupt)` ticks every second) so a genuinely-live turn never
   trips it; only `working` is time-gated (`blocked`/`done` are not). The DB row is
-  left untouched — the override is purely in the per-tick derivation, like
-  exited → `Idle`.
+  left untouched — the override is purely in the per-tick derivation, like the
+  exited → `Error`/`Idle` mapping. (The exit check runs *first*, so a session
+  that both went quiet and exited lands on the exit result, not the
+  stuck-working `Idle`.)
 - **Rollup.** Repo groups roll up to their most-urgent member
   (`Blocked > Error > Working > Done > Idle`), rendered as a colored dot on
   the group header (`ui::project_list::group_status` +

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -628,7 +628,8 @@ impl Session {
     }
 
     /// Force the session into the "process exited" state, for tests that need to
-    /// exercise the exited → `Idle` status branch.
+    /// exercise the exited status branch (`Error` on a crash, `Idle` on a
+    /// graceful exit after a clean hook edge).
     #[cfg(test)]
     pub fn mark_exited_for_test(&self) {
         self.exited.store(true, Ordering::SeqCst);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -780,22 +780,38 @@ const EDITOR_NOT_CONFIGURED: &str =
 const WORKING_OUTPUT_STALE_MS: u64 = 10_000;
 
 /// Map a session's persisted hook state to its rendered [`SessionStatus`]. Pure
-/// so it's unit-testable without an `App`/DB. `exited` forces `Idle` (a crashed/
-/// finished process); `just_seen` is `true` when the user just moved focus off a
-/// `done` session this tick (acknowledged → `Idle`); `quiet_for_ms` is the time
-/// since the session's last terminal output, used to rescue a stuck `working`
-/// state (see [`WORKING_OUTPUT_STALE_MS`]). A `done` session is `Done` (blue)
-/// until seen; `idle`/missing/unknown states are `Idle`.
+/// so it's unit-testable without an `App`/DB. `exited` maps to `Error`
+/// (`Exited`) for a crash/launch-failure or `Idle` for a graceful shutdown,
+/// decided from the last hook edge (see below); `just_seen` is `true` when the
+/// user just moved focus off a `done` session this tick (acknowledged →
+/// `Idle`); `quiet_for_ms` is the time since the session's last terminal output,
+/// used to rescue a stuck `working` state (see [`WORKING_OUTPUT_STALE_MS`]). A
+/// `done` session is `Done` (blue) until seen; `idle`/missing/unknown states are
+/// `Idle`.
 fn derive_session_status(
     hook: Option<&crate::storage::HookRow>,
     exited: bool,
     just_seen: bool,
     quiet_for_ms: u64,
 ) -> SessionStatus {
+    let state = hook.and_then(|h| h.state.as_deref());
     if exited {
-        return SessionStatus::Idle;
+        // A process exit is terminal but not always alarming. If the agent last
+        // reported a clean edge before the pane closed — `done` (a turn just
+        // finished) or `idle` (at rest, e.g. its boot hook) — treat it as a
+        // graceful shutdown and stay `Idle`. But an exit while `working`/
+        // `blocked`, or with *no* hook signal at all (the process died before
+        // its boot hook fired — the missing-binary / launch-failure case), is a
+        // crash: surface it as `Error` so a dead session no longer masquerades
+        // as a quiet green `Idle` dot. This runs before the stuck-`working`
+        // quiescence fallback below, so an interrupted-then-exited turn lands on
+        // `Error` (more informative) rather than being rescued to `Idle`.
+        return match state {
+            Some("done") | Some("idle") => SessionStatus::Idle,
+            _ => SessionStatus::Error,
+        };
     }
-    match hook.and_then(|h| h.state.as_deref()) {
+    match state {
         // A live `working` turn keeps emitting output; a stuck one (interrupt /
         // crash / an agent that missed its done edge) goes quiet → fall to Idle.
         Some("working") if quiet_for_ms <= WORKING_OUTPUT_STALE_MS => SessionStatus::Working,
@@ -6159,9 +6175,56 @@ mod tests {
             seen_at: Some(seen_at),
         };
 
-        // Exited forces Idle, even with a live hook state.
+        // Exited while `working` is a crash/interrupt → Error (Exited), even
+        // though a fresh, non-exited `working` row would read as Working.
         assert_eq!(
             derive_session_status(Some(&row("working", 1, 0)), true, false, 0),
+            SessionStatus::Error
+        );
+        // Exited while `blocked` (agent was waiting on the user, then the pane
+        // died) is likewise abnormal → Error.
+        assert_eq!(
+            derive_session_status(Some(&row("blocked", 1, 0)), true, false, 0),
+            SessionStatus::Error
+        );
+        // Exited with no hook at all (died before its boot hook — the
+        // missing-binary / launch-failure case) → Error.
+        assert_eq!(
+            derive_session_status(None, true, false, 0),
+            SessionStatus::Error
+        );
+        // A graceful exit after a clean edge stays Idle, not Error: `done` (a
+        // turn finished then the process quit) and `idle` (at rest then quit).
+        assert_eq!(
+            derive_session_status(Some(&row("done", 5, 0)), true, false, 0),
+            SessionStatus::Idle
+        );
+        assert_eq!(
+            derive_session_status(Some(&row("idle", 1, 0)), true, false, 0),
+            SessionStatus::Idle
+        );
+        // The exit check runs *before* the stuck-`working` quiescence fallback,
+        // so a session that both went quiet past the staleness window *and*
+        // exited lands on Error (the exit result), not the Idle the quiescence
+        // timer would give a live-but-stuck `working` state. Its graceful mirror
+        // (`done` + quiet + exited) still resolves to Idle — exit wins both ways.
+        assert_eq!(
+            derive_session_status(
+                Some(&row("working", 1, 0)),
+                true,
+                false,
+                WORKING_OUTPUT_STALE_MS + 1
+            ),
+            SessionStatus::Error,
+            "an exited pane is Error even once its output has gone stale"
+        );
+        assert_eq!(
+            derive_session_status(
+                Some(&row("done", 5, 0)),
+                true,
+                false,
+                WORKING_OUTPUT_STALE_MS + 1
+            ),
             SessionStatus::Idle
         );
         // No hook / idle / unknown → Idle.
@@ -6456,10 +6519,25 @@ mod tests {
     }
 
     #[test]
-    fn refresh_exited_session_is_idle_regardless_of_hook() {
+    fn refresh_exited_session_while_active_is_error() {
+        // A pane that dies while the agent is mid-turn (`blocked`/`working`) is a
+        // crash/interrupt, not a rest → surface it as Error (Exited) so it no
+        // longer masquerades as a quiet Idle dot.
         let mut app = app_with_sessions(1);
         let id = persist_session(&app, 0);
         signal_hook(&mut app, id, "blocked");
+        app.sessions[0].mark_exited_for_test();
+        app.refresh_session_statuses();
+        assert_eq!(app.sessions[0].info.status, SessionStatus::Error);
+    }
+
+    #[test]
+    fn refresh_exited_session_after_clean_edge_is_idle() {
+        // A graceful shutdown — the agent reported `done` (turn finished) and the
+        // process then quit — stays Idle rather than raising a false alarm.
+        let mut app = app_with_sessions(1);
+        let id = persist_session(&app, 0);
+        signal_hook(&mut app, id, "done");
         app.sessions[0].mark_exited_for_test();
         app.refresh_session_statuses();
         assert_eq!(app.sessions[0].info.status, SessionStatus::Idle);

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -110,10 +110,12 @@ pub enum SessionStatus {
     Done,
     /// 🟢 Acknowledged (focus moved off a `Done`), at rest, or never-active.
     Idle,
-    /// Reserved for a crashed agent. **Not currently derived** — process exit has
-    /// no failure signal yet (a clean or crashed exit both map to `Idle`), so this
-    /// variant is wired through colour/glyph/rollup but never assigned. Kept for
-    /// when exit-code plumbing lands.
+    /// The agent process has exited abnormally — it crashed, failed to launch
+    /// (missing binary), or was interrupted mid-turn. Derived when a pane exits
+    /// while `working`/`blocked` or with no hook signal at all; a graceful exit
+    /// after a clean `done`/`idle` edge stays `Idle` instead. Rendered as
+    /// "Exited" (no real exit *code* is captured yet — `has_exited()` is a
+    /// boolean).
     Error,
 }
 
@@ -122,7 +124,7 @@ impl SessionStatus {
     /// the state survives in greyscale / for colour-blind users: a spinner
     /// (working — the live session list animates it, see `ui::SPINNER_FRAMES`)
     /// vs. diamond (blocked) vs. filled circle (done, unseen) vs. hollow circle
-    /// (idle, seen) vs. cross (error). The filled/hollow pair makes
+    /// (idle, seen) vs. cross (exited/failed). The filled/hollow pair makes
     /// done-vs-idle read at a glance.
     pub fn icon(self) -> &'static str {
         match self {
@@ -142,7 +144,7 @@ impl fmt::Display for SessionStatus {
             Self::Blocked => write!(f, "Blocked"),
             Self::Done => write!(f, "Done"),
             Self::Idle => write!(f, "Idle"),
-            Self::Error => write!(f, "Error"),
+            Self::Error => write!(f, "Exited"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Wire the reserved `SessionStatus::Error` variant (already plumbed through glyph `✗`, `status_error` colour, and group rollup) so an exited pane no longer masquerades as a green hollow `Idle` dot.
- `derive_session_status` now maps an exit to **Error** (rendered "Exited") when the pane died while `working`/`blocked` or with **no hook signal at all** (crash / missing-binary launch failure), and keeps **Idle** for a graceful exit after a clean `done`/`idle` edge — so a deliberate `/exit` isn't a false alarm.
- The exit check runs **before** the stuck-`working` quiescence fallback, so an interrupted-then-exited turn lands on the more-informative Error rather than being rescued to Idle.
- Pure per-tick derivation — no DB write; Error auto-clears on restart/re-adopt when `has_exited()` resets.
- Renamed the `Display` impl to "Exited" (variant name stays `Error` internally); updated the enum/`icon()`/backend-helper docs and the CLAUDE.md session-status table.

## Test plan

- New/updated unit coverage in `derive_session_status_covers_every_state`: exited+`working`/`blocked`/no-hook → Error; exited+`done`/`idle` → Idle; and the ordering interaction (exit wins over the past-staleness quiescence fallback, both directions).
- New `refresh_*` integration tests: `refresh_exited_session_while_active_is_error`, `refresh_exited_session_after_clean_edge_is_idle`.
- Full suite (1748 tests), `cargo fmt --check`, `cargo clippy -D warnings`, and `rumdl` all pass.

Closes #749