### PR TITLE
refactor(ui): drop the repo-group rollup status dot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -670,7 +670,7 @@ via `App::backend_for`).
   `%subscription-changed` pushes (≤1/s), queued on the connection and drained
   each tick by `App::drain_remote_hook_events` into the same `set_hook_state`
   columns local signals use — so Done→seen acknowledgment, OS notifications,
-  rollups, and the stuck-`working` fallback are shared. Events are matched by
+  and the stuck-`working` fallback are shared. Events are matched by
   **backend name + pane id** (pane ids collide across hosts), allow-listed
   (remote-controlled text), and deduped against the cache (a reconnect
   re-report must not resurrect an acknowledged `done`). Carve-outs: psmux
@@ -1458,11 +1458,12 @@ frame; the static `icon()` is used in non-animated contexts (info panel).
   trips it; only `working` is time-gated (`blocked`/`done` are not). The DB row is
   left untouched — the override is purely in the per-tick derivation, like
   exited → `Idle`.
-- **Rollup.** Repo groups roll up to their most-urgent member
-  (`Blocked > Error > Working > Done > Unreachable > Idle`), rendered as a colored dot on
-  the group header (`ui::project_list::group_status` +
-  `group_header_line`). Status only recolors — it **never** reorders rows
-  (the order cache stays status-independent).
+- **Per-session only.** Status is rendered on the session's own row (and in the
+  ` Sessions ` panel border title, one dot per session). Repo-group headers
+  (`ui::project_list::group_header_line`) carry **no** status — a rolled-up
+  group dot would restate what every member row already shows. Status only
+  recolors — it **never** reorders rows (the order cache stays
+  status-independent).
 - **Colours** are tunable theme fields: `status_working` / `status_blocked`
   / `status_done` / `status_idle` / `status_error`
   (`session::theme_config`, all 15 presets + custom-theme overrides), mapped

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use super::highlight::append_highlighted as append_name_spans;
 use super::theme::Theme;
 use super::{focus_block, status_color, FocusLevel};
-use crate::session::{SessionInfo, SessionStatus};
+use crate::session::SessionInfo;
 
 /// Per-field fuzzy match positions for a session entry.
 #[derive(Clone)]
@@ -637,24 +637,6 @@ fn render_session_section(
     // Available width inside the block (subtract 2 for borders)
     let inner_width = area.width.saturating_sub(2) as usize;
 
-    // The header row each row belongs to, used to roll each group's members up
-    // to a single status dot on the header below.
-    let group_of = header_group_of(headers);
-
-    // Roll each repo group up to its most-urgent member status, keyed by the
-    // group's header row index, so the header shows a single dot you can scan.
-    // Computed at render time (not in `SessionOrder`) so status never feeds the
-    // order cache or reorders rows — it only recolors.
-    let mut group_rollup: std::collections::HashMap<usize, SessionStatus> =
-        std::collections::HashMap::new();
-    for (i, info) in sessions.iter().enumerate() {
-        let h = group_of[i];
-        group_rollup
-            .entry(h)
-            .and_modify(|s| *s = group_status([*s, info.status]))
-            .or_insert(info.status);
-    }
-
     let mut item_heights: Vec<u16> = Vec::with_capacity(sessions.len());
 
     // Session ids on screen, for the cross-group child mark (a child whose
@@ -687,11 +669,10 @@ fn render_session_section(
             )];
 
             // Prepend a subtle repo-group header above the first session of
-            // each group. The header carries the group's rolled-up status dot
-            // but never reflects selection (that stays on the session rows).
+            // each group. The header never reflects selection (that stays on
+            // the session rows).
             if let Some(Some(label)) = headers.get(i) {
-                let rollup = group_rollup.get(&i).copied().unwrap_or(info.status);
-                item_lines.insert(0, group_header_line(label, rollup, inner_width, spinner));
+                item_lines.insert(0, group_header_line(label, inner_width));
             }
 
             item_heights.push(item_lines.len() as u16);
@@ -757,68 +738,17 @@ fn render_empty_sessions(frame: &mut Frame, area: Rect, block: ratatui::widgets:
     frame.render_widget(text, area);
 }
 
