### PR TITLE
feat(config): wire pi.dev status hooks into thurbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1291,7 +1291,12 @@ refused if a user file already exists), an `[[external_files]]` drops a managed
 hook entries into `antigravity`'s shared `~/.gemini/settings.json`
 (idle/working/blocked/done; `agy` adopted claude's hook schema, verified
 against agy 1.0.9 — `PreToolUse` drives working, `Notification` blocked, see
-`extensions/hooks/README.md`).
+`extensions/hooks/README.md`), and an `[[external_files]]` drops a managed
+TypeScript extension into `~/.pi/agent/extensions/thurbox-status.ts` for the
+pi.dev CLI (`pi`) (idle/working/done + blocked; **experimental** — pi has no
+claude-style Stop/permission hook, so `blocked` is inferred only from a
+structured `ask_user_question` tool call). Remote pi sessions are provisioned
+like the other config-dir agents; a psmux/Windows host shows `Hooks: degraded`.
 Opt out with `thurbox-cli extension deactivate hooks` (records a
 `builtin_hooks_optout` metadata flag so self-heal won't resurrect it);
 `activate`/`install hooks` clears it. See the Session-status section.

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -89,6 +89,20 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
   `$THURBOX_SESSION` may not reach the hook, in which case the signal is a
   fail-open no-op. If a future `agy` changes the hook schema, edit
   `antigravity-hooks.json` (no code change).
+- **pi** *(experimental)* — the pi.dev CLI auto-discovers TypeScript extensions
+  from `~/.pi/agent/extensions/*.ts`, so we drop a managed extension in (an
+  `[[external_files]]`, guarded by `requires_dir`, only when pi is installed). It
+  subscribes to pi's lifecycle events: `session_start` → idle, `agent_start` and
+  `tool_execution_start` → working, `agent_end` → done, and a tool call to
+  `ask_user_question` → blocked. **Caveats:** pi has no claude-style
+  `Stop`/permission hook, so `blocked` is inferred only from a structured
+  `ask_user_question` tool call — a turn that ends by asking something in prose
+  signals `done`, not `blocked`. If you already maintain your own file at that
+  path the write is **refused** (no managed marker), so it's never clobbered — pi
+  simply goes unreported rather than broken. Remote (SSH/WSL) pi sessions are
+  provisioned like the other config-dir agents (the rewritten payload ships
+  into the host's extensions dir); a psmux/Windows host shows `Hooks: degraded`.
+  If a future `pi` renames its events, edit `pi-status.ts` (no code change).
 
 ## Custom agents (`hook_schema`)
 
@@ -132,6 +146,7 @@ other agents are wired by a reversible merge into — or a managed file dropped 
 | vibe | `~/.vibe/hooks.toml` | managed file (refused if you already have one) |
 | copilot | `~/.copilot/hooks/thurbox-status.json` | managed standalone file (`requires_dir`) |
 | antigravity | `~/.gemini/settings.json` | reversible JSON-merge of our entries |
+| pi | `~/.pi/agent/extensions/thurbox-status.ts` | managed extension file (`requires_dir`) |
 
 The home dir is `~/.config/thurbox/hooks` for a release build and
 `~/.config/thurbox-dev/hooks` for a dev build, so the two stay isolated.

--- a/extensions/hooks/extension.toml
+++ b/extensions/hooks/extension.toml
@@ -14,7 +14,7 @@
 name = "hooks"
 description = "Report each agent's lifecycle state (working/blocked/done) to thurbox via agent hooks."
 config_version = 1
-version = "1.4.0"
+version = "1.5.0"  # v1.5: pi (pi.dev) status extension
 # Default home; the auto-activation path overrides this with *this build's*
 # resolved config dir (`~/.config/thurbox` or `~/.config/thurbox-dev`) so dev and
 # release installs stay isolated. See `session_ops::builtin_hooks::hooks_home`.
@@ -81,6 +81,27 @@ requires_dir = "~/.codex"
 path = "~/.vibe/hooks.toml"
 source = "vibe-hooks.toml"
 requires_dir = "~/.vibe"
+
+# pi (the pi.dev CLI) auto-discovers TypeScript extensions from
+# ~/.pi/agent/extensions/*.ts, so we drop a managed file in (only when pi is
+# installed, guarded by requires_dir). It subscribes to pi's lifecycle events:
+# session_start → idle, agent_start + tool_execution_start → working (a tool call
+# to ask_user_question → blocked), agent_end → done. As with the other
+# config-dir drops the write is refused (no managed marker) if a file already
+# exists at that path, so pi simply goes unreported rather than broken.
+#
+# EXPERIMENTAL: the event names are verified against pi 0.80.x; if a future pi
+# renames them, edit pi-status.ts (no code change). pi has no claude-style
+# Stop/permission hook, so `blocked` is inferred only from a structured
+# ask_user_question tool call — a turn that ends by asking something in prose
+# signals `done`, not `blocked`. As with the other config-dir agents, remote
+# (SSH/WSL) pi sessions are provisioned at spawn time (the rewritten payload is
+# shipped into the host's ~/.pi/agent/extensions/); the one carve-out is a
+# psmux/Windows host, which shows `Hooks: degraded` instead.
+[[external_files]]
+path = "~/.pi/agent/extensions/thurbox-status.ts"
+source = "pi-status.ts"
+requires_dir = "~/.pi/agent"
 
 # GitHub Copilot CLI (the `copilot` command) loads hooks from its own dir,
 # ~/.copilot/hooks/*.json (each file loaded alphabetically), so we drop a managed

--- a/extensions/hooks/pi-status.ts
+++ b/extensions/hooks/pi-status.ts
@@ -1,0 +1,37 @@
+// Managed by thurbox `extension install` (the built-in "hooks" extension).
+// Reinstalling or updating overwrites this file — do not edit; uninstalling
+// removes it. Reports pi's lifecycle state to thurbox. Identity comes from the
+// inherited $THURBOX_SESSION env var; every call is best-effort so it can never
+// break a session running outside thurbox.
+//
+// This is a pi extension (TypeScript), auto-discovered from
+// ~/.pi/agent/extensions/*.ts by the pi.dev CLI. It subscribes to pi's
+// lifecycle events and reports them to thurbox's status reporter:
+//   session_start → idle, agent_start + tool_execution_start → working
+//   (a tool call to ask_user_question → blocked), agent_end → done.
+import { exec } from "node:child_process";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+// Exact marker prefix kept on one line so the remote (SSH/WSL) rewrite can swap
+// this command for a tmux pane-option setter (there is no thurbox-cli on a
+// remote host). Do not split the words across lines or reorder the flags.
+const SIGNAL = "thurbox-cli session signal --state ";
+
+// Fire-and-forget; the callback swallows errors so a hook never surfaces into
+// the agent. exec inherits the pi process env, so $THURBOX_SESSION travels.
+const report = (state: string): void => {
+  exec(SIGNAL + state, () => {});
+};
+
+// `pi` is injected by the pi runtime; the `import type` above is erased at
+// runtime, so this file has no hard dependency beyond Node's built-ins.
+export default function (pi: ExtensionAPI): void {
+  pi.on("session_start", () => report("idle"));
+  pi.on("agent_start", () => report("working"));
+  pi.on("tool_execution_start", (event?: { toolName?: string }) => {
+    // A structured question to the user blocks the turn until it is answered;
+    // any other tool call means the agent is actively working.
+    report(event?.toolName === "ask_user_question" ? "blocked" : "working");
+  });
+  pi.on("agent_end", () => report("done"));
+}

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -32,6 +32,7 @@ pub(crate) const ANTIGRAVITY_HOOKS: &str =
 pub(crate) const CODEX_HOOKS: &str = include_str!("../../extensions/hooks/codex-hooks.json");
 pub(crate) const VIBE_HOOKS: &str = include_str!("../../extensions/hooks/vibe-hooks.toml");
 pub(crate) const COPILOT_HOOKS: &str = include_str!("../../extensions/hooks/copilot-hooks.json");
+pub(crate) const PI_STATUS: &str = include_str!("../../extensions/hooks/pi-status.ts");
 
 /// Marker prefix of every thurbox-managed hook command; the state word
 /// (`working`/`blocked`/`done`/`idle`) follows it directly.
@@ -158,6 +159,7 @@ fn materialize_source() -> Result<PathBuf, String> {
         ("codex-hooks.json", CODEX_HOOKS),
         ("vibe-hooks.toml", VIBE_HOOKS),
         ("copilot-hooks.json", COPILOT_HOOKS),
+        ("pi-status.ts", PI_STATUS),
     ];
     for (name, contents) in writes {
         let path = dir.join(name);
@@ -279,6 +281,7 @@ mod tests {
             ("codex-hooks.json", CODEX_HOOKS),
             ("vibe-hooks.toml", VIBE_HOOKS),
             ("copilot-hooks.json", COPILOT_HOOKS),
+            ("pi-status.ts", PI_STATUS),
             ("extension.toml", MANIFEST), // aider's literal --notifications-command arg
         ] {
             // Key on the invocation-with-flags form (`thurbox-cli session
@@ -375,6 +378,11 @@ mod tests {
         // (external-file uninstall, see `is_user_modified`).
         assert!(COPILOT_HOOKS.contains("thurbox-cli session signal"));
         assert!(COPILOT_HOOKS.contains("thurbox `extension install`"));
+        // The pi payload is a TypeScript extension dropped into pi's extensions
+        // dir; it carries the signal command and the managed marker (external-
+        // file uninstall, see `is_user_modified`).
+        assert!(PI_STATUS.contains("thurbox-cli session signal"));
+        assert!(PI_STATUS.contains("thurbox `extension install`"));
     }
 
     #[test]

--- a/src/session_ops/remote_hooks.rs
+++ b/src/session_ops/remote_hooks.rs
@@ -93,6 +93,12 @@ fn remote_asset_for(agent: &str) -> Option<RemoteHookAsset> {
             requires_dir: "~/.copilot",
             payload: builtin_hooks::COPILOT_HOOKS,
         }),
+        "pi" => Some(RemoteHookAsset {
+            kind: RemoteAssetKind::WriteFile,
+            remote_path: "~/.pi/agent/extensions/thurbox-status.ts",
+            requires_dir: "~/.pi/agent",
+            payload: builtin_hooks::PI_STATUS,
+        }),
         _ => None,
     }
 }
@@ -520,6 +526,8 @@ mod tests {
                 "vibe"
             } else if path.contains(".copilot") {
                 "copilot"
+            } else if path.contains(".pi") {
+                "pi"
             } else {
                 panic!("unknown config-dir wiring path in manifest: {path}")
             }
@@ -551,7 +559,7 @@ mod tests {
             covered += 1;
         }
         // Every table entry is reachable from the manifest (no orphan assets).
-        assert_eq!(covered, 5, "manifest wiring count changed — sync the table");
+        assert_eq!(covered, 6, "manifest wiring count changed — sync the table");
         // claude/aider stay arg-handled.
         assert!(remote_asset_for("claude").is_none());
         assert!(remote_asset_for("aider").is_none());


### PR DESCRIPTION
## Summary

- `pi` is a built-in agent (added in 28def05) but had no lifecycle hooks, so every pi session sat at a hollow `○ Idle` forever — it never reported working/blocked/done like the other eight agents.
- Adds a managed TypeScript extension (`pi-status.ts`) to the built-in `hooks` extension, dropped at `~/.pi/agent/extensions/thurbox-status.ts` (guarded by `requires_dir = "~/.pi/agent"`, no-op when pi isn't installed). pi auto-discovers it.
- Maps pi's lifecycle events onto `thurbox-cli session signal`: `session_start` → idle, `agent_start` + `tool_execution_start` → working, `agent_end` → done, and an `ask_user_question` tool call → blocked.
- Remote (SSH/WSL) pi sessions are provisioned like the other five config-dir agents (codex/opencode/vibe/copilot/antigravity); the signal marker is kept contiguous so the existing remote rewrite swaps it for the tmux pane-option setter. psmux/Windows hosts keep the existing repo-wide `Hooks: degraded` carve-out.
- Wired through `builtin_hooks.rs` (embedded asset + both asset lists) and `remote_hooks.rs` (the sync-enforcement test is what surfaced the remote-provisioning gap).

### Honest limitation
pi has no claude-style `Stop`/permission hook, so `blocked` is inferred **only** from a structured `ask_user_question` tool call — a turn that ends by asking something in prose signals `done`, not `blocked`.

## Test plan

- [x] `cargo nextest run --all` — 1874 passed (incl. the `remote_assets_stay_in_sync_with_embedded_manifest` sync test, now counting 6 config-dir wirings)
- [x] `cargo fmt --all --check`, `cargo clippy --all-targets --all-features`, `RUSTDOCFLAGS="-D warnings" cargo doc --all-features` — clean
- [x] `cargo nextest run --test architecture_rules` — 12 passed
- [x] `rumdl check` on the edited markdown — clean
- [x] prek pre-commit stack (fmt/clippy/check/nextest/architecture/deny/doc/rumdl/cocogitto-verify) — passed on commit
- [ ] Manual: a `pi` session in thurbox animates working/done (and goes blocked on an `ask_user_question`)