### PR TITLE
ci(deps): throttle winget submissions to one PR per 30 days

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -553,6 +553,19 @@ jobs:
   # secret (a classic PAT with `public_repo` scope that can fork/PR against
   # microsoft/winget-pkgs); skipped automatically if unset (e.g. on forks).
   # New versions go through winget-pkgs PR review before going live.
+  #
+  # Like Chocolatey, winget-pkgs is a *manually moderated* repo that can't keep
+  # up with thurbox's per-`feat`/`fix`/`perf` cadence — each `submit` opens a PR
+  # a human has to review, so a release every few hours buries the maintainers
+  # (30 open PRs at once, flagged in microsoft/winget-pkgs#405639). So this job
+  # mirrors the Chocolatey throttle: it submits at most once per THROTTLE_DAYS
+  # window, coalescing the intervening patch releases into a single winget
+  # version (the latest binary still ships immediately via GitHub Releases +
+  # Homebrew/AUR, and Chocolatey on its own monthly window). When the window
+  # hasn't elapsed the job records a `::warning::` and exits green — a backed-up
+  # winget channel must never turn the whole release red. The
+  # close-superseded-PRs step below still runs as a second-line cleanup for any
+  # PRs that did stack (e.g. a manual dispatch inside the window).
   publish-winget:
     name: Publish winget manifest
     needs: [check-release, create-tag, publish]
@@ -562,14 +575,66 @@ jobs:
     # (the `secrets` context cannot be used directly in an `if` condition).
     env:
       WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+      # Minimum days between winget-pkgs submissions. One PR/month keeps thurbox
+      # well within what the winget moderators can review while still shipping a
+      # recent version. Mirrors the Chocolatey window; tune here.
+      THROTTLE_DAYS: "30"
     steps:
       - name: Checkout code at tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.check-release.outputs.version }}
 
-      - name: Download release checksums
+      # Find the most recent thurbox PR we've submitted to winget-pkgs (merged
+      # = a version went live, or still-open = one is already awaiting review)
+      # and when it was raised. If that is younger than THROTTLE_DAYS, skip this
+      # release (green + warning) so patch releases coalesce into one monthly
+      # winget submission instead of flooding the moderation queue. This is the
+      # winget analog of the Chocolatey feed check (there the signal is the
+      # community feed's Published date; here it is our own last PR's date).
+      - name: Check throttle window
+        id: throttle
         if: env.WINGET_TOKEN != ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $throttleDays = [int]$env:THROTTLE_DAYS
+          $shouldPush = $true
+          $reason = ""
+          try {
+            # Newest thurbox PR from the token account in any state (merged or
+            # open) — its creation time is the last time we touched the channel.
+            $prs = gh pr list --repo microsoft/winget-pkgs --author "@me" `
+              --search "Thurbeen.thurbox in:title" --state all `
+              --json createdAt --limit 100 | ConvertFrom-Json
+            $last = $prs | Sort-Object { [datetime]$_.createdAt } -Descending | Select-Object -First 1
+            if (-not $last) {
+              $reason = "no prior thurbox PR on winget-pkgs — first submission"
+            } else {
+              $ageDays = ((Get-Date).ToUniversalTime() - ([datetime]$last.createdAt).ToUniversalTime()).TotalDays
+              if ($ageDays -lt $throttleDays) {
+                $shouldPush = $false
+                $reason = ("last winget submission was {0:N1} days ago (< {1}d throttle)" -f $ageDays, $throttleDays)
+              } else {
+                $reason = ("last winget submission was {0:N1} days ago (>= {1}d throttle)" -f $ageDays, $throttleDays)
+              }
+            }
+          } catch {
+            # A lookup hiccup must not block a legitimate release; err toward submitting.
+            $reason = "could not query winget-pkgs PRs ($($_.Exception.Message)); proceeding with submission"
+          }
+          "should_push=$($shouldPush.ToString().ToLower())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          if ($shouldPush) {
+            Write-Host "winget throttle: SUBMIT — $reason"
+          } else {
+            Write-Host "::warning title=winget submission throttled::Skipping this release — $reason. It will be coalesced into the next monthly winget submission."
+            "winget submission **throttled** (green): $reason." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          }
+
+      - name: Download release checksums
+        if: env.WINGET_TOKEN != '' && steps.throttle.outputs.should_push == 'true'
         shell: pwsh
         run: |
           $version = "${{ needs.check-release.outputs.version }}"
@@ -580,7 +645,7 @@ jobs:
           Get-Content checksums.txt
 
       - name: Bump manifests to the release version
