### PR TITLE
ci: gate releases on shipped-artifact changes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,11 @@ jobs:
     name: Analyze commits for release
     runs-on: ubuntu-latest
     outputs:
-      should_release: ${{ steps.parse.outputs.should_release }}
+      # Gated by BOTH the commit-type decision (`parse`) and the
+      # artifact-relevance gate (`shipped`): a `feat`/`fix` that touches only
+      # the website, docs, or CI config bumps nothing shippable, so it must not
+      # cut a release. See the `shipped` step for the rationale + path list.
+      should_release: ${{ steps.parse.outputs.should_release == 'true' && steps.shipped.outputs.shipped != 'false' }}
       version: ${{ steps.parse.outputs.version }}
       # The exact `cog bump` args create-tag runs. Computed here in bash (not
       # via a YAML `${{ && || }}` ternary in create-tag) so the forced-version
@@ -96,6 +100,50 @@ jobs:
             echo "version=" >> "$GITHUB_OUTPUT"
             echo "bump_args=--auto --disable-bump-commit" >> "$GITHUB_OUTPUT"
             echo "ℹ️  No releasable commits detected"
+          fi
+
+      - name: Check the release touches a shipped artifact
+        id: shipped
+        if: steps.parse.outputs.should_release == 'true' && inputs.version == ''
+        run: |
+          # Commit *type* alone over-releases: cocogitto sees `fix`/`feat` and
+          # bumps, but Renovate labels a GitHub-Actions pin bump `fix(deps)` and
+          # the website is versioned as `feat(ui)`/`fix(ui)`. Those change no
+          # byte of the shipped binary, yet each cut a release (v1.2.13..v1.3.0
+          # were four CSS-only releases, one of them a *minor*). Every such
+          # release also re-runs the 4-platform build and pushes to Homebrew/AUR/
+          # Chocolatey/winget — the moderated channels that then rate-limit us.
+          #
+          # So gate on the diff as well: release only when something a user
+          # actually installs changed. The range is the whole span since the last
+          # tag, NOT this single push — a website-only push landing on top of an
+          # unreleased `src/` commit still owes that release.
+          #
+          # A forced `workflow_dispatch` version skips this gate entirely (the
+          # `if:` above): an explicit human cut is always honoured.
+          SHIPPED_PATHS='^(src/|tests/|build\.rs$|Cargo\.toml$|Cargo\.lock$|rust-toolchain\.toml$|Cross\.toml$|extensions/|packaging/|scripts/install\.(sh|ps1)$|\.github/workflows/cd\.yml$)'
+
+          LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+
+          if [ -z "$LAST_TAG" ]; then
+            # No tag yet: nothing to diff against, so the first release always
+            # ships. Reported as a single pseudo-path so the decision below
+            # stays a plain "is RELEVANT empty?" test for both branches.
+            LAST_TAG="(none)"
+            RELEVANT="(no previous tag — first release)"
+          else
+            echo "Files changed since $LAST_TAG:"
+            git diff --name-only "$LAST_TAG"..HEAD | sed 's/^/  /'
+            RELEVANT="$(git diff --name-only "$LAST_TAG"..HEAD | grep -E "$SHIPPED_PATHS" || true)"
+          fi
+
+          if [ -n "$RELEVANT" ]; then
+            echo "shipped=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Shipped artifact changed — releasing:"
+            printf '%s\n' "$RELEVANT" | sed 's/^/  /'
+          else
+            echo "shipped=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping release ${{ steps.parse.outputs.version }} — no shipped artifact changed since $LAST_TAG (docs/website/CI only). The commits stay in history and ride along with the next real release."
           fi
 
   # Create git tag (only if release needed)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,9 +345,24 @@ are created - version is determined by git tags only.
 Every push to `main` automatically triggers the release workflow:
 
 1. **Commit Analysis**: Analyzes all commits since last tag using cocogitto
