### PR TITLE
feat(ui): give terminal editors (vim/nano/ttt) a real TTY on Ctrl+O

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -781,7 +781,11 @@ Subcommands: `session` (create/list/get/delete/restore/restart/
 send/capture/focus/signal), `automation` (alias `auto`:
 create/list/show/edit/remove/run/runs/tick), `task` (alias `todo`:
 create/list/show/edit/remove/run), `message` (alias `msg`:
-send/inbox/prune — the inter-session mailbox queue; see below), `editor`, `config`
+send/inbox/prune — the inter-session mailbox queue; see below), `editor`
+(get/set the Ctrl+O editor command; `editor mode <auto|terminal|gui>` chooses
+how it launches — terminal editors get a real TTY via a tmux popup or TUI
+suspend, GUI editors spawn detached; see the Editor Integration section of
+`docs/FEATURES.md`), `config`
 (validate/show — strict-parses every config file / prints the
 effective resolved config; see `docs/CONFIG.md`), `extension`
 (alias `ext`: install/uninstall/reinstall/list/available/update/activate/

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -627,6 +627,7 @@ Live in the `metadata` table and apply immediately (no restart):
 |-----|---------|---------|
 | `active_theme` | `Ctrl+Y` / `F4` picker | TUI palette (fifteen built-ins) |
 | `editor_command` | `thurbox-cli editor set "<cmd>"` | what `Ctrl+O` runs |
+| `editor_mode` | `thurbox-cli editor mode <auto\|terminal\|gui>` | how `Ctrl+O` runs the editor: `auto` (default) detects terminal vs GUI and gives terminal editors a real TTY (tmux popup / TUI suspend); `terminal` forces the TTY path; `gui` forces detached |
 | `active_extensions` | `thurbox-cli extension activate/deactivate` | JSON array of active extensions to self-heal |
 | `builtin_hooks_optout` | `thurbox-cli extension deactivate hooks` | `1` when the user opted out of the auto-activated hooks extension |
 | `perf_snapshot` | the TUI, while perf timing is active (`THURBOX_PERF_LOG` or an open perf HUD) | JSON perf snapshot read by `thurbox-cli perf` (see `docs/PERFORMANCE.md`) |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -602,11 +602,28 @@ session after recycling.
 configured external editor. The editor command is a global setting
 stored in SQLite, defaulting to a sensible value on first run.
 
-**Why a configurable command rather than `$EDITOR`?** `$EDITOR` is
-typically a terminal editor (vim, nano) — wrong for "open this
-folder in my GUI". A separate setting lets users point at
-`code`, `cursor`, `idea`, etc. without disrupting their shell
-environment.
+**Terminal editors are first-class.** A terminal editor (vim, nano,
+`ttt`, helix, micro, …) needs a controlling TTY, which the old
+fire-and-forget detached spawn did not provide. So `Ctrl+O` now runs
+terminal editors with a real TTY: when thurbox is **inside tmux** the
+editor floats in a `tmux display-popup` (the TUI keeps running
+underneath, the popup closes on editor exit), and when it is **not**
+the TUI is suspended and the editor inherits the terminal (the
+git/sudoedit pattern — the TUI resumes on editor exit). GUI editors
+(`code`, `zed`, …) keep spawning detached as before, so they still pop
+their own window while the TUI stays interactive.
+
+**Auto detection + override.** In the default `auto` mode the launch
+path is chosen from the command name (curated terminal/GUI lists;
+`emacs -nw` and `--tty`-style flags force the terminal path). Force it
+explicitly with `thurbox-cli editor mode terminal` (TTY path for every
+editor) or `gui` (detached spawn for every editor — the pre-terminal
+behavior).
+
+**Why a configurable command rather than just `$EDITOR`?** A separate
+setting lets users point at `code`, `cursor`, `idea`, etc. without
+disrupting their shell environment; `$VISUAL`/`$EDITOR` are still
+honored as the fallback when no command is set.
 
 **Why all worktrees, not just cwd?** Multi-repo sessions touch
 several directories at once; opening only the cwd would hide the

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -2879,6 +2879,61 @@ fn split_utf8_output_chunks_render_intact() {
     );
 }
 
+// ── Ctrl+O editor: terminal vs GUI routing ─────────────────────────────
+
+#[test]
+fn terminal_editor_stages_pending_run_for_main_loop() {
+    // `ttt` is a known terminal editor, so Ctrl+O must NOT fire a null-stdio
+    // spawn (which would die with no TTY). Instead it stages an invocation for
+    // the main loop to run with a real TTY (popup/suspend).
+    let mut h = Harness::standard(0);
+    h.app.db.set_editor_command("ttt").unwrap();
+    h.app.launch_editor(
+        &[std::path::PathBuf::from("/tmp/repo")],
+        Some("paths".to_string()),
+    );
+    let inv = h
+        .app
+        .take_pending_editor_run()
+        .expect("ttt stages a terminal-editor run");
+    assert_eq!(inv.program, "ttt");
+    assert_eq!(inv.args, ["/tmp/repo".to_string()]);
+    // One-shot: a second drain yields nothing.
+    assert!(h.app.take_pending_editor_run().is_none());
+}
+
+#[test]
+fn editor_mode_terminal_forces_tty_even_for_a_gui_editor() {
+    // `code` is normally GUI (detached), but `editor mode terminal` overrides:
+    // it must stage a terminal run too, keeping extra flags before the paths.
+    let mut h = Harness::standard(0);
+    h.app.db.set_editor_command("code --wait").unwrap();
+    h.app
+        .db
+        .set_editor_mode(crate::session::settings::EditorMode::Terminal)
+        .unwrap();
+    h.app.launch_editor(
+        &[
+            std::path::PathBuf::from("/tmp/repo"),
+            std::path::PathBuf::from("/other"),
+        ],
+        Some("paths".to_string()),
+    );
+    let inv = h
+        .app
+        .take_pending_editor_run()
+        .expect("terminal mode forces the TTY path even for `code`");
+    assert_eq!(inv.program, "code");
+    assert_eq!(
+        inv.args,
+        [
+            "--wait".to_string(),
+            "/tmp/repo".to_string(),
+            "/other".to_string()
+        ]
+    );
+}
+
 // ── Invariant tripwires + deterministic monkey test ──────────────────────────
 
 /// Structural invariants that must hold after *any* event, in any order. The

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -2,6 +2,8 @@
 
 use std::path::PathBuf;
 