-        if: env.WINGET_TOKEN != ''
+        if: env.WINGET_TOKEN != '' && steps.throttle.outputs.should_push == 'true'
         shell: pwsh
         run: |
           python packaging/winget/bump-manifests.py `
@@ -590,7 +655,7 @@ jobs:
           Get-Content packaging/winget/manifests/Thurbeen.thurbox.installer.yaml
 
       - name: Install wingetcreate
-        if: env.WINGET_TOKEN != ''
+        if: env.WINGET_TOKEN != '' && steps.throttle.outputs.should_push == 'true'
         shell: pwsh
         run: |
           Invoke-WebRequest -UseBasicParsing `
@@ -606,25 +671,24 @@ jobs:
       # WINGET_CREATE_GITHUB_TOKEN (Microsoft's recommended CI path) instead of
       # --token, which wingetcreate warns can leak the token into logs.
       - name: Submit manifests to winget-pkgs
-        if: env.WINGET_TOKEN != ''
+        if: env.WINGET_TOKEN != '' && steps.throttle.outputs.should_push == 'true'
         shell: pwsh
         env:
           WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
         run: |
           .\wingetcreate.exe submit packaging/winget/manifests
 
-      # thurbox releases far faster than winget-pkgs' manual moderation merges,
-      # so each `submit` above stacks yet another open PR on top of the prior
-      # ones (wingetcreate has no "supersede the previous open PR" mode —
-      # `--replace` only supersedes a *published* manifest version, not a
-      # pending PR). Left alone they pile up (30 open at once, flagged in
-      # microsoft/winget-pkgs#405639) and annoy the moderators. So right after
-      # submitting the new version, close every *older* still-open
-      # Thurbeen.thurbox PR authored by the token account, keeping only the
-      # newest (the one just opened). Best-effort: never fail the release on a
-      # cleanup hiccup.
+      # Second-line cleanup behind the throttle above: even at one submission per
+      # window, a stray manual dispatch (or a race) can leave more than one open
+      # Thurbeen.thurbox PR. wingetcreate has no "supersede the previous open PR"
+      # mode (`--replace` only supersedes a *published* manifest version, not a
+      # pending PR), so right after submitting the new version, close every
+      # *older* still-open PR authored by the token account, keeping only the one
+      # just opened. Runs only when the throttle let us submit (so it never
+      # closes a pending PR we deliberately coalesced into). Best-effort: never
+      # fail the release on a cleanup hiccup.
       - name: Close superseded winget-pkgs PRs
-        if: env.WINGET_TOKEN != ''
+        if: env.WINGET_TOKEN != '' && steps.throttle.outputs.should_push == 'true'
         shell: pwsh
         continue-on-error: true
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,15 +425,26 @@ package channels (each gated on its secret, skipped on forks):
   PR to `microsoft/winget-pkgs`. Runs on `windows-latest`; needs the
   `WINGET_TOKEN` secret (a `public_repo` PAT owning a fork of
   `microsoft/winget-pkgs`). New versions go through winget-pkgs PR
