### PR TITLE
ci: fix winget publish token (classic PAT via env var)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -469,9 +469,15 @@ jobs:
       # `submit` validates the bumped manifests and opens a PR against
       # microsoft/winget-pkgs from a fork of the WINGET_TOKEN account. Works for
       # both the first submission and every subsequent version from the same
-      # in-repo manifest set.
+      # in-repo manifest set. WINGET_TOKEN MUST be a classic PAT with the
+      # `public_repo` scope — wingetcreate rejects fine-grained tokens as
+      # invalid (microsoft/winget-create#595). The token is passed via
+      # WINGET_CREATE_GITHUB_TOKEN (Microsoft's recommended CI path) instead of
+      # --token, which wingetcreate warns can leak the token into logs.
       - name: Submit manifests to winget-pkgs
         if: env.WINGET_TOKEN != ''
         shell: pwsh
+        env:
+          WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
-          .\wingetcreate.exe submit --token $env:WINGET_TOKEN packaging/winget/manifests
+          .\wingetcreate.exe submit packaging/winget/manifests


### PR DESCRIPTION
## Summary

- Fixes the recurring `publish-winget` job failure: `wingetcreate submit` was dying with `Token was invalid. Please generate a new GitHub token and try again.`
- Root cause: wingetcreate rejects fine-grained GitHub tokens as invalid (microsoft/winget-create#595) and requires a classic PAT with `public_repo` scope.
- Passes the token via the Microsoft-recommended `WINGET_CREATE_GITHUB_TOKEN` env var instead of the `--token` flag, which wingetcreate warns can leak the token into CI logs.
- Documents the classic-PAT requirement inline so this doesn't regress.

Note: the `WINGET_TOKEN` secret itself was separately regenerated as a classic PAT (out-of-band), which was the actual blocker; this change hardens the workflow.

## Test plan

- No local test surface (CI-only workflow change).
- Validated by the next release triggering `publish-winget`, or a re-run of the job, submitting the winget-pkgs PR successfully.