### PR TITLE
feat(core): keep the TUI usable when remote SSH hosts fail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1334,8 +1334,8 @@ global_search` in settings.toml; scopes whose feature is disabled
 ## Session status (hooks-driven)
 
 The session list shows, at a glance, which agents are blocked, working,
-or done. `SessionStatus` (`src/session/mod.rs`) has five states driven by
-**agent hooks**, not heuristics:
+or done. `SessionStatus` (`src/session/mod.rs`) has six states — five driven by
+**agent hooks**, not heuristics, plus `Unreachable` for a down remote host:
 
 | State | Colour | Glyph | Meaning |
 |-------|--------|-------|---------|
@@ -1344,6 +1344,32 @@ or done. `SessionStatus` (`src/session/mod.rs`) has five states driven by
 | `Done` | blue | `●` (filled) | a turn just finished; shown until you switch away |
 | `Idle` | green | `○` (hollow) | acknowledged (you moved off a Done), never active, or at rest |
 | `Error` | red | `✗` | reserved for a crashed agent — **not derived yet** (no exit-code signal; exited → `Idle`) |
+| `Unreachable` | muted grey | `⊘` | remote host down/offline; a **placeholder** row (no live pane) awaiting reconnect |
+
+**Unreachable / placeholder sessions.** A persisted **remote** session whose host
+is unreachable at restore (SSH down / auth failing / offline) is inserted as a
+`Session::placeholder` (`src/agent/backend.rs`) so it **always appears** in the
+list instead of silently vanishing, tagged `Unreachable`. A placeholder holds no
+live backend pane — its reader/writer loops are never spawned, keystrokes are
+dropped with a hint, and `resize`/`kill`/`detach`/`save_state` skip it (so it
+never issues a blocking ssh call on the UI thread nor clobbers the persisted
+row). The remote-restore loop (`App::poll_remote_restore` /
+`maybe_retry_remote_restore`) readies each remote backend off-thread, retries a
+down host every `REMOTE_RETRY_INTERVAL` (20 s) — or immediately on restart
+(`Ctrl+R`) — and, once the host recovers, replaces the placeholder **in place**
+with the adopted session (same `SessionId`, so the order signature is unchanged).
+
+The same treatment covers **mid-session host loss**: `App::detect_lost_remote_sessions`
+(per tick) spots a *live* remote session whose control-mode connection just died
+and converts it in place to an `Unreachable` placeholder + queues it for
+reconnect (`enqueue_remote_reconnect`). The reliable signal is `has_exited()`:
+because tmux runs with `remain-on-exit=on`, a clean agent exit keeps its pane
+alive (no reader EOF), so a remote session's reader hitting EOF means the host/SSH
+connection dropped, not a normal exit. So a running session whose host dies flips
+to `Unreachable` and auto-reconnects instead of silently going `Idle`.
+This composes with the fail-fast SSH hardening (`crate::shell::SSH_HARDENING_OPTS`
+= `BatchMode=yes` + `ConnectTimeout` + `ServerAlive*`), which stops a broken host
+from prompting for a password on the TUI's terminal or hanging the render loop.
 
 The live session list **animates** the `Working` spinner (`ui::SPINNER_FRAMES`,
 `App::spinner_frame` advanced from `tick_count`, ~8 fps, repaints forced only
@@ -1395,7 +1421,7 @@ frame; the static `icon()` is used in non-animated contexts (info panel).
   left untouched — the override is purely in the per-tick derivation, like
   exited → `Idle`.
 - **Rollup.** Repo groups roll up to their most-urgent member
-  (`Blocked > Error > Working > Done > Idle`), rendered as a colored dot on
+  (`Blocked > Error > Working > Done > Unreachable > Idle`), rendered as a colored dot on
   the group header (`ui::project_list::group_status` +
   `group_header_line`). Status only recolors — it **never** reorders rows
   (the order cache stays status-independent).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -372,8 +372,8 @@ no id. A finished turn shows `Done` (blue) — for the session you're watching t
 The hooks are wired up automatically by the built-in **hooks** extension
 (auto-activated on first run). Opt out with `thurbox-cli extension deactivate
 hooks`. The status colours are tunable theme keys (`status_working` /
-`status_blocked` / `status_done` / `status_idle` / `status_error` — see
-`themes.toml`).
+`status_blocked` / `status_done` / `status_idle` / `status_error` /
+`status_unreachable` — see `themes.toml`).
 
 The wiring is applied **only to agents thurbox launches** — it never edits your
 own global agent config (e.g. your personal `~/.claude/settings.json`). thurbox's

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -63,7 +63,7 @@ The colored **status dot** is driven by **agent hooks**, not output
 heuristics. Each agent CLI's lifecycle hooks call `thurbox-cli session
 signal --state <working|blocked|done|idle>` (identity from the injected
 `THURBOX_SESSION`), and `refresh_session_statuses` maps the persisted
-state to one of five `SessionStatus` values once per tick:
+state to one of six `SessionStatus` values once per tick:
 
 | State | Colour | Glyph | Meaning |
 |-------|--------|-------|---------|
@@ -72,13 +72,20 @@ state to one of five `SessionStatus` values once per tick:
 | `Done` | blue | `●` | a turn just finished; shown until you switch away |
 | `Idle` | green | `○` | acknowledged, never active, or at rest |
 | `Error` | red | `✗` | reserved for a crashed agent (not derived yet) |
+| `Unreachable` | muted grey | `⊘` | remote host is down/offline; placeholder row awaiting reconnect |
 
 A `Done` session becomes `Idle` once you move focus off it (you've
 acknowledged it); a `working` session that goes quiet for 10 s is
-treated as `Idle` so an interrupted turn never spins forever. Status
-only **recolors** the dot — the manual order is never disturbed (see
-*Smart ordering* below). Repo groups roll up to their most-urgent
-member (`Blocked > Error > Working > Done > Idle`).
+treated as `Idle` so an interrupted turn never spins forever. A remote
+session whose host is unreachable is shown as a **placeholder** tagged
+`Unreachable` — it never silently vanishes from the list, and the host
+is retried in the background (or on demand via restart) until the session
+reconnects and adopts in place. This covers both a host that is down at
+restore *and* a live session whose host dies mid-run (detected via the
+control-mode connection dropping). Status only **recolors** the dot — the
+manual order is never disturbed (see *Smart ordering* below). Repo groups
+roll up to their most-urgent member
+(`Blocked > Error > Working > Done > Unreachable > Idle`).
 
 The hooks are wired automatically by the built-in **hooks** extension
 (auto-activated on first run; opt out with `thurbox-cli extension

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -363,6 +363,13 @@ pub struct Session {
     pub shell_pane: Option<ShellPane>,
     /// Session environment variables, passed to shell pane spawns.
     env: HashMap<String, String>,
+    /// True for a **placeholder** session: a persisted remote session whose host
+    /// is currently unreachable, so it has no live backend pane / reader / writer
+    /// (its `input_tx` is a dead channel and its `parser` holds a static "host
+    /// unreachable" notice). Rendered with `SessionStatus::Unreachable` and
+    /// replaced in place by the real adopted session once the host recovers. See
+    /// `App::start_remote_restore` / the remote retry loop.
+    placeholder: bool,
 }
 
 impl Session {
@@ -528,7 +535,79 @@ impl Session {
             attention_ack_at: 0,
             shell_pane: None,
             env,
+            placeholder: false,
         }
+    }
+
+    /// Build a **placeholder** session for a persisted remote session whose host
+    /// is currently unreachable. It carries no live backend pane: the reader /
+    /// writer loops are never spawned, `input_tx` is a dead channel (keystrokes
+    /// are silently dropped), and the `parser` is seeded with a static notice.
+    /// The row renders like any other (grouping/ordering/nesting all key off
+    /// `info`) but shows `SessionStatus::Unreachable` until the host recovers and
+    /// [`Self::adopt`] replaces it in place. `info.status` is forced to
+    /// `Unreachable` here regardless of the caller's value.
+    pub fn placeholder(
+        mut info: SessionInfo,
+        rows: u16,
+        cols: u16,
+        backend: &Arc<dyn SessionBackend>,
+        provider: &Arc<dyn AgentProvider>,
+        env: HashMap<String, String>,
+    ) -> Self {
+        info.status = crate::session::SessionStatus::Unreachable;
+        info.backend_id = None;
+
+        let last_title = Arc::new(Mutex::new(None));
+        let attention_at = Arc::new(AtomicU64::new(0));
+        let notification = Arc::new(Mutex::new(None));
+        let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
+            rows.max(1),
+            cols.max(1),
+            crate::session::settings::global().scrollback_lines,
+            TermSignals {
+                title: Arc::clone(&last_title),
+                attention_at: Arc::clone(&attention_at),
+                notification: Arc::clone(&notification),
+            },
+        )));
+        let host = info.remote_host.clone().unwrap_or_else(|| "?".into());
+        let notice = format!(
+            "\r\n  \u{2298} Remote host '{host}' unreachable \u{2014} retrying\u{2026}\r\n\r\n  \
+             This session will reconnect automatically when the host comes back.\r\n  \
+             Press restart to retry now, or delete to remove it.\r\n"
+        );
+        if let Ok(mut p) = parser.lock() {
+            p.process(notice.as_bytes());
+        }
+
+        // A dead input channel: the receiver is dropped immediately, so any
+        // keystroke `try_send` fails fast and the byte is discarded.
+        let (input_tx, _dead_rx) = mpsc::channel(INPUT_CHANNEL_CAPACITY);
+
+        Self {
+            info,
+            parser,
+            input_tx,
+            backend_id: String::new(),
+            backend: Arc::clone(backend),
+            provider: Arc::clone(provider),
+            exited: Arc::new(AtomicBool::new(false)),
+            last_output_at: Arc::new(AtomicU64::new(0)),
+            last_title,
+            attention_at,
+            notification,
+            attention_ack_at: 0,
+            shell_pane: None,
+            env,
+            placeholder: true,
+        }
+    }
+
+    /// Whether this is a placeholder for an unreachable remote session (no live
+    /// backend pane). See [`Self::placeholder`].
+    pub fn is_placeholder(&self) -> bool {
+        self.placeholder
     }
 
     /// Blocking read loop feeding the vt100 parser. Runs on a
