### PR TITLE
feat(config): add built-in support for Oh My Pi (omp) agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,7 +449,7 @@ Enforced by cocogitto via pre-commit hooks.
 
 The set of launchable coding agents is declared **as data** in
 `~/.config/thurbox/agents.toml`, seeded with built-ins
-(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`, `pi`) on first run.
+(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`, `pi`, `omp`) on first run.
 Each `[[agents]]` entry is an `AgentDef`:
 
 ```toml
@@ -475,6 +475,14 @@ Each `*_args` group is appended only when its driving value is
 present, with `{id}` substituted; `args` is always passed. No
 model is ever passed — each agent uses its own default config
 (put `["--model", "opus"]` in `args` if you want to pin one).
+A second token, `{home}`, expands (at spawn, on the spawn worker —
+`session_ops::expand_home_in_def`, called from
+`spawn::adapt_def_for_launch` for a launch and `App::launch_provider_for`
+for a restart) to the resolved home dir — the **remote** home for an
+SSH/WSL host — so an agent that wants a session *file path* rather than a
+bare id (the built-in `omp`, below) launches against a concrete,
+quote-safe absolute path (a literal `~` would never expand — args are
+POSIX-quoted).
 Agents that omit `resume_args` simply start fresh on restart (the
 live tmux process is what carries state across TUI restarts). Add
 your own `[[agents]]` entry to support any CLI — no recompile.
@@ -492,8 +500,19 @@ This works because restart reuses the session's cwd and a single-repo
 fork reuses the parent's cwd. `resume_latest` only changes *when* the
 resume group fires (see `session_ops::resume_trigger_for`): for these
 agents restart always triggers resume; for claude it still defers to an
-on-disk transcript check. Caveats: agents without `fork_args`
-(`antigravity`, `aider`, `copilot` — none of these CLIs fork) start fresh on
+on-disk transcript check. **`omp`** (Oh My Pi) is a third kind: it
+generates its own internal id and won't take thurbox's, but its
+`--session <path>` creates a fresh session at a missing path, so thurbox
+maps its UUID to a deterministic file (`--session
+{home}/.omp/agent/sessions/thurbox-{id}.jsonl` on create, `--resume` the
+same on restart). It is neither id-pinned nor `resume_latest`:
+`resume_trigger_for` resumes it iff that JSONL exists on disk
+(`session_file_template` — agent-neutral, keyed on a `new_session_args`
+token that is a path *and* carries `{id}`, not on the agent name). A
+remote-omp restart can't stat the host file from the UI thread, so it
+starts fresh (documented fallback). Caveats: agents without `fork_args`
+(`antigravity`, `aider`, `copilot`, `omp` — none of these CLIs fork, or
+`omp` can't pin a fork target) start fresh on
 `Ctrl+F`; and a
 **multi-repo** fork of a cwd-scoped agent lands in a fresh symlink
 workspace, so `--last`/`--continue` finds no parent session (multi-repo
@@ -1312,7 +1331,12 @@ against agy 1.0.9 — `PreToolUse` drives working, `Notification` blocked, see
 TypeScript extension into `~/.pi/agent/extensions/thurbox-status.ts` for the
 pi.dev CLI (`pi`) (idle/working/done + blocked; **experimental** — pi has no
 claude-style Stop/permission hook, so `blocked` is inferred only from a
-structured `ask_user_question` tool call). Remote pi sessions are provisioned
+structured `ask_user_question` tool call), and an `[[external_files]]` drops a
+managed TypeScript extension into `~/.omp/agent/extensions/thurbox-status.ts`
+for the Oh My Pi CLI (`omp`) (idle/working/done + blocked; **experimental**,
+verified against OMP 17.0.6 — mirrors pi but its structured user-question tool
+is named `ask`, so `blocked` fires on **either** `ask` or `ask_user_question`).
+Remote pi/omp sessions are provisioned
 like the other config-dir agents; a psmux/Windows host shows `Hooks: degraded`.
 Opt out with `thurbox-cli extension deactivate hooks` (records a
 `builtin_hooks_optout` metadata flag so self-heal won't resurrect it);

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -93,11 +93,21 @@ way), making it usable as a dotfiles CI gate.
 ## agents.toml
 
 Declares the launchable coding agents. Seeded with the built-ins
-(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`, `pi`) on
+(`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`, `pi`,
+`omp`) on
 first run; edit or add `[[agents]]` entries to support any CLI — no
 recompile. A malformed `[[agents]]` entry is skipped (with a toast
 naming it) and the rest still load; only a document-level syntax error
 falls back to the built-ins. Either way the error is shown.
