### PR TITLE
fix(ui): anchor code-review file jump to top of pane

### DIFF
--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -977,6 +977,24 @@ fn review_files_pane_navigates_and_opens_into_diff() {
 }
 
 #[test]
+fn review_jump_to_file_anchors_header_to_top() {
+    let mut h = Harness::standard(1);
+    open_review(&mut h, 5);
+
+    // Jumping to a file below the current window must scroll its header to the
+    // top of the viewport, not leave it pinned to the bottom line (the renderer
+    // only clamps the *upper* edge). Regression: clicking a changed-files row
+    // landed the file at the last visible row.
+    h.app.cr_jump_to_file(3);
+    let cr = h.app.active_review().unwrap();
+    assert_eq!(cr.current_file(), Some(3));
+    assert_eq!(
+        cr.scroll, cr.selected,
+        "the jumped-to file header sits at the top of the viewport"
+    );
+}
+
+#[test]
 fn review_files_pane_demoted_to_terminal_when_review_closes() {
     let mut h = Harness::standard(1);
     open_review(&mut h, 2);

--- a/src/app/code_review.rs
+++ b/src/app/code_review.rs
@@ -766,8 +766,14 @@ impl App {
             .iter()
             .position(|r| matches!(r, ReviewRow::FileHeader(fi) if *fi == file_idx))
         {
+            // Clicking a file in the changed-files list means "reveal this
+            // file", so anchor its header to the top of the viewport. Setting
+            // `scroll = selected` subsumes `ensure_visible` (which only pulls
+            // the window up); without it a downward jump would let the renderer
+            // clamp the header to the bottom row. The renderer's `total -
+            // height` clamp still handles a file near the end.
             cr.selected = pos;
-            cr.ensure_visible();
+            cr.scroll = pos;
         }
     }
 


### PR DESCRIPTION
## Summary

- Clicking a file in the code-review changed-files list (or pressing `g`/`G`/`Home`) landed the file header on the **bottom** line of the diff pane instead of the top.
- `cr_jump_to_file` only called `ensure_visible`, which pulls the scroll window up but never down, so a downward jump let the renderer clamp the header to the last visible row. Now the scroll offset is anchored explicitly to the header row (the renderer's `total - height` clamp still handles a file near the end).

## Test plan

- New regression test `review_jump_to_file_anchors_header_to_top` asserts the header anchors to the top after a downward jump.
- CI checks pass.