### PR TITLE
Add refactor prompt and publish skill for pi agent

### DIFF
--- a/.pi/prompts/refactor.md
+++ b/.pi/prompts/refactor.md
@@ -1,0 +1,131 @@
+---
+description: Multi-pass refactor (structure, coherence, tests) of newly implemented code.
+---
+
+# Refactor
+
+Perform a multi-pass refactoring of the newly implemented
+code in this project. You MUST execute 3 independent review
+passes, re-reading the code from scratch each time to catch
+incoherences that a single pass would miss.
+
+---
+
+## Pre-work
+
+**Identify recent changes**: Look at recently modified files
+(use git diff or git log) to find newly implemented code.
+Establish the list of files to review.
+
+---
+
+## Pass 1 — Structure & Clean Code
+
+Re-read all identified files from disk, then:
+
+1. **Apply Clean Code principles**:
+   - Use clear, intention-revealing names for variables,
+     functions, and classes.
+   - Keep functions small — each should do one thing well
+     (Single Responsibility).
+   - Eliminate duplication (DRY).
+   - Remove dead code, unused imports, and unnecessary
+     comments.
+   - Replace magic numbers/strings with named constants.
+
+2. **Keep It Simple (KISS)**:
+   - Prefer straightforward logic over clever tricks.
+   - Reduce nesting — use early returns and guard clauses.
+   - Avoid premature abstractions — only extract when there
+     is real duplication.
+   - Minimize function arguments; group related parameters
+     into objects if needed.
+
+3. **Improve readability**:
+   - Ensure consistent formatting and code style with the
+     rest of the project.
+   - Structure code so it reads top-down.
+   - **Optimize comments aggressively** (full rubric: the
+     "Comments" section in `CLAUDE.md`). Let the code be
+     self-documenting: keep only comments that convey "why" /
+     rationale / non-obvious constraints / cross-references
+     (`ADR-*`, `schema vNN`, `see fn_x`). Cut restatements,
+     obvious trailing labels (`// list`, `// EOF`), and obvious
+     test-step narration — if an LLM could infer it from the
+     code, delete it. Tighten verbose doc comments, but never
+     delete a public doc that carries intra-doc links or
+     examples.
+
+Apply fixes, then summarize what was changed in Pass 1.
+
+---
+
+## Pass 2 — Coherence & Consistency
+
+Re-read ALL the same files again from disk (fresh read, do
+not rely on memory from Pass 1), then:
+
+1. **Cross-file coherence**: Check that naming conventions,
+   patterns, and abstractions are consistent across all
+   changed files and with the rest of the project.
+2. **API & contract consistency**: Verify that function
+   signatures, return types, error handling, and data shapes
+   are coherent between callers and callees.
+3. **Logic review**: Look for contradictory logic, redundant
+   conditions, unreachable branches, or mismatched
+   assumptions between modules.
+4. **Comment accuracy**: Re-read every comment in the changed
+   files against the code it describes. Any comment that
+   describes a prior implementation, a wrong signature, or
+   behavior the code no longer has must be rewritten to match
+   or deleted. A stale comment is worse than none — it
+   anchors readers (and LLM agents) on the wrong intent.
+5. **Import & dependency hygiene**: Ensure no circular
+   dependencies, unused imports, or misplaced
+   responsibilities were introduced.
+
+Apply fixes, then summarize what was changed in Pass 2.
+
+---
+
+## Pass 3 — Tests & Final Validation
+
+Re-read ALL the same files again from disk (fresh read, do
+not rely on memory from previous passes), then:
+
+1. **Add or improve tests**:
+   - Identify the existing test framework and patterns used
+     in the project.
+   - Add unit tests for individual functions and methods
+     that were changed or created.
+   - Add integration tests where components interact with
+     each other.
+   - Add e2e tests if the project already has an e2e test
+     setup and the changes affect user-facing flows.
+   - Follow the existing test conventions (naming,
+     structure, assertions).
+   - Ensure tests cover both happy paths and edge cases.
+
+2. **Final coherence check**: With tests written, re-examine
+   whether the code under test reveals any remaining
+   incoherence, naming mismatch, or logic flaw. Fix
+   anything found.
+
+3. **Run tests**: Execute the test suite to confirm
+   everything passes.
+
+Apply fixes, then summarize what was changed in Pass 3.
+
+---
+
+## Final Summary
+
+Present a consolidated report:
+
+- **Pass 1** changes (structure & clean code)
+- **Pass 2** changes (coherence & consistency)
+- **Pass 3** changes (tests & validation)
+- Total number of issues found and fixed across all passes
+
+Do NOT change external behavior or add new features. This is
+a pure refactoring and test coverage pass.

