### PR TITLE
feat(ui): surface config paths + validation, add config-problems badge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2061,6 +2061,34 @@ The renderer is `ui::settings_modal::render_settings_modal` (modeled on
 Notifications / Scalars sections, an aligned value column, and
 scroll-windowing for short terminals).
 
+### Config-file paths + validation (discoverability)
+
+The Settings modal leads with a **read-only "Config files"** band above the
+editable sections: one non-selectable row per config file (`agents.toml` /
+`hosts.toml` / `settings.toml` / `themes.toml` / `keybindings.json` / the
+`database`) with its **resolved path** and an at-a-glance validity mark
+(`✓ ok` / `✗ invalid` / `· absent`), problem detail expanded inline under an
+invalid file. A **`Validate`** footer action (key `v`) re-runs validation on
+demand. The single source of truth for both paths and validity is
+`session_ops::config_check::check_all() -> Vec<session::ConfigFile>` (pure data
+in `session::config_status`, so `ui` can render it); `cli::config`
+(`validate`/`show`) and the TUI both consume it, so the CLI and the panel never
+disagree. The snapshot is cached on `App.config_status`, computed once at
+startup and refreshed on the config live-reload (`poll_config_reload`) + the
+`Validate` action — never per frame (each refresh re-parses every file).
+
+When any file fails validation (`App::config_has_problems`), a **persistent
+`Config ⚠` badge** renders in the status-bar footer (`status_bar::render_footer`
+via the `FooterButton::ConfigProblems` pill — an *essential* pill, never
+dropped by the narrow-footer trim, unlike the optional Info/Files/Tasks
+toggles). It has no rebindable action (it's a conditional problem indicator, not
+a standing command): a click records the bespoke `ClickAction::OpenConfigProblems`,
+opening a read-only **"Config problems"** modal
+(`Modal::ConfigProblems` / `ui::config_problems_modal`) that lists each broken
+file + its messages, with `Open Settings` (Enter) jumping into the panel. The
+badge is purely derived from current validity — fixing the file clears it on the
+next reload; there is no dismiss state.
+
 ## Design Documentation
 
 For rationale behind decisions, see `docs/`:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -45,6 +45,14 @@ the panel — set it only by hand-editing `settings.toml`. Hand-editing
 the file (or the panel in another instance) is picked up the same way,
 via the live mtime poll.
 
+The panel also leads with a **read-only "Config files"** band: every config
+file (`agents.toml` / `hosts.toml` / `settings.toml` / `themes.toml` /
+`keybindings.json` / the database) with its **resolved path** and an
+at-a-glance validity mark (`✓ ok` / `✗ invalid` / `· absent`) — the same
+paths + validity `thurbox-cli config show`/`validate` report, so you no longer
+need the CLI to find where a file lives. A **`Validate`** action (key `v` / the
+footer button) re-runs strict validation on demand.
+
 All paths respect `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME`.
 
 ### Which file do I edit?
@@ -69,7 +77,13 @@ fall back to built-in defaults.
 
 Config problems are **not silent**: parse errors, unknown fields,
 invalid chords, and chord conflicts surface as a status-bar toast on
-startup (and in the log file). Unknown TOML keys are tolerated —
+startup (and in the log file). That toast is transient, so a problem also
+lights a **persistent `Config ⚠` badge** in the status-bar footer for as long
+as any file fails validation (it clears itself when you fix the file — the
+badge is re-derived on the config live-reload). Clicking the badge opens a
+read-only **"Config problems"** modal listing each broken file and its
+messages, with an `Open Settings` jump into the Settings panel's Config-files
+section. Unknown TOML keys are tolerated —
 stale keys from older versions or typos are *reported by name* but
 your file still loads — while syntax/type errors fall back to
 built-ins (agents), zero hosts, or defaults (settings).

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -571,6 +571,132 @@ fn settings_panel_esc_discards() {
     );
 }
 
