### PR TITLE
Add opencode project support

### DIFF
--- a/.opencode/commands/refactor.md
+++ b/.opencode/commands/refactor.md
@@ -1,0 +1,132 @@
+---
+description: Multi-pass refactor (structure, coherence, tests) of newly implemented code.
+agent: build
+---
+
+# Refactor
+
+Perform a multi-pass refactoring of the newly implemented
+code in this project. You MUST execute 3 independent review
+passes, re-reading the code from scratch each time to catch
+incoherences that a single pass would miss.
+
+---
+
+## Pre-work
+
+**Identify recent changes**: Look at recently modified files
+(use git diff or git log) to find newly implemented code.
+Establish the list of files to review.
+
+---
+
+## Pass 1 — Structure & Clean Code
+
+Re-read all identified files from disk, then:
+
+1. **Apply Clean Code principles**:
+   - Use clear, intention-revealing names for variables,
+     functions, and classes.
+   - Keep functions small — each should do one thing well
+     (Single Responsibility).
+   - Eliminate duplication (DRY).
+   - Remove dead code, unused imports, and unnecessary
+     comments.
+   - Replace magic numbers/strings with named constants.
+
+2. **Keep It Simple (KISS)**:
+   - Prefer straightforward logic over clever tricks.
+   - Reduce nesting — use early returns and guard clauses.
+   - Avoid premature abstractions — only extract when there
+     is real duplication.
+   - Minimize function arguments; group related parameters
+     into objects if needed.
+
+3. **Improve readability**:
+   - Ensure consistent formatting and code style with the
+     rest of the project.
+   - Structure code so it reads top-down.
+   - **Optimize comments aggressively** (full rubric: the
+     "Comments" section in `CLAUDE.md`). Let the code be
+     self-documenting: keep only comments that convey "why" /
+     rationale / non-obvious constraints / cross-references
+     (`ADR-*`, `schema vNN`, `see fn_x`). Cut restatements,
+     obvious trailing labels (`// list`, `// EOF`), and obvious
+     test-step narration — if an LLM could infer it from the
+     code, delete it. Tighten verbose doc comments, but never
+     delete a public doc that carries intra-doc links or
+     examples.
+
+Apply fixes, then summarize what was changed in Pass 1.
+
+---
+
+## Pass 2 — Coherence & Consistency
+
+Re-read ALL the same files again from disk (fresh read, do
+not rely on memory from Pass 1), then:
+
+1. **Cross-file coherence**: Check that naming conventions,
+   patterns, and abstractions are consistent across all
+   changed files and with the rest of the project.
+2. **API & contract consistency**: Verify that function
+   signatures, return types, error handling, and data shapes
+   are coherent between callers and callees.
+3. **Logic review**: Look for contradictory logic, redundant
+   conditions, unreachable branches, or mismatched
+   assumptions between modules.
+4. **Comment accuracy**: Re-read every comment in the changed
+   files against the code it describes. Any comment that
+   describes a prior implementation, a wrong signature, or
+   behavior the code no longer has must be rewritten to match
+   or deleted. A stale comment is worse than none — it
+   anchors readers (and LLM agents) on the wrong intent.
+5. **Import & dependency hygiene**: Ensure no circular
+   dependencies, unused imports, or misplaced
+   responsibilities were introduced.
+
+Apply fixes, then summarize what was changed in Pass 2.
+
+---
+
+## Pass 3 — Tests & Final Validation
+
+Re-read ALL the same files again from disk (fresh read, do
+not rely on memory from previous passes), then:
+
+1. **Add or improve tests**:
+   - Identify the existing test framework and patterns used
+     in the project.
+   - Add unit tests for individual functions and methods
+     that were changed or created.
+   - Add integration tests where components interact with
+     each other.
+   - Add e2e tests if the project already has an e2e test
+     setup and the changes affect user-facing flows.
+   - Follow the existing test conventions (naming,
+     structure, assertions).
+   - Ensure tests cover both happy paths and edge cases.
+
+2. **Final coherence check**: With tests written, re-examine
+   whether the code under test reveals any remaining
+   incoherence, naming mismatch, or logic flaw. Fix
+   anything found.
+
+3. **Run tests**: Execute the test suite to confirm
+   everything passes.
+
+Apply fixes, then summarize what was changed in Pass 3.
+
+---
+
+## Final Summary
+
+Present a consolidated report:
+
+- **Pass 1** changes (structure & clean code)
+- **Pass 2** changes (coherence & consistency)
+- **Pass 3** changes (tests & validation)
+- Total number of issues found and fixed across all passes
+
+Do NOT change external behavior or add new features. This is
+a pure refactoring and test coverage pass.

