### PR TITLE
fix(core): survive cramped layouts; add hermetic TUI test seams

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,30 @@ The TUI has two layers of end-to-end coverage:
   module). A `Harness` builds a real `App` on a no-op `StubBackend` +
   `Database::open_in_memory()` + a `TestPathGuard` tempdir (fully hermetic),
   feeds `AppMessage::KeyPress` events exactly as `main.rs`'s loop does, and
-  renders to a headless ratatui `TestBackend`. Stable screens (welcome state,
+  renders to a headless ratatui `TestBackend`. It also drives the loop's
+  **tick**: `App::tick` is split into a deterministic `tick_core` (status
+  derivation, timer expiry, search debounce, automation firing, external-change
+  polling — what `Harness::tick` runs, hermetic and runtime-free) and a
+  spawning `tick_background` (sysinfo/git/usage shell-outs, update checks —
+  `main` only). Wall-clock-gated behavior is fast-forwarded via
+  `Harness::advance` (the `app::clock` test clock — a thread-local offset every
+  UI-thread timer reads through), and agent output is injected per session via
+  `Harness::feed_output` (same vt100 + `TermSignals` path as the PTY reader),
+  so redraw detection, OSC title/bell signals, buffer-content search, and
+  terminal rendering are all testable. Stable screens (welcome state,
   F1 help, theme picker) are pinned with **`insta`** snapshots
   (`src/app/snapshots/`); dynamic flows (navigation, modals, panel toggles,
   quit) assert on `App` state instead, so live metrics/clock never make them
   flaky. Runs in the normal `cargo nextest --all` — no tmux/TTY needed. Update
   snapshots with `INSTA_UPDATE=always cargo test` (or `cargo insta review`).
+- **Invariant monkey test** (`monkey_random_events_uphold_invariants` in
+  `src/app/acceptance.rs`). Seeded pseudo-random event streams (keys, chords,
+  mouse, ticks, clock jumps, resizes, injected agent output) against the
+  harness, rendering after **every** step and checking `assert_invariants`
+  (selection indices in bounds, focus never on a hidden surface, panels never
+  outlive their feature flag). A failure prints the seed + step for exact
+  replay. When a "weird TUI behavior" reduces to a rule, add it to
+  `assert_invariants` and let the monkey hunt for a violating sequence.
 - **Black-box smoke test** (`scripts/dev/smoke/tui-smoke.sh`). Launches the real
   `thurbox` binary inside a throwaway tmux pane (isolated `HOME`/XDG/
   `TMUX_TMPDIR`, mirroring `scripts/demo/record.sh`), drives it with

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -684,12 +684,16 @@ impl Session {
     }
 
     pub fn resize(&self, rows: u16, cols: u16) {
+        // A cramped layout (tiny terminal + open panels/strips) can compute a
+        // zero-row/col content area; vt100's `set_size` underflows on 0 and
+        // tmux rejects it, so clamp at this boundary for every path below.
+        let (rows, cols) = (rows.max(1), cols.max(1));
         // A placeholder has no live pane; only resize its local notice buffer.
         // Talking to the (possibly-down) backend here would issue a blocking
         // ssh resize on the UI thread — the freeze we're avoiding.
         if self.placeholder {
             if let Ok(mut parser) = self.parser.lock() {
-                parser.screen_mut().set_size(rows.max(1), cols.max(1));
+                parser.screen_mut().set_size(rows, cols);
             }
             return;
         }
@@ -983,13 +987,23 @@ impl Session {
         provider: &Arc<dyn AgentProvider>,
     ) -> (Self, mpsc::Receiver<Vec<u8>>) {
         let (input_tx, input_rx) = mpsc::channel(INPUT_CHANNEL_CAPACITY);
+        // Wire TermSignals to the session's accessor cells exactly like
+        // `wire_up`, so bytes injected via `feed_output_for_test` drive
+        // `agent_title`/`needs_attention` the same way live PTY output does.
+        let last_title = Arc::new(Mutex::new(None));
+        let attention_at = Arc::new(AtomicU64::new(0));
+        let notification = Arc::new(Mutex::new(None));
         let session = Self {
             info: SessionInfo::new(name.to_string()),
             parser: Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
                 24,
                 80,
                 0,
-                TermSignals::default(),
+                TermSignals {
+                    title: Arc::clone(&last_title),
+                    attention_at: Arc::clone(&attention_at),
+                    notification: Arc::clone(&notification),
+                },
             ))),
             input_tx,
             backend_id: String::new(),
@@ -997,15 +1011,32 @@ impl Session {
             provider: Arc::clone(provider),
             exited: Arc::new(AtomicBool::new(false)),
             last_output_at: Arc::new(AtomicU64::new(now_millis())),
-            last_title: Arc::new(Mutex::new(None)),
-            attention_at: Arc::new(AtomicU64::new(0)),
-            notification: Arc::new(Mutex::new(None)),
+            last_title,
+            attention_at,
+            notification,
             attention_ack_at: 0,
             shell_pane: None,
             env: HashMap::new(),
             placeholder: false,
         };
         (session, input_rx)
+    }
+
+    /// Feed raw agent-output bytes into the session exactly as the reader loop
+    /// would: bump `last_output_at` and run the bytes through the vt100 parser
+    /// (firing `TermSignals` callbacks). This is the test seam for everything
+    /// downstream of PTY output — terminal rendering, the output-change redraw
+    /// detector, OSC title/bell signals, and buffer-content search.
+    #[cfg(test)]
+    pub fn feed_output_for_test(&self, bytes: &[u8]) {
+        // Strictly-increasing bump: two feeds within the same millisecond must
+        // still read as *new* output to `App::detect_output_redraw`'s signature.
+        let prev = self.last_output_at.load(Ordering::Relaxed);
+        self.last_output_at
+            .store(now_millis().max(prev + 1), Ordering::Relaxed);
+        if let Ok(mut p) = self.parser.lock() {
+            p.process(bytes);
+        }
     }
 }
 

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -2,17 +2,21 @@
 //!
 //! Where the focused unit tests in [`super::tests`] poke individual methods,
 //! these drive a *real* [`App`] the way `main.rs`'s loop does — feeding
