### PR TITLE
fix(config): set tmux extended-keys-format to csi-u for pi.dev

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -356,6 +356,10 @@ bugs (#641, #2989), required 3 external deps in the data path
 - `default-terminal xterm-256color` — standard terminal type
 - `history-limit 5000` — reasonable scrollback
 - `extended-keys on` — enhanced key reporting
+- `extended-keys-format csi-u` — the modern, unambiguous format some agents
+  (e.g. `pi`) probe for at startup; thurbox injects keys via `send-keys` so this
+  only sets the reported format, not the bytes agents receive. Best-effort: the
+  option is tmux 3.3+ while thurbox's floor is 3.2, so a 3.2 host silently skips it
 - `window-size manual` — windows size independently
 - `pause-after 5` — flow control (auto-resumed by reader)
 

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -829,13 +829,27 @@ impl TmuxBackend {
             self.tmux_run(&["set-option", "-s", "default-command", &shell])?;
         }
 
-        // Server-wide options
+        // Server-wide options every supported tmux understands. A failure here
+        // means the server can't host sessions, so it is propagated.
         let server_opts = [
             ("default-terminal", "xterm-256color"),
             ("extended-keys", "on"),
         ];
         for (key, val) in &server_opts {
             self.tmux_run(&["set-option", "-s", key, val])?;
+        }
+
+        // `extended-keys-format csi-u` is best-effort: the option landed in tmux
+        // 3.3, but thurbox's floor is 3.2, so an older tmux rejects it ("invalid
+        // option"). It is advisory only — thurbox injects keystroke bytes directly
+        // via `send-keys` (not through tmux's key forwarder), so it never
+        // re-encodes what an agent receives; it just sets what `tmux show-options`
+        // reports, which some agents (notably `pi`) probe at startup and warn about
+        // unless it is `csi-u`. Ignoring the error keeps a 3.2 host working (pi
+        // users there simply miss the hint) while 3.3+ hosts get the preferred
+        // format.
+        if let Err(e) = self.tmux_run(&["set-option", "-s", "extended-keys-format", "csi-u"]) {
+            debug!("extended-keys-format=csi-u not set (likely tmux < 3.3): {e}");
         }
 
         // Session-level options


### PR DESCRIPTION
## Summary
- `pi` probes `tmux extended-keys-format` at startup and warns that it works best with `csi-u`; thurbox set `extended-keys on` but left the format at tmux's default (`xterm`).
- Set `extended-keys-format csi-u` server-wide in `TmuxBackend::apply_session_config` (alongside the existing `extended-keys on`), and updated ADR-12's option list in `docs/ARCHITECTURE.md`.
- Safe because thurbox injects keystroke bytes directly via `send-keys` and reads output via control mode, so this option never re-encodes what an agent receives — it only changes what `tmux show-options` reports (what `pi` probes). Other agents get byte-identical input either way, and thurbox already emits one csi-u sequence (`Shift+Enter` → `CSI 13;2u`).

## Test plan
- [x] Pre-commit hooks green: `cargo fmt` / `clippy --all-targets --all-features` / `nextest --all` / architecture rules / `cargo deny` / `cargo doc` / rumdl
- [x] `tmux set-option -s extended-keys-format csi-u` accepted on tmux 3.7 (server scope)
- [x] End-to-end: built `thurbox-cli`, ran a headless `session create` on an isolated `THURBOX_SOCKET` — `tmux -L <socket> show-options -s extended-keys-format` returns `csi-u` (was unset/`xterm`)
- [ ] Manual: restart thurbox, start a `pi` session, confirm the warning no longer appears
