### PR TITLE
ci: fix forced-version cut (compute bump args in bash)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,11 @@ jobs:
     outputs:
       should_release: ${{ steps.parse.outputs.should_release }}
       version: ${{ steps.parse.outputs.version }}
+      # The exact `cog bump` args create-tag runs. Computed here in bash (not
+      # via a YAML `${{ && || }}` ternary in create-tag) so the forced-version
+      # path is deterministic — the ternary form silently fell back to `--auto`
+      # when an output briefly evaluated empty, defeating the forced cut.
+      bump_args: ${{ steps.parse.outputs.bump_args }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -70,7 +75,7 @@ jobs:
             VERSION="v${FORCED_VERSION#v}"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "forced=true" >> "$GITHUB_OUTPUT"
+            echo "bump_args=--version $VERSION --disable-bump-commit" >> "$GITHUB_OUTPUT"
             echo "✅ Forced release: $VERSION"
             exit 0
           fi
@@ -81,12 +86,12 @@ jobs:
           if [ -n "$VERSION" ]; then
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "forced=false" >> "$GITHUB_OUTPUT"
+            echo "bump_args=--auto --disable-bump-commit" >> "$GITHUB_OUTPUT"
             echo "✅ Release needed: $VERSION"
           else
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "version=" >> "$GITHUB_OUTPUT"
-            echo "forced=false" >> "$GITHUB_OUTPUT"
+            echo "bump_args=--auto --disable-bump-commit" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No releasable commits detected"
           fi
 
@@ -109,13 +114,10 @@ jobs:
         id: bump
         with:
           command: bump
-          # A forced dispatch passes the exact version via `--version`, bypassing
-          # `--auto` (which can't cross a major boundary on a 0.x line). Otherwise
-          # compute the next tag from the commit history as usual.
-          args: >-
-            ${{ needs.check-release.outputs.forced == 'true'
-                && format('--version {0} --disable-bump-commit', needs.check-release.outputs.version)
-                || '--auto --disable-bump-commit' }}
+          # `bump_args` is resolved by check-release: `--version <v>` for a
+          # forced cut (the only way across a major boundary on a 0.x line),
+          # `--auto` otherwise. Computed in bash upstream to stay deterministic.
+          args: ${{ needs.check-release.outputs.bump_args }}
           git-user: 'github-actions[bot]'
           git-user-email: 'github-actions[bot]@users.noreply.github.com'
 


### PR DESCRIPTION
## Fix: forced-version dispatch didn't create the tag

Follow-up to #838. The first attempt used a YAML ternary in `create-tag`:
```yaml
args: ${{ needs.check-release.outputs.forced == 'true'
            && format('--version {0} --disable-bump-commit', needs.check-release.outputs.version)
            || '--auto --disable-bump-commit' }}
```
On the actual `version=1.0.0` dispatch this resolved to `--auto` (cog printed "No conventional commits", no `v1.0.0` tag created). The `${{ A && B || C }}` form is not a real ternary — it falls through to `C` whenever `B` evaluates falsy.

### Fix
Move the decision into the `check-release` bash step, which now emits a single `bump_args` output. `create-tag` uses it verbatim:
```yaml
args: ${{ needs.check-release.outputs.bump_args }}
```
Deterministic in all three branches — verified locally:
- forced `1.0.0` → `--version v1.0.0 --disable-bump-commit`
- forced `v1.0.0` → `--version v1.0.0 --disable-bump-commit` (leading `v` stripped)
- auto with bump → `--auto --disable-bump-commit`
- auto no releasable → `--auto --disable-bump-commit`

Once merged, re-dispatch `cd.yml` with `version=1.0.0` to cut v1.0.0.
