### PR TITLE
feat(core): hooks-driven status for all agents on remote hosts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -694,16 +694,20 @@ not block startup, so `check_available`/`ensure_ready` are deferred to first use
   connection (`refresh-client -B 'thurbox-status:%*:#{@thurbox_state}'`,
   armed in `ControlMode::start` so reconnects re-arm; tmux ≥ 3.2 = the
   existing floor) and receives `%subscription-changed` pushes (≤1/s); a
-  **psmux** connection instead runs a 1 s **poller thread** (`list-panes -F`
-  diffed by `control_mode::diff_polled_hook_states`) feeding the same queue. Both
+  **remote psmux** connection instead runs a 1 s **poller thread**
+  (`list-panes -F` diffed by `control_mode::diff_polled_hook_states`) feeding
+  the same queue — armed only behind the psmux gate below (a poll is an
+  active per-second command, unlike the passive subscription, and a *local*
+  psmux session signals via `thurbox-cli` directly). Both
   channels drain each tick via `App::drain_remote_hook_events` into the same
   `set_hook_state` columns local signals use — so Done→seen acknowledgment,
   OS notifications, and the stuck-`working` fallback are shared. Events are
   matched by **backend name + pane id** (pane ids collide across hosts),
   allow-listed (remote-controlled text), and deduped against the cache (a
   reconnect re-report must not resurrect an acknowledged `done`). Remaining
-  carve-out: hook **provisioning onto psmux/Windows hosts** is gated off
-  (`spawn::psmux_hook_rewrite_supported`) until the psmux behaviors are
+  carve-out: the **whole psmux/Windows-host path** — hook provisioning,
+  rewrite shipping, and the status poller — is gated off on the one switch
+  (`session::psmux_hook_rewrite_supported`) until the psmux behaviors are
   proven by `scripts/dev/e2e/windows-vm.sh test`'s probes — such sessions
   show a `Hooks: degraded` hint instead of silently idling.
 - **Remote teardown** (WSL inherits the SSH path): `session delete --force`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -662,33 +662,50 @@ not block startup, so `check_available`/`ensure_ready` are deferred to first use
 - **Agent config on the host**: agent args referencing thurbox-managed config
   by *local* path (the hooks extension's `--settings <config>/hooks/
   claude.json`) would kill the remote agent on launch ("Settings file not
-  found"). `session_ops::spawn::adapt_agent_args_for_remote` (shared by
-  headless spawn and the TUI) rewrites them per host: on a POSIX remote the
-  home-anchored path is **translated to the remote home**, the file copied
-  there, and the arg substituted; on a psmux host / non-POSIX config root /
-  failed copy the **flag+path pair is stripped** so the agent launches clean.
+  found"). `session_ops::spawn::adapt_def_for_launch` (shared by headless
+  spawn and the TUI, run on the spawn worker — never the UI thread) rewrites
+  them per host: on a POSIX remote the home-anchored path is **translated to
+  the remote home**, the file copied there, and the arg substituted; on a
+  psmux host (while `psmux_hook_rewrite_supported` stays off) / non-POSIX
+  config root / failed copy the **flag+path pair is stripped** so the agent
+  launches clean — surfaced as a `Hooks: degraded` row in the info panel
+  (`SessionInfo.hook_wiring`). Literal signal commands carried directly in
+  args (aider's `--notifications-command`) are rewritten too.
   The local-path env hints
   (`THURBOX_METRICS_DIR`/`THURBOX_CONFIG_DIR`/`THURBOX_DATA_DIR`) are likewise
   skipped for remote spawns (`inject_thurbox_env`); only the opaque identity
   vars travel.
-- **Remote session status** (hooks-driven, like local): `thurbox-cli session
-  signal` can't work from a host (no CLI there; it would write the host's own
-  DB), so the materialized hook file's commands are **rewritten**
-  (`builtin_hooks::rewrite_hook_signals_for_remote`) to set a tmux **pane user
+- **Remote session status** (hooks-driven, like local, **all agents**):
+  `thurbox-cli session signal` can't work from a host (no CLI there; it would
+  write the host's own DB), so hook commands are **rewritten**
+  (`builtin_hooks::rewrite_hook_signals_for_target`) to set a tmux **pane user
   option** instead — `tmux set-option -p @thurbox_state <s>` needs no socket,
-  pane id, or identity inside a pane. The local TUI's persistent control-mode
-  connection subscribes once per connection (`refresh-client -B
-  'thurbox-status:%*:#{@thurbox_state}'`, armed in `ControlMode::start` so
-  reconnects re-arm; tmux ≥ 3.2 = the existing floor) and receives
-  `%subscription-changed` pushes (≤1/s), queued on the connection and drained
-  each tick by `App::drain_remote_hook_events` into the same `set_hook_state`
-  columns local signals use — so Done→seen acknowledgment, OS notifications,
-  and the stuck-`working` fallback are shared. Events are matched by
-  **backend name + pane id** (pane ids collide across hosts), allow-listed
-  (remote-controlled text), and deduped against the cache (a reconnect
-  re-report must not resurrect an acknowledged `done`). Carve-outs: psmux
-  remotes (no subscriptions; hooks stripped) and non-claude agents (their hook
-  configs aren't materialized remotely) stay Idle-only.
+  pane id, or identity inside a pane (the psmux form bakes in
+  `-L <socket>`). Delivery per agent: claude's hooks file travels via its
+  `--settings` arg; agents wired through their **own config dir** (codex,
+  antigravity, opencode, vibe, copilot) are provisioned at spawn time by
+  `session_ops::remote_hooks::provision_agent_hooks_on_host` — the rewritten
+  payload is shipped into the host's agent config dir with the local
+  installer's safety rules (`requires_dir` probe over ssh, prune-then-merge
+  for shared JSON, managed-marker guard for standalone files,
+  compare-before-write; cached per `(backend, agent)`, best-effort, never
+  fails the spawn; remote **cleanup** is a documented leave-behind). The
+  local TUI's persistent control-mode connection subscribes once per
+  connection (`refresh-client -B 'thurbox-status:%*:#{@thurbox_state}'`,
+  armed in `ControlMode::start` so reconnects re-arm; tmux ≥ 3.2 = the
+  existing floor) and receives `%subscription-changed` pushes (≤1/s); a
+  **psmux** connection instead runs a 1 s **poller thread** (`list-panes -F`
+  diffed by `control_mode::diff_polled_hook_states`) feeding the same queue. Both
+  channels drain each tick via `App::drain_remote_hook_events` into the same
+  `set_hook_state` columns local signals use — so Done→seen acknowledgment,
+  OS notifications, and the stuck-`working` fallback are shared. Events are
+  matched by **backend name + pane id** (pane ids collide across hosts),
+  allow-listed (remote-controlled text), and deduped against the cache (a
+  reconnect re-report must not resurrect an acknowledged `done`). Remaining
+  carve-out: hook **provisioning onto psmux/Windows hosts** is gated off
+  (`spawn::psmux_hook_rewrite_supported`) until the psmux behaviors are
+  proven by `scripts/dev/e2e/windows-vm.sh test`'s probes — such sessions
+  show a `Hooks: degraded` hint instead of silently idling.
 - **Remote teardown** (WSL inherits the SSH path): `session delete --force`
   teardown is **backend-aware** — `teardown_runtime_resources` resolves the
   session's `HostDef` from its `backend_type` and, for a remote session, kills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -704,7 +704,14 @@ not block startup, so `check_available`/`ensure_ready` are deferred to first use
   OS notifications, and the stuck-`working` fallback are shared. Events are
   matched by **backend name + pane id** (pane ids collide across hosts),
   allow-listed (remote-controlled text), and deduped against the cache (a
-  reconnect re-report must not resurrect an acknowledged `done`). Remaining
+  reconnect re-report must not resurrect an acknowledged `done`). Those live
+  channels die with the TUI, so the headless **`automation tick`** (the 60 s
+  heartbeat keeper) also polls each host that has live remote sessions in the
+  DB (`session_ops::remote_hooks::poll_remote_hook_states` — one-shot
+  `list-panes -F`, allow-listed, diffed against the stored `hook_state` so an
+  acknowledged `done` is never resurrected) and writes changes into the same
+  columns — remote status keeps flowing with the TUI closed, at tick cadence.
+  Remaining
   carve-out: the **whole psmux/Windows-host path** — hook provisioning,
   rewrite shipping, and the status poller — is gated off on the one switch
   (`session::psmux_hook_rewrite_supported`) until the psmux behaviors are

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,7 @@ version = "0.0.0-dev"
 dependencies = [
  "anyhow",
  "arboard",
+ "base64",
  "chrono",
  "chrono-tz",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ unicode-width = "0.2"
 # Markdown parsing (task description rendering)
 pulldown-cmark = { version = "0.13", default-features = false }
 
+# Base64 payload framing for the Windows-host remote file copy (already in the
+# dependency tree transitively; pinned to the same resolved version)
+base64 = "0.22"
+
 # Async runtime
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "process", "io-util", "signal", "net"] }
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -103,7 +103,10 @@ claude's via its `--settings` arg, the config-dir agents via
 managed-file write, best-effort). The local TUI receives changes over its
 control-mode connection (a format subscription on tmux hosts; a 1 s
 pane-option poller on psmux hosts, armed once the psmux gate —
-`session::psmux_hook_rewrite_supported` — is flipped). When wiring is
+`session::psmux_hook_rewrite_supported` — is flipped). With the TUI closed,
+the headless `automation tick` (60 s heartbeat) polls hosts that have live
+remote sessions and writes changed states into the same DB columns, so
+remote status never freezes at its last pushed value. When wiring is
 degraded (host
 unreachable mid-provision, a user-owned file refused, or the
 still-gated psmux provisioning), the session shows a `Hooks: degraded`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -102,7 +102,9 @@ claude's via its `--settings` arg, the config-dir agents via
 `session_ops::remote_hooks` provisioning (probe → prune-then-merge or
 managed-file write, best-effort). The local TUI receives changes over its
 control-mode connection (a format subscription on tmux hosts; a 1 s
-pane-option poller on psmux hosts). When wiring is degraded (host
+pane-option poller on psmux hosts, armed once the psmux gate —
+`session::psmux_hook_rewrite_supported` — is flipped). When wiring is
+degraded (host
 unreachable mid-provision, a user-owned file refused, or the
 still-gated psmux provisioning), the session shows a `Hooks: degraded`
 row in the info panel instead of silently idling. See the

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -95,6 +95,19 @@ report the full range, codex reports idle/working/done, aider reports
 blocked, and vibe is experimental. See the per-agent matrix in
 `extensions/hooks/README.md` (and the website's *Agent hooks* page).
 
+**Remote sessions report status too** (same per-agent range): at spawn
+time the hook commands are rewritten to a tmux pane user option
+(`@thurbox_state`) and each agent's hook config is shipped to the host —
+claude's via its `--settings` arg, the config-dir agents via
+`session_ops::remote_hooks` provisioning (probe → prune-then-merge or
+managed-file write, best-effort). The local TUI receives changes over its
+control-mode connection (a format subscription on tmux hosts; a 1 s
+pane-option poller on psmux hosts). When wiring is degraded (host
+unreachable mid-provision, a user-owned file refused, or the
+still-gated psmux provisioning), the session shows a `Hooks: degraded`
+row in the info panel instead of silently idling. See the
+*Remote SSH & WSL Sessions* section in `CLAUDE.md` for the full pipeline.
+
 ### Smart ordering & repo groups
 
 The list is **grouped by repository** under subtle headers

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -167,4 +167,4 @@ Provisioning is **best-effort** (a down host or refused write degrades to a
 **one-way**: thurbox never uninstalls from remote hosts (same policy as remote
 worktrees). The files it leaves carry both prune markers, so removing them by
 hand — or a future remote prune — needs no schema knowledge. Windows (`psmux`)
-hosts are not provisioned yet (gated in `session_ops::spawn`).
+hosts are not provisioned yet (gated on `session::psmux_hook_rewrite_supported`).

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -142,3 +142,29 @@ This extension exercises two extension-manifest capabilities (see
   Note: on the **first** merge, thurbox rewrites `settings.json` with normalized
   formatting (alphabetized keys, 2-space indent). This is one-time and lossless —
   your values are untouched and the file is stable afterward.
+
+## Remote (SSH/WSL) sessions
+
+`thurbox-cli` isn't installed on a remote host, so the shipped hook commands
+are rewritten there to set a tmux **pane user option**
+(`tmux set-option -p @thurbox_state <s>`) that the local TUI picks up over its
+control-mode connection. Delivery per agent, at spawn time:
+
+- **claude** — the `--settings` hooks file is copied to the host (rewritten)
+  and the arg substituted.
+- **aider** — its literal `--notifications-command` arg is rewritten in place.
+- **codex / antigravity / opencode / vibe / copilot** — the rewritten payload
+  is provisioned into the host's agent config dir
+  (`session_ops::remote_hooks`), with the same safety rules as the local
+  install: skipped when the agent isn't installed there (`requires_dir` probed
+  over ssh), deep-merge-not-clobber for shared JSON (prune-then-merge on both
+  the `session signal` and `@thurbox_state` markers, so upgrades replace
+  rather than accumulate), managed-marker guard for standalone files, and
+  compare-before-write.
+
+Provisioning is **best-effort** (a down host or refused write degrades to a
+`Hooks: degraded` hint in the info panel — never a failed spawn) and
+**one-way**: thurbox never uninstalls from remote hosts (same policy as remote
+worktrees). The files it leaves carry both prune markers, so removing them by
+hand — or a future remote prune — needs no schema knowledge. Windows (`psmux`)
+hosts are not provisioned yet (gated in `session_ops::spawn`).

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -162,6 +162,11 @@ control-mode connection. Delivery per agent, at spawn time:
   rather than accumulate), managed-marker guard for standalone files, and
   compare-before-write.
 
+The local TUI receives the state over its persistent control-mode connection;
+with the TUI closed, the headless `automation tick` (the 60 s tmux heartbeat)
+polls hosts that have live remote sessions and writes changes to the same
+database columns, so remote status keeps flowing either way.
+
 Provisioning is **best-effort** (a down host or refused write degrades to a
 `Hooks: degraded` hint in the info panel — never a failed spawn) and
 **one-way**: thurbox never uninstalls from remote hosts (same policy as remote

--- a/scripts/dev/e2e/linux-container.sh
+++ b/scripts/dev/e2e/linux-container.sh
@@ -159,6 +159,11 @@ EOF
   remote_reset
   log "creating a remote session via thurbox-cli (isolated DB)"
   export XDG_CONFIG_HOME="$xdg/config" XDG_DATA_HOME="$xdg/data"
+  # Running this script from inside a thurbox session injects THURBOX_*_DIR
+  # overrides that outrank XDG_* (paths.rs) and would point the CLI at the
+  # real config/DB — pin them to the sandbox (same pattern as
+  # scripts/dev/lib/sandbox-env.sh).
+  export THURBOX_CONFIG_DIR="$xdg/config/thurbox-dev" THURBOX_DATA_DIR="$xdg/data/thurbox-dev"
   local result backend
   result="$(e2e_create_and_get \
     --name e2e --host podman --repo-path "$REMOTE_REPO" \
@@ -207,6 +212,29 @@ EOF
   case "$(ssh_remote "cat '$xdg/config/thurbox-dev/hooks/claude.json' 2>/dev/null" || true)" in
     *"tmux set-option -p @thurbox_state done"*) ok "arg-carried config materialized rewritten" ;;
     *) bad "arg-carried config missing or not rewritten on the host" ;;
+  esac
+
+  # --- headless remote-status poll (automation tick) --------------------------
+  # With no TUI attached (no control-mode subscription alive), an
+  # `automation tick` must pull the pane's @thurbox_state option into the DB —
+  # visible as `hook_state` in `session list --json`. Simulate the rewritten
+  # hook firing by setting the option on every remote pane, exactly as the
+  # in-pane command would.
+  log "asserting the headless remote-status poll (tick pulls @thurbox_state)"
+  # shellcheck disable=SC2016 # $p expands on the remote side on purpose
+  ssh_remote 'tmux -L thurbox-dev list-panes -s -t thurbox-dev -F "#{pane_id}" 2>/dev/null \
+    | while read -r p; do tmux -L thurbox-dev set-option -p -t "$p" @thurbox_state working; done'
+  e2e_cli automation tick >/dev/null || die "automation tick failed"
+  case "$(e2e_cli session list)" in
+    *'"hook_state":"working"'*) ok "tick polled the pane option into hook_state" ;;
+    *) bad "hook_state not updated by the headless poll" ;;
+  esac
+  # Steady state must stay silent: a second tick re-reads the same option but
+  # must not error or change the value (dedup against the stored state).
+  e2e_cli automation tick >/dev/null || die "second automation tick failed"
+  case "$(e2e_cli session list)" in
+    *'"hook_state":"working"'*) ok "second tick is a stable no-op" ;;
+    *) bad "hook_state lost after a steady-state tick" ;;
   esac
 
   if [ "$FAILS" -gt 0 ]; then

--- a/scripts/dev/e2e/linux-container.sh
+++ b/scripts/dev/e2e/linux-container.sh
@@ -116,7 +116,9 @@ remote_reset() {
     git worktree list --porcelain | awk "/^worktree/ {print \$2}" | grep -v "^/srv/repo$" \
       | while read -r w; do git worktree remove --force "$w"; done
     git worktree prune
-    git branch -D test/e2e 2>/dev/null || true
+    git for-each-ref --format="%(refname:short)" "refs/heads/test/*" \
+      | while read -r b; do git branch -D "$b"; done
+    rm -rf /root/.codex
     tmux -L thurbox-dev kill-server 2>/dev/null || true
   ' 2>/dev/null || true
 }
@@ -129,13 +131,29 @@ cmd_test() {
   # running TUI watches this database.
   local xdg; xdg="$(mktemp -d)"
   trap 'rm -rf "$xdg"; remote_reset' RETURN
-  mkdir -p "$xdg/config/thurbox-dev"
+  mkdir -p "$xdg/config/thurbox-dev/hooks"
   container_hosts_block > "$xdg/config/thurbox-dev/hosts.toml"
-  cat > "$xdg/config/thurbox-dev/agents.toml" <<'EOF'
+  # `codex` (a config-dir-hooked agent name) exercises the remote hook
+  # provisioning; `clauded` carries a thurbox-managed config file as a launch
+  # arg (claude's `--settings` shape) exercising the arg materialization. Both
+  # just run bash — only the *name*/args drive the remote wiring under test.
+  cat > "$xdg/config/thurbox-dev/agents.toml" <<EOF
 default = "shell"
 [[agents]]
 name = "shell"
 command = "bash"
+[[agents]]
+name = "codex"
+command = "bash"
+[[agents]]
+name = "clauded"
+command = "bash"
+args = ["$xdg/config/thurbox-dev/hooks/claude.json"]
+EOF
+  # A claude-shaped hooks file carrying the signal marker the remote rewrite
+  # keys on.
+  cat > "$xdg/config/thurbox-dev/hooks/claude.json" <<'EOF'
+{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"thurbox-cli session signal --state done || true"}]}]}}
 EOF
 
   remote_reset
@@ -152,8 +170,51 @@ EOF
   remote_window="$(ssh_remote 'tmux -L thurbox-dev list-windows -t thurbox-dev -F "#{window_name}" 2>/dev/null' | grep -c '^tb-e2e$' || true)"
   remote_wt="$(ssh_remote 'cd /srv/repo && git worktree list | grep -c test-e2e' 2>/dev/null || echo 0)"
 
+  # --- remote hooks-driven status wiring ------------------------------------
+  # A codex spawn must ship the rewritten hooks payload into the host's
+  # ~/.codex (created here = "agent installed"), idempotently across spawns;
+  # the arg-carried config file must land rewritten at its mirrored path.
+  log "asserting remote hook provisioning (codex config-dir + arg-carried file)"
+  FAILS=0
+  ssh_remote 'mkdir -p /root/.codex'
+  e2e_cli session create --name e2e-codex --host podman --repo-path "$REMOTE_REPO" \
+    --agent codex --worktree-branch test/e2e-codex --base-branch main >/dev/null \
+    || die "codex session create failed"
+  local hooks_json
+  hooks_json="$(ssh_remote 'cat /root/.codex/hooks.json 2>/dev/null' || true)"
+  case "$hooks_json" in
+    *"tmux set-option -p @thurbox_state"*) ok "codex hooks.json shipped rewritten" ;;
+    *) bad "codex hooks.json missing or not rewritten" ;;
+  esac
+  case "$hooks_json" in
+    *thurbox-cli*) bad "codex hooks.json still references thurbox-cli" ;;
+    *) ok "no thurbox-cli reference survives the rewrite" ;;
+  esac
+  # Second spawn (fresh process, so no in-process cache): byte-stable file.
+  e2e_cli session create --name e2e-codex2 --host podman --repo-path "$REMOTE_REPO" \
+    --agent codex --worktree-branch test/e2e-codex2 --base-branch main >/dev/null \
+    || die "second codex session create failed"
+  if [ "$(ssh_remote 'cat /root/.codex/hooks.json 2>/dev/null' || true)" = "$hooks_json" ]; then
+    ok "re-provisioning is idempotent (byte-stable hooks.json)"
+  else
+    bad "second spawn changed hooks.json (merge not idempotent)"
+  fi
+  e2e_cli session create --name e2e-arg --host podman --repo-path "$REMOTE_REPO" \
+    --agent clauded --worktree-branch test/e2e-arg --base-branch main >/dev/null \
+    || die "arg-carried session create failed"
+  # The local config root is outside $HOME, so it mirrors at the same path.
+  # shellcheck disable=SC2029 # $xdg expands locally on purpose (it names the remote mirror path)
+  case "$(ssh_remote "cat '$xdg/config/thurbox-dev/hooks/claude.json' 2>/dev/null" || true)" in
+    *"tmux set-option -p @thurbox_state done"*) ok "arg-carried config materialized rewritten" ;;
+    *) bad "arg-carried config missing or not rewritten on the host" ;;
+  esac
+
+  if [ "$FAILS" -gt 0 ]; then
+    fail "remote hook provisioning checks failed ($FAILS)"
+    return 1
+  fi
   e2e_assert "ssh:podman" "$backend" "$remote_window" "$remote_wt" \
-    "remote SSH session created on the container" \
+    "remote SSH session created on the container (+ hook provisioning verified)" \
     "expected ssh:podman + remote window + remote worktree"
 }
 

--- a/scripts/dev/e2e/windows-vm.sh
+++ b/scripts/dev/e2e/windows-vm.sh
@@ -292,7 +292,7 @@ cmd_test() {
 
   # --- psmux hook-status gate probes (evidence, not verdict) ----------------
   # Remote hooks-driven status on a psmux host is gated off in the binary
-  # (`psmux_hook_rewrite_supported` in src/session_ops/spawn.rs) until these
+  # (`psmux_hook_rewrite_supported` in src/session/mod.rs) until these
   # behaviors are proven against the pinned psmux: (A) pane **user options**
   # settable via `set-option -p -t` and expanded by `#{@opt}` in
   # `list-panes -F` (what the status poller reads); (B) an **id-less** in-pane

--- a/scripts/dev/e2e/windows-vm.sh
+++ b/scripts/dev/e2e/windows-vm.sh
@@ -290,6 +290,37 @@ cmd_test() {
   sessions="$(ssh_vm "psmux -L $SOCKET list-sessions -F '#{session_name}'" 2>/dev/null | tr -d '\r')"
   ssh_vm "psmux -L $SOCKET kill-server" >/dev/null 2>&1 || true
 
+  # --- psmux hook-status gate probes (evidence, not verdict) ----------------
+  # Remote hooks-driven status on a psmux host is gated off in the binary
+  # (`psmux_hook_rewrite_supported` in src/session_ops/spawn.rs) until these
+  # behaviors are proven against the pinned psmux: (A) pane **user options**
+  # settable via `set-option -p -t` and expanded by `#{@opt}` in
+  # `list-panes -F` (what the status poller reads); (B) an **id-less** in-pane
+  # `set-option -p` landing on the calling pane (what the rewritten hook
+  # command runs). Probes report ok/-- but never fail this smoke test.
+  log "probing psmux pane-user-option support (hook-status gate evidence)"
+  local pane opt inpane
+  ssh_vm "psmux -L $SOCKET new-session -d -s probe" >/dev/null 2>&1 || true
+  pane="$(ssh_vm "psmux -L $SOCKET list-panes -s -t probe -F '#{pane_id}'" 2>/dev/null | tr -d '\r' | head -n1)"
+  if [ -n "$pane" ]; then
+    ssh_vm "psmux -L $SOCKET set-option -p -t $pane @thurboxprobe working" >/dev/null 2>&1 || true
+    opt="$(ssh_vm "psmux -L $SOCKET list-panes -s -t probe -F '#{pane_id} #{@thurboxprobe}'" 2>/dev/null | tr -d '\r')"
+    case "$opt" in
+      *"$pane working"*) ok "probe A: set-option -p + #{@opt} list-panes -F expansion works" ;;
+      *) info "probe A: pane user options / -F expansion unsupported (got: ${opt:-<none>})" ;;
+    esac
+    ssh_vm "psmux -L $SOCKET send-keys -t $pane 'psmux -L $SOCKET set-option -p @thurboxinpane done' Enter" >/dev/null 2>&1 || true
+    sleep 2
+    inpane="$(ssh_vm "psmux -L $SOCKET list-panes -s -t probe -F '#{pane_id} #{@thurboxinpane}'" 2>/dev/null | tr -d '\r')"
+    case "$inpane" in
+      *"$pane done"*) ok "probe B: id-less in-pane set-option -p lands on the calling pane" ;;
+      *) info "probe B: id-less in-pane set-option unsupported (got: ${inpane:-<none>})" ;;
+    esac
+  else
+    info "gate probes skipped: could not resolve a probe pane id"
+  fi
+  ssh_vm "psmux -L $SOCKET kill-server" >/dev/null 2>&1 || true
+
   echo
   if printf '%s\n' "$sessions" | grep -qx smoke; then
     pass "psmux is installed and a -L $SOCKET session round-tripped"

