### PR TITLE
feat(core): wire status hooks for custom agents via hook_schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -499,6 +499,22 @@ workspace, so `--last`/`--continue` finds no parent session (multi-repo
 A session stores only its **agent name**; there are no
 per-session model/permission/prompt/tool knobs.
 
+**Custom-agent status hooks (`hook_schema`).** thurbox stays agent-neutral, so
+the built-in **hooks** extension wires status hooks only for the built-ins it
+knows by name — a **custom** agent (e.g. a rebranded-claude `fleet`) gets no
+`--settings` patch and so never reports working/blocked/done. An optional
+`AgentDef.hook_schema: Option<String>` closes this: it names the hook **family**
+the CLI speaks, and `agent::extension_config::apply_agent_patches` (+ its
+uninstall reverse) fans each `[[agent_patches]]` out to the built-in named
+`patch.name` **and** every agent with `hook_schema == patch.name`. So
+`hook_schema = "claude"` on `fleet` injects the same `--settings {home}/
+claude.json` claude gets — and, because the remote rewrite
+(`session_ops::spawn::adapt_agent_args_for_remote`) keys off the `--settings`
+arg rather than the agent name, remote/WSL wiring follows for free. Only the
+per-arg-patch families (claude, aider) need it; codex/opencode/antigravity/vibe/
+copilot wire through their own config dir, so a rebrand sharing that dir already
+reports. thurbox bakes in no agent knowledge — the *user* asserts the family.
+
 ### Multi-repo sessions (symlink workspace)
 
 A session can span several repositories (the repo picker allows

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -111,6 +111,9 @@ resume_args = ["--resume", "{id}"]            # emitted when resuming
 fork_args = ["--resume", "{id}", "--fork-session"]
 new_session_args = ["--session-id", "{id}"]   # emitted on a fresh spawn
 resume_latest = false       # true = id-less "resume last session in cwd"
+# hook_schema = "claude"    # optional: name the hook FAMILY this CLI speaks so
+                            #   the built-in hooks extension wires its status
+                            #   hooks under this custom agent's name too
 ```
 
 `{id}` is substituted with the thurbox-generated session UUID. Groups
@@ -118,6 +121,16 @@ are emitted only when their driving value exists; precedence is
 fork > resume > new-session. See the seeded file's comments and
 CLAUDE.md's *Agent Definitions* section for the `resume_latest`
 semantics.
+
+`hook_schema` is optional. Custom agents are agent-neutral, so the built-in
+**hooks** extension normally wires status hooks only for the built-ins it knows
+by name. Set `hook_schema = "claude"` on a **rebranded** agent (one whose
+`command` runs `claude` under a different `name`) and it inherits claude's hook
+wiring — the `--settings` patch locally, and the same rewrite on a remote/WSL
+host. It names the *family* to imitate, not a boolean; today the useful value is
+`"claude"` (the only family wired via a per-agent arg patch — codex/opencode/
+antigravity/vibe/copilot are wired through their own config dir, so a rebrand
+sharing that dir already reports status).
 
 The seeded file also ships two commented, copy-pasteable templates
 below the built-ins — **Add your own agent** (every field annotated)

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -90,6 +90,29 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
   fail-open no-op. If a future `agy` changes the hook schema, edit
   `antigravity-hooks.json` (no code change).
 
+## Custom agents (`hook_schema`)
+
+The wiring above is keyed to the built-in agent **names**, so a **custom** agent
+you add to `agents.toml` (e.g. a rebranded-claude `fleet`) normally gets no
+hooks — its status dot stays driven only by the agent-neutral fallbacks (working
+inferred from output, done from output quiescence). To opt a custom agent into a
+known family, set `hook_schema` on its `[[agents]]` entry:
+
+```toml
+[[agents]]
+name = "fleet"
+command = "fleet"        # runs claude under the hood
+hook_schema = "claude"   # ⇒ inherit claude's --settings hook wiring
+```
+
+thurbox then applies the `claude` `[[agent_patches]]` to `fleet` as well, so it
+reports working/blocked/done exactly like `claude` (locally and on a remote/WSL
+host). `hook_schema` names the *family* to imitate; today `"claude"` is the
+useful value — it's the family wired via a per-agent arg patch. The
+config-dir-wired families (codex/opencode/antigravity/vibe/copilot) don't need
+it: a rebrand that runs the same CLI reads the same `~/.<agent>/…` hook file and
+already reports.
+
 ## Where the config lives
 
 The wiring is applied **only to agents thurbox launches** — it never edits your

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -106,6 +106,12 @@ command = "vibe"
 # new_session_args = []         # appended on a fresh spawn, with {id} substituted
 # resume_latest = false         # true ⇒ resume "the last session in this dir"
 #                               #   (id-less flags); leave false to pin by {id}
+# hook_schema = "claude"        # OPTIONAL: name the hook FAMILY this CLI speaks
+#                               #   so the built-in `hooks` extension wires its
+#                               #   status hooks as if this were that built-in.
+#                               #   A rebranded-claude CLI sets "claude" to get
+#                               #   claude's --settings hook wiring under its own
+#                               #   name. Omit if the agent has no known family.
 #
 # {id} is a thurbox-generated UUID. Only agents that accept it at creation
 # (like claude's `--session-id {id}`) can resume/fork by that exact id; for

--- a/src/agent/extension_config.rs
+++ b/src/agent/extension_config.rs
@@ -496,11 +496,14 @@ pub fn remove_agents_from_toml(names: &[String]) -> Result<Vec<String>, String> 
     Ok(removed)
 }
 
-/// Append each patch's `append_args` to the named existing agent's `args` in
+/// Append each patch's `append_args` to the matching agents' `args` in
 /// `agents.toml`, idempotently and preserving comments/formatting (toml_edit).
-/// Unlike [`ensure_agents_registered`] (which only adds *new* agents), this
-/// extends an agent the extension does not own (e.g. the built-in `claude`).
-/// Agents not present are skipped. Returns the names actually patched.
+/// A patch matches the agent literally named `patch.name` **and** every custom
+/// agent that declared `hook_schema = "<patch.name>"` — so a rebranded-claude
+/// agent picks up the same `--settings` wiring as the built-in `claude`. Unlike
+/// [`ensure_agents_registered`] (which only adds *new* agents), this extends
+/// agents the extension does not own. Agents not present are skipped. Returns
+/// the names actually patched (one entry per matched agent).
 pub fn apply_agent_patches(patches: &[AgentPatch]) -> Result<Vec<String>, String> {
     edit_agent_patches(patches, true)
 }
@@ -539,15 +542,34 @@ fn edit_agent_patches(patches: &[AgentPatch], add: bool) -> Result<Vec<String>, 
         if patch.append_args.is_empty() {
             continue;
         }
+        // A patch targets its named built-in agent AND every custom agent that
+        // declared `hook_schema = "<patch.name>"` — so a rebranded-claude agent
+        // gets the same `--settings` wiring. No `break`: fan out to all matches.
         for table in agents.iter_mut() {
-            if table.get("name").and_then(|v| v.as_str()) != Some(patch.name.as_str()) {
+            // Snapshot the identity fields into owned strings first: the args
+            // mutation below reborrows `table` mutably.
+            let agent_name = table
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let hook_schema = table
+                .get("hook_schema")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let matches = agent_name.as_deref() == Some(patch.name.as_str())
+                || hook_schema.as_deref() == Some(patch.name.as_str());
+            if !matches {
                 continue;
             }
+            // A hook_schema match with no `name` can't be patched — skip it.
+            let Some(agent_name) = agent_name else {
+                continue;
+            };
             if table.get("args").is_none() {
                 table["args"] = toml_edit::value(Array::new());
             }
             let Some(args) = table.get_mut("args").and_then(|i| i.as_array_mut()) else {
-                break;
+                continue;
             };
             let current: Vec<String> = args
                 .iter()
@@ -558,16 +580,15 @@ fn edit_agent_patches(patches: &[AgentPatch], add: bool) -> Result<Vec<String>, 
                 for a in &patch.append_args {
                     args.push(a.as_str());
                 }
-                changed.push(patch.name.clone());
+                changed.push(agent_name);
             } else if !add && present {
                 let mut arr = Array::new();
                 for a in remove_subsequence(&current, &patch.append_args) {
                     arr.push(a.as_str());
                 }
                 table["args"] = toml_edit::value(arr);
-                changed.push(patch.name.clone());
+                changed.push(agent_name);
             }
-            break;
         }
     }
 
@@ -863,6 +884,7 @@ mod tests {
             fork_args: vec![],
             new_session_args: vec![],
             resume_latest: false,
+            hook_schema: None,
         };
         // claude already exists in the seeded built-ins → not re-added.
         let claude = AgentDef {
@@ -895,6 +917,7 @@ mod tests {
             fork_args: vec![],
             new_session_args: vec![],
             resume_latest: false,
+            hook_schema: None,
         };
         ensure_agents_registered(&[flow]).unwrap();
         // Sanity: flow + the seeded built-ins are present.
@@ -962,6 +985,63 @@ mod tests {
             append_args: vec!["--x".into()],
         };
         assert!(apply_agent_patches(&[ghost]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn agent_patch_fans_out_to_hook_schema_family() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let _guard = crate::paths::TestPathGuard::new(temp.path());
+
+        // A custom rebranded-claude agent declaring it speaks the claude hook
+        // family. It should pick up the claude `--settings` patch too.
+        let fleet = AgentDef {
+            name: "fleet".into(),
+            command: "fleet".into(),
+            args: vec![],
+            resume_args: vec![],
+            fork_args: vec![],
+            new_session_args: vec![],
+            resume_latest: false,
+            hook_schema: Some("claude".into()),
+        };
+        ensure_agents_registered(&[fleet]).unwrap();
+
+        let patch = AgentPatch {
+            name: "claude".into(),
+            append_args: vec!["--settings".into(), "/x/hooks.json".into()],
+        };
+        let mut patched = apply_agent_patches(std::slice::from_ref(&patch)).unwrap();
+        patched.sort();
+        // The built-in `claude` and the family member `fleet` both get it.
+        assert_eq!(patched, ["claude", "fleet"]);
+
+        let reg = super::super::agent_config::load_or_seed();
+        for name in ["claude", "fleet"] {
+            let args = &reg.get(name).unwrap().args;
+            assert!(
+                args.windows(2)
+                    .any(|w| w == ["--settings".to_string(), "/x/hooks.json".to_string()]),
+                "{name} carries the injected flag: {args:?}"
+            );
+        }
+
+        // Idempotent across the family.
+        assert!(apply_agent_patches(std::slice::from_ref(&patch))
+            .unwrap()
+            .is_empty());
+
+        // Reverse strips it from every family member.
+        let mut removed = remove_agent_patches(std::slice::from_ref(&patch)).unwrap();
+        removed.sort();
+        assert_eq!(removed, ["claude", "fleet"]);
+        let reg = super::super::agent_config::load_or_seed();
+        for name in ["claude", "fleet"] {
+            assert!(!reg
+                .get(name)
+                .unwrap()
+                .args
+                .contains(&"--settings".to_string()));
+        }
     }
 
     #[test]

--- a/src/session/agent_def.rs
+++ b/src/session/agent_def.rs
@@ -49,6 +49,16 @@ pub struct AgentDef {
     /// (claude) leave this `false` and resume by a thurbox-known id instead.
     #[serde(default)]
     pub resume_latest: bool,
+    /// Names the hook *family* this CLI understands, letting the built-in
+    /// `hooks` extension wire status hooks for a **custom** agent as if it were
+    /// that built-in. A rebranded-claude agent sets `hook_schema = "claude"` so
+    /// the same `--settings` patch (and remote rewrite) that targets the
+    /// built-in `claude` also targets it. `None` = wire only if this agent's own
+    /// `name` matches a built-in family. thurbox bakes in no agent knowledge —
+    /// the *user* asserts the family here. See [`crate::agent::extension_config`]
+    /// (`apply_agent_patches`) and `extensions/hooks/`.
+    #[serde(default)]
+    pub hook_schema: Option<String>,
 }
 
 impl AgentDef {
@@ -152,6 +162,7 @@ mod tests {
             fork_args: vec!["--resume".into(), "{id}".into(), "--fork-session".into()],
             new_session_args: vec!["--session-id".into(), "{id}".into()],
             resume_latest: false,
+            hook_schema: None,
         }
     }
 
@@ -188,6 +199,7 @@ mod tests {
             fork_args: vec![],
             new_session_args: vec![],
             resume_latest: false,
+            hook_schema: None,
         };
         let args = d.build_args(None, None, Some("ignored"));
         assert_eq!(args, vec!["--quiet"]);
@@ -205,6 +217,7 @@ mod tests {
             fork_args: vec!["fork".into(), "--last".into()],
             new_session_args: vec![],
             resume_latest: true,
+            hook_schema: None,
         };
         // resume id present, but no {id} token -> tokens unchanged.
         assert_eq!(
@@ -229,6 +242,7 @@ mod tests {
             fork_args: vec![],
             new_session_args: vec![],
             resume_latest: true,
+            hook_schema: None,
         };
         // Flag set but no resume_args -> nothing to emit, so not "resumes latest".
         assert!(!d.resumes_latest());
@@ -253,6 +267,7 @@ mod tests {
                     fork_args: vec![],
                     new_session_args: vec![],
                     resume_latest: false,
+                    hook_schema: None,
                 },
             ],
         };

--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -539,6 +539,7 @@ prompt = "tick"
                 fork_args: vec![],
                 new_session_args: vec![],
                 resume_latest: false,
+                hook_schema: None,
             }],
             files: vec![ExtensionFile {
                 path: "FLOW.md".into(),


### PR DESCRIPTION
## Summary

- Custom agents (e.g. a rebranded-claude `fleet` in `agents.toml`) got **no lifecycle hooks**: the built-in `hooks` extension keys its `[[agent_patches]]` to the built-in agent **names**, so a custom agent never reported working/blocked/done — its dot was driven only by the agent-neutral fallbacks.
- Add an optional `AgentDef.hook_schema: Option<String>` naming the hook **family** a CLI speaks. `apply_agent_patches` (and its uninstall reverse) now fans each patch out to the built-in named `patch.name` **and** every agent with `hook_schema == patch.name`.
- So `fleet` with `hook_schema = "claude"` inherits claude's `--settings {home}/claude.json` wiring. The remote/WSL rewrite (`adapt_agent_args_for_remote`) keys off the `--settings` arg, not the agent name, so it follows for free.
- Scope boundary: only the per-arg-patch families (claude, aider) need it; codex/opencode/antigravity/vibe/copilot wire through their own config dir, so a rebrand sharing that dir already reports.
- Docs: seed `agents.toml` template, `docs/CONFIG.md`, CLAUDE.md *Agent Definitions*, and `extensions/hooks/README.md`.

## Test plan

- `agent_patch_fans_out_to_hook_schema_family` — a custom agent with `hook_schema = "claude"` gets the patch alongside `claude`, idempotently, and the reverse strips it from every family member.
- Existing agent/extension/config/architecture tests pass; `serde_ignored` recognizes the new field so `config validate` won't flag it.
- Build, clippy, `cargo doc -D warnings`, rumdl all clean.