### PR TITLE
fix(ui): advertise Shift+Tab back-to-list in repo picker footer

### DIFF
--- a/src/ui/repo_picker_modal.rs
+++ b/src/ui/repo_picker_modal.rs
@@ -484,6 +484,8 @@ fn footer_line(state: &RepoPickerState<'_>) -> Line<'static> {
             Span::styled(" open/pick  ", Theme::keybind_desc()),
             Span::styled("Tab", Theme::keybind()),
             Span::styled(" refresh  ", Theme::keybind_desc()),
+            Span::styled("S-Tab", Theme::keybind()),
+            Span::styled(" list  ", Theme::keybind_desc()),
             Span::styled("Esc", Theme::keybind()),
             Span::styled(" close", Theme::keybind_desc()),
         ]),
@@ -500,6 +502,8 @@ fn footer_line(state: &RepoPickerState<'_>) -> Line<'static> {
                 Span::styled(" add repo  ", Theme::keybind_desc()),
                 Span::styled("Ctrl+P", Theme::keybind()),
                 Span::styled(" import parent  ", Theme::keybind_desc()),
+                Span::styled("S-Tab", Theme::keybind()),
+                Span::styled(" list  ", Theme::keybind_desc()),
                 Span::styled("Esc", Theme::keybind()),
                 Span::styled(" cancel", Theme::keybind_desc()),
             ])
@@ -620,6 +624,9 @@ mod tests {
         let without_text = span_text(&footer_line(&without).spans);
         assert!(without_text.contains("browse"));
         assert!(!without_text.contains("complete"));
+        // Shift+Tab back to the list is discoverable from the input.
+        assert!(without_text.contains("S-Tab"));
+        assert!(without_text.contains("list"));
     }
 
     #[test]
@@ -636,6 +643,7 @@ mod tests {
         assert!(text.contains("open/pick"));
         assert!(text.contains("refresh"));
         assert!(text.contains("close"));
+        assert!(text.contains("S-Tab"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The repo picker's path-input and folder-browser focuses already support `Shift+Tab` to return to the bookmark list, but the footer hint never advertised it — leaving no discoverable keyboard route back (`Esc` from the input closes the whole modal instead).
- Add an `S-Tab list` hint to both Input-focus footer branches (browser-open and closed), positioned before `Esc` to match the List/Search footers that already advertise their exits.
- Kept the label compact (`S-Tab`/`list`) so the footer line stays clear of the right-aligned Done/Cancel pills.
- No behavior change — hints only.

## Test plan

- `cargo nextest run -E 'test(footer_line)'` — the 4 footer_line tests pass, including new assertions that the Input and browser-open footers contain `S-Tab`/`list`.
- `cargo fmt --all -- --check` clean.