### PR TITLE
ci: add winget distribution channel

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -415,3 +415,63 @@ jobs:
         run: |
           $nupkg = Get-ChildItem packaging/chocolatey/thurbox.*.nupkg | Select-Object -First 1
           choco push $nupkg.FullName --source https://push.chocolatey.org/ --api-key $env:CHOCOLATEY_API_KEY
+
+  # Submit the winget manifests to microsoft/winget-pkgs.
+  # Runs after `publish` so the release zip + checksums.txt exist. wingetcreate
+  # is Windows-only, so this runs on windows-latest. Requires the WINGET_TOKEN
+  # secret (a classic PAT with `public_repo` scope that can fork/PR against
+  # microsoft/winget-pkgs); skipped automatically if unset (e.g. on forks).
+  # New versions go through winget-pkgs PR review before going live.
+  publish-winget:
+    name: Publish winget manifest
+    needs: [check-release, create-tag, publish]
+    if: needs.check-release.outputs.should_release == 'true'
+    runs-on: windows-latest
+    # Hoisted so the steps can be skipped when the secret is unset
+    # (the `secrets` context cannot be used directly in an `if` condition).
+    env:
+      WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+    steps:
+      - name: Checkout code at tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.check-release.outputs.version }}
+
+      - name: Download release checksums
+        if: env.WINGET_TOKEN != ''
+        shell: pwsh
+        run: |
+          $version = "${{ needs.check-release.outputs.version }}"
+          $repo = "${{ github.repository }}"
+          Invoke-WebRequest -UseBasicParsing `
+            -Uri "https://github.com/$repo/releases/download/$version/thurbox-$version-checksums.txt" `
+            -OutFile checksums.txt
+          Get-Content checksums.txt
+
+      - name: Bump manifests to the release version
+        if: env.WINGET_TOKEN != ''
+        shell: pwsh
+        run: |
+          python packaging/winget/bump-manifests.py `
+            "${{ needs.check-release.outputs.version }}" `
+            packaging/winget/manifests `
+            checksums.txt
+          Get-Content packaging/winget/manifests/Thurbeen.thurbox.installer.yaml
+
+      - name: Install wingetcreate
+        if: env.WINGET_TOKEN != ''
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -UseBasicParsing `
+            -Uri https://aka.ms/wingetcreate/latest `
+            -OutFile wingetcreate.exe
+
+      # `submit` validates the bumped manifests and opens a PR against
+      # microsoft/winget-pkgs from a fork of the WINGET_TOKEN account. Works for
+      # both the first submission and every subsequent version from the same
+      # in-repo manifest set.
+      - name: Submit manifests to winget-pkgs
+        if: env.WINGET_TOKEN != ''
+        shell: pwsh
+        run: |
+          .\wingetcreate.exe submit --token $env:WINGET_TOKEN packaging/winget/manifests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,7 +338,7 @@ Each release includes:
   - `thurbox-v{ver}-x86_64-unknown-linux-musl.tar.gz`
   - `thurbox-v{ver}-aarch64-apple-darwin.tar.gz`
   - `thurbox-v{ver}-x86_64-pc-windows-msvc.zip` (the Windows artifact
-    extracted by `install.ps1` / packaged by Chocolatey)
+    extracted by `install.ps1` / packaged by Chocolatey + winget)
 - `thurbox-v{ver}-checksums.txt` (SHA256 sums for verification)
 - Changelog with categorized commits
 
@@ -363,6 +363,17 @@ package channels (each gated on its secret, skipped on forks):
   community repo. Runs on `windows-latest`; needs the `CHOCOLATEY_API_KEY`
   secret. New versions go through community-repo moderation.
   Install: `choco install thurbox`. Windows x86_64 only.
