### PR TITLE
fix(core): expand a leading `~` in an extension session's repo_path

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -522,7 +522,8 @@ requires_dir = "~/.gemini"      #   exactly our entries (by marker). no-op write
 [[sessions]]
 name = "flow"
 agent = "flow"
-repo_path = "{home}"            # resolved to the absolute home at install
+repo_path = "{home}"            # absolute, `~`-relative, or `{home}`; resolved
+                                #   to an absolute path at install
 
 # [[automations]] is an OPTIONAL runtime resource (flow itself ships none —
 # it is purely event-driven). An extension that wants a scheduled tick declares:

--- a/src/agent/extension_config.rs
+++ b/src/agent/extension_config.rs
@@ -326,19 +326,10 @@ pub fn resolve_source(target: &str) -> ExtensionSource {
 
 /// Expand a leading `~/` (or bare `~`) to the user's home directory. Shared by
 /// the source resolver and the installer so both agree on home expansion.
+/// Delegates to [`crate::paths::expand_tilde`] — the single implementation —
+/// which additionally honours `~\` on Windows.
 pub fn expand_tilde(path: &str) -> PathBuf {
-    // `$HOME` on Unix, `%USERPROFILE%` on Windows (matches `paths::home_dir`).
-    let home_var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
-    if let Some(rest) = path.strip_prefix("~/") {
-        if let Some(home) = std::env::var_os(home_var) {
-            return PathBuf::from(home).join(rest);
-        }
-    } else if path == "~" {
-        if let Some(home) = std::env::var_os(home_var) {
-            return PathBuf::from(home);
-        }
-    }
-    PathBuf::from(path)
+    crate::paths::expand_tilde(path)
 }
 
 /// Fetch one file's text content from a source (`<source>/<rel>`).

--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -14,7 +14,7 @@
 //! orchestration) can depend on the same type without crossing module-isolation
 //! rules — exactly like [`crate::session::HostDef`].
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -168,7 +168,10 @@ pub struct ExtensionSession {
     pub name: String,
     /// Agent name to launch (an `agents.toml` entry the installer registers).
     pub agent: String,
-    /// Directory the agent runs in (absolute; the installer resolves any `~`).
+    /// Directory the agent runs in: absolute, `~`-relative, or containing
+    /// `{home}` — the same forms accepted for file destinations. Both are
+    /// resolved by [`ExtensionDef::resolved_for_home`] at install time, so the
+    /// stored manifest always holds an absolute path.
     pub repo_path: PathBuf,
 }
 
@@ -308,12 +311,21 @@ impl ExtensionDef {
     /// This is what gets written to the discovery dir at install time, so
     /// `activate`/self-heal read absolute paths (they don't expand tokens
     /// themselves) and uninstall knows the real home directory.
-    pub fn resolved_for_home(&self, home: &str) -> ExtensionDef {
+    ///
+    /// A session `repo_path` may also be `~`-relative; `user_home` is the user's
+    /// home directory ([`crate::paths::home_dir`]), passed in because `session`
+    /// is the dependency sink and never resolves paths itself. `None` (no
+    /// `$HOME`) leaves a leading `~` verbatim, matching
+    /// [`crate::paths::expand_tilde`]'s graceful fallback.
+    pub fn resolved_for_home(&self, home: &str, user_home: Option<&Path>) -> ExtensionDef {
         let mut out = self.clone();
         out.home = Some(home.to_string());
         for s in &mut out.sessions {
+            // `{home}` first, `~` second: an extension home that itself lives
+            // under `~` resolves to an absolute path here, so the tilde pass
+            // finds nothing left to expand and can't double-resolve it.
             let p = s.repo_path.to_string_lossy().replace(HOME_TOKEN, home);
-            s.repo_path = PathBuf::from(p);
+            s.repo_path = expand_leading_tilde(&p, user_home);
         }
         // External-file destinations and patched agent args may reference the
         // home dir (e.g. `--settings {home}/hooks/claude.json`); resolve them so
@@ -386,6 +398,29 @@ impl ExtensionDef {
         } else {
             None
         }
+    }
+}
+
+/// Expand a leading `~` (bare, or followed by a path separator) against
+/// `user_home`. The pure counterpart of [`crate::paths::expand_tilde`], which
+/// reads `$HOME` itself — `session` may not reach into `paths`, so the home dir
+/// arrives as an argument. Same rules: `~` anywhere but the front is an ordinary
+/// filename character, `~user` is not expanded (no passwd lookup), and an
+/// unresolvable home leaves the path untouched.
+fn expand_leading_tilde(path: &str, user_home: Option<&Path>) -> PathBuf {
+    let Some(home) = user_home else {
+        return PathBuf::from(path);
+    };
+    if path == "~" {
+        return home.to_path_buf();
+    }
+    // `\` is a separator on Windows only; on Unix it is a legal filename char.
+    let rest = path
+        .strip_prefix("~/")
+        .or_else(|| cfg!(windows).then(|| path.strip_prefix("~\\")).flatten());
+    match rest {
+        Some(rest) => home.join(rest),
+        None => PathBuf::from(path),
     }
 }
 
@@ -570,7 +605,7 @@ prompt = "tick"
             "name = \"hooks\"\n[[config_merges]]\npath = \"{home}/settings.json\"\nrequires_dir = \"{home}\"\n",
         )
         .unwrap();
-        let resolved = def.resolved_for_home("/home/me/.gemini");
+        let resolved = def.resolved_for_home("/home/me/.gemini", None);
         assert_eq!(
             resolved.config_merges[0].path,
             "/home/me/.gemini/settings.json"
@@ -583,19 +618,83 @@ prompt = "tick"
         assert_eq!(def.config_merges[0].path, "{home}/settings.json");
     }
 
+    /// The env var `paths::home_dir()` reads on this platform: `USERPROFILE` on
+    /// Windows, `HOME` elsewhere. The tilde tests source the home directory from
+    /// the same var the installer passes in, so they pass on every target.
+    const HOME_VAR: &str = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+
+    /// The user home the installer would pass to `resolved_for_home`.
+    fn user_home() -> PathBuf {
+        PathBuf::from(std::env::var_os(HOME_VAR).expect("home var set in tests"))
+    }
+
+    /// Resolve a single-session manifest exactly as the installer does, and
+    /// return the session's `repo_path`.
+    fn resolved_repo_path(repo_path: &str, home: &str) -> PathBuf {
+        let def: ExtensionDef = toml::from_str(&format!(
+            "name = \"x\"\n[[sessions]]\nname = \"x\"\nagent = \"x\"\nrepo_path = '{repo_path}'\n"
+        ))
+        .unwrap();
+        let home_dir = user_home();
+        let mut resolved = def.resolved_for_home(home, Some(&home_dir));
+        resolved.sessions.remove(0).repo_path
+    }
+
     #[test]
     fn resolved_for_home_substitutes_session_repo_path() {
         let def: ExtensionDef = toml::from_str(
             "name = \"flow\"\n[[sessions]]\nname = \"flow\"\nagent = \"flow\"\nrepo_path = \"{home}\"\n",
         )
         .unwrap();
-        let resolved = def.resolved_for_home("/home/me/flow");
+        let resolved = def.resolved_for_home("/home/me/flow", Some(&user_home()));
         assert_eq!(
             resolved.sessions[0].repo_path,
             PathBuf::from("/home/me/flow")
         );
         // Original is untouched.
         assert_eq!(def.sessions[0].repo_path, PathBuf::from("{home}"));
+    }
+
+    #[test]
+    fn resolved_for_home_expands_leading_tilde_in_session_repo_path() {
+        assert_eq!(
+            resolved_repo_path("~/Repositories/fleet", "/home/me/flow"),
+            user_home().join("Repositories").join("fleet")
+        );
+        assert_eq!(resolved_repo_path("~", "/home/me/flow"), user_home());
+    }
+
+    #[test]
+    fn resolved_for_home_leaves_absolute_session_repo_path_alone() {
+        assert_eq!(
+            resolved_repo_path("/abs/path", "/home/me/flow"),
+            PathBuf::from("/abs/path")
+        );
+    }
+
+    #[test]
+    fn resolved_for_home_ignores_non_leading_tilde_in_session_repo_path() {
+        // `~` is an ordinary filename character anywhere but the front — so a
+        // resolved `{home}` that happens to contain one is not re-expanded.
+        assert_eq!(
+            resolved_repo_path("/tmp/a~b", "/home/me/flow"),
+            PathBuf::from("/tmp/a~b")
+        );
+        assert_eq!(
+            resolved_repo_path("{home}", "/tmp/a~b/flow"),
+            PathBuf::from("/tmp/a~b/flow")
+        );
+    }
+
+    #[test]
+    fn resolved_for_home_keeps_tilde_when_home_is_unresolvable() {
+        let def: ExtensionDef = toml::from_str(
+            "name = \"x\"\n[[sessions]]\nname = \"x\"\nagent = \"x\"\nrepo_path = \"~/x\"\n",
+        )
+        .unwrap();
+        // No `$HOME`: leave the path verbatim rather than inventing a root.
+        let resolved = def.resolved_for_home("/home/me/x", None);
+        assert_eq!(resolved.sessions[0].repo_path, PathBuf::from("~/x"));
     }
 
     #[test]

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -260,7 +260,7 @@ pub fn install_extension(
     //    activate. `target` is recorded verbatim so `update` re-fetches the same
     //    source (a bare name re-resolves against the *current* binary's tag).
     let resolved = def
-        .resolved_for_home(&home_str)
+        .resolved_for_home(&home_str, crate::paths::home_dir().as_deref())
         .with_provenance(current, target);
     crate::agent::extension_config::write_manifest(&resolved)?;
     report.ensure = activate_extension(db, &resolved)?;


### PR DESCRIPTION
## The bug

`extension.toml` lets an extension declare a long-lived session:

```toml
[[sessions]]
name = "fleet"
agent = "fleet"
repo_path = "~/Repositories/fleet"
```

`ExtensionDef::resolved_for_home()` substituted the `{home}` token but never
expanded a leading `~`, so the session was created with its cwd set to a
relative directory literally named `~`. No error, no warning. Reproduced
against `0.174.1`: `thurbox-cli session list --json` reports
`"cwd": "~/Repositories/fleet"`.

Two things already disagreed with that behavior:

- `[[automations]]`' spawn `repo_path` **does** expand `~`
  (`spawn_automation_expands_tilde_in_repo_path`).
- The `ExtensionSession::repo_path` doc comment already promised
  "*absolute; the installer resolves any `~`*".

## The fix

Expand a leading `~` **after** the `{home}` substitution, so `{home}` keeps
winning and a resolved home path that itself contains a `~` (e.g. `/tmp/a~b`)
is not re-expanded. Non-leading `~` is an ordinary filename character and is
left alone; with no `$HOME` the path is left verbatim, matching
`paths::expand_tilde`'s graceful fallback.

### Two deviations from the obvious implementation, both deliberate

1. **`session` cannot call `paths::expand_tilde`.** `tests/architecture_rules.rs`
   pins `session` as the dependency sink (`allowed: &[]`, no crate-internal
   references in any form, `use` or fully-qualified), and no file under
   `src/session/` reads `std::env` today. So `resolved_for_home` now takes the
   user home as an argument — `resolved_for_home(&home_str, paths::home_dir().as_deref())`
   at its single production call site — and expands it with a pure helper. The
   module stays pure and the expansion stays unit-testable without touching the
   environment.
2. **No third `expand_tilde`.** `agent::extension_config::expand_tilde` was a
   near-copy of `paths::expand_tilde`; it now delegates to it. Net effect: one
   env-reading implementation (`paths`), one pure one (`session`), down from two
   env-reading copies. The delegation also gains `~\` handling on Windows, which
   the copy lacked.

## Answer to "do extension-declared automations have the same hole?"

**No — there is nothing to fix.** `ExtensionAutomation` (`src/session/extension_def.rs`)
has no `repo_path`-equivalent field: it is `name` / `trigger` / `session_ref` /
`prompt` / `command`. `ensure_automation` (`src/session_ops/extensions.rs`) can
only build an `AutomationAction::Send { session_id }` or `AutomationAction::Exec
{ command }` from a manifest — never a `Spawn`, which is the only variant that
carries a `repo_path`. A manifest automation reaches a directory solely through
its `session_ref`, i.e. through the `[[sessions]]` `repo_path` this PR fixes.
The `Spawn` tilde expansion already exists on the TUI/CLI authoring paths.

## Tests

Added to `src/session/extension_def.rs`, alongside the existing
`resolved_for_home` tests:

| Test | Asserts |
|---|---|
| `resolved_for_home_expands_leading_tilde_in_session_repo_path` | `~/Repositories/fleet` → `<home>/Repositories/fleet`, and bare `~` → `<home>` (home sourced from `$HOME`/`%USERPROFILE%`, not hardcoded) |
| `resolved_for_home_leaves_absolute_session_repo_path_alone` | `/abs/path` passes through unchanged |
| `resolved_for_home_ignores_non_leading_tilde_in_session_repo_path` | `/tmp/a~b` untouched; `{home}` resolving to `/tmp/a~b/flow` is not double-expanded |
| `resolved_for_home_keeps_tilde_when_home_is_unresolvable` | no `$HOME` → `~/x` left verbatim |
| `resolved_for_home_substitutes_session_repo_path` (existing) | `{home}` regression — still resolves to the extension home |

```
$ cargo test --lib extension_def
running 17 tests
test session::extension_def::tests::automation_validate_rejects_invalid_flavours ... ok
test session::extension_def::tests::compare_versions_orders_numerically ... ok
test session::extension_def::tests::compat_warning_fires_only_when_binary_too_old ... ok
test session::extension_def::tests::is_dev_version_detects_unstable_builds ... ok
test session::extension_def::tests::file_source_path_falls_back_to_path ... ok
test session::extension_def::tests::config_merge_source_path_defaults_to_dest_filename ... ok
test session::extension_def::tests::resolved_for_home_keeps_tilde_when_home_is_unresolvable ... ok
test session::extension_def::tests::resolved_for_home_leaves_absolute_session_repo_path_alone ... ok
test session::extension_def::tests::resolved_for_home_ignores_non_leading_tilde_in_session_repo_path ... ok
test session::extension_def::tests::resolved_for_home_expands_leading_tilde_in_session_repo_path ... ok
test session::extension_def::tests::resolved_for_home_substitutes_config_merge_paths ... ok
test session::extension_def::tests::is_stale_compares_install_version_to_current ... ok
test session::extension_def::tests::with_provenance_stamps_install_metadata ... ok
test session::extension_def::tests::minimal_manifest_has_no_resources ... ok
test session::extension_def::tests::parses_full_manifest ... ok
test session::extension_def::tests::resolved_for_home_substitutes_session_repo_path ... ok
test session::extension_def::tests::round_trips_through_toml ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 1754 filtered out; finished in 0.00s
```

Full suite green: `cargo nextest run --all` → 1804 passed, and the pre-commit
hooks (fmt / clippy / check / nextest / architecture / deny / doc / rumdl) all
pass.

One caveat worth naming: `cargo test --lib` (single process, threaded) flaked
twice for me on `git::tests::resolve_base_ref_none_without_remote` and
`session_ops::extensions::tests::uninstall_reverses_install`. That is a
**pre-existing** global-env race — `paths::tests::which_on_path_*` overwrites
`$PATH` process-wide and `paths::tests::expand_tilde_no_home` removes `$HOME`,
so a concurrent `Command::new("git")` can fail `NotFound`. Both tests are
untouched here, and `cargo nextest` (the repo's runner, and what CI uses) is
process-per-test and always green. Five consecutive `cargo test --lib` runs on
this branch also pass.

## Compatibility

`{home}` semantics are unchanged, so the shipped extensions (`flow`, `forge`,
`ci-shepherd`, `github-issues`, `hooks`) that all use `repo_path = "{home}"`
keep working. No `extensions/*/extension.toml` touched.

## Docs

- `ExtensionSession::repo_path` doc comment now states all three accepted forms,
  matching the wording used for file destinations.
- `docs/CONFIG.md`'s manifest reference updated to match.