### PR TITLE
docs: document built-in agents + add-a-built-in checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,6 +447,10 @@ Enforced by cocogitto via pre-commit hooks.
 
 ## Agent Definitions
 
+> Per-agent reference + the "adding a new built-in" checklist:
+> `docs/AGENTS.md` (each built-in's exact config, ID model, and status-hook
+> mechanism, plus every file to update when promoting a CLI to a built-in).
+
 The set of launchable coding agents is declared **as data** in
 `~/.config/thurbox/agents.toml`, seeded with built-ins
 (`claude`, `codex`, `antigravity`, `opencode`, `aider`, `copilot`, `vibe`, `pi`, `omp`) on first run.
@@ -2270,6 +2274,8 @@ For rationale behind decisions, see `docs/`:
 - `docs/ARCHITECTURE.md` — Architectural decisions with rationale
 - `docs/FEATURES.md` — Feature-level design choices
 - `docs/CONFIG.md` — Every config file/env var/DB setting in one place
+- `docs/AGENTS.md` — Each built-in agent's exact config + behavior, and
+  the checklist for adding a new built-in
 - `docs/PERFORMANCE.md` — Render/tick performance: demand-driven redraw,
   perf counters, the session-order cache, and how to measure
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,212 @@
+# Built-in Agents Reference
+
+The exact configuration and runtime behavior of every **built-in** coding
+agent, plus the checklist for **adding a new one**.
+
+Thurbox is agent-neutral: it knows nothing about a coding agent's model,
+prompts, permissions, or tools — only how to launch the CLI and how that CLI
+resumes, forks, and reports status. Every agent is **data**, not code. The
+built-ins are just the entries thurbox ships pre-seeded; a user adds their own
+by editing `agents.toml` (see [CONFIG.md](CONFIG.md#agentstoml) for the file
+format). This document is the single source of truth for **what each built-in's
+data actually is and why**, and it exists because adding a new built-in touches
+several files that are *not* updated automatically — see
+[Adding a new built-in agent](#adding-a-new-built-in-agent).
+
+Related docs:
+
+- [CONFIG.md → agents.toml](CONFIG.md#agentstoml) — the config-file format and
+  per-field syntax (`{id}` substitution, `resume_latest`, `hook_schema`).
+- [FEATURES.md → Agent definitions](FEATURES.md#agent-definitions) — the
+  agents-as-data design.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — the `session::AgentDef` purity rule.
+- `../CLAUDE.md` → *Agent Definitions* — the in-repo working reference.
+
+## Where the built-ins live
+
+The built-in registry is **not** hand-constructed in Rust. It is an embedded
+TOML document, `BUILTIN_AGENTS_TOML`, in
+[`src/agent/agent_config.rs`](../src/agent/agent_config.rs). `builtin_registry()`
+parses that string, and `seed_agents_toml()` writes it verbatim to
+`~/.config/thurbox/agents.toml` on first run. So the same text is both the
+in-binary fallback and the seed the user then edits — keep it authoritative.
+
+Status hooks (working / blocked / done) are wired **separately** by the built-in
+**hooks** extension, whose per-agent mechanism is declared in
+[`extensions/hooks/extension.toml`](../extensions/hooks/extension.toml). An
+`AgentDef` says *how to launch* an agent; the hooks manifest says *how that agent
+reports state back*. Adding a built-in agent means touching **both**.
+
+## The built-in agents
+
+Nine agents ship pre-seeded. `default = "claude"`.
+
+| Name | Command | Resume | Fork | ID model | Status hooks |
+|------|---------|--------|------|----------|--------------|
+| `claude` | `claude` | `--resume {id}` | `--resume {id} --fork-session` | **pinned** (`--session-id {id}`) | `--settings` arg patch (`claude.json`) |
+| `codex` | `codex` | `resume --last` | `fork --last` | id-less (`resume_latest`) | `config_merges` → `~/.codex/hooks.json` |
+| `antigravity` | `agy` | `--continue` | — (none) | id-less (`resume_latest`) | `config_merges` → `~/.gemini/settings.json` |
+| `opencode` | `opencode` | `--continue` | `--continue --fork` | id-less (`resume_latest`) | `external_files` → `~/.config/opencode/plugin/` |
+| `aider` | `aider` | `--restore-chat-history` | — (none) | id-less (`resume_latest`) | `--notifications-command` arg patch (blocked only) |
+| `copilot` | `copilot` | `--continue` | — (none) | id-less (`resume_latest`) | `external_files` → `~/.copilot/hooks/` |
+| `vibe` | `vibe` | — (starts fresh) | — (none) | none | `external_files` → `~/.vibe/hooks.toml` |
+| `pi` | `pi` | `--session-id {id}` | `--fork {id}` | **pinned** (`--session-id {id}`) | `external_files` → `~/.pi/agent/extensions/` |
+| `omp` | `omp` | `--resume {home}/.omp/…/thurbox-{id}.jsonl` | — (none) | **path-pinned** (`--session <file>`) | `external_files` → `~/.omp/agent/extensions/` |
+
+### ID model: pinned vs. id-less
+
+This is the single most important behavioral distinction, because it decides
+whether resume/fork can target *this* session or only *the last* one.
+
+- **Pinned** (`claude`, `pi`) — the CLI accepts a thurbox-generated UUID at
+  creation via `new_session_args = ["--session-id", "{id}"]`, so it can
+  resume/fork **that exact session** by id. `resume_latest` stays `false`.
+- **Path-pinned** (`omp`) — the CLI generates its *own* internal session id and
+  can't accept thurbox's, but it takes a session **file path**. thurbox maps its
+  UUID to a deterministic JSONL under OMP's default root
+  (`--session {home}/.omp/agent/sessions/thurbox-{id}.jsonl` on create,
+  `--resume` on the same path to restore), so restart reattaches the exact
+  session even though the id itself is opaque. The new `{home}` token is expanded
+  to the resolved home dir **at spawn time by thurbox** (args are POSIX-quoted, so
+  a literal `~` would never expand), and it translates onto the remote/WSL home.
+  It has no `fork_args` (OMP can't pin a fork's target file to a thurbox UUID), so
+  `Ctrl+F` starts fresh.
+- **id-less** (`codex`, `antigravity`, `opencode`, `aider`, `copilot`) — the CLI
+  can neither pin nor report a session id, so the agent's own flags resolve *"the
+  last session in this directory"* (`codex resume --last`, `--continue`,
+  `--restore-chat-history`). These entries set `resume_latest = true` and use no
+  `{id}` token. This works because restart reuses the session's cwd and a
+  single-repo fork reuses the parent's cwd. **Caveat:** a *multi-repo* fork lands
+  in a fresh symlink workspace, so `--last`/`--continue` finds no parent session
+  there (multi-repo *restart* still works — same workspace dir).
+- **none** (`vibe`) — no resume group at all, so it always starts fresh on
+  restart. The live tmux process is what carries its state across TUI restarts.
+
+`resume_latest` only changes **when** the resume group fires
+(`session_ops::resume_trigger_for`): for id-less agents restart always triggers
+resume; for `claude` it defers to an on-disk transcript check.
+
+### Fork
+
+Agents that declare no `fork_args` (`antigravity`, `aider`, `copilot`, `vibe`,
+`omp`) cannot fork — `Ctrl+F` starts a **fresh** session instead. None of those
+CLIs support forking a conversation to a thurbox-pinned target.
+
+### Status hook mechanisms
+
+Every built-in reports status via the **hooks** extension, but *how* the hook is
+delivered differs by what each CLI supports. All are declared in
+[`extensions/hooks/extension.toml`](../extensions/hooks/extension.toml); the
+embedded hook assets live in
+[`extensions/hooks/`](../extensions/hooks/) and are `include_str!`'d by
+[`src/session_ops/builtin_hooks.rs`](../src/session_ops/builtin_hooks.rs).
+
+- **`agent_patches` (arg injection)** — appends args to the agent's launch
+  command, reversibly.
+  - `claude`: `--settings {home}/claude.json` (claude *merges* it with the user's
+    own settings, never clobbering). Full lifecycle: idle/working/blocked/done.
+  - `aider`: `--notifications-command "thurbox-cli session signal --state
+    blocked"`. aider has only a "waiting for input" callback, so **blocked is the
+    only state it can report**.
+- **`config_merges` (reversible JSON deep-merge into a shared config file)** —
+  for agents whose hooks live in a file thurbox must not overwrite.
+  - `codex`: merged into `~/.codex/hooks.json` (SessionStart→idle,
+    UserPromptSubmit/PreToolUse→working, Stop→done; **no blocked**). *Experimental.*
+  - `antigravity` (`agy`): merged into the shared `~/.gemini/settings.json` (agy
+    adopted claude's hook schema — PreToolUse→working, Notification→blocked,
+    Stop→done; no UserPromptSubmit, so working fires at the first tool call).
+- **`external_files` (drop a standalone managed file into the agent's config
+  dir)** — refused if a non-managed file already exists there (the agent goes
+  *unreported*, never *broken*).
+  - `opencode`: a plugin at `~/.config/opencode/plugin/thurbox-status.js`
+    (idle/working/blocked/done).
+  - `copilot`: `~/.copilot/hooks/thurbox-status.json`
+    (sessionStart→idle, userPromptSubmitted/preToolUse→working, agentStop→done,
+    notification→blocked). Ships both `bash` and `powershell` commands.
+    *Experimental.*
+  - `vibe`: a managed `~/.vibe/hooks.toml` (pre_tool→working, post_agent→done;
+    **no blocked** — vibe has no permission/notification hook). Verified against
+    vibe 2.21.0.
+  - `pi`: a TypeScript extension at `~/.pi/agent/extensions/thurbox-status.ts`
+    (session_start→idle, agent_start/tool_execution_start→working, agent_end→done;
+    **blocked inferred only** from an `ask_user_question` tool call). *Experimental.*
+  - `omp`: a TypeScript extension at `~/.omp/agent/extensions/thurbox-status.ts`,
+    mirroring pi's but mapping OMP's structured user-question tool — named `ask`
+    — to blocked (it recognizes both `ask` and pi's `ask_user_question`). Verified
+    against OMP 17.0.6. *Experimental.*
+
+Each `requires_dir` guard makes the drop a no-op when that agent isn't installed,
+so a fresh install with only claude present doesn't scatter files for agents you
+don't have.
+
+### `hook_schema` (custom rebrands only)
+
+The built-ins never set `hook_schema` — the hooks extension already knows them by
+name. It exists for a **user's** custom agent that runs a built-in under a
+different name (e.g. a rebranded-claude CLI called `fleet`): set `hook_schema =
+"claude"` and it inherits claude's `--settings` hook wiring under its own name.
+Only the per-arg-patch families (`claude`, `aider`) need it; the config-dir
+agents (codex/opencode/antigravity/vibe/copilot/pi) wire through their own config
+dir, so a rebrand sharing that dir already reports without it. See
+[CONFIG.md](CONFIG.md#agentstoml) and the `AgentDef.hook_schema` doc comment.
+
+## Adding a new built-in agent
+
+Adding support for a new CLI as a **user** needs only an `agents.toml` edit — no
+recompile (that's the whole point of agents-as-data). But promoting a CLI to a
+shipped **built-in** touches several places that are **not** kept in sync
+automatically. Work the checklist top to bottom:
+
+1. **Seed entry** — add an `[[agents]]` block to `BUILTIN_AGENTS_TOML` in
+   [`src/agent/agent_config.rs`](../src/agent/agent_config.rs). Set `command`,
+   the resume/fork/new-session groups, and `resume_latest` per the ID model
+   above. Add a short comment explaining the CLI's resume/fork semantics, as the
+   existing entries do. **Decide the ID model first** — whether the CLI can pin a
+   session id — because it determines every `*_args` group.
+
+2. **Status hooks** — add the wiring to
+   [`extensions/hooks/extension.toml`](../extensions/hooks/extension.toml) and
+   the hook asset file under [`extensions/hooks/`](../extensions/hooks/). Pick the
+   mechanism from [Status hook mechanisms](#status-hook-mechanisms):
+   `agent_patches` if hooks are launch flags, `config_merges` if they live in a
+   shared config file thurbox must not clobber, `external_files` for a standalone
+   drop into the agent's own config dir. Register any new embedded asset with an
+   `include_str!` in
+   [`src/session_ops/builtin_hooks.rs`](../src/session_ops/builtin_hooks.rs).
+   Bump the hooks extension `version`. Skipping this step means the new agent
+   launches fine but **never shows working/blocked/done**.
+
+3. **Docs — update every list of built-ins** (these are prose, not generated, so
+   they drift):
+   - [The built-in agents](#the-built-in-agents) table above.
+   - [CONFIG.md → agents.toml](CONFIG.md#agentstoml) — the parenthetical list and
+     the "N built-ins" count.
+   - [FEATURES.md → Agent definitions](FEATURES.md#agent-definitions) — the prose
+     list and the pinned-id sentence.
+   - `../CLAUDE.md` → *Agent Definitions* and *Custom-agent status hooks* — the
+     built-in lists and the resume/fork caveats.
+
+4. **Tests** — the seed TOML must still parse and produce the expected registry.
+   Run the agent-config tests and update any fixture that enumerates the built-in
+   set:
+
+   ```bash
+   cargo nextest run -E 'test(agent)'
+   ```
+
+5. **Verify end-to-end** (optional but recommended) — install the CLI and confirm
+   in a sandbox that resume, fork, and the status dot all behave:
+
+   ```bash
+   scripts/dev/sandbox.sh
+   ```
+
+### What is auto-handled (don't do these)
+
+- No provider code — `agent::GenericProvider` drives *any* `AgentDef` from its
+  data; there is no per-agent Rust launcher to write.
+- No agent picker change — the new-session picker reads the registry.
+- No migration for existing users — `agents.toml` is only seeded when absent, so
+  a new built-in appears for **fresh installs**; existing users keep their file
+  and add the entry themselves (this is intentional — thurbox never rewrites a
+  user's edited config).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -634,7 +634,7 @@ trivially testable. Composite styles (e.g., `focused_title()`) are
 at creation time; each agent runs with its own default config.
 Agents are described as **data** in `~/.config/thurbox/agents.toml`
 (sibling of any other config), seeded with built-ins (claude,
-codex, antigravity, opencode, aider, copilot, vibe, pi) on first run via
+codex, antigravity, opencode, aider, copilot, vibe, pi, omp) on first run via
 `agent::agent_config::load_or_seed`. An `AgentDef` carries a
 `command`, `args` (always passed — bake in flags like a model
 here if you want), and argument-template groups (`resume_args`,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -159,6 +159,11 @@ and **Pin a model** (a `claude-opus` variant baking `--model opus`
 into `args`). Both stay commented, so a fresh install still resolves
 to exactly the nine built-ins.
 
+For **each built-in's** exact config and runtime behavior (resume/fork
+semantics, ID model, and which status-hook mechanism it uses), and the
+checklist for **adding a new built-in**, see
+[AGENTS.md](AGENTS.md).
+
 ## hosts.toml
 
 Declares off-local hosts — **remote SSH machines** and **local WSL

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -272,10 +272,12 @@ from accumulating stale entries.
 
 The set of available agents is **data**, not code. On first run
 Thurbox seeds `~/.config/thurbox/agents.toml` with built-in
-definitions for claude, codex, antigravity, opencode, aider, vibe, and pi
-(`agent::agent_config::load_or_seed`). Editing the file — adding an
-`[[agents]]` entry or tweaking an existing one — extends the agent
-picker with no recompile.
+definitions for claude, codex, antigravity, opencode, aider, copilot,
+vibe, and pi (`agent::agent_config::load_or_seed`). Editing the file —
+adding an `[[agents]]` entry or tweaking an existing one — extends the
+agent picker with no recompile. Each built-in's exact config and
+behavior (and the checklist for adding a new built-in) is in
+[AGENTS.md](AGENTS.md).
 
 Each definition (`session::AgentDef`) carries:
 
@@ -294,8 +296,8 @@ each group **only when its driving value is present**, substituting
 new-session id; static `args` follow. A group with no value is
 simply omitted — no unresolved-placeholder heuristics.
 
-Only `claude` accepts the thurbox-generated id at creation
-(`--session-id {id}`), so only it resumes/forks by that exact id.
+Only `claude` and `pi` accept the thurbox-generated id at creation
+(`--session-id {id}`), so only they resume/fork by that exact id.
 The other built-ins can't pin or report their session id, so they
 set `resume_latest = true` and resume/fork via id-less, cwd-scoped
 flags (`codex resume --last`, `opencode --continue`, `agy

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -12,16 +12,21 @@ use crate::session::{AgentDef, AgentRegistry};
 
 /// Built-in agent definitions, also used to seed `agents.toml` on first run.
 ///
+/// Adding a built-in here is only step 1 — status-hook wiring
+/// (`extensions/hooks/extension.toml`) and the doc lists are **not** updated
+/// automatically. See the checklist in `docs/AGENTS.md`.
+///
 /// Kept deliberately small per agent: just the command, plus resume/fork/
 /// session-id groups. `claude` and `pi` pin a thurbox-generated id
-/// (`--session-id`) so they can resume/fork by that exact id. The other
-/// built-ins can't pin or report their session id, so they use
-/// `resume_latest = true` with id-less,
-/// cwd-scoped flags (`codex resume --last`, `opencode --continue`, …): the agent
-/// resolves "the last session in this directory" itself. Agents without any
-/// resume group simply start fresh on restart. No model is passed — each agent
-/// uses its own default config. Bake extra flags (including a model) into
-/// `args` if you want them.
+/// (`--session-id`) so they can resume/fork by that exact id; `omp` pins the
+/// same id as a session-file path (`--session {home}/…/thurbox-{id}.jsonl`)
+/// since it generates its own id but accepts a file. The other built-ins can't
+/// pin or report their session id, so they use `resume_latest = true` with
+/// id-less, cwd-scoped flags (`codex resume --last`, `opencode --continue`, …):
+/// the agent resolves "the last session in this directory" itself. Agents
+/// without any resume group simply start fresh on restart. No model is passed —
+/// each agent uses its own default config. Bake extra flags (including a model)
+/// into `args` if you want them.
 pub const BUILTIN_AGENTS_TOML: &str = r#"# Thurbox coding-agent definitions.
 #
 # Each [[agents]] entry describes how to launch one coding-agent CLI. The

--- a/website/_includes/sidebar.njk
+++ b/website/_includes/sidebar.njk
@@ -27,6 +27,13 @@
     { href: "features.html#session-persistence", label: "Session Persistence" },
     { href: "features.html#headless-cli", label: "Headless CLI" }
   ]},
+  { heading: "Agents", links: [
+    { slug: "agents", href: "agents.html", label: "Built-in agents" }
+  ]},
+  { heading: "Configurations", links: [
+    { slug: "configuration", href: "configuration.html", label: "Configuration" },
+    { slug: "keybindings", href: "keybindings.html", label: "Keybindings" }
+  ]},
   { heading: "Extensions", links: [
     { slug: "extensions", href: "extensions.html", label: "Overview" },
     { subheading: "Built in" },
@@ -42,10 +49,6 @@
     { slug: "extension-gitlab-issues", href: "extension-gitlab-issues.html", label: "GitLab issues" },
     { slug: "extension-linear", href: "extension-linear.html", label: "Linear" },
     { slug: "extension-jira", href: "extension-jira.html", label: "Jira" }
-  ]},
-  { heading: "Configurations", links: [
-    { slug: "configuration", href: "configuration.html", label: "Configuration" },
-    { slug: "keybindings", href: "keybindings.html", label: "Keybindings" }
   ]},
   { heading: "Reference", links: [
     { slug: "architecture", href: "architecture.html", label: "Architecture" },

--- a/website/docs/agent-hooks.html
+++ b/website/docs/agent-hooks.html
@@ -1,7 +1,7 @@
 ---
 layout: docs.njk
 title: 'Agent hooks — Thurbox Docs'
-description: 'The built-in hooks extension: wire each coding agent CLI lifecycle hook to thurbox-cli session signal so every session reports working/blocked/done/idle. Per-agent coverage matrix for claude, codex, antigravity, opencode, aider, copilot, and vibe.'
+description: 'The built-in hooks extension: wire each coding agent CLI lifecycle hook to thurbox-cli session signal so every session reports working/blocked/done/idle. Per-agent coverage matrix for claude, codex, antigravity, opencode, aider, copilot, vibe, pi, and omp.'
 currentPage: 'agent-hooks'
 breadcrumb: 'Agent hooks'
 onThisPage:
@@ -191,6 +191,20 @@ onThisPage:
                 <td>vibe <sup>*</sup></td>
                 <td>&mdash;</td>
                 <td>&#x2713;</td>
+                <td>&mdash;</td>
+                <td>&#x2713;</td>
+              </tr>
+              <tr>
+                <td>pi <sup>*</sup></td>
+                <td>&#x2713;</td>
+                <td>&#x2713;</td>
+                <td>&#x2713;</td>
+                <td>&#x2713;</td>
+              </tr>
+              <tr>
+                <td>omp <sup>*</sup></td>
+                <td>&#x2713;</td>
+                <td>&#x2713;</td>
                 <td>&#x2713;</td>
                 <td>&#x2713;</td>
               </tr>
@@ -199,8 +213,8 @@ onThisPage:
           <p>
             <sup>*</sup>
             <strong>Experimental</strong>
-            &mdash; the hook schema for codex, copilot, and vibe is newer or not exhaustively
-            verified against the live CLI. If event names differ, the fix is a one-file edit to the
+            &mdash; the hook schema for codex, copilot, vibe, pi, and omp is newer or not
+            exhaustively verified against the live CLI. If event names differ, the fix is a one-file edit to the
             extension payload (no code change), and an unrecognized hook is a fail-open no-op
             (
             <code>|| true</code>
@@ -299,13 +313,19 @@ onThisPage:
               <em>(experimental)</em>
               &mdash; Mistral Vibe loads hooks from
               <code>~/.vibe/hooks.toml</code>
-              ; Thurbox drops a managed file in (only when vibe is installed).
-              <code>before_tool</code>
+              ; Thurbox drops a managed file in (only when vibe is installed). Verified against vibe
+              2.21.0:
+              <code>pre_tool</code>
               &rarr; working,
-              <code>after_turn</code>
-              &rarr; done,
-              <code>notification</code>
-              &rarr; blocked. If you already maintain your own
+              <code>post_agent</code>
+              &rarr; done. No blocked &mdash; vibe's only hook types are
+              <code>pre_tool</code>
+              /
+              <code>post_tool</code>
+              /
+              <code>post_agent</code>
+              (no permission event), so a tool awaiting approval reads as working. If you already
+              maintain your own
               <code>hooks.toml</code>
               the write is
               <strong>refused</strong>
@@ -334,6 +354,39 @@ onThisPage:
               and
               <code>powershell</code>
               commands ship, so status works on Windows too.
+            </li>
+            <li>
+              <strong>pi</strong>
+              <em>(experimental)</em>
+              &mdash; the pi.dev CLI auto-discovers TypeScript extensions from
+              <code>~/.pi/agent/extensions/</code>
+              , so Thurbox drops a managed one in (only when pi is installed).
+              <code>session_start</code>
+              &rarr; idle,
+              <code>agent_start</code>
+              /
+              <code>tool_execution_start</code>
+              &rarr; working,
+              <code>agent_end</code>
+              &rarr; done, and a structured
+              <code>ask_user_question</code>
+              tool call &rarr; blocked (pi has no permission hook, so a turn that ends by asking in
+              prose signals done, not blocked).
+            </li>
+            <li>
+              <strong>omp</strong>
+              <em>(experimental)</em>
+              &mdash; Oh My Pi is Pi-compatible and likewise auto-discovers TypeScript extensions,
+              from
+              <code>~/.omp/agent/extensions/</code>
+              , so Thurbox drops a managed one in (only when omp is installed). It mirrors pi's
+              extension but maps OMP's structured user-question tool &mdash; named
+              <code>ask</code>
+              &mdash; to blocked (it recognizes both
+              <code>ask</code>
+              and pi's
+              <code>ask_user_question</code>
+              ). Verified against OMP 17.0.6.
             </li>
           </ul>
           <p>
@@ -421,6 +474,16 @@ onThisPage:
                 <td>antigravity</td>
                 <td><code>~/.gemini/settings.json</code></td>
                 <td>reversible JSON-merge of our entries</td>
+              </tr>
+              <tr>
+                <td>pi</td>
+                <td><code>~/.pi/agent/extensions/thurbox-status.ts</code></td>
+                <td>managed extension file (refused if you already have one)</td>
+              </tr>
+              <tr>
+                <td>omp</td>
+                <td><code>~/.omp/agent/extensions/thurbox-status.ts</code></td>
+                <td>managed extension file (refused if you already have one)</td>
               </tr>
             </tbody>
           </table>

--- a/website/docs/agents.html
+++ b/website/docs/agents.html
@@ -1,0 +1,472 @@
+---
+layout: docs.njk
+title: 'Built-in agents — Thurbox Docs'
+description: 'Every built-in coding agent Thurbox ships (claude, codex, antigravity, opencode, aider, copilot, vibe, pi, omp) with its recommended agents.toml configuration, resume/fork behavior, and status-hook support.'
+currentPage: 'agents'
+breadcrumb: 'Built-in agents'
+onThisPage:
+  - { id: 'overview', label: 'Overview' }
+  - { id: 'at-a-glance', label: 'At a glance' }
+  - { id: 'claude', label: 'claude' }
+  - { id: 'codex', label: 'codex' }
+  - { id: 'antigravity', label: 'antigravity' }
+  - { id: 'opencode', label: 'opencode' }
+  - { id: 'aider', label: 'aider' }
+  - { id: 'copilot', label: 'copilot' }
+  - { id: 'vibe', label: 'vibe' }
+  - { id: 'pi', label: 'pi' }
+  - { id: 'omp', label: 'omp' }
+  - { id: 'adding', label: 'Adding your own' }
+---
+<h1>Built-in agents</h1>
+          <p>
+            Thurbox is
+            <strong>agent-neutral</strong>
+            : it knows nothing about a coding agent's model, prompts, permissions, or tools &mdash;
+            only how to launch the CLI and how that CLI resumes, forks, and reports status. Every
+            agent is
+            <strong>data</strong>
+            , declared in
+            <a href="configuration.html#agents-toml"><code>~/.config/thurbox/agents.toml</code></a>
+            . The nine agents below are what Thurbox
+            <strong>seeds on first run</strong>
+            ; each block is the recommended configuration, ready to copy.
+          </p>
+          <div class="info-box">
+            <p>
+              <strong>No model is ever passed.</strong>
+              Each agent runs with its
+              <strong>own default config</strong>
+              . To pin a model or any other flag, add it to
+              <code>args</code>
+              (always passed) &mdash; e.g.
+              <code>args = ["--model", "opus"]</code>
+              . Keep the default entry and add a second
+              <code>[[agents]]</code>
+              variant if you want both.
+            </p>
+          </div>
+
+          <h2 id="overview">
+            Overview
+            <a href="#overview" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Each
+            <code>[[agents]]</code>
+            entry carries a
+            <code>command</code>
+            plus optional argument-template groups that Thurbox appends
+            <strong>only when their driving value is present</strong>
+            , substituting the thurbox-generated session id for
+            <code>{id}</code>
+            :
+          </p>
+          <ul>
+            <li>
+              <code>args</code>
+              &mdash; always passed (bake a model or any flag here).
+            </li>
+            <li>
+              <code>new_session_args</code>
+              &mdash; emitted on a fresh spawn (used to pin a session id).
+            </li>
+            <li>
+              <code>resume_args</code>
+              &mdash; emitted on restart/resume.
+            </li>
+            <li>
+              <code>fork_args</code>
+              &mdash; emitted on
+              <code>Ctrl+F</code>
+              fork.
+            </li>
+            <li>
+              <code>resume_latest</code>
+              &mdash;
+              <code>true</code>
+              means resume/fork target
+              <em>the last session in the launch directory</em>
+              (id-less flags), for CLIs that can't pin a session id.
+            </li>
+          </ul>
+          <p>
+            Selection precedence is
+            <strong>fork &gt; resume &gt; new-session</strong>
+            ; static
+            <code>args</code>
+            always follow. ID models matter: agents that
+            <strong>pin</strong>
+            a thurbox id (<code>claude</code>, <code>pi</code>) resume/fork
+            <em>that exact session</em>
+            ,
+            <code>omp</code>
+            is
+            <strong>path-pinned</strong>
+            (thurbox maps its id to a fixed session file), and the rest are
+            <strong>id-less</strong>
+            and resolve "the last session in this directory" themselves. Status reporting is wired
+            separately by the built-in
+            <a href="agent-hooks.html">hooks extension</a>
+            .
+          </p>
+
+          <h2 id="at-a-glance">
+            At a glance
+            <a href="#at-a-glance" class="heading-anchor">#</a>
+          </h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Agent</th>
+                <th>Command</th>
+                <th>Resume</th>
+                <th>Fork</th>
+                <th>ID model</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><a href="#claude"><code>claude</code></a></td>
+                <td><code>claude</code></td>
+                <td>by id</td>
+                <td>yes</td>
+                <td>pinned</td>
+                <td>full</td>
+              </tr>
+              <tr>
+                <td><a href="#codex"><code>codex</code></a></td>
+                <td><code>codex</code></td>
+                <td>last in dir</td>
+                <td>yes</td>
+                <td>id-less</td>
+                <td>no blocked</td>
+              </tr>
+              <tr>
+                <td><a href="#antigravity"><code>antigravity</code></a></td>
+                <td><code>agy</code></td>
+                <td>last in dir</td>
+                <td>&mdash;</td>
+                <td>id-less</td>
+                <td>full</td>
+              </tr>
+              <tr>
+                <td><a href="#opencode"><code>opencode</code></a></td>
+                <td><code>opencode</code></td>
+                <td>last in dir</td>
+                <td>yes</td>
+                <td>id-less</td>
+                <td>full</td>
+              </tr>
+              <tr>
+                <td><a href="#aider"><code>aider</code></a></td>
+                <td><code>aider</code></td>
+                <td>chat history</td>
+                <td>&mdash;</td>
+                <td>id-less</td>
+                <td>blocked only</td>
+              </tr>
+              <tr>
+                <td><a href="#copilot"><code>copilot</code></a></td>
+                <td><code>copilot</code></td>
+                <td>last in dir</td>
+                <td>&mdash;</td>
+                <td>id-less</td>
+                <td>full</td>
+              </tr>
+              <tr>
+                <td><a href="#vibe"><code>vibe</code></a></td>
+                <td><code>vibe</code></td>
+                <td>&mdash; (fresh)</td>
+                <td>&mdash;</td>
+                <td>none</td>
+                <td>no blocked</td>
+              </tr>
+              <tr>
+                <td><a href="#pi"><code>pi</code></a></td>
+                <td><code>pi</code></td>
+                <td>by id</td>
+                <td>yes</td>
+                <td>pinned</td>
+                <td>full</td>
+              </tr>
+              <tr>
+                <td><a href="#omp"><code>omp</code></a></td>
+                <td><code>omp</code></td>
+                <td>by session file</td>
+                <td>&mdash;</td>
+                <td>path-pinned</td>
+                <td>full</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            "Status" is what the session-list dot can reflect (see the
+            <a href="agent-hooks.html#coverage">per-agent coverage matrix</a>
+            ). The
+            <code>default</code>
+            agent is
+            <code>claude</code>
+            ; change it with
+            <code>default = "&lt;name&gt;"</code>
+            at the top of the file.
+          </p>
+
+          <h2 id="claude">
+            claude
+            <a href="#claude" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Anthropic's
+            <a href="https://github.com/anthropics/claude-code" target="_blank" rel="noopener">Claude Code</a>
+            . Accepts a thurbox-generated session id at creation, so it resumes and forks
+            <strong>that exact session</strong>
+            by id.
+          </p>
+          <p>
+            <span class="badge">Resume: by id</span>
+            <span class="badge">Fork: yes</span>
+            <span class="badge badge-green">Status: full (idle/working/blocked/done)</span>
+          </p>
+          <pre data-title="agents.toml"><code class="language-toml">[[agents]]
+name = "claude"
+command = "claude"
+resume_args = ["--resume", "{id}"]
+fork_args = ["--resume", "{id}", "--fork-session"]
+new_session_args = ["--session-id", "{id}"]</code></pre>
+
+          <h2 id="codex">
+            codex
+            <a href="#codex" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            OpenAI's
+            <a href="https://github.com/openai/codex" target="_blank" rel="noopener">Codex CLI</a>
+            . It can't pin or report a session id, so resume/fork target the most recent session in
+            the launch directory (<code>resume_latest = true</code>). Thurbox keeps that directory
+            stable across restart (same cwd) and single-repo fork (child reuses the parent cwd).
+          </p>
+          <p>
+            <span class="badge">Resume: last in dir</span>
+            <span class="badge">Fork: yes</span>
+            <span class="badge badge-yellow">Status: no blocked (experimental)</span>
+          </p>
+          <pre data-title="agents.toml"><code class="language-toml">[[agents]]
+name = "codex"
+command = "codex"
+resume_args = ["resume", "--last"]
+fork_args = ["fork", "--last"]
+resume_latest = true</code></pre>
+
+          <h2 id="antigravity">
+            antigravity
+            <a href="#antigravity" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            The
+            <code>agy</code>
+            CLI (the Gemini CLI successor). Resumes the latest session in the launch directory via
+            <code>--continue</code>
+            ; it has no fork, so
+            <code>Ctrl+F</code>
+            starts a fresh session.
+          </p>
+          <p>
+            <span class="badge">Resume: last in dir</span>
+            <span class="badge">Fork: &mdash;</span>
+            <span class="badge badge-green">Status: full (idle/working/blocked/done)</span>
+          </p>
+          <pre data-title="agents.toml"><code class="language-toml">[[agents]]
+name = "antigravity"
+command = "agy"
+resume_args = ["--continue"]
+resume_latest = true</code></pre>
+
+          <h2 id="opencode">
+            opencode
+            <a href="#opencode" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            <a href="https://opencode.ai" target="_blank" rel="noopener">opencode</a>
+            .
+            <code>--continue</code>
+            resumes the last session in the cwd;
+            <code>--fork</code>
+            branches it.
+          </p>
+          <p>
+            <span class="badge">Resume: last in dir</span>
+            <span class="badge">Fork: yes</span>
+            <span class="badge badge-green">Status: full (idle/working/blocked/done)</span>
+          </p>
+          <pre data-title="agents.toml"><code class="language-toml">[[agents]]
+name = "opencode"
+command = "opencode"
+resume_args = ["--continue"]
+fork_args = ["--continue", "--fork"]
+resume_latest = true</code></pre>
+
+          <h2 id="aider">
+            aider
+            <a href="#aider" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            <a href="https://aider.chat" target="_blank" rel="noopener">aider</a>
+            restores the chat-history file in the cwd; it has no separate session id and no fork. Its
+            only lifecycle callback is "waiting for input", so the status dot reflects
+            <strong>blocked</strong>
+            only.
+          </p>
+          <p>
+            <span class="badge">Resume: chat history</span>
+            <span class="badge">Fork: &mdash;</span>
+            <span class="badge badge-yellow">Status: blocked only</span>
+          </p>
+          <pre data-title="agents.toml"><code class="language-toml">[[agents]]
+name = "aider"
+command = "aider"
+resume_args = ["--restore-chat-history"]
+resume_latest = true</code></pre>
+
+          <h2 id="copilot">
+            copilot
+            <a href="#copilot" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            <a href="https://github.com/github/copilot-cli" target="_blank" rel="noopener">GitHub Copilot CLI</a>
+            (the
+            <code>copilot</code>
+            command). Resumes the most recent session in the launch directory via
+            <code>--continue</code>
+            ; it can't pin or report a session id and has no fork.
+          </p>
+          <p>
+            <span class="badge">Resume: last in dir</span>
+            <span class="badge">Fork: &mdash;</span>
+            <span class="badge badge-green">Status: full (experimental)</span>
+          </p>
+          <pre data-title="agents.toml"><code class="language-toml">[[agents]]
+name = "copilot"
+command = "copilot"
+resume_args = ["--continue"]
+resume_latest = true</code></pre>
+
+          <h2 id="vibe">
+            vibe
+            <a href="#vibe" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Mistral's
+            <code>vibe</code>
+            CLI. It declares no resume group, so it always starts
+            <strong>fresh</strong>
+            on restart &mdash; the live tmux process is what carries its state across TUI restarts.
+            No fork.
+          </p>
+          <p>
+            <span class="badge">Resume: &mdash; (fresh)</span>
+            <span class="badge">Fork: &mdash;</span>
+            <span class="badge badge-yellow">Status: no blocked (experimental)</span>
+          </p>
+          <pre data-title="agents.toml"><code class="language-toml">[[agents]]
+name = "vibe"
+command = "vibe"</code></pre>
+
+          <h2 id="pi">
+            pi
+            <a href="#pi" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            The
+            <a href="https://pi.dev" target="_blank" rel="noopener">pi.dev</a>
+            CLI. Like claude, it accepts a thurbox-generated session id at creation, so it
+            resumes/forks by that exact id. Sessions live under
+            <code>~/.pi/agent/</code>
+            , organized by working directory.
+          </p>
+          <p>
+            <span class="badge">Resume: by id</span>
+            <span class="badge">Fork: yes</span>
+            <span class="badge badge-green">Status: full (experimental)</span>
+          </p>
+          <pre data-title="agents.toml"><code class="language-toml">[[agents]]
+name = "pi"
+command = "pi"
+resume_args = ["--session-id", "{id}"]
+fork_args = ["--fork", "{id}"]
+new_session_args = ["--session-id", "{id}"]</code></pre>
+
+          <h2 id="omp">
+            omp
+            <a href="#omp" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            <a href="https://github.com/can1357/oh-my-pi" target="_blank" rel="noopener">Oh My Pi</a>
+            (the
+            <code>omp</code>
+            command) is Pi-compatible but generates its
+            <strong>own</strong>
+            internal session id, so it can't accept thurbox's. Instead it takes a session
+            <strong>file path</strong>
+            : thurbox maps its UUID to a deterministic JSONL under OMP's default root
+            (<code>--session &lt;file&gt;</code>
+            on create,
+            <code>--resume</code>
+            on the same path to restore), so restart reattaches the exact session. The
+            <code>{home}</code>
+            token expands to the resolved home dir at spawn time (thurbox, not the shell &mdash;
+            args are POSIX-quoted, so a literal
+            <code>~</code>
+            never expands), and it translates onto a remote/WSL home too. No fork &mdash; OMP can't
+            pin a fork's target file, so
+            <code>Ctrl+F</code>
+            starts fresh.
+          </p>
+          <p>
+            <span class="badge">Resume: by session file</span>
+            <span class="badge">Fork: &mdash;</span>
+            <span class="badge badge-green">Status: full (experimental)</span>
+          </p>
+          <pre data-title="agents.toml"><code class="language-toml">[[agents]]
+name = "omp"
+command = "omp"
+resume_args = ["--resume", "{home}/.omp/agent/sessions/thurbox-{id}.jsonl"]
+new_session_args = ["--session", "{home}/.omp/agent/sessions/thurbox-{id}.jsonl"]</code></pre>
+
+          <h2 id="adding">
+            Adding your own
+            <a href="#adding" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            Any CLI works &mdash; add an
+            <code>[[agents]]</code>
+            entry with a
+            <code>command</code>
+            and whichever
+            <code>*_args</code>
+            groups it supports. No recompile.
+          </p>
+          <pre data-title="agents.toml"><code class="language-toml">[[agents]]
+name = "my-agent"             # shown in the new-session picker
+command = "my-agent-cli"      # the executable on your PATH
+args = []                     # always passed (put a model flag here)
+resume_args = []              # appended on resume, with {id} substituted
+fork_args = []                # appended on Ctrl+F fork, with {id} substituted
+new_session_args = []         # appended on a fresh spawn, with {id} substituted
+resume_latest = false         # true = id-less "resume last session in cwd"
+# hook_schema = "claude"      # optional: name the hook FAMILY this CLI speaks so
+#                             #   the hooks extension wires status under this name</code></pre>
+          <p>
+            Set
+            <code>hook_schema = "claude"</code>
+            on a
+            <strong>rebranded</strong>
+            agent (one whose
+            <code>command</code>
+            runs claude under a different name) so it inherits claude's status-hook wiring. See the
+            <a href="configuration.html#agents-toml"><code>agents.toml</code> reference</a>
+            for the full field list and the
+            <a href="agent-hooks.html">hooks page</a>
+            for how status is wired.
+          </p>

--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -219,6 +219,10 @@ thurbox-cli config show       # effective config + where each value came from</c
             <code>copilot</code>
             ,
             <code>vibe</code>
+            ,
+            <code>pi</code>
+            ,
+            <code>omp</code>
             ) on first run; edit or add
             <code>[[agents]]</code>
             entries to support any CLI &mdash; no recompile. A malformed file falls back to the
@@ -239,6 +243,11 @@ resume_latest = false       # true = id-less "resume last session in cwd"</code>
             <code>{id}</code>
             is substituted with the thurbox-generated session UUID. Groups are emitted only when
             their driving value exists; precedence is fork &gt; resume &gt; new-session.
+          </p>
+          <p>
+            For each built-in's recommended configuration and runtime behavior &mdash; resume/fork
+            semantics, whether it pins a session id, and how it reports status &mdash; see
+            <a href="agents.html">Built-in agents</a>.
           </p>
 
           <h2 id="hosts-toml">

--- a/website/docs/faq.html
+++ b/website/docs/faq.html
@@ -14,8 +14,8 @@ breadcrumb: 'FAQ'
 <h2 id="what-is-thurbox">What is Thurbox?</h2>
 <p>
   Thurbox is a multi-session TUI orchestrator that runs any coding-agent CLI
-  — Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe,
-  or any CLI you define — inside persistent tmux panes. Sessions, agents, and
+  — Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, pi,
+  Oh My Pi, or any CLI you define — inside persistent tmux panes. Sessions, agents, and
   git worktrees are first-class citizens, and sessions survive crashes,
   restarts, and reboots because tmux keeps the processes alive.
 </p>
@@ -37,8 +37,8 @@ breadcrumb: 'FAQ'
 <h2 id="supported-agents">Which coding agents does Thurbox support?</h2>
 <p>
   Thurbox is agent-neutral. It ships built-in definitions for Claude Code,
-  Codex, Antigravity, opencode, aider, GitHub Copilot CLI, and Vibe, and you can
-  add any other CLI by editing agents.toml — no recompile required. Thurbox only
+  Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, pi, and Oh My Pi,
+  and you can add any other CLI by editing agents.toml — no recompile required. Thurbox only
   knows how to launch each CLI with the right command and arguments; it never
   touches the
   agent's model, prompts, or permissions.
@@ -96,7 +96,7 @@ breadcrumb: 'FAQ'
         "name": "What is Thurbox?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Thurbox is a multi-session TUI orchestrator that runs any coding-agent CLI — Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, or any CLI you define — inside persistent tmux panes. Sessions, agents, and git worktrees are first-class citizens, and sessions survive crashes, restarts, and reboots because tmux keeps the processes alive."
+          "text": "Thurbox is a multi-session TUI orchestrator that runs any coding-agent CLI — Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, pi, Oh My Pi, or any CLI you define — inside persistent tmux panes. Sessions, agents, and git worktrees are first-class citizens, and sessions survive crashes, restarts, and reboots because tmux keeps the processes alive."
         }
       },
       {
@@ -112,7 +112,7 @@ breadcrumb: 'FAQ'
         "name": "Which coding agents does Thurbox support?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Thurbox is agent-neutral. It ships built-in definitions for Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, and Vibe, and you can add any other CLI by editing agents.toml — no recompile required. Thurbox only knows how to launch each CLI with the right command and arguments; it never touches the agent's model, prompts, or permissions."
+          "text": "Thurbox is agent-neutral. It ships built-in definitions for Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, pi, and Oh My Pi, and you can add any other CLI by editing agents.toml — no recompile required. Thurbox only knows how to launch each CLI with the right command and arguments; it never touches the agent's model, prompts, or permissions."
         }
       },
       {

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -41,8 +41,9 @@ breadcrumb: 'Features'
           </figure>
           <p>
             Run multiple coding-agent CLIs side-by-side, each in its own tmux pane. A session runs
-            one agent (Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, or
-            your own), each with its own default config. Sessions persist across crashes, restarts,
+            one agent (Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, pi,
+            Oh My Pi, or your own), each with its own default config. Sessions persist across crashes,
+            restarts,
             and even
             multiple concurrent Thurbox instances &mdash; tmux keeps them alive in the background.
           </p>
@@ -105,8 +106,10 @@ breadcrumb: 'Features'
           <p>
             The set of available agents is data, not code. On first run Thurbox seeds
             <code>~/.config/thurbox/agents.toml</code>
-            with built-ins (claude, codex, antigravity, opencode, aider, vibe). Edit the file to tweak an
-            agent or add a new one &mdash; no recompile required.
+            with built-ins (claude, codex, antigravity, opencode, aider, copilot, vibe, pi, omp).
+            Edit the file to tweak an agent or add a new one &mdash; no recompile required. See
+            <a href="agents.html">Built-in agents</a>
+            for each one's recommended config and behavior.
           </p>
           <ul>
             <li>

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -255,8 +255,8 @@ cargo build --release</code></pre>
                   >
                     claude
                   </a>
-                  , codex, antigravity, opencode, aider, copilot, or vibe &mdash; whichever agents you
-                  plan to run
+                  , codex, antigravity, opencode, aider, copilot, vibe, pi, or omp &mdash; whichever
+                  agents you plan to run
                 </td>
               </tr>
               <tr>

--- a/website/index.html
+++ b/website/index.html
@@ -1,7 +1,7 @@
 ---
 layout: base.njk
 title: 'Thurbox — TUI Agentic IDE'
-description: 'Thurbox runs any coding-agent CLI (Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe) in persistent tmux panes — sessions, agents, and git worktrees as first-class citizens.'
+description: 'Thurbox runs any coding-agent CLI (Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, pi, Oh My Pi) in persistent tmux panes — sessions, agents, and git worktrees as first-class citizens.'
 root: '.'
 extraCss: ['landing.css']
 footer: true
@@ -15,8 +15,9 @@ footer: true
           Agentic IDE
         </h1>
         <p class="subtitle">
-          Run Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe — or any CLI
-          you define — side by side in persistent tmux panes that survive crashes and restarts.
+          Run Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, pi, Oh My
+          Pi — or any CLI you define — side by side in persistent tmux panes that survive crashes and
+          restarts.
         </p>
         <p class="agent-support">
           Built-in agent support for
@@ -320,7 +321,7 @@ cargo build --release</code></pre>
               <h3>Any Coding Agent</h3>
               <p>
                 A session runs one agent of your choice &mdash; Claude Code, Codex, Antigravity,
-                opencode, aider, GitHub Copilot CLI, Vibe, or any CLI you describe. Each agent runs
+                opencode, aider, GitHub Copilot CLI, Vibe, pi, Oh My Pi, or any CLI you describe. Each agent runs
                 with its own default
                 config. Mix different agents across the sidebar.
               </p>
@@ -803,7 +804,7 @@ Ctrl+O  Open repos in editor</pre>
                 <a href="https://github.com/anthropics/claude-code" target="_blank" rel="noopener">
                   claude
                 </a>
-                , codex, antigravity, opencode, aider, copilot, or vibe
+                , codex, antigravity, opencode, aider, copilot, vibe, pi, or omp
               </li>
               <li>
                 <strong>git</strong>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -1,8 +1,8 @@
 # Thurbox
 
 > Thurbox is a multi-session TUI orchestrator that runs any coding-agent CLI
-> — Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe,
-> or any CLI you define — inside persistent tmux panes. Sessions, agents, and
+> — Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, pi,
+> Oh My Pi, or any CLI you define — inside persistent tmux panes. Sessions, agents, and
 > git worktrees
 > are first-class citizens, and sessions survive crashes, restarts, and
 > reboots because tmux keeps the agent processes alive. It is written in Rust,
@@ -15,6 +15,7 @@
 - [Documentation hub](https://thurbox.thurbeen.eu/docs/index.html): entry point to all Thurbox documentation.
 - [FAQ](https://thurbox.thurbeen.eu/docs/faq.html): short answers to the most common questions (what it is, how it differs, install, platforms, license).
 - [Features](https://thurbox.thurbeen.eu/docs/features.html): sessions, agent definitions, git worktrees, remote SSH, automations, tasks, code review, headless CLI.
+- [Built-in agents](https://thurbox.thurbeen.eu/docs/agents.html): every built-in coding agent (claude, codex, antigravity, opencode, aider, copilot, vibe, pi, omp) with its recommended agents.toml config, resume/fork behavior, and status support.
 - [Comparison](https://thurbox.thurbeen.eu/docs/comparison.html): how Thurbox compares to Conductor, Claude Squad, Cursor, and other parallel coding-agent tools.
 - [Installation](https://thurbox.thurbeen.eu/docs/installation.html): install via curl, Homebrew, AUR, winget, Chocolatey, or from source; prerequisites.
 - [Configuration](https://thurbox.thurbeen.eu/docs/configuration.html): every config file and knob — agents.toml, hosts.toml, settings.toml, themes, keybindings.


### PR DESCRIPTION
## Summary

- Add **`docs/AGENTS.md`** — a per-agent reference for every built-in coding agent: its recommended `agents.toml` config, ID model (pinned / path-pinned / id-less), fork support, and status-hook mechanism, plus a step-by-step checklist for adding a new built-in (the files that aren't kept in sync automatically).
- Add a **Built-in agents** website page (`website/docs/agents.html`) in a new sidebar section, with a copy-pasteable config block + status badges per agent.
- Fold in **omp (Oh My Pi)** across every built-in list and the hooks coverage matrix.
- Fix pre-existing doc drift: missing `copilot`/`pi` in several lists, and a wrong `vibe` "blocked" cell in the hooks coverage matrix (vibe has no permission hook).
- Cross-link the new reference from `CLAUDE.md`, `CONFIG.md`, `FEATURES.md`, `ARCHITECTURE.md`, and a pointer comment on `BUILTIN_AGENTS_TOML`.

The only code change is documentation comments; no behavior changes.

## Test plan

- [x] `cargo check --lib` passes (doc-comment-only Rust change)
- [x] Eleventy builds all pages cleanly; `htmlhint` passes on the new/edited pages
- [x] `rumdl` clean on the new/edited Markdown (one pre-existing unrelated MD034 warning remains)
- [x] Every built-in list across docs + website is consistent (all nine agents, incl. omp)