### PR TITLE
feat(ui): show thurbox data-folder size in the info panel

### DIFF
--- a/src/app/metrics_state.rs
+++ b/src/app/metrics_state.rs
@@ -248,6 +248,12 @@ pub(crate) struct MetricsState {
     pub(crate) sys: Option<sysinfo::System>,
     /// Cached system metrics for the info panel.
     pub(crate) system_metrics: info_panel::SystemMetrics,
+    /// thurbox's on-disk data-directory size (`~/.local/share/thurbox`) in
+    /// bytes, `None` until the first background scan completes. Kept separate
+    /// from [`system_metrics`](Self::system_metrics) because the ~1 s metrics
+    /// refresh replaces that struct wholesale, whereas the folder scan runs on a
+    /// far slower cadence and must survive between scans.
+    pub(crate) thurbox_dir_bytes: Option<u64>,
     /// Deterministic render/tick performance counters (perf regression tests).
     pub(crate) perf: PerfCounters,
     /// Wall-clock timing stats (frame/tick histograms + slow-op ring),
@@ -267,6 +273,7 @@ impl MetricsState {
                 session_cpu_percent: 0.0,
                 session_memory_bytes: 0,
             },
+            thurbox_dir_bytes: None,
             perf: PerfCounters::default(),
             timings: PerfTimings::default(),
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -19,7 +19,7 @@ mod tasks;
 mod view;
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Arc};
 
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -106,6 +106,13 @@ const GIT_REFRESH_TICKS: u64 = 500;
 /// Ticks (~10 ms each) between config-file mtime polls (~1 s). Cheap: two
 /// `stat` calls per poll.
 const CONFIG_RELOAD_TICKS: u64 = 100;
+
+/// How often to recompute thurbox's on-disk data-directory size (in ticks). At
+/// ~10 ms per tick, 6000 ≈ 60 s. Walking the whole data tree (worktrees,
+/// workspaces, db, logs) is the most expensive periodic disk read and the size
+/// drifts slowly, so it runs far less often than the other metrics — fired once
+/// early, then once a minute.
+const DISK_USAGE_REFRESH_TICKS: u64 = 6_000;
 
 /// How often to refresh account usage / rate-limits (in ticks). At ~10ms per
 /// tick, 30000 ≈ 5 minutes. Usage windows are coarse and fetching hits the
@@ -510,6 +517,36 @@ fn aggregate_git_stats(paths: &[PathBuf]) -> Option<crate::session::GitStats> {
     agg
 }
 
