### PR TITLE
feat(ui): render a new session under its own repo header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,11 @@ connect for a remote host), and `Session::spawn` all run on workers. Because
 those phases can run for tens of seconds on a large repo, progress is carried by
 `App::pending_spawn` (`PendingSpawn`/`SpawnPhase`) rather than a
 `status_message` (which expires after 5 s): it renders a **placeholder row** in
-the session list plus a **status badge**. It lives for the **whole wizard** —
+the session list plus a **status badge**. The row sits **inside the repo group
+the session will land in** (`ui::project_list::pending_spawn_slot`, keyed on
+`PendingSpawn.repo_display_names`), at that group's end — where the real row
+will appear — bringing its own header when the repo has no rows yet.
+It lives for the **whole wizard** —
 background phases *and* the modals between them (`SpawnPhase::Configuring`, a
 static `◌` with no spinner/elapsed, since nothing is running) — and is cleared
 only when the session lands, the flow errors, or the user Escs out

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -529,10 +529,19 @@ strand a placeholder row forever).
 
 - A **placeholder row** in the session list (`ui::project_list`), so the session
   appears the moment the wizard is confirmed rather than after a slow shell-out.
-  It carries no `SessionInfo`, records **no hitbox**, and is appended last — so
-  selection indices stay a valid range over the real sessions and the monkey
-  test's invariants are untouched. Its label upgrades as the wizard learns it:
-  the repo, then the session name.
+  It carries no `SessionInfo` and records **no hitbox** — so selection indices
+  stay a valid range over the real sessions and the monkey test's invariants are
+  untouched. Its label upgrades as the wizard learns it: the repo, then the
+  session name. It renders **inside the repo group it will land in**
+  (`pending_spawn_slot`), at the end of that group — where the real row will
+  appear, since a new session has no `display_order` and sorts after its ordered
+  siblings. A repo with no rows yet brings its own header rather than floating
+  loose at the bottom. `PendingSpawn.repo_display_names` (resolved once when the
+  repo is chosen — `git::repo_display_name` can shell out on a cache miss, so it
+  must not run per frame) mirrors what `SessionInfo::repo_display_names` will
+  carry, so the pending row and the real one group identically. Because the row
+  is inserted rather than appended, the widget's item indices are offset past it
+  when mapping back to session indices (hitboxes and the selected item).
 - An **animated badge** in the status row (`⠹ NEW  Creating worktree(s)… feat/x
   · 14s`), reusing the `Ctrl+S` sync spinner's surface, with an elapsed counter
   so a long wait reads as progressing rather than hung.

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -2741,6 +2741,59 @@ fn spawn_placeholder_row_is_not_selectable() {
     assert_invariants(&h.app, "placeholder row present");
 }
 