+use crate::session::settings::EditorMode;
+
 pub(super) fn open_url(url: &str) {
     let cmd = if cfg!(target_os = "macos") {
         "open"
@@ -21,22 +23,18 @@ pub(super) fn open_url(url: &str) {
 ///
 /// `editor_cmd` is whitespace-split so callers can include flags
 /// (e.g. `"code --wait"` or `"nvim --server /tmp/s --remote"`). Returns an
-/// error if the command string is empty or fails to spawn.
+/// error if the command string is empty or fails to spawn. This is the
+/// **detached** path for GUI editors (launchers that fork-and-exit / open
+/// their own window); terminal editors must instead get a real TTY via
+/// [`classify_editor`] + the main loop's popup/suspend path.
 pub(super) fn open_in_editor(paths: &[PathBuf], editor_cmd: &str) -> std::io::Result<()> {
+    let (program, extra_args) = parse_editor_command(editor_cmd)?;
     if paths.is_empty() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             "no paths to open",
         ));
     }
-    let mut parts = editor_cmd.split_whitespace();
-    let Some(program) = parts.next() else {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "editor command is empty",
-        ));
-    };
-    let extra_args: Vec<&str> = parts.collect();
 
     let mut cmd = std::process::Command::new(program);
     cmd.args(&extra_args)
@@ -58,6 +56,171 @@ pub(super) fn open_in_editor(paths: &[PathBuf], editor_cmd: &str) -> std::io::Re
     cmd.spawn().map(|_| ())
 }
 
+/// Split a configured editor command into `(program, extra_args)`. Whitespace-
+/// split; the program is the first token. Errors on an empty/whitespace-only
+/// command (no program token).
+pub(super) fn parse_editor_command(editor_cmd: &str) -> std::io::Result<(String, Vec<String>)> {
+    let mut parts = editor_cmd.split_whitespace();
+    let Some(program) = parts.next() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "editor command is empty",
+        ));
+    };
+    let extra_args: Vec<String> = parts.map(String::from).collect();
+    Ok((program.to_string(), extra_args))
+}
+
+/// Editors known to run **in the terminal** (need a controlling TTY). Matched
+/// against the configured program basename, case-insensitively. Deliberately
+/// the well-known set only: a terminal editor left off the list just falls
+/// back to the detached GUI path (override with `editor mode terminal`),
+/// whereas a GUI launcher wrongly on this list would get a TTY and misbehave —
+/// so precision matters more than recall here.
+const TERMINAL_EDITORS: &[&str] = &[
+    "vim",
+    "nvim",
+    "vi",
+    "view",
+    "ex",
+    "nano",
+    "pico",
+    "joe",
+    "jmacs",
+    "jstar",
+    "jpico",
+    "jove",
+    "jed",
+    "ne",
+    "mcedit",
+    "mc",
+    "kak",
+    "kakoune",
+    "micro",
+    "helix",
+    "hx",
+    "amp",
+    "emacsclient",
+    "ttt",
+];
+
+/// Editors that open their **own window** (launcher scripts that fork-and-exit
+/// or message a running server, independent of any terminal). Matched
+/// case-insensitively on the basename.
+const GUI_EDITORS: &[&str] = &[
+    "code",
+    "code-insiders",
+    "codium",
+    "vscodium",
+    "vscode",
+    "cursor",
+    "zed",
+    "zeditor",
+    "subl",
+    "sublime",
+    "atom",
+    "mate",
+    "idea",
+    "idea.sh",
+    "webstorm",
+    "phpstorm",
+    "pycharm",
+    "goland",
+    "clion",
+    "rust-rover",
+    "rustrover",
+    "datagrip",
+    "rubymine",
+    "fleet",
+    "nova",
+    "bbedit",
+    "textmate",
+    "notepad++",
+    "notepad-plus-plus",
+    "codeblocks",
+    "geany",
+    "leafpad",
+    "mousepad",
+    "pluma",
+    "gedit",
+    "kate",
+    "kwrite",
+    "xfwrite",
+];
+
+/// Flags that force a GUI editor onto the terminal path (it then runs with a
+/// real TTY). `emacs -nw` / `--no-window-system` flip emacs; `--tty` /
+/// `--terminal` are the generic spellings some launchers accept. (`emacsclient`
+/// is already in [`TERMINAL_EDITORS`], so its `-t` needs no flag here — and
+/// bare `-t` is too generic a token to match.)
+const FORCE_TERMINAL_FLAGS: &[&str] = &["-nw", "--no-window-system", "--tty", "--terminal"];
+
+/// The basename of a command path (`/usr/bin/nvim` → `nvim`), or the whole
+/// string when it carries no separator.
+fn basename_of(program: &str) -> &str {
+    match program.rfind(['/', '\\']) {
+        Some(i) => &program[i + 1..],
+        None => program,
+    }
+}
+
+/// Whether the resolved editor should be launched with a real TTY (the terminal
+/// path) rather than detached. Honors an explicit [`EditorMode`] override; in
+/// `Auto` mode it consults the curated lists plus the `emacs -nw`-style flag.
+///
+/// `Auto` falls back to **GUI** (detached) for unknown editors so an unlisted
+/// GUI launcher keeps working as before — force the TTY path with
+/// `editor mode terminal` for an unlisted terminal editor.
+pub(super) fn is_terminal_editor(program: &str, extra_args: &[String], mode: EditorMode) -> bool {
+    match mode {
+        EditorMode::Terminal => true,
+        EditorMode::Gui => false,
+        EditorMode::Auto => {
+            let base = basename_of(program);
+            let listed_terminal = TERMINAL_EDITORS
+                .iter()
+                .any(|e| e.eq_ignore_ascii_case(base));
+            let listed_gui = GUI_EDITORS.iter().any(|g| g.eq_ignore_ascii_case(base));
+            let force_term = extra_args
+                .iter()
+                .any(|a| FORCE_TERMINAL_FLAGS.iter().any(|f| a == *f));
+            // `emacs` is GUI by default; `-nw`/`--no-window-system` forces terminal.
+            force_term || (listed_terminal && !listed_gui)
+        }
+    }
+}
+
+/// How the main loop should run the editor for one `Ctrl+O` press.
+pub(super) enum EditorLaunch {
+    /// GUI editor: fire-and-forget detached spawn (the classic path), done
+    /// here in `helpers` so it never touches the render loop.
+    Detached,
+    /// Terminal editor: hand the constructed invocation to the main loop,
+    /// which runs it with a real TTY (`tmux display-popup` inside tmux, or a
+    /// TUI suspend-and-resume outside). The `paths` are appended to `args`.
+    Terminal(crate::app::EditorInvocation),
+}
+
+/// Resolve the editor command + mode, parse it, and decide detached vs TTY.
+/// Returns `Err` on an empty/unparseable command string.
+pub(super) fn classify_editor(
+    paths: &[PathBuf],
+    editor_cmd: &str,
+    mode: EditorMode,
+) -> std::io::Result<EditorLaunch> {
+    let (program, extra_args) = parse_editor_command(editor_cmd)?;
+    if is_terminal_editor(&program, &extra_args, mode) {
+        let mut args = extra_args;
+        args.extend(paths.iter().map(|p| p.to_string_lossy().into_owned()));
+        Ok(EditorLaunch::Terminal(crate::app::EditorInvocation {
+            program,
+            args,
+        }))
+    } else {
+        Ok(EditorLaunch::Detached)
+    }
+}
+
 /// Resolve the editor command from the DB setting, falling back to
 /// `$VISUAL` then `$EDITOR`. Returns `None` if none are set.
 pub(super) fn resolve_editor_command(db: &crate::storage::Database) -> Option<String> {
@@ -76,6 +239,11 @@ pub(super) fn resolve_editor_command(db: &crate::storage::Database) -> Option<St
         }
     }
     None