-//! `update(AppMessage)` events and rendering `view(Frame)` to a headless
-//! ratatui [`TestBackend`]. (The loop's third step, `tick()`, is deliberately
-//! skipped: it spawns Tokio tasks and so needs a runtime these synchronous
-//! tests don't have; nothing under test here depends on it.) No TTY, tmux
-//! server, or agent process is involved:
+//! `update(AppMessage)` events, running the loop's deterministic tick half
+//! ([`App::tick_core`] via [`Harness::tick`]; the excluded `tick_background`
+//! spawns Tokio tasks that shell out), and rendering `view(Frame)` to a
+//! headless ratatui [`TestBackend`]. No TTY, tmux server, or agent process is
+//! involved:
 //!
 //! * sessions are inert [`Session::stub`]s on a no-op [`FakeBackend`],
 //! * the database is `Database::open_in_memory()`,
 //! * every config/data path is redirected to a throwaway tempdir via
 //!   [`crate::paths::TestPathGuard`], so the suite never touches the
-//!   developer's real `~/.config/thurbox`.
+//!   developer's real `~/.config/thurbox`,
+//! * agent output is injected per session with [`Harness::feed_output`]
+//!   (through the same vt100 parser + `TermSignals` path the PTY reader uses),
+//! * wall-clock-gated behavior (timeouts, debounces, the redraw floor) is
+//!   fast-forwarded with [`Harness::advance`] (see [`clock`]) — never slept.
 //!
 //! Stable, deterministic screens (the empty welcome state, the keybindings
 //! help overlay, the theme picker) are pinned with `insta` snapshots so a UI
@@ -20,6 +24,12 @@
 //! `INSTA_UPDATE=always cargo test`). Flows whose output depends on live
 //! metrics or wall-clock time are asserted on `App` *state* instead (modal
 //! kind, selection index, panel visibility, quit flag) to stay robust.
+//!
+//! Finally, [`monkey_random_events_uphold_invariants`] fuzzes the whole
+//! surface: thousands of seeded pseudo-random events (keys, chords, mouse,
+//! ticks, clock jumps, resizes, injected output) with [`assert_invariants`]
+//! checked after every step — the regression net for "weird TUI behavior"
+//! that no directed test anticipated.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -337,6 +347,42 @@ impl Harness {
             y: rect.y,
             modifiers: KeyModifiers::NONE,
         });
+        self
+    }
+
+    /// Run one deterministic tick — the third step of `main.rs`'s loop, minus
+    /// its background half ([`App::tick_core`]; the excluded
+    /// `tick_background` spawns Tokio tasks that shell out / hit the network).
+    /// This drives everything tick-dependent hermetically: status derivation,
+    /// timer expiry, the global-search debounce, automation firing, and the
+    /// external-change poll.
+    fn tick(&mut self) -> &mut Self {
+        self.app.tick_core();
+        self
+    }
+
+    /// Fast-forward the app's clock by `d` (see [`clock`]). Timers, debounces
+    /// and retry windows age deterministically — the next [`Self::tick`] (or
+    /// `should_redraw` check) observes the elapsed time without real waiting.
+    fn advance(&mut self, d: std::time::Duration) -> &mut Self {
+        clock::advance(d);
+        self
+    }
+
+    /// Feed raw agent-output bytes to session `idx`, exactly as its PTY reader
+    /// loop would — the seam for testing everything downstream of output:
+    /// terminal rendering, the output-change redraw detector, OSC
+    /// title/bell/notification signals, and buffer-content search.
+    fn feed_output(&mut self, idx: usize, bytes: &[u8]) -> &mut Self {
+        self.app.sessions[idx].feed_output_for_test(bytes);
+        self
+    }
+
+    /// Resize both the app (as the real loop would on a terminal resize) and
+    /// the headless backend, so subsequent renders draw at the new size.
+    fn resize(&mut self, cols: u16, rows: u16) -> &mut Self {
+        self.app.update(AppMessage::Resize(cols, rows));
+        self.terminal = Terminal::new(TestBackend::new(cols, rows)).unwrap();
         self
     }
 