-  validation + review. Because thurbox releases far faster than that manual
-  moderation merges, each `submit` would otherwise stack another open PR
-  (wingetcreate's `--replace` only supersedes a *published* manifest version,
-  not a pending PR); a follow-up `gh pr close` step therefore closes every
-  older still-open `Thurbeen.thurbox` PR from the token account, keeping only
-  the newest (best-effort, never fails the release). The release zip is a `zip` installer with
+  validation + review.
+  **Throttled to one submission per `THROTTLE_DAYS` (30d) window**, mirroring
+  Chocolatey, because winget-pkgs is a *manually moderated* repo that can't keep
+  up with thurbox's per-`feat`/`fix`/`perf` cadence — each `submit` opens a PR a
+  human must review, so a release every few hours buried the maintainers (30
+  open PRs at once, flagged in
+  [microsoft/winget-pkgs#405639](https://github.com/microsoft/winget-pkgs/pull/405639)).
+  The throttle step queries our own last thurbox PR on winget-pkgs (via
+  `gh pr list`, merged or open) for its age — the winget analog of the choco
+  feed's Published date; if it's younger than the window it **skips the
+  submission and exits green** with a `::warning::` (patch releases coalesce into
+  the next monthly winget PR — the binary still ships immediately via GitHub
+  Releases + Homebrew/AUR). As a second-line cleanup for any PR that still stacks
+  (e.g. a manual dispatch inside the window), a follow-up `gh pr close` step
+  closes every older still-open `Thurbeen.thurbox` PR from the token account,
+  keeping only the one just opened (wingetcreate's `--replace` only supersedes a
+  *published* manifest version, not a pending PR; best-effort, never fails the
+  release). The release zip is a `zip` installer with
   `NestedInstallerType = portable` (PATH aliases `thurbox`/`thurbox-cli`, no
-  MSI). Install: `winget install Thurbeen.thurbox`. Windows x86_64 only (added
-  as a moderation-independent alternative to the Chocolatey channel).
+  MSI). Install: `winget install Thurbeen.thurbox`. Windows x86_64 only.
 
 See `packaging/README.md` for the full packaging overview.
 

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -31,12 +31,14 @@ committed here are a last-known-good template — CI overrides them per release.
 
 ## Why winget as well as Chocolatey
 
-The [Chocolatey](../chocolatey/README.md) package sits behind community-repo
-moderation, which can hold a new package (and each new version) for a long time.
-winget is Microsoft's first-party Windows package manager (bundled with Windows
-10/11 via *App Installer*), so this gives Windows users a channel that doesn't
-depend on Chocolatey moderation. Both channels are published from the same
-release; neither replaces the other.
+winget is Microsoft's first-party Windows package manager, bundled with Windows
+10/11 via *App Installer* — so a Windows user can `winget install
+Thurbeen.thurbox` with nothing else installed, whereas Chocolatey must be set up
+first. Both are published from the same release and neither replaces the other.
+Both are also *manually moderated* channels that can't keep pace with thurbox's
+release cadence, so **both are throttled to one submission per 30 days** (see
+[Automated publishing](#automated-publishing-ci)); the newest binary always
+ships immediately via GitHub Releases regardless.
 
 ## Supported platforms
 
@@ -65,16 +67,20 @@ are documented in the package `Description` rather than auto-installed:
 Every release submits to winget-pkgs **automatically** — including the first.
 The `publish-winget` job in
 [`.github/workflows/cd.yml`](../../.github/workflows/cd.yml) runs on
-`windows-latest` after the GitHub Release is created and:
+`windows-latest` after the GitHub Release is created and, **when the throttle
+window has elapsed** (below):
 
 1. downloads the release `thurbox-<version>-checksums.txt`,
 2. runs [`bump-manifests.py`](bump-manifests.py) to set `PackageVersion` across
    the manifests and the installer manifest's `InstallerUrl`/`InstallerSha256`
    (uppercased, as winget-pkgs expects) plus the locale `ReleaseNotesUrl` from
    those checksums,
-3. downloads `wingetcreate` (`https://aka.ms/wingetcreate/latest`), then
+3. downloads `wingetcreate` (`https://aka.ms/wingetcreate/latest`),
 4. `wingetcreate submit`s the manifest set, which validates it and opens a PR
-   against [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
+   against [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs),
+   then
+5. closes any *older* still-open `Thurbeen.thurbox` PR from the token account,
+   keeping only the one just opened (second-line cleanup behind the throttle).
 
 The job needs a `WINGET_TOKEN` secret — a classic PAT with the `public_repo`
 scope on the account that owns a fork of `microsoft/winget-pkgs` (wingetcreate
@@ -83,6 +89,24 @@ where the secret is absent (e.g. on forks). The committed template files are not
 modified by CI — they stay as last-known-good, exactly like the Chocolatey /
 Homebrew templates.
 
+> **Throttled to one submission per `THROTTLE_DAYS` (30 days)**, mirroring
+> Chocolatey. winget-pkgs is a *manually moderated* repo — each `submit` opens a
+> PR a human must review — so it can't absorb thurbox's per-`feat`/`fix`/`perf`
+> release cadence: a release every few hours buries the maintainers under stale
+> version-bump PRs (30 open at once, flagged in
+> [microsoft/winget-pkgs#405639](https://github.com/microsoft/winget-pkgs/pull/405639)).
+> So the job first reads our own last thurbox PR on winget-pkgs (via `gh pr list`,
+> merged or open) for its age — the winget analog of the Chocolatey feed's
+> Published date. If it is younger than `THROTTLE_DAYS` the job **skips the
+> submission and exits green** with a `::warning::`, coalescing the intervening
+> patch releases into the next monthly winget PR. The binary itself always ships
+> immediately via GitHub Releases (and Homebrew/AUR); only the winget channel
+> lags. Tune the cadence via the `THROTTLE_DAYS` env in the job. When the window
+> *has* elapsed and a submission goes out, the follow-up cleanup step closes any
+> older still-open PR (best-effort, never fails the release) — since
+> `wingetcreate` has no supersede-pending-PR mode (`--replace` only affects a
+> *published* manifest version).
+>
 > **Review (winget-pkgs side, not CI).** microsoft/winget-pkgs runs automated
 > validation (manifest schema, installer hash, a sandbox install/uninstall
 > smoke test) and then human review before a version goes live. The

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -123,9 +123,8 @@ onThisPage:
               <strong>not yet merged</strong>
               , so
               <code>winget install Thurbeen.thurbox</code>
-              will not resolve until the PR is approved. Use
-              <a href="#chocolatey">Chocolatey</a>
-              or the PowerShell installer above in the meantime.
+              will not resolve until the PR is approved. Use the PowerShell
+              installer above in the meantime.
             </p>
           </div>
           <p>
@@ -139,6 +138,19 @@ onThisPage:
             <a href="https://github.com/psmux/psmux">psmux</a>
             as the multiplexer, installed separately.
           </p>
+          <div class="info-box">
+            <p>
+              <strong>Release cadence.</strong>
+              winget-pkgs is manually reviewed, so thurbox submits a new winget
+              version
+              <strong>at most once every 30 days</strong>
+              (intermediate releases are coalesced into the next submission). The
+              latest build always ships immediately via the PowerShell installer
+              above and
+              <a href="https://github.com/Thurbeen/thurbox/releases">GitHub Releases</a>
+              ; the winget channel intentionally trails a little.
+            </p>
+          </div>
 
           <h2 id="chocolatey">
             Chocolatey (Windows)
@@ -162,6 +174,19 @@ onThisPage:
             as the multiplexer, installed separately (there is no Chocolatey package for it).
             New versions go through community-repo moderation before they appear.
           </p>
+          <div class="info-box">
+            <p>
+              <strong>Release cadence.</strong>
+              Like winget, the Chocolatey community repo is moderated and
+              rate-limited, so thurbox pushes a new Chocolatey version
+              <strong>at most once every 30 days</strong>
+              (intermediate releases are coalesced into the next push). The
+              latest build always ships immediately via the PowerShell installer
+              above and
+              <a href="https://github.com/Thurbeen/thurbox/releases">GitHub Releases</a>
+              ; the Chocolatey channel intentionally trails a little.
+            </p>
+          </div>
 
           <h2 id="homebrew">
             Homebrew


### PR DESCRIPTION
## Summary

- `winget-pkgs` is a **manually moderated** repo, just like Chocolatey — each `wingetcreate submit` opens a PR a human must review. thurbox releases far faster than that cadence, so submissions piled up (30 open PRs at once, flagged in [microsoft/winget-pkgs#405639](https://github.com/microsoft/winget-pkgs/pull/405639)).
- Adds a **`Check throttle window`** step to `publish-winget` mirroring the existing Chocolatey throttle: it reads our own last thurbox PR on winget-pkgs (merged or open) via `gh pr list` for its age, and when younger than **`THROTTLE_DAYS` (30d)** skips the submission and **exits green with a `::warning::`**, coalescing intermediate patch releases into the next monthly PR. Errs toward submitting on any lookup failure.
- All downstream steps (checksums, bump, install wingetcreate, submit, close-superseded) are gated on the throttle. The **close-superseded-PRs** step now runs only behind the throttle as second-line cleanup.
- The latest binary still ships immediately via GitHub Releases + Homebrew/AUR regardless; only the winget channel intentionally trails.

## Docs

- `CLAUDE.md`: winget bullet rewritten to document the throttle mirroring choco.
- `packaging/winget/README.md`: throttle blockquote + reframed "Why winget as well as Chocolatey" (first-party bundling is the real differentiator; both channels are throttled).
- `website/docs/installation.html`: "Release cadence" info-box added to **both** the winget and Chocolatey sections.

## Test plan

- `cd.yml` YAML validated (`yaml.safe_load`); `rumdl` clean on the changed markdown.
- Logic is a direct mirror of the shipped-and-working `publish-chocolatey` throttle (same `THROTTLE_DAYS` env, `should_push` output, green-on-error semantics).
- The throttle only exercises on a real release with `WINGET_TOKEN` set; gated + best-effort, so a no-op on forks.
- Website linter could not run locally (WSL/UNC-path issue in the npm chain); added HTML hand-matched to the file's existing prettier-formatted `info-box` blocks and CI runs the linters.