### PR TITLE
ci: pass a bare semver to cog bump --version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,7 +75,10 @@ jobs:
             VERSION="v${FORCED_VERSION#v}"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "bump_args=--version $VERSION --disable-bump-commit" >> "$GITHUB_OUTPUT"
+            # `cog bump --version` parses a bare semver (no `v`); the tag_prefix
+            # in cog.toml re-adds the `v` on the created tag. `version` (above)
+            # keeps the `v` because the tag_name / `ref: <tag>` lookups need it.
+            echo "bump_args=--version ${VERSION#v} --disable-bump-commit" >> "$GITHUB_OUTPUT"
             echo "✅ Forced release: $VERSION"
             exit 0
           fi


### PR DESCRIPTION
## Fix: `cog bump --version` rejects the `v` prefix

The second v1.0.0 dispatch reached `create-tag` correctly (`args: --version v1.0.0 --disable-bump-commit`) but cog failed:
```
Error: failed to bump version
	unexpected character 'v' while parsing major version number
```

`cog bump --version` parses a **bare** semver; the `v` tag prefix is re-added by `tag_prefix = "v"` in `cog.toml` when the tag is created. Fix: strip the `v` in `bump_args` only. The `version` output stays `v`-prefixed because the `tag_name` / `ref: <tag>` lookups downstream need the prefix.

Verified: both `1.0.0` and `v1.0.0` inputs now yield `bump_args=--version 1.0.0 --disable-bump-commit` with `version=v1.0.0`.

Follow-up to #838 / #840. Once merged, re-dispatch `cd.yml` with `version=1.0.0`.