--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -385,6 +385,41 @@ pub fn is_valid_pane_id(s: &str) -> bool {
         .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
 }
 
+/// Diff one psmux hook-poll result against the previous poll, returning the
+/// `(pane_id, value)` pairs to report — the poller-side equivalent of tmux's
+/// `%subscription-changed` edge semantics.
+///
+/// `body` is `list-panes -F "#{pane_id} #{@thurbox_state}"` output: one
+/// `%<id> [value]` line per pane. Reported: a pane's **non-empty** value seen
+/// for the first time (parity with the subscription's arm-time catch-up
+/// report) or changed since the last poll. Not reported: an unchanged value
+/// (steady state stays silent), an empty value (option unset — also *clears*
+/// the pane's entry, like a vanished pane, so a respawned pane's state
+/// re-reports). Malformed lines are skipped; wire data never panics.
+pub fn diff_polled_hook_states(
+    last: &mut std::collections::HashMap<String, String>,
+    body: &str,
+) -> Vec<(String, String)> {
+    let mut current = std::collections::HashMap::new();
+    let mut changed = Vec::new();
+    for line in body.lines() {
+        let line = line.trim();
+        let (pane_id, value) = match line.split_once(' ') {
+            Some((id, v)) => (id, v.trim()),
+            None => (line, ""),
+        };
+        if !is_valid_pane_id(pane_id) || value.is_empty() {
+            continue;
+        }
+        if last.get(pane_id).map(String::as_str) != Some(value) {
+            changed.push((pane_id.to_string(), value.to_string()));
+        }
+        current.insert(pane_id.to_string(), value.to_string());
+    }
+    *last = current;
+    changed
+}
+
 /// Format a `send-keys -H` command for a pane.
 ///
 /// Each byte is encoded as two hex digits.