+/// The Settings panel carries the read-only "Config files" band listing every
+/// config file's resolved path (discoverability the CLI used to hold alone).
+#[test]
+fn settings_panel_lists_config_files() {
+    let mut h = Harness::standard(1);
+    h.ctrl(','); // OpenSettings
+    let screen = h.render();
+    assert!(
+        screen.contains("CONFIG FILES"),
+        "config-files section header renders: {screen}"
+    );
+    for file in [
+        "agents.toml",
+        "hosts.toml",
+        "settings.toml",
+        "keybindings.json",
+    ] {
+        assert!(
+            screen.contains(file),
+            "config section lists {file}: {screen}"
+        );
+    }
+    // A fresh (hermetic) environment has no config files on disk, so each row
+    // reads as absent — the mark column renders, and none are flagged invalid.
+    assert!(
+        screen.contains("absent"),
+        "absent files show an absent mark: {screen}"
+    );
+    assert!(
+        !screen.contains("invalid"),
+        "clean env has no invalid files: {screen}"
+    );
+    assert!(
+        !h.app.config_has_problems(),
+        "fresh env has no config problems"
+    );
+}
+
+/// The Settings "Validate" action (key `v` / the footer button) re-runs config
+/// validation on demand, so a file broken *after* the panel opened surfaces
+/// without a restart.
+#[test]
+fn settings_validate_action_refreshes_config_status() {
+    let mut h = Harness::standard(1);
+    h.ctrl(','); // OpenSettings — snapshot taken at open (clean)
+    assert!(!h.app.config_has_problems());
+
+    // Break hosts.toml behind the panel's back.
+    let path = crate::agent::host_config::hosts_config_path().unwrap();
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, "not valid toml {{{").unwrap();
+
+    // Validate (plain `v`) re-reads from disk; the modal stays open.
+    h.key(KeyCode::Char('v'), KeyModifiers::NONE);
+    assert!(
+        h.app.config_has_problems(),
+        "Validate re-runs the check and finds the broken file"
+    );
+    assert!(
+        matches!(h.app.modal, modals::Modal::Settings(_)),
+        "Validate keeps the Settings panel open"
+    );
+    let screen = h.render();
+    assert!(
+        screen.contains("invalid"),
+        "the broken file now shows an invalid mark: {screen}"
+    );
+}
+
+/// A malformed config file lights the persistent `Config ⚠` footer badge;
+/// clicking it opens the read-only problems modal, and `Enter` jumps to
+/// Settings. The badge is absent on a clean config (so snapshots stay green).
+#[test]
+fn config_badge_opens_problems_modal() {
+    let mut h = Harness::standard(1);
+    assert!(!h.app.config_has_problems(), "fresh env is clean");
+    let clean = h.render();
+    assert!(!clean.contains("Config ⚠"), "no badge when clean: {clean}");
+
+    // Break hosts.toml and re-validate (mirrors the live-reload path).
+    let path = crate::agent::host_config::hosts_config_path().unwrap();
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, "not valid toml {{{").unwrap();
+    h.app.refresh_config_status();
+    assert!(h.app.config_has_problems());
+
+    // The badge renders and records an OpenConfigProblems click target.
+    let screen = h.render();
+    assert!(
+        screen.contains("Config"),
+        "badge visible with problems: {screen}"
+    );
+    let rect = h
+        .app
+        .click_targets
+        .iter()
+        .find_map(|t| match t.action {
+            ClickAction::OpenConfigProblems => Some(t.rect),
+            _ => None,
+        })
+        .expect("badge records an OpenConfigProblems click target");
+
+    // Clicking the badge opens the read-only problems modal listing the file.
+    h.app.update(AppMessage::MouseClick {
+        x: rect.x + 1,
+        y: rect.y,
+        modifiers: KeyModifiers::NONE,
+    });
+    assert!(
+        matches!(h.app.modal, modals::Modal::ConfigProblems(_)),
+        "the badge opens the problems modal"
+    );
+    let modal_screen = h.render();
+    assert!(
+        modal_screen.contains("hosts.toml"),
+        "problems modal names the broken file: {modal_screen}"
+    );
+
+    // Enter jumps into the Settings panel (its "Open Settings" button).
+    h.key(KeyCode::Enter, KeyModifiers::NONE);
+    assert!(
+        matches!(h.app.modal, modals::Modal::Settings(_)),
+        "Enter jumps from the problems modal into Settings"
+    );
+}
+
 #[test]
 fn ctrl_q_requests_quit() {
     let mut h = Harness::standard(1);

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -375,6 +375,7 @@ impl App {
             Modal::ConfirmDelete(_) => self.handle_confirm_delete_key(code),
             Modal::ConfirmRestore(_) => self.handle_confirm_restore_key(code),
             Modal::Settings(_) => self.handle_settings_key(code, mods),
+            Modal::ConfigProblems(_) => self.handle_config_problems_key(code),
             _ => return false,
         }
         true
@@ -399,6 +400,14 @@ impl App {
     /// Drive the Settings panel: edits a working copy, persists on `Ctrl+S`,
     /// discards on `Esc` (no live preview to revert).
     fn handle_settings_key(&mut self, code: KeyCode, mods: KeyModifiers) {
+        // "Validate" — re-run config validation on demand (also replayed by the
+        // footer button). Intercepted before the field editor so a plain `v`
+        // never leaks into field handling. The modal reads `App::config_status`
+        // at render time, so refreshing the cache updates the section in place.
+        if mods.is_empty() && matches!(code, KeyCode::Char('v') | KeyCode::Char('V')) {
+            self.refresh_config_status();
+            return;
+        }
         let super::modals::Modal::Settings(ref mut m) = self.modal else {
             return;
         };
@@ -406,6 +415,16 @@ impl App {
             super::modals::EditorOutcome::Continue => {}
             super::modals::EditorOutcome::Save => self.submit_settings_panel(),
             super::modals::EditorOutcome::Cancel => self.modal.close(),
+        }
+    }
+
+    /// Drive the read-only "Config problems" modal: `Enter` (or the `Open
+    /// Settings` button) jumps into the Settings panel; `Esc` closes it.
+    fn handle_config_problems_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Enter => self.open_settings_panel(),
+            KeyCode::Esc => self.modal.close(),
+            _ => {}
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -480,6 +480,9 @@ pub(crate) enum ClickAction {
     /// Copy the current status-bar message to the clipboard (click the status
     /// row). Dispatched by `activate_click_target`.
     CopyStatus,
+    /// Open the read-only "Config problems" modal (click the persistent
+    /// `Config ⚠` footer badge). Dispatched by `activate_click_target`.
+    OpenConfigProblems,
 }
 
 /// One clickable region rendered this frame: its rect plus what a click on it
@@ -702,6 +705,12 @@ pub struct App {
     /// agents.toml/hosts.toml reported by main), shown joined in one status
     /// toast via [`Self::report_config_warnings`].
     config_warnings: Vec<String>,
+    /// Per-file config validity snapshot (paths + parse status) surfaced in the
+    /// Settings "Config files" section and the persistent `Config ⚠` footer
+    /// badge. Computed once at startup and refreshed on the config live-reload
+    /// path + the Settings "Validate" action — never every frame (each refresh
+    /// re-parses every file from disk). See [`Self::refresh_config_status`].
+    config_status: Vec<crate::session::ConfigFile>,
     /// Receives the result of the silent startup auto-update, which runs on a
     /// background thread so a slow download never blocks the TUI from starting
     /// (`[features] auto_update`; see `main::spawn_auto_update`). `None` when the
@@ -960,6 +969,9 @@ impl App {
             usage_tx,
             usage_rx,
             config_warnings: Vec::new(),
+            // Strict-validate every config file once at startup so the badge +
+            // Settings section reflect real on-disk state from the first frame.
+            config_status: crate::session_ops::config_check::check_all(),
             auto_update_rx: None,
             config_reload: config_reload::ConfigReloadState {
                 agents_mtime: config_reload::agents_mtime(),
@@ -992,6 +1004,24 @@ impl App {
         self.config_warnings.extend(warnings);
         let text = format!("Config: {}", self.config_warnings.join(" · "));
         self.set_status(StatusLevel::Error, text);
+    }
+
+    /// Re-strict-validate every config file and cache the result. Called at the
+    /// Settings "Validate" action and whenever the config live-reload poll
+    /// detects a change — not every frame (each call re-reads from disk).
+    pub(crate) fn refresh_config_status(&mut self) {
+        self.config_status = crate::session_ops::config_check::check_all();
+    }
+
+    /// The cached per-file config validity snapshot (for the Settings section).
+    pub(crate) fn config_status(&self) -> &[crate::session::ConfigFile] {
+        &self.config_status
+    }
+
+    /// Whether any config file currently fails validation — drives the
+    /// persistent `Config ⚠` footer badge.
+    pub(crate) fn config_has_problems(&self) -> bool {
+        crate::session::any_problem(&self.config_status)
     }
 
     /// Attach the receiver for the background startup auto-update (see
@@ -1027,18 +1057,30 @@ impl App {
     /// (the F1 editor persisting a rebind) refresh the stored mtime at save
     /// time, so they don't re-toast here.
     fn poll_config_reload(&mut self) {
+        let mut changed = false;
         if config_reload::agents_mtime() != self.config_reload.agents_mtime {
             self.reload_agents_config();
+            changed = true;
         }
 
         let kb_mtime = config_reload::keybindings_mtime();
         if kb_mtime != self.config_reload.keybindings_mtime {
             self.config_reload.keybindings_mtime = kb_mtime;
             self.reload_keybindings_config();
+            changed = true;
         }
 
         if config_reload::settings_mtime() != self.config_reload.settings_mtime {
             self.reload_settings_config();
+            changed = true;
+        }
+
+        // Re-validate on any live-reloadable change so the `Config ⚠` badge +
+        // the Settings section clear (or appear) without a restart. hosts.toml /
+        // themes.toml aren't mtime-tracked; the Settings "Validate" action
+        // covers those on demand.
+        if changed {
+            self.refresh_config_status();
         }
     }
 
@@ -1905,6 +1947,16 @@ impl App {
         self.modal = modals::Modal::Settings(modals::SettingsModal::new(draft));
     }
 
+    /// Open the read-only "Config problems" modal (from the `Config ⚠` footer
+    /// badge). Re-validates first so the list reflects the current on-disk state
+    /// even for the mtime-untracked files (hosts.toml / themes.toml).
+    pub(crate) fn open_config_problems_modal(&mut self) {
+        self.refresh_config_status();
+        self.modal = modals::Modal::ConfigProblems(modals::ConfigProblemsModal::from_status(
+            &self.config_status,
+        ));
+    }
+
     /// Persist the Settings panel draft to `settings.toml`, apply the live
     /// feature flags immediately, and toast the result. Keeps the modal open on
     /// a write error so edits aren't lost.
@@ -2621,6 +2673,10 @@ impl App {
             }
             ClickAction::CopyStatus => {
                 self.copy_status_to_clipboard();
+                true
+            }
+            ClickAction::OpenConfigProblems => {
+                self.open_config_problems_modal();
                 true
             }
         }

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -1845,6 +1845,26 @@ fn step_clamp(current: i64, delta: i32, step: i64, min: i64, max: i64) -> i64 {
     (current + i64::from(delta) * step).clamp(min, max)
 }
 
+/// Read-only "Config problems" modal: opened from the persistent `Config ⚠`
+/// footer badge, it lists each config file that failed validation and its
+/// problem messages, with an `[ Open Settings ]` jump into the full editor.
+/// Purely a display snapshot (the fields are captured when it opens).
+#[derive(Debug, Clone)]
+pub struct ConfigProblemsModal {
+    /// The problem files (existing + invalid), captured at open time.
+    pub files: Vec<crate::session::ConfigFile>,
+}
+
+impl ConfigProblemsModal {
+    /// Build from the app's cached config snapshot, keeping only the problem
+    /// files (an existing validated file that failed to parse).
+    pub fn from_status(status: &[crate::session::ConfigFile]) -> Self {
+        Self {
+            files: status.iter().filter(|f| f.is_problem()).cloned().collect(),
+        }
+    }
+}
+
 /// Single, discriminated union replacing boolean flags for modal state.
 /// Only one modal can be active at a time, making invalid states unrepresentable.
 #[derive(Debug, Clone, Default)]
@@ -1866,6 +1886,7 @@ pub enum Modal {
     ConfirmDelete(ConfirmDeleteModal),
     ConfirmRestore(ConfirmRestoreModal),
     Settings(SettingsModal),
+    ConfigProblems(ConfigProblemsModal),
 }
 
 impl Modal {

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -146,6 +146,7 @@ impl App {
                         | ClickAction::CentralTab(_)
                         | ClickAction::PaneField { .. }
                         | ClickAction::CopyStatus
+                        | ClickAction::OpenConfigProblems
                 )
             };
             reachable && t.rect.contains(pos)
@@ -167,6 +168,7 @@ impl App {
                 | ClickAction::ModalButton { .. }
                 | ClickAction::ReviewButton(_)
                 | ClickAction::CentralTab(_)
+                | ClickAction::OpenConfigProblems
         );
         let hover_bg = if is_button {
             Theme::accent_bright()
@@ -824,6 +826,7 @@ impl App {
             tasks_enabled: self.features.tasks,
             file_viewer_enabled: self.features.file_viewer,
             info_panel_enabled: self.features.info_panel,
+            config_problems: self.config_has_problems(),
             keybindings: &self.keybindings,
         }
     }
@@ -831,10 +834,16 @@ impl App {
     /// Render the bottom status-bar footer.
     fn render_footer(&mut self, frame: &mut Frame, footer: Rect) {
         let button_hits = status_bar::render_footer(frame, footer, &self.footer_state());
-        // The renderer pairs each surviving button with its Action, so the
-        // click map can't drift from the (feature-filtered) render.
-        for (hit, action) in button_hits {
-            self.record_click(hit.rect, ClickAction::Global(action));
+        // The renderer pairs each surviving button with what it dispatches, so
+        // the click map can't drift from the (feature-filtered) render. The
+        // `Config ⚠` badge has no rebindable action — it maps to a bespoke
+        // click target that opens the read-only problems modal.
+        for (hit, button) in button_hits {
+            let action = match button {
+                status_bar::FooterButton::Action(a) => ClickAction::Global(a),
+                status_bar::FooterButton::ConfigProblems => ClickAction::OpenConfigProblems,
+            };
+            self.record_click(hit.rect, action);
         }
     }
 
@@ -927,6 +936,14 @@ impl App {
             );
         }
 
+        // Read-only "Config problems" modal (from the `Config ⚠` footer badge)
+        if let super::modals::Modal::ConfigProblems(ref cp) = self.modal {
+            return crate::ui::config_problems_modal::render_config_problems_modal(
+                frame,
+                &crate::ui::config_problems_modal::ConfigProblemsState { files: &cp.files },
+            );
+        }
+
         Vec::new()
     }
 
@@ -988,6 +1005,7 @@ impl App {
                 &crate::ui::settings_modal::SettingsModalState {
                     modal: m,
                     restart_pending: m.restart_required_changed(),
+                    config_files: self.config_status(),
                 },
             );
             return Some(((fields, None), buttons));

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -46,116 +46,56 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
     }
 }
 
-/// One file's validation outcome.
-fn file_report(path: Option<std::path::PathBuf>, problems: Vec<String>, exists: bool) -> Value {
+/// The validated config files in stable order, as `(display label, JSON key)`
+/// pairs. Shared by [`validate`] (which builds the report) and
+/// [`render_validate`] (which prints it) so their ordering can't drift. The
+/// database is path-only and lives in `show`'s paths block, not here.
+const VALIDATED_FILES: [(&str, &str); 5] = [
+    ("agents.toml", "agents_toml"),
+    ("hosts.toml", "hosts_toml"),
+    ("settings.toml", "settings_toml"),
+    ("themes.toml", "themes_toml"),
+    ("keybindings.json", "keybindings_json"),
+];
+
+/// One file's validation outcome as the JSON block `config validate`/`show`
+/// consumers expect.
+fn file_report(file: &crate::session::ConfigFile) -> Value {
     json!({
-        "path": path.map(|p| p.display().to_string()),
-        "exists": exists,
-        "valid": problems.is_empty(),
-        "problems": problems,
+        "path": file.path.as_ref().map(|p| p.display().to_string()),
+        "exists": file.exists,
+        "valid": file.valid,
+        "problems": file.problems,
     })
 }
 
-/// Validate one TOML config file against `T`. Absent files are valid
-/// (defaults/seeding apply). Unknown fields don't fail the *load* at startup,
-/// but they do fail *validation* — they are typos or stale keys either way.
-fn validate_toml<T: serde::de::DeserializeOwned>(
-    path: Option<std::path::PathBuf>,
-    label: &str,
-) -> (Value, bool) {
-    let Some(path) = path else {
-        return (
-            file_report(None, vec!["could not resolve path".into()], false),
-            false,
-        );
-    };
-    if !path.exists() {
-        return (file_report(Some(path), Vec::new(), false), true);
-    }
-    let problems = match std::fs::read_to_string(&path) {
-        Ok(contents) => {
-            match crate::agent::agent_config::parse_toml_reporting_unknown::<T>(&contents, label) {
-                Ok((_, warnings)) => warnings,
-                Err(e) => vec![e.to_string()],
-            }
-        }
-        Err(e) => vec![format!("read failed: {e}")],
-    };
-    let ok = problems.is_empty();
-    (file_report(Some(path), problems, true), ok)
-}
-
-fn validate_keybindings() -> (Value, bool) {
-    let path = crate::paths::keybindings_file();
-    match crate::storage::keybindings::load_keybindings_json() {
-        Ok(Some(jsonbody)) => {
-            let problems = match crate::session::KeyBindings::from_json_with_warnings(&jsonbody) {
-                Ok((_, warnings)) => warnings,
-                Err(e) => vec![e],
-            };
-            let ok = problems.is_empty();
-            (file_report(path, problems, true), ok)
-        }
-        Ok(None) => (file_report(path, Vec::new(), false), true),
-        Err(e) => (file_report(path, vec![e], true), false),
-    }
-}
-
 /// Validate every config file. Returns the full report plus the list of files
-/// that failed (empty = all valid).
+/// that failed (empty = all valid). Sources its data from the shared
+/// [`crate::session_ops::config_check`] so the TUI badge/section and the CLI
+/// never disagree about validity.
 fn validate() -> (Value, Vec<String>) {
-    let (agents, agents_ok) = validate_toml::<crate::session::AgentRegistry>(
-        crate::agent::agent_config::agents_config_path(),
-        "agents.toml",
-    );
-    let (hosts, hosts_ok) = validate_toml::<crate::session::HostRegistry>(
-        crate::agent::host_config::hosts_config_path(),
-        "hosts.toml",
-    );
-    let (settings, settings_ok) = validate_toml::<crate::session::settings::Settings>(
-        crate::agent::settings_config::settings_config_path(),
-        "settings.toml",
-    );
-    let (themes, themes_ok) = validate_toml::<crate::session::theme_config::ThemesFile>(
-        crate::agent::themes_config::themes_config_path(),
-        "themes.toml",
-    );
-    let (keybindings, kb_ok) = validate_keybindings();
+    let files = crate::session_ops::config_check::check_all();
+    let get = |label: &str| files.iter().find(|f| f.label == label);
 
-    let failed: Vec<String> = [
-        ("agents.toml", agents_ok),
-        ("hosts.toml", hosts_ok),
-        ("settings.toml", settings_ok),
-        ("themes.toml", themes_ok),
-        ("keybindings.json", kb_ok),
-    ]
-    .iter()
-    .filter(|(_, ok)| !ok)
-    .map(|(name, _)| (*name).to_string())
-    .collect();
+    let failed: Vec<String> = VALIDATED_FILES
+        .iter()
+        .filter(|(label, _)| get(label).is_some_and(|f| !f.valid))
+        .map(|(label, _)| (*label).to_string())
+        .collect();
 
-    let report = json!({
-        "valid": failed.is_empty(),
-        "agents_toml": agents,
-        "hosts_toml": hosts,
-        "settings_toml": settings,
-        "themes_toml": themes,
-        "keybindings_json": keybindings,
-    });
+    let mut report = json!({ "valid": failed.is_empty() });
+    for (label, key) in VALIDATED_FILES {
+        if let Some(f) = get(label) {
+            report[key] = file_report(f);
+        }
+    }
     (report, failed)
 }
 
 /// Render `config validate` as a per-file status list.
 fn render_validate(report: &Value, failed: &[String]) -> String {
-    let files = [
-        ("agents.toml", "agents_toml"),
-        ("hosts.toml", "hosts_toml"),
-        ("settings.toml", "settings_toml"),
-        ("themes.toml", "themes_toml"),
-        ("keybindings.json", "keybindings_json"),
-    ];
     let mut lines = Vec::new();
-    for (label, key) in files {
+    for (label, key) in VALIDATED_FILES {
         push_validate_file_lines(&mut lines, label, &report[key]);
     }
     if failed.is_empty() {
@@ -246,19 +186,25 @@ fn show(db: &Database) -> Result<Value, String> {
     let (editor, editor_source) = resolve_editor(db);
     let overridden_actions = overridden_action_names();
 
+    // Path set from the shared checker, so `show` and `validate` (and the TUI's
+    // "Config files" section) resolve every path the same way.
+    let files = crate::session_ops::config_check::check_all();
+    let path_of = |label: &str| {
+        files
+            .iter()
+            .find(|f| f.label == label)
+            .and_then(|f| f.path.as_ref())
+            .map(|p| p.display().to_string())
+    };
+
     Ok(json!({
         "paths": {
-            "agents_toml": crate::agent::agent_config::agents_config_path()
-                .map(|p| p.display().to_string()),
-            "hosts_toml": crate::agent::host_config::hosts_config_path()
-                .map(|p| p.display().to_string()),
-            "settings_toml": crate::agent::settings_config::settings_config_path()
-                .map(|p| p.display().to_string()),
-            "themes_toml": crate::agent::themes_config::themes_config_path()
-                .map(|p| p.display().to_string()),
-            "keybindings_json": crate::paths::keybindings_file()
-                .map(|p| p.display().to_string()),
-            "database": crate::paths::database_file().map(|p| p.display().to_string()),
+            "agents_toml": path_of("agents.toml"),
+            "hosts_toml": path_of("hosts.toml"),
+            "settings_toml": path_of("settings.toml"),
+            "themes_toml": path_of("themes.toml"),
+            "keybindings_json": path_of("keybindings.json"),
+            "database": path_of("database"),
         },
         "agents": { "default": agents.default_name(), "names": agents.names() },
         "hosts": { "names": hosts.names() },

--- a/src/session/config_status.rs
+++ b/src/session/config_status.rs
@@ -1,0 +1,157 @@
+//! Pure data describing one config file's on-disk state + validity — the
+//! discoverability/validation snapshot surfaced in the TUI (the Settings
+//! panel's "Config files" section and the persistent `Config ⚠` footer badge).
+//!
+//! The *behavior* that fills these in (path resolution + strict parsing) lives
+//! in [`crate::session_ops::config_check`]; this module is pure data so both
+//! `ui` (which may reference `session` but not `session_ops`) and the CLI can
+//! consume the same type without an architecture-rule violation.
+
+use std::path::PathBuf;
+
+/// A config file's semantic validity, independent of any display string — so
+/// renderers switch on this rather than on the [`ConfigFile::mark`] text (which
+/// would couple styling to the exact glyphs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigValidity {
+    /// A validated file that exists and parsed cleanly.
+    Ok,
+    /// A validated file that exists but failed to parse.
+    Invalid,
+    /// A validated file that isn't on disk (defaults/seeding apply).
+    Absent,
+    /// A path-only entry (the database) — never parsed, so no mark.
+    Unchecked,
+}
+
+/// One config file's resolved path, existence, and validity.
+///
+/// `validated` distinguishes files we strict-parse (`agents.toml`,
+/// `keybindings.json`, …) from path-only entries like the database, which have
+/// no parseable schema — so an absent DB path isn't reported as a "problem".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigFile {
+    /// Display name, e.g. `agents.toml` / `keybindings.json` / `database`.
+    pub label: &'static str,
+    /// Resolved absolute path (`None` when the path couldn't be resolved at all
+    /// — no home dir, etc.).
+    pub path: Option<PathBuf>,
+    /// Whether the file exists on disk.
+    pub exists: bool,
+    /// Whether it parsed cleanly (always `true` for absent validated files —
+    /// defaults/seeding apply — and for path-only entries).
+    pub valid: bool,
+    /// Whether validity was actually checked (a strict parse). Path-only
+    /// entries (the database) are `false` and never render a validity mark.
+    pub validated: bool,
+    /// Human-readable problems (parse errors, unknown keys, conflicts). Empty
+    /// unless `valid` is `false`.
+    pub problems: Vec<String>,
+}
+
+impl ConfigFile {
+    /// The file's semantic validity — the single source of truth behind both
+    /// [`Self::mark`] and [`Self::is_problem`], and what renderers should switch
+    /// on to pick styling.
+    pub fn validity(&self) -> ConfigValidity {
+        if !self.validated {
+            return ConfigValidity::Unchecked;
+        }
+        match (self.exists, self.valid) {
+            (false, _) => ConfigValidity::Absent,
+            (true, true) => ConfigValidity::Ok,
+            (true, false) => ConfigValidity::Invalid,
+        }
+    }
+
+    /// An at-a-glance validity mark for the row: `✓ ok` / `✗ invalid` /
+    /// `· absent`. Returns `None` for path-only entries (no parse to report).
+    pub fn mark(&self) -> Option<&'static str> {
+        match self.validity() {
+            ConfigValidity::Unchecked => None,
+            ConfigValidity::Ok => Some("✓ ok"),
+            ConfigValidity::Invalid => Some("✗ invalid"),
+            ConfigValidity::Absent => Some("· absent"),
+        }
+    }
+
+    /// Whether this file is a *problem* worth flagging (a validated file that
+    /// exists but failed to parse). Absent files are fine (defaults apply).
+    pub fn is_problem(&self) -> bool {
+        matches!(self.validity(), ConfigValidity::Invalid)
+    }
+
+    /// The resolved path as a display string, or `—` when unresolved.
+    pub fn path_display(&self) -> String {
+        self.path
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "—".to_string())
+    }
+}
+
+/// Whether any file in the snapshot is a problem (drives the footer badge).
+pub fn any_problem(files: &[ConfigFile]) -> bool {
+    files.iter().any(ConfigFile::is_problem)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(exists: bool, valid: bool, validated: bool) -> ConfigFile {
+        ConfigFile {
+            label: "x.toml",
+            path: Some(PathBuf::from("/tmp/x.toml")),
+            exists,
+            valid,
+            validated,
+            problems: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn validity_classifies_each_state() {
+        assert_eq!(file(true, true, true).validity(), ConfigValidity::Ok);
+        assert_eq!(file(true, false, true).validity(), ConfigValidity::Invalid);
+        assert_eq!(file(false, true, true).validity(), ConfigValidity::Absent);
+        // Path-only entries are never parsed, regardless of exists/valid.
+        assert_eq!(
+            file(true, true, false).validity(),
+            ConfigValidity::Unchecked
+        );
+        assert_eq!(
+            file(false, false, false).validity(),
+            ConfigValidity::Unchecked
+        );
+    }
+
+    #[test]
+    fn mark_reflects_existence_and_validity() {
+        assert_eq!(file(true, true, true).mark(), Some("✓ ok"));
+        assert_eq!(file(true, false, true).mark(), Some("✗ invalid"));
+        assert_eq!(file(false, true, true).mark(), Some("· absent"));
+        // Path-only entries render no mark.
+        assert_eq!(file(true, true, false).mark(), None);
+    }
+
+    #[test]
+    fn is_problem_only_for_existing_invalid_validated_files() {
+        assert!(file(true, false, true).is_problem());
+        assert!(!file(false, false, true).is_problem()); // absent → fine
+        assert!(!file(true, true, true).is_problem()); // valid → fine
+        assert!(!file(true, false, false).is_problem()); // path-only → never
+    }
+
+    #[test]
+    fn any_problem_detects_a_single_bad_file() {
+        assert!(!any_problem(&[
+            file(true, true, true),
+            file(false, true, true)
+        ]));
+        assert!(any_problem(&[
+            file(true, true, true),
+            file(true, false, true)
+        ]));
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_def;
 pub mod automation;
+pub mod config_status;
 pub mod extension_def;
 pub mod host_def;
 pub mod keybindings;
@@ -14,6 +15,7 @@ pub use automation::{
     parse_hhmm, preset_to_cron, Automation, AutomationAction, AutomationRun, AutomationRunStatus,
     AutomationSchedule, ExtraRepo, SchedulePreset,
 };
+pub use config_status::{any_problem, ConfigFile, ConfigValidity};
 pub use extension_def::{
     AgentPatch, ConfigMerge, ExtensionAutomation, ExtensionDef, ExtensionFile, ExtensionSession,
     ExtensionSymlink, ExternalFile,

--- a/src/session_ops/config_check.rs
+++ b/src/session_ops/config_check.rs
@@ -1,0 +1,191 @@
+//! Config-file discovery + strict validation, shared by `thurbox-cli config`
+//! and the TUI (Settings "Config files" section + `Config ⚠` footer badge).
+//!
+//! This is the single source of truth for *where* each config file lives and
+//! *whether* it parses. The pure result type is [`crate::session::ConfigFile`]
+//! (so `ui` can render it); the logic here does the disk reads + parsing.
+//!
+//! The `agent` loaders are reached via fully-qualified paths (no `use
+//! crate::agent`), like `cli`/`session_ops` elsewhere — see
+//! `tests/architecture_rules.rs`.
+
+use crate::session::ConfigFile;
+
+/// Validate every config file plus resolve the database path, in the order the
+/// TUI/CLI render them. The database is a **path-only** entry (`validated =
+/// false`): it has no parseable schema, so it never shows a validity mark or
+/// counts as a "problem".
+pub fn check_all() -> Vec<ConfigFile> {
+    vec![
+        check_toml::<crate::session::AgentRegistry>(
+            "agents.toml",
+            crate::agent::agent_config::agents_config_path(),
+        ),
+        check_toml::<crate::session::HostRegistry>(
+            "hosts.toml",
+            crate::agent::host_config::hosts_config_path(),
+        ),
+        check_toml::<crate::session::settings::Settings>(
+            "settings.toml",
+            crate::agent::settings_config::settings_config_path(),
+        ),
+        check_toml::<crate::session::theme_config::ThemesFile>(
+            "themes.toml",
+            crate::agent::themes_config::themes_config_path(),
+        ),
+        check_keybindings(),
+        check_database(),
+    ]
+}
+
+/// Validate one TOML config file against `T`. Absent files are valid
+/// (defaults/seeding apply). Unknown fields don't fail the *load* at startup,
+/// but they do fail *validation* — they are typos or stale keys either way.
+fn check_toml<T: serde::de::DeserializeOwned>(
+    label: &'static str,
+    path: Option<std::path::PathBuf>,
+) -> ConfigFile {
+    let Some(path) = path else {
+        return ConfigFile {
+            label,
+            path: None,
+            exists: false,
+            valid: false,
+            validated: true,
+            problems: vec!["could not resolve path".into()],
+        };
+    };
+    if !path.exists() {
+        return ConfigFile {
+            label,
+            path: Some(path),
+            exists: false,
+            valid: true,
+            validated: true,
+            problems: Vec::new(),
+        };
+    }
+    let problems = match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            match crate::agent::agent_config::parse_toml_reporting_unknown::<T>(&contents, label) {
+                Ok((_, warnings)) => warnings,
+                Err(e) => vec![e.to_string()],
+            }
+        }
+        Err(e) => vec![format!("read failed: {e}")],
+    };
+    ConfigFile {
+        label,
+        path: Some(path),
+        exists: true,
+        valid: problems.is_empty(),
+        validated: true,
+        problems,
+    }
+}
+
+/// Validate `keybindings.json` — parses via the same loader the app uses, so a
+/// chord conflict / skipped entry surfaces exactly like at startup.
+fn check_keybindings() -> ConfigFile {
+    let path = crate::paths::keybindings_file();
+    let (exists, valid, problems) = match crate::storage::keybindings::load_keybindings_json() {
+        Ok(Some(json)) => match crate::session::KeyBindings::from_json_with_warnings(&json) {
+            Ok((_, warnings)) => (true, warnings.is_empty(), warnings),
+            Err(e) => (true, false, vec![e]),
+        },
+        Ok(None) => (false, true, Vec::new()),
+        Err(e) => (true, false, vec![e]),
+    };
+    ConfigFile {
+        label: "keybindings.json",
+        path,
+        exists,
+        valid,
+        validated: true,
+        problems,
+    }
+}
+
+/// The SQLite database — a path-only entry: it's created on demand and has no
+/// schema to validate here, so it renders as a discoverable path with no mark.
+fn check_database() -> ConfigFile {
+    let path = crate::paths::database_file();
+    let exists = path.as_ref().is_some_and(|p| p.exists());
+    ConfigFile {
+        label: "database",
+        path,
+        exists,
+        valid: true,
+        validated: false,
+        problems: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paths::TestPathGuard;
+
+    #[test]
+    fn check_all_passes_on_a_fresh_environment() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let files = check_all();
+        assert!(
+            !crate::session::any_problem(&files),
+            "fresh env should have no problems: {files:?}"
+        );
+        // Every declared file is present, in order.
+        let labels: Vec<_> = files.iter().map(|f| f.label).collect();
+        assert_eq!(
+            labels,
+            vec![
+                "agents.toml",
+                "hosts.toml",
+                "settings.toml",
+                "themes.toml",
+                "keybindings.json",
+                "database",
+            ]
+        );
+    }
+
+    #[test]
+    fn check_all_flags_a_malformed_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let path = crate::agent::agent_config::agents_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "not toml {{{").unwrap();
+
+        let files = check_all();
+        assert!(crate::session::any_problem(&files));
+        let agents = files.iter().find(|f| f.label == "agents.toml").unwrap();
+        assert!(agents.is_problem());
+        assert!(!agents.problems.is_empty());
+    }
+
+    #[test]
+    fn check_all_flags_an_unknown_settings_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let path = crate::agent::settings_config::settings_config_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "[features]\nbogus = true\n").unwrap();
+
+        let files = check_all();
+        let settings = files.iter().find(|f| f.label == "settings.toml").unwrap();
+        assert!(settings.is_problem(), "unknown key must fail validation");
+    }
+
+    #[test]
+    fn database_is_path_only_never_a_problem() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = TestPathGuard::new(tmp.path());
+        let files = check_all();
+        let db = files.iter().find(|f| f.label == "database").unwrap();
+        assert!(!db.validated);
+        assert_eq!(db.mark(), None);
+        assert!(!db.is_problem());
+    }
+}

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -6,6 +6,7 @@
 //! thurbox` server.
 
 pub mod builtin_hooks;
+pub mod config_check;
 pub mod delete;
 pub mod extensions;
 pub mod restart;

--- a/src/ui/config_problems_modal.rs
+++ b/src/ui/config_problems_modal.rs
@@ -1,0 +1,136 @@
+//! Renderer for the read-only "Config problems" modal
+//! (`crate::app::modals::ConfigProblemsModal`), opened from the persistent
+//! `Config ⚠` footer badge. Lists each config file that failed validation and
+//! its problem messages, with `[ Open Settings ]` / `[ Close ]` buttons.
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use super::theme::Theme;
+use super::{render_modal_frame, ModalButtons};
+
+const MODAL_WIDTH_PCT: u16 = 70;
+
+/// Borrowed view of a `ConfigProblemsModal` for rendering.
+pub struct ConfigProblemsState<'a> {
+    pub files: &'a [crate::session::ConfigFile],
+}
+
+/// Build the body: a lead line, then per problem file its `✗ <label>` heading
+/// (with resolved path) and one indented line per problem message.
+fn body_lines(files: &[crate::session::ConfigFile]) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line> = vec![Line::from(Span::styled(
+        "These config files failed validation and were ignored or partially applied:",
+        Style::default().fg(Theme::text_secondary()),
+    ))];
+    for f in files {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("✗ {}", f.label),
+                Style::default()
+                    .fg(Theme::status_error())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("  {}", f.path_display()),
+                Style::default().fg(Theme::text_muted()),
+            ),
+        ]));
+        for p in &f.problems {
+            lines.push(Line::from(Span::styled(
+                format!("    - {p}"),
+                Style::default().fg(Theme::text_secondary()),
+            )));
+        }
+    }
+    lines
+}
+
+/// Render the modal and return its `[ Open Settings ]` (Enter) / `[ Close ]`
+/// (Esc) buttons paired with the keys they replay through the modal handler.
+pub fn render_config_problems_modal(
+    frame: &mut Frame,
+    state: &ConfigProblemsState<'_>,
+) -> ModalButtons {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let body = body_lines(state.files);
+    let height = body.len() as u16 + 2 + 2; // body + blank spacer + footer + border
+    let area = super::centered_fixed_height_rect(MODAL_WIDTH_PCT, height, frame.area());
+    let inner = render_modal_frame(frame, area, "Config problems");
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(body.len() as u16),
+            Constraint::Length(1), // blank spacer
+            Constraint::Length(1), // footer
+        ])
+        .split(inner);
+
+    frame.render_widget(Paragraph::new(body), chunks[0]);
+
+    let hits = super::render_button_bar(
+        frame,
+        chunks[2],
+        &[
+            super::ButtonSpec::primary("Open Settings"),
+            super::ButtonSpec::secondary("Close"),
+        ],
+        true,
+    );
+    super::modal_button_keys(
+        hits,
+        &[
+            (KeyCode::Enter, KeyModifiers::NONE),
+            (KeyCode::Esc, KeyModifiers::NONE),
+        ],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn problem(label: &'static str, problems: Vec<String>) -> crate::session::ConfigFile {
+        crate::session::ConfigFile {
+            label,
+            path: Some(PathBuf::from("/home/me/.config/thurbox").join(label)),
+            exists: true,
+            valid: false,
+            validated: true,
+            problems,
+        }
+    }
+
+    fn text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn body_lists_each_file_and_its_problems() {
+        let files = vec![
+            problem("hosts.toml", vec!["unknown field `destinaton`".into()]),
+            problem(
+                "keybindings.json",
+                vec!["ctrl+a bound to two actions".into()],
+            ),
+        ];
+        let out: String = body_lines(&files)
+            .iter()
+            .map(text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(out.contains("✗ hosts.toml"), "{out}");
+        assert!(out.contains("unknown field `destinaton`"), "{out}");
+        assert!(out.contains("✗ keybindings.json"), "{out}");
+        assert!(out.contains("ctrl+a bound to two actions"), "{out}");
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ pub mod automations_list_modal;
 pub mod automations_panel;
 pub mod branch_selector_modal;
 pub mod code_review;
+pub mod config_problems_modal;
 pub mod confirm_delete_modal;
 pub mod confirm_restore_modal;
 pub mod file_viewer;

--- a/src/ui/settings_modal.rs
+++ b/src/ui/settings_modal.rs
@@ -14,7 +14,7 @@ use ratatui::{
 use crate::app::modals::SettingsField;
 
 use super::theme::Theme;
-use super::{key_hint_line, render_action_footer, render_modal_frame};
+use super::{key_hint_line, render_modal_frame};
 
 /// Default modal width. Sized to fit the value column with a tidy gap on a
 /// normal terminal. Clamped to the screen on narrow terminals.
@@ -62,6 +62,10 @@ pub struct SettingsModalState<'a> {
     pub modal: &'a crate::app::modals::SettingsModal,
     /// Whether any restart-required field has changed (drives the note).
     pub restart_pending: bool,
+    /// The per-file config validity snapshot (`App::config_status`), rendered as
+    /// a read-only "Config files" band above the editable settings. Paths aren't
+    /// editable in-TUI; this is discoverability + at-a-glance validity.
+    pub config_files: &'a [crate::session::ConfigFile],
 }
 
 /// Sections, in render order: a header label and the fields under it.
@@ -114,9 +118,10 @@ pub fn render_settings_modal(
     // around the active field when the modal is shorter than the content.
     let footer = footer_lines(state);
     let width = modal_width_for(frame.area().width);
-    // Build the rows first so the modal height matches the real content
-    // (section headers, blank separators between sections, and field rows).
-    let rows = build_rows(state.modal, (width - 2) as usize);
+    // Build the rows first so the modal height matches the real content (the
+    // read-only "Config files" band, section headers, blank separators, and
+    // field rows).
+    let rows = build_rows(state.modal, state.config_files, (width - 2) as usize);
     let desired = rows.len() as u16 + footer.len() as u16 + 2;
     let height = desired.min(frame.area().height.saturating_sub(2)).max(6);
     let area = centered_rect(width, height, frame.area());
@@ -156,22 +161,33 @@ pub fn render_settings_modal(
 
     frame.render_widget(Paragraph::new(lines), inner);
 
-    // Clickable `[ Save ]` / `[ Cancel ]` buttons over the bottom footer row.
+    // Clickable `[ Validate ]` / `[ Save ]` / `[ Cancel ]` buttons over the
+    // bottom footer row. Validate re-runs config validation on demand (replays
+    // `v` through the modal handler); Save/Cancel mirror the keyboard path.
     let footer_row = Rect::new(
         inner.x,
         inner.y + inner.height.saturating_sub(1),
         inner.width,
         1,
     );
-    let buttons = render_action_footer(
+    use crossterm::event::{KeyCode, KeyModifiers};
+    let hits = super::render_button_bar(
         frame,
         footer_row,
-        (
-            "Save",
-            crossterm::event::KeyCode::Char('s'),
-            crossterm::event::KeyModifiers::CONTROL,
-        ),
-        "Cancel",
+        &[
+            super::ButtonSpec::secondary("Validate·v"),
+            super::ButtonSpec::primary("Save"),
+            super::ButtonSpec::secondary("Cancel"),
+        ],
+        true,
+    );
+    let buttons = super::modal_button_keys(
+        hits,
+        &[
+            (KeyCode::Char('v'), KeyModifiers::NONE),
+            (KeyCode::Char('s'), KeyModifiers::CONTROL),
+            (KeyCode::Esc, KeyModifiers::NONE),
+        ],
     );
     (field_hits, buttons)
 }
@@ -203,11 +219,118 @@ fn footer_lines<'a>(state: &SettingsModalState<'_>) -> Vec<Line<'a>> {
     footer
 }
 
-/// Build the display rows: each section header (no field) followed by its field
-/// rows (carrying their [`SettingsField`] so the active row can be located).
-/// `width` is the modal's inner column count, used to right-align the values.
+/// A section-header row (accent, bold, no field), matching the settings
+/// sections so the "Config files" band reads as a peer.
+fn section_header<'a>(title: &str) -> (Line<'a>, Option<SettingsField>) {
+    (
+        Line::from(Span::styled(
+            format!("  {}", title.to_uppercase()),
+            Style::default()
+                .fg(Theme::accent())
+                .add_modifier(Modifier::BOLD),
+        )),
+        None,
+    )
+}
+
+/// Build the read-only "Config files" band: one non-selectable row per config
+/// file (name + resolved path + validity mark), with problem detail indented
+/// beneath any invalid file. All rows carry `None` for the field so they're
+/// skipped by field navigation and produce no click hitbox.
+fn config_rows<'a>(
+    files: &[crate::session::ConfigFile],
+    width: usize,
+) -> Vec<(Line<'a>, Option<SettingsField>)> {
+    let mut rows = vec![section_header("Config files")];
+    for f in files {
+        rows.push((config_file_line(f, width), None));
+        if f.is_problem() {
+            for p in &f.problems {
+                // Indented, danger-tinted detail so a malformed file's reason is
+                // visible without leaving the modal.
+                let mut text = format!("      - {p}");
+                if text.chars().count() > width {
+                    text = text.chars().take(width.saturating_sub(1)).collect();
+                    text.push('…');
+                }
+                rows.push((
+                    Line::from(Span::styled(
+                        text,
+                        Style::default().fg(Theme::status_error()),
+                    )),
+                    None,
+                ));
+            }
+        }
+    }
+    rows
+}
+
+/// One config-file row: `  <name>  <path (dimmed, truncated)> … <mark>`, the
+/// mark right-justified and colored by validity.
+fn config_file_line<'a>(f: &crate::session::ConfigFile, width: usize) -> Line<'a> {
+    use crate::session::ConfigValidity;
+    let name = f.label.to_string();
+    let mark = f.mark().unwrap_or("");
+    // Switch on the semantic validity, not the mark string, so the styling can't
+    // silently drift if a mark glyph changes. The name stays a bold secondary
+    // label except when invalid, where it reads in the error colour too.
+    let name_bold = |fg| Style::default().fg(fg).add_modifier(Modifier::BOLD);
+    let (mark_style, name_style) = match f.validity() {
+        ConfigValidity::Invalid => (
+            name_bold(Theme::status_error()),
+            name_bold(Theme::status_error()),
+        ),
+        ConfigValidity::Ok => (
+            Style::default().fg(Theme::tool_allowed()),
+            name_bold(Theme::text_secondary()),
+        ),
+        ConfigValidity::Absent | ConfigValidity::Unchecked => (
+            Style::default().fg(Theme::text_muted()),
+            name_bold(Theme::text_secondary()),
+        ),
+    };
+
+    // Columns: 2 pad + name(padded) + 1 gap + path + pad + mark. Truncate the
+    // path (its left is the stable, informative part) so the mark stays visible.
+    let name_col = 16usize;
+    let name_pad = name_col.saturating_sub(name.chars().count());
+    let mark_w = mark.chars().count();
+    let left = 2 + name_col + 1;
+    let path_budget = width.saturating_sub(left + mark_w + 1);
+    let mut path = f.path_display();
+    if path.chars().count() > path_budget {
+        // Keep the tail of the path (filename end) — the leading home dir is the
+        // least informative part when it must be clipped.
+        let keep: String = path
+            .chars()
+            .rev()
+            .take(path_budget.saturating_sub(1))
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        path = format!("…{keep}");
+    }
+    let pad = width
+        .saturating_sub(left + path.chars().count() + mark_w)
+        .max(1);
+
+    Line::from(vec![
+        Span::styled(format!("  {name}{}", " ".repeat(name_pad + 1)), name_style),
+        Span::styled(path, Style::default().fg(Theme::text_muted())),
+        Span::raw(" ".repeat(pad)),
+        Span::styled(mark.to_string(), mark_style),
+    ])
+}
+
+/// Build the display rows: the read-only "Config files" band, then each section
+/// header (no field) followed by its field rows (carrying their
+/// [`SettingsField`] so the active row can be located). `width` is the modal's
+/// inner column count, used to right-align the values.
 fn build_rows<'a>(
     m: &crate::app::modals::SettingsModal,
+    config_files: &[crate::session::ConfigFile],
     width: usize,
 ) -> Vec<(Line<'a>, Option<SettingsField>)> {
     // Width of the value column: the widest value across all fields, so every
@@ -225,22 +348,18 @@ fn build_rows<'a>(
         .max()
         .unwrap_or(0);
 
-    let mut rows: Vec<(Line<'a>, Option<SettingsField>)> = Vec::new();
+    // The read-only "Config files" band leads, then a blank separator before
+    // the first editable section.
+    let mut rows: Vec<(Line<'a>, Option<SettingsField>)> = config_rows(config_files, width);
+    rows.push((Line::default(), None));
+
     for (section_idx, (title, fields)) in SECTIONS.iter().enumerate() {
         // Blank separator above every section but the first, so the titles
         // stand clearly apart.
         if section_idx > 0 {
             rows.push((Line::default(), None));
         }
-        rows.push((
-            Line::from(Span::styled(
-                format!("  {}", title.to_uppercase()),
-                Style::default()
-                    .fg(Theme::accent())
-                    .add_modifier(Modifier::BOLD),
-            )),
-            None,
-        ));
+        rows.push(section_header(title));
         for field in *fields {
             rows.push((
                 field_line(m, *field, width, keyword_width, value_width),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -18,6 +18,10 @@ fn brand_style() -> Style {
 
 const SPINNER_CHARS: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
+/// Label of the persistent "config has problems" footer badge. Shown only when
+/// a config file fails validation; opens the read-only problems modal.
+const CONFIG_BADGE_LABEL: &str = "Config ⚠";
+
 pub fn render_header(frame: &mut Frame, area: Rect, badge: Option<HeaderBadge<'_>>) {
     if area.height == 0 {
         return;
@@ -84,8 +88,20 @@ pub struct FooterState<'a> {
     pub tasks_enabled: bool,
     pub file_viewer_enabled: bool,
     pub info_panel_enabled: bool,
+    /// Whether any config file currently fails validation — shows the
+    /// persistent `Config ⚠` badge (an essential, never-trimmed pill).
+    pub config_problems: bool,
     /// Live keybindings, so each footer pill can show its (rebindable) shortcut.
     pub keybindings: &'a KeyBindings,
+}
+
+/// What a clicked footer pill dispatches: either a rebindable global `Action`,
+/// or the bespoke "open config problems" badge (which has no rebindable action
+/// — it's a conditional problem indicator, not a standing command).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FooterButton {
+    Action(Action),
+    ConfigProblems,
 }
 
 /// The clickable footer buttons, in render order, paired with the `Action` each
@@ -145,7 +161,7 @@ pub fn render_footer(
     frame: &mut Frame,
     area: Rect,
     state: &FooterState<'_>,
-) -> Vec<(super::ButtonHit, Action)> {
+) -> Vec<(super::ButtonHit, FooterButton)> {
     // The footer always carries the idle session/automation counts + the focus
     // hint; the transient status/error message (and sync spinner) now live on
     // their own dedicated row above the footer (`render_status_message_row`), so
@@ -159,40 +175,64 @@ pub fn render_footer(
 
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 
-    let mut entries = footer_entries(state);
-    // Suffix each pill with its live shortcut (`Help · F1`); own the strings so
-    // the borrowed `ButtonSpec`s can reference them. Kept index-aligned with
-    // `entries` through the responsive trim below.
-    let mut labels: Vec<String> = entries
+    // One pill per button: the leading `Config ⚠` badge (only when config has
+    // problems) is a primary, essential pill; the action pills carry their live
+    // shortcut. `essential` pills survive the narrow-footer trim below.
+    struct Pill {
+        label: String,
+        button: FooterButton,
+        primary: bool,
+        essential: bool,
+    }
+    let mut pills: Vec<Pill> = Vec::new();
+    if state.config_problems {
+        pills.push(Pill {
+            label: CONFIG_BADGE_LABEL.to_string(),
+            button: FooterButton::ConfigProblems,
+            primary: true,
+            essential: true,
+        });
+    }
+    // Panel-toggle pills (Info/Files/Tasks) are the *optional* set: dropped
+    // together when the full row won't fit, so the essential pills never fall
+    // off. The badge above is never optional (a dropped problem indicator
+    // defeats its purpose).
+    let optional = |a: Action| {
+        matches!(
+            a,
+            Action::ToggleInfoPanel | Action::ToggleFileViewer | Action::FocusTasks
+        )
+    };
+    for (label, action) in footer_entries(state) {
+        let shortcut = crate::session::compact_shortcut(state.keybindings.chords_for(action));
+        let full = match shortcut {
+            Some(sc) => format!("{label} · {sc}"),
+            None => label.to_string(),
+        };
+        pills.push(Pill {
+            label: full,
+            button: FooterButton::Action(action),
+            primary: false,
+            essential: !optional(action),
+        });
+    }
+
+    // When the full set won't fit, drop the optional pills together rather than
+    // letting `render_button_bar` shed the rightmost essential pill.
+    let all_labels: Vec<String> = pills.iter().map(|p| p.label.clone()).collect();
+    if pill_block_width(&all_labels) > area.width {
+        pills.retain(|p| p.essential);
+    }
+
+    let specs: Vec<super::ButtonSpec<'_>> = pills
         .iter()
-        .map(|(label, action)| {
-            match crate::session::compact_shortcut(state.keybindings.chords_for(*action)) {
-                Some(sc) => format!("{label} · {sc}"),
-                None => label.to_string(),
+        .map(|p| {
+            if p.primary {
+                super::ButtonSpec::primary(&p.label)
+            } else {
+                super::ButtonSpec::secondary(&p.label)
             }
         })
-        .collect();
-    // When the full set won't fit, drop the optional panel-toggle pills
-    // together (all-or-nothing) rather than letting `render_button_bar` shed
-    // the rightmost essential pill (Quit).
-    if pill_block_width(&labels) > area.width {
-        let optional = |a: &Action| {
-            matches!(
-                a,
-                Action::ToggleInfoPanel | Action::ToggleFileViewer | Action::FocusTasks
-            )
-        };
-        labels = entries
-            .iter()
-            .zip(&labels)
-            .filter(|((_, a), _)| !optional(a))
-            .map(|(_, l)| l.clone())
-            .collect();
-        entries.retain(|(_, a)| !optional(a));
-    }
-    let specs: Vec<super::ButtonSpec<'_>> = labels
-        .iter()
-        .map(|l| super::ButtonSpec::secondary(l))
         .collect();
     let hits = super::render_button_bar(frame, area, &specs, true);
 
@@ -215,12 +255,12 @@ pub fn render_footer(
         }
     }
 
-    // Each placed hit keeps its index into `entries`, so the click→action map
-    // follows the same feature-filtered list that was rendered.
+    // Each placed hit keeps its index into `pills`, so the click→button map
+    // follows the same trimmed list that was rendered.
     hits.into_iter()
         .map(|hit| {
-            let action = entries[hit.index].1;
-            (hit, action)
+            let button = pills[hit.index].button;
+            (hit, button)
         })
         .collect()
 }
@@ -393,15 +433,16 @@ mod tests {
             tasks_enabled: true,
             file_viewer_enabled: true,
             info_panel_enabled: true,
+            config_problems: false,
             keybindings: test_keybindings(),
         }
     }
 
-    /// Render the given state into a 120×1 buffer and return (button+action
+    /// Render the given state into a 120×1 buffer and return (button+button
     /// hits, line text).
     fn render_footer_state(
         state: &FooterState<'_>,
-    ) -> (Vec<(super::super::ButtonHit, Action)>, String) {
+    ) -> (Vec<(super::super::ButtonHit, FooterButton)>, String) {
         let backend = TestBackend::new(120, 1);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut hits = Vec::new();
@@ -417,12 +458,21 @@ mod tests {
 
     /// Render a default footer (all features on) with the given file-viewer
     /// visibility.
-    fn footer_render(file_viewer_open: bool) -> (Vec<(super::super::ButtonHit, Action)>, String) {
+    fn footer_render(
+        file_viewer_open: bool,
+    ) -> (Vec<(super::super::ButtonHit, FooterButton)>, String) {
         render_footer_state(&footer_state(file_viewer_open))
     }
 
-    fn hit_actions(hits: &[(super::super::ButtonHit, Action)]) -> Vec<Action> {
-        hits.iter().map(|(_, a)| *a).collect()
+    /// The rebindable actions among the placed pills (the `Config ⚠` badge has
+    /// no action, so it's filtered out here).
+    fn hit_actions(hits: &[(super::super::ButtonHit, FooterButton)]) -> Vec<Action> {
+        hits.iter()
+            .filter_map(|(_, b)| match b {
+                FooterButton::Action(a) => Some(*a),
+                FooterButton::ConfigProblems => None,
+            })
+            .collect()
     }
 
     #[test]
@@ -542,6 +592,56 @@ mod tests {
         // The rightmost button ends at the footer's right edge.
         let last = hits.iter().max_by_key(|(h, _)| h.rect.x).unwrap().0.rect;
         assert_eq!(last.x + last.width, 120);
+    }
+
+    /// The `Config ⚠` badge appears only when config has problems, renders as a
+    /// clickable pill mapped to `FooterButton::ConfigProblems`, and never shows
+    /// on a healthy footer.
+    #[test]
+    fn config_badge_shows_only_with_problems() {
+        // Healthy: no badge.
+        let (hits, line) = footer_render(false);
+        assert!(!line.contains("Config"), "no badge when clean: {line:?}");
+        assert!(
+            !hits.iter().any(|(_, b)| *b == FooterButton::ConfigProblems),
+            "no ConfigProblems hit when clean"
+        );
+
+        // With problems: the badge is present and clickable.
+        let mut state = footer_state(false);
+        state.config_problems = true;
+        let (hits, line) = render_footer_state(&state);
+        assert!(
+            line.contains("Config"),
+            "badge present with problems: {line:?}"
+        );
+        assert!(
+            hits.iter().any(|(_, b)| *b == FooterButton::ConfigProblems),
+            "ConfigProblems click target present"
+        );
+    }
+
+    /// The badge is essential: on a footer too narrow for every pill, the
+    /// optional panel toggles drop but `Config ⚠` survives.
+    #[test]
+    fn config_badge_survives_a_narrow_footer() {
+        let mut state = footer_state(false);
+        state.config_problems = true;
+        let backend = TestBackend::new(70, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut hits = Vec::new();
+        terminal
+            .draw(|f| hits = render_footer(f, Rect::new(0, 0, 70, 1), &state))
+            .unwrap();
+        assert!(
+            hits.iter().any(|(_, b)| *b == FooterButton::ConfigProblems),
+            "badge must survive a narrow footer: {hits:?}"
+        );
+        let actions = hit_actions(&hits);
+        assert!(
+            !actions.contains(&Action::ToggleInfoPanel),
+            "optional pills still drop when narrow: {actions:?}"
+        );
     }
 
     fn long_error() -> StatusMessage {


### PR DESCRIPTION
## Summary

Closes #751. Makes config-file locations + validity discoverable inside the TUI, and makes config warnings persistent instead of a fire-and-forget toast.

- **Settings modal** gains a read-only **"Config files"** band: each config file (`agents.toml` / `hosts.toml` / `settings.toml` / `themes.toml` / `keybindings.json` / the database) with its resolved path and an at-a-glance validity mark (`✓ ok` / `✗ invalid` / `· absent`), problem detail expanded inline. A **`Validate`** action (key `v` / footer button) re-runs validation on demand.
- **Persistent `Config ⚠` footer badge** appears whenever a config file fails validation (an *essential* pill, never dropped by the narrow-footer trim). Clicking it opens a read-only **"Config problems"** modal listing each broken file + its messages, with an `Open Settings` jump. The badge is derived purely from current validity (no dismiss state); it clears on the config live-reload once the file is fixed.
- **Single source of truth:** new pure `session::ConfigFile` (+ `ConfigValidity`) type filled by `session_ops::config_check::check_all()`, reused by `thurbox-cli config` (`validate`/`show`) so the CLI and TUI never disagree. `config show`/`validate` JSON output is byte-identical.
- Validity is cached on `App.config_status`, computed at startup and refreshed on the existing config live-reload path + the Validate action — never per frame.

## Test plan

- New unit + acceptance tests: `ConfigFile` validity/mark, `config_check::check_all`, footer badge (shown only on problems, essential/never-trimmed), config-problems modal, Settings config-files section, the Validate action, and the badge → problems-modal → Settings flow. Existing `cli::config` JSON tests unchanged.
- Full suite (1761 tests) + clippy `-D warnings` + fmt + rumdl all green; architecture rules pass.
- The healthy welcome-screen snapshot is unchanged (badge absent on clean config).

## Notes

- Auto-merge intentionally **not** enabled — opened for manual review.