### PR TITLE
Add pi.dev as a built-in agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,7 +437,7 @@ Enforced by cocogitto via pre-commit hooks.
 
 The set of launchable coding agents is declared **as data** in
 `~/.config/thurbox/agents.toml`, seeded with built-ins
-(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`) on first run.
+(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`, `pi`) on first run.
 Each `[[agents]]` entry is an `AgentDef`:
 
 ```toml
@@ -468,8 +468,8 @@ live tmux process is what carries state across TUI restarts). Add
 your own `[[agents]]` entry to support any CLI — no recompile.
 
 **Session id pinning vs. `resume_latest`.** thurbox generates the
-`agent_session_id` (a UUID) and only `claude` accepts it at creation
-(`--session-id {id}`), so only claude can resume/fork by that exact id.
+`agent_session_id` (a UUID) and `claude`/`pi` accept it at creation
+(`--session-id {id}`), so only those two can resume/fork by that exact id.
 The other built-ins (`codex`, `opencode`, `antigravity`, `aider`, `copilot`)
 can't pin or report their id, so they set `resume_latest = true` with
 **id-less** resume/fork flags (no `{id}` token): the agent resolves "the last

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -630,7 +630,7 @@ trivially testable. Composite styles (e.g., `focused_title()`) are
 at creation time; each agent runs with its own default config.
 Agents are described as **data** in `~/.config/thurbox/agents.toml`
 (sibling of any other config), seeded with built-ins (claude,
-codex, antigravity, opencode, aider, copilot, vibe) on first run via
+codex, antigravity, opencode, aider, copilot, vibe, pi) on first run via
 `agent::agent_config::load_or_seed`. An `AgentDef` carries a
 `command`, `args` (always passed — bake in flags like a model
 here if you want), and argument-template groups (`resume_args`,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -93,7 +93,7 @@ way), making it usable as a dotfiles CI gate.
 ## agents.toml
 
 Declares the launchable coding agents. Seeded with the built-ins
-(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`) on
+(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`, `pi`) on
 first run; edit or add `[[agents]]` entries to support any CLI — no
 recompile. A malformed `[[agents]]` entry is skipped (with a toast
 naming it) and the rest still load; only a document-level syntax error

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -272,7 +272,7 @@ from accumulating stale entries.
 
 The set of available agents is **data**, not code. On first run
 Thurbox seeds `~/.config/thurbox/agents.toml` with built-in
-definitions for claude, codex, antigravity, opencode, aider, and vibe
+definitions for claude, codex, antigravity, opencode, aider, vibe, and pi
 (`agent::agent_config::load_or_seed`). Editing the file — adding an
 `[[agents]]` entry or tweaking an existing one — extends the agent
 picker with no recompile.

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -13,9 +13,10 @@ use crate::session::{AgentDef, AgentRegistry};
 /// Built-in agent definitions, also used to seed `agents.toml` on first run.
 ///
 /// Kept deliberately small per agent: just the command, plus resume/fork/
-/// session-id groups. `claude` pins a thurbox-generated id (`--session-id`) so
-/// it can resume/fork by that exact id. The other built-ins can't pin or report
-/// their session id, so they use `resume_latest = true` with id-less,
+/// session-id groups. `claude` and `pi` pin a thurbox-generated id
+/// (`--session-id`) so they can resume/fork by that exact id. The other
+/// built-ins can't pin or report their session id, so they use
+/// `resume_latest = true` with id-less,
 /// cwd-scoped flags (`codex resume --last`, `opencode --continue`, …): the agent
 /// resolves "the last session in this directory" itself. Agents without any
 /// resume group simply start fresh on restart. No model is passed — each agent
@@ -89,6 +90,16 @@ resume_latest = true
 name = "vibe"
 command = "vibe"
 
+# pi (the pi.dev CLI) accepts a thurbox-generated session id at creation
+# (`--session-id`), so — like claude — it resumes/forks by that exact id.
+# Sessions live under ~/.pi/agent/, organized by working directory.
+[[agents]]
+name = "pi"
+command = "pi"
+resume_args = ["--session-id", "{id}"]
+fork_args = ["--fork", "{id}"]
+new_session_args = ["--session-id", "{id}"]
+
 # ──────────────────────────────────────────────────────────────────────────
 # Add your own agent (uncomment and edit)
 # ──────────────────────────────────────────────────────────────────────────
@@ -114,8 +125,8 @@ command = "vibe"
 #                               #   name. Omit if the agent has no known family.
 #
 # {id} is a thurbox-generated UUID. Only agents that accept it at creation
-# (like claude's `--session-id {id}`) can resume/fork by that exact id; for
-# everything else use `resume_latest = true` with id-less, cwd-scoped flags
+# (claude and pi both take `--session-id {id}`) can resume/fork by that exact
+# id; for everything else use `resume_latest = true` with id-less, cwd-scoped flags
 # (e.g. `["resume", "--last"]`). Omit every resume group to start fresh on
 # restart.
 #
@@ -370,12 +381,21 @@ mod tests {
         assert!(reg.get("aider").is_some());
         assert!(reg.get("copilot").is_some());
         assert!(reg.get("vibe").is_some());
+        assert!(reg.get("pi").is_some());
 
         // Claude pins a thurbox id and resumes/forks by it.
         let claude = reg.get("claude").unwrap();
         assert!(!claude.resume_args.is_empty());
         assert!(!claude.resume_latest);
         assert!(claude.resume_args.iter().any(|t| t.contains("{id}")));
+
+        // pi pins the same way (new_session + resume via --session-id, fork
+        // via --fork), so it is NOT a resume_latest / id-less agent.
+        let pi = reg.get("pi").unwrap();
+        assert!(!pi.resume_latest);
+        assert_eq!(pi.new_session_args, ["--session-id", "{id}"]);
+        assert_eq!(pi.resume_args, ["--session-id", "{id}"]);
+        assert_eq!(pi.fork_args, ["--fork", "{id}"]);
 
         // codex/opencode resume + fork via id-less, cwd-scoped flags.
         let codex = reg.get("codex").unwrap();
@@ -411,7 +431,7 @@ mod tests {
 
     /// The seed must carry copy-pasteable examples (add-your-own-agent +
     /// pin-a-model) but keep them commented, so parsing still yields exactly
-    /// the seven built-ins — a fresh install boots on pure defaults.
+    /// the eight built-ins — a fresh install boots on pure defaults.
     #[test]
     fn seed_documents_examples_yet_stays_builtin_only() {
         for marker in [
@@ -428,7 +448,7 @@ mod tests {
         // Examples are commented, so the seed parses to just the built-ins.
         let reg = builtin_registry();
         assert_eq!(reg.default, "claude");
-        assert_eq!(reg.agents.len(), 7, "examples must stay commented out");
+        assert_eq!(reg.agents.len(), 8, "examples must stay commented out");
         assert!(
             reg.get("claude-opus").is_none(),
             "example must not register"


### PR DESCRIPTION
## Summary
- Add `pi` (the pi.dev CLI) as an 8th built-in agent, seeded into `~/.config/thurbox/agents.toml` on first run and shown in the new-session agent picker.
- Pi supports `--session-id <id>` ("exact project session ID, creating it if missing") and `--fork <id>`, so it pins thurbox's generated UUID at creation and resumes/forks by exact id — the same robust pattern `claude` uses (strictly better than the `resume_latest` path codex/opencode/… rely on).
- Updated the built-in lists and the "who pins" note in `CLAUDE.md`, `docs/CONFIG.md`, `docs/ARCHITECTURE.md`, `docs/FEATURES.md`.

## Test plan
- [x] `cargo check --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] full `cargo nextest run` via the pre-commit hook (incl. `builtin_registry_parses_and_has_claude_default`, `seed_documents_examples_yet_stays_builtin_only`)
- [x] rumdl clean on touched Markdown
- Note (follow-up, not this PR): pi has no native `--settings` hooks, so lifecycle status (working/blocked/done) is not wired — pi sessions show `Idle` until a pi extension calling `thurbox-cli session signal` is added.