+/// A session being created belongs under the header of the repo it is being cut
+/// from — appending it below every group made a new `webapp` session look like
+/// it was landing somewhere else entirely.
+#[test]
+fn spawn_placeholder_renders_inside_its_repo_group() {
+    let mut h = Harness::standard(2);
+    h.app.sessions[0].info.repo_display_names = vec!["webapp".to_string()];
+    h.app.sessions[1].info.repo_display_names = vec!["infra".to_string()];
+
+    let mut pending = PendingSpawn::new("feat/x", SpawnPhase::Spawning);
+    pending.repo_display_names = vec!["webapp".to_string()];
+    h.app.pending_spawn = Some(pending);
+
+    let screen = h.render();
+    let line_of = |needle: &str| {
+        screen
+            .lines()
+            .position(|l| l.contains(needle))
+            .unwrap_or_else(|| panic!("{needle:?} missing from:\n{screen}"))
+    };
+
+    // Groups render infra-then-webapp (label order); the placeholder must sit
+    // in the webapp run, i.e. below the webapp header and after its session.
+    assert!(
+        line_of("webapp") < line_of("feat/x"),
+        "placeholder sits under the webapp header:\n{screen}"
+    );
+    assert!(
+        line_of("infra") < line_of("webapp"),
+        "sanity: infra group precedes webapp:\n{screen}"
+    );
+    assert_invariants(&h.app, "placeholder inside its repo group");
+}
+
+/// …and a repo with no sessions yet gets its own header, so the row is filed
+/// under a label rather than floating loose at the bottom.
+#[test]
+fn spawn_placeholder_for_a_new_repo_brings_its_own_header() {
+    let mut h = Harness::standard(1);
+    h.app.sessions[0].info.repo_display_names = vec!["webapp".to_string()];
+
+    let mut pending = PendingSpawn::new("feat/x", SpawnPhase::Spawning);
+    pending.repo_display_names = vec!["brand-new-repo".to_string()];
+    h.app.pending_spawn = Some(pending);
+
+    let screen = h.render();
+    assert!(
+        screen.contains("brand-new-repo"),
+        "the new group is labelled:\n{screen}"
+    );
+    assert_invariants(&h.app, "placeholder opening a new repo group");
+}
+
 /// With no sessions at all, the placeholder must replace the "No sessions yet"
 /// empty state — otherwise the very first `Ctrl+N` shows nothing happening.
 #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -264,6 +264,15 @@ pub struct PendingSpawn {
     /// picked), then the branch, then the session name.
     pub label: String,
     pub phase: SpawnPhase,
+    /// Display names of the repos the session will span, in the session's
+    /// natural order (primary first) — the same strings
+    /// `SessionInfo::repo_display_names` will carry once it lands. Lets the
+    /// placeholder row render **inside its own repo group** instead of trailing
+    /// the whole list, so a session appears where it will actually live.
+    /// Resolved once when the repo is chosen (`repo_display_name` can shell out
+    /// on a cache miss, so it must not run per frame); empty when no repo is
+    /// known yet, which groups it with `(no repo)` exactly like a real session.
+    pub repo_display_names: Vec<String>,
     started_at: std::time::Instant,
 }
 
@@ -275,13 +284,59 @@ fn spawn_label_for_repo(repo: Option<&std::path::Path>) -> String {
         .unwrap_or_else(|| "new session".to_string())
 }
 
