### PR TITLE
feat(ui): make copy work over SSH via OSC 52

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1828,12 +1828,17 @@ Mouse drag selects text in the terminal panel. The selection is
 confined to the active pane bounds.
 
 - **Mouse drag**: Select text (anchor at press, cursor follows
-  drag).
-- **`Ctrl+C`** (with active selection): Copies selected text to
-  the system clipboard via `arboard`. Trailing whitespace is
-  trimmed per line.
+  drag). Dragging past the top/bottom edge scrolls the grid, so a
+  selection can extend beyond one screenful.
+- **`Shift`+drag**: Bypasses thurbox entirely and uses your
+  **terminal's own** selection. Most emulators reserve Shift for this
+  while an application holds the mouse; use it when you want the
+  terminal's native copy behaviour (including its own clipboard
+  integration) instead of thurbox's.
+- **`Ctrl+C`** (with active selection): Copies the selection. See
+  the transport section below.
 - **`Ctrl+C`** (no selection): Forwarded to the terminal as SIGINT.
-- **`Ctrl+V`**: Pastes from the system clipboard. When a modal text
+- **`Ctrl+V`**: Pastes from the local clipboard. When a modal text
   input (worktree/session name, repo-picker path or search,
   automation editor) or an in-pane editor (task/automation) is
   focused, the text is inserted into that field instead of the PTY
@@ -1842,11 +1847,76 @@ confined to the active pane bounds.
   modal is open the paste is swallowed so it can never leak into the
   terminal in the pane behind the overlay; otherwise it pastes into
   the active PTY.
