### PR TITLE
fix(ui): hide the easter-egg clue on phones

### DIFF
--- a/website/css/components.css
+++ b/website/css/components.css
@@ -497,6 +497,17 @@
   opacity: 0.75;
 }
 
+/* The egg is keyboard-only (a keydown sequence — see js/main.js), and a phone
+   has no keyboard and no text field on this page to summon one, so the clue
+   would invite something impossible. Hidden at the same 639px the HUD bar's
+   "God Mode" segment uses, so both hints appear and disappear together.
+   Anyone who pairs a physical keyboard is above this breakpoint anyway. */
+@media (max-width: 639px) {
+  .footer-secret {
+    display: none;
+  }
+}
+
 /* ---- God-mode overlay (typing the Doom cheat; see js/main.js) ---- */
 
 /* Locks the page behind the modal so a wheel scroll does not move it. */


### PR DESCRIPTION
## Summary

Follow-up to #894. The `iddqd` easter egg is **keyboard-only** — it fires on a `keydown` sequence — but the footer clue told phone users to "type it anywhere", which is impossible there:

- The landing page has **zero text inputs**, so a mobile on-screen keyboard can never be summoned.
- Keys typed into a text field are ignored by design anyway (`isTypingContext`).
- There is no tap / long-press / gesture trigger.

Worse, the split was backwards: `.footer-secret` had no mobile hide rule, while the *other* clue (the HUD bar's `God Mode / 5 keys` segment) is already hidden below 639px via `hud-bar__seg--hide-sm`. So phones got the dead-end hint and lost the informative one.

This hides `.footer-secret` at that same 639px breakpoint, so both hints now appear and disappear together. Anyone who pairs a physical keyboard to a tablet is above the breakpoint anyway, and the egg genuinely works for them.

Kept as a width breakpoint rather than `(hover: none) and (pointer: coarse)` to match the codebase — every other responsive rule here uses `max-width: 639px`, and there are no pointer/hover feature queries anywhere in it.

## Test plan

- `npm run lint:website` — passes (prettier, htmlhint, stylelint, eslint).
- Verified the generated `core.css` bundle wraps the rule correctly, and confirmed it in the bundle actually served by a local Eleventy instance.
- No JS change, so the 24 existing jsdom assertions for the egg are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)