### PR TITLE
feat(ui): add 21 theme presets and a filterable theme picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2266,11 +2266,16 @@ exists). On top of that:
 
 ## Themes
 
-The TUI ships with fifteen palettes — eleven dark (**Default**, **Catppuccin
-Mocha**, **Tokyo Night**, **Gruvbox Dark**, **Doom**, **Nord**, **Dracula**,
-**One Dark**, **Rosé Pine Moon**, **Everforest**, **Kanagawa**) and four light
-(**Catppuccin Latte**, **Tokyo Night Day**, **Gruvbox Light**,
-**Solarized Light**). Users can add **custom themes** in
+The TUI ships with thirty-six palettes — twenty-eight dark (**Default**,
+**Catppuccin Mocha**, **Tokyo Night**, **Gruvbox Dark**, **Doom**, **Nord**,
+**Dracula**, **One Dark**, **Rosé Pine Moon**, **Everforest**, **Kanagawa**,
+**Solarized Dark**, **Monokai**, **Ayu Dark**, **Ayu Mirage**, **Material**,
+**Rosé Pine**, **Oxocarbon**, **GitHub Dark**, **Nightfox**, **Sonokai**,
+**Melange**, **Zenburn**, **Iceberg**, **Vesper**, **Synthwave**,
+**Nightfly**, **Tomorrow Night**) and eight light (**Catppuccin Latte**,
+**Tokyo Night Day**, **Gruvbox Light**, **Solarized Light**, **Ayu Light**,
+**One Light**, **Rosé Pine Dawn**, **GitHub Light**). Users can add
+**custom themes** in
 `~/.config/thurbox/themes.toml` (a built-in `base` plus per-colour
 overrides — see `docs/CONFIG.md`); they appear in the picker after the
 built-ins and persist by name exactly like a preset
@@ -2282,6 +2287,25 @@ which avoids terminals that intercept Ctrl+Y as DSUSP); the choice
 is persisted in SQLite under `metadata.active_theme` and survives
 restarts. Other thurbox processes pick up theme changes within one
 tick via `PRAGMA data_version` polling.
+
+Because the list is long, the picker (`ui::theme_picker_modal`) can
+**filter**, but behind `/` (mirroring the file viewer's and code
+review's find) so its keys stay consistent with the other selectors:
+`j`/`k` (+ `↑`/`↓`, `PageUp`/`PageDown` by the rendered list height via
+`App::theme_picker_page`, `g`/`G`, `Home`/`End`, `Ctrl+N`/`Ctrl+P`)
+navigate, and only after `/` do letters append to a query — matched
+against each theme's display name *and* its stable id, with a live
+`matched/total` count. `ThemePickerModal::filter` is `Option<TextInput>`
+(`None` = navigation mode); `Esc` closes the filter first (restoring the
+full list, cursor kept on the same theme) and the picker second.
+Entries group under `Dark`/`Light` headers that are drawn *inside*
+their entry's row, so selection, hitboxes, and the scrollbar all stay
+in entry space (a header is never selectable) and a header disappears
+with its section when filtered out. `ThemePickerModal::index` indexes
+the **match** list, not the entry list, and every consumer resolves it
+through `matches` — refining a query keeps the cursor on the same
+theme when it survives, so narrowing can't apply a palette other than
+the previewed one. See `docs/FEATURES.md`.
 
 ## Settings panel
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -443,7 +443,7 @@ per-agent detail: `extensions/hooks/README.md`.
 
 ## themes.toml
 
-User-defined themes, offered in the `Ctrl+Y` picker alongside the fifteen
+User-defined themes, offered in the `Ctrl+Y` picker alongside the thirty-six
 built-in presets and persisted by `name` like any preset. Each
 `[[themes]]` entry starts from a built-in `base` and overrides only the
 colours it names:

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1631,15 +1631,57 @@ palette. Widget files reference named colors (accent, text, status,
 border) rather than hard-coded `Color::*` values, so the whole UI
 can be re-skinned by swapping the active palette.
 
-Thurbox ships fifteen built-in presets — eleven dark (Default,
-Catppuccin Mocha, Tokyo Night, Gruvbox Dark, Doom, Nord, Dracula,
-One Dark, Rosé Pine Moon, Everforest, Kanagawa) and four light
-(Catppuccin Latte, Tokyo Night Day, Gruvbox Light, Solarized
-Light). Press `Ctrl+Y` (or `F4`, which avoids terminals that
+Thurbox ships thirty-six built-in presets — twenty-eight dark
+(Default, Catppuccin Mocha, Tokyo Night, Gruvbox Dark, Doom, Nord,
+Dracula, One Dark, Rosé Pine Moon, Everforest, Kanagawa, Solarized
+Dark, Monokai, Ayu Dark, Ayu Mirage, Material, Rosé Pine, Oxocarbon,
+GitHub Dark, Nightfox, Sonokai, Melange, Zenburn, Iceberg, Vesper,
+Synthwave, Nightfly, Tomorrow Night) and eight light (Catppuccin
+Latte, Tokyo Night Day, Gruvbox Light, Solarized Light, Ayu Light,
+One Light, Rosé Pine Dawn, GitHub Light). Press `Ctrl+Y` (or `F4`,
+which avoids terminals that
 intercept `Ctrl+Y` as DSUSP) to pick one. The choice is persisted
 in SQLite under `metadata.active_theme` and survives restarts;
 other Thurbox processes pick it up within one tick via
 `PRAGMA data_version` polling.
+
+### The picker at this list length
+
+Thirty-six presets (plus any custom themes) is far more than fits on
+one screen, so the picker (`ui::theme_picker_modal`) is built around
+the long list rather than scrolling a flat one:
+
+- **Filter behind `/`.** The picker keeps the shared selector keys —
+  `j`/`k` (plus `↑`/`↓`, `PageUp`/`PageDown`, `g`/`G`, `Home`/`End`)
+  select, and `Ctrl+N`/`Ctrl+P` are accepted as alternates. Only `/`
+  opens a filter sub-mode, in which letters append to a query matched
+  against each theme's display name *and* its stable id (so both `rose`
+  and `rose-pine-dawn` find the same entry). This mirrors the file
+  viewer's and code review's find rather than swallowing every letter,
+  so no key means something different here than in the other pickers.
+  `PageUp`/`PageDown` step by the list's *rendered* height, fed back
+  from the view each frame (`App::theme_picker_page`).
+- **Two `Esc` levels.** While filtering, `Esc` closes just the filter
+  and restores the full list — keeping the cursor on the theme it was
+  on, so leaving the sub-mode never jumps the preview elsewhere. A
+  second `Esc` cancels the picker. The header line shows the live query
+  (with a block cursor) or, in navigation mode, a `/ filter themes`
+  hint; either way it carries a `matched/total themes` count, so a
+  query that narrows to nothing is legible instead of an unexplained
+  empty list.
+- **`Dark` / `Light` section headers.** Emitted at the first entry of
+  each run, so filtering away every light theme also drops the `Light`
+  header. Headers are rendering decoration drawn *within* their entry's
+  row, which keeps selection indices, click hitboxes, and the scrollbar
+  all in plain entry space — a header is never separately selectable.
+- **Filtered-space selection.** `ThemePickerModal::index` indexes the
+  *match* list, not the full entry list, and every consumer resolves it
+  through `matches`. Refining a query keeps the cursor on the same
+  *theme* when it survives the filter, so narrowing can never silently
+  apply a different palette than the one previewed.
+- The modal grows with its content up to ~85% of the frame, then
+  scroll-windows with a scrollbar. The live swatch also previews text,
+  diff, border and modal-background colours, not just the accent.
 
 ### Why centralized?
 

--- a/src/agent/themes_config.rs
+++ b/src/agent/themes_config.rs
@@ -20,9 +20,15 @@ pub const SEED_THEMES_TOML: &str = r##"# Thurbox custom themes  —  ~/.config/t
 #
 # Colours accept anything ratatui parses: "#rrggbb", ANSI names ("red",
 # "lightcyan"), indexed ("14"), or "reset" (terminal default — useful for
-# app_bg). Bases: default, catppuccin-mocha, tokyo-night, gruvbox-dark, doom,
+# app_bg).
+#
+# Dark bases: default, catppuccin-mocha, tokyo-night, gruvbox-dark, doom,
 # nord, dracula, one-dark, rose-pine-moon, everforest, kanagawa,
-# catppuccin-latte, tokyo-night-day, gruvbox-light, solarized-light.
+# solarized-dark, monokai, ayu-dark, ayu-mirage, material, rose-pine,
+# oxocarbon, github-dark, nightfox, sonokai, melange, zenburn, iceberg,
+# vesper, synthwave, nightfly, tomorrow-night.
+# Light bases: catppuccin-latte, tokyo-night-day, gruvbox-light,
+# solarized-light, ayu-light, one-light, rose-pine-dawn, github-light.
 #
 # Overridable colour keys: accent, accent_bright, status_working,
 # status_blocked, status_done, status_idle, status_error, status_unreachable,

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -438,6 +438,19 @@ fn theme_picker_lists_palettes() {
 }
 
 #[test]
+fn theme_picker_filtered_shows_both_sections() {
+    // A query spanning dark and light themes: pins the `Dark`/`Light` section
+    // headers, the narrowed match count, and the echoed query.
+    let mut h = Harness::snapshot();
+    h.ctrl('y');
+    h.key(KeyCode::Char('/'), KeyModifiers::NONE); // open the filter sub-mode
+    for c in "light".chars() {
+        h.key(KeyCode::Char(c), KeyModifiers::NONE);
+    }
+    insta::assert_snapshot!(h.render());
+}
+
+#[test]
 fn repo_picker_path_browser_snapshot() {
     // The dropdown under the path input: a `●git`-marked repo, a plain dir,
     // and the browser footer hints. Paths are `~`-relative (the guarded test
@@ -3354,4 +3367,245 @@ async fn monkey_random_events_uphold_invariants() {
             assert_invariants(&h.app, &ctx);
         }
     }
+}
+
+#[test]
+fn theme_picker_filter_narrows_the_list_and_previews_a_match() {
+    // Typing filters the list; the selection lands on the first match and is
+    // live-previewed, and `Enter` commits *that* theme (not the entry that
+    // happened to share the pre-filter index).
+    let mut h = Harness::standard(0);
+    h.ctrl('y');
+    h.key(KeyCode::Char('/'), KeyModifiers::NONE); // open the filter sub-mode
+    for c in "gruvbox".chars() {
+        h.key(KeyCode::Char(c), KeyModifiers::NONE);
+    }
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    let entries = crate::ui::theme::all_theme_entries();
+    let names: Vec<&str> = tp
+        .matches
+        .iter()
+        .map(|&i| entries[i].name.as_str())
+        .collect();
+    assert_eq!(names, vec!["gruvbox-dark", "gruvbox-light"]);
+    assert_eq!(tp.index, 0, "selection resets to the first match");
+    assert_eq!(
+        crate::ui::theme::current(),
+        crate::ui::theme::find_theme_entry("gruvbox-dark")
+            .unwrap()
+            .palette,
+        "the first match is previewed"
+    );
+
+    h.key(KeyCode::Down, KeyModifiers::NONE);
+    h.key(KeyCode::Enter, KeyModifiers::NONE);
+    assert_eq!(
+        h.app.active_theme.name, "gruvbox-light",
+        "Enter commits the selected *match*, not the same-numbered entry"
+    );
+}
+
+#[test]
+fn theme_picker_filter_matching_nothing_keeps_the_modal_usable() {
+    let mut h = Harness::standard(0);
+    h.ctrl('y');
+    h.key(KeyCode::Char('/'), KeyModifiers::NONE); // open the filter sub-mode
+    for c in "zzzz".chars() {
+        h.key(KeyCode::Char(c), KeyModifiers::NONE);
+    }
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert!(tp.matches.is_empty());
+    assert!(tp.selected_entry().is_none());
+    // Rendering an empty match set must not panic, and Enter must be a no-op
+    // rather than committing a stale index.
+    h.render();
+    h.key(KeyCode::Enter, KeyModifiers::NONE);
+    assert!(!h.app.modal.is_open(), "Enter closes the picker");
+    assert_eq!(
+        h.app.active_theme.name, "default",
+        "no match means nothing is committed"
+    );
+
+    // Backspacing back to a real query restores the list.
+    let mut h = Harness::standard(0);
+    h.ctrl('y');
+    h.key(KeyCode::Char('/'), KeyModifiers::NONE); // open the filter sub-mode
+    for c in "nordx".chars() {
+        h.key(KeyCode::Char(c), KeyModifiers::NONE);
+    }
+    h.key(KeyCode::Backspace, KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.matches.len(), 1, "'nord' matches exactly one theme");
+}
+
+#[test]
+fn theme_picker_page_keys_move_by_a_screenful() {
+    // PageDown steps by the rendered list height, so a 36-entry list is
+    // traversable without holding Down.
+    let mut h = Harness::standard(0);
+    h.ctrl('y');
+    h.render(); // establishes the page height
+    let page = h.app.theme_picker_page;
+    assert!(page > 1, "the list should render several rows, got {page}");
+
+    h.key(KeyCode::PageDown, KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.index, page);
+
+    h.key(KeyCode::End, KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(
+        tp.index,
+        crate::ui::theme::all_theme_entries().len() - 1,
+        "End jumps to the last theme"
+    );
+
+    h.key(KeyCode::Home, KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.index, 0, "Home jumps back to the first");
+}
+
+#[test]
+fn theme_picker_ctrl_n_p_navigate_and_other_ctrl_chords_dont_type() {
+    // Parity with the global-search strip: Ctrl+N/Ctrl+P move the selection.
+    // Any *other* Ctrl chord must be swallowed, never inserted as a letter —
+    // a stray Ctrl+W would otherwise silently filter the list down to "w".
+    let mut h = Harness::standard(0);
+    h.ctrl('y');
+
+    h.key(KeyCode::Char('n'), KeyModifiers::CONTROL);
+    h.key(KeyCode::Char('n'), KeyModifiers::CONTROL);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.index, 2, "Ctrl+N moves down");
+    assert!(tp.filter_query().is_empty(), "Ctrl+N must not type");
+
+    h.key(KeyCode::Char('p'), KeyModifiers::CONTROL);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.index, 1, "Ctrl+P moves up");
+
+    h.key(KeyCode::Char('w'), KeyModifiers::CONTROL);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert!(
+        tp.filter_query().is_empty(),
+        "an unhandled Ctrl chord must not leak into the filter"
+    );
+    assert_eq!(tp.index, 1, "and must not move the selection");
+}
+
+#[test]
+fn theme_picker_jk_navigate_until_slash_opens_the_filter() {
+    // The picker keeps the shared selector keys: `j`/`k` select, and only `/`
+    // starts a query. Letters are literal navigation until then, so typing
+    // `j` can never silently filter the list.
+    let mut h = Harness::standard(0);
+    h.ctrl('y');
+
+    h.key(KeyCode::Char('j'), KeyModifiers::NONE);
+    h.key(KeyCode::Char('j'), KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.index, 2, "j moves down");
+    assert!(tp.filter.is_none(), "j must not open the filter");
+
+    h.key(KeyCode::Char('k'), KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.index, 1, "k moves up");
+
+    // g/G jump to the ends, as in the other list surfaces.
+    h.key(KeyCode::Char('G'), KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.index, crate::ui::theme::all_theme_entries().len() - 1);
+    h.key(KeyCode::Char('g'), KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.index, 0);
+
+    // `/` switches modes; only now do letters become query text.
+    h.key(KeyCode::Char('/'), KeyModifiers::NONE);
+    h.key(KeyCode::Char('j'), KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.filter_query(), "j", "after / a letter types");
+    // No built-in name contains a `j`, so this also shows the letter really
+    // reached the query rather than moving the cursor.
+    assert!(tp.matches.is_empty(), "'j' matches no theme name");
+}
+
+#[test]
+fn theme_picker_esc_closes_filter_first_then_the_modal() {
+    // Two Esc levels, like the code-review find: the first leaves the filter
+    // sub-mode (restoring the full list), the second cancels the picker.
+    let mut h = Harness::standard(0);
+    h.ctrl('y');
+    h.key(KeyCode::Char('/'), KeyModifiers::NONE);
+    for c in "nord".chars() {
+        h.key(KeyCode::Char(c), KeyModifiers::NONE);
+    }
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.matches.len(), 1, "filtered down to Nord");
+
+    h.key(KeyCode::Esc, KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("first Esc must keep the picker open");
+    };
+    assert!(tp.filter.is_none(), "first Esc closes the filter");
+    assert_eq!(
+        tp.matches.len(),
+        crate::ui::theme::all_theme_entries().len(),
+        "clearing the filter restores every theme"
+    );
+    // The cursor stayed on the theme the filter had selected, so leaving the
+    // sub-mode doesn't jump the preview somewhere unrelated.
+    assert_eq!(
+        tp.selected_entry()
+            .map(|i| crate::ui::theme::all_theme_entries()[i].name.clone()),
+        Some("nord".to_string())
+    );
+
+    h.key(KeyCode::Esc, KeyModifiers::NONE);
+    assert!(!h.app.modal.is_open(), "second Esc closes the picker");
+}
+
+#[test]
+fn theme_picker_slash_is_not_query_text() {
+    // `/` opens the sub-mode; pressing it again keeps the query rather than
+    // inserting a literal slash (no theme name contains one).
+    let mut h = Harness::standard(0);
+    h.ctrl('y');
+    h.key(KeyCode::Char('/'), KeyModifiers::NONE);
+    for c in "nord".chars() {
+        h.key(KeyCode::Char(c), KeyModifiers::NONE);
+    }
+    h.key(KeyCode::Char('/'), KeyModifiers::NONE);
+    let modals::Modal::ThemePicker(ref tp) = h.app.modal else {
+        panic!("expected the theme picker");
+    };
+    assert_eq!(tp.filter_query(), "nord", "a second / must not type");
 }

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -322,7 +322,7 @@ impl App {
             Modal::AutomationsList(_) => self.handle_automations_list_key(code),
             Modal::AgentPicker(_) => self.handle_agent_picker_key(code),
             Modal::HostPicker(_) => self.handle_host_picker_key(code),
-            Modal::ThemePicker(_) => self.handle_theme_picker_key(code),
+            Modal::ThemePicker(_) => self.handle_theme_picker_key(code, mods),
             Modal::RepoPicker(_) => self.handle_repo_picker_key(code, mods),
             Modal::TaskActionPicker(_) => self.handle_task_action_picker_key(code),
             Modal::ConfirmDelete(_) => self.handle_confirm_delete_key(code),
@@ -1385,33 +1385,83 @@ impl App {
         }
     }
 