+- **`Ctrl+Shift+V`** (your terminal's paste): the way to paste when
+  thurbox runs over SSH — see "Pasting over SSH" below.
 - Any other keypress clears the selection.
 
 Selection is highlighted in the terminal render buffer using
-inverted colors. The clipboard handle is kept alive for the app
-lifetime to avoid Linux-specific "dropped too quickly" issues.
+inverted colors.
+
+### What gets copied
+
+For a selection in the **terminal pane**, the text is read from the
+session's vt100 grid rather than the painted cells
+(`selection::extract_text_from_screen`). Two consequences:
+
+- **Scrollback is selectable.** The grid resolves through the current
+  scroll offset, so text you scrolled back to copies correctly.
+- **Soft-wrapped lines are rejoined.** A line longer than the pane is
+  stored as several rows with a wrap flag; those are one logical line,
+  so they copy without a newline at the pane edge. A wrapped URL or
+  code line pastes intact.
+
+Trailing whitespace is trimmed per logical line; interior spacing is
+preserved so column alignment survives. Other panes (session list,
+info panel) have no grid behind them and are read from the frame
+buffer as before.
+
+### Copying over SSH (OSC 52)
+
+Copy uses two transports, in order — configured by `[clipboard]
+provider` in settings.toml (`auto` | `native` | `osc52` | `none`):
+
+1. **Native** (`arboard`) — the local display server. Reports real
+   success or failure, but only exists on the machine holding the
+   clipboard. The handle is kept alive for the app lifetime to avoid
+   Linux-specific "dropped too quickly" issues.
+2. **OSC 52** — an escape sequence your *terminal emulator*
+   interprets, so it reaches the clipboard of whoever is looking at
+   the screen regardless of how many SSH hops are in between. Written
+   to `/dev/tty` rather than stdout, because a multiplexer intercepts
+   OSC 52 arriving on a child's stdout.
+
+`auto` tries native first (it is the only one that can confirm it
+worked) and falls back to OSC 52. There is deliberately **no**
+`$SSH_TTY` check: the SSH env vars are only a proxy for "no local
+clipboard", trying the local clipboard answers that directly, and
+under tmux those vars are frequently stale (the server daemonizes with
+its first client's environment). Neovim shipped SSH detection here and
+removed it in 0.11 for the same reason.
+
+The toast names the transport (`Copied to clipboard (OSC 52)`) so a
+terminal that silently ignores the sequence is diagnosable. Text over
+~74 KB is refused with an explicit error rather than written, because
+tmux discards an oversized OSC 52 sequence **entirely**.
+
+thurbox sets `set-clipboard on` and `terminal-features ,*:clipboard`
+on its own tmux server (`TmuxBackend::apply_clipboard_config`). Both
+are required: tmux's default `set-clipboard external` **silently
+discards** an OSC 52 originating inside a pane, and a missing `Ms`
+terminfo capability drops it again at a second gate. Note the
+tradeoff — `set-clipboard on` lets any process in a pane write your
+system clipboard, which is why tmux's own default is more
+conservative.
+
+### Pasting over SSH
+
+Paste never uses OSC 52. Terminals disable clipboard *reads* by
+default (a remote host could exfiltrate your clipboard), and probing
+for one can stall for seconds. When no local clipboard is reachable,
+`Ctrl+V` shows a hint pointing at your terminal's own paste
+(usually **`Ctrl+Shift+V`**), which delivers the text as an ordinary
+bracketed paste that thurbox routes exactly like `Ctrl+V`.
 
 ---
 

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -76,6 +76,17 @@ config_version = 1
 # min_interval_secs = 5         # per-session dedup floor (seconds)
 # backend = "auto"              # delivery backend: auto | dbus | windows | off
 
+# Clipboard transport for copy (Ctrl+C). `auto` writes to the local clipboard
+# when one is reachable and otherwise emits an OSC 52 escape sequence, which
+# your *terminal emulator* turns into a clipboard write — so copy works over
+# SSH, including nested SSH, with no setup on either end. Force `native` if
+# your terminal mangles OSC 52, `osc52` to always target the terminal you're
+# looking at, or `none` to disable copy. Pasting never uses OSC 52 (terminals
+# disable clipboard reads for security) — over SSH use your terminal's own
+# paste, usually Ctrl+Shift+V.
+# [clipboard]
+# provider = "auto"             # auto | native | osc52 | none
+
 # ──────────────────────────────────────────────────────────────────────────
 # Common recipes (uncomment the lines under the recipe you want)
 # ──────────────────────────────────────────────────────────────────────────

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -867,12 +867,52 @@ impl TmuxBackend {
             debug!("extended-keys-format=csi-u not set (likely tmux < 3.3): {e}");
         }
 
+        self.apply_clipboard_config();
+
         // Session-level options
         for (key, val) in SESSION_OPTS {
             self.tmux_run(&["set-option", "-t", &self.session, key, val])?;
         }
 
         Ok(())
+    }
+
+    /// Open the two silent gates that would otherwise drop an OSC 52 clipboard
+    /// write originating **inside** a pane (thurbox's own copy, or an agent's).
+    ///
+    /// Both are no-ops-on-failure by design, hence best-effort:
+    ///
+    /// 1. `set-clipboard` must be exactly `on`. tmux's `input_osc_52_parse`
+    ///    bails on `!= 2`, and the shipped default is `external` (1) — which
+    ///    forwards tmux's *own* copy-mode yanks but **discards** an
+    ///    application's OSC 52 with no error and no visual artifact. This is
+    ///    the default-broken case: without it every other part of the
+    ///    clipboard path is dead under tmux.
+    /// 2. The `Ms` terminfo capability must be present, or `tty_set_selection`
+    ///    returns early — a second, independent silent drop. `terminal-features
+    ///    ,*:clipboard` injects it for every terminal (tmux 3.2+, matching
+    ///    thurbox's floor; the pre-3.2 form was a raw `terminal-overrides` Ms=
+    ///    string).
+    ///
+    /// Security tradeoff: `set-clipboard on` lets any process in a pane set the
+    /// user's system clipboard — an exfiltration channel, and why tmux moved
+    /// the default to `external` in 2.6. Scoped here to thurbox's own socket,
+    /// and the price of copy working at all over SSH.
+    ///
+    /// Skipped on psmux, which has no OSC 52 clipboard forwarding (a local
+    /// Windows session copies via the native clipboard path instead).
+    fn apply_clipboard_config(&self) {
+        if self.transport.uses_psmux() {
+            return;
+        }
+        for args in [
+            ["set-option", "-s", "set-clipboard", "on"],
+            ["set-option", "-as", "terminal-features", ",*:clipboard"],
+        ] {
+            if let Err(e) = self.tmux_run(&args) {
+                debug!("clipboard option {} not set: {e}", args[2]);
+            }
+        }
     }
 
     /// Ensure the thurbox tmux session exists and its options are applied,

--- a/src/app/code_review.rs
+++ b/src/app/code_review.rs
@@ -1367,12 +1367,12 @@ impl App {
             self.set_status(StatusLevel::Info, "No review comments yet");
             return;
         };
-        match self.clipboard.as_mut() {
-            Some(cb) => match cb.set_text(&md) {
-                Ok(_) => self.set_status(StatusLevel::Success, "Review copied to clipboard"),
-                Err(e) => self.set_error(format!("Clipboard write failed: {e}")),
-            },
-            None => self.set_error("Clipboard not available"),
+        match self.write_clipboard(&md) {
+            Ok(route) => {
+                let msg = format!("Review copied to clipboard{}", route.toast_suffix());
+                self.set_status(StatusLevel::Success, msg);
+            }
+            Err(e) => self.set_error(e.to_string()),
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3351,6 +3351,19 @@ impl App {
         true
     }
 
+    /// The terminal pane's content area (borders excluded).
+    ///
+    /// Selection code compares a [`Selection`]'s pane against this to decide
+    /// whether the vt100 grid is the right source for the selected text (and
+    /// whether a drag past the edge should scroll it). `handle_mouse_click`
+    /// derives the anchoring pane the same way, so both must stay in step —
+    /// hence one helper rather than three reconstructions of the block.
+    pub(crate) fn terminal_inner_rect(&self) -> Rect {
+        Block::default()
+            .borders(Borders::ALL)
+            .inner(self.screen_layout().terminal)
+    }
+
     fn handle_mouse_drag(&mut self, x: u16, y: u16) {
         // A scrollbar drag takes precedence: keep driving the grabbed pane's
         // scroll state (y can leave the track — `position_for_y` clamps it).
@@ -3363,12 +3376,38 @@ impl App {
             return;
         }
 
+        // Only the terminal pane has a scrollable grid behind it; a drag out of
+        // the session list must not scroll the terminal's scrollback.
+        let terminal_inner = self.terminal_inner_rect();
+
         if let Some(ref mut sel) = self.text_selection {
+            let rect = sel.pane.rect();
+            // Dragging past the top/bottom edge scrolls the grid under the
+            // selection, so a selection can run past what one screen shows —
+            // the behaviour a native terminal gives. One line per drag event
+            // (which arrive continuously while the button is held) keeps it
+            // proportional to how long the user holds outside the pane.
+            let in_terminal = rect == terminal_inner;
+            let scroll_up = in_terminal && y < rect.y;
+            let scroll_down = in_terminal && y >= rect.y + rect.height;
+
             let (cx, cy) = sel.pane.clamp(x, y);
             sel.cursor = TermPos {
                 row: cy as usize,
                 col: cx as usize,
             };
+
+            if scroll_up || scroll_down {
+                self.with_active_parser(|parser| {
+                    let cur = parser.screen().scrollback();
+                    let next = if scroll_up {
+                        cur + 1
+                    } else {
+                        cur.saturating_sub(1)
+                    };
+                    parser.screen_mut().set_scrollback(next);
+                });
+            }
         }
     }
 
@@ -3668,19 +3707,27 @@ impl App {
             _ => return,
         };
 
-        let Some(clipboard) = &mut self.clipboard else {
-            self.set_error("Clipboard not available");
-            return;
-        };
-
-        if let Err(e) = clipboard.set_text(&text) {
-            self.set_error(format!("Clipboard write failed: {e}"));
-            return;
+        match self.write_clipboard(&text) {
+            Ok(route) => {
+                self.text_selection = None;
+                self.selected_text_cache = None;
+                let msg = format!("Copied to clipboard{}", route.toast_suffix());
+                self.set_status(StatusLevel::Info, msg);
+            }
+            Err(e) => self.set_error(e.to_string()),
         }
+    }
 
-        self.text_selection = None;
-        self.selected_text_cache = None;
-        self.set_status(StatusLevel::Info, "Copied to clipboard");
+    /// Write `text` to the clipboard over the configured transport, returning
+    /// which one carried it. Centralises the native/OSC 52 fallback so every
+    /// copy path (selection, status line, code review) behaves identically —
+    /// notably including the OSC 52 leg that makes copy work over SSH.
+    pub(crate) fn write_clipboard(
+        &mut self,
+        text: &str,
+    ) -> Result<crate::clipboard::CopyRoute, crate::clipboard::CopyError> {
+        let provider = crate::session::settings::global().clipboard.provider;
+        crate::clipboard::copy(text, self.clipboard.as_mut(), provider)
     }
 
     /// Copy the current status-bar message (info / error / …) to the clipboard.
@@ -3697,17 +3744,13 @@ impl App {
             return; // nothing shown → no-op (no "copied" toast to overwrite it)
         };
 
-        let Some(clipboard) = &mut self.clipboard else {
-            self.set_error("Clipboard not available");
-            return;
-        };
-
-        if let Err(e) = clipboard.set_text(&text) {
-            self.set_error(format!("Clipboard write failed: {e}"));
-            return;
+        match self.write_clipboard(&text) {
+            Ok(route) => {
+                let msg = format!("Status message copied to clipboard{}", route.toast_suffix());
+                self.set_status(StatusLevel::Info, msg);
+            }
+            Err(e) => self.set_error(e.to_string()),
         }
-
-        self.set_status(StatusLevel::Info, "Status message copied to clipboard");
     }
 
     /// Wrap text in bracketed paste escape sequences and send it to the
@@ -3747,17 +3790,17 @@ impl App {
         self.text_selection = None;
         self.selected_text_cache = None;
 
-        let Some(clipboard) = &mut self.clipboard else {
-            self.set_error("Clipboard not available");
+        // No OSC 52 read fallback: terminals disable clipboard *reads* by
+        // default (an exfiltration risk) and probing for one can stall for
+        // seconds. Over SSH the working path is the terminal's own paste, which
+        // arrives as a bracketed paste through `handle_paste` — so point at it
+        // rather than reporting a failure the user cannot act on.
+        let Some(text) = crate::clipboard::paste(self.clipboard.as_mut()) else {
+            self.set_status(
+                StatusLevel::Info,
+                crate::clipboard::PASTE_UNAVAILABLE_HINT.to_string(),
+            );
             return;
-        };
-
-        let text = match clipboard.get_text() {
-            Ok(t) => t,
-            Err(e) => {
-                self.set_error(format!("Clipboard read failed: {e}"));
-                return;
-            }
         };
 
         if self.try_paste_into_modal_input(&text) {
@@ -7104,8 +7147,7 @@ impl App {
     }
 
     pub(crate) fn content_area_size(&self) -> (u16, u16) {
-        let terminal = self.screen_layout().terminal;
-        let inner = Block::default().borders(Borders::ALL).inner(terminal);
+        let inner = self.terminal_inner_rect();
         (inner.height, inner.width)
     }
 }
@@ -8787,6 +8829,39 @@ mod tests {
 
         app.scroll_terminal_up(1);
         assert!(app.text_selection.is_none());
+    }
+
+    /// Dragging out of a pane that has no vt100 grid behind it (the session
+    /// list) must not scroll the terminal's scrollback — the autoscroll is
+    /// scoped to the terminal pane, whose grid the selection is actually
+    /// reading from.
+    #[test]
+    fn drag_out_of_non_terminal_pane_does_not_scroll_terminal() {
+        let mut app = app_with_sessions(1);
+        // A pane deliberately unlike the terminal's inner rect.
+        let list_pane = ratatui::layout::Rect::new(0, 0, 20, 10);
+        app.text_selection = Some(Selection::new(
+            TermPos { row: 5, col: 0 },
+            PaneBounds::from_rect(list_pane),
+        ));
+
+        let before = {
+            let mut sb = 0;
+            app.with_active_parser(|p| sb = p.screen().scrollback());
+            sb
+        };
+
+        // Drag well above the pane's top edge — the direction that would
+        // scroll back if the gate were missing.
+        app.handle_mouse_drag(5, 0);
+        app.handle_mouse_drag(5, 0);
+
+        let after = {
+            let mut sb = 0;
+            app.with_active_parser(|p| sb = p.screen().scrollback());
+            sb
+        };
+        assert_eq!(before, after, "session-list drag scrolled the terminal");
     }
 
     #[test]

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -192,7 +192,7 @@ impl App {
         }
         self.repaint_theme_background(frame);
         self.apply_hover_highlight(frame);
-        self.apply_selection_highlight(frame);
+        self.apply_selection_highlight(frame, areas.terminal);
     }
 
     /// Highlight the clickable element under the mouse pointer so what a click
@@ -1396,7 +1396,13 @@ impl App {
 
     /// Apply the selection highlight and refresh the selected-text cache —
     /// runs after all rendering.
-    fn apply_selection_highlight(&mut self, frame: &mut Frame) {
+    ///
+    /// The highlight is always painted on the frame buffer (it is a visual
+    /// effect on what was drawn), but the *text* is read from the session's
+    /// vt100 grid when the selection lies in the terminal pane — that grid, not
+    /// the painted cells, is what holds scrollback and the soft-wrap flags. Any
+    /// other pane has no grid behind it and falls back to the buffer.
+    fn apply_selection_highlight(&mut self, frame: &mut Frame, terminal_area: Rect) {
         let Some(ref sel) = self.text_selection else {
             self.selected_text_cache = None;
             return;
@@ -1408,7 +1414,34 @@ impl App {
 
         selection::highlight_buffer(frame.buffer_mut(), &sel_clone, sel_style);
 
-        let text = selection::extract_text_from_buffer(frame.buffer_mut(), &sel_clone);
+        // Derived from this frame's rect rather than `App::terminal_inner_rect`
+        // (which reads the cached size) so a resize frame compares against what
+        // was actually painted. Must match how `handle_mouse_click` derives the
+        // pane it anchors a selection to, or the rects never compare equal.
+        let inner = ratatui::widgets::Block::default()
+            .borders(ratatui::widgets::Borders::ALL)
+            .inner(terminal_area);
+        let in_terminal = sel_clone.pane.rect() == inner;
+
+        let text = if in_terminal {
+            let origin = (inner.x, inner.y);
+            let mut from_grid = None;
+            self.with_active_parser(|parser| {
+                from_grid = Some(selection::extract_text_from_screen(
+                    parser.screen(),
+                    &sel_clone,
+                    origin,
+                ));
+            });
+            // No active parser (welcome screen, placeholder session) → nothing
+            // was painted from a grid either, so the buffer read is correct.
+            from_grid.unwrap_or_else(|| {
+                selection::extract_text_from_buffer(frame.buffer_mut(), &sel_clone)
+            })
+        } else {
+            selection::extract_text_from_buffer(frame.buffer_mut(), &sel_clone)
+        };
+
         self.selected_text_cache = if text.is_empty() { None } else { Some(text) };
     }
 
@@ -1831,7 +1864,14 @@ fn render_help_overlay(
         "Mouse wheel".into(),
         "Terminal: scroll three lines",
     ));
-    help_lines.push(help_line("Click+drag".into(), "Select text"));
+    help_lines.push(help_line(
+        "Click+drag".into(),
+        "Select text (drag past the edge scrolls; wrapped lines copy rejoined)",
+    ));
+    help_lines.push(help_line(
+        "Shift+drag".into(),
+        "Select using your terminal's own selection instead of thurbox's",
+    ));
     help_lines.push(help_line(
         "Click".into(),
         "Select row / focus pane; pickers: confirm row; footer & modal buttons",

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,263 @@
+//! Clipboard writes that survive SSH.
+//!
+//! Two transports, tried in order (see [`ClipboardProvider`] for the config
+//! knob that overrides the order):
+//!
+//! 1. **Native** ([`arboard`]) — talks to the local display server. Verifiable:
+//!    it reports real success or a real error. Unavailable the moment thurbox
+//!    runs anywhere but the machine holding the clipboard.
+//! 2. **OSC 52** — an escape sequence the *terminal emulator* interprets, so it
+//!    reaches the clipboard of whoever is looking at the screen no matter how
+//!    many SSH hops are in between. Fire-and-forget: a terminal that doesn't
+//!    implement it discards the sequence, and we can never tell.
+//!
+//! ## Why the order is "native, then OSC 52" and not a check for SSH
+//!
+//! The obvious design — sniff `$SSH_TTY` and pick a transport — is a trap, and
+//! the ecosystem has already walked out of it. Neovim shipped exactly that in
+//! 0.10 and **removed it as a breaking change** in 0.11 (PR #31730): the SSH
+//! check is only ever a proxy for "no local clipboard here", and *trying* the
+//! local clipboard answers that question directly and correctly. Helix and
+//! gitui order their providers the same way; nothing modern branches on SSH for
+//! a clipboard *write*.
+//!
+//! thurbox has an extra reason to distrust the env: the tmux server daemonizes
+//! with the environment of its **first** client, so panes routinely carry stale
+//! or missing `SSH_*` from whenever the server happened to start.
+//!
+//! ## Why we don't probe for OSC 52 support either
+//!
+//! Terminfo `Ms` and the `XTGETTCAP` query both false-negative constantly (only
+//! foot/kitty/WezTerm answer; iTerm2 supports OSC 52 but reports that it does
+//! not), and the query itself can corrupt output on older terminals. A false
+//! negative silently disables copy — strictly worse than emitting a sequence a
+//! terminal harmlessly ignores.
+//!
+//! Reading the clipboard over OSC 52 is not attempted at all: terminals disable
+//! it by default as an exfiltration risk, and probing for it is actively
+//! harmful (a read that times out stalled Neovim for >10 s on Windows
+//! Terminal). Paste over SSH is the terminal's own `Ctrl+Shift+V`, which
+//! arrives as an ordinary bracketed paste.
+
+use std::io::Write;
+
+use base64::Engine as _;
+
+use crate::session::settings::ClipboardProvider;
+
+/// Practical ceiling on the text of one OSC 52 sequence.
+///
+/// The convention is a 100,000-byte total sequence; base64 costs 4 bytes per 3,
+/// and the `ESC ] 52 ; c ; … BEL` framing costs 8, leaving ~74,994 bytes of
+/// payload. Oversized writes are not truncated by tmux — `input_input` sets
+/// `INPUT_DISCARD` and drops the **whole** sequence — so exceeding this is
+/// total silent loss, and worth an explicit error instead.
+pub const OSC52_MAX_BYTES: usize = 74_994;
+
+/// Which transport actually took the copy — surfaced in the status toast so a
+/// silently-ignored OSC 52 is diagnosable rather than mysterious.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CopyRoute {
+    /// The local display server accepted it (verified).
+    Native,
+    /// An OSC 52 sequence was written to the terminal (unverifiable).
+    Osc52,
+}
+
+impl CopyRoute {
+    /// Suffix for the "Copied" toast. The native path is silent because it is
+    /// the unremarkable case; OSC 52 is named so that a user whose terminal
+    /// drops it can tell which path ran.
+    pub fn toast_suffix(self) -> &'static str {
+        match self {
+            CopyRoute::Native => "",
+            CopyRoute::Osc52 => " (OSC 52)",
+        }
+    }
+}
+
+/// Why a copy failed. Carries enough detail for an actionable message.
+#[derive(Debug)]
+pub enum CopyError {
+    /// Text exceeds what one OSC 52 sequence can carry.
+    TooLarge { bytes: usize },
+    /// Every permitted transport failed (or none was permitted).
+    NoTransport { detail: String },
+}
+
+impl std::fmt::Display for CopyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CopyError::TooLarge { bytes } => write!(
+                f,
+                "Selection too large to copy ({bytes} bytes; limit {OSC52_MAX_BYTES})"
+            ),
+            CopyError::NoTransport { detail } => write!(f, "Clipboard write failed: {detail}"),
+        }
+    }
+}
+
+/// Encode `text` as a complete OSC 52 clipboard-set sequence.
+///
+/// Terminated with **BEL** (`\a`) rather than ST (`ESC \`): both are legal, but
+/// BEL is the more widely tolerated of the two across older terminals and
+/// multiplexers. (crossterm's own `CopyToClipboard` hardcodes ST, which is why
+/// this is spelled out here rather than delegated to it.)
+///
+/// Emitted raw, *not* wrapped in tmux's DCS passthrough: the raw form is
+/// handled by tmux's own OSC 52 handler, which also keeps its paste buffer in
+/// sync, and needs only `set-clipboard on` (which thurbox sets on its own
+/// server — see `TmuxBackend::apply_clipboard_config`). The DCS form would
+/// instead require `allow-passthrough`, which is off by default.
+pub fn osc52_sequence(text: &str) -> String {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+    format!("\x1b]52;c;{encoded}\x07")
+}
+
+/// Write an OSC 52 sequence for `text` to the controlling terminal.
+///
+/// Targets `/dev/tty` rather than stdout. This is the subtle part: a
+/// multiplexer *intercepts* OSC 52 arriving on a child's stdout and does not
+/// necessarily forward it, so writing to the tty directly is what makes copy
+/// work from inside tmux/Zellij (the same reason lazygit and Neovim do it).
+/// Falls back to stdout where `/dev/tty` cannot be opened (Windows, or a
+/// detached process).
+fn write_osc52(text: &str) -> std::io::Result<()> {
+    let seq = osc52_sequence(text);
+
+    #[cfg(unix)]
+    {
+        if let Ok(mut tty) = std::fs::OpenOptions::new().write(true).open("/dev/tty") {
+            tty.write_all(seq.as_bytes())?;
+            return tty.flush();
+        }
+    }
+
+    let mut out = std::io::stdout();
+    out.write_all(seq.as_bytes())?;
+    out.flush()
+}
+
+/// Copy `text`, returning which transport carried it.
+///
+/// `native` is the app-lifetime [`arboard`] handle (kept alive to dodge the
+/// Linux "dropped too quickly" problem); `None` means construction failed at
+/// startup, which is the normal state on a headless/SSH host.
+pub fn copy(
+    text: &str,
+    native: Option<&mut arboard::Clipboard>,
+    provider: ClipboardProvider,
+) -> Result<CopyRoute, CopyError> {
+    if provider == ClipboardProvider::None {
+        return Err(CopyError::NoTransport {
+            detail: "clipboard disabled by config ([clipboard] provider = \"none\")".into(),
+        });
+    }
+
+    let mut detail = String::new();
+
+    // Native first when permitted: it is the only transport that can confirm it
+    // worked, so preferring it keeps the common local case verifiable.
+    if provider != ClipboardProvider::Osc52 {
+        match native {
+            Some(cb) => match cb.set_text(text) {
+                Ok(()) => return Ok(CopyRoute::Native),
+                Err(e) => detail = format!("native: {e}"),
+            },
+            None => detail = "native: unavailable".into(),
+        }
+        if provider == ClipboardProvider::Native {
+            return Err(CopyError::NoTransport { detail });
+        }
+    }
+
+    // OSC 52 carries the payload whole or not at all, so refuse oversized text
+    // rather than let tmux discard it silently.
+    if text.len() > OSC52_MAX_BYTES {
+        return Err(CopyError::TooLarge { bytes: text.len() });
+    }
+
+    match write_osc52(text) {
+        Ok(()) => Ok(CopyRoute::Osc52),
+        Err(e) => {
+            if !detail.is_empty() {
+                detail.push_str("; ");
+            }
+            detail.push_str(&format!("osc52: {e}"));
+            Err(CopyError::NoTransport { detail })
+        }
+    }
+}
+
+/// Read the clipboard, if a local one is reachable.
+///
+/// `None` means "no local clipboard" — the SSH case — and is not an error worth
+/// reporting as a failure: the caller should point the user at their terminal's
+/// native paste instead. There is deliberately no OSC 52 read fallback (see the
+/// module docs).
+pub fn paste(native: Option<&mut arboard::Clipboard>) -> Option<String> {
+    native.and_then(|cb| cb.get_text().ok())
+}
+
+/// The message shown when [`paste`] finds no local clipboard. Names the
+/// terminal's own paste chord, which delivers the text as a bracketed paste
+/// that `App::handle_paste` already routes correctly.
+pub const PASTE_UNAVAILABLE_HINT: &str =
+    "No local clipboard — use your terminal's paste (Ctrl+Shift+V)";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn osc52_sequence_is_bel_terminated_base64() {
+        // "foo" -> Zm9v; BEL terminator, clipboard ('c') selection.
+        assert_eq!(osc52_sequence("foo"), "\x1b]52;c;Zm9v\x07");
+    }
+
+    #[test]
+    fn osc52_sequence_encodes_multibyte_and_newlines() {
+        let seq = osc52_sequence("a\né");
+        assert!(seq.starts_with("\x1b]52;c;"));
+        assert!(seq.ends_with('\x07'));
+        let b64 = seq
+            .trim_start_matches("\x1b]52;c;")
+            .trim_end_matches('\x07');
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .unwrap();
+        assert_eq!(String::from_utf8(decoded).unwrap(), "a\né");
+    }
+
+    #[test]
+    fn provider_none_refuses_every_transport() {
+        let err = copy("x", None, ClipboardProvider::None).unwrap_err();
+        assert!(matches!(err, CopyError::NoTransport { .. }));
+    }
+
+    #[test]
+    fn provider_native_does_not_fall_through_to_osc52() {
+        // No native handle available → error rather than an OSC 52 write.
+        let err = copy("x", None, ClipboardProvider::Native).unwrap_err();
+        match err {
+            CopyError::NoTransport { detail } => assert!(detail.contains("native")),
+            other => panic!("expected NoTransport, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oversized_text_is_refused_before_writing() {
+        let big = "a".repeat(OSC52_MAX_BYTES + 1);
+        let err = copy(&big, None, ClipboardProvider::Osc52).unwrap_err();
+        match err {
+            CopyError::TooLarge { bytes } => assert_eq!(bytes, OSC52_MAX_BYTES + 1),
+            other => panic!("expected TooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn toast_suffix_names_only_the_unverifiable_route() {
+        assert_eq!(CopyRoute::Native.toast_suffix(), "");
+        assert!(CopyRoute::Osc52.toast_suffix().contains("OSC 52"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod agent;
 pub mod app;
 pub mod cli;
+pub mod clipboard;
 pub(crate) mod fuzzy;
 pub mod git;
 pub mod notifications;

--- a/src/session/settings.rs
+++ b/src/session/settings.rs
@@ -43,6 +43,9 @@ pub struct Settings {
     /// per-session dedup).
     #[serde(default)]
     pub notifications: NotificationSettings,
+    /// Clipboard transport settings (`[clipboard]` table). Absent = `auto`.
+    #[serde(default)]
+    pub clipboard: ClipboardSettings,
 }
 
 /// Whole-feature switches (`[features]` in settings.toml). Each flag hides the
@@ -135,6 +138,37 @@ pub enum NotificationBackend {
     /// Disable delivery (the dispatcher still starts but drops every
     /// notification — a soft off-switch distinct from `[features]`).
     Off,
+}
+
+/// Which clipboard transport to use (`[clipboard] provider`). `Auto` (the
+/// default) tries the local display server first and falls back to OSC 52,
+/// which reaches the terminal emulator's clipboard through any number of SSH
+/// hops. The forcing variants exist because no auto-detection is right for
+/// everyone: `Native` suits a local desktop whose terminal mangles OSC 52,
+/// `Osc52` suits a machine with a stale/unwanted local clipboard, and `None`
+/// disables writes entirely.
+///
+/// Copy only — clipboard *reads* never use OSC 52 (see [`crate::clipboard`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ClipboardProvider {
+    /// Native clipboard when it works, OSC 52 otherwise.
+    #[default]
+    Auto,
+    /// Local display server only; never emit OSC 52.
+    Native,
+    /// OSC 52 only; skip the native clipboard.
+    Osc52,
+    /// Disable clipboard writes.
+    None,
+}
+
+/// Clipboard settings (`[clipboard]` in settings.toml).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ClipboardSettings {
+    /// Transport selection. See [`ClipboardProvider`].
+    #[serde(default)]
+    pub provider: ClipboardProvider,
 }
 
 /// How `Ctrl+O` launches the editor (the DB `editor_mode` key, set via
@@ -299,6 +333,7 @@ impl Default for Settings {
             audit_retention_days: default_audit_retention_days(),
             features: FeatureFlags::default(),
             notifications: NotificationSettings::default(),
+            clipboard: ClipboardSettings::default(),
         }
     }
 }

--- a/src/ui/selection.rs
+++ b/src/ui/selection.rs
@@ -128,7 +128,94 @@ pub fn highlight_buffer(
     }
 }
 
+/// Extract selected text from a vt100 screen (the terminal pane's own grid)
+/// rather than the rendered frame buffer.
+///
+/// Two things this buys over [`extract_text_from_buffer`], which reads the
+/// painted cells:
+///
+/// - **Scrollback.** [`vt100::Screen::cell`] resolves through the current
+///   scrollback offset, so a selection made after scrolling up copies the
+///   history the user is actually looking at.
+/// - **Soft-wrap joining.** A line longer than the pane is stored by vt100 as
+///   several rows with the wrap flag set on all but the last. Those are one
+///   logical line, so they are rejoined with no `\n` — a wrapped URL or code
+///   line pastes intact instead of acquiring a break at the pane edge.
+///
+/// `pane_origin` is the top-left of the pane's *inner* (border-excluded) area;
+/// `PseudoTerminal` paints the screen 1:1 there, so subtracting it converts a
+/// screen position to a parser position. A selection reaching past the last
+/// grid row stops there.
+///
+/// A hard newline still separates logical lines, and trailing whitespace is
+/// trimmed per logical line (not per visual row — trimming a wrapped row's tail
+/// would eat the space that belongs mid-line). Wholly-blank trailing lines are
+/// dropped.
+pub fn extract_text_from_screen(
+    screen: &vt100::Screen,
+    selection: &Selection,
+    pane_origin: (u16, u16),
+) -> String {
+    let (grid_rows, grid_cols) = screen.size();
+    let (ox, oy) = pane_origin;
+
+    // Logical lines, each possibly assembled from several wrapped grid rows.
+    let mut lines: Vec<String> = Vec::new();
+    // Whether the previous row soft-wrapped, i.e. this row continues it.
+    let mut continues_previous = false;
+
+    for (row, col_start, col_end) in selection.row_spans() {
+        // A selection may extend past the grid (a short session in a tall
+        // pane). Rows are yielded in ascending order, so nothing further can
+        // be in range.
+        let Some(grid_row) = (row as u16).checked_sub(oy).filter(|r| *r < grid_rows) else {
+            break;
+        };
+
+        let lo = (col_start as u16).saturating_sub(ox);
+        let hi = (col_end as u16).saturating_sub(ox).min(grid_cols);
+
+        let mut text = String::new();
+        for col in lo..hi {
+            if let Some(cell) = screen.cell(grid_row, col) {
+                // A blank cell has no contents; the visual equivalent is a
+                // space, and dropping it would collapse column alignment.
+                if cell.has_contents() {
+                    text.push_str(cell.contents());
+                } else {
+                    text.push(' ');
+                }
+            }
+        }
+
+        match lines.last_mut() {
+            Some(last) if continues_previous => last.push_str(&text),
+            _ => lines.push(text),
+        }
+
+        // Only a span reaching the grid's right edge can be a wrap
+        // continuation; a selection ending mid-row is a deliberate stop.
+        continues_previous = screen.row_wrapped(grid_row) && hi >= grid_cols;
+    }
+
+    // Trim per logical line, then drop trailing blanks so a selection dragged
+    // past the last line of output doesn't carry empty rows with it.
+    while lines.last().is_some_and(|l| l.trim_end().is_empty()) {
+        lines.pop();
+    }
+
+    lines
+        .iter()
+        .map(|l| l.trim_end())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Extract selected text from a ratatui frame buffer.
+///
+/// Used for non-terminal panes (session list, info panel), which have no vt100
+/// grid behind them. Terminal panes go through [`extract_text_from_screen`],
+/// which also sees scrollback and rejoins soft-wrapped lines.
 ///
 /// Reads cell symbols within the selection, clamped to pane bounds.
 /// Trailing whitespace is trimmed per line, lines joined with `\n`.
@@ -350,6 +437,87 @@ mod tests {
         // Row 1: cols 10..25 (full pane width) = "content here..."
         // Row 2: cols 10..23 = "more content!"
         assert_eq!(text, "content here...\nmore content!");
+    }
+
+    /// Feed `input` to a fresh parser sized `rows`x`cols` with scrollback.
+    fn screen_with(rows: u16, cols: u16, scrollback: usize, input: &str) -> vt100::Parser {
+        let mut p = vt100::Parser::new(rows, cols, scrollback);
+        p.process(input.as_bytes());
+        p
+    }
+
+    #[test]
+    fn screen_extract_reads_grid_at_pane_origin() {
+        let p = screen_with(5, 20, 0, "hello world");
+        // Pane inner area starts at (10, 3): screen col 10 == grid col 0.
+        let pane = PaneBounds::from_rect(Rect::new(10, 3, 20, 5));
+        let sel = make_sel((3, 10), (3, 14), pane);
+        assert_eq!(extract_text_from_screen(p.screen(), &sel, (10, 3)), "hello");
+    }
+
+    #[test]
+    fn screen_extract_joins_soft_wrapped_rows() {
+        // 10 cols; the URL is longer, so vt100 wraps it and flags the seam.
+        let url = "https://example.com/a/b";
+        let p = screen_with(5, 10, 0, url);
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 10, 5));
+        // Select every row the wrapped line occupies.
+        let sel = make_sel((0, 0), (2, 9), pane);
+        // Rejoined with no newline at the wrap seams.
+        assert_eq!(extract_text_from_screen(p.screen(), &sel, (0, 0)), url);
+    }
+
+    #[test]
+    fn screen_extract_keeps_hard_newlines_between_logical_lines() {
+        let p = screen_with(5, 20, 0, "first\r\nsecond");
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 20, 5));
+        let sel = make_sel((0, 0), (1, 19), pane);
+        assert_eq!(
+            extract_text_from_screen(p.screen(), &sel, (0, 0)),
+            "first\nsecond"
+        );
+    }
+
+    #[test]
+    fn screen_extract_follows_scrollback() {
+        // 3 visible rows, 10 lines of history: "line0".."line9".
+        let input: String = (0..10).map(|i| format!("line{i}\r\n")).collect();
+        let mut p = screen_with(3, 20, 20, &input);
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 20, 3));
+        let sel = make_sel((0, 0), (0, 19), pane);
+
+        // At the bottom, the top visible row is recent history.
+        let bottom = extract_text_from_screen(p.screen(), &sel, (0, 0));
+
+        // Scrolled up, the same screen position resolves to older content —
+        // the whole point of reading the grid rather than the painted cells.
+        p.screen_mut().set_scrollback(5);
+        let scrolled = extract_text_from_screen(p.screen(), &sel, (0, 0));
+
+        assert_ne!(bottom, scrolled);
+        // Offset 5 puts "line3" at the top of the 3-row viewport (the last
+        // lines written are "line8"/"line9"), so the same screen row now
+        // resolves to older history.
+        assert_eq!(scrolled.trim(), "line3");
+    }
+
+    #[test]
+    fn screen_extract_skips_rows_outside_the_grid() {
+        let p = screen_with(2, 10, 0, "ab");
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 10, 8));
+        // Rows 0..7 selected, but the grid only has 2 — the rest are skipped
+        // rather than panicking or emitting blank lines.
+        let sel = make_sel((0, 0), (7, 9), pane);
+        assert_eq!(extract_text_from_screen(p.screen(), &sel, (0, 0)), "ab");
+    }
+
+    #[test]
+    fn screen_extract_preserves_interior_blanks() {
+        let p = screen_with(2, 20, 0, "a    b");
+        let pane = PaneBounds::from_rect(Rect::new(0, 0, 20, 2));
+        let sel = make_sel((0, 0), (0, 19), pane);
+        // Interior spacing kept (column alignment), trailing trimmed.
+        assert_eq!(extract_text_from_screen(p.screen(), &sel, (0, 0)), "a    b");
     }
 
     #[test]

