### PR TITLE
perf(core): bound and parallelize backend teardown on quit

### DIFF
--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -265,6 +265,24 @@ pub trait SessionBackend: Send + Sync {
     fn take_hook_state_events(&self) -> Vec<(String, String)> {
         Vec::new()
     }
+
+    /// Tear down the backend's own long-lived resources (for a tmux backend,
+    /// its control-mode connection: child process + reader thread).
+    ///
+    /// Distinct from [`Self::detach`], which retires one *session*'s pane. This
+    /// retires the *connection*, and is called once per backend at quit.
+    ///
+    /// Exists as an explicit method rather than relying on `Drop` so quit can
+    /// run every backend's teardown **concurrently**: the registry holds each
+    /// backend behind an `Arc`, so dropping it is both hard to sequence and
+    /// serial by nature, and each connection's teardown blocks on a child exit.
+    /// Total quit cost is then the slowest connection rather than their sum —
+    /// which matters because the backend count grows with every configured SSH
+    /// host and auto-discovered WSL distro. Must be idempotent: a later `Drop`
+    /// still runs and has to be a no-op.
+    ///
+    /// Default: nothing to tear down.
+    fn shutdown(&self) {}
 }
 
 /// Internal bundle of I/O handles before wiring.

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -222,6 +222,14 @@ impl Default for TmuxBackend {
     }
 }
 
+/// How many times [`ControlMode::drop`] re-checks for a graceful child exit
+/// before force-killing, and how long it waits between checks. The product is
+/// the per-connection ceiling on a graceful detach (~50 ms); a control-mode
+/// client that has not exited by then is not going to, and killing it is
+/// harmless (see the rationale in `impl Drop for ControlMode`).
+const GRACEFUL_EXIT_POLLS: u32 = 10;
+const GRACEFUL_EXIT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(5);
+
 /// A live tmux control mode connection.
 ///
 /// Commands are sent serially (stdin lock ensures ordering) and responses arrive
