### PR TITLE
feat(ui): show new-session progress and unfreeze the wizard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,19 @@ moves — so an idle `tick` no longer rescans the `sessions` table (ADR-P6), wit
 the `PRAGMA` itself throttled to ~100 ms and the per-session OSC title/
 notification re-read gated on a reader-thread generation counter (ADR-P10).
 Restore prefetches all history captures in parallel (ADR-P9) and code-review
-diffs build off the UI thread with a loading state (ADR-P8). **Observability**:
+diffs build off the UI thread with a loading state (ADR-P8). The **whole
+new-session flow is non-blocking** (ADR-P12): the branch `git fetch` + listing
+(`App::branch_list` → `poll_branch_list`), `git worktree add`
+(`worktree_create`), the backend ready-up (`ensure_backend_ready`, an ssh
+connect for a remote host), and `Session::spawn` all run on workers. Because
+those phases can run for tens of seconds on a large repo, progress is carried by
+`App::pending_spawn` (`PendingSpawn`/`SpawnPhase`) rather than a
+`status_message` (which expires after 5 s): it renders a **placeholder row** in
+the session list plus a **status badge**. It lives for the **whole wizard** —
+background phases *and* the modals between them (`SpawnPhase::Configuring`, a
+static `◌` with no spinner/elapsed, since nothing is running) — and is cleared
+only when the session lands, the flow errors, or the user Escs out
+(`abandon_pending_spawn`). **Observability**:
 `F12` toggles a live perf HUD (counters + frame/tick percentiles + slow ops;
 `[features] perf_hud`); launching with `THURBOX_PERF_LOG=1` logs a `startup`
 line (phase breakdown + `first_frame_ms`, plus `restore_discover`/
@@ -623,7 +635,8 @@ Each host registers a backend named
 `ssh:<name>` / `wsl:<name>` (`TmuxBackend::from_host`, registered lazily in
 `main.rs` from `host_config::load_all_with_warnings`: discovery/down hosts must
 not block startup, so `check_available`/`ensure_ready` are deferred to first use
-via `App::backend_for`).
+— `App::select_backend` only looks the backend up, and the blocking
+`ensure_backend_ready` runs on a worker at spawn time, ADR-P12).
 
 - **Data**: `session::HostDef` (with `kind: HostKind {Ssh, Wsl}`) /
   `HostRegistry` (pure data, in `session/` so both `agent` and `git` can use

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -448,8 +448,10 @@ WSL needs no credentials at all.
 
 - **Lazy registration**: off-local backends are registered but *not*
   connected at startup (`check_available`/`ensure_ready` deferred to
-  first use via `App::backend_for`), so a down host (or slow WSL
-  discovery) never blocks the TUI.
+  first use), so a down host (or slow WSL discovery) never blocks the
+  TUI. `App::select_backend` only resolves the backend from the
+  registry; the blocking `ensure_backend_ready` runs on the spawn
+  worker, never on the UI thread (ADR-P12).
 - **Auto-discovery**: WSL distros appear with zero config; an explicit
   `kind = "wsl"` entry of the same name wins (for overrides like
   `worktrees_dir`). `discover_wsl_hosts` decodes `wsl.exe`'s UTF-16LE

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -494,6 +494,99 @@ rule holds.
 
 ---
 
+## ADR-P12: Make the whole new-session flow non-blocking, and show it working
+
+**Choice**: `Ctrl+N` had one phase left on the UI thread and one with no
+feedback; both are fixed, and the flow now reports itself for its full
+duration.
+
+*Off-thread* (the R1 recommendation from the 2026-07-09 investigation):
+
+- **Branch listing.** `start_branch_selection` ran `fetch_pending_repos`
+  (`git fetch` — a network round-trip **per repo**, ssh-wrapped for a remote
+  host), `list_branches_on`, and `ordered_branch_list` inline in the key
+  handler. Since the repo picker closes *before* it runs, the freeze happened
+  with **no modal, no toast and no repaint** on screen — measured at ~2 s
+  locally, unbounded on a slow network, ~5 s per unreachable host. It now
+  dispatches a `BackgroundTask` (`App::branch_list`) and the selector opens in
+  `App::poll_branch_list`, mirroring `worktree_create`/`poll_worktree_create`.
+- **Backend ready-up.** `build_spawn_inputs` called `backend_for`, whose
+  `ensure_ready()` is an ssh connect + remote tmux bring-up (15–30 s on a slow
+  host, per ADR-P7) — and it sat in the *prelude* of `do_spawn_session_async`,
+  so a remote spawn blocked the loop before the worker was ever dispatched.
+  Split into `App::select_backend` (registry lookup, cheap, UI thread) and the
+  free `ensure_backend_ready` (blocking), which the async path now calls
+  **inside** its `spawn_blocking` closure. The synchronous `do_spawn_session`
+  (automations/tasks/restore, which need the id back immediately) calls it on
+  its own thread by contract.
+
+*Feedback* — `App::pending_spawn` (`PendingSpawn` + `SpawnPhase`), which lives
+for the **whole wizard**: from the repo being chosen until the session is live,
+across both the background phases *and* the modals between them. It is cleared
+only when the session lands, the flow errors, or the user Escs out (every wizard
+modal's cancel path calls `abandon_pending_spawn`, or a cancelled flow would
+strand a placeholder row forever).
+
+- A **placeholder row** in the session list (`ui::project_list`), so the session
+  appears the moment the wizard is confirmed rather than after a slow shell-out.
+  It carries no `SessionInfo`, records **no hitbox**, and is appended last — so
+  selection indices stay a valid range over the real sessions and the monkey
+  test's invariants are untouched. Its label upgrades as the wizard learns it:
+  the repo, then the session name.
+- An **animated badge** in the status row (`⠹ NEW  Creating worktree(s)… feat/x
+  · 14s`), reusing the `Ctrl+S` sync spinner's surface, with an elapsed counter
+  so a long wait reads as progressing rather than hung.
+- `SpawnPhase::is_working()` splits the three shell-out phases from
+  `Configuring` (a wizard modal is open). A `Configuring` spawn keeps its row and
+  badge — the session is still on its way — but shows a **static `◌`**, no
+  elapsed counter, and does not drive `advance_spinner_frame`: spinning a spinner
+  while the app waits on the *user*, and timing how long they take to answer,
+  would both be lies. A working phase animates at ~8 fps instead of resting on
+  the 250 ms redraw floor.
+
+*Re-entrancy.* Unfreezing the flow makes its window **interactive**, which is a
+new hazard: `branch_list` and `worktree_create` carry `new_session` state across
+a thread boundary, so a second `Ctrl+N` in that window would overwrite the repo
+the in-flight job is resolving — repo A's branch list would land on repo B's
+config, cutting a worktree from a branch B may not have. `start_new_session`
+therefore refuses re-entry while `new_session_in_flight()`, and drops anything
+the caller staged (a task-spawn's `pending_task_prompt` would otherwise be
+`take()`n by the session already in flight — the wrong one).
+
+**Why**: the phases were *already* mostly backgrounded (ADR-P8's shape), but the
+progress was announced with a `status_message` — and those expire after
+`STATUS_MESSAGE_TIMEOUT` (5 s). A `git worktree add` on a large repo runs well
+past that, so the toast vanished mid-job and the app looked idle: the user's
+report was "creating takes time and I have no info on screen that creation is in
+progress". Progress that outlives a 5 s timer cannot *be* a status message, hence
+a separate piece of state that lives exactly as long as the work.
+
+Gate: `spawn_progress_outlives_the_status_message_timeout`,
+`spawn_progress_reports_elapsed_time`, `spawn_placeholder_row_is_not_selectable`,
+`spawn_placeholder_replaces_the_empty_state` (`src/app/acceptance.rs`);
+`poll_branch_list_*`, `indicator_survives_every_wizard_modal`,
+`escaping_a_wizard_modal_drops_the_indicator`,
+`new_session_is_refused_while_the_branch_list_is_in_flight`
+(`src/app/mod.rs` tests).
+
+**Rejected**:
+
+- *Keeping the repo picker open in a `loading` state instead of a placeholder
+  row* — the row doubles as the answer to "where did my session go", and the
+  modal would block the rest of the TUI for no gain.
+- *Exempting `status_message` from expiry while a spawn is in flight* — the
+  smaller diff, but it overloads a transient-toast slot with durable state, and
+  a frozen string still reads as hung. The elapsed counter is what proves
+  liveness.
+- *Making the placeholder selectable* — it has no `SessionId` to select, and a
+  clickable row that resolves to nothing is worse than an inert one.
+- *Clearing the indicator whenever a wizard modal opens* (the first cut) — it
+  made the session blink in and out of the list between phases, which reads as
+  "it disappeared". A session being created exists from the moment you commit to
+  it; the phase only changes what it's waiting on.
+
+---
+
 ## Investigation 2026-07-09: where the time actually goes
 
 A measurement pass over the render loop, the tick, the draw path, startup, the
@@ -529,6 +622,10 @@ Reproduce: build release, export the five env vars above to temp dirs, run
 ### Findings
 
 #### 1. `git fetch` blocks the UI thread for ~2 s on the new-session path
+
+> **Fixed by ADR-P12.** `start_branch_selection` now dispatches to a worker and
+> the selector opens in `poll_branch_list`. The measurement below is what
+> motivated it.
 
 `App::start_branch_selection` (`src/app/key_handlers.rs:1448`) calls
 `fetch_pending_repos` (`src/app/key_handlers.rs:1486`), which runs
@@ -651,8 +748,9 @@ means "looked at", not "not looked at".
   (`linux-hp` 317 ms rc=0; `windows-hp` connects, returns `ALIVE`) — ssh
   returns 255 on connect failure, and neither did. No **active** session is
   remote: all 3 live sessions are `local-tmux`; the 8 `ssh:*` rows are
-  soft-deleted. Backends are registered lazily (`App::backend_for`) and readied
-  on background threads (ADR-P7), so a down host cannot block `tick_core`. For
+  soft-deleted. Backends are registered lazily (`App::select_backend`) and
+  readied on background threads (ADR-P7/P12), so a down host cannot block
+  `tick_core`. For
   the paths reachable here, "keep the TUI usable when remote SSH hosts fail"
   holds.
 
@@ -660,7 +758,7 @@ means "looked at", not "not looked at".
 
 | # | Change | Benefit | Cost | Safe independently? |
 | --- | --- | --- | --- | --- |
-| R1 | Move the new-session `git fetch` off the UI thread, mirroring `poll_worktree_create` | Removes the only multi-second freeze on the normal interactive path (~2 s, unbounded) | Medium: needs a loading state + a `poll_*` drain | Yes |
+| R1 | Move the new-session `git fetch` off the UI thread, mirroring `poll_worktree_create` | Removes the only multi-second freeze on the normal interactive path (~2 s, unbounded) | Medium: needs a loading state + a `poll_*` drain | Yes — **done**, ADR-P12 |
 | R2 | Route the automation `Spawn` through the existing `do_spawn_session_async` | Removes a ~93 ms x repos + tmux-spawn freeze per fire | Low–medium: the async path already exists | **No** — must edit `src/app/automation.rs`, reserved by `fix/automation-exec-nonblocking` |
 | R3 | Refuse a dead pane in `send_prompt_now` | `woke`/run-status stop lying; applies to all five callers | One tmux round-trip per send | Yes — **applied in this PR** |
 | R4 | Clamp output-driven repaint to ~30 fps | ~3x less TUI CPU while agents stream (65.6 % -> ~20 % of a core) | Low (one clamp) but needs an input-latency measurement first | Yes — **not done**, see gaps |

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -2423,6 +2423,92 @@ fn status_message_expires_after_timeout_via_tick() {
     );
 }
 
