### PR TITLE
fix(config): use vibe's real pre_tool/post_agent hook schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1282,8 +1282,9 @@ a `[[config_merges]]` deep-merges `codex`'s claude-shaped hooks into
 the old `-c notify=…` done-only override — a reversible write into `hooks.json`,
 never `config.toml`), an `[[external_files]]` drops an opencode plugin into
 `~/.config/opencode/plugin/` (idle/working/blocked/done) and a managed
-`~/.vibe/hooks.toml` for Mistral `vibe` (working/blocked/done; **experimental**,
-refused if a user file already exists), an `[[external_files]]` drops a managed
+`~/.vibe/hooks.toml` for Mistral `vibe` (working/done, no blocked; verified
+against vibe 2.21.0's `pre_tool`/`post_agent` schema, refused if a user file
+already exists), an `[[external_files]]` drops a managed
 `~/.copilot/hooks/thurbox-status.json` for GitHub Copilot CLI (`copilot`)
 (idle/working/blocked/done; **experimental**, copilot's own hook schema —
 `notification` matched to `permission_prompt` drives blocked; ships both

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -60,9 +60,12 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
 - **vibe** *(experimental)* — Mistral Vibe loads hooks from `~/.vibe/hooks.toml`.
   It's TOML, so we can't JSON-merge it — we drop a managed file in (an
   `[[external_files]]`, guarded by `requires_dir`, only when vibe is installed).
-  Events: `before_tool` → working, `after_turn` → done, `notification` (awaiting
-  approval / question) → blocked. **Caveats:** the `hooks.toml` schema is not
-  verified against the live `vibe` binary — if event/key names differ, edit
+  Verified against vibe 2.21.0 (`vibe.core.hooks.models.HookConfig`): each entry
+  needs `name` + `type` (`pre_tool`/`post_tool`/`post_agent`) + `command`. Events:
+  `pre_tool` → working, `post_agent` → done. **No blocked** — vibe's only hook
+  types are pre_tool/post_tool/post_agent (no permission/notification event),
+  so a tool awaiting approval reads as `working` (`pre_tool` fires *before* the
+  approval prompt). If a future vibe renames the types/fields, edit
   `vibe-hooks.toml` (no code change). And if you already maintain your own
   `~/.vibe/hooks.toml`, the write is **refused** (no managed marker) so it's never
   clobbered — vibe simply goes unreported rather than broken.

--- a/extensions/hooks/extension.toml
+++ b/extensions/hooks/extension.toml
@@ -14,7 +14,7 @@
 name = "hooks"
 description = "Report each agent's lifecycle state (working/blocked/done) to thurbox via agent hooks."
 config_version = 1
-version = "1.5.0"  # v1.5: pi (pi.dev) status extension
+version = "1.6.0"  # v1.6: vibe hooks rewritten to vibe 2.21.0's real schema (pre_tool/post_agent); v1.5: pi (pi.dev) status extension
 # Default home; the auto-activation path overrides this with *this build's*
 # resolved config dir (`~/.config/thurbox` or `~/.config/thurbox-dev`) so dev and
 # release installs stay isolated. See `session_ops::builtin_hooks::hooks_home`.
@@ -74,9 +74,13 @@ requires_dir = "~/.codex"
 # ~/.vibe/hooks.toml, the write is refused (no managed marker), so we never
 # clobber it — vibe just goes unreported rather than broken.
 #
-# EXPERIMENTAL: the hooks.toml schema is not verified against the live `vibe`
-# binary. If event/key names differ, edit vibe-hooks.toml (no code change).
-# Events: before_tool → working, after_turn → done, notification → blocked.
+# Verified against vibe 2.21.0 (`vibe.core.hooks.models.HookConfig`): each
+# `[[hooks]]` entry needs `name` + `type` (one of `pre_tool` / `post_tool` /
+# `post_agent`) + `command`. Events: pre_tool → working, post_agent → done.
+# No `blocked` — vibe's only hook types are pre_tool/post_tool/post_agent
+# (no permission/notification event), so a tool awaiting approval reads as
+# `working` (pre_tool fires before the approval prompt). If a future vibe
+# renames the types/fields, edit vibe-hooks.toml (no code change).
 [[external_files]]
 path = "~/.vibe/hooks.toml"
 source = "vibe-hooks.toml"

--- a/extensions/hooks/vibe-hooks.toml
+++ b/extensions/hooks/vibe-hooks.toml
@@ -5,20 +5,29 @@
 # $THURBOX_SESSION env var; every call is best-effort (`|| true`) so it can
 # never break a session running outside thurbox.
 #
-# EXPERIMENTAL: the hooks.toml schema below is not verified against the live
-# `vibe` binary. If the event/key names differ, edit this file (no code change
-# needed) — a wrong name just means the state isn't reported (the `|| true`
-# keeps vibe itself safe). before_tool -> working, after_turn -> done,
-# notification (awaiting approval / question) -> blocked.
+# Verified against vibe 2.21.0 (`vibe.core.hooks.models.HookConfig`). Vibe's
+# hook schema is TOML with one `[[hooks]]` entry per hook, each requiring a
+# `name`, a `type` (one of `pre_tool` / `post_tool` / `post_agent`), and a
+# `command` (run via the shell with the invocation JSON on stdin; the parent
+# env is inherited, so $THURBOX_SESSION travels). If a future vibe renames the
+# types or fields, edit this file (no code change) — a wrong name just means
+# the state isn't reported (vibe logs a per-hook config issue and skips it;
+# the `|| true` keeps vibe itself safe).
+#
+# Vibe exposes only those three hook types — there is no permission/
+# notification event — so `blocked` is **not** reported. `pre_tool` fires
+# *before* the tool-approval prompt (agent_loop `_run_pre_tool_pipeline` runs
+# ahead of `_should_execute_tool`), so a tool awaiting approval still reads as
+# `working` (accurate: the agent is mid-turn). pre_tool -> working,
+# post_agent -> done. post_tool is intentionally unused (redundant with
+# pre_tool for the working signal, and carries no turn-end edge).
 
 [[hooks]]
-event = "before_tool"
+name = "thurbox-pre-tool"
+type = "pre_tool"
 command = "thurbox-cli session signal --state working || true"
 
 [[hooks]]
-event = "after_turn"
+name = "thurbox-post-agent"
+type = "post_agent"
 command = "thurbox-cli session signal --state done || true"
-
-[[hooks]]
-event = "notification"
-command = "thurbox-cli session signal --state blocked || true"

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -427,11 +427,45 @@ mod tests {
         // typo can't ship a file vibe would reject.
         let vibe_payload: toml::Value =
             toml::from_str(VIBE_HOOKS).expect("vibe payload is valid TOML");
+        let vibe_hooks = vibe_payload["hooks"]
+            .as_array()
+            .expect("vibe payload declares a [[hooks]] table array");
+        assert!(!vibe_hooks.is_empty(), "vibe payload has >=1 hook");
+        // Vibe 2.21.0's `HookConfig` requires `name` + `type` and accepts only
+        // `pre_tool` / `post_tool` / `post_agent` — the old shipped schema used
+        // invented `event = "before_tool"/"after_turn"/"notification"` names
+        // that vibe silently rejected (every entry failed validation), so
+        // status never reported. Guard the real schema: every entry has a
+        // `name`, a valid `type`, a `command`, and maps to working/done only
+        // (vibe has no permission/notification hook, so no `blocked`).
+        let valid_types = ["pre_tool", "post_tool", "post_agent"];
+        for hook in vibe_hooks {
+            let name = hook["name"].as_str().expect("vibe hook has a name");
+            let htype = hook["type"].as_str().expect("vibe hook has a type");
+            assert!(
+                valid_types.contains(&htype),
+                "vibe hook `{name}` has type `{htype}`, expected one of {valid_types:?}"
+            );
+            assert!(
+                hook["command"].as_str().is_some_and(|c| !c.is_empty()),
+                "vibe hook `{name}` has a non-empty command"
+            );
+            assert!(
+                hook.get("event").is_none(),
+                "vibe hook `{name}` uses the old (nonexistent) `event` field"
+            );
+        }
+        let vibe_cmds = vibe_hooks
+            .iter()
+            .filter_map(|h| h["command"].as_str())
+            .collect::<String>();
         assert!(
-            vibe_payload["hooks"]
-                .as_array()
-                .is_some_and(|h| !h.is_empty()),
-            "vibe payload should declare hook entries"
+            vibe_cmds.contains("--state working") && vibe_cmds.contains("--state done"),
+            "vibe hooks map pre_tool/post_agent to working/done"
+        );
+        assert!(
+            !vibe_cmds.contains("--state blocked"),
+            "vibe has no permission/notification hook, so blocked is not reported"
         );
 
         // antigravity (agy) shares gemini's ~/.gemini/settings.json for hooks.


### PR DESCRIPTION
## Problem

The shipped `~/.vibe/hooks.toml` used invented field/event names that **vibe rejects**, so every hook entry failed validation and vibe status never reported:

```
[[hooks]]
event = "before_tool"      # ← no such field
command = "..."
```

vibe 2.21.0's `HookConfig` (`vibe.core.hooks.models`) requires `name` + `type` (`pre_tool`/`post_tool`/`post_agent`) + `command`. Loading the old shipped file through vibe's own loader yields **0 hooks, 3 issues** (`name: Field required ; type: Field required` × 3) — i.e. vibe status has been silently broken since it was added.

## Fix

Rewritten against vibe's verified schema:

| vibe hook | thurbox state | why |
|-----------|---------------|-----|
| `pre_tool` | `working` | fires before each tool call (at `_loop.py:1744`, **before** the permission prompt at `:1755`, so a tool awaiting approval correctly reads as working) |
| `post_agent` | `done` | fires at end of every turn |
| — | *(no `blocked`)* | vibe's only 3 hook types have no permission/notification event — genuine limitation, documented like codex's |

## Verification (3 layers)

1. **Schema** — new file loads through vibe's own `_load_hooks_file` / `HookConfig` with **0 issues** (old: 0 hooks, 3 issues).
2. **Dispatch** — drove vibe's real `HooksManager` with fake invocations + a `thurbox-cli` shim: it shell-executed `working` then `done` in the correct order.
3. **Tests** — strengthened `embedded_manifest_parses_with_codex_vibe_and_antigravity_wiring` to assert the real schema (`name`+valid `type`+`command`, no `event` field, working/done only, no `blocked`). Full suite green (1874/1874), clippy clean, rumdl clean.

## Changes

- `extensions/hooks/vibe-hooks.toml` — rewritten with the real `name`+`type`+`command` schema (2 hooks).
- `extensions/hooks/extension.toml` — comment corrected; hooks ext version `1.5.0` → `1.6.0`.
- `extensions/hooks/README.md` + `CLAUDE.md` — corrected the vibe docs (drops "experimental/not-verified" caveats; documents the no-`blocked` limitation).
- `src/session_ops/builtin_hooks.rs` — strengthened the test guarding the vibe schema.

Existing users get the fix on `extension reinstall hooks` (or automatically via `auto_update`'s stale-extension refresh).

🤓 Generated in pi