### PR TITLE
perf: runtime perf observability + startup/interactive-stall optimizations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -729,7 +729,9 @@ release — `--force` bypasses the up-to-date/dev-build guards; gated on
 `[features] auto_update`, off by default; the TUI also runs this silently on
 startup when the flag is on), `notify`
 (diagnose OS desktop notifications: prints the detected delivery backend
-and last error; `--test` fires a sample — see OS notifications below).
+and last error; `--test` fires a sample — see OS notifications below), `perf`
+(print the perf snapshot a running TUI publishes while `THURBOX_PERF_LOG`
+or its perf HUD is active — see `docs/PERFORMANCE.md`).
 Output is
 **human-readable by default** and switches to JSON automatically when stdout is
 piped (so `… | jq` keeps working); force a format with `--json` (compact),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1677,10 +1677,14 @@ code_review`.
   `y` copies the review as markdown to the clipboard, and `e` (Send→Agent) pastes
   the compiled review into the session's agent as a prompt to address it — the
   review → agent → re-review loop, the orchestrator-native equivalent of submit.
+- **Async diff build.** Opening/retargeting a review runs its git pipeline
+  (base resolution, commit listing, the diffs — over SSH for a remote session)
+  on a background worker with a "Building diff…" loading state, applied by
+  `App::poll_review_build` per tick — the pane opens instantly (ADR-P8,
+  `docs/PERFORMANCE.md`).
 - **v1 follow-ups** (named, not silently dropped): range/multi-line comments,
   token-level intra-line word diffs on a paired row (v1 aligns whole lines
-  positionally, not sub-line), async diff build for
-  huge repos (v1 builds synchronously on toggle), grammar-aware syntax
+  positionally, not sub-line), grammar-aware syntax
   highlighting (v1's lexer is heuristic + language-agnostic), horizontal
   scroll in the **side-by-side** layout (wrap now works there; paired rows still
   pin `h_scroll = 0`), per-side search-match highlighting in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,11 +140,18 @@ covers time-driven UI (clock/metrics/cursor blink). Idle paints drop ~100 fps �
 keyed by a content signature (`App::session_order_signature`), rebuilt only when
 its grouping/nesting inputs change. The per-tick session-status read is likewise
 cached (`App::cached_hook_states`), reloaded only when `PRAGMA data_version`
-moves — so an idle `tick` no longer rescans the `sessions` table (ADR-P6). Launch
-with `THURBOX_PERF_LOG=1` to log a `startup` line (phase breakdown +
-`first_frame_ms`, plus `restore_discover`/`restore_adopt`/`adopt_split`) to
-`thurbox.log`. Full rationale + intentionally-skipped optimizations:
-`docs/PERFORMANCE.md`.
+moves — so an idle `tick` no longer rescans the `sessions` table (ADR-P6), with
+the `PRAGMA` itself throttled to ~100 ms and the per-session OSC title/
+notification re-read gated on a reader-thread generation counter (ADR-P10).
+Restore prefetches all history captures in parallel (ADR-P9) and code-review
+diffs build off the UI thread with a loading state (ADR-P8). **Observability**:
+`F12` toggles a live perf HUD (counters + frame/tick percentiles + slow ops;
+`[features] perf_hud`); launching with `THURBOX_PERF_LOG=1` logs a `startup`
+line (phase breakdown + `first_frame_ms`, plus `restore_discover`/
+`restore_adopt`/`adopt_split`/`restore_capture_prefetch`), steady-state
+`perf_window` lines (~10 s), and `slow op` warnings to `thurbox.log`; while
+either is active the TUI publishes a JSON snapshot read by `thurbox-cli perf`.
+Full rationale + intentionally-skipped optimizations: `docs/PERFORMANCE.md`.
 
 ### Windows test environment (VM)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1953,6 +1953,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+,` / `F6` | Settings panel (edit settings.toml) | **,** = preferences |
 | `Ctrl+B` / `F2` | Toggle info panel (visible at width >= 120) | Info **b**ox |
 | `Ctrl+E` / `F3` | Toggle file viewer | **E**xplore files |
+| `F12` | Toggle perf HUD (live counters + frame/tick timing) | Diagnostics |
 | `F1` / `Ctrl+G` | Keybindings help + interactive editor | Universal |
 
 List contexts use plain `j`/`k`/`Enter` for navigation.

--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ repos? Add `--add-repo PATH@main` (its own worktree per repo) or
 | `F1` / `Ctrl+G` | Keybindings help + interactive editor | Universal |
 | `Ctrl+B` / `F2` | Toggle info panel | **B**rief |
 | `Ctrl+E` / `F3` | Toggle file viewer | **E**xplorer |
+| `F12` | Toggle perf HUD (live counters + frame/tick timing) | Diagnostics |
 
 Every chord above is rebindable from the `F1` editor (or by editing
 `~/.config/thurbox/keybindings.json`). `Shift+J`/`Shift+K`/`Shift+S`

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -27,7 +27,7 @@ development checkout never touches your real setup.
 the TUI polls their mtime (~1/s) and applies edits with a confirmation
 toast — no restart. For `settings.toml` only the **feature flags that
 gate UI panels** (`tasks`, `file_viewer`, `info_panel`, `global_search`,
-`shell_pane`, `code_review`, `soft_delete`) apply live; the restart-only values stay
+`shell_pane`, `code_review`, `perf_hud`, `soft_delete`) apply live; the restart-only values stay
 published through a write-once global (so they can't drift mid-frame),
 and the reload toast says when a restart is needed. `hosts.toml` (SSH
 backends register at startup) and `themes.toml` need a restart.
@@ -193,8 +193,10 @@ global_search = true
 info_panel    = true
 shell_pane    = true
 code_review   = true
+perf_hud      = true
 mouse         = true
 notifications = true
+soft_delete   = true
 version_check = false          # opt-in: makes a network call
 auto_update   = false          # opt-in: downloads + replaces binaries
 
@@ -211,7 +213,7 @@ Turn major TUI features off entirely. All default to `true` **except
 `version_check` and `auto_update`, which default to `false`** (both
 reach the network, so they are opt-in). The UI-panel flags
 (`tasks`, `file_viewer`, `info_panel`, `global_search`, `shell_pane`,
-`code_review`, `soft_delete`) apply **live** on save; the rest
+`code_review`, `perf_hud`, `soft_delete`) apply **live** on save; the rest
 (`automations`, `mouse`, `notifications`, `version_check`, `auto_update`)
 take effect on the next launch.
 A disabled feature's pane never renders, its keybinding shows
@@ -227,6 +229,7 @@ no results. Data is never touched, so re-enabling a flag is lossless.
 | `info_panel` | `true` | info panel column (`F2`) |
 | `shell_pane` | `true` | per-session shell toggle (`Ctrl+T`) |
 | `code_review` | `true` | native code-review view (diff + comments, `Ctrl+X`) |
+| `perf_hud` | `true` | perf HUD overlay (`F12`): live perf counters + frame/tick timing (see `docs/PERFORMANCE.md`) |
 | `mouse` | `true` | mouse capture: clicks, wheel, drag-select, hover, scrollbars |
 | `notifications` | `true` | OS desktop notifications when a session needs attention |
 | `soft_delete` | `true` | TUI `Ctrl+D` soft-deletes (Ctrl+Z undo); off = hard delete after a confirmation prompt |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -615,6 +615,7 @@ Live in the `metadata` table and apply immediately (no restart):
 | `editor_command` | `thurbox-cli editor set "<cmd>"` | what `Ctrl+O` runs |
 | `active_extensions` | `thurbox-cli extension activate/deactivate` | JSON array of active extensions to self-heal |
 | `builtin_hooks_optout` | `thurbox-cli extension deactivate hooks` | `1` when the user opted out of the auto-activated hooks extension |
+| `perf_snapshot` | the TUI, while perf timing is active (`THURBOX_PERF_LOG` or an open perf HUD) | JSON perf snapshot read by `thurbox-cli perf` (see `docs/PERFORMANCE.md`) |
 
 These are in the DB rather than a file because they are written
 concurrently by multiple thurbox processes (TUI, CLI, MCP) and picked

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -627,6 +627,7 @@ User-set (read by thurbox):
 | `VISUAL`, then `EDITOR` | `Ctrl+O` editor when `editor_command` is unset |
 | `SHELL` | the `Ctrl+T` companion shell pane (fallback `/bin/sh`). For a remote/WSL session the pane uses the **host's** `$SHELL` as an interactive login shell (the SSH-login environment), not the local one. |
 | `RUST_LOG` | log filter for `thurbox.log` |
+| `THURBOX_PERF_LOG` | opt-in performance logging: a one-shot `startup` phase breakdown at first paint, per-session `restore_adopt`/`adopt_split` lines, steady-state `perf_window` lines (~10 s cadence), and wall-clock frame/tick timing collection. Any value enables it. See `docs/PERFORMANCE.md`. |
 | `THURBOX_SOCKET` | overrides the **local** multiplexer socket name (default `thurbox`; dev builds `thurbox-dev`). For test/sandbox tooling: Unix scoping uses `TMUX_TMPDIR`, but psmux (Windows) resolves every `-L <name>` machine-wide, so this is the only way to fully scope an instance there. Remote hosts are unaffected (socket from `hosts.toml`). Empty = unset. |
 
 Set **by** thurbox into every spawned agent process (not user-set;

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -170,10 +170,13 @@ won't pay off.
   `startup …` line to `~/.local/share/thurbox/thurbox.log` with a **phase
   breakdown** that sums to roughly `first_frame_ms` —
   `config_init_ms` (config-file loads + local backend ready), `db_open_ms`,
+  `theme_activate_ms` (persisted-theme lookup + custom-theme publish),
   `extension_heal_ms` (self-heal + built-in hooks wiring + agents reload),
+  `app_new_ms` (`App::new`: keybindings load, settings snapshot, channels),
   `restore_ms` (the synchronous local-session restore — remote backends restore
-  on background threads, off this phase; see ADR-P7), and `first_frame_ms`
-  (total to first paint).
+  on background threads, off this phase; see ADR-P7), `heartbeat_ms` (arming
+  the automation-heartbeat tmux window), and `first_frame_ms` (total to first
+  paint).
   When restore is the long pole, the same flag also emits per-backend
   `restore_discover` lines (`discover_ms`; for a remote backend the line comes
   from its background thread) and per-session `restore_adopt` lines
@@ -300,12 +303,60 @@ already brought up and is cheap on the main thread.
 
 ---
 
+## ADR-P11: Runtime observability — timing histograms, slow ops, perf window
+
+**Choice**: The deterministic counters (ADR-P2) now have a **runtime
+observability layer** on top — wall-clock stats that are **display/logging
+only** and never CI-asserted (the counters remain the sole regression gate):
+
+- `App::perf_counters()` is a runtime accessor (previously `#[cfg(test)]`).
+- `MetricsState.timings` (`src/app/metrics_state.rs`) holds two hand-rolled
+  fixed-bucket `DurationHistogram`s — `terminal.draw` duration per painted
+  frame and `App::tick` duration per iteration — plus a 16-slot `SlowOps`
+  ring of named synchronous UI-thread operations (`SlowOp { name, ms, tick }`).
+  No new dependencies: the histogram is ~40 lines with power-of-two µs buckets
+  (250 µs → 1 s + overflow), good enough to answer "is a frame 1 ms or 30 ms".
+- **Gating**: the hot-loop `Instant` reads run only while
+  `App::perf_timing_active()` — `THURBOX_PERF_LOG` set (cached at
+  construction) or the perf HUD open — so a normal run pays a single cached
+  bool check per loop iteration, keeping ADR-P5's zero-overhead promise.
+- **Slow ops**: `App::time_op(name, f)` wraps rare, user-triggered synchronous
+  operations (the code-review build/retarget/reload, and `App::update` outliers
+  as `input_dispatch`). Always measured (call sites are not the hot path):
+  ≥ 5 ms lands in the ring, ≥ 100 ms also logs a `slow op` warning — so an
+  interactive stall is attributable even when nobody was watching.
+- **Steady-state reporting**: under `THURBOX_PERF_LOG`, every 1000 ticks
+  (~10 s) `App::tick_perf_window` logs one `perf_window` line — counter
+  **deltas** for the window (`PerfCounters::delta`), frame/tick p50/p95/max,
+  and the window's slow ops — then resets the per-window timing state. The
+  one-shot `startup` line is unchanged.
+
+**Why**: the counters gate regressions in CI but were invisible in a live
+build, and they deliberately count rather than time — so a user-perceived
+stall ("opening review froze for 3 s") had no signal at all. The histograms
+and slow-op ring answer *how long*, the `perf_window` line answers *what is
+the app doing while idle*, and both stay out of CI so ADR-P2's no-flaky-timing
+rule holds.
+
+**Rejected**:
+
+- *Always-on timing* — two `Instant::now()` calls per ≤10 ms loop iteration is
+  cheap but not free, and observability nobody asked for shouldn't tax every
+  run; the opt-in gate costs one bool.
+- *A timing dependency (hdrhistogram etc.)* — same licensing/vetting cost
+  ADR-P5 rejected for criterion; the fixed-bucket histogram is sufficient.
+- *CI assertions on the new timings* — explicitly ruled out; ADR-P2 stands.
+
+---
+
 ## Quick reference
 
 | I want to… | Do this |
 | --- | --- |
 | Measure startup | `THURBOX_PERF_LOG=1 thurbox`, read the `startup` line in `thurbox.log` |
-| Break down startup time | Read the `startup` phase fields (`config_init_ms`/`db_open_ms`/`extension_heal_ms`/`restore_ms`) + the `restore_discover`/`restore_adopt` lines |
+| Break down startup time | Read the `startup` phase fields (`config_init_ms`/`db_open_ms`/`theme_activate_ms`/`extension_heal_ms`/`app_new_ms`/`restore_ms`/`heartbeat_ms`) + the `restore_discover`/`restore_adopt` lines |
+| Watch steady-state cost | `THURBOX_PERF_LOG=1 thurbox`, read the `perf_window` lines (~10 s cadence: counter deltas + frame/tick percentiles + slow ops) |
+| Attribute an interactive stall | Look for `slow op` warnings in `thurbox.log` (named op + ms), or the slow-op list in `perf_window` |
 | Verify the status-hook cache (ADR-P6) | `cargo nextest run -E 'test(perf_hook_states)'`; `hook_state_loads` stays flat while idle, +1 per external `session signal` |
 | See binary size | Check the `Binary Size` CI job summary, or `cargo bloat --release --crates` |
 | Profile CPU | `cargo flamegraph --profile release-with-debug --bin thurbox` |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -330,6 +330,16 @@ only** and never CI-asserted (the counters remain the sole regression gate):
   **deltas** for the window (`PerfCounters::delta`), frame/tick p50/p95/max,
   and the window's slow ops — then resets the per-window timing state. The
   one-shot `startup` line is unchanged.
+- **The perf HUD** (`src/ui/perf_hud.rs`, F12, `[features] perf_hud`): a
+  floating, non-modal overlay with the same counters/percentiles/slow-ops,
+  refreshed by the existing 250 ms forced-redraw floor.
+- **External inspection**: while timing is active the TUI also publishes a
+  JSON snapshot (counters + percentiles + slow ops + the startup phases) into
+  the SQLite `metadata` table (`perf_snapshot` key, ~every 5–10 s), read by
+  **`thurbox-cli perf`** (`--json` for machine output). Publishing is gated on
+  timing being active because each write bumps *other* thurbox connections'
+  `data_version` (a full shared-state reload on their next poll) — an idle,
+  default-config instance must never churn that row.
 
 **Why**: the counters gate regressions in CI but were invisible in a live
 build, and they deliberately count rather than time — so a user-perceived
@@ -357,6 +367,8 @@ rule holds.
 | Break down startup time | Read the `startup` phase fields (`config_init_ms`/`db_open_ms`/`theme_activate_ms`/`extension_heal_ms`/`app_new_ms`/`restore_ms`/`heartbeat_ms`) + the `restore_discover`/`restore_adopt` lines |
 | Watch steady-state cost | `THURBOX_PERF_LOG=1 thurbox`, read the `perf_window` lines (~10 s cadence: counter deltas + frame/tick percentiles + slow ops) |
 | Attribute an interactive stall | Look for `slow op` warnings in `thurbox.log` (named op + ms), or the slow-op list in `perf_window` |
+| Watch perf live in the TUI | Press `F12` (perf HUD overlay; `[features] perf_hud`) |
+| Inspect a running TUI from outside | `thurbox-cli perf` (needs THURBOX_PERF_LOG or an open HUD in that TUI) |
 | Verify the status-hook cache (ADR-P6) | `cargo nextest run -E 'test(perf_hook_states)'`; `hook_state_loads` stays flat while idle, +1 per external `session signal` |
 | See binary size | Check the `Binary Size` CI job summary, or `cargo bloat --release --crates` |
 | Profile CPU | `cargo flamegraph --profile release-with-debug --bin thurbox` |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -78,6 +78,8 @@ wall-clock-free `u64` counters bumped at the render/tick hot paths:
 | `external_poll_checks` / `external_poll_reloads` | `poll_external_changes` ran its cheap `PRAGMA data_version` check / found a change and did a full shared-state reload |
 | `review_builds_dispatched` / `review_builds_applied` | code-review diff builds handed to the background worker / applied back on the UI thread (ADR-P8) |
 | `restore_seed_prefetches` | restore history captures prefetched in parallel, one per matched pane (ADR-P9) |
+| `agent_meta_syncs` | a session's OSC title/notification actually re-read (gated on the reader thread's meta generation, ADR-P10) |
+| `data_version_checks` | the status refresh actually ran its `PRAGMA data_version` read (throttled ~10×/s, ADR-P10) |
 
 `hook_state_loads` is the regression gate for ADR-P6: it climbs once at startup
 and then only when an external `session signal` commits, instead of ~1 per tick.
@@ -383,6 +385,56 @@ control-mode serialization ADR-P5 documents.
 - *Unbounded capture fan-out* — a 50-session restore would fork 50
   subprocesses at once; the cap keeps the burst bounded with the same
   wall-clock win.