-/// For each row, the index of the group header row it belongs to. Lets a group's
-/// members roll up to a single status dot on their header. Rows before the first
-/// header map to row 0, which is harmless since those rows carry no header.
-fn header_group_of(headers: &[Option<String>]) -> Vec<usize> {
-    let mut out = Vec::with_capacity(headers.len());
-    let mut current = 0;
-    for (i, h) in headers.iter().enumerate() {
-        if h.is_some() {
-            current = i;
-        }
-        out.push(current);
-    }
-    out
-}
-
-/// A full-width repo-group header: `● ── label ──────────`. The leading dot is
-/// the group's rolled-up most-urgent status; the label is always muted. The
-/// header never reflects selection — highlighting belongs to the session rows
-/// alone, so selecting a group's first row must not light up its header.
-fn group_header_line(
-    label: &str,
-    rollup: SessionStatus,
-    inner_width: usize,
-    spinner: &str,
-) -> Line<'static> {
-    let style = Style::default().fg(Theme::text_muted());
-    let dot = format!("{} ", super::status_glyph(rollup, spinner));
+/// A full-width repo-group header: `── label ──────────`. The label is always
+/// muted, and the header never reflects selection — highlighting belongs to the
+/// session rows alone, so selecting a group's first row must not light up its
+/// header. Status lives on the session rows, never here.
+fn group_header_line(label: &str, inner_width: usize) -> Line<'static> {
     let mut text = format!("\u{2500}\u{2500} {label} ");
-    let used = dot.chars().count() + text.chars().count();
+    let used = text.chars().count();
     if inner_width > used {
         text.push_str(&"\u{2500}".repeat(inner_width - used));
     }
-    Line::from(vec![
-        Span::styled(dot, Style::default().fg(status_color(rollup))),
-        Span::styled(text, style),
-    ])
-}
-
-/// Urgency rank for the repo-group rollup; higher is more urgent.
-///
-/// `Unreachable` sits just above `Idle`: a group whose only notable member is a
-/// down remote session rolls up as unreachable, but any live member (Done and
-/// up) still dominates the header dot.
-fn status_urgency(s: SessionStatus) -> u8 {
-    match s {
-        SessionStatus::Blocked => 5,
-        SessionStatus::Error => 4,
-        SessionStatus::Working => 3,
-        SessionStatus::Done => 2,
-        SessionStatus::Unreachable => 1,
-        SessionStatus::Idle => 0,
-    }
-}
-
-/// The most-urgent status across a group's members (Blocked > Error > Working >
-/// Done > Unreachable > Idle), so the group header dot surfaces whatever needs
-/// attention first. Empty input rolls up to `Idle`.
-pub fn group_status(statuses: impl IntoIterator<Item = SessionStatus>) -> SessionStatus {
-    statuses
-        .into_iter()
-        .max_by_key(|s| status_urgency(*s))
-        .unwrap_or(SessionStatus::Idle)
+    Line::from(Span::styled(text, Style::default().fg(Theme::text_muted())))
 }
 
 /// Resolve the agent-reported status text for a session row, if any.