@@ -673,13 +681,20 @@ impl Drop for ControlMode {
 
         // Give the child a moment to exit gracefully, then force-kill so the
         // reader thread gets EOF promptly and we never block indefinitely.
+        //
+        // The check goes *after* the sleep: `try_wait` runs immediately after
+        // `detach-client` is flushed, long before tmux has processed it, so a
+        // leading check never succeeds and only costs a full interval. Every
+        // backend pays this at quit, so the interval is kept short.
+        //
+        // Force-killing is safe: the tmux *server* and the agent panes are
+        // independent processes, so this only tears down the control-mode
+        // client. The graceful `detach-client` above is a courtesy, which is
+        // why the budget can be this aggressive.
         if let Ok(mut child) = self.child.lock() {
-            let exited = (0..3).any(|_| {
-                if matches!(child.try_wait(), Ok(Some(_))) {
-                    return true;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(100));
-                false
+            let exited = (0..GRACEFUL_EXIT_POLLS).any(|_| {
+                std::thread::sleep(GRACEFUL_EXIT_POLL_INTERVAL);
+                matches!(child.try_wait(), Ok(Some(_)))
             });
             if !exited {
                 let _ = child.kill();
@@ -1527,6 +1542,18 @@ impl SessionBackend for TmuxBackend {
             "display-message -t {backend_id} -p '#{{pane_pid}}'"
         ))?;
         Ok(result.trim().parse().ok())
+    }
+
+    fn shutdown(&self) {
+        // Taking the connection out runs `ControlMode::drop` on the calling
+        // thread, which is what lets quit fan the (blocking) teardown out
+        // across backends. Idempotent: the mutex holds `None` afterwards, so
+        // `TmuxBackend`'s own drop later is a no-op.
+        //
+        // `lock()` rather than `try_lock()`: a contended lock means another
+        // thread is mid-command on this connection, and skipping the teardown
+        // would leak the child + reader thread for the process lifetime.
+        drop(self.control.lock().ok().and_then(|mut c| c.take()));
     }
 
     fn take_hook_state_events(&self) -> Vec<(String, String)> {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -300,6 +300,13 @@ type RemoteDiscovery = (String, bool, Vec<crate::agent::backend::DiscoveredSessi
 /// How long to wait between retry sweeps for a still-unreachable remote backend.
 const REMOTE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
 
+/// Total budget for tearing down every backend's control-mode connection at
+/// quit (see [`App::shutdown_backends`]). Shared across the concurrent
+/// teardowns, not per backend. Generous relative to the ~50 ms a healthy
+/// connection needs — it is a backstop against a wedged transport hanging the
+/// process, not the expected cost.
+const BACKEND_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Background restore + reconnect loop for remote-backed sessions. Startup
 /// readies + discovers only *local* backends synchronously; each remote
 /// (`ssh:`/`wsl:`) backend is readied on its own thread, because a single ssh
@@ -5820,18 +5827,76 @@ impl App {
         self.should_quit
     }
 
-    /// Persist state, then detach. The order is forced: `Session::detach`
-    /// consumes the session by value, so `save_state` (which reads
-    /// `session.info`) must run while `self.sessions` is intact. A hung save
-    /// is bounded by the SQLite busy_timeout, after which upsert errors are
-    /// logged and detach still runs.
+    /// Persist state, detach every session, then tear down the backends
+    /// themselves. The order is forced: `Session::detach` consumes the session
+    /// by value, so `save_state` (which reads `session.info`) must run while
+    /// `self.sessions` is intact. A hung save is bounded by the SQLite
+    /// busy_timeout, after which upsert errors are logged and detach still runs.
+    ///
+    /// Backend teardown (`shutdown_backends`) comes last and is what actually
+    /// ends the control-mode connections; without it they would be closed
+    /// one-by-one by `Drop` after `main` returns, which is invisible in the log
+    /// and used to dominate quit.
     pub fn shutdown(mut self) {
         self.finalize_pending_delete();
         self.save_state();
         // Do NOT remove worktrees — they persist for resume.
         // Detach from backend sessions without killing them — they persist in tmux.
-        for session in self.sessions {
+        // `take` rather than consuming `self.sessions`: that would partially move
+        // `self` and make the `shutdown_backends` call below unreachable.
+        for session in std::mem::take(&mut self.sessions) {
             session.detach();
+        }
+        // Sessions first: detach unregisters each pane, so the per-session reader
+        // threads are already unwinding while the connections are torn down.
+        self.shutdown_backends();
+    }
+
+    /// Tear down every backend's control-mode connection, concurrently.
+    ///
+    /// Each connection's teardown blocks on its child exiting, so doing this
+    /// serially cost the sum over backends — and the backend count grows with
+    /// every configured SSH host and auto-discovered WSL distro. One thread per
+    /// backend makes quit cost the slowest connection instead.
+    ///
+    /// Bounded by [`BACKEND_SHUTDOWN_TIMEOUT`]: a wedged transport (an ssh child
+    /// ignoring its kill, say) must not hang the process. Abandoning a straggler
+    /// is safe — these are the last threads doing anything, the agent panes live
+    /// on in tmux regardless, and the process is about to exit.
+    fn shutdown_backends(&self) {
+        let backends: Vec<_> = self.backends.all_backends().cloned().collect();
+        let total = backends.len();
+        if total == 0 {
+            return;
+        }
+
+        // Completion is signalled over a channel rather than by `join`ing the
+        // handles: a `join` on a wedged thread blocks past the deadline, which
+        // is the exact hang this timeout exists to prevent. Each worker sends on
+        // its way out; we wait for `total` sends or the deadline, whichever
+        // comes first, and simply never join — a straggler is left detached and
+        // dies with the process.
+        let (tx, rx) = mpsc::channel();
+        for b in backends {
+            let tx = tx.clone();
+            std::thread::spawn(move || {
+                b.shutdown();
+                let _ = tx.send(());
+            });
+        }
+        // Drop the extra sender so `recv_timeout` can't wait on a live handle
+        // this thread still owns.
+        drop(tx);
+
+        let deadline = std::time::Instant::now() + BACKEND_SHUTDOWN_TIMEOUT;
+        for _ in 0..total {
+            // A deadline already past yields a zero timeout, which `recv_timeout`
+            // reports as an immediate error — so this needs no separate check.
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if rx.recv_timeout(remaining).is_err() {
+                warn!("backend shutdown timed out; abandoning remaining teardown");
+                return;
+            }
         }
     }
 
@@ -7139,6 +7204,125 @@ mod tests {
 
     fn test_db() -> Database {
         Database::open_in_memory().unwrap()
+    }
+
+    /// Backend whose `shutdown` sleeps, to exercise `shutdown_backends`. With
+    /// `name` unique per instance so several can share one registry (which is
+    /// keyed by name).
+    struct SlowShutdownBackend {
+        backend_name: String,
+        delay: std::time::Duration,
+        done: Arc<std::sync::atomic::AtomicUsize>,
+    }
+    impl SessionBackend for SlowShutdownBackend {
+        fn name(&self) -> &str {
+            &self.backend_name
+        }
+        fn check_available(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn ensure_ready(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn spawn(
+            &self,
+            _: &str,
+            _: &str,
+            _: &[String],
+            _: Option<&Path>,
+            _: &std::collections::HashMap<String, String>,
+            _: u16,
+            _: u16,
+        ) -> anyhow::Result<crate::agent::backend::SpawnedSession> {
+            unimplemented!()
+        }
+        fn adopt(
+            &self,
+            _: &str,
+            _: u16,
+            _: u16,
+            _: Option<Vec<u8>>,
+        ) -> anyhow::Result<crate::agent::backend::AdoptedSession> {
+            unimplemented!()
+        }
+        fn discover(&self) -> anyhow::Result<Vec<crate::agent::backend::DiscoveredSession>> {
+            Ok(vec![])
+        }
+        fn resize(&self, _: &str, _: u16, _: u16) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn is_dead(&self, _: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        fn kill(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn detach(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn pane_pid(&self, _: &str) -> anyhow::Result<Option<u32>> {
+            Ok(None)
+        }
+        fn shutdown(&self) {
+            std::thread::sleep(self.delay);
+            self.done.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    fn slow_backend_app(
+        count: usize,
+        delay: std::time::Duration,
+    ) -> (App, Arc<std::sync::atomic::AtomicUsize>) {
+        let done = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut registry = BackendRegistry::new(stub_backend_arc());
+        for i in 0..count {
+            registry.register(Arc::new(SlowShutdownBackend {
+                backend_name: format!("slow-{i}"),
+                delay,
+                done: Arc::clone(&done),
+            }));
+        }
+        let app = App::new(24, 80, registry, stub_agents(), test_db());
+        (app, done)
+    }
+
+    /// Backends tear down concurrently, so the cost is the slowest connection
+    /// rather than the sum. Serially this would be ~1.2 s; the assertion has
+    /// wide headroom so it fails only on an actual regression to serial.
+    #[test]
+    fn shutdown_backends_runs_concurrently() {
+        let delay = std::time::Duration::from_millis(200);
+        let (app, done) = slow_backend_app(6, delay);
+
+        let start = std::time::Instant::now();
+        app.shutdown_backends();
+        let elapsed = start.elapsed();
+
+        assert_eq!(
+            done.load(std::sync::atomic::Ordering::SeqCst),
+            6,
+            "every backend torn down"
+        );
+        assert!(
+            elapsed < delay * 3,
+            "expected concurrent teardown, took {elapsed:?} for 6 × {delay:?}"
+        );
+    }
+
+    /// A wedged backend must not hang quit: `shutdown_backends` gives up at
+    /// `BACKEND_SHUTDOWN_TIMEOUT` and returns, leaving the straggler detached.
+    #[test]
+    fn shutdown_backends_gives_up_on_wedged_backend() {
+        let (app, _done) = slow_backend_app(1, BACKEND_SHUTDOWN_TIMEOUT * 10);
+
+        let start = std::time::Instant::now();
+        app.shutdown_backends();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < BACKEND_SHUTDOWN_TIMEOUT * 3,
+            "expected the timeout to bound teardown, took {elapsed:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Quitting thurbox took ~20s once a few backends were configured. Everything thurbox itself logs finishes in ~15ms — the delay was in `impl Drop for ControlMode`, which runs *after* `main` returns and so never shows up in the log at all.

Two compounding causes:

- **The graceful-exit loop wasted a fixed 300ms per connection.** It slept *before* re-checking and never re-checked after its final sleep, so the first `try_wait` (which runs immediately after `detach-client` is flushed, long before tmux has processed it) always missed, and a child that exited during the last sleep was force-killed anyway. It now polls every 5ms for up to 50ms, checking *after* each wait.

- **That cost was paid serially, once per backend.** Backends live behind `Arc` in the registry, so drop order is both hard to sequence and serial by nature. A new `SessionBackend::shutdown()` — default no-op, so the other nine implementors are untouched — lets `App::shutdown` fan teardown out across threads, bounded by a 2s shared timeout so a wedged ssh/WSL transport cannot hang the process.

This regressed when remote/WSL support landed: every configured SSH host and every auto-discovered WSL distro owns a connection paying the fixed cost, and WSL distros are discovered with **no config at all** (my machine had two I never opted into).

Force-killing is safe here: the tmux server and the agent panes are independent processes, so this only tears down the control-mode client — panes still persist for resume.

## Test plan

- `cargo nextest run --all` — 1914 pass (1912 existing + 2 new)
- `cargo clippy --all-targets --all-features` — clean
- `cargo test --test architecture_rules` — 12/12
- `RUSTDOCFLAGS="-D warnings" cargo doc` — clean
- `cargo deny check advisories` / `bans licenses sources` — ok
- Two new regression tests cover the properties that could silently regress:
  - `shutdown_backends_runs_concurrently` — 6 backends x 200ms finishes in 0.26s, not the 1.2s a serial regression would cost
  - `shutdown_backends_gives_up_on_wedged_backend` — a wedged backend is abandoned at the timeout instead of hanging
- Measured end-to-end by driving the real binary against 6 live backends (local + 3 hosts.toml + 2 auto-discovered WSL): **~20s -> 160ms**