### PR TITLE
Release v1.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -791,10 +791,10 @@ effective resolved config; see `docs/CONFIG.md`), `extension`
 (alias `ext`: install/uninstall/reinstall/list/available/update/activate/
 deactivate/status — manage opt-in extensions; see below), `version`
 (prints the running version; `--check` queries GitHub's latest release —
-gated on `[features] version_check`, off by default), `update`
+gated on `[features] version_check`, on by default for 1.0), `update`
 (downloads, verifies, and replaces the installed binaries with the latest
 release — `--force` bypasses the up-to-date/dev-build guards; gated on
-`[features] auto_update`, off by default; the TUI also runs this silently on
+`[features] auto_update`, on by default for 1.0; the TUI also runs this silently on
 startup when the flag is on), `notify`
 (diagnose OS desktop notifications: prints the detected delivery backend
 and last error; `--test` fires a sample — see OS notifications below), `perf`
@@ -1356,7 +1356,7 @@ fields into the discovery-dir copy: `installed_with` (the thurbox version
 that installed it) and `source` (the resolved install target). After a
 thurbox upgrade the on-disk copy is older than the binary, so
 `ExtensionDef::is_stale` flags it (`extension list`/`status`, and a
-self-heal nudge). With `[features] auto_update` on (the same opt-in flag that
+self-heal nudge). With `[features] auto_update` on (the same flag that
 self-updates the binary), the self-heal pass — `heal_one_extension`, run on TUI
 startup **and** the headless `automation tick` — goes a step past the nudge and
 **refreshes the stale extension in place** (calls `update_extension`); the

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -210,8 +210,8 @@ perf_hud      = true
 mouse         = true
 notifications = true
 soft_delete   = true
-version_check = false          # opt-in: makes a network call
-auto_update   = false          # opt-in: downloads + replaces binaries
+version_check = true           # on by default (1.0): makes a network call
+auto_update   = true           # on by default (1.0): downloads + replaces binaries
 
 [notifications]
 also_on_waiting     = false    # also fire when a session finishes (Working → Done)
@@ -222,9 +222,9 @@ min_interval_secs   = 5        # per-session floor between notifications
 
 ### `[features]` — whole-feature switches
 
-Turn major TUI features off entirely. All default to `true` **except
-`version_check` and `auto_update`, which default to `false`** (both
-reach the network, so they are opt-in). The UI-panel flags
+Turn major TUI features off entirely. All default to `true` — as of 1.0
+that includes `version_check` and `auto_update`, which both reach the
+network (they were opt-in before 1.0). The UI-panel flags
 (`tasks`, `file_viewer`, `info_panel`, `global_search`, `shell_pane`,
 `code_review`, `perf_hud`, `soft_delete`) apply **live** on save; the rest
 (`automations`, `mouse`, `notifications`, `version_check`, `auto_update`)
@@ -246,8 +246,8 @@ no results. Data is never touched, so re-enabling a flag is lossless.
 | `mouse` | `true` | mouse capture: clicks, wheel, drag-select, hover, scrollbars |
 | `notifications` | `true` | OS desktop notifications when a session needs attention |
 | `soft_delete` | `true` | TUI `Ctrl+D` soft-deletes (Ctrl+Z undo); off = hard delete after a confirmation prompt |