+
+---
+
+## ADR-P10: Cut the idle tick's per-session churn
+
+**Choice**: two reductions in `refresh_session_statuses`' ~100 Hz work, both
+gated by counters:
+
+- **Agent meta generation gate.** `apply_session_status_fields` called
+  `session.agent_title()` + `session.notification()` for every session every
+  tick — 2·N mutex locks and up to 2·N `String` clones at ~100 Hz, almost
+  always re-reading unchanged values. The reader thread's `TermSignals` now
+  bumps a shared `meta_gen` atomic **after** each title/notification write,
+  and `Session::sync_agent_meta` re-reads the mutexes only when the
+  generation moved (one relaxed/acquire atomic load per session per tick
+  otherwise). Status derivation itself still runs every tick, so
+  blocked/working/done latency is unchanged; a generation observed mid-write
+  only delays the text by one ~10 ms tick (the counter is bumped after the
+  value lands). Gate: `agent_meta_syncs` +
+  `perf_agent_meta_cached_across_idle_ticks` /
+  `perf_agent_meta_resyncs_on_change`.
+- **Throttled `data_version` read.** The ADR-P6 cache still ran its `PRAGMA
+  data_version` `query_row` every tick (~100 rusqlite round-trips/s). The
+  read now runs every `HOOK_VERSION_CHECK_TICKS` (10 ticks ≈ 100 ms) — except
+  when the cache was explicitly invalidated (a remote hook event or restart
+  wrote on our own connection, which the pragma can't see; those check
+  immediately). Worst case an external `session signal` displays ~100 ms
+  late instead of ~10 ms — far below the 250 ms coupling ADR-P6 rejected as
+  visible. Gate: `data_version_checks` +
+  `perf_data_version_read_is_throttled` (and
+  `perf_hook_states_reload_on_external_change` now ticks through a full
+  throttle window before asserting).
+
+**Why**: with the render loop demand-driven (ADR-P1) and the hook reload
+cached (ADR-P6), these two were the largest remaining per-tick costs, and
+both scale with session count. Neither changes any user-visible latency
+budget.
+
+**Rejected**:
+
+- *Sharing `poll_external_changes`' cursor for the hook check* — still the
+  ADR-P6 rejection: `has_external_changes` mutates the shared
+  `last_data_version`, so two consumers would steal each other's edges.
+- *Gating the whole status derivation on the generation* — the
+  output-quiescence `working → Idle` fallback and the spinner are
+  time-driven; they must run every tick regardless.
+- *Deferred follow-ups* (measure first via the new observability):
+  extension self-heal gating on a fingerprint (watch `extension_heal_ms`),
+  and an adaptive idle poll interval for the 100 Hz loop itself (idle CPU
+  was not a reported pain point; the tick is now cheap).
 
 ---
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -76,6 +76,7 @@ wall-clock-free `u64` counters bumped at the render/tick hot paths:
 | `automation_entries_built` | automations-pane entry list built |
 | `hook_state_loads` | `refresh_session_statuses` actually reloaded the persisted hook columns (`load_hook_states`) — gated on a `data_version` change (ADR-P6), so it stays flat while idle |
 | `external_poll_checks` / `external_poll_reloads` | `poll_external_changes` ran its cheap `PRAGMA data_version` check / found a change and did a full shared-state reload |
+| `review_builds_dispatched` / `review_builds_applied` | code-review diff builds handed to the background worker / applied back on the UI thread (ADR-P8) |
 
 `hook_state_loads` is the regression gate for ADR-P6: it climbs once at startup
 and then only when an external `session signal` commits, instead of ~1 per tick.
@@ -300,6 +301,46 @@ already brought up and is cheap on the main thread.
 - *Adopting on the background thread too* — `restore_single_session` mutates
   `App` (session list, wizard state on the respawn path); shipping a built
   `Session` across the channel would split that invariant for no measured win.
+
+---
+
+## ADR-P8: Build code-review diffs off the UI thread
+
+**Choice**: Opening the code-review view (`Ctrl+X`/`F7`) and switching its
+target used to run the whole git pipeline **synchronously in the key
+handler** — per repo: base resolution (`branch_exists` + `list_branches` +
+`default_branch`), the target-picker commit listing, and the diff itself,
+each a `git` subprocess and **each an ssh round-trip for a remote session**.
+Measured via the `code_review_build` slow op (ADR-P11): seconds of frozen UI
+on a remote host. Now `toggle_code_review` does only the cheap gather
+(session id, host, worktree list, label dedup), installs the review in a
+`loading` state — the pane opens instantly with a "Building diff…"
+placeholder — and hands the git work to a `spawn_blocking` worker
+(`build_review_open` / `build_review_retarget` in `src/app/code_review.rs`,
+via the shared `BackgroundTask` fire-and-poll shape). `App::poll_review_build`
+(a `tick` step) applies the result **by session id** into `App::code_reviews`,
+so a review closed (or switched away from) mid-build simply drops the result.
+One build runs at a time; a second open/retarget while one is in flight is
+refused with a toast.
+
+Gate: `review_builds_dispatched` / `review_builds_applied` +
+`perf_review_open_never_builds_on_ui_thread`,
+`perf_review_build_result_applied_via_poll`,
+`review_build_for_closed_review_is_dropped` (`src/app/mod.rs` tests).
+
+**Why**: this was the largest *interactive* stall in the app, and the inputs
+are all owned/cloneable data (`ReviewRepo`, `HostDef`, the target), so the
+work moves off-thread wholesale with the same pattern the codebase already
+uses for git stats and worktree creation.
+
+**Rejected**:
+
+- *Queueing a second build behind the in-flight one* — a rapid open→retarget
+  would apply two results in sequence for no benefit; the refuse-with-toast
+  is simpler and the loading state makes it obvious.
+- *An async-aware diff stream (progressive per-repo fill-in)* — more moving
+  parts for a build that is fast locally; revisit only if multi-repo remote
+  reviews prove slow *after* this change.
 
 ---
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -77,6 +77,7 @@ wall-clock-free `u64` counters bumped at the render/tick hot paths:
 | `hook_state_loads` | `refresh_session_statuses` actually reloaded the persisted hook columns (`load_hook_states`) — gated on a `data_version` change (ADR-P6), so it stays flat while idle |
 | `external_poll_checks` / `external_poll_reloads` | `poll_external_changes` ran its cheap `PRAGMA data_version` check / found a change and did a full shared-state reload |
 | `review_builds_dispatched` / `review_builds_applied` | code-review diff builds handed to the background worker / applied back on the UI thread (ADR-P8) |
+| `restore_seed_prefetches` | restore history captures prefetched in parallel, one per matched pane (ADR-P9) |
 
 `hook_state_loads` is the regression gate for ADR-P6: it climbs once at startup
 and then only when an external `session signal` commits, instead of ~1 per tick.
@@ -188,10 +189,13 @@ won't pay off.
   `adopt_split` line (in `TmuxBackend::adopt`) further breaks `adopt_ms` into
   `capture_ms` (the independent `tmux capture-pane` subprocess — the only part
   that could run in parallel across sessions) and `connect_ms` (the
-  control-mode attach). This split is the deciding measurement for parallelizing
-  restore: the control-mode connection is serialized by a single mutex held
-  across each command's full round-trip (`TmuxBackend::with_control`), so
-  `connect_ms` is inherently sequential and only `capture_ms` can be overlapped.
+  control-mode attach). This split was the deciding measurement for
+  parallelizing restore: the control-mode connection is serialized by a single
+  mutex held across each command's full round-trip
+  (`TmuxBackend::with_control`), so `connect_ms` is inherently sequential and
+  only `capture_ms` can be overlapped — which ADR-P9 now does (on the startup
+  restore path `capture_ms` reads ≈ 0 and a `restore_capture_prefetch` line
+  reports the overlapped batch).
   Off by default — never affects normal runs or the smoke test; the timing reads
   are gated on the flag so there is zero overhead otherwise.
 - **Binary size**: the non-gating `binary-size` CI job
@@ -341,6 +345,44 @@ uses for git stats and worktree creation.
 - *An async-aware diff stream (progressive per-repo fill-in)* — more moving
   parts for a build that is fast locally; revisit only if multi-repo remote
   reviews prove slow *after* this change.
+
+---
+
+## ADR-P9: Prefetch restore's history captures in parallel
+
+**Choice**: The sequential local-session restore adopts one session at a time,
+and ADR-P5's `adopt_split` measurement shows each adopt is `capture_ms` (an
+independent `tmux capture-pane` subprocess) + `connect_ms` (the control-mode
+attach, serialized by the connection mutex — inherently sequential). Restore
+now runs all matched panes' captures **in parallel** up front
+(`App::prefetch_capture_seeds`, a bounded `std::thread::scope` fan-out capped
+at 8 concurrent subprocesses) and passes each seed into the adopt:
+`SessionBackend::adopt` takes `seed: Option<Vec<u8>>` (`None` = capture
+inline, exactly the old behavior — used by mid-run adopts, shell-pane
+re-adoption, and the remote restore path) and the new
+`SessionBackend::capture_history` exposes the capture as its own trait method.
+With N sessions the restore's capture cost drops from `N × capture_ms` to
+roughly one `capture_ms`; `adopt_split` now logs `capture_ms ≈ 0` on the
+startup path, and a `restore_capture_prefetch` line (`sessions`,
+`prefetch_ms`) reports the overlapped batch.
+
+Gate: `restore_seed_prefetches` (one per prefetched pane) +
+`perf_restore_prefetches_capture_seeds` (`src/app/mod.rs` tests — a recording
+backend asserts every adopt received a prefetched seed and the capture ran
+exactly once per session; count-based, no timing).
+
+**Why**: startup time is dominated by restore once a few sessions exist, and
+the capture half is the only slice that parallelizes without touching the
+control-mode serialization ADR-P5 documents.
+
+**Rejected**:
+
+- *Parallelizing whole adopts* — `connect_pane` shares one control-mode
+  connection guarded by a mutex held across each command round-trip; threads
+  would just queue on it.
+- *Unbounded capture fan-out* — a 50-session restore would fork 50
+  subprocesses at once; the cap keeps the burst bounded with the same
+  wall-clock win.
 
 ---
 

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -191,8 +191,27 @@ pub trait SessionBackend: Send + Sync {
         cols: u16,
     ) -> Result<SpawnedSession>;
 
-    /// Reconnect to an existing session.
-    fn adopt(&self, backend_id: &str, rows: u16, cols: u16) -> Result<AdoptedSession>;
+    /// Reconnect to an existing session. `seed` is pre-captured scrollback
+    /// history to prepend to the live stream (see [`Self::capture_history`]);
+    /// `None` makes the backend capture it itself — the two paths produce the
+    /// same bytes, `Some` just lets restore overlap the captures (ADR-P9).
+    fn adopt(
+        &self,
+        backend_id: &str,
+        rows: u16,
+        cols: u16,
+        seed: Option<Vec<u8>>,
+    ) -> Result<AdoptedSession>;
+
+    /// Capture a session's scrollback history as terminal bytes suitable for
+    /// seeding a fresh parser, to pass into [`Self::adopt`]. An independent
+    /// subprocess per pane, safe to run concurrently across sessions — unlike
+    /// `adopt`'s control-mode connect, which is serialized. Default: no
+    /// history (backends without a capture facility adopt with an empty
+    /// scrollback, exactly as if the capture had failed).
+    fn capture_history(&self, _backend_id: &str) -> Result<Vec<u8>> {
+        Ok(Vec::new())
+    }
 
     /// Discover existing sessions managed by this backend.
     fn discover(&self) -> Result<Vec<DiscoveredSession>>;
@@ -428,7 +447,10 @@ impl Session {
         ))
     }
 