@@ -2292,4 +2338,432 @@ fn remote_hook_event_dedupes_repeated_state() {
         first_at, second_at,
         "an identical re-report must not re-stamp state_at"
     );
+}
+
+// ── Tick-driven behavior: timers, debounce, redraw floor ─────────────────────
+//
+// These drive `App::tick_core` (the deterministic half of the event loop's
+// tick) with the clock fast-forwarded via `Harness::advance`, so every
+// wall-clock-gated behavior is asserted without sleeping.
+
+#[test]
+fn status_message_expires_after_timeout_via_tick() {
+    let mut h = Harness::standard(1);
+    h.app.set_status(StatusLevel::Info, "transient note");
+    assert!(h.app.status_message.is_some());
+
+    h.tick();
+    assert!(
+        h.app.status_message.is_some(),
+        "a fresh message survives a tick"
+    );
+
+    h.advance(STATUS_MESSAGE_TIMEOUT).tick();
+    assert!(
+        h.app.status_message.is_none(),
+        "the tick clears an expired status message"
+    );
+}
+
+#[test]
+fn pending_delete_finalizes_after_undo_window() {
+    let mut h = Harness::standard(2);
+    h.ctrl('d'); // DeleteSession (soft) — starts the undo window
+    assert!(h.app.pending_delete.is_some());
+
+    // Inside the window the delete stays pending (undoable).
+    h.advance(UNDO_TIMEOUT - std::time::Duration::from_secs(1))
+        .tick();
+    assert!(
+        h.app.pending_delete.is_some(),
+        "still undoable inside the window"
+    );
+
+    h.advance(std::time::Duration::from_secs(2)).tick();
+    assert!(
+        h.app.pending_delete.is_none(),
+        "the expired window finalizes the delete"
+    );
+
+    h.ctrl('z'); // UndoDelete — too late now
+    assert_eq!(
+        h.app.sessions.len(),
+        1,
+        "a finalized delete can no longer be undone"
+    );
+}
+
+#[test]
+fn global_search_content_scan_waits_for_debounce() {
+    let mut h = Harness::standard(2);
+    h.feed_output(1, b"a unique zebra-crossing appears\r\n");
+
+    h.ctrl('/'); // GlobalSearch
+    for c in "zebra".chars() {
+        h.key(KeyCode::Char(c), KeyModifiers::NONE);
+    }
+    let content_hit = |app: &App| {
+        app.global_search
+            .results
+            .iter()
+            .any(|r| r.kind == search::SearchKind::Session && r.snippet.is_some())
+    };
+
+    h.tick();
+    assert!(
+        !content_hit(&h.app),
+        "the expensive buffer scan is debounced — no content hit immediately"
+    );
+    assert!(h.app.global_search.content_dirty, "a scan is pending");
+
+    h.advance(std::time::Duration::from_millis(
+        search::CONTENT_DEBOUNCE_MS + 10,
+    ))
+    .tick();
+    assert!(
+        content_hit(&h.app),
+        "once the query settles, the tick scans session buffers"
+    );
+    assert!(!h.app.global_search.content_dirty);
+}
+
+#[test]
+fn forced_redraw_floor_repaints_after_interval() {
+    let mut h = Harness::standard(1);
+    h.app.mark_redrawn();
+    assert!(
+        !h.app.should_redraw(),
+        "clean state right after a paint — no redraw needed"
+    );
+
+    h.advance(FORCE_REDRAW_INTERVAL);
+    assert!(
+        h.app.should_redraw(),
+        "the forced-redraw floor repaints time-driven UI"
+    );
+}
+
+// ── Regressions the monkey test originally caught ────────────────────────────
+
+#[test]
+fn global_search_on_short_terminal_does_not_panic_session_resize() {
+    // The search strip + footer can eat a short terminal's entire height,
+    // producing a zero-row content area. `Session::resize` must clamp before
+    // vt100's `set_size` (which underflows on 0) — this panicked pre-clamp.
+    let mut h = Harness::new(30, 8, 1);
+    h.render();
+    h.ctrl('/'); // GlobalSearch — resizes sessions to the shrunken content area
+    h.render();
+    assert!(h.app.global_search.active);
+}
+
+#[test]
+fn narrow_resize_rescues_task_editor_focus() {
+    // Shrinking below 120 cols hides the tasks panel; focus must leave the
+    // *editor* too, or it keeps capturing every key for an invisible surface.
+    let mut h = Harness::standard(1);
+    h.ctrl('w'); // FocusTasks
+    h.key(KeyCode::Char('n'), KeyModifiers::NONE); // new task → TaskEditor
+    assert!(matches!(h.app.focus, InputFocus::TaskEditor));
+
+    h.resize(100, 40);
+    assert!(!h.app.show_tasks_panel, "narrow layout hides the panel");
+    assert!(
+        matches!(h.app.focus, InputFocus::SessionList),
+        "focus is rescued off the hidden panel's editor"
+    );
+    h.render();
+}
+
+// ── Injected agent output: the PTY seam ──────────────────────────────────────
+
+#[test]
+fn injected_output_marks_redraw_and_renders() {
+    let mut h = Harness::standard(1);
+    // Sync the output-change detector, then settle to a clean state.
+    h.app.detect_output_redraw();
+    h.app.mark_redrawn();
+    h.app.detect_output_redraw();
+    assert!(!h.app.should_redraw(), "no new output ⇒ no repaint");
+
+    h.feed_output(0, b"MARKER-7f3a output line\r\n");
+    h.app.detect_output_redraw();
+    assert!(h.app.should_redraw(), "new output marks the UI dirty");
+
+    let screen = h.render();
+    assert!(
+        screen.contains("MARKER-7f3a"),
+        "injected output reaches the rendered terminal pane:\n{screen}"
+    );
+}
+
+#[test]
+fn osc_title_and_bell_reach_the_session() {
+    let mut h = Harness::standard(1);
+
+    h.feed_output(0, b"\x1b]0;Reticulating splines\x07");
+    assert_eq!(
+        h.app.sessions[0].agent_title().as_deref(),
+        Some("Reticulating splines"),
+        "an OSC 0 title lands in the session's activity text"
+    );
+
+    assert!(!h.app.sessions[0].needs_attention());
+    h.feed_output(0, b"\x07");
+    assert!(
+        h.app.sessions[0].needs_attention(),
+        "a BEL raises the attention flag"
+    );
+}
+
+#[test]
+fn split_utf8_output_chunks_render_intact() {
+    // The reader loop protects vt100 from mid-codepoint chunks with a carry
+    // buffer; `feed_output` bypasses the reader, so this documents that a test
+    // feeding whole-codepoint chunks renders multi-byte text correctly (the
+    // carry logic itself is unit-tested via `utf8_ready_prefix_len`).
+    let mut h = Harness::standard(1);
+    h.feed_output(0, "boîte — ünïcode ✓\r\n".as_bytes());
+    let screen = h.render();
+    assert!(
+        screen.contains("boîte — ünïcode ✓"),
+        "multi-byte output renders intact:\n{screen}"
+    );
+}
+
+// ── Invariant tripwires + deterministic monkey test ──────────────────────────
+
+/// Structural invariants that must hold after *any* event, in any order. The
+/// monkey test checks these after every step; when a "weird TUI behavior" is
+/// reduced to a rule ("focus never rests on a hidden pane"), add it here and
+/// the monkey hunts for a sequence that breaks it.
+fn assert_invariants(app: &App, ctx: &str) {
+    assert!(
+        app.sessions.is_empty() || app.active_index < app.sessions.len(),
+        "[{ctx}] active_index {} out of bounds ({} sessions)",
+        app.active_index,
+        app.sessions.len()
+    );
+    assert!(
+        app.task_ui.filtered_task_indices.is_empty()
+            || app.task_ui.task_panel_index < app.task_ui.filtered_task_indices.len(),
+        "[{ctx}] task panel selection out of bounds"
+    );
+    assert!(
+        app.automation_ui.cached_automations.is_empty()
+            || app.automation_ui.automation_panel_index
+                < app.automation_ui.cached_automations.len(),
+        "[{ctx}] automation pane selection out of bounds"
+    );
+
+    // Panel visibility never outlives its feature flag.
+    assert!(
+        !app.show_tasks_panel || app.features.tasks,
+        "[{ctx}] tasks panel shown with the feature disabled"
+    );
+    assert!(
+        !app.show_file_viewer || app.features.file_viewer,
+        "[{ctx}] file viewer shown with the feature disabled"
+    );
+
+    // Focus only ever rests on a surface that exists.
+    match app.focus {
+        InputFocus::TaskList | InputFocus::TaskEditor => assert!(
+            app.features.tasks && app.show_tasks_panel,
+            "[{ctx}] focus {:?} but the tasks panel is hidden",
+            app.focus
+        ),
+        InputFocus::FileViewer => assert!(
+            app.show_file_viewer,
+            "[{ctx}] focus on a hidden file viewer"
+        ),
+        InputFocus::GlobalSearch => assert!(
+            app.global_search.active,
+            "[{ctx}] focus on a closed search strip"
+        ),
+        InputFocus::CodeReview | InputFocus::ReviewFiles => {
+            assert!(
+                app.features.code_review,
+                "[{ctx}] review focus with the feature disabled"
+            );
+            assert!(
+                app.active_review().is_some(),
+                "[{ctx}] focus {:?} but the active session has no open review",
+                app.focus
+            );
+        }
+        InputFocus::Automations
+        | InputFocus::AutomationEditor
+        | InputFocus::AutomationRunHistory => assert!(
+            app.features.automations,
+            "[{ctx}] automations focus with the feature disabled"
+        ),
+        InputFocus::SessionList | InputFocus::Terminal => {}
+    }
+
+    if app.global_search.active {
+        assert!(
+            app.features.global_search,
+            "[{ctx}] search strip active with the feature disabled"
+        );
+    }
+}
+
+/// Deterministic pseudo-random stream (an LCG — no dev-dependency, and a
+/// failing seed reproduces exactly).
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0 >> 33
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+/// `Ctrl` chords the monkey may press. Excluded on purpose:
+/// `n` (repo picker `Enter` can reach real-git branch listing on the dev
+/// machine), `o` (spawns `$EDITOR`), `v` (reads the system clipboard),
+/// `q` (quit is a terminal state with nothing to fuzz behind it).
+const MONKEY_CTRL: &[char] = &[
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'p', 'r', 's', 't', 'u', 'w', 'x', 'y',
+    'z', '/', ',',
+];
+
+/// Plain (unmodified) keys the monkey may press: pane-scoped letters, digits,
+/// and the structural navigation/editing keys.
+const MONKEY_KEYS: &[KeyCode] = &[
+    KeyCode::Char('j'),
+    KeyCode::Char('k'),
+    KeyCode::Char('h'),
+    KeyCode::Char('l'),
+    KeyCode::Char('g'),
+    KeyCode::Char('r'),
+    KeyCode::Char('d'),
+    KeyCode::Char('e'),
+    KeyCode::Char('n'),
+    KeyCode::Char('s'),
+    KeyCode::Char('w'),
+    KeyCode::Char('y'),
+    KeyCode::Char('/'),
+    KeyCode::Char(' '),
+    KeyCode::Char('1'),
+    KeyCode::Char('9'),
+    KeyCode::Esc,
+    KeyCode::Enter,
+    KeyCode::Tab,
+    KeyCode::Backspace,
+    KeyCode::Up,
+    KeyCode::Down,
+    KeyCode::Left,
+    KeyCode::Right,
+    KeyCode::PageUp,
+    KeyCode::PageDown,
+    KeyCode::Home,
+    KeyCode::End,
+];
+
+/// Realistic agent-output chunks: plain text, SGR colour, OSC title, BEL,
+/// OSC 9 notification, unicode, screen clears, and alt-screen flips.
+const MONKEY_OUTPUT: &[&[u8]] = &[
+    b"compiling foo v0.1.0\r\n",
+    b"\x1b[31merror\x1b[0m: something\r\n",
+    b"\x1b]0;Agent thinking\x07",
+    b"\x07",
+    b"\x1b]9;needs input\x07",
+    "héllo wörld — \u{2714}\r\n".as_bytes(),
+    b"\x1b[2J\x1b[H",
+    b"\x1b[?1049h",
+    b"\x1b[?1049l",
+];
+
+/// Monkey test: drive a real `App` with thousands of pseudo-random events —
+/// keys, chords, ticks, clock jumps, resizes, mouse, and injected agent
+/// output — rendering after every step and asserting [`assert_invariants`].
+/// This is the net for "weird TUI behavior": any panic (in update *or* view)
+/// or invariant violation fails with the seed + step for exact replay.
+/// Tokio flavor: spawn-adjacent flows (fork/restart on the inert backend) may
+/// touch the runtime before erroring.
+#[tokio::test]
+async fn monkey_random_events_uphold_invariants() {
+    for seed in [0xDEADBEEFu64, 42, 20260707] {
+        let mut rng = Rng(seed);
+        let mut h = Harness::standard(3);
+        h.render();
+
+        for step in 0..2500 {
+            let ctx = format!("seed {seed:#x} step {step}");
+            match rng.below(100) {
+                // Plain keys: letters, digits, and structural keys.
+                0..=39 => {
+                    let code = MONKEY_KEYS[rng.below(MONKEY_KEYS.len())];
+                    h.key(code, KeyModifiers::NONE);
+                }
+                // Ctrl chords (thurbox's global namespace).
+                40..=59 => {
+                    let c = MONKEY_CTRL[rng.below(MONKEY_CTRL.len())];
+                    h.ctrl(c);
+                }
+                // Shift chords (reorder/sort) and F-keys.
+                60..=69 => {
+                    if rng.below(2) == 0 {
+                        let c = ['j', 'k', 's', 'd'][rng.below(4)];
+                        h.shift(c);
+                    } else {
+                        h.func((rng.below(8) + 1) as u8);
+                    }
+                }
+                // Deterministic tick, sometimes after a clock jump.
+                70..=79 => {
+                    if rng.below(2) == 0 {
+                        let ms = [50, 200, 1_000, 5_000, 11_000][rng.below(5)];
+                        h.advance(std::time::Duration::from_millis(ms));
+                    }
+                    h.tick();
+                }
+                // Mouse: click / scroll / move at a random point.
+                80..=89 => {
+                    let size = *h.terminal.backend().buffer().area();
+                    let x = (rng.below(size.width.max(1) as usize)) as u16;
+                    let y = (rng.below(size.height.max(1) as usize)) as u16;
+                    let msg = match rng.below(4) {
+                        0 => AppMessage::MouseClick {
+                            x,
+                            y,
+                            modifiers: KeyModifiers::NONE,
+                        },
+                        1 => AppMessage::MouseScrollUp { x, y },
+                        2 => AppMessage::MouseScrollDown { x, y },
+                        _ => AppMessage::MouseMove { x, y },
+                    };
+                    h.app.update(msg);
+                }
+                // Agent output into a random session.
+                90..=94 => {
+                    if !h.app.sessions.is_empty() {
+                        let idx = rng.below(h.app.sessions.len());
+                        let chunk = MONKEY_OUTPUT[rng.below(MONKEY_OUTPUT.len())];
+                        h.feed_output(idx, chunk);
+                        h.app.detect_output_redraw();
+                    }
+                }
+                // Resize, including below the 80/120 layout breakpoints.
+                _ => {
+                    let cols = (20 + rng.below(160)) as u16;
+                    let rows = (8 + rng.below(43)) as u16;
+                    h.resize(cols, rows);
+                }
+            }
+
+            // Render every step: a draw panic (layout overflow, index OOB in a
+            // widget) is as much a bug as an update panic.
+            h.render();
+            assert_invariants(&h.app, &ctx);
+        }
+    }
 }