+}
+
+/// Resolve the editor launch mode from the DB setting (defaults to `Auto`).
+pub(super) fn resolve_editor_mode(db: &crate::storage::Database) -> EditorMode {
+    db.get_editor_mode().unwrap_or(EditorMode::Auto)
 }
 
 #[cfg(test)]
@@ -106,6 +274,119 @@ mod tests {
             open_in_editor(&paths, "thurbox-nonexistent-editor-xyz --wait --flag").unwrap_err();
         // NOT the InvalidInput we return for an empty command: the spawn itself failed.
         assert_ne!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn parse_editor_command_splits_program_and_flags() {
+        let (program, args) = parse_editor_command("code --wait --new-window").unwrap();
+        assert_eq!(program, "code");
+        assert_eq!(args, vec!["--wait", "--new-window"]);
+    }
+
+    #[test]
+    fn parse_editor_command_rejects_blank() {
+        assert_eq!(
+            parse_editor_command("  ").unwrap_err().kind(),
+            std::io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn is_terminal_editor_auto_detects_known_names() {
+        // Terminal editors by basename (the ttt/vim/nano family).
+        for name in [
+            "vim", "nvim", "vi", "nano", "ttt", "helix", "hx", "micro", "kak",
+        ] {
+            assert!(
+                is_terminal_editor(name, &[], EditorMode::Auto),
+                "{name} should be terminal"
+            );
+        }
+        // …and full paths (basename match).
+        assert!(is_terminal_editor("/usr/bin/nvim", &[], EditorMode::Auto));
+        // Case-insensitive.
+        assert!(is_terminal_editor("VIM", &[], EditorMode::Auto));
+    }
+
+    #[test]
+    fn is_terminal_editor_auto_treats_gui_launchers_as_detached() {
+        for name in ["code", "code-insiders", "zed", "cursor", "subl", "idea"] {
+            assert!(
+                !is_terminal_editor(name, &[], EditorMode::Auto),
+                "{name} should be GUI"
+            );
+        }
+    }
+
+    #[test]
+    fn is_terminal_editor_emacs_nw_forces_terminal() {
+        // `emacs` alone is GUI; `-nw` flips it to terminal.
+        assert!(!is_terminal_editor("emacs", &[], EditorMode::Auto));
+        assert!(
+            is_terminal_editor("emacs", &["-nw".into()], EditorMode::Auto),
+            "emacs -nw must be terminal"
+        );
+        assert!(is_terminal_editor(
+            "emacs",
+            &["--no-window-system".into()],
+            EditorMode::Auto
+        ));
+    }
+
+    #[test]
+    fn is_terminal_editor_auto_defaults_unknown_to_gui() {
+        // Unknown editor → no regression of the old detached behavior.
+        assert!(!is_terminal_editor(
+            "my-custom-editor",
+            &[],
+            EditorMode::Auto
+        ));
+    }
+
+    #[test]
+    fn is_terminal_editor_mode_override_wins_over_name() {
+        // `Terminal` forces TTY even for `code`; `Gui` forces detached even for vim.
+        assert!(is_terminal_editor("code", &[], EditorMode::Terminal));
+        assert!(!is_terminal_editor("vim", &[], EditorMode::Gui));
+    }
+
+    #[test]
+    fn classify_editor_terminal_appends_paths_to_args() {
+        let paths = [PathBuf::from("/repo/a"), PathBuf::from("/repo/b")];
+        let launch = classify_editor(&paths, "ttt", EditorMode::Auto).unwrap();
+        let inv = match launch {
+            EditorLaunch::Terminal(inv) => inv,
+            EditorLaunch::Detached => panic!("ttt should classify as terminal"),
+        };
+        assert_eq!(inv.program, "ttt");
+        assert_eq!(inv.args, vec!["/repo/a", "/repo/b"]);
+    }
+
+    #[test]
+    fn classify_editor_terminal_keeps_extra_flags_before_paths() {
+        let paths = [PathBuf::from("/r")];
+        let launch = classify_editor(&paths, "nvim --clean", EditorMode::Auto).unwrap();
+        let inv = match launch {
+            EditorLaunch::Terminal(inv) => inv,
+            EditorLaunch::Detached => panic!(),
+        };
+        assert_eq!(inv.program, "nvim");
+        assert_eq!(inv.args, vec!["--clean", "/r"]);
+    }
+
+    #[test]
+    fn classify_editor_gui_yields_detached() {
+        let paths = [PathBuf::from("/r")];
+        assert!(matches!(
+            classify_editor(&paths, "code --wait", EditorMode::Auto).unwrap(),
+            EditorLaunch::Detached
+        ));
+    }
+
+    #[test]
+    fn resolve_editor_mode_defaults_auto_on_missing_row() {
+        let db = crate::storage::Database::open_in_memory().unwrap();
+        assert_eq!(resolve_editor_mode(&db), EditorMode::Auto);
     }
 
     #[test]

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -628,13 +628,11 @@ impl App {
     }
 
     fn open_file_in_editor(&mut self, root: std::path::PathBuf, file: std::path::PathBuf) {
-        let Some(editor) = super::helpers::resolve_editor_command(&self.db) else {
-            self.set_error(super::EDITOR_NOT_CONFIGURED);
-            return;
-        };
-        if let Err(e) = super::helpers::open_in_editor(&[root, file], &editor) {
-            warn!("file viewer: failed to open editor: {e}");
-        }
+        let subject = file
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        self.launch_editor(&[root, file], Some(subject));
     }
 
     /// Session-list keys are all rebindable `SessionList`-scoped actions

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -821,6 +821,19 @@ struct PendingDelete {
 }
 
 /// The TEA model: owns all session/UI state and coordinates side effects.
+/// A terminal editor invocation staged for the main loop to run with a real
+/// TTY (a `tmux display-popup` inside tmux, or a TUI suspend-and-resume
+/// outside). Built by `helpers::classify_editor` when `Ctrl+O` resolves to a
+/// terminal editor (vim, nano, `ttt`, …) and drained from `App` by `run_loop`.
+/// GUI editors never go through this — they stay detached.
+#[derive(Debug, Clone)]
+pub struct EditorInvocation {
+    /// Editor binary (first whitespace token of the configured command).
+    pub program: String,
+    /// Extra editor args followed by the paths to open, in order.
+    pub args: Vec<String>,
+}
+
 pub struct App {
     pub(crate) sessions: Vec<Session>,
     pub(crate) active_index: usize,
@@ -859,6 +872,11 @@ pub struct App {
     /// (if any) is reached via [`Self::active_review`] / [`Self::active_review_mut`].
     pub(crate) code_reviews: std::collections::HashMap<SessionId, code_review::CodeReviewState>,
     pub(crate) modal: modals::Modal,
+    /// A terminal-editor run staged for the main loop to execute with a real
+    /// TTY (set by `Ctrl+O` when the editor is a terminal one). Drained each
+    /// iteration by `run_loop` via [`Self::take_pending_editor_run`]; GUI
+    /// editors spawn detached and never populate this.
+    pub(crate) pending_editor_run: Option<EditorInvocation>,
     /// In-progress new-session wizard (also drives fork/restart re-spawns).
     pub(crate) new_session: new_session_state::NewSessionWizardState,
     /// Inter-instance DB sync (polls for changes from other thurbox instances).
@@ -1227,6 +1245,7 @@ impl App {
             file_viewer: crate::ui::file_viewer::FileViewerState::new(),
             code_reviews: std::collections::HashMap::new(),
             modal: modals::Modal::None,
+            pending_editor_run: None,
             new_session: new_session_state::NewSessionWizardState::default(),
             sync_state,
             worktree_sync: sync_state::WorktreeSyncState::default(),
@@ -2022,7 +2041,7 @@ impl App {
             Some(p) => p,
             None => return,
         };
-        self.launch_editor_with_paths(&paths);
+        self.launch_editor(&paths, Some(format!("{} path(s)", paths.len())));
     }
 
     /// If the file viewer is focused on a file, open `[root, file]` so editors
@@ -2034,19 +2053,11 @@ impl App {
         let Some((file, root)) = self.file_viewer.selected_file_with_root() else {
             return false;
         };
-        let Some(editor) = helpers::resolve_editor_command(&self.db) else {
-            self.set_error(EDITOR_NOT_CONFIGURED);
-            return true;
-        };
-        match helpers::open_in_editor(&[root, file.clone()], &editor) {
-            Ok(()) => self.set_info(format!(
-                "Opening {} in {editor}",
-                file.file_name()
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .unwrap_or_default()
-            )),
-            Err(e) => self.set_error(format!("Failed to launch editor `{editor}`: {e}")),
-        }
+        let subject = file
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        self.launch_editor(&[root, file.clone()], Some(subject));
         true
     }
 
@@ -2078,15 +2089,44 @@ impl App {
         Some(paths)
     }
 
-    fn launch_editor_with_paths(&mut self, paths: &[std::path::PathBuf]) {
+    /// Launch the configured editor over `paths`. Terminal editors (vim, nano,
+    /// `ttt`, …) get a real TTY: this stages an [`EditorInvocation`] for the
+    /// main loop (popup inside tmux, suspend outside) instead of spawning.
+    /// GUI editors spawn detached (the classic path). `subject` flavors the
+    /// status toast (e.g. the file name or "N path(s)").
+    fn launch_editor(&mut self, paths: &[std::path::PathBuf], subject: Option<String>) {
         let Some(editor) = helpers::resolve_editor_command(&self.db) else {
             self.set_error(EDITOR_NOT_CONFIGURED);
             return;
         };
-        match helpers::open_in_editor(paths, &editor) {
-            Ok(()) => self.set_info(format!("Opening {} path(s) in {editor}", paths.len())),
+        let mode = helpers::resolve_editor_mode(&self.db);
+        match helpers::classify_editor(paths, &editor, mode) {
+            Ok(helpers::EditorLaunch::Detached) => match helpers::open_in_editor(paths, &editor) {
+                Ok(()) => self.set_info(format!(
+                    "Opening {} in {editor}",
+                    subject.as_deref().unwrap_or("paths")
+                )),
+                Err(e) => self.set_error(format!("Failed to launch editor `{editor}`: {e}")),
+            },
+            Ok(helpers::EditorLaunch::Terminal(inv)) => {
+                // GUI-style toast, but defer the actual run to the main loop so
+                // the editor gets a real TTY (popup/suspend), not a null-stdio
+                // spawn. Cleared by `take_pending_editor_run` after it runs.
+                self.pending_editor_run = Some(inv);
+                self.set_info(format!(
+                    "Opening {} in {editor} (terminal)",
+                    subject.as_deref().unwrap_or("paths")
+                ));
+            }
             Err(e) => self.set_error(format!("Failed to launch editor `{editor}`: {e}")),
         }
+    }
+
+    /// Pop a terminal-editor invocation staged by `launch_editor`, if any.
+    /// Drained by `run_loop` after `update` so the render loop can hand the
+    /// TTY to the editor (popup/suspend) and repaint on return.
+    pub fn take_pending_editor_run(&mut self) -> Option<EditorInvocation> {
+        self.pending_editor_run.take()
     }
 
     fn fork_active_session(&mut self) {
@@ -4597,8 +4637,9 @@ impl App {
 
     /// Mark the UI dirty so the render loop paints on its next iteration.
     /// Cheap and idempotent; over-marking only costs an extra (correct) frame.
-    /// Internal-only — the loop in `main` drives painting via [`Self::should_redraw`].
-    pub(crate) fn request_redraw(&mut self) {
+    /// Also driven by the binary's `main` after a terminal-editor run (popup
+    /// cover / suspend teardown) to force a full repaint on return.
+    pub fn request_redraw(&mut self) {
         self.needs_redraw = true;
     }
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -244,6 +244,7 @@ fn show(db: &Database) -> Result<Value, String> {
 
     // Editor resolution mirrors the TUI's Ctrl+O chain: DB → $VISUAL → $EDITOR.
     let (editor, editor_source) = resolve_editor(db);
+    let editor_mode = db.get_editor_mode().unwrap_or_default();
     let overridden_actions = overridden_action_names();
 
     Ok(json!({
@@ -264,7 +265,7 @@ fn show(db: &Database) -> Result<Value, String> {
         "hosts": { "names": hosts.names() },
         "settings": settings,
         "keybindings": { "overridden_actions": overridden_actions },
-        "editor": { "command": editor, "source": editor_source },
+        "editor": { "command": editor, "source": editor_source, "mode": editor_mode.as_db_value() },
         "theme": db.get_active_theme().ok().flatten(),
         "custom_themes": custom_themes.iter().map(|t| t.name.as_str()).collect::<Vec<_>>(),
     }))

--- a/src/cli/editor.rs
+++ b/src/cli/editor.rs
@@ -4,6 +4,7 @@ use clap::Subcommand;
 use serde_json::json;
 
 use crate::cli::output::CommandOutput;
+use crate::session::settings::EditorMode;
 use crate::storage::Database;
 
 #[derive(Subcommand, Debug)]
@@ -14,6 +15,15 @@ pub enum Action {
     Set {
         /// Command line template. The worktree path is appended as a final arg.
         command: String,
+    },
+    /// Print or set how `Ctrl+O` launches the editor (`auto`/`terminal`/`gui`).
+    /// `auto` (default) detects terminal vs GUI editors from the command name
+    /// and gives terminal editors (vim, nano, ttt, …) a real TTY. `terminal`
+    /// forces the TTY path for everything; `gui` forces the detached spawn.
+    /// With no argument, prints the current mode.
+    Mode {
+        /// `auto`, `terminal`, or `gui`. Omit to print the current value.
+        mode: Option<String>,
     },
 }
 
@@ -44,6 +54,26 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 human,
             ))
         }
+        Action::Mode { mode } => match mode {
+            None => {
+                let current = db
+                    .get_editor_mode()
+                    .map_err(|e| format!("get_editor_mode: {e}"))?;
+                Ok(CommandOutput::new(
+                    json!({ "mode": current.as_db_value() }),
+                    format!("Editor mode: {}", current.as_db_value()),
+                ))
+            }
+            Some(value) => {
+                let parsed = EditorMode::parse_stored(Some(&value));
+                db.set_editor_mode(parsed)
+                    .map_err(|e| format!("set_editor_mode: {e}"))?;
+                Ok(CommandOutput::new(
+                    json!({ "mode": parsed.as_db_value() }),
+                    format!("Editor mode set to: {}", parsed.as_db_value()),
+                ))
+            }
+        },
     }
 }
 
@@ -95,5 +125,89 @@ mod tests {
         )
         .unwrap();
         assert!(v["command"].is_null());
+    }
+
+    #[test]
+    fn mode_prints_auto_when_unset() {
+        let db = db();
+        let v = run(Action::Mode { mode: None }, &db).unwrap();
+        assert_eq!(v["mode"].as_str(), Some("auto"));
+    }
+
+    #[test]
+    fn mode_set_then_get_roundtrips() {
+        let db = db();
+        let v = run(
+            Action::Mode {
+                mode: Some("terminal".into()),
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(v["mode"].as_str(), Some("terminal"));
+        let v = run(Action::Mode { mode: None }, &db).unwrap();
+        assert_eq!(v["mode"].as_str(), Some("terminal"));
+    }
+
+    #[test]
+    fn mode_normalizes_aliases_and_case() {
+        let db = db();
+        // "tty" → terminal, case-insensitive.
+        run(
+            Action::Mode {
+                mode: Some("TTY".into()),
+            },
+            &db,
+        )
+        .unwrap();
+        let v = run(Action::Mode { mode: None }, &db).unwrap();
+        assert_eq!(v["mode"].as_str(), Some("terminal"));
+        // "detached" → gui.
+        run(
+            Action::Mode {
+                mode: Some("detached".into()),
+            },
+            &db,
+        )
+        .unwrap();
+        let v = run(Action::Mode { mode: None }, &db).unwrap();
+        assert_eq!(v["mode"].as_str(), Some("gui"));
+    }
+
+    #[test]
+    fn mode_setting_auto_clears_the_row() {
+        let db = db();
+        run(
+            Action::Mode {
+                mode: Some("terminal".into()),
+            },
+            &db,
+        )
+        .unwrap();
+        run(
+            Action::Mode {
+                mode: Some("auto".into()),
+            },
+            &db,
+        )
+        .unwrap();
+        // `auto` is the default, so the row is cleared.
+        assert_eq!(
+            db.get_editor_mode().unwrap(),
+            crate::session::settings::EditorMode::Auto
+        );
+    }
+
+    #[test]
+    fn mode_unknown_value_falls_back_to_auto() {
+        let db = db();
+        let v = run(
+            Action::Mode {
+                mode: Some("nonsense".into()),
+            },
+            &db,
+        )
+        .unwrap();
+        assert_eq!(v["mode"].as_str(), Some("auto"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,142 @@ impl Drop for TerminalGuard {
     }
 }
 
+/// Re-establish the TUI's terminal mutations after a suspend, mirroring the
+/// startup sequence in `main` (alt screen + raw mode first, then the optional
+/// kitty flags, bracketed paste, and mouse capture). The inverse of
+/// [`restore_terminal`], used by [`run_pending_editor`]'s suspend path so the
+/// editor's exit leaves the TUI clean.
+fn resume_terminal() {
+    use crossterm::terminal::{enable_raw_mode, EnterAlternateScreen};
+    let _ = execute!(std::io::stdout(), EnterAlternateScreen);
+    let _ = enable_raw_mode();
+    push_keyboard_enhancement();
+    let _ = execute!(std::io::stdout(), EnableBracketedPaste);
+    if thurbox::session::settings::global().features.mouse {
+        let _ = execute!(std::io::stdout(), EnableMouseCapture);
+    }
+}
+
+/// Run a terminal editor staged by `Ctrl+O`, giving it a real controlling
+/// TTY. Inside tmux (`$TMUX` set, on a tmux ≥ 3.2 that has `display-popup`)
+/// the editor floats in a `tmux display-popup` with its own PTY — the TUI
+/// keeps its state underneath and the popup closes on editor exit. Otherwise
+/// the TUI is suspended (alt screen/raw mode/mouse torn down), the editor
+/// inherits the terminal, and the TUI resumes on exit — the git/sudoedit
+/// pattern. Either way the render loop is blocked for the editor's lifetime,
+/// which is correct (the user is editing).
+fn run_pending_editor(
+    terminal: &mut ratatui::DefaultTerminal,
+    inv: &thurbox::app::EditorInvocation,
+) -> Result<()> {
+    let use_popup = std::env::var_os("TMUX").is_some() && outer_tmux_supports_popup();
+    let popup_ok = if use_popup {
+        match run_editor_popup(inv) {
+            Ok(()) => true,
+            Err(e) => {
+                // `tmux` itself wouldn't spawn (not on PATH, etc.) — fall back
+                // to suspend rather than doing nothing.
+                tracing::warn!("tmux popup unavailable, suspending TUI instead: {e}");
+                false
+            }
+        }
+    } else {
+        false
+    };
+    if !popup_ok {
+        run_editor_suspended(terminal, inv)?;
+    }
+    Ok(())
+}
+
+/// Cached check that the *outer* tmux (the one `$TMUX` points at, whose client
+/// owns this process's terminal) supports `display-popup` (tmux ≥ 3.2). `tmux
+/// -V` prints the binary version, which matches the running server (a tmux
+/// client must match its server), so this is a reliable one-shot gate. Returns
+/// `false` when not inside tmux or the version can't be read.
+static OUTER_TMUX_POPUP_OK: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+fn outer_tmux_supports_popup() -> bool {
+    *OUTER_TMUX_POPUP_OK.get_or_init(|| {
+        let output = match std::process::Command::new("tmux").arg("-V").output() {
+            Ok(o) => o,
+            Err(_) => return false,
+        };
+        let v = String::from_utf8_lossy(&output.stdout);
+        // `tmux 3.4` → parse major.minor.
+        let nums: Vec<u32> = v
+            .split_whitespace()
+            .nth(1)
+            .map(|s| s.split('.').filter_map(|n| n.parse().ok()).collect())
+            .unwrap_or_default();
+        matches!(nums.as_slice(), [major, minor, ..] if (*major, *minor) >= (3, 2))
+    })
+}
+
+/// Float the editor in a `tmux display-popup` over the TUI. The popup gets its
+/// own PTY (the editor's termios init is independent of thurbox's), and `-E`
+/// closes it on editor exit. Returns `Ok(())` whenever tmux actually launched
+/// the command — the editor's own exit code is ignored (a nonzero editor exit
+/// must NOT trigger a fallback that would re-launch it). The command string is
+/// POSIX-quoted and run via tmux's shell, so paths/flags with spaces survive.
+/// Only called after [`outer_tmux_supports_popup`].
+fn run_editor_popup(inv: &thurbox::app::EditorInvocation) -> std::io::Result<()> {
+    let mut shell_cmd = String::new();
+    shell_cmd.push_str(&thurbox::shell::posix_quote(&inv.program));
+    for arg in &inv.args {
+        shell_cmd.push(' ');
+        shell_cmd.push_str(&thurbox::shell::posix_quote(arg));
+    }
+    // `-E` closes the popup on command exit; sized to 90% so the editor gets
+    // most of the screen while the TUI border stays visible.
+    let _status = std::process::Command::new("tmux")
+        .args([
+            "display-popup",
+            "-E",
+            "-w",
+            "90%",
+            "-h",
+            "90%",
+            "-T",
+            "thurbox editor",
+        ])
+        .arg(&shell_cmd)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()?;
+    Ok(())
+}
+
+/// Suspend the TUI and run the editor with the inherited terminal (the
+/// git/sudoedit pattern). The editor controls termios for the duration; on its
+/// exit the TUI's terminal mutations are re-established and the frame buffer
+/// cleared so the next `draw` repaints from scratch.
+fn run_editor_suspended(
+    terminal: &mut ratatui::DefaultTerminal,
+    inv: &thurbox::app::EditorInvocation,
+) -> Result<()> {
+    // Tear down everything `main` set up (the same path as quit), so the
+    // editor owns a normal cooked terminal — it then puts the terminal into its
+    // own raw mode for the duration of editing.
+    restore_terminal();
+    let result = std::process::Command::new(&inv.program)
+        .args(&inv.args)
+        .status();
+    resume_terminal();
+    // Drop the stale frame buffer so the next paint is full-screen, not a diff
+    // against the pre-suspend frame (which the editor overwrote).
+    let _ = terminal.clear();
+    let status = result?;
+    if !status.success() {
+        tracing::info!(
+            program = %inv.program,
+            code = ?status.code(),
+            "editor exited non-zero"
+        );
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Process start, for the opt-in time-to-first-frame measurement (logged
@@ -500,6 +636,19 @@ async fn run_loop(
                     app.record_update_time(start.elapsed());
                 }
             }
+        }
+
+        // Run a terminal editor staged by Ctrl+O. Blocks the loop for the
+        // editor's lifetime (by design — the user is editing); inside tmux the
+        // editor floats in a `display-popup` over the TUI, otherwise the TUI is
+        // suspended and the editor owns the terminal. Either way a forced
+        // repaint follows on return. See `App::take_pending_editor_run`.
+        if let Some(inv) = app.take_pending_editor_run() {
+            if let Err(e) = run_pending_editor(&mut *terminal, &inv) {
+                tracing::warn!("editor run failed: {e:#}");
+            }
+            // The popup covered / the suspend tore down the frame; repaint fully.
+            app.request_redraw();
         }
 
         // Cheap, lock-free check for new agent output (marks dirty on change).

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -136,6 +136,52 @@ pub enum NotificationBackend {
     Off,
 }
 
+/// How `Ctrl+O` launches the editor (the DB `editor_mode` key, set via
+/// `thurbox-cli editor mode`). `Auto` (the default) detects terminal vs GUI
+/// editors from the command name and gives terminal editors (vim, nano,
+/// `ttt`, helix, …) a real TTY — a floating `tmux display-popup` when thurbox
+/// runs inside tmux, or a TUI-suspend-and-resume when it does not — while GUI
+/// editors (`code`, `zed`, …) stay detached (the classic behavior). `Terminal`
+/// forces the TTY path for every editor; `Gui` forces the detached spawn.
+/// Stored in SQLite (not `settings.toml`) so it applies live, like
+/// `editor_command`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum EditorMode {
+    /// Detect from the command name (curated terminal/GUI lists).
+    #[default]
+    Auto,
+    /// Always give the editor a real TTY (popup / suspend).
+    Terminal,
+    /// Always spawn detached (the pre-terminal-support behavior).
+    Gui,
+}
+
+impl EditorMode {
+    /// Parse a stored `editor_mode` value, tolerating any case; `None`,
+    /// empty, or an unrecognized value yields the default (`Auto`). Used by
+    /// the DB getter so a corrupted row can't panic the TUI.
+    pub fn parse_stored(stored: Option<&str>) -> Self {
+        match stored.map(str::trim) {
+            Some(s) => match s.to_ascii_lowercase().as_str() {
+                "terminal" | "term" | "tty" => EditorMode::Terminal,
+                "gui" | "detached" | "graphical" => EditorMode::Gui,
+                _ => EditorMode::Auto,
+            },
+            None => EditorMode::Auto,
+        }
+    }
+
+    /// The value written back to the DB (canonical, lowercase).
+    pub fn as_db_value(self) -> &'static str {
+        match self {
+            EditorMode::Auto => "auto",
+            EditorMode::Terminal => "terminal",
+            EditorMode::Gui => "gui",
+        }
+    }
+}
+
 /// Knobs for the OS notification feature (`[notifications]` table). All
 /// fields have defaults so an empty / absent table behaves like the seeded
 /// configuration.

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -7,6 +7,7 @@ use super::Database;
 use crate::session::{SessionId, PENDING_FOCUS_SESSION_ID_KEY};
 
 const EDITOR_COMMAND_KEY: &str = "editor_command";
+const EDITOR_MODE_KEY: &str = "editor_mode";
 const THEME_KEY: &str = "active_theme";
 const ACTIVE_EXTENSIONS_KEY: &str = "active_extensions";
 const BUILTIN_HOOKS_OPTOUT_KEY: &str = "builtin_hooks_optout";
@@ -36,6 +37,43 @@ impl Database {
                 "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
                  ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                 params![EDITOR_COMMAND_KEY, command],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Get the configured editor launch mode (`auto`/`terminal`/`gui`),
+    /// tolerating a missing/blank/corrupt row (defaults to `Auto`).
+    pub fn get_editor_mode(&self) -> rusqlite::Result<crate::session::settings::EditorMode> {
+        let stored: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                params![EDITOR_MODE_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(crate::session::settings::EditorMode::parse_stored(
+            stored.as_deref(),
+        ))
+    }
+
+    /// Set the editor launch mode. Pass [`crate::session::settings::EditorMode::Auto`]
+    /// (or an empty-ish reset) to clear the row back to the default.
+    pub fn set_editor_mode(
+        &self,
+        mode: crate::session::settings::EditorMode,
+    ) -> rusqlite::Result<()> {
+        if mode == crate::session::settings::EditorMode::Auto {
+            self.conn.execute(
+                "DELETE FROM metadata WHERE key = ?1",
+                params![EDITOR_MODE_KEY],
+            )?;
+        } else {
+            self.conn.execute(
+                "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![EDITOR_MODE_KEY, mode.as_db_value()],
             )?;
         }
         Ok(())


### PR DESCRIPTION
## Summary

- `Ctrl+O` previously spawned the editor fully detached (`Stdio::null()` on all streams + a new process group). That only works for GUI launchers (`code`/`zed`, which fork-and-exit and open their own window). A **terminal** editor — vim, nano, `ttt`, helix, micro, … — got no controlling TTY, exited immediately, and thurbox still toasted "Opening…", masking the failure.
- Terminal editors now run with a **real TTY**:
  - **Inside tmux (≥ 3.2):** the editor floats in a `tmux display-popup -E` with its own PTY; the TUI keeps running underneath and the popup closes on editor exit. (Gated on `tmux -V` ≥ 3.2, cached via `OnceLock`; a pre-3.2 outer tmux falls back to the suspend path.)
  - **Outside tmux:** the TUI is suspended (alt-screen/raw-mode/mouse torn down), the editor inherits the terminal (the git/sudoedit pattern), and `resume_terminal()` + a buffer clear repaint on exit.
- **GUI editors are unchanged** — they keep the detached spawn, so `code`/`zed`/`cursor` workflows behave exactly as before.
- **Auto-detection** picks the path from the editor command name (curated terminal/GUI lists; `emacs -nw` / `--no-window-system` / `--tty` / `--terminal` force the terminal path). Precision is favored over recall so an unlisted GUI launcher can't be misrouted to a TTY; an unlisted terminal editor falls back to detached and is fixed with `editor mode terminal`.
- New override: **`thurbox-cli editor mode <auto|terminal|gui>`** (DB `editor_mode` key), also surfaced in `thurbox-cli config show`. Default `auto` means the common case just works.

## Test plan

- [x] `cargo nextest run --all` — 1898 passed (incl. 20 new unit tests for `parse_editor_command` / `is_terminal_editor` / `classify_editor` / `resolve_editor_mode` and the CLI `editor mode` round-trip/alias/clear/unknown-fallback, plus 2 acceptance tests asserting `ttt` stages a terminal run and `editor mode terminal` forces TTY even for `code`).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean.
- [x] `cargo test --test architecture_rules` passes (new `EditorMode` lives in the pure-data `session` layer; `EditorInvocation` is in `app`).
- [x] `rumdl check` on changed docs clean.
- [x] Manual CLI smoke: `editor mode` round-trips `auto`/`terminal`/`gui` (and aliases `term`/`tty`/`detached`), JSON pipes through `jq`, `config show` reports `editor.mode`.