### PR TITLE
docs: mark chocolatey live, winget pending review

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Installs the prebuilt x86_64 Windows binaries (`thurbox.exe` +
 Needs [psmux](https://github.com/psmux/psmux) as the multiplexer (installed
 separately).
 
+> **⚠️ Pending review.** The winget package has been submitted to
+> `microsoft/winget-pkgs` but is **not yet merged/live**, so `winget install
+> Thurbeen.thurbox` won't resolve it until the PR is approved. Use
+> **Chocolatey** or the PowerShell installer (both below) in the meantime.
+
 **Chocolatey (Windows):**
 
 ```powershell
@@ -82,11 +87,6 @@ Installs the prebuilt x86_64 Windows binaries (`thurbox.exe` +
 `thurbox-cli.exe`) from the GitHub Release and shims them onto your `PATH`.
 Needs [psmux](https://github.com/psmux/psmux) as the multiplexer (installed
 separately — there is no Chocolatey package for it).
-
-> **⚠️ Pending moderation.** The Chocolatey package has been pushed but is
-> **not yet approved** by the community-repo moderators, so `choco install
-> thurbox` won't resolve it from the community feed until it goes live. Use
-> **winget** or the PowerShell installer (both above) in the meantime.
 
 **Homebrew (macOS / Linux):**
 

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -8,13 +8,11 @@ from the GitHub Release and shims them onto your `PATH`.
 choco install thurbox
 ```
 
-> **Status: pending moderation.** The package has been pushed to the Chocolatey
-> community repository but has **not yet been approved by the moderators**, so
-> `choco install thurbox` will not resolve it from the community feed until it
-> goes live. This is expected for a new package (see
-> [Moderation](#automated-publishing-ci) below); until then, install with
-> [`scripts/install.ps1`](../../scripts/install.ps1) or pack/install the local
-> template (see [Test locally](#test-locally)).
+> **Status: live.** The package has been approved by the Chocolatey community
+> moderators and resolves from the community feed:
+> [community.chocolatey.org/packages/thurbox](https://community.chocolatey.org/packages/thurbox).
+> New versions still go through community-repo moderation before they appear (see
+> [Moderation](#automated-publishing-ci) below).
 
 The canonical package source lives here:
 [`thurbox.nuspec`](thurbox.nuspec) (metadata) plus

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -9,6 +9,15 @@ commands on your `PATH`.
 winget install Thurbeen.thurbox
 ```
 
+> **Status: pending review.** The package has been submitted to
+> [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs) but the PR
+> has **not yet merged**, so `winget install Thurbeen.thurbox` will not resolve
+> until it goes live (see [Automated publishing](#automated-publishing-ci)
+> below). Until then,
+> install with the approved [Chocolatey](../chocolatey/README.md) package,
+> [`scripts/install.ps1`](../../scripts/install.ps1), or validate the local
+> manifest (see [Manual publishing](#manual-publishing--initial-import)).
+
 The canonical manifest set lives here under [`manifests/`](manifests/):
 
 | File | Manifest type | Purpose |

--- a/website/docs/faq.html
+++ b/website/docs/faq.html
@@ -50,9 +50,10 @@ breadcrumb: 'FAQ'
   <code>curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code>.
   It is also available via Homebrew
   (<code>brew install thurbeen/thurbox/thurbox</code>), the AUR (<code>thurbox</code>
-  or <code>thurbox-bin</code>), and on Windows via PowerShell, winget
-  (<code>winget install Thurbeen.thurbox</code>), or Chocolatey
-  (<code>choco install thurbox</code>). You can also build from source with
+  or <code>thurbox-bin</code>), and on Windows via PowerShell or Chocolatey
+  (<code>choco install thurbox</code>). A winget package
+  (<code>winget install Thurbeen.thurbox</code>) is submitted but pending review.
+  You can also build from source with
   <code>cargo build --release</code>. See
   <a href="installation.html">installation</a> for details.
 </p>
@@ -119,7 +120,7 @@ breadcrumb: 'FAQ'
         "name": "How do I install Thurbox?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "On Linux or macOS, run: curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh. It is also available via Homebrew (brew install thurbeen/thurbox/thurbox), the AUR (thurbox or thurbox-bin), and on Windows via PowerShell, winget (winget install Thurbeen.thurbox), or Chocolatey (choco install thurbox). You can also build from source with cargo build --release."
+          "text": "On Linux or macOS, run: curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh. It is also available via Homebrew (brew install thurbeen/thurbox/thurbox), the AUR (thurbox or thurbox-bin), and on Windows via PowerShell or Chocolatey (choco install thurbox). A winget package (winget install Thurbeen.thurbox) is submitted but pending review. You can also build from source with cargo build --release."
         }
       },
       {

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -114,6 +114,20 @@ onThisPage:
             (Microsoft's package manager, bundled with Windows 10/11):
           </p>
           <pre><code class="language-powershell">winget install Thurbeen.thurbox</code></pre>
+          <div class="info-box warning">
+            <p>
+              <strong>Pending review.</strong>
+              The winget package has been submitted to
+              <code>microsoft/winget-pkgs</code>
+              but is
+              <strong>not yet merged</strong>
+              , so
+              <code>winget install Thurbeen.thurbox</code>
+              will not resolve until the PR is approved. Use
+              <a href="#chocolatey">Chocolatey</a>
+              or the PowerShell installer above in the meantime.
+            </p>
+          </div>
           <p>
             Installs
             <code>thurbox.exe</code>
@@ -136,18 +150,6 @@ onThisPage:
             :
           </p>
           <pre><code class="language-powershell">choco install thurbox</code></pre>
-          <div class="info-box warning">
-            <p>
-              <strong>Pending moderation.</strong>
-              The Chocolatey package has been pushed to the community repository but is
-              <strong>not yet approved</strong>
-              by the moderators, so
-              <code>choco install thurbox</code>
-              will not resolve it from the community feed until it goes live. Use
-              <a href="#winget">winget</a>
-              or the PowerShell installer above in the meantime.
-            </p>
-          </div>
           <p>
             Installs
             <code>thurbox.exe</code>

--- a/website/index.html
+++ b/website/index.html
@@ -177,6 +177,16 @@ footer: true
               <a href="https://github.com/psmux/psmux" target="_blank" rel="noopener">psmux</a>
               as the multiplexer (installed separately).
             </p>
+            <p>
+              <strong>Pending review:</strong>
+              the package is submitted to
+              <code>microsoft/winget-pkgs</code>
+              but not yet merged, so
+              <code>winget install Thurbeen.thurbox</code>
+              won't resolve until the PR is approved &mdash; use
+              <strong>Chocolatey</strong>
+              or the install script meanwhile.
+            </p>
             <pre><code class="language-powershell">winget install Thurbeen.thurbox</code></pre>
           </div>
 
@@ -195,14 +205,6 @@ footer: true
               . Needs
               <a href="https://github.com/psmux/psmux" target="_blank" rel="noopener">psmux</a>
               as the multiplexer (installed separately).
-            </p>
-            <p>
-              <strong>Pending moderation:</strong>
-              the package is pushed but not yet approved by the community-repo moderators, so
-              <code>choco install thurbox</code>
-              won't resolve until it goes live &mdash; use
-              <strong>winget</strong>
-              or the install script meanwhile.
             </p>
             <pre><code class="language-powershell">choco install thurbox</code></pre>
           </div>


### PR DESCRIPTION
## Summary

- Chocolatey package is now **approved** by community moderation — removed the pending-moderation caveats from the README, homepage, installation docs, and `packaging/chocolatey/README.md` (now marked "Status: live" with the community-repo link).
- winget package is submitted to `microsoft/winget-pkgs` but **not yet merged** — added pending-review notes in its place across the same surfaces plus `packaging/winget/README.md`.
- Updated the FAQ prose + its JSON-LD duplicate to lead with Chocolatey and note winget is pending review.

## Test plan

- `rumdl check` passes on all touched markdown files.
- Cross-reference anchors verified to resolve (`#chocolatey`, `#winget`, `#automated-publishing-ci`, `#manual-publishing--initial-import`).
- Docs-only change; no code paths affected.