### PR TITLE
ci(deps): auto-close superseded winget-pkgs PRs after submit

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -529,3 +529,44 @@ jobs:
           WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
           .\wingetcreate.exe submit packaging/winget/manifests
+
+      # thurbox releases far faster than winget-pkgs' manual moderation merges,
+      # so each `submit` above stacks yet another open PR on top of the prior
+      # ones (wingetcreate has no "supersede the previous open PR" mode —
+      # `--replace` only supersedes a *published* manifest version, not a
+      # pending PR). Left alone they pile up (30 open at once, flagged in
+      # microsoft/winget-pkgs#405639) and annoy the moderators. So right after
+      # submitting the new version, close every *older* still-open
+      # Thurbeen.thurbox PR authored by the token account, keeping only the
+      # newest (the one just opened). Best-effort: never fail the release on a
+      # cleanup hiccup.
+      - name: Close superseded winget-pkgs PRs
+        if: env.WINGET_TOKEN != ''
+        shell: pwsh
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          $ErrorActionPreference = "Continue"
+          $version = "${{ needs.check-release.outputs.version }}".TrimStart("v")
+          # Open PRs by the token account for this package. `search` matches the
+          # package moniker in the title that wingetcreate always emits.
+          $prs = gh pr list --repo microsoft/winget-pkgs --author "@me" `
+            --state open --search "Thurbeen.thurbox in:title" `
+            --json number,title,createdAt --limit 100 | ConvertFrom-Json
+          if (-not $prs -or $prs.Count -le 1) {
+            Write-Host "Nothing to close ($($prs.Count) open PR(s))."
+            exit 0
+          }
+          # Keep the PR for the version we just submitted; fall back to the most
+          # recently created one if the title match is somehow ambiguous.
+          $keep = $prs | Where-Object { $_.title -match [regex]::Escape("version $version") } | Select-Object -First 1
+          if (-not $keep) {
+            $keep = $prs | Sort-Object { [datetime]$_.createdAt } -Descending | Select-Object -First 1
+          }
+          Write-Host "Keeping #$($keep.number) ($($keep.title)); closing $($prs.Count - 1) superseded PR(s)."
+          foreach ($pr in $prs | Where-Object { $_.number -ne $keep.number }) {
+            gh pr close $pr.number --repo microsoft/winget-pkgs `
+              --comment "Superseded by #$($keep.number) ($($keep.title)). Auto-closing this stale version-bump PR from thurbox release CI."
+            Write-Host "Closed #$($pr.number) ($($pr.title))."
+          }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,7 +413,12 @@ package channels (each gated on its secret, skipped on forks):
   PR to `microsoft/winget-pkgs`. Runs on `windows-latest`; needs the
   `WINGET_TOKEN` secret (a `public_repo` PAT owning a fork of
   `microsoft/winget-pkgs`). New versions go through winget-pkgs PR
-  validation + review. The release zip is a `zip` installer with
+  validation + review. Because thurbox releases far faster than that manual
+  moderation merges, each `submit` would otherwise stack another open PR
+  (wingetcreate's `--replace` only supersedes a *published* manifest version,
+  not a pending PR); a follow-up `gh pr close` step therefore closes every
+  older still-open `Thurbeen.thurbox` PR from the token account, keeping only
+  the newest (best-effort, never fails the release). The release zip is a `zip` installer with
   `NestedInstallerType = portable` (PATH aliases `thurbox`/`thurbox-cli`, no
   MSI). Install: `winget install Thurbeen.thurbox`. Windows x86_64 only (added
   as a moderation-independent alternative to the Chocolatey channel).


### PR DESCRIPTION
## Summary

- thurbox cuts releases far faster than `microsoft/winget-pkgs` manually moderates/merges, so each `wingetcreate submit` in `publish-winget` stacked yet another open PR — 30 open at once, flagged by a maintainer in [microsoft/winget-pkgs#405639](https://github.com/microsoft/winget-pkgs/pull/405639).
- `wingetcreate` has no supersede-pending-PR mode (`--replace` only affects *published* manifest versions), so this adds a follow-up **Close superseded winget-pkgs PRs** step: it lists the token account's open `Thurbeen.thurbox` PRs, keeps the one for the version just submitted (falling back to the newest), and `gh pr close`s the rest.
- The step is `continue-on-error` so a cleanup hiccup never fails a release.
- Documented the behavior in the winget bullet of `CLAUDE.md`.

## Test plan

- YAML validated (`yaml.safe_load`).
- Behavior exercises only on a real release with `WINGET_TOKEN` set; the close step is gated on `env.WINGET_TOKEN != ''` and best-effort, so it is a no-op on forks and safe to land.
- The 30 pre-existing stale PRs were already closed manually in this session; this prevents recurrence.