-    fn handle_theme_picker_key(&mut self, code: KeyCode) {
+    /// Theme-picker input. Two modes, mirroring the file viewer's and code
+    /// review's find: normally `j`/`k` (+ arrows) select like every other
+    /// picker, and `/` opens a filter sub-mode in which letters append to the
+    /// query. Inside the sub-mode `Esc` closes just the filter (the modal stays
+    /// open) and the arrows still navigate, so `j` stays typable.
+    fn handle_theme_picker_key(&mut self, code: KeyCode, mods: KeyModifiers) {
         let entries = crate::ui::theme::all_theme_entries();
-        let entry_count = entries.len();
         let super::modals::Modal::ThemePicker(ref mut tp) = self.modal else {
             return;
         };
+        let ctrl = mods.contains(KeyModifiers::CONTROL);
+        let filtering = tp.filter.is_some();
+        // Page step derives from the last rendered list height so PageUp/Down
+        // move by exactly one visible screenful.
+        let page = self.theme_picker_page.max(1);
+        let last = tp.matches.len().saturating_sub(1);
         match code {
             KeyCode::Esc => {
-                // Cancel: undo the live preview by restoring the palette that
-                // was active when the picker opened (nothing is persisted).
-                crate::ui::theme::set_active(tp.original.clone());
-                self.modal.close();
-            }
-            KeyCode::Char('j') | KeyCode::Down if tp.index + 1 < entry_count => {
-                tp.index += 1;
-                crate::ui::theme::set_active(entries[tp.index].palette.clone());
-            }
-            KeyCode::Char('k') | KeyCode::Up if tp.index > 0 => {
-                tp.index -= 1;
-                crate::ui::theme::set_active(entries[tp.index].palette.clone());
+                if filtering {
+                    // Leave the filter, keep the picker — one Esc per level.
+                    tp.close_filter(&entries);
+                } else {
+                    // Cancel: undo the live preview by restoring the palette
+                    // active when the picker opened (nothing is persisted).
+                    crate::ui::theme::set_active(tp.original.clone());
+                    self.modal.close();
+                    return;
+                }
             }
             KeyCode::Enter => {
-                let idx = tp.index;
+                let selected = tp.selected_entry();
                 self.modal.close();
-                self.commit_theme_selection(entries, idx);
+                if let Some(idx) = selected {
+                    self.commit_theme_selection(entries, idx);
+                }
+                return;
             }
-            _ => {}
+            KeyCode::Down => tp.index = (tp.index + 1).min(last),
+            KeyCode::Up => tp.index = tp.index.saturating_sub(1),
+            KeyCode::PageDown => tp.index = (tp.index + page).min(last),
+            KeyCode::PageUp => tp.index = tp.index.saturating_sub(page),
+            KeyCode::Home => tp.index = 0,
+            KeyCode::End => tp.index = last,
+            // Ctrl+N/Ctrl+P navigate in both modes (global-search parity),
+            // checked before the letter arms so they never reach the query.
+            KeyCode::Char('n') if ctrl => tp.index = (tp.index + 1).min(last),
+            KeyCode::Char('p') if ctrl => tp.index = tp.index.saturating_sub(1),
+            // Any other Ctrl chord is swallowed rather than typed: a stray
+            // `Ctrl+W` must not insert a `w` into the query.
+            KeyCode::Char(_) if ctrl => return,
+            // `/` opens the filter. It is not itself query text: re-pressing it
+            // while filtering is a no-op rather than a literal slash.
+            KeyCode::Char('/') => tp.open_filter(),
+            KeyCode::Backspace if filtering => {
+                if let Some(f) = tp.filter.as_mut() {
+                    f.backspace();
+                }
+                tp.refilter(&entries);
+            }
+            KeyCode::Char(c) if filtering => {
+                if let Some(f) = tp.filter.as_mut() {
+                    f.insert(c);
+                }
+                tp.refilter(&entries);
+            }
+            // Normal mode: vim keys select, matching every other picker.
+            KeyCode::Char('j') => tp.index = (tp.index + 1).min(last),
+            KeyCode::Char('k') => tp.index = tp.index.saturating_sub(1),
+            KeyCode::Char('g') => tp.index = 0,
+            KeyCode::Char('G') => tp.index = last,
+            _ => return,
+        }
+        // Every surviving arm moved the cursor or refiltered — live-preview
+        // whatever it now points at. An empty match set leaves the previous
+        // preview in place (there is nothing to show).
+        if let Some(idx) = tp.selected_entry() {
+            crate::ui::theme::set_active(entries[idx].palette.clone());
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -934,6 +934,11 @@ pub struct App {
     /// (if any) is reached via [`Self::active_review`] / [`Self::active_review_mut`].
     pub(crate) code_reviews: std::collections::HashMap<SessionId, code_review::CodeReviewState>,
     pub(crate) modal: modals::Modal,
+    /// Height (rows) of the theme picker's list as last rendered, so
+    /// `PageUp`/`PageDown` step by exactly one visible screenful. Written by
+    /// the view each frame; `0` before the first render, hence the `max(1)` at
+    /// the use site.
+    pub(crate) theme_picker_page: usize,
     /// A terminal-editor run staged for the main loop to execute with a real
     /// TTY (set by `Ctrl+O` when the editor is a terminal one). Drained each
     /// iteration by `run_loop` via [`Self::take_pending_editor_run`]; GUI
@@ -1307,6 +1312,7 @@ impl App {
             file_viewer: crate::ui::file_viewer::FileViewerState::new(),
             code_reviews: std::collections::HashMap::new(),
             modal: modals::Modal::None,
+            theme_picker_page: 0,
             pending_editor_run: None,
             new_session: new_session_state::NewSessionWizardState::default(),
             sync_state,
@@ -2546,7 +2552,14 @@ impl App {
             .and_then(|name| entries.iter().position(|e| e.name == name))
             .unwrap_or(0);
         let original = crate::ui::theme::current();
-        self.modal = modals::Modal::ThemePicker(modals::ThemePickerModal { index, original });
+        // Opens in navigation mode (no filter), so the match list is every
+        // entry and the filtered index equals the full-list index.
+        self.modal = modals::Modal::ThemePicker(modals::ThemePickerModal {
+            index,
+            original,
+            filter: None,
+            matches: (0..entries.len()).collect(),
+        });
     }
 
     /// Open the Settings panel. The draft reflects the live source of truth:
@@ -7615,6 +7628,19 @@ mod tests {
     }
 
     /// Create an App with N stub sessions.
+    /// An unfiltered theme picker selecting `index`, as `open_theme_picker`
+    /// would build it (match list = every entry, so filtered index == entry
+    /// index).
+    fn theme_picker_at(index: usize) -> modals::ThemePickerModal {
+        let count = crate::ui::theme::all_theme_entries().len();
+        modals::ThemePickerModal {
+            index,
+            original: crate::ui::theme::current(),
+            filter: None,
+            matches: (0..count).collect(),
+        }
+    }
+
     fn app_with_sessions(count: usize) -> App {
         let backend_arc = stub_backend_arc();
         let provider = stub_provider();
@@ -9770,10 +9796,7 @@ mod tests {
     #[test]
     fn click_with_modal_open_is_swallowed() {
         let mut app = app_with_sessions(1);
-        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal {
-            index: 0,
-            original: crate::ui::theme::current(),
-        });
+        app.modal = modals::Modal::ThemePicker(theme_picker_at(0));
         // A scrollbar track and a pane target beneath the overlay must both
         // be unreachable while the modal is open.
         app.scrollbar_hits.push(ScrollbarHit {
@@ -9799,10 +9822,7 @@ mod tests {
     #[test]
     fn click_theme_picker_row_confirms_theme() {
         let mut app = app_with_sessions(1);
-        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal {
-            index: 2,
-            original: crate::ui::theme::current(),
-        });
+        app.modal = modals::Modal::ThemePicker(theme_picker_at(2));
         // As in a real frame: the pane targets beneath the overlay are
         // recorded first and overlap the modal — the modal row must still
         // win while a modal is open.
@@ -9932,10 +9952,7 @@ mod tests {
         // targets *and* the theme-picker rows; clicking a rendered row must
         // reach the modal, not the pane beneath it.
         let mut app = app_with_sessions(1);
-        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal {
-            index: 1,
-            original: crate::ui::theme::current(),
-        });
+        app.modal = modals::Modal::ThemePicker(theme_picker_at(1));
         let backend = ratatui::backend::TestBackend::new(120, 30);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal.draw(|f| app.view(f)).unwrap();
@@ -10021,10 +10038,7 @@ mod tests {
     #[test]
     fn footer_button_swallowed_while_modal_open() {
         let mut app = app_with_sessions(1);
-        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal {
-            index: 0,
-            original: crate::ui::theme::current(),
-        });
+        app.modal = modals::Modal::ThemePicker(theme_picker_at(0));
         // The footer still renders its buttons beneath the overlay.
         let r = rendered_target(&mut app, |a| {
             *a == ClickAction::Global(crate::session::Action::QuitApp)
@@ -14336,10 +14350,7 @@ mod tests {
     #[test]
     fn paste_into_selector_only_modal_is_swallowed_not_sent_to_terminal() {
         let mut app = app_with_sessions(1);
-        app.modal = modals::Modal::ThemePicker(modals::ThemePickerModal {
-            index: 0,
-            original: crate::ui::theme::current(),
-        });
+        app.modal = modals::Modal::ThemePicker(theme_picker_at(0));
 
         // A theme picker has no text field, but the paste must still be
         // consumed so it can't leak into the terminal behind the overlay.

--- a/src/app/modals.rs
+++ b/src/app/modals.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use crossterm::event::{KeyCode, KeyModifiers};
 
+use crate::session::theme_config::ThemeEntry;
 use crate::storage::DeletedSessionInfo;
 
 // ── TextInput Helper ────────────────────────────────────────────────────────
@@ -537,11 +538,85 @@ pub struct SessionNameModal {
 
 #[derive(Debug, Clone)]
 pub struct ThemePickerModal {
+    /// Selection cursor in *filtered* space — an index into
+    /// [`ThemePickerModal::matches`], not into the full entry list. Every
+    /// consumer resolves it through `matches` so a typed filter can never
+    /// apply the wrong theme.
     pub index: usize,
     /// Palette active when the picker opened. The picker live-previews by
     /// mutating the global palette as the selection moves, so cancelling
     /// (`Esc`) restores this snapshot; only confirming (`Enter`) persists.
     pub original: crate::session::ThemePalette,
+    /// The open filter sub-mode, entered with `/` — `None` in normal
+    /// navigation mode, where `j`/`k` select like every other picker.
+    ///
+    /// With 36 built-ins plus custom themes the list is far taller than any
+    /// terminal, so a query narrows it; but it sits behind `/` (mirroring the
+    /// file viewer's and code review's find) rather than swallowing every
+    /// letter, so the picker's keys stay consistent with its siblings. While
+    /// `Some`, letters append to the query and `Esc` closes the sub-mode.
+    pub filter: Option<TextInput>,
+    /// Indices into the full entry list that match `filter`, in list order.
+    /// Recomputed by [`ThemePickerModal::refilter`] on every query change.
+    pub matches: Vec<usize>,
+}
+
+impl ThemePickerModal {
+    /// The active query, or `""` when the filter sub-mode is closed.
+    pub fn filter_query(&self) -> &str {
+        self.filter.as_ref().map_or("", |f| f.value())
+    }
+
+    /// Case-insensitive substring match over a theme's display name and its
+    /// stable id, so both "rose" and "rose-pine-dawn" find the same entry.
+    /// `needle` must already be lowercased. Both sides are lowercased: built-in
+    /// ids are all lowercase, but a custom theme may name itself anything.
+    fn is_match(entry: &ThemeEntry, needle: &str) -> bool {
+        entry.display_name.to_lowercase().contains(needle)
+            || entry.name.to_lowercase().contains(needle)
+    }
+
+    /// All entry indices matching the current query (every index when empty).
+    pub fn compute_matches(entries: &[ThemeEntry], filter: &str) -> Vec<usize> {
+        let needle = filter.trim().to_lowercase();
+        entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| needle.is_empty() || Self::is_match(e, &needle))
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Recompute `matches` after a query edit, keeping the cursor on the
+    /// previously selected *entry* when it survives the filter — so refining a
+    /// query never silently previews a different theme. Falls back to the first
+    /// match (the caller then previews it).
+    pub fn refilter(&mut self, entries: &[ThemeEntry]) {
+        let previous = self.selected_entry();
+        self.matches = Self::compute_matches(entries, self.filter_query());
+        self.index = previous
+            .and_then(|entry| self.matches.iter().position(|&i| i == entry))
+            .unwrap_or(0);
+    }
+
+    /// Open the filter sub-mode (`/`). Idempotent — re-pressing `/` while it
+    /// is already open keeps the query rather than clearing it.
+    pub fn open_filter(&mut self) {
+        self.filter.get_or_insert_with(TextInput::new);
+    }
+
+    /// Close the filter sub-mode and restore the full list, keeping the cursor
+    /// on the theme it was on so `Esc` never jumps the selection elsewhere.
+    pub fn close_filter(&mut self, entries: &[ThemeEntry]) {
+        self.filter = None;
+        self.refilter(entries);
+    }
+
+    /// The full-list entry index under the cursor, or `None` when the filter
+    /// matches nothing.
+    pub fn selected_entry(&self) -> Option<usize> {
+        self.matches.get(self.index).copied()
+    }
 }
 
 /// What a hard delete would destroy: uncommitted changes and/or unmerged
@@ -3398,5 +3473,91 @@ mod tests {
                 "{field:?}: restart_required and restart_only_differs disagree",
             );
         }
+    }
+
+    // ── ThemePickerModal filtering ──────────────────────────────────────────
+
+    fn theme_entry(name: &str, display: &str) -> ThemeEntry {
+        ThemeEntry {
+            name: name.to_string(),
+            display_name: display.to_string(),
+            palette: crate::session::ThemePalette::default(),
+            is_light: false,
+        }
+    }
+
+    #[test]
+    fn theme_filter_matches_display_name_and_id_case_insensitively() {
+        // A custom theme may name itself anything, so the *id* side must be
+        // lowercased too — matching on the raw id would make "MyTheme"
+        // unfindable by any lowercase query.
+        let entries = vec![
+            theme_entry("rose-pine-dawn", "Rosé Pine Dawn"),
+            theme_entry("MyTheme", "Custom"),
+            theme_entry("nord", "Nord"),
+        ];
+
+        // By display name, and by id.
+        assert_eq!(ThemePickerModal::compute_matches(&entries, "dawn"), vec![0]);
+        assert_eq!(
+            ThemePickerModal::compute_matches(&entries, "rose-pine"),
+            vec![0]
+        );
+        // Mixed-case id found by a lowercase query, and vice versa.
+        assert_eq!(
+            ThemePickerModal::compute_matches(&entries, "mytheme"),
+            vec![1]
+        );
+        assert_eq!(ThemePickerModal::compute_matches(&entries, "NORD"), vec![2]);
+        // An empty / whitespace query keeps everything.
+        assert_eq!(
+            ThemePickerModal::compute_matches(&entries, "   "),
+            vec![0, 1, 2]
+        );
+        assert!(ThemePickerModal::compute_matches(&entries, "zzz").is_empty());
+    }
+
+    #[test]
+    fn theme_refilter_keeps_the_cursor_on_the_same_theme() {
+        let entries = vec![
+            theme_entry("nord", "Nord"),
+            theme_entry("dracula", "Dracula"),
+            theme_entry("monokai", "Monokai"),
+        ];
+        let mut modal = ThemePickerModal {
+            index: 2, // Monokai
+            original: crate::session::ThemePalette::default(),
+            filter: None,
+            matches: (0..entries.len()).collect(),
+        };
+        modal.open_filter();
+        let query = |modal: &mut ThemePickerModal, q: &str| {
+            modal.filter.as_mut().expect("filter is open").set(q);
+            modal.refilter(&entries);
+        };
+
+        // Narrowing to a set that still contains Monokai must follow it, not
+        // stay on the old ordinal (which would now be a different theme).
+        query(&mut modal, "o");
+        assert_eq!(
+            modal.selected_entry(),
+            Some(2),
+            "cursor should track the theme, not the index"
+        );
+
+        // Narrowing it away falls back to the first match.
+        query(&mut modal, "dracula");
+        assert_eq!(modal.selected_entry(), Some(1));
+
+        // No match at all: nothing selected, and nothing panics.
+        query(&mut modal, "zzz");
+        assert_eq!(modal.selected_entry(), None);
+
+        // Closing the filter restores the whole list, keeping the cursor on a
+        // real theme rather than stranding it on the empty match set.
+        modal.close_filter(&entries);
+        assert_eq!(modal.matches.len(), entries.len());
+        assert!(modal.selected_entry().is_some());
+        assert!(modal.filter.is_none());
     }
 }

--- a/src/app/snapshots/thurbox__app__acceptance__theme_picker_filtered_shows_both_sections.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__theme_picker_filtered_shows_both_sections.snap
@@ -1,0 +1,34 @@
+---
+source: src/app/acceptance.rs
+expression: h.render()
+---
+ thurbox  Multi-Session Agent Orchestrator  v0.0.0-dev                                    ◐ Default
+╭ Sessions ─────────────╮┌ No Session ─────────────────────────────────────────────────────────────┐
+│                       ││                                                                         │
+│    No sessions yet    ││                                                                         │
+│Press Ctrl+N to create ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                 ╭ Theme ───────────────────────────────────────────────────────╮                 │
+│                 │ / light█                                         5/36 themes │                 │
+│                 │ Light                        Accent      █████ █████         │                 │
+│                 │▸ Gruvbox Light               Status      ◐ ◆ ● ○ ✗           │                 │
+│                 │  Solarized Light             Text        Aa Aa Aa            │                 │
+│                 │  Ayu Light                   Diff         +   -              │                 │
+│                 │  One Light                   Border      ╭─────╮             │                 │
+│                 │  GitHub Light                Modal bg                        │                 │
+│                 │                                                              │                 │
+│                 │  theme id: gruvbox-light                                     │                 │
+│                 │↑/↓ navigate  type filter  Esc clear filter   Select   Cancel │                 │
+│                 ╰──────────────────────────────────────────────────────────────╯                 │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+│                       ││                                                                         │
+╰───────────────────────╯│                                                                         │
+┌ Automations ──────────┐│                                                                         │
+│none                   ││                                                                         │
+└───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
+ Sessions  Help · F1   Info · F2   Files · F3   Theme · F4   Tasks · F5   Settings · F6   Quit · ^Q

--- a/src/app/snapshots/thurbox__app__acceptance__theme_picker_lists_palettes.snap
+++ b/src/app/snapshots/thurbox__app__acceptance__theme_picker_lists_palettes.snap
@@ -5,30 +5,30 @@ expression: h.render()
  thurbox  Multi-Session Agent Orchestrator  v0.0.0-dev                                    ◐ Default
 ╭ Sessions ─────────────╮┌ No Session ─────────────────────────────────────────────────────────────┐
 │                       ││                                                                         │
-│    No sessions yet    ││                                                                         │
-│Press Ctrl+N to create ││                                                                         │
-│                   ╭ Theme ───────────────────────────────────────────────────╮                   │
-│                   │▸ Default                   Accent      █████ █████       │                   │
-│                   │  Catppuccin Mocha          Status      ◐ ◆ ● ○ ✗         │                   │
-│                   │  Tokyo Night               Border      ╭─────╮           │                   │
-│                   │  Gruvbox Dark              Modal bg                      │                   │
-│                   │  Doom                                                    │                   │
-│                   │  Nord                                                    │                   │
-│                   │  Dracula                                                 │                   │
-│                   │  One Dark                                                │                   │
-│                   │  Rosé Pine Moon                                          │                   │
-│                   │  Everforest                                              │                   │
-│                   │  Kanagawa                                                │                   │
-│                   │  Catppuccin Latte (light)                                │                   │
-│                   │  Tokyo Night Day (light)                                 │                   │
-│                   │  Gruvbox Light (light)                                   │                   │
-│                   │  Solarized Light (light)                                 │                   │
-│                   │                                                          │                   │
-│                   │                                                          │                   │
-│                   │  theme id: default                                       │                   │
-│                   │j/k navigate                              Select   Cancel │                   │
-╰───────────────────╰──────────────────────────────────────────────────────────╯                   │
-┌ Automations ──────────┐│                                                                         │
-│none                   ││                                                                         │
+│    No sessions y╭ Theme ───────────────────────────────────────────────────────╮                 │
+│Press Ctrl+N to c│ / filter themes                                 36/36 themes │                 │
+│                 │ Dark                      ▲  Accent      █████ █████         │                 │
+│                 │▸ Default                  █  Status      ◐ ◆ ● ○ ✗           │                 │
+│                 │  Catppuccin Mocha         █  Text        Aa Aa Aa            │                 │
+│                 │  Tokyo Night              █  Diff         +   -              │                 │
+│                 │  Gruvbox Dark             █  Border      ╭─────╮             │                 │
+│                 │  Doom                     █  Modal bg                        │                 │
+│                 │  Nord                     █                                  │                 │
+│                 │  Dracula                  █                                  │                 │
+│                 │  One Dark                 ║                                  │                 │
+│                 │  Rosé Pine Moon           ║                                  │                 │
+│                 │  Everforest               ║                                  │                 │
+│                 │  Kanagawa                 ║                                  │                 │
+│                 │  Solarized Dark           ║                                  │                 │
+│                 │  Monokai                  ║                                  │                 │
+│                 │  Ayu Dark                 ║                                  │                 │
+│                 │  Ayu Mirage               ║                                  │                 │
+│                 │  Material                 ║                                  │                 │
+│                 │  Rosé Pine                ║                                  │                 │
+│                 │  Oxocarbon                ║                                  │                 │
+│                 │  GitHub Dark              ▼                                  │                 │
+╰─────────────────│  theme id: default                                           │                 │
+┌ Automations ────│j/k navigate  PgUp/PgDn page  / filter        Select   Cancel │                 │
+│none             ╰──────────────────────────────────────────────────────────────╯                 │
 └───────────────────────┘└─────────────────────────────────────────────────────────────────────────┘
  Sessions  Help · F1   Info · F2   Files · F3   Theme · F4   Tasks · F5   Settings · F6   Quit · ^Q

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -1194,13 +1194,19 @@ impl App {
 
         // Theme picker modal
         if let super::modals::Modal::ThemePicker(ref tp) = self.modal {
-            return Some(theme_picker_modal::render_theme_picker_modal(
+            let (render, visible_rows) = theme_picker_modal::render_theme_picker_modal(
                 frame,
                 &theme_picker_modal::ThemePickerState {
                     entries: &crate::ui::theme::all_theme_entries(),
+                    matches: &tp.matches,
                     selected_index: tp.index,
+                    filter: tp.filter.as_ref().map(|f| f.value()),
                 },
-            ));
+            );
+            // Feed the rendered list height back so PageUp/PageDown step by
+            // exactly one visible screenful.
+            self.theme_picker_page = visible_rows;
+            return Some(render);
         }
 
         // Settings panel (centered overlay). The field hitboxes ride in the

--- a/src/session/theme_config.rs
+++ b/src/session/theme_config.rs
@@ -112,6 +112,48 @@ pub enum ThemePreset {
     Everforest,
     /// Kanagawa — muted, ink-wash dark palette inspired by Hokusai.
     Kanagawa,
+    /// Solarized Dark — Ethan Schoonover's classic dark palette.
+    SolarizedDark,
+    /// Monokai — the high-saturation classic from Sublime Text.
+    Monokai,
+    /// Ayu Dark — deep navy with warm orange accents.
+    AyuDark,
+    /// Ayu Mirage — Ayu's mid-tone slate variant.
+    AyuMirage,
+    /// Material — the Material Theme "Darker" palette.
+    Material,
+    /// Rosé Pine — the main (dark) Rosé Pine variant.
+    RosePine,
+    /// Oxocarbon — IBM Carbon-derived dark palette.
+    Oxocarbon,
+    /// GitHub Dark — GitHub's own dark interface palette.
+    GithubDark,
+    /// Nightfox — the Nightfox Neovim colourscheme.
+    Nightfox,
+    /// Sonokai — a vivid Monokai Pro descendant.
+    Sonokai,
+    /// Melange — warm, low-saturation dark palette.
+    Melange,
+    /// Zenburn — the low-contrast classic.
+    Zenburn,
+    /// Iceberg — cool bluish dark palette.
+    Iceberg,
+    /// Vesper — near-monochrome dark palette with amber accents.
+    Vesper,
+    /// Synthwave — neon retrowave palette on deep purple.
+    Synthwave,
+    /// Nightfly — dark navy palette with bright accents.
+    Nightfly,
+    /// Tomorrow Night — the Tomorrow theme's dark variant.
+    TomorrowNight,
+    /// Ayu Light — Ayu's cream-background light variant.
+    AyuLight,
+    /// One Light — Atom's light counterpart to One Dark.
+    OneLight,
+    /// Rosé Pine Dawn — Rosé Pine's light variant.
+    RosePineDawn,
+    /// GitHub Light — GitHub's own light interface palette.
+    GithubLight,
 }
 
 impl ThemePreset {
@@ -133,6 +175,27 @@ impl ThemePreset {
             Self::RosePineMoon => "rose-pine-moon",
             Self::Everforest => "everforest",
             Self::Kanagawa => "kanagawa",
+            Self::SolarizedDark => "solarized-dark",
+            Self::Monokai => "monokai",
+            Self::AyuDark => "ayu-dark",
+            Self::AyuMirage => "ayu-mirage",
+            Self::Material => "material",
+            Self::RosePine => "rose-pine",
+            Self::Oxocarbon => "oxocarbon",
+            Self::GithubDark => "github-dark",
+            Self::Nightfox => "nightfox",
+            Self::Sonokai => "sonokai",
+            Self::Melange => "melange",
+            Self::Zenburn => "zenburn",
+            Self::Iceberg => "iceberg",
+            Self::Vesper => "vesper",
+            Self::Synthwave => "synthwave",
+            Self::Nightfly => "nightfly",
+            Self::TomorrowNight => "tomorrow-night",
+            Self::AyuLight => "ayu-light",
+            Self::OneLight => "one-light",
+            Self::RosePineDawn => "rose-pine-dawn",
+            Self::GithubLight => "github-light",
         }
     }
 
@@ -154,6 +217,27 @@ impl ThemePreset {
             Self::RosePineMoon => "Rosé Pine Moon",
             Self::Everforest => "Everforest",
             Self::Kanagawa => "Kanagawa",
+            Self::SolarizedDark => "Solarized Dark",
+            Self::Monokai => "Monokai",
+            Self::AyuDark => "Ayu Dark",
+            Self::AyuMirage => "Ayu Mirage",
+            Self::Material => "Material",
+            Self::RosePine => "Rosé Pine",
+            Self::Oxocarbon => "Oxocarbon",
+            Self::GithubDark => "GitHub Dark",
+            Self::Nightfox => "Nightfox",
+            Self::Sonokai => "Sonokai",
+            Self::Melange => "Melange",
+            Self::Zenburn => "Zenburn",
+            Self::Iceberg => "Iceberg",
+            Self::Vesper => "Vesper",
+            Self::Synthwave => "Synthwave",
+            Self::Nightfly => "Nightfly",
+            Self::TomorrowNight => "Tomorrow Night",
+            Self::AyuLight => "Ayu Light",
+            Self::OneLight => "One Light",
+            Self::RosePineDawn => "Rosé Pine Dawn",
+            Self::GithubLight => "GitHub Light",
         }
     }
 
@@ -175,6 +259,27 @@ impl ThemePreset {
             "rose-pine-moon" => Some(Self::RosePineMoon),
             "everforest" => Some(Self::Everforest),
             "kanagawa" => Some(Self::Kanagawa),
+            "solarized-dark" => Some(Self::SolarizedDark),
+            "monokai" => Some(Self::Monokai),
+            "ayu-dark" => Some(Self::AyuDark),
+            "ayu-mirage" => Some(Self::AyuMirage),
+            "material" => Some(Self::Material),
+            "rose-pine" => Some(Self::RosePine),
+            "oxocarbon" => Some(Self::Oxocarbon),
+            "github-dark" => Some(Self::GithubDark),
+            "nightfox" => Some(Self::Nightfox),
+            "sonokai" => Some(Self::Sonokai),
+            "melange" => Some(Self::Melange),
+            "zenburn" => Some(Self::Zenburn),
+            "iceberg" => Some(Self::Iceberg),
+            "vesper" => Some(Self::Vesper),
+            "synthwave" => Some(Self::Synthwave),
+            "nightfly" => Some(Self::Nightfly),
+            "tomorrow-night" => Some(Self::TomorrowNight),
+            "ayu-light" => Some(Self::AyuLight),
+            "one-light" => Some(Self::OneLight),
+            "rose-pine-dawn" => Some(Self::RosePineDawn),
+            "github-light" => Some(Self::GithubLight),
             _ => None,
         }
     }
@@ -194,10 +299,31 @@ impl ThemePreset {
             Self::RosePineMoon,
             Self::Everforest,
             Self::Kanagawa,
+            Self::SolarizedDark,
+            Self::Monokai,
+            Self::AyuDark,
+            Self::AyuMirage,
+            Self::Material,
+            Self::RosePine,
+            Self::Oxocarbon,
+            Self::GithubDark,
+            Self::Nightfox,
+            Self::Sonokai,
+            Self::Melange,
+            Self::Zenburn,
+            Self::Iceberg,
+            Self::Vesper,
+            Self::Synthwave,
+            Self::Nightfly,
+            Self::TomorrowNight,
             Self::CatppuccinLatte,
             Self::TokyoNightDay,
             Self::GruvboxLight,
             Self::SolarizedLight,
+            Self::AyuLight,
+            Self::OneLight,
+            Self::RosePineDawn,
+            Self::GithubLight,
         ]
     }
 
@@ -219,6 +345,27 @@ impl ThemePreset {
             Self::RosePineMoon => rose_pine_moon_palette(),
             Self::Everforest => everforest_palette(),
             Self::Kanagawa => kanagawa_palette(),
+            Self::SolarizedDark => solarized_dark_palette(),
+            Self::Monokai => monokai_palette(),
+            Self::AyuDark => ayu_dark_palette(),
+            Self::AyuMirage => ayu_mirage_palette(),
+            Self::Material => material_palette(),
+            Self::RosePine => rose_pine_palette(),
+            Self::Oxocarbon => oxocarbon_palette(),
+            Self::GithubDark => github_dark_palette(),
+            Self::Nightfox => nightfox_palette(),
+            Self::Sonokai => sonokai_palette(),
+            Self::Melange => melange_palette(),
+            Self::Zenburn => zenburn_palette(),
+            Self::Iceberg => iceberg_palette(),
+            Self::Vesper => vesper_palette(),
+            Self::Synthwave => synthwave_palette(),
+            Self::Nightfly => nightfly_palette(),
+            Self::TomorrowNight => tomorrow_night_palette(),
+            Self::AyuLight => ayu_light_palette(),
+            Self::OneLight => one_light_palette(),
+            Self::RosePineDawn => rose_pine_dawn_palette(),
+            Self::GithubLight => github_light_palette(),
         }
     }
 
@@ -227,7 +374,14 @@ impl ThemePreset {
     pub fn is_light(self) -> bool {
         matches!(
             self,
-            Self::CatppuccinLatte | Self::TokyoNightDay | Self::GruvboxLight | Self::SolarizedLight
+            Self::CatppuccinLatte
+                | Self::TokyoNightDay
+                | Self::GruvboxLight
+                | Self::SolarizedLight
+                | Self::AyuLight
+                | Self::OneLight
+                | Self::RosePineDawn
+                | Self::GithubLight
         )
     }
 }
@@ -940,6 +1094,10 @@ fn doom_palette() -> ThemePalette {
     let bright_red = Color::Rgb(0xFF, 0x5C, 0x54);
     let bright_green = Color::Rgb(0x6E, 0xFF, 0x6E);
     let cyan = Color::Rgb(0x00, 0xD9, 0xFF);
+    // Hellfire amber, not `red`: the yellow slot drives `status_working`, and
+    // reusing red there made a working session indistinguishable from a
+    // blocked one (both `status_blocked` and `status_error` are red).
+    let amber = Color::Rgb(0xFF, 0xA5, 0x00);
     let text = Color::Rgb(0xE0, 0xE0, 0xE0);
     let subtext = Color::Rgb(0xA0, 0xA0, 0xA0);
     let muted = Color::Rgb(0x60, 0x60, 0x60);
@@ -950,7 +1108,7 @@ fn doom_palette() -> ThemePalette {
         accent: bright_red,
         accent_bright: bright_green,
         green: bright_green,
-        yellow: red,
+        yellow: amber,
         red,
         blue: cyan,
         text_primary: text,
@@ -960,7 +1118,7 @@ fn doom_palette() -> ThemePalette {
         role_name: bright_red,
         branch_name: bright_green,
         search_bar: cyan,
-        keybind_hint: red,
+        keybind_hint: amber,
         selection_bg: highlight,
         selection_fg: bright_green,
         modal_dim_bg: bg_dark,
@@ -1205,6 +1363,816 @@ fn kanagawa_palette() -> ThemePalette {
     .build()
 }
 
+fn solarized_dark_palette() -> ThemePalette {
+    let yellow = Color::Rgb(0xB5, 0x89, 0x00);
+    let orange = Color::Rgb(0xCB, 0x4B, 0x16);
+    let red = Color::Rgb(0xDC, 0x32, 0x2F);
+    let magenta = Color::Rgb(0xD3, 0x36, 0x82);
+    let violet = Color::Rgb(0x6C, 0x71, 0xC4);
+    let blue = Color::Rgb(0x26, 0x8B, 0xD2);
+    let cyan = Color::Rgb(0x2A, 0xA1, 0x98);
+    let green = Color::Rgb(0x85, 0x99, 0x00);
+    let base03 = Color::Rgb(0x00, 0x2B, 0x36);
+    let base02 = Color::Rgb(0x07, 0x36, 0x42);
+    let base01 = Color::Rgb(0x58, 0x6E, 0x75);
+    let base0 = Color::Rgb(0x83, 0x94, 0x96);
+    let base1 = Color::Rgb(0x93, 0xA1, 0xA1);
+    PaletteSlots {
+        // Cyan accent keeps Solarized Dark distinct from Solarized Light,
+        // which takes the blue.
+        accent: cyan,
+        accent_bright: blue,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: base1,
+        text_secondary: base0,
+        text_muted: base01,
+        border_unfocused: base02,
+        role_name: magenta,
+        branch_name: green,
+        search_bar: violet,
+        keybind_hint: orange,
+        selection_bg: base02,
+        selection_fg: base1,
+        modal_dim_bg: base03,
+        modal_bg: base02,
+        modal_border: cyan,
+        base_bg: base03,
+    }
+    .build()
+}
+
+fn monokai_palette() -> ThemePalette {
+    let pink = Color::Rgb(0xF9, 0x26, 0x72);
+    let green = Color::Rgb(0xA6, 0xE2, 0x2E);
+    let yellow = Color::Rgb(0xE6, 0xDB, 0x74);
+    let orange = Color::Rgb(0xFD, 0x97, 0x1F);
+    let purple = Color::Rgb(0xAE, 0x81, 0xFF);
+    let cyan = Color::Rgb(0x66, 0xD9, 0xEF);
+    let fg = Color::Rgb(0xF8, 0xF8, 0xF2);
+    let fg_dim = Color::Rgb(0xCF, 0xCF, 0xC2);
+    let comment = Color::Rgb(0x75, 0x71, 0x5E);
+    let bg_light = Color::Rgb(0x3E, 0x3D, 0x32);
+    let bg = Color::Rgb(0x27, 0x28, 0x22);
+    let bg_dark = Color::Rgb(0x1D, 0x1E, 0x19);
+    PaletteSlots {
+        accent: pink,
+        accent_bright: orange,
+        green,
+        yellow,
+        red: pink,
+        blue: cyan,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: comment,
+        border_unfocused: bg_light,
+        role_name: purple,
+        branch_name: green,
+        search_bar: cyan,
+        keybind_hint: yellow,
+        selection_bg: bg_light,
+        selection_fg: fg,
+        modal_dim_bg: bg_dark,
+        modal_bg: bg_light,
+        modal_border: pink,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn ayu_dark_palette() -> ThemePalette {
+    let orange = Color::Rgb(0xFF, 0xB4, 0x54);
+    let amber = Color::Rgb(0xE6, 0xB4, 0x50);
+    let green = Color::Rgb(0xAA, 0xD9, 0x4C);
+    let red = Color::Rgb(0xF0, 0x71, 0x78);
+    let blue = Color::Rgb(0x59, 0xC2, 0xFF);
+    let purple = Color::Rgb(0xD2, 0xA6, 0xFF);
+    let fg = Color::Rgb(0xBF, 0xBD, 0xB6);
+    let fg_dim = Color::Rgb(0x9B, 0x99, 0x93);
+    let muted = Color::Rgb(0x5C, 0x61, 0x66);
+    let panel = Color::Rgb(0x1F, 0x24, 0x30);
+    let line = Color::Rgb(0x25, 0x2B, 0x38);
+    let bg = Color::Rgb(0x0B, 0x0E, 0x14);
+    PaletteSlots {
+        accent: orange,
+        accent_bright: amber,
+        green,
+        yellow: amber,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: line,
+        role_name: purple,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: amber,
+        selection_bg: line,
+        selection_fg: fg,
+        modal_dim_bg: bg,
+        modal_bg: panel,
+        modal_border: orange,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn ayu_mirage_palette() -> ThemePalette {
+    let orange = Color::Rgb(0xFF, 0xCC, 0x66);
+    let amber = Color::Rgb(0xFF, 0xD1, 0x73);
+    let green = Color::Rgb(0xD5, 0xFF, 0x80);
+    let red = Color::Rgb(0xF2, 0x87, 0x79);
+    let blue = Color::Rgb(0x73, 0xD0, 0xFF);
+    let purple = Color::Rgb(0xDF, 0xBF, 0xFF);
+    let fg = Color::Rgb(0xCC, 0xCA, 0xC2);
+    let fg_dim = Color::Rgb(0xA6, 0xAC, 0xB9);
+    let muted = Color::Rgb(0x70, 0x76, 0x84);
+    let panel = Color::Rgb(0x1F, 0x24, 0x30);
+    let line = Color::Rgb(0x2D, 0x34, 0x40);
+    let bg = Color::Rgb(0x24, 0x29, 0x36);
+    PaletteSlots {
+        accent: amber,
+        accent_bright: green,
+        green,
+        yellow: orange,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: line,
+        role_name: purple,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: orange,
+        selection_bg: line,
+        selection_fg: fg,
+        modal_dim_bg: panel,
+        modal_bg: line,
+        modal_border: amber,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn material_palette() -> ThemePalette {
+    let cyan = Color::Rgb(0x89, 0xDD, 0xFF);
+    let teal = Color::Rgb(0x80, 0xCB, 0xC4);
+    let green = Color::Rgb(0xC3, 0xE8, 0x8D);
+    let yellow = Color::Rgb(0xFF, 0xCB, 0x6B);
+    let red = Color::Rgb(0xF0, 0x71, 0x78);
+    let blue = Color::Rgb(0x82, 0xAA, 0xFF);
+    let purple = Color::Rgb(0xC7, 0x92, 0xEA);
+    let fg = Color::Rgb(0xEE, 0xFF, 0xFF);
+    let fg_dim = Color::Rgb(0xB2, 0xCC, 0xD6);
+    let comment = Color::Rgb(0x54, 0x6E, 0x7A);
+    let line = Color::Rgb(0x31, 0x36, 0x3B);
+    let surface = Color::Rgb(0x26, 0x2A, 0x2E);
+    let bg = Color::Rgb(0x21, 0x25, 0x29);
+    PaletteSlots {
+        accent: teal,
+        accent_bright: cyan,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: comment,
+        border_unfocused: line,
+        role_name: purple,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: yellow,
+        selection_bg: line,
+        selection_fg: fg,
+        modal_dim_bg: bg,
+        modal_bg: surface,
+        modal_border: teal,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn rose_pine_palette() -> ThemePalette {
+    let iris = Color::Rgb(0xC4, 0xA7, 0xE7);
+    let rose = Color::Rgb(0xEB, 0xBC, 0xBA);
+    let foam = Color::Rgb(0x9C, 0xCF, 0xD8);
+    let gold = Color::Rgb(0xF6, 0xC1, 0x77);
+    let love = Color::Rgb(0xEB, 0x6F, 0x92);
+    let pine = Color::Rgb(0x31, 0x74, 0x8F);
+    let text = Color::Rgb(0xE0, 0xDE, 0xF4);
+    let subtle = Color::Rgb(0x90, 0x8C, 0xAA);
+    let muted = Color::Rgb(0x6E, 0x6A, 0x86);
+    let highlight_med = Color::Rgb(0x40, 0x3D, 0x52);
+    let surface = Color::Rgb(0x1F, 0x1D, 0x2E);
+    let base = Color::Rgb(0x19, 0x17, 0x24);
+    PaletteSlots {
+        // The Moon variant already takes iris; use rose here so the two
+        // Rosé Pine flavours read differently in the picker swatch.
+        accent: rose,
+        accent_bright: iris,
+        green: foam,
+        yellow: gold,
+        red: love,
+        blue: pine,
+        text_primary: text,
+        text_secondary: subtle,
+        text_muted: muted,
+        border_unfocused: highlight_med,
+        role_name: iris,
+        branch_name: foam,
+        search_bar: pine,
+        keybind_hint: gold,
+        selection_bg: highlight_med,
+        selection_fg: text,
+        modal_dim_bg: base,
+        modal_bg: surface,
+        modal_border: rose,
+        base_bg: base,
+    }
+    .build()
+}
+
+fn oxocarbon_palette() -> ThemePalette {
+    let cyan = Color::Rgb(0x3D, 0xDB, 0xD9);
+    let blue = Color::Rgb(0x78, 0xA9, 0xFF);
+    let purple = Color::Rgb(0xBE, 0x95, 0xFF);
+    let magenta = Color::Rgb(0xFF, 0x7E, 0xB6);
+    let green = Color::Rgb(0x42, 0xBE, 0x65);
+    let yellow = Color::Rgb(0xFF, 0xE9, 0x7C);
+    let red = Color::Rgb(0xEE, 0x53, 0x96);
+    let fg = Color::Rgb(0xF2, 0xF4, 0xF8);
+    let fg_dim = Color::Rgb(0xC6, 0xC6, 0xC6);
+    let muted = Color::Rgb(0x6F, 0x6F, 0x6F);
+    let gray80 = Color::Rgb(0x39, 0x39, 0x39);
+    let gray90 = Color::Rgb(0x26, 0x26, 0x26);
+    let gray100 = Color::Rgb(0x16, 0x16, 0x16);
+    PaletteSlots {
+        accent: cyan,
+        accent_bright: magenta,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: gray80,
+        role_name: purple,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: yellow,
+        selection_bg: gray80,
+        selection_fg: fg,
+        modal_dim_bg: gray100,
+        modal_bg: gray90,
+        modal_border: cyan,
+        base_bg: gray100,
+    }
+    .build()
+}
+
+fn github_dark_palette() -> ThemePalette {
+    let blue = Color::Rgb(0x58, 0xA6, 0xFF);
+    let cyan = Color::Rgb(0x76, 0xE3, 0xEA);
+    let green = Color::Rgb(0x3F, 0xB9, 0x50);
+    let yellow = Color::Rgb(0xD2, 0x99, 0x22);
+    let red = Color::Rgb(0xF8, 0x51, 0x49);
+    let purple = Color::Rgb(0xBC, 0x8C, 0xFF);
+    let fg = Color::Rgb(0xC9, 0xD1, 0xD9);
+    let fg_dim = Color::Rgb(0xB1, 0xBA, 0xC4);
+    let muted = Color::Rgb(0x6E, 0x76, 0x81);
+    let border = Color::Rgb(0x30, 0x36, 0x3D);
+    let canvas_subtle = Color::Rgb(0x16, 0x1B, 0x22);
+    let canvas = Color::Rgb(0x0D, 0x11, 0x17);
+    PaletteSlots {
+        accent: blue,
+        accent_bright: cyan,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: border,
+        role_name: purple,
+        branch_name: green,
+        search_bar: cyan,
+        keybind_hint: yellow,
+        selection_bg: border,
+        selection_fg: fg,
+        modal_dim_bg: canvas,
+        modal_bg: canvas_subtle,
+        modal_border: blue,
+        base_bg: canvas,
+    }
+    .build()
+}
+
+fn nightfox_palette() -> ThemePalette {
+    let blue = Color::Rgb(0x71, 0x9C, 0xD6);
+    let cyan = Color::Rgb(0x63, 0xCD, 0xCF);
+    let green = Color::Rgb(0x81, 0xB2, 0x9A);
+    let yellow = Color::Rgb(0xDB, 0xC0, 0x74);
+    let red = Color::Rgb(0xC9, 0x4F, 0x6D);
+    let magenta = Color::Rgb(0x9D, 0x79, 0xD6);
+    let fg = Color::Rgb(0xCD, 0xCE, 0xCF);
+    let fg_dim = Color::Rgb(0xAE, 0xAF, 0xB0);
+    let muted = Color::Rgb(0x73, 0x82, 0x91);
+    let sel = Color::Rgb(0x2B, 0x3B, 0x51);
+    let bg1 = Color::Rgb(0x19, 0x24, 0x30);
+    let bg0 = Color::Rgb(0x13, 0x1A, 0x24);
+    PaletteSlots {
+        accent: cyan,
+        accent_bright: blue,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: sel,
+        role_name: magenta,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: yellow,
+        selection_bg: sel,
+        selection_fg: fg,
+        modal_dim_bg: bg0,
+        modal_bg: bg1,
+        modal_border: cyan,
+        base_bg: bg0,
+    }
+    .build()
+}
+
+fn sonokai_palette() -> ThemePalette {
+    let red = Color::Rgb(0xFC, 0x5D, 0x7C);
+    let orange = Color::Rgb(0xF3, 0x96, 0x60);
+    let yellow = Color::Rgb(0xE7, 0xC6, 0x64);
+    let green = Color::Rgb(0x9E, 0xD0, 0x72);
+    let blue = Color::Rgb(0x76, 0xCC, 0xE0);
+    let purple = Color::Rgb(0xB3, 0x9D, 0xF3);
+    let fg = Color::Rgb(0xE2, 0xE2, 0xE3);
+    let fg_dim = Color::Rgb(0xC1, 0xC1, 0xC3);
+    let grey = Color::Rgb(0x7F, 0x84, 0x90);
+    let bg4 = Color::Rgb(0x3B, 0x3E, 0x48);
+    let bg2 = Color::Rgb(0x33, 0x35, 0x3F);
+    let bg0 = Color::Rgb(0x2C, 0x2E, 0x34);
+    PaletteSlots {
+        accent: orange,
+        accent_bright: yellow,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: grey,
+        border_unfocused: bg4,
+        role_name: purple,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: yellow,
+        selection_bg: bg4,
+        selection_fg: fg,
+        modal_dim_bg: bg0,
+        modal_bg: bg2,
+        modal_border: orange,
+        base_bg: bg0,
+    }
+    .build()
+}
+
+fn melange_palette() -> ThemePalette {
+    let tan = Color::Rgb(0xEB, 0xC0, 0x6D);
+    let peach = Color::Rgb(0xD4, 0x77, 0x66);
+    let green = Color::Rgb(0x85, 0xB6, 0x95);
+    let yellow = Color::Rgb(0xEB, 0xC0, 0x6D);
+    let red = Color::Rgb(0xD4, 0x73, 0x66);
+    let blue = Color::Rgb(0xA3, 0xA9, 0xCE);
+    let purple = Color::Rgb(0xCF, 0x9B, 0xC2);
+    let fg = Color::Rgb(0xEC, 0xE1, 0xD7);
+    let fg_dim = Color::Rgb(0xC1, 0xB2, 0xA4);
+    let muted = Color::Rgb(0x86, 0x78, 0x6D);
+    let sel = Color::Rgb(0x40, 0x36, 0x30);
+    let surface = Color::Rgb(0x33, 0x2C, 0x28);
+    let bg = Color::Rgb(0x29, 0x24, 0x22);
+    PaletteSlots {
+        accent: tan,
+        accent_bright: peach,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: sel,
+        role_name: purple,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: peach,
+        selection_bg: sel,
+        selection_fg: fg,
+        modal_dim_bg: bg,
+        modal_bg: surface,
+        modal_border: tan,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn zenburn_palette() -> ThemePalette {
+    let sand = Color::Rgb(0xF0, 0xDF, 0xAF);
+    let orange = Color::Rgb(0xDF, 0xAF, 0x8F);
+    let green = Color::Rgb(0x7F, 0x9F, 0x7F);
+    let yellow = Color::Rgb(0xE3, 0xCE, 0xAB);
+    let red = Color::Rgb(0xCC, 0x93, 0x93);
+    let blue = Color::Rgb(0x8C, 0xD0, 0xD3);
+    let purple = Color::Rgb(0xDC, 0x8C, 0xC3);
+    let fg = Color::Rgb(0xDC, 0xDC, 0xCC);
+    let fg_dim = Color::Rgb(0xC0, 0xC0, 0xB0);
+    let muted = Color::Rgb(0x70, 0x80, 0x70);
+    let bg_plus2 = Color::Rgb(0x4F, 0x4F, 0x4F);
+    let bg_plus1 = Color::Rgb(0x40, 0x40, 0x40);
+    let bg = Color::Rgb(0x3F, 0x3F, 0x3F);
+    let bg_minus = Color::Rgb(0x2B, 0x2B, 0x2B);
+    PaletteSlots {
+        accent: sand,
+        accent_bright: orange,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: bg_plus2,
+        role_name: purple,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: yellow,
+        selection_bg: bg_plus2,
+        selection_fg: fg,
+        modal_dim_bg: bg_minus,
+        modal_bg: bg_plus1,
+        modal_border: sand,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn iceberg_palette() -> ThemePalette {
+    let blue = Color::Rgb(0x84, 0xA0, 0xC6);
+    let cyan = Color::Rgb(0x89, 0xB8, 0xC2);
+    let green = Color::Rgb(0xB4, 0xBE, 0x82);
+    let yellow = Color::Rgb(0xE2, 0xA4, 0x78);
+    let red = Color::Rgb(0xE2, 0x78, 0x78);
+    let purple = Color::Rgb(0xA0, 0x93, 0xC7);
+    let fg = Color::Rgb(0xC6, 0xC8, 0xD1);
+    let fg_dim = Color::Rgb(0xAD, 0xB1, 0xC4);
+    let muted = Color::Rgb(0x6B, 0x70, 0x89);
+    let line = Color::Rgb(0x3E, 0x44, 0x51);
+    let surface = Color::Rgb(0x1E, 0x21, 0x32);
+    let bg = Color::Rgb(0x16, 0x18, 0x21);
+    PaletteSlots {
+        accent: blue,
+        accent_bright: cyan,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: line,
+        role_name: purple,
+        branch_name: green,
+        search_bar: cyan,
+        keybind_hint: yellow,
+        selection_bg: line,
+        selection_fg: fg,
+        modal_dim_bg: bg,
+        modal_bg: surface,
+        modal_border: blue,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn vesper_palette() -> ThemePalette {
+    let amber = Color::Rgb(0xFF, 0xC7, 0x7B);
+    let peach = Color::Rgb(0xFF, 0xA8, 0x5C);
+    let green = Color::Rgb(0x99, 0xFF, 0xE4);
+    let yellow = Color::Rgb(0xFF, 0xCF, 0xA8);
+    let red = Color::Rgb(0xFF, 0x80, 0x80);
+    let blue = Color::Rgb(0xA0, 0xA0, 0xA0);
+    let fg = Color::Rgb(0xFF, 0xFF, 0xFF);
+    let fg_dim = Color::Rgb(0xA0, 0xA0, 0xA0);
+    let muted = Color::Rgb(0x50, 0x50, 0x50);
+    let line = Color::Rgb(0x2A, 0x2A, 0x2A);
+    let surface = Color::Rgb(0x18, 0x18, 0x18);
+    let bg = Color::Rgb(0x10, 0x10, 0x10);
+    PaletteSlots {
+        accent: amber,
+        accent_bright: peach,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: line,
+        role_name: peach,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: yellow,
+        selection_bg: line,
+        selection_fg: fg,
+        modal_dim_bg: bg,
+        modal_bg: surface,
+        modal_border: amber,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn synthwave_palette() -> ThemePalette {
+    let magenta = Color::Rgb(0xFF, 0x7E, 0xDB);
+    let cyan = Color::Rgb(0x36, 0xF9, 0xF6);
+    let green = Color::Rgb(0x72, 0xF1, 0xB8);
+    let yellow = Color::Rgb(0xFE, 0xDE, 0x5D);
+    let red = Color::Rgb(0xFE, 0x44, 0x50);
+    let orange = Color::Rgb(0xFF, 0x8B, 0x39);
+    let fg = Color::Rgb(0xF9, 0xF9, 0xF9);
+    let fg_dim = Color::Rgb(0xD3, 0xC5, 0xE8);
+    let muted = Color::Rgb(0x84, 0x8B, 0xBD);
+    let line = Color::Rgb(0x34, 0x29, 0x4F);
+    let surface = Color::Rgb(0x26, 0x1E, 0x3C);
+    let bg = Color::Rgb(0x26, 0x22, 0x35);
+    PaletteSlots {
+        accent: magenta,
+        accent_bright: cyan,
+        green,
+        yellow,
+        red,
+        blue: cyan,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: line,
+        role_name: orange,
+        branch_name: green,
+        search_bar: cyan,
+        keybind_hint: yellow,
+        selection_bg: line,
+        selection_fg: fg,
+        modal_dim_bg: surface,
+        modal_bg: line,
+        modal_border: magenta,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn nightfly_palette() -> ThemePalette {
+    let blue = Color::Rgb(0x82, 0xAA, 0xFF);
+    let cyan = Color::Rgb(0x7F, 0xDB, 0xCA);
+    let green = Color::Rgb(0xA1, 0xCD, 0x5E);
+    let yellow = Color::Rgb(0xE3, 0xD1, 0x8A);
+    let red = Color::Rgb(0xFC, 0x51, 0x4E);
+    let purple = Color::Rgb(0xAE, 0x81, 0xFF);
+    let fg = Color::Rgb(0xBD, 0xC1, 0xC6);
+    let fg_dim = Color::Rgb(0xA1, 0xAA, 0xB8);
+    let muted = Color::Rgb(0x63, 0x6D, 0x83);
+    let line = Color::Rgb(0x2F, 0x3B, 0x54);
+    let surface = Color::Rgb(0x1D, 0x30, 0x43);
+    let bg = Color::Rgb(0x01, 0x16, 0x27);
+    PaletteSlots {
+        accent: cyan,
+        accent_bright: blue,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: line,
+        role_name: purple,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: yellow,
+        selection_bg: line,
+        selection_fg: fg,
+        modal_dim_bg: bg,
+        modal_bg: surface,
+        modal_border: cyan,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn tomorrow_night_palette() -> ThemePalette {
+    let blue = Color::Rgb(0x81, 0xA2, 0xBE);
+    let aqua = Color::Rgb(0x8A, 0xBE, 0xB7);
+    let green = Color::Rgb(0xB5, 0xBD, 0x68);
+    let yellow = Color::Rgb(0xF0, 0xC6, 0x74);
+    let red = Color::Rgb(0xCC, 0x66, 0x66);
+    let purple = Color::Rgb(0xB2, 0x94, 0xBB);
+    let orange = Color::Rgb(0xDE, 0x93, 0x5F);
+    let fg = Color::Rgb(0xC5, 0xC8, 0xC6);
+    let fg_dim = Color::Rgb(0xB4, 0xB7, 0xB4);
+    let comment = Color::Rgb(0x96, 0x98, 0x96);
+    let line = Color::Rgb(0x37, 0x3B, 0x41);
+    let surface = Color::Rgb(0x28, 0x2A, 0x2E);
+    let bg = Color::Rgb(0x1D, 0x1F, 0x21);
+    PaletteSlots {
+        accent: blue,
+        accent_bright: aqua,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: comment,
+        border_unfocused: line,
+        role_name: purple,
+        branch_name: green,
+        search_bar: aqua,
+        keybind_hint: orange,
+        selection_bg: line,
+        selection_fg: fg,
+        modal_dim_bg: bg,
+        modal_bg: surface,
+        modal_border: blue,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn ayu_light_palette() -> ThemePalette {
+    let orange = Color::Rgb(0xFA, 0x8D, 0x3E);
+    let amber = Color::Rgb(0xE6, 0xBA, 0x7E);
+    let green = Color::Rgb(0x6C, 0xA3, 0x00);
+    let yellow = Color::Rgb(0xA3, 0x71, 0x00);
+    let red = Color::Rgb(0xF0, 0x71, 0x71);
+    let blue = Color::Rgb(0x39, 0x9E, 0xE6);
+    let purple = Color::Rgb(0xA3, 0x7A, 0xCC);
+    let fg = Color::Rgb(0x5C, 0x61, 0x66);
+    let fg_dim = Color::Rgb(0x78, 0x7B, 0x80);
+    let muted = Color::Rgb(0x8A, 0x91, 0x99);
+    let line = Color::Rgb(0xE7, 0xE8, 0xE9);
+    let panel = Color::Rgb(0xF3, 0xF4, 0xF5);
+    let bg = Color::Rgb(0xFC, 0xFC, 0xFC);
+    PaletteSlots {
+        accent: orange,
+        accent_bright: amber,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: line,
+        role_name: purple,
+        branch_name: green,
+        search_bar: blue,
+        keybind_hint: yellow,
+        selection_bg: line,
+        selection_fg: fg,
+        modal_dim_bg: panel,
+        modal_bg: bg,
+        modal_border: orange,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn one_light_palette() -> ThemePalette {
+    let blue = Color::Rgb(0x40, 0x78, 0xF2);
+    let cyan = Color::Rgb(0x01, 0x84, 0xBC);
+    let green = Color::Rgb(0x50, 0xA1, 0x4F);
+    let yellow = Color::Rgb(0xC1, 0x84, 0x01);
+    let red = Color::Rgb(0xE4, 0x56, 0x49);
+    let purple = Color::Rgb(0xA6, 0x26, 0xA4);
+    let fg = Color::Rgb(0x38, 0x3A, 0x42);
+    let fg_dim = Color::Rgb(0x50, 0x53, 0x5C);
+    let muted = Color::Rgb(0x9D, 0xA5, 0xB4);
+    let line = Color::Rgb(0xE5, 0xE5, 0xE6);
+    let panel = Color::Rgb(0xEA, 0xEA, 0xEB);
+    let bg = Color::Rgb(0xFA, 0xFA, 0xFA);
+    PaletteSlots {
+        accent: blue,
+        accent_bright: cyan,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: line,
+        role_name: purple,
+        branch_name: green,
+        search_bar: cyan,
+        keybind_hint: yellow,
+        selection_bg: line,
+        selection_fg: fg,
+        modal_dim_bg: panel,
+        modal_bg: bg,
+        modal_border: blue,
+        base_bg: bg,
+    }
+    .build()
+}
+
+fn rose_pine_dawn_palette() -> ThemePalette {
+    let iris = Color::Rgb(0x90, 0x7A, 0xA9);
+    let rose = Color::Rgb(0xD7, 0x82, 0x7E);
+    let foam = Color::Rgb(0x56, 0x94, 0x9F);
+    let gold = Color::Rgb(0xEA, 0x9D, 0x34);
+    let love = Color::Rgb(0xB4, 0x63, 0x7A);
+    let pine = Color::Rgb(0x28, 0x69, 0x83);
+    let text = Color::Rgb(0x57, 0x52, 0x79);
+    let subtle = Color::Rgb(0x79, 0x75, 0x93);
+    let muted = Color::Rgb(0x98, 0x93, 0xA5);
+    let highlight_med = Color::Rgb(0xDF, 0xDA, 0xD9);
+    let surface = Color::Rgb(0xFF, 0xFA, 0xF3);
+    let base = Color::Rgb(0xFA, 0xF4, 0xED);
+    PaletteSlots {
+        accent: iris,
+        accent_bright: rose,
+        green: foam,
+        yellow: gold,
+        red: love,
+        blue: pine,
+        text_primary: text,
+        text_secondary: subtle,
+        text_muted: muted,
+        border_unfocused: highlight_med,
+        role_name: iris,
+        branch_name: foam,
+        search_bar: pine,
+        keybind_hint: gold,
+        selection_bg: highlight_med,
+        selection_fg: text,
+        modal_dim_bg: highlight_med,
+        modal_bg: surface,
+        modal_border: iris,
+        base_bg: base,
+    }
+    .build()
+}
+
+fn github_light_palette() -> ThemePalette {
+    let blue = Color::Rgb(0x09, 0x69, 0xDA);
+    let cyan = Color::Rgb(0x1B, 0x7C, 0x83);
+    let green = Color::Rgb(0x1A, 0x7F, 0x37);
+    let yellow = Color::Rgb(0x95, 0x6C, 0x05);
+    let red = Color::Rgb(0xCF, 0x22, 0x2E);
+    let purple = Color::Rgb(0x82, 0x50, 0xDF);
+    let fg = Color::Rgb(0x1F, 0x23, 0x28);
+    let fg_dim = Color::Rgb(0x42, 0x4A, 0x53);
+    let muted = Color::Rgb(0x6E, 0x77, 0x81);
+    let border = Color::Rgb(0xD0, 0xD7, 0xDE);
+    let canvas_subtle = Color::Rgb(0xF6, 0xF8, 0xFA);
+    let canvas = Color::Rgb(0xFF, 0xFF, 0xFF);
+    PaletteSlots {
+        accent: blue,
+        accent_bright: cyan,
+        green,
+        yellow,
+        red,
+        blue,
+        text_primary: fg,
+        text_secondary: fg_dim,
+        text_muted: muted,
+        border_unfocused: border,
+        role_name: purple,
+        branch_name: green,
+        search_bar: cyan,
+        keybind_hint: yellow,
+        selection_bg: border,
+        selection_fg: fg,
+        modal_dim_bg: canvas_subtle,
+        modal_bg: canvas,
+        modal_border: blue,
+        base_bg: canvas,
+    }
+    .build()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1271,9 +2239,30 @@ mod tests {
                 ThemePreset::RosePineMoon => 0,
                 ThemePreset::Everforest => 0,
                 ThemePreset::Kanagawa => 0,
+                ThemePreset::SolarizedDark => 0,
+                ThemePreset::Monokai => 0,
+                ThemePreset::AyuDark => 0,
+                ThemePreset::AyuMirage => 0,
+                ThemePreset::Material => 0,
+                ThemePreset::RosePine => 0,
+                ThemePreset::Oxocarbon => 0,
+                ThemePreset::GithubDark => 0,
+                ThemePreset::Nightfox => 0,
+                ThemePreset::Sonokai => 0,
+                ThemePreset::Melange => 0,
+                ThemePreset::Zenburn => 0,
+                ThemePreset::Iceberg => 0,
+                ThemePreset::Vesper => 0,
+                ThemePreset::Synthwave => 0,
+                ThemePreset::Nightfly => 0,
+                ThemePreset::TomorrowNight => 0,
+                ThemePreset::AyuLight => 0,
+                ThemePreset::OneLight => 0,
+                ThemePreset::RosePineDawn => 0,
+                ThemePreset::GithubLight => 0,
             }
         }
-        const EXPECTED: usize = 15;
+        const EXPECTED: usize = 36;
         assert_eq!(ThemePreset::all().len(), EXPECTED);
         for p in ThemePreset::all() {
             classify(*p);
@@ -1348,5 +2337,72 @@ mod tests {
         let (entry, warnings) = def.resolve();
         assert!(warnings.is_empty());
         assert_eq!(entry.palette.diff_added, Color::Rgb(0, 0xff, 0));
+    }
+
+    #[test]
+    fn every_preset_distinguishes_its_semantic_slots() {
+        // Cross-preset coherence: a copy-paste slip while adding a palette
+        // (leaving accent == accent_bright, or a status trio collapsed onto one
+        // colour) makes the UI read as broken rather than themed. Assert the
+        // pairs that must stay visually distinct in *every* preset.
+        for preset in ThemePreset::all() {
+            let p = preset.palette();
+            assert_ne!(
+                p.accent, p.accent_bright,
+                "{preset:?}: accent and accent_bright must differ"
+            );
+            assert_ne!(
+                p.status_working, p.status_blocked,
+                "{preset:?}: working and blocked must be tellable apart"
+            );
+            assert_ne!(
+                p.status_done, p.status_idle,
+                "{preset:?}: done and idle are the done-vs-seen pair"
+            );
+            assert_ne!(
+                p.text_primary, p.text_muted,
+                "{preset:?}: primary and muted text must differ"
+            );
+            // The palette must actually contrast with its own background.
+            assert_ne!(
+                p.text_primary, p.app_bg,
+                "{preset:?}: primary text is invisible on the app background"
+            );
+            assert_ne!(
+                p.selection_fg, p.selection_bg,
+                "{preset:?}: selected text is invisible on the selection band"
+            );
+        }
+    }
+
+    #[test]
+    fn light_presets_are_light_and_dark_presets_are_dark() {
+        // `is_light` drives the picker's Dark/Light sections, so it must agree
+        // with the palette's actual background luminance — a mislabeled preset
+        // would sort into the wrong section and break the ordering invariant
+        // `dark_presets_precede_light_presets_in_all` relies on.
+        fn luminance(c: Color) -> Option<f32> {
+            match c {
+                // Rec. 601 luma, good enough to separate light from dark bg.
+                Color::Rgb(r, g, b) => Some(0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32),
+                _ => None,
+            }
+        }
+        for preset in ThemePreset::all() {
+            let Some(luma) = luminance(preset.palette().app_bg) else {
+                continue; // the Default preset keeps app_bg = Reset
+            };
+            if preset.is_light() {
+                assert!(
+                    luma > 128.0,
+                    "{preset:?} is marked light but its background is dark (luma {luma:.0})"
+                );
+            } else {
+                assert!(
+                    luma < 128.0,
+                    "{preset:?} is marked dark but its background is light (luma {luma:.0})"
+                );
+            }
+        }
     }
 }

--- a/src/ui/theme_picker_modal.rs
+++ b/src/ui/theme_picker_modal.rs
@@ -1,11 +1,20 @@
 //! Modal that lets the user pick a theme (built-in preset or custom).
 //!
-//! Renders the preset list on the left and a small live colour swatch for
+//! Renders a filterable preset list on the left and a live colour swatch for
 //! the highlighted preset on the right, so users can preview the palette
 //! before committing.
+//!
+//! The list is long — 30+ built-ins plus any custom themes from `themes.toml`
+//! — so the modal is sized to most of the frame, groups entries under `Dark` /
+//! `Light` headers, and can be narrowed by a query. The query lives behind `/`
+//! (a sub-mode, like the file viewer's find) so `j`/`k` keep selecting as in
+//! every other picker; `filter: None` is navigation mode. Headers are
+//! *rendered* decoration only: they are drawn inside the same rows the entries
+//! occupy, so selection indices, hitboxes, and the scrollbar all stay in plain
+//! entry space (see `build_rows`).
 
 use ratatui::{
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Rect},
     style::Style,
     text::{Line, Span},
     widgets::Paragraph,
@@ -13,103 +22,448 @@ use ratatui::{
 };
 
 use super::{
-    centered_fixed_height_rect, render_modal_frame, render_selector_footer, render_selector_rows,
-    selector_line, theme::Theme,
+    centered_fixed_height_rect, render_modal_frame, scrollbar, selector_line, theme::Theme,
+    RowHitbox, SelectorHits,
 };
 use crate::session::theme_config::ThemeEntry;
 
 pub struct ThemePickerState<'a> {
+    /// Every theme, in list order. Indices in `matches` point into this.
     pub entries: &'a [ThemeEntry],
+    /// Indices of `entries` surviving the filter, in list order.
+    pub matches: &'a [usize],
+    /// Cursor position within `matches` (not within `entries`).
     pub selected_index: usize,
+    /// The open filter query, or `None` in normal navigation mode. The two are
+    /// rendered differently: a live `/`-prefixed query vs. a hint advertising
+    /// the key that opens it.
+    pub filter: Option<&'a str>,
 }
 
+/// A visible list row: an entry to draw, optionally preceded by a section
+/// header. Keeping the header attached to its entry (rather than making it its
+/// own row) is what lets the whole list stay indexed in entry space.
+struct Row {
+    /// Index into `matches` — i.e. the value the selection cursor takes.
+    match_index: usize,
+    /// Index into `entries`.
+    entry_index: usize,
+    /// Section header to draw on the line above this entry, if it opens a
+    /// section.
+    header: Option<&'static str>,
+}
+
+/// Pair each filtered entry with the section header that precedes it. A header
+/// is emitted at the first entry of each `Dark`/`Light` run, so a filter that
+/// removes every light theme also removes the `Light` header.
+fn build_rows(entries: &[ThemeEntry], matches: &[usize]) -> Vec<Row> {
+    let mut rows = Vec::with_capacity(matches.len());
+    let mut current: Option<bool> = None;
+    for (match_index, &entry_index) in matches.iter().enumerate() {
+        let is_light = entries[entry_index].is_light;
+        let header = (current != Some(is_light)).then_some(if is_light { "Light" } else { "Dark" });
+        current = Some(is_light);
+        rows.push(Row {
+            match_index,
+            entry_index,
+            header,
+        });
+    }
+    rows
+}
+
+/// Screen lines a row occupies: its own line, plus one for a section header
+/// when it opens a section.
+fn row_height(row: &Row) -> u16 {
+    1 + u16::from(row.header.is_some())
+}
+
+/// Total screen lines `rows` would occupy if drawn in full. Saturating: a
+/// `themes.toml` with thousands of entries must clamp, not wrap a `u16`.
+fn total_height(rows: &[Row]) -> u16 {
+    rows.iter()
+        .map(row_height)
+        .fold(0u16, |acc, h| acc.saturating_add(h))
+}
+
+/// Choose the first visible row so the selected row stays on screen, keeping a
+/// few rows of context above it where possible. Returns an index into `rows`.
+///
+/// Row heights vary (a section-opening row costs an extra line for its
+/// header), so this walks rows rather than doing the flat index arithmetic
+/// [`super::file_viewer::visible_window`] can get away with.
+fn scroll_start(rows: &[Row], selected: usize, height: u16) -> usize {
+    /// Rows of context to keep above the selection while scrolling, matching
+    /// the other selectors' feel.
+    const MAX_MARGIN: u16 = 3;
+
+    let selected = selected.min(rows.len().saturating_sub(1));
+    // Back off from the selection far enough to show the margin above it...
+    let margin = (height / 4).min(MAX_MARGIN);
+    let mut start = selected;
+    let mut used = 0u16;
+    while start > 0 && used + row_height(&rows[start - 1]) <= margin {
+        used += row_height(&rows[start - 1]);
+        start -= 1;
+    }
+    // ...then, if that leaves blank space at the bottom (we're near the end of
+    // the list), pull the top back up to fill the pane.
+    let mut total = total_height(&rows[start..]);
+    while start > 0 && total + row_height(&rows[start - 1]) <= height {
+        start -= 1;
+        total += row_height(&rows[start]);
+    }
+    start
+}
+
+/// Draw the (header-annotated) entry rows into `area`, windowed around the
+/// selection, with a scrollbar when they overflow. Hitboxes are returned in
+/// *match* space so a click maps straight back to the selection cursor.
+fn render_rows(
+    frame: &mut Frame,
+    area: Rect,
+    entries: &[ThemeEntry],
+    rows: &[Row],
+    selected: usize,
+) -> SelectorHits {
+    if rows.is_empty() || area.height == 0 || area.width == 0 {
+        let empty = Line::from(Span::styled(
+            "  no matching theme",
+            Style::default().fg(Theme::text_muted()),
+        ));
+        frame.render_widget(Paragraph::new(vec![empty]), area);
+        return (Vec::new(), None);
+    }
+
+    // Reserve the scrollbar track up front (against the full un-windowed
+    // height) so the rows column keeps one width as the window scrolls.
+    let (rows_area, track) =
+        scrollbar::reserve_track(area, total_height(rows) as usize, area.height as usize);
+
+    let start = scroll_start(rows, selected, rows_area.height);
+    let mut lines: Vec<Line<'_>> = Vec::new();
+    let mut hitboxes: Vec<RowHitbox> = Vec::new();
+    for row in &rows[start..] {
+        let remaining = rows_area.height.saturating_sub(lines.len() as u16);
+        if remaining < row_height(row) {
+            break;
+        }
+        if let Some(header) = row.header {
+            lines.push(Line::from(Span::styled(
+                format!(" {header}"),
+                Style::default()
+                    .fg(Theme::text_muted())
+                    .add_modifier(ratatui::style::Modifier::BOLD),
+            )));
+        }
+        let entry = &entries[row.entry_index];
+        hitboxes.push(RowHitbox {
+            rect: Rect::new(
+                rows_area.x,
+                rows_area.y + lines.len() as u16,
+                rows_area.width,
+                1,
+            ),
+            index: row.match_index,
+        });
+        lines.push(selector_line(
+            &entry.display_name,
+            row.match_index == selected,
+        ));
+    }
+    frame.render_widget(Paragraph::new(lines), rows_area);
+
+    // The scrollbar tracks rows, not lines, so its thumb matches what the
+    // selection cursor moves through (headers don't get their own stop).
+    let geom = track.and_then(|t| {
+        scrollbar::render_into(frame, t, rows.len(), rows_area.height as usize, selected)
+    });
+    (hitboxes, geom)
+}
+
+/// Colour swatch + identity block for the highlighted theme.
+fn render_preview(frame: &mut Frame, area: Rect, entry: &ThemeEntry) {
+    let palette = &entry.palette;
+    let label = |text: &'static str| Span::styled(text, Style::default().fg(Theme::text_muted()));
+    let swatch = vec![
+        Line::from(vec![
+            label("  Accent      "),
+            Span::styled("█████", Style::default().fg(palette.accent)),
+            Span::raw(" "),
+            Span::styled("█████", Style::default().fg(palette.accent_bright)),
+        ]),
+        Line::from(vec![
+            label("  Status      "),
+            Span::styled("◐", Style::default().fg(palette.status_working)),
+            Span::raw(" "),
+            Span::styled("◆", Style::default().fg(palette.status_blocked)),
+            Span::raw(" "),
+            Span::styled("●", Style::default().fg(palette.status_done)),
+            Span::raw(" "),
+            Span::styled("○", Style::default().fg(palette.status_idle)),
+            Span::raw(" "),
+            Span::styled("✗", Style::default().fg(palette.status_error)),
+        ]),
+        Line::from(vec![
+            label("  Text        "),
+            Span::styled("Aa", Style::default().fg(palette.text_primary)),
+            Span::raw(" "),
+            Span::styled("Aa", Style::default().fg(palette.text_secondary)),
+            Span::raw(" "),
+            Span::styled("Aa", Style::default().fg(palette.text_muted)),
+        ]),
+        Line::from(vec![
+            label("  Diff        "),
+            Span::styled(
+                " + ",
+                Style::default()
+                    .fg(palette.diff_added)
+                    .bg(palette.diff_added_bg),
+            ),
+            Span::raw(" "),
+            Span::styled(
+                " - ",
+                Style::default()
+                    .fg(palette.diff_removed)
+                    .bg(palette.diff_removed_bg),
+            ),
+        ]),
+        Line::from(vec![
+            label("  Border      "),
+            Span::styled("╭─────╮", Style::default().fg(palette.border_focused)),
+        ]),
+        Line::from(vec![
+            label("  Modal bg    "),
+            Span::styled(
+                "         ",
+                Style::default()
+                    .bg(palette.modal_bg)
+                    .fg(palette.text_primary),
+            ),
+        ]),
+    ];
+    frame.render_widget(Paragraph::new(swatch), area);
+}
+
+/// Render the picker. Returns the usual [`super::ModalRender`] plus the number
+/// of entry rows the list showed this frame, which the app stores as its
+/// page-scroll step.
 pub fn render_theme_picker_modal(
     frame: &mut Frame,
     state: &ThemePickerState<'_>,
-) -> super::ModalRender {
-    // Grow with the entry count, but never taller than the frame so the id line
-    // and footer stay visible on short terminals; `render_selector_rows` then
-    // scroll-windows the list (with a scrollbar) when it can't show every row.
-    let height = ((state.entries.len() as u16).max(4) + 6).min(frame.area().height);
-    let area = centered_fixed_height_rect(60, height, frame.area());
+) -> (super::ModalRender, usize) {
+    let rows = build_rows(state.entries, state.matches);
+
+    // Grow with the content, but cap at a share of the frame so the app chrome
+    // stays visible; the list then scroll-windows inside.
+    /// Non-list rows the modal always spends: top+bottom border, filter line,
+    /// theme-id line, footer, and one spacer.
+    const CHROME: u16 = 6;
+    /// Tallest the modal may grow, as a percent of the frame height.
+    const MAX_FRAME_PCT: u16 = 85;
+    /// Floor so the modal stays usable on a very short terminal.
+    const MIN_HEIGHT: u16 = 10;
+    let frame_h = frame.area().height;
+    let desired = total_height(&rows).saturating_add(CHROME).max(MIN_HEIGHT);
+    let cap = (frame_h * MAX_FRAME_PCT / 100).max(MIN_HEIGHT);
+    let height = desired.min(cap).min(frame_h);
+    let area = centered_fixed_height_rect(64, height, frame.area());
 
     let inner = render_modal_frame(frame, area, "Theme");
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(1),
-            Constraint::Length(1),
-            Constraint::Length(1),
+            Constraint::Length(1), // filter query
+            Constraint::Min(1),    // list + preview
+            Constraint::Length(1), // theme id
+            Constraint::Length(1), // footer buttons
         ])
         .split(inner);
+
+    // Header line: while filtering, the live `/`-prefixed query (with a block
+    // cursor, so the sub-mode is unmistakably focused); otherwise a hint
+    // advertising the key that opens it. Either way the match count sits at the
+    // right, so a query that narrows to nothing is obvious rather than an
+    // unexplained empty list.
+    /// Blank column kept right of the count so it doesn't touch the border.
+    const RIGHT_GUTTER: usize = 1;
+    let count = format!("{}/{} themes", state.matches.len(), state.entries.len());
+    let head: Vec<Span<'_>> = match state.filter {
+        Some(query) => vec![
+            Span::styled(" / ", Style::default().fg(Theme::accent())),
+            Span::styled(
+                query.to_string(),
+                Style::default().fg(Theme::text_primary()),
+            ),
+            Span::styled("█", Style::default().fg(Theme::accent())),
+        ],
+        None => vec![
+            Span::styled(" / ", Style::default().fg(Theme::accent())),
+            Span::styled("filter themes", Style::default().fg(Theme::text_muted())),
+        ],
+    };
+    // Right-align the count against the line's right edge (not the query's
+    // width) so it holds one column as the query grows and shrinks.
+    let used: usize = head.iter().map(|s| s.content.chars().count()).sum();
+    let pad =
+        (chunks[0].width as usize).saturating_sub(used + count.chars().count() + RIGHT_GUTTER);
+    let mut header = head;
+    header.push(Span::raw(" ".repeat(pad)));
+    header.push(Span::styled(
+        count,
+        Style::default().fg(Theme::text_muted()),
+    ));
+    frame.render_widget(Paragraph::new(Line::from(header)), chunks[0]);
 
     let columns = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
-        .split(chunks[0]);
+        .split(chunks[1]);
 
-    let lines: Vec<Line<'_>> = state
-        .entries
-        .iter()
-        .enumerate()
-        .map(|(i, entry)| {
-            let label = if entry.is_light {
-                format!("{} (light)", entry.display_name)
-            } else {
-                entry.display_name.clone()
-            };
-            selector_line(&label, i == state.selected_index)
-        })
-        .collect();
+    let hits = render_rows(
+        frame,
+        columns[0],
+        state.entries,
+        &rows,
+        state.selected_index,
+    );
 
-    let hits = render_selector_rows(frame, columns[0], lines, state.selected_index);
-
-    if let Some(entry) = state.entries.get(state.selected_index) {
-        let palette = &entry.palette;
-        let swatch = vec![
-            Line::from(vec![
-                Span::styled("  Accent      ", Style::default().fg(Theme::text_muted())),
-                Span::styled("█████", Style::default().fg(palette.accent)),
-                Span::styled(" ", Style::default()),
-                Span::styled("█████", Style::default().fg(palette.accent_bright)),
-            ]),
-            Line::from(vec![
-                Span::styled("  Status      ", Style::default().fg(Theme::text_muted())),
-                Span::styled("◐", Style::default().fg(palette.status_working)),
-                Span::styled(" ", Style::default()),
-                Span::styled("◆", Style::default().fg(palette.status_blocked)),
-                Span::styled(" ", Style::default()),
-                Span::styled("●", Style::default().fg(palette.status_done)),
-                Span::styled(" ", Style::default()),
-                Span::styled("○", Style::default().fg(palette.status_idle)),
-                Span::styled(" ", Style::default()),
-                Span::styled("✗", Style::default().fg(palette.status_error)),
-            ]),
-            Line::from(vec![
-                Span::styled("  Border      ", Style::default().fg(Theme::text_muted())),
-                Span::styled("╭─────╮", Style::default().fg(palette.border_focused)),
-            ]),
-            Line::from(vec![
-                Span::styled("  Modal bg    ", Style::default().fg(Theme::text_muted())),
-                Span::styled(
-                    "         ",
-                    Style::default()
-                        .bg(palette.modal_bg)
-                        .fg(palette.text_primary),
-                ),
-            ]),
-        ];
-        frame.render_widget(Paragraph::new(swatch), columns[1]);
-
+    let selected_entry = state
+        .matches
+        .get(state.selected_index)
+        .and_then(|&i| state.entries.get(i));
+    if let Some(entry) = selected_entry {
+        render_preview(frame, columns[1], entry);
         let id = Line::from(Span::styled(
             format!("  theme id: {}", entry.name),
             Style::default().fg(Theme::text_muted()),
         ));
-        frame.render_widget(Paragraph::new(id), chunks[1]);
+        frame.render_widget(Paragraph::new(id), chunks[2]);
     }
 
-    let buttons = render_selector_footer(frame, chunks[2]);
+    // Not the shared `render_selector_footer`: its fixed `j/k navigate` hint
+    // can't show the extra keys, and while filtering `j`/`k` are query text.
+    let hint = Line::from(if state.filter.is_some() {
+        vec![
+            Span::styled("↑/↓", Theme::keybind()),
+            Span::styled(" navigate  ", Theme::keybind_desc()),
+            Span::styled("type", Theme::keybind()),
+            Span::styled(" filter  ", Theme::keybind_desc()),
+            Span::styled("Esc", Theme::keybind()),
+            Span::styled(" clear filter", Theme::keybind_desc()),
+        ]
+    } else {
+        vec![
+            Span::styled("j/k", Theme::keybind()),
+            Span::styled(" navigate  ", Theme::keybind_desc()),
+            Span::styled("PgUp/PgDn", Theme::keybind()),
+            Span::styled(" page  ", Theme::keybind_desc()),
+            Span::styled("/", Theme::keybind()),
+            Span::styled(" filter", Theme::keybind_desc()),
+        ]
+    });
+    let buttons = super::render_hint_action_footer(
+        frame,
+        chunks[3],
+        hint,
+        (
+            "Select",
+            crossterm::event::KeyCode::Enter,
+            crossterm::event::KeyModifiers::NONE,
+        ),
+        "Cancel",
+    );
+    // One hitbox per visible entry row, so its count *is* the page step.
+    let visible_rows = hits.0.len();
     // Rows live in the left column only; the swatch column isn't clickable.
-    (hits, buttons)
+    ((hits, buttons), visible_rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::theme_config::ThemePreset;
+
+    fn entries() -> Vec<ThemeEntry> {
+        ThemePreset::all()
+            .iter()
+            .map(|p| ThemeEntry::from_preset(*p))
+            .collect()
+    }
+
+    #[test]
+    fn build_rows_emits_one_header_per_section() {
+        let entries = entries();
+        let matches: Vec<usize> = (0..entries.len()).collect();
+        let rows = build_rows(&entries, &matches);
+        assert_eq!(rows.len(), entries.len());
+        let headers: Vec<&str> = rows.iter().filter_map(|r| r.header).collect();
+        // `all()` is dark-then-light, so exactly two sections in that order.
+        assert_eq!(headers, vec!["Dark", "Light"]);
+    }
+
+    #[test]
+    fn build_rows_drops_a_header_whose_section_is_filtered_out() {
+        let entries = entries();
+        // Only dark entries survive.
+        let matches: Vec<usize> = entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| !e.is_light)
+            .map(|(i, _)| i)
+            .collect();
+        let rows = build_rows(&entries, &matches);
+        let headers: Vec<&str> = rows.iter().filter_map(|r| r.header).collect();
+        assert_eq!(headers, vec!["Dark"]);
+    }
+
+    #[test]
+    fn build_rows_indexes_in_match_space() {
+        let entries = entries();
+        // A sparse filter: every third entry.
+        let matches: Vec<usize> = (0..entries.len()).step_by(3).collect();
+        let rows = build_rows(&entries, &matches);
+        for (i, row) in rows.iter().enumerate() {
+            assert_eq!(row.match_index, i, "match_index must be filtered-space");
+            assert_eq!(row.entry_index, matches[i]);
+        }
+    }
+
+    #[test]
+    fn scroll_start_keeps_selection_visible() {
+        let entries = entries();
+        let matches: Vec<usize> = (0..entries.len()).collect();
+        let rows = build_rows(&entries, &matches);
+        let height = 10u16;
+        for selected in 0..rows.len() {
+            let start = scroll_start(&rows, selected, height);
+            assert!(start <= selected, "selection scrolled off the top");
+            // Walk the window and confirm the selected row fits inside it.
+            let mut used = 0u16;
+            let mut visible = false;
+            for row in &rows[start..] {
+                if used + row_height(row) > height {
+                    break;
+                }
+                used += row_height(row);
+                if row.match_index == selected {
+                    visible = true;
+                    break;
+                }
+            }
+            assert!(
+                visible,
+                "selection {selected} not visible from start {start}"
+            );
+        }
+    }
+
+    #[test]
+    fn scroll_start_is_zero_when_everything_fits() {
+        let entries = entries();
+        let matches: Vec<usize> = (0..3).collect();
+        let rows = build_rows(&entries, &matches);
+        assert_eq!(scroll_start(&rows, 2, 40), 0);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds **21 built-in theme presets** (15 → 36): 17 dark (Solarized Dark, Monokai, Ayu Dark, Ayu Mirage, Material, Rosé Pine, Oxocarbon, GitHub Dark, Nightfox, Sonokai, Melange, Zenburn, Iceberg, Vesper, Synthwave, Nightfly, Tomorrow Night) and 4 light (Ayu Light, One Light, Rosé Pine Dawn, GitHub Light). Each goes through the existing `PaletteSlots` IR, so derived fields and review diff colours come for free.
- **Reworks the theme picker for a long list**: `Dark`/`Light` section headers, growth to ~85% of the frame before scroll-windowing, and a richer swatch (text, diff and border colours alongside the accent).
- **Adds a `/` filter sub-mode.** `j`/`k` keep selecting exactly as in every other picker; only `/` starts a query, matched against both display name and stable id. This mirrors the file viewer's and code review's find rather than swallowing every letter, so no key means something different here than in the sibling pickers. `Esc` closes the filter before the modal, keeping the cursor on the same theme.
- Section headers are drawn *inside* their entry's row, so selection indices, click hitboxes and the scrollbar all stay in plain entry space — a header is never separately selectable. `ThemePickerModal::index` indexes the **match** list, so refining a query follows the selected theme rather than the ordinal.
- **Fixes a pre-existing Doom palette bug** where the yellow slot reused red, making `status_working` indistinguishable from `status_blocked`. Surfaced by a new coherence test rather than found by eye.

## Test plan

- `cargo nextest run --all` — **1929/1929 pass**
- `cargo test --test architecture_rules` — 12/12
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc` — all clean
- New coverage: 5 unit tests on the pure row/scroll helpers, 8 behaviour tests (`/` gating, two-level `Esc`, filter narrowing + correct commit-after-filter, `Ctrl+N`/`P`, stray-Ctrl swallowing, page keys), 2 insta snapshots (default and filtered states), and 3 palette-coherence tests asserting every preset keeps its semantic slots distinct and its `is_light` flag matches actual background luminance
- Manually verified in a real tmux terminal: `jjj` navigates without typing, `/ayu` narrows to `3/36 themes`, `Esc` restores `36/36` with the cursor still on Ayu Dark