### PR TITLE
feat(website): add Oh My Pi to home-page agent logo list

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -56,6 +56,11 @@ footer: true
             <svg class="agent-logo" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M17.143 3.429v3.428h-3.429v3.429h-3.428V6.857H6.857V3.43H3.43v13.714H0v3.428h10.286v-3.428H6.857v-3.429h3.429v3.429h3.429v-3.429h3.428v3.429h-3.428v3.428H24v-3.428h-3.43V3.429z"/></svg>
             Vibe
           </span>
+          <span>
+            <!-- prettier-ignore -->
+            <svg class="agent-logo" viewBox="0 0 64 64" aria-hidden="true" focusable="false"><path d="M14 16h36v8H40v32h-8V24h-6v22h-8V24h-4z"/></svg>
+            Oh My Pi
+          </span>
           <span class="agent-support-any">plus any CLI agent</span>
         </p>
         <div class="hero-ctas">


### PR DESCRIPTION
## Summary

- Add an **Oh My Pi (omp)** entry to the hero agent-support logo list on the website home page (`website/index.html`), after Vibe and before the "plus any CLI agent" span.
- Uses the omp project's official favicon glyph (from `omp.sh/favicon.svg`) as an inline monochrome single-path SVG, rendered in `currentColor` to match the seven existing agent logos. The gradient fill and background rect from the source favicon are dropped for style consistency; the native `0 0 64 64` viewBox is kept (each `<svg>` carries its own).
- No CSS changes needed — the new `<span>` picks up the existing `.agent-logo` layout/hover/sizing rules.

## Test plan

- [ ] `npm run lint:website` passes (htmlhint + prettier)
- [ ] Visual check: the omp logo renders alongside Claude Code, Codex, Antigravity, opencode, aider, Copilot, and Vibe in the hero section