-    /// Reconnect to an existing backend session.
+    /// Reconnect to an existing backend session. `seed` is optional
+    /// pre-captured scrollback (see [`SessionBackend::capture_history`]);
+    /// `None` = the backend captures it during the adopt.
+    #[allow(clippy::too_many_arguments)]
     pub fn adopt(
         name: String,
         rows: u16,
@@ -437,8 +459,9 @@ impl Session {
         backend: &Arc<dyn SessionBackend>,
         provider: &Arc<dyn AgentProvider>,
         env: HashMap<String, String>,
+        seed: Option<Vec<u8>>,
     ) -> Result<Self> {
-        let adopted = backend.adopt(backend_id, rows, cols)?;
+        let adopted = backend.adopt(backend_id, rows, cols, seed)?;
 
         debug!(
             backend_id = %backend_id,
@@ -938,7 +961,7 @@ impl Session {
 
     /// Re-adopt an existing shell pane from a backend_id (for restore on restart).
     pub fn adopt_shell_pane(&mut self, backend_id: &str, rows: u16, cols: u16) -> Result<()> {
-        let adopted = self.backend.adopt(backend_id, rows, cols)?;
+        let adopted = self.backend.adopt(backend_id, rows, cols, None)?;
 
         let (state, bid) = Self::wire_up(
             rows,

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -76,6 +76,10 @@ pub struct TermSignals {
     attention_at: Arc<AtomicU64>,
     /// Message text from the most recent OSC 9/777 notification, if any.
     notification: Arc<Mutex<Option<String>>>,
+    /// Generation counter bumped after every title/notification write, so the
+    /// per-tick status refresh can skip the mutex locks + String clones while
+    /// nothing changed (ADR-P10; see [`Session::sync_agent_meta`]).
+    meta_gen: Arc<AtomicU64>,
 }
 
 impl TermSignals {
@@ -84,6 +88,9 @@ impl TermSignals {
         if let Ok(mut guard) = self.title.lock() {
             *guard = (!s.is_empty()).then_some(s);
         }
+        // After the write, so a reader that observes the new generation also
+        // observes the new value.
+        self.meta_gen.fetch_add(1, Ordering::Release);
     }
 
     /// Mark an attention signal, optionally with notification message text.
@@ -94,6 +101,7 @@ impl TermSignals {
             if let Ok(mut guard) = self.notification.lock() {
                 *guard = (!msg.is_empty()).then_some(msg);
             }
+            self.meta_gen.fetch_add(1, Ordering::Release);
         }
     }
 }
@@ -314,6 +322,7 @@ struct WiredState {
     last_title: Arc<Mutex<Option<String>>>,
     attention_at: Arc<AtomicU64>,
     notification: Arc<Mutex<Option<String>>>,
+    meta_gen: Arc<AtomicU64>,
 }
 
 /// A companion shell pane running alongside an agent session.
@@ -375,6 +384,12 @@ pub struct Session {
     attention_at: Arc<AtomicU64>,
     /// Message text from the latest OSC 9/777 notification, if any.
     notification: Arc<Mutex<Option<String>>>,
+    /// Shared with [`TermSignals::meta_gen`]: bumped by the reader thread on
+    /// every title/notification write.
+    meta_gen: Arc<AtomicU64>,
+    /// The generation last consumed by [`Self::sync_agent_meta`]. Starts at
+    /// `u64::MAX` so the first tick always syncs.
+    last_synced_meta_gen: u64,
     /// `now_millis()` of the last attention acknowledgement (set while the
     /// session is the active one). Attention is pending when
     /// `attention_at > attention_ack_at`.
@@ -496,6 +511,7 @@ impl Session {
         let last_title = Arc::new(Mutex::new(None));
         let attention_at = Arc::new(AtomicU64::new(0));
         let notification = Arc::new(Mutex::new(None));
+        let meta_gen = Arc::new(AtomicU64::new(0));
         let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
             rows,
             cols,
@@ -504,6 +520,7 @@ impl Session {
                 title: Arc::clone(&last_title),
                 attention_at: Arc::clone(&attention_at),
                 notification: Arc::clone(&notification),
+                meta_gen: Arc::clone(&meta_gen),
             },
         )));
 
@@ -528,6 +545,7 @@ impl Session {
             last_title,
             attention_at,
             notification,
+            meta_gen,
         };
         (state, io.backend_id)
     }
@@ -555,6 +573,8 @@ impl Session {
             last_title: state.last_title,
             attention_at: state.attention_at,
             notification: state.notification,
+            meta_gen: state.meta_gen,
+            last_synced_meta_gen: u64::MAX,
             attention_ack_at: 0,
             shell_pane: None,
             env,
@@ -584,6 +604,7 @@ impl Session {
         let last_title = Arc::new(Mutex::new(None));
         let attention_at = Arc::new(AtomicU64::new(0));
         let notification = Arc::new(Mutex::new(None));
+        let meta_gen = Arc::new(AtomicU64::new(0));
         let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
             rows.max(1),
             cols.max(1),
@@ -592,6 +613,7 @@ impl Session {
                 title: Arc::clone(&last_title),
                 attention_at: Arc::clone(&attention_at),
                 notification: Arc::clone(&notification),
+                meta_gen: Arc::clone(&meta_gen),
             },
         )));
         let host = info.remote_host.clone().unwrap_or_else(|| "?".into());
@@ -620,6 +642,8 @@ impl Session {
             last_title,
             attention_at,
             notification,
+            meta_gen,
+            last_synced_meta_gen: u64::MAX,
             attention_ack_at: 0,
             shell_pane: None,
             env,
@@ -775,6 +799,33 @@ impl Session {
     /// Latest OSC window title the agent emitted, if any (live activity text).
     pub fn agent_title(&self) -> Option<String> {
         self.last_title.lock().ok().and_then(|t| t.clone())
+    }
+
+    /// Read the agent's title + notification **only when they changed** since
+    /// the last call: `None` means unchanged (reuse the previously-synced
+    /// values), `Some` carries the fresh pair. The reader thread bumps a
+    /// generation counter on every write (`TermSignals::meta_gen`), so the
+    /// ~100 Hz status refresh pays one atomic load per session instead of two
+    /// mutex locks + two `String` clones (ADR-P10). A generation observed
+    /// before its write completes only delays the sync by one ~10 ms tick —
+    /// the counter is bumped *after* the value write, never before.
+    pub fn sync_agent_meta(&mut self) -> Option<(Option<String>, Option<String>)> {
+        let gen = self.meta_gen.load(Ordering::Acquire);
+        if gen == self.last_synced_meta_gen {
+            return None;
+        }
+        self.last_synced_meta_gen = gen;
+        Some((self.agent_title(), self.notification()))
+    }
+
+    /// Simulate a reader-thread title/notification write for the ADR-P10
+    /// perf tests (mirrors [`Self::mark_exited_for_test`]).
+    #[cfg(test)]
+    pub(crate) fn bump_meta_gen_for_test(&self, title: &str) {
+        if let Ok(mut guard) = self.last_title.lock() {
+            *guard = Some(title.to_string());
+        }
+        self.meta_gen.fetch_add(1, Ordering::Release);
     }
 
     /// Whether the agent has signalled for attention (bell / OSC 9 / OSC 777)
@@ -1016,6 +1067,7 @@ impl Session {
         let last_title = Arc::new(Mutex::new(None));
         let attention_at = Arc::new(AtomicU64::new(0));
         let notification = Arc::new(Mutex::new(None));
+        let meta_gen = Arc::new(AtomicU64::new(0));
         let session = Self {
             info: SessionInfo::new(name.to_string()),
             parser: Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
@@ -1026,6 +1078,7 @@ impl Session {
                     title: Arc::clone(&last_title),
                     attention_at: Arc::clone(&attention_at),
                     notification: Arc::clone(&notification),
+                    meta_gen: Arc::clone(&meta_gen),
                 },
             ))),
             input_tx,
@@ -1037,6 +1090,8 @@ impl Session {
             last_title,
             attention_at,
             notification,
+            meta_gen,
+            last_synced_meta_gen: u64::MAX,
             attention_ack_at: 0,
             shell_pane: None,
             env: HashMap::new(),

--- a/src/agent/registry.rs
+++ b/src/agent/registry.rs
@@ -102,7 +102,7 @@ mod tests {
         ) -> Result<SpawnedSession> {
             unimplemented!()
         }
-        fn adopt(&self, _: &str, _: u16, _: u16) -> Result<AdoptedSession> {
+        fn adopt(&self, _: &str, _: u16, _: u16, _: Option<Vec<u8>>) -> Result<AdoptedSession> {
             unimplemented!()
         }
         fn discover(&self) -> Result<Vec<DiscoveredSession>> {

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -46,6 +46,7 @@ config_version = 1
 # global_search = true    # Ctrl+/ search strip
 # info_panel = true       # F2 info panel
 # shell_pane = true       # Ctrl+T per-session shell
+# code_review = true      # native code-review view (diff + comments)
 # mouse = true            # mouse capture: clicks, wheel, drag-select, hover
 # notifications = true    # OS desktop notifications when a session needs attention
 # soft_delete = true      # Ctrl+D soft-deletes (Ctrl+Z undo); false = hard delete after a prompt
@@ -230,6 +231,7 @@ pub fn save_settings(settings: &Settings) -> std::io::Result<()> {
         set_table_bool(features, "global_search", f.global_search);
         set_table_bool(features, "info_panel", f.info_panel);
         set_table_bool(features, "shell_pane", f.shell_pane);
+        set_table_bool(features, "code_review", f.code_review);
         set_table_bool(features, "mouse", f.mouse);
         set_table_bool(features, "notifications", f.notifications);
         set_table_bool(features, "soft_delete", f.soft_delete);
@@ -292,6 +294,7 @@ mod tests {
             "global_search",
             "info_panel",
             "shell_pane",
+            "code_review",
             "notifications",
             "[notifications]",
             "also_on_waiting",

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -47,6 +47,7 @@ config_version = 1
 # info_panel = true       # F2 info panel
 # shell_pane = true       # Ctrl+T per-session shell
 # code_review = true      # native code-review view (diff + comments)
+# perf_hud = true         # F12 perf HUD overlay (live counters + timing)
 # mouse = true            # mouse capture: clicks, wheel, drag-select, hover
 # notifications = true    # OS desktop notifications when a session needs attention
 # soft_delete = true      # Ctrl+D soft-deletes (Ctrl+Z undo); false = hard delete after a prompt
@@ -232,6 +233,7 @@ pub fn save_settings(settings: &Settings) -> std::io::Result<()> {
         set_table_bool(features, "info_panel", f.info_panel);
         set_table_bool(features, "shell_pane", f.shell_pane);
         set_table_bool(features, "code_review", f.code_review);
+        set_table_bool(features, "perf_hud", f.perf_hud);
         set_table_bool(features, "mouse", f.mouse);
         set_table_bool(features, "notifications", f.notifications);
         set_table_bool(features, "soft_delete", f.soft_delete);
@@ -295,6 +297,7 @@ mod tests {
             "info_panel",
             "shell_pane",
             "code_review",
+            "perf_hud",
             "notifications",
             "[notifications]",
             "also_on_waiting",

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -1218,23 +1218,33 @@ impl SessionBackend for TmuxBackend {
         })
     }
 
-    fn adopt(&self, backend_id: &str, rows: u16, cols: u16) -> Result<AdoptedSession> {
+    fn adopt(
+        &self,
+        backend_id: &str,
+        rows: u16,
+        cols: u16,
+        seed: Option<Vec<u8>>,
+    ) -> Result<AdoptedSession> {
         // backend_id comes from the shared DB — never interpolate it unvalidated.
         if !control_mode::is_valid_pane_id(backend_id) {
             bail!("refusing to adopt invalid pane id: {backend_id:?}");
         }
-        // Opt-in split timing (THURBOX_PERF_LOG): `capture_history_seed` is an
-        // independent `tmux capture-pane` subprocess (parallelizable), while
-        // `connect_pane` drives the serialized control-mode connection. Knowing
-        // their ratio decides whether parallelizing the capture half is worth it.
+        // Opt-in split timing (THURBOX_PERF_LOG): the history capture is an
+        // independent `tmux capture-pane` subprocess, while `connect_pane`
+        // drives the serialized control-mode connection. Restore prefetches
+        // the captures in parallel and passes them in (ADR-P9), so
+        // `capture_ms` here reads 0 on that path; a `None` seed (a mid-run
+        // adopt) still captures inline, before connecting so seeded history
+        // can't duplicate live output. Best-effort: adoption must survive a
+        // failed capture.
         let perf_log = std::env::var_os("THURBOX_PERF_LOG").is_some();
 
-        // Capture before connecting so seeded history can't duplicate live
-        // output. Best-effort: adoption must survive a failed capture.
         let capture_start = perf_log.then(std::time::Instant::now);
-        let seed = self.capture_history_seed(backend_id).unwrap_or_else(|e| {
-            warn!("Failed to capture history for pane {backend_id}: {e}");
-            Vec::new()
+        let seed = seed.unwrap_or_else(|| {
+            self.capture_history(backend_id).unwrap_or_else(|e| {
+                warn!("Failed to capture history for pane {backend_id}: {e}");
+                Vec::new()
+            })
         });
         let capture_ms = capture_start.map(|s| s.elapsed().as_millis() as u64);
 
@@ -1257,6 +1267,13 @@ impl SessionBackend for TmuxBackend {
             output: Box::new(Cursor::new(seed).chain(connected.output)),
             input: connected.input,
         })
+    }
+
+    fn capture_history(&self, backend_id: &str) -> Result<Vec<u8>> {
+        if !control_mode::is_valid_pane_id(backend_id) {
+            bail!("refusing to capture invalid pane id: {backend_id:?}");
+        }
+        self.capture_history_seed(backend_id)
     }
 
     fn discover(&self) -> Result<Vec<DiscoveredSession>> {

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -149,6 +149,7 @@ impl SessionBackend for FakeBackend {
         _: &str,
         _: u16,
         _: u16,
+        _: Option<Vec<u8>>,
     ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
         anyhow::ensure!(self.spawnable, "inert fake backend does not adopt");
         Ok(crate::agent::backend::AdoptedSession {

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -1785,6 +1785,7 @@ fn open_minimal_review(h: &mut Harness) {
         sid,
         crate::app::code_review::CodeReviewState {
             session_id: sid,
+            loading: false,
             repos: Vec::new(),
             multi: false,
             files: Vec::new(),
@@ -2165,9 +2166,12 @@ fn side_by_side_click_records_column_side() {
 }
 
 /// The review-target picker is mouse-driven too: clicking one of its entries
-/// switches the diff to that target, mirroring the keyboard Enter path.
-#[test]
-fn clicking_review_target_entry_switches_target() {
+/// dispatches the switch to that target, mirroring the keyboard Enter path.
+/// The rebuild itself runs on a background worker (ADR-P8) — its application
+/// is covered by `perf_review_build_result_applied_via_poll` — so this asserts
+/// the dispatch side: picker closed, loading state on, build handed off.
+#[tokio::test]
+async fn clicking_review_target_entry_switches_target() {
     use crate::app::code_review::ReviewTarget;
     let mut h = Harness::new(STD_COLS, STD_ROWS, 1);
     let sid = h.app.sessions[0].info.id;
@@ -2199,12 +2203,18 @@ fn clicking_review_target_entry_switches_target() {
     let cr = h.app.active_review().unwrap();
     assert_eq!(
         cr.target,
-        ReviewTarget::Working,
-        "clicking a target-picker entry switches the diff to that target"
+        ReviewTarget::Branch,
+        "the target only switches once the background build lands"
     );
+    assert!(cr.loading, "the click enters the loading state");
     assert!(
         cr.target_picker.is_none(),
         "selecting a target closes the picker"
+    );
+    assert_eq!(
+        h.app.perf_counters().review_builds_dispatched,
+        1,
+        "the rebuild was handed to the background worker"
     );
 }
 

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -1524,6 +1524,35 @@ async fn info_panel_hides_automations_when_feature_off() {
 // in the `#[tokio::test]` units in `super::tests`.
 
 #[test]
+fn perf_hud_toggles_with_f12_and_activates_timing() {
+    let mut h = Harness::standard(1);
+    assert!(!h.app.perf_timing_active(), "timing is off by default");
+    h.key(KeyCode::F(12), KeyModifiers::NONE);
+    assert!(h.app.show_perf_hud, "F12 opens the perf HUD");
+    assert!(
+        h.app.perf_timing_active(),
+        "an open HUD switches timing collection on"
+    );
+    h.render(); // the overlay renders without disturbing the panes
+    h.key(KeyCode::F(12), KeyModifiers::NONE);
+    assert!(!h.app.show_perf_hud, "F12 closes it again");
+}
+
+#[test]
+fn perf_hud_feature_flag_disables_toggle_and_closes_overlay() {
+    let mut h = Harness::standard(1);
+    h.key(KeyCode::F(12), KeyModifiers::NONE);
+    assert!(h.app.show_perf_hud);
+    // Disabling the live flag tears the overlay down and blocks the chord.
+    let mut settings = crate::session::settings::Settings::default();
+    settings.features.perf_hud = false;
+    h.app.apply_live_settings(&settings);
+    assert!(!h.app.show_perf_hud, "disabling the flag closes the HUD");
+    h.key(KeyCode::F(12), KeyModifiers::NONE);
+    assert!(!h.app.show_perf_hud, "the chord toasts instead of toggling");
+}
+
+#[test]
 fn perf_render_counter_tracks_painted_frames() {
     let mut h = Harness::standard(2);
     assert_eq!(h.app.perf_counters().frames_rendered, 0);

--- a/src/app/code_review.rs
+++ b/src/app/code_review.rs
@@ -126,9 +126,40 @@ pub(crate) struct ComposeState {
     pub editing_id: Option<i64>,
 }
 
+/// What an off-thread review build produced (see [`App::poll_review_build`]).
+/// The git subprocess fan-out — base resolution, commit listing, the diffs
+/// themselves, possibly over SSH — happens on a `spawn_blocking` worker so
+/// opening or retargeting a review never stalls the UI thread (ADR-P8).
+pub(crate) struct ReviewBuildResult {
+    pub session_id: SessionId,
+    /// Worker-measured wall time, reported as the `code_review_build` slow op.
+    pub elapsed_ms: u64,
+    pub kind: ReviewBuildKind,
+}
+
+pub(crate) enum ReviewBuildKind {
+    /// A fresh open: bases resolved per repo, commits listed, default target
+    /// chosen, diff built.
+    Open {
+        repos: Vec<ReviewRepo>,
+        commits: Vec<(usize, String, String)>,
+        target: ReviewTarget,
+        files: Vec<DiffFile>,
+    },
+    /// A target switch on an already-open review (repos/commits unchanged).
+    Retarget {
+        target: ReviewTarget,
+        files: Vec<DiffFile>,
+    },
+}
+
 /// The open code-review view for the active session (rebuilt per toggle).
 pub(crate) struct CodeReviewState {
     pub session_id: SessionId,
+    /// A background build (open or retarget) is in flight; the view shows a
+    /// "Building diff…" placeholder until [`App::poll_review_build`] applies
+    /// the result. Navigation is safe meanwhile (`rows` is empty or stale).
+    pub loading: bool,
     /// The repos under review (one per worktree; ≥2 = multi-repo). Cached so
     /// switching targets doesn't re-resolve the session.
     pub repos: Vec<ReviewRepo>,
@@ -501,20 +532,24 @@ impl CodeReviewState {
 }
 
 impl App {
-    /// Toggle the native code-review view for the active session. Building it
-    /// runs `git diff <base>..HEAD` synchronously (normally fast); a huge-repo
-    /// async build is a follow-up.
+    /// Toggle the native code-review view for the active session. The git
+    /// work (base resolution, commit listing, the diff) runs on a background
+    /// worker — the pane opens instantly in a loading state (ADR-P8).
     pub(crate) fn toggle_code_review(&mut self) {
         if self.active_review().is_some() {
             self.close_code_review();
             return;
         }
-        // Measured as a slow op: the build shells out to git (over SSH for a
-        // remote session), and the duration attributes any perceived stall.
-        self.time_op("code_review_build", |s| s.open_code_review());
+        self.open_code_review();
     }
 
     fn open_code_review(&mut self) {
+        // One build at a time: a second open while a build is in flight would
+        // orphan the first receiver (see `BackgroundTask::start`).
+        if self.review_build.in_progress() {
+            self.set_info("A code-review build is already in progress…");
+            return;
+        }
         let Some(session) = self.sessions.get(self.active_index) else {
             return;
         };
@@ -536,18 +571,19 @@ impl App {
 
         // One review repo per worktree (multi-repo sessions have several); a
         // session with no worktree reviews its bare cwd. Attached `additional_dirs`
-        // are reference-only (no branch) and are not reviewed.
+        // are reference-only (no branch) and are not reviewed. Only the cheap
+        // gather happens here — base resolution and the diffs are git
+        // subprocesses (over SSH for a remote session) and run on the worker.
         let worktrees = session.info.worktrees.clone();
         let mut repos: Vec<ReviewRepo> = if worktrees.is_empty() {
             let Some(cwd) = session.info.cwd.clone() else {
                 self.set_error("This session has no working directory to review");
                 return;
             };
-            let base = resolve_repo_base(session_base.as_deref(), &cwd, host.as_ref());
             vec![ReviewRepo {
                 label: String::new(),
                 dir: cwd,
-                base,
+                base: None,
             }]
         } else {
             worktrees
@@ -559,12 +595,10 @@ impl App {
                             .map(|n| n.to_string_lossy().into_owned())
                             .unwrap_or_default()
                     });
-                    let base =
-                        resolve_repo_base(session_base.as_deref(), &w.worktree_path, host.as_ref());
                     ReviewRepo {
                         label,
                         dir: w.worktree_path.clone(),
-                        base,
+                        base: None,
                     }
                 })
                 .collect()
@@ -574,29 +608,12 @@ impl App {
         dedup_repo_labels(&mut repos);
         let multi = repos.len() > 1;
 
-        // Commits across every repo for the target picker (tagged by repo index).
-        let mut commits: Vec<(usize, String, String)> = Vec::new();
-        for (i, r) in repos.iter().enumerate() {
-            if let Some(b) = r.base.as_deref() {
-                for (sha, subj) in crate::git::list_commits_on(host.as_ref(), &r.dir, b) {
-                    commits.push((i, sha, subj));
-                }
-            }
-        }
-        // Default to the branch diff when any repo has a base; otherwise the
-        // uncommitted changes (a bare / unknown-base session still reviews its tree).
-        let target = if repos.iter().any(|r| r.base.is_some()) {
-            ReviewTarget::Branch
-        } else {
-            ReviewTarget::Working
-        };
-        let files = build_files(&repos, &target, host.as_ref(), multi);
-
         let state = CodeReviewState {
             session_id,
-            repos,
+            loading: true,
+            repos: repos.clone(),
             multi,
-            files,
+            files: Vec::new(),
             comments: Vec::new(),
             reviewed_files: HashSet::new(),
             reviewed_hunks: HashSet::new(),
@@ -609,17 +626,72 @@ impl App {
             click_side: None,
             h_scroll: 0,
             wrap: false,
-            target,
-            commits,
-            host,
+            target: ReviewTarget::Working,
+            commits: Vec::new(),
+            host: host.clone(),
             target_picker: None,
             search: None,
         };
-        // Install the bare state for this session, then load comments + marks +
-        // build rows through the single shared path (`reload_review_data`).
+        // Install the loading state (the pane opens instantly with a
+        // "Building diff…" placeholder), load comments + marks through the
+        // single shared path, and hand the git work to the worker.
         self.code_reviews.insert(session_id, state);
         self.reload_review_data();
         self.focus = InputFocus::CodeReview;
+
+        self.metrics.bump(|p| &mut p.review_builds_dispatched);
+        let tx = self.review_build.start();
+        tokio::task::spawn_blocking(move || {
+            let _ = tx.send(build_review_open(session_id, repos, session_base, host));
+        });
+    }
+
+    /// Apply a finished background review build (a `tick` step). A result whose
+    /// review was closed (or replaced by another session's) in the meantime is
+    /// dropped — the map lookup by session id is the ownership check.
+    pub(crate) fn poll_review_build(&mut self) {
+        use super::background::TaskPoll;
+        match self.review_build.poll() {
+            TaskPoll::Pending => {}
+            TaskPoll::Died => {
+                // The worker panicked; stop any spinner so the view shows its
+                // (empty) rows instead of loading forever.
+                for cr in self.code_reviews.values_mut() {
+                    cr.loading = false;
+                }
+                self.set_error("Code-review build failed");
+                self.request_redraw();
+            }
+            TaskPoll::Done(result) => {
+                self.note_slow_op("code_review_build", result.elapsed_ms);
+                let Some(cr) = self.code_reviews.get_mut(&result.session_id) else {
+                    return;
+                };
+                match result.kind {
+                    ReviewBuildKind::Open {
+                        repos,
+                        commits,
+                        target,
+                        files,
+                    } => {
+                        cr.repos = repos;
+                        cr.commits = commits;
+                        cr.target = target;
+                        cr.files = files;
+                    }
+                    ReviewBuildKind::Retarget { target, files } => {
+                        cr.target = target;
+                        cr.files = files;
+                        cr.selected = 0;
+                        cr.scroll = 0;
+                    }
+                }
+                cr.loading = false;
+                cr.rebuild_rows();
+                self.metrics.bump(|p| &mut p.review_builds_applied);
+                self.request_redraw();
+            }
+        }
     }
 
     /// Reload comments + marks from the DB into the open review and rebuild rows.
@@ -848,26 +920,30 @@ impl App {
 
     /// Switch the diff to a different target, recomputing it from git.
     pub(crate) fn cr_set_target(&mut self, target: ReviewTarget) {
-        if self.active_review().is_none() {
+        let Some(cr) = self.active_review() else {
+            return;
+        };
+        // Same git-subprocess cost profile as opening the review, so it runs
+        // on the same worker (one build at a time).
+        if self.review_build.in_progress() {
+            self.set_info("A code-review build is already in progress…");
             return;
         }
-        // Same git-subprocess cost profile as opening the review.
-        self.time_op("code_review_retarget", |s| {
-            let Some(cr) = s.active_review() else {
-                return;
-            };
-            let repos = cr.repos.clone();
-            let host = cr.host.clone();
-            let multi = cr.multi;
-            let files = build_files(&repos, &target, host.as_ref(), multi);
-            if let Some(cr) = s.active_review_mut() {
-                cr.target = target;
-                cr.files = files;
-                cr.selected = 0;
-                cr.scroll = 0;
-                cr.target_picker = None;
-                cr.rebuild_rows();
-            }
+        let session_id = cr.session_id;
+        let repos = cr.repos.clone();
+        let host = cr.host.clone();
+        let multi = cr.multi;
+        if let Some(cr) = self.active_review_mut() {
+            cr.loading = true;
+            cr.target_picker = None;
+        }
+        self.request_redraw();
+        self.metrics.bump(|p| &mut p.review_builds_dispatched);
+        let tx = self.review_build.start();
+        tokio::task::spawn_blocking(move || {
+            let _ = tx.send(build_review_retarget(
+                session_id, repos, host, multi, target,
+            ));
         });
     }
 
@@ -1569,6 +1645,67 @@ fn resolve_repo_base(
     crate::git::default_branch_on(host, dir, &branches)
 }
 
+/// Off-thread worker for a fresh review open: resolve each repo's base, list
+/// the target-picker commits, pick the default target, and build the diff —
+/// every step a git subprocess (over SSH for a remote host). Pure of `App`.
+fn build_review_open(
+    session_id: SessionId,
+    mut repos: Vec<ReviewRepo>,
+    session_base: Option<String>,
+    host: Option<HostDef>,
+) -> ReviewBuildResult {
+    let start = std::time::Instant::now();
+    for r in &mut repos {
+        r.base = resolve_repo_base(session_base.as_deref(), &r.dir, host.as_ref());
+    }
+    // Commits across every repo for the target picker (tagged by repo index).
+    let mut commits: Vec<(usize, String, String)> = Vec::new();
+    for (i, r) in repos.iter().enumerate() {
+        if let Some(b) = r.base.as_deref() {
+            for (sha, subj) in crate::git::list_commits_on(host.as_ref(), &r.dir, b) {
+                commits.push((i, sha, subj));
+            }
+        }
+    }
+    // Default to the branch diff when any repo has a base; otherwise the
+    // uncommitted changes (a bare / unknown-base session still reviews its tree).
+    let target = if repos.iter().any(|r| r.base.is_some()) {
+        ReviewTarget::Branch
+    } else {
+        ReviewTarget::Working
+    };
+    let multi = repos.len() > 1;
+    let files = build_files(&repos, &target, host.as_ref(), multi);
+    ReviewBuildResult {
+        session_id,
+        elapsed_ms: start.elapsed().as_millis() as u64,
+        kind: ReviewBuildKind::Open {
+            repos,
+            commits,
+            target,
+            files,
+        },
+    }
+}
+
+/// Off-thread worker for a target switch: rebuild the diff for `target`
+/// against the already-resolved repos.
+fn build_review_retarget(
+    session_id: SessionId,
+    repos: Vec<ReviewRepo>,
+    host: Option<HostDef>,
+    multi: bool,
+    target: ReviewTarget,
+) -> ReviewBuildResult {
+    let start = std::time::Instant::now();
+    let files = build_files(&repos, &target, host.as_ref(), multi);
+    ReviewBuildResult {
+        session_id,
+        elapsed_ms: start.elapsed().as_millis() as u64,
+        kind: ReviewBuildKind::Retarget { target, files },
+    }
+}
+
 /// Disambiguate repos that share a display name so the `"<label>/<path>"`
 /// namespacing stays unique (two members basenamed `app` would otherwise key
 /// comments/marks identically). Colliding labels get a ` (2)`, ` (3)`, … suffix
@@ -1750,6 +1887,7 @@ impl CodeReviewState {
             .collect();
         let mut s = CodeReviewState {
             session_id,
+            loading: false,
             repos: vec![ReviewRepo {
                 label: String::new(),
                 dir: PathBuf::from("/tmp"),
@@ -1818,6 +1956,7 @@ mod tests {
     fn state_with(files: Vec<DiffFile>, comments: Vec<ReviewComment>) -> CodeReviewState {
         let mut s = CodeReviewState {
             session_id: SessionId::default(),
+            loading: false,
             repos: vec![ReviewRepo {
                 label: String::new(),
                 dir: PathBuf::from("/tmp"),

--- a/src/app/code_review.rs
+++ b/src/app/code_review.rs
@@ -509,6 +509,12 @@ impl App {
             self.close_code_review();
             return;
         }
+        // Measured as a slow op: the build shells out to git (over SSH for a
+        // remote session), and the duration attributes any perceived stall.
+        self.time_op("code_review_build", |s| s.open_code_review());
+    }
+
+    fn open_code_review(&mut self) {
         let Some(session) = self.sessions.get(self.active_index) else {
             return;
         };
@@ -618,6 +624,10 @@ impl App {
 
     /// Reload comments + marks from the DB into the open review and rebuild rows.
     pub(crate) fn reload_review_data(&mut self) {
+        self.time_op("code_review_reload", |s| s.reload_review_data_inner());
+    }
+
+    fn reload_review_data_inner(&mut self) {
         let Some(cr) = self.active_review() else {
             return;
         };
@@ -838,21 +848,27 @@ impl App {
 
     /// Switch the diff to a different target, recomputing it from git.
     pub(crate) fn cr_set_target(&mut self, target: ReviewTarget) {
-        let Some(cr) = self.active_review() else {
+        if self.active_review().is_none() {
             return;
-        };
-        let repos = cr.repos.clone();
-        let host = cr.host.clone();
-        let multi = cr.multi;
-        let files = build_files(&repos, &target, host.as_ref(), multi);
-        if let Some(cr) = self.active_review_mut() {
-            cr.target = target;
-            cr.files = files;
-            cr.selected = 0;
-            cr.scroll = 0;
-            cr.target_picker = None;
-            cr.rebuild_rows();
         }
+        // Same git-subprocess cost profile as opening the review.
+        self.time_op("code_review_retarget", |s| {
+            let Some(cr) = s.active_review() else {
+                return;
+            };
+            let repos = cr.repos.clone();
+            let host = cr.host.clone();
+            let multi = cr.multi;
+            let files = build_files(&repos, &target, host.as_ref(), multi);
+            if let Some(cr) = s.active_review_mut() {
+                cr.target = target;
+                cr.files = files;
+                cr.selected = 0;
+                cr.scroll = 0;
+                cr.target_picker = None;
+                cr.rebuild_rows();
+            }
+        });
     }
 
     /// Apply the target-picker entry at `idx` (a click), mirroring the keyboard

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1150,6 +1150,10 @@ impl App {
                 "Global search",
                 Self::open_global_search,
             ),
+            Action::TogglePerfHud => self.gated(self.features.perf_hud, "Perf HUD", |s| {
+                s.show_perf_hud = !s.show_perf_hud;
+                s.request_redraw();
+            }),
             _ => return None,
         };
         Some(consumed)

--- a/src/app/metrics_state.rs
+++ b/src/app/metrics_state.rs
@@ -57,6 +57,16 @@ pub(crate) struct PerfCounters {
     /// restore, one per matched pane (ADR-P9). Proves the sequential adopt
     /// loop received pre-captured seeds instead of capturing inline.
     pub(crate) restore_seed_prefetches: u64,
+    /// Times a session's agent title/notification was actually re-read
+    /// (mutex locks + String clones) during the per-tick status refresh.
+    /// Gated on the reader thread's meta generation counter (ADR-P10), so it
+    /// stays flat while agents emit nothing — not 2·N locks per tick.
+    pub(crate) agent_meta_syncs: u64,
+    /// Times the per-tick status refresh actually ran its `PRAGMA
+    /// data_version` read. Throttled to every `HOOK_VERSION_CHECK_TICKS`
+    /// ticks (~100 ms) unless the cache was explicitly invalidated
+    /// (ADR-P10), so it climbs ~10×/s, not ~100×/s.
+    pub(crate) data_version_checks: u64,
 }
 
 impl PerfCounters {
@@ -94,6 +104,10 @@ impl PerfCounters {
             restore_seed_prefetches: self
                 .restore_seed_prefetches
                 .wrapping_sub(prev.restore_seed_prefetches),
+            agent_meta_syncs: self.agent_meta_syncs.wrapping_sub(prev.agent_meta_syncs),
+            data_version_checks: self
+                .data_version_checks
+                .wrapping_sub(prev.data_version_checks),
         }
     }
 }

--- a/src/app/metrics_state.rs
+++ b/src/app/metrics_state.rs
@@ -188,8 +188,6 @@ impl DurationHistogram {
 pub(crate) struct SlowOp {
     pub(crate) name: &'static str,
     pub(crate) ms: u64,
-    /// `tick_count` when recorded, so the HUD can show recency without a clock.
-    pub(crate) tick: u64,
 }
 
 /// Fixed-capacity ring of the most recent [`SlowOp`]s (newest first on read).
@@ -329,11 +327,7 @@ mod tests {
     fn slow_ops_ring_drops_oldest_past_capacity() {
         let mut ring = SlowOps::default();
         for i in 0..20u64 {
-            ring.push(SlowOp {
-                name: "op",
-                ms: i,
-                tick: i,
-            });
+            ring.push(SlowOp { name: "op", ms: i });
         }
         let recent: Vec<u64> = ring.iter_recent().map(|o| o.ms).collect();
         assert_eq!(recent.len(), SlowOps::CAP);

--- a/src/app/metrics_state.rs
+++ b/src/app/metrics_state.rs
@@ -46,6 +46,13 @@ pub(crate) struct PerfCounters {
     /// full shared-state reload ran. The ratio of reloads to checks shows how
     /// often the poll does real work vs. spins.
     pub(crate) external_poll_reloads: u64,
+    /// Code-review diff builds handed to a background worker (open/retarget).
+    /// Proves the git subprocess fan-out left the UI thread (ADR-P8): the
+    /// toggle path bumps this and must leave `files` empty until the poll.
+    pub(crate) review_builds_dispatched: u64,
+    /// Worker-built review results applied back on the UI thread (a dispatched
+    /// build whose review was closed before delivery is dropped, not applied).
+    pub(crate) review_builds_applied: u64,
 }
 
 impl PerfCounters {
@@ -74,6 +81,12 @@ impl PerfCounters {
             external_poll_reloads: self
                 .external_poll_reloads
                 .wrapping_sub(prev.external_poll_reloads),
+            review_builds_dispatched: self
+                .review_builds_dispatched
+                .wrapping_sub(prev.review_builds_dispatched),
+            review_builds_applied: self
+                .review_builds_applied
+                .wrapping_sub(prev.review_builds_applied),
         }
     }
 }

--- a/src/app/metrics_state.rs
+++ b/src/app/metrics_state.rs
@@ -48,6 +48,159 @@ pub(crate) struct PerfCounters {
     pub(crate) external_poll_reloads: u64,
 }
 
+impl PerfCounters {
+    /// Field-wise wrapping difference `self - prev`, for windowed reporting
+    /// (the counters stay cumulative; the perf-window log line and snapshot
+    /// publish deltas so idle windows read as zeros).
+    pub(crate) fn delta(&self, prev: &PerfCounters) -> PerfCounters {
+        PerfCounters {
+            frames_rendered: self.frames_rendered.wrapping_sub(prev.frames_rendered),
+            redraws_requested: self.redraws_requested.wrapping_sub(prev.redraws_requested),
+            redraws_skipped: self.redraws_skipped.wrapping_sub(prev.redraws_skipped),
+            status_refreshes: self.status_refreshes.wrapping_sub(prev.status_refreshes),
+            ordered_sessions_rebuilds: self
+                .ordered_sessions_rebuilds
+                .wrapping_sub(prev.ordered_sessions_rebuilds),
+            parser_locks_render: self
+                .parser_locks_render
+                .wrapping_sub(prev.parser_locks_render),
+            automation_entries_built: self
+                .automation_entries_built
+                .wrapping_sub(prev.automation_entries_built),
+            hook_state_loads: self.hook_state_loads.wrapping_sub(prev.hook_state_loads),
+            external_poll_checks: self
+                .external_poll_checks
+                .wrapping_sub(prev.external_poll_checks),
+            external_poll_reloads: self
+                .external_poll_reloads
+                .wrapping_sub(prev.external_poll_reloads),
+        }
+    }
+}
+
+/// Upper bounds (µs) of the fixed histogram buckets: powers of two from 250µs
+/// to ~1s, with the last bucket catching everything slower. Coarse on purpose —
+/// the histogram answers "is a frame 1ms or 30ms", not microbenchmarks.
+const HISTO_BUCKETS_US: [u64; 13] = [
+    250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 33_000, 66_000, 100_000, 250_000, 500_000,
+    1_000_000,
+];
+
+/// Fixed-bucket duration histogram for display/logging only — never asserted
+/// in CI (ADR-P2: wall-clock stats are observability, deterministic counters
+/// are the regression gate).
+#[derive(Default, Clone, Copy, Debug)]
+pub(crate) struct DurationHistogram {
+    /// One count per `HISTO_BUCKETS_US` bound, plus a final overflow bucket.
+    counts: [u64; HISTO_BUCKETS_US.len() + 1],
+    /// Total recorded samples.
+    total: u64,
+    /// Largest single sample seen (µs).
+    max_us: u64,
+}
+
+impl DurationHistogram {
+    pub(crate) fn record(&mut self, d: std::time::Duration) {
+        let us = u64::try_from(d.as_micros()).unwrap_or(u64::MAX);
+        let idx = HISTO_BUCKETS_US
+            .iter()
+            .position(|&bound| us <= bound)
+            .unwrap_or(HISTO_BUCKETS_US.len());
+        self.counts[idx] = self.counts[idx].wrapping_add(1);
+        self.total = self.total.wrapping_add(1);
+        self.max_us = self.max_us.max(us);
+    }
+
+    /// Approximate percentile (0–100) as the upper bound (µs) of the bucket
+    /// containing that rank; the overflow bucket reports the observed max.
+    pub(crate) fn percentile_us(&self, p: u8) -> u64 {
+        if self.total == 0 {
+            return 0;
+        }
+        let rank = (self.total * u64::from(p)).div_ceil(100).max(1);
+        let mut seen = 0u64;
+        for (i, &count) in self.counts.iter().enumerate() {
+            seen += count;
+            if seen >= rank {
+                return HISTO_BUCKETS_US.get(i).copied().unwrap_or(self.max_us);
+            }
+        }
+        self.max_us
+    }
+
+    pub(crate) fn max_us(&self) -> u64 {
+        self.max_us
+    }
+
+    #[cfg(test)]
+    pub(crate) fn total(&self) -> u64 {
+        self.total
+    }
+
+    pub(crate) fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// One measured slow operation (a named synchronous UI-thread op that took
+/// long enough to matter), kept in a small ring for the HUD / perf log.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct SlowOp {
+    pub(crate) name: &'static str,
+    pub(crate) ms: u64,
+    /// `tick_count` when recorded, so the HUD can show recency without a clock.
+    pub(crate) tick: u64,
+}
+
+/// Fixed-capacity ring of the most recent [`SlowOp`]s (newest first on read).
+#[derive(Default, Clone, Debug)]
+pub(crate) struct SlowOps {
+    ops: std::collections::VecDeque<SlowOp>,
+}
+
+impl SlowOps {
+    const CAP: usize = 16;
+
+    pub(crate) fn push(&mut self, op: SlowOp) {
+        if self.ops.len() == Self::CAP {
+            self.ops.pop_front();
+        }
+        self.ops.push_back(op);
+    }
+
+    /// Newest-first iteration (the HUD and log line show recent ops first).
+    pub(crate) fn iter_recent(&self) -> impl Iterator<Item = &SlowOp> {
+        self.ops.iter().rev()
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.ops.clear();
+    }
+}
+
+/// Wall-clock timing stats for the render/tick hot paths plus named slow ops.
+/// Populated only while timing is active (`THURBOX_PERF_LOG` or the perf HUD);
+/// display/logging only, never CI-asserted (ADR-P2).
+#[derive(Default)]
+pub(crate) struct PerfTimings {
+    /// `terminal.draw` duration per painted frame.
+    pub(crate) frame: DurationHistogram,
+    /// `App::tick` duration per loop iteration.
+    pub(crate) tick: DurationHistogram,
+    /// Recent named synchronous UI-thread operations.
+    pub(crate) slow_ops: SlowOps,
+}
+
+impl PerfTimings {
+    /// Clear per-window state after a perf-window report so each window's
+    /// percentiles and slow-op list stand alone.
+    pub(crate) fn reset_window(&mut self) {
+        self.frame.reset();
+        self.tick.reset();
+        self.slow_ops.clear();
+    }
+}
+
 /// CPU/RAM metrics collection plus the app-wide tick counter that paces the
 /// periodic refreshes (metrics, git stats, usage).
 pub(crate) struct MetricsState {
@@ -59,6 +212,9 @@ pub(crate) struct MetricsState {
     pub(crate) system_metrics: info_panel::SystemMetrics,
     /// Deterministic render/tick performance counters (perf regression tests).
     pub(crate) perf: PerfCounters,
+    /// Wall-clock timing stats (frame/tick histograms + slow-op ring),
+    /// recorded only while perf timing is active.
+    pub(crate) timings: PerfTimings,
 }
 
 impl MetricsState {
@@ -74,6 +230,7 @@ impl MetricsState {
                 session_memory_bytes: 0,
             },
             perf: PerfCounters::default(),
+            timings: PerfTimings::default(),
         }
     }
 
@@ -85,5 +242,78 @@ impl MetricsState {
     pub(crate) fn bump(&mut self, select: impl FnOnce(&mut PerfCounters) -> &mut u64) {
         let counter = select(&mut self.perf);
         *counter = counter.wrapping_add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn histogram_percentiles_from_explicit_samples() {
+        let mut h = DurationHistogram::default();
+        // 9 fast frames (~1ms bucket) and 1 slow one (~33ms bucket).
+        for _ in 0..9 {
+            h.record(Duration::from_micros(900));
+        }
+        h.record(Duration::from_millis(30));
+        assert_eq!(h.total(), 10);
+        assert_eq!(h.percentile_us(50), 1_000);
+        assert_eq!(h.percentile_us(95), 33_000);
+        assert_eq!(h.max_us(), 30_000);
+    }
+
+    #[test]
+    fn histogram_overflow_bucket_reports_observed_max() {
+        let mut h = DurationHistogram::default();
+        h.record(Duration::from_secs(3));
+        assert_eq!(h.percentile_us(50), 3_000_000);
+        assert_eq!(h.percentile_us(100), 3_000_000);
+    }
+
+    #[test]
+    fn histogram_empty_and_reset_read_zero() {
+        let mut h = DurationHistogram::default();
+        assert_eq!(h.percentile_us(95), 0);
+        h.record(Duration::from_millis(5));
+        h.reset();
+        assert_eq!(h.total(), 0);
+        assert_eq!(h.percentile_us(95), 0);
+        assert_eq!(h.max_us(), 0);
+    }
+
+    #[test]
+    fn slow_ops_ring_drops_oldest_past_capacity() {
+        let mut ring = SlowOps::default();
+        for i in 0..20u64 {
+            ring.push(SlowOp {
+                name: "op",
+                ms: i,
+                tick: i,
+            });
+        }
+        let recent: Vec<u64> = ring.iter_recent().map(|o| o.ms).collect();
+        assert_eq!(recent.len(), SlowOps::CAP);
+        assert_eq!(recent.first(), Some(&19), "newest first");
+        assert_eq!(recent.last(), Some(&4), "oldest surviving entry");
+    }
+
+    #[test]
+    fn perf_window_line_uses_counter_deltas() {
+        let base = PerfCounters {
+            frames_rendered: 10,
+            redraws_skipped: 100,
+            ..Default::default()
+        };
+        let now = PerfCounters {
+            frames_rendered: 14,
+            redraws_skipped: 350,
+            ..base
+        };
+        let d = now.delta(&base);
+        assert_eq!(d.frames_rendered, 4);
+        assert_eq!(d.redraws_skipped, 250);
+        assert_eq!(d.hook_state_loads, 0);
     }
 }

--- a/src/app/metrics_state.rs
+++ b/src/app/metrics_state.rs
@@ -53,6 +53,10 @@ pub(crate) struct PerfCounters {
     /// Worker-built review results applied back on the UI thread (a dispatched
     /// build whose review was closed before delivery is dropped, not applied).
     pub(crate) review_builds_applied: u64,
+    /// Scrollback captures prefetched in parallel during the local session
+    /// restore, one per matched pane (ADR-P9). Proves the sequential adopt
+    /// loop received pre-captured seeds instead of capturing inline.
+    pub(crate) restore_seed_prefetches: u64,
 }
 
 impl PerfCounters {
@@ -87,6 +91,9 @@ impl PerfCounters {
             review_builds_applied: self
                 .review_builds_applied
                 .wrapping_sub(prev.review_builds_applied),
+            restore_seed_prefetches: self
+                .restore_seed_prefetches
+                .wrapping_sub(prev.restore_seed_prefetches),
         }
     }
 }

--- a/src/app/metrics_state.rs
+++ b/src/app/metrics_state.rs
@@ -146,7 +146,9 @@ impl DurationHistogram {
     }
 
     /// Approximate percentile (0–100) as the upper bound (µs) of the bucket
-    /// containing that rank; the overflow bucket reports the observed max.
+    /// containing that rank, clamped to the observed max so a high percentile
+    /// can never read above the max next to it (the overflow bucket reports
+    /// the max directly).
     pub(crate) fn percentile_us(&self, p: u8) -> u64 {
         if self.total == 0 {
             return 0;
@@ -156,7 +158,11 @@ impl DurationHistogram {
         for (i, &count) in self.counts.iter().enumerate() {
             seen += count;
             if seen >= rank {
-                return HISTO_BUCKETS_US.get(i).copied().unwrap_or(self.max_us);
+                return HISTO_BUCKETS_US
+                    .get(i)
+                    .copied()
+                    .unwrap_or(self.max_us)
+                    .min(self.max_us);
             }
         }
         self.max_us
@@ -294,7 +300,9 @@ mod tests {
         h.record(Duration::from_millis(30));
         assert_eq!(h.total(), 10);
         assert_eq!(h.percentile_us(50), 1_000);
-        assert_eq!(h.percentile_us(95), 33_000);
+        // The slow sample lands in the 33 ms bucket, but the reported p95 is
+        // clamped to the observed max so it never reads above it.
+        assert_eq!(h.percentile_us(95), 30_000);
         assert_eq!(h.max_us(), 30_000);
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -697,6 +697,9 @@ pub struct App {
     /// interactive new-session flow, polled each tick. Programmatic spawns
     /// stay synchronous.
     session_spawn: background::BackgroundTask<Result<Session, String>>,
+    /// Off-thread code-review diff build (open/retarget), applied by
+    /// [`Self::poll_review_build`]. See ADR-P8 in `docs/PERFORMANCE.md`.
+    review_build: background::BackgroundTask<code_review::ReviewBuildResult>,
     /// Continuation for a completed background spawn: the metadata + follow-up
     /// (task prompt) to apply once the session is live.
     pending_session_spawn: Option<PendingSessionSpawn>,
@@ -1010,6 +1013,7 @@ impl App {
             worktree_create: background::BackgroundTask::default(),
             pending_worktree_create: None,
             session_spawn: background::BackgroundTask::default(),
+            review_build: background::BackgroundTask::default(),
             pending_session_spawn: None,
             remote_restore: None,
             deferred_inputs: Vec::new(),
@@ -3947,6 +3951,9 @@ impl App {
         self.poll_worktree_create();
         self.poll_session_spawn();
 
+        // Apply a finished off-thread code-review diff build (ADR-P8).
+        self.poll_review_build();
+
         // Adopt remote-backed sessions whose host discovery (started at
         // restore) has since completed.
         self.poll_remote_restore();
@@ -4135,6 +4142,18 @@ impl App {
             .timings
             .slow_ops
             .push(metrics_state::SlowOp { name, ms, tick });
+    }
+
+    /// Record an already-measured operation duration under the same
+    /// thresholds as [`Self::time_op`] — for work timed elsewhere (e.g. by a
+    /// background worker reporting its own elapsed time).
+    pub(crate) fn note_slow_op(&mut self, name: &'static str, ms: u64) {
+        if ms >= SLOW_OP_WARN_MS {
+            tracing::warn!(op = name, ms, "slow op");
+        }
+        if ms >= SLOW_OP_RECORD_MS {
+            self.push_slow_op(name, ms);
+        }
     }
 
     /// Measure a named synchronous UI-thread operation. Call sites are rare,
@@ -11232,6 +11251,81 @@ mod tests {
         assert!(msg.text.contains("branch exists"));
         assert!(!app.worktree_create.in_progress());
         assert!(app.pending_worktree_create.is_none());
+    }
+
+    /// ADR-P8: opening a review dispatches the git work to a background
+    /// worker; the toggle path itself must leave the diff empty (loading).
+    #[tokio::test]
+    async fn perf_review_open_never_builds_on_ui_thread() {
+        let mut app = app_with_sessions(1);
+        app.sessions[0].info.cwd = Some(std::env::temp_dir());
+
+        app.toggle_code_review();
+
+        assert_eq!(app.perf_counters().review_builds_dispatched, 1);
+        assert!(app.review_build.in_progress());
+        let cr = app.active_review().expect("the pane opens instantly");
+        assert!(cr.loading, "opens in the loading state");
+        assert!(cr.files.is_empty(), "no git work ran on the UI thread");
+        assert_eq!(app.focus, InputFocus::CodeReview);
+    }
+
+    /// The worker's result lands via the tick poll: loading clears, the rows
+    /// rebuild from the delivered files, and the applied counter bumps.
+    #[test]
+    fn perf_review_build_result_applied_via_poll() {
+        let mut app = app_with_sessions(1);
+        let sid = app.sessions[0].info.id;
+        let built = code_review::CodeReviewState::for_test(sid, 2);
+        let mut pending = code_review::CodeReviewState::for_test(sid, 0);
+        pending.loading = true;
+        let repos = built.repos.clone();
+        app.code_reviews.insert(sid, pending);
+
+        let tx = app.review_build.start();
+        tx.send(code_review::ReviewBuildResult {
+            session_id: sid,
+            elapsed_ms: 7,
+            kind: code_review::ReviewBuildKind::Open {
+                repos,
+                commits: Vec::new(),
+                target: code_review::ReviewTarget::Branch,
+                files: built.files.clone(),
+            },
+        })
+        .unwrap();
+        app.poll_review_build();
+
+        let cr = &app.code_reviews[&sid];
+        assert!(!cr.loading);
+        assert_eq!(cr.files.len(), 2);
+        assert!(!cr.rows.is_empty(), "rows rebuilt from the delivered diff");
+        assert_eq!(app.perf_counters().review_builds_applied, 1);
+        assert!(!app.review_build.in_progress());
+    }
+
+    /// A build whose review was closed before delivery is dropped without
+    /// panicking or resurrecting state.
+    #[test]
+    fn review_build_for_closed_review_is_dropped() {
+        let mut app = app_with_sessions(1);
+        let sid = app.sessions[0].info.id;
+        let tx = app.review_build.start();
+        tx.send(code_review::ReviewBuildResult {
+            session_id: sid,
+            elapsed_ms: 3,
+            kind: code_review::ReviewBuildKind::Retarget {
+                target: code_review::ReviewTarget::Working,
+                files: Vec::new(),
+            },
+        })
+        .unwrap();
+
+        app.poll_review_build();
+
+        assert!(app.code_reviews.is_empty(), "no state resurrected");
+        assert_eq!(app.perf_counters().review_builds_applied, 0);
+        assert!(!app.review_build.in_progress());
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod code_review;
 mod config_reload;
 mod helpers;
 mod key_handlers;
-mod metrics_state;
+pub(crate) mod metrics_state;
 pub(crate) mod modals;
 mod new_session_state;
 mod notify_state;
@@ -1201,6 +1201,9 @@ impl App {
             if matches!(self.focus, InputFocus::CodeReview | InputFocus::ReviewFiles) {
                 self.focus = InputFocus::Terminal;
             }
+        }
+        if !self.features.perf_hud {
+            self.show_perf_hud = false;
         }
     }
 
@@ -7972,6 +7975,7 @@ mod tests {
             info_panel: false,
             shell_pane: false,
             code_review: false,
+            perf_hud: false,
             mouse: true,
             notifications: false,
             soft_delete: true,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -63,6 +63,19 @@ const SPINNER_TICKS_PER_FRAME: u64 = 12;
 /// `docs/PERFORMANCE.md`.
 const FORCE_REDRAW_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
 
+/// Slow-op thresholds (ms): a named synchronous UI-thread operation at or
+/// above `RECORD` lands in the slow-op ring (HUD / perf-window line); at or
+/// above `WARN` it also gets a `tracing::warn!` — a visible stall (multiple
+/// dropped frames) worth a log entry even when nobody is watching the HUD.
+const SLOW_OP_RECORD_MS: u64 = 5;
+const SLOW_OP_WARN_MS: u64 = 100;
+
+/// Ticks (~10 ms each) per steady-state perf report window (~10 s): under
+/// `THURBOX_PERF_LOG` each window emits one `perf_window` log line (counter
+/// deltas + timing percentiles) and refreshes the published snapshot.
+/// Tick-based so tests can drive windows without a wall clock.
+const PERF_WINDOW_TICKS: u64 = 1_000;
+
 /// Prompt sent to Claude sessions when a worktree rebase has conflicts.
 const SYNC_CONFLICT_PROMPT: &str = "Please sync this worktree with main. Run: git fetch origin && git rebase origin/main -- if there are conflicts, resolve them and continue the rebase with git rebase --continue.";
 
@@ -800,6 +813,16 @@ pub struct App {
     /// reused across frames until [`Self::session_order_signature`] changes,
     /// skipping the per-frame grouping/sort/nest work. See `render_left_panel`.
     cached_session_order: Option<(u64, crate::ui::project_list::SessionOrder)>,
+    /// `THURBOX_PERF_LOG` presence, read once at construction so the hot loop's
+    /// timing gate ([`Self::perf_timing_active`]) is a bool check, not an env
+    /// lookup per iteration.
+    perf_log_env: bool,
+    /// Whether the perf HUD overlay is visible (toggled by
+    /// `Action::TogglePerfHud`); also enables timing collection.
+    show_perf_hud: bool,
+    /// Counter values at the last `perf_window` report, so each window logs
+    /// deltas (the counters themselves stay cumulative for the tests/HUD).
+    perf_window_base: metrics_state::PerfCounters,
 }
 
 const EDITOR_NOT_CONFIGURED: &str =
@@ -1016,6 +1039,9 @@ impl App {
             last_draw_at: clock::now(),
             last_output_gen: 0,
             cached_session_order: None,
+            perf_log_env: std::env::var_os("THURBOX_PERF_LOG").is_some(),
+            show_perf_hud: false,
+            perf_window_base: metrics_state::PerfCounters::default(),
         };
         app.report_config_warnings(config_warnings);
         app
@@ -3943,13 +3969,109 @@ impl App {
         self.tick_version_check();
 
         self.poll_auto_update();
+
+        self.tick_perf_window();
     }
 
-    /// Snapshot of the deterministic render/tick performance counters. Used by
-    /// the perf regression tests. See [`metrics_state::PerfCounters`].
-    #[cfg(test)]
+    /// Steady-state perf reporting: once per window (under `THURBOX_PERF_LOG`)
+    /// log counter deltas + timing percentiles + the window's slow ops, then
+    /// reset the per-window timing state so each report stands alone. The
+    /// startup line at first paint is separate and unaffected.
+    fn tick_perf_window(&mut self) {
+        if !self.perf_log_env || self.metrics.tick_count % PERF_WINDOW_TICKS != 0 {
+            return;
+        }
+        let now = self.perf_counters();
+        let d = now.delta(&self.perf_window_base);
+        let timings = &self.metrics.timings;
+        let slow_ops = timings
+            .slow_ops
+            .iter_recent()
+            .map(|op| format!("{}={}ms", op.name, op.ms))
+            .collect::<Vec<_>>()
+            .join(",");
+        tracing::info!(
+            frames = d.frames_rendered,
+            redraws_requested = d.redraws_requested,
+            redraws_skipped = d.redraws_skipped,
+            status_refreshes = d.status_refreshes,
+            order_rebuilds = d.ordered_sessions_rebuilds,
+            hook_state_loads = d.hook_state_loads,
+            external_poll_checks = d.external_poll_checks,
+            external_poll_reloads = d.external_poll_reloads,
+            frame_p50_us = timings.frame.percentile_us(50),
+            frame_p95_us = timings.frame.percentile_us(95),
+            frame_max_us = timings.frame.max_us(),
+            tick_p50_us = timings.tick.percentile_us(50),
+            tick_p95_us = timings.tick.percentile_us(95),
+            tick_max_us = timings.tick.max_us(),
+            slow_ops = %slow_ops,
+            sessions = self.sessions.len(),
+            "perf_window"
+        );
+        self.perf_window_base = now;
+        self.metrics.timings.reset_window();
+    }
+
+    /// Snapshot of the deterministic render/tick performance counters. Read by
+    /// the perf regression tests, the perf HUD, the `perf_window` log line, and
+    /// the published snapshot. See [`metrics_state::PerfCounters`].
     pub(crate) fn perf_counters(&self) -> metrics_state::PerfCounters {
         self.metrics.perf
+    }
+
+    /// Whether wall-clock perf timing should be collected this iteration:
+    /// opted in via `THURBOX_PERF_LOG` or by opening the perf HUD. A cached
+    /// bool so the hot loop pays nothing when observability is off.
+    pub fn perf_timing_active(&self) -> bool {
+        self.perf_log_env || self.show_perf_hud
+    }
+
+    /// Record one `terminal.draw` duration (called from the render loop, only
+    /// while [`Self::perf_timing_active`]).
+    pub fn record_frame_time(&mut self, d: std::time::Duration) {
+        self.metrics.timings.frame.record(d);
+    }
+
+    /// Record one `App::tick` duration (called from the render loop, only
+    /// while [`Self::perf_timing_active`]).
+    pub fn record_tick_time(&mut self, d: std::time::Duration) {
+        self.metrics.timings.tick.record(d);
+    }
+
+    /// Record one `App::update` (input dispatch) duration; outliers land in
+    /// the slow-op ring so a stalling key handler is attributable.
+    pub fn record_update_time(&mut self, d: std::time::Duration) {
+        let ms = d.as_millis() as u64;
+        if ms >= SLOW_OP_WARN_MS {
+            tracing::warn!(op = "input_dispatch", ms, "slow op");
+            self.push_slow_op("input_dispatch", ms);
+        }
+    }
+
+    fn push_slow_op(&mut self, name: &'static str, ms: u64) {
+        let tick = self.metrics.tick_count;
+        self.metrics
+            .timings
+            .slow_ops
+            .push(metrics_state::SlowOp { name, ms, tick });
+    }
+
+    /// Measure a named synchronous UI-thread operation. Call sites are rare,
+    /// user-triggered ops (never the per-tick hot path), so this measures
+    /// unconditionally: notable durations land in the slow-op ring and
+    /// stall-grade ones also get a `warn!` in the log.
+    pub(crate) fn time_op<T>(&mut self, name: &'static str, f: impl FnOnce(&mut Self) -> T) -> T {
+        let start = std::time::Instant::now();
+        let out = f(self);
+        let ms = start.elapsed().as_millis() as u64;
+        if ms >= SLOW_OP_WARN_MS {
+            tracing::warn!(op = name, ms, "slow op");
+        }
+        if ms >= SLOW_OP_RECORD_MS {
+            self.push_slow_op(name, ms);
+        }
+        out
     }
 
     /// Mark the UI dirty so the render loop paints on its next iteration.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -76,6 +76,11 @@ const SLOW_OP_WARN_MS: u64 = 100;
 /// Tick-based so tests can drive windows without a wall clock.
 const PERF_WINDOW_TICKS: u64 = 1_000;
 
+/// Ticks between perf-snapshot publishes while the perf HUD is open (~5 s).
+/// Snapshot writes bump other connections' `data_version`, so this stays
+/// coarse and only runs while someone is actually looking at perf data.
+const PERF_SNAPSHOT_TICKS: u64 = 500;
+
 /// Prompt sent to Claude sessions when a worktree rebase has conflicts.
 const SYNC_CONFLICT_PROMPT: &str = "Please sync this worktree with main. Run: git fetch origin && git rebase origin/main -- if there are conflicts, resolve them and continue the rebase with git rebase --continue.";
 
@@ -823,6 +828,10 @@ pub struct App {
     /// Counter values at the last `perf_window` report, so each window logs
     /// deltas (the counters themselves stay cumulative for the tests/HUD).
     perf_window_base: metrics_state::PerfCounters,
+    /// Startup phase breakdown handed over by `main` (the `startup` log line's
+    /// fields), included in the published perf snapshot so `thurbox-cli perf`
+    /// shows boot cost too.
+    startup_phases: Option<serde_json::Value>,
 }
 
 const EDITOR_NOT_CONFIGURED: &str =
@@ -1042,6 +1051,7 @@ impl App {
             perf_log_env: std::env::var_os("THURBOX_PERF_LOG").is_some(),
             show_perf_hud: false,
             perf_window_base: metrics_state::PerfCounters::default(),
+            startup_phases: None,
         };
         app.report_config_warnings(config_warnings);
         app
@@ -3979,9 +3989,20 @@ impl App {
     /// Steady-state perf reporting: once per window (under `THURBOX_PERF_LOG`)
     /// log counter deltas + timing percentiles + the window's slow ops, then
     /// reset the per-window timing state so each report stands alone. The
-    /// startup line at first paint is separate and unaffected.
+    /// startup line at first paint is separate and unaffected. Both the window
+    /// report and an open HUD also refresh the published snapshot
+    /// (`thurbox-cli perf`); a default run publishes nothing.
     fn tick_perf_window(&mut self) {
-        if !self.perf_log_env || self.metrics.tick_count % PERF_WINDOW_TICKS != 0 {
+        let tick = self.metrics.tick_count;
+        let window_due = self.perf_log_env && tick % PERF_WINDOW_TICKS == 0;
+        let snapshot_due = self.show_perf_hud && tick % PERF_SNAPSHOT_TICKS == 0;
+        if !window_due && !snapshot_due {
+            return;
+        }
+        // Publish before the window reset below so the snapshot carries this
+        // window's timing percentiles rather than an empty histogram.
+        self.publish_perf_snapshot();
+        if !window_due {
             return;
         }
         let now = self.perf_counters();
@@ -4014,6 +4035,62 @@ impl App {
         );
         self.perf_window_base = now;
         self.metrics.timings.reset_window();
+    }
+
+    /// Startup phase durations from `main`, for the published snapshot.
+    pub fn set_startup_phases(&mut self, phases: serde_json::Value) {
+        self.startup_phases = phases.into();
+    }
+
+    /// Write the current counters + timing stats as a JSON blob into the
+    /// `metadata` table for `thurbox-cli perf`. Only called while perf timing
+    /// is active (see [`Self::tick_perf_window`]) — the write bumps other
+    /// thurbox connections' `data_version`, so it must never run on a
+    /// default-config idle instance. Best-effort: a failed write only warns.
+    fn publish_perf_snapshot(&self) {
+        let p = self.perf_counters();
+        let t = &self.metrics.timings;
+        let histo = |h: &metrics_state::DurationHistogram| {
+            serde_json::json!({
+                "p50_us": h.percentile_us(50),
+                "p95_us": h.percentile_us(95),
+                "max_us": h.max_us(),
+            })
+        };
+        let slow_ops: Vec<serde_json::Value> = t
+            .slow_ops
+            .iter_recent()
+            .map(|op| serde_json::json!({ "op": op.name, "ms": op.ms }))
+            .collect();
+        let captured_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let snapshot = serde_json::json!({
+            "pid": std::process::id(),
+            "captured_at": captured_at,
+            "session_count": self.sessions.len(),
+            "tick_count": self.metrics.tick_count,
+            "counters": {
+                "frames_rendered": p.frames_rendered,
+                "redraws_requested": p.redraws_requested,
+                "redraws_skipped": p.redraws_skipped,
+                "status_refreshes": p.status_refreshes,
+                "ordered_sessions_rebuilds": p.ordered_sessions_rebuilds,
+                "parser_locks_render": p.parser_locks_render,
+                "automation_entries_built": p.automation_entries_built,
+                "hook_state_loads": p.hook_state_loads,
+                "external_poll_checks": p.external_poll_checks,
+                "external_poll_reloads": p.external_poll_reloads,
+            },
+            "frame": histo(&t.frame),
+            "tick": histo(&t.tick),
+            "slow_ops": slow_ops,
+            "startup": self.startup_phases,
+        });
+        if let Err(e) = self.db.set_perf_snapshot(&snapshot.to_string()) {
+            warn!("failed to publish perf snapshot: {e}");
+        }
     }
 
     /// Snapshot of the deterministic render/tick performance counters. Read by

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -81,6 +81,12 @@ const PERF_WINDOW_TICKS: u64 = 1_000;
 /// coarse and only runs while someone is actually looking at perf data.
 const PERF_SNAPSHOT_TICKS: u64 = 500;
 
+/// Ticks (~10 ms each) between the status refresh's `PRAGMA data_version`
+/// reads (~100 ms). Bounds an external `session signal`'s worst-case display
+/// latency while cutting the per-tick rusqlite round-trip 10× (ADR-P10);
+/// own-connection writes bypass the throttle via cache invalidation.
+const HOOK_VERSION_CHECK_TICKS: u64 = 10;
+
 /// Prompt sent to Claude sessions when a worktree rebase has conflicts.
 const SYNC_CONFLICT_PROMPT: &str = "Please sync this worktree with main. Run: git fetch origin && git rebase origin/main -- if there are conflicts, resolve them and continue the rebase with git rebase --continue.";
 
@@ -4329,13 +4335,23 @@ impl App {
         // an *external* `session signal` bumps `data_version`, but our own
         // `seen_at` writes (below) do not — otherwise reuse the cached map. This
         // replaces a full sessions-table scan on every (~10 ms) tick with a
-        // cheap in-memory `PRAGMA data_version` read on idle ticks. See
-        // `docs/PERFORMANCE.md`.
-        let version = self.db.data_version().ok();
-        if self.hook_states_version.is_none() || version != self.hook_states_version {
-            self.metrics.bump(|p| &mut p.hook_state_loads);
-            self.cached_hook_states = self.db.load_hook_states().unwrap_or_default();
-            self.hook_states_version = version;
+        // cheap in-memory `PRAGMA data_version` read — itself throttled to
+        // every `HOOK_VERSION_CHECK_TICKS` ticks (~100 ms; still ~10 rusqlite
+        // round-trips/s saved), except when the cache was explicitly
+        // invalidated (a remote hook event / restart wrote on our own
+        // connection, which the pragma can't see — check immediately). Worst
+        // case an external signal shows ~100 ms late, under any perceptible
+        // threshold. See `docs/PERFORMANCE.md` (ADR-P6 + ADR-P10).
+        let version_check_due = self.hook_states_version.is_none()
+            || self.metrics.tick_count % HOOK_VERSION_CHECK_TICKS == 0;
+        if version_check_due {
+            self.metrics.bump(|p| &mut p.data_version_checks);
+            let version = self.db.data_version().ok();
+            if self.hook_states_version.is_none() || version != self.hook_states_version {
+                self.metrics.bump(|p| &mut p.hook_state_loads);
+                self.cached_hook_states = self.db.load_hook_states().unwrap_or_default();
+                self.hook_states_version = version;
+            }
         }
         // "Seen" writes are deferred past the &mut self.sessions borrow below.
         let mut seen_writes: Vec<(crate::session::SessionId, i64)> = Vec::new();
@@ -4358,11 +4374,13 @@ impl App {
         // Track whether any visible field changed so a quiet transition (no new
         // output, so the output detector won't catch it) still repaints promptly
         // instead of waiting for the forced-redraw floor.
-        let changed = Self::apply_session_status_fields(
+        let (changed, meta_syncs) = Self::apply_session_status_fields(
             &mut self.sessions,
             &self.cached_hook_states,
             &seen_writes,
         );
+        self.metrics.perf.agent_meta_syncs =
+            self.metrics.perf.agent_meta_syncs.wrapping_add(meta_syncs);
 
         // Persist the seen marks now that the sessions borrow is released, and
         // mirror them into the cache write-through: our own write doesn't move
@@ -4505,8 +4523,9 @@ impl App {
         sessions: &mut [Session],
         hooks: &HashMap<crate::session::SessionId, crate::storage::HookRow>,
         seen_writes: &[(crate::session::SessionId, i64)],
-    ) -> bool {
+    ) -> (bool, u64) {
         let mut changed = false;
+        let mut meta_syncs = 0u64;
         for session in sessions.iter_mut() {
             // A placeholder (unreachable remote) has no live pane / hooks; keep
             // its `Unreachable` status until the host recovers and it adopts.
@@ -4524,24 +4543,27 @@ impl App {
                 just_seen,
                 session.millis_since_last_output(),
             );
-
-            // Live activity text from the agent-emitted OSC terminal title.
-            let new_activity = session.agent_title();
-            // Retain the agent's latest pushed notification (OSC 9/777) so the
-            // info panel can show it as a persistent "last signal".
-            let new_notification = session.notification();
-
-            if session.info.status != new_status
-                || session.info.agent_activity != new_activity
-                || session.info.notification != new_notification
-            {
+            if session.info.status != new_status {
                 changed = true;
             }
             session.info.status = new_status;
-            session.info.agent_activity = new_activity;
-            session.info.notification = new_notification;
+
+            // Live activity text (OSC title) + latest pushed notification
+            // (OSC 9/777): re-read only when the reader thread wrote something
+            // new — its generation counter gates the two mutex locks + String
+            // clones that otherwise ran per session per ~10 ms tick (ADR-P10).
+            if let Some((new_activity, new_notification)) = session.sync_agent_meta() {
+                meta_syncs += 1;
+                if session.info.agent_activity != new_activity
+                    || session.info.notification != new_notification
+                {
+                    changed = true;
+                }
+                session.info.agent_activity = new_activity;
+                session.info.notification = new_notification;
+            }
         }
-        changed
+        (changed, meta_syncs)
     }
 
     /// Advance the Working spinner from the (deterministic) tick counter, and
@@ -11085,16 +11107,79 @@ mod tests {
         app.tick();
         assert_eq!(app.perf_counters().hook_state_loads, 1);
 
-        // A different connection commits → `data_version` moves.
+        // A different connection commits → `data_version` moves. The pragma
+        // read itself is throttled (ADR-P10), so tick past a full
+        // `HOOK_VERSION_CHECK_TICKS` window for the change to be observed.
         let db2 = Database::open(tmp.path()).unwrap();
         db2.set_session_counter(7).unwrap();
 
-        app.tick();
+        for _ in 0..HOOK_VERSION_CHECK_TICKS {
+            app.tick();
+        }
         assert_eq!(
             app.perf_counters().hook_state_loads,
             2,
             "an external commit must invalidate the cache exactly once"
         );
+    }
+
+    #[tokio::test]
+    async fn perf_data_version_read_is_throttled() {
+        // The status refresh's `PRAGMA data_version` runs on the throttle
+        // cadence (~100 ms), not per ~10 ms tick: 100 idle ticks = the forced
+        // first check + one per `HOOK_VERSION_CHECK_TICKS` window (ADR-P10).
+        let mut app = App::new(24, 80, stub_backend(), stub_agents(), test_db());
+        for _ in 0..100 {
+            app.tick();
+        }
+        let checks = app.perf_counters().data_version_checks;
+        assert!(
+            checks <= 100 / HOOK_VERSION_CHECK_TICKS + 1,
+            "expected ≤{} throttled checks over 100 ticks, got {checks}",
+            100 / HOOK_VERSION_CHECK_TICKS + 1
+        );
+        assert!(
+            checks >= 100 / HOOK_VERSION_CHECK_TICKS,
+            "still polls each window"
+        );
+    }
+
+    #[tokio::test]
+    async fn perf_agent_meta_cached_across_idle_ticks() {
+        // The agent title/notification mutexes are re-read only when the
+        // reader thread bumped the meta generation: one initial sync per
+        // session, then flat across idle ticks — not 2·N locks per tick
+        // (ADR-P10).
+        let mut app = app_with_sessions(2);
+        for _ in 0..50 {
+            app.tick();
+        }
+        assert_eq!(
+            app.perf_counters().agent_meta_syncs,
+            2,
+            "one initial sync per session, then cached"
+        );
+    }
+
+    #[tokio::test]
+    async fn perf_agent_meta_resyncs_on_change() {
+        let mut app = app_with_sessions(1);
+        app.tick();
+        assert_eq!(app.perf_counters().agent_meta_syncs, 1);
+
+        // The reader thread writes a new title → next tick re-reads it.
+        app.sessions[0].bump_meta_gen_for_test("build: cargo");
+        app.tick();
+        assert_eq!(app.perf_counters().agent_meta_syncs, 2);
+        assert_eq!(
+            app.sessions[0].info.agent_activity.as_deref(),
+            Some("build: cargo"),
+            "the fresh title landed in the session info"
+        );
+
+        // And goes quiet again.
+        app.tick();
+        assert_eq!(app.perf_counters().agent_meta_syncs, 2);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4135,30 +4135,23 @@ impl App {
     /// Record one `App::update` (input dispatch) duration; outliers land in
     /// the slow-op ring so a stalling key handler is attributable.
     pub fn record_update_time(&mut self, d: std::time::Duration) {
-        let ms = d.as_millis() as u64;
-        if ms >= SLOW_OP_WARN_MS {
-            tracing::warn!(op = "input_dispatch", ms, "slow op");
-            self.push_slow_op("input_dispatch", ms);
-        }
+        self.note_slow_op("input_dispatch", d.as_millis() as u64);
     }
 
-    fn push_slow_op(&mut self, name: &'static str, ms: u64) {
-        let tick = self.metrics.tick_count;
-        self.metrics
-            .timings
-            .slow_ops
-            .push(metrics_state::SlowOp { name, ms, tick });
-    }
-
-    /// Record an already-measured operation duration under the same
-    /// thresholds as [`Self::time_op`] — for work timed elsewhere (e.g. by a
-    /// background worker reporting its own elapsed time).
+    /// Record an already-measured operation duration: at or above
+    /// `SLOW_OP_RECORD_MS` it lands in the slow-op ring (HUD / perf-window
+    /// line); at or above `SLOW_OP_WARN_MS` it also gets a `warn!` in the log.
+    /// The single sink behind [`Self::time_op`] and the workers that time
+    /// themselves (e.g. the code-review build).
     pub(crate) fn note_slow_op(&mut self, name: &'static str, ms: u64) {
         if ms >= SLOW_OP_WARN_MS {
             tracing::warn!(op = name, ms, "slow op");
         }
         if ms >= SLOW_OP_RECORD_MS {
-            self.push_slow_op(name, ms);
+            self.metrics
+                .timings
+                .slow_ops
+                .push(metrics_state::SlowOp { name, ms });
         }
     }
 
@@ -4169,13 +4162,7 @@ impl App {
     pub(crate) fn time_op<T>(&mut self, name: &'static str, f: impl FnOnce(&mut Self) -> T) -> T {
         let start = std::time::Instant::now();
         let out = f(self);
-        let ms = start.elapsed().as_millis() as u64;
-        if ms >= SLOW_OP_WARN_MS {
-            tracing::warn!(op = name, ms, "slow op");
-        }
-        if ms >= SLOW_OP_RECORD_MS {
-            self.push_slow_op(name, ms);
-        }
+        self.note_slow_op(name, start.elapsed().as_millis() as u64);
         out
     }
 
@@ -11491,6 +11478,53 @@ mod tests {
         assert!(app.code_reviews.is_empty(), "no state resurrected");
         assert_eq!(app.perf_counters().review_builds_applied, 0);
         assert!(!app.review_build.in_progress());
+    }
+
+    #[test]
+    fn note_slow_op_applies_record_threshold() {
+        let mut app = app_with_sessions(0);
+        app.note_slow_op("fast", SLOW_OP_RECORD_MS - 1);
+        assert!(
+            app.metrics.timings.slow_ops.iter_recent().next().is_none(),
+            "below the record threshold nothing lands in the ring"
+        );
+        app.note_slow_op("slow", SLOW_OP_RECORD_MS);
+        assert_eq!(
+            app.metrics
+                .timings
+                .slow_ops
+                .iter_recent()
+                .next()
+                .map(|o| o.name),
+            Some("slow")
+        );
+    }
+
+    /// The perf snapshot write bumps *other* connections' `data_version`
+    /// (forcing their shared-state reload), so a default-config idle instance
+    /// must never publish it — only THURBOX_PERF_LOG or an open HUD opts in
+    /// (ADR-P11).
+    #[tokio::test]
+    async fn perf_snapshot_published_only_while_timing_active() {
+        let mut app = app_with_sessions(0);
+        app.perf_log_env = false;
+        for _ in 0..=PERF_WINDOW_TICKS {
+            app.tick();
+        }
+        assert_eq!(
+            app.db.get_perf_snapshot().unwrap(),
+            None,
+            "no snapshot churn without opt-in"
+        );
+
+        app.show_perf_hud = true;
+        for _ in 0..=PERF_SNAPSHOT_TICKS {
+            app.tick();
+        }
+        assert!(
+            app.db.get_perf_snapshot().unwrap().is_some(),
+            "an open HUD publishes the snapshot"
+        );
     }
 
     /// Local backend that records capture/adopt interplay for the ADR-P9

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5081,6 +5081,7 @@ impl App {
             backend,
             &provider,
             HashMap::new(),
+            None,
         ) {
             Ok(mut adopted_session) => {
                 // Preserve the original session ID from shared state
@@ -5356,6 +5357,16 @@ impl App {
 
         let discovered_by_backend = self.discover_windows_by_backend(&local, perf_log);
 
+        // Prefetch every matched pane's scrollback capture in parallel before
+        // the sequential adopt loop: the captures are independent subprocesses,
+        // only the control-mode connect is serialized (ADR-P9).
+        let seeds = self.prefetch_capture_seeds(&local, &discovered_by_backend, perf_log);
+        self.metrics.perf.restore_seed_prefetches = self
+            .metrics
+            .perf
+            .restore_seed_prefetches
+            .wrapping_add(seeds.len() as u64);
+
         for shared in local {
             let discovered = discovered_by_backend
                 .get(&shared.backend_type)
@@ -5363,7 +5374,7 @@ impl App {
                 .unwrap_or_default();
             let adopt_start = perf_log.then(std::time::Instant::now);
             let name = perf_log.then(|| shared.name.clone());
-            self.restore_single_session(shared, &discovered);
+            self.restore_single_session(shared, &discovered, &seeds);
             if let (Some(start), Some(name)) = (adopt_start, name) {
                 tracing::info!(
                     session = %name,
@@ -5708,7 +5719,9 @@ impl App {
                     continue;
                 }
                 let retry_copy = shared.clone();
-                self.restore_single_session(shared, &discovered);
+                // Remote adoption keeps the inline capture (`seed: None` path)
+                // — the SSH control-mode round-trips dominate there anyway.
+                self.restore_single_session(shared, &discovered, &HashMap::new());
                 if self
                     .sessions
                     .iter()
@@ -5838,10 +5851,75 @@ impl App {
 
     /// Restore a single session synchronously (used during startup). The
     /// backend is selected from the session's persisted `backend_type`.
+    /// Capture every matched local pane's scrollback in parallel, keyed by
+    /// pane id, for [`Self::restore_single_session`] to pass into
+    /// [`Session::adopt`]. `tmux capture-pane` is an independent subprocess
+    /// per pane, so overlapping them shrinks the sequential restore's
+    /// `capture_ms` slice to ~0 (ADR-P9); the control-mode connect stays
+    /// sequential. Concurrency is bounded so a big restore doesn't fork one
+    /// subprocess per session at once. A failed capture is simply absent from
+    /// the map — the adopt falls back to its inline capture.
+    fn prefetch_capture_seeds(
+        &self,
+        local: &[sync::SharedSession],
+        discovered_by_backend: &HashMap<String, Vec<crate::agent::backend::DiscoveredSession>>,
+        perf_log: bool,
+    ) -> HashMap<String, Vec<u8>> {
+        const MAX_CONCURRENT_CAPTURES: usize = 8;
+
+        let mut jobs: Vec<(String, Arc<dyn SessionBackend>)> = Vec::new();
+        for shared in local {
+            let Some(discovered) = discovered_by_backend.get(&shared.backend_type) else {
+                continue;
+            };
+            let Some(disc) = Self::find_matching_discovered(shared, discovered) else {
+                continue;
+            };
+            let Some(backend) = self.resolve_persisted_backend(&shared.backend_type) else {
+                continue;
+            };
+            jobs.push((disc.backend_id.clone(), backend));
+        }
+        if jobs.is_empty() {
+            return HashMap::new();
+        }
+
+        let start = std::time::Instant::now();
+        let count = jobs.len();
+        let queue = std::sync::Mutex::new(jobs);
+        let results = std::sync::Mutex::new(HashMap::new());
+        let workers = MAX_CONCURRENT_CAPTURES.min(count);
+        std::thread::scope(|s| {
+            for _ in 0..workers {
+                s.spawn(|| loop {
+                    let job = queue.lock().ok().and_then(|mut q| q.pop());
+                    let Some((pane, backend)) = job else { break };
+                    match backend.capture_history(&pane) {
+                        Ok(seed) => {
+                            if let Ok(mut r) = results.lock() {
+                                r.insert(pane, seed);
+                            }
+                        }
+                        Err(e) => warn!("Failed to prefetch history for pane {pane}: {e}"),
+                    }
+                });
+            }
+        });
+        if perf_log {
+            tracing::info!(
+                sessions = count as u64,
+                prefetch_ms = start.elapsed().as_millis() as u64,
+                "restore_capture_prefetch"
+            );
+        }
+        results.into_inner().unwrap_or_default()
+    }
+
     fn restore_single_session(
         &mut self,
         shared: sync::SharedSession,
         discovered: &[crate::agent::backend::DiscoveredSession],
+        seeds: &HashMap<String, Vec<u8>>,
     ) {
         let name = shared.name.clone();
 
@@ -5882,6 +5960,7 @@ impl App {
                 &backend,
                 &provider,
                 HashMap::new(),
+                seeds.get(&disc.backend_id).cloned(),
             ) {
                 Ok(session) => Some(session),
                 Err(e) => {
@@ -6396,6 +6475,7 @@ mod tests {
             _: &str,
             _: u16,
             _: u16,
+            _: Option<Vec<u8>>,
         ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
             anyhow::bail!("stub backend does not adopt")
         }
@@ -11328,6 +11408,125 @@ mod tests {
         assert!(!app.review_build.in_progress());
     }
 
+    /// Local backend that records capture/adopt interplay for the ADR-P9
+    /// restore-prefetch gate: `capture_history` counts calls and returns
+    /// recognizable bytes; `adopt` asserts it always receives a prefetched
+    /// seed (never `None`, which would mean an inline capture on the
+    /// sequential path).
+    struct RecordingCaptureBackend {
+        captures: std::sync::atomic::AtomicUsize,
+        seeded_adopts: std::sync::atomic::AtomicUsize,
+    }
+    impl RecordingCaptureBackend {
+        fn new() -> Self {
+            Self {
+                captures: std::sync::atomic::AtomicUsize::new(0),
+                seeded_adopts: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+    }
+    impl SessionBackend for RecordingCaptureBackend {
+        fn name(&self) -> &str {
+            "capture-stub"
+        }
+        fn check_available(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn ensure_ready(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn spawn(
+            &self,
+            _: &str,
+            _: &str,
+            _: &[String],
+            _: Option<&Path>,
+            _: &std::collections::HashMap<String, String>,
+            _: u16,
+            _: u16,
+        ) -> anyhow::Result<crate::agent::backend::SpawnedSession> {
+            anyhow::bail!("capture stub does not spawn")
+        }
+        fn adopt(
+            &self,
+            _: &str,
+            _: u16,
+            _: u16,
+            seed: Option<Vec<u8>>,
+        ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
+            assert!(
+                seed.is_some(),
+                "restore must pass the prefetched seed (ADR-P9), not capture inline"
+            );
+            self.seeded_adopts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(crate::agent::backend::AdoptedSession {
+                output: Box::new(std::io::empty()),
+                input: Box::new(std::io::sink()),
+            })
+        }
+        fn capture_history(&self, backend_id: &str) -> anyhow::Result<Vec<u8>> {
+            self.captures
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(format!("history:{backend_id}").into_bytes())
+        }
+        fn discover(&self) -> anyhow::Result<Vec<crate::agent::backend::DiscoveredSession>> {
+            Ok(vec![
+                make_discovered("%1", "tb-one", true),
+                make_discovered("%2", "tb-two", true),
+            ])
+        }
+        fn resize(&self, _: &str, _: u16, _: u16) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn is_dead(&self, _: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        fn kill(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn detach(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn pane_pid(&self, _: &str) -> anyhow::Result<Option<u32>> {
+            Ok(None)
+        }
+    }
+
+    /// ADR-P9: the local restore prefetches every matched pane's scrollback
+    /// capture in parallel and hands the seeds to the sequential adopt loop —
+    /// one `capture_history` per session, every `adopt` seeded, counter == N.
+    #[tokio::test]
+    async fn perf_restore_prefetches_capture_seeds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(tmp.path());
+        let mut app = app_with_sessions(0);
+        let backend = Arc::new(RecordingCaptureBackend::new());
+        app.backends.register(backend.clone());
+
+        let mut one = make_shared_session("%1", "one");
+        one.backend_type = "capture-stub".to_string();
+        let mut two = make_shared_session("%2", "two");
+        two.backend_type = "capture-stub".to_string();
+
+        app.restore_sessions(vec![one, two], 2);
+
+        assert_eq!(
+            backend.captures.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "one prefetched capture per matched pane"
+        );
+        assert_eq!(
+            backend
+                .seeded_adopts
+                .load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "every adopt received its prefetched seed"
+        );
+        assert_eq!(app.perf_counters().restore_seed_prefetches, 2);
+        assert_eq!(app.sessions.len(), 2);
+    }
+
     #[test]
     fn poll_worktree_create_disconnected_clears_guard() {
         let mut app = app_with_sessions(0);
@@ -11815,6 +12014,7 @@ mod tests {
             _: &str,
             _: u16,
             _: u16,
+            _: Option<Vec<u8>>,
         ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
             Ok(crate::agent::backend::AdoptedSession {
                 output: Box::new(std::io::empty()),
@@ -11871,6 +12071,7 @@ mod tests {
             _: &str,
             _: u16,
             _: u16,
+            _: Option<Vec<u8>>,
         ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
             anyhow::bail!("host down")
         }
@@ -11992,6 +12193,7 @@ mod tests {
             _: &str,
             _: u16,
             _: u16,
+            _: Option<Vec<u8>>,
         ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
             Ok(crate::agent::backend::AdoptedSession {
                 output: Box::new(std::io::empty()),

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -1505,6 +1505,7 @@ pub enum SettingsField {
     FeatInfoPanel,
     FeatShellPane,
     FeatCodeReview,
+    FeatPerfHud,
     FeatMouse,
     FeatNotifications,
     FeatSoftDelete,
@@ -1525,7 +1526,7 @@ pub enum SettingsField {
 impl SettingsField {
     /// Field nav order — also the render order (headers are interleaved by the
     /// renderer). Used by [`cycle_field`] and the scroll-windowing logic.
-    pub const ORDER: [SettingsField; 20] = [
+    pub const ORDER: [SettingsField; 21] = [
         SettingsField::FeatTasks,
         SettingsField::FeatAutomations,
         SettingsField::FeatFileViewer,
@@ -1533,6 +1534,7 @@ impl SettingsField {
         SettingsField::FeatInfoPanel,
         SettingsField::FeatShellPane,
         SettingsField::FeatCodeReview,
+        SettingsField::FeatPerfHud,
         SettingsField::FeatMouse,
         SettingsField::FeatNotifications,
         SettingsField::FeatSoftDelete,
@@ -1570,6 +1572,11 @@ impl SettingsField {
                 "code_review",
                 "Code review",
                 "Native code-review view (diff + comments)",
+            ),
+            FeatPerfHud => (
+                "perf_hud",
+                "Perf HUD",
+                "Live perf counters + frame/tick timing overlay",
             ),
             FeatMouse => ("mouse", "Mouse", "Mouse: clicks, wheel, drag-select, hover"),
             FeatNotifications => (
@@ -1724,6 +1731,7 @@ impl SettingsModal {
             FeatInfoPanel => f.info_panel = !f.info_panel,
             FeatShellPane => f.shell_pane = !f.shell_pane,
             FeatCodeReview => f.code_review = !f.code_review,
+            FeatPerfHud => f.perf_hud = !f.perf_hud,
             FeatMouse => f.mouse = !f.mouse,
             FeatNotifications => f.notifications = !f.notifications,
             FeatSoftDelete => f.soft_delete = !f.soft_delete,
@@ -1781,6 +1789,7 @@ impl SettingsModal {
             FeatInfoPanel => on(f.info_panel),
             FeatShellPane => on(f.shell_pane),
             FeatCodeReview => on(f.code_review),
+            FeatPerfHud => on(f.perf_hud),
             FeatMouse => on(f.mouse),
             FeatNotifications => on(f.notifications),
             FeatSoftDelete => on(f.soft_delete),
@@ -3198,7 +3207,7 @@ mod tests {
 
     #[test]
     fn settings_order_lists_every_field_once() {
-        assert_eq!(SettingsField::ORDER.len(), 20);
+        assert_eq!(SettingsField::ORDER.len(), 21);
         for f in SettingsField::ORDER {
             assert_eq!(
                 SettingsField::ORDER.iter().filter(|x| **x == f).count(),
@@ -3273,6 +3282,7 @@ mod tests {
             FeatInfoPanel,
             FeatShellPane,
             FeatCodeReview,
+            FeatPerfHud,
             FeatSoftDelete,
         ] {
             assert!(!f.restart_required(), "{f:?} should be live");

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -65,6 +65,7 @@ mod tests {
             _: &str,
             _: u16,
             _: u16,
+            _: Option<Vec<u8>>,
         ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
             anyhow::bail!("stub backend does not adopt")
         }

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -100,6 +100,16 @@ impl App {
         }
         self.render_footer(frame, areas.footer);
         self.render_modals(frame);
+        if self.show_perf_hud {
+            crate::ui::perf_hud::render_perf_hud(
+                frame,
+                frame.area(),
+                &crate::ui::perf_hud::PerfHudView {
+                    metrics: &self.metrics,
+                    session_count: self.sessions.len(),
+                },
+            );
+        }
         self.repaint_theme_background(frame);
         self.apply_hover_highlight(frame);
         self.apply_selection_highlight(frame);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -22,6 +22,7 @@ pub mod identity;
 pub mod messages;
 pub mod notify;
 pub mod output;
+pub mod perf;
 pub mod sessions;
 pub mod tasks;
 pub mod update;
@@ -102,6 +103,9 @@ pub enum Command {
     Update(update::UpdateArgs),
     /// Diagnose OS desktop notifications; `--test` fires a sample.
     Notify(notify::NotifyArgs),
+    /// Print the perf snapshot a running TUI publishes (THURBOX_PERF_LOG or
+    /// the perf HUD must be active in that TUI).
+    Perf,
 }
 
 /// Build the additional-repo list for a multi-repo `Spawn` from the repeatable
@@ -154,6 +158,7 @@ pub fn run(cli: Cli, db: &Database) -> Result<(), String> {
         Command::Version(args) => Ok(version::run(args)),
         Command::Update(args) => Ok(update::run(args)),
         Command::Notify(args) => Ok(notify::run(args)),
+        Command::Perf => perf::run(db),
     }?;
 
     println!("{}", format.render(&output));

--- a/src/cli/perf.rs
+++ b/src/cli/perf.rs
@@ -1,0 +1,161 @@
+//! `thurbox-cli perf` — read the perf snapshot a running TUI publishes.
+//!
+//! The TUI writes a JSON snapshot (counters, frame/tick timing percentiles,
+//! slow ops, startup phase breakdown) into the SQLite `metadata` table while
+//! perf timing is active — `THURBOX_PERF_LOG=1` or an open perf HUD (F12).
+//! This command prints the latest one, so a running instance can be inspected
+//! from outside without tailing `thurbox.log`. See `docs/PERFORMANCE.md`.
+
+use serde_json::Value;
+
+use crate::storage::Database;
+
+use super::output::{kv, CommandOutput};
+
+/// Human hint shown when no snapshot exists (or it can't be parsed).
+const NO_SNAPSHOT_HINT: &str = "No perf snapshot published. Run the TUI with THURBOX_PERF_LOG=1 \
+     or open its perf HUD (F12), then retry.";
+
+/// Run the `perf` command: print the last published snapshot.
+pub fn run(db: &Database) -> Result<CommandOutput, String> {
+    let raw = db
+        .get_perf_snapshot()
+        .map_err(|e| format!("failed to read perf snapshot: {e}"))?;
+    let Some(raw) = raw else {
+        return Ok(CommandOutput::failed(
+            serde_json::json!({ "snapshot": null }),
+            NO_SNAPSHOT_HINT,
+            "no perf snapshot",
+        ));
+    };
+    let snapshot: Value =
+        serde_json::from_str(&raw).map_err(|e| format!("perf snapshot is not valid JSON: {e}"))?;
+    let human = render_human(&snapshot);
+    Ok(CommandOutput::new(snapshot, human))
+}
+
+fn u(v: &Value, path: &[&str]) -> u64 {
+    let mut cur = v;
+    for p in path {
+        cur = &cur[*p];
+    }
+    cur.as_u64().unwrap_or(0)
+}
+
+/// Format a µs value compactly (mirrors the HUD's formatting).
+fn fmt_us(us: u64) -> String {
+    if us < 1_000 {
+        format!("{us}µs")
+    } else if us < 1_000_000 {
+        format!("{:.1}ms", us as f64 / 1_000.0)
+    } else {
+        format!("{:.1}s", us as f64 / 1_000_000.0)
+    }
+}
+
+fn render_human(s: &Value) -> String {
+    let captured_at = u(s, &["captured_at"]);
+    let age = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs().saturating_sub(captured_at))
+        .unwrap_or(0);
+
+    let mut pairs: Vec<(&str, String)> = vec![
+        ("captured", format!("{age}s ago (pid {})", u(s, &["pid"]))),
+        ("sessions", u(s, &["session_count"]).to_string()),
+        ("ticks", u(s, &["tick_count"]).to_string()),
+        ("frames", u(s, &["counters", "frames_rendered"]).to_string()),
+        (
+            "idle skips",
+            u(s, &["counters", "redraws_skipped"]).to_string(),
+        ),
+        (
+            "order rebuilds",
+            u(s, &["counters", "ordered_sessions_rebuilds"]).to_string(),
+        ),
+        (
+            "hook loads",
+            u(s, &["counters", "hook_state_loads"]).to_string(),
+        ),
+        (
+            "frame p50/p95/max",
+            format!(
+                "{} / {} / {}",
+                fmt_us(u(s, &["frame", "p50_us"])),
+                fmt_us(u(s, &["frame", "p95_us"])),
+                fmt_us(u(s, &["frame", "max_us"])),
+            ),
+        ),
+        (
+            "tick p50/p95/max",
+            format!(
+                "{} / {} / {}",
+                fmt_us(u(s, &["tick", "p50_us"])),
+                fmt_us(u(s, &["tick", "p95_us"])),
+                fmt_us(u(s, &["tick", "max_us"])),
+            ),
+        ),
+    ];
+
+    if let Some(startup) = s.get("startup").filter(|v| v.is_object()) {
+        pairs.push((
+            "startup",
+            format!(
+                "config {}ms · db {}ms · heal {}ms · restore {}ms",
+                u(startup, &["config_init_ms"]),
+                u(startup, &["db_open_ms"]),
+                u(startup, &["extension_heal_ms"]),
+                u(startup, &["restore_ms"]),
+            ),
+        ));
+    }
+
+    let mut out = kv(&pairs);
+    match s.get("slow_ops").and_then(Value::as_array) {
+        Some(ops) if !ops.is_empty() => {
+            out.push_str("\n\nslow ops (recent first):");
+            for op in ops {
+                out.push_str(&format!(
+                    "\n  {:<20} {}ms",
+                    op["op"].as_str().unwrap_or("?"),
+                    u(op, &["ms"]),
+                ));
+            }
+        }
+        _ => out.push_str("\n\nslow ops: none recorded"),
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_snapshot_exits_nonzero_with_hint() {
+        let db = Database::open_in_memory().unwrap();
+        let out = run(&db).unwrap();
+        assert!(out.human.contains("THURBOX_PERF_LOG=1"));
+        assert!(out.failure.is_some(), "no snapshot → non-zero exit");
+    }
+
+    #[test]
+    fn snapshot_renders_counters_and_slow_ops() {
+        let db = Database::open_in_memory().unwrap();
+        db.set_perf_snapshot(
+            r#"{"pid":42,"captured_at":0,"session_count":3,"tick_count":100,
+                "counters":{"frames_rendered":7,"redraws_skipped":90,
+                            "ordered_sessions_rebuilds":1,"hook_state_loads":2},
+                "frame":{"p50_us":900,"p95_us":4000,"max_us":30000},
+                "tick":{"p50_us":250,"p95_us":500,"max_us":1000},
+                "slow_ops":[{"op":"code_review_build","ms":320}]}"#,
+        )
+        .unwrap();
+        let out = run(&db).unwrap();
+        assert!(out.failure.is_none());
+        assert!(out.human.contains("pid 42"));
+        assert!(out.human.contains("code_review_build"));
+        assert!(out.human.contains("320ms"));
+        assert_eq!(out.json["counters"]["frames_rendered"], 7);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,10 @@ async fn main() -> Result<()> {
     let t_phase = std::time::Instant::now();
     let db = open_database()?;
     startup.db_open_ms = t_phase.elapsed().as_millis();
+
+    let t_phase = std::time::Instant::now();
     activate_persisted_theme(&db);
+    startup.theme_activate_ms = t_phase.elapsed().as_millis();
 
     let t_phase = std::time::Instant::now();
 
@@ -179,7 +182,9 @@ async fn main() -> Result<()> {
     push_keyboard_enhancement();
     let size = terminal.size()?;
 
+    let t_phase = std::time::Instant::now();
     let mut app = App::new(size.height, size.width, backends, agents, db);
+    startup.app_new_ms = t_phase.elapsed().as_millis();
     app.set_hosts(hosts);
     if let Some(rx) = auto_update_rx {
         app.set_auto_update_receiver(rx);
@@ -194,7 +199,9 @@ async fn main() -> Result<()> {
     }
     startup.restore_ms = t_phase.elapsed().as_millis();
 
+    let t_phase = std::time::Instant::now();
     arm_automation_heartbeat();
+    startup.heartbeat_ms = t_phase.elapsed().as_millis();
 
     let res = run_loop(&mut terminal, &mut app, process_start, startup).await;
 
@@ -404,11 +411,17 @@ struct StartupTimings {
     config_init_ms: u128,
     /// `Database::open` (schema migrations included).
     db_open_ms: u128,
+    /// `activate_persisted_theme`: the metadata read + custom-theme publish.
+    theme_activate_ms: u128,
     /// Extension self-heal + built-in hooks wiring + agents.toml reload.
     extension_heal_ms: u128,
+    /// `App::new` (keybindings JSON load, settings snapshot, channel setup).
+    app_new_ms: u128,
     /// `load_persisted_state_from_db` + `restore_sessions` (sequential local
     /// adopt; remote backends restore on background threads, off this phase).
     restore_ms: u128,
+    /// `arm_automation_heartbeat`: a synchronous tmux subprocess.
+    heartbeat_ms: u128,
 }
 
 async fn run_loop(
@@ -429,16 +442,27 @@ async fn run_loop(
         // or the forced-redraw floor elapsed. The loop still spins every ≤10ms
         // (cheap: poll + output check + tick), but the expensive layout/vt100
         // render is skipped when idle — see App::should_redraw / docs/PERFORMANCE.md.
+        // Wall-clock timing is opt-in (THURBOX_PERF_LOG or the perf HUD): the
+        // cached-bool gate keeps the default hot loop free of Instant reads.
+        let timing = app.perf_timing_active();
+
         if app.should_redraw() {
+            let draw_start = timing.then(std::time::Instant::now);
             terminal.draw(|f| app.view(f))?;
+            if let Some(start) = draw_start {
+                app.record_frame_time(start.elapsed());
+            }
             app.mark_redrawn();
 
             if perf_log && !first_frame_logged {
                 tracing::info!(
                     config_init_ms = startup.config_init_ms as u64,
                     db_open_ms = startup.db_open_ms as u64,
+                    theme_activate_ms = startup.theme_activate_ms as u64,
                     extension_heal_ms = startup.extension_heal_ms as u64,
+                    app_new_ms = startup.app_new_ms as u64,
                     restore_ms = startup.restore_ms as u64,
+                    heartbeat_ms = startup.heartbeat_ms as u64,
                     first_frame_ms = process_start.elapsed().as_millis() as u64,
                     "startup"
                 );
@@ -450,14 +474,22 @@ async fn run_loop(
 
         if event::poll(Duration::from_millis(10))? {
             if let Some(msg) = event_to_message(event::read()?) {
+                let update_start = timing.then(std::time::Instant::now);
                 app.update(msg); // marks the UI dirty
+                if let Some(start) = update_start {
+                    app.record_update_time(start.elapsed());
+                }
             }
         }
 
         // Cheap, lock-free check for new agent output (marks dirty on change).
         app.detect_output_redraw();
 
+        let tick_start = timing.then(std::time::Instant::now);
         app.tick();
+        if let Some(start) = tick_start {
+            app.record_tick_time(start.elapsed());
+        }
 
         if app.should_quit() {
             break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,10 @@ async fn main() -> Result<()> {
     arm_automation_heartbeat();
     startup.heartbeat_ms = t_phase.elapsed().as_millis();
 
+    // Hand the phase breakdown to the app so the published perf snapshot
+    // (`thurbox-cli perf`) can show boot cost alongside the runtime stats.
+    app.set_startup_phases(startup.as_json());
+
     let res = run_loop(&mut terminal, &mut app, process_start, startup).await;
 
     // Restore the terminal *before* the (potentially slow) session detach:
@@ -422,6 +426,22 @@ struct StartupTimings {
     restore_ms: u128,
     /// `arm_automation_heartbeat`: a synchronous tmux subprocess.
     heartbeat_ms: u128,
+}
+
+impl StartupTimings {
+    /// The phase breakdown as JSON, mirroring the `startup` log line's fields
+    /// (sans `first_frame_ms`, which isn't known until the first paint).
+    fn as_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "config_init_ms": self.config_init_ms as u64,
+            "db_open_ms": self.db_open_ms as u64,
+            "theme_activate_ms": self.theme_activate_ms as u64,
+            "extension_heal_ms": self.extension_heal_ms as u64,
+            "app_new_ms": self.app_new_ms as u64,
+            "restore_ms": self.restore_ms as u64,
+            "heartbeat_ms": self.heartbeat_ms as u64,
+        })
+    }
 }
 
 async fn run_loop(

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -53,6 +53,8 @@ pub enum Action {
     GlobalSearch,
     /// Open the Settings panel (view/edit settings.toml in the TUI).
     OpenSettings,
+    /// Toggle the perf HUD overlay (live counters + frame/tick timing).
+    TogglePerfHud,
     /// Copy the active mouse selection. With no selection it copies the current
     /// status-bar message instead — except in a focused terminal, where it falls
     /// through to SIGINT (the status row stays click-to-copy there).
@@ -152,6 +154,7 @@ impl Action {
             Action::FocusTasks,
             Action::GlobalSearch,
             Action::OpenSettings,
+            Action::TogglePerfHud,
             Action::Copy,
             Action::Paste,
             Action::SessionListNext,
@@ -217,6 +220,7 @@ impl Action {
             Action::FocusTasks => "Tasks",
             Action::GlobalSearch => "Global search",
             Action::OpenSettings => "Settings",
+            Action::TogglePerfHud => "Toggle perf HUD",
             Action::Copy => "Copy selection / status",
             Action::Paste => "Paste",
             Action::SessionListNext => "Next item",
@@ -419,6 +423,10 @@ impl Action {
             // from a focused terminal too). F6 is a discoverable alternate
             // (F1–F5 are already bound). Fully rebindable.
             Action::OpenSettings => vec![KeyChord::ctrl(','), KeyChord::function(6)],
+            // F12 only — a diagnostic surface, not worth spending a scarce
+            // Ctrl+<letter> on. F-keys dispatch from every pane (a focused
+            // terminal included), which is exactly what a HUD toggle needs.
+            Action::TogglePerfHud => vec![KeyChord::function(12)],
             Action::Copy => vec![KeyChord::ctrl('c')],
             Action::Paste => vec![KeyChord::ctrl('v')],
             // Scoped single-letter / arrow nav. These only fire while their
@@ -554,6 +562,7 @@ pub fn help_sections() -> Vec<(&'static str, Vec<Action>)> {
                 OpenThemePicker,
                 OpenSettings,
                 GlobalSearch,
+                TogglePerfHud,
             ],
         ),
         ("Clipboard", vec![Copy, Paste]),
@@ -1341,6 +1350,7 @@ mod tests {
                 Action::FocusTasks => 0,
                 Action::GlobalSearch => 0,
                 Action::OpenSettings => 0,
+                Action::TogglePerfHud => 0,
                 Action::Copy => 0,
                 Action::Paste => 0,
                 Action::SessionListNext => 0,
@@ -1381,7 +1391,7 @@ mod tests {
         }
         // The listed variants must equal Action::all().len(). If you add
         // a variant, update both `Action::all()` and the match above.
-        const EXPECTED: usize = 59;
+        const EXPECTED: usize = 60;
         assert_eq!(Action::all().len(), EXPECTED);
         for a in Action::all() {
             classify(*a);

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -74,6 +74,10 @@ pub struct FeatureFlags {
     /// keybinding.
     #[serde(default = "default_true")]
     pub code_review: bool,
+    /// Perf HUD overlay (F12): live perf counters + frame/tick timing. Opening
+    /// it also turns on wall-clock timing collection (see docs/PERFORMANCE.md).
+    #[serde(default = "default_true")]
+    pub perf_hud: bool,
     /// Mouse support: terminal mouse capture plus all click/scroll/hover
     /// handling (click-to-select, drag selection, Ctrl+Click URLs,
     /// scrollbars). Disable to keep the terminal's native mouse behavior
@@ -195,6 +199,7 @@ impl Default for FeatureFlags {
             info_panel: true,
             shell_pane: true,
             code_review: true,
+            perf_hud: true,
             mouse: true,
             notifications: true,
             soft_delete: true,
@@ -463,6 +468,7 @@ mod tests {
             info_panel,
             shell_pane,
             code_review,
+            perf_hud,
             mouse,
             notifications,
             soft_delete,
@@ -480,6 +486,7 @@ mod tests {
             info_panel,
             shell_pane,
             code_review,
+            perf_hud,
             mouse,
             notifications,
             soft_delete,
@@ -490,13 +497,14 @@ mod tests {
         // `live` flags gate UI panels read from `App.features` every frame, so
         // flipping one is NOT a restart-only difference; the rest are read once
         // at startup and MUST register as one.
-        let live: [fn(&mut FeatureFlags); 7] = [
+        let live: [fn(&mut FeatureFlags); 8] = [
             |f| f.tasks = !f.tasks,
             |f| f.file_viewer = !f.file_viewer,
             |f| f.global_search = !f.global_search,
             |f| f.info_panel = !f.info_panel,
             |f| f.shell_pane = !f.shell_pane,
             |f| f.code_review = !f.code_review,
+            |f| f.perf_hud = !f.perf_hud,
             |f| f.soft_delete = !f.soft_delete,
         ];
         let restart: [fn(&mut FeatureFlags); 5] = [

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -10,6 +10,7 @@ const EDITOR_COMMAND_KEY: &str = "editor_command";
 const THEME_KEY: &str = "active_theme";
 const ACTIVE_EXTENSIONS_KEY: &str = "active_extensions";
 const BUILTIN_HOOKS_OPTOUT_KEY: &str = "builtin_hooks_optout";
+const PERF_SNAPSHOT_KEY: &str = "perf_snapshot";
 
 impl Database {
     /// Get the configured editor command (e.g. `code`, `nvim --remote-tab`).
@@ -64,6 +65,31 @@ impl Database {
             )?;
         }
         Ok(())
+    }
+
+    /// Publish the TUI's latest perf snapshot (a JSON blob) for
+    /// `thurbox-cli perf` to read. Written only while perf timing is active
+    /// (THURBOX_PERF_LOG or an open perf HUD) — each write bumps other
+    /// connections' `data_version`, so an idle default-config TUI must never
+    /// churn this row.
+    pub fn set_perf_snapshot(&self, json: &str) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![PERF_SNAPSHOT_KEY, json],
+        )?;
+        Ok(())
+    }
+
+    /// The last published perf snapshot, if any (see [`Self::set_perf_snapshot`]).
+    pub fn get_perf_snapshot(&self) -> rusqlite::Result<Option<String>> {
+        self.conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![PERF_SNAPSHOT_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
     }
 
     /// The set of currently-active extension names (e.g. `["flow"]`), stored as
@@ -296,6 +322,19 @@ mod tests {
             Some(second.to_string().as_str())
         );
         assert_eq!(db.take_pending_focus_session_id().unwrap(), None);
+    }
+
+    #[test]
+    fn perf_snapshot_round_trips_and_overwrites() {
+        let db = Database::open_in_memory().unwrap();
+        assert_eq!(db.get_perf_snapshot().unwrap(), None);
+        db.set_perf_snapshot(r#"{"frames":1}"#).unwrap();
+        db.set_perf_snapshot(r#"{"frames":2}"#).unwrap();
+        assert_eq!(
+            db.get_perf_snapshot().unwrap().as_deref(),
+            Some(r#"{"frames":2}"#),
+            "the latest snapshot wins"
+        );
     }
 
     #[test]

--- a/src/ui/code_review.rs
+++ b/src/ui/code_review.rs
@@ -95,7 +95,21 @@ pub(crate) fn render(
     // The target picker, when open, replaces the diff body. Its entries are
     // clickable (`targets`), on top of the keyboard-driven ↑/↓/Enter path.
     let mut targets = Vec::new();
-    let hits = if state.target_picker.is_some() {
+    let hits = if state.loading {
+        // A background build is in flight (ADR-P8): the pane opened instantly
+        // and fills in when the worker delivers. No rows = nothing clickable.
+        let msg = Line::from(Span::styled(
+            "Building diff…",
+            Style::default().fg(Theme::text_muted()),
+        ))
+        .centered();
+        let y = diff_area.y + diff_area.height / 2;
+        frame.render_widget(
+            Paragraph::new(msg),
+            Rect::new(diff_area.x, y, diff_area.width, 1),
+        );
+        (Vec::new(), None)
+    } else if state.target_picker.is_some() {
         targets = render_target_picker(frame, diff_area, state);
         (Vec::new(), None)
     } else {
@@ -1351,6 +1365,7 @@ mod tests {
         };
         let mut s = CodeReviewState {
             session_id: SessionId::default(),
+            loading: false,
             repos: vec![crate::app::code_review::ReviewRepo {
                 label: String::new(),
                 dir: std::path::PathBuf::from("/tmp"),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,6 +15,7 @@ pub mod info_panel;
 pub mod layout;
 pub mod links;
 pub mod markdown;
+pub mod perf_hud;
 pub mod project_list;
 pub mod repo_picker_modal;
 pub mod restore_sessions_modal;

--- a/src/ui/perf_hud.rs
+++ b/src/ui/perf_hud.rs
@@ -27,7 +27,8 @@ pub(crate) struct PerfHudView<'a> {
 const HUD_WIDTH: u16 = 46;
 const HUD_HEIGHT: u16 = 18;
 
-/// Format a µs value compactly: `420µs`, `3.2ms`, `1.8s`.
+/// Format a µs value compactly: `420µs`, `3.2ms`, `1.8s`. Mirrored by
+/// `cli::perf::fmt_us` (the architecture rules bar `cli` from importing `ui`).
 fn fmt_us(us: u64) -> String {
     if us < 1_000 {
         format!("{us}µs")

--- a/src/ui/perf_hud.rs
+++ b/src/ui/perf_hud.rs
@@ -1,0 +1,150 @@
+//! Perf HUD overlay: a small right-anchored box with the live perf counters,
+//! frame/tick timing percentiles, and the most recent slow ops. Toggled by
+//! `Action::TogglePerfHud` (F12); opening it also switches on wall-clock
+//! timing collection (`App::perf_timing_active`). Unlike a modal it never dims
+//! or captures input — it floats above the normal panes so the app stays fully
+//! drivable while the numbers update (~4 fps via the forced-redraw floor).
+
+use ratatui::{
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use crate::app::metrics_state::MetricsState;
+
+use super::theme::Theme;
+
+/// Borrowed snapshot of everything the HUD shows.
+pub(crate) struct PerfHudView<'a> {
+    pub(crate) metrics: &'a MetricsState,
+    pub(crate) session_count: usize,
+}
+
+/// Preferred HUD width/height; clamped to the frame on small terminals.
+const HUD_WIDTH: u16 = 46;
+const HUD_HEIGHT: u16 = 18;
+
+/// Format a µs value compactly: `420µs`, `3.2ms`, `1.8s`.
+fn fmt_us(us: u64) -> String {
+    if us < 1_000 {
+        format!("{us}µs")
+    } else if us < 1_000_000 {
+        format!("{:.1}ms", us as f64 / 1_000.0)
+    } else {
+        format!("{:.1}s", us as f64 / 1_000_000.0)
+    }
+}
+
+fn row<'a>(label: &'a str, value: String) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(
+            format!("{label:<14}"),
+            Style::default().fg(Theme::text_muted()),
+        ),
+        Span::styled(value, Style::default().fg(Theme::text_primary())),
+    ])
+}
+
+/// Render the HUD into the top-right corner of `area` (the full frame).
+pub(crate) fn render_perf_hud(frame: &mut Frame, area: Rect, view: &PerfHudView<'_>) {
+    let w = HUD_WIDTH.min(area.width);
+    let h = HUD_HEIGHT.min(area.height.saturating_sub(1));
+    if w < 20 || h < 6 {
+        return;
+    }
+    // Top-right, below the header row, so it covers neither the session list
+    // nor the footer hints.
+    let hud = Rect::new(area.x + area.width - w, area.y + 1, w, h);
+    frame.render_widget(Clear, hud);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(Theme::border_unfocused()))
+        .title(Span::styled(" Perf ", Style::default().fg(Theme::accent())))
+        .style(Style::default().bg(Theme::modal_bg()));
+    let inner = block.inner(hud);
+    frame.render_widget(block, hud);
+
+    let p = view.metrics.perf;
+    let t = &view.metrics.timings;
+    // Idle efficiency: the share of loop iterations that skipped the paint.
+    let attempts = p.redraws_requested + p.redraws_skipped;
+    let skip_pct = if attempts == 0 {
+        0.0
+    } else {
+        p.redraws_skipped as f64 * 100.0 / attempts as f64
+    };
+
+    let mut lines: Vec<Line> = vec![
+        row("sessions", view.session_count.to_string()),
+        row("ticks", view.metrics.tick_count.to_string()),
+        row("frames", p.frames_rendered.to_string()),
+        row(
+            "idle skips",
+            format!("{} ({skip_pct:.0}%)", p.redraws_skipped),
+        ),
+        row("order builds", p.ordered_sessions_rebuilds.to_string()),
+        row("hook loads", p.hook_state_loads.to_string()),
+        row(
+            "ext polls",
+            format!(
+                "{} ({} reloads)",
+                p.external_poll_checks, p.external_poll_reloads
+            ),
+        ),
+        row(
+            "frame p50/p95",
+            format!(
+                "{} / {} (max {})",
+                fmt_us(t.frame.percentile_us(50)),
+                fmt_us(t.frame.percentile_us(95)),
+                fmt_us(t.frame.max_us()),
+            ),
+        ),
+        row(
+            "tick p50/p95",
+            format!(
+                "{} / {} (max {})",
+                fmt_us(t.tick.percentile_us(50)),
+                fmt_us(t.tick.percentile_us(95)),
+                fmt_us(t.tick.max_us()),
+            ),
+        ),
+    ];
+
+    lines.push(Line::from(Span::styled(
+        "slow ops",
+        Style::default().fg(Theme::text_muted()),
+    )));
+    let mut any = false;
+    for op in t.slow_ops.iter_recent().take(4) {
+        any = true;
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("  {:<18}", op.name),
+                Style::default().fg(Theme::text_secondary()),
+            ),
+            Span::styled(
+                format!("{}ms", op.ms),
+                Style::default().fg(Theme::status_working()),
+            ),
+        ]));
+    }
+    if !any {
+        lines.push(Line::from(Span::styled(
+            "  none ≥5ms",
+            Style::default().fg(Theme::text_muted()),
+        )));
+    }
+
+    // Discoverability: the log-based counterpart of this overlay.
+    lines.push(Line::from(Span::styled(
+        "THURBOX_PERF_LOG=1 logs windows",
+        Style::default().fg(Theme::keybind_hint()),
+    )));
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}

--- a/src/ui/settings_modal.rs
+++ b/src/ui/settings_modal.rs
@@ -76,6 +76,7 @@ const SECTIONS: [(&str, &[SettingsField]); 3] = [
             SettingsField::FeatInfoPanel,
             SettingsField::FeatShellPane,
             SettingsField::FeatCodeReview,
+            SettingsField::FeatPerfHud,
             SettingsField::FeatMouse,
             SettingsField::FeatNotifications,
             SettingsField::FeatSoftDelete,


### PR DESCRIPTION
## Summary

- **Runtime observability layer**: frame/tick duration histograms + a slow-op ring (opt-in via `THURBOX_PERF_LOG` or the new **F12 perf HUD**), steady-state `perf_window` log lines, richer startup phase breakdown, and a published perf snapshot readable via the new `thurbox-cli perf` subcommand (ADR-P11).
- **Targeted optimizations**, each gated by deterministic counters + `perf_*` tests: code-review diffs build off the UI thread with a loading state (ADR-P8 — was seconds of freeze over SSH), restore prefetches tmux history captures in parallel (ADR-P9), and the idle tick drops its per-session mutex/String churn + throttles the `PRAGMA data_version` read 10× (ADR-P10).
- **Fixes along the way**: the `code_review` feature flag was never persisted by the Settings panel; histogram percentiles clamped to the observed max.

## Test plan

- `cargo nextest run --all` (1799 tests) + `perf_*` counter gates for every optimization
- Verified live: HUD renders at ~4 fps with 96% idle-skip ratio, `perf_window`/`startup` lines land in `thurbox.log`, `thurbox-cli perf` reads the published snapshot
- CI checks pass

https://claude.ai/code/session_01P3gBfqKh9dn7F4NhUc2JrC