@@ -416,6 +451,56 @@ mod tests {
     use std::sync::mpsc::sync_channel;
 
     use super::*;
+
+    // --- diff_polled_hook_states tests ---
+
+    #[test]
+    fn poll_diff_reports_first_seen_and_changes_only() {
+        let mut last = std::collections::HashMap::new();
+        // First poll: every non-empty value reports (arm-time catch-up parity).
+        let events = diff_polled_hook_states(&mut last, "%1 working\n%2 \n%3 done");
+        assert_eq!(
+            events,
+            vec![
+                ("%1".to_string(), "working".to_string()),
+                ("%3".to_string(), "done".to_string())
+            ]
+        );
+        // Steady state stays silent.
+        assert!(diff_polled_hook_states(&mut last, "%1 working\n%3 done").is_empty());
+        // Only the changed pane reports.
+        let events = diff_polled_hook_states(&mut last, "%1 done\n%3 done");
+        assert_eq!(events, vec![("%1".to_string(), "done".to_string())]);
+    }
+
+    #[test]
+    fn poll_diff_clears_vanished_and_unset_panes_so_they_rereport() {
+        let mut last = std::collections::HashMap::new();
+        diff_polled_hook_states(&mut last, "%1 working\n%2 blocked");
+        // %1 vanishes (respawn), %2's option is unset.
+        assert!(diff_polled_hook_states(&mut last, "%2").is_empty());
+        // Both re-report when they come back with a value.
+        let events = diff_polled_hook_states(&mut last, "%1 working\n%2 blocked");
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn poll_diff_skips_malformed_lines_and_trims_values() {
+        let mut last = std::collections::HashMap::new();
+        let events = diff_polled_hook_states(
+            &mut last,
+            "not-a-pane working\n%x done\n\n%7  done  \n%8 two words",
+        );
+        // Invalid pane tokens are dropped; values are trimmed; a multi-word
+        // value passes through (the app-side allow-list rejects it there).
+        assert_eq!(
+            events,
+            vec![
+                ("%7".to_string(), "done".to_string()),
+                ("%8".to_string(), "two words".to_string())
+            ]
+        );
+    }
 
     // --- is_valid_pane_id tests ---
 

--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -385,36 +385,46 @@ pub fn is_valid_pane_id(s: &str) -> bool {
         .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
 }
 
+/// Parse `list-panes -F "#{pane_id} #{@thurbox_state}"` output into the
+/// `(pane_id, value)` pairs whose option is **set**: one `%<id> [value]` line
+/// per pane; empty values (option unset) and malformed lines are skipped —
+/// wire data never panics. Shared by the psmux poller's diff below and the
+/// headless status poll (`session_ops::remote_hooks::poll_remote_hook_states`).
+pub fn parse_pane_hook_states(body: &str) -> Vec<(String, String)> {
+    body.lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let (pane_id, value) = match line.split_once(' ') {
+                Some((id, v)) => (id, v.trim()),
+                None => (line, ""),
+            };
+            (is_valid_pane_id(pane_id) && !value.is_empty())
+                .then(|| (pane_id.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
 /// Diff one psmux hook-poll result against the previous poll, returning the
 /// `(pane_id, value)` pairs to report — the poller-side equivalent of tmux's
 /// `%subscription-changed` edge semantics.
 ///
-/// `body` is `list-panes -F "#{pane_id} #{@thurbox_state}"` output: one
-/// `%<id> [value]` line per pane. Reported: a pane's **non-empty** value seen
-/// for the first time (parity with the subscription's arm-time catch-up
-/// report) or changed since the last poll. Not reported: an unchanged value
-/// (steady state stays silent), an empty value (option unset — also *clears*
-/// the pane's entry, like a vanished pane, so a respawned pane's state
-/// re-reports). Malformed lines are skipped; wire data never panics.
+/// `body` is parsed by [`parse_pane_hook_states`]. Reported: a pane's
+/// **non-empty** value seen for the first time (parity with the
+/// subscription's arm-time catch-up report) or changed since the last poll.
+/// Not reported: an unchanged value (steady state stays silent), an empty
+/// value (option unset — also *clears* the pane's entry, like a vanished
+/// pane, so a respawned pane's state re-reports).
 pub fn diff_polled_hook_states(
     last: &mut std::collections::HashMap<String, String>,
     body: &str,
 ) -> Vec<(String, String)> {
     let mut current = std::collections::HashMap::new();
     let mut changed = Vec::new();
-    for line in body.lines() {
-        let line = line.trim();
-        let (pane_id, value) = match line.split_once(' ') {
-            Some((id, v)) => (id, v.trim()),
-            None => (line, ""),
-        };
-        if !is_valid_pane_id(pane_id) || value.is_empty() {
-            continue;
+    for (pane_id, value) in parse_pane_hook_states(body) {
+        if last.get(&pane_id).map(String::as_str) != Some(value.as_str()) {
+            changed.push((pane_id.clone(), value.clone()));
         }
-        if last.get(pane_id).map(String::as_str) != Some(value) {
-            changed.push((pane_id.to_string(), value.to_string()));
-        }
-        current.insert(pane_id.to_string(), value.to_string());
+        current.insert(pane_id, value);
     }
     *last = current;
     changed

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::io::{BufRead, BufReader, Cursor, Read, Write};
 use std::path::Path;
 use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{sync_channel, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
@@ -40,6 +41,17 @@ fn local_socket() -> String {
     std::env::var(SOCKET_OVERRIDE_ENV)
         .ok()
         .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| TMUX_SOCKET.to_string())
+}
+
+/// The `-L` socket name a remote `host`'s multiplexer runs on: the host's
+/// `socket` override, else the same compile-time default the local backend
+/// uses. Single source of truth shared by [`TmuxBackend::from_host`] and the
+/// psmux hook-signal rewrite (which must bake the socket into the command —
+/// psmux has no `$TMUX`-style in-pane socket resolution to rely on).
+pub fn host_socket(host: &crate::session::HostDef) -> String {
+    host.socket
+        .clone()
         .unwrap_or_else(|| TMUX_SOCKET.to_string())
 }
 
@@ -226,6 +238,10 @@ struct ControlMode {
     /// [`Self::take_sub_events`]. Bounded (drop-oldest): a short-lived
     /// connection (e.g. a headless spawn's) has no drainer.
     sub_events: Arc<Mutex<VecDeque<(String, String)>>>,
+    /// True while this connection lives; cleared on reader EOF and in `Drop`.
+    /// The psmux hook poller checks it each cycle so a replaced connection's
+    /// poller winds down instead of writing into a dead pipe forever.
+    alive: Arc<AtomicBool>,
     reader_handle: Mutex<Option<JoinHandle<()>>>,
     child: Mutex<Child>,
 }
@@ -234,6 +250,11 @@ struct ControlMode {
 /// queue is drained every TUI tick — the cap only guards an undrained
 /// connection against unbounded growth.
 const SUB_EVENTS_CAP: usize = 256;
+
+/// How often the psmux hook poller lists pane options — matches tmux's own
+/// ≤1/s subscription-report cadence, so both channels have the same worst-case
+/// status latency.
+const PSMUX_HOOK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(1000);
 
 impl ControlMode {
     /// Start a control mode connection to the thurbox tmux session over the
@@ -265,11 +286,13 @@ impl ControlMode {
             Arc::new(Mutex::new(VecDeque::new()));
         let sub_events: Arc<Mutex<VecDeque<(String, String)>>> =
             Arc::new(Mutex::new(VecDeque::new()));
+        let alive = Arc::new(AtomicBool::new(true));
 
         let reader_stdin = Arc::clone(&stdin);
         let reader_pane_senders = Arc::clone(&pane_senders);
         let reader_queue = Arc::clone(&response_queue);
         let reader_sub_events = Arc::clone(&sub_events);
+        let reader_alive = Arc::clone(&alive);
 
         let reader_handle = std::thread::Builder::new()
             .name("tmux-control-reader".into())
@@ -281,6 +304,7 @@ impl ControlMode {
                     reader_queue,
                     reader_sub_events,
                 );
+                reader_alive.store(false, Ordering::Relaxed);
             })
             .context("Failed to spawn control reader thread")?;
 
@@ -289,6 +313,7 @@ impl ControlMode {
             pane_senders,
             response_queue,
             sub_events,
+            alive,
             reader_handle: Mutex::new(Some(reader_handle)),
             child: Mutex::new(child),
         };
@@ -318,9 +343,73 @@ impl ControlMode {
             if let Err(e) = control.send_command(&arm) {
                 warn!("failed to arm the remote-hook status subscription: {e:#}");
             }
+        } else {
+            control.spawn_psmux_hook_poller(session);
         }
 
         Ok(control)
+    }
+
+    /// psmux has no format subscriptions, so a psmux connection **polls** the
+    /// remote-hook pane option instead: a background thread lists every pane of
+    /// the session with its `@thurbox_state` each [`PSMUX_HOOK_POLL_INTERVAL`],
+    /// diffs against the previous poll ([`control_mode::diff_polled_hook_states`]),
+    /// and feeds changes into the same `sub_events` queue the tmux subscription
+    /// uses — everything downstream (`take_hook_state_events` → the app's
+    /// drain) is shared. Best-effort: a command failure ends the thread (the
+    /// connection is dying; a reconnect's fresh `ControlMode` spawns a fresh
+    /// poller), and an idle server pays one cheap command per second on an
+    /// already-persistent connection.
+    ///
+    /// The thread is deliberately **detached** (not joined in `Drop`): a poll
+    /// blocked in its command timeout when the connection dies would stall the
+    /// drop for [`COMMAND_TIMEOUT`]; instead it exits on its own via the
+    /// `alive` flag or the dead pipe shortly after.
+    fn spawn_psmux_hook_poller(&self, session: &str) {
+        let stdin = Arc::clone(&self.stdin);
+        let queue = Arc::clone(&self.response_queue);
+        let events = Arc::clone(&self.sub_events);
+        let alive = Arc::clone(&self.alive);
+        // Double-quoted format: psmux's tokenizer passes `'` through `"…"`
+        // tokens but mangles adjacent `'…'` segments (see
+        // `psmux_window_command`), so double quotes are the safe framing.
+        let cmd = format!(
+            "list-panes -s -t {session} -F \"#{{pane_id}} #{{{}}}\"",
+            crate::session::REMOTE_HOOK_STATE_OPTION,
+        );
+        let spawned = std::thread::Builder::new()
+            .name("psmux-hook-poller".into())
+            .spawn(move || {
+                let mut last = std::collections::HashMap::new();
+                loop {
+                    std::thread::sleep(PSMUX_HOOK_POLL_INTERVAL);
+                    if !alive.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let body = match Self::send_command_on(&stdin, &queue, &cmd) {
+                        Ok(body) => body,
+                        Err(e) => {
+                            debug!("psmux hook poller stopping: {e:#}");
+                            break;
+                        }
+                    };
+                    let changed = control_mode::diff_polled_hook_states(&mut last, &body);
+                    if changed.is_empty() {
+                        continue;
+                    }
+                    if let Ok(mut events) = events.lock() {
+                        for ev in changed {
+                            if events.len() >= SUB_EVENTS_CAP {
+                                events.pop_front();
+                            }
+                            events.push_back(ev);
+                        }
+                    }
+                }
+            });
+        if let Err(e) = spawned {
+            warn!("failed to spawn the psmux hook poller: {e}");
+        }
     }
 
     /// Background thread that reads and dispatches control mode output.
@@ -477,25 +566,37 @@ impl ControlMode {
 
     /// Send a command and wait for its response.
     fn send_command(&self, cmd: &str) -> Result<String> {
+        Self::send_command_on(&self.stdin, &self.response_queue, cmd)
+    }
+
+    /// [`Self::send_command`] without `&self`, so background threads holding
+    /// only the shared handles (the psmux hook poller) can issue commands.
+    ///
+    /// Both locks are held across enqueue **and** write: concurrent senders
+    /// (a backend caller vs the poller) must not interleave one thread's
+    /// waiter-push with another's stdin-write, or the FIFO waiter order stops
+    /// matching the on-wire command order and every later response is
+    /// delivered one command off. A failed write pops the just-enqueued
+    /// waiter for the same reason.
+    fn send_command_on(
+        stdin: &Arc<Mutex<ChildStdin>>,
+        response_queue: &Arc<Mutex<VecDeque<SyncSender<CommandResponse>>>>,
+        cmd: &str,
+    ) -> Result<String> {
         let (tx, rx) = sync_channel(1);
 
-        // Enqueue our response channel before sending, so the reader thread
-        // can deliver the response even if it arrives before we start waiting.
         {
-            let mut queue = self
-                .response_queue
+            let mut queue = response_queue
                 .lock()
                 .map_err(|e| anyhow::anyhow!("response_queue lock: {e}"))?;
-            queue.push_back(tx);
-        }
-
-        {
-            let mut stdin = self
-                .stdin
+            let mut stdin = stdin
                 .lock()
                 .map_err(|e| anyhow::anyhow!("stdin lock: {e}"))?;
-            writeln!(stdin, "{cmd}")?;
-            stdin.flush()?;
+            queue.push_back(tx);
+            if let Err(e) = writeln!(stdin, "{cmd}").and_then(|()| stdin.flush()) {
+                queue.pop_back();
+                return Err(e.into());
+            }
         }
 
         let response = rx
@@ -529,6 +630,10 @@ impl ControlMode {
 
 impl Drop for ControlMode {
     fn drop(&mut self) {
+        // Wind down the (detached) psmux hook poller; it observes the flag on
+        // its next cycle, or exits via the dead pipe once the child is killed.
+        self.alive.store(false, Ordering::Relaxed);
+
         // Try to gracefully detach.
         if let Ok(mut stdin) = self.stdin.lock() {
             let _ = writeln!(stdin, "detach-client");
@@ -616,10 +721,7 @@ impl TmuxBackend {
     /// `ssh:<host.name>` / `wsl:<host.name>` and uses the same socket/session
     /// names as the local backend unless the host overrides them.
     pub fn from_host(host: &crate::session::HostDef) -> Self {
-        let socket = host
-            .socket
-            .clone()
-            .unwrap_or_else(|| TMUX_SOCKET.to_string());
+        let socket = host_socket(host);
         let session = host
             .session
             .clone()

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -18,8 +18,10 @@ use crate::agent::control_mode::{
 use crate::agent::transport::{TmuxTransport, DEFAULT_MUX};
 
 /// Dedicated tmux socket name — isolates thurbox sessions from the user's tmux.
-/// Dev builds use "thurbox-dev" to avoid interfering with an installed release binary.
-const TMUX_SOCKET: &str = if cfg!(dev_build) {
+/// Dev builds use "thurbox-dev" to avoid interfering with an installed release
+/// binary. Crate-visible as the last-resort fallback when a host's configured
+/// socket sanitizes to empty (`builtin_hooks::remote_signal_target`).
+pub(crate) const TMUX_SOCKET: &str = if cfg!(dev_build) {
     "thurbox-dev"
 } else {
     "thurbox"
@@ -343,22 +345,30 @@ impl ControlMode {
             if let Err(e) = control.send_command(&arm) {
                 warn!("failed to arm the remote-hook status subscription: {e:#}");
             }
-        } else {
+        } else if transport.is_remote() && crate::session::psmux_hook_rewrite_supported() {
+            // Unlike the subscription (passive — zero recurring cost), the
+            // poller is a 1 Hz command, so it only runs where a producer can
+            // exist: a *remote* psmux host with the hook rewrite enabled. A
+            // local psmux (Windows) session signals via `thurbox-cli` straight
+            // into the DB and never sets the pane option.
             control.spawn_psmux_hook_poller(session);
         }
 
         Ok(control)
     }
 
-    /// psmux has no format subscriptions, so a psmux connection **polls** the
-    /// remote-hook pane option instead: a background thread lists every pane of
-    /// the session with its `@thurbox_state` each [`PSMUX_HOOK_POLL_INTERVAL`],
-    /// diffs against the previous poll ([`control_mode::diff_polled_hook_states`]),
-    /// and feeds changes into the same `sub_events` queue the tmux subscription
-    /// uses — everything downstream (`take_hook_state_events` → the app's
-    /// drain) is shared. Best-effort: a command failure ends the thread (the
-    /// connection is dying; a reconnect's fresh `ControlMode` spawns a fresh
-    /// poller), and an idle server pays one cheap command per second on an
+    /// psmux has no format subscriptions, so a remote psmux connection
+    /// **polls** the remote-hook pane option instead (once
+    /// [`crate::session::psmux_hook_rewrite_supported`] is flipped — the same
+    /// gate that enables shipping the rewritten hooks that set it): a
+    /// background thread lists every pane of the session with its
+    /// `@thurbox_state` each [`PSMUX_HOOK_POLL_INTERVAL`], diffs against the
+    /// previous poll ([`control_mode::diff_polled_hook_states`]), and feeds
+    /// changes into the same `sub_events` queue the tmux subscription uses —
+    /// everything downstream (`take_hook_state_events` → the app's drain) is
+    /// shared. Best-effort: a command failure ends the thread (the connection
+    /// is dying; a reconnect's fresh `ControlMode` spawns a fresh poller), and
+    /// an idle server pays one cheap command per second on an
     /// already-persistent connection.
     ///
     /// The thread is deliberately **detached** (not joined in `Drop`): a poll

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -380,11 +380,18 @@ impl ControlMode {
         let queue = Arc::clone(&self.response_queue);
         let events = Arc::clone(&self.sub_events);
         let alive = Arc::clone(&self.alive);
-        // Double-quoted format: psmux's tokenizer passes `'` through `"…"`
+        // Double-quoted framing: psmux's tokenizer passes `'` through `"…"`
         // tokens but mangles adjacent `'…'` segments (see
-        // `psmux_window_command`), so double quotes are the safe framing.
+        // `psmux_window_command`). The session name is user-authored
+        // hosts.toml text embedded in a wire command, so it gets the same
+        // double-quote framing, minus the `"`/`\` it can't carry — mirroring
+        // the socket sanitization in `builtin_hooks::remote_signal_target`.
+        let session_safe: String = session
+            .chars()
+            .filter(|c| !matches!(c, '"' | '\\'))
+            .collect();
         let cmd = format!(
-            "list-panes -s -t {session} -F \"#{{pane_id}} #{{{}}}\"",
+            "list-panes -s -t \"{session_safe}\" -F \"#{{pane_id}} #{{{}}}\"",
             crate::session::REMOTE_HOOK_STATE_OPTION,
         );
         let spawned = std::thread::Builder::new()
@@ -596,15 +603,29 @@ impl ControlMode {
         let (tx, rx) = sync_channel(1);
 
         {
-            let mut queue = response_queue
-                .lock()
-                .map_err(|e| anyhow::anyhow!("response_queue lock: {e}"))?;
+            // Lock order: stdin first, queue only for the brief push/pop.
+            // Holding stdin across enqueue AND write keeps the FIFO waiter
+            // order matching the on-wire command order for concurrent senders
+            // (a backend caller vs the psmux poller) — while never holding the
+            // queue lock across the pipe write, so a write blocked on a wedged
+            // transport can't stall the reader thread (whose response dispatch
+            // needs the queue lock) or any other `send_command` caller beyond
+            // the command itself.
             let mut stdin = stdin
                 .lock()
                 .map_err(|e| anyhow::anyhow!("stdin lock: {e}"))?;
-            queue.push_back(tx);
+            {
+                let mut queue = response_queue
+                    .lock()
+                    .map_err(|e| anyhow::anyhow!("response_queue lock: {e}"))?;
+                queue.push_back(tx);
+            }
             if let Err(e) = writeln!(stdin, "{cmd}").and_then(|()| stdin.flush()) {
-                queue.pop_back();
+                // Un-enqueue our waiter — still under the stdin lock, so no
+                // other sender can have pushed after us: the back is ours.
+                if let Ok(mut queue) = response_queue.lock() {
+                    queue.pop_back();
+                }
                 return Err(e.into());
             }
         }

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -1924,6 +1924,25 @@ pub fn spawn_window_remote(
     Ok(spawned.backend_id)
 }
 
+/// One-shot read of every pane's remote-hook state option on `host`:
+/// `list-panes -s -t <session> -F "#{pane_id} #{@thurbox_state}"` over the
+/// host launcher, parsed to the set `(pane_id, state)` pairs. The headless
+/// status poll (`session_ops::remote_hooks::poll_remote_hook_states`) uses it
+/// to keep remote hook states flowing with no TUI attached. Read-only by
+/// design — no `ensure_ready`, so a poll never creates the remote
+/// server/session; an unreachable host or absent server is an `Err` the
+/// caller treats as "no reports this cycle".
+pub fn list_remote_hook_states(host: &crate::session::HostDef) -> Result<Vec<(String, String)>> {
+    let backend = TmuxBackend::from_host(host);
+    let session = backend.session.clone();
+    let format = format!(
+        "#{{pane_id}} #{{{}}}",
+        crate::session::REMOTE_HOOK_STATE_OPTION
+    );
+    let body = backend.tmux_output(&["list-panes", "-s", "-t", &session, "-F", &format])?;
+    Ok(control_mode::parse_pane_hook_states(&body))
+}
+
 /// Kill a remote tmux pane on `host` by its pane id (`%N`), best-effort.
 ///
 /// Mirror of [`kill_window`] for the SSH transport. Used to tear down a window

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4780,7 +4780,7 @@ impl App {
     fn drain_remote_hook_events(&mut self) {
         // The value is remote-host-controlled free text: allow-list it (the
         // same states `session signal` accepts) and never interpolate it.
-        const VALID_STATES: [&str; 4] = ["working", "blocked", "done", "idle"];
+        const VALID_STATES: [&str; 4] = crate::session::HOOK_STATES;
         // Unmatched events are retried this long — comfortably past a slow
         // host's background restore — then dropped (bounded below, so another
         // instance's panes can't accumulate).

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -141,9 +141,35 @@ struct SpawnInputs {
     /// The primary repo path restored onto `SessionInfo.cwd` after spawn.
     primary_cwd: Option<PathBuf>,
     backend: Arc<dyn SessionBackend>,
-    provider: Arc<dyn crate::agent::AgentProvider>,
+    /// Un-adapted agent def; the launch provider is built by
+    /// [`finalize_launch_provider`] on the *consumer's* thread, because for a
+    /// remote host the adaptation performs ssh round-trips (arg materialization
+    /// + hook provisioning) that must stay off the UI thread on the async path.
+    agent_def: AgentDef,
+    /// The remote host `config.backend` targets (`None` = local).
+    spawn_host: Option<crate::session::HostDef>,
+    /// Whether the built-in hooks extension is active (drives remote hook
+    /// provisioning); read on the UI thread so the worker needs no DB handle.
+    hooks_enabled: bool,
     rows: u16,
     cols: u16,
+}
+
+/// Build the launch provider from prepared [`SpawnInputs`] parts: remote arg
+/// adaptation + per-agent hook provisioning
+/// ([`crate::session_ops::spawn::adapt_def_for_launch`]), then the generic
+/// provider. For a remote host this performs ssh round-trips — call it on a
+/// worker, never the UI thread (the synchronous spawn path eats it on the
+/// calling thread by contract, like `ensure_backend_ready`). Also returns the
+/// hook-wiring degradation note destined for [`SessionInfo::hook_wiring`].
+fn finalize_launch_provider(
+    agent_def: AgentDef,
+    host: Option<&crate::session::HostDef>,
+    hooks_enabled: bool,
+) -> (Arc<dyn crate::agent::AgentProvider>, Option<String>) {
+    let (def, degraded) =
+        crate::session_ops::spawn::adapt_def_for_launch(agent_def, host, hooks_enabled);
+    (Arc::new(GenericProvider::new(def)), degraded)
 }
 
 /// Continuation for a backgrounded interactive `Session::spawn`: the metadata
@@ -1455,8 +1481,10 @@ impl App {
     /// for the host — materialized at a home-translated remote path, or stripped
     /// when no remote path can work — because an unresolvable path kills the
     /// agent on launch ("Settings file not found"). Shares the headless spawn's
-    /// implementation; used by every path that launches a new agent process
-    /// (spawn, restore, respawn-on-restore).
+    /// implementation; used by restart/respawn-on-restore (which run on the
+    /// caller's thread and re-launch into an already-provisioned host). The
+    /// spawn paths use [`finalize_launch_provider`] instead, which additionally
+    /// provisions the agent's remote hook files and runs on a worker.
     fn launch_provider_for(&self, config: &SessionConfig) -> Arc<dyn crate::agent::AgentProvider> {
         let mut def = self.agent_def_for(&config.agent);
         if let Some(h) = self.host_for_backend(config.backend.as_deref()) {
@@ -3857,13 +3885,19 @@ impl App {
             }
         };
 
-        let provider = self.launch_provider_for(&config);
+        // The def is looked up here (cheap registry read); its remote
+        // adaptation — ssh round-trips — is deferred to
+        // `finalize_launch_provider` on the consumer's thread (ADR-P12).
+        let agent_def = self.agent_def_for(&config.agent);
+        let hooks_enabled = !self.db.builtin_hooks_opted_out().unwrap_or(false);
 
         Some(SpawnInputs {
             config,
             primary_cwd,
             backend,
-            provider,
+            agent_def,
+            spawn_host,
+            hooks_enabled,
             rows,
             cols,
         })
@@ -3950,13 +3984,19 @@ impl App {
             return;
         };
         // This path is synchronous by contract (its callers need the session id
-        // back immediately), so it eats the ready-up on the calling thread —
-        // unlike `do_spawn_session_async`, which hands it to a worker.
+        // back immediately), so it eats the ready-up + remote adaptation on the
+        // calling thread — unlike `do_spawn_session_async`, which hands both to
+        // a worker.
         if let Err(e) = ensure_backend_ready(&inputs.backend) {
             error!("Failed to ready backend: {e}");
             self.set_error(e);
             return;
         }
+        let (provider, hook_wiring) = finalize_launch_provider(
+            inputs.agent_def,
+            inputs.spawn_host.as_ref(),
+            inputs.hooks_enabled,
+        );
 
         match Session::spawn(
             name,
@@ -3964,9 +4004,10 @@ impl App {
             inputs.cols,
             &inputs.config,
             &inputs.backend,
-            &inputs.provider,
+            &provider,
         ) {
-            Ok(session) => {
+            Ok(mut session) => {
+                session.info.hook_wiring = hook_wiring;
                 let task_prompt = self.task_ui.pending_task_prompt.take();
                 self.finalize_spawned_session(
                     session,
@@ -4013,7 +4054,9 @@ impl App {
             config,
             primary_cwd,
             backend,
-            provider,
+            agent_def,
+            spawn_host,
+            hooks_enabled,
             rows,
             cols,
         } = inputs;
@@ -4032,12 +4075,20 @@ impl App {
         self.mark_spawn_working(name.clone(), SpawnPhase::Spawning);
 
         tokio::task::spawn_blocking(move || {
-            // `ensure_ready` is inside the worker, not in the prelude above: for a
-            // remote backend it is an ssh connect + remote tmux bring-up, 15–30 s
-            // on a slow host (ADR-P7), and on the UI thread that froze the loop
-            // before the spawn was ever dispatched.
+            // `ensure_ready` AND the launch-provider finalization are inside the
+            // worker, not in the prelude above: for a remote backend they are an
+            // ssh connect + remote tmux bring-up (15–30 s on a slow host,
+            // ADR-P7) plus the agent-config materialization/hook provisioning
+            // round-trips, and on the UI thread those froze the loop before the
+            // spawn was ever dispatched.
             let result = ensure_backend_ready(&backend).and_then(|()| {
+                let (provider, hook_wiring) =
+                    finalize_launch_provider(agent_def, spawn_host.as_ref(), hooks_enabled);
                 Session::spawn(name, rows, cols, &config, &backend, &provider)
+                    .map(|mut session| {
+                        session.info.hook_wiring = hook_wiring;
+                        session
+                    })
                     .map_err(|e| format!("{e:#}"))
             });
             let _ = tx.send(result);

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -438,6 +438,17 @@ fn tick(db: &Database) -> Result<Value, String> {
     if let Err(e) = db.prune_old_messages() {
         tracing::debug!("prune_old_messages: {e}");
     }
+    // Headless remote-status poll: the live control-mode channels
+    // (subscription / psmux poller) die with the TUI, so this keeps remote
+    // sessions' hook states flowing at the heartbeat's 60 s cadence — the TUI
+    // stays the sub-second channel while open. Skipped when the built-in
+    // hooks extension is opted out (nothing sets the pane option then).
+    if !db.builtin_hooks_opted_out().unwrap_or(false) {
+        let polled = crate::session_ops::remote_hooks::poll_remote_hook_states(db);
+        if polled > 0 {
+            tracing::info!("remote status poll: {polled} hook state(s) updated");
+        }
+    }
     let now = current_time_millis();
     let due = db
         .due_automations(now)

--- a/src/cli/automations.rs
+++ b/src/cli/automations.rs
@@ -438,17 +438,6 @@ fn tick(db: &Database) -> Result<Value, String> {
     if let Err(e) = db.prune_old_messages() {
         tracing::debug!("prune_old_messages: {e}");
     }
-    // Headless remote-status poll: the live control-mode channels
-    // (subscription / psmux poller) die with the TUI, so this keeps remote
-    // sessions' hook states flowing at the heartbeat's 60 s cadence — the TUI
-    // stays the sub-second channel while open. Skipped when the built-in
-    // hooks extension is opted out (nothing sets the pane option then).
-    if !db.builtin_hooks_opted_out().unwrap_or(false) {
-        let polled = crate::session_ops::remote_hooks::poll_remote_hook_states(db);
-        if polled > 0 {
-            tracing::info!("remote status poll: {polled} hook state(s) updated");
-        }
-    }
     let now = current_time_millis();
     let due = db
         .due_automations(now)
@@ -477,6 +466,19 @@ fn tick(db: &Database) -> Result<Value, String> {
             "status": status.as_str(),
             "detail": detail,
         }));
+    }
+    // Headless remote-status poll: the live control-mode channels
+    // (subscription / psmux poller) die with the TUI, so this keeps remote
+    // sessions' hook states flowing at the heartbeat's 60 s cadence — the TUI
+    // stays the sub-second channel while open. AFTER the due-automation pass:
+    // an unreachable host costs up to ConnectTimeout per attempt, which must
+    // never delay a scheduled firing. Skipped when the built-in hooks
+    // extension is opted out (nothing sets the pane option then).
+    if !db.builtin_hooks_opted_out().unwrap_or(false) {
+        let polled = crate::session_ops::remote_hooks::poll_remote_hook_states(db);
+        if polled > 0 {
+            tracing::info!("remote status poll: {polled} hook state(s) updated");
+        }
     }
     Ok(json!({ "fired": fired, "skipped": skipped, "healed": healed }))
 }

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -144,13 +144,20 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 .into_iter()
                 .filter(|s| parent_id.is_none() || s.parent_session_id == parent_id)
                 .collect();
-            let json = Value::Array(sessions.iter().map(shared_session_to_json).collect());
+            let states = db.load_hook_states().unwrap_or_default();
+            let json = Value::Array(
+                sessions
+                    .iter()
+                    .map(|s| session_json_with_state(s, &states))
+                    .collect(),
+            );
             Ok(CommandOutput::new(json, render_session_list(&sessions)))
         }
         Action::Get { uuid } => {
             let session = resolve(db, &uuid)?;
+            let states = db.load_hook_states().unwrap_or_default();
             Ok(CommandOutput::new(
-                shared_session_to_json(&session),
+                session_json_with_state(&session, &states),
                 render_session_detail(&session),
             ))
         }
@@ -429,6 +436,24 @@ fn resolve(db: &Database, uuid: &str) -> Result<SharedSession, String> {
     db.get_session_by_id(id)
         .map_err(|e| format!("get_session_by_id: {e}"))?
         .ok_or_else(|| format!("Session not found: {uuid}"))
+}
+
+/// [`shared_session_to_json`] plus the session's persisted hooks-driven state
+/// (`hook_state`: `working`/`blocked`/`done`/`idle`, `null` when never
+/// reported). This is the **raw persisted value** written by `session signal`
+/// and the headless remote-status poll — the TUI's display status additionally
+/// derives exited→Idle and the stuck-`working` quiescence fallback, which need
+/// a live pane and don't exist headless.
+fn session_json_with_state(
+    s: &SharedSession,
+    states: &std::collections::HashMap<crate::session::SessionId, crate::storage::HookRow>,
+) -> Value {
+    let mut json = shared_session_to_json(s);
+    json["hook_state"] = states
+        .get(&s.id)
+        .and_then(|r| r.state.clone())
+        .map_or(Value::Null, Value::String);
+    json
 }
 
 fn shared_session_to_json(s: &SharedSession) -> Value {

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -125,7 +125,7 @@ pub enum Action {
     Signal {
         /// The reported state. `idle` = agent ready/at-rest (e.g. a fresh
         /// session boot); `done` = a turn just finished (shows until you look).
-        #[arg(long, value_parser = ["working", "blocked", "done", "idle"])]
+        #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(crate::session::HOOK_STATES))]
         state: String,
         /// Override the calling session (UUID). Defaults to $THURBOX_SESSION,
         /// then a lookup by the agent conversation id ($THURBOX_SESSION_ID).

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -328,6 +328,12 @@ pub fn expand_remote_tilde(host: &HostDef, path: &str) -> Result<String> {
 /// or the probed command's own 1).
 const REMOTE_PROBE_NEGATIVE: i32 = 3;
 
+/// Sentinel for "the path exists but is not a regular file" — distinct from
+/// [`REMOTE_PROBE_NEGATIVE`] *and* from the probed command's own exit 1 (e.g.
+/// `cat` failing on a permission-denied file must not be misreported as a
+/// file-type problem).
+const REMOTE_PROBE_NOT_FILE: i32 = 4;
+
 /// Resolve `%USERPROFILE%` on a **native-Windows** SSH host (a `psmux` host),
 /// normalized to forward slashes (`C:/Users/me`) and cached like
 /// [`remote_home`] (same key space — a host is either POSIX or Windows, never
@@ -445,8 +451,8 @@ pub(crate) fn read_remote_file(host: &HostDef, path: &str) -> Result<Option<Stri
     let path = expand_remote_tilde(host, path)?;
     let quoted = posix_quote(&path);
     let script = format!(
-        "if test -f {quoted}; then cat {quoted}; elif test -e {quoted}; then exit 1; \
-         else exit {REMOTE_PROBE_NEGATIVE}; fi"
+        "if test -f {quoted}; then cat {quoted}; elif test -e {quoted}; then \
+         exit {REMOTE_PROBE_NOT_FILE}; else exit {REMOTE_PROBE_NEGATIVE}; fi"
     );
     let output = host_shell_c(host, &script)
         .stderr(Stdio::piped())
@@ -455,7 +461,11 @@ pub(crate) fn read_remote_file(host: &HostDef, path: &str) -> Result<Option<Stri
     match output.status.code() {
         Some(0) => Ok(Some(String::from_utf8_lossy(&output.stdout).into_owned())),
         Some(REMOTE_PROBE_NEGATIVE) => Ok(None),
-        Some(1) => anyhow::bail!("remote path {path} exists but is not a regular file"),
+        Some(REMOTE_PROBE_NOT_FILE) => {
+            anyhow::bail!("remote path {path} exists but is not a regular file")
+        }
+        // Anything else includes `cat`'s own failure (e.g. permission denied,
+        // exit 1) — surface its stderr rather than misreporting the file type.
         _ => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!("remote file read failed: {}", stderr.trim())

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -323,6 +323,146 @@ pub fn expand_remote_tilde(host: &HostDef, path: &str) -> Result<String> {
     }
 }
 
+/// Sentinel exit code remote probe scripts use for their "negative" answer, so
+/// it can't be confused with a transport failure (ssh's 255, a launch error,
+/// or the probed command's own 1).
+const REMOTE_PROBE_NEGATIVE: i32 = 3;
+
+/// Resolve `%USERPROFILE%` on a **native-Windows** SSH host (a `psmux` host),
+/// normalized to forward slashes (`C:/Users/me`) and cached like
+/// [`remote_home`] (same key space — a host is either POSIX or Windows, never
+/// both). Runs `powershell -NoProfile -Command Write-Output $env:USERPROFILE`,
+/// which works whether the host's default sshd shell is `cmd` or PowerShell
+/// (`cmd` passes `$env:…` through untouched for PowerShell to evaluate).
+pub(crate) fn remote_home_windows(host: &HostDef) -> Result<String> {
+    let key = host.backend_name();
+    if let Ok(guard) = remote_home_cache().lock() {
+        if let Some(home) = guard.get(&key) {
+            return Ok(home.clone());
+        }
+    }
+    let mut cmd = host_launcher(host);
+    cmd.args(["powershell", "-NoProfile", "-Command"])
+        .arg("Write-Output $env:USERPROFILE");
+    let output = cmd
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to resolve host %USERPROFILE%")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("resolving %USERPROFILE% on {key} failed: {}", stderr.trim());
+    }
+    let home = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .replace('\\', "/");
+    if home.is_empty() {
+        anyhow::bail!("%USERPROFILE% resolved empty for {key}");
+    }
+    if let Ok(mut guard) = remote_home_cache().lock() {
+        guard.insert(key, home.clone());
+    }
+    Ok(home)
+}
+
+/// The longest command line safely below Windows `cmd.exe`'s ~8191-char limit
+/// (the sshd default shell may be `cmd`), leaving headroom for the PowerShell
+/// wrapper around the base64 payload.
+const WINDOWS_COMMAND_BUDGET: usize = 7_500;
+
+/// [`copy_bytes_to_remote`] for a **native-Windows** SSH host: `cat > file`
+/// doesn't exist there, so the payload travels base64-encoded inside a
+/// PowerShell one-liner (`[IO.File]::WriteAllBytes` + `New-Item -Force` for
+/// the parent dir). Bounded by the Windows command-line limit — thurbox's hook
+/// payloads are 1–4 KB, well within it; anything larger errors instead of
+/// truncating. `remote_path` must be `/`-separated (PowerShell accepts it).
+pub(crate) fn copy_bytes_to_remote_windows(
+    host: &HostDef,
+    bytes: &[u8],
+    remote_path: &str,
+) -> Result<()> {
+    use base64::Engine as _;
+
+    let parent = Path::new(remote_path)
+        .parent()
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_default();
+    anyhow::ensure!(
+        !remote_path.contains('\'') && !parent.contains('\''),
+        "remote path {remote_path} contains a quote"
+    );
+    let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+    let script = format!(
+        "New-Item -ItemType Directory -Force -Path '{parent}' | Out-Null; \
+         [IO.File]::WriteAllBytes('{remote_path}', [Convert]::FromBase64String('{b64}'))"
+    );
+    anyhow::ensure!(
+        script.len() <= WINDOWS_COMMAND_BUDGET,
+        "payload too large for a Windows command line ({} bytes)",
+        bytes.len()
+    );
+    let mut cmd = host_launcher(host);
+    // Double-quoted so the host's default shell (cmd or PowerShell) hands the
+    // script to `powershell -Command` as one argument; the payload/path are
+    // single-quoted inside, and base64 text never contains quotes.
+    cmd.args(["powershell", "-NoProfile", "-Command"])
+        .arg(format!("\"{script}\""));
+    let output = cmd
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to spawn windows remote file-copy")?;
+    remote_output_or_stderr(output, "windows file-copy").map(|_| ())
+}
+
+/// Whether `dir` exists as a directory on `host` (a leading `~` expands against
+/// the remote home). `Ok(false)` means the probe *ran* and answered no — a
+/// transport failure is an `Err`, distinguished by the exit code: the script
+/// answers only 0 / [`REMOTE_PROBE_NEGATIVE`] itself.
+pub(crate) fn remote_dir_exists(host: &HostDef, dir: &str) -> Result<bool> {
+    let dir = expand_remote_tilde(host, dir)?;
+    let script = format!(
+        "if test -d {}; then exit 0; else exit {REMOTE_PROBE_NEGATIVE}; fi",
+        posix_quote(&dir)
+    );
+    let output = host_shell_c(host, &script)
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to run remote dir probe")?;
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(REMOTE_PROBE_NEGATIVE) => Ok(false),
+        _ => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("remote dir probe failed: {}", stderr.trim())
+        }
+    }
+}
+
+/// Read a regular file on `host` (a leading `~` expands against the remote
+/// home). `Ok(None)` = the path doesn't exist; an existing-but-not-regular
+/// path or a transport failure is an `Err` (see [`remote_dir_exists`] for the
+/// exit-code discipline).
+pub(crate) fn read_remote_file(host: &HostDef, path: &str) -> Result<Option<String>> {
+    let path = expand_remote_tilde(host, path)?;
+    let quoted = posix_quote(&path);
+    let script = format!(
+        "if test -f {quoted}; then cat {quoted}; elif test -e {quoted}; then exit 1; \
+         else exit {REMOTE_PROBE_NEGATIVE}; fi"
+    );
+    let output = host_shell_c(host, &script)
+        .stderr(Stdio::piped())
+        .output()
+        .context("failed to run remote file read")?;
+    match output.status.code() {
+        Some(0) => Ok(Some(String::from_utf8_lossy(&output.stdout).into_owned())),
+        Some(REMOTE_PROBE_NEGATIVE) => Ok(None),
+        Some(1) => anyhow::bail!("remote path {path} exists but is not a regular file"),
+        _ => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("remote file read failed: {}", stderr.trim())
+        }
+    }
+}
+
 /// Global cache for repo display names (path → name).
 static REPO_NAME_CACHE: std::sync::OnceLock<Mutex<HashMap<PathBuf, String>>> =
     std::sync::OnceLock::new();

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -67,6 +67,24 @@ pub const REMOTE_HOOK_STATE_OPTION: &str = "@thurbox_state";
 /// notifications for every pane of the attached session.
 pub const REMOTE_HOOK_SUBSCRIPTION: &str = "thurbox-status";
 
+/// Whether the remote hooks-driven status path is enabled for a **psmux**
+/// (native-Windows SSH) host — both halves of it: shipping hook configs with
+/// their commands rewritten to the psmux pane-option form
+/// (`session_ops::spawn::remote_config_root`), and arming the 1 s pane-option
+/// poller on the host's control-mode connection (`agent::tmux`). **Gate,
+/// currently closed**: the path rests on behaviors not yet proven against
+/// psmux 3.3.6 — in-pane `set-option -p` without `-t` (no `$TMUX_PANE`
+/// guarantee), `#{@user_option}` expansion for the poller, and claude
+/// accepting a forward-slash `--settings` path on Windows.
+/// `scripts/dev/e2e/windows-vm.sh test` carries the probes; flip this to
+/// `true` only with that evidence. Closed = exactly the old strip behavior
+/// (the agent launches clean with no hooks, surfaced via
+/// `SessionInfo::hook_wiring`). Defined in the pure-data layer so `agent`
+/// (poller) and `session_ops` (rewrite/shipping) flip on the one switch.
+pub fn psmux_hook_rewrite_supported() -> bool {
+    false
+}
+
 #[derive(Debug, Clone)]
 pub struct WorktreeInfo {
     pub repo_path: PathBuf,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -67,6 +67,14 @@ pub const REMOTE_HOOK_STATE_OPTION: &str = "@thurbox_state";
 /// notifications for every pane of the attached session.
 pub const REMOTE_HOOK_SUBSCRIPTION: &str = "thurbox-status";
 
+/// The states `session signal` accepts — the single source for the CLI's
+/// value parser, the TUI's remote-event allow-list
+/// (`App::drain_remote_hook_events`), and the headless status poll
+/// (`session_ops::remote_hooks`). One list, so a future state (e.g. `error`
+/// once exit-code derivation lands) can't be accepted by the CLI yet silently
+/// dropped by the remote channels.
+pub const HOOK_STATES: [&str; 4] = ["working", "blocked", "done", "idle"];
+
 /// Whether the remote hooks-driven status path is enabled for a **psmux**
 /// (native-Windows SSH) host — both halves of it: shipping hook configs with
 /// their commands rewritten to the psmux pane-option form

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -263,6 +263,11 @@ pub struct SessionInfo {
     /// Manual position in the session list. `None` = never moved: renders
     /// after all ordered sessions, in creation order.
     pub display_order: Option<i64>,
+    /// Why hooks-driven status is degraded/absent on this (remote) session —
+    /// e.g. the hooks config was stripped for the host, or provisioning
+    /// failed. Set at spawn time, transient (never persisted); rendered as a
+    /// hint in the info panel. `None` = healthy or local.
+    pub hook_wiring: Option<String>,
 }
 
 impl SessionInfo {
@@ -286,6 +291,7 @@ impl SessionInfo {
             repo_display_names: Vec::new(),
             parent_session_id: None,
             display_order: None,
+            hook_wiring: None,
         }
     }
 }

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -281,15 +281,17 @@ mod tests {
             ("copilot-hooks.json", COPILOT_HOOKS),
             ("extension.toml", MANIFEST), // aider's literal --notifications-command arg
         ] {
-            // Key on the command-with-flag form — a bare `session signal`
-            // mention in a comment is fine, an actual `--state` invocation
-            // must carry the exact marker prefix.
-            let occurrences = asset.matches("session signal --state").count();
+            // Key on the invocation-with-flags form (`thurbox-cli session
+            // signal --…`): a bare mention in a comment (ends at a backtick/
+            // newline) is fine, but ANY flagged invocation — including one
+            // whose flags drifted, e.g. `--quiet --state` — must carry the
+            // exact marker prefix, or the remote rewrite silently misses it.
+            let occurrences = asset.matches("thurbox-cli session signal --").count();
             assert!(occurrences > 0, "{name} carries no session-signal command");
             assert_eq!(
                 asset.matches(SIGNAL_MARKER).count(),
                 occurrences,
-                "a `session signal --state` command in {name} doesn't match SIGNAL_MARKER"
+                "a `thurbox-cli session signal --…` command in {name} doesn't match SIGNAL_MARKER"
             );
         }
         assert_eq!(

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -24,41 +24,87 @@ use super::install_extension;
 /// The extension name (matches `extensions/hooks/extension.toml`).
 pub const HOOKS_EXTENSION_NAME: &str = "hooks";
 
-const MANIFEST: &str = include_str!("../../extensions/hooks/extension.toml");
-const CLAUDE_SETTINGS: &str = include_str!("../../extensions/hooks/claude.json");
-const OPENCODE_PLUGIN: &str = include_str!("../../extensions/hooks/opencode-status.js");
-const ANTIGRAVITY_HOOKS: &str = include_str!("../../extensions/hooks/antigravity-hooks.json");
-const CODEX_HOOKS: &str = include_str!("../../extensions/hooks/codex-hooks.json");
-const VIBE_HOOKS: &str = include_str!("../../extensions/hooks/vibe-hooks.toml");
-const COPILOT_HOOKS: &str = include_str!("../../extensions/hooks/copilot-hooks.json");
+pub(crate) const MANIFEST: &str = include_str!("../../extensions/hooks/extension.toml");
+pub(crate) const CLAUDE_SETTINGS: &str = include_str!("../../extensions/hooks/claude.json");
+pub(crate) const OPENCODE_PLUGIN: &str = include_str!("../../extensions/hooks/opencode-status.js");
+pub(crate) const ANTIGRAVITY_HOOKS: &str =
+    include_str!("../../extensions/hooks/antigravity-hooks.json");
+pub(crate) const CODEX_HOOKS: &str = include_str!("../../extensions/hooks/codex-hooks.json");
+pub(crate) const VIBE_HOOKS: &str = include_str!("../../extensions/hooks/vibe-hooks.toml");
+pub(crate) const COPILOT_HOOKS: &str = include_str!("../../extensions/hooks/copilot-hooks.json");
 
 /// Marker prefix of every thurbox-managed hook command; the state word
 /// (`working`/`blocked`/`done`/`idle`) follows it directly.
 const SIGNAL_MARKER: &str = "thurbox-cli session signal --state ";
 
-/// Rewrite thurbox-managed hook commands for a **remote (real-tmux) host**:
+/// How a remote host's rewritten hook commands report state — which
+/// multiplexer binary sets the pane user option.
+pub(crate) enum RemoteSignalTarget {
+    /// POSIX host with real tmux: `tmux set-option -p @thurbox_state <s>`.
+    /// Inside a pane tmux resolves its own socket/pane from `$TMUX`/`$TMUX_PANE`.
+    Tmux,
+    /// Native-Windows host with psmux: `psmux -L <socket> set-option -p …`.
+    /// psmux has no `TMUX_TMPDIR`-style socket dir — every `-L <name>` resolves
+    /// machine-wide — so the socket is baked into the command at rewrite time.
+    Psmux { socket: String },
+}
+
+impl RemoteSignalTarget {
+    /// The replacement for [`SIGNAL_MARKER`]. Must stay free of `"` and `\` so
+    /// the byte-level replace on JSON text stays safe (guarded by a test; the
+    /// only variable part is the socket name, `thurbox`/`thurbox-dev`).
+    fn replacement(&self) -> String {
+        let option = crate::session::REMOTE_HOOK_STATE_OPTION;
+        match self {
+            RemoteSignalTarget::Tmux => format!("tmux set-option -p {option} "),
+            RemoteSignalTarget::Psmux { socket } => {
+                format!("psmux -L {socket} set-option -p {option} ")
+            }
+        }
+    }
+}
+
+/// Rewrite thurbox-managed hook commands for a **remote host**:
 /// `thurbox-cli session signal --state <s>` →
-/// `tmux set-option -p @thurbox_state <s>`.
+/// `<mux> set-option -p @thurbox_state <s>`.
 ///
 /// `thurbox-cli` can't signal from a remote host (it isn't installed there,
 /// and it would write the host's own DB — never the one the local TUI reads).
 /// A tmux **pane user option** can: inside a pane `set-option -p` needs no
 /// socket, pane id, or identity (`$TMUX`/`$TMUX_PANE` are in the pane env),
 /// and the local TUI's control-mode connection receives changes through its
-/// [`crate::session::REMOTE_HOOK_SUBSCRIPTION`] format subscription. Applied
-/// by the spawn-time materialization (`adapt_agent_args_for_remote`) to every
-/// config file it ships. Prefix-replace keeps the state word and whatever
-/// trails it (`|| true`, `;; esac; true`) intact; the replacement contains no
-/// `"`/`\`, so a byte-level replace on JSON text is safe. Idempotent, and a
-/// no-op for marker-free content.
+/// [`crate::session::REMOTE_HOOK_SUBSCRIPTION`] format subscription (tmux) or
+/// pane-option polling (psmux). Applied by the spawn-time materialization
+/// (`adapt_agent_args_for_remote`) to every launch arg and every config file
+/// it ships, and by `remote_hooks` to the per-agent config-dir payloads.
+/// Prefix-replace keeps the state word and whatever trails it (`|| true`,
+/// `;; esac; true`) intact; the replacement contains no `"`/`\`, so a
+/// byte-level replace on JSON text is safe. Idempotent, and a no-op for
+/// marker-free content.
+pub(crate) fn rewrite_hook_signals_for_target(
+    contents: &str,
+    target: &RemoteSignalTarget,
+) -> String {
+    contents.replace(SIGNAL_MARKER, &target.replacement())
+}
+
+/// [`rewrite_hook_signals_for_target`] for a real-tmux POSIX host — the
+/// original remote rewrite, kept as the common-case shorthand.
 pub(crate) fn rewrite_hook_signals_for_remote(contents: &str) -> String {
-    contents.replace(
-        SIGNAL_MARKER,
-        &format!(
-            "tmux set-option -p {} ",
-            crate::session::REMOTE_HOOK_STATE_OPTION
-        ),
-    )
+    rewrite_hook_signals_for_target(contents, &RemoteSignalTarget::Tmux)
+}
+
+/// The signal target for `host`, derived from its multiplexer: a psmux host
+/// gets the socket-explicit `psmux` form, everything else (tmux over SSH, tmux
+/// inside a WSL distro) the plain `tmux` form.
+pub(crate) fn remote_signal_target(host: &crate::session::HostDef) -> RemoteSignalTarget {
+    if host.mux() == "psmux" {
+        RemoteSignalTarget::Psmux {
+            socket: crate::agent::tmux::host_socket(host),
+        }
+    } else {
+        RemoteSignalTarget::Tmux
+    }
 }
 
 /// The hooks extension's home, under this build's resolved config dir
@@ -196,19 +242,61 @@ mod tests {
 
     #[test]
     fn signal_marker_matches_shipped_hook_commands() {
-        // Guard: a future edit to the hook asset that drifts from the marker
+        // Guard: a future edit to a hook asset that drifts from the marker
         // (e.g. reordering flags) would silently break the remote rewrite.
-        // Every `session signal` occurrence in the claude asset must carry the
-        // exact marker prefix.
-        let occurrences = CLAUDE_SETTINGS.matches("session signal").count();
+        // Every `session signal` occurrence in EVERY shipped asset must carry
+        // the exact marker prefix — all of them are candidates for the remote
+        // rewrite (claude via `--settings`, the rest via `remote_hooks`).
+        for (name, asset) in [
+            ("claude.json", CLAUDE_SETTINGS),
+            ("opencode-status.js", OPENCODE_PLUGIN),
+            ("antigravity-hooks.json", ANTIGRAVITY_HOOKS),
+            ("codex-hooks.json", CODEX_HOOKS),
+            ("vibe-hooks.toml", VIBE_HOOKS),
+            ("copilot-hooks.json", COPILOT_HOOKS),
+            ("extension.toml", MANIFEST), // aider's literal --notifications-command arg
+        ] {
+            // Key on the command-with-flag form — a bare `session signal`
+            // mention in a comment is fine, an actual `--state` invocation
+            // must carry the exact marker prefix.
+            let occurrences = asset.matches("session signal --state").count();
+            assert!(occurrences > 0, "{name} carries no session-signal command");
+            assert_eq!(
+                asset.matches(SIGNAL_MARKER).count(),
+                occurrences,
+                "a `session signal --state` command in {name} doesn't match SIGNAL_MARKER"
+            );
+        }
         assert_eq!(
             CLAUDE_SETTINGS.matches(SIGNAL_MARKER).count(),
-            occurrences,
-            "a `session signal` command in claude.json doesn't match SIGNAL_MARKER"
-        );
-        assert_eq!(
-            occurrences, 5,
+            5,
             "claude.json hook count changed — review the rewrite"
+        );
+    }
+
+    #[test]
+    fn psmux_target_rewrite_embeds_socket_and_stays_json_safe() {
+        let target = RemoteSignalTarget::Psmux {
+            socket: "thurbox".into(),
+        };
+        // The replacement must never contain `"`/`\` — it is spliced into JSON
+        // strings by a byte-level replace.
+        assert!(!target.replacement().contains(['"', '\\']));
+        let rewritten = rewrite_hook_signals_for_target(CLAUDE_SETTINGS, &target);
+        assert!(!rewritten.contains("thurbox-cli"));
+        for state in ["idle", "working", "blocked", "done"] {
+            assert!(
+                rewritten.contains(&format!(
+                    "psmux -L thurbox set-option -p @thurbox_state {state}"
+                )),
+                "missing rewritten {state} command"
+            );
+        }
+        // Still valid JSON, and idempotent.
+        serde_json::from_str::<serde_json::Value>(&rewritten).expect("still valid JSON");
+        assert_eq!(
+            rewrite_hook_signals_for_target(&rewritten, &target),
+            rewritten
         );
     }
 

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -51,8 +51,9 @@ pub(crate) enum RemoteSignalTarget {
 
 impl RemoteSignalTarget {
     /// The replacement for [`SIGNAL_MARKER`]. Must stay free of `"` and `\` so
-    /// the byte-level replace on JSON text stays safe (guarded by a test; the
-    /// only variable part is the socket name, `thurbox`/`thurbox-dev`).
+    /// the byte-level replace on JSON text stays safe (guarded by a test). The
+    /// only variable part is the socket name, sanitized to a conservative
+    /// charset at construction ([`remote_signal_target`]).
     fn replacement(&self) -> String {
         let option = crate::session::REMOTE_HOOK_STATE_OPTION;
         match self {
@@ -97,10 +98,34 @@ pub(crate) fn rewrite_hook_signals_for_remote(contents: &str) -> String {
 /// The signal target for `host`, derived from its multiplexer: a psmux host
 /// gets the socket-explicit `psmux` form, everything else (tmux over SSH, tmux
 /// inside a WSL distro) the plain `tmux` form.
+///
+/// The socket name is user-authored (`hosts.toml`) but gets spliced into
+/// JSON/JS/TOML hook text by a byte-level replace and tokenized by psmux
+/// without quoting, so it is **sanitized** here to a filename-safe charset
+/// (`[A-Za-z0-9._-]`). A violating name keeps only its safe characters (warn
+/// logged): the signal lands dark on a wrong socket instead of corrupting the
+/// shipped config file — and such a name would break every other
+/// `-L <socket>` invocation anyway.
 pub(crate) fn remote_signal_target(host: &crate::session::HostDef) -> RemoteSignalTarget {
     if host.mux() == "psmux" {
+        let socket = crate::agent::tmux::host_socket(host);
+        let safe: String = socket
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+            .collect();
+        if safe != socket {
+            tracing::warn!(
+                "host '{}' socket {socket:?} has characters unsafe for the hook \
+                 rewrite; using {safe:?}",
+                host.name
+            );
+        }
         RemoteSignalTarget::Psmux {
-            socket: crate::agent::tmux::host_socket(host),
+            socket: if safe.is_empty() {
+                crate::agent::tmux::TMUX_SOCKET.to_string()
+            } else {
+                safe
+            },
         }
     } else {
         RemoteSignalTarget::Tmux
@@ -298,6 +323,37 @@ mod tests {
             rewrite_hook_signals_for_target(&rewritten, &target),
             rewritten
         );
+    }
+
+    #[test]
+    fn remote_signal_target_sanitizes_a_hostile_socket_name() {
+        // The socket is user-authored hosts.toml text spliced into JSON by a
+        // byte-level replace — unsafe characters must never survive into the
+        // replacement.
+        let host = crate::session::HostDef {
+            name: "winbox".into(),
+            destination: "user@winbox".into(),
+            multiplexer: Some("psmux".into()),
+            socket: Some("we\"ird sock\\et".into()),
+            ..Default::default()
+        };
+        match remote_signal_target(&host) {
+            RemoteSignalTarget::Psmux { socket } => assert_eq!(socket, "weirdsocket"),
+            RemoteSignalTarget::Tmux => panic!("psmux host must get the psmux target"),
+        }
+
+        // An all-invalid socket falls back to the compile-time default rather
+        // than emitting `psmux -L  set-option …`.
+        let host = crate::session::HostDef {
+            socket: Some("\"\\ ".into()),
+            ..host
+        };
+        match remote_signal_target(&host) {
+            RemoteSignalTarget::Psmux { socket } => {
+                assert_eq!(socket, crate::agent::tmux::TMUX_SOCKET)
+            }
+            RemoteSignalTarget::Tmux => panic!("psmux host must get the psmux target"),
+        }
     }
 
     #[test]

--- a/src/session_ops/extensions.rs
+++ b/src/session_ops/extensions.rs
@@ -385,8 +385,10 @@ fn install_external_file(
 
 /// Marker present in every hook command we ship (`thurbox-cli session signal
 /// …`). [`crate::agent::json_merge::prune_marked`] uses it to remove exactly our
-/// merged entries on uninstall — robust across payload schema changes.
-const HOOK_SIGNAL_MARKER: &str = "thurbox-cli session signal";
+/// merged entries on uninstall — robust across payload schema changes. The
+/// remote provisioning (`remote_hooks`) prunes on it too, paired with the
+/// rewritten form's [`crate::session::REMOTE_HOOK_STATE_OPTION`] marker.
+pub(crate) const HOOK_SIGNAL_MARKER: &str = "thurbox-cli session signal";
 
 /// Read the JSON config at `path` (or `{}` when absent), parsed. A malformed
 /// file is an error rather than a silent overwrite — we never clobber config we
@@ -774,8 +776,9 @@ fn safe_join(home: &Path, rel: &str) -> Result<PathBuf, String> {
 
 /// Marker an installer-managed `substitute` file carries (in the template
 /// content) so reinstall can overwrite *its own* file but not one the user has
-/// edited (or whose marker they removed).
-const MANAGED_MARKER: &str = "thurbox `extension install`";
+/// edited (or whose marker they removed). The remote provisioning
+/// (`remote_hooks`) applies the same rule to files it ships to a host.
+pub(crate) const MANAGED_MARKER: &str = "thurbox `extension install`";
 
 /// Whether `dest` is a `substitute` file the user has taken ownership of: it
 /// exists but no longer carries the managed marker. A missing file (fresh

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -8,6 +8,7 @@
 pub mod builtin_hooks;
 pub mod delete;
 pub mod extensions;
+pub mod remote_hooks;
 pub mod restart;
 pub mod spawn;
 

--- a/src/session_ops/remote_hooks.rs
+++ b/src/session_ops/remote_hooks.rs
@@ -123,11 +123,10 @@ enum ProvisionOutcome {
 /// at startup. Only [`ProvisionOutcome::Provisioned`] lands in `provisioned`,
 /// so repeat spawns of the same agent on the same host skip the ssh
 /// round-trips while failures and not-installed skips are re-tried.
-/// `in_flight` guards the read-merge-write per key **without** holding the
-/// lock across the ssh round-trips (a slow or down host must not stall an
-/// unrelated host's spawn): a concurrent spawn of the same key skips
-/// provisioning entirely — the first pass either succeeds, or the next spawn
-/// retries.
+/// `in_flight` makes the read-merge-write exclusive per key **without**
+/// holding the lock across the ssh round-trips (a slow or down host must not
+/// stall an unrelated host's spawn): a concurrent spawn of the same key waits
+/// for the holder (bounded), then reads the cache or retries the pass itself.
 #[derive(Default)]
 struct ProvisionCache {
     provisioned: HashSet<(String, String)>,
@@ -138,6 +137,35 @@ fn provisioned_cache() -> &'static Mutex<ProvisionCache> {
     static CACHE: OnceLock<Mutex<ProvisionCache>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(ProvisionCache::default()))
 }
+
+/// Lock the cache, recovering from poison: every mutation under this lock is
+/// a single `insert`/`remove`/`contains` (no multi-step invariant a panic
+/// could tear), so a poisoned mutex — e.g. [`InFlightGuard`]'s own release
+/// during an unwind — carries consistent data and is safe to keep using.
+fn cache_lock() -> std::sync::MutexGuard<'static, ProvisionCache> {
+    provisioned_cache()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// Removes its key from `in_flight` on drop — **including on unwind**, so a
+/// panic inside the provisioning pass can never leak the key and permanently
+/// (and silently) disable provisioning for that `(host, agent)`.
+struct InFlightGuard {
+    key: (String, String),
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        cache_lock().in_flight.remove(&self.key);
+    }
+}
+
+/// How a same-key waiter polls the in-flight holder, and for how long. The
+/// cap only trips if the holder is wedged past every ssh timeout — the waiter
+/// then degrades with a note instead of spinning forever.
+const IN_FLIGHT_WAIT_STEP: std::time::Duration = std::time::Duration::from_millis(200);
+const IN_FLIGHT_WAIT_MAX: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Ensure `agent`'s hook config exists (rewritten for the host) on `host`,
 /// returning the degradation reason when it can't. Called from the spawn
@@ -162,28 +190,36 @@ pub(crate) fn provision_agent_hooks_on_host(
     }
 
     let key = (host.backend_name(), agent.to_string());
-    {
-        let Ok(mut cache) = provisioned_cache().lock() else {
-            // A poisoned lock means a prior provisioning pass panicked —
-            // report it rather than claiming healthy wiring.
-            return Some("hook provisioning unavailable (cache lock poisoned)".to_string());
-        };
-        if cache.provisioned.contains(&key) {
-            return None;
+    // Claim the key, or wait for the concurrent spawn that holds it: skipping
+    // would report this session healthy while its agent may boot before the
+    // holder's file lands (or after the holder *fails*). Waiting is bounded —
+    // the holder's ssh calls are ConnectTimeout/ServerAlive-bounded and the
+    // guard releases the key even on panic — and runs on a spawn worker by
+    // contract, never the UI thread. If the holder succeeded we return
+    // healthy from the cache; if it failed, we retry the pass ourselves.
+    let mut waited = std::time::Duration::ZERO;
+    let _guard = loop {
+        {
+            let mut cache = cache_lock();
+            if cache.provisioned.contains(&key) {
+                return None;
+            }
+            if cache.in_flight.insert(key.clone()) {
+                break InFlightGuard { key: key.clone() };
+            }
         }
-        if !cache.in_flight.insert(key.clone()) {
-            // Another spawn is mid-provision for this exact key; don't
-            // interleave its read-merge-write (and don't wait out its ssh
-            // round-trips either — see `ProvisionCache`).
-            return None;
+        if waited >= IN_FLIGHT_WAIT_MAX {
+            return Some(format!(
+                "{agent} hook provisioning still in flight on host '{}' (concurrent spawn)",
+                host.name
+            ));
         }
-    }
+        std::thread::sleep(IN_FLIGHT_WAIT_STEP);
+        waited += IN_FLIGHT_WAIT_STEP;
+    };
     let outcome = provision_uncached(host, &asset);
-    if let Ok(mut cache) = provisioned_cache().lock() {
-        cache.in_flight.remove(&key);
-        if matches!(outcome, ProvisionOutcome::Provisioned) {
-            cache.provisioned.insert(key);
-        }
+    if matches!(outcome, ProvisionOutcome::Provisioned) {
+        cache_lock().provisioned.insert(key);
     }
     match outcome {
         ProvisionOutcome::Provisioned | ProvisionOutcome::NotInstalled => None,
@@ -302,7 +338,7 @@ fn merged_remote_doc(existing: &str, payload: &str) -> Result<Option<String>, St
 /// The hook states a headless poll may write — the same allow-list the TUI's
 /// drain applies (`App::drain_remote_hook_events`): the polled value is
 /// remote-host-controlled free text, so it is matched, never interpolated.
-const VALID_POLL_STATES: [&str; 4] = ["working", "blocked", "done", "idle"];
+const VALID_POLL_STATES: [&str; 4] = crate::session::HOOK_STATES;
 
 /// Join one host's polled `(pane_id, state)` pairs against that backend's
 /// sessions, returning the `(session, state)` writes that change anything.
@@ -407,6 +443,25 @@ pub(crate) fn poll_remote_hook_states(db: &crate::storage::Database) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn in_flight_guard_releases_on_unwind() {
+        // A panic inside the provisioning pass must not leak the in-flight
+        // key (which would silently disable provisioning for the process
+        // lifetime while reporting healthy).
+        let key = ("test-guard-backend".to_string(), "codex".to_string());
+        assert!(cache_lock().in_flight.insert(key.clone()));
+        let k = key.clone();
+        let unwound = std::panic::catch_unwind(move || {
+            let _guard = InFlightGuard { key: k };
+            panic!("simulated provisioning panic");
+        });
+        assert!(unwound.is_err());
+        assert!(
+            !cache_lock().in_flight.contains(&key),
+            "guard must release the key on unwind"
+        );
+    }
 
     #[test]
     fn remote_status_updates_writes_changes_only() {

--- a/src/session_ops/remote_hooks.rs
+++ b/src/session_ops/remote_hooks.rs
@@ -1,0 +1,389 @@
+//! Remote provisioning of per-agent hook configs, so **every** agent — not
+//! just claude — reports hooks-driven session status from a remote (SSH/WSL)
+//! host.
+//!
+//! Locally the built-in hooks extension wires most agents through files in the
+//! agent's *own* config dir (`~/.codex/hooks.json`, the opencode plugin, …).
+//! Those files never travel with the launch args, so before this module a
+//! remote codex/opencode/… session was silently Idle-only. At spawn time this
+//! module ships the same payloads to the host — with their commands rewritten
+//! to the tmux pane-option form (`builtin_hooks::rewrite_hook_signals_for_target`)
+//! so the local TUI receives state over its control-mode subscription — using
+//! the same safety rules as the local installer: `requires_dir` probe (skip
+//! when the agent isn't installed there), deep-merge-not-clobber for shared
+//! config files, managed-marker guard for standalone files, and
+//! compare-before-write idempotency.
+//!
+//! **Best-effort by contract**: a down host, a permission error, or a
+//! malformed remote file degrades to a warning (surfaced on the session as
+//! `hook_wiring`) — it never fails the spawn.
+//!
+//! **Remote cleanup is deliberately out of scope** (thurbox never uninstalls
+//! anything from a host — same policy as remote worktrees). The shipped
+//! entries carry two prune markers (`thurbox-cli session signal` pre-rewrite,
+//! `@thurbox_state` post-rewrite), so a future remote prune needs no schema
+//! knowledge.
+
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
+
+use crate::session::HostDef;
+
+use super::builtin_hooks;
+use super::extensions::{HOOK_SIGNAL_MARKER, MANAGED_MARKER};
+
+/// How an asset lands on the host — mirrors the local installer's
+/// `config_merges` vs `external_files` split.
+enum RemoteAssetKind {
+    /// Deep-merge into a shared JSON config the agent (and its user) own.
+    MergeJson,
+    /// Write a standalone thurbox-managed file (refused if a user-owned file
+    /// — one without [`MANAGED_MARKER`] — already sits there).
+    WriteFile,
+}
+
+/// One agent's hook payload and where it lives on a POSIX host.
+struct RemoteHookAsset {
+    kind: RemoteAssetKind,
+    /// Destination, `~`-anchored (expanded against the *remote* home).
+    remote_path: &'static str,
+    /// Agent-installed guard: skip silently when this dir is absent.
+    requires_dir: &'static str,
+    payload: &'static str,
+}
+
+/// The config-dir hook asset for `agent`, or `None` when the agent has no
+/// remote provisioning to do — claude (hooks travel via `--settings`) and
+/// aider (a literal arg) are handled by `adapt_agent_args_for_remote`
+/// instead. Kept in sync with `extensions/hooks/extension.toml` (guarded by a
+/// test against the embedded manifest).
+fn remote_asset_for(agent: &str) -> Option<RemoteHookAsset> {
+    match agent {
+        "codex" => Some(RemoteHookAsset {
+            kind: RemoteAssetKind::MergeJson,
+            remote_path: "~/.codex/hooks.json",
+            requires_dir: "~/.codex",
+            payload: builtin_hooks::CODEX_HOOKS,
+        }),
+        "antigravity" => Some(RemoteHookAsset {
+            kind: RemoteAssetKind::MergeJson,
+            remote_path: "~/.gemini/settings.json",
+            requires_dir: "~/.gemini",
+            payload: builtin_hooks::ANTIGRAVITY_HOOKS,
+        }),
+        "opencode" => Some(RemoteHookAsset {
+            kind: RemoteAssetKind::WriteFile,
+            remote_path: "~/.config/opencode/plugin/thurbox-status.js",
+            requires_dir: "~/.config/opencode",
+            payload: builtin_hooks::OPENCODE_PLUGIN,
+        }),
+        "vibe" => Some(RemoteHookAsset {
+            kind: RemoteAssetKind::WriteFile,
+            remote_path: "~/.vibe/hooks.toml",
+            requires_dir: "~/.vibe",
+            payload: builtin_hooks::VIBE_HOOKS,
+        }),
+        "copilot" => Some(RemoteHookAsset {
+            kind: RemoteAssetKind::WriteFile,
+            remote_path: "~/.copilot/hooks/thurbox-status.json",
+            requires_dir: "~/.copilot",
+            payload: builtin_hooks::COPILOT_HOOKS,
+        }),
+        _ => None,
+    }
+}
+
+/// Human-readable reason hooks-driven status will be degraded/absent for a
+/// session (probe failed, user-owned file refused, copy failed, …). `None` =
+/// healthy, or nothing to provision. Informational only — provisioning never
+/// fails a spawn.
+pub(crate) type HookDegradation = Option<String>;
+
+/// Successfully provisioned `(backend_name, agent)` pairs — provisioning runs
+/// per spawn, so repeat spawns of the same agent on the same host skip the ssh
+/// round-trips. Failures are *not* recorded (retried on the next spawn).
+/// Process-lifetime, like `git`'s remote-home cache: `hosts.toml` is read once
+/// at startup. The lock is held across the whole read-merge-write, so two
+/// concurrent spawns of the same agent on the same host can't interleave the
+/// merge (the ssh launcher is hardened with `ConnectTimeout`, bounding how
+/// long a down host can hold it).
+fn provisioned_cache() -> &'static Mutex<HashSet<(String, String)>> {
+    static CACHE: OnceLock<Mutex<HashSet<(String, String)>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Ensure `agent`'s hook config exists (rewritten for the host) on `host`,
+/// returning the degradation reason when it can't. Called from the spawn
+/// worker paths — this performs ssh round-trips, so it must never run on the
+/// UI thread.
+pub(crate) fn provision_agent_hooks_on_host(
+    host: &HostDef,
+    agent: &str,
+    hooks_enabled: bool,
+) -> HookDegradation {
+    if !hooks_enabled {
+        return None;
+    }
+    let asset = remote_asset_for(agent)?;
+    // Windows/psmux hosts are deferred: these payloads' hook commands run
+    // through `sh`, and each agent's Windows config dir / hook shell differs.
+    if host.mux() == "psmux" {
+        return Some(format!(
+            "{agent} hooks not provisioned on psmux host '{}'",
+            host.name
+        ));
+    }
+
+    let key = (host.backend_name(), agent.to_string());
+    let Ok(mut cache) = provisioned_cache().lock() else {
+        return None;
+    };
+    if cache.contains(&key) {
+        return None;
+    }
+    match provision_uncached(host, &asset) {
+        None => {
+            cache.insert(key);
+            None
+        }
+        Some(reason) => {
+            tracing::warn!(
+                "remote hook provisioning degraded on host '{}': {reason}",
+                host.name
+            );
+            Some(reason)
+        }
+    }
+}
+
+/// The uncached provisioning pass: probe → rewrite → merge/write →
+/// compare-before-copy.
+fn provision_uncached(host: &HostDef, asset: &RemoteHookAsset) -> HookDegradation {
+    match crate::git::remote_dir_exists(host, asset.requires_dir) {
+        // Agent not installed on the host — nothing to wire, not a degradation
+        // (the pane would have no hooks locally either).
+        Ok(false) => return None,
+        Ok(true) => {}
+        Err(e) => {
+            return Some(format!(
+                "cannot probe {} on host: {e:#}",
+                asset.requires_dir
+            ))
+        }
+    }
+
+    // POSIX remotes only (psmux is deferred above), so the tmux form is fixed.
+    let rewritten = builtin_hooks::rewrite_hook_signals_for_remote(asset.payload);
+
+    let existing = match crate::git::read_remote_file(host, asset.remote_path) {
+        Ok(existing) => existing,
+        Err(e) => return Some(format!("cannot read {} on host: {e:#}", asset.remote_path)),
+    };
+
+    let to_write = match asset.kind {
+        RemoteAssetKind::MergeJson => {
+            match merged_remote_doc(existing.as_deref().unwrap_or(""), &rewritten) {
+                Ok(Some(merged)) => merged,
+                // Already up to date — record success without a write.
+                Ok(None) => return None,
+                Err(e) => {
+                    return Some(format!(
+                        "cannot merge into {} on host: {e}",
+                        asset.remote_path
+                    ))
+                }
+            }
+        }
+        RemoteAssetKind::WriteFile => match existing {
+            Some(content) if content == rewritten => return None,
+            // A pre-existing file without the managed marker belongs to the
+            // remote user — never clobber it (same rule as the local
+            // installer's `is_user_modified`).
+            Some(content) if !content.contains(MANAGED_MARKER) => {
+                return Some(format!(
+                    "{} on host is user-owned (no managed marker)",
+                    asset.remote_path
+                ))
+            }
+            _ => rewritten,
+        },
+    };
+
+    let dest = match crate::git::expand_remote_tilde(host, asset.remote_path) {
+        Ok(dest) => dest,
+        Err(e) => {
+            return Some(format!(
+                "cannot resolve {} on host: {e:#}",
+                asset.remote_path
+            ))
+        }
+    };
+    match crate::git::copy_bytes_to_remote(host, to_write.as_bytes(), &dest) {
+        Ok(()) => None,
+        Err(e) => Some(format!("cannot write {dest} on host: {e:#}")),
+    }
+}
+
+/// Pure merge core (unit-testable without ssh): deep-merge the rewritten
+/// `payload` into the remote file's `existing` JSON (empty/blank = `{}`),
+/// **prune-then-merge** so a payload upgrade replaces our old entries instead
+/// of accumulating next to them. Returns the pretty-serialized doc to write,
+/// or `None` when the file is already up to date. A malformed existing doc is
+/// an `Err` — never clobber config we can't parse.
+fn merged_remote_doc(existing: &str, payload: &str) -> Result<Option<String>, String> {
+    let before: serde_json::Value = if existing.trim().is_empty() {
+        serde_json::Value::Object(serde_json::Map::new())
+    } else {
+        serde_json::from_str(existing)
+            .map_err(|e| format!("existing file is not valid JSON: {e}"))?
+    };
+    let to_merge: serde_json::Value =
+        serde_json::from_str(payload).map_err(|e| format!("payload is not valid JSON: {e}"))?;
+
+    let mut doc = before.clone();
+    // Prune both command forms: the pre-rewrite local marker (a stale entry
+    // from an older thurbox that shipped the un-rewritten payload) and the
+    // rewritten pane-option marker (our own previous version).
+    crate::agent::json_merge::prune_marked(&mut doc, HOOK_SIGNAL_MARKER);
+    crate::agent::json_merge::prune_marked(&mut doc, crate::session::REMOTE_HOOK_STATE_OPTION);
+    crate::agent::json_merge::merge(&mut doc, &to_merge);
+
+    if doc == before {
+        return Ok(None);
+    }
+    serde_json::to_string_pretty(&doc)
+        .map(Some)
+        .map_err(|e| format!("serialize merged doc: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every config-dir wiring in the embedded manifest must have a matching
+    /// remote asset (same destination, guard dir, and payload), so the local
+    /// and remote installs can never drift apart.
+    #[test]
+    fn remote_assets_stay_in_sync_with_embedded_manifest() {
+        let def: crate::session::ExtensionDef =
+            toml::from_str(builtin_hooks::MANIFEST).expect("manifest parses");
+
+        let agent_for_path = |path: &str| -> &'static str {
+            if path.contains(".codex") {
+                "codex"
+            } else if path.contains(".gemini") {
+                "antigravity"
+            } else if path.contains("opencode") {
+                "opencode"
+            } else if path.contains(".vibe") {
+                "vibe"
+            } else if path.contains(".copilot") {
+                "copilot"
+            } else {
+                panic!("unknown config-dir wiring path in manifest: {path}")
+            }
+        };
+
+        let mut covered = 0;
+        for m in &def.config_merges {
+            let agent = agent_for_path(&m.path);
+            let asset = remote_asset_for(agent).expect("merge agent has a remote asset");
+            assert!(matches!(asset.kind, RemoteAssetKind::MergeJson), "{agent}");
+            assert_eq!(asset.remote_path, m.path, "{agent} destination drifted");
+            assert_eq!(
+                Some(asset.requires_dir),
+                m.requires_dir.as_deref(),
+                "{agent} requires_dir drifted"
+            );
+            covered += 1;
+        }
+        for f in &def.external_files {
+            let agent = agent_for_path(&f.path);
+            let asset = remote_asset_for(agent).expect("file agent has a remote asset");
+            assert!(matches!(asset.kind, RemoteAssetKind::WriteFile), "{agent}");
+            assert_eq!(asset.remote_path, f.path, "{agent} destination drifted");
+            assert_eq!(
+                Some(asset.requires_dir),
+                f.requires_dir.as_deref(),
+                "{agent} requires_dir drifted"
+            );
+            covered += 1;
+        }
+        // Every table entry is reachable from the manifest (no orphan assets).
+        assert_eq!(covered, 5, "manifest wiring count changed — sync the table");
+        // claude/aider stay arg-handled.
+        assert!(remote_asset_for("claude").is_none());
+        assert!(remote_asset_for("aider").is_none());
+    }
+
+    #[test]
+    fn merged_doc_into_empty_writes_rewritten_payload() {
+        let payload = builtin_hooks::rewrite_hook_signals_for_remote(builtin_hooks::CODEX_HOOKS);
+        let merged = merged_remote_doc("", &payload)
+            .expect("merges")
+            .expect("writes");
+        assert!(merged.contains("tmux set-option -p @thurbox_state"));
+        assert!(!merged.contains("thurbox-cli"));
+        // Idempotent: merging into the just-written doc is a no-op.
+        assert_eq!(merged_remote_doc(&merged, &payload).unwrap(), None);
+    }
+
+    #[test]
+    fn merged_doc_preserves_user_entries_and_replaces_stale_thurbox_ones() {
+        // The remote file carries a user hook plus a stale *un-rewritten*
+        // thurbox entry (an older thurbox shipped the local command form).
+        let existing = serde_json::json!({
+            "hooks": {
+                "SessionStart": [
+                    { "hooks": [{ "type": "command", "command": "echo user-hook" }] },
+                    { "hooks": [{ "type": "command",
+                        "command": "thurbox-cli session signal --state idle || true" }] }
+                ]
+            },
+            "userSetting": true
+        })
+        .to_string();
+        let payload = builtin_hooks::rewrite_hook_signals_for_remote(builtin_hooks::CODEX_HOOKS);
+        let merged = merged_remote_doc(&existing, &payload)
+            .expect("merges")
+            .expect("writes");
+        // User content survives; the stale local-form entry is replaced by the
+        // rewritten one, not accumulated next to it.
+        assert!(merged.contains("echo user-hook"));
+        assert!(merged.contains("\"userSetting\": true"));
+        assert!(!merged.contains("thurbox-cli"));
+        assert!(merged.contains("tmux set-option -p @thurbox_state idle"));
+    }
+
+    #[test]
+    fn merged_doc_refuses_malformed_existing() {
+        let payload = builtin_hooks::rewrite_hook_signals_for_remote(builtin_hooks::CODEX_HOOKS);
+        assert!(merged_remote_doc("{not json", &payload).is_err());
+    }
+
+    #[test]
+    fn psmux_host_is_deferred_with_a_degradation_note() {
+        let host = HostDef {
+            name: "winbox".into(),
+            destination: "user@winbox".into(),
+            multiplexer: Some("psmux".into()),
+            ..Default::default()
+        };
+        let degraded = provision_agent_hooks_on_host(&host, "codex", true);
+        assert!(degraded.is_some_and(|d| d.contains("psmux")));
+    }
+
+    #[test]
+    fn opted_out_and_assetless_agents_are_noops() {
+        let host = HostDef {
+            name: "devbox".into(),
+            destination: "user@devbox".into(),
+            ..Default::default()
+        };
+        // Hooks opted out → no-op even for a covered agent (no ssh attempted;
+        // the host doesn't exist).
+        assert!(provision_agent_hooks_on_host(&host, "codex", false).is_none());
+        // claude/aider are arg-handled → no-op.
+        assert!(provision_agent_hooks_on_host(&host, "claude", true).is_none());
+    }
+}

--- a/src/session_ops/remote_hooks.rs
+++ b/src/session_ops/remote_hooks.rs
@@ -99,17 +99,40 @@ fn remote_asset_for(agent: &str) -> Option<RemoteHookAsset> {
 /// fails a spawn.
 pub(crate) type HookDegradation = Option<String>;
 
-/// Successfully provisioned `(backend_name, agent)` pairs — provisioning runs
-/// per spawn, so repeat spawns of the same agent on the same host skip the ssh
-/// round-trips. Failures are *not* recorded (retried on the next spawn).
+/// Outcome of one uncached provisioning pass.
+enum ProvisionOutcome {
+    /// The payload is verified present on the host (written now, or already
+    /// up to date) — cacheable for the process lifetime.
+    Provisioned,
+    /// The agent isn't installed on the host (guard dir absent): nothing to
+    /// wire *yet*. Deliberately **not** cached — installing the agent on the
+    /// host later is picked up by the next spawn, at the cost of one cheap
+    /// probe per spawn.
+    NotInstalled,
+    /// Provisioning failed; the reason is surfaced as the session's
+    /// hook-wiring degradation. Not cached (retried on the next spawn).
+    Degraded(String),
+}
+
+/// Provisioning bookkeeping, keyed by `(backend_name, agent)`.
 /// Process-lifetime, like `git`'s remote-home cache: `hosts.toml` is read once
-/// at startup. The lock is held across the whole read-merge-write, so two
-/// concurrent spawns of the same agent on the same host can't interleave the
-/// merge (the ssh launcher is hardened with `ConnectTimeout`, bounding how
-/// long a down host can hold it).
-fn provisioned_cache() -> &'static Mutex<HashSet<(String, String)>> {
-    static CACHE: OnceLock<Mutex<HashSet<(String, String)>>> = OnceLock::new();
-    CACHE.get_or_init(|| Mutex::new(HashSet::new()))
+/// at startup. Only [`ProvisionOutcome::Provisioned`] lands in `provisioned`,
+/// so repeat spawns of the same agent on the same host skip the ssh
+/// round-trips while failures and not-installed skips are re-tried.
+/// `in_flight` guards the read-merge-write per key **without** holding the
+/// lock across the ssh round-trips (a slow or down host must not stall an
+/// unrelated host's spawn): a concurrent spawn of the same key skips
+/// provisioning entirely — the first pass either succeeds, or the next spawn
+/// retries.
+#[derive(Default)]
+struct ProvisionCache {
+    provisioned: HashSet<(String, String)>,
+    in_flight: HashSet<(String, String)>,
+}
+
+fn provisioned_cache() -> &'static Mutex<ProvisionCache> {
+    static CACHE: OnceLock<Mutex<ProvisionCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(ProvisionCache::default()))
 }
 
 /// Ensure `agent`'s hook config exists (rewritten for the host) on `host`,
@@ -135,18 +158,32 @@ pub(crate) fn provision_agent_hooks_on_host(
     }
 
     let key = (host.backend_name(), agent.to_string());
-    let Ok(mut cache) = provisioned_cache().lock() else {
-        return None;
-    };
-    if cache.contains(&key) {
-        return None;
-    }
-    match provision_uncached(host, &asset) {
-        None => {
-            cache.insert(key);
-            None
+    {
+        let Ok(mut cache) = provisioned_cache().lock() else {
+            // A poisoned lock means a prior provisioning pass panicked —
+            // report it rather than claiming healthy wiring.
+            return Some("hook provisioning unavailable (cache lock poisoned)".to_string());
+        };
+        if cache.provisioned.contains(&key) {
+            return None;
         }
-        Some(reason) => {
+        if !cache.in_flight.insert(key.clone()) {
+            // Another spawn is mid-provision for this exact key; don't
+            // interleave its read-merge-write (and don't wait out its ssh
+            // round-trips either — see `ProvisionCache`).
+            return None;
+        }
+    }
+    let outcome = provision_uncached(host, &asset);
+    if let Ok(mut cache) = provisioned_cache().lock() {
+        cache.in_flight.remove(&key);
+        if matches!(outcome, ProvisionOutcome::Provisioned) {
+            cache.provisioned.insert(key);
+        }
+    }
+    match outcome {
+        ProvisionOutcome::Provisioned | ProvisionOutcome::NotInstalled => None,
+        ProvisionOutcome::Degraded(reason) => {
             tracing::warn!(
                 "remote hook provisioning degraded on host '{}': {reason}",
                 host.name
@@ -158,14 +195,16 @@ pub(crate) fn provision_agent_hooks_on_host(
 
 /// The uncached provisioning pass: probe → rewrite → merge/write →
 /// compare-before-copy.
-fn provision_uncached(host: &HostDef, asset: &RemoteHookAsset) -> HookDegradation {
+fn provision_uncached(host: &HostDef, asset: &RemoteHookAsset) -> ProvisionOutcome {
+    use ProvisionOutcome::{Degraded, NotInstalled, Provisioned};
+
     match crate::git::remote_dir_exists(host, asset.requires_dir) {
         // Agent not installed on the host — nothing to wire, not a degradation
         // (the pane would have no hooks locally either).
-        Ok(false) => return None,
+        Ok(false) => return NotInstalled,
         Ok(true) => {}
         Err(e) => {
-            return Some(format!(
+            return Degraded(format!(
                 "cannot probe {} on host: {e:#}",
                 asset.requires_dir
             ))
@@ -177,7 +216,7 @@ fn provision_uncached(host: &HostDef, asset: &RemoteHookAsset) -> HookDegradatio
 
     let existing = match crate::git::read_remote_file(host, asset.remote_path) {
         Ok(existing) => existing,
-        Err(e) => return Some(format!("cannot read {} on host: {e:#}", asset.remote_path)),
+        Err(e) => return Degraded(format!("cannot read {} on host: {e:#}", asset.remote_path)),
     };
 
     let to_write = match asset.kind {
@@ -185,9 +224,9 @@ fn provision_uncached(host: &HostDef, asset: &RemoteHookAsset) -> HookDegradatio
             match merged_remote_doc(existing.as_deref().unwrap_or(""), &rewritten) {
                 Ok(Some(merged)) => merged,
                 // Already up to date — record success without a write.
-                Ok(None) => return None,
+                Ok(None) => return Provisioned,
                 Err(e) => {
-                    return Some(format!(
+                    return Degraded(format!(
                         "cannot merge into {} on host: {e}",
                         asset.remote_path
                     ))
@@ -195,12 +234,12 @@ fn provision_uncached(host: &HostDef, asset: &RemoteHookAsset) -> HookDegradatio
             }
         }
         RemoteAssetKind::WriteFile => match existing {
-            Some(content) if content == rewritten => return None,
+            Some(content) if content == rewritten => return Provisioned,
             // A pre-existing file without the managed marker belongs to the
             // remote user — never clobber it (same rule as the local
             // installer's `is_user_modified`).
             Some(content) if !content.contains(MANAGED_MARKER) => {
-                return Some(format!(
+                return Degraded(format!(
                     "{} on host is user-owned (no managed marker)",
                     asset.remote_path
                 ))
@@ -212,15 +251,15 @@ fn provision_uncached(host: &HostDef, asset: &RemoteHookAsset) -> HookDegradatio
     let dest = match crate::git::expand_remote_tilde(host, asset.remote_path) {
         Ok(dest) => dest,
         Err(e) => {
-            return Some(format!(
+            return Degraded(format!(
                 "cannot resolve {} on host: {e:#}",
                 asset.remote_path
             ))
         }
     };
     match crate::git::copy_bytes_to_remote(host, to_write.as_bytes(), &dest) {
-        Ok(()) => None,
-        Err(e) => Some(format!("cannot write {dest} on host: {e:#}")),
+        Ok(()) => Provisioned,
+        Err(e) => Degraded(format!("cannot write {dest} on host: {e:#}")),
     }
 }
 

--- a/src/session_ops/remote_hooks.rs
+++ b/src/session_ops/remote_hooks.rs
@@ -23,11 +23,15 @@
 //! entries carry two prune markers (`thurbox-cli session signal` pre-rewrite,
 //! `@thurbox_state` post-rewrite), so a future remote prune needs no schema
 //! knowledge.
+//!
+//! Besides provisioning (the write side), this module also owns the
+//! **headless status poll** (`poll_remote_hook_states`) — the read side that
+//! keeps remote hook states flowing while no TUI is attached.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 
-use crate::session::HostDef;
+use crate::session::{HostDef, SessionId};
 
 use super::builtin_hooks;
 use super::extensions::{HOOK_SIGNAL_MARKER, MANAGED_MARKER};
@@ -295,9 +299,152 @@ fn merged_remote_doc(existing: &str, payload: &str) -> Result<Option<String>, St
         .map_err(|e| format!("serialize merged doc: {e}"))
 }
 
+/// The hook states a headless poll may write — the same allow-list the TUI's
+/// drain applies (`App::drain_remote_hook_events`): the polled value is
+/// remote-host-controlled free text, so it is matched, never interpolated.
+const VALID_POLL_STATES: [&str; 4] = ["working", "blocked", "done", "idle"];
+
+/// Join one host's polled `(pane_id, state)` pairs against that backend's
+/// sessions, returning the `(session, state)` writes that change anything.
+/// Pure — the ssh/DB plumbing lives in [`poll_remote_hook_states`].
+///
+/// Comparing against the **stored** state is the resurrection guard: an
+/// acknowledged `done` still stores `done` (`seen_at` is a separate column),
+/// so a steady-state re-report compares equal and is dropped — the headless
+/// equivalent of the TUI drain's dedup against its cache.
+fn remote_status_updates(
+    polled: &[(String, String)],
+    sessions: &[(SessionId, &str, Option<&str>)],
+) -> Vec<(SessionId, String)> {
+    let states: HashMap<&str, &str> = polled
+        .iter()
+        .map(|(pane, state)| (pane.as_str(), state.as_str()))
+        .collect();
+    sessions
+        .iter()
+        .filter_map(|(id, backend_id, stored)| {
+            let state = states.get(backend_id)?;
+            if !VALID_POLL_STATES.contains(state) {
+                return None;
+            }
+            (*stored != Some(*state)).then(|| (*id, state.to_string()))
+        })
+        .collect()
+}
+
+/// Headless counterpart of the TUI's live status channels: poll each remote
+/// host that has **live sessions in the DB** and write changed pane states
+/// into the same hook columns `session signal` uses. Returns the number of
+/// states written.
+///
+/// The subscription/poller channels live on the TUI's persistent control-mode
+/// connection and die with it, so with the TUI closed a remote session's
+/// status froze at its last pushed value (local sessions are immune —
+/// `session signal` writes SQLite directly). Called from the headless
+/// `automation tick` (the 60 s tmux heartbeat keeper): coarse latency is fine
+/// there — no human is watching a dot; the consumers are `session list
+/// --json` readers — while the TUI stays the sub-second channel when open.
+///
+/// Best-effort everywhere: an unreachable host (bounded by the ssh
+/// `ConnectTimeout`) or a host with no running server is skipped for the
+/// cycle. Hosts from `hosts.toml` with **no** live remote sessions are never
+/// contacted, and psmux hosts stay excluded behind
+/// [`crate::session::psmux_hook_rewrite_supported`] (nothing sets the pane
+/// option there yet).
+pub(crate) fn poll_remote_hook_states(db: &crate::storage::Database) -> usize {
+    let Ok(sessions) = db.list_active_sessions() else {
+        return 0;
+    };
+    let mut by_backend: HashMap<String, Vec<&crate::sync::SharedSession>> = HashMap::new();
+    for s in &sessions {
+        if crate::session::is_remote_backend(&s.backend_type) {
+            by_backend
+                .entry(s.backend_type.clone())
+                .or_default()
+                .push(s);
+        }
+    }
+    if by_backend.is_empty() {
+        return 0;
+    }
+    let hook_rows = db.load_hook_states().unwrap_or_default();
+    let hosts = crate::agent::host_config::load_all();
+    let mut written = 0;
+    for (backend_name, group) in by_backend {
+        let Some(host) = hosts.get_by_backend(&backend_name) else {
+            continue;
+        };
+        if host.mux() == "psmux" && !crate::session::psmux_hook_rewrite_supported() {
+            continue;
+        }
+        let polled = match crate::agent::tmux::list_remote_hook_states(host) {
+            Ok(polled) => polled,
+            Err(e) => {
+                tracing::debug!("remote status poll skipped for host '{}': {e:#}", host.name);
+                continue;
+            }
+        };
+        let rows: Vec<(SessionId, &str, Option<&str>)> = group
+            .iter()
+            .map(|s| {
+                (
+                    s.id,
+                    s.backend_id.as_str(),
+                    hook_rows.get(&s.id).and_then(|r| r.state.as_deref()),
+                )
+            })
+            .collect();
+        for (id, state) in remote_status_updates(&polled, &rows) {
+            match db.set_hook_state(id, &state) {
+                Ok(()) => written += 1,
+                Err(e) => tracing::debug!("remote status poll write failed for {id}: {e}"),
+            }
+        }
+    }
+    written
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remote_status_updates_writes_changes_only() {
+        let a = SessionId::default();
+        let b = SessionId::default();
+        let polled = vec![
+            ("%1".to_string(), "working".to_string()),
+            ("%2".to_string(), "done".to_string()),
+            ("%9".to_string(), "blocked".to_string()), // no matching session
+        ];
+        let sessions = [
+            (a, "%1", None),         // first report → write
+            (b, "%2", Some("done")), // unchanged (incl. an acknowledged done) → silent
+        ];
+        assert_eq!(
+            remote_status_updates(&polled, &sessions),
+            vec![(a, "working".to_string())]
+        );
+        // A change writes; a pane whose option is unset stays untouched.
+        let sessions = [(a, "%1", Some("working")), (b, "%3", Some("done"))];
+        let polled = vec![("%1".to_string(), "done".to_string())];
+        assert_eq!(
+            remote_status_updates(&polled, &sessions),
+            vec![(a, "done".to_string())]
+        );
+    }
+
+    #[test]
+    fn remote_status_updates_allowlists_states() {
+        // The polled value is remote-controlled text — anything outside the
+        // states `session signal` accepts is dropped, never written.
+        let a = SessionId::default();
+        let polled = vec![
+            ("%1".to_string(), "pwned; DROP TABLE".to_string()),
+            ("%1".to_string(), "Working".to_string()), // case-sensitive
+        ];
+        assert!(remote_status_updates(&polled, &[(a, "%1", None)]).is_empty());
+    }
 
     /// Every config-dir wiring in the embedded manifest must have a matching
     /// remote asset (same destination, guard dir, and payload), so the local

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use crate::session::{ExtraRepo, HostDef, SessionConfig, SessionId};
+use crate::session::{psmux_hook_rewrite_supported, ExtraRepo, HostDef, SessionConfig, SessionId};
 use crate::storage::Database;
 use crate::sync::{SharedSession, SharedWorktree};
 
@@ -492,19 +492,6 @@ pub(crate) fn adapt_def_for_launch(
         ))
     };
     (def, degraded)
-}
-
-/// Whether hook configs may be shipped to (and their commands rewritten for) a
-/// **psmux** (native-Windows SSH) host. **Gate, currently closed**: the psmux
-/// path rests on behaviors not yet proven against psmux 3.3.6 — in-pane
-/// `set-option -p` without `-t` (no `$TMUX_PANE` guarantee), `#{@user_option}`
-/// expansion for the poller, and claude accepting a forward-slash `--settings`
-/// path on Windows. `scripts/dev/e2e/windows-vm.sh test` carries the probes;
-/// flip this to `true` only with that evidence. Closed = exactly the old strip
-/// behavior (the agent launches clean with no hooks, surfaced via
-/// `SessionInfo::hook_wiring`).
-pub(crate) fn psmux_hook_rewrite_supported() -> bool {
-    false
 }
 
 /// Where the local thurbox config root lands on `host`, or `None` when no

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -80,11 +80,16 @@ pub fn spawn_session_headless(db: &Database, req: SpawnRequest) -> Result<SpawnR
     // *local* absolute path (e.g. claude's hooks `--settings <config>/hooks/
     // claude.json`), which the agent errors on when the path doesn't exist on
     // the host ("Settings file not found" → the pane dies instantly). Rewrite
-    // them for the host: materialize the file remotely (translating a
+    // them for the host — materialize the file remotely (translating a
     // home-anchored path to the remote home) or, when that's impossible, strip
-    // the flag so the agent at least launches.
-    if let Some(h) = host.as_ref() {
-        agent_def.args = adapt_agent_args_for_remote(h, agent_def.args);
+    // the flag so the agent at least launches — and provision the agent's
+    // config-dir hook files on the host so it reports status remotely.
+    // Degradation is best-effort-logged (headless has no info panel).
+    let hooks_enabled = !db.builtin_hooks_opted_out().unwrap_or(false);
+    let (adapted, hook_degraded) = adapt_def_for_launch(agent_def, host.as_ref(), hooks_enabled);
+    agent_def = adapted;
+    if let Some(reason) = hook_degraded {
+        tracing::warn!("remote hook wiring degraded for '{}': {reason}", req.name);
     }
     let (primary_cwd, worktrees, additional_dirs) = resolve_dirs(&req, host.as_ref())?;
 
@@ -379,52 +384,166 @@ pub(crate) fn build_multi_repo_workspace(
 /// path in the agent's own args — a repo path, a user file — is never
 /// rewritten or shipped. Each shipped file also has its thurbox-managed hook
 /// commands rewritten for the host
-/// ([`super::builtin_hooks::rewrite_hook_signals_for_remote`]): the local
+/// ([`super::builtin_hooks::rewrite_hook_signals_for_target`]): the local
 /// `thurbox-cli session signal` can't work there, but a tmux pane user option
-/// can — the local TUI receives it over its control-mode subscription, so
-/// remote sessions get live hooks-driven status.
+/// can — the local TUI receives it over its control-mode subscription (tmux)
+/// or pane-option polling (psmux), so remote sessions get live hooks-driven
+/// status. The same rewrite maps over every **literal** arg too, so a hook
+/// command carried directly in the args (aider's
+/// `--notifications-command "thurbox-cli session signal --state blocked"`)
+/// also reports remotely instead of invoking a CLI that isn't there — it is
+/// marker-keyed and idempotent, so non-matching args pass through
+/// byte-identical.
 ///
 /// Shared by the headless spawn and the TUI (`App::build_spawn_inputs`) so
 /// both paths launch a remote session with the same args.
 pub(crate) fn adapt_agent_args_for_remote(host: &HostDef, args: Vec<String>) -> Vec<String> {
+    adapt_agent_args_for_remote_with_report(host, args).0
+}
+
+/// [`adapt_agent_args_for_remote`] plus the list of local config paths that
+/// were **stripped** (no remote location could hold them) — the caller
+/// surfaces those as a hook-wiring degradation, since a stripped hooks config
+/// means the session reports no status.
+pub(crate) fn adapt_agent_args_for_remote_with_report(
+    host: &HostDef,
+    args: Vec<String>,
+) -> (Vec<String>, Vec<String>) {
+    let target = super::builtin_hooks::remote_signal_target(host);
+    let rewrite_literals = |args: Vec<String>| -> Vec<String> {
+        args.into_iter()
+            .map(|a| super::builtin_hooks::rewrite_hook_signals_for_target(&a, &target))
+            .collect()
+    };
     let Some(config_root) = crate::paths::config_file()
         .and_then(|p| p.parent().map(|d| d.to_string_lossy().into_owned()))
     else {
-        return args;
+        return (rewrite_literals(args), Vec::new());
     };
     // Resolve the translation target lazily (one ssh round-trip) and at most
     // once; `None` = strip mode.
     let mut remote_root: Option<Option<String>> = None;
-    rewrite_config_path_args(args, &config_root, |local_path| {
-        let root = remote_root
-            .get_or_insert_with(|| remote_config_root(host, &config_root))
-            .clone()?;
-        let remote_path = format!("{root}{}", &local_path[config_root.len()..]);
-        // Read failure (missing/unreadable/non-file) → strip, as before.
-        let contents = std::fs::read_to_string(local_path).ok()?;
-        let contents = super::builtin_hooks::rewrite_hook_signals_for_remote(&contents);
-        match crate::git::copy_bytes_to_remote(host, contents.as_bytes(), &remote_path) {
-            Ok(()) => Some(remote_path),
-            Err(e) => {
-                tracing::warn!(
-                    "failed to materialize agent config {local_path} on host '{}': {e:#}",
-                    host.name
-                );
-                None
+    let mut stripped: Vec<String> = Vec::new();
+    let args = rewrite_config_path_args(args, &config_root, |local_path| {
+        let materialized = (|| {
+            let root = remote_root
+                .get_or_insert_with(|| remote_config_root(host, &config_root))
+                .clone()?;
+            let remote_path = format!("{root}{}", &local_path[config_root.len()..]);
+            // Read failure (missing/unreadable/non-file) → strip, as before.
+            let contents = std::fs::read_to_string(local_path).ok()?;
+            let contents =
+                super::builtin_hooks::rewrite_hook_signals_for_target(&contents, &target);
+            // A psmux host is native Windows — no `sh`/`cat` for the POSIX
+            // stream copy, so the payload goes via the PowerShell variant.
+            let copied = if host.mux() == "psmux" {
+                crate::git::copy_bytes_to_remote_windows(host, contents.as_bytes(), &remote_path)
+            } else {
+                crate::git::copy_bytes_to_remote(host, contents.as_bytes(), &remote_path)
+            };
+            match copied {
+                Ok(()) => Some(remote_path),
+                Err(e) => {
+                    tracing::warn!(
+                        "failed to materialize agent config {local_path} on host '{}': {e:#}",
+                        host.name
+                    );
+                    None
+                }
             }
+        })();
+        if materialized.is_none() {
+            stripped.push(local_path.to_string());
         }
-    })
+        materialized
+    });
+    (rewrite_literals(args), stripped)
+}
+
+/// Adapt an agent def for launch on an optional remote host: rewrite/ship its
+/// args ([`adapt_agent_args_for_remote_with_report`]) and provision the
+/// agent's config-dir hook files there
+/// ([`super::remote_hooks::provision_agent_hooks_on_host`]). Returns the
+/// adapted def plus a human-readable note when remote hooks-driven status
+/// will be degraded/absent. Performs ssh round-trips for a remote host — call
+/// on a worker, never the UI thread (ADR-P12). Identity for a local launch.
+pub(crate) fn adapt_def_for_launch(
+    mut def: crate::session::AgentDef,
+    host: Option<&HostDef>,
+    hooks_enabled: bool,
+) -> (
+    crate::session::AgentDef,
+    super::remote_hooks::HookDegradation,
+) {
+    let Some(h) = host else {
+        return (def, None);
+    };
+    let (args, stripped) = adapt_agent_args_for_remote_with_report(h, def.args);
+    def.args = args;
+    // A stripped config path outranks a provisioning note: it means the
+    // agent's own hooks file never reached the host at all.
+    let degraded = if stripped.is_empty() {
+        super::remote_hooks::provision_agent_hooks_on_host(h, &def.name, hooks_enabled)
+    } else {
+        Some(format!(
+            "hooks config stripped for host '{}' (no status): {}",
+            h.name,
+            stripped.join(", ")
+        ))
+    };
+    (def, degraded)
+}
+
+/// Whether hook configs may be shipped to (and their commands rewritten for) a
+/// **psmux** (native-Windows SSH) host. **Gate, currently closed**: the psmux
+/// path rests on behaviors not yet proven against psmux 3.3.6 — in-pane
+/// `set-option -p` without `-t` (no `$TMUX_PANE` guarantee), `#{@user_option}`
+/// expansion for the poller, and claude accepting a forward-slash `--settings`
+/// path on Windows. `scripts/dev/e2e/windows-vm.sh test` carries the probes;
+/// flip this to `true` only with that evidence. Closed = exactly the old strip
+/// behavior (the agent launches clean with no hooks, surfaced via
+/// `SessionInfo::hook_wiring`).
+pub(crate) fn psmux_hook_rewrite_supported() -> bool {
+    false
 }
 
 /// Where the local thurbox config root lands on `host`, or `None` when no
 /// remote location can hold it (→ strip the args instead):
-/// - a non-POSIX (Windows `C:\…`) local root or a `psmux` host can't take a
-///   POSIX copy at all;
+/// - a non-POSIX (Windows `C:\…`) local root can't take a POSIX copy at all;
+/// - a `psmux` (native-Windows) host maps onto
+///   `%USERPROFILE%/.config/<root-name>` — dev/release isolation carries over
+///   via the root's final component — but only once
+///   [`psmux_hook_rewrite_supported`] is flipped;
 /// - a home-anchored root translates onto the **remote** home (identity when
 ///   local and remote `$HOME` agree — the common same-user WSL/devbox case);
 /// - a root outside the local home is mirrored at the same absolute path.
 fn remote_config_root(host: &HostDef, config_root: &str) -> Option<String> {
-    if !config_root.starts_with('/') || host.mux() == "psmux" {
+    if host.mux() == "psmux" {
+        if !psmux_hook_rewrite_supported() {
+            tracing::warn!(
+                "stripping local agent-config args for host '{}': psmux hook rewrite \
+                 is not enabled",
+                host.name
+            );
+            return None;
+        }
+        let name = std::path::Path::new(config_root)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("thurbox");
+        return match crate::git::remote_home_windows(host) {
+            Ok(home) => Some(format!("{home}/.config/{name}")),
+            Err(e) => {
+                tracing::warn!(
+                    "stripping local agent-config args for host '{}': cannot resolve \
+                     Windows home: {e:#}",
+                    host.name
+                );
+                None
+            }
+        };
+    }
+    if !config_root.starts_with('/') {
         tracing::warn!(
             "stripping local agent-config args for host '{}': no POSIX path for the \
              thurbox config dir there",
@@ -634,6 +753,50 @@ mod tests {
             .map(String::from)
             .into();
         assert_eq!(adapt_agent_args_for_remote(&host, args.clone()), args);
+    }
+
+    #[test]
+    fn adapt_agent_args_rewrites_literal_signal_commands() {
+        // aider carries its hook as a literal arg (`--notifications-command
+        // "thurbox-cli session signal --state blocked"`), not a config-file
+        // path — the remote adaptation must rewrite it to the pane-option form
+        // or the host invokes a CLI that isn't there.
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+        let host = HostDef {
+            name: "devbox".into(),
+            destination: "user@devbox".into(),
+            ..Default::default()
+        };
+        let args: Vec<String> = [
+            "--notifications",
+            "--notifications-command",
+            "thurbox-cli session signal --state blocked",
+        ]
+        .map(String::from)
+        .into();
+        let out = adapt_agent_args_for_remote(&host, args.clone());
+        assert_eq!(
+            out,
+            [
+                "--notifications",
+                "--notifications-command",
+                "tmux set-option -p @thurbox_state blocked",
+            ]
+            .map(String::from)
+        );
+
+        // A psmux host gets the socket-explicit psmux form (psmux has no
+        // in-pane `$TMUX` socket resolution).
+        let psmux_host = HostDef {
+            name: "winbox".into(),
+            destination: "user@winbox".into(),
+            multiplexer: Some("psmux".into()),
+            socket: Some("tb".into()),
+            ..Default::default()
+        };
+        let out = adapt_agent_args_for_remote(&psmux_host, args);
+        assert_eq!(out[2], "psmux -L tb set-option -p @thurbox_state blocked");
     }
 
     #[test]

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -131,6 +131,17 @@ fn append_session_section<'a>(
             ),
         ]));
     }
+    // Hooks-driven status is degraded on this (remote) session — without this
+    // hint the dot just silently stays Idle and looks like an agent at rest.
+    if let Some(reason) = info.hook_wiring.as_deref() {
+        lines.push(Line::from(vec![
+            Span::styled("Hooks: ", Theme::label()),
+            Span::styled(
+                format!("degraded — {reason}"),
+                Style::default().fg(Theme::text_muted()),
+            ),
+        ]));
+    }
     // Live activity from the agent-emitted OSC terminal title.
     if let Some(activity) = info.agent_activity.as_deref() {
         lines.push(Line::from(vec![
@@ -623,6 +634,35 @@ fn format_tokens(count: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── append_session_section tests ──
+
+    #[test]
+    fn session_section_renders_hook_wiring_degradation() {
+        let mut info = SessionInfo::new("demo".into());
+        let mut lines = Vec::new();
+        append_session_section(&mut lines, &info, None);
+        let text = |lines: &[Line]| {
+            lines
+                .iter()
+                .map(|l| {
+                    l.spans
+                        .iter()
+                        .map(|s| s.content.as_ref())
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        // Healthy/local session: no Hooks row at all.
+        assert!(!text(&lines).contains("Hooks:"));
+
+        info.hook_wiring = Some("codex hooks not provisioned on psmux host 'win'".into());
+        let mut lines = Vec::new();
+        append_session_section(&mut lines, &info, None);
+        let rendered = text(&lines);
+        assert!(rendered.contains("Hooks: degraded — codex hooks not provisioned"));
+    }
 
     // ── human_bytes tests ──
 


### PR DESCRIPTION
## Summary
- Remote sessions now report hooks-driven status for **every** agent, not just claude: `session_ops::remote_hooks` provisions each config-dir agent's hook payload (codex, antigravity, opencode, vibe, copilot) onto the host at spawn time, with the local installer's safety rules — `requires_dir` probed over ssh, prune-then-merge for shared JSON (both `session signal` and `@thurbox_state` markers, so upgrades replace instead of accumulate), managed-marker guard for standalone files, compare-before-write, cached per `(backend, agent)`, best-effort (never fails a spawn).
- The remote signal rewrite now maps over **every launch arg**, fixing aider's literal `--notifications-command "thurbox-cli …"` silently no-oping on hosts.
- Mux-aware rewrite target: psmux hosts get a socket-explicit `psmux -L <socket> set-option -p @thurbox_state` form (psmux has no in-pane `$TMUX` socket resolution).
- psmux hosts get a **status channel**: psmux has no format subscriptions, so `ControlMode` runs a 1 s pane-option poller (`list-panes -F` diffed by the pure `diff_polled_hook_states`) feeding the same `sub_events` queue — everything downstream of `drain_remote_hook_events` is shared and unchanged. The poller (an active 1 Hz command, unlike the passive tmux subscription) arms only on **remote** psmux connections and only once the gate below is flipped — a local psmux (Windows) session signals via `thurbox-cli` directly and never sets the pane option.
- the whole psmux path — hook **shipping** and the **poller** — stays gated off on one switch (`session::psmux_hook_rewrite_supported()` = false) until `windows-vm.sh test`'s new probes prove the pane-user-option behavior against the pinned psmux; the Windows-copy helpers (`remote_home_windows`, base64 PowerShell file write) land ready behind the gate.
- **Status flows with the TUI closed too**: the live channels above die with the TUI's control-mode connection, so the headless `automation tick` (the 60 s heartbeat keeper) now polls each host that has live remote sessions (`remote_hooks::poll_remote_hook_states` — one-shot `list-panes -F`, allow-listed, diffed against the stored `hook_state`, so an acknowledged `done` is never resurrected and no new table is needed) and writes changes into the same columns; `session list`/`get` JSON now carries the raw `hook_state` so headless consumers can actually read it.
- **Degradation is visible**: stripped/failed hook wiring lands on `SessionInfo.hook_wiring` and renders as a `Hooks: degraded — <reason>` row in the info panel instead of only a log warn.
- Latent freeze fix: the interactive spawn's remote arg adaptation (ssh round-trips) moves off the UI thread into the spawn worker, alongside `ensure_backend_ready` (ADR-P12).

## Test plan
- `cargo nextest run --all` — 1848 pass, incl. new unit tests for the mux-aware rewrite, all-assets marker guard, merge idempotency/upgrade-safety, poll diff semantics, and the info-panel row
- `cargo clippy --all-targets --all-features -- -D warnings`, rustdoc, `cargo deny` (new direct dep `base64`, already in the tree transitively), architecture rules — all clean
- **Live e2e**: `scripts/dev/e2e/linux-container.sh test` (extended) — verified against a real sshd+tmux container: codex `hooks.json` lands rewritten in `~/.codex`, no `thurbox-cli` reference survives, byte-stable across a second spawn (cross-process merge idempotency), arg-carried config materializes rewritten, and the headless poll round-trips (pane option set in-pane-style → `automation tick` → `hook_state` in the CLI JSON; second tick a stable no-op) — PASS. The e2e sandbox now pins `THURBOX_CONFIG_DIR`/`THURBOX_DATA_DIR` so running it from inside a thurbox session can't leak onto the real config/DB
- `scripts/dev/e2e/windows-vm.sh test` gains gate-evidence probes A/B (pane user options in `list-panes -F`; id-less in-pane `set-option -p`) — not run here (needs KVM + Windows VM); the gate stays closed so no behavior depends on them yet