--- a/src/app/clock.rs
+++ b/src/app/clock.rs
@@ -1,0 +1,67 @@
+//! Monotonic "now" for the app layer's timers, fast-forwardable in tests.
+//!
+//! Every wall-clock comparison the TUI makes on the UI thread (status-message
+//! expiry, the delete-undo window, the forced-redraw floor, the global-search
+//! debounce, remote-reconnect retry pacing) reads time through [`now`] instead
+//! of `Instant::now()`. In a normal build [`now`] *is* `Instant::now()`; under
+//! `cfg(test)` it adds a thread-local offset that [`advance`] grows, so a test
+//! can jump past any timeout deterministically — no sleeping, no flakes.
+//!
+//! The offset is thread-local because the `App` runs single-threaded (the main
+//! event loop, or a test body / current-thread Tokio runtime): timestamps are
+//! only ever taken *and* compared on that one thread. Background threads keep
+//! their own time bases (`now_millis` in the agent layer) and are unaffected.
+
+use std::time::{Duration, Instant};
+
+#[cfg(test)]
+use std::cell::Cell;
+
+#[cfg(test)]
+thread_local! {
+    static TEST_OFFSET: Cell<Duration> = const { Cell::new(Duration::ZERO) };
+}
+
+/// The app layer's monotonic clock. Equals `Instant::now()` in production;
+/// in tests it is shifted forward by whatever [`advance`] has accumulated on
+/// the current thread.
+pub(crate) fn now() -> Instant {
+    #[cfg(test)]
+    {
+        Instant::now() + TEST_OFFSET.with(Cell::get)
+    }
+    #[cfg(not(test))]
+    {
+        Instant::now()
+    }
+}
+
+/// How long ago `t` was on this clock — the [`now`]-based replacement for
+/// `t.elapsed()`. Saturates to zero if `t` is in the future (a timestamp taken
+/// after the offset grew).
+pub(crate) fn elapsed_since(t: Instant) -> Duration {
+    now().saturating_duration_since(t)
+}
+
+/// Fast-forward the current thread's clock by `d`. Timestamps taken via
+/// [`now`] before the call age by `d` relative to ones taken after, so an
+/// `elapsed >= TIMEOUT` guard trips without real waiting.
+#[cfg(test)]
+pub(crate) fn advance(d: Duration) {
+    TEST_OFFSET.with(|o| o.set(o.get() + d));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advance_ages_prior_timestamps() {
+        let t0 = now();
+        advance(Duration::from_secs(30));
+        let elapsed = elapsed_since(t0);
+        assert!(elapsed >= Duration::from_secs(30));
+        // Well under a real 31 s: proves no actual sleeping happened.
+        assert!(elapsed < Duration::from_secs(31));
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,7 @@
 mod automation;
 mod automation_state;
 mod background;
+pub(crate) mod clock;
 pub(crate) mod code_review;
 mod config_reload;
 mod helpers;
@@ -1012,7 +1013,7 @@ impl App {
             cached_hook_states: HashMap::new(),
             pending_remote_hook_events: Vec::new(),
             hook_states_version: None,
-            last_draw_at: std::time::Instant::now(),
+            last_draw_at: clock::now(),
             last_output_gen: 0,
             cached_session_order: None,
         };
@@ -1716,7 +1717,7 @@ impl App {
             self.pending_delete = Some(PendingDelete {
                 session: removed,
                 session_id,
-                created_at: std::time::Instant::now(),
+                created_at: clock::now(),
             });
             self.set_status(
                 StatusLevel::Info,
@@ -1765,7 +1766,7 @@ impl App {
         self.pending_delete = Some(PendingDelete {
             session: removed_session,
             session_id,
-            created_at: std::time::Instant::now(),
+            created_at: clock::now(),
         });
 
         self.set_status(
@@ -3858,7 +3859,9 @@ impl App {
         if cols < 120 {
             self.show_info_panel = false;
             self.show_tasks_panel = false;
-            if self.focus == InputFocus::TaskList {
+            // Rescue the editor too, not just the list — otherwise focus stays
+            // on the hidden panel's editor, which keeps capturing every key.
+            if matches!(self.focus, InputFocus::TaskList | InputFocus::TaskEditor) {
                 self.focus = InputFocus::SessionList;
             }
         }
@@ -3875,6 +3878,17 @@ impl App {
     }
 
     pub fn tick(&mut self) {
+        self.tick_core();
+        self.tick_background();
+    }
+
+    /// The deterministic half of [`Self::tick`]: everything that only reads
+    /// state, polls already-running work, or writes through the in-process DB —
+    /// no Tokio task is ever spawned here. Split out so the acceptance harness
+    /// can drive the tick pipeline (status derivation, timer expiry, search
+    /// debounce, automation firing, external-change polling) hermetically and
+    /// without a runtime; `main`'s loop always runs both halves via `tick()`.
+    pub(crate) fn tick_core(&mut self) {
         self.metrics.tick_count = self.metrics.tick_count.wrapping_add(1);
 
         self.tick_global_search_content();
@@ -3916,7 +3930,14 @@ impl App {
             self.refresh_automations();
             self.refresh_tasks();
         }
+    }
 
+    /// The spawning half of [`Self::tick`]: kicks off background refreshes
+    /// (sysinfo/git/usage shell-outs), the opt-in update check, and the
+    /// auto-updater — each lands on a Tokio task. Kept out of
+    /// [`Self::tick_core`] so tests driving the tick pipeline never touch the
+    /// network, the filesystem outside the harness tempdir, or a runtime.
+    fn tick_background(&mut self) {
         self.tick_background_refreshes();
 
         self.tick_version_check();
@@ -3943,14 +3964,14 @@ impl App {
     /// elapsed (so time-driven UI — clock, metrics, cursor blink, quiet-session
     /// status transitions — still refreshes without an explicit dirty flag).
     pub fn should_redraw(&self) -> bool {
-        self.needs_redraw || self.last_draw_at.elapsed() >= FORCE_REDRAW_INTERVAL
+        self.needs_redraw || clock::elapsed_since(self.last_draw_at) >= FORCE_REDRAW_INTERVAL
     }
 
     /// Record that a frame was just painted: clear the dirty flag, reset the
     /// forced-redraw timer, and count the requested redraw.
     pub fn mark_redrawn(&mut self) {
         self.needs_redraw = false;
-        self.last_draw_at = std::time::Instant::now();
+        self.last_draw_at = clock::now();
         self.metrics.bump(|p| &mut p.redraws_requested);
     }
 
@@ -4026,14 +4047,14 @@ impl App {
     fn tick_expire_timers(&mut self) {
         // Finalize pending delete after undo timeout
         if let Some(ref pending) = self.pending_delete {
-            if pending.created_at.elapsed() >= UNDO_TIMEOUT {
+            if clock::elapsed_since(pending.created_at) >= UNDO_TIMEOUT {
                 self.finalize_pending_delete();
             }
         }
 
         // Auto-expire status messages so default project/session counts reappear
         if let Some(ref msg) = self.status_message {
-            if msg.created_at.elapsed() >= STATUS_MESSAGE_TIMEOUT {
+            if clock::elapsed_since(msg.created_at) >= STATUS_MESSAGE_TIMEOUT {
                 self.status_message = None;
             }
         }
@@ -4181,7 +4202,7 @@ impl App {
             .filter(|(_, events)| !events.is_empty())
             .collect();
         // Older pending retries first, so per-pane event order is preserved.
-        let now = std::time::Instant::now();
+        let now = clock::now();
         let mut queue = std::mem::take(&mut self.pending_remote_hook_events);
         for (backend_name, events) in batches {
             for (pane_id, state) in events {
@@ -4330,7 +4351,7 @@ impl App {
             return;
         };
         let active_index = self.active_index;
-        let now = std::time::Instant::now();
+        let now = clock::now();
         for (idx, session) in self.sessions.iter().enumerate() {
             let id = session.info.id;
             let status = session.info.status;
@@ -4997,7 +5018,7 @@ impl App {
         self.status_message = Some(StatusMessage {
             text: text.into(),
             level,
-            created_at: std::time::Instant::now(),
+            created_at: clock::now(),
         });
     }
 
@@ -5153,8 +5174,7 @@ impl App {
                 .push(shared);
         }
 
-        let mut restore =
-            RemoteRestore::new(perf_log, std::time::Instant::now() + REMOTE_RETRY_INTERVAL);
+        let mut restore = RemoteRestore::new(perf_log, clock::now() + REMOTE_RETRY_INTERVAL);
         for (backend_type, sessions) in grouped {
             // Always show the session, even before (or without) a live host:
             // insert a placeholder row up front so it never silently vanishes.
@@ -5298,7 +5318,7 @@ impl App {
         if self.resolve_persisted_backend(&backend_type).is_none() {
             return;
         }
-        let now = std::time::Instant::now();
+        let now = clock::now();
         if self.remote_restore.is_none() {
             // Reconnect as soon as the next tick, not after the retry interval.
             self.remote_restore = Some(RemoteRestore::new(false, now));
@@ -5364,7 +5384,7 @@ impl App {
     /// [`REMOTE_RETRY_INTERVAL`] has elapsed, so a recovered host auto-adopts its
     /// placeholder sessions without a restart.
     fn maybe_retry_remote_restore(&mut self) {
-        let now = std::time::Instant::now();
+        let now = clock::now();
         if !self
             .remote_restore
             .as_ref()
@@ -5404,7 +5424,7 @@ impl App {
     fn retry_remote_backend_now(&mut self, backend_type: &str) {
         if let Some(s) = self.remote_restore.as_mut() {
             if s.pending.contains_key(backend_type) {
-                s.next_retry_at = std::time::Instant::now();
+                s.next_retry_at = clock::now();
             }
         }
     }

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use super::modals::TextInput;
-use super::{App, InputFocus};
+use super::{clock, App, InputFocus};
 use crossterm::event::{KeyCode, KeyModifiers};
 
 /// Max results kept per group (sessions/tasks/automations/files), so a broad
@@ -169,7 +169,7 @@ impl App {
         self.recompute_global_search_metadata();
         self.preview_global_search_result();
         self.global_search.content_dirty = true;
-        self.global_search.query_changed_at = Some(Instant::now());
+        self.global_search.query_changed_at = Some(clock::now());
     }
 
     /// Rebuild the metadata results (sessions/tasks/automations/files) — fast
@@ -534,7 +534,7 @@ impl App {
         let settled = self
             .global_search
             .query_changed_at
-            .map(|t| t.elapsed() >= Duration::from_millis(CONTENT_DEBOUNCE_MS))
+            .map(|t| clock::elapsed_since(t) >= Duration::from_millis(CONTENT_DEBOUNCE_MS))
             .unwrap_or(false);
         if settled {
             self.recompute_global_search_content();


### PR DESCRIPTION
## Summary

- Fixes two TUI bugs caught by the new invariant monkey test: `Session::resize` clamps rows/cols to ≥ 1 (vt100 `set_size` underflow panic when e.g. global search opens on a short terminal), and a narrow resize now rescues `TaskEditor` focus off the hidden tasks panel (it previously kept capturing every key).
- Makes the TUI's tick pipeline testable: `App::tick` splits into a deterministic `tick_core` (drivable hermetically by the acceptance harness) and a spawning `tick_background`; a new test-advanceable `app::clock` backs every UI-thread timer (undo window, status expiry, redraw floor, search debounce, remote retry) so timeouts are tested without sleeping.
- Adds agent-output injection (`Session::feed_output_for_test` through the real vt100/`TermSignals` path, with the stub's signals now wired), harness `tick`/`advance`/`feed_output`/`resize` helpers, directed tests for tick/debounce/output behavior, and a seeded random-event monkey test asserting structural invariants (indices in bounds, focus never on a hidden surface) after every step.

## Test plan

- CI checks pass
- `cargo nextest run --all` (1780 tests, includes the new monkey + regression tests)