+/// Sum the size of every regular file under `root`, iteratively (an explicit
+/// stack, so a deeply nested worktree can't blow the call stack). Runs off the
+/// UI thread; best-effort — unreadable entries are skipped rather than erroring,
+/// and symlinks are not followed (via `symlink_metadata`) so a multi-repo
+/// symlink workspace isn't double-counted against its worktree.
+fn directory_size(root: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            // symlink_metadata: don't follow links, so workspace symlinks add
+            // their own (tiny) size, not the whole linked worktree again.
+            let Ok(meta) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            let file_type = meta.file_type();
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if file_type.is_file() {
+                total = total.saturating_add(meta.len());
+            }
+        }
+    }
+    total
+}
+
 /// Parse agent metrics from a Claude CLI statusline JSON value.
 fn parse_agent_metrics(raw: &serde_json::Value) -> crate::session::AgentMetrics {
     use crate::session::AgentMetrics;
@@ -829,6 +866,11 @@ pub struct App {
     metrics_refresh: background::BackgroundTask<MetricsRefresh>,
     /// Background active-session git-stats refresh, polled each tick.
     git_stats: background::BackgroundTask<(SessionId, Option<crate::session::GitStats>)>,
+    /// Background scan of thurbox's data-directory size (bytes), polled each
+    /// tick. Walks the whole tree off the UI thread on a slow cadence
+    /// ([`DISK_USAGE_REFRESH_TICKS`]); the result lands in
+    /// `metrics.thurbox_dir_bytes` for the info panel.
+    disk_usage: background::BackgroundTask<u64>,
     /// Cached update-check result, rendered as the header "update available"
     /// badge. `Some` only when `[features] version_check` is on and a newer
     /// release is known (from the on-disk cache). Read off the network — see
@@ -1184,6 +1226,7 @@ impl App {
             metrics: metrics_state::MetricsState::new(),
             metrics_refresh: background::BackgroundTask::default(),
             git_stats: background::BackgroundTask::default(),
+            disk_usage: background::BackgroundTask::default(),
             // Seed the badge from the cache (no network); refreshed on first
             // tick if the flag is on and the cache is stale.
             update_status: if crate::session::settings::global().features.version_check {
@@ -4647,12 +4690,21 @@ impl App {
     fn tick_background_refreshes(&mut self) {
         self.poll_metrics_refresh();
         self.poll_git_stats();
+        self.poll_disk_usage();
 
         if self.metrics.tick_count % METRICS_REFRESH_TICKS == 0 {
             self.start_metrics_refresh();
         }
         if self.metrics.tick_count % GIT_REFRESH_TICKS == 0 {
             self.start_git_stats_refresh();
+        }
+        // Fire ~1 s after startup, then once a minute (folder size is slow to
+        // walk and slow to change). Offset by the metrics cadence rather than
+        // firing at tick 1 so this shares the metrics refresh's contract that a
+        // background spawn never lands on the first ticks a runtime-less unit
+        // `tick()` drives (`spawn_blocking` would panic without a reactor).
+        if self.metrics.tick_count % DISK_USAGE_REFRESH_TICKS == METRICS_REFRESH_TICKS {
+            self.start_disk_usage_refresh();
         }
         if self.metrics.tick_count % CONFIG_RELOAD_TICKS == 0 {
             self.poll_config_reload();
@@ -5151,6 +5203,33 @@ impl App {
             if let Some(session) = self.sessions.iter_mut().find(|s| s.info.id == session_id) {
                 session.info.git_stats = stats;
             }
+        }
+    }
+
+    /// Kick off a background scan of thurbox's data-directory size.
+    ///
+    /// Resolves the data dir on the UI thread (cheap) and walks the whole tree
+    /// on a blocking task; the byte count is applied in [`Self::poll_disk_usage`].
+    /// Only one scan runs at a time.
+    fn start_disk_usage_refresh(&mut self) {
+        if self.disk_usage.in_progress() {
+            return;
+        }
+        let Some(dir) = crate::paths::log_directory() else {
+            return;
+        };
+        let tx = self.disk_usage.start();
+        tokio::task::spawn_blocking(move || {
+            let _ = tx.send(directory_size(&dir));
+        });
+    }
+
+    /// Apply a completed background disk-usage scan, if one has finished.
+    fn poll_disk_usage(&mut self) {
+        // A dead worker (e.g. panic) just clears the guard so the next
+        // cadence can retry; the last measured value stays on screen.
+        if let background::TaskPoll::Done(bytes) = self.disk_usage.poll() {
+            self.metrics.thurbox_dir_bytes = Some(bytes);
         }
     }
 
@@ -12266,6 +12345,50 @@ mod tests {
         app.poll_git_stats();
 
         assert!(app.git_stats.in_progress());
+    }
+
+    #[test]
+    fn poll_disk_usage_applies_byte_count() {
+        let mut app = app_with_sessions(1);
+        assert_eq!(app.metrics.thurbox_dir_bytes, None);
+
+        let tx = app.disk_usage.start();
+        tx.send(4_096).unwrap();
+        app.poll_disk_usage();
+
+        assert_eq!(app.metrics.thurbox_dir_bytes, Some(4_096));
+        assert!(!app.disk_usage.in_progress());
+    }
+
+    #[test]
+    fn poll_disk_usage_disconnected_keeps_last_value() {
+        let mut app = app_with_sessions(1);
+        app.metrics.thurbox_dir_bytes = Some(1_000);
+        drop(app.disk_usage.start()); // worker died without delivering
+
+        app.poll_disk_usage();
+
+        // A dead scan clears the guard but leaves the last measurement visible.
+        assert_eq!(app.metrics.thurbox_dir_bytes, Some(1_000));
+        assert!(!app.disk_usage.in_progress());
+    }
+
+    #[test]
+    fn directory_size_sums_nested_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), vec![0u8; 100]).unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(sub.join("b.txt"), vec![0u8; 50]).unwrap();
+
+        assert_eq!(directory_size(dir.path()), 150);
+    }
+
+    #[test]
+    fn directory_size_missing_dir_is_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        assert_eq!(directory_size(&missing), 0);
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -433,6 +433,7 @@ impl App {
             &automation_entries,
             agent_usage,
             parent_name.as_deref(),
+            self.metrics.thurbox_dir_bytes,
         );
     }
 

--- a/src/ui/info_panel.rs
+++ b/src/ui/info_panel.rs
@@ -29,6 +29,7 @@ pub struct SystemMetrics {
     pub session_memory_bytes: u64,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn render_info_panel(
     frame: &mut Frame,
     area: Rect,
@@ -37,6 +38,7 @@ pub fn render_info_panel(
     automations: &[AutomationEntry],
     usage: Option<&crate::session::AgentUsage>,
     parent_name: Option<&str>,
+    thurbox_dir_bytes: Option<u64>,
 ) {
     let block = Block::default()
         .title(" Info ")
@@ -71,7 +73,7 @@ pub fn render_info_panel(
     }
 
     if let Some(m) = metrics {
-        append_system_section(&mut lines, m, inner_width);
+        append_system_section(&mut lines, m, thurbox_dir_bytes, inner_width);
     }
 
     append_automations_section(&mut lines, automations, inner_width);
@@ -180,8 +182,15 @@ fn append_session_resources(lines: &mut Vec<Line<'_>>, m: &SystemMetrics, inner_
     }
 }
 
-/// Append the System Resources section (global CPU/RAM gauges).
-fn append_system_section(lines: &mut Vec<Line<'_>>, m: &SystemMetrics, inner_width: usize) {
+/// Append the System Resources section (global CPU/RAM gauges), plus thurbox's
+/// own on-disk footprint (`~/.local/share/thurbox`) when it has been measured —
+/// a heads-up when accumulated worktrees/workspaces have grown the data dir.
+fn append_system_section(
+    lines: &mut Vec<Line<'_>>,
+    m: &SystemMetrics,
+    thurbox_dir_bytes: Option<u64>,
+    inner_width: usize,
+) {
     lines.push(separator(inner_width));
     lines.push(Line::from(Span::styled("System", Theme::section_header())));
 
@@ -199,6 +208,16 @@ fn append_system_section(lines: &mut Vec<Line<'_>>, m: &SystemMetrics, inner_wid
         inner_width,
     );
     lines.extend(ram_lines);
+
+    if let Some(bytes) = thurbox_dir_bytes {
+        lines.push(Line::from(vec![
+            Span::styled("Disk", Style::default().fg(Theme::text_muted())),
+            Span::styled(
+                format!("  {} (thurbox dir)", format_bytes(bytes)),
+                Style::default().fg(Theme::text_primary()),
+            ),
+        ]));
+    }
 }
 
 /// Append the upcoming-automations section (skipped when there are none).
@@ -662,6 +681,47 @@ mod tests {
         append_session_section(&mut lines, &info, None);
         let rendered = text(&lines);
         assert!(rendered.contains("Hooks: degraded — codex hooks not provisioned"));
+    }
+
+    // ── append_system_section tests ──
+
+    fn render_system(m: &SystemMetrics, thurbox_dir_bytes: Option<u64>) -> String {
+        let mut lines: Vec<Line> = Vec::new();
+        append_system_section(&mut lines, m, thurbox_dir_bytes, 24);
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn sample_metrics() -> SystemMetrics {
+        SystemMetrics {
+            cpu_percent: 10.0,
+            memory_used: 8_589_934_592,
+            memory_total: 17_179_869_184,
+            session_cpu_percent: 0.0,
+            session_memory_bytes: 0,
+        }
+    }
+
+    #[test]
+    fn system_section_shows_thurbox_dir_size_when_measured() {
+        let out = render_system(&sample_metrics(), Some(524_288_000));
+        assert!(out.contains("Disk"));
+        assert!(out.contains("500.0 MB"));
+        assert!(out.contains("thurbox dir"));
+    }
+
+    #[test]
+    fn system_section_omits_disk_line_before_first_scan() {
+        let out = render_system(&sample_metrics(), None);
+        assert!(!out.contains("thurbox dir"));
     }
 
     // ── human_bytes tests ──


### PR DESCRIPTION
## Summary

- Adds a **`Disk … (thurbox dir)`** line to the info panel's **System** section, reporting the on-disk size of `~/.local/share/thurbox`. With many accumulated worktrees/workspaces the data dir can grow large, and this makes that visible at a glance.
- The size is computed by an iterative (stack-based) tree walk that sums regular-file sizes and does **not** follow symlinks (`symlink_metadata`), so multi-repo symlink workspaces aren't double-counted against their worktrees.
- The walk is the most expensive periodic disk read, so it runs **off the UI thread** via a dedicated `BackgroundTask<u64>` on a slow ~60 s cadence (mirroring the git-stats refresh), first firing ~1 s after startup. Its result is cached separately from the ~1 s `SystemMetrics` (which is replaced wholesale each refresh) so it survives between scans and stays on screen if a scan worker dies.

## Test plan

- `cargo nextest run` — full suite green via pre-commit hook.
- New unit tests: `directory_size` sums nested files / returns 0 for a missing dir; `poll_disk_usage` applies the byte count and preserves the last value on a dead worker; the System section renders the `Disk` line when measured and omits it before the first scan.
- Verified the pre-existing `tick_increments_tick_count` (runtime-less `#[test]`) still passes — the scan's first fire is offset to the metrics-cadence tick so a `spawn_blocking` never lands on the first ticks a runtime-less `tick()` drives.
- `cargo clippy --all-features` and `cargo fmt --check` clean.