-2. **Release Decision**:
-   - **If** commits include `feat`, `fix`, or `perf` → creates release
-   - **If** only docs/chore/ci commits → no release (workflow exits)
+2. **Release Decision** — a release needs **both** gates to pass:
+   - **Commit type** (`check-release`'s `parse` step): commits must include
+     `feat`, `fix`, or `perf`. Only docs/chore/ci commits → no release.
+   - **Artifact relevance** (`check-release`'s `shipped` step): the diff since
+     the last tag must touch something a user installs (`src/`, `tests/`,
+     `build.rs`, `Cargo.toml`/`Cargo.lock`, `rust-toolchain.toml`, `Cross.toml`,
+     `extensions/`, `packaging/`, `scripts/install.{sh,ps1}`, `cd.yml`).
+     Commit type alone over-releases: Renovate labels a GitHub-Actions pin bump
+     `fix(deps)` and the website is versioned `feat(ui)`/`fix(ui)`, so a
+     CSS-only or lint-action-only change used to cut a real release (v1.2.13
+     through v1.3.0 were four website-only releases, one a *minor*) — burning a
+     4-platform build and pushing to the moderated Chocolatey/winget channels
+     for a no-op binary. Such commits stay in history and ride along in the
+     next real release's changelog.
+   - The gate is evaluated over the **whole span since the last tag**, not the
+     single push, so a website-only push landing on an unreleased `src/` commit
+     still cuts the release it owes. A forced `workflow_dispatch` version
+     **skips** the relevance gate — an explicit human cut is always honoured.
 3. **Automated Release** (if needed):
    - Determines semantic version (feat→minor, fix/perf→patch, breaking→major)
    - Creates lightweight git tag: `v{version}` (e.g., v1.0.0)


### PR DESCRIPTION
## Summary

Release decisions were made purely from **commit types**: `cog bump --auto`
sees `fix`/`feat` and bumps, with no notion of *which files* changed.
Renovate labels a GitHub-Actions pin bump `fix(deps)`, and the website is
versioned `feat(ui)`/`fix(ui)` — so lint-action and CSS-only changes cut real
releases.

**Measured over the last 60 commits: 21 of 48 releases (43%) changed no shipped
byte.** v1.2.13 → v1.3.0 were four consecutive website-only releases, one of
them a *minor*. Each burned a 4-platform build and pushed to the moderated
Chocolatey/winget channels — the ones that then rate-limit us (`403`s).

- Add an **artifact-relevance gate** (`check-release`'s new `shipped` step):
  release only when the diff since the last tag touches something a user
  installs — `src/`, `tests/`, `build.rs`, `Cargo.toml`/`Cargo.lock`,
  `rust-toolchain.toml`, `Cross.toml`, `extensions/`, `packaging/`,
  `scripts/install.{sh,ps1}`, `cd.yml`.
- `should_release` now requires **both** the commit-type and relevance gates.
- Suppressed commits are not lost — they stay in history and ride along in the
  next real release's changelog.
- Document the two-gate decision in `CLAUDE.md` (repo rule: a change that
  extends a documented decision updates the doc in the same PR).

### Design notes

- **Range, not push.** The gate diffs the whole span since the last tag, so a
  website-only push landing on an unreleased `src/` commit still cuts the
  release it owes.
- **Forced dispatch bypasses it.** An explicit `workflow_dispatch` version is
  always honoured — the only route across a major boundary.
- **Fails closed.** Nothing releases unless the commit-type gate explicitly
  evaluates `true`, avoiding the silent-fallback class of bug the existing
  comment on `bump_args` warns about.
- `cd.yml` is itself a shipped path, so changes to the release machinery always
  release (this PR included).

CI is deliberately untouched: every heavy Rust job is already gated behind
`changes.outputs.rust`. Editing `ci.yml` does still re-run the full matrix
because all 7 filters self-reference it by design (editing a job should re-run
it) — removing that would trade correctness for CI minutes.

## Test plan

- [x] Replayed **12 real historical commits** through the gate: 6 correctly
      suppressed (4 website-only, 2 action/devDep pins, `.pi`-only), 6 correctly
      released (`src/`, `Cargo.lock`, `extensions/`) — no genuine release lost.
- [x] Full truth table incl. every empty/unexpected input combination (9 cases)
      — confirms fail-closed behavior and the intended forced-dispatch bypass.
- [x] Verified the mixed-range safety case: website commits **+** a `src/` fix
      still releases.
- [x] `cd.yml` parses as valid YAML; step body passes `sh -n`.
- [x] Doc path list cross-checked against `SHIPPED_PATHS` (all entries agree).
- [x] `rumdl check CLAUDE.md` clean.