-| `version_check` | `false` | GitHub update check: TUI header "update available" badge + `thurbox-cli version --check` |
-| `auto_update` | `false` | Silent self-update: download + verify + replace the binaries on startup + `thurbox-cli update`; also auto-refreshes stale extensions |
+| `version_check` | `true` | GitHub update check: TUI header "update available" badge + `thurbox-cli version --check` |
+| `auto_update` | `true` | Silent self-update: download + verify + replace the binaries on startup + `thurbox-cli update`; also auto-refreshes stale extensions |
 
 `automations = false` is a full stop on the TUI side: the pane
 disappears (the session list takes the whole left column and `j`/`k`
@@ -275,8 +275,8 @@ still written last, so the session remains restorable via `Ctrl+U`
 `thurbox-cli session delete` always soft-deletes unless you pass
 `--force`, regardless of the setting.
 
-`version_check = true` enables the update check (default `false`, since
-it makes a network call). On launch the TUI reads a cached result
+`version_check` (on by default for 1.0) enables the update check — it
+makes a network call. On launch the TUI reads a cached result
 (`~/.local/share/thurbox/version-check.json`) and, if it is older than
 24 h, fires a single best-effort background fetch of GitHub's latest
 release (`api.github.com/repos/Thurbeen/thurbox/releases/latest`, via
@@ -288,8 +288,9 @@ builds (`0.0.0-dev`) never show the badge. The same flag enables
 current vs. latest (`thurbox-cli version` with no flag always prints the
 current version, regardless of the flag).
 
-`auto_update = true` goes a step further than `version_check`: instead of
-just showing a badge, the TUI **silently updates itself** on startup. On every
+`auto_update` (on by default for 1.0) goes a step further than
+`version_check`: instead of just showing a badge, the TUI **silently
+updates itself** on startup. On every
 launch (it does **not** reuse the `version_check` badge's 24 h cache — sharing
 that gate let the badge keep the cache "fresh" and starve the updater) it
 fetches the latest release tag; if a newer release exists it downloads that

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1179,8 +1179,8 @@ Whole features can be switched off declaratively: `tasks`,
 `true`. `soft_delete` is the odd one out: it is not a pane gate but a
 behaviour switch for the TUI `Ctrl+D` delete (soft-delete with a
 `Ctrl+Z` undo window when on; a confirmation-gated hard delete when
-off — see *Explicit close vs quit*). Two flags are the opposite —
-opt-in (default `false`, because they reach the network):
+off — see *Explicit close vs quit*). Two flags reach the network and
+were opt-in before 1.0 — now both default on:
 `version_check` (the "update available" badge +
 `thurbox-cli version --check`) and `auto_update` (silent self-update on
 startup + `thurbox-cli update`). See `docs/CONFIG.md`.
@@ -1251,8 +1251,9 @@ network — see *Feature Flags*) cover staying current:
   replaces the installed binaries with the latest release. `--force`
   bypasses the up-to-date and dev-build guards.
 
-Both are off by default so a fresh install makes **no** network calls and
-never mutates its own binary unless the user asks.
+Both are on by default for 1.0 so a fresh install stays current on its
+own; set them to `false` if you'd rather make no network calls or have
+thurbox never mutate its own binary unless you ask.
 
 ---
 

--- a/src/agent/self_update.rs
+++ b/src/agent/self_update.rs
@@ -1,9 +1,8 @@
 //! Self-update: download, verify, and replace the installed thurbox binaries.
 //!
-//! This is the **opt-in** auto-update feature (gated behind `[features]
-//! auto_update`, off by default — see
-//! [`crate::session::settings::FeatureFlags`]). It surfaces two ways, both
-//! calling [`perform_update`]:
+//! This is the auto-update feature (gated behind `[features] auto_update`, on
+//! by default for 1.0 — see [`crate::session::settings::FeatureFlags`]). It
+//! surfaces two ways, both calling [`perform_update`]:
 //!
 //! - **TUI** — a silent check on startup (`main::spawn_auto_update`), run on a
 //!   background thread so a slow download never blocks the first frame. A newer

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -52,16 +52,16 @@ config_version = 1
 # notifications = true    # OS desktop notifications when a session needs attention
 # soft_delete = true      # Ctrl+D soft-deletes (Ctrl+Z undo); false = hard delete after a prompt
 #
