### PR TITLE
feat(ui): hide the session-list pane with F9 for a full-width terminal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2034,6 +2034,7 @@ Global keys use `Ctrl` + semantic Vim conventions:
 | `Ctrl+,` / `F6` | Settings panel (edit settings.toml) | **,** = preferences |
 | `Ctrl+B` / `F2` | Toggle info panel (visible at width >= 120) | Info **b**ox |
 | `Ctrl+E` / `F3` | Toggle file viewer | **E**xplore files |
+| `F9` | Toggle session-list pane (hide for full-width terminal) | Sessions list |
 | `F12` | Toggle perf HUD (live counters + frame/tick timing) | Diagnostics |
 | `F1` / `Ctrl+G` | Keybindings help + interactive editor | Universal |
 

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -610,6 +610,91 @@ fn f5_toggles_tasks_panel_like_ctrl_w() {
 }
 
 #[test]
+fn f9_toggles_session_list_pane() {
+    use ratatui::layout::Rect;
+    let screen = Rect::new(0, 0, STD_COLS, STD_ROWS);
+    let mut h = Harness::standard(1);
+    assert!(h.app.show_session_list, "list visible by default");
+    assert_eq!(h.app.focus, InputFocus::SessionList);
+    assert!(h.app.layout_for(screen).left_panel.is_some());
+    let shown_terminal_width = h.app.layout_for(screen).terminal.width;
+
+    // F9 hides the list. Focus can't rest on the now-hidden column, so it
+    // retreats to the terminal, and the left column disappears from the layout.
+    h.func(9);
+    assert!(!h.app.show_session_list, "F9 hides the list");
+    assert_eq!(
+        h.app.focus,
+        InputFocus::Terminal,
+        "focus retreats off the hidden list onto the terminal"
+    );
+    let hidden = h.app.layout_for(screen);
+    assert!(hidden.left_panel.is_none(), "no left column while hidden");
+    assert!(
+        hidden.automations_panel.is_none(),
+        "automations pane shares the column"
+    );
+    // The terminal reclaims the width the list would have reserved.
+    assert!(
+        hidden.terminal.width > shown_terminal_width,
+        "terminal widens when the list is hidden"
+    );
+
+    // The rendered screen drops the `Sessions` panel border.
+    let shown_screen = {
+        let mut g = Harness::standard(1);
+        g.render()
+    };
+    let hidden_screen = h.render();
+    let sessions_border = shown_screen
+        .lines()
+        .find(|row| row.contains("Sessions"))
+        .expect("the ` Sessions ` panel renders when shown");
+    assert!(
+        !hidden_screen.contains(sessions_border.trim()),
+        "the Sessions panel border is gone while hidden"
+    );
+
+    // The focus ring skips the hidden list: from the terminal, Ctrl+L wraps
+    // back to the terminal (no SessionList stop) with no side panels shown.
+    h.ctrl('l'); // FocusForward
+    assert_eq!(
+        h.app.focus,
+        InputFocus::Terminal,
+        "Ctrl+L stays on the terminal — the ring has no SessionList stop while hidden"
+    );
+
+    // F9 again reveals the list. Focus stays put (showing is a visibility
+    // toggle, not an interaction switch — it does not grab focus).
+    h.func(9);
+    assert!(h.app.show_session_list, "F9 reveals the list again");
+    assert_eq!(
+        h.app.focus,
+        InputFocus::Terminal,
+        "revealing the list does not steal focus from the terminal"
+    );
+    assert!(h.app.layout_for(screen).left_panel.is_some());
+}
+
+#[test]
+fn f9_toggles_session_list_from_focused_terminal() {
+    // F9 has no Ctrl+<letter> primary, so it is not a terminal-passthrough
+    // chord — it toggles the list even while the agent terminal is focused.
+    let mut h = Harness::standard(1);
+    h.ctrl('l'); // focus the terminal
+    assert_eq!(h.app.focus, InputFocus::Terminal);
+    assert!(h.app.show_session_list);
+
+    h.func(9);
+    assert!(
+        !h.app.show_session_list,
+        "F9 hides the list from the terminal"
+    );
+    // Focus was already on the terminal; hiding the list leaves it there.
+    assert_eq!(h.app.focus, InputFocus::Terminal);
+}
+
+#[test]
 fn ctrl_slash_opens_global_search_strip() {
     let mut h = Harness::standard(2);
     assert!(!h.app.global_search.active);
@@ -2857,11 +2942,22 @@ fn assert_invariants(app: &App, ctx: &str) {
         }
         InputFocus::Automations
         | InputFocus::AutomationEditor
-        | InputFocus::AutomationRunHistory => assert!(
-            app.features.automations,
-            "[{ctx}] automations focus with the feature disabled"
+        | InputFocus::AutomationRunHistory => {
+            assert!(
+                app.features.automations,
+                "[{ctx}] automations focus with the feature disabled"
+            );
+            assert!(
+                app.show_session_list,
+                "[{ctx}] automations focus but the left column (list) is hidden"
+            );
+        }
+        InputFocus::SessionList => assert!(
+            app.show_session_list,
+            "[{ctx}] focus {:?} but the session list is hidden",
+            app.focus
         ),
-        InputFocus::SessionList | InputFocus::Terminal => {}
+        InputFocus::Terminal => {}
     }
 
     if app.global_search.active {

--- a/src/app/automation.rs
+++ b/src/app/automation.rs
@@ -839,7 +839,7 @@ impl App {
     /// session list (last row) at the top / when empty.
     fn automations_pane_move_up(&mut self, count: usize) {
         if self.automation_ui.automation_panel_index == 0 || count == 0 {
-            self.focus = InputFocus::SessionList;
+            self.focus = self.focus_fallback();
             self.select_last_session();
         } else {
             self.automation_ui.automation_panel_index -= 1;
@@ -851,7 +851,7 @@ impl App {
     /// the session list past the last row / when empty.
     fn automations_pane_move_down(&mut self, count: usize) {
         if count == 0 || self.automation_ui.automation_panel_index + 1 >= count {
-            self.focus = InputFocus::SessionList;
+            self.focus = self.focus_fallback();
             self.select_first_session();
         } else {
             self.automation_ui.automation_panel_index += 1;

--- a/src/app/code_review.rs
+++ b/src/app/code_review.rs
@@ -1436,6 +1436,7 @@ impl App {
                     | crate::session::Action::OpenSettings
                     | crate::session::Action::OpenThemePicker
                     | crate::session::Action::ToggleInfoPanel
+                    | crate::session::Action::ToggleSessionList
                     | crate::session::Action::GlobalSearch
             )
         )

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -493,7 +493,13 @@ impl App {
                 // the review open.
                 let review = self.active_review().is_some();
                 let central = if review { CodeReview } else { Terminal };
-                let mut ring = vec![SessionList, central];
+                // The session list is the ring's left-most stop only while
+                // shown; hidden, the cycle is central ↔ right-side panels.
+                let mut ring = vec![];
+                if self.show_session_list {
+                    ring.push(SessionList);
+                }
+                ring.push(central);
                 if self.show_tasks_panel {
                     ring.push(TaskList);
                 }
@@ -1105,6 +1111,12 @@ impl App {
                 "File viewer",
                 Self::act_toggle_file_viewer,
             ),
+            // The session list is core nav, not an opt-in feature — no feature
+            // flag to gate, so call the helper directly (no `gated` wrapper).
+            Action::ToggleSessionList => {
+                Self::act_toggle_session_list(self);
+                true
+            }
             Action::GlobalSearch => self.gated(
                 self.features.global_search,
                 "Global search",
@@ -1297,7 +1309,7 @@ impl App {
             // this the workspace shows the empty hint).
             self.sync_task_editor();
         } else if self.focus == InputFocus::TaskList {
-            self.focus = InputFocus::SessionList;
+            self.focus = self.focus_fallback();
         }
         self.resize_sessions_to_content_area();
     }
@@ -1309,7 +1321,25 @@ impl App {
         if self.show_file_viewer {
             self.rebuild_file_viewer_for_active();
         } else if self.focus == InputFocus::FileViewer {
-            self.focus = InputFocus::SessionList;
+            self.focus = self.focus_fallback();
+        }
+        self.resize_sessions_to_content_area();
+    }
+
+    /// Toggle the session-list pane (F9). Hiding it moves focus off the left
+    /// column onto the terminal (the list/automations pane can't hold focus
+    /// while unrendered); showing it leaves focus in place — this is a
+    /// visibility toggle for screen real estate, not an interaction switch, so
+    /// it doesn't grab focus the way opening Tasks/Files does.
+    fn act_toggle_session_list(&mut self) {
+        self.show_session_list = !self.show_session_list;
+        if !self.show_session_list
+            && matches!(
+                self.focus,
+                InputFocus::SessionList | InputFocus::Automations
+            )
+        {
+            self.focus = InputFocus::Terminal;
         }
         self.resize_sessions_to_content_area();
     }

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1114,7 +1114,7 @@ impl App {
             // The session list is core nav, not an opt-in feature — no feature
             // flag to gate, so call the helper directly (no `gated` wrapper).
             Action::ToggleSessionList => {
-                Self::act_toggle_session_list(self);
+                self.act_toggle_session_list();
                 true
             }
             Action::GlobalSearch => self.gated(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -846,6 +846,12 @@ pub struct App {
     /// Whether the tasks panel column is shown (toggled like the file viewer).
     pub(crate) show_tasks_panel: bool,
     pub(crate) show_file_viewer: bool,
+    /// Whether the session-list pane (the left column: sessions + automations)
+    /// is shown. Inverse of the other `show_*` flags — defaults to `true` since
+    /// the list is the primary nav surface, not an opt-in panel. In-memory only
+    /// (resets to shown on restart), matching the other view toggles. Toggled
+    /// by `Action::ToggleSessionList` (F9).
+    pub(crate) show_session_list: bool,
     pub(crate) file_viewer: crate::ui::file_viewer::FileViewerState,
     /// Open native code-review views, keyed by session — persisted per session
     /// like [`Self::session_terminal_views`] (the shell view), so switching
@@ -1217,6 +1223,7 @@ impl App {
             show_info_panel: false,
             show_tasks_panel: false,
             show_file_viewer: false,
+            show_session_list: true,
             file_viewer: crate::ui::file_viewer::FileViewerState::new(),
             code_reviews: std::collections::HashMap::new(),
             modal: modals::Modal::None,
@@ -1397,6 +1404,19 @@ impl App {
         self.resize_sessions_to_content_area();
     }
 
+    /// Where focus should retreat to when a pane is hidden or closed. The
+    /// session list is the natural home, but when it's hidden
+    /// (`show_session_list == false`) fall back to the terminal so focus never
+    /// rests on an unrendered surface. Every site that drops a pane's focus
+    /// routes through here so the hidden-list case stays consistent.
+    pub(crate) fn focus_fallback(&self) -> InputFocus {
+        if self.show_session_list {
+            InputFocus::SessionList
+        } else {
+            InputFocus::Terminal
+        }
+    }
+
     /// Tear down any panel/view/focus that a now-disabled live feature flag
     /// leaves stranded. The open-state booleans (`show_*`), the per-session
     /// shell views, and the open code reviews are all opt-in toggles that
@@ -1411,13 +1431,13 @@ impl App {
         if !self.features.file_viewer {
             self.show_file_viewer = false;
             if self.focus == InputFocus::FileViewer {
-                self.focus = InputFocus::SessionList;
+                self.focus = self.focus_fallback();
             }
         }
         if !self.features.tasks {
             self.show_tasks_panel = false;
             if matches!(self.focus, InputFocus::TaskList | InputFocus::TaskEditor) {
-                self.focus = InputFocus::SessionList;
+                self.focus = self.focus_fallback();
             }
         }
         if !self.features.automations
@@ -1428,7 +1448,7 @@ impl App {
                     | InputFocus::AutomationRunHistory
             )
         {
-            self.focus = InputFocus::SessionList;
+            self.focus = self.focus_fallback();
         }
         if !self.features.global_search && self.global_search.active {
             self.close_global_search();
@@ -4315,7 +4335,7 @@ impl App {
             // Rescue the editor too, not just the list — otherwise focus stays
             // on the hidden panel's editor, which keeps capturing every key.
             if matches!(self.focus, InputFocus::TaskList | InputFocus::TaskEditor) {
-                self.focus = InputFocus::SessionList;
+                self.focus = self.focus_fallback();
             }
         }
 
@@ -6819,6 +6839,7 @@ impl App {
     pub(crate) fn layout_for(&self, area: Rect) -> layout::PanelAreas {
         layout::compute_layout(
             area,
+            self.show_session_list,
             self.show_info_panel,
             self.show_tasks_panel,
             // The review's changed-files list lives in the file-viewer column, so

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -243,7 +243,7 @@ impl App {
     /// panel) is handled here.
     pub(crate) fn handle_task_list_key(&mut self, code: KeyCode) {
         if matches!(code, KeyCode::Esc) {
-            self.focus = InputFocus::SessionList;
+            self.focus = self.focus_fallback();
             self.task_ui.task_editor = None;
         }
     }

--- a/src/session/keybindings.rs
+++ b/src/session/keybindings.rs
@@ -50,6 +50,10 @@ pub enum Action {
     ToggleInfoPanel,
     ToggleFileViewer,
     FocusTasks,
+    /// Toggle the session-list pane (the left column). The only panel toggle
+    /// without a `Ctrl+<letter>` primary — F9 is the sole chord, so it never
+    /// collides with readline and needs no `terminal_passthrough` deferral.
+    ToggleSessionList,
     GlobalSearch,
     /// Open the Settings panel (view/edit settings.toml in the TUI).
     OpenSettings,
@@ -152,6 +156,7 @@ impl Action {
             Action::ToggleInfoPanel,
             Action::ToggleFileViewer,
             Action::FocusTasks,
+            Action::ToggleSessionList,
             Action::GlobalSearch,
             Action::OpenSettings,
             Action::TogglePerfHud,
@@ -218,6 +223,7 @@ impl Action {
             Action::ToggleInfoPanel => "Toggle info panel",
             Action::ToggleFileViewer => "Toggle file viewer",
             Action::FocusTasks => "Tasks",
+            Action::ToggleSessionList => "Toggle session list",
             Action::GlobalSearch => "Global search",
             Action::OpenSettings => "Settings",
             Action::TogglePerfHud => "Toggle perf HUD",
@@ -405,6 +411,12 @@ impl Action {
             Action::ToggleInfoPanel => vec![KeyChord::ctrl('b'), KeyChord::function(2)],
             Action::ToggleFileViewer => vec![KeyChord::ctrl('e'), KeyChord::function(3)],
             Action::FocusTasks => vec![KeyChord::ctrl('w'), KeyChord::function(5)],
+            // F9 only — no Ctrl primary. Every other panel toggle reuses a
+            // readline `Ctrl+<letter>` (B/E/W) and defers to the PTY in a
+            // focused terminal; the session list has no such collision, so a
+            // single F-key keeps it reachable from every pane (including the
+            // terminal) with no passthrough special-casing. F1–F8 are taken.
+            Action::ToggleSessionList => vec![KeyChord::function(9)],
             // Ctrl+/ — the near-universal "search" chord. Terminals encode it
             // inconsistently: kitty-protocol ones deliver `Ctrl+/`, while legacy
             // ones send the raw 0x1F byte that crossterm decodes as `Ctrl+7` /
@@ -559,6 +571,7 @@ pub fn help_sections() -> Vec<(&'static str, Vec<Action>)> {
                 ToggleHelp,
                 ToggleInfoPanel,
                 ToggleFileViewer,
+                ToggleSessionList,
                 OpenThemePicker,
                 OpenSettings,
                 GlobalSearch,
@@ -1159,6 +1172,21 @@ mod tests {
     }
 
     #[test]
+    fn toggle_session_list_has_f9_chord() {
+        // The session-list pane toggle is F9 only — no Ctrl primary, so unlike
+        // the other panel toggles it has no dual chord and no PTY deferral.
+        let kb = KeyBindings::default();
+        assert_eq!(
+            kb.lookup(KeyCode::F(9), KeyModifiers::NONE),
+            Some(Action::ToggleSessionList)
+        );
+        assert_eq!(
+            kb.chords_for(Action::ToggleSessionList),
+            &[KeyChord::function(9)]
+        );
+    }
+
+    #[test]
     fn toggle_shell_has_dual_ctrl_and_f8_chord() {
         // Ctrl+T is the only panel toggle that historically lacked an F-key
         // alternate; F8 was the first free function key.
@@ -1348,6 +1376,7 @@ mod tests {
                 Action::ToggleInfoPanel => 0,
                 Action::ToggleFileViewer => 0,
                 Action::FocusTasks => 0,
+                Action::ToggleSessionList => 0,
                 Action::GlobalSearch => 0,
                 Action::OpenSettings => 0,
                 Action::TogglePerfHud => 0,
@@ -1391,7 +1420,7 @@ mod tests {
         }
         // The listed variants must equal Action::all().len(). If you add
         // a variant, update both `Action::all()` and the match above.
-        const EXPECTED: usize = 60;
+        const EXPECTED: usize = 61;
         assert_eq!(Action::all().len(), EXPECTED);
         for a in Action::all() {
             classify(*a);

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -124,18 +124,25 @@ fn left_column_split(
 }
 
 /// Build the wide (≥ three_panel_min_cols) layout with optional info / tasks /
-/// file-viewer columns. Column order: list | info? | terminal | tasks? |
-/// file_viewer?.
+/// file-viewer columns. Column order: list? | info? | terminal | tasks? |
+/// file_viewer?. The list column is omitted entirely when
+/// `show_session_list` is false (the terminal expands to fill the freed width),
+/// but the right-side columns are unaffected.
+#[allow(clippy::too_many_arguments)]
 fn three_panel_layout(
     bands: &VerticalBands,
     content: Rect,
+    show_session_list: bool,
     show_info_panel: bool,
     show_tasks_panel: bool,
     show_file_viewer: bool,
     show_automations_pane: bool,
     automation_count: usize,
 ) -> PanelAreas {
-    let mut constraints: Vec<Constraint> = vec![Constraint::Percentage(18)];
+    let mut constraints: Vec<Constraint> = Vec::new();
+    if show_session_list {
+        constraints.push(Constraint::Percentage(18));
+    }
     if show_info_panel {
         constraints.push(Constraint::Percentage(15));
     }
@@ -154,7 +161,22 @@ fn three_panel_layout(
         .constraints(constraints)
         .split(content);
 
-    let info_panel = show_info_panel.then(|| horizontal[1]);
+    // Walk the split left→right. The list column (when present) is index 0,
+    // followed by info; the terminal sits at `terminal_idx` regardless of
+    // whether the list column was emitted.
+    let mut idx = 0;
+    let (left_panel, automations_panel) = if show_session_list {
+        let (lp, ap) = left_column_split(horizontal[idx], show_automations_pane, automation_count);
+        idx += 1;
+        (Some(lp), ap)
+    } else {
+        (None, None)
+    };
+    let info_panel = show_info_panel.then(|| {
+        let r = horizontal[idx];
+        idx += 1;
+        r
+    });
     let terminal = horizontal[terminal_idx];
     // Tasks (if shown) immediately follow the terminal; the file viewer
     // follows tasks (or the terminal when tasks are hidden).
@@ -166,11 +188,9 @@ fn three_panel_layout(
     });
     let file_viewer = show_file_viewer.then(|| horizontal[next]);
 
-    let (left_panel, automations_panel) =
-        left_column_split(horizontal[0], show_automations_pane, automation_count);
     PanelAreas {
         header: bands.header,
-        left_panel: Some(left_panel),
+        left_panel,
         automations_panel,
         info_panel,
         tasks_panel,
@@ -182,13 +202,29 @@ fn three_panel_layout(
     }
 }
 
-/// Build the 2-panel layout: 25% list | 75% terminal.
+/// Build the 2-panel layout: 25% list | 75% terminal. When the session list
+/// is hidden the terminal takes the full content width (no list column).
 fn two_panel_layout(
     bands: &VerticalBands,
     content: Rect,
+    show_session_list: bool,
     show_automations_pane: bool,
     automation_count: usize,
 ) -> PanelAreas {
+    if !show_session_list {
+        return PanelAreas {
+            header: bands.header,
+            left_panel: None,
+            automations_panel: None,
+            info_panel: None,
+            tasks_panel: None,
+            file_viewer: None,
+            global_search: bands.global_search,
+            status_message: bands.status_message,
+            terminal: content,
+            footer: bands.footer,
+        };
+    }
     let horizontal = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(25), Constraint::Percentage(75)])
@@ -214,13 +250,15 @@ fn two_panel_layout(
 /// right-side panel visibility.
 ///
 /// At width ≥ 120, the layout becomes
-/// `list | info? | terminal | tasks? | file_viewer?` with info (15%), tasks
+/// `list? | info? | terminal | tasks? | file_viewer?` with info (15%), tasks
 /// (20%), and file_viewer (20%) appearing only when requested. The tasks panel
 /// sits between the terminal and the file viewer (both right-side columns). The
 /// left column is further split into a session list and an automations pane
 /// beneath it (whenever the column is tall enough and `show_automations_pane`
 /// is set — false when the `automations` feature flag is off);
-/// `automation_count` only sizes that pane.
+/// `automation_count` only sizes that pane. When `show_session_list` is false
+/// the whole left column (sessions + automations) is dropped and the terminal
+/// expands — the right-side panels are unaffected.
 ///
 /// `show_status_row` carves a transient full-width 1-row band directly above the
 /// footer for the active status/error message (or the sync spinner), so a long
@@ -229,6 +267,7 @@ fn two_panel_layout(
 #[allow(clippy::too_many_arguments)]
 pub fn compute_layout(
     area: Rect,
+    show_session_list: bool,
     show_info_panel: bool,
     show_tasks_panel: bool,
     show_file_viewer: bool,
@@ -264,6 +303,7 @@ pub fn compute_layout(
         return three_panel_layout(
             &bands,
             content,
+            show_session_list,
             show_info_panel,
             show_tasks_panel,
             show_file_viewer,
@@ -272,7 +312,13 @@ pub fn compute_layout(
         );
     }
 
-    two_panel_layout(&bands, content, show_automations_pane, automation_count)
+    two_panel_layout(
+        &bands,
+        content,
+        show_session_list,
+        show_automations_pane,
+        automation_count,
+    )
 }
 
 #[cfg(test)]
@@ -285,7 +331,17 @@ mod tests {
 
     #[test]
     fn narrow_terminal_hides_left_panel() {
-        let areas = compute_layout(area(79, 24), false, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(79, 24),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.left_panel.is_none());
         assert!(areas.info_panel.is_none());
         assert!(areas.file_viewer.is_none());
@@ -293,7 +349,17 @@ mod tests {
 
     #[test]
     fn normal_width_shows_two_panels() {
-        let areas = compute_layout(area(100, 24), false, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(100, 24),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_none());
         assert!(areas.file_viewer.is_none());
@@ -301,7 +367,17 @@ mod tests {
 
     #[test]
     fn wide_terminal_with_info_panel_shows_three_panels() {
-        let areas = compute_layout(area(120, 24), true, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(120, 24),
+            true,
+            true,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_some());
         assert!(areas.file_viewer.is_none());
@@ -309,7 +385,17 @@ mod tests {
 
     #[test]
     fn wide_terminal_without_info_panel_shows_two_panels() {
-        let areas = compute_layout(area(120, 24), false, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(120, 24),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_none());
         assert!(areas.file_viewer.is_none());
@@ -317,7 +403,17 @@ mod tests {
 
     #[test]
     fn wide_terminal_with_file_viewer_only() {
-        let areas = compute_layout(area(160, 24), false, false, true, false, true, 0, false);
+        let areas = compute_layout(
+            area(160, 24),
+            true,
+            false,
+            false,
+            true,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_none());
         assert!(areas.file_viewer.is_some());
@@ -325,7 +421,17 @@ mod tests {
 
     #[test]
     fn wide_terminal_with_info_and_file_viewer() {
-        let areas = compute_layout(area(160, 24), true, false, true, false, true, 0, false);
+        let areas = compute_layout(
+            area(160, 24),
+            true,
+            true,
+            false,
+            true,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_some());
         assert!(areas.file_viewer.is_some());
@@ -336,7 +442,17 @@ mod tests {
 
     #[test]
     fn wide_terminal_with_tasks_panel_only() {
-        let areas = compute_layout(area(160, 24), false, true, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(160, 24),
+            true,
+            false,
+            true,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.left_panel.is_some());
         assert!(areas.info_panel.is_none());
         assert!(areas.tasks_panel.is_some());
@@ -348,7 +464,17 @@ mod tests {
 
     #[test]
     fn tasks_panel_sits_left_of_file_viewer() {
-        let areas = compute_layout(area(180, 24), false, true, true, false, true, 0, false);
+        let areas = compute_layout(
+            area(180, 24),
+            true,
+            false,
+            true,
+            true,
+            false,
+            true,
+            0,
+            false,
+        );
         let term = areas.terminal;
         let tp = areas.tasks_panel.expect("tasks panel shown");
         let fv = areas.file_viewer.expect("file viewer shown");
@@ -358,19 +484,49 @@ mod tests {
 
     #[test]
     fn tasks_panel_ignored_below_120_cols() {
-        let areas = compute_layout(area(119, 24), false, true, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(119, 24),
+            true,
+            false,
+            true,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.tasks_panel.is_none());
     }
 
     #[test]
     fn global_search_strip_absent_by_default() {
-        let areas = compute_layout(area(120, 40), false, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(120, 40),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.global_search.is_none());
     }
 
     #[test]
     fn global_search_strip_present_when_active() {
-        let areas = compute_layout(area(120, 40), false, false, false, true, true, 0, false);
+        let areas = compute_layout(
+            area(120, 40),
+            true,
+            false,
+            false,
+            false,
+            true,
+            true,
+            0,
+            false,
+        );
         let strip = areas.global_search.expect("strip shown when active");
         // Full width, carved directly above the footer.
         assert_eq!(strip.width, 120);
@@ -381,24 +537,64 @@ mod tests {
 
     #[test]
     fn global_search_strip_shrinks_content() {
-        let without =
-            compute_layout(area(120, 40), false, false, false, false, true, 0, false).terminal;
-        let with =
-            compute_layout(area(120, 40), false, false, false, true, true, 0, false).terminal;
+        let without = compute_layout(
+            area(120, 40),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        )
+        .terminal;
+        let with = compute_layout(
+            area(120, 40),
+            true,
+            false,
+            false,
+            false,
+            true,
+            true,
+            0,
+            false,
+        )
+        .terminal;
         // The terminal (content) region loses the strip's rows.
         assert_eq!(without.height - with.height, GLOBAL_SEARCH_HEIGHT);
     }
 
     #[test]
     fn status_row_absent_by_default() {
-        let areas = compute_layout(area(120, 40), false, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(120, 40),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.status_message.is_none());
         assert_eq!(areas.footer.height, 1);
     }
 
     #[test]
     fn status_row_present_when_active() {
-        let areas = compute_layout(area(120, 40), false, false, false, false, true, 0, true);
+        let areas = compute_layout(
+            area(120, 40),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            true,
+        );
         let row = areas
             .status_message
             .expect("row shown when a message is active");
@@ -411,17 +607,47 @@ mod tests {
 
     #[test]
     fn status_row_shrinks_content_by_one() {
-        let without =
-            compute_layout(area(120, 40), false, false, false, false, true, 0, false).terminal;
-        let with =
-            compute_layout(area(120, 40), false, false, false, false, true, 0, true).terminal;
+        let without = compute_layout(
+            area(120, 40),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        )
+        .terminal;
+        let with = compute_layout(
+            area(120, 40),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            true,
+        )
+        .terminal;
         assert_eq!(without.height - with.height, 1);
     }
 
     #[test]
     fn status_row_stacks_below_global_search() {
         // Both strips active: search on top, status row just above the footer.
-        let areas = compute_layout(area(120, 40), false, false, false, true, true, 0, true);
+        let areas = compute_layout(
+            area(120, 40),
+            true,
+            false,
+            false,
+            false,
+            true,
+            true,
+            0,
+            true,
+        );
         let gs = areas.global_search.expect("search strip shown");
         let sm = areas.status_message.expect("status row shown");
         assert!(
@@ -437,14 +663,34 @@ mod tests {
 
     #[test]
     fn header_and_footer_are_one_line() {
-        let areas = compute_layout(area(100, 24), false, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(100, 24),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert_eq!(areas.header.height, 1);
         assert_eq!(areas.footer.height, 1);
     }
 
     #[test]
     fn compact_mode_hides_header_below_20_rows() {
-        let areas = compute_layout(area(100, 19), false, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(100, 19),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert_eq!(areas.header.height, 0);
         assert_eq!(areas.footer.height, 1);
         assert!(areas.left_panel.is_some());
@@ -452,19 +698,49 @@ mod tests {
 
     #[test]
     fn header_returns_at_20_rows() {
-        let areas = compute_layout(area(100, 20), false, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(100, 20),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert_eq!(areas.header.height, 1);
     }
 
     #[test]
     fn info_panel_ignored_below_120_cols() {
-        let areas = compute_layout(area(119, 24), true, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(119, 24),
+            true,
+            true,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.info_panel.is_none());
     }
 
     #[test]
     fn file_viewer_ignored_below_120_cols() {
-        let areas = compute_layout(area(119, 24), false, false, true, false, true, 0, false);
+        let areas = compute_layout(
+            area(119, 24),
+            true,
+            false,
+            false,
+            true,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.file_viewer.is_none());
     }
 
@@ -472,6 +748,7 @@ mod tests {
         use ratatui::widgets::{Block, Borders};
         let terminal = compute_layout(
             area(width, height),
+            true,
             show_info,
             false,
             false,
@@ -517,7 +794,17 @@ mod tests {
     #[test]
     fn automations_pane_present_even_when_empty() {
         // Zero automations still get a minimum-height pane (so it's discoverable).
-        let areas = compute_layout(area(100, 24), false, false, false, false, true, 0, false);
+        let areas = compute_layout(
+            area(100, 24),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
         assert!(areas.left_panel.is_some());
         let autos = areas.automations_panel.expect("empty pane still shown");
         assert_eq!(autos.height, AUTOMATIONS_PANE_MIN_ROWS);
@@ -525,7 +812,17 @@ mod tests {
 
     #[test]
     fn automations_pane_appears_below_sessions() {
-        let areas = compute_layout(area(100, 30), false, false, false, false, true, 2, false);
+        let areas = compute_layout(
+            area(100, 30),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            2,
+            false,
+        );
         let sessions = areas.left_panel.unwrap();
         let autos = areas.automations_panel.expect("automations pane shown");
         assert_eq!(sessions.x, autos.x);
@@ -538,7 +835,17 @@ mod tests {
 
     #[test]
     fn automations_pane_height_is_capped() {
-        let areas = compute_layout(area(100, 60), false, false, false, false, true, 50, false);
+        let areas = compute_layout(
+            area(100, 60),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            50,
+            false,
+        );
         assert_eq!(
             areas.automations_panel.unwrap().height,
             AUTOMATIONS_PANE_MAX_ROWS
@@ -547,8 +854,28 @@ mod tests {
 
     #[test]
     fn automations_pane_hidden_when_feature_disabled() {
-        let with = compute_layout(area(100, 30), false, false, false, false, true, 2, false);
-        let without = compute_layout(area(100, 30), false, false, false, false, false, 2, false);
+        let with = compute_layout(
+            area(100, 30),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            2,
+            false,
+        );
+        let without = compute_layout(
+            area(100, 30),
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+            2,
+            false,
+        );
         assert!(without.automations_panel.is_none());
         // The session list absorbs the whole left column.
         let full = without.left_panel.unwrap();
@@ -562,8 +889,121 @@ mod tests {
     #[test]
     fn automations_pane_hidden_when_column_too_short() {
         // Content height ≈ 4 rows leaves no room for both lists.
-        let areas = compute_layout(area(100, 6), false, false, false, false, true, 3, false);
+        let areas = compute_layout(
+            area(100, 6),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            3,
+            false,
+        );
         assert!(areas.left_panel.is_some());
         assert!(areas.automations_panel.is_none());
+    }
+
+    #[test]
+    fn hidden_session_list_drops_left_column_two_panel() {
+        // Two-panel width: hiding the list gives the terminal the full content
+        // width (no 25% list column).
+        let shown = compute_layout(
+            area(100, 24),
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
+        let hidden = compute_layout(
+            area(100, 24),
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        );
+        assert!(shown.left_panel.is_some());
+        assert!(hidden.left_panel.is_none());
+        assert!(hidden.automations_panel.is_none());
+        assert!(hidden.terminal.width > shown.terminal.width);
+    }
+
+    #[test]
+    fn hidden_session_list_keeps_right_side_panels() {
+        // Hiding the left column must not drop the right-side panels — the
+        // terminal expands into the list's freed width while info/tasks/files
+        // stay put.
+        let areas = compute_layout(
+            area(160, 24),
+            false,
+            true,
+            true,
+            true,
+            false,
+            true,
+            0,
+            false,
+        );
+        assert!(areas.left_panel.is_none(), "list column dropped");
+        assert!(areas.automations_panel.is_none());
+        assert!(areas.info_panel.is_some(), "info panel survives");
+        assert!(areas.tasks_panel.is_some(), "tasks panel survives");
+        assert!(areas.file_viewer.is_some(), "file viewer survives");
+        let term = areas.terminal;
+        // Terminal sits between the info column (left edge now) and tasks.
+        let info = areas.info_panel.unwrap();
+        let tasks = areas.tasks_panel.unwrap();
+        assert!(
+            term.x >= info.x + info.width,
+            "terminal right of info: {term:?} vs {info:?}"
+        );
+        assert!(
+            tasks.x >= term.x + term.width,
+            "tasks right of terminal: {tasks:?} vs {term:?}"
+        );
+    }
+
+    #[test]
+    fn hidden_session_list_three_panel_terminal_widens() {
+        // With info open and the list hidden, the terminal reclaims the 18%
+        // the list would have reserved.
+        let with_list = compute_layout(
+            area(160, 24),
+            true,
+            true,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        )
+        .terminal;
+        let no_list = compute_layout(
+            area(160, 24),
+            false,
+            true,
+            false,
+            false,
+            false,
+            true,
+            0,
+            false,
+        )
+        .terminal;
+        assert!(
+            no_list.width > with_list.width,
+            "terminal widens when the list is hidden: {} vs {}",
+            no_list.width,
+            with_list.width
+        );
     }
 }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -99,6 +99,10 @@ pub struct FooterState<'a> {
 ///
 /// Ordered by F-key (`Help · F1`, `Info · F2`, … `Settings · F6`) with `Quit`
 /// last, so the row reads in the same order as the function-key alternates.
+/// `ToggleSessionList` (F9) is intentionally NOT here: adding an eighth pill
+/// tips the block past the 120-col footer width and evicts Info/Files/Tasks via
+/// the narrow-drop below, so the toggle is surfaced via the F1 help overlay
+/// instead.
 const FOOTER_BUTTONS: &[(&str, Action)] = &[
     ("Help", Action::ToggleHelp),
     ("Info", Action::ToggleInfoPanel),

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -271,6 +271,13 @@ onThisPage:
                 <td>Toggle file viewer</td>
                 <td>Next to F2</td>
               </tr>
+              <tr>
+                <td>
+                  <code>F9</code>
+                </td>
+                <td>Toggle session-list pane</td>
+                <td>Hide for a full-width terminal; right-side panels stay</td>
+              </tr>
             </tbody>
           </table>
 


### PR DESCRIPTION
## Summary

- New `ToggleSessionList` action (bound to **F9**) hides the session-list pane — the left column (sessions + automations) — so the terminal expands to full width. Press F9 again to bring it back.
- Focus retreats off the hidden column onto the terminal (never rests on an unrendered surface); the `Ctrl+L`/`Ctrl+H` focus ring skips the hidden list. Showing the list does not steal focus — it is a visibility/real-estate toggle, not an interaction switch.
- Right-side panels (info/tasks/files) are unaffected when the list is hidden; they keep their columns and the terminal reclaims only the list's freed width.
- F9 has no `Ctrl+<letter>` primary (every free letter was bound or a readline chord), so it needs no terminal-passthrough deferral and works from any pane including a focused terminal. No footer pill — adding one tipped the 120-col footer past its width and evicted Info/Files/Tasks, so the toggle is surfaced via the F1 help overlay instead.

## Test plan

- `cargo nextest run -p thurbox` — 1882 tests pass, including 2 new acceptance tests (`f9_toggles_session_list_pane`, `f9_toggles_session_list_from_focused_terminal`), 3 new layout tests, and the strengthened `assert_invariants` (monkey test now catches focus-on-hidden-list regressions).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- Manual: launch TUI, press F9 → list disappears, terminal widens; Ctrl+L stays on terminal; F9 again → list returns. Works from a focused terminal too.