### PR TITLE
fix(ui): drop extra trailing space after remote session glyph

### DIFF
--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -880,10 +880,11 @@ fn push_prefix_marks(
 
     // Remote (ssh:/wsl:) sessions get a remote-link mark so it's clear at a
     // glance the agent runs on another machine. Sits right after the status
-    // dot; two trailing spaces keep it off the session name.
+    // dot; a single trailing space keeps it off the session name, matching
+    // the worktree mark's spacing.
     if info.remote_host.is_some() {
         spans.push(Span::styled(
-            "\u{21c5}  ",
+            "\u{21c5} ",
             mark_style(is_dimmed, Theme::accent),
         ));
     }


### PR DESCRIPTION
## Summary

- The remote-host mark (⇅) in the session list rendered with two trailing spaces while the worktree mark uses one, misaligning remote session names.
- Use a single trailing space so remote and worktree marks align consistently.

## Test plan

- CI checks pass
- Existing `line_shows_remote_glyph_when_remote_host_present` test still passes (asserts glyph presence, not spacing)