+- **winget** (`publish-winget`): bumps `PackageVersion`/`InstallerUrl`/
+  `InstallerSha256`/`ReleaseNotesUrl` in the three manifests under
+  `packaging/winget/manifests/` (via `packaging/winget/bump-manifests.py`,
+  reading the release `checksums.txt`), then `wingetcreate submit`s the set as a
+  PR to `microsoft/winget-pkgs`. Runs on `windows-latest`; needs the
+  `WINGET_TOKEN` secret (a `public_repo` PAT owning a fork of
+  `microsoft/winget-pkgs`). New versions go through winget-pkgs PR
+  validation + review. The release zip is a `zip` installer with
+  `NestedInstallerType = portable` (PATH aliases `thurbox`/`thurbox-cli`, no
+  MSI). Install: `winget install Thurbeen.thurbox`. Windows x86_64 only (added
+  as a moderation-independent alternative to the Chocolatey channel).
 
 See `packaging/README.md` for the full packaging overview.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ verification. Pin a version or directory with the `THURBOX_VERSION` /
 `THURBOX_INSTALL_DIR` env vars. Needs [psmux](https://github.com/psmux/psmux)
 as the multiplexer.
 
+**winget (Windows):**
+
+```powershell
+winget install Thurbeen.thurbox
+```
+
+Installs the prebuilt x86_64 Windows binaries (`thurbox.exe` +
+`thurbox-cli.exe`) from the GitHub Release as portable commands on your `PATH`.
+Needs [psmux](https://github.com/psmux/psmux) as the multiplexer (installed
+separately).
+
 **Chocolatey (Windows):**
 
 ```powershell
@@ -71,6 +82,11 @@ Installs the prebuilt x86_64 Windows binaries (`thurbox.exe` +
 `thurbox-cli.exe`) from the GitHub Release and shims them onto your `PATH`.
 Needs [psmux](https://github.com/psmux/psmux) as the multiplexer (installed
 separately — there is no Chocolatey package for it).
+
+> **⚠️ Pending moderation.** The Chocolatey package has been pushed but is
+> **not yet approved** by the community-repo moderators, so `choco install
+> thurbox` won't resolve it from the community feed until it goes live. Use
+> **winget** or the PowerShell installer (both above) in the meantime.
 
 **Homebrew (macOS / Linux):**
 
@@ -426,6 +442,7 @@ Remove the binary, depending on how you installed it:
 rm ~/.local/bin/thurbox        # curl one-liner / manual install
 brew uninstall thurbox         # Homebrew
 paru -R thurbox thurbox-bin    # Arch (AUR)
+winget uninstall Thurbeen.thurbox  # winget (Windows)
 choco uninstall thurbox        # Chocolatey (Windows)
 ```
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -9,6 +9,7 @@ Optional OS-level integration and distribution packages for thurbox.
 | `homebrew/` | Homebrew tap (macOS/Linux) | prebuilt release binaries — see [`homebrew/README.md`](homebrew/README.md) |
 | `aur/`      | Arch Linux (AUR)         | source + prebuilt binary — see [`aur/README.md`](aur/README.md) |
 | `chocolatey/` | Chocolatey (Windows)   | prebuilt release zip — see [`chocolatey/README.md`](chocolatey/README.md) |
+| `winget/`   | winget (Windows)         | prebuilt release zip (portable) — see [`winget/README.md`](winget/README.md) |
 
 These are published automatically on each release by jobs in
 [`.github/workflows/cd.yml`](../.github/workflows/cd.yml). For the

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,104 @@
+# winget packaging
+
+Thurbox ships a [winget](https://learn.microsoft.com/windows/package-manager/)
+package that installs the **prebuilt** x86_64 Windows release binaries
+(`thurbox.exe` + `thurbox-cli.exe`) from the GitHub Release as **portable**
+commands on your `PATH`.
+
+```powershell
+winget install Thurbeen.thurbox
+```
+
+The canonical manifest set lives here under [`manifests/`](manifests/):
+
+| File | Manifest type | Purpose |
+| ---- | ------------- | ------- |
+| [`Thurbeen.thurbox.yaml`](manifests/Thurbeen.thurbox.yaml) | `version` | ties the version to the locale + installer manifests |
+| [`Thurbeen.thurbox.installer.yaml`](manifests/Thurbeen.thurbox.installer.yaml) | `installer` | the release zip URL + SHA256 + nested portable exes |
+| [`Thurbeen.thurbox.locale.en-US.yaml`](manifests/Thurbeen.thurbox.locale.en-US.yaml) | `defaultLocale` | descriptive metadata (publisher, license, tags, description) |
+
+The `PackageVersion`/`InstallerUrl`/`InstallerSha256`/`ReleaseNotesUrl` values
+committed here are a last-known-good template — CI overrides them per release.
+
+## Why winget as well as Chocolatey
+
+The [Chocolatey](../chocolatey/README.md) package sits behind community-repo
+moderation, which can hold a new package (and each new version) for a long time.
+winget is Microsoft's first-party Windows package manager (bundled with Windows
+10/11 via *App Installer*), so this gives Windows users a channel that doesn't
+depend on Chocolatey moderation. Both channels are published from the same
+release; neither replaces the other.
+
+## Supported platforms
+
+Windows x86_64 only — the single published Windows release artifact is
+`thurbox-v<version>-x86_64-pc-windows-msvc.zip`. ARM64 Windows installs the
+x86_64 build and runs it under x64 emulation (matching
+[`scripts/install.ps1`](../../scripts/install.ps1)).
+
+The installer is a `zip` whose `NestedInstallerType` is `portable`: winget
+extracts the archive and registers PATH aliases (`thurbox`, `thurbox-cli`) — no
+MSI, no per-machine installer, and `winget uninstall Thurbeen.thurbox` removes
+them cleanly.
+
+## Runtime dependencies
+
+winget manifests have no cross-package dependency mechanism for this, so these
+are documented in the package `Description` rather than auto-installed:
+
+- **[psmux](https://github.com/psmux/psmux)** — the native-Windows terminal
+  multiplexer thurbox drives (a drop-in tmux clone). Install it separately.
+- A coding-agent CLI (claude, codex, antigravity, opencode, aider, …) on your
+  PATH.
+
+## Automated publishing (CI)
+
+Every release submits to winget-pkgs **automatically** — including the first.
+The `publish-winget` job in
+[`.github/workflows/cd.yml`](../../.github/workflows/cd.yml) runs on
+`windows-latest` after the GitHub Release is created and:
+
+1. downloads the release `thurbox-<version>-checksums.txt`,
+2. runs [`bump-manifests.py`](bump-manifests.py) to set `PackageVersion` across
+   the manifests and the installer manifest's `InstallerUrl`/`InstallerSha256`
+   (uppercased, as winget-pkgs expects) plus the locale `ReleaseNotesUrl` from
+   those checksums,
+3. downloads `wingetcreate` (`https://aka.ms/wingetcreate/latest`), then
+4. `wingetcreate submit`s the manifest set, which validates it and opens a PR
+   against [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
+
+The job needs a `WINGET_TOKEN` secret — a classic PAT with the `public_repo`
+scope on the account that owns a fork of `microsoft/winget-pkgs` (wingetcreate
+pushes the manifest branch to that fork and opens the PR). The job is skipped
+where the secret is absent (e.g. on forks). The committed template files are not
+modified by CI — they stay as last-known-good, exactly like the Chocolatey /
+Homebrew templates.
+
+> **Review (winget-pkgs side, not CI).** microsoft/winget-pkgs runs automated
+> validation (manifest schema, installer hash, a sandbox install/uninstall
+> smoke test) and then human review before a version goes live. The
+> `wingetcreate submit` succeeds when the PR is opened; the package appears in
+> `winget search thurbox` only after that PR merges. This is not a CI failure.
+
+## Manual publishing / initial import
+
+Publishing is automated (above), so this is only a fallback — e.g. to re-submit
+a version outside the release flow. On Windows with
+[wingetcreate](https://github.com/microsoft/winget-create) installed
+(`winget install wingetcreate`):
+
+```powershell
+# Bump the local template to a published release.
+$ver = "<version>"   # a tag with published release assets, e.g. 0.79.46
+# curl.exe (not the `curl` alias for Invoke-WebRequest) ships on Windows 10+.
+curl.exe -fsSL -o checksums.txt `
+  "https://github.com/Thurbeen/thurbox/releases/download/v$ver/thurbox-v$ver-checksums.txt"
+python packaging\winget\bump-manifests.py "v$ver" packaging\winget\manifests checksums.txt
+
+# Validate, then submit a PR to microsoft/winget-pkgs.
+wingetcreate submit --token <your-github-pat> packaging\winget\manifests
+```
+
+Pick a `<version>` that has **published release assets** (the manifest points at
+a release zip). To only sanity-check the manifests without submitting, use
+`winget validate --manifest packaging\winget\manifests`.

--- a/packaging/winget/bump-manifests.py
+++ b/packaging/winget/bump-manifests.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Bump the winget manifests to a released version.
+
+Usage: bump-manifests.py <version> <manifests_dir> <checksums.txt>
+
+Sets PackageVersion across all three manifests, and InstallerUrl/InstallerSha256
+(installer manifest) + ReleaseNotesUrl (locale manifest) to match the freshly
+published release. The Windows artifact's sha256 is read from the release
+`checksums.txt` (`thurbox-v<version>-x86_64-pc-windows-msvc.zip`) and emitted
+uppercase (winget-pkgs validation normalizes to uppercase). Exits non-zero if
+that checksum is missing or any template anchor is not found, so CI fails loudly
+rather than submitting a stale/partial manifest set.
+"""
+import re
+import sys
+from pathlib import Path
+
+TARGET = "x86_64-pc-windows-msvc"
+
+
+def sub_once(text: str, pattern: str, repl: str, what: str) -> str:
+    out, n = re.subn(pattern, repl, text, count=1)
+    if n != 1:
+        print(f"error: anchor not found: {what}", file=sys.stderr)
+        raise SystemExit(1)
+    return out
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    version_tag, manifests_dir, checksums_path = sys.argv[1], sys.argv[2], sys.argv[3]
+    version = version_tag.lstrip("v")
+    base = Path(manifests_dir)
+
+    checks = {}
+    for line in Path(checksums_path).read_text().splitlines():
+        parts = line.split()
+        if len(parts) == 2:
+            checks[parts[1]] = parts[0]
+
+    fname = f"thurbox-v{version}-{TARGET}.zip"
+    sha = checks.get(fname)
+    if sha is None:
+        print(f"error: checksum missing for: {fname}", file=sys.stderr)
+        return 1
+    sha = sha.upper()
+
+    version_manifest = base / "Thurbeen.thurbox.yaml"
+    installer_manifest = base / "Thurbeen.thurbox.installer.yaml"
+    locale_manifest = base / "Thurbeen.thurbox.locale.en-US.yaml"
+
+    url = f"https://github.com/Thurbeen/thurbox/releases/download/v{version}/{fname}"
+    notes = f"https://github.com/Thurbeen/thurbox/releases/tag/v{version}"
+    pv = rf"(?m)^PackageVersion:\s*.*$"
+
+    # Version manifest: PackageVersion only.
+    vt = version_manifest.read_text()
+    vt = sub_once(vt, pv, f"PackageVersion: {version}", "PackageVersion (version manifest)")
+    version_manifest.write_text(vt)
+
+    # Installer manifest: PackageVersion, InstallerUrl, InstallerSha256.
+    it = installer_manifest.read_text()
+    it = sub_once(it, pv, f"PackageVersion: {version}", "PackageVersion (installer manifest)")
+    it = sub_once(
+        it,
+        r"(?m)^(\s*InstallerUrl:\s*).*$",
+        rf"\g<1>{url}",
+        "InstallerUrl",
+    )
+    it = sub_once(
+        it,
+        r"(?m)^(\s*InstallerSha256:\s*).*$",
+        rf"\g<1>{sha}",
+        "InstallerSha256",
+    )
+    installer_manifest.write_text(it)
+
+    # Locale manifest: PackageVersion, ReleaseNotesUrl.
+    lt = locale_manifest.read_text()
+    lt = sub_once(lt, pv, f"PackageVersion: {version}", "PackageVersion (locale manifest)")
+    lt = sub_once(
+        lt,
+        r"(?m)^(ReleaseNotesUrl:\s*).*$",
+        rf"\g<1>{notes}",
+        "ReleaseNotesUrl",
+    )
+    locale_manifest.write_text(lt)
+
+    print(f"Bumped winget manifests to {version} ({fname})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/winget/manifests/Thurbeen.thurbox.installer.yaml
+++ b/packaging/winget/manifests/Thurbeen.thurbox.installer.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+#
+# Winget installer manifest for thurbox. CI bumps PackageVersion, InstallerUrl,
+# and InstallerSha256 on every release (packaging/winget/bump-manifests.py,
+# reading the release checksums.txt). The values below are a last-known-good
+# template.
+#
+# The Windows release artifact is a plain .zip of portable binaries
+# (thurbox.exe + thurbox-cli.exe + LICENSE), so this is a `zip` installer whose
+# nested files are `portable`: winget extracts the zip and registers PATH
+# aliases (`thurbox`, `thurbox-cli`) via its Portable install flow — no MSI, no
+# per-machine installer. Only Windows x86_64 is published; ARM64 runs it under
+# x64 emulation.
+PackageIdentifier: Thurbeen.thurbox
+PackageVersion: 0.79.46
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: thurbox.exe
+    PortableCommandAlias: thurbox
+  - RelativeFilePath: thurbox-cli.exe
+    PortableCommandAlias: thurbox-cli
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Thurbeen/thurbox/releases/download/v0.79.46/thurbox-v0.79.46-x86_64-pc-windows-msvc.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/manifests/Thurbeen.thurbox.locale.en-US.yaml
+++ b/packaging/winget/manifests/Thurbeen.thurbox.locale.en-US.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+#
+# Winget default-locale manifest for thurbox. CI bumps PackageVersion and
+# ReleaseNotesUrl on every release (packaging/winget/bump-manifests.py); the
+# rest is descriptive metadata that rarely changes.
+PackageIdentifier: Thurbeen.thurbox
+PackageVersion: 0.79.46
+PackageLocale: en-US
+Publisher: LeTuR
+PublisherUrl: https://github.com/Thurbeen
+PublisherSupportUrl: https://github.com/Thurbeen/thurbox/issues
+Author: LeTuR
+PackageName: thurbox
+PackageUrl: https://thurbeen.github.io/thurbox/
+License: MIT
+LicenseUrl: https://github.com/Thurbeen/thurbox/blob/main/LICENSE
+Copyright: Copyright (c) 2026 LeTuR
+CopyrightUrl: https://github.com/Thurbeen/thurbox/blob/main/LICENSE
+ShortDescription: TUI for orchestrating multiple coding-agent CLI sessions in persistent panels.
+Description: |-
+  thurbox is a TUI for orchestrating multiple coding-agent CLI sessions
+  (claude, codex, gemini, opencode, aider, ...) in persistent multiplexer
+  panels. Sessions survive crashes/restarts because the multiplexer keeps the
+  processes alive.
+
+  Windows support is experimental for now — it sees less testing than
+  Linux/macOS, so expect rough edges and please report issues. This package
+  installs the prebuilt x86_64 Windows release binaries (thurbox.exe +
+  thurbox-cli.exe) as portable commands on your PATH.
+
+  Not installed by this package: psmux (the native-Windows tmux clone thurbox
+  drives as its session backend — https://github.com/psmux/psmux) and a
+  coding-agent CLI (claude, codex, gemini, opencode, aider, ...).
+Moniker: thurbox
+Tags:
+  - agent
+  - aider
+  - claude
+  - cli
+  - coding-agent
+  - codex
+  - developer-tools
+  - orchestrator
+  - terminal
+  - tui
+ReleaseNotesUrl: https://github.com/Thurbeen/thurbox/releases/tag/v0.79.46
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/manifests/Thurbeen.thurbox.yaml
+++ b/packaging/winget/manifests/Thurbeen.thurbox.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+#
+# Winget version manifest for thurbox. Canonical source, kept in the main repo.
+# CI (the `publish-winget` job in .github/workflows/cd.yml) bumps PackageVersion
+# here and in the installer/locale manifests on every release via
+# packaging/winget/bump-manifests.py, then submits the set to
+# microsoft/winget-pkgs with wingetcreate. The version below is a
+# last-known-good template — CI overrides it per release.
+PackageIdentifier: Thurbeen.thurbox
+PackageVersion: 0.79.46
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/website/docs/faq.html
+++ b/website/docs/faq.html
@@ -50,7 +50,8 @@ breadcrumb: 'FAQ'
   <code>curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code>.
   It is also available via Homebrew
   (<code>brew install thurbeen/thurbox/thurbox</code>), the AUR (<code>thurbox</code>
-  or <code>thurbox-bin</code>), and on Windows via PowerShell or Chocolatey
+  or <code>thurbox-bin</code>), and on Windows via PowerShell, winget
+  (<code>winget install Thurbeen.thurbox</code>), or Chocolatey
   (<code>choco install thurbox</code>). You can also build from source with
   <code>cargo build --release</code>. See
   <a href="installation.html">installation</a> for details.
@@ -118,7 +119,7 @@ breadcrumb: 'FAQ'
         "name": "How do I install Thurbox?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "On Linux or macOS, run: curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh. It is also available via Homebrew (brew install thurbeen/thurbox/thurbox), the AUR (thurbox or thurbox-bin), and on Windows via PowerShell or Chocolatey (choco install thurbox). You can also build from source with cargo build --release."
+          "text": "On Linux or macOS, run: curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh. It is also available via Homebrew (brew install thurbeen/thurbox/thurbox), the AUR (thurbox or thurbox-bin), and on Windows via PowerShell, winget (winget install Thurbeen.thurbox), or Chocolatey (choco install thurbox). You can also build from source with cargo build --release."
         }
       },
       {

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -104,6 +104,28 @@ onThisPage:
             </tbody>
           </table>
 
+          <h2 id="winget">
+            winget (Windows)
+            <a href="#winget" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            On Windows, install the prebuilt x86_64 binaries with
+            <a href="https://learn.microsoft.com/windows/package-manager/">winget</a>
+            (Microsoft's package manager, bundled with Windows 10/11):
+          </p>
+          <pre><code class="language-powershell">winget install Thurbeen.thurbox</code></pre>
+          <p>
+            Installs
+            <code>thurbox.exe</code>
+            and
+            <code>thurbox-cli.exe</code>
+            from the GitHub Release as portable commands on your
+            <code>PATH</code>
+            . Needs
+            <a href="https://github.com/psmux/psmux">psmux</a>
+            as the multiplexer, installed separately.
+          </p>
+
           <h2 id="chocolatey">
             Chocolatey (Windows)
             <a href="#chocolatey" class="heading-anchor">#</a>
@@ -114,6 +136,18 @@ onThisPage:
             :
           </p>
           <pre><code class="language-powershell">choco install thurbox</code></pre>
+          <div class="info-box warning">
+            <p>
+              <strong>Pending moderation.</strong>
+              The Chocolatey package has been pushed to the community repository but is
+              <strong>not yet approved</strong>
+              by the moderators, so
+              <code>choco install thurbox</code>
+              will not resolve it from the community feed until it goes live. Use
+              <a href="#winget">winget</a>
+              or the PowerShell installer above in the meantime.
+            </p>
+          </div>
           <p>
             Installs
             <code>thurbox.exe</code>
@@ -305,6 +339,7 @@ cargo build --release</code></pre>
           <pre><code class="language-bash">rm ~/.local/bin/thurbox        # curl one-liner / manual install
 brew uninstall thurbox         # Homebrew
 paru -R thurbox thurbox-bin    # Arch (AUR)
+winget uninstall Thurbeen.thurbox  # winget (Windows)
 choco uninstall thurbox        # Chocolatey (Windows)</code></pre>
           <p>
             Sessions outlive Thurbox in tmux, so stop them too &mdash; and optionally delete state

--- a/website/index.html
+++ b/website/index.html
@@ -84,6 +84,16 @@ footer: true
             </button>
             <button
               class="install-tab"
+              id="tab-winget"
+              role="tab"
+              aria-controls="panel-winget"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              winget
+            </button>
+            <button
+              class="install-tab"
               id="tab-choco"
               role="tab"
               aria-controls="panel-choco"
@@ -151,6 +161,25 @@ footer: true
             <pre data-wrap><code class="language-powershell">irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
           </div>
 
+          <div class="install-panel" role="tabpanel" id="panel-winget" aria-labelledby="tab-winget" hidden>
+            <p>
+              Windows x86_64 via
+              <a href="https://learn.microsoft.com/windows/package-manager/" target="_blank" rel="noopener">
+                winget
+              </a>
+              (bundled with Windows 10/11). Installs the prebuilt
+              <code>thurbox.exe</code>
+              +
+              <code>thurbox-cli.exe</code>
+              as portable commands on your
+              <code>PATH</code>
+              . Needs
+              <a href="https://github.com/psmux/psmux" target="_blank" rel="noopener">psmux</a>
+              as the multiplexer (installed separately).
+            </p>
+            <pre><code class="language-powershell">winget install Thurbeen.thurbox</code></pre>
+          </div>
+
           <div class="install-panel" role="tabpanel" id="panel-choco" aria-labelledby="tab-choco" hidden>
             <p>
               Windows x86_64 via the
@@ -166,6 +195,14 @@ footer: true
               . Needs
               <a href="https://github.com/psmux/psmux" target="_blank" rel="noopener">psmux</a>
               as the multiplexer (installed separately).
+            </p>
+            <p>
+              <strong>Pending moderation:</strong>
+              the package is pushed but not yet approved by the community-repo moderators, so
+              <code>choco install thurbox</code>
+              won't resolve until it goes live &mdash; use
+              <strong>winget</strong>
+              or the install script meanwhile.
             </p>
             <pre><code class="language-powershell">choco install thurbox</code></pre>
           </div>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -16,7 +16,7 @@
 - [FAQ](https://thurbox.thurbeen.eu/docs/faq.html): short answers to the most common questions (what it is, how it differs, install, platforms, license).
 - [Features](https://thurbox.thurbeen.eu/docs/features.html): sessions, agent definitions, git worktrees, remote SSH, automations, tasks, code review, headless CLI.
 - [Comparison](https://thurbox.thurbeen.eu/docs/comparison.html): how Thurbox compares to Conductor, Claude Squad, Cursor, and other parallel coding-agent tools.
-- [Installation](https://thurbox.thurbeen.eu/docs/installation.html): install via curl, Homebrew, AUR, Chocolatey, or from source; prerequisites.
+- [Installation](https://thurbox.thurbeen.eu/docs/installation.html): install via curl, Homebrew, AUR, winget, Chocolatey, or from source; prerequisites.
 - [Configuration](https://thurbox.thurbeen.eu/docs/configuration.html): every config file and knob — agents.toml, hosts.toml, settings.toml, themes, keybindings.
 - [Architecture](https://thurbox.thurbeen.eu/docs/architecture.html): the Elm Architecture, module isolation, the tmux session backend, and design decisions.
 


### PR DESCRIPTION
## Summary

Adds a **winget** package published alongside the existing Chocolatey one, following the repo's packaging pattern (canonical templates in-repo + a Python bump script + a `windows-latest` CI publish job). winget is Microsoft's first-party Windows package manager and is **independent of Chocolatey community-repo moderation**, which has held the choco package pending.

## What's added

- **`packaging/winget/manifests/`** — three manifests (version / installer / locale, schema 1.6.0). The release zip is modeled as a `zip` installer with `NestedInstallerType: portable`, so winget registers PATH aliases `thurbox` / `thurbox-cli` (no MSI; clean `winget uninstall`).
- **`packaging/winget/bump-manifests.py`** — sets `PackageVersion` across all three manifests + `InstallerUrl`/`InstallerSha256` (uppercased) + `ReleaseNotesUrl` from the release `checksums.txt`; fails loudly on a missing checksum/anchor. Tested end-to-end.
- **`cd.yml` `publish-winget` job** — on `windows-latest` after `publish`: bump manifests → download `wingetcreate` → `wingetcreate submit` a PR to `microsoft/winget-pkgs`. Gated on the `WINGET_TOKEN` secret (skipped when unset, like the choco/homebrew/AUR jobs).
- **Docs** — CLAUDE.md, `packaging/README.md`, top-level `README.md`, and the website (install tab, installation/faq pages, `llms.txt`).

## Chocolatey warning

Keeps the choco package but adds a **pending-moderation warning** to every user-facing install spot (README, website install tab, installation page), pointing users to winget / the PowerShell installer meanwhile.

## Follow-ups / notes

- **`WINGET_TOKEN` secret is configured** on the repo, so `publish-winget` fires on the next release.
- **PackageIdentifier is `Thurbeen.thurbox`** — case-sensitive and effectively permanent once the first winget-pkgs PR merges. Change now if `Thurbeen.Thurbox` is preferred.
- The first winget-pkgs submission still goes through their automated validation + sandbox install + human review before it's live.

## Test plan

- [x] `bump-manifests.py` verified against a sample `checksums.txt` (version/URL/sha/notes all updated; sha uppercased)
- [x] Manifests parse as valid YAML
- [x] `cd.yml` parses as valid YAML
- [x] Full pre-commit hook suite passes (rumdl, cargo-deny, cargo-doc, HTMLHint on the built site, cog verify)
- [x] Signed commit