+/// The regression this whole indicator exists for: creating a session used to
+/// announce itself with a `status_message`, which expires after 5 s — so a
+/// `git worktree add` on a large repo went silent partway through and the app
+/// looked idle. `pending_spawn` is not a status message and must outlive it.
+#[test]
+fn spawn_progress_outlives_the_status_message_timeout() {
+    let mut h = Harness::standard(1);
+    h.app.pending_spawn = Some(PendingSpawn::new("feat/big", SpawnPhase::Worktree));
+
+    h.advance(STATUS_MESSAGE_TIMEOUT * 4).tick();
+
+    assert!(
+        h.app.pending_spawn.is_some(),
+        "a spawn still in flight is never expired by the status-message timer"
+    );
+    let screen = h.render();
+    assert!(
+        screen.contains("Creating worktree(s)…"),
+        "the status row still shows the phase after 20s:\n{screen}"
+    );
+    assert!(
+        screen.contains("feat/big"),
+        "the placeholder row names the session being created:\n{screen}"
+    );
+}
+
+/// The elapsed counter is what makes a long wait read as progressing rather
+/// than hung, so it must actually advance with the clock.
+#[test]
+fn spawn_progress_reports_elapsed_time() {
+    let mut h = Harness::standard(1);
+    h.app.pending_spawn = Some(PendingSpawn::new("feat/big", SpawnPhase::Worktree));
+    assert_eq!(h.app.pending_spawn.as_ref().unwrap().elapsed_secs(), 0);
+
+    h.advance(std::time::Duration::from_secs(14)).tick();
+
+    assert_eq!(h.app.pending_spawn.as_ref().unwrap().elapsed_secs(), 14);
+    let screen = h.render();
+    assert!(
+        screen.contains("14s"),
+        "elapsed shown in the badge:\n{screen}"
+    );
+}
+
+/// The placeholder row has no session behind it: it must not be selectable, and
+/// the session-list indices must stay a valid range over the real sessions.
+#[test]
+fn spawn_placeholder_row_is_not_selectable() {
+    let mut h = Harness::standard(2);
+    h.app.pending_spawn = Some(PendingSpawn::new("feat/x", SpawnPhase::Spawning));
+    h.render();
+
+    let max_session_index = h
+        .app
+        .click_targets
+        .iter()
+        .filter_map(|t| match t.action {
+            ClickAction::SelectSession(i) => Some(i),
+            _ => None,
+        })
+        .max();
+    assert_eq!(
+        max_session_index,
+        Some(1),
+        "only the 2 real sessions are clickable — the placeholder records no hitbox"
+    );
+    assert_invariants(&h.app, "placeholder row present");
+}
+
+/// With no sessions at all, the placeholder must replace the "No sessions yet"
+/// empty state — otherwise the very first `Ctrl+N` shows nothing happening.
+#[test]
+fn spawn_placeholder_replaces_the_empty_state() {
+    let mut h = Harness::standard(0);
+    assert!(h.render().contains("No sessions yet"));
+
+    h.app.pending_spawn = Some(PendingSpawn::new("thurbox", SpawnPhase::Branches));
+
+    let screen = h.render();
+    assert!(
+        !screen.contains("No sessions yet"),
+        "the empty state gives way to the session being created:\n{screen}"
+    );
+    assert!(screen.contains("Fetching branches…"), "{screen}");
+}
+
 #[test]
 fn pending_delete_finalizes_after_undo_window() {
     let mut h = Harness::standard(2);

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -776,6 +776,7 @@ impl App {
         match code {
             KeyCode::Esc => {
                 self.modal.close();
+                self.abandon_pending_spawn();
                 self.new_session.repo_path = None;
                 self.new_session.all_repos = None;
                 self.new_session.normal_repos.clear();
@@ -822,6 +823,7 @@ impl App {
 
     /// Clear the worktree-flow pending state when the branch-name modal is cancelled.
     fn cancel_worktree_name(&mut self) {
+        self.abandon_pending_spawn();
         self.new_session.base_branch = None;
         self.new_session.repo_path = None;
         self.new_session.all_repos = None;
@@ -873,6 +875,7 @@ impl App {
 
     /// Clear pending state when the session-name modal is cancelled.
     fn cancel_session_name(&mut self) {
+        self.abandon_pending_spawn();
         if self.new_session.base_branch.is_some() {
             // Worktree flow — clean up worktree-specific pending state.
             self.new_session.base_branch = None;
@@ -893,6 +896,9 @@ impl App {
         if self.new_session.base_branch.is_some() {
             // Worktree flow — proceed to branch name input.
             let branch = session_name_to_branch(&name);
+            // The name is settled, so the placeholder row stops going by the
+            // repo and takes the name the real row will have.
+            self.mark_spawn_configuring(name.clone());
             self.new_session.session_name = Some(name);
             let mut modal = super::modals::WorktreeNameModal::default();
             modal.name.set(&branch);
@@ -960,6 +966,7 @@ impl App {
         match code {
             KeyCode::Esc => {
                 self.modal.close();
+                self.abandon_pending_spawn();
                 self.new_session.spawn_config = None;
                 self.new_session.spawn_worktrees.clear();
                 self.new_session.spawn_name = None;
@@ -1445,28 +1452,80 @@ impl App {
         self.active_theme = entry;
     }
 
+    /// Kick off the branch listing that feeds the branch selector.
+    ///
+    /// The git work — a `git fetch` per repo (a network round-trip each, ssh for
+    /// a remote host) plus the branch/default-branch queries — runs on a worker,
+    /// not here. On the UI thread it froze the whole TUI in the gap between the
+    /// repo picker closing and the branch selector opening: no modal, no repaint,
+    /// no message (ADR-P12). The selector opens in [`Self::poll_branch_list`];
+    /// meanwhile `pending_spawn` drives the placeholder row + status badge.
     pub(crate) fn start_branch_selection(&mut self) {
+        // Belt-and-braces: `start_new_session` already refuses re-entry while a
+        // listing is in flight, so reaching here means a caller bypassed the
+        // wizard entry. Never silently drop it — a no-op would strand the user
+        // with a repo picked and nothing happening.
+        if self.branch_list.in_progress() {
+            self.set_status(
+                super::StatusLevel::Info,
+                "Still listing branches — try again in a moment",
+            );
+            return;
+        }
         // Resolve the remote host (if any) so branch listing targets the
-        // session's machine. Cloned so we don't hold a borrow on `self`.
+        // session's machine. Owned so the worker can take it.
         let host = self
             .host_for_backend(self.new_session.backend.as_deref())
             .cloned();
-        let host = host.as_ref();
 
         let Some(repo_path) = self.new_session.repo_path.clone() else {
             return;
         };
-        let repo_path = repo_path.as_path();
+        let all_repos = self.new_session.all_repos.clone();
 
-        Self::fetch_pending_repos(host, repo_path, self.new_session.all_repos.as_ref());
+        let label = super::spawn_label_for_repo(Some(&repo_path));
+        self.mark_spawn_working(label, super::SpawnPhase::Branches);
 
-        match crate::git::list_branches_on(host, repo_path) {
-            Ok(branches) if branches.is_empty() => {
-                self.set_error("No branches found in repository");
+        let tx = self.branch_list.start();
+        tokio::task::spawn_blocking(move || {
+            let host = host.as_ref();
+            Self::fetch_pending_repos(host, &repo_path, all_repos.as_ref());
+            let result = match crate::git::list_branches_on(host, &repo_path) {
+                Ok(branches) if branches.is_empty() => {
+                    Err("No branches found in repository".to_string())
+                }
+                Ok(branches) => Ok(Self::ordered_branch_list(host, &repo_path, branches)),
+                Err(e) => Err(format!("Failed to list branches: {e:#}")),
+            };
+            let _ = tx.send(result);
+        });
+    }
+
+    /// Open the branch selector once the backgrounded fetch + listing lands.
+    pub(crate) fn poll_branch_list(&mut self) {
+        let result = match self.branch_list.poll() {
+            super::background::TaskPoll::Pending => return,
+            super::background::TaskPoll::Died => {
+                self.abandon_pending_spawn();
                 self.new_session.repo_path = None;
+                self.set_error("Branch listing failed (worker died)");
+                self.request_redraw();
+                return;
             }
+            super::background::TaskPoll::Done(result) => result,
+        };
+
+        match result {
             Ok(branches) => {
-                let branches = Self::ordered_branch_list(host, repo_path, branches);
+                // The session is still on its way — park the indicator on the
+                // user (it keeps its row, stops spinning) rather than clearing
+                // it, so it doesn't vanish behind the branch selector.
+                let label = self
+                    .pending_spawn
+                    .as_ref()
+                    .map(|p| p.label.clone())
+                    .unwrap_or_default();
+                self.mark_spawn_configuring(label);
                 self.modal =
                     super::modals::Modal::BranchSelector(super::modals::BranchSelectorModal {
                         index: 0,
@@ -1474,11 +1533,13 @@ impl App {
                     });
             }
             Err(e) => {
+                self.abandon_pending_spawn();
                 error!("Failed to list branches: {e}");
-                self.set_error(format!("Failed to list branches: {e:#}"));
+                self.set_error(e);
                 self.new_session.repo_path = None;
             }
         }
+        self.request_redraw();
     }
 
     /// Fetch origin for the primary repo and any extra worktree repos so

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -148,6 +148,96 @@ struct PendingSessionSpawn {
     base_branch: Option<String>,
 }
 
+/// Where the interactive new-session flow currently is. Ordered as the wizard
+/// runs them, and split two ways: three phases are **shell-outs on a worker**
+/// (git/ssh/tmux), while `Configuring` is the wizard **waiting on the user** at
+/// one of its modals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpawnPhase {
+    /// `git fetch` (one network round-trip per repo) + the branch listing that
+    /// feeds the branch selector.
+    Branches,
+    /// A wizard modal is open (base branch / session name / branch name / agent
+    /// picker) and nothing is churning in the background — the session is still
+    /// on its way, so it keeps its place in the list rather than blinking out of
+    /// existence between steps.
+    Configuring,
+    /// `git worktree add` — the slow one on a large repo.
+    Worktree,
+    /// Backend ready-up (an ssh connect for a remote host) + the tmux/PTY spawn.
+    Spawning,
+}
+
+impl SpawnPhase {
+    /// Whether a background job is actually running. Drives whether the UI spins
+    /// a spinner and counts elapsed time — a spinner turning while the app waits
+    /// on the *user* would be a lie.
+    pub fn is_working(self) -> bool {
+        !matches!(self, SpawnPhase::Configuring)
+    }
+
+    pub fn message(self) -> &'static str {
+        match self {
+            SpawnPhase::Branches => "Fetching branches…",
+            SpawnPhase::Configuring => "Setting up…",
+            SpawnPhase::Worktree => "Creating worktree(s)…",
+            SpawnPhase::Spawning => "Spawning agent…",
+        }
+    }
+
+    /// The compact form for the session list's placeholder row. Kept short
+    /// enough to fit beside a name in the default ~28-column panel (the row
+    /// drops it rather than overflow); the full phase is in the status badge.
+    pub fn short_label(self) -> &'static str {
+        match self {
+            SpawnPhase::Branches => "fetching…",
+            SpawnPhase::Configuring => "setting up…",
+            SpawnPhase::Worktree => "creating…",
+            SpawnPhase::Spawning => "spawning…",
+        }
+    }
+}
+
+/// A session between "confirmed in the wizard" and "live in the list".
+///
+/// Every phase above shells out to git/ssh/tmux on a background worker, which on
+/// a large repo runs for tens of seconds. This is what the UI shows meanwhile: a
+/// placeholder row in the session list plus an animated status badge. It exists
+/// because the old feedback was a `status_message`, and those auto-expire after
+/// `STATUS_MESSAGE_TIMEOUT` — so a long `git worktree add` went silent partway
+/// through and the app looked idle.
+pub struct PendingSpawn {
+    /// Whatever names the session at this phase: the repo (before a branch is
+    /// picked), then the branch, then the session name.
+    pub label: String,
+    pub phase: SpawnPhase,
+    started_at: std::time::Instant,
+}
+
+/// What to call a session the wizard hasn't named yet: the repo it's being cut
+/// from. Replaced by the real name as soon as the user supplies one.
+fn spawn_label_for_repo(repo: Option<&std::path::Path>) -> String {
+    repo.and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "new session".to_string())
+}
+
+impl PendingSpawn {
+    fn new(label: impl Into<String>, phase: SpawnPhase) -> Self {
+        Self {
+            label: label.into(),
+            phase,
+            started_at: clock::now(),
+        }
+    }
+
+    /// Whole seconds since this phase started — shown so a long wait reads as
+    /// progressing rather than hung.
+    pub fn elapsed_secs(&self) -> u64 {
+        clock::elapsed_since(self.started_at).as_secs()
+    }
+}
+
 /// One remote backend's discovery result: its `backend_type`, whether the host
 /// was **reachable** (its `ensure_ready` succeeded — distinguishes "host down"
 /// from "host up but no windows"), plus the windows it reported. Sent once per
@@ -218,6 +308,16 @@ struct PendingWorktreeCreate {
     /// Base branch the worktrees were forked from, carried through to the spawn
     /// so it can be persisted for the code-review view.
     base_branch: String,
+}
+
+/// Bring a backend up so a session can spawn on it. For a remote backend this
+/// establishes the SSH control-mode connection (an ssh connect + remote tmux
+/// bring-up — 15–30 s on a slow host, per ADR-P7), so every caller runs it off
+/// the UI thread. Returns a status-line-friendly error.
+fn ensure_backend_ready(backend: &Arc<dyn SessionBackend>) -> Result<(), String> {
+    backend
+        .ensure_ready()
+        .map_err(|e| format!("Backend '{}' not ready: {e:#}", backend.name()))
 }
 
 /// Create one worktree per repo off the UI thread, rolling back any already
@@ -692,6 +792,11 @@ pub struct App {
     /// once on startup when the cache is stale; on success the cache is rewritten
     /// and `update_status` re-read from it.
     version_check_task: background::BackgroundTask<Result<(), String>>,
+    /// Background `git fetch` + branch listing for the new-session wizard, polled
+    /// each tick. On the UI thread this was a hard freeze between the repo picker
+    /// closing and the branch selector opening — one network round-trip per repo,
+    /// an ssh round-trip each for a remote host (ADR-P8).
+    branch_list: background::BackgroundTask<Result<Vec<String>, String>>,
     /// Background worktree-creation (`git worktree add`) for the new-session
     /// wizard, polled each tick; in-flight state guards against re-entry and
     /// clobbering the pending continuation.
@@ -712,6 +817,11 @@ pub struct App {
     /// Continuation for a completed background spawn: the metadata + follow-up
     /// (task prompt) to apply once the session is live.
     pending_session_spawn: Option<PendingSessionSpawn>,
+    /// The new session the wizard is currently building, if any — what the
+    /// placeholder row and the status badge render. Spans all three phases
+    /// (`branch_list` → `worktree_create` → `session_spawn`), so it outlives any
+    /// single [`background::BackgroundTask`] above.
+    pending_spawn: Option<PendingSpawn>,
     /// Remote-backed sessions still being restored in the background (one
     /// discovery thread per host), drained each tick by
     /// [`Self::poll_remote_restore`]. `None` once every remote backend has
@@ -1019,12 +1129,14 @@ impl App {
                 None
             },
             version_check_task: background::BackgroundTask::default(),
+            branch_list: background::BackgroundTask::default(),
             worktree_create: background::BackgroundTask::default(),
             pending_worktree_create: None,
             session_spawn: background::BackgroundTask::default(),
             review_build: background::BackgroundTask::default(),
             automation_exec: automation::ExecJobs::default(),
             pending_session_spawn: None,
+            pending_spawn: None,
             remote_restore: None,
             deferred_inputs: Vec::new(),
             session_terminal_views: HashMap::new(),
@@ -1328,6 +1440,46 @@ impl App {
             })
     }
 
+    /// A background phase (`Branches`/`Worktree`/`Spawning`) just started: the
+    /// indicator spins and counts elapsed for as long as it runs.
+    fn mark_spawn_working(&mut self, label: impl Into<String>, phase: SpawnPhase) {
+        debug_assert!(phase.is_working(), "use mark_spawn_configuring instead");
+        self.pending_spawn = Some(PendingSpawn::new(label, phase));
+    }
+
+    /// Hand the "being created" indicator back to the user: a wizard modal is
+    /// up, so the session keeps its placeholder row and its badge, but stops
+    /// spinning and stops counting (no background job is running).
+    ///
+    /// Every step that opens a wizard modal goes through here, so the indicator
+    /// survives the modals instead of blinking off between phases.
+    fn mark_spawn_configuring(&mut self, label: impl Into<String>) {
+        self.pending_spawn = Some(PendingSpawn::new(label, SpawnPhase::Configuring));
+    }
+
+    /// The wizard ended — the session landed, the flow errored, or the user Esc'd
+    /// out of one of its modals. Drop the indicator, or a cancelled flow would
+    /// strand a placeholder row in the session list forever.
+    ///
+    /// The single way `pending_spawn` is cleared, so no path can forget.
+    fn abandon_pending_spawn(&mut self) {
+        self.pending_spawn = None;
+    }
+
+    /// The wizard is mid-flight in a phase that carries `new_session` state
+    /// across a thread boundary: `branch_list` resolves the repo that was chosen
+    /// *before* it was dispatched, and `worktree_create` the branch. Re-entering
+    /// the wizard would overwrite that state underneath the in-flight job — repo
+    /// A's branch list would land on top of repo B's config, and the worktree
+    /// would be cut from a branch that may not even exist in B.
+    ///
+    /// This can only happen now that those phases no longer freeze the UI
+    /// (ADR-P12): the window is real and the user can type into it, so the
+    /// wizard has to refuse re-entry itself.
+    fn new_session_in_flight(&self) -> bool {
+        self.branch_list.in_progress() || self.worktree_create.in_progress()
+    }
+
     /// Entry point for the new-session wizard.
     ///
     /// When any off-local host is available — a configured SSH/WSL host
@@ -1335,6 +1487,20 @@ impl App {
     /// picker so the user can choose where the session runs; otherwise goes
     /// straight to the repo picker (preserving the local-only UX).
     pub(crate) fn start_new_session(&mut self) {
+        if self.new_session_in_flight() {
+            // The wizard never starts, so drop what the caller staged for it.
+            // A task-spawn sets `pending_task_prompt` *before* calling in, and
+            // leaving it set would hand the task's prompt to the session already
+            // in flight — the wrong one entirely.
+            self.task_ui.pending_task_prompt = None;
+            self.new_session.parent_session_id = None;
+            self.set_status(
+                StatusLevel::Info,
+                "Already creating a session — try again in a moment",
+            );
+            return;
+        }
+
         // Clear any choice left over from a previously cancelled flow.
         self.new_session.backend = None;
 
@@ -1503,6 +1669,10 @@ impl App {
     /// Shows an empty session-name modal. After the user enters a name, the
     /// agent picker is shown, then spawn.
     pub(crate) fn prepare_spawn(&mut self, config: SessionConfig, worktrees: Vec<WorktreeInfo>) {
+        // No name yet, so the placeholder row goes by the repo it's being cut
+        // from — the same thing the user just picked.
+        self.mark_spawn_configuring(spawn_label_for_repo(config.cwd.as_deref()));
+
         // Show session name modal (empty — user types from scratch).
         self.new_session.spawn_config = Some(config);
         self.new_session.spawn_worktrees = worktrees;
@@ -1540,6 +1710,10 @@ impl App {
                 command: a.command.clone(),
             })
             .collect();
+
+        // The name is settled now, so the placeholder row can go by it — the
+        // same label the real row will carry once the agent picker is answered.
+        self.mark_spawn_configuring(name.clone());
         self.new_session.spawn_name = Some(name);
         self.new_session.spawn_config = Some(config);
         self.new_session.spawn_worktrees = worktrees;
@@ -3327,6 +3501,9 @@ impl App {
 
         // Shell out to `git worktree add` off the UI thread (one per repo, with
         // rollback on failure); the spawn flow resumes in `poll_worktree_create`.
+        // Go by the session name where we have one (the label the real row will
+        // carry); the branch is the only handle we have otherwise.
+        let label = session_name.clone().unwrap_or_else(|| new_branch.clone());
         let tx = self.worktree_create.start();
         self.pending_worktree_create = Some(PendingWorktreeCreate {
             backend,
@@ -3334,7 +3511,7 @@ impl App {
             session_name,
             base_branch: base_branch.clone(),
         });
-        self.set_status(StatusLevel::Info, "Creating worktree(s)…");
+        self.mark_spawn_working(label, SpawnPhase::Worktree);
         tokio::task::spawn_blocking(move || {
             let result = create_worktrees(host.as_ref(), &repo_paths, &new_branch, &base_branch);
             let _ = tx.send(result);
@@ -3348,6 +3525,7 @@ impl App {
             background::TaskPoll::Pending => return,
             background::TaskPoll::Died => {
                 self.pending_worktree_create = None;
+                self.abandon_pending_spawn();
                 self.set_error("Worktree creation failed (worker died)");
                 return;
             }
@@ -3358,8 +3536,14 @@ impl App {
         };
 
         match result {
+            // The indicator is *not* cleared here: the flow continues into the
+            // name/agent modal, and `prepare_spawn`/`finish_prepare_spawn` park
+            // it on `Configuring` so the session stays in the list across them.
             Ok(worktree_infos) => self.continue_worktree_spawn(worktree_infos, pending),
-            Err(e) => self.set_error(format!("Failed to create worktree: {e}")),
+            Err(e) => {
+                self.abandon_pending_spawn();
+                self.set_error(format!("Failed to create worktree: {e}"));
+            }
         }
     }
 
@@ -3489,28 +3673,18 @@ impl App {
         Some(self.backends.default_backend().clone())
     }
 
-    /// Resolve the backend a session should spawn on, ensuring it is ready.
-    ///
-    /// Looks up `config.backend` in the registry (falling back to the default
-    /// local backend), then calls `ensure_ready()` so a remote backend's SSH
-    /// control-mode connection is established lazily on first use. Returns a
-    /// status-line-friendly error if the backend is unknown or unreachable.
-    pub(crate) fn backend_for(
-        &self,
-        config: &SessionConfig,
-    ) -> Result<Arc<dyn SessionBackend>, String> {
-        let backend = match config.backend.as_deref() {
+    /// Look up the backend a session should spawn on, **without** readying it.
+    /// Cheap (a registry lookup), so it is safe on the UI thread; the caller is
+    /// responsible for [`ensure_backend_ready`] before spawning.
+    fn select_backend(&self, config: &SessionConfig) -> Result<Arc<dyn SessionBackend>, String> {
+        match config.backend.as_deref() {
             Some(name) if !name.is_empty() => self
                 .backends
                 .get(name)
                 .cloned()
-                .ok_or_else(|| format!("Unknown backend '{name}'"))?,
-            _ => self.backends.default_backend().clone(),
-        };
-        backend
-            .ensure_ready()
-            .map_err(|e| format!("Backend '{}' not ready: {e:#}", backend.name()))?;
-        Ok(backend)
+                .ok_or_else(|| format!("Unknown backend '{name}'")),
+            _ => Ok(self.backends.default_backend().clone()),
+        }
     }
 
     /// Common spawn preparation shared by the sync and async paths: fill in
@@ -3559,7 +3733,10 @@ impl App {
             spawn_host.as_ref(),
         );
 
-        let backend = match self.backend_for(&config) {
+        // Registry lookup only — readying the backend (an ssh connect for a
+        // remote host) is left to the caller, so the async path can do it on its
+        // worker rather than here on the UI thread.
+        let backend = match self.select_backend(&config) {
             Ok(b) => b,
             Err(e) => {
                 error!("Failed to select backend: {e}");
@@ -3660,6 +3837,14 @@ impl App {
         let Some(inputs) = self.build_spawn_inputs(config, &worktrees, &additional_dirs) else {
             return;
         };
+        // This path is synchronous by contract (its callers need the session id
+        // back immediately), so it eats the ready-up on the calling thread —
+        // unlike `do_spawn_session_async`, which hands it to a worker.
+        if let Err(e) = ensure_backend_ready(&inputs.backend) {
+            error!("Failed to ready backend: {e}");
+            self.set_error(e);
+            return;
+        }
 
         match Session::spawn(
             name,
@@ -3732,11 +3917,17 @@ impl App {
             agent,
             base_branch,
         });
-        self.set_status(StatusLevel::Info, format!("Spawning {name}…"));
+        self.mark_spawn_working(name.clone(), SpawnPhase::Spawning);
 
         tokio::task::spawn_blocking(move || {
-            let result = Session::spawn(name, rows, cols, &config, &backend, &provider)
-                .map_err(|e| format!("{e:#}"));
+            // `ensure_ready` is inside the worker, not in the prelude above: for a
+            // remote backend it is an ssh connect + remote tmux bring-up, 15–30 s
+            // on a slow host (ADR-P7), and on the UI thread that froze the loop
+            // before the spawn was ever dispatched.
+            let result = ensure_backend_ready(&backend).and_then(|()| {
+                Session::spawn(name, rows, cols, &config, &backend, &provider)
+                    .map_err(|e| format!("{e:#}"))
+            });
             let _ = tx.send(result);
         });
     }
@@ -3747,11 +3938,14 @@ impl App {
             background::TaskPoll::Pending => return,
             background::TaskPoll::Died => {
                 self.pending_session_spawn = None;
+                self.abandon_pending_spawn();
                 self.set_error("Session spawn failed (worker died)");
                 return;
             }
             background::TaskPoll::Done(result) => result,
         };
+        // The wizard is over either way — the session is live, or it failed.
+        self.abandon_pending_spawn();
         let Some(pending) = self.pending_session_spawn.take() else {
             return;
         };
@@ -3956,8 +4150,9 @@ impl App {
         // Poll for sync results from background worktree sync threads
         self.poll_sync_results();
 
-        // Poll for backgrounded interactive spawn work (worktree creation +
-        // `Session::spawn`) so `Ctrl+N` never freezes the UI.
+        // Poll for backgrounded interactive spawn work (branch fetch + listing,
+        // worktree creation, `Session::spawn`) so `Ctrl+N` never freezes the UI.
+        self.poll_branch_list();
         self.poll_worktree_create();
         self.poll_session_spawn();
 
@@ -4559,18 +4754,25 @@ impl App {
 
     /// Advance the Working spinner from the (deterministic) tick counter, and
     /// report whether a repaint is needed because the frame ticked over *while*
-    /// something is working — so an idle TUI still rests at ~4 fps but a working
-    /// session animates smoothly.
+    /// something is animating — a working session, or a session being spawned
+    /// (whose placeholder row + status badge spin too). So an idle TUI still
+    /// rests at ~4 fps but either animates smoothly.
     fn advance_spinner_frame(&mut self) -> bool {
         let new_frame = (self.metrics.tick_count / SPINNER_TICKS_PER_FRAME) as usize
             % crate::ui::SPINNER_FRAMES.len();
         let spinner_advanced = new_frame != self.spinner_frame;
         self.spinner_frame = new_frame;
-        let any_working = self
-            .sessions
-            .iter()
-            .any(|s| s.info.status == SessionStatus::Working);
-        any_working && spinner_advanced
+        // A spawn parked on the user at a modal (`Configuring`) shows a static
+        // glyph, so it must not force repaints — only a running job does.
+        let any_animating = self
+            .pending_spawn
+            .as_ref()
+            .is_some_and(|p| p.phase.is_working())
+            || self
+                .sessions
+                .iter()
+                .any(|s| s.info.status == SessionStatus::Working);
+        any_animating && spinner_advanced
     }
 
     /// Current `Working`-spinner frame index (into [`crate::ui::SPINNER_FRAMES`]).
@@ -6326,9 +6528,12 @@ impl App {
             self.features.automations,
             self.automation_ui.cached_automations.len(),
             // Carve the transient status row whenever there's a message to show
-            // (a status/error toast or the live sync spinner) — must match what
-            // `render_status_message_row` renders so the row is never empty.
-            self.worktree_sync.in_progress || self.status_message.is_some(),
+            // (a status/error toast, the live sync spinner, or a spawn in
+            // flight) — must match what `render_status_message_row` renders so
+            // the row is never empty.
+            self.worktree_sync.in_progress
+                || self.pending_spawn.is_some()
+                || self.status_message.is_some(),
         )
     }
 
@@ -7248,32 +7453,32 @@ mod tests {
     }
 
     #[test]
-    fn backend_for_defaults_to_registry_default() {
+    fn select_backend_defaults_to_registry_default() {
         let app = app_with_sessions(0);
         let config = SessionConfig::default();
-        let backend = app.backend_for(&config).expect("default backend");
+        let backend = app.select_backend(&config).expect("default backend");
         assert_eq!(backend.name(), "stub");
     }
 
     #[test]
-    fn backend_for_empty_name_uses_default() {
+    fn select_backend_empty_name_uses_default() {
         let app = app_with_sessions(0);
         let config = SessionConfig {
             backend: Some(String::new()),
             ..SessionConfig::default()
         };
-        let backend = app.backend_for(&config).expect("default backend");
+        let backend = app.select_backend(&config).expect("default backend");
         assert_eq!(backend.name(), "stub");
     }
 
     #[test]
-    fn backend_for_unknown_backend_errors() {
+    fn select_backend_unknown_backend_errors() {
         let app = app_with_sessions(0);
         let config = SessionConfig {
             backend: Some("ssh:does-not-exist".into()),
             ..SessionConfig::default()
         };
-        match app.backend_for(&config) {
+        match app.select_backend(&config) {
             Ok(b) => panic!("expected error, got backend {}", b.name()),
             Err(err) => assert!(err.contains("Unknown backend"), "got: {err}"),
         }
@@ -11507,6 +11712,157 @@ mod tests {
 
         assert!(app.metrics.sys.is_some());
         assert!(!app.metrics_refresh.in_progress());
+    }
+
+    /// Backgrounding the branch fetch made its window *interactive*, so a second
+    /// `Ctrl+N` can land in it. It must not overwrite `new_session.repo_path`
+    /// under the in-flight job, or the branch list for repo A would be applied
+    /// to repo B and the worktree cut from a branch B may not have.
+    #[test]
+    fn new_session_is_refused_while_the_branch_list_is_in_flight() {
+        let mut app = app_with_sessions(0);
+        app.new_session.repo_path = Some(PathBuf::from("/repo-a"));
+        let _in_flight = app.branch_list.start();
+
+        app.start_new_session();
+
+        assert!(
+            matches!(app.modal, modals::Modal::None),
+            "the repo picker must not open over an in-flight listing"
+        );
+        assert_eq!(
+            app.new_session.repo_path,
+            Some(PathBuf::from("/repo-a")),
+            "the in-flight job's repo is left intact"
+        );
+        assert!(app.status_message.is_some(), "and the user is told why");
+    }
+
+    /// A refused task-spawn must not leave its prompt staged — the session
+    /// already in flight would `take()` it and receive another task's prompt.
+    #[test]
+    fn refused_new_session_does_not_leak_its_task_prompt() {
+        let mut app = app_with_sessions(0);
+        let _in_flight = app.worktree_create.start();
+        app.task_ui.pending_task_prompt = Some((7, "do the thing".into()));
+
+        app.start_new_session();
+
+        assert!(
+            app.task_ui.pending_task_prompt.is_none(),
+            "the staged prompt is dropped, not handed to the in-flight spawn"
+        );
+    }
+
+    #[test]
+    fn poll_branch_list_opens_the_branch_selector() {
+        let mut app = app_with_sessions(0);
+        app.pending_spawn = Some(PendingSpawn::new("repo", SpawnPhase::Branches));
+        let tx = app.branch_list.start();
+        tx.send(Ok(vec!["origin/main".into(), "main".into()]))
+            .unwrap();
+
+        app.poll_branch_list();
+
+        assert!(!app.branch_list.in_progress());
+        match app.modal {
+            modals::Modal::BranchSelector(ref m) => {
+                assert_eq!(m.branches, vec!["origin/main", "main"]);
+                assert_eq!(m.index, 0);
+            }
+            _ => panic!("expected the branch selector to open"),
+        }
+        // The session is still being created — it keeps its place in the list
+        // behind the modal, it just stops spinning.
+        let pending = app.pending_spawn.as_ref().expect("indicator survives");
+        assert_eq!(pending.phase, SpawnPhase::Configuring);
+        assert!(!pending.phase.is_working());
+        assert_eq!(pending.label, "repo", "and keeps the label it had");
+    }
+
+    /// The wizard's modal steps must not drop the indicator — that flicker is
+    /// exactly what made a session being created look like it had vanished.
+    #[test]
+    fn indicator_survives_every_wizard_modal() {
+        let mut app = app_with_sessions(0);
+
+        // Session-name modal (the normal, non-worktree flow enters here).
+        app.prepare_spawn(
+            SessionConfig {
+                cwd: Some(PathBuf::from("/repos/thurbox")),
+                ..SessionConfig::default()
+            },
+            Vec::new(),
+        );
+        assert!(matches!(app.modal, modals::Modal::SessionName(_)));
+        let pending = app.pending_spawn.as_ref().expect("shown at the name modal");
+        assert_eq!(pending.phase, SpawnPhase::Configuring);
+        assert_eq!(pending.label, "thurbox", "labelled by the repo until named");
+
+        // Agent picker — now labelled by the name the real row will carry.
+        app.finish_prepare_spawn("my-session".into(), SessionConfig::default(), Vec::new());
+        if matches!(app.modal, modals::Modal::AgentPicker(_)) {
+            let pending = app
+                .pending_spawn
+                .as_ref()
+                .expect("shown at the agent picker");
+            assert_eq!(pending.phase, SpawnPhase::Configuring);
+            assert_eq!(pending.label, "my-session");
+        }
+    }
+
+    /// …but an abandoned wizard must not strand a placeholder row forever.
+    #[test]
+    fn escaping_a_wizard_modal_drops_the_indicator() {
+        let mut app = app_with_sessions(0);
+        app.prepare_spawn(SessionConfig::default(), Vec::new());
+        assert!(app.pending_spawn.is_some());
+
+        app.handle_key(KeyCode::Esc, KeyModifiers::NONE);
+
+        assert!(matches!(app.modal, modals::Modal::None));
+        assert!(
+            app.pending_spawn.is_none(),
+            "cancelling the flow clears the row it was holding"
+        );
+    }
+
+    #[test]
+    fn poll_branch_list_error_sets_status_and_resets_the_wizard() {
+        let mut app = app_with_sessions(0);
+        app.new_session.repo_path = Some(PathBuf::from("/repo"));
+        app.pending_spawn = Some(PendingSpawn::new("repo", SpawnPhase::Branches));
+        let tx = app.branch_list.start();
+        tx.send(Err("No branches found in repository".into()))
+            .unwrap();
+
+        app.poll_branch_list();
+
+        assert_eq!(
+            app.status_message.as_ref().map(|m| m.level),
+            Some(StatusLevel::Error)
+        );
+        assert!(app.pending_spawn.is_none());
+        assert!(app.new_session.repo_path.is_none());
+        assert!(matches!(app.modal, modals::Modal::None));
+    }
+
+    /// A panicking worker drops its sender; the wizard must not be left with a
+    /// spinner running forever over a job that will never land.
+    #[test]
+    fn poll_branch_list_disconnected_clears_guard() {
+        let mut app = app_with_sessions(0);
+        app.pending_spawn = Some(PendingSpawn::new("repo", SpawnPhase::Branches));
+        drop(app.branch_list.start());
+
+        app.poll_branch_list();
+
+        assert!(!app.branch_list.in_progress());
+        assert!(app.pending_spawn.is_none());
+        assert_eq!(
+            app.status_message.as_ref().map(|m| m.level),
+            Some(StatusLevel::Error)
+        );
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -314,6 +314,7 @@ impl App {
                 headers: ordered.headers,
                 depths: ordered.depths,
                 spinner,
+                pending_spawn: self.pending_spawn.as_ref(),
             },
         );
         self.record_row_clicks(
@@ -818,6 +819,7 @@ impl App {
             status: self.status_message.as_ref(),
             focus_label,
             sync_in_progress: self.worktree_sync.in_progress,
+            pending_spawn: self.pending_spawn.as_ref(),
             tick_count: self.metrics.tick_count,
             // With automations disabled the badge would advertise a feature the
             // TUI won't fire — report 0 so it stays hidden.

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -507,6 +507,11 @@ pub struct LeftPanelState<'a> {
     /// Current animated spinner frame for the `Working` status
     /// (`SPINNER_FRAMES[App::spinner_frame()]`).
     pub spinner: &'a str,
+    /// A session being created (git fetch / `worktree add` / spawn), rendered as
+    /// a trailing placeholder row so it shows up the moment the wizard is
+    /// confirmed rather than after a slow shell-out. Not selectable and not
+    /// clickable — it has no `SessionId` to select yet.
+    pub pending_spawn: Option<&'a crate::app::PendingSpawn>,
 }
 
 pub fn render_left_panel(
@@ -529,6 +534,7 @@ pub fn render_left_panel(
         state.headers,
         state.depths,
         state.spinner,
+        state.pending_spawn,
     )
 }
 
@@ -613,6 +619,7 @@ fn render_session_section(
     headers: &[Option<String>],
     depths: &[u8],
     spinner: &str,
+    pending_spawn: Option<&crate::app::PendingSpawn>,
 ) -> Vec<super::RowHitbox> {
     let mut block = focus_block(" Sessions ", level);
 
@@ -629,7 +636,7 @@ fn render_session_section(
         block = block.title_top(Line::from(dots).right_aligned());
     }
 
-    if sessions.is_empty() {
+    if sessions.is_empty() && pending_spawn.is_none() {
         render_empty_sessions(frame, area, block);
         return Vec::new();
     }
@@ -644,7 +651,7 @@ fn render_session_section(
     let visible_ids: std::collections::HashSet<crate::session::SessionId> =
         sessions.iter().map(|s| s.id).collect();
 
-    let items: Vec<ListItem> = sessions
+    let mut items: Vec<ListItem> = sessions
         .iter()
         .enumerate()
         .map(|(i, info)| {
@@ -680,6 +687,18 @@ fn render_session_section(
         })
         .collect();
 
+    // The session being created, appended last. It carries no `SessionInfo`, so
+    // it gets no hitbox below and can never be selected — the list's selection
+    // indices stay a valid range over `sessions`.
+    if let Some(pending) = pending_spawn {
+        items.push(ListItem::new(vec![pending_spawn_line(
+            pending,
+            inner_width,
+            spinner,
+        )]));
+        item_heights.push(1);
+    }
+
     // The active-row selection background is painted by `build_session_line`
     // itself (per-span, full width), *not* by the List's `highlight_style` —
     // because `highlight_style` patches the whole item area, which for a row
@@ -711,13 +730,53 @@ fn render_session_section(
             break;
         }
         let height = h.min(bottom - y);
-        hitboxes.push(super::RowHitbox {
-            rect: Rect::new(inner.x, y, inner.width, height),
-            index: i,
-        });
+        // The trailing placeholder row (`i == sessions.len()`) is skipped: its
+        // index isn't a session index, and clicking a session that doesn't exist
+        // yet has nothing to select.
+        if i < sessions.len() {
+            hitboxes.push(super::RowHitbox {
+                rect: Rect::new(inner.x, y, inner.width, height),
+                index: i,
+            });
+        }
         y += h;
     }
     hitboxes
+}
+
+/// The placeholder row for a session still being created: a spinner, the name
+/// we know it by so far, and the phase it's blocked on. Muted throughout — it is
+/// not selectable, and shouldn't read as a live session.
+fn pending_spawn_line(
+    pending: &crate::app::PendingSpawn,
+    inner_width: usize,
+    spinner: &str,
+) -> Line<'static> {
+    let phase = pending.phase.short_label();
+    // A spinner only while something is actually running; waiting on the user at
+    // a modal gets a static glyph (distinct from the ○/● of a live session).
+    let (glyph, glyph_color) = if pending.phase.is_working() {
+        (spinner, Theme::status_working())
+    } else {
+        ("◌", Theme::text_muted())
+    };
+    let mut spans = vec![
+        Span::styled(format!(" {glyph} "), Style::default().fg(glyph_color)),
+        Span::styled(
+            pending.label.clone(),
+            Style::default().fg(Theme::text_secondary()),
+        ),
+    ];
+    // Drop the phase text rather than overflow a narrow panel; the spinner and
+    // the badge in the status row still carry the "in progress" signal.
+    let used = 3 + pending.label.chars().count();
+    if inner_width > used + phase.chars().count() + 2 {
+        spans.push(Span::styled(
+            format!("  {phase}"),
+            Style::default().fg(Theme::text_muted()),
+        ));
+    }
+    Line::from(spans)
 }
 
 /// Render the centered "no sessions yet" placeholder inside the given block.
@@ -1206,6 +1265,7 @@ mod tests {
                         headers: ordered.headers,
                         depths: ordered.depths,
                         spinner: "◐",
+                        pending_spawn: None,
                     },
                 );
             })

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use super::theme::Theme;
-use crate::app::{StatusLevel, StatusMessage};
+use crate::app::{PendingSpawn, StatusLevel, StatusMessage};
 use crate::session::{Action, KeyBindings};
 
 fn brand_style() -> Style {
@@ -77,6 +77,10 @@ pub struct FooterState<'a> {
     pub status: Option<&'a StatusMessage>,
     pub focus_label: &'a str,
     pub sync_in_progress: bool,
+    /// A new session is being created (fetch / worktree / spawn). Takes over the
+    /// status row with a live badge for the whole wait — a `status` toast can't,
+    /// since those expire after 5 s and these phases routinely run longer.
+    pub pending_spawn: Option<&'a PendingSpawn>,
     pub tick_count: u64,
     pub automation_count: usize,
     pub file_viewer_open: bool,
@@ -237,7 +241,11 @@ pub fn render_status_message_row(frame: &mut Frame, area: Rect, state: &FooterSt
         return;
     }
     let mut spans: Vec<Span<'_>> = Vec::new();
-    if state.sync_in_progress {
+    if let Some(spawn) = state.pending_spawn {
+        // Wins over `status`: an error toast from an *earlier* action shouldn't
+        // hide the fact that a session is being created right now.
+        push_pending_spawn(&mut spans, spawn, state.tick_count);
+    } else if state.sync_in_progress {
         push_spinner_badge(&mut spans, state.tick_count, "SYNC");
         let text = state
             .status
@@ -253,6 +261,32 @@ pub fn render_status_message_row(frame: &mut Frame, area: Rect, state: &FooterSt
     }
     // A status row is a single line; ratatui clips a longer message to width.
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+/// The "a session is being created" badge: `⠹ NEW  Creating worktree(s)… feat/x
+/// · 14s` while a background phase runs, `◌ NEW  Setting up… feat/x` while the
+/// wizard waits on the user at a modal — no spinner and no elapsed there, since
+/// nothing is running and the clock would just be timing the user.
+fn push_pending_spawn<'a>(spans: &mut Vec<Span<'a>>, spawn: &PendingSpawn, tick_count: u64) {
+    let working = spawn.phase.is_working();
+    if working {
+        push_spinner_badge(spans, tick_count, "NEW");
+    } else {
+        push_badge(spans, '◌', "NEW");
+    }
+    spans.push(Span::styled(
+        format!(" {} ", spawn.phase.message()),
+        Style::default().fg(Theme::accent()),
+    ));
+    let detail = if working {
+        format!("{} · {}s ", spawn.label, spawn.elapsed_secs())
+    } else {
+        format!("{} ", spawn.label)
+    };
+    spans.push(Span::styled(
+        detail,
+        Style::default().fg(Theme::text_muted()),
+    ));
 }
 
 fn push_status_message<'a>(spans: &mut Vec<Span<'a>>, msg: &'a StatusMessage) {
@@ -321,9 +355,14 @@ fn file_viewer_shortcut_spans() -> Vec<Span<'static>> {
 
 fn push_spinner_badge<'a>(spans: &mut Vec<Span<'a>>, tick_count: u64, label: &'a str) {
     let idx = (tick_count as usize / 10) % SPINNER_CHARS.len();
-    let spinner = SPINNER_CHARS[idx];
+    push_badge(spans, SPINNER_CHARS[idx], label);
+}
+
+/// A filled `<glyph> LABEL` badge. The glyph is a spinner frame while work is
+/// running, or a static marker when the state is live but idle.
+fn push_badge<'a>(spans: &mut Vec<Span<'a>>, glyph: char, label: &'a str) {
     spans.push(Span::styled(
-        format!(" {spinner} {label} "),
+        format!(" {glyph} {label} "),
         Style::default()
             .fg(Theme::text_primary())
             .bg(Theme::accent()),
@@ -389,6 +428,7 @@ mod tests {
             status: None,
             focus_label: "Files",
             sync_in_progress: false,
+            pending_spawn: None,
             tick_count: 0,
             automation_count: 0,
             file_viewer_open,


### PR DESCRIPTION
## Summary

Creating a session on a large repo took tens of seconds with nothing on screen to say so. Two separate causes.

**The UI was actually freezing.** `start_branch_selection` ran `git fetch` (a network round-trip per repo, ssh-wrapped for a remote host), `list_branches` and `default_branch` **synchronously on the UI thread** — and it fires *after* the repo picker closes, so the stall happened with no modal, no repaint and no message on screen. This is finding #1 / R1 of the 2026-07-09 perf investigation: *"the only multi-second freeze on the ordinary interactive path"* (~2 s locally, unbounded on a slow network, ~5 s per unreachable host). It now runs on a worker, with the selector opening in `poll_branch_list`. `backend.ensure_ready()` — an ssh connect + remote tmux bring-up, 15–30 s on a slow host (ADR-P7) — also moves out of the `do_spawn_session_async` prelude and into its spawn worker.

**Then the progress went silent.** The worktree/spawn phases were *already* backgrounded and each set a `status_message` — but those expire after `STATUS_MESSAGE_TIMEOUT` (5 s), so a long `git worktree add` lost its toast partway through and the app looked idle. Progress that outlives a 5 s timer can't *be* a status message, so it's now separate state (`App::pending_spawn`) that lives exactly as long as the work: a **placeholder row** in the session list plus an animated **status badge** with an elapsed counter.

**It spans the whole wizard**, background phases *and* the modals between them, so the session never blinks out of the list between steps. `SpawnPhase::is_working()` splits the two: a `Configuring` spawn (a modal is open) keeps its row but shows a static `◌` with no spinner and no elapsed — spinning at work that isn't happening, and timing how long the user takes to answer, would both be lies.

**One hazard this introduced, and fixed.** Unfreezing the flow makes its window *interactive*: `branch_list`/`worktree_create` carry `new_session` state across a thread boundary, so a second `Ctrl+N` in that window would overwrite the repo the in-flight job is resolving — landing repo A's branch list on repo B's config, cutting a worktree from a branch B may not have. `start_new_session` now refuses re-entry and drops what the caller staged (a task-spawn's `pending_task_prompt` would otherwise be `take()`n by the session already in flight).

| Step | Session list | Status row |
|---|---|---|
| branch fetch | `⠴ sample-repo  fetching…` | `⠋ NEW  Fetching branches… sample-repo · 1s` |
| branch selector | `◌ sample-repo  setting up…` | `◌ NEW  Setting up… sample-repo` |
| session-name modal | `◌ sample-repo  setting up…` | `◌ NEW  Setting up… sample-repo` |
| worktree add | `⠇ feat-slow  creating…` | `⠴ NEW  Creating worktree(s)… feat-slow · 1s` |
| agent picker | `◌ feat-slow  setting up…` | `◌ NEW  Setting up… feat-slow` |
| live | `○ ⑂ feat-slow` | — |

Documented as **ADR-P12** in `docs/PERFORMANCE.md`; finding #1 / R1 marked resolved. `App::backend_for` is split into `select_backend` (cheap lookup, UI thread) + `ensure_backend_ready` (blocking, worker), and the three stale doc references to it are updated.

## Test plan

- [x] `cargo nextest run --all` — **1819 pass** (10 new), including the seeded-random monkey invariant test.
- [x] New coverage: `spawn_progress_outlives_the_status_message_timeout` (the regression this exists for), `spawn_progress_reports_elapsed_time`, `spawn_placeholder_row_is_not_selectable`, `spawn_placeholder_replaces_the_empty_state`, `indicator_survives_every_wizard_modal`, `escaping_a_wizard_modal_drops_the_indicator`, `new_session_is_refused_while_the_branch_list_is_in_flight`, `refused_new_session_does_not_leak_its_task_prompt`, `poll_branch_list_*`.
- [x] **Driven against the real binary**, not just tests: `Ctrl+N` through a tmux pane with a `git` shim that sleeps 6 s on `fetch` and 10 s on `worktree add`. 21 assertions — the spinner visibly *animated* during the fetch (⠴ → ⠦, which is the proof the loop isn't blocked), the elapsed counter advanced 1s → 3s, progress was still on screen past 5 s, the row survived all four wizard modals, and the placeholder gave way to a real session row with no ghost left behind.
- [x] `cargo clippy --all-targets --all-features -D warnings`, `cargo fmt --check`, `cargo test --test architecture_rules` (the new `ui → app` reference is within the allowed TEA coupling), `cargo deny`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `rumdl` — all clean.
- [x] Placeholder row records **no hitbox** and is appended last, so selection indices stay a valid range over real sessions.