### PR TITLE
fix(ui): separate F9 chevron from the central tab strip on hover

### DIFF
--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -739,6 +739,82 @@ fn session_collapse_chevron_renders_and_toggles() {
     assert!(h.app.show_session_list, "clicking ▶ re-expands the list");
 }
 
+/// Leftmost recorded click-target rect whose action satisfies `pred` — the
+/// on-border chevron/tab lookups both want the first hitbox left-to-right.
+/// Panics when nothing matches, so a test that stops rendering its target
+/// fails loudly instead of silently asserting nothing.
+fn first_target_rect(app: &super::App, pred: impl Fn(&ClickAction) -> bool) -> Rect {
+    app.click_targets
+        .iter()
+        .filter(|t| pred(&t.action))
+        .map(|t| t.rect)
+        .min_by_key(|r| r.x)
+        .expect("click target recorded this frame")
+}
+
+/// The two on-border central-pane hitboxes the collapse-chevron tests compare:
+/// the chevron itself and the leftmost view tab (Agent).
+fn chevron_and_first_tab_rects(app: &super::App) -> (Rect, Rect) {
+    let chevron = first_target_rect(app, |a| {
+        matches!(
+            a,
+            ClickAction::Global(crate::session::Action::ToggleSessionList)
+        )
+    });
+    let tab = first_target_rect(app, |a| matches!(a, ClickAction::CentralTab(_)));
+    (chevron, tab)
+}
+
+#[test]
+fn session_collapse_chevron_keeps_a_gap_before_the_tab_strip() {
+    // The chevron is packed left of the tab strip, but it must keep the same
+    // one-cell gap the pills keep between themselves: their hover fills are
+    // adjacent rects, so a flush chevron/Agent pair lights up as one chip.
+    let mut h = Harness::standard(1);
+    h.render();
+    let (chevron, first_tab) = chevron_and_first_tab_rects(&h.app);
+    assert_eq!(
+        first_tab.x,
+        chevron.right() + 1,
+        "one blank border cell separates the chevron from the first pill \
+         (chevron {chevron:?}, first tab {first_tab:?})"
+    );
+}
+
+#[test]
+fn session_collapse_chevron_hovers_lighter_than_a_pill() {
+    // The chevron is a bare border glyph, not a filled pill, so hovering it must
+    // use the subtle row band (`selection_bg`) rather than the pill's bright
+    // `accent_bright` fill — otherwise hover dresses it up as the peer view-tab
+    // it deliberately isn't. Contrast it against a real pill (the Agent tab),
+    // which keeps the bright treatment.
+    let mut h = Harness::standard(1);
+    h.render();
+    let (chevron, pill) = chevron_and_first_tab_rects(&h.app);
+
+    // Background the hovered cell ends up with, for the target under `rect`.
+    let hovered_bg = |h: &mut Harness, rect: Rect| {
+        h.app.update(AppMessage::MouseMove {
+            x: rect.x,
+            y: rect.y,
+        });
+        h.render();
+        h.terminal.backend().buffer()[(rect.x, rect.y)].bg
+    };
+
+    // Hovering the pill brightens it; hovering the chevron only bands it.
+    assert_eq!(
+        hovered_bg(&mut h, pill),
+        crate::ui::theme::Theme::accent_bright(),
+        "a real tab pill keeps the bright button hover"
+    );
+    assert_eq!(
+        hovered_bg(&mut h, chevron),
+        crate::ui::theme::Theme::selection_bg(),
+        "the collapse chevron gets the subtle row band instead"
+    );
+}
+
 #[test]
 fn ctrl_slash_opens_global_search_strip() {
     let mut h = Harness::standard(2);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9890,13 +9890,18 @@ mod tests {
     #[test]
     fn hovering_footer_button_brightens_it() {
         let mut app = app_with_sessions(1);
-        let backend = ratatui::backend::TestBackend::new(120, 30);
+        let (cols, rows) = (120, 30);
+        let backend = ratatui::backend::TestBackend::new(cols, rows);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal.draw(|f| app.view(f)).unwrap();
+        // Pick a *footer* pill specifically: the collapse chevron is also a
+        // `Global` target but is deliberately hovered as a subtle band, not a
+        // pill (see `apply_hover_highlight`), and it is recorded first.
+        let footer_y = rows - 1;
         let r = app
             .click_targets
             .iter()
-            .find(|t| matches!(t.action, ClickAction::Global(_)))
+            .find(|t| matches!(t.action, ClickAction::Global(_)) && t.rect.y == footer_y)
             .map(|t| t.rect)
             .expect("footer buttons recorded");
         app.update(AppMessage::MouseMove { x: r.x, y: r.y });

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -197,10 +197,11 @@ impl App {
 
     /// Highlight the clickable element under the mouse pointer so what a click
     /// would hit is visible before clicking. List/selector rows get a subtle
-    /// background band (the theme's `selection_bg`); buttons brighten their
-    /// fill to `accent_bright`. Runs on the recorded click targets, after all
-    /// rendering; the text selection highlight is applied later and wins on
-    /// overlap.
+    /// background band (the theme's `selection_bg`); filled pill buttons
+    /// brighten their fill to `accent_bright`. The collapse chevron is a button
+    /// by action but a bare border glyph by look, so it takes the subtle band
+    /// too. Runs on the recorded click targets, after all rendering; the text
+    /// selection highlight is applied later and wins on overlap.
     fn apply_hover_highlight(&self, frame: &mut Frame) {
         let Some((hx, hy)) = self.mouse_hover else {
             return;
@@ -250,14 +251,22 @@ impl App {
         // chip stays legible regardless of the resting style (primary's accent
         // fill and the neutral selection-filled secondary chip carry different fg
         // colours); for rows we tint only the background, leaving each cell's
-        // fg/modifiers intact.
-        let is_button = matches!(
+        // fg/modifiers intact. The collapse chevron is the one `Global` target
+        // that is *not* a filled pill (see `draw_session_collapse_toggle`) — a
+        // pane-visibility toggle, not a peer of the Shell/Review view tabs — so
+        // it takes the row band and keeps its own accent/muted colouring.
+        let is_collapse_chevron = matches!(
             target.action,
-            ClickAction::Global(_)
-                | ClickAction::ModalButton { .. }
-                | ClickAction::ReviewButton(_)
-                | ClickAction::CentralTab(_)
+            ClickAction::Global(crate::session::Action::ToggleSessionList)
         );
+        let is_button = !is_collapse_chevron
+            && matches!(
+                target.action,
+                ClickAction::Global(_)
+                    | ClickAction::ModalButton { .. }
+                    | ClickAction::ReviewButton(_)
+                    | ClickAction::CentralTab(_)
+            );
         let hover_bg = if is_button {
             Theme::accent_bright()
         } else {
@@ -708,9 +717,12 @@ impl App {
         // an on-border click wins over a plain pane-focus click. The review
         // overlay takes the pane whenever the active session has one open
         // (persisted per session like the shell view, so it survives switches).
+        // One blank border cell after the chevron, matching the gap the tab
+        // strip keeps between its own pills — without it the chevron's hover
+        // fill runs flush into the Agent pill and the two read as one chip.
         let tab_start = chevron
             .as_ref()
-            .map_or(terminal.x + 1, |(r, _)| r.x + r.width);
+            .map_or(terminal.x + 1, |(r, _)| r.x + r.width + 1);
         if let Some((rect, _)) = chevron.as_ref() {
             self.record_click(
                 *rect,


### PR DESCRIPTION
## Summary

- The session-list collapse chevron (`◀ F9`) was packed **flush** against the first central-pane tab: `tab_start` began at the chevron's right edge, while the tab strip separates its own pills by one cell. The chevron/Agent seam was the only gapless one in the strip.
- At rest this is invisible — the chevron is a bare accent glyph on the border, not a filled pill — but on hover `apply_hover_highlight` paints a fill across its whole hitbox, which then butted straight into the Agent pill so the two read as a single merged chip.
- Fix 1: give the chevron the same one-cell gap the pills keep between themselves. `reserved_left` derives from the rendered rects' `right()`, so the right-aligned session title followed automatically.
- Fix 2: stop dressing the chevron up as a pill on hover. It is the one `ClickAction::Global` target that is *not* a filled button — a pane-visibility toggle rather than a peer of the Shell/Review view tabs (see `draw_session_collapse_toggle`) — so it now takes the subtle `selection_bg` row band instead of the bright `accent_bright` fill, and keeps its own accent/muted colouring rather than being flattened to `inverted_fg`.

### Drive-by test fix

`hovering_footer_button_brightens_it` grabbed the *first* `ClickAction::Global` target as a stand-in for "a footer button" — but the chevron is also `Global` and is recorded earlier in the frame, so the test had silently been asserting on the chevron, not the footer. Scoped it to a target on the footer row. Verified it is not vacuous: broadening the chevron exemption to all `Global` actions still makes it fail.

## Test plan

- `session_collapse_chevron_keeps_a_gap_before_the_tab_strip` — asserts `first_tab.x == chevron.right() + 1` off the real recorded click targets. Confirmed to be a true regression test: stashing the fix reproduces the old flush geometry (chevron ends at x=36, Agent pill started at 37 instead of 38).
- `session_collapse_chevron_hovers_lighter_than_a_pill` — asserts the chevron hovers `selection_bg` **and**, in the same test, that a real Agent tab pill still hovers `accent_bright`, so the exemption cannot silently widen. Stashing the fix flips the chevron to the bright fill while the pill assertion keeps passing, proving the change is scoped to the chevron alone.
- Full suite `cargo nextest run --all`: 1914/1914 pass (insta snapshots included).
- `cargo test --test architecture_rules`: 12/12.
- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` all clean.