@@ -1414,10 +1344,23 @@ mod tests {
     fn group_header_is_always_muted_without_background() {
         // The header never reflects selection: selecting a group's first row
         // must not light up its header. Always muted, never a background tint.
-        let line = group_header_line("repo", SessionStatus::Idle, WIDE, "◐");
+        let line = group_header_line("repo", WIDE);
         assert!(line.spans.iter().all(|sp| sp.style.bg.is_none()));
-        assert_eq!(line.spans[1].style.fg, Some(Theme::text_muted()));
-        assert!(!line.spans[1].style.add_modifier.contains(Modifier::BOLD));
+        assert_eq!(line.spans[0].style.fg, Some(Theme::text_muted()));
+        assert!(!line.spans[0].style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn group_header_starts_with_the_rule_and_carries_no_status_glyph() {
+        // Status belongs to the session rows; the header is a plain rule.
+        let text = line_text(&group_header_line("repo", WIDE));
+        assert!(text.starts_with("\u{2500}\u{2500} repo "), "{text:?}");
+        for glyph in ["\u{25c6}", "\u{25cf}", "\u{25cb}", "\u{2717}", "\u{2298}"]
+            .iter()
+            .chain(super::super::SPINNER_FRAMES.iter())
+        {
+            assert!(!text.contains(glyph), "{text:?} contains {glyph:?}");
+        }
     }
 
     #[test]
@@ -1556,19 +1499,6 @@ mod tests {
             order_names(&flipped),
             vec!["infra-1", "web-attn", "web-busy"]
         );
-    }
-
-    #[test]
-    fn group_status_rolls_up_to_most_urgent() {
-        use SessionStatus::*;
-        // Precedence: Blocked > Error > Working > Done > Idle.
-        assert_eq!(group_status([Idle, Done, Working]), Working);
-        assert_eq!(group_status([Done, Idle]), Done);
-        assert_eq!(group_status([Working, Error]), Error);
-        assert_eq!(group_status([Working, Blocked, Error]), Blocked);
-        assert_eq!(group_status([Idle, Idle]), Idle);
-        // Empty rolls up to Idle.
-        assert_eq!(group_status(std::iter::empty()), Idle);
     }
 
     #[test]
@@ -1999,28 +1929,6 @@ mod tests {
         );
         // Single composite group, header from the first member ("b").
         assert_eq!(headers, vec![Some("webapp + infra".to_string()), None]);
-    }
-
-    // --- header_group_of (group-header highlight membership) ---
-
-    #[test]
-    fn header_group_of_maps_each_row_to_its_header() {
-        // Two groups: rows 0-1 under header 0, rows 2-4 under header 2.
-        let headers = vec![
-            Some("a".to_string()),
-            None,
-            Some("b".to_string()),
-            None,
-            None,
-        ];
-        assert_eq!(header_group_of(&headers), vec![0, 0, 2, 2, 2]);
-    }
-
-    #[test]
-    fn header_group_of_rows_before_first_header_map_to_zero() {
-        // Rows with no header preceding the first group header at row 2.
-        let headers = vec![None, None, Some("repo".to_string()), None];
-        assert_eq!(header_group_of(&headers), vec![0, 0, 2, 2]);
     }
 
     // --- visible_count_from_heights ---


### PR DESCRIPTION
## Rationale

The group dot is redundant — every session already carries its own status glyph
on its own row, so the rollup restates information the user is already looking
at, and it does so with a severity heuristic the user never asked for. Status
belongs at the session level.

## Before / after

The repo-group header used to lead with a rolled-up most-urgent status dot:

```
● ── thurbox ──────────────────
  ◐ fleet-docs
  ● fleet-template
```

It is now a plain rule (the rule extends two chars further):

```
── thurbox ────────────────────
  ◐ fleet-docs
  ● fleet-template
```

## Intentionally retained

- **The per-session status glyph** before each session name
  (`build_session_line`). This is the thing we are keeping.
- **The right-aligned dot row in the ` Sessions ` panel border title**
  (`render_session_section`'s `block.title_top(...)`, one `Span` per session).
- The top bar's `◐` in `src/ui/status_bar.rs` — a hardcoded decorative glyph in
  front of the theme label, unrelated to `SessionStatus`.
- The theme picker's `◐ ◆ ● ○ ✗` legend — also not group dots.
- `SessionStatus`, `status_glyph`, `status_color` — all still used.

## Files touched

- **`src/ui/project_list.rs`** — dropped the dot from `group_header_line` (and
  its now-unused `rollup` / `spinner` params + doc comment). Removed the code
  that existed only to feed it: the `group_rollup` map and its population loop,
  the `group_rollup`/`status_urgency` helpers, and `header_group_of` (its only
  caller was the rollup loop). Removed their unit tests. Updated the
  `group_header_is_always_muted_without_background` test (its `spans[1]` index
  assumed a leading dot span) and added
  `group_header_starts_with_the_rule_and_carries_no_status_glyph`, asserting the
  line starts with `──` and contains no status glyph or spinner frame.
- **`CLAUDE.md`** — the "Rollup" bullet documented the group dot and pointed at
  the deleted `group_status`; rewritten to state that status is per-session
  only. Dropped the stale "rollups" mention from the remote-hook bullet.

No dead code is left behind: `grep -rn "group_rollup\|status_urgency\|
header_group_of\|group_status" src/` is empty. Nothing was silenced with
`#[allow(dead_code)]` or a leading `_`.

## Snapshots

No `src/app/snapshots/*.snap` changed — every acceptance snapshot renders an
empty session list (welcome screen / modals), so none contains a repo-group
header. The `◐` glyphs remaining in the snapshots are the status-bar theme label
and the theme-picker legend, both explicitly out of scope.

Verified the real render instead, via a throwaway test driving
`render_session_section` onto a ratatui `TestBackend`:

```
╭ Sessions ──────────────────────────⠋●╮   <- panel title dots: kept
│── thurbox ───────────────────────────│   <- group header: no dot
│ ⠋ fleet-docs                         │   <- per-session glyph: kept
│ ● fleet-template                     │
╰──────────────────────────────────────╯
```

## Quality gate

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D
warnings`, and `cargo test` all pass (1769 lib tests). All 17 pre-commit hooks
pass.

> Note: `git::tests::resolve_base_ref_none_without_remote` can fail under a
> parallel full-suite run. That is a pre-existing flake unrelated to this change
> — `src/paths.rs:599` sets `PATH` process-globally to a temp dir, so a
> concurrent test that spawns `git` can't find it. It reproduces on a clean
> checkout of `main` and passes in isolation.
