### PR TITLE
feat(ui): surface Ctrl+O open-in-editor hint in the footer

### DIFF
--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -670,10 +670,7 @@ impl App {
 
     fn open_file_in_editor(&mut self, root: std::path::PathBuf, file: std::path::PathBuf) {
         let Some(editor) = super::helpers::resolve_editor_command(&self.db) else {
-            self.set_status(
-                super::StatusLevel::Error,
-                "No editor configured — set `editor_command` via MCP or $VISUAL / $EDITOR.",
-            );
+            self.set_error(super::EDITOR_NOT_CONFIGURED);
             return;
         };
         if let Err(e) = super::helpers::open_in_editor(&[root, file], &editor) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -763,7 +763,7 @@ pub struct App {
 }
 
 const EDITOR_NOT_CONFIGURED: &str =
-    "No editor configured — set `editor_command` via MCP or export $EDITOR/$VISUAL";
+    "No editor configured — run `thurbox-cli editor set <cmd>` or export $EDITOR/$VISUAL";
 
 /// Output-quiescence threshold that breaks a *stuck* `working` hook state.
 ///

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -287,7 +287,7 @@ fn push_idle_counts<'a>(spans: &mut Vec<Span<'a>>, state: &FooterState<'a>) {
 }
 
 fn push_shortcut_hints(spans: &mut Vec<Span<'_>>) {
-    // Focus stays an informational hint (no single click target); the footer
+    // Focus + Open stay informational hints (no single click target); the footer
     // buttons (Help / Info / Files / Theme / Tasks / Settings / Quit) are
     // rendered as right-aligned clickable pills.
     let bold_key = Theme::keybind().add_modifier(Modifier::BOLD);
@@ -297,6 +297,8 @@ fn push_shortcut_hints(spans: &mut Vec<Span<'_>>) {
         Span::styled("/", desc),
         Span::styled("^L", bold_key),
         Span::styled(" Focus ", desc),
+        Span::styled("^O", bold_key),
+        Span::styled(" Open ", desc),
     ]);
 }
 
@@ -603,5 +605,20 @@ mod tests {
         );
         let last = hits.iter().max_by_key(|(h, _)| h.rect.x).unwrap().0.rect;
         assert_eq!(last.x + last.width, 120);
+    }
+
+    /// The left informational hint cluster advertises both Focus (^H/^L) and
+    /// Open (^O). Asserted on the spans directly — on a narrow footer the
+    /// right-aligned pills overlay this text, so a full render can't see it.
+    #[test]
+    fn shortcut_hints_advertise_focus_and_open() {
+        let mut spans = Vec::new();
+        push_shortcut_hints(&mut spans);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("^H"), "Focus-previous key present: {text:?}");
+        assert!(text.contains("^L"), "Focus-next key present: {text:?}");
+        assert!(text.contains("Focus"), "Focus label present: {text:?}");
+        assert!(text.contains("^O"), "Open key present: {text:?}");
+        assert!(text.contains("Open"), "Open label present: {text:?}");
     }
 }


### PR DESCRIPTION
## Summary

- Add a `^O Open` hint to the footer's left informational cluster (next to `^H/^L Focus`) so the Ctrl+O "open working dirs in $EDITOR" action is discoverable at a glance.
- Fix the two "editor not configured" messages that referenced the removed MCP surface — they now point at `thurbox-cli editor set <cmd>`.
- Unify both editor-not-configured sites on the shared `EDITOR_NOT_CONFIGURED` constant via `set_error`.

## Test plan

- New unit test `shortcut_hints_advertise_focus_and_open` guards the `^H/^L Focus` + `^O Open` hint cluster (asserted on spans, since pills overlay the text in a full render).
- `cargo nextest run --all` — 1762 passed
- CI checks pass