-# `version_check` and `auto_update` are the two flags that default to FALSE:
-# both reach the network (GitHub) on startup. `version_check` only *notifies*
-# (TUI header "update available" badge + `thurbox-cli version --check`);
-# `auto_update` goes further and silently downloads, verifies, and replaces the
-# installed binaries when a newer release exists (the new version applies on the
-# next launch); it also auto-refreshes any installed extension that the upgrade
-# left stale (self-heal, TUI startup + headless tick). `thurbox-cli update` does
-# the same binary update on demand.
-# version_check = false   # GitHub update check (TUI badge + `version --check`)
-# auto_update = false     # silently download+verify+replace binaries on startup
+# `version_check` and `auto_update` are ON by default for 1.0: both reach the
+# network (GitHub) on startup. `version_check` only *notifies* (TUI header
+# "update available" badge + `thurbox-cli version --check`); `auto_update` goes
+# further and silently downloads, verifies, and replaces the installed binaries
+# when a newer release exists (the new version applies on the next launch); it
+# also auto-refreshes any installed extension that the upgrade left stale
+# (self-heal, TUI startup + headless tick). `thurbox-cli update` does the same
+# binary update on demand. Set either to `false` to opt out.
+# version_check = true    # GitHub update check (TUI badge + `version --check`)
+# auto_update = true      # silently download+verify+replace binaries on startup
 
 # OS desktop notifications. Linux gets click-to-focus (clicking the banner
 # selects the session in the running TUI); macOS shows a passive banner only.
@@ -99,15 +99,13 @@ config_version = 1
 # suppress_for_active = false   # also notify the focused session
 # min_interval_secs = 30        # at most one notification / 30 s per session
 #
-# Show an "update available" badge in the TUI header (makes a network call to
-# GitHub on startup):
+# Turn OFF the "update available" badge (stops the startup GitHub call):
 # [features]
-# version_check = true
+# version_check = false
 #
-# Keep thurbox up to date automatically — silently download+verify+replace the
-# binaries on startup when a newer release exists (restart to apply):
+# Turn OFF silent auto-update (don't download+replace binaries on startup):
 # [features]
-# auto_update = true
+# auto_update = false
 "#;
 
 /// Path to the settings file: `~/.config/thurbox/settings.toml`.