+
+The file is **seeded once** and never rewritten — so it stays yours to
+edit, but a thurbox **update that adds a new built-in agent does not
+merge it into an existing `agents.toml`**. To pick up a newly-bundled
+agent, add its `[[agents]]` block by hand (copy it from this file's
+built-in list) or delete `agents.toml` to re-seed the full set. The
+matching status hook is wired automatically once the agent's config dir
+exists — the built-in hooks extension self-heals on every startup/tick,
+independent of `agents.toml`.
 
 ```toml
 config_version = 1
@@ -116,7 +126,18 @@ resume_latest = false       # true = id-less "resume last session in cwd"
                             #   hooks under this custom agent's name too
 ```
 
-`{id}` is substituted with the thurbox-generated session UUID. Groups
+`{id}` is substituted with the thurbox-generated session UUID. `{home}`
+is substituted with the resolved home dir at spawn time (the remote home
+for an SSH/WSL host) — for an agent that wants a session *file path*
+rather than a bare id. The built-in `omp` (Oh My Pi) uses it: it generates
+its own internal id and won't take thurbox's, but its `--session <path>`
+creates a fresh session at a missing path, so thurbox maps its UUID to a
+deterministic `--session {home}/.omp/agent/sessions/thurbox-{id}.jsonl`
+(creation) / `--resume` the same (restart). `{home}` is expanded by
+thurbox, not the shell — args are POSIX-quoted, so a literal `~` would
+never expand. `omp` ships no `fork_args`, so `Ctrl+F` starts a fresh
+session (OMP has no way to pin a fork's target file to a thurbox UUID).
+Groups
 are emitted only when their driving value exists; precedence is
 fork > resume > new-session. See the seeded file's comments and
 CLAUDE.md's *Agent Definitions* section for the `resume_latest`
@@ -136,7 +157,7 @@ The seeded file also ships two commented, copy-pasteable templates
 below the built-ins — **Add your own agent** (every field annotated)
 and **Pin a model** (a `claude-opus` variant baking `--model opus`
 into `args`). Both stay commented, so a fresh install still resolves
-to exactly the seven built-ins.
+to exactly the nine built-ins.
 
 ## hosts.toml
 

--- a/extensions/hooks/README.md
+++ b/extensions/hooks/README.md
@@ -106,6 +106,18 @@ passed by hand) and is suffixed `|| true` so it can never break the agent.
   provisioned like the other config-dir agents (the rewritten payload ships
   into the host's extensions dir); a psmux/Windows host shows `Hooks: degraded`.
   If a future `pi` renames its events, edit `pi-status.ts` (no code change).
+- **omp** *(experimental)* — Oh My Pi (`omp`) is Pi-compatible and likewise
+  auto-discovers TypeScript extensions, from `~/.omp/agent/extensions/*.ts`, so
+  we drop a managed extension in (an `[[external_files]]`, guarded by
+  `requires_dir`, only when omp is installed). It mirrors pi's status extension
+  but maps OMP's structured user-question tool — named `ask` — to `blocked`;
+  it recognizes **both** `ask` and pi's `ask_user_question`, so reusing pi's
+  file unchanged would leave OMP stuck `working` while it waits. Events:
+  `session_start` → idle, `agent_start`/`tool_execution_start` → working
+  (`ask`/`ask_user_question` → blocked), `agent_end` → done. Same caveats as pi
+  (managed-marker refusal, remote provisioning, psmux `Hooks: degraded`).
+  Verified against OMP 17.0.6; if a future `omp` renames its events, edit
+  `omp-status.ts` (no code change).
 
 ## Custom agents (`hook_schema`)
 
@@ -150,6 +162,7 @@ other agents are wired by a reversible merge into — or a managed file dropped 
 | copilot | `~/.copilot/hooks/thurbox-status.json` | managed standalone file (`requires_dir`) |
 | antigravity | `~/.gemini/settings.json` | reversible JSON-merge of our entries |
 | pi | `~/.pi/agent/extensions/thurbox-status.ts` | managed extension file (`requires_dir`) |
+| omp | `~/.omp/agent/extensions/thurbox-status.ts` | managed extension file (`requires_dir`) |
 
 The home dir is `~/.config/thurbox/hooks` for a release build and
 `~/.config/thurbox-dev/hooks` for a dev build, so the two stay isolated.

--- a/extensions/hooks/extension.toml
+++ b/extensions/hooks/extension.toml
@@ -14,7 +14,7 @@
 name = "hooks"
 description = "Report each agent's lifecycle state (working/blocked/done) to thurbox via agent hooks."
 config_version = 1
-version = "1.6.0"  # v1.6: vibe hooks rewritten to vibe 2.21.0's real schema (pre_tool/post_agent); v1.5: pi (pi.dev) status extension
+version = "1.7.0"  # v1.7: omp (Oh My Pi) status extension (ask/ask_user_question → blocked); v1.6: vibe hooks rewritten to vibe 2.21.0's real schema (pre_tool/post_agent); v1.5: pi (pi.dev) status extension
 # Default home; the auto-activation path overrides this with *this build's*
 # resolved config dir (`~/.config/thurbox` or `~/.config/thurbox-dev`) so dev and
 # release installs stay isolated. See `session_ops::builtin_hooks::hooks_home`.
@@ -106,6 +106,25 @@ requires_dir = "~/.vibe"
 path = "~/.pi/agent/extensions/thurbox-status.ts"
 source = "pi-status.ts"
 requires_dir = "~/.pi/agent"
+
+# omp (Oh My Pi) is Pi-compatible and auto-discovers TypeScript extensions from
+# ~/.omp/agent/extensions/*.ts, so we drop a managed file in (only when omp is
+# installed, guarded by requires_dir). It mirrors pi's status extension but maps
+# OMP's structured user-question tool — named `ask` (upstream pi uses
+# `ask_user_question`) — to `blocked`; both names are recognized. Events:
+# session_start → idle, agent_start + tool_execution_start → working (ask /
+# ask_user_question → blocked), agent_end → done. As with the other config-dir
+# drops the write is refused (no managed marker) if a file already exists at that
+# path, so omp simply goes unreported rather than broken.
+#
+# EXPERIMENTAL: verified against OMP 17.0.6. As with the other config-dir agents,
+# remote (SSH/WSL) omp sessions are provisioned at spawn time (the rewritten
+# payload is shipped into the host's ~/.omp/agent/extensions/); the one carve-out
+# is a psmux/Windows host, which shows `Hooks: degraded` instead.
+[[external_files]]
+path = "~/.omp/agent/extensions/thurbox-status.ts"
+source = "omp-status.ts"
+requires_dir = "~/.omp/agent"
 
 # GitHub Copilot CLI (the `copilot` command) loads hooks from its own dir,
 # ~/.copilot/hooks/*.json (each file loaded alphabetically), so we drop a managed

--- a/extensions/hooks/omp-status.ts
+++ b/extensions/hooks/omp-status.ts
@@ -1,0 +1,45 @@
+// Managed by thurbox `extension install` (the built-in "hooks" extension).
+// Reinstalling or updating overwrites this file — do not edit; uninstalling
+// removes it. Reports Oh My Pi's lifecycle state to thurbox. Identity comes
+// from the inherited $THURBOX_SESSION env var; every call is best-effort so it
+// can never break a session running outside thurbox.
+//
+// This is an OMP (Oh My Pi, https://github.com/can1357/oh-my-pi) extension
+// (TypeScript), auto-discovered from ~/.omp/agent/extensions/*.ts by the omp
+// CLI. It subscribes to OMP's lifecycle events and reports them to thurbox's
+// status reporter:
+//   session_start → idle, agent_start + tool_execution_start → working
+//   (a structured user-question tool call → blocked), agent_end → done.
+//
+// OMP is Pi-compatible, but its structured user-question tool is named `ask`
+// (upstream pi uses `ask_user_question`). We treat BOTH as blocking so the dot
+// turns red while OMP waits for the user instead of staying yellow (working).
+import { exec } from "node:child_process";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+// Tool names that block the turn until the user answers.
+const BLOCKING_TOOLS = new Set(["ask", "ask_user_question"]);
+
+// Exact marker prefix kept on one line so the remote (SSH/WSL) rewrite can swap
+// this command for a tmux pane-option setter (there is no thurbox-cli on a
+// remote host). Do not split the words across lines or reorder the flags.
+const SIGNAL = "thurbox-cli session signal --state ";
+
+// Fire-and-forget; the callback swallows errors so a hook never surfaces into
+// the agent. exec inherits the OMP process env, so $THURBOX_SESSION travels.
+const report = (state: string): void => {
+  exec(SIGNAL + state, () => {});
+};
+
+// `pi` is injected by the OMP runtime; the `import type` above is erased at
+// runtime, so this file has no hard dependency beyond Node's built-ins.
+export default function (pi: ExtensionAPI): void {
+  pi.on("session_start", () => report("idle"));
+  pi.on("agent_start", () => report("working"));
+  pi.on("tool_execution_start", (event?: { toolName?: string }) => {
+    // A structured question to the user blocks the turn until it is answered;
+    // any other tool call means the agent is actively working.
+    report(BLOCKING_TOOLS.has(event?.toolName ?? "") ? "blocked" : "working");
+  });
+  pi.on("agent_end", () => report("done"));
+}

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -100,6 +100,22 @@ resume_args = ["--session-id", "{id}"]
 fork_args = ["--fork", "{id}"]
 new_session_args = ["--session-id", "{id}"]
 
+# omp (Oh My Pi, https://github.com/can1357/oh-my-pi) is Pi-compatible but
+# generates its own internal session id and won't accept thurbox's UUID as one.
+# Its `--session <path>` flag creates a fresh session at a missing path (and
+# reopens an existing one), so thurbox maps its UUID to a deterministic JSONL
+# under OMP's default root (~/.omp/agent/sessions/). The `{home}` token is
+# expanded to the resolved home dir at spawn time (thurbox, not the shell —
+# args are POSIX-quoted, so a literal `~` would never expand); it also
+# translates onto the remote/WSL home. No fork_args: OMP has no way to pin a
+# fork's target file to a thurbox UUID, so Ctrl+F starts a fresh session (see
+# the OMP note in docs/CONFIG.md).
+[[agents]]
+name = "omp"
+command = "omp"
+resume_args = ["--resume", "{home}/.omp/agent/sessions/thurbox-{id}.jsonl"]
+new_session_args = ["--session", "{home}/.omp/agent/sessions/thurbox-{id}.jsonl"]
+
 # ──────────────────────────────────────────────────────────────────────────
 # Add your own agent (uncomment and edit)
 # ──────────────────────────────────────────────────────────────────────────
@@ -128,7 +144,9 @@ new_session_args = ["--session-id", "{id}"]
 # (claude and pi both take `--session-id {id}`) can resume/fork by that exact
 # id; for everything else use `resume_latest = true` with id-less, cwd-scoped flags
 # (e.g. `["resume", "--last"]`). Omit every resume group to start fresh on
-# restart.
+# restart. {home} expands to the resolved home dir at spawn (the remote home for
+# an SSH/WSL host) — use it for an agent that wants a session *path* rather than
+# a bare id (e.g. `["--session", "{home}/.foo/thurbox-{id}.jsonl"]`).
 #
 # ──────────────────────────────────────────────────────────────────────────
 # Pin a model (or any flag) — put it in `args`, which is always passed
@@ -382,6 +400,7 @@ mod tests {
         assert!(reg.get("copilot").is_some());
         assert!(reg.get("vibe").is_some());
         assert!(reg.get("pi").is_some());
+        assert!(reg.get("omp").is_some());
 
         // Claude pins a thurbox id and resumes/forks by it.
         let claude = reg.get("claude").unwrap();
@@ -396,6 +415,21 @@ mod tests {
         assert_eq!(pi.new_session_args, ["--session-id", "{id}"]);
         assert_eq!(pi.resume_args, ["--session-id", "{id}"]);
         assert_eq!(pi.fork_args, ["--fork", "{id}"]);
+
+        // omp (Oh My Pi) pins by a deterministic session-file PATH, not a bare
+        // id: `--session {home}/…/thurbox-{id}.jsonl` on create, `--resume` the
+        // same on restart. It has no native fork (Ctrl+F → fresh session).
+        let omp = reg.get("omp").unwrap();
+        assert!(!omp.resume_latest);
+        assert_eq!(
+            omp.new_session_args,
+            ["--session", "{home}/.omp/agent/sessions/thurbox-{id}.jsonl"]
+        );
+        assert_eq!(
+            omp.resume_args,
+            ["--resume", "{home}/.omp/agent/sessions/thurbox-{id}.jsonl"]
+        );
+        assert!(omp.fork_args.is_empty(), "omp has no native fork target");
 
         // codex/opencode resume + fork via id-less, cwd-scoped flags.
         let codex = reg.get("codex").unwrap();
@@ -448,7 +482,7 @@ mod tests {
         // Examples are commented, so the seed parses to just the built-ins.
         let reg = builtin_registry();
         assert_eq!(reg.default, "claude");
-        assert_eq!(reg.agents.len(), 8, "examples must stay commented out");
+        assert_eq!(reg.agents.len(), 9, "examples must stay commented out");
         assert!(
             reg.get("claude-opus").is_none(),
             "example must not register"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1569,7 +1569,20 @@ impl App {
     /// provisions the agent's remote hook files and runs on a worker.
     fn launch_provider_for(&self, config: &SessionConfig) -> Arc<dyn crate::agent::AgentProvider> {
         let mut def = self.agent_def_for(&config.agent);
-        if let Some(h) = self.host_for_backend(config.backend.as_deref()) {
+        let host = self.host_for_backend(config.backend.as_deref());
+        // Expand `{home}` in a path-pinned agent's arg groups (omp's
+        // `--resume/--session {home}/…`) so a restart relaunches against a
+        // concrete path — local home for a local session, the resolved host home
+        // for a remote one. A def with no `{home}` (every built-in but omp) is
+        // untouched. Mirrors the spawn path's `adapt_def_for_launch`.
+        let home = match host {
+            Some(h) => crate::session_ops::spawn::resolve_launch_home(h),
+            None => crate::paths::home_dir().map(|p| p.to_string_lossy().into_owned()),
+        };
+        if let Some(home) = home {
+            crate::session_ops::expand_home_in_def(&mut def, &home);
+        }
+        if let Some(h) = host {
             def.args = crate::session_ops::spawn::adapt_agent_args_for_remote(h, def.args);
         }
         Arc::new(GenericProvider::new(def))
@@ -1990,6 +2003,10 @@ impl App {
         // and the metrics/status hooks break.
         crate::session_ops::inject_thurbox_env(&mut config, &agent_session_id, None);
         let def = self.agent_def_for(&config.agent);
+        // `resume_trigger_for` decides resume-vs-fresh for a path-pinned agent
+        // (omp) by stat'ing its deterministic session file, expanding `{home}`
+        // to the local home itself; the actual launch args are re-expanded per
+        // host in `launch_provider_for` (inside `do_restart`).
         config.resume_session_id =
             crate::session_ops::resume_trigger_for(&def, &agent_session_id, &config.env);
 

--- a/src/session/agent_def.rs
+++ b/src/session/agent_def.rs
@@ -14,7 +14,9 @@
 use serde::{Deserialize, Serialize};
 
 /// Placeholder substituted with a session id in resume/fork/new-session groups.
-const ID_PLACEHOLDER: &str = "{id}";
+/// Exposed so `session_ops` can reconstruct a path-pinned agent's session file
+/// (omp) using the *same* token [`AgentDef::build_args`] substitutes.
+pub const ID_PLACEHOLDER: &str = "{id}";
 
 /// One coding-agent CLI definition.
 ///

--- a/src/session_ops/builtin_hooks.rs
+++ b/src/session_ops/builtin_hooks.rs
@@ -33,6 +33,7 @@ pub(crate) const CODEX_HOOKS: &str = include_str!("../../extensions/hooks/codex-
 pub(crate) const VIBE_HOOKS: &str = include_str!("../../extensions/hooks/vibe-hooks.toml");
 pub(crate) const COPILOT_HOOKS: &str = include_str!("../../extensions/hooks/copilot-hooks.json");
 pub(crate) const PI_STATUS: &str = include_str!("../../extensions/hooks/pi-status.ts");
+pub(crate) const OMP_STATUS: &str = include_str!("../../extensions/hooks/omp-status.ts");
 
 /// Marker prefix of every thurbox-managed hook command; the state word
 /// (`working`/`blocked`/`done`/`idle`) follows it directly.
@@ -160,6 +161,7 @@ fn materialize_source() -> Result<PathBuf, String> {
         ("vibe-hooks.toml", VIBE_HOOKS),
         ("copilot-hooks.json", COPILOT_HOOKS),
         ("pi-status.ts", PI_STATUS),
+        ("omp-status.ts", OMP_STATUS),
     ];
     for (name, contents) in writes {
         let path = dir.join(name);
@@ -282,6 +284,7 @@ mod tests {
             ("vibe-hooks.toml", VIBE_HOOKS),
             ("copilot-hooks.json", COPILOT_HOOKS),
             ("pi-status.ts", PI_STATUS),
+            ("omp-status.ts", OMP_STATUS),
             ("extension.toml", MANIFEST), // aider's literal --notifications-command arg
         ] {
             // Key on the invocation-with-flags form (`thurbox-cli session
@@ -383,6 +386,11 @@ mod tests {
         // file uninstall, see `is_user_modified`).
         assert!(PI_STATUS.contains("thurbox-cli session signal"));
         assert!(PI_STATUS.contains("thurbox `extension install`"));
+        // The omp payload mirrors pi's shape but recognizes OMP's `ask` tool (and
+        // upstream pi's `ask_user_question`) as the blocking edge.
+        assert!(OMP_STATUS.contains("thurbox-cli session signal"));
+        assert!(OMP_STATUS.contains("thurbox `extension install`"));
+        assert!(OMP_STATUS.contains("\"ask\""));
     }
 
     #[test]

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -25,6 +25,7 @@ pub use spawn::{spawn_session_headless, SpawnRequest, SpawnResult};
 
 use std::collections::HashMap;
 
+use crate::session::agent_def::ID_PLACEHOLDER;
 use crate::session::{AutomationRunStatus, SessionConfig};
 
 /// Run an `Exec` automation's shell command headlessly (`sh -c`, or `cmd /C` on
@@ -128,7 +129,44 @@ pub(crate) fn resume_trigger_for(
     if def.resumes_latest() {
         return Some(agent_session_id.to_string());
     }
+    // A path-pinned agent (omp) records its conversation at a deterministic file
+    // thurbox chose — `--session {home}/.../thurbox-{id}.jsonl`. If that file
+    // exists, resume it; the `resume_args` (`--resume <same path>`) reopen it
+    // exactly. This must run before the claude-transcript check, which only
+    // knows claude's `~/.claude` layout. The check is inherently *local* — it
+    // stats the local FS — so `{home}` resolves to the local home even for a
+    // caller that hasn't expanded it. A remote session's file can't be stat'd
+    // here, so it starts fresh (documented remote-omp fallback); its launch args
+    // are still expanded per host in `spawn::adapt_def_for_launch` /
+    // `App::launch_provider_for`.
+    if let Some(path) = session_file_template(def) {
+        let expanded = match crate::paths::home_dir() {
+            Some(home) => path.replace(HOME_PLACEHOLDER, &home.to_string_lossy()),
+            None => path,
+        };
+        let file = expanded.replace(ID_PLACEHOLDER, agent_session_id);
+        if std::path::Path::new(&file).exists() {
+            return Some(agent_session_id.to_string());
+        }
+        // The template exists but the file doesn't (never launched, remote, or
+        // gone) → a fresh session, not the claude fallback (which would
+        // false-positive on a coincident claude transcript for the same id).
+        return None;
+    }
     resume_id_if_transcript_exists(agent_session_id, env)
+}
+
+/// The session *file* template of a path-pinned agent — a `new_session_args`
+/// token that both names a filesystem path (has a separator) and carries the
+/// `{id}` placeholder (e.g. omp's `{home}/.omp/.../thurbox-{id}.jsonl`).
+/// `None` for id-only agents (claude/pi pass a bare `{id}`, not a path). Used to
+/// decide resume-vs-fresh by that file's existence. Agent-neutral: it reads the
+/// def's own args rather than matching an agent name.
+fn session_file_template(def: &crate::session::AgentDef) -> Option<String> {
+    def.new_session_args
+        .iter()
+        .find(|t| t.contains(ID_PLACEHOLDER) && (t.contains('/') || t.contains('\\')))
+        .cloned()
 }
 
 /// Resolve the [`AgentDef`](crate::session::AgentDef) for a requested agent name
@@ -149,6 +187,37 @@ pub(crate) fn resolve_agent_def(requested: Option<&str>) -> crate::session::Agen
                 .cloned()
                 .expect("built-in registry always has a default agent")
         })
+}
+
+/// Placeholder in an [`AgentDef`](crate::session::AgentDef)'s arg groups,
+/// expanded to the resolved home dir at spawn time. Unlike `{id}` (a bare
+/// UUID substituted in `build_args`), `{home}` needs a filesystem side effect
+/// — the home dir — so it is resolved here in `session_ops`, not in the pure
+/// `session` layer. Used by agents that want a session *file path* rather than
+/// a bare id (e.g. omp's `--session {home}/.omp/…/thurbox-{id}.jsonl`); the
+/// path can't rely on the shell to expand `~`, since args are POSIX-quoted.
+pub(crate) const HOME_PLACEHOLDER: &str = "{home}";
+
+/// Rewrite every `{home}` token in `def`'s arg groups (`args`, `resume_args`,
+/// `fork_args`, `new_session_args`) to `home`, in place.
+///
+/// `home` is the target's home dir: the *local* home for a local launch/restart
+/// (via [`crate::paths::home_dir`]), or the *remote* home for an SSH/WSL host
+/// (resolved by [`crate::git::remote_home`] in
+/// [`spawn::adapt_def_for_launch`]). A def with no `{home}` token (every
+/// built-in but `omp`) is left byte-identical, so this is a no-op for them.
+pub(crate) fn expand_home_in_def(def: &mut crate::session::AgentDef, home: &str) {
+    let subst = |tokens: &mut Vec<String>| {
+        for t in tokens.iter_mut() {
+            if t.contains(HOME_PLACEHOLDER) {
+                *t = t.replace(HOME_PLACEHOLDER, home);
+            }
+        }
+    };
+    subst(&mut def.args);
+    subst(&mut def.resume_args);
+    subst(&mut def.fork_args);
+    subst(&mut def.new_session_args);
 }
 
 /// Build the `(command, args)` invocation for an already-resolved [`AgentDef`].
@@ -420,5 +489,93 @@ mod tests {
             resume_trigger_for(&claude, sid, &env),
             Some(sid.to_string())
         );
+    }
+
+    #[test]
+    fn expand_home_rewrites_only_home_token() {
+        let mut omp = crate::agent::agent_config::builtin_registry()
+            .get("omp")
+            .expect("omp is a built-in")
+            .clone();
+        expand_home_in_def(&mut omp, "/home/me");
+        assert_eq!(
+            omp.new_session_args,
+            vec![
+                "--session".to_string(),
+                "/home/me/.omp/agent/sessions/thurbox-{id}.jsonl".to_string()
+            ]
+        );
+        assert_eq!(
+            omp.resume_args,
+            vec![
+                "--resume".to_string(),
+                "/home/me/.omp/agent/sessions/thurbox-{id}.jsonl".to_string()
+            ]
+        );
+        // `{id}` is left for build_args; only `{home}` was touched.
+        assert!(omp.new_session_args.iter().any(|a| a.contains("{id}")));
+
+        // A def with no `{home}` (claude) is byte-identical after expansion.
+        let claude = crate::agent::agent_config::builtin_registry()
+            .get("claude")
+            .unwrap()
+            .clone();
+        let mut expanded = claude.clone();
+        expand_home_in_def(&mut expanded, "/home/me");
+        assert_eq!(expanded, claude);
+    }
+
+    #[test]
+    fn session_file_template_only_for_path_pinned_agents() {
+        let reg = crate::agent::agent_config::builtin_registry();
+        // omp pins a session file path (has a separator + `{id}`).
+        let omp = reg.get("omp").unwrap();
+        assert_eq!(
+            session_file_template(omp).as_deref(),
+            Some("{home}/.omp/agent/sessions/thurbox-{id}.jsonl")
+        );
+        // claude/pi pass a bare `{id}`, not a path → no template.
+        assert_eq!(session_file_template(reg.get("claude").unwrap()), None);
+        assert_eq!(session_file_template(reg.get("pi").unwrap()), None);
+    }
+
+    #[test]
+    fn resume_trigger_omp_resumes_only_when_session_file_exists() {
+        // omp is path-pinned: it resumes iff its deterministic JSONL exists.
+        let tmp = tempfile::tempdir().unwrap();
+        let sid = "99999999-aaaa-bbbb-cccc-dddddddddddd";
+        let mut omp = crate::agent::agent_config::builtin_registry()
+            .get("omp")
+            .unwrap()
+            .clone();
+        // The caller expands `{home}` before the trigger check; here `{home}` is
+        // the tempdir so the check is hermetic (never touches the real ~/.omp).
+        expand_home_in_def(&mut omp, &tmp.path().display().to_string());
+        let env = HashMap::new();
+
+        // No file yet → fresh session.
+        assert_eq!(resume_trigger_for(&omp, sid, &env), None);
+
+        // Create the exact JSONL thurbox would launch against → resume triggers.
+        let file = tmp
+            .path()
+            .join(".omp/agent/sessions")
+            .join(format!("thurbox-{sid}.jsonl"));
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, b"").unwrap();
+        assert_eq!(resume_trigger_for(&omp, sid, &env), Some(sid.to_string()));
+    }
+
+    #[test]
+    fn omp_is_a_builtin_and_pi_is_unchanged() {
+        let reg = crate::agent::agent_config::builtin_registry();
+        // omp exists alongside pi (not replacing it).
+        let omp = reg.get("omp").expect("omp seeded");
+        assert_eq!(omp.command, "omp");
+        assert!(omp.fork_args.is_empty(), "omp has no native fork target");
+        // pi keeps its id-pinned resume/fork, untouched by the omp addition.
+        let pi = reg.get("pi").expect("pi still present");
+        assert_eq!(pi.resume_args, vec!["--session-id", "{id}"]);
+        assert_eq!(pi.fork_args, vec!["--fork", "{id}"]);
     }
 }

--- a/src/session_ops/remote_hooks.rs
+++ b/src/session_ops/remote_hooks.rs
@@ -99,6 +99,12 @@ fn remote_asset_for(agent: &str) -> Option<RemoteHookAsset> {
             requires_dir: "~/.pi/agent",
             payload: builtin_hooks::PI_STATUS,
         }),
+        "omp" => Some(RemoteHookAsset {
+            kind: RemoteAssetKind::WriteFile,
+            remote_path: "~/.omp/agent/extensions/thurbox-status.ts",
+            requires_dir: "~/.omp/agent",
+            payload: builtin_hooks::OMP_STATUS,
+        }),
         _ => None,
     }
 }
@@ -526,6 +532,8 @@ mod tests {
                 "vibe"
             } else if path.contains(".copilot") {
                 "copilot"
+            } else if path.contains(".omp") {
+                "omp"
             } else if path.contains(".pi") {
                 "pi"
             } else {
@@ -559,7 +567,7 @@ mod tests {
             covered += 1;
         }
         // Every table entry is reachable from the manifest (no orphan assets).
-        assert_eq!(covered, 6, "manifest wiring count changed — sync the table");
+        assert_eq!(covered, 7, "manifest wiring count changed — sync the table");
         // claude/aider stay arg-handled.
         assert!(remote_asset_for("claude").is_none());
         assert!(remote_asset_for("aider").is_none());

--- a/src/session_ops/restart.rs
+++ b/src/session_ops/restart.rs
@@ -45,7 +45,14 @@ fn build_restart_plan(session: &SharedSession) -> Result<RestartPlan, String> {
         ..SessionConfig::default()
     };
     super::inject_thurbox_env(&mut config, &agent_session_id, None);
-    let def = super::resolve_agent_def(Some(&config.agent));
+    let mut def = super::resolve_agent_def(Some(&config.agent));
+    // Headless restart is local-only (remote sessions are refused up front), so
+    // `{home}` in a session-path arg (omp's `--resume {home}/…`) resolves against
+    // the local home — matching what the original local spawn expanded it to, so
+    // `--resume` reopens the same JSONL.
+    if let Some(home) = crate::paths::home_dir() {
+        super::expand_home_in_def(&mut def, &home.to_string_lossy());
+    }
     config.resume_session_id = super::resume_trigger_for(&def, &agent_session_id, &config.env);
 
     // A multi-repo session (≥2 members) launches in its per-session symlink

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -475,9 +475,28 @@ pub(crate) fn adapt_def_for_launch(
     crate::session::AgentDef,
     super::remote_hooks::HookDegradation,
 ) {
+    // Expand `{home}` in every arg group before anything else so a session-path
+    // agent (omp) launches against a concrete, quote-safe absolute path — the
+    // local home for a local launch, the resolved remote home for an SSH/WSL
+    // host. A def with no `{home}` (every built-in but omp) is untouched.
     let Some(h) = host else {
+        if let Some(home) = crate::paths::home_dir() {
+            super::expand_home_in_def(&mut def, &home.to_string_lossy());
+        }
         return (def, None);
     };
+    if let Some(home) = resolve_launch_home(h) {
+        super::expand_home_in_def(&mut def, &home);
+    } else if def_references_home(&def) {
+        // A session-path arg still carries a literal `{home}` — the agent would
+        // create a file named "{home}" in the cwd. Better to surface it.
+        tracing::warn!(
+            "could not resolve remote home for host '{}'; agent '{}' may launch \
+             with an unexpanded {{home}} in its session path",
+            h.name,
+            def.name
+        );
+    }
     let (args, stripped) = adapt_agent_args_for_remote_with_report(h, def.args);
     def.args = args;
     // A stripped config path outranks a provisioning note: it means the
@@ -492,6 +511,31 @@ pub(crate) fn adapt_def_for_launch(
         ))
     };
     (def, degraded)
+}
+
+/// The home dir to expand `{home}` against for a launch on `host`: the remote
+/// `$HOME` for a POSIX SSH/WSL host, or the Windows home for a psmux host.
+/// `None` when it can't be resolved (host down, no client) — the caller then
+/// leaves the token unexpanded and warns.
+pub(crate) fn resolve_launch_home(host: &HostDef) -> Option<String> {
+    let result = if host.mux() == "psmux" {
+        crate::git::remote_home_windows(host)
+    } else {
+        crate::git::remote_home(host)
+    };
+    match result {
+        Ok(home) => Some(home),
+        Err(e) => {
+            tracing::warn!("cannot resolve home for host '{}': {e:#}", host.name);
+            None
+        }
+    }
+}
+
+/// Whether any of `def`'s arg groups still carries an unexpanded `{home}`.
+fn def_references_home(def: &crate::session::AgentDef) -> bool {
+    let has = |v: &[String]| v.iter().any(|t| t.contains(super::HOME_PLACEHOLDER));
+    has(&def.args) || has(&def.resume_args) || has(&def.fork_args) || has(&def.new_session_args)
 }
 
 /// Where the local thurbox config root lands on `host`, or `None` when no


### PR DESCRIPTION
## Summary

- Adds `omp` (Oh My Pi) as a built-in coding agent alongside `pi` (does **not** replace it).
- OMP generates its own internal session id, so thurbox maps its UUID to a deterministic JSONL: `--session {home}/.omp/agent/sessions/thurbox-{id}.jsonl` on create, `--resume` the same on restart.
- New `{home}` arg-token expands to the resolved home dir at spawn — local home for a local launch, remote/WSL home for an off-local host — since POSIX-quoted args never expand a literal `~`.
- Resume-vs-fresh for a path-pinned agent is decided by that JSONL's existence (agent-neutral `session_file_template`, not an agent-name match).
- Ships `omp-status.ts` hook wired into the built-in hooks extension (local + remote/WSL): recognizes **both** OMP's `ask` and pi's `ask_user_question` as the `blocked` edge.
- No `fork_args`: OMP can't pin a fork target, so `Ctrl+F` starts fresh (documented).
- Existing `pi` behavior is unchanged.

Closes #842

## Test plan

- `cargo nextest run --all` — new tests cover the omp seed, `{home}` expansion (only `{home}`, leaves `{id}`), `session_file_template` detection, resume-only-when-file-exists, and the remote-asset/manifest sync.
- Manually verified end-to-end with a fake `omp` on PATH: create launches `--session <abs path>`; restart launches `--resume <same abs path>`; the hook lands in `~/.omp/agent/extensions/` when that dir exists and is skipped otherwise.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt`, architecture rules all clean.

_Not exercised here (no real `omp` binary / Windows host available): OMP's live `ask` → `blocked` and psmux/Windows path handling; wiring follows the proven `pi` path and is unit-tested. Reporter verified against OMP 17.0.6._