### PR TITLE
feat(core): pre-flight an agent's binary on PATH before spawning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,6 +447,25 @@ workspace, so `--last`/`--continue` finds no parent session (multi-repo
   implements the `AgentProvider` trait (`command()` +
   `build_args(&SessionConfig)`). `App::provider_for(&config)`
   picks the provider for the session's agent.
+- **Spawn-time binary pre-flight**: before a tmux window is created, both
+  spawn paths probe that the resolved agent `command` is runnable (the agent
+  analogue of the startup `LocalTmuxBackend::check_available` guard). A missing
+  binary otherwise makes the window's shell exit instantly ("command not
+  found") and the pane die with no upfront error. `agent::preflight::
+  command_on_path` walks `$PATH` locally (with `PATHEXT` on Windows);
+  `git::command_available_on_host` runs `command -v` under a **login** shell on
+  a remote host (matching `login_wrap_for_remote`'s PATH), short-circuiting to
+  "present" on psmux hosts. The check is **advisory** — any uncertainty
+  (unreadable `$PATH`, a shell-function `command`, an unreachable host) assumes
+  present. `session_ops::spawn::agent_command_present` is the single source of
+  truth for that local-vs-remote dispatch and the assume-present policy. The
+  scriptable headless spawns (`session create` / `task run` / automation
+  `Spawn`, gated by `SpawnRequest.preflight`) hard-error (no leaked window); the
+  resilient self-heal path (`ensure_extension`, run every heartbeat tick) sets
+  `preflight = false` so a not-yet-installed agent CLI never aborts activation.
+  The TUI (`App::do_spawn_session_async` → `preflight_missing_command`) shows a
+  "spawn anyway?" confirm (`Modal::ConfirmSpawnMissingBinary`) since a
+  shell-function/rc-only `command` is a valid spawn the walk can't see.
 
 A session stores only its **agent name**; there are no
 per-session model/permission/prompt/tool knobs.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,6 +6,7 @@ pub mod generic;
 pub mod host_config;
 pub mod input;
 pub mod json_merge;
+pub mod preflight;
 pub mod provider;
 pub mod registry;
 pub mod self_update;

--- a/src/agent/preflight.rs
+++ b/src/agent/preflight.rs
@@ -1,0 +1,186 @@
+//! Best-effort pre-flight: is an agent's `command` runnable before we spawn a
+//! tmux window for it?
+//!
+//! A missing binary (a typo in `agents.toml`, or a seeded-but-never-installed
+//! built-in like `agy`/`copilot`/`vibe`) makes the window's shell exit instantly
+//! with `command not found` and the pane dies — with no upfront error in the
+//! new-session flow. This module resolves the `command` the way a shell would so
+//! the spawn paths can catch that up front.
+//!
+//! **Advisory, never authoritative.** The check answers only "is this `command`
+//! runnable?", agent-neutrally. Any uncertainty — an unreadable `$PATH`, a
+//! `command` that's actually a shell function/alias the walk can't see —
+//! resolves to "assume present" so a valid spawn is never blocked. Callers that
+//! can prompt (the TUI) treat a negative as advisory (confirm, not block); the
+//! scriptable headless path hard-errors.
+
+/// Best-effort: is `command` on `PATH` (or a runnable path)?
+///
+/// Returns `false` **only** when we can confidently say the binary is not
+/// resolvable; every uncertain case returns `true`. Mirrors shell resolution:
+/// a `command` containing a path separator is checked directly, a bare name is
+/// looked up across `$PATH` (and, on Windows, each `PATHEXT` extension).
+pub fn command_on_path(command: &str) -> bool {
+    let path = std::env::var("PATH").ok();
+    #[cfg(windows)]
+    let pathext =
+        Some(std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string()));
+    #[cfg(not(windows))]
+    let pathext: Option<String> = None;
+    resolve(command, path.as_deref(), pathext.as_deref(), &is_executable)
+}
+
+/// The real filesystem executability predicate. On Unix a candidate must be a
+/// file with an execute bit set; elsewhere (Windows) the extension has already
+/// been appended by [`resolve`], so a plain file-exists check is enough.
+#[cfg(unix)]
+fn is_executable(candidate: &str) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(candidate)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(candidate: &str) -> bool {
+    std::path::Path::new(candidate).is_file()
+}
+
+/// Pure PATH resolution, factored out so it's testable with an injected `$PATH`,
+/// `PATHEXT`, and a fake `exists` predicate — independent of the host OS.
+///
+/// `pathext` being `Some` selects Windows semantics: `;`-separated `PATH`,
+/// backslash as a path separator, and each extension appended when a candidate
+/// has no direct hit. `None` selects POSIX semantics (`:`-separated, `/` only).
+fn resolve(
+    command: &str,
+    path: Option<&str>,
+    pathext: Option<&str>,
+    exists: &dyn Fn(&str) -> bool,
+) -> bool {
+    // An empty command is nonsensical to probe; don't block on it.
+    if command.is_empty() {
+        return true;
+    }
+
+    let windows = pathext.is_some();
+    let list_sep = if windows { ';' } else { ':' };
+    let dir_sep = if windows { '\\' } else { '/' };
+    let exts: Vec<&str> = pathext
+        .map(|pe| pe.split(';').filter(|e| !e.is_empty()).collect())
+        .unwrap_or_default();
+    let is_sep = |c: char| c == '/' || (windows && c == '\\');
+
+    // Does `base` (or `base` + a PATHEXT extension, on Windows) resolve?
+    let hit = |base: &str| -> bool {
+        if exists(base) {
+            return true;
+        }
+        windows && exts.iter().any(|ext| exists(&format!("{base}{ext}")))
+    };
+
+    // A command with a path separator is resolved directly, never via PATH.
+    if command.chars().any(is_sep) {
+        return hit(command);
+    }
+
+    // A bare name is looked up across PATH. If PATH is unreadable/empty we can't
+    // judge — assume present.
+    let Some(path) = path.filter(|p| !p.is_empty()) else {
+        return true;
+    };
+    path.split(list_sep)
+        .filter(|dir| !dir.is_empty())
+        .any(|dir| hit(&format!("{dir}{dir_sep}{command}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    /// Build an `exists` predicate from a fixed set of resolvable paths.
+    fn present(paths: &[&str]) -> impl Fn(&str) -> bool {
+        let set: HashSet<String> = paths.iter().map(|s| s.to_string()).collect();
+        move |p: &str| set.contains(p)
+    }
+
+    #[test]
+    fn bare_name_found_in_path() {
+        let exists = present(&["/home/me/.local/bin/claude"]);
+        assert!(resolve(
+            "claude",
+            Some("/usr/bin:/home/me/.local/bin"),
+            None,
+            &exists
+        ));
+    }
+
+    #[test]
+    fn bare_name_not_found_is_confidently_missing() {
+        let exists = present(&["/usr/bin/ls"]);
+        assert!(!resolve("agy", Some("/usr/bin:/bin"), None, &exists));
+    }
+
+    #[test]
+    fn path_separator_command_checked_directly() {
+        let exists = present(&["/opt/agent/claude"]);
+        assert!(resolve("/opt/agent/claude", None, None, &exists));
+        assert!(!resolve("/opt/agent/missing", None, None, &exists));
+        // A directory-separator command never falls back to a PATH walk.
+        assert!(!resolve(
+            "./claude",
+            Some("/dir-with-claude"),
+            None,
+            &present(&["/dir-with-claude/claude"])
+        ));
+    }
+
+    #[test]
+    fn unreadable_or_empty_path_assumes_present() {
+        let exists = present(&[]);
+        assert!(resolve("claude", None, None, &exists));
+        assert!(resolve("claude", Some(""), None, &exists));
+    }
+
+    #[test]
+    fn empty_command_assumes_present() {
+        assert!(resolve("", Some("/usr/bin"), None, &present(&[])));
+    }
+
+    #[test]
+    fn windows_appends_pathext() {
+        let exists = present(&["C:\\bin\\agy.EXE"]);
+        // Bare name resolves only after a PATHEXT extension is appended.
+        assert!(resolve(
+            "agy",
+            Some("C:\\bin"),
+            Some(".COM;.EXE;.CMD"),
+            &exists
+        ));
+        assert!(!resolve("agy", Some("C:\\bin"), Some(".COM;.CMD"), &exists));
+    }
+
+    #[test]
+    fn windows_direct_extension_and_backslash_separator() {
+        // An explicit extension resolves directly.
+        let exists = present(&["C:\\tools\\claude.cmd"]);
+        assert!(resolve(
+            "C:\\tools\\claude.cmd",
+            None,
+            Some(".EXE;.CMD"),
+            &exists
+        ));
+        // A backslash marks a path command under Windows semantics (no PATH walk);
+        // the extension is appended. (`resolve` matches the extension verbatim —
+        // the real predicate defers case-insensitivity to the filesystem — so the
+        // fixture keeps PATHEXT and the file casing consistent.)
+        let exists = present(&["C:\\tools\\claude.CMD"]);
+        assert!(resolve(
+            "C:\\tools\\claude",
+            Some("C:\\other"),
+            Some(".CMD"),
+            &exists
+        ));
+    }
+}

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -374,6 +374,7 @@ impl App {
             Modal::TaskActionPicker(_) => self.handle_task_action_picker_key(code),
             Modal::ConfirmDelete(_) => self.handle_confirm_delete_key(code),
             Modal::ConfirmRestore(_) => self.handle_confirm_restore_key(code),
+            Modal::ConfirmSpawnMissingBinary(_) => self.handle_confirm_spawn_missing_key(code),
             Modal::Settings(_) => self.handle_settings_key(code, mods),
             _ => return false,
         }
@@ -442,6 +443,23 @@ impl App {
             }
             KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
                 self.modal.close();
+            }
+            _ => {}
+        }
+    }
+
+    /// Drive the "agent not found" confirm: `Enter`/`y` spawns anyway (the
+    /// binary may be a shell function / rc-only PATH entry the probe can't see),
+    /// `Esc`/`n` cancels and drops the deferred spawn.
+    fn handle_confirm_spawn_missing_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
+                self.modal.close();
+                self.confirm_preflight_spawn();
+            }
+            KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
+                self.modal.close();
+                self.pending_preflight_spawn = None;
             }
             _ => {}
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -123,6 +123,16 @@ struct PendingSessionSpawn {
     base_branch: Option<String>,
 }
 
+/// A spawn deferred behind the "agent not found" confirm modal
+/// ([`modals::Modal::ConfirmSpawnMissingBinary`]). Captured *before* any
+/// wizard state is consumed so confirming re-enters the normal async spawn with
+/// everything intact; cancelling just drops it.
+struct PendingPreflightSpawn {
+    name: String,
+    config: SessionConfig,
+    worktrees: Vec<WorktreeInfo>,
+}
+
 /// One remote backend's discovery result: its `backend_type` plus the windows
 /// its host reported. Sent once per backend by the restore threads.
 type RemoteDiscovery = (String, Vec<crate::agent::backend::DiscoveredSession>);
@@ -642,6 +652,9 @@ pub struct App {
     /// Continuation for a completed background spawn: the metadata + follow-up
     /// (task prompt) to apply once the session is live.
     pending_session_spawn: Option<PendingSessionSpawn>,
+    /// A spawn deferred behind the "agent not found" confirm modal, launched on
+    /// confirm and dropped on cancel.
+    pending_preflight_spawn: Option<PendingPreflightSpawn>,
     /// Remote-backed sessions still being restored in the background (one
     /// discovery thread per host), drained each tick by
     /// [`Self::poll_remote_restore`]. `None` once every remote backend has
@@ -939,6 +952,7 @@ impl App {
             pending_worktree_create: None,
             session_spawn: background::BackgroundTask::default(),
             pending_session_spawn: None,
+            pending_preflight_spawn: None,
             remote_restore: None,
             deferred_inputs: Vec::new(),
             session_terminal_views: HashMap::new(),
@@ -1217,6 +1231,33 @@ impl App {
             def.args = crate::session_ops::spawn::adapt_agent_args_for_remote(h, def.args);
         }
         Arc::new(GenericProvider::new(def))
+    }
+
+    /// Best-effort pre-flight: is the agent `command` for this spawn config
+    /// *confidently* not runnable? Returns `Some((command, remote))` only on a
+    /// confident miss (so the caller can confirm before spawning); any
+    /// uncertainty — unreadable `$PATH`, a shell-function command, an unreachable
+    /// host — returns `None` and the spawn proceeds. `remote` reports whether the
+    /// probe ran against a host (tunes the confirm modal's hint).
+    fn preflight_missing_command(&self, config: &SessionConfig) -> Option<(String, bool)> {
+        let command = self.agent_def_for(&config.agent).command;
+        if command.is_empty() {
+            return None;
+        }
+        let host = self.host_for_backend(config.backend.as_deref());
+        if crate::session_ops::spawn::agent_command_present(&command, host) {
+            return None;
+        }
+        // `remote` tunes the confirm modal's hint (host PATH vs. local PATH).
+        Some((command, host.is_some()))
+    }
+
+    /// Launch a spawn deferred behind the "agent not found" confirm modal (the
+    /// user chose "spawn anyway"). A no-op if the pending spawn is missing.
+    fn confirm_preflight_spawn(&mut self) {
+        if let Some(p) = self.pending_preflight_spawn.take() {
+            self.spawn_session_async_unchecked(p.name, &p.config, p.worktrees);
+        }
     }
 
     /// Resolve the [`AgentDef`] for an agent name via the same fallback chain as
@@ -3558,6 +3599,40 @@ impl App {
     /// Falls back to the synchronous path if a spawn is already in flight (so a
     /// double-trigger is never silently dropped).
     pub(crate) fn do_spawn_session_async(
+        &mut self,
+        name: String,
+        config: &SessionConfig,
+        worktrees: Vec<WorktreeInfo>,
+    ) {
+        // An overlapping spawn falls back to the synchronous path (unchanged);
+        // the interactive pre-flight/confirm only guards a fresh async spawn.
+        if self.session_spawn.in_progress() {
+            self.do_spawn_session(name, config, worktrees);
+            return;
+        }
+        // Pre-flight the agent binary before touching any wizard state. A miss is
+        // advisory (a shell-function/alias `command`, or one on an rc-only PATH,
+        // is a valid spawn), so stash the spawn and confirm rather than block.
+        if let Some((command, remote)) = self.preflight_missing_command(config) {
+            self.pending_preflight_spawn = Some(PendingPreflightSpawn {
+                name,
+                config: config.clone(),
+                worktrees,
+            });
+            self.modal =
+                modals::Modal::ConfirmSpawnMissingBinary(modals::ConfirmSpawnMissingBinaryModal {
+                    command,
+                    remote,
+                });
+            return;
+        }
+        self.spawn_session_async_unchecked(name, config, worktrees);
+    }
+
+    /// The spawn body proper, bypassing the pre-flight — reached either when the
+    /// binary probe passed or when the user chose "spawn anyway" at the
+    /// [`modals::Modal::ConfirmSpawnMissingBinary`] prompt.
+    fn spawn_session_async_unchecked(
         &mut self,
         name: String,
         config: &SessionConfig,
@@ -10716,10 +10791,13 @@ mod tests {
     async fn do_spawn_session_async_roundtrips_to_error_for_stub_backend() {
         // End-to-end: kick off the background spawn, let the blocking task run,
         // and confirm the failure (the stub backend refuses to spawn) is
-        // surfaced via the poll path with no session added.
+        // surfaced via the poll path with no session added. Uses the
+        // pre-flight-bypassing entry point so the test exercises the spawn
+        // machinery, not the agent-binary probe (the default agent's binary
+        // isn't installed in CI).
         let mut app = app_with_sessions(0);
         let config = SessionConfig::default();
-        app.do_spawn_session_async("x".into(), &config, vec![]);
+        app.spawn_session_async_unchecked("x".into(), &config, vec![]);
         assert!(app.session_spawn.in_progress());
 
         for _ in 0..200 {
@@ -10754,6 +10832,90 @@ mod tests {
         // The synchronous fallback ran and surfaced the stub spawn failure.
         let msg = app.status_message.as_ref().unwrap();
         assert_eq!(msg.level, StatusLevel::Error);
+    }
+
+    #[test]
+    fn missing_agent_binary_opens_confirm_then_esc_cancels() {
+        let mut app = app_with_sessions(0);
+        // Register an agent whose command is certainly not installed.
+        let bogus = "thurbox-definitely-not-a-real-binary-xyz";
+        app.agents.agents.push(AgentDef {
+            name: "broken".into(),
+            command: bogus.into(),
+            args: Vec::new(),
+            resume_args: Vec::new(),
+            fork_args: Vec::new(),
+            new_session_args: Vec::new(),
+            resume_latest: false,
+        });
+        let config = SessionConfig {
+            agent: "broken".into(),
+            ..SessionConfig::default()
+        };
+
+        app.do_spawn_session_async("x".into(), &config, vec![]);
+
+        // The pre-flight tripped: a confirm modal opens and the spawn is stashed,
+        // with no background spawn kicked off.
+        match &app.modal {
+            modals::Modal::ConfirmSpawnMissingBinary(m) => {
+                assert_eq!(m.command, bogus);
+                assert!(!m.remote, "a local backend is not a remote miss");
+            }
+            other => panic!("expected the agent-not-found modal, got {other:?}"),
+        }
+        assert!(app.pending_preflight_spawn.is_some());
+        assert!(!app.session_spawn.in_progress(), "no spawn was started");
+
+        // Esc cancels: the modal closes and the deferred spawn is dropped.
+        app.update(AppMessage::KeyPress(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(!app.modal.is_open());
+        assert!(app.pending_preflight_spawn.is_none());
+        assert!(app.sessions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn missing_agent_binary_confirm_spawns_anyway() {
+        let mut app = app_with_sessions(0);
+        let bogus = "thurbox-definitely-not-a-real-binary-xyz";
+        app.agents.agents.push(AgentDef {
+            name: "broken".into(),
+            command: bogus.into(),
+            args: Vec::new(),
+            resume_args: Vec::new(),
+            fork_args: Vec::new(),
+            new_session_args: Vec::new(),
+            resume_latest: false,
+        });
+        let config = SessionConfig {
+            agent: "broken".into(),
+            ..SessionConfig::default()
+        };
+
+        app.do_spawn_session_async("x".into(), &config, vec![]);
+        assert!(matches!(
+            app.modal,
+            modals::Modal::ConfirmSpawnMissingBinary(_)
+        ));
+
+        // "Spawn anyway": Enter confirms, drops the stash, and kicks off the
+        // spawn despite the missing binary (the probe is only advisory).
+        app.update(AppMessage::KeyPress(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(!app.modal.is_open());
+        assert!(app.pending_preflight_spawn.is_none());
+        assert!(
+            app.session_spawn.in_progress(),
+            "spawn-anyway kicks off the background spawn"
+        );
+
+        // Drain the background task so the runtime isn't left with an orphan.
+        for _ in 0..200 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            app.poll_session_spawn();
+            if !app.session_spawn.in_progress() {
+                break;
+            }
+        }
     }
 
     #[test]

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -618,6 +618,19 @@ pub struct ConfirmRestoreModal {
     pub deleted: DeletedSessionInfo,
 }
 
+/// Confirmation prompt shown when the spawn pre-flight can't find the agent's
+/// `command` on PATH. The check is advisory (a shell-function/alias command, or
+/// one resolved via an rc file the walk can't see, is a valid spawn), so this
+/// offers a proceed-anyway escape hatch rather than hard-blocking. The pending
+/// spawn is stashed in [`crate::app::App`] and launched on confirm.
+#[derive(Debug, Clone)]
+pub struct ConfirmSpawnMissingBinaryModal {
+    /// The resolved agent command the pre-flight couldn't find.
+    pub command: String,
+    /// Whether the miss was on a remote host (tunes the modal's hint text).
+    pub remote: bool,
+}
+
 // ── RestoreSessionsModal ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Default)]
@@ -1865,6 +1878,7 @@ pub enum Modal {
     TaskActionPicker(TaskActionPickerModal),
     ConfirmDelete(ConfirmDeleteModal),
     ConfirmRestore(ConfirmRestoreModal),
+    ConfirmSpawnMissingBinary(ConfirmSpawnMissingBinaryModal),
     Settings(SettingsModal),
 }
 

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -927,6 +927,17 @@ impl App {
             );
         }
 
+        // "Agent not found" spawn confirmation (pre-flight PATH miss)
+        if let super::modals::Modal::ConfirmSpawnMissingBinary(ref cs) = self.modal {
+            return crate::ui::confirm_spawn_modal::render_confirm_spawn_modal(
+                frame,
+                &crate::ui::confirm_spawn_modal::ConfirmSpawnState {
+                    command: &cs.command,
+                    remote: cs.remote,
+                },
+            );
+        }
+
         Vec::new()
     }
 

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -584,6 +584,8 @@ fn fire_spawn(
         parent_session_id: None,
         task_id: None,
         extra_repos: extra_repos.to_vec(),
+        // Scheduled Spawn: surface a missing agent binary in the run history.
+        preflight: true,
     };
     match action::spawn_and_deliver(db, &name, req, &auto.prompt) {
         Ok(session_id) => (

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -178,6 +178,8 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 parent_session_id,
                 task_id: None,
                 extra_repos,
+                // Scriptable create: fail loudly if the agent binary is missing.
+                preflight: true,
             };
             let res = crate::session_ops::spawn_session_headless(db, req)?;
             let human = format!(

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -346,6 +346,8 @@ fn run_task(db: &Database, task: &Task) -> Result<Value, String> {
                 parent_session_id: None,
                 task_id: Some(task.id),
                 extra_repos: extra_repos.clone(),
+                // Scriptable task run: fail loudly if the agent binary is missing.
+                preflight: true,
             };
             action::spawn_and_deliver(db, &name, req, &prompt).map_err(|e| match e {
                 SpawnDeliverError::Spawn(msg) | SpawnDeliverError::Deliver { message: msg, .. } => {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -243,6 +243,37 @@ fn run_host_script(host: &HostDef, script: &str, action: &str) -> Result<()> {
     remote_output_or_stderr(output, action).map(|_| ())
 }
 
+/// Best-effort pre-flight: is `command` runnable on `host`?
+///
+/// The remote analogue of [`crate::agent::preflight::command_on_path`]. A
+/// missing agent binary makes the remote window command exit 1 and the pane die
+/// instantly — the same symptom [`crate::agent::tmux`]'s `login_wrap_for_remote`
+/// exists to avoid — so we probe before spawning the window. The probe runs
+/// `command -v` under a **login** shell (`/bin/sh -lc …`), matching how the
+/// agent itself launches on a remote (`login_wrap_for_remote`), so the profile
+/// `PATH` — where agents like `~/.local/bin/claude` live — is on the path exactly
+/// as it will be at launch. `command -v` also resolves shell functions/aliases a
+/// bare file check would miss.
+///
+/// psmux (Windows SSH) hosts short-circuit to `Ok(true)`: the POSIX `sh -c`
+/// probe doesn't apply there and the whole psmux remote path already degrades
+/// gracefully (hooks stripped, no subscriptions). Callers treat any `Err`
+/// (unreachable/slow host) as "assume present" — the check must never block a
+/// spawn on its own failure.
+pub fn command_available_on_host(host: &HostDef, command: &str) -> Result<bool> {
+    if host.mux() == "psmux" {
+        return Ok(true);
+    }
+    let probe = format!("command -v {} >/dev/null 2>&1", posix_quote(command));
+    let script = format!("/bin/sh -lc {}", posix_quote(&probe));
+    let output = host_shell_c(host, &script)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .context("failed to run remote agent-command probe")?;
+    Ok(output.status.success())
+}
+
 /// Build a `<launcher> sh -c <script>` [`Command`] for a host, correct for each
 /// transport's argument handling.
 ///
@@ -1265,6 +1296,23 @@ mod tests {
         for var in GIT_LOCATION_ENV {
             assert!(removed.contains(var), "git_program must scrub {var}");
         }
+    }
+
+    #[test]
+    fn command_available_short_circuits_on_psmux_host() {
+        // A psmux (Windows SSH) host can't be POSIX-probed; the check degrades to
+        // "assume present" without any network round-trip (the destination here
+        // is unreachable, so a real probe would hang/fail).
+        let host = HostDef {
+            name: "winbox".into(),
+            destination: "user@unreachable-winbox".into(),
+            multiplexer: Some("psmux".into()),
+            ..Default::default()
+        };
+        assert!(
+            command_available_on_host(&host, "claude").unwrap(),
+            "psmux host must skip the probe"
+        );
     }
 
     #[test]

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -895,6 +895,9 @@ pub fn ensure_extension(db: &Database, def: &ExtensionDef) -> Result<EnsureRepor
                         parent_session_id: None,
                         task_id: None,
                         extra_repos: Vec::new(),
+                        // Self-heal runs every heartbeat tick; a not-yet-installed
+                        // agent CLI must not abort the whole extension activation.
+                        preflight: false,
                     },
                 )?;
                 report.sessions_created.push(sess.name.clone());

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -47,6 +47,14 @@ pub struct SpawnRequest {
     /// as-is as an additional directory. When any extra is non-empty the agent
     /// launches in a per-session symlink workspace gathering every member.
     pub extra_repos: Vec<ExtraRepo>,
+    /// Hard-fail the spawn when the resolved agent `command` isn't on PATH
+    /// (via `preflight_agent_command`). `true` for the scriptable CLI spawns
+    /// (`session create`, `task run`, automation `Spawn`) so a missing binary
+    /// surfaces loudly instead of leaving a dead window. `false` for the
+    /// resilient self-heal path (`ensure_extension`, run every heartbeat tick),
+    /// which must not abort activation just because an agent CLI isn't installed
+    /// — that would resurrect the pre-check behaviour where the pane simply dies.
+    pub preflight: bool,
 }
 
 /// Result returned on successful headless spawn.
@@ -121,6 +129,16 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     super::inject_thurbox_env(&mut config, &agent_session_id, req.task_id);
 
     let (command, args) = super::build_agent_invocation(&agent_def, &config);
+
+    // Pre-flight the agent binary before creating the window. A missing command
+    // would make the window's shell exit instantly ("command not found") and the
+    // pane die — leaving an orphaned dead session with no upfront error. Fail
+    // loudly here instead (scriptable), mirroring the backend `check_available`
+    // guard at startup. Advisory-degrading: any uncertainty assumes present.
+    // Skipped for the resilient self-heal path (`req.preflight == false`).
+    if req.preflight {
+        preflight_agent_command(&command, host.as_ref())?;
+    }
 
     // Remote spawns drive the SSH backend's control mode to learn the real pane
     // id; local spawns leave `backend_id` empty for the TUI to resolve by name.
@@ -541,6 +559,39 @@ fn resolve_host(host_name: Option<&str>) -> Result<(String, Option<HostDef>), St
     }
 }
 
+/// Core of the spawn pre-flight: is `command` runnable for this spawn target?
+///
+/// Local spawns walk `$PATH`; remote spawns probe the host over its launcher,
+/// treating a probe error (unreachable/slow host) as "assume present". The
+/// single source of truth for the check's local-vs-remote dispatch and its
+/// uncertainty-degrades-to-present policy — shared by the headless guard
+/// ([`preflight_agent_command`]) and the TUI confirm
+/// (`App::preflight_missing_command`) so the two can't drift.
+pub(crate) fn agent_command_present(command: &str, host: Option<&HostDef>) -> bool {
+    match host {
+        None => crate::agent::preflight::command_on_path(command),
+        Some(h) => crate::git::command_available_on_host(h, command).unwrap_or(true),
+    }
+}
+
+/// Best-effort pre-flight that the resolved agent `command` is runnable, run
+/// before the tmux window is created. Wraps [`agent_command_present`] with a
+/// helpful error for the scriptable headless path; the guard only trips on a
+/// *confident* miss, so it never blocks a valid spawn.
+fn preflight_agent_command(command: &str, host: Option<&HostDef>) -> Result<(), String> {
+    if agent_command_present(command, host) {
+        return Ok(());
+    }
+    let where_ = match host {
+        Some(h) => format!(" on host '{}'", h.name),
+        None => String::new(),
+    };
+    Err(format!(
+        "Agent command '{command}' was not found on PATH{where_}. Install it, or \
+         fix the agent's `command` in agents.toml."
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -563,6 +614,7 @@ mod tests {
             parent_session_id: None,
             task_id: None,
             extra_repos: Vec::new(),
+            preflight: true,
         }
     }
 
@@ -616,6 +668,34 @@ mod tests {
         };
         db.upsert_session(&parent).unwrap();
         assert!(validate_parent_session(&db, Some(parent.id)).is_ok());
+    }
+
+    #[test]
+    fn agent_command_present_local_reflects_path() {
+        assert!(!agent_command_present(
+            "thurbox-definitely-not-a-real-binary-xyz",
+            None
+        ));
+        // `sh` is on PATH on every unix CI host; skip the assertion elsewhere.
+        if cfg!(unix) {
+            assert!(agent_command_present("sh", None));
+        }
+    }
+
+    #[test]
+    fn preflight_local_errors_on_missing_command() {
+        let bogus = "thurbox-definitely-not-a-real-binary-xyz";
+        let err = preflight_agent_command(bogus, None).unwrap_err();
+        assert!(err.contains(bogus), "got {err}");
+        assert!(err.to_lowercase().contains("path"), "got {err}");
+    }
+
+    #[test]
+    fn preflight_local_accepts_present_command() {
+        // `sh` is on PATH on every unix CI host; skip the assertion elsewhere.
+        if cfg!(unix) {
+            assert!(preflight_agent_command("sh", None).is_ok());
+        }
     }
 
     #[test]

--- a/src/ui/confirm_spawn_modal.rs
+++ b/src/ui/confirm_spawn_modal.rs
@@ -1,0 +1,100 @@
+use ratatui::{
+    style::{Modifier, Style},
+    text::{Line, Span},
+    Frame,
+};
+
+use super::theme::Theme;
+
+const MODAL_WIDTH_PCT: u16 = 60;
+
+pub struct ConfirmSpawnState<'a> {
+    /// The agent `command` the pre-flight couldn't find.
+    pub command: &'a str,
+    /// Whether the missing binary was probed on a remote host (changes the hint).
+    pub remote: bool,
+}
+
+/// Render the "spawn anyway?" confirmation shown when the agent's `command`
+/// isn't resolvable on PATH. The check is advisory — a `command` that's a shell
+/// function/alias, or resolved via an rc file the walk can't see, is a valid
+/// spawn the user knows about — so this offers a proceed-anyway escape hatch
+/// rather than hard-blocking.
+pub fn render_confirm_spawn_modal(
+    frame: &mut Frame,
+    state: &ConfirmSpawnState<'_>,
+) -> super::ModalButtons {
+    let hint = if state.remote {
+        "It isn't on the host's PATH. If it resolves via a login rc the probe"
+    } else {
+        "It isn't on your PATH. If it's a shell function or resolves via an rc"
+    };
+    let body: Vec<Line> = vec![
+        Line::from(vec![
+            Span::styled(
+                format!("'{}'", state.command),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" wasn't found — spawn anyway?"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            hint,
+            Style::default().fg(Theme::text_secondary()),
+        )),
+        Line::from(Span::styled(
+            "can't see, it may still launch; otherwise the pane will die on start.",
+            Style::default().fg(Theme::text_secondary()),
+        )),
+    ];
+
+    super::render_confirm_modal(
+        frame,
+        MODAL_WIDTH_PCT,
+        "Agent not found",
+        false,
+        body,
+        (
+            "Spawn anyway",
+            crossterm::event::KeyCode::Enter,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn rendered_text(command: &str, remote: bool) -> String {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_confirm_spawn_modal(frame, &ConfirmSpawnState { command, remote });
+            })
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn shows_command_and_footer() {
+        let out = rendered_text("agy", false);
+        assert!(out.contains("agy"), "{out}");
+        assert!(out.contains("Spawn anyway"), "{out}");
+        assert!(out.contains("Cancel"), "{out}");
+    }
+
+    #[test]
+    fn remote_hint_differs() {
+        assert!(rendered_text("claude", true).contains("host's PATH"));
+        assert!(rendered_text("claude", false).contains("your PATH"));
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ pub mod branch_selector_modal;
 pub mod code_review;
 pub mod confirm_delete_modal;
 pub mod confirm_restore_modal;
+pub mod confirm_spawn_modal;
 pub mod file_viewer;
 pub mod global_search;
 pub mod highlight;


### PR DESCRIPTION
## Summary

- Adds a best-effort, agent-neutral **PATH pre-flight** for the resolved agent `command`, run *before* the tmux window is created — the agent analogue of the startup `LocalTmuxBackend::check_available` guard. A missing binary otherwise made the window's shell exit instantly (`command not found`) and the pane die with no upfront error in the new-session flow.
- `agent::preflight::command_on_path` walks `$PATH` locally (with `PATHEXT` on Windows); `git::command_available_on_host` probes a remote host with `command -v` under a **login** shell (matching `login_wrap_for_remote`'s PATH), short-circuiting to "present" on psmux (Windows SSH) hosts. `session_ops::spawn::agent_command_present` is the single source of truth for the local/remote dispatch + "uncertainty assumes present" policy.
- **Headless** (`spawn_session_headless`) hard-errors (scriptable, no leaked window). **TUI** shows a "spawn anyway?" confirm modal (`Modal::ConfirmSpawnMissingBinary`), since a shell-function/rc-only `command` is a valid spawn the walk can't see.
- The check is **advisory**: any uncertainty (unreadable `$PATH`, a shell-function command, an unreachable host) degrades to "assume present" and never blocks a valid spawn.

Closes #745.

## Test plan

- New unit tests: pure `resolve` PATH walk (found / missing / path-separator / empty-PATH / Windows PATHEXT), `agent_command_present` local dispatch, headless `preflight_agent_command` (Err on miss / Ok on present), psmux host short-circuit, the confirm-modal renderer, and the TUI flow (missing binary → confirm modal → Esc cancels / Enter spawns anyway).
- Full suite green (1762 tests), clippy/fmt/architecture-rules/doc-build all clean.
- CI checks pass.