+/// The repo display names a set of chosen repo paths will produce, in order and
+/// de-duplicated — mirroring what `resolve_repo_display_names` derives for a
+/// live session, so a pending row groups with the sessions it will join.
+fn spawn_repo_display_names<'a>(
+    repos: impl IntoIterator<Item = &'a std::path::Path>,
+) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+    for path in repos {
+        if let Some(name) = git::repo_display_name(path) {
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+    }
+    names
+}
+
+/// The repo group a spawn config will land in, mirroring the member set
+/// `session_member_dirs` derives for the real session: the worktrees' **source**
+/// repos when the session is worktree-backed (`cwd` is then the checkout, whose
+/// name is the branch, not the repo), otherwise the plain `cwd` repo — plus any
+/// additional dirs, which are members too.
+fn spawn_config_repo_names(
+    config: &SessionConfig,
+    worktrees: &[WorktreeInfo],
+    additional_dirs: &[PathBuf],
+) -> Vec<String> {
+    let roots: Vec<&std::path::Path> = if worktrees.is_empty() {
+        config.cwd.as_deref().into_iter().collect()
+    } else {
+        worktrees.iter().map(|wt| wt.repo_path.as_path()).collect()
+    };
+    spawn_repo_display_names(
+        roots
+            .into_iter()
+            .chain(additional_dirs.iter().map(PathBuf::as_path)),
+    )
+}
+
 impl PendingSpawn {
     fn new(label: impl Into<String>, phase: SpawnPhase) -> Self {
         Self {
             label: label.into(),
             phase,
+            repo_display_names: Vec::new(),
             started_at: clock::now(),
         }
+    }
+
+    /// Place this pending row in the repo group it will land in.
+    fn in_repo_group(mut self, repo_display_names: Vec<String>) -> Self {
+        self.repo_display_names = repo_display_names;
+        self
     }
 
     /// Whole seconds since this phase started — shown so a long wait reads as
@@ -1608,7 +1663,28 @@ impl App {
     /// indicator spins and counts elapsed for as long as it runs.
     fn mark_spawn_working(&mut self, label: impl Into<String>, phase: SpawnPhase) {
         debug_assert!(phase.is_working(), "use mark_spawn_configuring instead");
-        self.pending_spawn = Some(PendingSpawn::new(label, phase));
+        let group = self.pending_spawn_group();
+        self.pending_spawn = Some(PendingSpawn::new(label, phase).in_repo_group(group));
+    }
+
+    /// The repo group the pending row should sit in. Carried over from the
+    /// current indicator when there is one — the wizard's later phases re-mark
+    /// the row on every step, and re-resolving the names there would both hit
+    /// `repo_display_name` again and lose the group once the wizard state that
+    /// named it (`repo_path`) has been consumed.
+    fn pending_spawn_group(&self) -> Vec<String> {
+        match self.pending_spawn.as_ref() {
+            Some(p) if !p.repo_display_names.is_empty() => p.repo_display_names.clone(),
+            _ => spawn_repo_display_names(
+                self.new_session.repo_path.as_deref().into_iter().chain(
+                    self.new_session
+                        .all_repos
+                        .iter()
+                        .flatten()
+                        .map(PathBuf::as_path),
+                ),
+            ),
+        }
     }
 
     /// Hand the "being created" indicator back to the user: a wizard modal is
@@ -1618,7 +1694,9 @@ impl App {
     /// Every step that opens a wizard modal goes through here, so the indicator
     /// survives the modals instead of blinking off between phases.
     fn mark_spawn_configuring(&mut self, label: impl Into<String>) {
-        self.pending_spawn = Some(PendingSpawn::new(label, SpawnPhase::Configuring));
+        let group = self.pending_spawn_group();
+        self.pending_spawn =
+            Some(PendingSpawn::new(label, SpawnPhase::Configuring).in_repo_group(group));
     }
 
     /// The wizard ended — the session landed, the flow errored, or the user Esc'd
@@ -1904,6 +1982,14 @@ impl App {
     /// Shows an empty session-name modal. After the user enters a name, the
     /// agent picker is shown, then spawn.
     pub(crate) fn prepare_spawn(&mut self, config: SessionConfig, worktrees: Vec<WorktreeInfo>) {
+        // Group the placeholder by the repos the session will actually span,
+        // derived from the spawn config itself. The wizard's `repo_path` is not
+        // enough: the non-worktree path (`spawn_repo_picker_normal`) never sets
+        // it, passing the repo through `cwd`/`additional_dirs` instead — reading
+        // only the wizard state filed those rows under `(no repo)`.
+        let names = spawn_config_repo_names(&config, &worktrees, &self.new_session.additional_dirs);
+        self.pending_spawn =
+            Some(PendingSpawn::new(String::new(), SpawnPhase::Configuring).in_repo_group(names));
         // No name yet, so the placeholder row goes by the repo it's being cut
         // from — the same thing the user just picked.
         self.mark_spawn_configuring(spawn_label_for_repo(config.cwd.as_deref()));
@@ -12639,6 +12725,66 @@ mod tests {
             assert_eq!(pending.phase, SpawnPhase::Configuring);
             assert_eq!(pending.label, "my-session");
         }
+    }
+
+    /// A **non-worktree** spawn (repo picker with the worktree toggle off) never
+    /// populates the wizard's `repo_path` — it passes the repo through
+    /// `config.cwd`. Reading only the wizard state filed those rows under
+    /// `(no repo)` instead of the repo the user just picked.
+    #[test]
+    fn non_worktree_spawn_groups_under_its_repo() {
+        let mut app = app_with_sessions(0);
+        assert!(
+            app.new_session.repo_path.is_none(),
+            "precondition: the non-worktree path leaves the wizard repo unset"
+        );
+
+        app.prepare_spawn(
+            SessionConfig {
+                cwd: Some(PathBuf::from("/repos/thurbox")),
+                ..SessionConfig::default()
+            },
+            Vec::new(),
+        );
+
+        let pending = app.pending_spawn.as_ref().expect("indicator is shown");
+        assert_eq!(
+            pending.repo_display_names,
+            vec!["thurbox".to_string()],
+            "grouped by the repo it spawns in, not (no repo)"
+        );
+
+        // …and the group survives the rest of the wizard, which re-marks the row.
+        app.finish_prepare_spawn("my-session".into(), SessionConfig::default(), Vec::new());
+        let pending = app.pending_spawn.as_ref().expect("indicator survives");
+        assert_eq!(pending.repo_display_names, vec!["thurbox".to_string()]);
+    }
+
+    /// A worktree spawn groups by the worktrees' **source** repos — `cwd` is the
+    /// checkout, whose directory name is the branch, not the repo.
+    #[test]
+    fn worktree_spawn_groups_by_source_repo_not_checkout() {
+        let mut app = app_with_sessions(0);
+        let worktrees = vec![WorktreeInfo {
+            repo_path: PathBuf::from("/repos/thurbox"),
+            worktree_path: PathBuf::from("/worktrees/feat-x"),
+            branch: "feat/x".to_string(),
+        }];
+
+        app.prepare_spawn(
+            SessionConfig {
+                cwd: Some(PathBuf::from("/worktrees/feat-x")),
+                ..SessionConfig::default()
+            },
+            worktrees,
+        );
+
+        let pending = app.pending_spawn.as_ref().expect("indicator is shown");
+        assert_eq!(
+            pending.repo_display_names,
+            vec!["thurbox".to_string()],
+            "the source repo, not the `feat-x` checkout directory"
+        );
     }
 
     /// …but an abandoned wizard must not strand a placeholder row forever.

--- a/src/ui/project_list.rs
+++ b/src/ui/project_list.rs
@@ -71,10 +71,17 @@ const NO_REPO_GROUP: &str = "(no repo)";
 /// The `\0` join separator can't occur in a repo name, so distinct sets never
 /// collide. This is only a map key — never displayed (see [`group_display`]).
 fn group_key(info: &SessionInfo) -> String {
-    if info.repo_display_names.is_empty() {
+    repo_set_key(&info.repo_display_names)
+}
+
+/// [`group_key`] over bare repo names, for a session that doesn't exist yet (a
+/// pending spawn). Both go through here so a pending row can never be keyed
+/// differently from the real row it becomes.
+fn repo_set_key(repo_names: &[String]) -> String {
+    if repo_names.is_empty() {
         return NO_REPO_GROUP.to_string();
     }
-    let mut names: Vec<&str> = info.repo_display_names.iter().map(String::as_str).collect();
+    let mut names: Vec<&str> = repo_names.iter().map(String::as_str).collect();
     names.sort_unstable();
     names.dedup();
     names.join("\0")
@@ -84,17 +91,72 @@ fn group_key(info: &SessionInfo) -> String {
 /// ` + ` in the session's natural order (primary repo first), de-duplicated.
 /// Falls back to `(no repo)`.
 fn group_display(info: &SessionInfo) -> String {
-    if info.repo_display_names.is_empty() {
+    repo_set_display(&info.repo_display_names)
+}
+
+/// [`group_display`] over bare repo names (see [`repo_set_key`]).
+fn repo_set_display(repo_names: &[String]) -> String {
+    if repo_names.is_empty() {
         return NO_REPO_GROUP.to_string();
     }
     let mut seen = std::collections::HashSet::new();
-    let parts: Vec<&str> = info
-        .repo_display_names
+    let parts: Vec<&str> = repo_names
         .iter()
         .map(String::as_str)
         .filter(|n| seen.insert(*n))
         .collect();
     parts.join(" + ")
+}
+
+/// Where a still-being-created session's placeholder row belongs, and whether it
+/// needs to bring its own repo header along.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingSpawnSlot {
+    /// Index into the rendered rows to insert *before*; `rows` (the length) puts
+    /// it last.
+    pub index: usize,
+    /// The group header to draw above the placeholder — `Some` only when the
+    /// session opens a repo group that has no rows yet, so an existing group's
+    /// header is never duplicated.
+    pub header: Option<String>,
+}
+
+/// Place a pending session's placeholder row under the header of the repo group
+/// it will join, rather than trailing the whole list.
+///
+/// It lands at the **end of its group** — the same place the real row will
+/// appear, since a brand-new session has no `display_order` and so sorts after
+/// its ordered siblings (see [`compute_session_order`]). A group that doesn't
+/// exist yet is appended last with its own header, which is exactly where
+/// `compute_session_order` will put it once the session lands (a group's order
+/// key is its lowest member `display_order`, and an unordered one is `i64::MAX`).
+///
+/// `repo_names` is the pending session's repo display names; `sessions`/`headers`
+/// are the already-ordered rows.
+pub fn pending_spawn_slot(
+    sessions: &[&SessionInfo],
+    headers: &[Option<String>],
+    repo_names: &[String],
+) -> PendingSpawnSlot {
+    let key = repo_set_key(repo_names);
+    // Scan for the group's last row: group membership is contiguous in the
+    // rendered order, so the run ends at the next header (or the list's end).
+    let start = sessions.iter().position(|info| group_key(info) == key);
+    match start {
+        Some(start) => {
+            let end = (start + 1..sessions.len())
+                .find(|&i| headers.get(i).is_some_and(Option::is_some))
+                .unwrap_or(sessions.len());
+            PendingSpawnSlot {
+                index: end,
+                header: None,
+            }
+        }
+        None => PendingSpawnSlot {
+            index: sessions.len(),
+            header: Some(repo_set_display(repo_names)),
+        },
+    }
 }
 
 /// Canonical render order for the session list, shared by the rendering widget
@@ -687,17 +749,24 @@ fn render_session_section(
         })
         .collect();
 
-    // The session being created, appended last. It carries no `SessionInfo`, so
-    // it gets no hitbox below and can never be selected — the list's selection
+    // The session being created, slotted into the repo group it will land in
+    // (see `pending_spawn_slot`) so it appears where it will actually live
+    // rather than below every other group. It carries no `SessionInfo`, so it
+    // gets no hitbox below and can never be selected — the list's selection
     // indices stay a valid range over `sessions`.
-    if let Some(pending) = pending_spawn {
-        items.push(ListItem::new(vec![pending_spawn_line(
-            pending,
-            inner_width,
-            spinner,
-        )]));
-        item_heights.push(1);
-    }
+    let pending_row = pending_spawn.map(|pending| {
+        let slot = pending_spawn_slot(sessions, headers, &pending.repo_display_names);
+        let mut lines = Vec::new();
+        // A group with no rows yet brings its own header, so the placeholder is
+        // filed under a label instead of floating loose at the end.
+        if let Some(label) = slot.header.as_deref() {
+            lines.push(group_header_line(label, inner_width));
+        }
+        lines.push(pending_spawn_line(pending, inner_width, spinner));
+        item_heights.insert(slot.index, lines.len() as u16);
+        items.insert(slot.index, ListItem::new(lines));
+        slot.index
+    });
 
     // The active-row selection background is painted by `build_session_line`
     // itself (per-span, full width), *not* by the List's `highlight_style` —
@@ -707,7 +776,10 @@ fn render_session_section(
     // session line only; the header stays muted regardless of selection.
     let list = List::new(items).block(block);
 
-    list_state.select(show_selection.then_some(active_index));
+    // `active_index` indexes `sessions`; the widget's items may carry an extra
+    // placeholder row, which shifts every item at or after it down by one.
+    let selected_item = active_index + usize::from(pending_row.is_some_and(|p| p <= active_index));
+    list_state.select(show_selection.then_some(selected_item));
     frame.render_stateful_widget(list, area, list_state);
 
     render_scroll_indicators_variable(frame, area, list_state, &item_heights);
@@ -730,13 +802,19 @@ fn render_session_section(
             break;
         }
         let height = h.min(bottom - y);
-        // The trailing placeholder row (`i == sessions.len()`) is skipped: its
-        // index isn't a session index, and clicking a session that doesn't exist
-        // yet has nothing to select.
-        if i < sessions.len() {
+        // Map the row back to its session index: the placeholder occupies a row
+        // but is not a session, so rows after it are shifted by one. It gets no
+        // hitbox itself — clicking a session that doesn't exist yet has nothing
+        // to select — and selection indices stay a valid range over `sessions`.
+        let session_index = match pending_row {
+            Some(p) if i == p => None,
+            Some(p) if i > p => Some(i - 1),
+            _ => Some(i),
+        };
+        if let Some(index) = session_index.filter(|&i| i < sessions.len()) {
             hitboxes.push(super::RowHitbox {
                 rect: Rect::new(inner.x, y, inner.width, height),
-                index: i,
+                index,
             });
         }
         y += h;
@@ -1576,6 +1654,108 @@ mod tests {
         let b2 = info_repo("b", "webapp", SessionStatus::Idle);
         let flipped = vec![&a2, &b2, &c];
         assert_eq!(order_names(&flipped), vec!["a", "b", "c"]);
+    }
+
+    /// Build the ordered rows the renderer sees, then place a pending session.
+    fn slot_for(sessions: &[&SessionInfo], repo_names: &[&str]) -> PendingSpawnSlot {
+        let order = compute_session_order(sessions);
+        let ordered: Vec<&SessionInfo> = order.order.iter().map(|&i| sessions[i]).collect();
+        let names: Vec<String> = repo_names.iter().map(|s| s.to_string()).collect();
+        pending_spawn_slot(&ordered, &order.headers, &names)
+    }
+
+    #[test]
+    fn pending_row_lands_at_the_end_of_its_own_repo_group() {
+        // Ordered: infra(c) | webapp(a, b). A session being created for infra
+        // belongs under the infra header, not below webapp.
+        let a = info_repo("a", "webapp", SessionStatus::Working);
+        let b = info_repo("b", "webapp", SessionStatus::Working);
+        let c = info_repo("c", "infra", SessionStatus::Blocked);
+        let sessions = vec![&a, &b, &c];
+
+        assert_eq!(
+            slot_for(&sessions, &["infra"]),
+            PendingSpawnSlot {
+                index: 1,
+                header: None
+            },
+            "slots after infra's last row, reusing the existing header"
+        );
+        assert_eq!(
+            slot_for(&sessions, &["webapp"]),
+            PendingSpawnSlot {
+                index: 3,
+                header: None
+            },
+            "the last group's pending row still goes last"
+        );
+    }
+
+    #[test]
+    fn pending_row_for_a_new_repo_brings_its_own_header() {
+        let a = info_repo("a", "webapp", SessionStatus::Working);
+        let sessions = vec![&a];
+
+        assert_eq!(
+            slot_for(&sessions, &["infra"]),
+            PendingSpawnSlot {
+                index: 1,
+                header: Some("infra".to_string())
+            },
+            "a group with no rows yet is appended, labelled"
+        );
+    }
+
+    /// A pending multi-repo session forms its own group, exactly as the real
+    /// session will — it must not be filed under either constituent repo.
+    #[test]
+    fn pending_multi_repo_row_groups_by_its_repo_set() {
+        let a = info_repo("a", "webapp", SessionStatus::Working);
+        let both = info_repos("both", &["webapp", "infra"], SessionStatus::Working);
+        let sessions = vec![&a, &both];
+
+        // Order is webapp(a) | webapp + infra(both).
+        assert_eq!(
+            slot_for(&sessions, &["webapp", "infra"]),
+            PendingSpawnSlot {
+                index: 2,
+                header: None
+            },
+            "joins the existing multi-repo group"
+        );
+        // Repo-set equality is order-insensitive, matching `group_key`.
+        assert_eq!(
+            slot_for(&sessions, &["infra", "webapp"]).header,
+            None,
+            "the same set in another order is the same group"
+        );
+        assert_eq!(
+            slot_for(&sessions, &["infra"]),
+            PendingSpawnSlot {
+                index: 2,
+                header: Some("infra".to_string())
+            },
+            "a lone infra session is its own group, not the webapp+infra one"
+        );
+    }
+
+    #[test]
+    fn pending_row_with_no_repo_joins_the_no_repo_group() {
+        let a = info_repo("a", "webapp", SessionStatus::Working);
+        let n = info("no-repo");
+        let sessions = vec![&a, &n];
+
+        let slot = slot_for(&sessions, &[]);
+        assert_eq!(slot.header, None, "reuses the existing (no repo) header");
+        let empty: Vec<&SessionInfo> = Vec::new();
+        assert_eq!(
+            pending_spawn_slot(&empty, &[], &[]),
+            PendingSpawnSlot {
+                index: 0,
+                header: Some(NO_REPO_GROUP.to_string())
+            },
+            "the very first session labels its own group"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The placeholder row for a session being created was **appended below every repo group**, so creating a session in `webapp` showed it at the bottom of the list — far from where it would actually land — then made it jump into place once the spawn finished.
- It now renders **inside the repo group it will join**, at that group's end: where the real row will sort, since a new session has no `display_order` and follows its ordered siblings. A repo with no rows yet brings its own header instead of floating loose at the bottom.

```
── infra ────────────        ── infra ────────────
 ⠋ session-1                  ⠋ session-1
── webapp ───────────        ── webapp ───────────
 ⠋ session-0          →       ⠋ session-0
 ⠋ session-2                  ⠋ session-2
 ⠋ feat/new-thing             ⠋ feat/new-thing   ← under its own header
```

### How

- `PendingSpawn` carries the repo display names the session will span, resolved **once** when the repo is chosen (`git::repo_display_name` can shell out on a cache miss, so it must not run per frame) and carried across the wizard's later phases, which re-mark the row after the state that named it is consumed.
- The names are derived from the spawn config the same way `session_member_dirs` derives them for the real session. The wizard's `repo_path` alone is **not** enough: the non-worktree path (`spawn_repo_picker_normal`) never sets it, passing the repo through `cwd`/`additional_dirs` — reading only the wizard state filed those rows under `(no repo)`.
- A pure `pending_spawn_slot` picks the insertion point; grouping reuses the same repo-set key as live sessions (`repo_set_key`/`repo_set_display`, now shared by real and pending rows so the two can't drift), so a pending multi-repo session forms its own group rather than being filed under either constituent repo.

### Worth a reviewer's eye

Because the row is now *inserted* rather than appended, widget item indices no longer equal session indices. Both the **click hitboxes** (a click below the placeholder would have selected the wrong session) and the **selected item** (the list would have scrolled to the wrong row) are offset past it. The placeholder itself still records no hitbox, so selection indices stay a valid range over real sessions and the monkey test's invariants hold.

## Test plan

- [x] `cargo nextest run --all` — 1920/1920 pass (5 new tests: slot placement incl. multi-repo, non-worktree grouping regression, worktree-source-repo grouping, 2 acceptance render tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --test architecture_rules` — 12/12 (`ui` still cannot reach `git`; names are resolved in `app` and passed in as strings)
- [x] `cargo fmt --all --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `rumdl check` — clean
- [x] Verified by rendering the real TUI session list for both the worktree and non-worktree flows
- [x] Docs updated in the same PR (`CLAUDE.md`, `docs/PERFORMANCE.md` ADR-P12 both said "appended last")