--- a/tests/architecture_rules.rs
+++ b/tests/architecture_rules.rs
@@ -126,6 +126,14 @@ const MODULE_RULES: &[ModuleRules] = &[
         allowed: &["session", "paths"],
         allowed_path_only: &[],
     },
+    // Leaf side-effect module: clipboard writes (native + OSC 52). Knows
+    // `session` only for the `ClipboardProvider` setting; writes to the tty
+    // and never reaches into agent / ui / app / storage.
+    ModuleRules {
+        name: "clipboard",
+        allowed: &["session"],
+        allowed_path_only: &[],
+    },
 ];
 
 /// Modules exempt from the allowlist: `app` is the coordinator (imports


### PR DESCRIPTION
## Summary

- **Copy works over SSH.** Copy relied solely on `arboard` (local display server), so `Ctrl+C` was dead the moment thurbox ran remotely. It now falls back to an **OSC 52** escape sequence the terminal emulator turns into a clipboard write — working through any number of SSH hops, including thurbox-over-SSH driving remote sessions.
- **Opens two silent tmux gates.** An OSC 52 originating inside a pane is honored only when `set-clipboard` is exactly `on`; tmux's shipped default `external` **discards it with no error**, and a missing `Ms` terminfo capability drops it at a second gate. Both are now set on thurbox's own server (`TmuxBackend::apply_clipboard_config`) — without them the entire path is a no-op under tmux, which is how every agent runs.
- **Selection reads the vt100 grid** instead of the painted frame buffer, so scrollback is selectable and soft-wrapped rows rejoin into one logical line (a wrapped URL pastes intact). Dragging past the pane edge autoscrolls.
- **Paste degrades gracefully** to a hint pointing at the terminal's own `Ctrl+Shift+V`.
- New `[clipboard] provider = auto|native|osc52|none`. **No new dependencies.**

