### PR TITLE
fix(ui): let empty-field Enter confirm the repo picker

### DIFF
--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -462,6 +462,34 @@ fn ctrl_n_opens_repo_picker() {
     assert!(!h.app.modal.is_open(), "Esc should dismiss the modal");
 }
 
+/// Regression: clicking into the path-input field (here reached via Tab) must
+/// not trap the user. With nothing typed, Enter — which the footer "Done"
+/// button also replays — finishes the picker instead of being swallowed as an
+/// empty "add repo". Previously the confirm arm lived only in the list focus,
+/// so an empty Enter here did nothing and the modal never advanced.
+#[test]
+fn repo_picker_enter_on_empty_path_input_confirms() {
+    let mut h = Harness::standard(0);
+    h.render();
+    h.ctrl('n'); // open the repo picker
+    h.key(KeyCode::Tab, KeyModifiers::NONE); // list → path input focus
+    assert!(
+        matches!(
+            h.app.modal,
+            modals::Modal::RepoPicker(ref rp)
+                if rp.focus == modals::RepoPickerFocus::Input
+        ),
+        "Tab should move focus into the path input"
+    );
+
+    h.key(KeyCode::Enter, KeyModifiers::NONE); // Done on an empty field
+    // No repos selected → the picker submits and advances to the name modal.
+    assert!(
+        matches!(h.app.modal, modals::Modal::SessionName(_)),
+        "empty-field Enter should confirm the picker, not stay stuck in it"
+    );
+}
+
 /// Create `~/code` under the harness's guarded home with one git child and
 /// one plain child, and drive the picker to the path input with `~/code/`
 /// typed — the setup shared by the path-browser tests. (Local listings

--- a/src/app/key_handlers.rs
+++ b/src/app/key_handlers.rs
@@ -1773,7 +1773,16 @@ impl App {
                 return;
             }
             KeyCode::Enter => {
-                self.repo_picker_commit_path_input();
+                // A non-empty field commits the typed path (add repo); an empty
+                // one has nothing to add, so Enter finishes the picker instead.
+                // This is also what the footer "Done" button replays, so without
+                // it a user who clicked into the path field could never confirm
+                // (the Enter/confirm arm otherwise lives only in the list focus).
+                if rp.path_input.value().trim().is_empty() {
+                    self.submit_repo_picker();
+                } else {
+                    self.repo_picker_commit_path_input();
+                }
                 return;
             }
             other => {

--- a/src/ui/repo_picker_modal.rs
+++ b/src/ui/repo_picker_modal.rs
@@ -495,11 +495,18 @@ fn footer_line(state: &RepoPickerState<'_>) -> Line<'static> {
             } else {
                 " browse  "
             };
+            // Enter on an empty field finishes the picker (Done); with a path
+            // typed it commits it as a repo — mirror that in the hint.
+            let enter_hint = if state.path_input.trim().is_empty() {
+                " done  "
+            } else {
+                " add repo  "
+            };
             Line::from(vec![
                 Span::styled("Tab", Theme::keybind()),
                 Span::styled(tab_hint, Theme::keybind_desc()),
                 Span::styled("Enter", Theme::keybind()),
-                Span::styled(" add repo  ", Theme::keybind_desc()),
+                Span::styled(enter_hint, Theme::keybind_desc()),
                 Span::styled("Ctrl+P", Theme::keybind()),
                 Span::styled(" import parent  ", Theme::keybind_desc()),
                 Span::styled("S-Tab", Theme::keybind()),
@@ -615,7 +622,8 @@ mod tests {
 
     #[test]
     fn footer_line_input_focus_tab_hint_depends_on_suggestion() {
-        let with = picker_state(RepoPickerFocus::Input, Some("/home/me/proj"));
+        let mut with = picker_state(RepoPickerFocus::Input, Some("/home/me/proj"));
+        with.path_input = "/home/me/proj";
         let with_text = span_text(&footer_line(&with).spans);
         assert!(with_text.contains("complete"));
         assert!(with_text.contains("add repo"));
@@ -627,6 +635,16 @@ mod tests {
         // Shift+Tab back to the list is discoverable from the input.
         assert!(without_text.contains("S-Tab"));
         assert!(without_text.contains("list"));
+    }
+
+    #[test]
+    fn footer_line_input_focus_empty_field_shows_done() {
+        // With nothing typed, Enter finishes the picker, so the hint reads
+        // "done" rather than "add repo" (empty-field confirm, matching Done).
+        let empty = picker_state(RepoPickerFocus::Input, None);
+        let empty_text = span_text(&footer_line(&empty).spans);
+        assert!(empty_text.contains("done"));
+        assert!(!empty_text.contains("add repo"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Clicking into the repo picker's *add a directory* path field set focus to `Input`, but the confirm action (`submit_repo_picker`) lived only in the **list**-focus Enter arm. The footer **Done** button just replays `Enter`, so once focus was in the path field, Done/Enter routed to `repo_picker_commit_path_input` — which on an **empty** field did nothing. The user was trapped: Done wouldn't work until they Shift+Tab/Esc'd back out of the field.
- Now `Enter` on an **empty** path field finishes the picker (matching what Done means, and giving keyboard users a quick "done"), while a **non-empty** field still commits the typed path as a repo.
- The footer hint reflects it: `Enter done` when the field is empty, `Enter add repo` when a path is typed.

## Test plan
- `cargo nextest run -E 'test(repo_picker)'` — new acceptance test `repo_picker_enter_on_empty_path_input_confirms` (Tab into path input → empty Enter advances to the name modal instead of staying stuck).
- `cargo nextest run -E 'test(footer_line)'` — footer-hint unit tests (empty → "done", non-empty → "add repo").
- Manual: `Ctrl+N` → click the path field → click **Done** with nothing typed → picker confirms.