--- a/.opencode/commands/ship.md
+++ b/.opencode/commands/ship.md
@@ -1,0 +1,89 @@
+---
+description: Commit, rebase, push, and open/auto-merge a PR for the current branch.
+agent: build
+---
+
+# Ship
+
+Ship the current branch: commit (or amend), sync with
+remote, push, and create/update a PR. Be efficient — batch
+commands together, run independent commands in parallel, and
+do NOT deliberate or explore. Just execute.
+
+---
+
+## Step 1 — Gather state (single parallel batch)
+
+Run ALL of these commands in parallel in a single tool-call
+round:
+
+- `git status --porcelain`
+- `git diff --stat && git diff --cached --stat`
+- `git log --oneline -5`
+- `git remote show origin | grep 'HEAD branch' | awk '{print $NF}'`
+- `git branch --show-current`
+
+From the results, determine: `DEFAULT_BRANCH`,
+`CURRENT_BRANCH`, whether there are uncommitted changes, and
+whether you're on the default branch. If on the default
+branch, STOP and warn: "You're on the default branch. Create
+a feature branch first."
+
+---
+
+## Step 2 — Commit or amend (skip if no changes)
+
+If there are changes:
+
+1. Run `git add` for all relevant files (skip `.env`,
+   credentials, large binaries) AND
+   `git merge-base --is-ancestor HEAD origin/<DEFAULT_BRANCH>`
+   in parallel.
+2. Based on the merge-base result:
+   - Exit code 0 (HEAD is on default branch) → create a
+     **new** conventional commit.
+   - Exit code 1 (HEAD is local-only) → **amend** with
+     `git commit --amend`.
+3. Use conventional commit format. Infer type and scope from
+   the diff. Do not ask — just pick the best fit.
+
+---
+
+## Step 3 — Sync, push, and check PR (single batch)
+
+Run these sequentially in a single chained command:
+
+```bash
+git fetch origin && git rebase origin/<DEFAULT_BRANCH>
+```
+
+If rebase conflicts occur, STOP and show conflicting files.
+Otherwise, immediately run in parallel:
+
+- `git push --force-with-lease origin HEAD`
+- `gh pr view --json url,title,state 2>/dev/null`
+
+---
+
+## Step 4 — PR + auto-merge
+
+Based on the `gh pr view` result from Step 3:
+
+- **PR exists**: Run `gh pr merge --auto --rebase` and print
+  the PR URL.
+- **No PR**: Run `gh pr create` targeting the default branch
+  with a concise title (<70 chars) and a body with
+  `## Summary` (bullet points) and `## Test plan` sections.
+  Then immediately run `gh pr merge --auto --rebase`.
+
+---
+
+## Final Output
+
+Print a short summary (no more than 5 lines):
+
+- Commit: new or amended, with the message
+- Rebase: clean or skipped
+- Push: done
+- PR: URL
+- Auto-merge: enabled

--- a/.opencode/commands/sync.md
+++ b/.opencode/commands/sync.md
@@ -1,0 +1,31 @@
+---
+description: Rebase the current branch onto the remote default branch.
+agent: build
+---
+
+# Sync
+
+Sync the current branch with the remote default branch. Be
+efficient — do not deliberate, just execute.
+
+## Execute
+
+Run these two commands in parallel:
+
+- `git fetch origin`
+- `git remote show origin | grep 'HEAD branch' | awk '{print $NF}'`
+
+Then rebase onto the default branch:
+
+```bash
+git rebase origin/<DEFAULT_BRANCH>
+```
+
+If conflicts occur, STOP and show the conflicting files. Ask
+the user how to proceed.
+
+## Output
+
+Print one line:
+`Rebased on origin/<DEFAULT_BRANCH> — up to date.`
+or the conflict details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,25 @@ sandbox for trying thurbox in isolation — lives in
 | `just arch` | architecture-rule + rustdoc checks |
 | `just sandbox` | run thurbox in an isolated dev sandbox |
 
+## Coding agents
+
+Thurbox is agent-neutral, so the repo works with any coding-agent CLI.
+[`CLAUDE.md`](CLAUDE.md) is the canonical guidance doc — Claude Code reads it
+directly, and [opencode](https://opencode.ai) loads it automatically as project
+rules via its Claude-Code compatibility (it's picked up when no `AGENTS.md`
+exists, so there's deliberately no `AGENTS.md` duplicating it).
+
+Slash-command workflows and skills are checked in for both:
+
+| Kind | Claude Code | opencode | Notes |
+|------|-------------|----------|-------|
+| Commands (`/refactor`, `/ship`, `/sync`) | `.claude/commands/` | `.opencode/commands/` | opencode does **not** auto-discover `.claude/commands/`, so the two are kept in sync by hand |
+| Skills (`publish`, `ui-review`) | `.claude/skills/` | `.claude/skills/` | opencode auto-discovers `.claude/skills/`, so one copy serves both — don't mirror them under `.opencode/skills/` (it would double-register) |
+
+A minimal [`opencode.json`](opencode.json) declares the `$schema` for editor
+validation. When you add or change a command, update **both** directories so the
+two agents stay in sync.
+
 ## Testing
 
 Thurbox follows **test-driven development** — write a failing test first, make

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://opencode.ai/config.json"
+}


### PR DESCRIPTION
## Summary

- Port the `refactor`/`ship`/`sync` slash commands to `.opencode/commands/` — opencode does **not** auto-discover `.claude/commands/`, so these are the one piece that needed porting. Bodies are kept in sync with the `.claude/commands/` originals.
- Add a minimal `opencode.json` (`$schema` only) as an explicit support marker and to enable editor validation.
- Document the coding-agent layout in `CONTRIBUTING.md` (a new "Coding agents" section).

opencode already loads `CLAUDE.md` as project rules via its Claude-Code compatibility fallback (so there is deliberately no `AGENTS.md` duplicating it) and auto-discovers `.claude/skills/`, meaning the `publish` and `ui-review` skills already work for opencode with zero duplication — they are intentionally **not** mirrored under `.opencode/skills/` (that would double-register them).

## Test plan

- [x] `rumdl check` passes on all new/changed markdown.
- [x] `opencode.json` is valid JSON (`$schema` only; every field optional per the opencode schema).
- [x] Verified the existing skills (`publish`, `ui-review`) are opencode-discoverable: frontmatter has `name`+`description`, `name` matches the directory, unknown Claude fields (`user-invocable`/`allowed-tools`) are ignored by opencode.
- [x] Command bodies match the `.claude/commands/` originals (diffed; only the mandatory post-frontmatter blank line differs).
- [x] Pre-commit hooks passed (markdown lint + conventional-commit verification).