@@ -605,6 +684,15 @@ impl Session {
     }
 
     pub fn resize(&self, rows: u16, cols: u16) {
+        // A placeholder has no live pane; only resize its local notice buffer.
+        // Talking to the (possibly-down) backend here would issue a blocking
+        // ssh resize on the UI thread — the freeze we're avoiding.
+        if self.placeholder {
+            if let Ok(mut parser) = self.parser.lock() {
+                parser.screen_mut().set_size(rows.max(1), cols.max(1));
+            }
+            return;
+        }
         if let Err(e) = self.backend.resize(&self.backend_id, rows, cols) {
             tracing::warn!("Failed to resize session: {e}");
             return;
@@ -769,6 +857,10 @@ impl Session {
 
     /// Kill/destroy the backend session (for Ctrl+X close).
     pub fn kill(&self) {
+        // A placeholder owns no live backend pane (see `placeholder`).
+        if self.placeholder {
+            return;
+        }
         self.kill_shell_pane();
         if let Err(e) = self.backend.kill(&self.backend_id) {
             tracing::warn!("Failed to kill session: {e}");
@@ -777,6 +869,11 @@ impl Session {
 
     /// Detach from the backend session without killing it (for Ctrl+Q quit).
     pub fn detach(self) {
+        // A placeholder owns no live backend pane — detaching would issue a
+        // blocking ssh call (possibly to a down host) for nothing.
+        if self.placeholder {
+            return;
+        }
         if let Some(shell) = &self.shell_pane {
             if let Err(e) = self.backend.detach(&shell.backend_id) {
                 tracing::warn!("Failed to detach shell pane: {e}");
@@ -906,6 +1003,7 @@ impl Session {
             attention_ack_at: 0,
             shell_pane: None,
             env: HashMap::new(),
+            placeholder: false,
         };
         (session, input_rx)
     }

--- a/src/agent/themes_config.rs
+++ b/src/agent/themes_config.rs
@@ -25,7 +25,7 @@ pub const SEED_THEMES_TOML: &str = r##"# Thurbox custom themes  —  ~/.config/t
 # catppuccin-latte, tokyo-night-day, gruvbox-light, solarized-light.
 #
 # Overridable colour keys: accent, accent_bright, status_working,
-# status_blocked, status_done, status_idle, status_error,
+# status_blocked, status_done, status_idle, status_error, status_unreachable,
 # text_primary, text_secondary, text_muted,
 # border_focused, border_unfocused, role_name, branch_name, search_bar,
 # keybind_hint, tool_allowed, tool_disallowed, danger, selection_bg,
@@ -189,6 +189,7 @@ mod tests {
             "status_done",
             "status_idle",
             "status_error",
+            "status_unreachable",
             "text_primary",
             "text_secondary",
             "text_muted",

--- a/src/agent/transport.rs
+++ b/src/agent/transport.rs
@@ -169,11 +169,16 @@ mod tests {
         let cmd = t.tmux_command("thurbox", &["has-session", "-t", "thurbox"]);
         let (prog, args) = program_and_args(&cmd);
         assert_eq!(prog, "ssh");
-        assert_eq!(
-            args,
+        // User opts, then the always-appended fail-fast hardening
+        // (crate::shell::SSH_HARDENING_OPTS), then the destination + remote cmd.
+        let mut expected: Vec<String> = vec!["-o".into(), "ControlMaster=auto".into()];
+        expected.extend(
+            crate::shell::SSH_HARDENING_OPTS
+                .iter()
+                .map(|s| s.to_string()),
+        );
+        expected.extend(
             [
-                "-o",
-                "ControlMaster=auto",
                 "me@devbox",
                 "tmux",
                 "-L",
@@ -182,7 +187,10 @@ mod tests {
                 "-t",
                 "thurbox",
             ]
+            .iter()
+            .map(|s| s.to_string()),
         );
+        assert_eq!(args, expected);
     }
 
     #[test]
@@ -195,7 +203,16 @@ mod tests {
         let cmd = t.tmux_command("thurbox", &["has-session"]);
         let (prog, args) = program_and_args(&cmd);
         assert_eq!(prog, "ssh");
-        assert_eq!(args, ["me@winbox", "psmux", "-L", "thurbox", "has-session"]);
+        let mut expected: Vec<String> = crate::shell::SSH_HARDENING_OPTS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        expected.extend(
+            ["me@winbox", "psmux", "-L", "thurbox", "has-session"]
+                .iter()
+                .map(|s| s.to_string()),
+        );
+        assert_eq!(args, expected);
     }
 
     #[test]

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -694,6 +694,25 @@ impl App {
             }
         });
 
+        // A placeholder (unreachable remote) has no live pane; swallow the
+        // keystroke and hint how to recover instead of silently dropping it.
+        if self
+            .sessions
+            .get(self.active_index)
+            .is_some_and(|s| s.is_placeholder())
+        {
+            let host = self
+                .sessions
+                .get(self.active_index)
+                .and_then(|s| s.info.remote_host.clone())
+                .unwrap_or_else(|| "?".into());
+            self.set_status(
+                super::StatusLevel::Info,
+                format!("Session unreachable — host '{host}' is offline (restart to retry)"),
+            );
+            return;
+        }
+
         if let Some(session) = self.sessions.get(self.active_index) {
             if let Some(bytes) = input::key_to_bytes(code, mods) {
                 let result = if let (TerminalView::Shell, Some(shell)) =

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -123,21 +123,60 @@ struct PendingSessionSpawn {
     base_branch: Option<String>,
 }
 
-/// One remote backend's discovery result: its `backend_type` plus the windows
-/// its host reported. Sent once per backend by the restore threads.
-type RemoteDiscovery = (String, Vec<crate::agent::backend::DiscoveredSession>);
+/// One remote backend's discovery result: its `backend_type`, whether the host
+/// was **reachable** (its `ensure_ready` succeeded — distinguishes "host down"
+/// from "host up but no windows"), plus the windows it reported. Sent once per
+/// discovery attempt by the restore threads.
+type RemoteDiscovery = (String, bool, Vec<crate::agent::backend::DiscoveredSession>);
 
-/// In-flight background restore of remote-backed sessions. Startup readies +
-/// discovers only *local* backends synchronously; each remote (`ssh:`/`wsl:`)
-/// backend is readied on its own thread, because a single ssh connect can take
-/// tens of seconds (or minutes for a down host) and must never block the first
-/// frame. Each thread sends one [`RemoteDiscovery`] message; the backend's
-/// sessions wait in `pending` and are adopted on the main thread once it
-/// reports (in [`App::poll_remote_restore`]).
+/// How long to wait between retry sweeps for a still-unreachable remote backend.
+const REMOTE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Background restore + reconnect loop for remote-backed sessions. Startup
+/// readies + discovers only *local* backends synchronously; each remote
+/// (`ssh:`/`wsl:`) backend is readied on its own thread, because a single ssh
+/// connect can take seconds (fail-fast is bounded by
+/// [`crate::shell::SSH_HARDENING_OPTS`]) and must never block the first frame.
+///
+/// Every remote session is inserted as a **placeholder** row up front (see
+/// [`crate::agent::backend::Session::placeholder`]) so it always shows in the
+/// list, tagged `SessionStatus::Unreachable`. Each discovery thread sends one
+/// [`RemoteDiscovery`]; on success the placeholder is replaced in place by the
+/// real adopted session, and on failure it stays and the backend is retried
+/// every [`REMOTE_RETRY_INTERVAL`]. This struct lives as long as any backend
+/// still has placeholder rows awaiting adoption.
 struct RemoteRestore {
     rx: mpsc::Receiver<RemoteDiscovery>,
-    /// Sessions awaiting their backend's discovery, keyed by `backend_type`.
+    /// Kept so retry sweeps can re-spawn discovery threads on the same channel.
+    tx: mpsc::Sender<RemoteDiscovery>,
+    /// Sessions still awaiting adoption, keyed by `backend_type`.
     pending: HashMap<String, Vec<sync::SharedSession>>,
+    /// Backends with a discovery thread currently running (don't double-spawn).
+    inflight: std::collections::HashSet<String>,
+    /// When the next retry sweep for still-pending backends is due.
+    next_retry_at: std::time::Instant,
+    /// Backends already surfaced as unreachable via a toast (dedup so the retry
+    /// loop doesn't re-toast every sweep).
+    notified_unreachable: std::collections::HashSet<String>,
+    perf_log: bool,
+}
+
+impl RemoteRestore {
+    /// An empty restore with its own discovery channel and the first retry due
+    /// at `next_retry_at`. Callers fill `pending`/`inflight` and spawn discovery
+    /// threads on `tx`.
+    fn new(perf_log: bool, next_retry_at: std::time::Instant) -> Self {
+        let (tx, rx) = mpsc::channel();
+        Self {
+            rx,
+            tx,
+            pending: HashMap::new(),
+            inflight: std::collections::HashSet::new(),
+            next_retry_at,
+            notified_unreachable: std::collections::HashSet::new(),
+            perf_log,
+        }
+    }
 }
 
 /// Continuation for a backgrounded worktree-creation: the wizard inputs needed
@@ -1460,6 +1499,15 @@ impl App {
         let Some(session) = self.sessions.get(self.active_index) else {
             return;
         };
+        // A placeholder (unreachable remote) has no live pane to restart — a
+        // manual restart means "reconnect now", so kick an immediate retry sweep
+        // for its backend instead of the live-restart path.
+        if session.is_placeholder() {
+            let backend_type = session.backend_name().to_string();
+            self.retry_remote_backend_now(&backend_type);
+            self.set_status(StatusLevel::Info, "Retrying remote host…");
+            return;
+        }
         let Some(agent_session_id) = session.info.agent_session_id.clone() else {
             return;
         };
@@ -1650,6 +1698,33 @@ impl App {
         };
 
         let session_id = session.info.id;
+
+        // A placeholder (unreachable remote) has no live pane / local resource to
+        // tear down — deleting it just removes the row (a hard delete would run
+        // blocking remote git/worktree ops against the down host). Always soft-
+        // delete it, regardless of the `soft_delete` feature flag.
+        if session.is_placeholder() {
+            if let Err(e) = self.db.soft_delete_session(session_id) {
+                error!("Failed to soft-delete session in DB: {e}");
+            }
+            let removed = self.sessions.remove(self.active_index);
+            let name = removed.info.name.clone();
+            self.session_terminal_views.remove(&session_id);
+            self.code_reviews.remove(&session_id);
+            self.sync_active_session_to_project();
+            self.finalize_pending_delete();
+            self.pending_delete = Some(PendingDelete {
+                session: removed,
+                session_id,
+                created_at: std::time::Instant::now(),
+            });
+            self.set_status(
+                StatusLevel::Info,
+                format!("Deleted '{name}'. Ctrl+Z to undo"),
+            );
+            self.save_state();
+            return;
+        }
 
         // When soft-delete is disabled, a TUI delete is a destructive hard
         // delete (kills the tmux window, removes worktrees) with no Ctrl+Z
@@ -3806,6 +3881,11 @@ impl App {
 
         self.refresh_session_statuses();
 
+        // Convert any live remote session whose host connection just dropped into
+        // an unreachable placeholder + queue it for reconnect (see the method
+        // doc for why `has_exited()` is the reliable host-loss signal here).
+        self.detect_lost_remote_sessions();
+
         // Poll for sync results from background worktree sync threads
         self.poll_sync_results();
 
@@ -4186,6 +4266,11 @@ impl App {
     ) -> bool {
         let mut changed = false;
         for session in sessions.iter_mut() {
+            // A placeholder (unreachable remote) has no live pane / hooks; keep
+            // its `Unreachable` status until the host recovers and it adopts.
+            if session.is_placeholder() {
+                continue;
+            }
             let id = session.info.id;
             // `just_seen`: the focus-leave check above queued this session's seen
             // mark this tick (the DB write lands after this loop), so reflect it
@@ -4406,9 +4491,12 @@ impl App {
             return;
         };
 
+        // Skip a placeholder (unreachable remote): it has no live pane, and its
+        // dummy backend/empty id would trigger a pointless ssh round-trip.
         let active = self
             .sessions
             .get(self.active_index)
+            .filter(|s| !s.is_placeholder())
             .map(|s| s.backend_handle());
 
         let metrics_files: Vec<(SessionId, PathBuf)> = match crate::paths::metrics_directory() {
@@ -4932,6 +5020,13 @@ impl App {
         }
 
         for session in &self.sessions {
+            // Never persist a placeholder (unreachable remote): its row already
+            // exists in the DB, and its empty `backend_id`/`shell_backend_id`
+            // (and, for an unknown host, a fallback local `backend_type`) would
+            // clobber the real persisted values and break re-adoption.
+            if session.is_placeholder() {
+                continue;
+            }
             let shared_session = self.session_to_shared(session);
             if let Err(e) = self.db.upsert_session(&shared_session) {
                 error!("Failed to upsert session to DB: {e}");
@@ -5058,17 +5153,30 @@ impl App {
                 .push(shared);
         }
 
-        let (tx, rx) = mpsc::channel();
-        let mut pending: HashMap<String, Vec<sync::SharedSession>> = HashMap::new();
+        let mut restore =
+            RemoteRestore::new(perf_log, std::time::Instant::now() + REMOTE_RETRY_INTERVAL);
         for (backend_type, sessions) in grouped {
-            let Some(backend) = self.resolve_persisted_backend(&backend_type) else {
-                continue;
-            };
-            Self::spawn_remote_discovery(backend, backend_type.clone(), perf_log, tx.clone());
-            pending.insert(backend_type, sessions);
+            // Always show the session, even before (or without) a live host:
+            // insert a placeholder row up front so it never silently vanishes.
+            for shared in &sessions {
+                self.insert_remote_placeholder(shared);
+            }
+            // A backend we can resolve gets a discovery thread + retry tracking.
+            // An unknown host (no config) keeps its placeholder but can't be
+            // adopted, so it isn't queued for retries.
+            if let Some(backend) = self.resolve_persisted_backend(&backend_type) {
+                Self::spawn_remote_discovery(
+                    backend,
+                    backend_type.clone(),
+                    perf_log,
+                    restore.tx.clone(),
+                );
+                restore.inflight.insert(backend_type.clone());
+                restore.pending.insert(backend_type, sessions);
+            }
         }
-        if !pending.is_empty() {
-            self.remote_restore = Some(RemoteRestore { rx, pending });
+        if !restore.pending.is_empty() {
+            self.remote_restore = Some(restore);
         }
     }
 
@@ -5082,67 +5190,253 @@ impl App {
     ) {
         std::thread::spawn(move || {
             let start = std::time::Instant::now();
-            let discovered = Self::ready_and_discover(&backend);
+            let (reachable, discovered) = Self::ready_and_discover(&backend);
             if perf_log {
                 tracing::info!(
                     backend = %backend_type,
+                    reachable,
                     windows = discovered.len() as u64,
                     discover_ms = start.elapsed().as_millis() as u64,
                     "restore_discover"
                 );
             }
-            let _ = tx.send((backend_type, discovered));
+            let _ = tx.send((backend_type, reachable, discovered));
         });
     }
 
-    /// Drain finished remote-backend discoveries and adopt their sessions.
-    /// Adoption runs on the main thread but talks to the control-mode
-    /// connection the background thread already brought up, so the expensive
-    /// part (ssh connect + remote tmux ready) never blocks a frame.
-    fn poll_remote_restore(&mut self) {
-        let Some(state) = &mut self.remote_restore else {
-            return;
+    /// Build (but don't insert) a placeholder [`Session`] for a persisted remote
+    /// session — a row tagged `SessionStatus::Unreachable` with no live pane. See
+    /// [`crate::agent::backend::Session::placeholder`].
+    fn build_placeholder_session(&self, shared: &sync::SharedSession) -> Session {
+        let agent = if shared.agent.is_empty() {
+            DEFAULT_AGENT_NAME.to_string()
+        } else {
+            shared.agent.clone()
         };
+        // Dummy backend/provider: a placeholder never does I/O, but the fields
+        // must be populated. Fall back to the local default when the host is
+        // unknown (unconfigured) so the row can still render.
+        let backend = self
+            .resolve_persisted_backend(&shared.backend_type)
+            .unwrap_or_else(|| self.backends.default_backend().clone());
+        let provider = self.provider_for(&SessionConfig {
+            agent: agent.clone(),
+            ..SessionConfig::default()
+        });
+
+        let mut info = SessionInfo::new(shared.name.clone());
+        info.id = shared.id;
+        info.agent = agent;
+        info.agent_session_id = shared.agent_session_id.clone();
+        info.cwd = shared.cwd.clone();
+        info.additional_dirs = shared.additional_dirs.clone();
+        info.worktrees = shared.worktrees.iter().cloned().map(Into::into).collect();
+        info.parent_session_id = shared.parent_session_id;
+        info.display_order = shared.display_order;
+        info.remote_host = host_label_from_backend_type(&shared.backend_type);
+        resolve_repo_display_names(&mut info);
+
+        let (rows, cols) = self.content_area_size();
+        Session::placeholder(info, rows, cols, &backend, &provider, HashMap::new())
+    }
+
+    /// Insert a placeholder row for a persisted remote session whose host is not
+    /// yet (or no longer) reachable, so it always appears in the list tagged
+    /// `SessionStatus::Unreachable`. Idempotent: skips if a session with this id
+    /// already exists (a real adopted session or an earlier placeholder).
+    fn insert_remote_placeholder(&mut self, shared: &sync::SharedSession) {
+        if self.sessions.iter().any(|s| s.info.id == shared.id) {
+            return;
+        }
+        let session = self.build_placeholder_session(shared);
+        self.sessions.push(session);
+        self.request_redraw();
+    }
+
+    /// Detect **mid-session host loss**: a live (non-placeholder) remote session
+    /// whose control-mode connection has died. Because tmux runs with
+    /// `remain-on-exit=on`, a normal agent exit keeps its pane alive (no reader
+    /// EOF), so for a *remote* session `has_exited()` becoming true reliably means
+    /// the host/SSH connection dropped — not a clean agent exit. Such a session is
+    /// converted **in place** to an `Unreachable` placeholder and queued for the
+    /// reconnect retry loop, so it never looks like a normal idle session and
+    /// auto-adopts when the host returns.
+    fn detect_lost_remote_sessions(&mut self) {
+        let lost: Vec<usize> = self
+            .sessions
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| {
+                !s.is_placeholder()
+                    && s.has_exited()
+                    && crate::session::is_remote_backend(s.backend_name())
+            })
+            .map(|(i, _)| i)
+            .collect();
+        if lost.is_empty() {
+            return;
+        }
+        for i in lost {
+            // Capture the persisted shape before swapping in the placeholder, so
+            // the reconnect keeps the real `backend_id` / worktrees / identity.
+            let shared = self.session_to_shared(&self.sessions[i]);
+            // Replace in place (same index) so the active selection is undisturbed.
+            self.sessions[i] = self.build_placeholder_session(&shared);
+            self.enqueue_remote_reconnect(shared);
+        }
+        self.set_error("Remote host connection lost — reconnecting…");
+        self.request_redraw();
+    }
+
+    /// Queue a remote session for the reconnect retry loop, creating the
+    /// `remote_restore` state if it isn't running (e.g. host lost after the
+    /// startup restore already finished). Sets the retry clock to now so the next
+    /// `poll_remote_restore` probes the host immediately. No-op for an unknown
+    /// (unconfigured) host — its placeholder simply stays until reconfigured.
+    fn enqueue_remote_reconnect(&mut self, shared: sync::SharedSession) {
+        let backend_type = shared.backend_type.clone();
+        if self.resolve_persisted_backend(&backend_type).is_none() {
+            return;
+        }
+        let now = std::time::Instant::now();
+        if self.remote_restore.is_none() {
+            // Reconnect as soon as the next tick, not after the retry interval.
+            self.remote_restore = Some(RemoteRestore::new(false, now));
+        }
+        if let Some(s) = self.remote_restore.as_mut() {
+            let queue = s.pending.entry(backend_type).or_default();
+            if !queue.iter().any(|q| q.id == shared.id) {
+                queue.push(shared);
+            }
+            s.next_retry_at = now;
+        }
+    }
+
+    /// Drain finished remote-backend discoveries, adopt reachable ones (replacing
+    /// their placeholder rows in place), keep unreachable ones as placeholders,
+    /// and periodically retry the still-down backends. Adoption runs on the main
+    /// thread but talks to the control-mode connection the background thread
+    /// already brought up, and remote ssh is fail-fast
+    /// ([`crate::shell::SSH_HARDENING_OPTS`]), so it never blocks a frame. The
+    /// restore state is dropped only once every remote session has been adopted.
+    fn poll_remote_restore(&mut self) {
+        if self.remote_restore.is_none() {
+            return;
+        }
+
         let mut ready: Vec<RemoteDiscovery> = Vec::new();
-        let mut disconnected = false;
-        loop {
-            match state.rx.try_recv() {
-                Ok(msg) => ready.push(msg),
-                Err(mpsc::TryRecvError::Empty) => break,
-                Err(mpsc::TryRecvError::Disconnected) => {
-                    disconnected = true;
-                    break;
+        if let Some(state) = &self.remote_restore {
+            loop {
+                match state.rx.try_recv() {
+                    Ok(msg) => ready.push(msg),
+                    Err(mpsc::TryRecvError::Empty) => break,
+                    // The channel can't disconnect while `remote_restore` holds a
+                    // `tx`; treat it as "nothing more this tick".
+                    Err(mpsc::TryRecvError::Disconnected) => break,
                 }
             }
         }
 
-        self.adopt_remote_discoveries(ready);
+        // Each reported backend's discovery thread has finished.
+        if let Some(state) = &mut self.remote_restore {
+            for (backend_type, _, _) in &ready {
+                state.inflight.remove(backend_type);
+            }
+        }
 
-        let finished = disconnected
-            || self
-                .remote_restore
-                .as_ref()
-                .is_some_and(|s| s.pending.is_empty());
-        if finished {
-            if let Some(state) = self.remote_restore.take() {
-                for backend_type in state.pending.keys() {
-                    warn!(
-                        backend = %backend_type,
-                        "Remote restore ended without a discovery result"
-                    );
+        if !ready.is_empty() {
+            self.adopt_remote_discoveries(ready);
+        }
+
+        self.maybe_retry_remote_restore();
+
+        // Done once nothing is left to adopt (all placeholders replaced).
+        if self
+            .remote_restore
+            .as_ref()
+            .is_some_and(|s| s.pending.is_empty())
+        {
+            self.remote_restore = None;
+        }
+    }
+
+    /// Re-spawn discovery threads for still-pending (unreachable) backends once
+    /// [`REMOTE_RETRY_INTERVAL`] has elapsed, so a recovered host auto-adopts its
+    /// placeholder sessions without a restart.
+    fn maybe_retry_remote_restore(&mut self) {
+        let now = std::time::Instant::now();
+        if !self
+            .remote_restore
+            .as_ref()
+            .is_some_and(|s| now >= s.next_retry_at)
+        {
+            return;
+        }
+        let to_retry: Vec<String> = match &self.remote_restore {
+            Some(s) => s
+                .pending
+                .keys()
+                .filter(|b| !s.inflight.contains(*b))
+                .cloned()
+                .collect(),
+            None => return,
+        };
+        for backend_type in to_retry {
+            if let Some(backend) = self.resolve_persisted_backend(&backend_type) {
+                let (tx, perf_log) = match &self.remote_restore {
+                    Some(s) => (s.tx.clone(), s.perf_log),
+                    None => return,
+                };
+                Self::spawn_remote_discovery(backend, backend_type.clone(), perf_log, tx);
+                if let Some(s) = self.remote_restore.as_mut() {
+                    s.inflight.insert(backend_type);
                 }
+            }
+        }
+        if let Some(s) = self.remote_restore.as_mut() {
+            s.next_retry_at = now + REMOTE_RETRY_INTERVAL;
+        }
+    }
+
+    /// Trigger an immediate retry sweep for a backend (used by the manual
+    /// restart of an unreachable placeholder) — resets the retry clock so the
+    /// next `poll_remote_restore` re-spawns discovery right away.
+    fn retry_remote_backend_now(&mut self, backend_type: &str) {
+        if let Some(s) = self.remote_restore.as_mut() {
+            if s.pending.contains_key(backend_type) {
+                s.next_retry_at = std::time::Instant::now();
             }
         }
     }
 
-    /// Adopt every pending session whose backend just reported its windows.
+    /// Adopt every reachable backend's pending sessions, replacing their
+    /// placeholder rows in place; keep unreachable backends' placeholders and
+    /// toast the host once.
     fn adopt_remote_discoveries(&mut self, ready: Vec<RemoteDiscovery>) {
-        // Adopting makes each restored session active; a late-arriving host
-        // must not steal the user's current selection, so snapshot + restore it.
+        // Adoption reorders `self.sessions`; a late-arriving host must not steal
+        // the user's current selection, so snapshot + restore it by id.
         let prior_active = self.sessions.get(self.active_index).map(|s| s.info.id);
         let prior_focus = self.focus;
-        let before = self.sessions.len();
-        for (backend_type, discovered) in ready {
+        let mut restored = 0usize;
+        let mut unreachable_hosts: Vec<String> = Vec::new();
+
+        for (backend_type, reachable, discovered) in ready {
+            if !reachable {
+                let first_time = self
+                    .remote_restore
+                    .as_mut()
+                    .is_some_and(|s| s.notified_unreachable.insert(backend_type.clone()));
+                if first_time {
+                    if let Some(h) = host_label_from_backend_type(&backend_type) {
+                        unreachable_hosts.push(h);
+                    }
+                }
+                continue;
+            }
+            // Reachable again: allow a future drop to re-toast.
+            if let Some(s) = self.remote_restore.as_mut() {
+                s.notified_unreachable.remove(&backend_type);
+            }
             let Some(sessions) = self
                 .remote_restore
                 .as_mut()
@@ -5150,32 +5444,78 @@ impl App {
             else {
                 continue;
             };
+            let mut still_pending: Vec<sync::SharedSession> = Vec::new();
             for shared in sessions {
-                // Another path (e.g. the DB sync) may have adopted it meanwhile.
-                if self.sessions.iter().any(|s| s.info.id == shared.id) {
+                let id = shared.id;
+                let has_real = self
+                    .sessions
+                    .iter()
+                    .any(|s| s.info.id == id && !s.is_placeholder());
+                // Already adopted for real (e.g. via the DB sync) — just drop any
+                // leftover placeholder.
+                if has_real {
+                    self.remove_remote_placeholder(id);
                     continue;
                 }
+                // No placeholder left and no real session → the user deleted it
+                // while the host was down; don't resurrect it (drop from pending).
+                let has_placeholder = self
+                    .sessions
+                    .iter()
+                    .any(|s| s.info.id == id && s.is_placeholder());
+                if !has_placeholder {
+                    continue;
+                }
+                let retry_copy = shared.clone();
                 self.restore_single_session(shared, &discovered);
+                if self
+                    .sessions
+                    .iter()
+                    .any(|s| s.info.id == id && !s.is_placeholder())
+                {
+                    self.remove_remote_placeholder(id);
+                    restored += 1;
+                } else {
+                    // Adopt/respawn failed (host dropped again mid-adopt); keep
+                    // the placeholder and re-queue for the next retry.
+                    still_pending.push(retry_copy);
+                }
+            }
+            if !still_pending.is_empty() {
+                if let Some(s) = self.remote_restore.as_mut() {
+                    s.pending.insert(backend_type, still_pending);
+                }
             }
         }
-        // Count sessions actually added — an adopt/respawn that failed inside
-        // `restore_single_session` must not inflate the toast.
-        let adopted = self.sessions.len() - before;
-        if adopted == 0 {
-            return;
-        }
+
+        // Restore prior selection/focus (indices shifted during adoption).
         if let Some(id) = prior_active {
             if let Some(idx) = self.sessions.iter().position(|s| s.info.id == id) {
                 self.active_index = idx;
                 self.focus = prior_focus;
             }
         }
-        self.save_state();
-        self.set_status(
-            StatusLevel::Info,
-            format!("Restored {adopted} remote session(s)"),
-        );
-        self.request_redraw();
+
+        for host in &unreachable_hosts {
+            self.set_error(format!("Remote host '{host}' unavailable"));
+        }
+        if restored > 0 {
+            self.save_state();
+            self.set_status(
+                StatusLevel::Info,
+                format!("Restored {restored} remote session(s)"),
+            );
+        }
+        if restored > 0 || !unreachable_hosts.is_empty() {
+            self.request_redraw();
+        }
+    }
+
+    /// Remove the placeholder row for `id` (leaving a real adopted session with
+    /// the same id untouched). See [`Self::insert_remote_placeholder`].
+    fn remove_remote_placeholder(&mut self, id: SessionId) {
+        self.sessions
+            .retain(|s| !(s.info.id == id && s.is_placeholder()));
     }
 
     /// Discover existing backend windows once per distinct `backend_type`.
@@ -5223,30 +5563,36 @@ impl App {
         let Some(backend) = self.resolve_persisted_backend(backend_type) else {
             return Vec::new();
         };
-        Self::ready_and_discover(&backend)
+        // Local restore only cares about the windows; reachability is a
+        // remote-restore concern.
+        Self::ready_and_discover(&backend).1
     }
 
-    /// Ready a backend and list its windows, degrading to an empty list on
-    /// error (logged, never fatal). Associated (no `&self`) so the remote
+    /// Ready a backend and list its windows. Returns `(reachable, windows)`:
+    /// `reachable` is `false` when `ensure_ready` failed (host down / SSH auth /
+    /// network), which the remote restore uses to keep placeholder rows and
+    /// schedule a retry rather than treating an empty list as "no windows".
+    /// Errors are logged, never fatal. Associated (no `&self`) so the remote
     /// restore threads can run it off the UI thread.
     fn ready_and_discover(
         backend: &Arc<dyn SessionBackend>,
-    ) -> Vec<crate::agent::backend::DiscoveredSession> {
+    ) -> (bool, Vec<crate::agent::backend::DiscoveredSession>) {
         if let Err(e) = backend.ensure_ready() {
             warn!(
                 backend = backend.name(),
-                "Backend not ready during restore; skipping its sessions: {e}"
+                "Backend not ready during restore; keeping its sessions as unreachable: {e}"
             );
-            return Vec::new();
+            return (false, Vec::new());
         }
 
-        backend.discover().unwrap_or_else(|e| {
+        let windows = backend.discover().unwrap_or_else(|e| {
             warn!(
                 backend = backend.name(),
                 "Failed to discover sessions from backend: {e}"
             );
             Vec::new()
-        })
+        });
+        (true, windows)
     }
 
     /// Restore a single session synchronously (used during startup). The
@@ -5677,6 +6023,16 @@ fn resolve_repo_display_names(info: &mut SessionInfo) {
             .into_iter()
             .filter_map(|(name, _)| name)
             .collect();
+}
+
+/// The bare host name behind a remote `backend_type` (`ssh:<name>` /
+/// `wsl:<name>`), used to label a placeholder/unreachable session. `None` for a
+/// local backend.
+fn host_label_from_backend_type(backend_type: &str) -> Option<String> {
+    backend_type
+        .strip_prefix(crate::session::SSH_BACKEND_PREFIX)
+        .or_else(|| backend_type.strip_prefix(crate::session::WSL_BACKEND_PREFIX))
+        .map(str::to_string)
 }
 
 /// The `(display_name, directory)` pairs a session spans, in display order:
@@ -11168,6 +11524,298 @@ mod tests {
         }
     }
 
+    /// Stub remote backend whose host is **down**: `ensure_ready` fails, so
+    /// discovery reports unreachable and its sessions stay as placeholders.
+    struct DownRemoteStubBackend;
+    impl SessionBackend for DownRemoteStubBackend {
+        fn name(&self) -> &str {
+            "ssh:down-host"
+        }
+        fn check_available(&self) -> anyhow::Result<()> {
+            anyhow::bail!("host down")
+        }
+        fn ensure_ready(&self) -> anyhow::Result<()> {
+            anyhow::bail!("ssh: connect to host down-host port 22: No route to host")
+        }
+        fn spawn(
+            &self,
+            _: &str,
+            _: &str,
+            _: &[String],
+            _: Option<&Path>,
+            _: &std::collections::HashMap<String, String>,
+            _: u16,
+            _: u16,
+        ) -> anyhow::Result<crate::agent::backend::SpawnedSession> {
+            anyhow::bail!("host down")
+        }
+        fn adopt(
+            &self,
+            _: &str,
+            _: u16,
+            _: u16,
+        ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
+            anyhow::bail!("host down")
+        }
+        fn discover(&self) -> anyhow::Result<Vec<crate::agent::backend::DiscoveredSession>> {
+            anyhow::bail!("host down")
+        }
+        fn resize(&self, _: &str, _: u16, _: u16) -> anyhow::Result<()> {
+            anyhow::bail!("host down")
+        }
+        fn is_dead(&self, _: &str) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+        fn kill(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn detach(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn pane_pid(&self, _: &str) -> anyhow::Result<Option<u32>> {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn remote_session_on_down_host_stays_unreachable_and_retries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+        let mut app = app_with_sessions(0);
+        app.backends.register(Arc::new(DownRemoteStubBackend));
+
+        let mut shared = make_shared_session("%9", "remote-sess");
+        shared.backend_type = "ssh:down-host".to_string();
+        let id = shared.id;
+        // The real persisted row (as if written by a prior run).
+        app.db.upsert_session(&shared).unwrap();
+        app.restore_sessions(vec![shared], 1);
+
+        // Immediately visible as an unreachable placeholder.
+        assert_eq!(app.sessions.len(), 1);
+        assert!(app.sessions[0].is_placeholder());
+        assert_eq!(app.sessions[0].info.status, SessionStatus::Unreachable);
+
+        // Drain the discovery thread's "unreachable" report: the placeholder
+        // survives (not adopted) and stays queued for retry.
+        for _ in 0..500 {
+            app.poll_remote_restore();
+            if app
+                .remote_restore
+                .as_ref()
+                .is_some_and(|s| s.notified_unreachable.contains("ssh:down-host"))
+            {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(app.sessions.len(), 1);
+        assert!(app.sessions[0].is_placeholder());
+        assert_eq!(app.sessions[0].info.id, id);
+        // Still pending → the retry loop will keep trying the host.
+        assert!(app
+            .remote_restore
+            .as_ref()
+            .is_some_and(|s| s.pending.contains_key("ssh:down-host")));
+
+        // Its persisted row must be untouched by the placeholder (save_state
+        // skips placeholders), so re-adoption after recovery still works.
+        app.save_state();
+        let persisted = app.db.list_active_sessions().unwrap();
+        let row = persisted.iter().find(|s| s.id == id).unwrap();
+        assert_eq!(row.backend_type, "ssh:down-host");
+        assert_eq!(row.backend_id, "%9");
+    }
+
+    /// Stub remote backend that is **down at first, then recovers**:
+    /// `ensure_ready` fails until `ready_after` calls have been made, then
+    /// succeeds and discovers `%9`. Models a failing remote session that later
+    /// reconnects.
+    struct FlakyRemoteStubBackend {
+        calls: std::sync::atomic::AtomicUsize,
+        ready_after: usize,
+    }
+    impl FlakyRemoteStubBackend {
+        fn new(ready_after: usize) -> Self {
+            Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+                ready_after,
+            }
+        }
+    }
+    impl SessionBackend for FlakyRemoteStubBackend {
+        fn name(&self) -> &str {
+            "ssh:flaky-host"
+        }
+        fn check_available(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn ensure_ready(&self) -> anyhow::Result<()> {
+            let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n >= self.ready_after {
+                Ok(())
+            } else {
+                anyhow::bail!("host down")
+            }
+        }
+        fn spawn(
+            &self,
+            _: &str,
+            _: &str,
+            _: &[String],
+            _: Option<&Path>,
+            _: &std::collections::HashMap<String, String>,
+            _: u16,
+            _: u16,
+        ) -> anyhow::Result<crate::agent::backend::SpawnedSession> {
+            anyhow::bail!("flaky stub does not spawn")
+        }
+        fn adopt(
+            &self,
+            _: &str,
+            _: u16,
+            _: u16,
+        ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
+            Ok(crate::agent::backend::AdoptedSession {
+                output: Box::new(std::io::empty()),
+                input: Box::new(std::io::sink()),
+            })
+        }
+        fn discover(&self) -> anyhow::Result<Vec<crate::agent::backend::DiscoveredSession>> {
+            Ok(vec![make_discovered("%9", "tb-remote-sess", true)])
+        }
+        fn resize(&self, _: &str, _: u16, _: u16) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn is_dead(&self, _: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        fn kill(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn detach(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn pane_pid(&self, _: &str) -> anyhow::Result<Option<u32>> {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn live_remote_session_host_loss_becomes_unreachable_then_reconnects() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+        let mut app = app_with_sessions(0);
+        let remote: Arc<dyn SessionBackend> = Arc::new(RemoteStubBackend);
+        app.backends.register(Arc::clone(&remote));
+
+        // A live, adopted remote session (non-placeholder).
+        let mut session = Session::stub("remote-sess", &remote, &stub_provider());
+        session.info.agent_session_id = Some("sess-uuid".to_string());
+        let id = session.info.id;
+        app.sessions.push(session);
+        app.active_index = 0;
+        assert!(!app.sessions[0].is_placeholder());
+        assert!(crate::session::is_remote_backend(
+            app.sessions[0].backend_name()
+        ));
+
+        // Simulate the SSH/host connection dropping mid-session (control-mode
+        // EOF → `exited`); with `remain-on-exit=on` this only happens on host
+        // loss, never a clean agent exit.
+        app.sessions[0].mark_exited_for_test();
+
+        // The per-tick detector converts it in place to an unreachable
+        // placeholder and queues it for reconnect.
+        app.detect_lost_remote_sessions();
+        assert!(app.sessions[0].is_placeholder());
+        assert_eq!(app.sessions[0].info.status, SessionStatus::Unreachable);
+        assert_eq!(app.sessions[0].info.id, id);
+        assert!(app
+            .remote_restore
+            .as_ref()
+            .is_some_and(|s| s.pending.contains_key("ssh:test-host")));
+
+        // The host is reachable again → reconnects and re-adopts in place.
+        drain_remote_restore(&mut app);
+        assert_eq!(app.sessions.len(), 1);
+        assert!(!app.sessions[0].is_placeholder());
+        assert_eq!(app.sessions[0].info.id, id);
+    }
+
+    #[tokio::test]
+    async fn failing_remote_session_recovers_and_adopts_on_retry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+        let mut app = app_with_sessions(0);
+        // Down for the first discovery, up on the retry.
+        app.backends
+            .register(Arc::new(FlakyRemoteStubBackend::new(1)));
+
+        let mut shared = make_shared_session("%9", "remote-sess");
+        shared.backend_type = "ssh:flaky-host".to_string();
+        let id = shared.id;
+        app.restore_sessions(vec![shared], 1);
+        assert!(app.sessions[0].is_placeholder());
+
+        // Phase 1: the first discovery finds the host down — the placeholder
+        // survives as unreachable and stays queued for retry.
+        let mut down_seen = false;
+        for _ in 0..500 {
+            app.poll_remote_restore();
+            if app
+                .remote_restore
+                .as_ref()
+                .is_some_and(|s| s.notified_unreachable.contains("ssh:flaky-host"))
+            {
+                down_seen = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(down_seen, "first discovery should report the host down");
+        assert!(app.sessions[0].is_placeholder());
+        assert_eq!(app.sessions[0].info.status, SessionStatus::Unreachable);
+        assert!(app
+            .remote_restore
+            .as_ref()
+            .is_some_and(|s| s.pending.contains_key("ssh:flaky-host")));
+
+        // Phase 2: force a retry sweep; the host is up now, so the placeholder is
+        // replaced in place by the real adopted session (same id, no duplicate).
+        app.retry_remote_backend_now("ssh:flaky-host");
+        drain_remote_restore(&mut app);
+        assert_eq!(app.sessions.len(), 1);
+        assert!(!app.sessions[0].is_placeholder());
+        assert_eq!(app.sessions[0].info.id, id);
+        assert_eq!(app.sessions[0].backend_name(), "ssh:flaky-host");
+    }
+
+    #[tokio::test]
+    async fn deleting_placeholder_is_not_resurrected_on_recovery() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+        let mut app = app_with_sessions(0);
+        app.backends.register(Arc::new(RemoteStubBackend));
+
+        let mut shared = make_shared_session("%9", "remote-sess");
+        shared.backend_type = "ssh:test-host".to_string();
+        let id = shared.id;
+        app.db.upsert_session(&shared).unwrap();
+        app.restore_sessions(vec![shared], 1);
+        assert!(app.sessions[0].is_placeholder());
+
+        // The user deletes the placeholder before the host is reached.
+        app.active_index = 0;
+        app.close_active_session();
+        assert!(app.sessions.is_empty());
+
+        // The host is reachable now; draining discovery must NOT resurrect the
+        // deleted session.
+        drain_remote_restore(&mut app);
+        assert!(app.sessions.iter().all(|s| s.info.id != id));
+    }
+
     #[tokio::test]
     async fn remote_sessions_restore_in_background() {
         let tmp = tempfile::tempdir().unwrap();
@@ -11181,32 +11829,43 @@ mod tests {
 
         app.restore_sessions(vec![shared], 1);
 
-        // The first frame must not wait on the remote host: nothing is adopted
-        // synchronously; discovery runs on a background thread.
-        assert!(app.sessions.is_empty());
+        // The first frame must not wait on the remote host: the session shows
+        // immediately as an unreachable placeholder, and the real adopt runs on
+        // a background thread.
+        assert_eq!(app.sessions.len(), 1);
+        assert!(app.sessions[0].is_placeholder());
+        assert_eq!(app.sessions[0].info.id, id);
+        assert_eq!(app.sessions[0].info.status, SessionStatus::Unreachable);
         assert!(app.remote_restore.is_some());
 
-        // Drain like tick() would until the discovery thread reports.
+        // Drain like tick() would until the discovery thread reports; the
+        // placeholder is replaced in place by the real adopted session.
         drain_remote_restore(&mut app);
         assert_eq!(app.sessions.len(), 1);
+        assert!(!app.sessions[0].is_placeholder());
         assert_eq!(app.sessions[0].info.id, id);
         assert_eq!(app.sessions[0].backend_name(), "ssh:test-host");
     }
 
     #[test]
-    fn remote_session_on_unknown_host_is_left_unadopted() {
+    fn remote_session_on_unknown_host_shows_unreachable_placeholder() {
         let tmp = tempfile::tempdir().unwrap();
         let _guard = crate::paths::TestPathGuard::new(tmp.path());
         let mut app = app_with_sessions(0);
 
         let mut shared = make_shared_session("%9", "remote-sess");
         shared.backend_type = "ssh:unknown-host".to_string();
+        let id = shared.id;
 
         app.restore_sessions(vec![shared], 1);
 
-        // Same contract as the old synchronous path: an unmanageable backend's
-        // sessions are left un-adopted, and nothing stays pending.
-        assert!(app.sessions.is_empty());
+        // An unmanageable backend (host not in config) can't be adopted, but the
+        // session must still appear — as an unreachable placeholder — rather than
+        // silently vanish. It isn't queued for retries (nothing to retry against).
+        assert_eq!(app.sessions.len(), 1);
+        assert!(app.sessions[0].is_placeholder());
+        assert_eq!(app.sessions[0].info.id, id);
+        assert_eq!(app.sessions[0].info.status, SessionStatus::Unreachable);
         assert!(app.remote_restore.is_none());
     }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -339,11 +339,11 @@ pub fn expand_remote_tilde(host: &HostDef, path: &str) -> Result<String> {
 /// re-interpret the user-typed dir through a shell (`sh -c` loop; see the
 /// wsl list_dir test) or fail wholesale on a broken symlink (`ls -L`).
 ///
-/// This runs synchronously on the caller's (UI) thread, so the ssh variant
-/// adds `BatchMode=yes` + `ConnectTimeout=5` **after** the host's own
-/// `ssh_opts` (ssh honors the first occurrence of an option, so a user
-/// setting wins): completion fails fast on an unreachable or
-/// password-prompting host instead of freezing the TUI indefinitely.
+/// This runs synchronously on the caller's (UI) thread; the ssh launcher is
+/// hardened centrally ([`crate::shell::SSH_HARDENING_OPTS`] — `BatchMode=yes` +
+/// `ConnectTimeout=5` + `ServerAlive*`, appended after the host's own
+/// `ssh_opts`), so completion fails fast on an unreachable or password-prompting
+/// host instead of freezing the TUI indefinitely.
 pub fn list_dir_on(host: &HostDef, dir: &str) -> Result<Vec<String>> {
     let dir = expand_remote_tilde(host, dir)?;
     let output = list_dir_command(host, &dir)
@@ -373,13 +373,9 @@ fn list_dir_command(host: &HostDef, dir: &str) -> Command {
         }
         cmd
     } else {
-        let mut opts = host.ssh_opts.clone();
-        opts.extend(
-            ["-o", "BatchMode=yes", "-o", "ConnectTimeout=5"]
-                .iter()
-                .map(|s| s.to_string()),
-        );
-        let mut cmd = crate::shell::ssh_command(&host.destination, &opts);
+        // `host_launcher` builds `ssh <ssh_opts> <hardening> <dest>` — the
+        // fail-fast flags are applied centrally by `shell::ssh_command`.
+        let mut cmd = host_launcher(host);
         for tok in ["ls", "-1p", dir] {
             cmd.arg(posix_quote(tok));
         }
@@ -1683,11 +1679,16 @@ mod tests {
         );
         let (prog, args) = program_and_args(&cmd);
         assert_eq!(prog, "ssh");
-        assert_eq!(
-            args,
+        // User ssh_opts first, then the always-appended fail-fast hardening
+        // (crate::shell::SSH_HARDENING_OPTS), then destination + remote git.
+        let mut expected: Vec<String> = vec!["-o".into(), "ControlMaster=auto".into()];
+        expected.extend(
+            crate::shell::SSH_HARDENING_OPTS
+                .iter()
+                .map(|s| s.to_string()),
+        );
+        expected.extend(
             [
-                "-o",
-                "ControlMaster=auto",
                 "me@box",
                 "git",
                 "-C",
@@ -1697,7 +1698,10 @@ mod tests {
                 "-b",
                 "x",
             ]
+            .iter()
+            .map(|s| s.to_string()),
         );
+        assert_eq!(args, expected);
         // No local current_dir is set for the remote variant.
         assert_eq!(cmd.get_current_dir(), None);
     }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -115,6 +115,11 @@ pub enum SessionStatus {
     /// variant is wired through colour/glyph/rollup but never assigned. Kept for
     /// when exit-code plumbing lands.
     Error,
+    /// The session lives on a remote host that is currently unreachable (SSH
+    /// down / auth failing / host offline). Assigned to placeholder rows so a
+    /// remote session never silently vanishes from the list; cleared to the
+    /// real hook-driven status once the host recovers and the session adopts.
+    Unreachable,
 }
 
 impl SessionStatus {
@@ -131,6 +136,7 @@ impl SessionStatus {
             Self::Done => "●",
             Self::Idle => "○",
             Self::Error => "✗",
+            Self::Unreachable => "⊘",
         }
     }
 }
@@ -143,6 +149,7 @@ impl fmt::Display for SessionStatus {
             Self::Done => write!(f, "Done"),
             Self::Idle => write!(f, "Idle"),
             Self::Error => write!(f, "Error"),
+            Self::Unreachable => write!(f, "Unreachable"),
         }
     }
 }

--- a/src/session/theme_config.rs
+++ b/src/session/theme_config.rs
@@ -21,6 +21,10 @@ pub struct ThemePalette {
     pub status_done: Color,
     pub status_idle: Color,
     pub status_error: Color,
+    /// Colour of the "unreachable" status glyph (a remote host that is down /
+    /// offline). Muted grey by default so a placeholder row reads as inert, not
+    /// urgent.
+    pub status_unreachable: Color,
 
     pub text_primary: Color,
     pub text_secondary: Color,
@@ -286,6 +290,8 @@ pub struct CustomThemeDef {
     #[serde(default)]
     pub status_error: Option<String>,
     #[serde(default)]
+    pub status_unreachable: Option<String>,
+    #[serde(default)]
     pub text_primary: Option<String>,
     #[serde(default)]
     pub text_secondary: Option<String>,
@@ -367,7 +373,7 @@ impl CustomThemeDef {
     /// (`override_array_covers_every_color_field`) asserts it matches the
     /// struct's colour-field count, so a forgotten row can't silently make a
     /// colour un-overridable.
-    const COLOR_OVERRIDE_COUNT: usize = 30;
+    const COLOR_OVERRIDE_COUNT: usize = 31;
 
     /// Materialise the theme: base preset palette + overrides. Unparsable
     /// colours and an unknown base degrade to warnings, never to a hard
@@ -412,6 +418,11 @@ impl CustomThemeDef {
                 "status_error",
                 &self.status_error,
                 &mut palette.status_error,
+            ),
+            (
+                "status_unreachable",
+                &self.status_unreachable,
+                &mut palette.status_unreachable,
             ),
             (
                 "text_primary",
@@ -520,6 +531,7 @@ fn default_palette() -> ThemePalette {
         status_done: Color::LightBlue,
         status_idle: Color::Green,
         status_error: Color::Red,
+        status_unreachable: Color::DarkGray,
 
         text_primary: Color::White,
         text_secondary: Color::Gray,
@@ -599,6 +611,8 @@ impl PaletteSlots {
             status_done: self.blue,
             status_idle: self.green,
             status_error: self.red,
+            // Muted grey: an unreachable placeholder is inert, not urgent.
+            status_unreachable: self.text_muted,
             text_primary: self.text_primary,
             text_secondary: self.text_secondary,
             text_muted: self.text_muted,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -28,11 +28,42 @@ pub fn posix_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
-/// Build an `ssh <opts> <destination>` [`Command`], ready for the caller to
-/// append the remote command and its arguments.
+/// Defensive `ssh` options thurbox appends to **every** ssh invocation so a
+/// broken, unreachable, or password-only host fails fast and non-interactively
+/// instead of freezing the single-threaded TUI.
+///
+/// - `BatchMode=yes` — never fall back to a password/keyboard-interactive
+///   prompt. Such a prompt reads from the controlling `/dev/tty` (the terminal
+///   ratatui owns), so it would corrupt the display and steal keystrokes; with
+///   BatchMode ssh fails immediately instead.
+/// - `ConnectTimeout=5` — bound the connect phase for an unreachable host.
+/// - `ServerAliveInterval=5` + `ServerAliveCountMax=1` — bound a *hung
+///   established* connection (e.g. a mid-session network drop on the long-lived
+///   control-mode ssh), so it is detected in ~5s rather than hanging until the
+///   OS TCP timeout.
+///
+/// These are appended **after** the caller's own `ssh_opts`; ssh honors the
+/// first occurrence of each option, so a user-configured value still wins.
+pub const SSH_HARDENING_OPTS: [&str; 8] = [
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "ConnectTimeout=5",
+    "-o",
+    "ServerAliveInterval=5",
+    "-o",
+    "ServerAliveCountMax=1",
+];
+
+/// Build an `ssh <opts> <hardening> <destination>` [`Command`], ready for the
+/// caller to append the remote command and its arguments.
+///
+/// Every thurbox ssh use is non-interactive, so [`SSH_HARDENING_OPTS`] is always
+/// applied (after the caller's `ssh_opts`, which therefore take precedence).
 pub fn ssh_command(destination: &str, ssh_opts: &[String]) -> Command {
     let mut cmd = Command::new("ssh");
     cmd.args(ssh_opts);
+    cmd.args(SSH_HARDENING_OPTS);
     cmd.arg(destination);
     cmd
 }
@@ -105,14 +136,33 @@ mod tests {
     }
 
     #[test]
-    fn ssh_command_sets_program_opts_and_destination() {
+    fn ssh_command_sets_program_opts_hardening_and_destination() {
         let cmd = ssh_command("me@box", &["-p".into(), "2222".into()]);
         assert_eq!(cmd.get_program().to_string_lossy(), "ssh");
         let args: Vec<String> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
-        assert_eq!(args, ["-p", "2222", "me@box"]);
+        // Caller opts first, hardening appended, destination last.
+        let mut expected: Vec<&str> = vec!["-p", "2222"];
+        expected.extend(SSH_HARDENING_OPTS);
+        expected.push("me@box");
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn ssh_command_hardening_follows_user_opts_so_user_wins() {
+        // ssh honors the first occurrence of an option, so a user-set
+        // ConnectTimeout must precede ours in the arg list.
+        let cmd = ssh_command("me@box", &["-o".into(), "ConnectTimeout=30".into()]);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let user = args.iter().position(|a| a == "ConnectTimeout=30").unwrap();
+        let ours = args.iter().position(|a| a == "ConnectTimeout=5").unwrap();
+        assert!(user < ours, "user opt must precede hardening opt");
+        assert!(args.iter().any(|a| a == "BatchMode=yes"));
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -396,6 +396,7 @@ pub fn status_color(status: SessionStatus) -> Color {
         SessionStatus::Done => Theme::status_done(),
         SessionStatus::Idle => Theme::status_idle(),
         SessionStatus::Error => Theme::status_error(),
+        SessionStatus::Unreachable => Theme::status_unreachable(),
     }
 }
 

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -796,19 +796,24 @@ fn group_header_line(
 }
 
 /// Urgency rank for the repo-group rollup; higher is more urgent.
+///
+/// `Unreachable` sits just above `Idle`: a group whose only notable member is a
+/// down remote session rolls up as unreachable, but any live member (Done and
+/// up) still dominates the header dot.
 fn status_urgency(s: SessionStatus) -> u8 {
     match s {
-        SessionStatus::Blocked => 4,
-        SessionStatus::Error => 3,
-        SessionStatus::Working => 2,
-        SessionStatus::Done => 1,
+        SessionStatus::Blocked => 5,
+        SessionStatus::Error => 4,
+        SessionStatus::Working => 3,
+        SessionStatus::Done => 2,
+        SessionStatus::Unreachable => 1,
         SessionStatus::Idle => 0,
     }
 }
 
 /// The most-urgent status across a group's members (Blocked > Error > Working >
-/// Done > Idle), so the group header dot surfaces whatever needs attention
-/// first. Empty input rolls up to `Idle`.
+/// Done > Unreachable > Idle), so the group header dot surfaces whatever needs
+/// attention first. Empty input rolls up to `Idle`.
 pub fn group_status(statuses: impl IntoIterator<Item = SessionStatus>) -> SessionStatus {
     statuses
         .into_iter()

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -117,6 +117,9 @@ impl Theme {
     pub fn status_error() -> Color {
         current().status_error
     }
+    pub fn status_unreachable() -> Color {
+        current().status_unreachable
+    }
 
     // ── Text hierarchy ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Broken remote SSH hosts (login failing, network errors, host offline) used to **freeze the whole TUI** — a `user@<ip> password:` prompt bled into the middle of the UI (SSH falling back to interactive auth on the controlling TTY) and unreachable hosts hung the single-threaded render loop. Their sessions also **silently vanished** from the list.

This PR makes the orchestrator resilient to failing remote hosts:

- **Fail-fast SSH** — every ssh invocation now carries `BatchMode=yes` + `ConnectTimeout` + `ServerAlive*` (via a shared `shell::SSH_HARDENING_OPTS`, appended after the user's own `ssh_opts` so they still win). A broken host fails in ≤5s instead of prompting on the TUI's terminal or hanging the loop. Mirrors the pattern the git module already used.
- **Always-visible "unreachable" sessions** — a persisted remote session whose host is down at restore now shows as an `Unreachable` (`⊘`, muted grey) **placeholder** row instead of disappearing. Placeholders hold no live pane (keystrokes hinted, `resize`/`kill`/`detach`/`save_state` skip them), and the host is retried off-thread every 20s (or immediately via restart); on recovery the placeholder is replaced **in place** by the adopted session.
- **Mid-session host loss** — a live remote session whose control-mode connection drops (reliable signal: with `remain-on-exit=on`, a clean agent exit never EOFs the reader) is converted to an `Unreachable` placeholder and auto-reconnects, instead of silently going `Idle`.
- New `SessionStatus::Unreachable` wired across glyph/color/rollup + a `status_unreachable` theme key on all 15 presets. Docs updated (CLAUDE.md, FEATURES.md, CONFIG.md).

## Test plan

- 6 new unit tests: down-at-restore stays unreachable + retryable + row not clobbered; down→up recovery adopts on retry; up-at-restore adopts in place; unknown-host placeholder; deleted placeholder not resurrected; **mid-session host loss → unreachable → reconnect**.
- Full suite green (`cargo nextest run --all`), `cargo clippy -D warnings` + `cargo fmt` clean, architecture rules pass — all via the pre-commit hooks.
- CI checks pass.