### Design notes

**Providers are ordered, not gated on `$SSH_TTY`.** The env check is only a proxy for "no local clipboard"; trying `arboard` answers that directly. Under tmux those vars are routinely stale (the server inherits its *first* client's environment). Neovim shipped SSH detection here and removed it as a breaking change in 0.11 (PR #31730) for exactly this reason; Helix and gitui order the same way.

**No capability probing.** Terminfo `Ms` and XTGETTCAP false-negative constantly (only foot/kitty/WezTerm answer; iTerm2 supports OSC 52 but reports it doesn't), and the query corrupts output on older terminals. A false negative silently disables copy — worse than emitting a sequence a terminal harmlessly ignores (VTE parses-and-discards).

Other details: written to `/dev/tty` not stdout (multiplexers intercept a child's stdout); BEL-terminated (crossterm's `CopyToClipboard` hardcodes ST); payload capped at ~74KB because tmux `INPUT_DISCARD`s an oversized sequence *entirely*.

### Tradeoff worth flagging

`set-clipboard on` lets any process in a pane — including agents, and anything under `sudo` — write the system clipboard. That's an exfiltration channel, and why tmux's own default is more conservative. Scoped to thurbox's socket; it's the price of copy working at all over SSH.

## Test plan

- [x] `cargo nextest run --all` — 1954 passing (13 new: 5 clipboard, 6 screen-extraction, 1 cross-pane-scroll regression, 1 existing updated)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --test architecture_rules` — 12/12 (new `clipboard` leaf module declared)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` — clean
- [x] `cargo deny check` — clean
- [x] `rumdl check` + `cargo fmt --check` — clean
- [ ] **Manual:** copy over SSH into a real terminal — the case emulators vary on

🤖 Generated with [Claude Code](https://claude.com/claude-code)