@@ -320,8 +318,8 @@ mod tests {
         for marker in [
             "Common recipes",
             "scrollback_lines = 10000",
-            "version_check = true",
-            "auto_update = true",
+            "version_check = false",
+            "auto_update = false",
         ] {
             assert!(
                 SEED_SETTINGS_TOML.contains(marker),

--- a/src/agent/version_check.rs
+++ b/src/agent/version_check.rs
@@ -1,7 +1,7 @@
 //! Update check: is a newer thurbox release available?
 //!
-//! This is the side-effect half of the **opt-in** version-deployment indicator
-//! (gated behind `[features] version_check`, off by default — see
+//! This is the side-effect half of the version-deployment indicator (gated
+//! behind `[features] version_check`, on by default for 1.0 — see
 //! [`crate::session::settings::FeatureFlags`]). It surfaces two ways:
 //!
 //! - **TUI** — a small "⬆ vX.Y.Z available" badge in the header. The draw loop

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4454,7 +4454,7 @@ impl App {
     }
 
     /// The spawning half of [`Self::tick`]: kicks off background refreshes
-    /// (sysinfo/git/usage shell-outs), the opt-in update check, and the
+    /// (sysinfo/git/usage shell-outs), the update check, and the
     /// auto-updater — each lands on a Tokio task. Kept out of
     /// [`Self::tick_core`] so tests driving the tick pipeline never touch the
     /// network, the filesystem outside the harness tempdir, or a runtime.
@@ -4699,7 +4699,7 @@ impl App {
         h.finish()
     }
 
-    /// Drive the opt-in GitHub update check. Off the render path: on the first
+    /// Drive the GitHub update check. Off the render path: on the first
     /// tick (when the flag is on and the on-disk cache is stale) it fires a
     /// single background network refresh; the result only ever lands by
     /// re-reading the cache, so rendering never makes a network call.
@@ -4709,8 +4709,14 @@ impl App {
         }
 
         // One attempt per launch: fire on the first tick if the cache is stale.
+        // The runtime check upholds the contract that a background spawn never
+        // lands on the first ticks a runtime-less unit `tick()` drives
+        // (`spawn_blocking` panics without a reactor) — now that `version_check`
+        // defaults on, this is what lets hermetic full-`tick()` unit tests keep
+        // working. Production always runs under tokio, so this is a no-op there.
         if self.metrics.tick_count == 1
             && !self.version_check_task.in_progress()
+            && tokio::runtime::Handle::try_current().is_ok()
             && crate::agent::version_check::cache_is_stale()
         {
             let tx = self.version_check_task.start();

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -1,11 +1,11 @@
 //! `thurbox-cli update` — download, verify, and replace the installed binaries
 //! with the latest GitHub release.
 //!
-//! Gated behind the opt-in `[features] auto_update` flag (off by default, since
-//! it makes a network call and replaces files on disk). When the flag is off,
-//! `update` prints a one-line hint on how to enable it instead of reaching the
-//! network. `--force` re-downloads and replaces even when up to date or on a
-//! development build.
+//! Gated behind the `[features] auto_update` flag (on by default for 1.0,
+//! since thurbox now keeps itself current — it makes a network call and
+//! replaces files on disk). When the flag is off, `update` prints a one-line
+//! hint on how to enable it instead of reaching the network. `--force`
+//! re-downloads and replaces even when up to date or on a development build.
 
 use clap::Args;
 use serde_json::json;
@@ -25,9 +25,16 @@ pub struct UpdateArgs {
 /// Run the `update` command. Takes no database — it only reads the compiled-in
 /// version, the network, and the install directory.
 pub fn run(args: UpdateArgs) -> CommandOutput {
+    run_with(args, settings::global().features.auto_update)
+}
+
+/// Same as [`run`] but with the `auto_update` flag passed explicitly, so the
+/// disabled path is testable without depending on the process-global default
+/// (the flag is on by default for 1.0).
+fn run_with(args: UpdateArgs, enabled: bool) -> CommandOutput {
     let current = crate::agent::version_check::current_version();
 
-    if !settings::global().features.auto_update {
+    if !enabled {
         let hint = "update is disabled. Enable it by setting \
                     `[features] auto_update = true` in settings.toml.";
         return CommandOutput::new(
@@ -105,11 +112,10 @@ mod tests {
 
     #[test]
     fn update_when_flag_disabled_prints_enable_hint() {
-        // `settings::init` is only ever called by the binaries, so in the test
-        // process `settings::global()` is the all-default config — auto_update
-        // is off — and `update` degrades to the enable hint with no network or
+        // The flag is on by default for 1.0, so exercise the disabled path
+        // directly via `run_with` — no process-global settings, no network or
         // disk touch.
-        let out = run(UpdateArgs { force: false });
+        let out = run_with(UpdateArgs { force: false }, false);
         assert_eq!(out["update_enabled"], false);
         assert!(out.human.contains("disabled"), "got: {}", out.human);
         assert!(

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -1,9 +1,10 @@
 //! `thurbox-cli version [--check]` — print the running version and, with
 //! `--check`, query GitHub for the latest release.
 //!
-//! `--check` is gated behind the opt-in `[features] version_check` flag (off by
-//! default, since it makes a network call). When the flag is off, `--check`
-//! prints a one-line hint on how to enable it instead of reaching the network.
+//! `--check` is gated behind the `[features] version_check` flag (on by
+//! default for 1.0, since thurbox now keeps itself current). When the flag is
+//! off, `--check` prints a one-line hint on how to enable it instead of
+//! reaching the network.
 //! A successful check also refreshes the on-disk cache the TUI badge reads.
 
 use clap::Args;
@@ -24,13 +25,20 @@ pub struct VersionArgs {
 /// Run the `version` command. Takes no database — it only reads the compiled-in
 /// version and (with `--check`) the network.
 pub fn run(args: VersionArgs) -> CommandOutput {
+    run_with(args, settings::global().features.version_check)
+}
+
+/// Same as [`run`] but with the `version_check` flag passed explicitly, so the
+/// disabled path is testable without depending on the process-global default
+/// (the flag is on by default for 1.0).
+fn run_with(args: VersionArgs, enabled: bool) -> CommandOutput {
     let current = crate::agent::version_check::current_version();
 
     if !args.check {
         return CommandOutput::new(json!({ "version": current }), format!("thurbox {current}"));
     }
 
-    if !settings::global().features.version_check {
+    if !enabled {
         let hint = "version --check is disabled. Enable it by setting \
                     `[features] version_check = true` in settings.toml.";
         return CommandOutput::new(
@@ -105,10 +113,9 @@ mod tests {
 
     #[test]
     fn version_check_when_flag_disabled_prints_enable_hint() {
-        // `settings::init` is only ever called by the binaries, so in the test
-        // process `settings::global()` is the all-default config — version_check
-        // is off — and `--check` degrades to the enable hint with no network.
-        let out = run(VersionArgs { check: true });
+        // The flag is on by default for 1.0, so exercise the disabled path
+        // directly via `run_with` — no process-global settings, no network.
+        let out = run_with(VersionArgs { check: true }, false);
         assert_eq!(out["check_enabled"], false);
         assert!(out.human.contains("disabled"), "got: {}", out.human);
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,7 +301,7 @@ async fn main() -> Result<()> {
     let agents = thurbox::agent::agent_config::load_or_seed();
     startup.extension_heal_ms = t_phase.elapsed().as_millis();
 
-    // Silent auto-update (opt-in via [features] auto_update). Kicked off on a
+    // Silent auto-update (on by default for 1.0 via [features] auto_update). Kicked off on a
     // background thread *before* the TUI starts so a slow download never blocks
     // the first frame — the result is surfaced as a status toast once it lands
     // (App::poll_auto_update). The self-replace only swaps the on-disk binaries

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -99,19 +99,20 @@ pub struct FeatureFlags {
     #[serde(default = "default_true")]
     pub soft_delete: bool,
     /// Version-update check: the TUI header "update available" badge and the
-    /// `thurbox-cli version --check` command. **Off by default** — unlike the
-    /// other flags, this one is opt-in because it makes a network call to
-    /// GitHub. Enable it to learn when a newer release is available.
-    #[serde(default = "default_false")]
+    /// `thurbox-cli version --check` command. **On by default for 1.0** — it
+    /// makes a network call to GitHub to learn when a newer release is
+    /// available. Turn it off with `[features] version_check = false`.
+    #[serde(default = "default_true")]
     pub version_check: bool,
     /// Silent auto-update: the TUI silently downloads, verifies, and replaces
     /// the installed binaries on startup when a newer release exists, and the
     /// `thurbox-cli update` command does the same on demand. Also keeps installed
     /// extensions fresh — once the binary upgrades, the self-heal pass (TUI
     /// startup + headless tick) refreshes any extension that is now stale instead
-    /// of merely nudging. **Off by default** — opt-in because it makes a network
-    /// call and replaces files on disk. The new version applies on the next launch.
-    #[serde(default = "default_false")]
+    /// of merely nudging. **On by default for 1.0** — opt out with `[features]
+    /// auto_update = false`; it makes a network call and replaces files on
+    /// disk. The new version applies on the next launch.
+    #[serde(default = "default_true")]
     pub auto_update: bool,
 }
 
@@ -231,10 +232,6 @@ fn default_true() -> bool {
     true
 }
 
-fn default_false() -> bool {
-    false
-}
-
 impl Default for FeatureFlags {
     fn default() -> Self {
         Self {
@@ -249,8 +246,8 @@ impl Default for FeatureFlags {
             mouse: true,
             notifications: true,
             soft_delete: true,
-            version_check: false,
-            auto_update: false,
+            version_check: true,
+            auto_update: true,
         }
     }
 }
@@ -444,26 +441,26 @@ mod tests {
     }
 
     #[test]
-    fn version_check_flag_defaults_off_and_parses() {
-        // Unlike the other flags, version_check is opt-in (network call).
+    fn version_check_flag_defaults_on_and_parses() {
+        // On by default for 1.0 (it makes a network call to GitHub).
         let s: Settings = toml::from_str("[features]").unwrap();
-        assert!(!s.features.version_check, "version_check defaults off");
+        assert!(s.features.version_check, "version_check defaults on");
         assert!(s.features.tasks, "other flags still default on");
 
-        let s: Settings = toml::from_str("[features]\nversion_check = true").unwrap();
-        assert!(s.features.version_check);
+        let s: Settings = toml::from_str("[features]\nversion_check = false").unwrap();
+        assert!(!s.features.version_check);
         assert!(s.features.mouse, "untouched flags stay at their default");
     }
 
     #[test]
-    fn auto_update_flag_defaults_off_and_parses() {
-        // Like version_check, auto_update is opt-in (network call + writes to disk).
+    fn auto_update_flag_defaults_on_and_parses() {
+        // On by default for 1.0 (network call + writes to disk).
         let s: Settings = toml::from_str("[features]").unwrap();
-        assert!(!s.features.auto_update, "auto_update defaults off");
+        assert!(s.features.auto_update, "auto_update defaults on");
         assert!(s.features.tasks, "other flags still default on");
 
-        let s: Settings = toml::from_str("[features]\nauto_update = true").unwrap();
-        assert!(s.features.auto_update);
+        let s: Settings = toml::from_str("[features]\nauto_update = false").unwrap();
+        assert!(!s.features.auto_update);
         assert!(s.features.mouse, "untouched flags stay at their default");
     }
 


### PR DESCRIPTION
## v1.0.0

Thurbox is stable enough for a 1.0. This PR carries the single breaking
change that bumps `0.99.7 → 1.0.0` (cocogitto cuts the tag automatically
on merge to `main`).

### Breaking change

`feat(config)!: enable update check + auto-update by default for 1.0`

The two network-reaching `[features]` flags flip from opt-in (off) to
**on by default**:

| flag | before | after |
|------|--------|-------|
| `version_check` | `false` (opt-in) | `true` |
| `auto_update`   | `false` (opt-in) | `true` |

A fresh install now surfaces update availability (TUI badge +
`thurbox-cli version --check`) and silently self-updates when a newer
release exists. Both still reach `api.github.com` on startup; users who
prefer no network calls opt out with `[features] version_check = false`
/ `auto_update = false`.

### What changed
- `src/session/settings.rs` — flipped both defaults (+ `FeatureFlags::default`), removed the now-dead `default_false`, updated the default-on tests.
- `src/cli/{version,update}.rs` — added a `run_with(args, enabled)` seam so the disabled-path tests no longer depend on the process-global default.
- `src/app/mod.rs` — guarded `tick_version_check`'s spawn with a runtime check so hermetic full-`tick()` unit tests stay runtime-less-safe now that the flag defaults on (no-op in production, which always runs under tokio).
- Seed `settings.toml`, `CLAUDE.md`, `docs/CONFIG.md`, `docs/FEATURES.md` — updated every "off by default / opt-in" reference for accuracy.

### Verification
- `cargo nextest run --all` → 1898 passed
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `cargo deny check advisories bans licenses sources` → ok
- `rumdl check .` → clean
- `cog verify` → valid (BREAKING CHANGE detected → major bump)

### Release
Merging to `main` triggers the `Release` workflow (`cd.yml`): `cog bump
--auto` cuts **v1.0.0**, builds 4 platforms, publishes the GitHub
Release, then publishes to AUR / Homebrew / Chocolatey / winget.