--- a/.pi/skills/publish/SKILL.md
+++ b/.pi/skills/publish/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: publish
+description: Refactor the changes made in this session, ship them as a PR with auto-merge, then monitor CI and auto-fix failures until merged. Scopes itself to the repos this session actually worked in.
+allowed-tools: read edit write bash grep find agent fetch_content
+---
+
+## Publish
+
+Refactor the changes made in this session, ship them as a PR
+with auto-merge, then watch CI until the PR merges (or a
+hard-stop is reached). Be thorough on refactoring, efficient
+on shipping.
+
+**Input:** the user message appended after `/skill:publish`
+(if any).
+
+The input optionally describes what was done, used for the commit
+message and PR description, and/or names the repo(s) to
+publish. It may be empty.
+
+Everything here is plain `git` / `gh` run through Bash. There
+are no helper scripts: when a command's output is ambiguous or
+a step fails, read the actual error and adapt — do not retry a
+canned pipeline.
+
+---
+
+### Phase 0 — Scope (which repos)
+
+Publishing too much is the worst failure mode of this skill.
+Scope comes from **session context only** — never from scanning
+the filesystem.
+
+Build the candidate list in priority order:
+
+1. Repos explicitly named in the input.
+2. Repos containing files this session created or edited
+   (look back at the conversation, not at the disk).
+3. The repo containing the current working directory.
+4. Only if cwd is not itself a repo but a multi-repo workspace
+   (a directory of symlinks that each resolve to a git repo —
+   e.g. a thurbox symlink workspace): the member repos.
+
+Hard rules:
+
+- **Never** enumerate repos beyond the list above. No scanning
+  `~`, no "all accessible directories", no sibling worktrees,
+  no `find`/Glob sweeps for `.git`.
+- A candidate **qualifies** only if it is on a feature branch
+  (not the default branch) and has uncommitted changes or
+  commits ahead of `origin/<default>`.
+- A qualifying repo whose changes this session did **not**
+  make (pre-existing dirt, someone else's branch) is **not**
+  published. List it under "skipped" in the final output so
+  the user can decide.
+  Exception: the cwd repo when the user invoked `/skill:publish`
+  with no other context — they are standing in it, publish it.
+- Zero qualifying repos → STOP: "Nothing to publish."
+
+State the final scope in one line ("Publishing: <repos>;
+skipped: <repos + reason>") before doing any work, then run
+Phases 1–4 for each scoped repo sequentially.
+
+---
+
+### Phase 1 — Sync
+
+Per repo, before touching code:
+
+1. `git fetch origin`.
+2. Determine the default branch (e.g.
+   `git symbolic-ref --short refs/remotes/origin/HEAD`; if
+   unset, ask `gh repo view` — pick whichever works, don't
+   parse `git remote show` output).
+3. If on the default branch, STOP for this repo: "Create a
+   feature branch first."
+4. Rebase onto `origin/<default>`. On conflict: abort the
+   rebase, record the conflicting files, skip this repo's
+   remaining phases, continue with the next repo.
+
+---
+
+### Phase 2 — Refactor (2 passes)
+
+Review only the changes being shipped: the diff against
+`origin/<default>` plus uncommitted changes. Establish the
+file list from that diff.
+
+#### Pass 1 — Structure & Clean Code
+
+Re-read the identified files from disk, then:
+
+1. **Clean Code**: intention-revealing names, small
+   single-responsibility functions, DRY, remove dead code and
+   unused imports, replace magic values with constants.
+2. **KISS**: straightforward logic, early returns over
+   nesting, no premature abstractions.
+3. **Readability**: match project formatting, comments only
+   for non-obvious "why".
+
+Apply fixes, then summarize.
+
+#### Pass 2 — Coherence & Consistency
+
+Re-read the same files fresh, then:
+
+1. **Cross-file coherence**: naming, patterns, abstractions
+   consistent with each other and the project.
+2. **API consistency**: signatures, return types, error
+   handling coherent between callers and callees.
+3. **Logic review**: contradictions, redundant conditions,
+   unreachable branches, mismatched assumptions.
+
+Apply fixes, then summarize. These summaries are intermediate
+— continue straight into Phase 3.
+
+---
+
+### Phase 3 — Ship
+
+Execute efficiently; do not deliberate.
+
+1. **Stage deliberately.** Review `git status` and stage the
+   files that belong to this work — never `git add -A`
+   blindly. Leave out secrets and junk (`.env`, credentials,
+   keys, large binaries, scratch files).
+2. **Commit.** If `HEAD` is already on the remote (or shared
+   with the default branch), create a new conventional commit;
+   if the tip commit is local-only, amend it. Use the input
+   to inform the message; infer type and scope from the diff.
+   Skip if nothing to commit.
+3. **Re-sync.** `git fetch origin` and rebase again to pick up
+   anything that landed meanwhile (same conflict handling as
+   Phase 1).
+4. **Push.** `git push --force-with-lease origin HEAD`.
+5. **PR.** If `gh pr view` finds an open PR, reuse it.
+   Otherwise `gh pr create` — title under 70 chars, body with
+   `## Summary` bullets and a `## Test plan`.
+6. **Auto-merge.** `gh pr merge --auto --rebase`. If the repo
+   doesn't allow it, note that and move on — do not merge
+   without auto-merge unless the user asked.
+
+Record the PR URL for Phase 4.
+
+---
+
+### Phase 4 — Monitor & validate
+
+Watch the PR until it merges or hits a hard stop. Adapt to the
+repo: first check whether it has CI checks
+(`gh pr checks`) and whether auto-merge actually got enabled
+(`gh pr view --json autoMergeRequest`). No checks and no
+auto-merge → nothing to monitor, go to Final Output.
+
+**Monitor loop** — up to ~10 rounds, sleeping 30s at first and
+backing off toward 2 minutes between polls. Each round, check
+PR state and checks via `gh pr view` / `gh pr checks`:
+
+- Merged → validate (below), then next repo.
+- Closed without merging → record and stop this repo.
+- Merge conflict → record "rebase manually" and stop this repo.
+- A check failed → fix (below).
+- Otherwise → keep waiting.
+
+**Fixing a failed check** — at most 3 fix attempts per repo,
+then record "manual intervention required" and stop this repo.
+Pull the failing job's log (`gh run view <id> --log-failed`),
+diagnose the root cause from the actual error — don't guess
+from the check name. Apply the fix, commit
+(`fix: resolve CI failure in <check>`), rebase, push, and
+resume monitoring from a fresh 30s wait.
+
+**Validate after merge** — look for a deployment workflow on
+the default branch (`gh run list --branch <default>`). If one
+is running, poll briefly (a few rounds) until it concludes;
+if none exists, skip — not every repo deploys.
+
+---
+
+### Final Output
+
+One block per repo (and only now — nothing earlier is a
+terminal summary):
+
+- Refactor: Pass 1 + Pass 2 changes (counts)
+- Commit: new or amended, with message
+- PR: URL
+- CI: passed / fixed N times / no checks / failed
+- Merge: confirmed / pending / conflict
+- Deploy: status / no deployment detected
+
+If any repos were skipped in Phase 0, list them with the
+reason.

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,5 +1,5 @@
 [global]
-exclude = [".git", ".claude"]
+exclude = [".git", ".claude", ".pi"]
 
 [MD013]
 line_length = 100


### PR DESCRIPTION
## Summary

- Add `.pi/prompts/refactor.md` — pi prompt template invoked as `/refactor`, mirroring `.claude/commands/refactor.md` (pi unifies slash commands under prompt templates; filename → `/refactor`). Body is identical to the Claude command; only adds a pi `description` frontmatter.
- Add `.pi/skills/publish/SKILL.md` — pi Agent Skill invoked as `/skill:publish`, mirroring `.claude/skills/publish/SKILL.md`. Same 4-phase workflow (scope → sync → refactor → ship → monitor CI) with the intended pi adaptations: lowercase `allowed-tools` (`Glob`→`find`, `WebFetch`→`fetch_content`), the `User: <args>` skill input convention (no `$ARGUMENTS`), and `/skill:publish` invocation.
- Exclude `.pi` in `.rumdl.toml` (alongside `.git` and `.claude`) — these are agent-config artifacts whose frontmatter/heading conventions are dictated by the Agent Skills spec, not docs prose. Full repo lint remains clean.

Faithfulness verified by `diff`: refactor body byte-identical to Claude's command; publish differs only in the 4 intended pi adaptations.

## Test plan

- [x] `rumdl check .` passes (41 files, no issues) — `.pi` correctly excluded.
- [x] Pi skill rules validated: name `publish` (valid format, 1–64 chars, lowercase), description 189 chars (≤ 1024 limit).
- [x] `diff` confirms refactor body identical to `.claude/commands/refactor.md`.
- [x] `diff` confirms publish differs from `.claude/skills/publish/SKILL.md` only in the 4 intended adaptations (frontmatter, allowed-tools, Input section, invocation refs).
- [ ] In a trusted pi project, load `.pi/`: confirm `/refactor` appears in prompt-template autocomplete and `/skill:publish` loads the skill.