### PR TITLE
docs: add pi to website home-page agent logo list

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -58,6 +58,11 @@ footer: true
           </span>
           <span>
             <!-- prettier-ignore -->
+            <svg class="agent-logo" viewBox="0 0 800 800" aria-hidden="true" focusable="false"><path fill-rule="evenodd" d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"/><path d="M517.36 400H634.72V634.72H517.36Z"/></svg>
+            pi
+          </span>
+          <span>
+            <!-- prettier-ignore -->
             <svg class="agent-logo" viewBox="0 0 64 64" aria-hidden="true" focusable="false"><path d="M14 16h36v8H40v32h-8V24h-6v22h-8V24h-4z"/></svg>
             Oh My Pi
           </span>


### PR DESCRIPTION
## Summary

- Add a **pi (pi.dev)** entry to the hero agent-support logo list on the website home page (`website/index.html`), placed between Vibe and Oh My Pi to match the prose ordering used elsewhere in the file.
- Uses the pi.dev project's official favicon glyph (from `pi.dev/favicon.svg`) as inline monochrome SVG paths, rendered in `currentColor` to match the existing agent logos. The favicon's background rounded-rect is dropped for style consistency; the native `0 0 800 800` viewBox and the two shape paths (including `fill-rule="evenodd"`) are kept.
- No CSS changes needed — the new `<span>` picks up the existing `.agent-logo` layout/hover/sizing rules.

## Test plan

- [ ] `npm run lint:website` passes (htmlhint + prettier)
- [ ] Visual check: the pi logo renders between Vibe and Oh My Pi in the hero section