### PR TITLE
docs: drop the pre-1.0 framing from README, docs, and website

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,7 @@ ARM64 Windows installs the x86_64 build (runs under x64 emulation).
 - Colorized output (auto-disabled when stderr is not a TTY, `NO_COLOR` is set,
   or `TERM=dumb`); platforms Linux/macOS × x86_64/aarch64
 - No external deps beyond standard tools (curl/wget, tar, sha256sum/shasum)
-- Env vars: `VERSION=v0.1.0`, `INSTALL_DIR=/path` (default `~/.local/bin`)
+- Env vars: `VERSION=v1.0.0`, `INSTALL_DIR=/path` (default `~/.local/bin`)
 - Non-interactive (safe pipe-to-shell), cleanup via `trap`
 - Tested by `scripts/install.bats` (bats-core, ~28 tests; CI `install-script` job)
 
@@ -349,8 +349,8 @@ Every push to `main` automatically triggers the release workflow:
    - **If** commits include `feat`, `fix`, or `perf` → creates release
    - **If** only docs/chore/ci commits → no release (workflow exits)
 3. **Automated Release** (if needed):
-   - Determines semantic version (feat→minor, fix/perf→patch)
-   - Creates lightweight git tag: `v{version}` (e.g., v0.1.0)
+   - Determines semantic version (feat→minor, fix/perf→patch, breaking→major)
+   - Creates lightweight git tag: `v{version}` (e.g., v1.0.0)
    - Pushes tag to origin
    - Builds binaries for 4 platforms (3 Unix `.tar.gz` + 1 Windows `.zip`;
      version passed via environment variable)
@@ -360,11 +360,17 @@ Every push to `main` automatically triggers the release workflow:
 ### Version Management
 
 - **Cargo.toml version**: Always `0.0.0-dev` (static development marker)
-- **Real version**: Determined by release workflow (v0.1.0, v0.2.0, etc.)
+- **Real version**: Determined by release workflow (v1.0.0, v1.1.0, etc.)
 - **Build-time injection**: `build.rs` uses `THURBOX_RELEASE_VERSION` environment
   variable (set by workflow) to inject version into binary
 - **Development builds**: Show `0.0.0-dev` (when `THURBOX_RELEASE_VERSION` not set)
-- **Release builds**: Show actual version (e.g., `0.1.0`) via env variable from workflow
+- **Release builds**: Show actual version (e.g., `1.0.0`) via env variable from workflow
+- **Explicit cuts**: `cog bump --auto` computes the next version from commits and
+  works for every ordinary release (at 1.x+, a breaking change correctly bumps
+  the major). To cut a *specific* version that `--auto` can't reach — the only
+  way across a major boundary from a `0.x` line, or any one-off — dispatch the
+  Release workflow (`cd.yml`) with the `version` input (e.g. `1.0.0`); it runs
+  `cog bump --version <v>` instead of `--auto`.
 
 ### Release Artifacts
 
@@ -416,10 +422,16 @@ See `packaging/README.md` for the full packaging overview.
 
 ### Commit Types and Versioning
 
-- **feat**: Minor version bump (0.x.0)
-- **fix, perf**: Patch version bump (0.0.x)
+Thurbox 1.0+ follows [Semantic Versioning](https://semver.org/):
+
+- **feat**: Minor version bump (1.x.0)
+- **fix, perf**: Patch version bump (1.0.x)
 - **docs, chore, ci, style, test**: No release (appear in next version)
-- **BREAKING CHANGE**: Major version bump (x.0.0) - use cautiously for 0.x
+- **BREAKING CHANGE**: Major version bump (x.0.0)
+
+A breaking change bumps the major version automatically via `cog bump --auto`
+(at 1.x+; on a `0.x` line cocogitto maps breaking to a *minor* bump instead, so
+the only way to cross into 1.0 was the explicit-version Release dispatch).
 
 ## Conventional Commits
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ worktrees are first-class citizens.
 
 ![Thurbox Demo](./docs/media/thurbox-demo.gif)
 
-> **Note:** Thurbox is still **v0.x.x**. While we try hard to avoid
-> them, breaking changes may occasionally happen between releases
-> until the project reaches 1.0. Pin a version if you need stability.
-
 ## Installation
 
 **One-liner:**
@@ -40,7 +36,7 @@ verification and platform auto-detection.
 INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
 
 # Pin a version
-VERSION=v0.1.0 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
+VERSION=v1.0.0 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
 ```
 
 **Windows (PowerShell):**

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -667,7 +667,7 @@ Set **at build time** (not runtime):
 
 | Variable | Used for |
 |----------|----------|
-| `THURBOX_RELEASE_VERSION` | read by `build.rs` to inject the binary version at build (CI release workflow sets it, e.g. `v0.7.0`); absent → falls back to `CARGO_PKG_VERSION` |
+| `THURBOX_RELEASE_VERSION` | read by `build.rs` to inject the binary version at build (CI release workflow sets it, e.g. `v1.0.0`); absent → falls back to `CARGO_PKG_VERSION` |
 
 Editor resolution order: DB `editor_command` → `$VISUAL` → `$EDITOR` →
 error toast.

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -117,7 +117,7 @@ binaries have correct versions while keeping the source tree clean.
 
 **Result:**
 
-- Release builds: version from tag (e.g., 0.1.0)
+- Release builds: version from tag (e.g., 1.0.0)
 - Development builds: version from Cargo.toml (0.0.0-dev)
 
 ## Enforcement Map

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -49,7 +49,7 @@ onThisPage:
           <pre data-wrap><code class="language-bash">INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
 
           <h3>Specific version</h3>
-          <pre data-wrap><code class="language-bash">VERSION=v0.1.0 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
+          <pre data-wrap><code class="language-bash">VERSION=v1.0.0 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
 
           <h3>Windows (PowerShell)</h3>
           <div class="info-box warning">

--- a/website/index.html
+++ b/website/index.html
@@ -782,7 +782,7 @@ Ctrl+O  Open repos in editor</pre>
             </div>
             <div class="install-alt-item">
               <h4>Specific Version</h4>
-              <p><code>VERSION=v0.1.0 curl ...</code></p>
+              <p><code>VERSION=v1.0.0 curl ...</code></p>
             </div>
             <div class="install-alt-item">
               <h4>Full Guide</h4>


### PR DESCRIPTION
docs: drop the pre-1.0 framing from README, docs, and website

Thurbox 1.0.0 is released, so the "still v0.x.x" stability caveat and
the `VERSION=v0.1.0` install examples are now stale.

- README: removed the "still v0.x.x / breaking changes until 1.0"
  note (1.0 commits to semver); bumped the pin-version example to
  `v1.0.0`.
- Website (index + installation): same `v1.0.0` example update.
- CLAUDE.md: post-1.0 versioning rules (`1.x.0` / `1.0.x`), the
  release-process now notes breaking→major works via `--auto` at 1.x+,
  and documents the forced-version Release dispatch (how 1.0.0 itself
  was cut — the only route across a major boundary from a 0.x line).
- docs/CONSTITUTION.md + docs/CONFIG.md: refreshed the version examples
  to `1.0.0` / `v1.0.0`.

Left the `0.0.0-dev` references untouched — that's still the literal
Cargo.toml dev-build marker, and the extension "pin to an older
release" examples (`v0.112.0`) are legitimately about pinning.
