### PR TITLE
feat(core): scope account usage to the session's host

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -111,6 +111,25 @@ const CONFIG_RELOAD_TICKS: u64 = 100;
 /// network, so this is deliberately slow; fires once early then every 5 min.
 const USAGE_REFRESH_TICKS: u64 = 30_000;
 
+/// Cache key for account usage: `(agent name, host name)` (`None` = local).
+/// The credential source — and therefore the account — is the machine the
+/// agent process runs on, so two sessions with the same agent on different
+/// hosts get separate entries while same-host sessions share one fetch.
+pub(crate) type UsageKey = (String, Option<String>);
+
+/// One planned account-usage refresh from [`App::plan_usage_fetches`]: either
+/// a real background fetch, or a static note for a scope that can't be
+/// fetched right now (host unreachable / missing from `hosts.toml`).
+#[derive(Debug)]
+enum UsageFetchPlan {
+    /// Spawn [`crate::usage::fetch`] against these credentials
+    /// (`None` host = local).
+    Fetch(Option<crate::session::HostDef>),
+    /// Don't spawn anything; show this note **unless** an earlier fetch
+    /// already cached real data (last-known usage beats a transient outage).
+    Unavailable(&'static str),
+}
+
 /// Prepared inputs for a `Session::spawn`, produced on the UI thread by
 /// [`App::build_spawn_inputs`] and consumed either inline (synchronous spawn)
 /// or moved into a blocking task (interactive spawn).
@@ -870,14 +889,16 @@ pub struct App {
     /// `~/.config/thurbox/keybindings.json` on startup, falling back to defaults
     /// when the file is missing or malformed.
     pub(crate) keybindings: crate::session::KeyBindings,
-    /// Account-level usage/rate-limit info per agent name (the `/usage`
-    /// equivalent), fetched in the background and shown for the active
-    /// session's agent. Account-global, so keyed by agent rather than session.
-    pub(crate) usage: HashMap<String, crate::session::AgentUsage>,
+    /// Account-level usage/rate-limit info (the `/usage` equivalent), fetched
+    /// in the background and shown for the active session. Keyed per
+    /// [`UsageKey`] — agent **and** host — because the account is whatever
+    /// credentials live on the machine the agent runs on: a `claude` session
+    /// on `ssh:devbox` may be a different account than a local one.
+    pub(crate) usage: HashMap<UsageKey, crate::session::AgentUsage>,
     /// Sends background usage-fetch results back to the app loop.
-    usage_tx: mpsc::Sender<(String, crate::session::AgentUsage)>,
+    usage_tx: mpsc::Sender<(UsageKey, crate::session::AgentUsage)>,
     /// Receives background usage-fetch results, drained each tick.
-    usage_rx: mpsc::Receiver<(String, crate::session::AgentUsage)>,
+    usage_rx: mpsc::Receiver<(UsageKey, crate::session::AgentUsage)>,
     /// Config-load problems collected at startup (keybindings.json here,
     /// agents.toml/hosts.toml reported by main), shown joined in one status
     /// toast via [`Self::report_config_warnings`].
@@ -4492,8 +4513,8 @@ impl App {
         }
 
         // Drain any completed background usage fetches into the cache.
-        while let Ok((agent, usage)) = self.usage_rx.try_recv() {
-            self.usage.insert(agent, usage);
+        while let Ok((key, usage)) = self.usage_rx.try_recv() {
+            self.usage.insert(key, usage);
         }
         // Kick off usage fetches early and then on a slow cadence.
         if self.metrics.tick_count % USAGE_REFRESH_TICKS == 1 {
@@ -4871,22 +4892,76 @@ impl App {
         self.active_theme = entry;
     }
 
-    /// Spawn background usage/rate-limit fetches for each distinct supported
-    /// agent currently in the session list. Results return via `usage_tx` and
-    /// are drained in [`Self::tick`]. Network/process work runs off the UI
-    /// thread; unsupported agents are skipped entirely.
-    fn spawn_usage_fetches(&self) {
-        let mut seen = std::collections::HashSet::new();
+    /// Plan the account-usage refreshes for the current session list: one
+    /// entry per distinct [`UsageKey`] (agent + host), covering every case —
+    /// local sessions use local credentials; a remote session resolves its
+    /// `HostDef` so credentials are read on that host; a placeholder session
+    /// (host currently unreachable) or a host missing from `hosts.toml`
+    /// yields a static note instead of a doomed ssh attempt. Pure (no spawns)
+    /// so the scoping rules are unit-testable.
+    fn plan_usage_fetches(&self) -> Vec<(UsageKey, UsageFetchPlan)> {
+        let mut seen: HashMap<UsageKey, usize> = HashMap::new();
+        let mut plan: Vec<(UsageKey, UsageFetchPlan)> = Vec::new();
         for session in &self.sessions {
-            let agent = session.info.agent.clone();
-            if !crate::usage::is_supported(&agent) || !seen.insert(agent.clone()) {
+            if !crate::usage::is_supported(&session.info.agent) {
                 continue;
             }
-            let tx = self.usage_tx.clone();
-            tokio::spawn(async move {
-                let usage = crate::usage::fetch(&agent).await;
-                let _ = tx.send((agent, usage));
-            });
+            let key: UsageKey = (session.info.agent.clone(), session.info.remote_host.clone());
+            let entry = match &key.1 {
+                None => UsageFetchPlan::Fetch(None),
+                Some(_) if session.is_placeholder() => {
+                    UsageFetchPlan::Unavailable("usage unavailable (host unreachable)")
+                }
+                Some(host_name) => match self.hosts.get(host_name) {
+                    Some(host) => UsageFetchPlan::Fetch(Some(host.clone())),
+                    None => UsageFetchPlan::Unavailable("usage unavailable (host not configured)"),
+                },
+            };
+            match seen.get(&key) {
+                None => {
+                    seen.insert(key.clone(), plan.len());
+                    plan.push((key, entry));
+                }
+                // Mid-reconnect a host's sessions can be mixed (one adopted,
+                // one still a placeholder): a live session's fetch beats a
+                // placeholder's note for the same scope.
+                Some(&i) => {
+                    if matches!(plan[i].1, UsageFetchPlan::Unavailable(_))
+                        && matches!(entry, UsageFetchPlan::Fetch(_))
+                    {
+                        plan[i].1 = entry;
+                    }
+                }
+            }
+        }
+        plan
+    }
+
+    /// Spawn background usage/rate-limit fetches for each distinct supported
+    /// (agent, host) scope currently in the session list (see
+    /// [`Self::plan_usage_fetches`]). Results return via `usage_tx` and are
+    /// drained in [`Self::tick`]. Network/process work runs off the UI thread.
+    fn spawn_usage_fetches(&mut self) {
+        for (key, entry) in self.plan_usage_fetches() {
+            match entry {
+                UsageFetchPlan::Fetch(host) => {
+                    let tx = self.usage_tx.clone();
+                    tokio::spawn(async move {
+                        let usage = crate::usage::fetch(&key.0, host.as_ref()).await;
+                        let _ = tx.send((key, usage));
+                    });
+                }
+                // Keep last-known data over a transient outage; the note only
+                // fills a scope that never fetched successfully.
+                UsageFetchPlan::Unavailable(note) => {
+                    self.usage
+                        .entry(key)
+                        .or_insert_with(|| crate::session::AgentUsage {
+                            note: Some(note.to_string()),
+                            ..Default::default()
+                        });
+                }
+            }
         }
     }
 
@@ -7428,6 +7503,116 @@ mod tests {
         );
         assert!(app.host_for_backend(Some("wsl:Ubuntu")).unwrap().is_wsl());
         assert!(app.host_for_backend(Some("ssh:unknown")).is_none());
+    }
+
+    fn devbox_registry() -> crate::session::HostRegistry {
+        crate::session::HostRegistry {
+            config_version: None,
+            hosts: vec![crate::session::HostDef {
+                name: "devbox".into(),
+                destination: "me@devbox".into(),
+                ..Default::default()
+            }],
+        }
+    }
+
+    #[test]
+    fn usage_plan_scopes_by_agent_and_host() {
+        let mut app = app_with_sessions(3);
+        app.set_hosts(devbox_registry());
+        // Two local claude sessions (deduped) + one on devbox (own scope).
+        app.sessions[0].info.agent = "claude".into();
+        app.sessions[1].info.agent = "claude".into();
+        app.sessions[1].info.remote_host = Some("devbox".into());
+        app.sessions[2].info.agent = "claude".into();
+
+        let plan = app.plan_usage_fetches();
+        assert_eq!(plan.len(), 2);
+        assert_eq!(plan[0].0, ("claude".to_string(), None));
+        assert!(matches!(plan[0].1, UsageFetchPlan::Fetch(None)));
+        assert_eq!(plan[1].0, ("claude".to_string(), Some("devbox".into())));
+        match &plan[1].1 {
+            UsageFetchPlan::Fetch(Some(h)) => assert_eq!(h.destination, "me@devbox"),
+            other => panic!("expected host-scoped fetch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn usage_plan_notes_unknown_host_and_skips_unsupported() {
+        let mut app = app_with_sessions(2);
+        // A remote session whose host vanished from hosts.toml, plus an
+        // agent without usage support: only the former appears, as a note.
+        app.sessions[0].info.agent = "claude".into();
+        app.sessions[0].info.remote_host = Some("ghost".into());
+        app.sessions[1].info.agent = "aider".into();
+
+        let plan = app.plan_usage_fetches();
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan[0].0, ("claude".to_string(), Some("ghost".into())));
+        match plan[0].1 {
+            UsageFetchPlan::Unavailable(note) => assert!(note.contains("not configured")),
+            _ => panic!("expected an unavailable note for an unknown host"),
+        }
+    }
+
+    #[test]
+    fn usage_unreachable_host_notes_but_keeps_last_known_data() {
+        let mut app = app_with_sessions(0);
+        app.set_hosts(devbox_registry());
+        let backend_arc = stub_backend_arc();
+        let provider = stub_provider();
+        let mut info = crate::session::SessionInfo::new("remote".into());
+        info.agent = "claude".into();
+        info.remote_host = Some("devbox".into());
+        app.sessions.push(Session::placeholder(
+            info,
+            24,
+            80,
+            &backend_arc,
+            &provider,
+            HashMap::new(),
+        ));
+
+        // No cached data → the outage note fills the scope (no ssh spawned).
+        app.spawn_usage_fetches();
+        let key = ("claude".to_string(), Some("devbox".to_string()));
+        let note = app.usage.get(&key).unwrap().note.clone().unwrap();
+        assert!(note.contains("unreachable"), "got note: {note}");
+
+        // With real data cached from before the outage, the note must not
+        // clobber it — last-known usage beats a transient host drop.
+        app.usage.insert(
+            key.clone(),
+            crate::session::AgentUsage {
+                windows: vec![],
+                plan: Some("max".into()),
+                note: None,
+            },
+        );
+        app.spawn_usage_fetches();
+        assert_eq!(app.usage.get(&key).unwrap().plan.as_deref(), Some("max"));
+    }
+
+    #[test]
+    fn usage_plan_live_session_beats_placeholder_for_same_scope() {
+        // Mid-reconnect a host's sessions can be mixed: a placeholder seen
+        // first must not shadow an adopted (live) session's fetch.
+        let mut app = app_with_sessions(1);
+        app.set_hosts(devbox_registry());
+        let backend_arc = stub_backend_arc();
+        let provider = stub_provider();
+        let mut info = crate::session::SessionInfo::new("remote".into());
+        info.agent = "claude".into();
+        info.remote_host = Some("devbox".into());
+        let placeholder =
+            Session::placeholder(info, 24, 80, &backend_arc, &provider, HashMap::new());
+        app.sessions.insert(0, placeholder);
+        app.sessions[1].info.agent = "claude".into();
+        app.sessions[1].info.remote_host = Some("devbox".into());
+
+        let plan = app.plan_usage_fetches();
+        assert_eq!(plan.len(), 1);
+        assert!(matches!(plan[0].1, UsageFetchPlan::Fetch(Some(_))));
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -391,7 +391,10 @@ impl App {
             return;
         };
         let now = crate::sync::current_time_millis();
-        let agent_usage = self.usage.get(&info.agent);
+        // Usage is scoped per (agent, host): a remote session shows the
+        // account its *host* is logged into, not the local one.
+        let usage_key = (info.agent.clone(), info.remote_host.clone());
+        let agent_usage = self.usage.get(&usage_key);
         // Skip the upcoming-automations section entirely when the feature is
         // off: the TUI won't fire those schedules, so advertising their
         // countdowns here (the cache is loaded from the DB regardless) would

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -207,7 +207,9 @@ pub struct UsageWindow {
 }
 
 /// Account-level usage/rate-limit info for an agent, fetched from the vendor
-/// (the `/usage`-equivalent). Account-global, not per-session. Agent-neutral.
+/// (the `/usage`-equivalent). Account-global — but the *account* is scoped to
+/// wherever the agent's credentials live, i.e. the host the session runs on
+/// (local machine, SSH host, or WSL distro). Agent-neutral.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct AgentUsage {
     pub windows: Vec<UsageWindow>,

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -64,7 +64,9 @@ pub fn render_info_panel(
 
     if let Some(u) = usage {
         if !u.is_empty() {
-            append_usage_section(&mut lines, u, inner_width);
+            // Usage is per (agent, host); label the host so two sessions on
+            // different accounts read unambiguously.
+            append_usage_section(&mut lines, u, info.remote_host.as_deref(), inner_width);
         }
     }
 
@@ -465,15 +467,20 @@ fn format_countdown_secs(secs: u64) -> String {
 
 /// Append the account-level usage / rate-limit section (the `/usage`
 /// equivalent): one gauge per window with used-% and a reset countdown.
+/// `host` names the credential source for a remote session (`None` = local),
+/// so usage from different accounts is never mistaken for the local one.
 fn append_usage_section(
     lines: &mut Vec<Line<'_>>,
     usage: &crate::session::AgentUsage,
+    host: Option<&str>,
     width: usize,
 ) {
     lines.push(separator(width));
-    let header = match &usage.plan {
-        Some(plan) => format!("Usage ({plan})"),
-        None => "Usage".to_string(),
+    let header = match (&usage.plan, host) {
+        (Some(plan), Some(host)) => format!("Usage ({plan} · {host})"),
+        (Some(plan), None) => format!("Usage ({plan})"),
+        (None, Some(host)) => format!("Usage ({host})"),
+        (None, None) => "Usage".to_string(),
     };
     lines.push(Line::from(Span::styled(header, Theme::section_header())));
 
@@ -889,8 +896,12 @@ mod tests {
     }
 
     fn render_usage(u: &crate::session::AgentUsage) -> String {
+        render_usage_on(u, None)
+    }
+
+    fn render_usage_on(u: &crate::session::AgentUsage, host: Option<&str>) -> String {
         let mut lines: Vec<Line> = Vec::new();
-        append_usage_section(&mut lines, u, 24);
+        append_usage_section(&mut lines, u, host, 24);
         lines
             .iter()
             .map(|l| {
@@ -939,5 +950,24 @@ mod tests {
         let out = render_usage(&u);
         assert!(out.contains("Usage"));
         assert!(out.contains("not logged in"));
+    }
+
+    #[test]
+    fn usage_section_labels_remote_host() {
+        let u = crate::session::AgentUsage {
+            windows: vec![crate::session::UsageWindow {
+                label: "5h".into(),
+                used_percent: 42.0,
+                resets_at: None,
+            }],
+            plan: Some("max".into()),
+            note: None,
+        };
+        assert!(render_usage_on(&u, Some("devbox")).contains("Usage (max · devbox)"));
+        let no_plan = crate::session::AgentUsage {
+            plan: None,
+            ..u.clone()
+        };
+        assert!(render_usage_on(&no_plan, Some("devbox")).contains("Usage (devbox)"));
     }
 }

--- a/src/usage/mod.rs
+++ b/src/usage/mod.rs
@@ -1,18 +1,31 @@
-//! Account-level usage / rate-limit fetching, per agent.
+//! Account-level usage / rate-limit fetching, per agent **and per host**.
 //!
 //! Mirrors what an agent's `/usage` (Claude) or `/status` (Codex) command
 //! shows — the rolling rate-limit windows (e.g. 5-hour and weekly) with their
-//! used-percentage and reset time. This data is **account-global**, fetched
-//! directly from the vendor using the user's existing local credentials, the
-//! same way Claude Code and Orca obtain it. Agent-neutral at the type level
-//! ([`crate::session::AgentUsage`] is a plain list of named windows); the
-//! per-agent fetch logic lives here.
+//! used-percentage and reset time. This data is **account-global**, but the
+//! *account* is determined by the credentials on the machine the agent runs
+//! on: a session on `ssh:devbox` may be logged into a different Claude account
+//! than a local session. So every fetch is scoped to a host (`None` = local):
+//! credentials are read where the agent process lives — locally, over the SSH
+//! launcher, or inside the WSL distro — and the vendor API is then called
+//! *locally* with that token (the token, not the network path, selects the
+//! account; this also avoids requiring `curl` on the host). Codex has no
+//! separable credential file/API pair, so its `app-server` subprocess runs on
+//! the host itself over the same launcher (stdio JSON-RPC is transport-neutral).
+//!
+//! Agent-neutral at the type level ([`crate::session::AgentUsage`] is a plain
+//! list of named windows); the per-agent fetch logic lives here. Everything is
+//! best-effort — any missing credential, absent CLI, unreachable host, or
+//! network error yields an [`AgentUsage`] with a human `note` (naming the host
+//! when off-local) and no windows.
+//!
+//! Known limitation: a *remote* `CLAUDE_CONFIG_DIR` override is honored on
+//! POSIX hosts (the read script lets the host shell expand it) but not on a
+//! Windows (psmux) host, and per-session env overrides baked into a wrapper
+//! script are invisible here.
 //!
 //! No HTTP client dependency: authenticated requests shell out to `curl`
-//! (config piped over stdin so the bearer token never appears in argv), and
-//! Codex is queried via its `app-server` JSON-RPC subprocess. Everything is
-//! best-effort — any missing credential, absent CLI, or network error yields
-//! an [`AgentUsage`] with a human `note` and no windows.
+//! (config piped over stdin so the bearer token never appears in argv).
 
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -20,7 +33,8 @@ use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
 
-use crate::session::{AgentUsage, UsageWindow};
+use crate::session::{AgentUsage, HostDef, UsageWindow};
+use crate::shell::{posix_quote, ssh_command, wsl_command};
 
 /// Agents we know how to fetch usage for. Others are skipped entirely (no
 /// process spawned, no panel section shown).
@@ -31,13 +45,14 @@ pub fn is_supported(agent: &str) -> bool {
     SUPPORTED.contains(&agent)
 }
 
-/// Fetch account usage for `agent`. Best-effort; never errors — unavailability
-/// is reported via [`AgentUsage::note`] with no windows.
-pub async fn fetch(agent: &str) -> AgentUsage {
+/// Fetch account usage for `agent` as seen from `host` (`None` = the local
+/// machine). Best-effort; never errors — unavailability is reported via
+/// [`AgentUsage::note`] with no windows.
+pub async fn fetch(agent: &str, host: Option<&HostDef>) -> AgentUsage {
     match agent {
-        "claude" => claude().await,
-        "codex" => codex().await,
-        "antigravity" => antigravity().await,
+        "claude" => claude(host).await,
+        "codex" => codex(host).await,
+        "antigravity" => antigravity(host).await,
         other => AgentUsage {
             note: Some(format!("usage not supported for '{other}'")),
             ..Default::default()
@@ -46,6 +61,68 @@ pub async fn fetch(agent: &str) -> AgentUsage {
 }
 
 // ─────────────────────────── shared helpers ───────────────────────────
+
+/// `" on <host>"` suffix for notes, empty for local fetches.
+fn at_host(host: Option<&HostDef>) -> String {
+    host.map(|h| format!(" on {}", h.name)).unwrap_or_default()
+}
+
+/// Command that reads a small credentials file on `host`. Pure builder
+/// (returns a std [`std::process::Command`]) so quoting is unit-testable.
+///
+/// - POSIX hosts (SSH + tmux, or a WSL distro) run `sh -c <posix_script>`,
+///   letting the *host* shell expand `$HOME` / `$CLAUDE_CONFIG_DIR`. Quoting
+///   mirrors `git::host_shell_c`: ssh space-joins its trailing args into one
+///   string the remote login shell re-splits (so the script is POSIX-quoted),
+///   while `wsl.exe --exec` passes argv verbatim (so it must NOT be quoted).
+/// - A psmux host is native Windows with no `sh`. `type <rel-path>` works
+///   under both default OpenSSH shells (a cmd builtin; a PowerShell alias for
+///   `Get-Content`) and resolves relative to `%USERPROFILE%`, the OpenSSH
+///   default cwd — no env expansion needed, so no quoting hazards.
+fn remote_read_command(
+    host: &HostDef,
+    posix_script: &str,
+    windows_args: &[&str],
+) -> std::process::Command {
+    if host.is_wsl() {
+        let mut c = wsl_command(&host.distro_name());
+        c.arg("-e").arg("sh").arg("-c").arg(posix_script);
+        c
+    } else if host.mux() == "psmux" {
+        let mut c = ssh_command(&host.destination, &host.ssh_opts);
+        c.args(windows_args);
+        c
+    } else {
+        let mut c = ssh_command(&host.destination, &host.ssh_opts);
+        c.arg(posix_quote("sh"))
+            .arg(posix_quote("-c"))
+            .arg(posix_quote(posix_script));
+        c
+    }
+}
+
+/// Run a [`remote_read_command`] and return its stdout as text. `None` on
+/// spawn failure, timeout, or non-zero exit (host down, file missing…).
+async fn remote_read_text(
+    host: &HostDef,
+    posix_script: &str,
+    windows_args: &[&str],
+) -> Option<String> {
+    let mut cmd =
+        tokio::process::Command::from(remote_read_command(host, posix_script, windows_args));
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    let out = tokio::time::timeout(Duration::from_secs(15), cmd.output())
+        .await
+        .ok()?
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout).into_owned();
+    (!text.trim().is_empty()).then_some(text)
+}
 
 /// Run `curl` with a config supplied on stdin (keeps tokens out of argv) and
 /// parse stdout as JSON. Returns `None` on spawn/timeout/non-JSON.
@@ -73,12 +150,6 @@ async fn curl_json(config: String) -> Option<serde_json::Value> {
     serde_json::from_slice(&out.stdout).ok()
 }
 
-/// Read a JSON file (used for vendor credential files).
-fn read_json_file(path: &PathBuf) -> Option<serde_json::Value> {
-    let text = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&text).ok()
-}
-
 /// Parse an RFC 3339 timestamp to Unix epoch seconds.
 fn rfc3339_epoch(s: &str) -> Option<u64> {
     chrono::DateTime::parse_from_rfc3339(s)
@@ -91,11 +162,26 @@ fn clamp_pct(v: f64) -> f32 {
     v.clamp(0.0, 100.0) as f32
 }
 
+/// Reject tokens that could break the curl-config syntax (quote/newline
+/// injection from a tampered credentials file).
+fn token_is_clean(token: &str) -> bool {
+    !token.contains('"') && !token.contains('\n') && !token.contains('\r')
+}
+
 // ─────────────────────────────── Claude ───────────────────────────────
 
 const CLAUDE_USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
 const CLAUDE_OAUTH_BETA: &str = "oauth-2025-04-20";
 const CLAUDE_USER_AGENT: &str = "claude-code/2.1.0";
+
+/// POSIX read of Claude's credentials, honoring a host-side
+/// `CLAUDE_CONFIG_DIR` and falling back to the macOS Keychain (where Claude
+/// Code stores the same JSON blob when the file is absent).
+const CLAUDE_POSIX_READ: &str = "cat \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json\" \
+     2>/dev/null || security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null";
+
+/// Windows (psmux host) read — see [`remote_read_command`] for why `type`.
+const CLAUDE_WINDOWS_READ: &[&str] = &["type", ".claude\\.credentials.json"];
 
 /// Locate Claude's credentials file (`$CLAUDE_CONFIG_DIR/.credentials.json`,
 /// else `~/.claude/.credentials.json`).
@@ -112,15 +198,15 @@ fn claude_credentials_path() -> Option<PathBuf> {
     p.exists().then_some(p)
 }
 
-/// Read the subscription OAuth access token and plan tier from disk.
-fn claude_token() -> Option<(String, Option<String>)> {
-    let v = read_json_file(&claude_credentials_path()?)?;
+/// Extract the subscription OAuth access token and plan tier from the
+/// credentials JSON text (same shape on disk and in the macOS Keychain).
+fn parse_claude_credentials(text: &str) -> Option<(String, Option<String>)> {
+    let v: serde_json::Value = serde_json::from_str(text.trim()).ok()?;
     let token = v
         .pointer("/claudeAiOauth/accessToken")?
         .as_str()?
         .to_string();
-    // Reject anything that could break the curl config syntax.
-    if token.contains('"') || token.contains('\n') {
+    if !token_is_clean(&token) {
         return None;
     }
     let plan = v
@@ -130,10 +216,40 @@ fn claude_token() -> Option<(String, Option<String>)> {
     Some((token, plan))
 }
 
-async fn claude() -> AgentUsage {
-    let Some((token, plan)) = claude_token() else {
+/// Read Claude's local credentials: the on-disk file, else the macOS Keychain
+/// (where Claude Code stores them when no file exists). The keychain attempt
+/// is harmless off-macOS — `security` isn't on PATH, so spawn fails fast.
+async fn claude_local_credentials() -> Option<String> {
+    if let Some(path) = claude_credentials_path() {
+        return std::fs::read_to_string(path).ok();
+    }
+    let out = tokio::process::Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .await
+        .ok()?;
+    (out.status.success()).then(|| String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+async fn claude(host: Option<&HostDef>) -> AgentUsage {
+    let creds = match host {
+        None => claude_local_credentials().await,
+        Some(h) => remote_read_text(h, CLAUDE_POSIX_READ, CLAUDE_WINDOWS_READ).await,
+    };
+    let Some((token, plan)) = creds.as_deref().and_then(parse_claude_credentials) else {
         return AgentUsage {
-            note: Some("not logged in (no subscription token)".into()),
+            note: Some(format!(
+                "not logged in{} (no subscription token)",
+                at_host(host)
+            )),
             ..Default::default()
         };
     };
@@ -185,22 +301,53 @@ fn parse_claude_usage(v: &serde_json::Value, plan: Option<String>) -> AgentUsage
 
 // ─────────────────────────────── Codex ────────────────────────────────
 
+/// Codex's `app-server` argv. Every token is whitespace-free, so it survives
+/// ssh's space-join and `wsl.exe`'s token forwarding without quoting.
+const CODEX_SERVER_ARGS: &[&str] = &["-s", "read-only", "-a", "untrusted", "app-server"];
+
+/// Build the `codex app-server` command, locally or on `host` (the subprocess
+/// runs *on the host* — its stdio JSON-RPC pipes straight through ssh/wsl, and
+/// its credentials are wherever that codex is logged in). Pure for testing.
+fn codex_server_command(host: Option<&HostDef>) -> std::process::Command {
+    match host {
+        None => {
+            let mut c = std::process::Command::new("codex");
+            c.args(CODEX_SERVER_ARGS);
+            c
+        }
+        Some(h) if h.is_wsl() => {
+            let mut c = wsl_command(&h.distro_name());
+            c.arg("codex").args(CODEX_SERVER_ARGS);
+            c
+        }
+        // Plain tokens work for a POSIX *and* a Windows (psmux) SSH host: the
+        // remote shell resolves `codex`/`codex.exe` from PATH either way.
+        Some(h) => {
+            let mut c = ssh_command(&h.destination, &h.ssh_opts);
+            c.arg("codex").args(CODEX_SERVER_ARGS);
+            c
+        }
+    }
+}
+
 /// Query Codex's `app-server` over JSON-RPC for rate limits. Best-effort:
-/// requires a logged-in `codex` CLI on PATH. Newline-delimited JSON-RPC with a
-/// hard timeout; any framing/auth issue simply yields a note.
-async fn codex() -> AgentUsage {
-    match tokio::time::timeout(Duration::from_secs(15), codex_app_server()).await {
+/// requires a logged-in `codex` CLI on the target's PATH. Newline-delimited
+/// JSON-RPC with a hard timeout; any framing/auth issue simply yields a note.
+async fn codex(host: Option<&HostDef>) -> AgentUsage {
+    match tokio::time::timeout(Duration::from_secs(15), codex_app_server(host)).await {
         Ok(Some(v)) => parse_codex_ratelimits(&v),
         _ => AgentUsage {
-            note: Some("usage unavailable (codex not logged in?)".into()),
+            note: Some(format!(
+                "usage unavailable (codex not logged in{}?)",
+                at_host(host)
+            )),
             ..Default::default()
         },
     }
 }
 
-async fn codex_app_server() -> Option<serde_json::Value> {
-    let mut child = tokio::process::Command::new("codex")
-        .args(["-s", "read-only", "-a", "untrusted", "app-server"])
+async fn codex_app_server(host: Option<&HostDef>) -> Option<serde_json::Value> {
+    let mut child = tokio::process::Command::from(codex_server_command(host))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -273,22 +420,25 @@ fn parse_codex_ratelimits(v: &serde_json::Value) -> AgentUsage {
 const ANTIGRAVITY_QUOTA_URL: &str =
     "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota";
 
-fn antigravity_token() -> Option<String> {
-    let v = read_json_file(
-        &crate::paths::home_dir()?
-            .join(".gemini")
-            .join("oauth_creds.json"),
-    )?;
+const ANTIGRAVITY_POSIX_READ: &str = "cat \"$HOME/.gemini/oauth_creds.json\" 2>/dev/null";
+const ANTIGRAVITY_WINDOWS_READ: &[&str] = &["type", ".gemini\\oauth_creds.json"];
+
+/// Extract the Google OAuth access token from the credentials JSON text.
+fn parse_antigravity_credentials(text: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(text.trim()).ok()?;
     let token = v.get("access_token").and_then(|x| x.as_str())?.to_string();
-    (!token.contains('"') && !token.contains('\n')).then_some(token)
+    token_is_clean(&token).then_some(token)
 }
 
-async fn antigravity() -> AgentUsage {
-    let Some(token) = antigravity_token() else {
-        return AgentUsage {
-            note: Some("not logged in (no Google OAuth creds)".into()),
-            ..Default::default()
-        };
+async fn antigravity(host: Option<&HostDef>) -> AgentUsage {
+    let creds = match host {
+        None => crate::paths::home_dir()
+            .map(|h| h.join(".gemini").join("oauth_creds.json"))
+            .and_then(|p| std::fs::read_to_string(p).ok()),
+        Some(h) => remote_read_text(h, ANTIGRAVITY_POSIX_READ, ANTIGRAVITY_WINDOWS_READ).await,
+    };
+    let Some(token) = creds.as_deref().and_then(parse_antigravity_credentials) else {
+        return not_logged_in_google(host);
     };
     let config = format!(
         "url = \"{ANTIGRAVITY_QUOTA_URL}\"\n\
@@ -304,6 +454,16 @@ async fn antigravity() -> AgentUsage {
             note: Some("usage unavailable (API error)".into()),
             ..Default::default()
         },
+    }
+}
+
+fn not_logged_in_google(host: Option<&HostDef>) -> AgentUsage {
+    AgentUsage {
+        note: Some(format!(
+            "not logged in{} (no Google OAuth creds)",
+            at_host(host)
+        )),
+        ..Default::default()
     }
 }
 
@@ -357,6 +517,27 @@ fn parse_antigravity_quota(v: &serde_json::Value) -> AgentUsage {
 mod tests {
     use super::*;
 
+    fn ssh_host(name: &str) -> HostDef {
+        HostDef {
+            name: name.into(),
+            destination: format!("me@{name}"),
+            ..Default::default()
+        }
+    }
+
+    fn psmux_host(name: &str) -> HostDef {
+        HostDef {
+            multiplexer: Some("psmux".into()),
+            ..ssh_host(name)
+        }
+    }
+
+    fn args_of(cmd: &std::process::Command) -> Vec<String> {
+        cmd.get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
     #[test]
     fn supported_set() {
         assert!(is_supported("claude"));
@@ -365,6 +546,105 @@ mod tests {
         assert!(!is_supported("aider"));
         assert!(!is_supported("shell"));
     }
+
+    #[test]
+    fn at_host_labels_remote_only() {
+        assert_eq!(at_host(None), "");
+        assert_eq!(at_host(Some(&ssh_host("devbox"))), " on devbox");
+    }
+
+    // ── remote credential-read command construction ──
+
+    #[test]
+    fn remote_read_ssh_posix_quotes_script() {
+        let cmd = remote_read_command(&ssh_host("devbox"), "cat \"$HOME/x\"", &["type", "x"]);
+        assert_eq!(cmd.get_program(), "ssh");
+        let args = args_of(&cmd);
+        assert_eq!(args.last().unwrap(), &posix_quote("cat \"$HOME/x\""));
+        assert!(args.contains(&"me@devbox".to_string()));
+        // `sh -c` framing, each token quoted for the remote login shell.
+        let tail = &args[args.len() - 3..];
+        assert_eq!(tail[0], "sh");
+        assert_eq!(tail[1], "-c");
+    }
+
+    #[test]
+    fn remote_read_wsl_passes_script_unquoted_via_exec() {
+        let cmd = remote_read_command(&HostDef::wsl("Ubuntu"), "cat \"$HOME/x\"", &["type", "x"]);
+        assert_eq!(cmd.get_program(), "wsl.exe");
+        let args = args_of(&cmd);
+        // `--exec sh -c <script>`: argv reaches the in-distro sh verbatim.
+        assert!(args.contains(&"-e".to_string()));
+        assert_eq!(args.last().unwrap(), "cat \"$HOME/x\"");
+    }
+
+    #[test]
+    fn remote_read_psmux_uses_windows_args() {
+        let cmd = remote_read_command(
+            &psmux_host("winbox"),
+            "cat \"$HOME/x\"",
+            CLAUDE_WINDOWS_READ,
+        );
+        assert_eq!(cmd.get_program(), "ssh");
+        let args = args_of(&cmd);
+        assert_eq!(args.last().unwrap(), ".claude\\.credentials.json");
+        assert_eq!(args[args.len() - 2], "type");
+        assert!(!args.contains(&"sh".to_string()));
+    }
+
+    // ── codex app-server command construction ──
+
+    #[test]
+    fn codex_command_local_runs_codex_directly() {
+        let cmd = codex_server_command(None);
+        assert_eq!(cmd.get_program(), "codex");
+        assert_eq!(args_of(&cmd), CODEX_SERVER_ARGS);
+    }
+
+    #[test]
+    fn codex_command_remote_runs_on_host() {
+        let cmd = codex_server_command(Some(&ssh_host("devbox")));
+        assert_eq!(cmd.get_program(), "ssh");
+        let args = args_of(&cmd);
+        assert!(args.contains(&"codex".to_string()));
+        assert_eq!(args.last().unwrap(), "app-server");
+
+        let cmd = codex_server_command(Some(&HostDef::wsl("Ubuntu")));
+        assert_eq!(cmd.get_program(), "wsl.exe");
+        let args = args_of(&cmd);
+        assert!(args.contains(&"codex".to_string()));
+        assert_eq!(args.last().unwrap(), "app-server");
+    }
+
+    // ── credential parsing ──
+
+    #[test]
+    fn claude_credentials_parse_token_and_plan() {
+        let text =
+            r#"{ "claudeAiOauth": { "accessToken": "tok-123", "subscriptionType": "max" } }"#;
+        let (token, plan) = parse_claude_credentials(text).unwrap();
+        assert_eq!(token, "tok-123");
+        assert_eq!(plan.as_deref(), Some("max"));
+    }
+
+    #[test]
+    fn claude_credentials_reject_injection_and_garbage() {
+        let inj = r#"{ "claudeAiOauth": { "accessToken": "a\"\nb" } }"#;
+        assert!(parse_claude_credentials(inj).is_none());
+        assert!(parse_claude_credentials("not json").is_none());
+        assert!(parse_claude_credentials("{}").is_none());
+    }
+
+    #[test]
+    fn antigravity_credentials_parse_token() {
+        assert_eq!(
+            parse_antigravity_credentials(r#"{ "access_token": "ya29.x" }"#).as_deref(),
+            Some("ya29.x")
+        );
+        assert!(parse_antigravity_credentials("{}").is_none());
+    }
+
+    // ── vendor response parsing ──
 
     #[test]
     fn claude_usage_parses_windows_and_resets() {

--- a/tests/architecture_rules.rs
+++ b/tests/architecture_rules.rs
@@ -66,9 +66,11 @@ const MODULE_RULES: &[ModuleRules] = &[
         allowed: &["session", "storage", "workspace"],
         allowed_path_only: &[],
     },
+    // `shell` builds the host launchers (ssh/wsl) for reading a remote
+    // session's credentials where the agent actually runs.
     ModuleRules {
         name: "usage",
-        allowed: &["session"],
+        allowed: &["session", "shell"],
         // `paths::home_dir()` (fully-qualified, never `use`) to resolve agent
         // credential files cross-platform ($HOME / %USERPROFILE%).
         allowed_path_only: &["paths"],


### PR DESCRIPTION
## Summary
- Key the account usage/rate-limit cache per `(agent, host)` instead of per agent: the account is whatever credentials live on the machine the agent runs on, so a `claude` session on `ssh:devbox` no longer shows the local account's limits.
- Read remote credentials where the agent runs — over the SSH launcher (POSIX `sh -c`, honoring a remote `CLAUDE_CONFIG_DIR` and the macOS Keychain), inside the WSL distro (`wsl.exe --exec`), or via `type` on a Windows/psmux host — then call the vendor API locally with that token. Codex runs its `app-server` JSON-RPC subprocess on the host itself (stdio pipes through ssh/wsl).
- Degrade every unfetchable case to a labeled note: unreachable host (placeholder rows spawn no doomed ssh), host missing from `hosts.toml`, not logged in on the host — and never clobber last-known data during a transient outage. A live session's fetch beats a placeholder's note for the same scope mid-reconnect.
- Label the credential source in the info panel header (`Usage (max · devbox)`) so two accounts can't be confused.
- Local Claude sessions gain a macOS Keychain credentials fallback.

## Test plan
- `cargo nextest run --all` — 1833 tests pass, including new unit tests for the fetch plan scoping (dedupe, unknown host, placeholder note vs cached data, live-beats-placeholder), remote command construction/quoting (ssh/wsl/psmux), credential parsing, and the host-labeled panel header.
- `cargo clippy --all-targets --all-features`, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`, and the architecture rules (usage → shell allowance) all clean.