### PR TITLE
docs(docs): add the v2 plugin-architecture design set

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,13 @@ repos:
         types: [markdown]
         pass_filenames: false
 
+      - id: doc-links
+        name: Markdown cross-reference check
+        entry: scripts/dev/check-doc-links.sh
+        language: system
+        types: [markdown]
+        pass_filenames: false
+
       # Website linting (pre-commit stage)
       # Page .html files carry YAML front matter and are partial templates, so
       # Prettier/HTMLHint run on the CSS/JS sources and on the *built* _site

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,13 @@ event loop), see [`CLAUDE.md`](../CLAUDE.md).
 | [ORCHESTRATION.md](ORCHESTRATION.md) | The control-plane pattern for running sessions across many repos | Changing the session/message/extension surface the pattern relies on |
 | [CONFIG.md](CONFIG.md) | Every config file / env var / DB setting in one place | Adding/changing a config file, env var, or DB setting |
 
+## Forward-looking design
+
+[`v2/`](v2/README.md) holds the design set for **Thurbox v2** — the refactor
+that turns the TUI into a minimal Rust kernel hosting reloadable TypeScript
+plugins. Nothing there is implemented; the documents above remain
+authoritative for the shipping product until v2 lands.
+
 ## Keeping Docs Current
 
 **Rule**: If a code change invalidates or extends a documented decision,

--- a/docs/v2/ARCHITECTURE.md
+++ b/docs/v2/ARCHITECTURE.md
@@ -1,0 +1,1168 @@
+# Thurbox v2 — Architecture Decisions
+
+Same mini-ADR format as [`../ARCHITECTURE.md`](../ARCHITECTURE.md):
+**Choice**, **Why**, **Rejected alternatives**. Numbered `ADR-V*` so they never
+collide with v1's `ADR-*` (architecture) or `ADR-P*` (performance) series.
+
+## Index
+
+| # | Decision | Load-bearing for |
+|---|---|---|
+| [V1](#adr-v1) | Kernel / plugin split — everything but six things is a plugin | The whole design |
+| [V2](#adr-v2) | Plugins are Luau, in-process, one VM and thread each | Enforceable capabilities; footprint; reload |
+| [V3](#adr-v3) | No bundled runtime — the VM is linked in | Install story; artifact size |
+| [V4](#adr-v4) | One VM and thread per plugin, with declared capabilities | Enforcement by construction; blast radius; consent |
+| [V5](#adr-v5) | Plugins return a declarative view tree; the kernel renders | Frame ownership; theming |
+| [V6](#adr-v6) | Kernel-owned surfaces for content plugins cannot carry | Making "the session list is a plugin" affordable |
+| [V7](#adr-v7) | Hierarchical TEA — plugins own their state | Constitution rule 7 |
+| [V8](#adr-v8) | The v1 extension system is deleted, not migrated | One extensibility surface |
+| [V9](#adr-v9) | Plugin storage is namespaced in the existing database | *Partly superseded by V17* |
+| [V10](#adr-v10) | Every plugin command is agent-callable | The agent API |
+| [V11](#adr-v11) | The frame budget is defended by protocol, not convention | Preserving ADR-P1–P12 |
+| [V12](#adr-v12) | Module dependency rules extend to the kernel | Layer isolation |
+| [V13](#adr-v13) | Keep ratatui as the kernel's rendering substrate | Not rewriting the render layer |
+| [V14](#adr-v14) | Widgets are a Luau library; the catalog carries primitives | Keeping the catalog frozen |
+| [V15](#adr-v15) | Contribution points with lazy activation | Registry without running plugins |
+| [V16](#adr-v16) | A plugin has a headless service half and a TUI-only view half | Inheriting ADR-8b |
+| [V17](#adr-v17) | Plugins declare migrations; the kernel executes them | Relational plugin data |
+| [V18](#adr-v18) | Motion is declared, not pushed | Animation without a push per frame |
+| [V19](#adr-v19) | Real-time and dense panes are vt100 surfaces | Live content without a second renderer |
+| [V20](#adr-v20) | v2 is delivered on the trunk behind a compile-time gate | v1 stays shippable throughout |
+| [V21](#adr-v21) | Pane visibility is kernel state; the F1 editor stays kernel | Preserving v1's panel toggles and rebinding |
+| [V22](#adr-v22) | Anchored overlays instead of a floating-element ban | Dropdowns, context menus, inline compose |
+| [V23](#adr-v23) | Pane geometry is a workspace tree; slots are a preset | Grids, spanning panes, nested splits |
+
+---
+
+<a id="adr-v1"></a>
+
+## ADR-V1: Kernel / plugin split
+
+**Choice**: Thurbox v2 is a **minimal Rust kernel** hosting **Luau plugins**
+([ADR-V2](#adr-v2)). The kernel owns exactly six things:
+
+| Kernel responsibility | Why it cannot be a plugin |
+|---|---|
+| Session lifecycle + backends (tmux, SSH, WSL, psmux) | Blocking process/IO supervision, control-mode protocol, restart/adopt correctness |
+| Terminal grid (PTY read, vt100 parse, render) | Tens of KB of cells per frame per session — never crosses into a plugin VM |
+| Storage (SQLite, schema, migrations, multi-instance sync) | Single writer, transactional integrity, `PRAGMA data_version` polling |
+| Git + worktrees | Shared by every plugin; a plugin owning it makes it a hidden dependency |
+| Event loop, layout solver, theme, keymap, frame compositor | Global invariants: focus is unique, panes cannot overlap, one frame per paint |
+| Plugin host (VM lifecycle, host bindings, capabilities) | Bootstrap — it is what loads plugins |
+
+Everything else — **including the session list** — is a plugin.
+
+**Why**: The kernel list is precisely the set of things that are hard, shared,
+and rarely modified. The plugin list is precisely the set of things that are
+opinionated, frequently modified, and worth disagreeing about. v1 compiles both
+into one 95k-line binary where changing the second requires understanding the
+first.
+
+**Rejected**:
+
+- *Additive plugin API over the v1 core* — no first-party surface would
+ dogfood the API, so it stays second-class and diverges from what built-ins
+ can actually do. This is how most TUI plugin systems end up anemic.
+- *Strangler migration keeping session list + terminal native* — cheaper, but
+ leaves the two most important surfaces unable to demonstrate the API, and
+ guarantees "why can't my plugin do what the session list does" forever.
+
+---
+
+<a id="adr-v2"></a>
+
+## ADR-V2: Plugins are Luau, run in-process on a thread per plugin
+
+**Choice**: A plugin is **Luau**, executed by a `Lua` VM embedded via
+[`mlua`](https://github.com/mlua-rs/mlua) **inside the thurbox process**. Each
+plugin gets its own VM on its own OS thread. The host surface is a set of Rust
+functions bound into a sandboxed global environment; there is no RPC, no
+serialization, and no child process.
+
+Three conditions make this safe, and all three are binding:
+
+| | Condition | Buys |
+|---|---|---|
+| **C1** | One VM on one thread per plugin; never the UI thread | A slow or wedged plugin cannot stall a frame ([ADR-V11](#adr-v11)) |
+| **C2** | No native code — no FFI, no `dlopen`, no C modules | Crash isolation. This is the only thing a process boundary was buying that a thread cannot |
+| **C3** | The VM is the unit of reload; the kernel holds no handle outliving it | Reload is a guaranteed clean slate, enforced by Rust lifetimes rather than discipline |
+
+Full analysis in
+[DECISION-plugin-runtime.md](DECISION-plugin-runtime.md).
+
+**Why**: Three separate problems collapse into one solved one.
+
+- **The capability model becomes real.** Luau is built to run untrusted code —
+  it is Roblox's entire business — so there is no `io`, no `os.execute` and no
+  `require` unless the host binds them. `fs`, `net` and `shell` stop being
+  advisory and become enforced, closing the defect
+  [SECURITY.md](SECURITY.md) had to leave open under every JavaScript option.
+- **The bundled runtime disappears.** No 40–90 MB per platform archive, no
+  per-channel vendoring across brew/AUR/Chocolatey/winget, no runtime CVE
+  ownership, and no unanswered "does it build for musl and Windows ARM64".
+  The VM is part of the binary.
+- **Footprint and startup improve by orders of magnitude.** A Luau state is
+  kilobytes and starts in microseconds, against tens of megabytes and tens of
+  milliseconds per sidecar process. Lazy activation stops being load-bearing.
+
+Two further properties made it acceptable rather than merely cheap. Luau has
+**gradual typing** and `luau-analyze`, so the view-tree contract stays
+statically checkable — the objection that rules out plain Lua. And Luau is a
+fork of Lua 5.1, so ordinary Lua reads and runs largely unchanged: a plugin
+author who has written a neovim config is not learning a new language.
+
+**Rejected**:
+
+- *TypeScript in a sidecar process over JSON-RPC* — what this ADR replaces,
+  and the argument for it was sound: a process boundary contains crashes,
+  hangs and native-code faults absolutely, reload is a guaranteed clean slate
+  by construction, and npm is the largest library ecosystem there is. It was
+  rejected on cost. Two halves across seven bundled plugins is plausibly
+  200–400 MB of resident runtime for a terminal tool, and the boundary buys
+  its isolation by paying for a JS runtime thurbox then has to vendor, patch
+  and ship on four platforms — while *still* not being able to enforce
+  `fs`/`net`/`shell`, because no shipping JS runtime except Deno has a
+  permission model. C1–C3 recover every isolation property except protection
+  from native code, and C2 removes native code.
+- *Plain Lua 5.4* — the standard, so documentation, snippets, every neovim
+  user and every language model know it better. Rejected because it has no
+  gradual typing (Teal is another toolchain) and its sandbox is one you
+  assemble and maintain yourself rather than one an upstream maintains because
+  its business depends on it. The familiarity gap is narrow since Luau runs
+  ordinary Lua; the sandbox and typing gaps are not.
+- *LuaJIT* — fastest, frozen at 5.1 semantics with upstream in maintenance,
+  and its built-in `ffi` is exactly what C2 forbids, so it ships with the
+  sharp edge enabled. JIT also means writable-executable pages, which some
+  hardened environments refuse.
+- *QuickJS (`rquickjs`)* — would keep TypeScript in-process and satisfies
+  C1–C3, but gives up the sandbox that is Luau's main prize while keeping a
+  language that is no longer a requirement.
+- *Rhai* — the only candidate written in pure Rust, which removes even the
+  residual risk of the VM itself faulting, with sandboxing and operation
+  limits first-class. Rejected on adoption: a plugin system exists to attract
+  third-party authors, and almost nobody writes Rhai.
+- *Starlark* — hermetic by construction, and a *configuration* language: no
+  I/O, restricted recursion and loops. Right for `layout.toml`-shaped
+  problems, wrong for something that holds state and reacts to events.
+- *Embedded V8 (`deno_core`)* — keeps TypeScript and npm, and drags a large
+  V8-adjacent tree through `cargo-deny` for the life of the project while its
+  per-isolate memory gives back the reason for going in-process at all.
+- *WASM components (`wasmtime` + WIT)* — the strongest sandbox and
+  language-agnostic, but every host API must be hand-bound in WIT, the guest
+  toolchain for a scripting-shaped language is poor, and the dev loop regains
+  a build step that C3's reload story exists to remove.
+- *Rust dynamic libraries* — fastest, and reload requires recompiling, which
+  contradicts the premise. Rust has no stable ABI, so every kernel release
+  would break every plugin binary.
+
+**Reversal conditions**, since this is a decision taken on analysis rather
+than measurement: plugins routinely needing third-party libraries Luau cannot
+supply, or agent-authored plugins proving materially worse in Luau than in a
+mainstream language. Both are tested at the validation gate in
+[DECISION-plugin-runtime.md](DECISION-plugin-runtime.md).
+
+---
+
+<a id="adr-v3"></a>
+
+## ADR-V3: No bundled runtime — the VM is linked into the binary
+
+**Choice**: thurbox ships **one binary with no runtime dependency**. The Luau
+VM is compiled in via `mlua` ([ADR-V2](#adr-v2)). There is nothing to vendor,
+nothing to detect on the user's machine, and no `THURBOX_PLUGIN_RUNTIME`
+override.
+
+**This ADR previously said the opposite** — it specified bundling a pinned Bun
+per platform archive, accepting 40–90 MB of artifact growth as the price of
+plugins working on a machine with no Node ecosystem. Moving in-process
+([ADR-V2](#adr-v2)) does not reduce that cost; it deletes it.
+
+**Why**: The v1 install story survives untouched. `brew install thurbox &&
+thurbox` still works on a bare machine, `install.sh` still fetches one
+artifact, and the four platform builds stay the size they are. The obligations
+the bundled-runtime design created — per-channel packaging work across
+brew/AUR/Chocolatey/winget, ownership of a third-party runtime's CVE response,
+and an unanswered question about musl and Windows ARM64 — do not arise.
+
+**What this closes**:
+
+| Was open | Now |
+|---|---|
+| 40–90 MB per platform archive | No change from v1 |
+| Runtime CVE response, shippable as a patch release | `mlua` is an ordinary Cargo dependency under `cargo-deny` |
+| Does a suitable runtime exist for musl / Windows ARM64 / macOS universal? | Moot — it compiles wherever the binary does |
+| Packaging churn on four moderated channels | None |
+
+**Rejected**:
+
+- *Bundling a JS runtime* — the previous choice, and only necessary because
+  plugins ran out of process in a language thurbox does not compile.
+- *Requiring a system Lua* — smaller still, and reintroduces exactly the
+  "works on my machine" surface that pinning was meant to remove, for a
+  dependency measured in kilobytes.
+
+---
+
+<a id="adr-v4"></a>
+
+## ADR-V4: One VM and one thread per plugin, with declared capabilities
+
+**Choice**: Each plugin gets **its own Luau VM on its own OS thread**. Its
+manifest declares the capabilities it needs; the kernel binds **only** the host
+functions those capabilities grant into that VM's sandboxed global environment.
+
+```toml
+[capabilities]
+sessions = "read"                  # none | read | control
+db       = "kv"                    # none | kv | tables
+fs       = ["{repo}", "{plugin_data}"]
+net      = ["api.github.com"]
+shell    = false
+```
+
+**Why**:
+
+- **Enforcement is by construction, not by checking.** A plugin without `fs`
+  does not fail an `fs` call — there is no `io` table in its environment to
+  call. This is the difference between a capability system and a convention,
+  and it is what [ADR-V2](#adr-v2) buys.
+- **Blast radius.** A plugin that throws returns a `Result`; one that loops is
+  aborted by Luau's interrupt handler; one that allocates without bound hits
+  its per-VM memory limit. Each affects one pane.
+- **Reload granularity.** Dropping one VM does not disturb the others, and
+  costs microseconds rather than a process respawn.
+- **Informed consent.** `thurbox plugin install` shows exactly what a plugin
+  asked for, and a pane that only draws rows can be denied everything. v1
+  extensions ran arbitrary shell with no declaration; plugins run
+  continuously, so trust-on-install alone was a downgrade.
+
+**The limit, stated plainly**: C2 ([ADR-V2](#adr-v2)) forbids native code
+because a segfault in a plugin's C module would take the TUI with it — the one
+isolation property a thread cannot recover. Capabilities constrain what a
+plugin may *call*; C2 is what stops it reaching around them.
+
+**Rejected**:
+
+- *One process per plugin* — absolute crash isolation including native faults,
+  at 15–30 MB resident each and a JS runtime to vendor. See
+  [ADR-V2](#adr-v2)'s rejected list.
+- *One VM shared by all plugins* — lowest memory, and one plugin's globals,
+  faults and reloads become everyone's. Sandboxing between plugins inside a
+  single Lua state is far harder than between states.
+- *Capability checks at each host function instead of environment binding* —
+  equivalent on paper, worse in practice: it puts a check in every binding
+  rather than a decision in one place, and a missed check is a silent hole.
+
+---
+
+<a id="adr-v5"></a>
+
+## ADR-V5: Plugins return a declarative view tree; the kernel renders it
+
+**Choice**: A plugin never draws. It returns a **declarative view tree** — a
+plain-data node graph of `box`, `list`, `text`, `markdown`, `input`, `table`,
+… , carrying no closures and no host handles, converted once to an owned Rust
+value at push time —
+and the kernel renders it with ratatui using the active theme, derives mouse
+hitboxes from it, and routes input back as events. Full specification in
+[FEATURES-View-Tree.md](FEATURES-View-Tree.md).
+
+**Why**:
+
+- **The frame stays the kernel's.** Focus uniqueness, pane bounds, theme
+ consistency, scrollbars, and the demand-driven redraw loop (ADR-P*) remain
+ enforceable invariants rather than plugin conventions.
+- **Plugins cannot break rendering.** The worst a plugin can do is return an
+ ugly tree or none at all. It cannot corrupt the terminal, leak escape
+ sequences, or desynchronize the cursor.
+- **Theming and accessibility come free.** Nodes reference semantic theme
+ tokens, so all 36 palettes and every future one apply to third-party panes
+ with no plugin change.
+- **It is one value, not a call stream.** An immediate-mode drawing API would
+ mean hundreds of host calls per frame and a plugin holding the frame buffer;
+ a tree is one value handed over once.
+
+**Rejected**:
+
+- *Immediate-mode drawing into a rect* — maximum power, but per-frame call
+ chatter, off-theme output, and the ADR-P performance work becomes
+ unholdable.
+- *Data-only slots (plugin supplies rows, kernel owns the widget)* — simplest
+ and most consistent, but no plugin could ever build something like the
+ code-review diff, and ADR-V1 requires that built-ins be plugins.
+- *Declarative tree plus a raw-buffer escape hatch* — the pragmatic middle,
+ and reconsidered if a real pane proves unbuildable. Deferred because two
+ rendering paths means two sets of failure modes, and the escape hatch always
+ becomes the path of least resistance.
+
+---
+
+<a id="adr-v6"></a>
+
+## ADR-V6: Kernel-owned surfaces for content plugins cannot carry
+
+**Choice**: The view tree includes a small set of **surface nodes** that a
+plugin *places and configures* but does not *supply content for*. The kernel
+renders them directly from kernel-owned state:
+
+| Node | Kernel state rendered |
+|---|---|
+| `sessionTerminal { sessionId, scroll }` | The live vt100 grid for that session |
+| `pty { command, args, env, cwd, scroll }` | A live PTY process the kernel spawned |
+| `surface { id, cols, rows }` | A vt100 grid the plugin writes bytes into |
+| `diff { repo, target }` | A git diff the kernel computed |
+| `sparkline { metric }` | Kernel metrics ring buffers |
+
+**Why**: A session's terminal grid is ~200 rows × 200 columns of styled cells,
+changing many times a second. Rebuilding that as a tree in a plugin and
+converting it back every frame would cost more than the entire v1 render loop. The plugin decides
+*where* the terminal goes, how big it is, and what surrounds it; the kernel
+fills the rect. This is what makes "the session list is a plugin" affordable
+rather than aspirational.
+
+`pty` and `surface` extend the same mechanism past sessions: the first to an
+arbitrary process, the second to a grid with no process at all. Both reuse the
+`vt100` + `tui-term` pipeline the session pane already runs on, so neither adds
+a dependency or a second renderer. Their contract — input, resize, lifetime,
+and why they are the answer to real-time content rather than a loophole in
+[ADR-V5](#adr-v5) — is [ADR-V19](#adr-v19).
+
+**Rejected**:
+
+- *Stream the grid to plugins* — conceptually pure, catastrophic in practice.
+- *Keep the terminal as a hardcoded pane outside the tree* — then plugins
+ cannot lay out around it, and the central pane's tab strip (agent / shell /
+ review) cannot be a plugin.
+
+---
+
+<a id="adr-v7"></a>
+
+## ADR-V7: Plugins own their state; the kernel owns kernel state
+
+**Choice**: TEA is preserved but becomes **hierarchical**. The kernel keeps a
+single model for kernel state (sessions, focus, layout, theme). Each plugin
+keeps its own model, updated by its own reducer, in its own VM. The
+kernel treats a plugin as a pure function of `(events) → view tree`; it never
+inspects plugin state.
+
+**Why**: Constitution rule 7 forbids component-local state because in v1 it
+would mean state scattered across panes that all mutate the same `App`. That
+hazard does not exist across a VM boundary: a plugin's state cannot be
+reached, aliased, or corrupted by anything but its own reducer. The
+one-directional `Event → Message → update → view → Frame` flow holds at both
+levels; there are simply two levels. Constitution rule 7 is amended
+accordingly — see [CONSTITUTION-DELTA.md](CONSTITUTION-DELTA.md).
+
+**Rejected**:
+
+- *Single global model including plugin state* — every plugin state change
+ becomes a host call plus a broadcast; enormous chatter for no invariant that
+ ADR-V5 does not already give us.
+- *Free-form plugin state with callbacks* — the thing rule 7 was written to
+ prevent, and untestable.
+
+---
+
+<a id="adr-v8"></a>
+
+## ADR-V8: The v1 extension system is deleted, not migrated
+
+**Choice**: `extensions/`, `ExtensionDef`, `extension_config`,
+`session_ops::extensions`, `builtin_hooks`, the `thurbox-cli extension`
+subcommand, and the `active_extensions` metadata key are **removed** in v2.
+Plugins are the only extensibility surface. No compatibility shim, no
+deprecation window.
+
+**Why**: The extension system is unused in practice, and keeping it would mean
+shipping two manifest formats, two installers, two update paths, two self-heal
+loops, and two answers to "is tasks an extension or a plugin?" for the rest of
+the project's life. Its genuinely useful capabilities — declaring agents,
+seeding automations, placing files into agent config dirs, patching agent args
+— are re-expressed as plugin capabilities, which is strictly more general
+because a plugin can also draw.
+
+**What must survive the deletion**: the built-in **hooks** behavior. Agent
+status reporting (`working`/`blocked`/`done`) is core product behavior, not an
+extension, and is absorbed into the kernel's session layer. See
+[MIGRATION.md](MIGRATION.md) for the full teardown inventory.
+
+**Rejected**:
+
+- *Unify by re-expressing extensions as plugins* — the right answer if they
+ had users. They do not.
+- *Ship the extension machinery as one bundled plugin* — preserves v1 behavior
+ verbatim, but keeps two user-facing concepts alive indefinitely to serve
+ nobody.
+
+---
+
+<a id="adr-v9"></a>
+
+## ADR-V9: Plugin storage is namespaced inside the existing database
+
+> **Partly superseded by [ADR-V17](#adr-v17).** The "plugins do not create
+> tables" clause was too strong and no longer holds: plugins may declare
+> migrations that the *kernel* executes into a per-plugin namespace. Everything
+> else below stands — one database file, one schema owner, coherent
+> multi-instance sync, no raw SQL handle, kernel tables reachable only through
+> typed host APIs. Read this ADR for **why storage lives in the kernel
+> database**; read ADR-V17 for **what a plugin may do with it**.
+
+**Choice**: Plugin storage lives in the existing SQLite database: a namespaced
+key-value store (`plugin_kv(plugin, key, value, updated_at)`) plus read access
+to kernel tables through typed host APIs. No plugin receives a raw SQL handle.
+
+**Why**: One database keeps the multi-instance sync story (`PRAGMA
+data_version`, ADR-7b) intact for free, keeps backup/restore a single file,
+and keeps schema migrations under one owner. A plugin that could `CREATE
+TABLE` would make `SCHEMA_VERSION` meaningless and turn every plugin
+uninstall into an orphaned-table problem.
+
+**Consequence**: The v1 `tasks`, `automations`, `session_messages`,
+`review_comments`, and `review_marks` tables stay kernel tables with typed
+host APIs, because bundled plugins need them and because the headless CLI and
+the automation heartbeat use them without any plugin loaded. "Tasks is a
+plugin" means the *pane and its behavior* are a plugin, not that the storage
+moves.
+
+**Rejected**:
+
+- *Per-plugin SQLite file* — clean isolation, but breaks cross-plugin joins,
+ multiplies the sync mechanism, and scatters backups.
+- *Raw SQL handle scoped by capability* — maximum power, no way to enforce
+ schema ownership, and a single bad migration corrupts the user's sessions.
+
+---
+
+<a id="adr-v10"></a>
+
+## ADR-V10: Every plugin command is agent-callable
+
+**Choice**: Plugins register **named commands with JSON-Schema-typed
+arguments**. The same registry backs keybindings, the command palette,
+`thurbox-cli`, and a JSON-RPC control socket. Anything a user can trigger, an
+agent can trigger.
+
+**Why**: Thurbox already puts an agent inside every session, and v1's flow and
+shepherd workflows already coordinate through `thurbox-cli` and the message
+queue. Making the plugin surface agent-callable is the natural completion of
+that: a session's agent can create a task, open a review, or drive a pane
+without screen-scraping. It also gives plugins one entry-point abstraction
+instead of three parallel ones. Full design in [FEATURES-Agent-API.md](FEATURES-Agent-API.md).
+
+**Rejected**:
+
+- *Read/query only* — safer, but reduces agents to observers when the whole
+ point of thurbox is agents doing work.
+- *Defer to v2.1* — the command registry is load-bearing for keybindings and
+ the palette regardless; retrofitting the agent surface later means
+ redesigning schemas after third-party plugins depend on them.
+
+---
+
+<a id="adr-v11"></a>
+
+## ADR-V11: The frame budget is defended by protocol, not by convention
+
+**Choice**: The render protocol is designed so a slow plugin degrades its own
+pane and nothing else:
+
+1. **Views are cached and versioned.** The kernel keeps each plugin's last
+ view tree. A plugin pushes a new tree when its state changes; the kernel
+ does not request one per frame.
+2. **Rendering never blocks on a plugin.** A frame always paints from cache. A
+ plugin that has not answered simply shows its previous tree.
+3. **Every call into a plugin has a deadline** (default 250 ms), enforced by
+ the VM's interrupt handler. On timeout the pane renders its last tree with a
+ staleness marker; repeated timeouts suspend the plugin with a visible error
+ state.
+4. **The demand-driven loop is preserved.** A plugin pushing a view marks the
+ UI dirty exactly as `detect_output_redraw` does today. Idle plugins cost
+ zero frames.
+5. **Input is acknowledged, not awaited.** Key events are dispatched
+ fire-and-forget; the resulting view arrives when it arrives.
+
+**Why**: The v1 performance work (`docs/PERFORMANCE.md`, ADR-P1–P12) is a real
+asset — idle paints dropped from ~100 fps to ~4 fps, the whole new-session
+flow moved off the UI thread. A naive request-response render protocol would
+put a plugin call on the critical path of every frame and undo all of it.
+
+**Rejected**:
+
+- *The kernel calls `render()` on every frame* — the obvious design, and the
+ one that makes the TUI exactly as fast as its slowest plugin. In-process this
+ is *more* tempting than it was over a socket, and no less wrong: the render
+ thread would take a lock on every plugin's VM before it could paint.
+- *Plugins draw into a shared cell buffer* — removes the tree conversion but
+ reintroduces ADR-V5's rejected immediate mode plus a memory-safety problem
+ that [C2](#adr-v2)'s no-native-code rule exists to avoid.
+
+---
+
+<a id="adr-v12"></a>
+
+## ADR-V12: Module dependency rules extend to the kernel
+
+**Choice**: The `tests/architecture_rules.rs` allowlist continues to govern
+the Rust kernel, with one new module family:
+
+```text
+session ← pure data types, no crate-internal references
+agent ← session
+plugin ← session (+ paths/shell); NEVER ui, git, app
+ui ← session + app model/view state; NEVER agent, git, plugin
+app ← coordinator, imports all modules
+```
+
+`plugin` (host, supervisor, host bindings, capabilities) sits beside `agent` as a
+side-effect layer: it owns VM lifecycles and plugin threads, so it may not be
+imported by `ui`. The view-tree renderer lives in `ui` and consumes plain
+data types from `session`, exactly as the diff types do today (v1 ADR
+precedent: `session::review` exists so `ui` can render diffs without importing
+`git`).
+
+**Why**: The isolation rule is the reason v1's layers stayed clean under
+95k lines. A new subsystem owning foreign VMs and threads is precisely the
+kind of thing it exists to fence off.
+
+**Rejected**:
+
+- *Let `ui` call the plugin host directly to fetch views* — convenient, and it
+ would make `view()` impure and blocking, violating both the TEA rule and
+ ADR-V11.
+
+---
+
+<a id="adr-v13"></a>
+
+## ADR-V13: Keep ratatui as the kernel's rendering substrate
+
+**Choice**: The kernel keeps **ratatui + crossterm + tui-term + vt100**. The
+view-tree renderer is written as a ratatui consumer: nodes resolve to
+`Rect`s through ratatui's constraint solver and paint as `Line`/`Span` runs
+into the frame buffer.
+
+**Why**: Auditing how v1 actually uses ratatui settles this more firmly than
+expected.
+
+| Signal | Measurement |
+|---|---|
+| ratatui widget types used | 5 (`Block`, `Borders`, `Clear`, `ListItem`, `Paragraph`) |
+| `Span::styled` / `Line::from` call sites | 395 / 168 |
+| Files touching the raw cell buffer | 2 (`selection.rs`, `terminal_view.rs`) |
+| Pure view-model structs handed to renderers | 19 (`TaskPaneState`, `LeftPanelState`, …) |
+
+Two conclusions follow:
+
+1. **thurbox uses ratatui as a substrate, not a widget toolkit.** What it
+ consumes is the cell buffer with double-buffered diffing (only changed
+ cells are written — the thing that makes the demand-driven loop in
+ `docs/PERFORMANCE.md` affordable), the constraint layout solver, the
+ span/style model, and crossterm integration. It does not consume ratatui's
+ widget library, so nothing about the widget library constrains v2.
+2. **v1 already has the view-tree architecture — statically.** Each pane
+ renderer is a pure function from a plain view-model struct to spans, built
+ by the `app` layer. That is a view tree with 19 hand-written node types and
+ 19 bespoke renderers. v2 replaces those with one node set and one renderer.
+ This is a refactor of an existing pattern, not the introduction of a new
+ one.
+
+`tui-term` + `vt100` are separately decisive: they bridge a tmux-driven vt100
+grid into the frame, which is what makes the agent panes work at all, and they
+have no equivalent outside the Rust ecosystem.
+
+**Rejected**:
+
+- *Move the whole TUI to TypeScript* — the serious alternative. Rust demotes
+ to a headless session daemon; the TUI is a TS app on
+ [OpenTUI](https://github.com/anomalyco/opentui) (React/Solid components over
+ a Zig rendering core via Bun FFI, used in production by opencode — a CLI
+ thurbox itself launches) or pi's `pi-tui`. Plugins would then be in-process
+ TS modules: no serialization, no node catalog, unlimited widget power, one
+ language. Rejected because (a) the central pane is N live vt100 grids driven
+ by tmux control mode, so this means re-solving `vt100` + `tui-term` in
+ JavaScript on the hottest path thurbox has; (b) the kernel stays Rust
+ regardless — tmux control mode, SSH/WSL transports, SQLite, git — so the
+ outcome is still two languages, with the process boundary moved from a quiet
+ place (view trees, pushed on change) to a chatty one (terminal cells, every
+ frame); (c) it is a rewrite of the event loop, input translation, selection,
+ links, and mouse routing, not a refactor; (d) OpenTUI is pre-1.0, and
+ betting the entire render layer on it is a categorically larger risk than
+ betting the plugin layer on a runtime. Named here because if the view tree
+ ever proves too constraining, this is the direction to reconsider — not a
+ raw-buffer escape hatch bolted onto ADR-V5.
+- *A different Rust TUI crate* (`cursive`, `iocraft`, `zi`) — each would still
+ need the same view-tree layer built on top, none has the `tui-term`/`vt100`
+ bridge, and all would cost a full port for no capability gain.
+- *Render directly on crossterm* — drops a dependency and rebuilds buffer
+ diffing plus a layout solver by hand, which is the part of ratatui thurbox
+ actually depends on.
+
+---
+
+<a id="adr-v14"></a>
+
+## ADR-V14: Widgets are a Luau library; the node catalog carries primitives
+
+**Choice**: The view-tree node catalog is **two tiers**, and only these cross
+into the kernel as node types:
+
+- **Tier 1 — primitives.** `box`, `row`, `column`, `spacer`, `scroll`, `text`,
+  `input`, `textarea`. Deliberately small and **frozen**.
+- **Tier 2 — kernel surfaces.** Nodes whose content or clock lives in the
+  kernel: `sessionTerminal`, `pty`, `surface`, `diff`, `fileTree`, `code`,
+  `markdown`, `statusDot`, `sparkline` ([ADR-V6](#adr-v6)).
+
+Everything else — tables, badges, progress bars, key-hint rows, empty states,
+selectable lists — is **`thurbox.widgets`, an ordinary Luau module** that
+composes down to Tier 1.
+
+The line has one test: **does the kernel own the data or the clock?**
+
+**Why**: A featureful kernel catalog makes the kernel the bottleneck for every
+new widget. If an author who needs a tree-table has to file an issue and wait
+for a thurbox release, the API is decorative. Keeping widgets in plugin-space
+means they are written by whoever needs them, testable without a kernel, and
+forkable when opinions differ — and it keeps the protocol small enough that
+the additive-only rule
+([N4](CONSTITUTION-DELTA.md)) is holdable.
+
+**The distribution cost, stated because it is real.** An earlier draft of this
+ADR put widgets on npm, where versioning and forking are solved. Luau has no
+npm ([ADR-V2](#adr-v2)), so `thurbox.widgets` ships as a bundled module
+resolvable by every plugin, with third-party widget libraries distributed as
+ordinary plugins that export modules. That pulls widget versioning **back
+toward the kernel's release cycle**, which is precisely the coupling this ADR
+exists to prevent. It is the sharpest cost of the Luau decision and it is not
+fully bought off: the mitigation is that a plugin may vendor its own widget
+module and ignore the bundled one, so the bundled version is a default rather
+than a mandate.
+
+**Rejected**:
+
+- *Rich kernel catalog* — better defaults and less plugin code, at the cost of
+  making the kernel the bottleneck for every widget forever.
+- *Pure primitives, no Tier 2* — conceptually clean and unable to render a
+  terminal grid or a diff, which is the whole point of ADR-V6.
+- *Widgets as a kernel-versioned standard library with no override* — simpler
+  to document, and it makes the coupling above permanent instead of a default.
+
+---
+
+<a id="adr-v15"></a>
+
+## ADR-V15: Contribution points with lazy activation
+
+**Choice**: A plugin extends thurbox by declaring **contributions** in its
+manifest — never by imperative registration at runtime. Each contribution
+type is registered from the manifest **without starting the plugin's VM**;
+the VM is created only when an **activation event** fires.
+
+| Contribution | Extends |
+|---|---|
+| `panes` | Slot-placed surfaces |
+| `commands` | The command registry (keys, palette, CLI, agents) |
+| `keybindings` | Default chords, user-overridable as usual |
+| `settings` | Namespaced rows in the Settings panel |
+| `agents` | Entries in `agents.toml` |
+| `automations` | Seeded schedules |
+| `statusItems` | Footer pills |
+| `tabs` | Central-pane tabs |
+| `sessionDecorations` | Badges/columns on session-list rows owned by another plugin |
+
+Activation events: `onStartup`, `onPaneVisible:<id>`, `onCommand:<id>`,
+`onSession`, `onEvent:<name>`.
+
+**Why**:
+
+- **Nothing runs that nobody asked for.** Under
+ [ADR-V2](#adr-v2) a VM costs kilobytes and microseconds, so this is no
+ longer load-bearing for startup the way process-per-plugin made it — but a
+ plugin that never activates should still execute no code, which is a
+ correctness and consent property rather than a performance one.
+- **The UI is complete before any plugin runs.** Keybindings resolve, the
+ palette lists commands, Settings shows every row, and panes reserve their
+ slots — all from manifest data. A plugin that never activates costs nothing
+ and still appears in the F1 editor.
+- **`sessionDecorations` is how plugins compose without knowing about each
+ other.** A CI plugin adds a failing badge to a session row owned by the
+ session-list plugin, with no dependency between them. Without a decoration
+ point, cross-plugin composition forces plugins to import each other, which
+ is how plugin ecosystems ossify.
+
+**Rejected**:
+
+- *Imperative registration in `init()`* (the Ink/Express shape) — more
+ flexible, and it requires running every plugin at startup to know what the
+ keybindings even are.
+- *Eager activation of everything* — simpler lifecycle, N cold starts on every
+ launch, and idle memory proportional to plugins installed rather than
+ plugins used.
+
+---
+
+<a id="adr-v16"></a>
+
+## ADR-V16: A plugin has a headless service half and a TUI-only view half
+
+**Choice**: A plugin declares up to two entry points — `service.luau` and
+`view.luau` — running in **separate VMs on separate threads** with separate
+capability grants.
+The service half is hosted by whichever of the TUI, the tmux heartbeat keeper,
+or a `thurbox-cli` invocation needs it first; the view half exists only while
+the TUI does. Full contract in [FEATURES-Backend-API.md](FEATURES-Backend-API.md).
+
+**Why**: v1 guarantees automations fire with the TUI closed (`docs/ARCHITECTURE.md`
+ADR-8b — a detached keeper loops `automation tick` every 60 s, with optional
+systemd/launchd units). A plugin backend that only lived inside the running TUI
+would silently revoke that: a task-sync or CI-watch plugin would stop the
+moment you quit. Drawing the seam here means the plugin system inherits ADR-8b
+rather than fighting it.
+
+Three further properties fall out:
+
+- **A plugin with no UI is just a service.** The tracker-sync integrations that
+ v1 shipped as `Exec` automations become first-class plugins with no view
+ tree at all.
+- **Capabilities split naturally.** A view rarely needs `net` or `shell`; a
+ service rarely needs anything else. Granting per half makes the install
+ prompt meaningful instead of a union of everything.
+- **The halves fault independently.** A broken sync loop degrades a pane; it
+ does not remove it.
+
+Machine-wide single-instance is enforced with an advisory lock in the database,
+so a running TUI and a heartbeat tick never both run a plugin's poll loop.
+
+**Rejected**:
+
+- *One process per plugin doing both jobs* — simpler, and it either dies with
+ the TUI (losing ADR-8b) or keeps a renderer resident headless (paying for a
+ view nobody can see).
+- *Service work as kernel automations only* (`Exec` shelling out, the v1
+ pattern) — no state, no typed contract, no supervision, and every
+ integration reduced to parsing its own output.
+- *Service half in Rust* — faster, and it reintroduces recompiling for the
+ majority of what an integration plugin actually does.
+
+---
+
+<a id="adr-v17"></a>
+
+## ADR-V17: Plugins declare migrations; the kernel executes them
+
+**Choice**: A plugin may own **relational tables** in the kernel database. It
+declares an append-only migration list; the kernel rewrites each statement into
+the plugin's namespace (`runs` → `plugin_ci_runs`), executes it, and records
+the applied version in `plugin_migrations(plugin, version)`. Queries go through
+parameterized `ctx.db.all/run/tx`. There is no raw connection handle, and a
+statement touching anything outside the namespace is rejected.
+
+**Why**: [ADR-V9](#adr-v9)'s KV-only store is genuinely painful for a plugin
+with relational data — a CI plugin tracking runs across repos and branches ends
+up hand-rolling indexes in a key space. The usual answer in JS plugin ecosystems
+is to hand the plugin a live `better-sqlite3` handle, and that is undeniably
+more useful. But a raw handle would make `SCHEMA_VERSION` meaningless, let one
+plugin read another's data (and the user's sessions), and turn every uninstall
+into an orphaned-table problem.
+
+Kernel-executed migrations keep the useful half and drop the dangerous half:
+one schema owner, coherent `PRAGMA data_version` sync (ADR-7b), namespace
+isolation enforced rather than promised, and `plugin uninstall --purge` that
+actually removes everything.
+
+**Rejected**:
+
+- *A raw `Database` handle* — maximum power, and it forfeits schema ownership,
+ isolation, and clean uninstall in one step.
+- *A separate SQLite file per plugin* — clean isolation, and it multiplies the
+ sync mechanism, breaks single-file backup, and still needs migration
+ machinery.
+- *Staying KV-only* — the least code, and it pushes every plugin with real
+ data into either a hand-rolled index or its own file outside our control,
+ which is worse than granting the namespace.
+
+---
+
+<a id="adr-v18"></a>
+
+## ADR-V18: Motion is declared, not pushed
+
+**Choice**: An animation is a **property of a node**, evaluated by the kernel
+on its own frame clock, not a sequence of view pushes. A plugin declares what
+should move and how; it pushes once.
+
+```lua
+ui.text({ content = label, motion = { kind = "marquee", cps = 6 } })
+ui.box({ id = "thinking", motion = { kind = "cycle", fps = 8, frames = THINKING } })
+```
+
+The kernel grants the pane an **animation lease** while a live `motion` is in
+its tree: that pane — and only that pane — is exempt from the 250 ms redraw
+floor, up to a declared, capped rate. Leases drop when the pane is hidden,
+when it is unfocused and the motion declared `pauseWhenUnfocused`, and when
+the plugin's next push contains no motion. Catalog in
+[FEATURES-View-Tree.md §3.3](FEATURES-View-Tree.md#33-motion); the normative
+spec — phase and restart semantics, lease budgeting, accessibility caps,
+determinism — is [FEATURES-Animation.md](FEATURES-Animation.md).
+
+**Why**: The cost of animation in a push model is not the animation. It is the
+four things a push drags with it — a call into the plugin, a tree rebuild, a
+conversion and diff, and a paint — of which only the paint is inherent. Moving the clock into
+the kernel deletes the other three and leaves a cost identical to what
+`statusDot` already pays today.
+
+This is also the honest reading of [ADR-V14](#adr-v14)'s tier test. "Does the
+kernel own the data or the clock?" is two questions, and `statusDot` was
+sitting at an answer nobody had generalized: **the plugin owns the data, the
+kernel owns the clock**. Every cosmetic animation in
+[LIMITATIONS §2.2](LIMITATIONS.md#22-animation) — a spinner of your own
+design, a pulsing progress bar, a typing indicator, marquee text — is that
+same split. Tier 1 does not grow; a field on the envelope does.
+
+Three properties make it safe to grant:
+
+- **Advisory.** A kernel that declines to animate — a `reduce_motion` setting,
+ a pane over its rate budget — renders frame 0. Nothing breaks, and
+ accessibility gets a switch for free.
+- **Bounded by construction.** Frames are supplied up front, so a motion's
+ cost is known at push time rather than discovered at runtime. Rate is capped
+ (30 fps per pane, 30 fps aggregate across panes, degraded round-robin).
+- **Visible.** Live leases are listed by `thurbox plugin doctor` and counted
+ in the perf HUD, so "why is thurbox waking up" always has an answer.
+
+**Rejected**:
+
+- *Leave animation to per-frame pushes* — the status quo, which
+ [LIMITATIONS §2.2](LIMITATIONS.md#22-animation) correctly called the
+ sharpest limitation in the design. It does not merely make animation
+ expensive; it makes the *idle* case expensive too, because a plugin cannot
+ tell whether its pane is visible without asking.
+- *A per-frame callback into the plugin* — general, and it puts a plugin call
+ on the frame clock for every animated pane, which is [ADR-V11](#adr-v11)
+ inverted. In-process the call is cheap; the *lock the render thread must take
+ to make it* is not.
+- *Kernel timers that just dispatch an event faster* — a smaller change, and
+ it still pays a rebuild + conversion + diff per frame. It optimizes nothing
+ that matters.
+- *A general tween/easing engine over arbitrary props* — more expressive and
+ far more surface. The named kinds cover the enumerated demand; a general
+ engine can be added additively if they do not.
+
+---
+
+<a id="adr-v19"></a>
+
+## ADR-V19: Real-time and dense panes are vt100 surfaces
+
+**Choice**: Content that is too fast or too dense for a view tree does not get
+a faster view tree. It gets a **terminal grid**: `pty` (the kernel spawns a
+process) or `surface` (the kernel allocates a grid and the plugin writes a byte
+stream into it). Both render through the same `vt100` + `tui-term` path as a
+session pane.
+
+The contract is what makes them usable, and it is specified rather than
+implied ([FEATURES-View-Tree.md §3.4](FEATURES-View-Tree.md#34-real-time-surfaces)):
+
+| Concern | Rule |
+|---|---|
+| Input | A focused grid node is an **input sink** — keys go to the PTY, not to the plugin. Only the kernel-reserved chords (focus cycle, quit) and the node's declared `escape` chord are intercepted |
+| Key events | `keyReport: "press"` (default) or `"press-release"`, which pushes the kitty `REPORT_EVENT_TYPES` flag **only while that node is focused** |
+| Resize | The kernel resizes the pty and raises `SIGWINCH` from the resolved rect. Plugins do not set `COLUMNS`/`LINES` |
+| Lifetime | Bound to the **pane declaration**, not the plugin's VM: it survives suspension and hot reload, and is torn down on pane close or plugin deactivation |
+| Rate | Output marks only that pane dirty, at a capped fps — the `detect_output_redraw` path a session pane already uses |
+
+**Why**: The alternative to this is
+[ADR-V5](#adr-v5)'s rejected raw-buffer escape hatch, and the objection to
+that one was two renderers with two sets of failure modes. A vt100 grid is not
+a second renderer. It is *the* renderer — the hottest, most optimized path
+thurbox has, already carrying every agent pane, already proven to round-trip
+truecolour, half-blocks, and braille.
+
+It also resolves the tension in
+[LIMITATIONS §2.1](LIMITATIONS.md#21-graphics-and-dense-cell-art), which noted
+the asymmetry and left it standing: the Doom easter egg works because it renders
+inside an agent's PTY, and "a plugin cannot do what a process inside a session
+can." With `pty`/`surface` it can, without gaining a single new power over the
+user's actual terminal.
+
+**Why escapes are safe here and nowhere else.** N1
+([CONSTITUTION-DELTA](CONSTITUTION-DELTA.md#n1--the-kernel-renders-plugins-describe))
+forbids plugins emitting escape sequences, for good reasons: a leaked escape
+corrupts the frame, desynchronizes the cursor, or writes the user's clipboard.
+None of those are reachable through a `surface`. The bytes land in a parser the
+kernel owns, clipped to a rect the kernel assigned, and what reaches the real
+terminal is cells the kernel composited — exactly as with tmux output. N1 is
+amended to say what it always meant: **plugins never write to the terminal**;
+writing into a kernel-owned emulator is not writing to the terminal.
+
+**Costs, accepted explicitly**:
+
+- `pty` with an arbitrary `command` is arbitrary code execution. It is
+ *narrower* than `shell` in one specific way — the output goes into a kernel
+ grid the plugin cannot read back, so it is execution-capable but
+ exfiltration-limited — and that is the only claim made for it. The install
+ prompt treats it as full trust.
+- A grid pane costs what a session pane costs. Ten of them cost ten.
+- `surface` write throughput is a real channel that needs backpressure; the
+ kernel drops frames rather than growing a queue.
+
+**Rejected**:
+
+- *A raw cell buffer in shared memory* — faster and removes the vt100 parse,
+ and it reintroduces the memory-safety problem and a second compositing path
+ for a saving that does not show up against a parse thurbox already runs on
+ every agent pane.
+- *Binary frames of styled cells pushed like a view tree* — no new mechanism,
+ and it is [ADR-V5](#adr-v5)'s immediate mode with a smaller encoding.
+- *Telling plugin authors to run it in a session instead* — which is what v1
+ does, and it means a "plugin" that is really a wrapper around
+ `thurbox-cli session create`, with no pane, no layout, and no lifecycle.
+
+---
+
+<a id="adr-v20"></a>
+
+## ADR-V20: v2 is delivered on the trunk behind a compile-time gate
+
+**Choice**: Every phase of v2 lands on `main`, continuously, behind a Cargo
+feature (`plugins`) that is **absent from stable builds** until it is
+deliberately promoted. There is no long-lived `v2` branch. The nightly channel
+is a build configuration, not a branch: `main` compiled with the feature on,
+published as a prerelease. Full mechanics in
+[RELEASE-STRATEGY.md](RELEASE-STRATEGY.md).
+
+The gate moves in three steps, so capability ships before breakage:
+
+| Stage | Cargo `plugins` | Runtime `[features] plugins` | JS runtime | Ships as |
+|---|---|---|---|---|
+| A — development | off by default | — | user-supplied | nightly only |
+| B — experimental | on by default | off by default | user-supplied | a v1 **minor** release |
+| C — default | on | on by default | bundled | **2.0.0** |
+
+**Why**:
+
+- **A branch satisfies "stable can't ship v2" and violates "v1 stays
+  maintainable".** At ~3.5 commits/day, a 4–6 month refactor is 400–700 commits
+  to reconcile, and v2's work *is* the restructuring of `src/app/mod.rs`
+  (14,605 lines) and `src/ui/` (36 modules) — exactly the files v1 fixes touch.
+  Every merge conflicts inside the file being rewritten. A Cargo feature buys
+  the same isolation for a matrix leg.
+- **The plumbing a branch needs is plumbing this does not.** No `ci.yml`
+  widening (a PR into an unprotected `v2` would have run *no checks at all*), no
+  second release workflow drifting from `cd.yml`, no cross-branch checkout in
+  `pages.yml`. Each of those was a hazard the branch model had to actively
+  mitigate; here they do not exist.
+- **Almost all of v2 is additive.** The host, the renderer, the command
+  registry, the CLI verbs — none of it removes v1 behavior. Only the pane swaps
+  and the extension teardown do. Separating them lets the *value* of v2 reach
+  the stable channel at Stage B, months before the *breakage* of v2 at 2.0.0,
+  and gives the protocol real third-party exposure while N4's additive-only
+  promise is still cheap to keep.
+- **Abandonment is cheap and partial success is a real outcome.** Stopping
+  during Phases 1–5 is a feature-flag deletion. Stopping after Stage B still
+  leaves users a working plugin system on an undamaged v1. A branch makes
+  abandonment mean orphaning months of work, which is a bad incentive to have
+  pointed at a decision that should stay reversible.
+
+**Costs, accepted explicitly**:
+
+- Two build configurations to keep green — one extra CI matrix leg, and clippy
+  twice.
+- A migrated pane and its native predecessor coexist from Phase 4 until Phase 6.
+  This amends the "no dual implementations" principle; the interim is bounded,
+  the pair is self-checking against one insta snapshot, and it buys the ability
+  to ship 2.0.0 with a pane still native if one migration stalls.
+- One `cfg` branch per migrated pane at its dispatch site in `App::view`,
+  removed with the native pane.
+
+**Rejected**:
+
+- *A long-lived `v2` branch merged at 2.0.0* — the instinctive answer, and the
+  one the costs above are measured against. Retained as the documented fallback
+  with explicit adoption triggers
+  ([RELEASE-STRATEGY §10](RELEASE-STRATEGY.md#10-fallback-the-branch-model)), so
+  taking it later is a decision rather than a capitulation.
+- *A runtime-only flag with no compile-time gate* — simpler, one binary, and it
+  puts the whole plugin host and its JS runtime dependency inside the stable
+  artifact from day one. That forfeits the artifact-size deferral, widens
+  `cargo-deny`'s surface immediately, and makes "stable cannot ship v2" a
+  property of a boolean rather than of the compiler.
+- *Develop in a separate repository* — maximum isolation, and it makes the
+  kernel extraction — which is mostly *moving existing v1 code* — into a
+  permanent fork with no path back.
+
+---
+
+<a id="adr-v21"></a>
+
+## ADR-V21: Pane visibility is kernel state; the F1 editor stays kernel
+
+**Choice**: Two carve-outs from [ADR-V1](#adr-v1)'s "every visible surface is a
+plugin", both narrow and both mechanically forced.
+
+1. **Pane visibility is kernel-owned.** The manifest seeds it
+   (`default_visible`); the kernel owns it thereafter, persists it per pane id,
+   and generates `<plugin>.<pane>.{toggle,show,hide}` commands from the
+   manifest with no plugin code. `ctx.ui.showPane()` is a request, not the
+   source of truth.
+2. **The F1 keybinding editor is kernel chrome**, unlike the theme picker,
+   settings panel, and repo picker, which are ordinary `overlay`-slot plugin
+   panes.
+
+Specified in [FEATURES-Keybindings.md](FEATURES-Keybindings.md).
+
+**Why (1)**: Plugin-owned visibility is circular. A suspended plugin
+([ADR-V15](#adr-v15)) cannot show its own pane, and `onPaneVisible:<id>` is
+precisely the event meant to wake it. Kernel ownership also preserves a v1
+behavior that the migration was otherwise about to drop: `[features]` and the
+`F2`/`F3`/`F5`/`F9` panel toggles are **two axes**, not one. Replacing
+`[features]` with `thurbox plugin enable|disable` covers "does this surface
+exist"; nothing covered "is it on screen right now". Generating the toggle
+command means every third-party pane gets the uniform one-key show/hide model
+for free instead of each plugin inventing its own.
+
+**Why (2)**: The editor's core operation is capturing the *next physical
+keypress*, including chords the kernel would otherwise intercept — `Ctrl+Q`
+being the obvious one. A plugin cannot receive a keypress the kernel routes
+elsewhere, so a plugin implementation could not rebind the chords most worth
+rebinding. This is a structural limit, not a preference, and it is why the
+carve-out is exactly one modal rather than "modals are kernel".
+
+**Rejected**:
+
+- *Plugin-owned visibility with a kernel override* — two writers for one
+  boolean, and the suspension circularity survives.
+- *Each plugin declares its own toggle command* — no kernel change, and the
+  uniform panel-toggle model dies: fifteen plugins, fifteen conventions.
+- *F1 as a plugin with a kernel "capture mode" escape hatch* — a host call
+  that suspends kernel chord interception for one keystroke would be a
+  general-purpose input-hijacking primitive, which is a far larger grant than
+  the carve-out it avoids.
+- *Not persisting visibility (v1's behavior)* — v1 resets `show_*` every
+  launch, which is tolerable for four built-in panels and not for an
+  open-ended set of third-party panes.
+
+---
+
+<a id="adr-v22"></a>
+
+## ADR-V22: Anchored overlays instead of a floating-element ban
+
+**Choice**: A node may declare `anchor: { to, side, align, flip, offset }`,
+positioning itself against another node's resolved rect. Anchored subtrees
+resolve in a **second pass** and render into a per-pane **overlay layer**,
+z-ordered by pane order then declaration order, clipped to the pane. Nesting is
+capped at 3. Specified in [FEATURES-Layout.md §4](FEATURES-Layout.md#4-anchors--the-overlay-layer).
+
+**Why**: The ban was costing more than it saved. Dropdowns, context menus,
+tooltips and inline compose boxes are ordinary TUI furniture, and v1 already
+ships one — `render_compose_inline` floats a comment box at a diff line and
+flips above or below as room allows. v2 had answered that with a bespoke
+`inlineAt` slot on the `diff` node: a point fix that left every other pane with
+no route, and that this ADR deletes.
+
+The three properties that made the ban attractive survive:
+
+- **Focus uniqueness.** An anchored subtree belongs to its pane and is not a
+  focus target, so exactly one pane still holds focus.
+- **Single-pass layout for trees that do not use it.** Two passes are paid by
+  anchors, not by everyone.
+- **Determinism.** Z-order is positional, not a `z-index` free-for-all.
+
+What genuinely changes is one invariant: "nothing overlaps" becomes "the base
+layer never overlaps; the overlay layer may, and is strictly ordered." That is
+narrow enough to assert in the monkey test.
+
+**Rejected**:
+
+- *Keep the ban* — the status quo, which pushes every plugin toward an
+  `overlay`-slot modal (wrong shape for a dropdown) or inline expanding rows
+  (often better, sometimes not) and keeps `diff.inlineAt` as a permanent
+  special case.
+- *A `z-index` property* — familiar and unbounded; positional ordering is
+  enough for menus and cannot be abused into layering wars.
+- *Escaping the pane rect in 2.0* — needed for a dropdown at a narrow pane's
+  edge, and it requires cross-pane z-ordering plus a story for what happens
+  when the owning pane is hidden mid-interaction. Deferred deliberately.
+
+---
+
+<a id="adr-v23"></a>
+
+## ADR-V23: Pane geometry is a workspace tree; slots are a preset
+
+**Choice**: Space is divided by a **tree of splits** — branches are horizontal
+or vertical splits, leaves are panes or tab groups, each carrying
+`size`/`weight`/`min_*`. It persists as an optional
+`~/.config/thurbox/layout.toml`. The manifest's `slot` becomes an
+**auto-placement hint** for panes the tree does not name, and the five slots
+ship as the **default preset** — a synthesized tree reproducing v1's
+`PanelAreas` exactly. Specified in
+[FEATURES-Layout.md §2](FEATURES-Layout.md#2-the-workspace-tree).
+
+**Why**: The slot model answered "where does a pane go" with five fixed
+answers, and [LIMITATIONS §1.2](LIMITATIONS.md#12-pane-geometry) listed six
+things that needed a sixth, seventh and eighth. A tree answers all of them at
+once — full-width
+spanning regions, 2×2 grids, nested splits, runtime reordering, header docking
+— because they are all just shapes of the same structure. Adding slots one at a
+time would have been more total work for a worse result.
+
+It is also arguably a **simplification**: `compute_layout`'s 10 fixed `Rect`
+fields and 9-argument signature collapse into one recursive structure, and
+"tabbed when several are visible" stops being a property of the `center` slot
+and becomes a leaf kind available anywhere.
+
+Zero-config behavior is unchanged, which is the constraint that made this
+adoptable: a user who never writes `layout.toml` sees exactly the v1 layout,
+and a plugin author still declares `slot = "right"` and thinks no further.
+
+**Deferred**: interactive split resize (drag a border, tmux-style). The tree
+makes it possible — a drag writes back a `size` — but it needs border hit
+regions, a persistence policy for transient drags, and keyboard equivalents.
+The file is editable in the meantime.
+
+**Rejected**:
+
+- *Add slots as needed* — cheapest per request, and it ends with a dozen
+  ad-hoc slot names encoding positions that a tree expresses structurally.
+- *Expose the tree only internally, keep slots as the public API* — preserves
+  the simpler mental model, and then "I want a 2×2 dashboard" has no answer at
+  all, which is the complaint that started this.
+- *A CSS-grid-style declarative area map* — more expressive for fixed
+  layouts, worse for the nested-split and tab-group cases that terminal
+  workspaces actually use.
+- *Let tmux own pane geometry* — the obvious question for this project, since
+  thurbox already runs on tmux and tmux already has splits, resize, zoom and
+  named layouts its users know. Rejected because it dismantles the product:
+  each pane would need its own process rendering into its own PTY, so a plugin
+  pane stops being a view tree and becomes a full TUI application — no shared
+  theming, no unified focus, no view-tree contract, and no demand-driven
+  redraw loop. It also has no psmux/Windows story. thurbox is one coherent TUI
+  *over* tmux, not a tmux configuration.
+- *Adopt Zellij's KDL layout language* — familiar to exactly the audience
+  thurbox targets, and battle-tested. Rejected on format consistency: every
+  other config file in the repo is TOML, and a second format for one file
+  costs more than the familiarity buys.
+- *A `[[layoutProviders]]` contribution point, so a plugin can replace the
+  solver* — considered and rejected, despite the pull of
+  [ADR-V1](#adr-v1)'s "everything but six things is a plugin". Layout is
+  already one of those six, and for reasons that hold on inspection:
+  - The solver is **how the global invariants are enforced** — focus
+    uniqueness, panes never overlapping, kernel chrome placement. Delegating
+    enforcement of an invariant to the code it constrains is backwards, and it
+    would mean validating every returned rect precisely because the boundary
+    cannot be trusted.
+  - **The built-in solver has to be complete regardless.** It computes the
+    first frame before any plugin exists, and it is the only sane fallback on
+    a provider crash or deadline. A provider therefore adds a *second* path
+    that must be as good as the first, rather than replacing work.
+  - It would **freeze layout into the public protocol**. Under
+    [N4](CONSTITUTION-DELTA.md#n4--the-plugin-api-is-additive-within-a-major-version)
+    the request/response shape becomes additive-only for the life of the major
+    version, so the kernel could never restructure how it lays out.
+  - The flexibility people actually want is **configuration, not execution**.
+    `layout.toml` already makes geometry user-editable data; a process
+    boundary buys expressiveness nobody has asked for at the cost of a
+    total-loss failure mode.

--- a/docs/v2/CONSTITUTION-DELTA.md
+++ b/docs/v2/CONSTITUTION-DELTA.md
@@ -1,0 +1,288 @@
+# Thurbox v2 — Constitution and ADR Delta
+
+[`docs/CONSTITUTION.md`](../CONSTITUTION.md) holds rules that are
+**non-negotiable and automatically enforced**. v2 changes what some of them
+mean. This document states each change precisely, so the constitution is
+amended deliberately rather than eroded by implementation.
+
+Rule of thumb applied throughout: **a rule survives if it can still be
+enforced by a script.** A rule that v2 makes unenforceable is retired, not
+weakened into advice.
+
+---
+
+## 1. Amended principles
+
+Ordered by rule number.
+
+### Rule 1 — Crash-free operation
+
+**v1**: errors are displayed in the UI, never via panics; the only panic path
+is the terminal-restore hook.
+
+**v2**: unchanged for the kernel, and extended to cover the new failure mode.
+**A plugin fault must never reach the user as a broken frame.** A plugin that
+errors, loops, or exhausts its memory limit renders its pane's last tree with a
+visible error state and restarts with backoff — errors surface as `Result`s,
+runaway loops are cut by Luau's interrupt handler, and allocation is capped per
+VM ([ADR-V4](ARCHITECTURE.md#adr-v4)).
+
+**This rule is now conditional, and the condition is
+[C2](ARCHITECTURE.md#adr-v2).** Plugins run in the thurbox process, so a
+segfault in native code would take the TUI down and no supervisor could catch
+it. The rule holds *because* plugins may not carry native code — not because
+the architecture makes it impossible. That is a genuine weakening relative to
+the process model, and it is the one place v2 trades a Constitution guarantee
+for something else.
+
+**What the condition does not cover, and what happens then.** A memory-safety
+bug in the Luau VM itself is in-process and uncatchable — C2 bounds the
+*surface* to one vendored dependency, it does not eliminate it. The residual
+blast radius is smaller than it looks, and for the v1 reason: agent sessions
+live in tmux, not in thurbox. A kernel crash loses the TUI and the frame; it
+does not lose a session, a worktree, or an agent's turn in progress, and a
+relaunch re-adopts every pane. That is the same recovery v1 already relies on
+for a panic, which is why v2 adds no watchdog or supervisor process — one would
+restore nothing that a relaunch does not.
+
+**Enforcement**: conformance tests with a fixture plugin that errors on init,
+exceeds deadlines, exhausts its memory limit, and returns a malformed tree.
+
+---
+
+### Rule 2 — Module isolation
+
+**v1**: `session → agent → ui → app`, with `agent` and `ui` never importing
+each other.
+
+**v2**: unchanged in spirit; one module family added.
+
+```text
+session   ← pure data types (now including view-tree types)
+agent     ← session
+plugin    ← session (+ paths/shell); NEVER ui, git, app
+ui        ← session + app model/view state; NEVER agent, git, plugin
+app       ← coordinator
+```
+
+`plugin` is a side-effect layer beside `agent`. The view-tree types live in
+`session` so `ui` can render them without importing `plugin` — the same reason
+`session::review` exists so `ui` can render diffs without importing `git`.
+
+**Enforcement**: unchanged — `tests/architecture_rules.rs`, extended with the
+`plugin` allowlist entry.
+
+---
+
+### Rule 3 — Zero-warning policy
+
+**v1**: clippy and rustdoc with warnings as errors; rumdl for markdown.
+
+**v2**: extended to Luau. `luau-analyze` in strict mode and the plugin test
+suite gate CI for `plugins/` and the bundled `@thurbox` modules with the same
+zero-tolerance rule.
+
+**Enforcement**: new CI jobs and pre-commit stages, landing in
+[MIGRATION Phase 0](MIGRATION.md#phase-0--foundations-no-behavior-change) —
+before the first Luau PR, so that PR does not also have to carry the
+toolchain. The rule is unchanged; its scope grew.
+
+---
+
+### Rule 4 — Permissive licenses only, and Rule 5 — Zero known vulnerabilities
+
+**v1**: `cargo-deny` over the Rust dependency tree.
+
+**v2**: two supply chains, two gates, same standard.
+
+| Chain | Gate |
+|---|---|
+| Rust | `cargo deny check advisories bans licenses sources` (unchanged) |
+| Luau VM (`mlua`) | An ordinary Cargo dependency — already inside `cargo-deny`'s advisory, license and ban checks |
+| Plugin code | No package manager, so no transitive supply chain to audit ([ADR-V2](ARCHITECTURE.md#adr-v2)) |
+
+**This got simpler, not harder.** An earlier draft accepted a second supply
+chain — npm for plugin packages, plus a vendored JavaScript runtime whose CVE
+response thurbox would own. Embedding the VM
+([ADR-V3](ARCHITECTURE.md#adr-v3)) means there is one dependency tree, already
+governed by the existing gate.
+
+**Enforcement**: unchanged — the existing `cargo-deny` job.
+
+---
+
+### Rule 7 — TEA as the single architectural pattern
+
+**v1**: "No ad-hoc event handlers, no component-local state, no callback
+chains."
+
+**v2**: TEA becomes **hierarchical**. The kernel keeps one model. Each plugin
+keeps its own model in its own VM, updated by its own reducer, rendered by its
+own pure `render`. The prohibition holds at both levels; there are two levels.
+
+The clause that changes is "no component-local state". Its purpose was to
+prevent panes mutating shared `App` state through hidden paths. Across a VM
+boundary that hazard cannot occur: plugin state lives inside a `mlua::Lua`
+state the kernel never reads, reachable only through its own reducer, and the
+only thing crossing is events in and view trees out — which is TEA, not an
+escape from it.
+
+**Enforcement**: the host bindings themselves. Nothing bound into a plugin VM
+mutates kernel state directly; every mutation is a typed host call, and a
+capability the plugin lacks has no binding to call ([ADR-V4](ARCHITECTURE.md#adr-v4)).
+`render` purity is enforced structurally — it runs with the host tables
+unavailable, so a host call in `render` is an error rather than a convention.
+
+---
+
+### Rule 8 — Backend-first session model
+
+**v1**: sessions run through `SessionBackend`, backed by tmux; never mocked,
+emulated, or screen-scraped.
+
+**v2**: unchanged, and reinforced. The terminal grid is a kernel surface
+([ADR-V6](ARCHITECTURE.md#adr-v6)) precisely so no plugin can interpose
+itself between tmux and the screen. **Plugins may never emulate a terminal**
+— that is added as an explicit clause. A `surface`
+([ADR-V19](ARCHITECTURE.md#adr-v19)) is consistent with it rather than an
+exception to it: the plugin *produces bytes*, the kernel emulates. A plugin
+parsing vt100 itself, or rendering a session's grid from its own parse, is the
+prohibited thing and stays prohibited.
+
+---
+
+### Rule 9 — Logging never touches stdout
+
+**v1**: stdout belongs to the TUI; logs go to `thurbox.log`.
+
+**v2**: extended to plugins. Plugins share the kernel's process, so its stdout
+is the TUI's for exactly the v1 reason — a plugin write would paint over the
+frame. `print` is bound to a kernel function that routes to `thurbox.log`,
+tagged with the plugin name, rather than to the real stdout; `ctx.log()` is the
+sanctioned path and carries a level.
+
+**Enforcement**: the VM is created with no `io` library and a replaced `print`,
+so there is no binding through which a plugin can reach the real stdout — the
+same absence-not-checking pattern as capabilities.
+
+---
+
+### Rule 10 — Test-driven development
+
+**v1**: Red, Green, Refactor; tests written before or alongside
+implementation.
+
+**v2**: unchanged, applied to both languages. Additionally, a **migrated pane
+must pass the tests its Rust predecessor passed** before the Rust
+implementation is deleted — the insta snapshots and monkey invariants are the
+migration's acceptance criteria, not a separate exercise.
+
+Under [ADR-V20](ARCHITECTURE.md#adr-v20) this is stronger than it sounds. The
+two implementations coexist from Phase 4 until Phase 6, so the same snapshot is
+asserted against **both** in the same test run, and the plugin's fidelity is a
+live check rather than a comparison against a deleted predecessor.
+
+**Enforcement**: the existing insta and monkey suites, parameterized over both
+implementations while both exist.
+
+---
+
+## 2. Unchanged principles
+
+Rules **6** (conventional commits), **11** (deterministic CI — scripts over
+LLMs), and **12** (tag-based versioning) are untouched by v2.
+
+Two notes on rule 12, both mechanism rather than exception:
+
+- `cog bump --auto` cannot cross a major boundary on its own, so 2.0.0 ships via
+  the explicit-version release dispatch — a documented v1 mechanism.
+- Nightly prereleases are tagged `nightly-YYYY-MM-DD`, deliberately **not**
+  semver, so they never participate in version computation. Under
+  [ADR-V20](ARCHITECTURE.md#adr-v20) nightlies are built from `main`, which
+  makes their tags immediately reachable, so this is load-bearing rather than
+  cosmetic
+  ([RELEASE-STRATEGY §4.2](RELEASE-STRATEGY.md#42-tag-naming-and-why-it-is-not-semver)).
+
+---
+
+## 3. New principles proposed for v2
+
+Each is stated with its enforcement mechanism, per the constitution's own
+admission rule ("if it can't be enforced, it doesn't belong here").
+
+### N1 — The kernel renders; plugins describe
+
+No plugin writes to the user's terminal, and none receives a drawable buffer.
+The kernel is the sole renderer.
+
+The one place a plugin may emit escape sequences is **into** a kernel-owned
+vt100 emulator — a `surface` node ([ADR-V19](ARCHITECTURE.md#adr-v19)). That is
+not an exception: the bytes are parsed by the kernel, clipped to a rect the
+kernel assigned, and what reaches the terminal is composited cells, exactly as
+with tmux output. Escapes in the *view tree* remain forbidden outright.
+
+**Enforcement**: `text` node content is escape-stripped when the tree is
+converted at push time, with a test; `ctx.surface.write` is gated on the `pty`
+capability — the binding is absent without it — and its bytes
+never leave the emulator, with a test asserting an OSC 52 write through a
+`surface` sets no clipboard.
+
+### N2 — A frame never waits on a plugin
+
+Rendering always paints from cached view trees. No call into a plugin VM sits
+on the critical path of a frame — the render thread never acquires a plugin's
+`Lua` state.
+
+**Enforcement**: `perf_*` counter tests assert frames continue while a fixture
+plugin is unresponsive, plus a monkey invariant.
+
+### N3 — Capabilities are declared, gated, and shown
+
+Every privileged **host call** is gated by a manifest declaration, enforced at
+one place — the bind step that builds a VM's host tables — and displayed at
+install time.
+
+**Scope.** The rule binds everything a plugin can reach, which under
+[ADR-V2](ARCHITECTURE.md#adr-v2) is everything full stop: Luau ships no
+filesystem, network or process access, so `fs`, `net` and `shell` are host
+bindings like the rest rather than ambient powers a manifest can only describe.
+All sixteen capabilities are enforced. An earlier draft, written against an
+out-of-process JavaScript runtime, had to except those three; that exception is
+withdrawn ([SECURITY.md §3](SECURITY.md#3-resolved--fs-net-and-shell-are-now-enforced)).
+
+**Enforcement**: capability tests per host binding; a coverage test asserting
+every privileged binding is reachable only under its grant; and a test
+asserting an ungranted plugin's VM has no such global
+([SECURITY.md §4](SECURITY.md#4-plugin-environment)).
+
+### N4 — The plugin API is additive within a major version
+
+New node types, new optional command arguments, and new events are allowed.
+Removing or retyping is a protocol major bump. Unknown nodes render as a
+placeholder; unknown fields are ignored.
+
+**Enforcement**: a golden protocol schema checked into the repo, with a CI
+diff that fails on a non-additive change without a major version bump.
+
+---
+
+## 4. v1 ADRs affected
+
+| ADR | Effect in v2 |
+|---|---|
+| ADR-1 (TEA) | Amended — hierarchical, see rule 7 above |
+| ADR-2 (SessionBackend + vt100 + tui-term) | Unchanged; becomes kernel |
+| ADR-3 (tokio) | Unchanged; plugin supervision joins the runtime |
+| ADR-4 (input translation) | Unchanged; kernel keeps owning key → bytes |
+| ADR-5 (responsive breakpoints) | Superseded by the layout solver and manifest `min_width` |
+| ADR-6 (file-based logging) | Extended to plugin stderr |
+| ADR-8 (SQLite) / ADR-7b (multi-instance sync) | Unchanged; `plugin_kv` added ([ADR-V9](ARCHITECTURE.md#adr-v9)) |
+| ADR-9 (flat session list) | Moves into the session-list plugin's design |
+| ADR-11 / ADR-12 / ADR-13 (backends, tmux, SSH/WSL) | Unchanged; kernel |
+| ADR-14 (centralized theme) | Extended — theme tokens become the plugin styling vocabulary |
+| ADR-15 (headless CLI as separate binary) | Unchanged; gains the command registry |
+| ADR-19 (declarative agent definitions) | Unchanged; plugins may contribute `[[agents]]` |
+| ADR-20 (agent-agnostic extensions) | **Retired** — superseded by [ADR-V8](ARCHITECTURE.md#adr-v8) |
+| ADR-21 (declarative extension manifests) | **Retired** — superseded by [ADR-V8](ARCHITECTURE.md#adr-v8) |
+| ADR-22 (`App` decomposition) | Superseded — the kernel/plugin split is the decomposition |
+| ADR-P1–P12 (performance) | Preserved; [ADR-V11](ARCHITECTURE.md#adr-v11) exists to keep them true |

--- a/docs/v2/DECISION-plugin-runtime.md
+++ b/docs/v2/DECISION-plugin-runtime.md
@@ -1,0 +1,336 @@
+# Thurbox v2 — Decision: In-Process Luau Plugins
+
+[ADR-V2](ARCHITECTURE.md#adr-v2) puts plugins in a sidecar process. This
+document reopens that on performance grounds and answers the question it
+raises: **can in-process keep isolation and reload safety?**
+
+Short answer: **yes for everything except native code, and only under three
+conditions.** The conditions are the whole decision, and one of them couples
+the process model to the language choice in a way that is easy to miss.
+
+Status: **decided — in-process Luau via `mlua`.** The design set has been
+updated to match ([ADR-V2](ARCHITECTURE.md#adr-v2),
+[ADR-V3](ARCHITECTURE.md#adr-v3), [ADR-V4](ARCHITECTURE.md#adr-v4),
+[ADR-V14](ARCHITECTURE.md#adr-v14)). This document is kept as the reasoning
+behind it and as the record of what was traded away — §6 and §7 are the parts
+to re-read if the decision is ever revisited.
+
+The decision is taken on analysis, not measurement. §7's validation gate is
+what turns it into evidence, and §9 states the reversal conditions.
+
+---
+
+## 1. Where out-of-process actually costs
+
+Worth measuring the premise before optimizing it. Most of the obvious IPC costs
+were already designed out:
+
+| Path | IPC cost today | Why |
+|---|---|---|
+| Rendering a frame | **none** | Frames paint from cached view trees; plugins push on state change ([ADR-V11](ARCHITECTURE.md#adr-v11)) |
+| Animation | **none** | The kernel owns the clock ([ADR-V18](ARCHITECTURE.md#adr-v18)) |
+| Terminal / diff / file tree content | **none** | Kernel surfaces carry identifiers, never content ([ADR-V6](ARCHITECTURE.md#adr-v6)) |
+| Key event | one small notification, fire-and-forget | Not awaited |
+| Host call | one round trip, off the frame path | Async by contract |
+
+So the frame budget is not where the cost is. What remains is real but
+different from what "IPC is slow" suggests:
+
+| Real cost | Magnitude | Notes |
+|---|---|---|
+| **Memory** | ~15–30 MB RSS per Bun process | With two halves across ~7 bundled plugins this is plausibly 200–400 MB. For a terminal tool this is the cost users would actually notice |
+| **Cold start** | ~20–50 ms per process | Hidden by lazy activation until the first time a user opens a pane, when it is visible |
+| **Serialization** | 256 KB warn / 2 MB reject per push | A live-filtering pane re-serializes its tree per keystroke |
+
+These are estimates from published runtime characteristics, not measurements.
+**Phase 1 should measure them before this decision is made** — if bundled
+plugins land at 60 MB total rather than 300 MB, the premise weakens
+considerably.
+
+---
+
+## 2. What in-process can and cannot recover
+
+Isolation is not one property. Separating it is what makes the answer
+tractable:
+
+| Failure mode | Out-of-process | In-process, done well |
+|---|---|---|
+| Plugin throws | contained | contained — `Result` in mlua, catch in JS |
+| Infinite loop / hang | `SIGKILL` | contained — Luau's VM-level interrupt handler, V8's `TerminateExecution` |
+| Memory exhaustion | OS / process kill | contained — `set_memory_limit` per state, V8 heap caps |
+| Blocking the render loop | impossible | contained **iff** plugins run on their own threads |
+| Corrupting kernel memory | impossible | possible only via FFI |
+| **Segfault in native code** | contained | **kills the TUI. Not recoverable.** |
+
+One row is unrecoverable, and it is entirely about native code. That gives the
+decision a clean shape:
+
+> **In-process isolation is nearly as good as out-of-process, provided plugins
+> cannot execute native code.**
+
+---
+
+## 3. The three conditions
+
+In-process is safe if and only if all three hold. Dropping any one of them
+gives away something the current design has.
+
+### C1 — Thread per plugin, never the UI thread
+
+Each plugin gets its own OS thread with its own VM. The render loop never
+calls into a plugin synchronously, so a slow or wedged plugin cannot stall a
+frame. This preserves [ADR-V11](ARCHITECTURE.md#adr-v11) and
+[N2](CONSTITUTION-DELTA.md) unchanged — the mechanism moves from "another
+process" to "another thread", and the guarantee is identical.
+
+### C2 — No native code in plugins
+
+No FFI, no native addons, no `dlopen`. This is what buys back crash isolation,
+and it is not negotiable: a single native module segfaulting takes the whole
+TUI with it, which would violate Constitution rule 1 in a way no supervisor
+can catch.
+
+For Luau this is the natural state — the host provides every capability
+already. For JavaScript it means **pure-JS npm packages only**, which excludes
+a real if small slice of the ecosystem.
+
+### C3 — The VM is the unit of reload
+
+Reload destroys the entire VM and builds a new one. Not module-cache clearing,
+not selective re-require — full teardown. And the kernel must hold **no handle
+that can outlive the VM**.
+
+Rust makes the second half enforceable rather than aspirational: tie every
+registry key, callback and pane binding to the VM's lifetime, and dropping the
+VM invalidates them by construction. A stale reference becomes a compile
+error rather than a mysterious "my edit didn't apply".
+
+This is why in-process reload here would be **safer than neovim's**, which is
+the usual cautionary example: neovim reloads *modules inside a shared
+state*, so anything that captured a reference keeps the old version alive.
+Destroying the state sidesteps that entire class.
+
+Two residual risks, both answerable:
+
+- **Host-held resources** (open files, sockets, spawned children) are acquired
+  through host APIs, so the kernel already owns those handles and reclaims
+  them on teardown — arguably cleaner than out-of-process, where they die with
+  the process but the kernel never knew about them.
+- **Native modules cannot be unloaded** — which C2 forbids anyway.
+
+---
+
+## 4. Reload and hot-install under C1–C3
+
+Everything in
+[FEATURES-Plugin-API.md §4](FEATURES-Plugin-API.md#4-lifecycle) survives
+unchanged in wording; only the mechanism differs:
+
+| Operation | Out-of-process | In-process under C1–C3 |
+|---|---|---|
+| Install a new plugin while running | Read manifest, spawn on activation | Read manifest, create VM on activation |
+| Reload a changed plugin | `dispose()` → respawn | `dispose()` → drop VM → new VM |
+| Reload a **wedged** plugin | `SIGKILL` | Interrupt handler aborts, then drop VM |
+| State across reload | not preserved | not preserved — same rule |
+| Fault backoff | respawn 1s, 2s, 4s… | rebuild VM, same schedule |
+
+Reload gets **faster**, not just equivalent: dropping and rebuilding a VM is
+microseconds to low milliseconds, against ~20–50 ms for a process respawn.
+`thurbox plugin dev` watch-mode iteration improves noticeably.
+
+---
+
+## 5. Runtime candidates
+
+**The process model and the language choice are not independent.** C2 is what
+forces that: "no native code" rules out anything whose ecosystem assumes FFI,
+and rewards runtimes where the host provides every capability anyway.
+
+With TypeScript no longer a hard requirement, the field is wider than the
+JavaScript options:
+
+| Runtime | Footprint / start | Sandbox | Typing | Familiarity | VM written in |
+|---|---|---|---|---|---|
+| **Luau** (`mlua`) | KBs, µs | Purpose-built — Roblox runs untrusted code | Gradual + `luau-analyze` | Lua-5.1-shaped | C++ |
+| **Lua 5.4** (`mlua`) | KBs, µs | DIY — strip `io`/`os`/`package`, per-chunk `_ENV` | None (or Teal, which compiles to Lua) | **The standard everyone knows** | C |
+| **LuaJIT** (`mlua`) | KBs, µs | DIY, and `ffi` must be stripped | None | Lua 5.1 | C + asm |
+| **QuickJS** (`rquickjs`) | ~1 MB, sub-ms | DIY | TypeScript, transpiled at install | JS/TS | C |
+| **Rhai** | small, fast start | Sandbox-first; operation and memory limits built in | Dynamic, Rust-ish | **Nobody knows it** | **Pure Rust** |
+| **Starlark** (`starlark-rust`) | small | Hermetic by construction — no I/O in the language at all | Optional types | Python-shaped | Pure Rust |
+| **V8** (`deno_core`) | tens of MB/isolate | None; native addons possible | TypeScript | JS/TS | C++ |
+
+### Reading the field
+
+**Luau remains the pick**, and the familiarity objection against it is weaker
+than it first looks: Luau is a fork of Lua 5.1, so ordinary Lua reads and runs
+largely unchanged, and the type annotations are opt-in. A plugin author who
+knows Lua is not learning a new language — they are choosing whether to add
+types. It is not a strict superset (`setfenv`/`getfenv` are gone, some stdlib
+differs), but the gap is small.
+
+**Lua 5.4 is the credible alternative**, and the case for it is one thing:
+**it is the standard, so everything knows it** — documentation, snippets,
+every neovim user, and language models. If "ask an agent to write me a pane"
+matters, that gap is real and it runs the other way from every other criterion.
+What it costs: no gradual typing (Teal exists and compiles to Lua, but that is
+another toolchain), and a sandbox you assemble and own yourself rather than one
+the upstream project maintains because its business depends on it. Hang
+containment works via debug hooks rather than a purpose-built interrupt.
+
+**Rhai is the interesting outlier.** It is the only candidate written in pure
+Rust, which removes the one residual crash risk §6 names — with a C-based VM,
+"in-process is safe if plugins carry no native code" still rests on the VM
+itself not segfaulting. Rhai has no `unsafe` FFI surface, and sandboxing,
+operation limits and memory limits are first-class rather than assembled. The
+disqualifier is adoption: a plugin system exists to attract third-party
+authors, and asking them to learn a language almost nobody uses is a steeper
+tax than any of the safety properties are worth.
+
+**Rejected on inspection:**
+
+- *LuaJIT* — fastest, and frozen at 5.1 with upstream effectively in
+  maintenance. Its built-in `ffi` is precisely what C2 forbids, so it ships
+  with the sharp edge enabled and must be stripped. JIT also means writable-
+  executable pages, which some hardened environments refuse.
+- *Starlark* — sandboxed by construction, which is exactly right, and it is a
+  **configuration language**: no I/O, and dialects restrict recursion and
+  unbounded loops. Excellent for `layout.toml`-shaped problems, wrong for
+  something that has to hold state and react to events.
+- *V8 / `deno_core`* — the incoherent middle. It keeps the ecosystem but
+  surrenders the dependency-policy argument
+  [ADR-V2](ARCHITECTURE.md#adr-v2) rests on, and its per-isolate memory gives
+  back the reason for going in-process at all.
+
+### One choice, not two
+
+`mlua` compiles against a single Lua backend — the `lua54`, `luajit` and
+`luau` features are mutually exclusive. "Support both Lua and Luau" is not
+available; this is a real either/or.
+
+---
+
+## 6. What in-process still gives away
+
+Even with C1–C3 satisfied, these are real and permanent:
+
+1. **Native-code crashes kill the TUI.** C2 reduces this to "a bug in the
+   embedded VM itself", which is a much smaller surface than "any plugin" —
+   but it is not zero, and it is the property Constitution rule 1 currently
+   gets for free.
+2. **A plugin can consume the kernel's address space.** Per-VM memory limits
+   bound it, but fragmentation and allocator pressure are shared.
+3. **The blast radius of a VM bug is the whole app**, not one pane.
+4. **Debugging changes shape.** A crashed sidecar leaves a corpse to inspect;
+   an in-process abort takes the debugger with it.
+5. **npm shrinks** to pure-JS packages (or disappears entirely, with Luau).
+
+---
+
+## 7. Recommendation
+
+An earlier draft of this section recommended QuickJS, conditioned on "keeping
+the TypeScript decision intact". **That condition has since been withdrawn —
+TypeScript is not a hard requirement — and it changes the answer.**
+
+### With TypeScript optional, Luau is the stronger choice
+
+Not marginally. It collapses three separate open problems into one solved one:
+
+| Open problem | Under Luau |
+|---|---|
+| [SECURITY.md](SECURITY.md) Finding 1 — `fs`/`net`/`shell` declared but unenforceable | **Closed.** The sandbox is the design centre: there is no `io` or `os.execute` unless the host hands it over. Roblox's entire model is running untrusted code |
+| [ADR-V3](ARCHITECTURE.md#adr-v3) — 40–90 MB bundled runtime on every packaging channel, plus CVE ownership, plus an unanswered musl / Windows-ARM64 question | **Deleted.** A `mlua` embed is part of the binary. The ADR mostly disappears and takes a risk-register row and a packaging burden with it |
+| Plugin memory and cold start (§1) | **Answered by orders of magnitude.** A Luau state is kilobytes and starts in microseconds, against 15–30 MB and 20–50 ms per Bun process |
+
+It also fits C1–C3 (§3) without special pleading: no FFI by default satisfies
+C2 outright, `mlua` gives per-state memory limits and a VM-level interrupt for
+C1, and destroying a `Lua` state is the natural unit of reload for C3.
+
+And the objection I raised against plain Lua in
+[ADR-V2](ARCHITECTURE.md#adr-v2) does not apply: Luau has gradual typing and
+`luau-analyze`, so the view-tree contract stays statically checkable.
+
+### The npm objection is weaker than it looks — and this repo is the evidence
+
+The real cost of leaving TypeScript is losing npm. But thurbox's *own*
+extensions are a direct sample of the workload, and they use:
+
+| Dependency | Uses across `extensions/` |
+|---|---|
+| `jq` | 72 |
+| `curl` | 15 |
+| `gh` | 14 |
+| `glab` | 3 |
+| npm packages | **0** |
+
+The workload is **shell, HTTP and JSON** — not SDKs. And all three are already
+host APIs in this design (`ctx.exec`, `ctx.fetch`, plus a JSON binding), because
+the capability model routes them through the kernel by construction. The
+bundled plugin set needs even less: `markdown`, `diff`, `fileTree` and `code`
+are kernel surfaces, so tasks, files, review and the session list have no
+library needs at all.
+
+### What it genuinely costs
+
+Stated plainly, because these do not go away:
+
+1. **The ceiling drops for third parties.** A plugin wanting a chart renderer,
+   a YAML parser, or a vendor SDK has npm in TypeScript and nothing in Luau.
+   The evidence above is about what thurbox has needed, not what someone else
+   might want to build.
+2. **Agents author TypeScript better than Luau.** For a tool whose users
+   operate agent CLIs, "ask an agent to write me a pane" is a plausible
+   workflow, and training-data volume is not close.
+3. **[ADR-V14](ARCHITECTURE.md#adr-v14) loses its distribution mechanism.**
+   "Widgets live in TypeScript, versioned on npm, forkable" was half an
+   argument about *packaging*. Luau has no npm, so `@thurbox/widgets` becomes
+   a bundled module or a git-distributed one — which pulls widget versioning
+   back toward the kernel, the exact coupling ADR-V14 exists to prevent. This
+   is the sharpest cost and it needs an answer before committing.
+4. **Contributor familiarity.** More developers know TypeScript, though
+   thurbox's audience skews toward people who have written a neovim config.
+
+### So: measure, then commit — with one validation gate
+
+The §1 measurement still runs in Phase 1 and still decides in-process versus
+out-of-process. But if it says in-process, **go to Luau**: QuickJS keeps a
+language nobody now requires while giving up the sandbox that is Luau's main
+prize, and the wider field in §5 does not produce a better answer — Lua 5.4
+trades the sandbox and the typing for familiarity, and Rhai trades adoption for
+a memory-safe VM.
+
+**The one argument that could flip it to Lua 5.4** is agent authorship. Every
+other criterion favours Luau, but models know standard Lua far better, and
+"ask an agent to write me a pane" is a plausible primary workflow for this
+tool's users. If that turns out to be how plugins actually get written, the
+familiarity gap outweighs gradual typing. Worth testing during the validation
+gate below rather than arguing about: have an agent write the same pane in
+both.
+
+Before committing either way, **write one hard bundled pane in it** — the code
+review or the session list, not a hello-world. Those two exercise the
+view-tree contract at full width, and a language that makes them awkward will
+make every third-party pane awkward. That gate is cheap and it is the only
+thing that turns this from a paper comparison into a decision.
+
+---
+
+## 8. What moves if in-process is adopted
+
+So the cost of the change is visible rather than discovered:
+
+| Document | Change |
+|---|---|
+| [ADR-V2](ARCHITECTURE.md#adr-v2) | Rewritten: thread-per-plugin in-process, C1–C3 as the stated conditions; the sidecar becomes the rejected alternative with its isolation argument preserved |
+| [ADR-V3](ARCHITECTURE.md#adr-v3) | Largely deleted — no bundled runtime, so the 40–90 MB artifact cost and its packaging-channel risk disappear |
+| [ADR-V4](ARCHITECTURE.md#adr-v4) | "One process per plugin" → "one VM and one thread per plugin"; capability enforcement is unchanged for host RPC, and improves if Luau |
+| [ADR-V15](ARCHITECTURE.md#adr-v15) | Lazy activation stops being load-bearing; it stays as hygiene rather than necessity |
+| [SECURITY.md §3](SECURITY.md) | Finding 1 either closes (Luau sandbox) or persists unchanged (QuickJS — a JS VM without a permission model has the same gap Bun does) |
+| [SECURITY.md §4](SECURITY.md) | Environment scrubbing becomes *harder*, not easier: an in-process plugin sees the kernel's own `std::env`, so the scrub must happen at VM construction by not exposing an env binding at all |
+| [MIGRATION.md](MIGRATION.md) Phase 1 | Supervisor work is replaced by VM lifecycle and thread management; the measurement in §7 lands here |
+| [CONSTITUTION-DELTA](CONSTITUTION-DELTA.md) rule 1 | Must be amended: "a plugin fault never reaches the user as a broken frame" becomes conditional on C2 |
+
+That last row is the one to weigh hardest. It is the only place where going
+in-process forces a Constitution rule to become weaker rather than merely
+different.

--- a/docs/v2/FEATURES-Agent-API.md
+++ b/docs/v2/FEATURES-Agent-API.md
@@ -1,0 +1,214 @@
+# Thurbox v2 — Agent API
+
+Thurbox already puts a coding agent inside every session. v2 makes the
+orchestrator itself **operable by those agents**: every plugin command is
+discoverable, typed, and callable from inside a session
+([ADR-V10](ARCHITECTURE.md#adr-v10)).
+
+This is the piece that turns thurbox from "a TUI that agents run inside" into
+"an orchestrator agents can drive". v1 already has the coordination patterns
+(`docs/ORCHESTRATION.md`) but they run on `thurbox-cli` invocations, the message
+queue, and screen conventions; a typed command registry makes them ordinary tool
+calls (§7).
+
+---
+
+## 1. One registry, four entry points
+
+A command is declared once in a plugin manifest and reachable four ways:
+
+```text
+ ┌──────────────────────┐
+ │ command registry │
+ │ id · schema · perms │
+ └──────────┬───────────┘
+ ┌─────────────┬─────────┴────────┬──────────────┐
+ ▼ ▼ ▼ ▼
+ keybinding command palette thurbox-cli control socket
+ (user) (user) (scripts, (agents inside
+ agents) sessions)
+```
+
+The registry is populated from manifests **without starting any plugin
+process**, so discovery works even for suspended or not-yet-activated plugins.
+Invoking a command activates its plugin on demand.
+
+---
+
+## 2. Discovery
+
+```bash
+$ thurbox-cli command list --json
+[
+ {
+ "id": "tasks.create",
+ "plugin": "tasks",
+ "title": "New task",
+ "description": "Create a task in the todo list",
+ "args": {
+ "type": "object",
+ "properties": {
+ "title": { "type": "string" },
+ "description": { "type": "string" }
+ },
+ "required": ["title"]
+ },
+ "returns": { "type": "object", "properties": { "id": { "type": "string" } } },
+ "agent_callable": true
+ }
+]
+```
+
+The `args` schema is JSON Schema, which is deliberate: it is the same shape
+agent CLIs already consume for tool definitions, so an agent can be handed the
+command list as a toolset with no translation layer.
+
+```bash
+thurbox-cli command list # human table
+thurbox-cli command list --plugin tasks # scope to one plugin
+thurbox-cli command describe tasks.create # full schema + examples
+```
+
+---
+
+## 3. Invocation
+
+```bash
+# Positional/flag form, validated against the schema
+thurbox-cli command run tasks.create --title "Fix flaky test" --description "…"
+
+# JSON form, for structured callers
+thurbox-cli command run tasks.create --json '{"title":"Fix flaky test"}'
+
+# Result on stdout (JSON when piped, human when a TTY — same rule as v1)
+{"id": "t_01H…", "status": "todo"}
+```
+
+Errors are structured and non-zero exit:
+
+```json
+{ "error": "E_ARGS", "message": "missing required argument: title", "command": "tasks.create" }
+```
+
+| Code | Meaning |
+|---|---|
+| `E_ARGS` | Arguments failed schema validation |
+| `E_UNKNOWN_COMMAND` | Not in the registry |
+| `E_PLUGIN_UNAVAILABLE` | Plugin faulted or disabled |
+| `E_CAPABILITY` | Command needs a capability the plugin was not granted |
+| `E_DENIED` | Caller is not permitted to invoke this command (§5) |
+| `E_TIMEOUT` | Exceeded the command deadline |
+
+---
+
+## 4. Identity — an agent knows who it is
+
+v1 already injects `THURBOX_SESSION` (the session id) and `THURBOX_TASK` into
+every spawned agent process, which is what lets `thurbox-cli message send`
+stamp provenance with no ids passed. v2 extends the same mechanism to
+commands:
+
+```bash
+# Run from inside a session's agent — no ids needed anywhere
+thurbox-cli command run review.open # reviews THIS session's worktree
+thurbox-cli command run tasks.create --title "…" # attributed to this session/task
+```
+
+The kernel resolves `{session}` and `{task}` argument defaults from the
+caller's injected environment. An agent therefore operates thurbox in terms of
+*what it wants*, never in terms of ids it would have to scrape.
+
+---
+
+## 5. Permission model
+
+Two orthogonal gates, both required:
+
+1. **Can the plugin do this at all?** The plugin's manifest capabilities
+ ([PLUGIN-API §8](FEATURES-Plugin-API.md#8-capability-reference)). A command in a
+ plugin without `sessions = "control"` cannot delete a session no matter who
+ invokes it.
+2. **May this caller invoke it?** Per-command caller policy:
+
+```toml
+[[commands]]
+id = "sessions.delete"
+title = "Delete session"
+agent_callable = true
+agent_policy = "confirm" # allow | confirm | deny
+```
+
+| Policy | Behavior when invoked from inside a session |
+|---|---|
+| `allow` | Runs immediately |
+| `confirm` | Queues a prompt in the TUI; the CLI call blocks (with `--timeout`) until the user answers |
+| `deny` | `E_DENIED` — user-only, e.g. `plugin.install` |
+
+Defaults are conservative for destructive verbs: anything that deletes,
+force-pushes, or installs defaults to `confirm` or `deny`, and a plugin must
+opt *down* explicitly. `thurbox-cli command list` reports each command's
+policy so an agent can tell in advance which calls will block on a human.
+
+**Loop guard.** Commands invoked from inside a session carry a depth counter;
+a command that spawns a session whose agent invokes the same command is
+stopped at depth 3 with `E_DENIED`. Without it, a self-driving orchestrator
+can trivially fork-bomb itself.
+
+---
+
+## 6. Control socket
+
+For callers that need lower latency or streaming than process-per-call, the
+kernel exposes the same registry over a local socket
+(`$XDG_RUNTIME_DIR/thurbox/control.sock`, or a named pipe on Windows). This is
+the only place v2 has a wire protocol at all — plugins are in-process
+([ADR-V2](ARCHITECTURE.md#adr-v2)) and cross no socket — so it defines its own
+framing: JSON-RPC 2.0, one object per line, newline-delimited.
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"command/run","params":{"id":"tasks.create","args":{"title":"…"}}}
+```
+
+Additional socket-only methods:
+
+| Method | Purpose |
+|---|---|
+| `command/list` | Registry snapshot |
+| `event/subscribe` | Stream kernel events (session status, task changes) |
+| `state/query` | Read kernel state without a command round trip |
+
+`thurbox-cli` uses the socket when a TUI is running and falls back to direct
+database access when it is not — the same dual path v1 already has for
+headless operation. Commands whose plugin is not running are unavailable
+headlessly and report `E_PLUGIN_UNAVAILABLE`, which is why kernel-table
+operations (tasks, automations, messages, sessions) remain kernel APIs rather
+than plugin commands ([ADR-V9](ARCHITECTURE.md#adr-v9)).
+
+---
+
+## 7. What this enables
+
+The v1 orchestration patterns (`docs/ORCHESTRATION.md`) currently coordinate
+through `thurbox-cli` plus the message queue plus screen conventions. With a
+typed command surface they become ordinary tool calls:
+
+- A lead agent opens a review on a worker's session and reads the diff
+ summary, instead of asking the user to look.
+- A CI-watching plugin dispatches a fixer session, and the fixer's agent marks
+ the task done and closes its own pane.
+- A worker asks for input by queuing a `confirm` command; the answer routes
+ back through the same call rather than through a mailbox convention.
+- Any agent can enumerate what this thurbox can do (`command list`) and adapt,
+ rather than being told in a prompt.
+
+---
+
+## 8. Non-goals for v2.0
+
+- **No remote control surface.** The socket is local-only. Driving another
+ machine's thurbox is a separate design with its own auth story.
+- **No per-agent identity or ACLs.** Policy is per command, not per agent.
+- **No transactional composition.** Commands are individual calls; there is no
+ batch/rollback primitive.
+- **No streaming command results.** A command returns once. Long-running work
+ belongs in an automation or a spawned session.

--- a/docs/v2/FEATURES-Animation.md
+++ b/docs/v2/FEATURES-Animation.md
@@ -1,0 +1,316 @@
+# Thurbox v2 — Animation
+
+The normative specification for **motion**: how a plugin declares something
+that changes over time, and what the kernel guarantees about it.
+
+[FEATURES-View-Tree.md §3.3](FEATURES-View-Tree.md#33-motion) is the
+view-tree-facing summary; the decision and its rationale are
+[ADR-V18](ARCHITECTURE.md#adr-v18). This document is where the timing,
+identity, budget, accessibility, and testing rules live.
+
+**Scope.** Motion covers *a function of time over content the plugin already
+sent*. Content that is genuinely new per frame is a `surface` or `pty`
+([FEATURES-View-Tree.md §3.4](FEATURES-View-Tree.md#34-real-time-surfaces)),
+which is a different mechanism with different costs — see §8.
+
+---
+
+## 1. Model
+
+```text
+plugin: push once ──▶ tree contains motion ──▶ kernel grants a lease
+                                                      │
+                        kernel frame clock ───────────┤
+                                                      ▼
+                                       repaint that pane at the declared rate
+```
+
+The plugin never participates in a frame. It declares what should move; the
+kernel evaluates the motion each time it paints, from its own clock.
+
+Three invariants follow, and every rule in this document is a consequence of
+one of them:
+
+1. **The plugin owns the data; the kernel owns the clock.** All frames are in
+   the pushed tree.
+2. **Motion is advisory.** The kernel may decline. Frame 0 must be a correct,
+   readable rendering on its own.
+3. **Motion costs a repaint, nothing else.** No plugin call, no tree
+   conversion, no diff per frame — the kernel evaluates the motion against a
+   tree it already holds.
+
+---
+
+## 2. Declaration
+
+```lua
+motion: {
+    kind: "cycle" | "marquee" | "pulse" | "blink" | "tween",
+    fps: number?,                  -- default 8; clamped to [1, 30]
+    pauseWhenUnfocused: boolean?,  -- default false
+    -- …kind-specific
+}?
+```
+
+### 2.1 `cycle`
+
+Round-robins pre-supplied subtrees. The general case — spinners, typing
+indicators, hand-drawn frame animation.
+
+```lua
+ui.box({ id = "thinking", motion = { kind = "cycle", fps = 8, frames = FRAMES } })
+```
+
+| Prop | Type | Default | Meaning |
+|---|---|---|---|
+| `frames` | `Node[]` | required | 2–64 subtrees, rendered in order |
+| `loop` | `boolean` | `true` | `false` holds the last frame and drops the lease |
+| `hold` | `number[]` | — | Per-frame dwell multipliers, for uneven timing |
+
+### 2.2 `marquee`
+
+Scrolls `text` horizontally within its resolved rect. This works despite the
+no-measurement rule ([LIMITATIONS §1.3](LIMITATIONS.md#13-measurement)) precisely because the
+kernel is the one that knows the rect.
+
+| Prop | Type | Default | Meaning |
+|---|---|---|---|
+| `cps` | `number` | `6` | Cells per second |
+| `gap` | `number` | `4` | Cells between the tail and the repeated head |
+| `mode` | `"loop" \| "bounce" \| "once"` | `"loop"` | |
+| `pauseEnds` | `number` | `800` | Milliseconds held at each end in `bounce`/`once` |
+
+A `marquee` whose content already fits its rect **does not animate** and takes
+no lease. This is checked per resolved rect, so widening a pane silently stops
+the scroll.
+
+### 2.3 `pulse` and `blink`
+
+Oscillate a style token or visibility. No content changes.
+
+| Prop | Type | Default | Meaning |
+|---|---|---|---|
+| `from` / `to` | style token | required for `pulse` | Endpoints, interpolated in RGB |
+| `period` | `number` | `1200` | Milliseconds for a full cycle |
+| `duty` | `number` | `0.5` | Fraction of the period spent at `to` (`blink` only) |
+
+`blink` is **hard-capped at 2 Hz** regardless of `fps` or `period`. See §6.
+
+### 2.4 `tween`
+
+Interpolates a numeric prop — indeterminate progress, animated meters, bar
+growth.
+
+| Prop | Type | Default | Meaning |
+|---|---|---|---|
+| `prop` | `string` | required | The node prop to drive |
+| `from` / `to` | `number` | required | Endpoints |
+| `ms` | `number` | `400` | Duration |
+| `ease` | see below | `"easeOut"` | Easing curve |
+| `repeat` | `number \| "forever"` | `0` | |
+| `yoyo` | `boolean` | `false` | Reverse on alternate repeats |
+
+Easing vocabulary — deliberately small, and closed for v2.0:
+
+`linear`, `easeIn`, `easeOut`, `easeInOut`, `stepped`
+
+`stepped` quantizes to whole cells, which is usually what you want in a
+terminal: a smooth tween across a 20-cell bar has only 20 distinguishable
+states anyway, and `stepped` stops it repainting between them.
+
+---
+
+## 3. Identity and phase
+
+This is the section that prevents the most likely bug in the whole system.
+
+**Motion state is keyed by `(paneId, node id, motion signature)`**, where the
+signature is the motion's kind and parameters. The kernel records a **motion
+epoch** — the clock time that key was first seen — and every frame is computed
+from `now − epoch`.
+
+The rule that matters:
+
+> **Re-pushing an identical motion on the same node `id` preserves its epoch.**
+> The animation continues from where it was. It does not restart.
+
+Without this, any plugin that re-pushes on unrelated state changes — which is
+every plugin — would reset its spinner to frame 0 on every push, and a spinner
+next to a 1 Hz counter would simply never advance past frame 0. Continuity is
+not an optimization here; it is correctness.
+
+A new epoch starts when, and only when:
+
+- the node `id` changes, or
+- the motion signature changes (different `kind`, `fps`, `frames`, …), or
+- the pane was hidden and is shown again, or
+- the plugin reloaded.
+
+**Nodes carrying motion must have a stable `id`.** A motion on an id-less node
+falls back to a structural key (its path in the tree), which is correct only
+while the tree shape is stable and silently restarts when it is not. The kernel
+logs this once per node per session; `thurbox plugin doctor` lists it.
+
+### Synchronization
+
+Two nodes with the same signature and the same epoch tick together. Nodes with
+different epochs do not, and **there is no primitive to align them**. A global
+phase lock would mean the kernel choosing a wake schedule for every pane at
+once; the cost is not worth "two spinners in step". Plugins that want visual
+coherence should give sibling nodes one shared motion on a parent rather than
+one motion each.
+
+---
+
+## 4. Leases
+
+A pane whose current tree contains live motion holds an **animation lease**:
+that pane, and only that pane, is exempt from the 250 ms forced-redraw floor,
+up to its declared rate.
+
+| Event | Effect on the lease |
+|---|---|
+| Push contains motion | Granted (or retained) |
+| Push contains no motion | Dropped |
+| Pane hidden | Dropped |
+| Pane unfocused, motion declared `pauseWhenUnfocused` | Dropped |
+| `cycle` with `loop: false` reaches its last frame | Dropped |
+| `tween` completes with no `repeat` | Dropped |
+| Plugin suspended, faulted, or reloaded | Dropped |
+
+Leases are per pane, never per node: a pane with six animated nodes repaints
+at the highest declared rate among them, once.
+
+### Rate budget and degradation
+
+Two caps: **30 fps per pane** and **30 fps aggregate** across all panes. When
+declared rates exceed the aggregate cap, the kernel degrades in this order:
+
+1. The **focused pane** keeps its declared rate, up to the per-pane cap.
+2. Remaining budget is distributed round-robin over the other leases in
+   **ascending declared rate**, so cheap animations are served before greedy
+   ones.
+3. A lease that cannot be served at **≥ 4 fps** is **frozen at its current
+   frame** rather than served at a rate that reads as stutter.
+4. Frozen and denied leases are counted and surfaced (§7).
+
+Degradation is deliberately not proportional. Halving everyone makes every
+animation look broken; freezing the least important ones keeps the rest
+correct.
+
+---
+
+## 5. What the kernel already animates
+
+v1's existing animations become the reference implementations, and each must
+map onto this system rather than sitting beside it:
+
+| v1 animation | v2 form |
+|---|---|
+| Session-list working spinner (`SPINNER_FRAMES`, 10 braille frames at ~8 fps) | `statusDot` — a `cycle` whose frames are kernel-owned |
+| Sync progress spinner | `cycle` in the status band |
+| Cursor blink in a focused terminal | Kernel surface behavior; not a lease |
+| Pending-spawn placeholder (`◌`, deliberately static) | No motion — the design intent was "nothing is running yet", and it stays |
+
+`statusDot` remains a node rather than becoming a plain `cycle` because its
+*frames* are kernel-owned too: a plugin should not hard-code thurbox's spinner
+glyphs, and changing them should not require every plugin to re-publish.
+
+---
+
+## 6. Accessibility
+
+**`reduce_motion`** (`[motion] reduce_motion` in `settings.toml`, default
+`false`) suppresses every animation application-wide — plugin motion, the
+session spinner, and the sync indicator alike. With it on, no lease is ever
+granted and every motion renders **frame 0**. This is why frame 0 must be a
+correct, readable rendering rather than a blank or a placeholder: for some
+users it is the only frame.
+
+The setting is deliberately whole-app rather than per-plugin. A user who needs
+reduced motion needs it from thurbox, not from seven plugins individually.
+
+**Flashing.** `blink` is capped at 2 Hz and `pulse` at 2 Hz for full-cell
+background changes, regardless of what was declared. The guidance this
+implements is the general one for photosensitive seizure risk — stay below
+three flashes per second — and a plugin cannot opt out of it. A plugin that
+wants attention faster than that should use color or a glyph change, not
+flashing.
+
+**Terminals do not report a reduced-motion preference**, so there is nothing to
+detect and honor automatically. The setting is the whole mechanism.
+
+---
+
+## 7. Observability
+
+Motion is the one thing in v2 that makes an idle thurbox wake up, so "why is
+this repainting" must always have an answer:
+
+| Surface | Shows |
+|---|---|
+| `thurbox plugin doctor` | Live leases per plugin: pane, node id, kind, declared vs served rate |
+| Perf HUD (`F12`) | `motion_leases`, `motion_frames`, `motion_denied`, `motion_frozen` counters |
+| `thurbox.log` | One warning per id-less motion node; one per denied lease class |
+
+The perf counters are wall-clock-free `u64`s bumped at the paint path, matching
+the existing `perf_*` counter tests in `src/app/acceptance.rs`.
+
+---
+
+## 8. Motion versus surfaces
+
+| | `motion` | `surface` / `pty` |
+|---|---|---|
+| Content | Supplied up front, replayed | Generated per frame |
+| Cost | One push, then repaints of one pane | Same as a session terminal pane |
+| Repaint driver | Kernel frame clock, under a lease | Output arrival, via the existing redraw detection |
+| Theme | Full token styling | None inside the grid — the plugin owns its colors |
+| Budget | Rate-capped, degradable | Governed by output volume, not leases |
+
+A `surface` does **not** take an animation lease. It rides the same
+output-driven redraw path a session pane already uses, which is why an embedded
+program at 30 fps costs what an agent producing output at 30 fps costs — no
+more, and no new mechanism.
+
+Choose by asking what changes:
+
+- Frames are known when you push → `motion`.
+- Frames depend on data arriving *during* the animation → `surface`.
+- Neither, and it changes on state → just push on state change.
+
+---
+
+## 9. Determinism and testing
+
+Animation must not make the acceptance suite flaky, and it does not, because
+it reads the same clock the harness already controls.
+
+- **Motion evaluates through `app::clock`** — the thread-local test clock every
+  UI-thread timer already reads through. `Harness::advance` steps animation
+  exactly as it steps timers and search debounce.
+- **Snapshots render frame 0.** insta snapshots evaluate every motion at its
+  epoch, so a pinned screen never depends on wall time. A test that wants
+  frame N calls `advance` first and asserts on that.
+- **Invariants for the monkey test**: a pane with no live motion never holds a
+  lease; a lease never survives its pane being hidden; served rate never
+  exceeds declared rate; the aggregate cap is never exceeded.
+- **Conformance fixtures**: a plugin declaring 64 frames, one declaring 200 fps
+  (clamped), one declaring `blink` at 30 Hz (capped to 2), one with an id-less
+  motion node (warned, still renders), and one whose every push re-declares the
+  same motion (must not restart — the §3 rule, asserted directly).
+
+---
+
+## 10. Anti-patterns
+
+| Don't | Why | Instead |
+|---|---|---|
+| Push a tree per frame to animate | Pays a plugin call + tree conversion + diff for what the kernel evaluates for free | Declare `motion` |
+| Omit `id` on an animated node | Structural keying restarts the animation whenever the tree shape shifts | Give it a stable id |
+| Vary motion params every push | Each change starts a new epoch, so the animation restarts every time | Keep the signature constant while it should run |
+| Assume a frame was displayed | Motion is advisory; `reduce_motion` and budgets both render frame 0 | Keep state in your reducer, not in the animation |
+| Animate to convey state alone | Invisible under `reduce_motion` | Pair motion with a glyph or color that reads statically |
+| Use `blink` for emphasis | Capped at 2 Hz and hostile to read | A `badge`, a token change, or `pulse` |
+| Animate a large subtree | `cycle` frames all ship in the tree and count against its budget | Animate the smallest node that changes |
+| Reach for `motion` for live data | Frames must be known at push time | `surface`, or throttle and push |

--- a/docs/v2/FEATURES-Backend-API.md
+++ b/docs/v2/FEATURES-Backend-API.md
@@ -1,0 +1,575 @@
+# Thurbox v2 — Plugin Backend
+
+A plugin has two halves. [FEATURES-View-Tree.md](FEATURES-View-Tree.md) specifies the **view**
+half — what a plugin draws while the TUI is running. This document specifies
+the **service** half: what a plugin *does*, including when no TUI exists.
+
+```text
+plugin/
+├── plugin.toml
+└── src/
+ ├── service.luau ← this document — runs headless, owns data + integrations
+ └── view.luau ← FEATURES-View-Tree.md — runs only with the TUI, render + input
+```
+
+Either half may be omitted. A CI-status integration that only syncs data is
+service-only. A pane that renders kernel state is view-only.
+
+---
+
+## 1. Why the split exists
+
+v1 guarantees that **automations fire with the TUI closed** (`docs/ARCHITECTURE.md`
+ADR-8b): a detached tmux heartbeat keeper loops `thurbox-cli automation tick`
+every 60 s, with optional systemd/launchd units for reboot-proof firing. A
+plugin system whose backend only lived inside the TUI process would silently
+revoke that guarantee — a task-sync or CI-watch plugin would stop working the
+moment you quit.
+
+So the seam is drawn where thurbox's own seam already is
+([ADR-V16](ARCHITECTURE.md#adr-v16)):
+
+| Half | Hosted by | Lives while |
+|---|---|---|
+| **service** | The TUI when running; otherwise the heartbeat keeper or a `thurbox-cli` invocation | thurbox is *installed* |
+| **view** | The TUI only | thurbox is *on screen* |
+
+Three consequences worth internalizing:
+
+1. **A service must not assume a UI.** `ctx.ui.status(...)` is a no-op
+ headless. Report through logs, run history, and notifications instead.
+2. **The two halves are separate VMs on separate threads** and share no state.
+ They talk over a typed contract the kernel routes (§9).
+3. **Capabilities are granted per half.** A view rarely needs `net` or
+ `shell`; a service rarely needs anything else.
+
+---
+
+## 2. Entry point
+
+```lua
+local thurbox = require("@thurbox")
+
+return thurbox.defineService({
+    init = function(ctx)
+        ctx.db.migrate({
+            `CREATE TABLE runs (id TEXT PRIMARY KEY, repo TEXT, state TEXT, seen_at INTEGER)`,
+            `CREATE INDEX runs_repo ON runs (repo)`,
+        })
+    end,
+
+    services = {
+        poll = function(ctx, signal)
+            while not signal.aborted do
+                syncOnce(ctx)
+                ctx.sleep(60_000, signal)
+            end
+        end,
+    },
+
+    schedules = {
+        ["nightly-prune"] = { cron = "0 3 * * *", run = function(ctx) prune(ctx) end },
+    },
+
+    commands = {
+        ["ci.refresh"] = function(ctx) return { synced = syncOnce(ctx) } end,
+    },
+
+    cli = {
+        status = {
+            summary = "Show CI status for every watched repo",
+            run = function(ctx, argv)
+                ctx.out.table(ctx.db.all(`SELECT * FROM runs`))
+            end,
+        },
+    },
+
+    dispose = function(ctx) end,
+})
+```
+
+`init` runs once per activation. Everything else is registration: the kernel
+supervises services, fires schedules, routes commands, and dispatches CLI
+verbs.
+
+---
+
+## 3. Hosting and lifecycle
+
+A service VM is created by whichever host needs it first:
+
+| Host | Starts a service when |
+|---|---|
+| TUI | An activation event fires ([ADR-V15](ARCHITECTURE.md#adr-v15)) |
+| Heartbeat keeper (`automation tick`, 60 s) | The plugin declares `services` or `schedules` and is enabled |
+| `thurbox-cli` | A plugin CLI verb or command is invoked |
+
+**Exactly one service instance per plugin per machine.** The kernel enforces
+this with an advisory lock in the database, so a running TUI and a heartbeat
+tick never both run a plugin's `poll` loop. If the TUI starts while the
+heartbeat already hosts the service, the service **stays with the heartbeat**
+— migrating live work would break it in flight for no benefit.
+
+A CLI invocation is the exception: it creates an **ephemeral, service-less**
+VM that runs only the requested verb, with `services` and `schedules`
+suppressed. This keeps `thurbox-cli ci status` fast and side-effect-free.
+
+Lifecycle otherwise mirrors [PLUGIN-API §4](FEATURES-Plugin-API.md#4-lifecycle):
+lazy activation, backoff on fault, `dispose()` with a grace period. Two
+service-specific rules:
+
+- **Reload drains first.** Running services are aborted via their `signal` and
+ joined (2 s grace) before the replacement VM starts, so a reload never runs
+ two copies of a poll loop.
+- **A crashing service does not disable the plugin's view.** The halves fault
+ independently; a broken sync shows a degraded pane, not a missing one.
+
+---
+
+## 4. CLI verbs
+
+A plugin owns a namespace under `thurbox-cli`:
+
+```toml
+[[cli]]
+name = "ci"
+summary = "CI status and controls"
+```
+
+```lua
+cli = {
+    status = { summary = "Show CI status", run = function(ctx, argv) --[[ … ]] end },
+    retry = { summary = "Retry a failed run", args = { id = "string" }, run = retryRun },
+}
+```
+
+```bash
+thurbox-cli ci status
+thurbox-cli ci retry --id 4821
+```
+
+Output goes through `ctx.out`, which respects thurbox's existing convention —
+human-readable on a TTY, JSON when piped, forced by `--json` / `--pretty` /
+`--text`:
+
+```lua
+ctx.out.table(rows)             -- formats per the active output mode
+ctx.out.json({ synced = 12 })   -- structured only
+ctx.out.line("12 runs synced")  -- human only
+```
+
+Name collisions with kernel subcommands (`session`, `task`, `automation`,
+`message`, `plugin`, `command`, `config`, …) are rejected at install time, not
+at runtime.
+
+**Why this rather than only `command run`**: `thurbox-cli command run ci.refresh
+--json '{}'` works and is agent-friendly, but it is not a CLI a human wants to
+type or a shell script wants to read. Commands are the *machine* surface
+([FEATURES-Agent-API.md](FEATURES-Agent-API.md)); verbs are the human one, and a
+plugin that owns real functionality deserves both.
+
+---
+
+## 5. Services (supervised background work)
+
+```lua
+services = {
+    poll = function(ctx, signal) --[[ long-running ]] end,
+}
+```
+
+| Property | Behavior |
+|---|---|
+| Start | On activation, after `init` resolves |
+| Abort | `signal` fires on reload, disable, deactivate, and shutdown |
+| Restart | On unexpected return or throw, with backoff (1s, 2s, 4s, … capped 60 s) |
+| Grace | 2 s after abort before the thread is terminated |
+| Concurrency | One instance per named service, machine-wide |
+
+Services are for **watching** — polling an API, tailing a file, holding a
+websocket. They are not for scheduled work; use §6.
+
+`ctx.sleep(ms, signal)` is provided because a bare busy-wait cannot be
+cancelled and would hold the service alive past abort.
+
+---
+
+## 6. Schedules
+
+```lua
+schedules = {
+    ["nightly-prune"] = { cron = "0 3 * * *", run = function(ctx) prune(ctx) end },
+}
+```
+
+Schedules are **claimed through the kernel's existing automation machinery**,
+not run by a timer inside the plugin. That means they inherit ADR-8b's
+properties for free: they fire from the TUI, the heartbeat keeper, or a
+systemd/launchd unit; `claim_due_automation`'s atomic compare-and-swap
+guarantees exactly one firer; and each run is recorded in the run history
+where the automations pane already displays it.
+
+Choosing between the two:
+
+| Use | When |
+|---|---|
+| `schedules` | Work happens *at a time* — nightly prune, 15-minute sync |
+| `services` | Work happens *continuously* — a poll loop, a socket, a file watch |
+
+A `schedules` entry is preferable whenever it fits, because it costs nothing
+while idle: no VM is resident between firings.
+
+---
+
+## 7. Storage
+
+Two tiers, both inside the kernel database
+([ADR-V17](ARCHITECTURE.md#adr-v17)).
+
+### 7.1 Key-value
+
+```lua
+ctx.kv.set("cursor", { page = 3 })
+local cursor = ctx.kv.get("cursor")
+ctx.kv.list("repo:")  -- prefix scan
+```
+
+For cursors, caches, and small blobs. No schema, no migration.
+
+### 7.2 Namespaced tables
+
+For relational data, a plugin declares migrations and the **kernel executes
+and versions them**:
+
+```lua
+ctx.db.migrate({
+    `CREATE TABLE runs (id TEXT PRIMARY KEY, repo TEXT, state TEXT)`,  -- v1
+    `ALTER TABLE runs ADD COLUMN url TEXT`,                            -- v2
+})
+```
+
+Rules the kernel enforces:
+
+- Every table is created in the plugin's namespace — a declared `runs` becomes
+ `plugin_ci_runs`. A statement referencing anything outside the namespace is
+ **rejected**, so a plugin cannot read or write kernel tables or another
+ plugin's data through SQL.
+- The applied version is recorded in `plugin_migrations(plugin, version)`.
+ Migrations are append-only: editing an already-applied statement is a load
+ error, not a silent divergence.
+- `plugin uninstall --purge` drops the namespace. No orphaned tables.
+
+Queries are parameterized only:
+
+```lua
+local rows = ctx.db.all(`SELECT * FROM runs WHERE repo = ?`, { repo })
+ctx.db.run(`UPDATE runs SET state = ? WHERE id = ?`, { state, id })
+ctx.db.tx(function(t) --[[ … ]] end)  -- transaction
+```
+
+There is no raw connection handle, which is the deliberate difference from the
+usual JS-ecosystem answer of handing a plugin a live `better-sqlite3`
+`Database`. Keeping execution kernel-side is what preserves a single
+`SCHEMA_VERSION` owner, keeps multi-instance `PRAGMA data_version` sync
+coherent, and makes uninstall complete
+([ADR-V17](ARCHITECTURE.md#adr-v17)).
+
+**Kernel tables** (`sessions`, `tasks`, `automations`, `session_messages`, …)
+remain reachable only through typed host APIs, never SQL.
+
+---
+
+## 8. Event bus
+
+```lua
+ctx.bus.publish("ci:status", { repo = repo, state = state })
+ctx.bus.subscribe("flow:dispatch", function(payload) --[[ … ]] end)
+```
+
+Named channels brokered by the kernel. Both halves of a plugin can use them,
+and — with the `bus` capability — **so can other plugins**.
+
+This is the second cross-plugin composition primitive, alongside
+`sessionDecorations`. It is intentionally weaker than a direct call: channels are
+fire-and-forget, payloads are opaque JSON, there is no request/response, and a
+subscriber cannot tell whether a publisher exists. Two plugins can therefore
+cooperate when both opt in, without either being able to break the other by
+changing an interface.
+
+Channel names are namespaced by convention (`<plugin>:<topic>`) and by rule for
+publishing: a plugin may publish only on its own prefix, and may subscribe to
+any.
+
+---
+
+## 9. Talking to the view half
+
+The halves share a typed contract:
+
+```lua
+-- src/types.luau
+export type Contract = {
+    listRuns: (args: { repo: string }) -> { Run },
+    retry: (args: { id: string }) -> (),
+}
+```
+
+```lua
+-- src/service.luau
+rpc = {
+    listRuns = function(ctx, args)
+        return ctx.db.all(`… WHERE repo = ?`, { args.repo })
+    end,
+}
+```
+
+```lua
+-- src/view.luau
+local runs = ctx.service.listRuns({ repo = repo })
+```
+
+The kernel routes and validates against the shared declaration, so both halves
+type-check against one source. The two halves are separate VMs on separate
+threads, so the call yields the caller's coroutine and is deadline-bounded; a
+view must therefore fetch into state and render from state
+([LIMITATIONS §4.2](LIMITATIONS.md#42-no-synchronous-host-calls-during-render---by-design)).
+
+A service may also push to its view (`ctx.view.notify(event)`), which is how a
+finished sync updates a pane without polling.
+
+---
+
+## 10. Control-socket methods
+
+A plugin can expose methods on thurbox's control socket
+([AGENT-API §6](FEATURES-Agent-API.md#6-control-socket)):
+
+```lua
+socket = { ["ci.summary"] = function(ctx) return summarize(ctx) end }
+```
+
+These are for external tooling and scripts that want a persistent connection
+rather than a `thurbox-cli` invocation per call. They are **not** a general HTTP surface —
+thurbox has no HTTP server, and adding one is a separate decision with its own
+security story. A plugin cannot open a listening port through this API, and
+nothing here is reachable off the machine
+([FEATURES-Agent-API.md §8](FEATURES-Agent-API.md#8-non-goals-for-v20)).
+
+---
+
+## 11. Spawn contributions
+
+v1 extensions could patch an agent's argv (`[[agent_patches]]`), and dropping
+that outright would be a real regression (see
+[LIMITATIONS §4.5](LIMITATIONS.md#45-no-middleware)). A bounded form is restored:
+
+```lua
+spawn = {
+    contribute = function(ctx, spawn)
+        return {
+            env = { CI_TOKEN_FILE = "/run/secrets/ci" },
+            args = { "--settings", `{ctx.home}/ci.json` },
+        }
+    end,
+}
+```
+
+Hard limits, so this stays a contribution and not middleware:
+
+- **Append only.** It cannot remove or rewrite existing args or env.
+- **No veto.** It cannot cancel or redirect a spawn.
+- **Fail-open with a 500 ms deadline.** A slow or throwing contributor is
+ skipped and logged; the session still spawns.
+- **Conflicts are visible.** Two plugins setting the same env key is a logged
+ warning and last-declared-wins by manifest order, never a silent surprise.
+- **Dangerous env keys are refused.** `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`,
+ `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`, `BASH_ENV`, `NODE_OPTIONS` and the
+ like turn a contribution into arbitrary code execution inside every agent
+ session; `PATH` may only be **prepended** with paths under `{plugin_data}`.
+ Rejections are logged and listed by `thurbox plugin doctor`
+ ([SECURITY.md §8](SECURITY.md#8-spawn-contributions)). Append-only bounds
+ *who wins*, not *what can be injected* — this bounds the latter.
+
+The same shape carries the v1 `hook_schema` capability: a plugin contributing
+an agent declares which hook family that agent speaks, and status wiring
+follows.
+
+---
+
+## 12. Skills
+
+```toml
+[[skills]]
+path = "skills/ci"
+```
+
+A skill is agent-facing markdown shipped next to the code it describes — the
+missing half of [FEATURES-Agent-API.md](FEATURES-Agent-API.md). A JSON Schema
+tells an agent a command's *shape*; a skill tells it *when and why* to reach for
+it. v1 already ships this pattern by hand: `extensions/flow/FLOW.md` is a
+behavior spec surfaced to whichever CLI runs it through context-file symlinks.
+Skills make it a first-class, agent-neutral registry instead of a symlink
+convention.
+
+Skills register in a kernel registry and surface two ways:
+
+```bash
+thurbox-cli skill list # what this thurbox can teach an agent
+thurbox-cli skill show ci # the markdown
+```
+
+and, for agents that auto-discover context files, optional materialization
+into a session's workspace. Which files those are is agent-specific, so the
+kernel stays neutral: it exposes the registry and materializes on request,
+rather than knowing that one CLI reads `CLAUDE.md` and another reads
+`AGENTS.md`.
+
+---
+
+## 13. Settings
+
+Typed descriptors, declared in the manifest and readable in both halves, with
+change notification in the service:
+
+```lua
+ctx.settings.get()  -- typed values
+ctx.settings.onChange(function(next, prev) --[[ … ]] end)
+```
+
+Values live in the plugin's namespace and render in the Settings panel under
+the plugin's name. A service that caches a derived value from settings should
+rebuild it in `onChange` rather than at `init` only.
+
+---
+
+## 14. Capabilities used by this half
+
+The canonical capability table is
+[PLUGIN-API §8](FEATURES-Plugin-API.md#8-capability-reference) — one list, one
+place, covering both halves. Seven entries in it exist for the service half:
+
+| Capability | Values | Grants |
+|---|---|---|
+| `db` | `none` \| `kv` \| `tables` | KV only (§7.1), or namespaced tables with migrations (§7.2) |
+| `cli` | `bool` | Registering CLI verbs (§4) |
+| `services` | `bool` | Long-running supervised work (§5) — implies a resident VM |
+| `schedules` | `bool` | Cron entries in the kernel scheduler (§6) |
+| `bus` | `none` \| `own` \| `all` | `own` = publish on its own prefix; `all` = also subscribe to other plugins' channels (§8) |
+| `socket` | `bool` | Exposing control-socket methods (§10) |
+| `spawn` | `none` \| `contribute` | Appending env/args at session spawn (§11) |
+
+`services` is the one to scrutinize at install time: it is the difference
+between a plugin that runs when you look at it and a plugin that runs always.
+`thurbox plugin install` calls it out explicitly.
+
+Grants are **per half**. A view rarely needs `net` or `shell`; a service never
+needs `pty`. Declaring them separately is what keeps the install prompt
+meaningful instead of a union of everything either half might want.
+
+---
+
+## 15. Budgets and failure
+
+| Concern | Limit |
+|---|---|
+| `init` | 10 s, then the plugin faults |
+| Command / cross-half call | 250 ms soft (status shown), 10 s hard |
+| Spawn contribution | 500 ms, fail-open |
+| Service restart | Backoff to 60 s; 10 consecutive faults disables the service |
+| Schedule run | Recorded in run history with exit state and tail-truncated output |
+| Resident memory | Reported per plugin by `thurbox plugin doctor` |
+
+A service-half fault is surfaced where its consequences are, not only in a
+log: a degraded badge on the plugin's pane, an entry in `plugin doctor`, and —
+if the plugin declares `notify` — an OS notification for repeated failure.
+
+---
+
+## 16. Worked example
+
+A CI-watch plugin, end to end. Service-only until the last two lines.
+
+```toml
+# plugin.toml
+name = "ci"
+entry_service = "src/service.luau"
+entry_view = "src/view.luau"
+
+[capabilities]
+db = "tables"
+net = ["api.github.com"]
+cli = true
+services = true
+bus = "own"
+sessions = "read"
+
+[[panes]]
+id = "ci"
+slot = "right"
+title = "CI"
+
+[[cli]]
+name = "ci"
+summary = "CI status and controls"
+
+[[skills]]
+path = "skills/ci"
+
+activation = ["onStartup"]
+```
+
+```lua
+-- src/service.luau
+local thurbox = require("@thurbox")
+
+return thurbox.defineService({
+    init = function(ctx)
+        ctx.db.migrate({
+            `CREATE TABLE runs (id TEXT PRIMARY KEY, repo TEXT, branch TEXT, state TEXT)`,
+        })
+    end,
+
+    services = {
+        poll = function(ctx, signal)
+            while not signal.aborted do
+                for _, s in ctx.sessions.list() do
+                    local run = fetchRun(ctx, s.repo, s.branch)
+                    ctx.db.run(`INSERT OR REPLACE INTO runs VALUES (?,?,?,?)`,
+                        { run.id, s.repo, s.branch, run.state })
+                    ctx.bus.publish("ci:status", { session = s.id, state = run.state })
+                end
+                ctx.sleep(60_000, signal)
+            end
+        end,
+    },
+
+    rpc = { listRuns = function(ctx) return ctx.db.all(`SELECT * FROM runs`) end },
+    cli = { status = { summary = "Show CI status", run = showStatus } },
+})
+```
+
+What this gets for free, and would not get from a view-only plugin: it keeps
+syncing with the TUI closed, it owns `thurbox-cli ci status`, its failures land
+in run history, and any other plugin can react to `ci:status` — including
+decorating session rows it does not own.
+
+---
+
+## 17. What this closes, and what it does not
+
+The service half is what stops "plugin" meaning "a pane". It gives a plugin
+plugin-owned CLI verbs (§4), supervised background work (§5), scheduled work
+that inherits ADR-8b (§6), relational storage (§7), pub/sub (§8), a typed
+channel to its own view (§9), spawn contributions (§11), and agent-facing
+skills (§12) — the set of things v1 extensions could reach for and v1 *panes*
+could not.
+
+Still deliberately absent, with reasons:
+
+| Not provided | Why |
+|---|---|
+| Raw SQLite handle | One schema owner; clean uninstall (§7.2) |
+| HTTP routes | thurbox has no HTTP server (§10) |
+| Spawn veto or arg rewriting | Middleware; contributions are append-only (§11) |
+| Direct plugin-to-plugin calls | Interface coupling; the bus is the sanctioned path (§8) |
+| Access to another plugin's tables | Namespace enforcement (§7.2) |

--- a/docs/v2/FEATURES-Keybindings.md
+++ b/docs/v2/FEATURES-Keybindings.md
@@ -1,0 +1,294 @@
+# Thurbox v2 — Keybindings, Help, and Pane Visibility
+
+How a plugin's keys reach the user, how they coexist with 61 kernel actions and
+with whatever the agent in a focused terminal expects, and how panes are shown
+and hidden.
+
+v1's keybinding system is one of its better-designed parts — contexts, live
+rebinding from F1, conflict detection scoped by overlap, and readline
+passthrough. **None of it is replaced.** This document specifies how plugins
+join it.
+
+---
+
+## 1. The registry
+
+Every binding — kernel or plugin — resolves through one registry, persisted in
+one file (`~/.config/thurbox/keybindings.json`), edited in one place (the F1
+panel). A plugin declares defaults in its manifest:
+
+```toml
+[[commands]]
+id = "ci.refresh"
+title = "Refresh CI status"
+
+[[keybindings]]
+command = "ci.refresh"
+key = "r"
+context = "pane:ci"
+```
+
+Bindings register **from the manifest, without creating the plugin's VM**
+([ADR-V15](ARCHITECTURE.md#adr-v15)). A plugin that never activates still
+resolves its chords, still appears in F1, and still lists in the palette; it
+activates when a chord is actually pressed.
+
+### Precedence
+
+| Rank | Source | Notes |
+|---|---|---|
+| 1 | The user's `keybindings.json` | Always wins. Editing F1 writes here |
+| 2 | Kernel action defaults | The 61 v1 actions |
+| 3 | Plugin manifest defaults | Between plugins, install order |
+
+---
+
+## 2. Contexts
+
+v1 has six contexts (`Global`, `SessionList`, `Automations`, `Tasks`,
+`FileViewer`, `Terminal`) and one overlap rule:
+
+```rust
+a == KeyContext::Global || b == KeyContext::Global || a == b
+```
+
+v2 keeps the rule and makes the set **open**: every declared pane gets
+`pane:<id>` as a context. `SessionList`, `Tasks` and friends stop being
+hardcoded variants and become the pane contexts of the plugins that own them —
+which is the whole point of ADR-V1, and it costs no change to the overlap
+predicate. Two different plugin panes never overlap, so both may bind `j`.
+
+| Context | Active when |
+|---|---|
+| `global` | Always |
+| `pane:<id>` | That pane has focus |
+| `terminal` | A `sessionTerminal`, `pty`, or `surface` node has focus |
+
+---
+
+## 3. Conflicts
+
+Two situations that look alike and must behave differently.
+
+**A user rebinds in F1.** Stealing is correct: the user pressed the chord
+deliberately. v1's behavior stands — the chord is reassigned, the previous
+owner is unbound, and a toast names the move.
+
+**A plugin's manifest default collides on install.** Stealing is wrong. A newly
+installed plugin must not silently break muscle memory, and the user has not
+expressed any intent about that chord. So:
+
+> A plugin default that collides with an already-bound chord in an overlapping
+> context is **dropped, not applied.** The command stays fully reachable from
+> the palette, `thurbox-cli`, and the agent API; only the shortcut is withheld.
+
+`thurbox plugin install` reports dropped bindings, and `thurbox plugin doctor`
+lists them with the chord's current owner so the user can rebind deliberately
+in F1 if they want it.
+
+This asymmetry is the design: **a chord changes owner only when a human asks
+for it.**
+
+---
+
+## 4. Terminal passthrough
+
+v1 defers eleven actions to the PTY when a terminal is focused, because they
+sit on readline's namespace — `Ctrl+B` (backward char), `Ctrl+E` (end of line),
+`Ctrl+W` (delete word), `Ctrl+R` (reverse search), `Ctrl+X` (emacs prefix), and
+so on. Each keeps an F-key alternate that works everywhere.
+
+For plugins the problem mostly disappears by construction: a `pane:<id>`
+binding fires only while that pane has focus, and a focused terminal is a
+different pane. **Pane-scoped plugin bindings can never reach a terminal.**
+
+The exception is a plugin binding declared `context = "global"`:
+
+> A global plugin binding on a bare `Ctrl+<letter>` chord is **automatically
+> passthrough-deferred** while a terminal, `pty`, or `surface` node has focus.
+> Plugins cannot opt out.
+
+The readline namespace belongs to the program running in the pane, and no
+plugin author is in a position to know which of the user's agent CLIs needs
+`Ctrl+W`. The kernel applies the same `is_ctrl_letter_chord` test it uses for
+its own actions, so the rule is one predicate shared by both.
+
+**Guidance for plugin authors**: prefer a `pane:<id>` context. If you genuinely
+need a global chord, use an F-key or a modified chord (`Ctrl+Shift+…`,
+`Alt+…`) rather than a bare `Ctrl+<letter>` — those dispatch everywhere,
+including from a focused terminal.
+
+---
+
+## 5. The F1 panel stays kernel
+
+The theme picker, the settings panel, and the repo picker are all ordinary
+`overlay`-slot panes in v2. **The F1 keybinding editor is not**, and the reason
+is mechanical rather than a matter of taste:
+
+> The editor's core operation is capturing the **next physical keypress** —
+> including chords the kernel would otherwise intercept, like `Ctrl+Q`. A
+> plugin cannot receive a keypress the kernel routes elsewhere, so a plugin
+> implementation of the editor structurally could not rebind the chords most
+> worth rebinding.
+
+So F1 remains kernel chrome, alongside the frame, the footer, and the layout
+solver. It renders the merged registry, which means plugin actions appear in it
+automatically, grouped under the plugin's name, with no plugin code running at
+all.
+
+### What plugins contribute to F1
+
+| Element | Source |
+|---|---|
+| Section heading | Plugin `title` |
+| Rebindable rows | Each `[[keybindings]]` entry, with its live chord |
+| Non-rebindable rows | `documented_keys` (§6) |
+| Availability marker | Whether the plugin is enabled, suspended, or faulted |
+
+---
+
+## 6. In-pane keys and discoverability
+
+A plugin handling raw `key` events (§`plugin/event`) takes keys that never
+reach the registry — so they cannot be rebound, and F1 cannot list them. This
+is the same category as v1's "fixed" keys (modal selectors, the file-viewer
+search sub-mode), which the F1 panel documents but cannot edit.
+
+**Prefer commands.** A pane whose `j`/`k` are declared as commands with
+`pane:<id>` bindings gets rebinding, F1 documentation, palette entries, and
+agent-callability for free. Raw key events are for what genuinely needs them:
+text-entry-like interaction, high-frequency navigation, and sub-modes.
+
+For those, declare them as documentation:
+
+```toml
+[[panes]]
+id = "ci"
+documented_keys = [["/", "filter"], ["esc", "clear filter"]]
+```
+
+`documented_keys` is inert — it renders in F1 under the plugin's section, marked
+non-rebindable, and does nothing else. It exists so a plugin's raw-key
+sub-modes are discoverable rather than folklore.
+
+---
+
+## 7. Pane visibility
+
+v1 has two independent axes that v2 must keep separate, because collapsing them
+loses a behavior users rely on:
+
+| Axis | v1 | v2 |
+|---|---|---|
+| Does this surface exist at all? | `[features] tasks = false` | `thurbox plugin disable tasks` |
+| Is it on screen right now? | `F5` / `F9` / `F2` / `F3` | This section |
+
+### Kernel-owned, not plugin-owned
+
+**Pane visibility is kernel state.** The manifest declares the initial value;
+the kernel owns it thereafter.
+
+```toml
+[[panes]]
+id = "ci"
+slot = "right"
+default_visible = true
+min_width = 24
+toggle_key = "f6"        # optional default chord, subject to §3
+```
+
+Plugin-owned visibility would be circular: a suspended plugin cannot show its
+own pane, and `onPaneVisible:<id>` is precisely the event meant to wake it.
+`ctx.ui.showPane(id, visible)` therefore becomes a **request** the kernel
+honors, not the source of truth.
+
+### Auto-generated commands
+
+Every declared pane gets three commands, registered from the manifest with no
+plugin code:
+
+```text
+<plugin>.<pane>.toggle
+<plugin>.<pane>.show
+<plugin>.<pane>.hide
+```
+
+They appear in the palette, in `thurbox-cli command run`, in the agent API, and
+in F1 as rebindable rows. This is what preserves v1's uniform "one key shows or
+hides a panel" model across third-party panes, instead of every plugin
+inventing its own toggle.
+
+### Showing wakes a suspended plugin
+
+`show` on a suspended plugin's pane activates it and fires
+`onPaneVisible:<id>`. The frame paints the pane's chrome immediately with a
+loading state; the tree arrives when the plugin pushes it. Toggling a pane is
+therefore never blocked on a cold start.
+
+### Three states, kept distinct
+
+| State | Loaded? | Contributes keys/commands? | On screen? |
+|---|---|---|---|
+| **Disabled** (`plugin disable`) | No | No | No |
+| **Hidden** | Manifest registered; process may be suspended | Yes | No |
+| **Visible** | Yes | Yes | Yes, subject to `min_width` |
+
+A disabled plugin contributes nothing at all — its chords are free for other
+plugins to claim, which is the v2 equivalent of `[features] tasks = false`
+freeing up the tasks pane's keys.
+
+### Responsive hiding is not user intent
+
+A pane dropped by the layout solver for being under its `min_width` is
+**not** marked hidden. Widening the terminal restores it. This mirrors v1,
+where the info panel and tasks panel appear at width ≥ 120 without the user's
+toggle state changing underneath them.
+
+### Persistence — a deliberate change from v1
+
+v1 does **not** persist panel visibility: `show_info_panel`, `show_file_viewer`,
+`show_tasks_panel` and `show_session_list` are plain `bool` fields on `App`,
+reset on every launch.
+
+v2 **persists** per-pane visibility in the kernel database, keyed by pane id.
+With four built-in panels, re-toggling after each launch is a minor annoyance;
+with an open-ended set of third-party panes it is not, and a user who hides a
+plugin's pane means it. `thurbox plugin doctor` reports panes hidden by user
+state, so "my pane never appears" has a discoverable answer.
+
+---
+
+## 8. Worked example
+
+A CI plugin contributing one pane and two shortcuts:
+
+```toml
+[[panes]]
+id = "ci"
+title = "CI"
+slot = "right"
+default_visible = false
+toggle_key = "f6"
+documented_keys = [["/", "filter"], ["esc", "clear filter"]]
+
+[[commands]]
+id = "ci.refresh"
+title = "Refresh CI status"
+
+[[keybindings]]
+command = "ci.refresh"
+key = "r"
+context = "pane:ci"
+```
+
+What the user gets, with no plugin code beyond `render`:
+
+- `F6` toggles the pane, rebindable in F1, and it wakes the plugin if suspended.
+- `r` refreshes while the pane is focused, rebindable, and never fires while a
+  terminal has focus.
+- An F1 section titled **CI** listing `F6`, `r`, and the two documented keys.
+- `thurbox-cli command run ci.refresh` and `ci.ci.toggle` for scripts and
+  agents.
+- If `F6` was already taken, the binding is dropped with a warning and every
+  command above still works.

--- a/docs/v2/FEATURES-Layout.md
+++ b/docs/v2/FEATURES-Layout.md
@@ -1,0 +1,300 @@
+# Thurbox v2 — Layout
+
+How space is divided between panes, and how a plugin positions content that
+does not fit the normal flow.
+
+This supersedes the slot model sketched in
+[FEATURES-View-Tree.md §2](FEATURES-View-Tree.md#2-panes-and-roots) and the
+flex rules in [§5](FEATURES-View-Tree.md#5-layout-algebra); those sections
+remain the plugin-facing summary. Decisions:
+[ADR-V22](ARCHITECTURE.md#adr-v22) (anchors),
+[ADR-V23](ARCHITECTURE.md#adr-v23) (the workspace tree).
+
+Three of the four layout limitations in
+[LIMITATIONS §1](LIMITATIONS.md#1-layout) are resolved here. The fourth is
+deliberately not, and §6 says why.
+
+---
+
+## 1. Two layers
+
+```text
+┌─ workspace tree ────────────────────────────────────────┐  §2
+│  splits and tab groups; leaves are panes                │
+│                                                          │
+│   ┌─ pane ──────────────┐   base layer   ← normal flow   │  §3
+│   │  box / row / column │                                │
+│   │   ┌ overlay ┐       │   overlay layer ← anchored     │  §4
+│   │   └─────────┘       │                                │
+│   └─────────────────────┘                                │
+└──────────────────────────────────────────────────────────┘
+```
+
+The **base layer** keeps today's invariant: siblings never overlap, one axis
+per container, no absolute positioning. The **overlay layer** is where floating
+content lives, strictly z-ordered and resolved in a second pass.
+
+---
+
+## 2. The workspace tree
+
+Pane geometry is a **tree of splits**, not a fixed set of slots. A branch is a
+horizontal or vertical split; a leaf is a pane or a tab group.
+
+```toml
+# ~/.config/thurbox/layout.toml — optional. Absent = the default preset (§2.3).
+[workspace]
+split = "horizontal"
+children = [
+  { pane = "sessions", size = "18%", min_width = 20 },
+  { split = "vertical", children = [
+      { tabs = ["terminal", "review"], weight = 1 },
+      { pane = "search", size = 12 },
+  ]},
+  { pane = "tasks", size = "20%" },
+]
+```
+
+| Key | Applies to | Meaning |
+|---|---|---|
+| `split` | branch | `horizontal` \| `vertical` |
+| `children` | branch | Ordered child regions |
+| `pane` | leaf | A pane id contributed by a plugin |
+| `tabs` | leaf | Several panes sharing a region, one visible, tab strip on the border |
+| `size` | any | Fixed cells or a percentage of the parent |
+| `weight` | any | Share of the remainder, after fixed sizes |
+| `min_width` / `min_height` | any | Below this the region is **hidden, not squeezed** |
+
+### 2.1 What this unlocks
+
+Everything [LIMITATIONS §1.2](LIMITATIONS.md#12-pane-geometry) listed falls out of the tree
+rather than needing a feature each:
+
+| Wanted | Expressed as |
+|---|---|
+| A full-width pane above the list and terminal | A vertical root split whose first child is that pane |
+| A 2×2 dashboard across panes | A horizontal split of two vertical splits |
+| Nested splits | A branch inside a branch |
+| Reordering at runtime | Reordering `children` |
+| A header-docked pane | A `size = 1` first child of a vertical root |
+| Panes stacked in a column | What `left` already was, now explicit |
+
+### 2.2 Slots become placement hints
+
+`slot` does not disappear from the manifest — it becomes the answer to "where
+does a **newly installed** pane go when the workspace tree does not name it?"
+
+```toml
+[[panes]]
+id = "ci"
+slot = "right"    # auto-placement hint, not a position
+```
+
+The kernel appends the pane to the region its slot maps to. A user who has
+never touched `layout.toml` therefore gets the same behavior as today, and a
+plugin author still does not have to think about layout.
+
+### 2.3 The default preset
+
+With no `layout.toml`, the kernel synthesizes the tree that reproduces v1's
+`PanelAreas` exactly:
+
+```text
+vertical
+├── header                     (kernel chrome, size 1)
+├── horizontal
+│   ├── vertical  18%          left:   sessions, automations
+│   ├── tabs      weight 1     center: terminal / shell / review
+│   └── right     20% each     right:  tasks, files
+├── bottom strip               size 12 when shown
+├── status band                size 1 when shown
+└── footer                     (kernel chrome, size 1)
+```
+
+So zero-config output is byte-identical to the slot model, and the slot model
+stops being a separate mechanism — it is a preset over the general one.
+
+### 2.4 Responsive collapse
+
+Unchanged from v1 and from the slot model: a region under its `min_width` or
+`min_height` is **hidden, not squeezed**, and hiding is a *layout* decision
+that does not touch the user's visibility state
+([FEATURES-Keybindings §7](FEATURES-Keybindings.md#7-pane-visibility)).
+Widening restores it.
+
+### 2.5 What is deferred
+
+**Interactive resize** — dragging a split border with the mouse, tmux-style —
+is not in 2.0. The tree makes it possible (a drag writes back a `size`), but it
+needs hit regions on split borders, a persistence policy for transient drags,
+and keyboard equivalents. It is a follow-up, not a prerequisite, and the file
+is editable in the meantime.
+
+---
+
+## 3. Base-layer flow
+
+Unchanged. Inside a pane, layout is flex along one axis per container:
+
+1. Fixed children (`size: n`) take their size.
+2. `size: "auto"` children are measured by content.
+3. The remainder is distributed among `flex: n` children proportionally.
+4. Overflow clips; a `scroll` ancestor makes it scrollable instead.
+
+No absolute positioning, no negative margin, and siblings never overlap. That
+constraint is what keeps the solver a single pass for trees that do not use §4.
+
+---
+
+## 4. Anchors — the overlay layer
+
+A node may position itself against **another node's resolved rect** instead of
+taking part in the flow:
+
+```lua
+ui.box({
+    id = "completions",
+    anchor = {
+        to = "query-input",  -- an id in the same pane
+        side = "below",      -- below | above | right | left
+        align = "start",     -- start | center | end
+        flip = true,         -- use the opposite side when it does not fit
+        offset = { 0, 0 },
+    },
+}, { w.list({ items = matches }) })
+```
+
+This is the general capability behind autocomplete dropdowns, context menus,
+tooltips, and inline compose boxes — including v1's
+`render_compose_inline(frame, diff_area, anchor_y, comp)`, which floats a
+comment box at a diff line and flips above or below as room allows. That case
+was previously handled by a bespoke `inlineAt` slot on `diff`; **the special
+case is removed** in favour of this.
+
+### Rules
+
+1. **Two passes, only when needed.** The base flow resolves first; anchored
+   subtrees resolve against the resulting rects. A tree with no `anchor` is a
+   single pass, exactly as today.
+2. **Clipped to the pane.** An anchor cannot escape its pane's rect in 2.0.
+   `flip` and then clamping keep it inside. Escaping to screen bounds needs
+   cross-pane z-ordering and is deferred.
+3. **Z-order is deterministic**: pane order, then declaration order within the
+   pane. There is no `z-index`.
+4. **Focus is unchanged.** An anchored subtree belongs to its pane and is not a
+   separate focus target, so exactly one pane still holds focus. This is the
+   invariant that mattered, and anchors do not touch it.
+5. **Hit-testing runs overlay-first**, top of the z-order down, then the base
+   layer.
+6. **Nesting is capped at 3** (a menu, a submenu, its submenu). Deep enough for
+   real UIs, shallow enough that the pass count is bounded.
+7. **A dangling `to` is a no-op**, logged once — the subtree is not rendered
+   rather than rendered somewhere arbitrary.
+
+### The invariant that changes
+
+The kernel previously assumed nothing ever overlaps. It now assumes:
+
+> The **base layer** never overlaps. The **overlay layer** may overlap the base
+> layer and is strictly ordered.
+
+That is the honest restatement, and it is what the monkey test asserts
+(§7).
+
+---
+
+## 5. Measurement
+
+`render` stays pure and synchronous — it cannot ask how tall anything is. Two
+mechanisms replace the ability, and together they cover the real cases without
+making the frame two-way.
+
+### 5.1 Node props for the concrete cases
+
+The kernel owns the renderer, so it knows the mapping a plugin was trying to
+reconstruct:
+
+```lua
+ui.markdown({ content = content, revealSourceLine = 42 })  -- reveal source line 42
+ui.code({ content = content, revealLine = 108 })
+ui.scroll({ id = "list", revealNode = "row-17" }, children)
+```
+
+This solves "scroll to rendered line N" exactly, rather than approximately.
+
+### 5.2 Opt-in measurement feedback
+
+For the general case, a node may request its resolved rect back:
+
+```lua
+ui.box({ id = "card", measure = true }, children)
+```
+
+The kernel delivers, with the next event batch:
+
+```lua
+{ type = "measure", rects = { card = { x = x, y = y, width = w, height = h } } }
+```
+
+It is **one frame late** by construction. That is fine for virtualization
+windows, follow-the-selection scrolling, and progressive layouts; it is not
+fine for anything that must be correct in the frame it is computed.
+
+### 5.3 Still impossible
+
+Single-pass content-driven layout: sizing a box to its wrapped content *and*
+positioning a sibling relative to that result within the same frame. A plugin
+can converge over two frames; it cannot do it in one. Masonry is therefore
+approximate, and this stays a documented limit.
+
+---
+
+## 6. Cross-pane alignment stays unsupported
+
+Two sibling panes cannot share a column ruler, and this is **not** being fixed.
+
+The mechanism would be named size groups — a node declares `sizeGroup: "cols"`
+and the kernel resolves every member to a common width across panes. It is well
+understood and it would work.
+
+It is rejected on value, not difficulty. It requires a solver pass that couples
+panes which are otherwise independent, it interacts badly with a pane being
+hidden by §2.4 (does the group re-solve, or keep a ruler for content nobody can
+see?), and the demand is one hypothetical: a table spanning two panes, which in
+a terminal is almost always better as one pane. Adding cross-pane coupling to
+the solver for that is a bad trade.
+
+---
+
+## 7. Testing
+
+| Property | How |
+|---|---|
+| The default preset reproduces v1 | The existing insta snapshots, unchanged, against the synthesized tree |
+| Base layer never overlaps | Monkey invariant over random trees |
+| Overlay z-order is deterministic | Same tree renders identically across runs |
+| Anchors stay inside their pane | Property test: random anchor + random pane rect, assert containment |
+| `flip` picks the side with room | Table-driven test at each edge |
+| Single-pass when no anchors | A perf counter asserting pass count is 1 for anchor-free trees |
+| Collapse is layout-only | Narrowing then widening restores the pane without touching visibility state |
+| Measurement is one frame late | Fixture asserting the rect arrives in the following batch, not the current one |
+
+---
+
+## 8. Cost
+
+Stated plainly, because this is the largest single addition to the v2 kernel:
+
+- A real layout engine replaces `compute_layout`'s 10 fixed rects with a
+  recursive solver. Arguably simpler than what it replaces, but it is new code
+  on the frame path.
+- Two-pass layout and an overlay buffer, paid only by trees that use anchors.
+- `layout.toml` becomes a config file with a schema, validation, and a
+  migration story.
+- The hit-test registry gains z-ordering.
+
+What it buys: five of the six items in
+[LIMITATIONS §1.2](LIMITATIONS.md#12-pane-geometry), the whole of
+[§1.1](LIMITATIONS.md#11-floating-elements), most of
+[§1.3](LIMITATIONS.md#13-measurement), and the deletion of the
+`diff.inlineAt` special case.

--- a/docs/v2/FEATURES-Plugin-API.md
+++ b/docs/v2/FEATURES-Plugin-API.md
@@ -1,0 +1,716 @@
+# Thurbox v2 — Plugin API
+
+The contract between the Rust kernel and a plugin VM. This document is
+intended to be sufficient to write a working plugin without reading kernel
+source; the rendering contract it references is specified separately in
+[FEATURES-View-Tree.md](FEATURES-View-Tree.md).
+
+---
+
+## 0. Quickstart
+
+The smallest thing that is a plugin, end to end. Two files:
+
+```toml
+# hello/plugin.toml
+name = "hello"
+version = "0.1.0"
+entry_view = "src/view.luau"
+activation = ["onPaneVisible:hello"]
+
+[[panes]]
+id = "hello"
+title = "Hello"
+slot = "right"
+default_visible = true
+```
+
+```lua
+-- hello/src/view.luau
+local thurbox = require("@thurbox")
+local ui = thurbox.ui
+
+type State = { n: number }
+
+return thurbox.definePlugin({
+    init = function(ctx): State
+        return { n = 0 }
+    end,
+
+    render = function(ctx, s: State)
+        return ui.column({ padding = 1 }, {
+            ui.text({ content = `pressed {s.n} times`, style = { fg = "accent" } }),
+        })
+    end,
+
+    update = function(ctx, s: State, e)
+        if e.type == "key" then return { n = s.n + 1 } end
+        return s
+    end,
+})
+```
+
+```bash
+thurbox plugin dev ./hello    # loads it, watches the file, reloads on save
+```
+
+That is a real pane: themed, focusable, in the `Ctrl+L` focus ring, with a
+`hello.hello.toggle` command the kernel generated from the manifest and a row in
+the F1 editor. It declares **no capabilities**, so it can draw and receive its
+own input and nothing else — which is the default
+([§8](#8-capability-reference)).
+
+From here: [§2](#2-manifest-plugintoml) for what else the manifest can declare,
+[FEATURES-View-Tree.md](FEATURES-View-Tree.md) for what else `render` can
+return, and [FEATURES-Backend-API.md](FEATURES-Backend-API.md) when the plugin
+needs to do something while the TUI is closed.
+
+---
+
+## 1. What a plugin is
+
+A directory containing a manifest and up to two Luau entry points — a
+**service** half and a **view** half ([ADR-V16](ARCHITECTURE.md#adr-v16)):
+
+```text
+my-plugin/
+├── plugin.toml # manifest — identity, capabilities, contributions
+├── src/
+│ ├── service.luau # runs headless too — FEATURES-Backend-API.md
+│ ├── view.luau # runs only with the TUI — FEATURES-View-Tree.md
+│ └── types.luau # type definitions shared by both halves
+├── skills/ # optional — agent-facing markdown
+└── README.md
+```
+
+**Either half may be omitted.** A tracker-sync integration is service-only and
+draws nothing; a pane over kernel state is view-only and runs only while the
+TUI does. The halves are separate VMs on separate threads, with separate
+capability grants, and they fault independently.
+
+Install locations, in resolution order:
+
+| Location | Purpose |
+|---|---|
+| `$THURBOX_PLUGIN_PATH` (colon-separated) | Development override |
+| `~/.config/thurbox/plugins/<name>/` | User-installed |
+| Embedded in the binary | Bundled plugins (materialized to a cache dir on first run) |
+
+The first match by name wins, so a user can shadow a bundled plugin with their
+own fork by name alone.
+
+---
+
+## 2. Manifest (`plugin.toml`)
+
+```toml
+name = "tasks" # unique id; [a-z0-9-]+
+version = "2.0.0"
+description = "Todo list with agent dispatch"
+entry_service = "src/service.luau" # optional — omit for a view-only plugin
+entry_view = "src/view.luau" # optional — omit for a headless plugin
+min_thurbox = "2.0.0" # soft gate — warn, never block
+license = "MIT"
+activation = ["onPaneVisible:tasks", "onCommand:tasks.create"] # §2b
+
+# Canonical list in §8. A flat [capabilities] grants both halves; add
+# [capabilities.view] / [capabilities.service] to narrow one of them.
+[capabilities]
+sessions = "control" # none (default) | read | control
+db = "kv" # none (default) | kv | tables
+tasks = "write" # none | read | write (kernel-table access)
+fs = ["{plugin_data}"] # path templates; empty by default
+net = [] # allowed hosts; empty by default
+shell = false # spawn processes
+notify = true # post OS notifications
+
+# A pane the plugin contributes to the layout. Visibility is kernel state:
+# `default_visible` seeds it, the auto-generated `<plugin>.<pane>.toggle`
+# command changes it, and it persists. See FEATURES-Keybindings.md §7.
+[[panes]]
+id = "tasks"
+title = "Tasks"
+slot = "right" # left | right | center | bottom | overlay
+default_visible = true
+min_width = 24
+focusable = true
+toggle_key = "f5" # optional default chord for the generated toggle command
+documented_keys = [["space", "cycle status"]] # inert; shown in F1 as non-rebindable
+
+# A command — callable by keybinding, palette, CLI, or agent.
+[[commands]]
+id = "tasks.create"
+title = "New task"
+description = "Create a task in the todo list"
+args = { title = "string", description = "string?" }
+agent_callable = true # default true; false hides it from agents
+
+# A default keybinding. Users override in keybindings.json exactly as today.
+[[keybindings]]
+command = "tasks.create"
+key = "n"
+context = "pane:tasks" # global | pane:<id> | terminal
+
+# Namespaced settings, surfaced in the Settings panel under the plugin's name.
+[[settings]]
+key = "show_done"
+type = "bool"
+default = true
+label = "Show completed tasks"
+```
+
+**Every field is inert data.** The kernel reads the manifest without creating a
+VM, so `thurbox plugin list`, the command palette, the keybinding editor, and
+the Settings panel are all populated before a line of plugin code runs. A
+plugin that never activates still contributes its keybindings — they simply
+report the plugin as unavailable when invoked.
+
+---
+
+## 2b. Contribution points
+
+Everything a plugin adds to thurbox is a **contribution**: declared in the
+manifest, registered without creating a VM, and resolved by the kernel
+([ADR-V15](ARCHITECTURE.md#adr-v15)). There is no imperative
+`registerPane()` API.
+
+| Contribution | Extends | Notes |
+|---|---|---|
+| `[[panes]]` | Slot-placed surfaces | `left` / `right` / `center` / `bottom` / `overlay` |
+| `[[commands]]` | The command registry | Backs keys, palette, CLI, and agents alike |
+| `[[keybindings]]` | Default chords | Land in `keybindings.json`, user-overridable as always. Contexts, conflict handling, and terminal passthrough: [FEATURES-Keybindings.md](FEATURES-Keybindings.md) |
+| `[[settings]]` | Settings panel rows | Namespaced under the plugin |
+| `[[agents]]` | `agents.toml` entries | Replaces the v1 extension capability |
+| `[[automations]]` | Seeded schedules | Idempotent — matched by name |
+| `[[statusItems]]` | Footer pills | `{ id, position, command }` |
+| `[[tabs]]` | Central-pane tabs | For plugins contributing a `center` pane |
+| `[[sessionDecorations]]` | Session-list rows owned by *another* plugin | See below |
+| `[[cli]]` | A `thurbox-cli` verb namespace | Service half — [BACKEND-API §4](FEATURES-Backend-API.md#4-cli-verbs) |
+| `[[skills]]` | Agent-facing markdown | [BACKEND-API §12](FEATURES-Backend-API.md#12-skills) |
+
+Service-side registrations (`services`, `schedules`, `rpc`, `socket`, `spawn`)
+are declared in code rather than the manifest, because they carry handlers;
+their capabilities are still declared in the manifest so the kernel knows what
+to grant before starting anything. See
+[FEATURES-Backend-API.md](FEATURES-Backend-API.md).
+
+### The remaining contribution shapes
+
+`[[panes]]`, `[[commands]]`, `[[keybindings]]` and `[[settings]]` are in §2.
+The other four are small enough to state in full:
+
+```toml
+# A footer pill. `command` runs on click; `text` is the static label the pill
+# shows before the plugin is running, replaceable live via ctx.ui.setStatusItem.
+[[statusItems]]
+id = "ci-summary"
+position = "right"        # left | right — ordered by declaration within a side
+command = "ci.refresh"    # optional
+text = "CI"               # optional static label
+
+# A central-pane tab. Requires a pane with slot = "center".
+[[tabs]]
+pane = "ci-detail"
+title = "CI"
+shortcut = "f10"          # optional; same collision rules as any default chord
+
+# An agents.toml entry. Fields are v1's AgentDef verbatim, so this is the
+# extension capability moved, not redesigned.
+[[agents]]
+name = "ci-fixer"
+command = "claude"
+args = []
+hook_schema = "claude"    # optional — see docs/AGENTS.md
+
+# A seeded schedule, matched by name and idempotent across restarts.
+[[automations]]
+name = "ci-tick"
+cron = "*/15 * * * *"
+command = "ci.refresh"    # a command id, not a shell string
+enabled = true
+```
+
+Three rules apply to all four. They are **inert data** like everything else in
+the manifest, so they register with the plugin stopped. They are **idempotent**:
+re-running discovery matches an existing `[[agents]]`/`[[automations]]` entry by
+name rather than duplicating it, which is what replaces v1's self-heal loop
+([MIGRATION §4](MIGRATION.md#4-teardown-inventory--the-v1-extension-system)).
+And they are **removed on uninstall**, exactly as they were added.
+
+### Cross-plugin composition
+
+`sessionDecorations` is the primitive that lets plugins compose **without
+knowing about each other**. A CI plugin declares:
+
+```toml
+[[sessionDecorations]]
+id = "ci"
+position = "trailing" # leading | trailing | subtitle
+```
+
+…and pushes decorations keyed by session id:
+
+```lua
+ctx.decorate("ci", { [sessionId] = { text = "✗ 2", tone = "danger" } })
+```
+
+The session-list plugin renders whatever decorations exist for a row without
+importing, depending on, or knowing about the CI plugin. Without this, a
+plugin that wants to annotate a session row must either fork the session-list
+plugin or take a hard dependency on it — which is how plugin ecosystems
+ossify.
+
+### Activation events
+
+A plugin's VM is created on its first activation event, not at launch:
+
+| Event | Fires when |
+|---|---|
+| `onStartup` | TUI start — use sparingly; it is the only eager option |
+| `onPaneVisible:<id>` | One of the plugin's panes becomes visible |
+| `onCommand:<id>` | One of its commands is invoked (key, palette, CLI, agent) |
+| `onSession` | Any session exists |
+| `onEvent:<name>` | A kernel event it subscribes to fires |
+
+```toml
+activation = ["onPaneVisible:tasks", "onCommand:tasks.create"]
+```
+
+This is what keeps VM-per-plugin ([ADR-V4](ARCHITECTURE.md#adr-v4)) cheap
+even at high N: N is bounded by plugins *in use*, not plugins *installed*, and a
+plugin whose pane is never opened costs one manifest parse. A Luau state is
+kilobytes and starts in microseconds, so this is an optimization rather than
+the load-bearing constraint it was under a process-per-plugin model
+([ADR-V2](ARCHITECTURE.md#adr-v2)).
+
+---
+
+## 3. Entry point
+
+```lua
+local thurbox = require("@thurbox")
+local ui = thurbox.ui                    -- kernel primitives
+local w = require("@thurbox/widgets")    -- userland widgets
+
+type State = { tasks: { Task }, selected: number }
+
+return thurbox.definePlugin({
+    init = function(ctx): State
+        return { tasks = ctx.tasks.list(), selected = 1 }
+    end,
+
+    render = function(ctx, state: State)
+        return ui.box({ title = "Tasks", border = "focus" }, {
+            w.list({
+                id = "tasks",
+                selected = state.selected,
+                items = state.tasks,
+                render = function(t)
+                    return ui.row({}, { ui.text({ content = t.title }), statusGlyph(t.status) })
+                end,
+                onSelect = function(i) return { type = "select", index = i } end,
+            }),
+            w.keyHints({ hints = { { "n", "new" }, { "space", "cycle" }, { "d", "delete" } } }),
+        })
+    end,
+
+    update = function(ctx, state: State, event)
+        if event.type == "select" then
+            return { tasks = state.tasks, selected = event.index }
+        elseif event.type == "kernel:tasks-changed" then
+            return { tasks = event.tasks, selected = state.selected }
+        end
+        return state
+    end,
+
+    commands = {
+        ["tasks.create"] = function(ctx, args)
+            local task = ctx.tasks.create({ title = args.title })
+            ctx.dispatch({ type = "kernel:tasks-changed", tasks = ctx.tasks.list() })
+            return { id = task.id }
+        end,
+    },
+
+    dispose = function(ctx) end,
+})
+```
+
+The shape is deliberately TEA, mirroring the kernel: `init` produces state,
+`update` is a pure reducer over events, `render` is a pure function of state,
+and side effects live in `commands` and in host API calls. `render` **must not
+await, and must not call `ctx`** — it runs against in-memory state only, and its
+callbacks *return* event descriptors rather than dispatching, because no
+function crosses the wire
+([FEATURES-View-Tree.md §1](FEATURES-View-Tree.md#1-model)).
+
+Note what the entry point does **not** contain: the plugin's name, its panes,
+its keybindings, or its settings. Those are manifest data, registered without
+creating a VM at all ([ADR-V15](ARCHITECTURE.md#adr-v15)); the code
+supplies only behavior. The `commands` map here provides *handlers* for command
+ids the manifest declared — declaring a handler for an undeclared id is a load
+error.
+
+---
+
+## 4. Lifecycle
+
+```text
+discover read plugin.toml; register panes/commands/keys/settings (no VM)
+ │
+ ▼
+activate create Luau VM + thread → bind host tables → init() → first view
+ │ (lazy: on first pane display or first command invocation)
+ ▼
+running kernel delivers events; plugin pushes views
+ │
+ ├── reload file change in dev mode, or `thurbox plugin reload <name>`
+ │ → dispose() → drop the VM → new VM → init() → view;
+ │ state is NOT preserved
+ │
+ ├── suspend all panes hidden for > 60 s → VM dropped, manifest stays
+ │ registered; next display re-activates
+ │
+ └── fault error / deadline exceeded repeatedly
+ → pane shows error state, backoff restart (1s, 2s, 4s, capped
+ at 30 s), 5 consecutive faults → disabled; recover with
+ `thurbox plugin reload <name>`, or `plugin enable <name>` after
+ a `disable`. `plugin doctor` shows the last error.
+ │
+ ▼
+deactivate dispose() with a 2 s grace period, then the VM's interrupt
+ handler aborts the thread, then the VM is dropped
+```
+
+**Unload is a `Drop`, not a signal.** The VM is the unit of reload
+([ADR-V2](ARCHITECTURE.md#adr-v2) C3): every value the plugin created —
+closures, tables, host handles — lives inside that `Lua` state, so dropping it
+reclaims all of them at once with no teardown protocol to get wrong. A plugin
+that ignores its grace period is stopped by the VM-level interrupt handler,
+which raises inside the interpreter loop and cannot be caught by plugin code.
+This is only safe because plugins may not carry native code
+([ADR-V2](ARCHITECTURE.md#adr-v2) C2) — a C module could hold a lock or a raw
+pointer across the abort.
+
+**Reload does not preserve state.** A plugin that wants durable state persists
+it through `ctx.kv`. This keeps reload semantics honest — no partially
+migrated in-memory shapes — and matches how `init()` runs on every activation.
+
+---
+
+## 5. The host boundary
+
+There is no wire protocol. A plugin's VM is a `mlua::Lua` state owned by a
+kernel thread ([ADR-V2](ARCHITECTURE.md#adr-v2)), so both directions of the
+boundary are ordinary Rust ↔ Luau calls across it. The names below are the
+*shape* of that boundary — the set of entry points and their semantics — not
+message types on a socket.
+
+### Kernel → plugin
+
+The kernel calls into the VM from its own thread. Each call is bounded by the
+VM's interrupt handler, so a plugin that spins is stopped rather than hanging
+the kernel.
+
+| Entry point | Kind | Carries |
+|---|---|---|
+| *(bind)* | at VM creation | host version, capabilities granted, theme tokens, pane rects |
+| `init` | call → value | → initial view tree |
+| `update` | call → value | input or kernel event (see §6) → new state |
+| `commands[id]` | call → value | `(ctx, args)` → command result |
+| `onSettingsChanged` | call | new values for the plugin's settings |
+| `onThemeChanged` | call | new theme tokens |
+| `onResize` | call | new rect for each of the plugin's panes |
+| `dispose` | call | run teardown; the VM is dropped afterwards |
+
+Capabilities are applied at bind time by **omitting** the tables a plugin was
+not granted — an ungranted capability has no binding to reach
+([ADR-V4](ARCHITECTURE.md#adr-v4)). There is no per-call permission check to
+forget.
+
+Note the shape of `update`: it is a **call the kernel makes**, not a request for
+a frame. There is no `render` request — the kernel never asks a plugin for a
+view, which is [ADR-V11](ARCHITECTURE.md#adr-v11)'s central rule and the reason
+view pushes flow the other way.
+
+Plugin `print` and uncaught error text are captured and written to
+`thurbox.log`, tagged with the plugin name — the only place a plugin may write
+free text (Constitution rule 9: stdout belongs to the TUI).
+
+### Plugin → kernel
+
+| Call | Kind | Carries |
+|---|---|---|
+| `ctx.push(tree)` | one-way | `{ paneId, revision, tree }` — the core render path |
+| `ctx.surface.write(id, bytes)` | one-way | raw bytes into a `surface` grid, capability `pty` |
+| `ctx.*` | yielding call | host API (§7) |
+| `ctx.log(level, msg)` | one-way | a log line |
+
+A view push is **one-way, not a return value**. The kernel never asks for a
+frame; the plugin pushes when its state changes, and the kernel marks the UI
+dirty ([ADR-V11](ARCHITECTURE.md#adr-v11)). Every frame paints from the last
+pushed tree. Trees cross the boundary as an owned Rust value converted from the
+Luau table once, at push time — the kernel never reads plugin memory during a
+paint, so a reload mid-frame cannot tear the screen.
+
+`surface.write` is the one path that carries per-frame data, and it is
+deliberately *not* the view path: bytes go into a kernel-owned vt100 grid, not
+into a tree ([ADR-V19](ARCHITECTURE.md#adr-v19)). It is subject to
+backpressure — the kernel drops frames rather than queueing them, and reports
+the drop count in `surface:stats`. A plugin that has no `surface` node never
+uses it, which is the intended default.
+
+### Deadlines and failure
+
+| Situation | Kernel behavior |
+|---|---|
+| A command exceeds 250 ms | Status message "running…", result applied when it arrives |
+| A command exceeds 10 s | Interrupt handler aborts the call; error surfaced in the status bar |
+| No push after an event | Last tree keeps rendering — this is normal, not an error |
+| An uncaught Luau error | Pane shows error state; backoff restart |
+| Memory limit exceeded (`set_memory_limit`) | Allocation fails inside the VM; plugin faulted, VM dropped |
+| A returned tree fails validation | Push rejected, plugin faulted, offending node logged |
+
+---
+
+## 6. Events
+
+Delivered to `update(ctx, state, event)`.
+
+**Input events** — only while one of the plugin's panes has focus:
+
+```lua
+{ type = "key", key = "n", mods = { "ctrl" } }
+{ type = "paste", text = "…" }
+{ type = "mouse", kind = "click", x = 12, y = 4, target = "row-7" }
+{ type = "focus", focused = true }
+```
+
+`target` carries the id of the view-tree node under the cursor, so plugins do
+not do hit testing — the kernel derives hitboxes from the tree.
+
+One exception: while a `pty` or `surface` node holds focus it is an **input
+sink** — keys are encoded to bytes and written to the grid rather than
+delivered as `key` events. The plugin regains input when the node's `escape`
+chord fires ([FEATURES-View-Tree.md §3.4](FEATURES-View-Tree.md#34-real-time-surfaces)).
+
+**Kernel events** — delivered to any plugin that declared the matching
+capability:
+
+| Event | Requires |
+|---|---|
+| `session:created` / `:deleted` / `:statusChanged` / `:selected` | `sessions >= read` |
+| `session:output` (debounced, no content) | `sessions >= read` |
+| `task:changed` | `tasks >= read` |
+| `git:worktreeChanged` | `sessions >= read` |
+| `pty:exited` (`{ nodeId, code }`) | `pty` |
+| `surface:stats` (`{ nodeId, dropped }`) | `pty` |
+| `tick` (1 Hz) | none |
+
+Events a plugin has no capability for are never delivered, so an unprivileged
+pane sees only its own input.
+
+---
+
+## 7. Host API
+
+Every call is a Rust function bound into the VM, gated by the manifest's
+capabilities. Gating is by **absence**: a table the plugin was not granted is
+never bound, so an ungranted call fails as `attempt to index nil` at the point
+of use — an error, never a silent no-op, and one `luau-analyze` catches before
+the plugin ever runs ([ADR-V4](ARCHITECTURE.md#adr-v4)).
+
+```lua
+export type HostContext = {
+    -- Plain values, safe to read from `render`      no capability required
+    pane: { id: string, width: number, height: number, focused: boolean },
+    home: string,                        -- this plugin's directory
+    settings: { [string]: any },         -- this plugin's settings values
+
+    -- Rendering / state
+    dispatch: (event: Event) -> (),      -- queue an event into own update()
+    setState: (patch: { [string]: any }) -> (),
+    invalidate: (paneId: string?) -> (),
+    decorate: (id: string, bySessionId: { [string]: Decoration }) -> (),  -- §2b
+
+    -- Sessions                                      capability: sessions
+    sessions: {
+        list: () -> { SessionInfo },                 -- read
+        get: (id: string) -> SessionInfo,            -- read
+        create: (cfg: SessionConfig) -> string,      -- control
+        send: (id: string, text: string) -> (),      -- control
+        focus: (id: string) -> (),                   -- control
+        delete: (id: string, force: boolean?) -> (), -- control
+    },
+
+    -- Kernel tables                                 capability: tasks / automations
+    tasks: TaskApi,
+    automations: AutomationApi,
+    messages: MessageApi,
+
+    -- Plugin key-value storage                      capability: db >= kv
+    -- Relational tables (ctx.db) are service-half only — BACKEND-API §7.2
+    kv: {
+        get: (key: string) -> any?,
+        set: (key: string, value: any) -> (),
+        delete: (key: string) -> (),
+        list: (prefix: string?) -> { string },
+    },
+
+    git: GitApi,                         -- capability: sessions >= read
+
+    -- UI affordances                                no capability required
+    ui: {
+        status: (message: string, level: ("info" | "warn" | "error")?) -> (),
+        modal: (tree: Node) -> ModalResult,
+        focusPane: (paneId: string) -> (),
+        showPane: (paneId: string, visible: boolean) -> (),  -- a REQUEST
+        setStatusItem: (id: string, item: StatusItem?) -> (),
+        theme: () -> ThemeTokens,
+    },
+
+    -- Cross-plugin and cross-half channels
+    bus: BusApi,                         -- capability: bus     BACKEND-API §8
+    service: ServiceContract,            -- typed call into own service half
+
+    notify: (title: string, body: string) -> (),      -- capability: notify
+    exec: (cmd: { string }, opts: ExecOpts?) -> ExecResult,  -- capability: shell
+    fetch: (url: string, init: FetchInit?) -> Response,      -- capability: net
+    log: (level: string, message: string) -> (),
+}
+```
+
+**Host calls look synchronous and are not blocking.** Every one of them yields
+the plugin's coroutine and resumes when the kernel answers, so a plugin reads
+like straight-line code while its thread stays available. `render` is the
+exception — it may not call the host at all
+([FEATURES-View-Tree §1](FEATURES-View-Tree.md#1-model)).
+
+`ctx.pane`, `ctx.home`, and `ctx.settings` are plain values rather than calls,
+which is what lets `render` branch on `ctx.pane.width`
+([FEATURES-View-Tree.md §5](FEATURES-View-Tree.md#5-layout-algebra)) while still
+obeying the no-host-calls-in-render rule. Everything else is async and belongs
+in a command or an event handler.
+
+The service half receives a different context — `ctx.db`, `ctx.sleep`,
+`ctx.out`, `ctx.view`, and no `pane` or `ui` — specified in
+[FEATURES-Backend-API.md](FEATURES-Backend-API.md). The two contexts share
+`kv`, `bus`, `settings`, `home`, `log`, and the kernel-table APIs.
+
+`fs` is a host API like the rest — `ctx.fs`, bound only when granted, and only
+over the declared path templates. Luau ships no standard-library filesystem,
+network or process access at all, so there is no ambient alternative for a
+plugin to reach around it. Path templates expand at activation — `{repo}` (the
+active session's primary repo), `{plugin_data}`
+(`~/.local/share/thurbox/plugins/<name>/`), `{home}`.
+
+> **All sixteen capabilities are enforced**, including `fs`, `net` and `shell`.
+> Under the earlier sidecar design those three were advisory, because a
+> JavaScript runtime without a permission model gave a plugin ambient access
+> the manifest could not take away. Luau has no such ambient surface, so the
+> path-template and host-allowlist arguments are checked inside the binding
+> rather than merely printed at install time
+> ([SECURITY.md §3](SECURITY.md#3-resolved--fs-net-and-shell-are-now-enforced)).
+
+---
+
+## 8. Capability reference
+
+**This table is canonical.** It covers both halves;
+[FEATURES-Backend-API.md §14](FEATURES-Backend-API.md#14-capabilities-used-by-this-half)
+annotates the service-half subset rather than redefining it.
+
+Grants are **per half** ([ADR-V16](ARCHITECTURE.md#adr-v16)). A flat
+`[capabilities]` table grants both; `[capabilities.view]` and
+`[capabilities.service]` narrow one of them, and win over the flat table where
+they overlap. The **Half** column below is where a capability has any effect at
+all — granting `pty` to a service or `cli` to a view is a manifest warning, not
+a silent no-op.
+
+| Capability | Values | Grants | Half |
+|---|---|---|---|
+| `sessions` | `none` \| `read` \| `control` | Session list/metadata; `control` adds create/send/focus/delete | both |
+| `tasks` | `none` \| `read` \| `write` | Kernel task table | both |
+| `automations` | `none` \| `read` \| `write` | Kernel automation table and manual runs | both |
+| `messages` | `none` \| `read` \| `write` | The inter-session mailbox queue | both |
+| `db` | `none` \| `kv` \| `tables` | `kv` = the plugin's own key space; `tables` = namespaced relational tables with kernel-executed migrations ([ADR-V17](ARCHITECTURE.md#adr-v17)) | both read `kv`; `tables` migrations are service-only |
+| `fs` | path templates | Filesystem access, confined to the declared templates | both |
+| `net` | host allowlist | Outbound HTTP; `["*"]` is permitted but flagged at install | both |
+| `shell` | `bool` | Spawning processes | both |
+| `notify` | `bool` | OS desktop notifications | both |
+| `pty` | `bool` | `pty` / `surface` nodes — embedded programs and plugin-written grids | view |
+| `cli` | `bool` | Registering `thurbox-cli` verbs | service |
+| `services` | `bool` | Long-running supervised work — implies a resident VM | service |
+| `schedules` | `bool` | Cron entries in the kernel scheduler | service |
+| `bus` | `none` \| `own` \| `all` | `own` = publish on its own prefix; `all` = also subscribe to others' channels | both |
+| `socket` | `bool` | Exposing control-socket methods | service |
+| `spawn` | `none` \| `contribute` | Appending env/args at session spawn | service |
+
+> **`pty` is not a weaker `shell`.** A `pty` node takes an arbitrary `command`,
+> so `pty = true` is arbitrary code execution and the install prompt treats it
+> as full trust. It differs from `shell` in exactly one way: the child's
+> output goes into a kernel-owned grid the plugin cannot read back, so it is
+> execution-capable but exfiltration-limited. Nothing else should be inferred
+> from the split — it exists so a plugin that only *displays* a program does
+> not also need `exec()`.
+
+Defaults are the empty/`none` value for every capability: a plugin that
+declares nothing can draw a pane, receive its own input, and nothing else.
+`thurbox plugin install` prints the requested set and prompts on anything beyond
+`db`; `--yes` skips the prompt for scripted installs.
+
+Capabilities are **least privilege, not a security boundary**. The VM itself
+is confined — no ambient I/O, bounded memory, interruptible — but a plugin
+granted `shell`, or `fs` over a wide template, runs code under the user's own
+account and is equivalent to full trust. Confinement bounds what an *unprivileged*
+plugin can reach; it does not make a privileged one safe. They are an
+informed-consent and least-privilege mechanism, and they are documented as such
+at the install prompt.
+
+Threat model, the enforceable/advisory split, and the changes required before
+third-party plugins are installable: [SECURITY.md](SECURITY.md).
+
+---
+
+## 9. CLI surface
+
+```bash
+thurbox plugin list [--json] # installed, version, state, capabilities
+thurbox plugin info <name> # manifest, panes, commands, keybindings
+thurbox plugin install <name|url|path> # registry name, git URL, or local dir
+thurbox plugin uninstall <name> [--purge] # --purge also drops plugin data
+thurbox plugin enable|disable <name> # replaces v1's [features] flags
+thurbox plugin update [<name>] [--all] # re-resolve from the recorded source (§10)
+thurbox plugin reload <name> # respawn without restarting the TUI
+thurbox plugin dev <path> # load from disk, watch, reload on save
+thurbox plugin doctor # runtime, versions, faults, last errors
+```
+
+**Both binaries accept these.** `thurbox-cli plugin …` is the canonical form —
+it is where v1 put every headless verb, it is what scripts and agents should
+call, and it is what [FEATURES-Backend-API.md §4](FEATURES-Backend-API.md#4-cli-verbs)
+reserves against plugin verb collisions. `thurbox plugin …` is an alias on the
+TUI binary, because typing the CLI name to manage the thing you are looking at
+is friction. Documentation uses the short form; anything scripted should use the
+long one.
+
+`plugin dev` is the development loop: it loads an unpacked directory, watches
+the entry point's dependency graph, and reloads on save. Type errors surface in
+the pane rather than the terminal, so the TUI never has to be restarted during
+plugin development.
+
+---
+
+## 10. Versioning and compatibility
+
+- The **host API** carries a major version, checked at bind time against the
+ manifest's declared `api` major. A plugin built for an older major is refused
+ with a clear message rather than half-working.
+- The **manifest** declares `min_thurbox`; a newer requirement warns but does
+ not block (mirroring v1's soft compat gate).
+- **View-tree node types are additive.** Unknown node types render as a
+ visible placeholder, never a crash — a newer plugin degrades on an older
+ kernel instead of failing.
+- **Command argument schemas are additive.** New optional arguments are
+ allowed; removing or retyping one is a plugin major version.
+- Bundled plugins version with the binary and are re-materialized whenever
+ their embedded hash changes.

--- a/docs/v2/FEATURES-View-Tree.md
+++ b/docs/v2/FEATURES-View-Tree.md
@@ -1,0 +1,649 @@
+# Thurbox v2 — The View Tree
+
+The rendering contract between plugins and the kernel. A plugin never draws
+into a buffer; it returns a **view tree** — a plain data node graph, no
+closures and no host handles — and the kernel converts it to an owned Rust
+value, renders it with ratatui, applies the active theme, derives mouse
+hitboxes, and routes input back as events ([ADR-V5](ARCHITECTURE.md#adr-v5)).
+
+This is the largest surface a plugin author touches, so it is specified here in
+full: the model, the node catalog, the layout algebra, styling, input routing,
+scrolling, and the invariants the kernel enforces.
+
+The catalog is deliberately **small**. Anything that is not a layout
+primitive or a window onto kernel-owned state is a Luau widget, not a
+node type ([ADR-V14](ARCHITECTURE.md#adr-v14)) — §3 and §4 explain where the
+line falls and why.
+
+---
+
+## 1. Model
+
+```text
+plugin state ──render()──▶ view tree ──view/push──▶ kernel ──▶ ratatui frame
+      ▲                                                              │
+      └──────────── update(event) ◀──── input event ◀────────────────┘
+```
+
+Three properties define the contract:
+
+1. **`render` is pure and synchronous.** It receives state, returns a tree. It
+   may not yield, may not call host APIs, and must not have side effects.
+   Anything that waits on the kernel belongs in a command or an event handler
+   that dispatches back into `update`.
+2. **The tree is complete.** Each push replaces the pane's previous tree
+   entirely. There is no partial mutation API; the kernel diffs internally.
+3. **The tree is plain data.** Tables of primitives, nothing else. Callbacks
+   like `onSelect` are compiled by the `@thurbox` helpers into event
+   descriptors the kernel hands back through `update`, so the kernel never
+   holds a reference into the plugin's VM — which is what makes
+   [C3](ARCHITECTURE.md#adr-v2)'s reload guarantee enforceable.
+
+### Node envelope
+
+Every node shares the same envelope:
+
+```lua
+type Node = {
+    type: string,             -- node type, see §3
+    id: string?,              -- stable id — required for focus, hitboxes, scroll
+    style: Style?,            -- see §6
+    flex: number?,            -- growth weight within the parent (default 0)
+    size: (number | "auto")?, -- fixed rows/columns along the parent's axis
+    hidden: boolean?,
+    motion: Motion?,          -- kernel-timed animation, see §3.3
+    anchor: Anchor?,          -- float against another node's rect — Layout §4
+    measure: boolean?,        -- ask for this node's resolved rect back — Layout §5
+    -- ...type-specific fields
+}
+```
+
+`id` must be **stable across renders**. Scroll offsets, focus, hover state,
+motion phase, `anchor` targets, and `measure` results are all keyed by `id`; a
+tree that regenerates ids every render loses all of them.
+
+`anchor` and `measure` are envelope fields rather than node types, so any node
+can float or be measured. Both are specified in
+[FEATURES-Layout.md](FEATURES-Layout.md) — [§4](FEATURES-Layout.md#4-anchors--the-overlay-layer)
+and [§5](FEATURES-Layout.md#5-measurement) — because they are layout concerns,
+not rendering ones.
+
+---
+
+## 2. Panes and roots
+
+A plugin declares panes in its manifest and pushes one tree per pane. The
+kernel gives each pane a rect; the tree fills it.
+
+```lua
+ctx.view.push("tasks", ui.box({ title = "Tasks" }, { --[[ ... ]] }))
+```
+
+The kernel owns everything outside the pane rect: borders drawn from the
+theme's focus state, the pane title bar, the global footer, and the layout
+solver that decides how wide the pane is. A plugin can request a `min_width` /
+`min_height` in its manifest and hint at desired growth; it cannot position
+itself absolutely or overlap another pane.
+
+**Slots** determine placement. They are the *default preset* over the workspace
+tree ([ADR-V23](ARCHITECTURE.md#adr-v23)) and an auto-placement hint for panes
+a user's `layout.toml` does not name — so a plugin author declares a slot and
+thinks no further, while a user who wants a grid or a spanning region edits the
+tree ([FEATURES-Layout.md §2](FEATURES-Layout.md#2-the-workspace-tree)):
+
+| Slot | Position | v1 equivalent |
+|---|---|---|
+| `left` | Left column, stacked in declaration order | Session list, automations pane |
+| `center` | Central pane, tabbed when several are visible | Terminal, shell, code review |
+| `right` | Right columns, in declaration order | Tasks panel, file viewer |
+| `bottom` | Full-width strip above the footer | Global search |
+| `overlay` | Centered modal, one at a time | Theme picker, settings, repo picker |
+
+---
+
+## 3. Node catalog
+
+The catalog is **two tiers**, and the line between them has exactly one test
+([ADR-V14](ARCHITECTURE.md#adr-v14)):
+
+> **Does the kernel own the data or the clock?**
+> Yes → it is a kernel node. No → it is a widget, and widgets are userland.
+
+Everything that fails that test — tables, badges, progress bars, key-hint
+rows, empty states, selectable lists — is a **Luau library**, not a node
+type. See §4.
+
+### 3.1 Tier 1 — primitives
+
+Layout, text, style, and input. This set is deliberately small and is
+**frozen**: it is the vocabulary every widget compiles down to.
+
+| Node | Props | Notes |
+|---|---|---|
+| `box` | `title?`, `border?: none \| plain \| focus`, `padding?`, `direction?: vertical \| horizontal` | The workhorse container |
+| `row` / `column` | children | Directional `box` shorthands |
+| `spacer` | `size?` | Fixed or flexible gap |
+| `scroll` | `id`, `offset?`, `revealNode?`, `onScroll?` | Scrollable viewport; kernel draws the scrollbar and handles wheel, drag, `PageUp`/`PageDown`, `Ctrl+D`/`U`. `revealNode` scrolls a descendant id into view ([FEATURES-Layout §5.1](FEATURES-Layout.md#51-node-props-for-the-concrete-cases)) |
+| `text` | `content: string \| Span[]`, `wrap?`, `align?` | `Span` carries per-run style — the atom everything renders into |
+| `input` | `value`, `placeholder?`, `onChange`, `onSubmit?` | Single line |
+| `textarea` | `value`, `onChange`, `onSubmit?` | Multi-line, vertical cursor |
+
+Text inputs are kernel-implemented on purpose. Plugins never receive
+per-keystroke events for them, only `onChange` with the new value — which is
+what makes `Ctrl+A`/`Ctrl+E`/`Ctrl+W`/`Ctrl+U`, word motions, and bracketed
+paste behave identically in a third-party pane and in the session-name field.
+Re-implementing that in userland would be the fastest way to make thurbox feel
+inconsistent.
+
+`scroll` is likewise kernel-owned: a hand-rolled scrollbar would diverge
+visually from every other pane, and offset tracking needs to survive re-renders
+keyed by node `id`.
+
+### 3.2 Tier 2 — kernel surfaces
+
+Nodes that exist **only** because their content, their clock, or their
+emulator lives in the kernel ([ADR-V6](ARCHITECTURE.md#adr-v6)). A plugin
+places and configures them; it does not supply their content through the tree.
+(`surface` is the one that supplies content at all, and it does so over a
+separate byte channel rather than in a pushed tree — §3.4.)
+
+| Node | Props | Rendered from |
+|---|---|---|
+| `sessionTerminal` | `sessionId`, `view?: agent \| shell`, `scroll?` | Live vt100 grid via `tui-term` |
+| `pty` | `command`, `args?`, `env?`, `cwd?`, `scroll?` | A process the kernel spawned, via `tui-term` (§3.4) |
+| `surface` | `id`, `cols?`, `rows?`, `scroll?` | A vt100 grid the plugin writes bytes into (§3.4) |
+| `diff` | `repo`, `target`, `layout?: unified \| split`, `selected?`, `onSelectLine?` | Kernel-computed git diff |
+| `fileTree` | `root`, `expanded`, `selected`, `onSelect` | Kernel-walked directory tree |
+| `code` | `content`, `language?` | Kernel syntax lexer + theme |
+| `markdown` | `content` | Kernel markdown renderer + theme |
+| `statusDot` | `state: working \| blocked \| done \| idle \| error \| unreachable` | Kernel spinner clock — the animation frame is kernel-timed |
+| `sparkline` | `metric`, `window?` | Kernel metrics ring buffer |
+
+These carry only identifiers and view options across the wire, never content.
+A pane that embeds `sessionTerminal` costs the same per frame as v1's terminal
+pane, because it *is* v1's terminal pane.
+
+`code` and `markdown` are Tier 2 rather than userland for one reason each: the
+syntax lexer is themed by the kernel palette, and a plugin-side markdown
+renderer would produce a different look per plugin. `statusDot` is Tier 2
+because its spinner must advance on the kernel's frame clock — but note that
+this is a statement about the *clock*, not the data, which is why §3.3
+generalizes it rather than adding a node per animation.
+
+This tier grows only when the kernel gains a capability. It is not where new
+widgets go.
+
+### 3.3 Motion
+
+A node may declare **motion**: a change over time the kernel evaluates on its
+own frame clock ([ADR-V18](ARCHITECTURE.md#adr-v18)). The plugin pushes once.
+
+> Summary. The normative specification — per-kind schemas, easing, phase and
+> restart semantics, lease budgeting, accessibility caps, and the testing rules
+> — is [FEATURES-Animation.md](FEATURES-Animation.md).
+
+```lua
+motion: {
+    kind: "cycle" | "marquee" | "pulse" | "blink" | "tween",
+    fps: number?,                 -- default 8, capped at 30
+    pauseWhenUnfocused: boolean?, -- default false
+    -- ...kind-specific fields
+}?
+```
+
+| Kind | Applies to | Behavior |
+|---|---|---|
+| `cycle` | any node with `frames: Node[]` | Round-robins pre-supplied subtrees. The general case: spinners of your own design, typing indicators, hand-drawn frame animation |
+| `marquee` | `text` | Scrolls content horizontally within the resolved rect. The kernel knows the rect, which is why this works despite §1.3's no-measurement rule |
+| `pulse` / `blink` | any node | Oscillates a style token (`from`/`to`) or visibility. No content change |
+| `tween` | any numeric prop | Interpolates `{ from, to, ms, ease }` — indeterminate progress, animated meters, bar growth |
+
+Rules the kernel enforces:
+
+1. **Motion is advisory.** A kernel that declines to animate — a `reduce_motion`
+   setting, a pane over budget — renders frame 0. A plugin must never depend on
+   a frame having been shown.
+2. **Frames are supplied up front.** `cycle` carries its frames in the pushed
+   tree, so a motion's cost is known at push time and counts against the same
+   tree budget as everything else (§9). A 64-frame cap keeps that honest.
+3. **The lease is per pane.** A pane holding live motion is exempt from the
+   250 ms redraw floor at its declared rate; every other pane is unchanged.
+   Leases drop when the pane hides, when `pauseWhenUnfocused` motion loses
+   focus, or when the next pushed tree has no motion in it.
+4. **Rate is capped twice** — 30 fps per pane, 30 fps aggregate across panes,
+   degraded round-robin rather than summed.
+
+5. **Re-pushing an identical motion on the same node `id` does not restart it.**
+   Motion state is keyed by `(pane, id, signature)`, so a plugin that re-pushes
+   on unrelated state changes keeps its animation running. Animated nodes
+   therefore need a stable `id`. This rule and its edge cases are specified in
+   [FEATURES-Animation.md §3](FEATURES-Animation.md#3-identity-and-phase).
+
+`statusDot` is the degenerate case of `cycle` with a kernel-supplied frame
+table, and stays a node because its *frames* are kernel-owned too.
+
+What motion is not for: anything whose content is genuinely new per frame
+(a live log, a game, a video). That is §3.4.
+
+### 3.4 Real-time surfaces
+
+`pty` and `surface` give a plugin a **terminal grid** instead of a tree
+([ADR-V19](ARCHITECTURE.md#adr-v19)). `pty` spawns a process; `surface` gives
+you an empty grid and a write channel. Both render through the `vt100` +
+`tui-term` pipeline that powers `sessionTerminal`, so both cost exactly what a
+session pane costs and no more.
+
+```lua
+ui.pty({ id = "doom", command = "doom", args = { "-iwad", wad },
+         keyReport = "press-release", escape = "ctrl+esc" })
+```
+
+| Prop | Applies to | Meaning |
+|---|---|---|
+| `id` | both | Stable identity; the grid's lifetime is keyed by it |
+| `command` / `args` / `env` / `cwd` | `pty` | What to spawn. Requires the `pty` capability |
+| `cols` / `rows` | `surface` | Fixed grid size; omit to track the resolved rect |
+| `keyReport` | both | `"press"` (default) or `"press-release"` |
+| `escape` | both | Chord that releases focus back to the pane. Defaults to the kernel's terminal-escape chord |
+| `scroll` | both | Expose scrollback, as `sessionTerminal` does |
+
+**Input is sunk, not routed.** While a grid node holds focus, keystrokes are
+encoded to bytes and written to the PTY directly — they do not become
+`plugin/event`. Only two things are intercepted: the kernel-reserved chords
+(focus cycle, quit) and the node's `escape`. A plugin therefore does not — and
+cannot — sit on the keystroke path of its own embedded program, which is what
+keeps input latency identical to a session pane's.
+
+**`keyReport: "press-release"`** makes the kernel push the kitty
+`REPORT_EVENT_TYPES` flag while that node is focused and pop it on blur, so
+key-release events reach the program. This is scoped to the focused node on
+purpose: enabling release reporting globally would change input for every agent
+CLI thurbox launches. Programs that need held-key input — games, anything with
+continuous movement — do not work correctly without it, and terminals that do
+not implement the kitty protocol simply keep delivering presses only.
+
+**Resize is the kernel's.** When the resolved rect changes the kernel resizes
+the pty and raises `SIGWINCH`. Plugins do not set `COLUMNS`/`LINES` and should
+not try; a hand-set value goes stale the first time a panel toggles.
+
+**Lifetime follows the pane, not the VM.** A grid outlives plugin
+suspension ([ADR-V15](ARCHITECTURE.md#adr-v15)) and hot reload — tabbing away
+from a running program, or saving a file during plugin development, must not
+kill it. It is torn down when the pane closes, when the plugin is deactivated,
+or when a push no longer contains the node. A `pty` whose process exits holds
+its final grid with an exit marker, mirroring `remain-on-exit`.
+
+**Writing to a `surface`** goes over `ctx.surface.write`, a one-way call carrying
+raw bytes for a node id — not `view/push`. The kernel drops frames under
+backpressure rather than growing a queue, and the plugin can read the drop
+count. Escape sequences are legal in this channel and only in this channel:
+they are parsed by a kernel-owned emulator clipped to the pane rect, so they
+can never reach the user's real terminal
+([CONSTITUTION-DELTA N1](CONSTITUTION-DELTA.md#n1--the-kernel-renders-plugins-describe)).
+
+The `pty` capability covers both. It is arbitrary code execution — `command:
+"sh"` is not prevented — and is treated as full trust at the install prompt.
+Its one genuine narrowing over `shell` is that output lands in a kernel grid
+the plugin cannot read back.
+
+---
+
+## 4. Widgets are a Luau library
+
+`@thurbox/widgets` ships the things that used to be node types, composed from
+Tier 1 inside the plugin's own VM:
+
+```lua
+local w = require("@thurbox/widgets")  -- list, table, badge, keyHints, empty, progress
+```
+
+```lua
+-- list() is ~60 lines of Luau over box/scroll/row/text — selection styling,
+-- hover, activation events, and windowing.
+local function list<T>(opts: ListOpts<T>): Node
+    local rows = {}
+    for i, item in opts.items do
+        rows[i] = ui.row({
+            id = `{opts.id}:{i}`,
+            style = if i == opts.selected then { bg = "selection" } else nil,
+            onPress = function() if opts.onSelect then opts.onSelect(i) end end,
+        }, { opts.render(item) })
+    end
+    return ui.scroll(
+        { id = opts.id, revealNode = `{opts.id}:{opts.selected}` },
+        { ui.column({}, rows) }
+    )
+end
+```
+
+Why this matters more than it looks:
+
+- **No kernel release is on the critical path of someone else's plugin.** A
+  plugin author who needs a tree-table, a kanban column, or a sparkline grid
+  writes one and publishes it. In the rich-catalog design they file an issue
+  and wait for a thurbox release.
+- **Widgets are replaceable.** A plugin may vendor its own widget module and
+  ignore the bundled one, so the bundled version is a default rather than a
+  mandate ([ADR-V14](ARCHITECTURE.md#adr-v14)).
+- **Disagreement is forkable.** A plugin that wants different list semantics
+  imports a different library instead of arguing about kernel defaults.
+- **Widgets are unit-testable with no kernel.** They are pure functions from
+  options to nodes.
+
+The trade is real and worth stating: bundled plugins must all depend on the
+same widget library or thurbox's own panes will drift visually. That is
+enforced by convention and review for bundled plugins, and deliberately not
+enforced for third-party ones.
+
+---
+
+## 5. Layout algebra
+
+Layout is **flex along one axis per container**, resolved by the kernel:
+
+1. Fixed children (`size: n`) take their size.
+2. `size: "auto"` children are measured by content.
+3. Remaining space is distributed among `flex: n` children proportionally.
+4. Overflow clips; a `scroll` ancestor makes it scrollable instead.
+
+```lua
+ui.column({ padding = 1 }, {
+    ui.text({ content = "Header", size = 1 }),
+    ui.scroll({ flex = 1 }, { w.list({ items = items }) }),  -- all remaining rows
+    w.keyHints({ size = 1, hints = { { "n", "new" } } }),
+})
+```
+
+Within the base layer there is no absolute positioning, no z-index, and no
+negative margin — siblings never overlap. Content that must float above the
+flow (a dropdown, a context menu, a tooltip, a compose box pinned to a row)
+declares `anchor` instead and resolves in a second pass against another node's
+rect ([ADR-V22](ARCHITECTURE.md#adr-v22)); the full rules, including the
+workspace tree that divides space between panes, are in
+[FEATURES-Layout.md](FEATURES-Layout.md).
+
+### Responsive rendering
+
+The kernel passes the current pane rect in `plugin/resize` and in the render
+context, so a plugin can branch on width the way v1's `compute_layout` does:
+
+```lua
+render = function(ctx, state)
+    return if ctx.pane.width < 40 then compactView(state) else fullView(state)
+end
+```
+
+Panes below their manifest `min_width` are hidden by the layout solver, not
+squeezed — the same rule that drops v1's info panel below 120 columns.
+
+---
+
+## 6. Styling
+
+Styles reference **semantic theme tokens**, never literal colors:
+
+```lua
+ui.text({ content = "3 failing", style = { fg = "danger", bold = true } })
+```
+
+| Token group | Tokens |
+|---|---|
+| Surface | `bg`, `panel_bg`, `border`, `border_focus` |
+| Text | `fg`, `fg_muted`, `fg_dim`, `accent`, `heading` |
+| Semantic | `success`, `warn`, `danger`, `info` |
+| Status | `status_working`, `status_blocked`, `status_done`, `status_idle`, `status_error` |
+| Diff | `diff_added`, `diff_removed`, `diff_added_bg`, `diff_removed_bg` |
+| Emphasis | `selection`, `highlight`, `hover` |
+
+Modifiers: `bold`, `italic`, `underline`, `dim`, `reversed`.
+
+Token names are exactly v1's `ThemePalette` fields, so every one of the 36
+built-in palettes and every user theme in `themes.toml` applies to third-party
+panes with no plugin change. Literal colors are permitted
+(`fg: "#ff0000"`) but flagged by `thurbox plugin doctor`, because a pane that
+hardcodes color is broken in 35 of the 36 themes.
+
+Theme changes arrive as `plugin/themeChanged`; a plugin that only uses tokens
+needs no code to respond — the kernel re-renders its cached tree with the new
+palette.
+
+---
+
+## 7. Focus and input routing
+
+Focus is **kernel-owned and unique**. At most one pane holds focus; the kernel
+routes input to that pane's plugin only.
+
+```text
+key press
+   │
+   ├─ kernel chords (focus cycle, quit, new session) ──▶ handled, never forwarded
+   │
+   ├─ command bound in the focused pane's context ──▶ plugin/command
+   │
+   └─ otherwise ──▶ plugin/event { type: "key" } to the focused pane's plugin
+```
+
+Within a pane, the plugin decides what has focus among its own nodes and
+reflects that in the tree (`selected` on a list, `focused` on an input). The
+kernel does not track intra-pane focus, which keeps focus state in exactly one
+place per level and mirrors [ADR-V7](ARCHITECTURE.md#adr-v7).
+
+**Keybindings stay user-owned.** A plugin's manifest `[[keybindings]]` are
+*defaults*. They land in the same `keybindings.json`, the same F1 editor, and
+the same conflict-resolution rules as kernel actions, scoped by
+`context = "pane:<id>"`. A plugin cannot claim a chord the user has rebound,
+and it cannot capture input while unfocused.
+
+### Hit testing
+
+The kernel derives hitboxes from the tree during layout, so plugins never do
+coordinate math. A click resolves to the innermost node with an `id` and an
+interaction handler, and arrives as either the declared callback event or
+`{ type: "mouse", target: id }`. This is the same registry mechanism v1 uses
+for `ClickAction`, generalized.
+
+---
+
+## 8. Scrolling
+
+`scroll` nodes are kernel-managed: the kernel tracks the offset keyed by node
+`id`, draws the scrollbar, handles the wheel, drag, `PageUp`/`PageDown`, and
+`Ctrl+D`/`Ctrl+U`, and clamps to content height. A plugin only supplies
+content and, optionally, reads the offset via `onScroll`.
+
+A plugin that needs to move the viewport itself (jump to a search hit, follow
+a selection) sets `offset` explicitly in the next tree. Mixing both is
+well-defined: an explicit `offset` in a pushed tree always wins over the
+kernel's tracked value for that render.
+
+---
+
+## 9. Performance rules
+
+The view tree exists to keep the demand-driven loop intact
+([ADR-V11](ARCHITECTURE.md#adr-v11)). Five rules follow:
+
+1. **Push on change, not on frame.** Never push from a timer unless the
+   content actually changes. A pushed tree marks the UI dirty and costs a
+   paint.
+2. **Trees are diffed by revision.** Each push carries a monotonic `revision`;
+   the kernel skips the diff when the converted tree is structurally equal to
+   the previous one, so a defensive push is cheap but not free — the conversion
+   itself still runs.
+3. **Virtualize long lists yourself.** A `list` inside a `scroll` renders all
+   its items into the tree. Above ~1,000 items, slice to the visible window
+   plus a margin and use `onScroll`. The kernel does not virtualize for you,
+   because only the plugin knows how to page its data.
+4. **Kernel surfaces are free; content is not.** Prefer `diff` and
+   `sessionTerminal` over reconstructing their content in nodes.
+5. **Declare motion; do not push it.** Anything that changes on a clock rather
+   than on state belongs in `motion` (§3.3). Anything that changes faster than
+   ~10 Hz *because its content is genuinely new* belongs in a `surface` (§3.4).
+   Pushing trees is for state changes, and there is now no case where pushing
+   per frame is the right answer.
+
+Budget: a tree above **256 KB when flattened** logs a warning; above **2 MB**
+the push is rejected and the pane keeps its previous tree. Both thresholds are
+diagnosable through `thurbox plugin doctor`.
+
+---
+
+## 10. Worked example — the tasks pane
+
+The whole v1 tasks panel (`src/ui/tasks_panel.rs`, 400+ lines of Rust plus
+`InputFocus`, `Action`, `PanelAreas`, and `ClickAction` variants) as a plugin
+pane:
+
+```lua
+local ui = require("@thurbox").ui        -- Tier 1 primitives
+local w = require("@thurbox/widgets")    -- userland widgets
+
+local GLYPH = { todo = "☐", in_progress = "◐", done = "☑" }
+
+render = function(ctx, s)
+    return ui.column({ padding = 1 }, {
+        ui.scroll({ id = "tasks-scroll", flex = 1 }, {
+            if #s.tasks == 0
+                then w.empty({ message = "No tasks", hint = "n to create one" })
+                else w.list({
+                    id = "tasks-list",
+                    selected = s.selected,
+                    onSelect = function(i) return { type = "select", index = i } end,
+                    onActivate = function(i) return { type = "open", id = s.tasks[i].id } end,
+                    items = s.tasks,
+                    render = function(t)
+                        return ui.row({}, {
+                            ui.text({ content = GLYPH[t.status], style = { fg = toneFor(t.status) } }),
+                            ui.text({ content = t.title, flex = 1, style = { fg = "fg" } }),
+                            if t.sessionId then ui.text({ content = "⇄", style = { fg = "accent" } }) else nil,
+                        })
+                    end,
+                }),
+        }),
+        w.keyHints({ hints = { { "n", "new" }, { "space", "status" }, { "d", "delete" } } }),
+    })
+end
+```
+
+---
+
+Note what comes from where. `scroll` and `text` are kernel primitives, so the
+scrollbar, hover, click routing, theming, and the readline chords are kernel
+behavior. `list`, `keyHints`, and `empty` are ordinary Luau that composes down
+to `row`/`text` — replaceable, forkable, and not on the kernel's release
+schedule. The plugin itself contributes the glyph table, the row
+shape, and the reducer.
+
+---
+
+## 10b. Worked example — an embedded program
+
+A game, `lazygit`, or `htop` as a plugin pane. The interesting part is how
+little of it is rendering:
+
+```lua
+local thurbox = require("@thurbox")
+local ui, w = thurbox.ui, require("@thurbox/widgets")
+
+return thurbox.definePlugin({
+    init = function(ctx)
+        return { wads = findWads(ctx), running = nil, selected = 1 }
+    end,
+
+    render = function(ctx, s)
+        if s.running then
+            return ui.pty({
+                id = `doom:{s.running}`,
+                command = "doom",
+                args = { "-iwad", s.running },
+                keyReport = "press-release",  -- held movement needs key releases
+                escape = "ctrl+esc",
+            })
+        end
+        return ui.column({}, {
+            ui.text({ content = "Select a WAD", style = { fg = "heading" } }),
+            w.list({
+                id = "wads",
+                selected = s.selected,
+                items = s.wads,
+                render = function(wad) return ui.text({ content = wad.name }) end,
+                onActivate = function(i)
+                    return { type = "launch", wad = s.wads[i].path }
+                end,
+            }),
+        })
+    end,
+
+    update = function(ctx, s, e)
+        if e.type == "launch" then
+            return { wads = s.wads, running = e.wad, selected = s.selected }
+        end
+        return s
+    end,
+})
+```
+
+The kernel owns process spawning, PTY allocation, vt100 parsing, key encoding
+straight to stdin, key-release reporting while focused, `SIGWINCH` on resize,
+scrollback, theming, and the grid's lifetime across suspension and reload. The
+plugin owns a launcher list and one state field.
+
+That asymmetry is the point, and it is the test of whether §3.4 is drawn
+correctly. Everything a plugin adds over "just run it in a session" — WAD
+discovery, save-state management, a status pill showing the current level, a
+keybinding to resume — is ordinary tree and state work, and none of it sits on
+the frame path.
+
+---
+
+## 11. Expressiveness check
+
+The **kernel** catalog is sized by a single test: **can every v1 pane be
+rebuilt with it?** If one cannot, the kernel catalog is wrong — not the pane.
+Widget-tier gaps are not gaps at all: they are Luau someone writes.
+
+| v1 surface | Kernel nodes | Widgets | Kernel gap |
+|---|---|---|---|
+| Session list | `scroll`, `text`, `statusDot` | `list`, tree indentation | — |
+| Terminal / shell | `sessionTerminal`, `box` | `tabs` | — |
+| Info panel | `column`, `text`, `sparkline` | `badge`, definition rows | — |
+| File viewer | `fileTree`, `code`, `input` | find bar | — |
+| Tasks | `scroll`, `text`, `markdown`, `textarea` | `list`, `keyHints`, `empty` | — |
+| Automations | `scroll`, `text`, `input` | `list`, `table`, `select` | — |
+| Code review | `diff`, `input`, `box` + `anchor` | files `list`, footer pills | — |
+| Global search | `bottom` pane, `input`, `text` | `list`, grouped results | Cross-pane match highlighting needs a kernel-broadcast query |
+| Theme / settings / repo pickers | `overlay` pane, `scroll`, `input`, `text` | `list`, `checkbox`, modal chrome | — |
+| Embedded programs (lazygit, htop, a game) | `pty` | launcher `list` | — |
+| Animated indicators (spinners, pulses, marquee) | `motion` | frame tables | — |
+
+**One kernel gap** survives the audit: a kernel-broadcast search query that
+lets panes highlight matches in place. It is v2.0 scope; see
+[MIGRATION.md](MIGRATION.md).
+
+The other gap this audit originally found — a compose box anchored to a diff
+line — was closed generally rather than specially. `anchor`
+([ADR-V22](ARCHITECTURE.md#adr-v22)) serves every pane, so the `diff.inlineAt`
+child slot it would have needed no longer exists.
+
+That every other v1 surface reduces to **eight primitives plus nine kernel
+surfaces** is the evidence that the Tier 1 freeze is realistic rather than
+aspirational.
+
+---
+
+## 12. Anti-patterns
+
+| Don't | Why | Instead |
+|---|---|---|
+| Regenerate `id`s each render | Loses scroll, focus, hover | Derive ids from stable data keys |
+| Push from a repeating timer | Defeats the demand-driven loop | Push when state changes; declare `motion` for anything on a clock |
+| Animate by pushing a tree per frame | Pays a plugin call + conversion + diff for what the kernel can evaluate itself | `motion` (§3.3) for cosmetic motion, `surface` (§3.4) for real-time content |
+| Route a `pty`'s keys through your reducer | You cannot — a focused grid sinks input to the process | Use `escape` to get focus back |
+| Hardcode hex colors | Broken in 35 of 36 themes | Semantic tokens |
+| Do work in `render` | Blocks the reducer and the frame | Do it in a command, dispatch the result |
+| Reimplement text editing | Diverges from the readline chords everywhere else | `input` / `textarea` |
+| Build your own scrollbar | Diverges from every kernel pane | `scroll` |
+| Emit ANSI escapes in `text` | Escapes are stripped; may corrupt layout | `Span` styles |
+| Render 50k list items | Tree-build cost, rejected above 2 MB | Virtualize with `onScroll` |
+| Ask for a new kernel node type | Blocks you on a thurbox release | Compose it from Tier 1 and publish a widget |

--- a/docs/v2/LIMITATIONS.md
+++ b/docs/v2/LIMITATIONS.md
@@ -1,0 +1,472 @@
+# Thurbox v2 — Limitations
+
+Every architecture buys capability by spending something else. This document
+names what the v2 plugin design cannot do, so the cost is chosen rather than
+discovered in Phase 2.
+
+Limitations fall into three buckets, and the distinction matters:
+
+| Bucket | Meaning |
+|---|---|
+| **By design** | Structurally impossible; fixing it means changing an ADR |
+| **Impractical** | Expressible but pays a cost that makes it a bad idea |
+| **Kernel gap** | Would work if the kernel grew a surface or API — a scheduling question, not an architectural one |
+
+---
+
+## 1. Layout
+
+Three of the four limitations in this section were resolved after the design
+review that produced [FEATURES-Layout.md](FEATURES-Layout.md). The reasoning
+that once justified them is kept, because it is the reasoning the fixes had to
+answer.
+
+<a id="11-floating-elements"></a>
+
+### 1.1 Floating elements — *resolved by [ADR-V22](ARCHITECTURE.md#adr-v22)*
+
+> An earlier draft: "There is no absolute positioning, no z-index, and no
+> negative margin. A plugin cannot render anything that floats above its own
+> content" — no autocomplete dropdown, no context menu, no tooltip, no compose
+> box anchored to a diff line. The general fix was named (an `anchor` node) and
+> deferred, because it "requires two-pass layout and reintroduces overlap,
+> which the kernel currently gets to assume never happens."
+
+Both objections turned out to be affordable.
+[Anchors](FEATURES-Layout.md#4-anchors--the-overlay-layer) resolve against
+another node's rect in a **second pass paid only by trees that use them**, and
+render into a per-pane overlay layer that is z-ordered positionally. The
+invariant narrows rather than disappearing: the base layer still never
+overlaps, and exactly one pane still holds focus, because an anchored subtree
+belongs to its pane and is not a focus target.
+
+This also **deleted a special case** — `diff`'s bespoke `inlineAt` slot, which
+existed only to reproduce v1's `render_compose_inline` for one node type.
+
+**Still limited**: an anchor cannot escape its pane's rect in 2.0, so a
+dropdown at the edge of a narrow pane is clamped rather than overflowing onto
+its neighbour. Escaping needs cross-pane z-ordering and a rule for what happens
+when the owning pane hides mid-interaction.
+
+<a id="12-pane-geometry"></a>
+
+### 1.2 Pane geometry — *resolved by [ADR-V23](ARCHITECTURE.md#adr-v23)*
+
+> An earlier draft listed six things the five-slot model could not express: a
+> full-width pane spanning the list and terminal, a 2×2 dashboard across panes,
+> user-draggable splits, nested splits, a header-docked pane, and runtime
+> reordering.
+
+Five of the six fall out of the
+[workspace tree](FEATURES-Layout.md#2-the-workspace-tree) without a feature
+each, because they are all shapes of one structure. Slots survive as the
+**default preset** and as an auto-placement hint for panes the tree does not
+name, so zero-config behavior is unchanged and plugin authors still just
+declare `slot = "right"`.
+
+**Still limited**: interactive resize — dragging a split border — is deferred.
+The tree makes it possible (a drag writes back a `size`), but it needs border
+hit regions, a persistence policy for transient drags, and keyboard
+equivalents. `layout.toml` is editable in the meantime.
+
+Unchanged: a region under its `min_width` is hidden, not squeezed, and a plugin
+still cannot renegotiate its own allocation — it branches on `ctx.pane.width`.
+
+<a id="13-measurement"></a>
+
+### 1.3 Measurement — *mostly resolved*
+
+> An earlier draft: "`render` is pure and synchronous with no measurement API,
+> so a plugin never learns how tall its content resolved to" — no masonry, no
+> precise "scroll to rendered line N", no sizing a box to wrapped content and
+> positioning a sibling against it.
+
+Two mechanisms cover most of it without making the frame two-way
+([FEATURES-Layout §5](FEATURES-Layout.md#5-measurement)). The concrete cases
+get exact node props — `markdown({ revealSourceLine })`, `code({ revealLine })`,
+`scroll({ revealNode })` — because the kernel owns the renderer and knows the
+mapping the plugin was trying to reconstruct. The general case gets opt-in
+`measure: true`, returning a node's resolved rect with the **next** event
+batch.
+
+**Still limited, and structurally**: measurement is one frame late, so
+single-pass content-driven layout remains impossible. A plugin can converge
+over two frames; it cannot size a box to its wrapped content *and* position a
+sibling against that result within the same frame. Masonry is therefore
+approximate.
+
+<a id="14-cross-pane-alignment"></a>
+
+### 1.4 No cross-pane alignment — *by design, and staying that way*
+
+Two sibling panes cannot share a column ruler; each computes its own widths.
+
+The mechanism exists and is well understood — named size groups, resolving
+every member to a common width. It is rejected on **value, not difficulty**: it
+couples panes that are otherwise independent in the solver, it behaves
+ambiguously when one member is hidden by responsive collapse, and the demand is
+a single hypothetical — a table spanning two panes, which in a terminal is
+almost always better as one pane.
+
+---
+
+## 2. Rendering
+
+<a id="21-graphics-and-dense-cell-art"></a>
+
+### 2.1 Graphics and dense cell art — *impractical*
+
+A plugin can address every cell — `text` spans carry fg/bg — so half-block
+pixel art, sparkline grids, and heatmaps are *possible*. The cost makes most
+of them a bad idea.
+
+Rough tree arithmetic (a styled span ≈ 100 bytes once converted to the
+kernel's owned representation):
+
+| Content | Nodes | Converted size |
+|---|---|---|
+| A 50-row list, 5 spans/row | ~250 | ~25 KB |
+| A full-pane 2,000-line diff with syntax spans | ~20,000 | ~2 MB — rejected |
+| A 100×50 half-block image | ~5,000 | ~500 KB — over the warn threshold |
+
+The budget is 256 KB warn / 2 MB reject
+([VIEW-TREE §9](FEATURES-View-Tree.md#9-performance-rules)). In-process
+conversion is far cheaper per byte than the sidecar design's JSON encode, so
+these thresholds have headroom they did not have before — but the binding
+constraint is **rate × size**, not size: a static 500 KB image pushed once is
+tolerable; the same image rebuilt and converted at 10 Hz is not.
+
+**Escape hatch**: a `surface` node
+([VIEW-TREE §3.4](FEATURES-View-Tree.md#34-real-time-surfaces)) is a
+kernel-owned vt100 grid the plugin writes bytes into, and dense or fast cell art
+belongs there rather than in a tree. The tree budget is for structure; the grid
+is for pixels.
+
+Not available in *either* path: **sixel, the kitty graphics protocol, and
+iTerm2 inline images**. Those need escape sequences to reach the user's real
+terminal, and a `surface` deliberately terminates them in the kernel's parser
+([N1](CONSTITUTION-DELTA.md#n1--the-kernel-renders-plugins-describe)). Half-block
+and braille cell art round-trips fine; true image protocols do not.
+
+<a id="22-animation"></a>
+
+### 2.2 Animation — *resolved*
+
+Resolved by [ADR-V18](ARCHITECTURE.md#adr-v18) (declarative motion) and
+[ADR-V19](ARCHITECTURE.md#adr-v19) (real-time surfaces); specified in
+[FEATURES-Animation.md](FEATURES-Animation.md).
+
+> An earlier draft of this document called animation "the sharpest single
+> limitation of the design", and it was right about the symptom and wrong
+> about the cause. The cost was never the animation; it was that the only way
+> to express one was a view push per frame, which drags a plugin call, a tree
+> conversion, and a diff along with the paint. Three of those four costs are
+> incidental. The fix was to stop pushing.
+
+Animation now splits by what is actually changing:
+
+| What changes | Mechanism | Cost |
+|---|---|---|
+| A function of time over content the plugin already sent | `motion` on a node ([VIEW-TREE §3.3](FEATURES-View-Tree.md#33-motion)) | One push, then kernel-clock repaints of one pane |
+| Genuinely new content per frame | `surface` / `pty` ([VIEW-TREE §3.4](FEATURES-View-Tree.md#34-real-time-surfaces)) | Exactly what a session terminal pane costs |
+| New *data*, arriving faster than the eye | Throttle in the plugin and push on state change | Unchanged |
+
+Every case the old list named is covered: a spinner of your own design, a
+typing indicator, and hand-drawn frame animation are `motion: cycle`; a pulsing
+progress bar is `pulse` or `tween`; marquee text is `marquee`; a game or a live
+metric render at arbitrary rate is a `surface`.
+
+**What remains limited**, and these are real:
+
+- **Motion is a fixed vocabulary.** `cycle` / `marquee` / `pulse` / `blink` /
+  `tween`, not arbitrary per-frame computation. An animation whose frames
+  depend on data that arrives *during* the animation cannot be pre-supplied,
+  and belongs in a `surface`.
+- **Motion is advisory.** A plugin cannot know a frame was shown, cannot
+  synchronize two panes' animations, and must render correctly at frame 0.
+- **Rate is capped and shared.** 30 fps per pane, 30 fps aggregate, degraded
+  round-robin. A pane cannot buy more by asking.
+- **A `surface` is a terminal, with a terminal's ergonomics.** Cursor
+  addressing and escape sequences, not a scene graph, and no theme tokens
+  inside the grid — a plugin drawing there is responsible for its own colors.
+- **Still no per-frame path in the tree itself.** §4.3 (no incremental view
+  updates) is unchanged; the mid-band case — a live log or metric graph that is
+  neither cosmetic motion nor a full grid — still pays a whole-tree push per
+  update. A targeted `view/patch` is the obvious next lever and is *not* v2.0.
+
+### 2.3 No terminal-level output — *by design*
+
+Plugins cannot emit escape sequences to the user's terminal, so no OSC 8
+hyperlinks, no OSC 52 clipboard writes, no terminal title changes, no
+cursor-shape control, no bell. v1 handles the equivalents in the kernel (OSC
+0/1/2 → activity title, OSC 9/777 → notifications, `links.rs` → Ctrl+Click URL
+detection) and v2 keeps them there. A plugin that wants one needs a host API,
+not a rendering trick.
+
+A `surface` is not an exception to this. Escapes written there are parsed by a
+kernel-owned emulator clipped to a pane rect; what reaches the real terminal is
+composited cells, exactly as with tmux output. An OSC 52 sequence written into
+a `surface` sets nothing.
+
+### 2.4 Text selection is kernel-scoped — *by design*
+
+Mouse selection is confined to a pane's bounds (`PaneBounds` in
+`ui/selection.rs`) and owned by the kernel. A plugin cannot define what a
+selection *means* in its pane — e.g. column-select in a table, or selecting a
+logical record rather than a rectangle of characters.
+
+---
+
+## 3. Input
+
+### 3.1 No per-keystroke interception in kernel text inputs — *by design*
+
+`input` and `textarea` are kernel-implemented and emit only `onChange`. This
+is what makes readline chords identical everywhere, and it costs:
+
+- vim-modal editing inside a field
+- autocomplete driven by Tab with custom semantics
+- syntax highlighting while typing
+- multi-cursor
+- IME composition handling
+
+**Workaround**: build a field from `text` primitives plus raw key events. That
+works, and you have then reimplemented readline — inconsistently with every
+other field in the app. This is a real fork in the road for anything
+editor-like.
+
+### 3.2 Focus is pane-granular — *by design*
+
+Exactly one pane receives input. Two panes cannot both respond to keys.
+
+v1's global search does exactly that — the strip captures every key while
+*previewing* selection into the session list, tasks panel, and automations
+pane. A plugin can do this across **its own** panes. It cannot do it across
+another plugin's panes, which is why cross-pane search-match highlighting is
+the one kernel gap the expressiveness audit left open
+([VIEW-TREE §11](FEATURES-View-Tree.md#11-expressiveness-check)), scheduled in
+[MIGRATION Phase 4](MIGRATION.md#phase-4--bundled-plugins-easy-first).
+
+### 3.3 Limited mouse vocabulary — *kernel gap*
+
+Click, scroll, drag, move, and up. Not specified for v2.0: double-click,
+right-click, middle-click, modifier-qualified clicks, or gesture recognition.
+Context menus are blocked on both this and §1.1.
+
+---
+
+## 4. Plugin model
+
+### 4.1 Plugins cannot extend each other — *by design*
+
+There is no plugin-to-plugin RPC, no shared memory, and no way to wrap or
+patch another plugin's pane. Composition happens **only** through points the
+other plugin declared (`sessionDecorations`), the kernel-brokered event bus
+([BACKEND-API §8](FEATURES-Backend-API.md#8-event-bus)), or kernel state (commands,
+events, storage).
+
+The bus is deliberately the weaker primitive: fire-and-forget, opaque JSON
+payloads, no request/response, and a subscriber cannot tell whether a
+publisher exists. Two plugins can cooperate when both opt in, and neither can
+break the other by changing an interface — which is the property direct RPC
+would lose.
+
+Not possible unless the target plugin opted in:
+
+- adding a column to another plugin's table
+- injecting a button into another plugin's footer
+- wrapping another plugin's pane in your own chrome
+- a shared "theme engine" plugin others query at render time
+
+VS Code has the same limit for the same reasons. It is what keeps plugins from
+breaking each other on upgrade, and it means the set of composition points is
+a design surface the kernel must keep growing thoughtfully.
+
+<a id="42-no-synchronous-host-calls-during-render---by-design"></a>
+
+### 4.2 No synchronous host calls during render — *by design*
+
+`render` is pure and may not call the host; every host call yields the plugin's
+coroutine. So every piece of data must already be in state. A pane showing git
+status for 50 sessions must pre-fetch all 50 and keep them fresh through
+events — it cannot ask at paint time.
+
+The ergonomic tax is real: much of a non-trivial plugin is cache management.
+
+### 4.3 No incremental view updates — *by design*
+
+Each push replaces the pane's tree entirely. There is no "append row" or
+"patch node" operation. A plugin tailing a fast log must window to the visible
+rows and throttle its own pushes; at 1,000 lines/second, naive pushing is
+1,000 full tree rebuilds and conversions per second.
+
+### 4.4 Reload discards state — *by design*
+
+Hot reload respawns the process and re-runs `init()`. A plugin holding
+expensive derived state (a parsed index, a warmed cache) pays full
+reconstruction cost on every save during development. Persist through `ctx.kv`
+if that hurts.
+
+<a id="45-no-middleware"></a>
+
+### 4.5 No middleware over kernel behavior — *by design*
+
+Plugins observe, command, and *contribute*; they cannot intercept. There is no
+way to:
+
+- veto or cancel a session delete or spawn
+- rewrite or remove an existing agent arg
+- redirect a spawn to a different host, repo, or agent
+- transform a keystroke before the kernel routes it
+
+The one bounded exception is **spawn contributions**
+([BACKEND-API §11](FEATURES-Backend-API.md#11-spawn-contributions)), which restore v1's
+`[[agent_patches]]` capability: a plugin may **append** env vars and args at
+spawn, fail-open under a 500 ms deadline. Append-only and veto-free is what
+keeps it a contribution rather than middleware — a plugin can add to a spawn,
+never take it over.
+
+Everything else stays observational. If a genuine veto proves necessary it is
+a kernel event with a response, and it should be adopted reluctantly: the
+moment plugins can block kernel operations, every kernel operation inherits
+every plugin's latency and failure modes.
+
+---
+
+## 5. Features that cannot be plugins at all
+
+These are kernel by [ADR-V1](ARCHITECTURE.md#adr-v1), and each is something a
+user will plausibly want.
+
+One entry that used to be on this list is gone: **an embedded PTY for an
+arbitrary process** is now the `pty` surface
+([ADR-V19](ARCHITECTURE.md#adr-v19)), which covers `lazygit`, `htop`, a REPL, or
+a game. It is noted here because it is the only limitation this document has so
+far retired, and the mechanism that retired it — give the plugin a
+kernel-owned grid rather than a faster tree — is the one to reach for first when
+something else on this list starts hurting.
+
+| Wanted | Why it cannot be a plugin |
+|---|---|
+| **A new session backend** (Docker, Kubernetes, devcontainers, zellij, a cloud sandbox) | Backends are kernel. This is the most significant one — session transport *is* thurbox's domain, and "add a backend" is the most likely third-party ambition it cannot serve |
+| **Restructuring global chrome** (header, footer, status band, tab strip mechanics) | Plugins contribute `statusItems` and `tabs`; they cannot re-lay-out the frame |
+| **New theme tokens** | The palette is a kernel enum; plugins consume tokens and cannot define semantic ones |
+| **Shipping a theme** | Not currently a contribution point — a gap, since `themes.toml` already supports custom palettes |
+| **Pre-restore startup work** | No hook runs before the kernel restores sessions |
+| **A different keybinding resolution model** | Contexts, passthrough, and conflict rules are kernel |
+
+**Native code has an out-of-process escape hatch, and it is the only one.**
+[C2](ARCHITECTURE.md#adr-v2) forbids a plugin from linking a C module, which
+rules out binding an existing native library in-VM. It does not rule out
+*using* one: a plugin with `shell` runs it as a child through `ctx.exec` and
+parses the output, and a plugin with `pty` embeds it as a live grid — the same
+boundary tmux already gives every agent CLI. So "wrap a native tool" is
+supported and "wrap a native *library*" is not. A plugin that genuinely needs
+in-process native code is asking to be a kernel change, and should be one.
+
+---
+
+## 6. Cost ceilings
+
+| Dimension | Ceiling | Note |
+|---|---|---|
+| Tree size | 256 KB warn, 2 MB reject | ≈ 2,600 / 20,000 nodes |
+| Sustained push rate | ~10 Hz per pane before it shows | Each push = build + convert + diff + paint |
+| Animated pane rate | 30 fps per pane, 30 fps aggregate | Kernel-clock repaints; no push, no conversion |
+| `surface` throughput | Frames dropped under backpressure | Costs what a session terminal pane costs |
+| Memory per plugin | kilobytes per Luau VM, capped by a per-VM limit | Ten active plugins are noise against v1's footprint ([ADR-V2](ARCHITECTURE.md#adr-v2)) |
+| Cold start | microseconds per VM; dominated by the plugin's own `init` | Lazy activation ([ADR-V15](ARCHITECTURE.md#adr-v15)) is now an optimization, not a necessity |
+| Input→paint latency | sub-millisecond added | A reducer call plus a tree conversion; no boundary crossing |
+| Command deadline | 250 ms soft, 10 s hard | Longer work belongs in an automation or a session |
+
+Numbers are design targets to be validated in Phase 1, not measurements.
+
+---
+
+## 7. Kernel additions we already expect to want
+
+Naming these now keeps the Tier 1 freeze
+([ADR-V14](ARCHITECTURE.md#adr-v14)) honest — the catalog stays frozen because
+pressure has somewhere to go, not because nobody pushes.
+
+| Candidate | Unblocks | Cost |
+|---|---|---|
+| Mouse vocabulary (double/right-click) | Context menus, richer interaction | Small |
+| `themes` contribution point | Plugin-shipped palettes | Small |
+| Targeted subtree updates (a patch push) | The mid-band case in §2.2 — live logs, metric graphs | Medium; §4.3 exists because of it |
+| Spawn lifecycle events with responses | Pre-spawn hooks, delete veto | Reintroduces middleware — needs care |
+| Backend contribution point | Third-party session transports | Large; arguably a v3 question |
+
+---
+
+## 8. Tripwires — when to reconsider the architecture
+
+The alternative documented in [ADR-V13](ARCHITECTURE.md#adr-v13) (move the TUI
+to TypeScript on a JS TUI toolkit, demoting Rust to a headless daemon) is not
+dead; it is on hold.
+These are the conditions that should reopen it, decided in advance so the
+decision is evidential rather than exhausted:
+
+1. **The kernel-gap list grows faster than it is closed** for two consecutive
+ releases. That means the node catalog, not the plugin model, is the
+ bottleneck — and a JS-toolkit renderer has no catalog.
+2. **More than a third of plugin authors reach for §3.1's workaround**
+ (hand-built text inputs). It would mean the kernel-implemented-widget
+ premise does not hold in practice.
+3. **Motion and `surface` do not absorb animation demand** — plugins routinely
+ need per-frame *tree* updates that are neither a fixed motion kind nor
+ expressible as a grid. That would mean the tree, not the clock, is the
+ bottleneck.
+4. **Tree conversion shows up in a perf profile** as a top-three cost at
+ realistic plugin counts.
+
+Conversely, if none of these fire within a year of v2.0, the view-tree bet has
+paid and the escape hatch can be formally retired.
+
+---
+
+## 9. Which of these are terminal-inherent, and which are ours
+
+Worth separating, because only the second kind is negotiable — and because the
+first kind is not a cost of the *plugin model* at all.
+
+**Inherent to being a terminal application** — no plugin architecture would fix
+these, and a GUI app simply does not have them:
+
+- §1.3's residue (measurement is one frame late, so single-pass
+  content-driven layout is impossible) and §1.4 cross-pane alignment:
+  consequences of a fixed cell grid and a layout solver that resolves sizes
+  before content is drawn.
+- §2.1's ceiling on dense cell art, and the absence of sixel/kitty/iTerm2 image
+  protocols through a `surface` (§2.3).
+- §3.3's mouse vocabulary — terminals report what they report.
+
+The comparison worth making is not "a desktop app can do more" (it can, and it
+pays in reach: no ssh, no tmux, no headless host) but that these costs are the
+same ones v1 already pays. Nothing in the plugin model made the terminal less
+capable.
+
+**Ours, and therefore changeable** — every one of these is a scheduling
+decision, and §7 is the queue:
+
+- §3.1 kernel-owned text inputs, §3.2 pane-granular focus, §4.1 no
+  plugin-to-plugin RPC, §4.3 whole-tree pushes, §4.5 no middleware.
+
+**Already spent from that budget.** §1.1 (floating elements) and §1.2 (pane
+geometry) were on this list and were paid off by
+[ADR-V22](ARCHITECTURE.md#adr-v22) and [ADR-V23](ARCHITECTURE.md#adr-v23); so
+was §2.2 (animation), which an earlier draft called the design's sharpest single
+limitation, by [ADR-V18](ARCHITECTURE.md#adr-v18) and
+[ADR-V19](ARCHITECTURE.md#adr-v19). Each was resolved by generalizing a
+mechanism the kernel already needed rather than by adding a special case — the
+overlay layer instead of `diff.inlineAt`, a split tree instead of a sixth slot,
+a kernel-owned clock instead of a faster push path. That is the pattern to
+repeat against §7's queue, and it is why the residues above are stated as
+residues rather than as the original limitation.
+
+The honest summary: the design's real spend is **§4.2 (no synchronous host
+calls) and §4.3 (no incremental updates)**, which together mean a non-trivial
+plugin is substantially cache management. That is the tax an out-of-process,
+push-based model charges, it is the thing a fully in-language renderer
+(ADR-V13's rejected alternative) would not charge, and §8's tripwires are
+calibrated to notice if it turns out to be too high.

--- a/docs/v2/MIGRATION.md
+++ b/docs/v2/MIGRATION.md
@@ -1,0 +1,470 @@
+# Thurbox v2 — Migration Plan
+
+How v1 becomes v2 without a big-bang rewrite, what gets deleted, and what breaks
+for users.
+
+The delivery mechanics — one trunk, a Cargo feature gate, three stages, and the
+nightly channel — are specified in
+[RELEASE-STRATEGY.md](RELEASE-STRATEGY.md). This document is the work
+breakdown that runs inside them.
+
+---
+
+## 1. Principles for the transition
+
+1. **`main` stays shippable, and stays v1.** Every phase lands on `main` behind
+   the `plugins` Cargo feature, which is absent from stable builds until Stage B
+   ([RELEASE-STRATEGY §2](RELEASE-STRATEGY.md#2-the-delivery-model)).
+   v1 releases continue on their existing cadence, from the same trigger, with
+   the same process.
+2. **Additive before subtractive.** Everything that *adds* a capability ships
+   before anything that *removes* one. The plugin host reaches real users at
+   Stage B, in a v1 minor release, with every native pane intact. Only Stage C
+   deletes.
+3. **The acceptance harness is the safety net.** `src/app/acceptance.rs` (the
+   in-process `Harness`, the insta snapshots, the invariant monkey test, the
+   `perf_*` counter tests) already pins TUI behavior. A pane is migrated when
+   its plugin implementation passes the *same* tests the Rust pane passed —
+   asserted against both implementations in the same run, since both are
+   present.
+4. **Answer the hardest question early; land the hardest pane late.** The
+   session list is the pane that decides whether
+   [ADR-V1](ARCHITECTURE.md#adr-v1) holds. Prototype it as a throwaway spike in
+   Phase 1, against the pass/fail bar in §3, *before* six other panes are built
+   on the assumption it works; land it for real in Phase 4. Spiking early and
+   shipping last are not in tension: the spike exists to answer a question, not
+   to produce code.
+5. **Delete when the plugin becomes the default, not when it lands.** This
+   amends the earlier "no dual implementations" rule, and the reasoning is in
+   [RELEASE-STRATEGY §5](RELEASE-STRATEGY.md#5-why-coexistence-beats-divergence).
+   Deletion is still per-pane and still one PR; it just happens at Stage C
+   rather than at merge time.
+
+---
+
+## 2. Phases
+
+| Phase | Work | Gate | Stage |
+|---|---|---|---|
+| **0** | Foundations — release plumbing, kernel boundary, Luau toolchain | ungated | A |
+| **1** | Plugin host — VM lifecycle, host bindings, `@thurbox` modules | `plugins` | A |
+| **2** | Service half — headless plugins, storage, CLI verbs, bus | `plugins` | A |
+| **3** | Motion and real-time surfaces | `plugins` | A |
+| **4** | Bundled plugins, additive alongside the native panes | `plugins` | A |
+| **5** | Command registry and agent API | `plugins` | A |
+| — | **Stage B ships**: feature default-on, runtime opt-in, v1 minor release | default-on | B |
+| **6** | Teardown, defaults flipped, 2.0.0 | default | C |
+
+Phases 2 and 3 are independent of 4 and can run in parallel with it; they share
+only the supervisor. Everything else is ordered.
+
+### Phase 0 — Foundations (no behavior change)
+
+Establishes the seam and the tooling, with nothing gated and nothing plugin-shaped
+yet. All of it is either behavior-preserving or pure CI, so it ships to v1 users
+immediately and gets exercised by them before anything depends on it.
+
+**Release plumbing** ([RELEASE-STRATEGY §6](RELEASE-STRATEGY.md#6-ci),
+[§7](RELEASE-STRATEGY.md#7-the-installer-hazard)):
+
+- Add the `--features plugins` CI matrix leg (build, clippy, nextest), required
+  rather than advisory.
+- Add the Luau toolchain — `luau-analyze` in strict mode plus the plugin test
+  runner — as CI jobs and pre-commit stages, **before** the first Luau PR, so
+  that PR does not also carry the toolchain.
+- Harden both installer version fallbacks to accept only
+  `v<major>.<minor>.<patch>`, with a prerelease fixture regression test in
+  `install.bats` and `install.Tests.ps1`.
+- Add the workflow-invariant lint for
+  [RELEASE-STRATEGY §9](RELEASE-STRATEGY.md#9-invariants) 1–4.
+- Verify cocogitto's behavior on non-semver tags
+  ([RELEASE-STRATEGY §4.2](RELEASE-STRATEGY.md#42-tag-naming-and-why-it-is-not-semver)).
+
+**Kernel boundary:**
+
+- Identify which of `App`'s 80 fields survive as kernel state and which are pane
+  state. `src/app/mod.rs` is 14,605 lines; the output of this step is a map, not
+  a refactor.
+- Introduce the `plugin` module in `tests/architecture_rules.rs`
+  ([ADR-V12](ARCHITECTURE.md#adr-v12)) with no contents yet.
+- Introduce the view-tree data types in `session::view`, so `ui` can render them
+  without importing `plugin` — mirroring why `session::review` exists for diffs.
+- Add a **native view-tree renderer** in `ui/` over ratatui
+  ([ADR-V13](ARCHITECTURE.md#adr-v13)) and reimplement one simple v1 pane (the
+  info panel) through it, still in Rust, still in-process.
+- Replace `compute_layout`'s 10 fixed rects with the **workspace tree**
+  ([ADR-V23](ARCHITECTURE.md#adr-v23)), shipping only the synthesized default
+  preset — no `layout.toml`, no new capability. The insta snapshots must not
+  move, which is exactly the test that the preset reproduces v1.
+- Add the **overlay layer and `anchor` resolution**
+  ([ADR-V22](ARCHITECTURE.md#adr-v22)), and port v1's `render_compose_inline`
+  onto it. This retires the `diff.inlineAt` special case before anything
+  depends on it.
+
+Both layout items belong here rather than later: they are behavior-preserving
+refactors of kernel rendering, and doing them after panes are plugins would mean
+migrating every pane twice.
+
+This phase is smaller than it sounds: v1 already hands 19 pure view-model structs
+(`TaskPaneState`, `LeftPanelState`, …) to pure renderers that emit `Line`/`Span`.
+Phase 0 collapses 19 typed view models into one node set — it does not introduce
+the pattern.
+
+**Exit criteria**: the info panel renders through the view tree with
+byte-identical insta snapshots; the `--features plugins` leg is green against an
+empty feature; both installers resolve to stable with a prerelease fixture
+present.
+
+### Phase 1 — Plugin host
+
+- Embed `mlua` with the `luau` backend ([ADR-V2](ARCHITECTURE.md#adr-v2)).
+- VM supervisor: create, sandbox, per-VM memory limit, interrupt handler,
+  thread per plugin, backoff, suspend/resume
+  ([ADR-V4](ARCHITECTURE.md#adr-v4)). The sandbox binds **only** the host
+  functions a plugin's capabilities grant — no `io`, no `os.execute`, no
+  `os.getenv`, no `require` outside the plugin's own directory
+  ([SECURITY.md §3](SECURITY.md#3-resolved--fs-net-and-shell-are-now-enforced)).
+- The install prompt names **remote** reach for `sessions = "control"`
+  ([SECURITY.md §9](SECURITY.md#9-remote-blast-radius)).
+- The `@thurbox` module: `definePlugin`, `defineService`, `ui.*` node
+  constructors, and the type definitions `luau-analyze` checks against.
+- `@thurbox/widgets`: `list`, `table`, `badge`, `keyHints`, `empty`
+  ([ADR-V14](ARCHITECTURE.md#adr-v14)).
+- `thurbox plugin` CLI: `list`, `info`, `dev`, `reload`, `doctor`.
+- **Keybindings and pane visibility**
+  ([FEATURES-Keybindings.md](FEATURES-Keybindings.md),
+  [ADR-V21](ARCHITECTURE.md#adr-v21)) — needed here rather than in Phase 5,
+  because a pane is not usable without a way to show it. Open `pane:<id>`
+  contexts; manifest defaults that are dropped rather than stolen on
+  collision; automatic passthrough deferral for global bare-`Ctrl+<letter>`
+  plugin chords; kernel-owned per-pane visibility with generated
+  `<plugin>.<pane>.{toggle,show,hide}` commands, persisted, waking a suspended
+  plugin on show; plugin sections in the F1 editor.
+- **The session-list frame-budget spike** (§3). Throwaway code, answering one
+  question.
+
+**Exit criteria**: a hello-world plugin renders a `right`-slot pane, receives key
+events, and hot-reloads on save; its pane toggles from a rebindable chord and
+its keys appear in F1; the spike has produced a number against §3's bar and a
+recorded decision.
+
+### Phase 2 — Service half
+
+The backend contract ([FEATURES-Backend-API.md](FEATURES-Backend-API.md)).
+
+- Service hosting across all three hosts (TUI, heartbeat keeper, CLI invocation)
+  with the machine-wide advisory lock ([ADR-V16](ARCHITECTURE.md#adr-v16)).
+- `ctx.kv` plus kernel-executed namespaced migrations
+  ([ADR-V17](ARCHITECTURE.md#adr-v17)), with `plugin_migrations` and namespace
+  rejection tests.
+- CLI verb registration and collision checks against kernel subcommands.
+- Supervised `services`, `schedules` routed through `claim_due_automation`, the
+  event bus, and cross-half typed RPC.
+- Spawn contributions (append-only, fail-open) with the **env-key denylist** —
+  `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`,
+  `BASH_ENV`, `NODE_OPTIONS`, and `PATH` prepends confined to `{plugin_data}`
+  ([SECURITY.md §8](SECURITY.md#8-spawn-contributions)) — and the `skills`
+  registry. The denylist ships with the feature, not after it: append-only
+  bounds who wins, not what can be injected.
+
+**Exit criteria**: a service-only plugin syncs data with the TUI closed, driven by
+the heartbeat keeper, and owns a working `thurbox-cli <verb>`.
+
+### Phase 3 — Motion and real-time surfaces
+
+Independent of Phase 4 — it touches the renderer and the session layer, not any
+bundled pane — and it is what makes the plugin API demonstrable to third parties
+rather than only to ourselves.
+
+- `motion` evaluation on the frame clock, per-pane animation leases, the per-pane
+  and aggregate rate caps, and a `reduce_motion` setting
+  ([ADR-V18](ARCHITECTURE.md#adr-v18), specified in
+  [FEATURES-Animation.md](FEATURES-Animation.md)). `statusDot` re-expressed as a
+  kernel-supplied `cycle` is the first consumer. Two rules carry most of the risk
+  and need tests first: motion state keyed so an identical re-push does **not**
+  restart an animation ([§3](FEATURES-Animation.md#3-identity-and-phase)), and
+  evaluation through the existing `app::clock` test clock so insta snapshots stay
+  pinned at frame 0 ([§9](FEATURES-Animation.md#9-determinism-and-testing)).
+- `pty` and `surface` nodes over the existing `vt100` + `tui-term` path:
+  spawn/supervise, grid lifetime keyed to the node id across suspend and reload,
+  `SIGWINCH` from the resolved rect, `surface/write` with backpressure
+  ([ADR-V19](ARCHITECTURE.md#adr-v19)).
+- Input sinking for a focused grid node, the `escape` chord, and
+  `keyReport: "press-release"` — pushing kitty `REPORT_EVENT_TYPES` on focus and
+  popping it on blur. This is the one piece with a blast radius outside the plugin
+  system, so it ships with a test asserting an unfocused grid leaves every agent
+  pane's input encoding byte-identical to v1.
+
+**Exit criteria**: `perf_*` counters show an idle TUI unchanged with an animated
+pane present but hidden; a plugin embeds a full-screen interactive program
+(held-key input working) and survives tabbing away and a hot reload.
+
+### Phase 4 — Bundled plugins, easy first
+
+Each pane is built as a plugin and lands **alongside** its native implementation,
+selected by the runtime flag. Migrate in ascending order of coupling, one PR
+each:
+
+| Order | Pane | Why this position |
+|---|---|---|
+| 1 | Info panel | Read-only, no input, already view-tree in Phase 0 |
+| 2 | Tasks | Self-contained state, kernel-table API exercises `host/*` |
+| 3 | Automations | Adds an in-pane editor and run history — tests `input`/`table` |
+| 4 | File viewer | Tests the `fileTree` kernel surface and find sub-mode |
+| 5 | Global search | Tests the `bottom` slot and cross-pane query broadcast |
+| 6 | Code review | Largest: tests `diff`, `anchor` compose boxes, and the changed-files pane |
+| 7 | Session list | Tests nesting, ordering, status dots, and `sessionTerminal` |
+
+The session list is last by coupling, but its frame-budget spike ran in Phase 1
+(principle 4). If that spike said no, the fallback is a kernel `sessionList`
+surface ([ADR-V6](ARCHITECTURE.md#adr-v6)) that a plugin configures — a real
+retreat from [ADR-V1](ARCHITECTURE.md#adr-v1), and one that must be discovered
+before the other six panes are built on the opposite assumption.
+
+**Installation lands here too**, because Stage B's exit criterion requires a
+plugin thurbox did not write, and that plugin has to arrive somehow:
+`thurbox plugin install|uninstall|enable|disable`, resolving a registry name, a
+git URL, or a path; the capability prompt; and the supply-chain controls that
+must exist before the first third-party install — a **lockfile recording
+resolved version and content hash** per plugin and dependency, deterministic
+re-resolution with no floating ranges, and official plugins pinned to the
+binary's release tag as v1 pinned extensions
+([SECURITY.md §6](SECURITY.md#6-supply-chain)).
+
+One kernel gap is scheduled here rather than hand-waved
+([FEATURES-View-Tree.md §11](FEATURES-View-Tree.md#11-expressiveness-check)):
+a kernel-broadcast search query for cross-pane match highlighting (order 5).
+The other gap that audit found — a compose box anchored to a diff line — was
+closed generally by `anchor` in Phase 0
+([ADR-V22](ARCHITECTURE.md#adr-v22)) rather than by a `diff`-only slot.
+
+**Exit criteria**: with `plugins = true`, every pane above renders as a plugin and
+reproduces its native predecessor's insta snapshot; with `plugins = false`, v1 is
+byte-identical.
+
+### Phase 5 — Command registry and agent API
+
+- Registry generalized from the keybinding lookup built in Phase 1 into the
+  full command registry, with the palette on top of it.
+- `thurbox-cli command list|describe|run`.
+- Control socket hardening: mode `0600` in a `0700` directory, peer-UID check,
+  an explicit Windows DACL, unlinked on shutdown and on the panic path
+  ([SECURITY.md §5](SECURITY.md#5-the-control-socket)). It exposes `command/run`
+  to any local process otherwise.
+- Conservative `agent_policy` defaults — destructive verbs default to `confirm`
+  or `deny`, and capability-widening commands are permanently `deny`
+  ([SECURITY.md §7](SECURITY.md#7-agent-driven-execution-and-prompt-injection)).
+- Control socket, caller policy, loop guard
+  ([FEATURES-Agent-API.md §5](FEATURES-Agent-API.md#5-permission-model)).
+
+**Exit criteria**: every bundled plugin command is listable and invocable from
+inside a session.
+
+### Stage B — experimental release
+
+Not a phase of work but a decision point
+([RELEASE-STRATEGY §3](RELEASE-STRATEGY.md#3-three-stages-three-gate-positions)):
+the Cargo feature flips to default-on and ships in an ordinary v1 minor release,
+runtime-gated off. Native panes remain the
+default. Plugin authors get a stable binary to build against, and the protocol
+gets its exposure before N4 freezes it.
+
+**One decision must be closed before this flip, not after it**: whether `fs`,
+`net`, and `shell` are enforced or advisory
+([SECURITY.md §3](SECURITY.md#3-resolved--fs-net-and-shell-are-now-enforced)).
+Stage B is the moment third-party code starts running on users' machines under a
+stated trust model, and the model has to be true when it is stated. Choosing
+enforcement means a runtime reversal ([ADR-V3](ARCHITECTURE.md#adr-v3)), which
+is far cheaper here than after plugins exist; choosing advisory means amending
+[N3](CONSTITUTION-DELTA.md#n3--capabilities-are-declared-gated-and-shown) and
+saying so at the install prompt.
+
+**Exit criteria for leaving Stage B**: one full minor release with no
+non-additive protocol change, and at least one plugin that thurbox did not write.
+
+### Phase 6 — Teardown and 2.0.0
+
+- Flip the runtime default to `true`
+  ([ADR-V3](ARCHITECTURE.md#adr-v3)) and absorb the artifact-size increase across
+  all four platforms and every packaging channel.
+- Per pane, one PR: make the plugin the default and delete the native
+  implementation with its `InputFocus`, `Action`, `PanelAreas`, `ClickAction`,
+  and `FeatureFlags` entries.
+- Delete the v1 extension system (§4).
+- Absorb hooks into the kernel session layer.
+- Replace `[features]` flags with `thurbox plugin enable|disable` — the
+  *existence* axis. The **visibility** axis (`F2`/`F3`/`F5`/`F9`) is a
+  separate mechanism that must already be in place: kernel-owned per-pane
+  visibility with auto-generated `<plugin>.<pane>.toggle` commands
+  ([ADR-V21](ARCHITECTURE.md#adr-v21),
+  [FEATURES-Keybindings.md §7](FEATURES-Keybindings.md#7-pane-visibility)).
+  Collapsing the two loses a v1 behavior.
+- Documentation: fold `docs/v2/` into `docs/`, rewrite `CLAUDE.md`, move the
+  website's `/v2/` tree to `/`.
+- Ship `2.0.0` via the explicit-version release dispatch (`cog bump --version
+  2.0.0`), since `--auto` will not cross a major boundary on its own.
+
+---
+
+## 3. The session-list decision gate
+
+Open question 1 (§7) is the one that can invalidate
+[ADR-V1](ARCHITECTURE.md#adr-v1), so it gets a bar defined **in advance** rather
+than a judgement call made under sunk cost. The Phase 1 spike passes only if all
+four hold, measured through the existing `perf_*` counters and
+`THURBOX_PERF_LOG=1`:
+
+| Measure | Bar | Why this number |
+|---|---|---|
+| `view/push` rate, 20 sessions at 5 status transitions/s | ≤ 10 Hz sustained | The per-pane push ceiling in [LIMITATIONS §6](LIMITATIONS.md#6-cost-ceilings). Above it, the pane is fighting the protocol |
+| `first_frame_ms` with the default bundled set active | ≤ 115% of v1 | v1's number is the baseline users have; 15% is the largest regression that does not read as "slower to start" |
+| Idle paint rate, no activity | Unchanged from v1's ~4 fps floor | The demand-driven loop (ADR-P1–P12) is the asset [ADR-V11](ARCHITECTURE.md#adr-v11) exists to protect |
+| Added input→paint latency on selection change | ≤ 5 ms | The ceiling already claimed in [LIMITATIONS §6](LIMITATIONS.md#6-cost-ceilings) |
+
+Note the second row: measuring `first_frame_ms` with *no plugins active* is
+trivially satisfied by lazy activation and proves nothing. The bar is the default
+bundled set.
+
+**If the bar is missed**, the retreat is the kernel `sessionList` surface, taken
+at the end of Phase 1 and recorded as an amendment to ADR-V1 — not discovered in
+Phase 4 with six panes already built on the assumption.
+
+---
+
+## 4. Teardown inventory — the v1 extension system
+
+Deleted outright ([ADR-V8](ARCHITECTURE.md#adr-v8)):
+
+| Path | Lines | Notes |
+|---|---|---|
+| `src/session_ops/extensions.rs` | 2,368 | install/uninstall/reinstall/update/heal |
+| `src/agent/extension_config.rs` | 1,070 | manifest loading, agent patches, config merges |
+| `src/session/extension_def.rs` | 794 | `ExtensionDef`, version helpers |
+| `src/cli/extensions.rs` | 613 | the `thurbox-cli extension` subcommand + dispatch |
+| `src/agent/json_merge.rs` | 183 | only consumer was `[[config_merges]]` |
+| **Total deleted** | **5,028** | |
+| `extensions/` | 91 files, 580 KB | flow, forge, ci-shepherd, renovate, 4 tracker integrations, hooks |
+| `metadata.active_extensions`, `metadata.builtin_hooks_optout` | — | schema cleanup migration |
+
+Rewritten rather than deleted:
+
+| Path | Lines | Fate |
+|---|---|---|
+| `src/session_ops/builtin_hooks.rs` | 554 | Absorbed into the kernel session layer — the behavior is core product, not an extension |
+| `src/session_ops/remote_hooks.rs` | 646 | Untouched. Session infrastructure, not extension infrastructure |
+
+So: **5,028 lines of Rust deleted, 554 absorbed, and the `extensions/` tree
+removed.**
+
+### What must not be lost
+
+| v1 capability | v2 home |
+|---|---|
+| Agent status hooks (working/blocked/done) | **Kernel.** Core product behavior — moves into the session layer, including remote hook rewriting and the psmux gate |
+| Registering agents in `agents.toml` | Plugin manifest `[[agents]]` contribution |
+| Seeding sessions/automations | Plugin manifest `[[automations]]` + `init` via `host/*` APIs |
+| Placing files in agent config dirs | Plugin `fs` capability |
+| Patching agent args at spawn | Spawn contributions ([FEATURES-Backend-API.md §11](FEATURES-Backend-API.md#11-spawn-contributions)) |
+| Self-heal on startup/tick | Plugin activation is idempotent by construction |
+| Version/staleness/auto-update | `thurbox plugin update`, same release-tag pinning |
+
+---
+
+## 5. User-facing breakage
+
+Nothing breaks before 2.0.0. Stage B adds a capability and removes none.
+
+v2.0.0 is a **breaking major release**. What changes:
+
+| v1 | v2 | Migration |
+|---|---|---|
+| `[features] tasks = false` | `thurbox plugin disable tasks` | Automatic: the settings loader translates known flags on first run and writes a deprecation note |
+| `thurbox-cli extension …` | `thurbox plugin …` | Command removed; error message points at the replacement |
+| `extensions/` installs | Gone | Not migrated — the extensions are unused ([ADR-V8](ARCHITECTURE.md#adr-v8)) |
+| ~10 MB binary | ~60–100 MB archive | Documented in release notes and on the install page |
+| `settings.toml`, `agents.toml`, `hosts.toml`, `themes.toml`, `keybindings.json` | Unchanged | None |
+| SQLite database | Forward migration from schema 40 | Automatic on first open, as with every prior schema bump |
+| tmux sessions, worktrees, branches | Unchanged | v2 adopts running v1 sessions normally |
+
+**The valuable state — live sessions, worktrees, tasks, automations, message
+history — carries over untouched.** Only the extensibility surface breaks.
+
+---
+
+## 6. Test strategy
+
+The existing harness carries over and is extended:
+
+| Layer | v1 | v2 addition |
+|---|---|---|
+| In-process acceptance (`Harness`) | Feeds `AppMessage`, renders to `TestBackend` | Plugins stubbed by a fake returning canned view trees — no VM in the normal test suite |
+| insta snapshots | 7 pinned screens | Same screens through the view-tree renderer. During Phase 4 each screen is asserted against **both** implementations in one run |
+| Invariant monkey test | Random events, `assert_invariants` after each | New invariants: focus never lands on a suspended plugin's pane; a faulted plugin never blocks a frame; no pane renders a tree it did not push; motion invariants ([FEATURES-Animation.md §9](FEATURES-Animation.md#9-determinism-and-testing)) |
+| Perf counters (`perf_*`) | Idle iterations skip the paint, order cache rebuilds | New counters: pushes per second, dropped frames, RPC deadline misses, motion leases |
+| Protocol conformance | — | New: a fixture plugin exercising every node type and every failure mode (slow render, crash on init, oversized tree, malformed frame) |
+| Plugin unit tests | — | New: a Luau harness in `@thurbox` running reducers against event sequences, no kernel needed |
+| End-to-end | `scripts/dev/smoke/tui-smoke.sh` | Extended to boot with a real runtime and real bundled plugins, in the `--features plugins` configuration |
+| Feature-gate integrity | — | New: CI builds and tests both configurations; the ungated build must not link the runtime supervisor |
+
+---
+
+## 7. Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Session list cannot meet the frame budget as a plugin | Medium | High | The §3 bar, measured in Phase 1 before six panes depend on the answer; kernel `sessionList` surface as the recorded retreat |
+| First-frame regression from N cold starts | Medium | High | Activation events ([ADR-V15](ARCHITECTURE.md#adr-v15)) bound N to plugins in use; render kernel surfaces before plugins attach; §3's `first_frame_ms` bar |
+| Gated code rots — `--features plugins` breaks unnoticed | Medium | Medium | The matrix leg is a required check, not advisory ([RELEASE-STRATEGY §9](RELEASE-STRATEGY.md#9-invariants) invariant 7) |
+| Native and plugin implementations drift during Phase 4 | Medium | Medium | Both assert the same insta snapshot in the same run; the window is bounded and ends at Phase 6 |
+| Kernel node catalog becomes the bottleneck for plugin authors | Low | High | Two-tier catalog ([ADR-V14](ARCHITECTURE.md#adr-v14)) — widgets are userland Luau, so one kernel gap remains across all 9 v1 surfaces |
+| Artifact size breaks a packaging channel | Medium | High | Deferred to Stage C by [RELEASE-STRATEGY §3](RELEASE-STRATEGY.md#3-three-stages-three-gate-positions); validate Chocolatey/winget/AUR limits during Stage B, with months of warning |
+| View tree cannot express the code review | Medium | High | Built in Phase 4 *before* the native one is deleted in Phase 6; its one hard case, the anchored compose box, is solved generally in Phase 0 |
+| Two-language contributor friction | High | Medium | `@thurbox` type definitions, `plugin dev`, and a template repo; Luau is Lua-5.1-shaped, so neovim-config experience transfers |
+| Luau proves awkward for a real pane | Medium | High | Phase 1's validation gate writes the code review or session list in it, and has an agent write it too, before six panes assume it works |
+| Plugin API churn after third-party adoption | Medium | Medium | Protocol major version; additive-only rules; Stage B is the window in which mistakes are still free to fix |
+| Scope creep — v2 never lands | High | High | Stage B is a shippable outcome on its own. Even if Phase 6 never happens, the plugin host is in users' hands and v1 is undamaged |
+
+The last row is the structural difference from the branch model: under trunk-based
+delivery, **abandoning v2 costs a feature-flag deletion**, and abandoning it
+*after Stage B* still leaves users with a working plugin system on a stable v1.
+
+---
+
+## 8. Rollback
+
+| Point of failure | Cost of stopping |
+|---|---|
+| During Phase 0 | Nothing to roll back. Every item is a CI or behavior-preserving improvement worth having on its own |
+| During Phases 1–5 | Delete the `plugins` Cargo feature and its modules in one PR. Stable builds never contained them |
+| At Stage B | Flip the Cargo feature back to default-off in a patch release. Users who opted in lose plugins; nothing else changes |
+| During Phase 6 | The riskiest window, and the only one that needs care: pane deletions are irreversible within a release. Each deletion is its own PR and its own revert |
+| After 2.0.0 | Normal major-version support: v1 stays installable at its last tag through every packaging channel |
+
+---
+
+## 9. Open questions
+
+Deliberately unresolved, to be settled with evidence rather than in advance:
+
+1. **Does the session list meet the frame budget as a plugin?** The bar is §3;
+   the answer is due at the end of Phase 1.
+2. **Does `mlua`'s vendored Luau build cleanly on every target?** Windows
+   ARM64, musl, and the macOS universal build each need a green cross-build
+   before [ADR-V3](ARCHITECTURE.md#adr-v3) is locked. This is a *build* question
+   rather than a distribution one — the VM is linked in, so there is no separate
+   runtime to ship or find — and it is answerable in CI during Phase 0 rather
+   than by user reports. It replaces the earlier "which JS runtime, and does it
+   exist on every target?", which the sidecar design could only settle with
+   months of Stage B evidence.
+3. **Do modals belong in the `overlay` slot or as a kernel primitive?**
+   `ctx.ui.modal()` exists for kernel-driven prompts; whether plugins should own
+   full modal panes is unsettled.
+4. **How much of `git` needs a host API?** Phase 4's review migration will reveal
+   whether `diff` as a kernel surface is enough or whether plugins need general
+   git access.
+5. **Suspension policy.** Sixty seconds is a guess. Real usage during Stage B
+   should set it.
+6. **Where exactly does the Cargo feature boundary fall in Phase 0?** The
+   view-tree types and native renderer are behavior-preserving and arguably
+   belong ungated in stable; the host is clearly gated. See
+   [RELEASE-STRATEGY §11](RELEASE-STRATEGY.md#11-open-questions).

--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -1,0 +1,140 @@
+# Thurbox v2 — Design Documentation
+
+Thurbox v2 turns the TUI inside out: instead of a Rust binary that owns every
+pane, thurbox becomes a **plugin host** with a minimal Rust kernel and a Luau
+plugin layer that can be reloaded without recompiling.
+
+This directory holds the design set for that refactor. It is **forward-looking
+documentation** — nothing here is implemented yet. Until v2 ships, `docs/` (one
+level up) describes the shipping product and remains authoritative.
+
+## The shape of v2 in one page
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│ Rust kernel (thurbox)                                        │
+│                                                              │
+│  sessions · backends (tmux/ssh/wsl) · git · SQLite · PTY     │
+│  event loop · layout solver · theme · keymap · renderer      │
+│  plugin host: VM lifecycle, host bindings, capabilities      │
+└───────────────┬──────────────────────────────────────────────┘
+                │  one sandboxed Luau VM + thread per plugin
+   ┌────────────┴────────────┬─────────────┬──────────────┐
+   ▼                         ▼             ▼              ▼
+┌────────────┐  ┌───────────────┐  ┌────────────┐  ┌────────────┐
+│ sessions   │  │ tasks         │  │ files      │  │ review     │
+│ (bundled)  │  │ (bundled)     │  │ (bundled)  │  │ (bundled)  │
+└────────────┘  └───────────────┘  └────────────┘  └────────────┘
+   Luau, hot-reloadable, capability-scoped, agent-callable
+```
+
+Everything below the line is a plugin — including the session list. The kernel
+never renders a feature; it renders **view trees** that plugins return, and owns
+only the things a plugin cannot: session supervision, the terminal grid,
+persistence, and the frame.
+
+## The five decisions that carry the rest
+
+If you read nothing else:
+
+| Decision | Consequence if it is wrong |
+|---|---|
+| [V1](ARCHITECTURE.md#adr-v1) — everything but six things is a plugin, **including the session list** | The API stays second-class, because nothing important dogfoods it |
+| [V2](ARCHITECTURE.md#adr-v2) — Luau in-process, one VM and thread per plugin, no native code | Either a plugin fault takes the TUI down, or the capability model goes back to being advisory |
+| [V5](ARCHITECTURE.md#adr-v5) + [V14](ARCHITECTURE.md#adr-v14) — declarative view tree, frozen primitives, widgets in userland | Either plugins cannot draw what they need, or the kernel becomes the bottleneck for every widget |
+| [V16](ARCHITECTURE.md#adr-v16) — plugins have a headless service half | Automations stop firing when the TUI closes, silently revoking a v1 guarantee |
+| [V20](ARCHITECTURE.md#adr-v20) — trunk-based delivery behind a compile-time gate | v1 velocity collapses under merge debt, and abandoning v2 orphans months of work |
+
+Two more are worth knowing because they resolve limitations rather than create
+them: [V18](ARCHITECTURE.md#adr-v18) (motion is declared, not pushed) and
+[V19](ARCHITECTURE.md#adr-v19) (real-time content is a vt100 surface, not a
+faster tree).
+
+## Reading paths
+
+**Deciding whether this is a good idea** — start here, ~30 minutes:
+
+1. [VISION.md](VISION.md) — why v2 exists, what it costs, how it arrives
+2. [ARCHITECTURE.md](ARCHITECTURE.md) — the index, then the five ADRs above
+3. [LIMITATIONS.md](LIMITATIONS.md) — what the design cannot do, and §8's
+   tripwires for reopening it
+
+**Planning or doing the work**:
+
+1. [RELEASE-STRATEGY.md](RELEASE-STRATEGY.md) — delivery model, the three
+   stages, the nightly channel, the website
+2. [MIGRATION.md](MIGRATION.md) — phases, decision gates, teardown inventory,
+   rollback
+3. [SECURITY.md](SECURITY.md) — threat model, what capabilities do and do not
+   buy, and what must land before third-party plugins are installable
+4. [DECISION-plugin-runtime.md](DECISION-plugin-runtime.md) — why in-process
+   Luau, what it costs, and the conditions it rests on
+5. [CONSTITUTION-DELTA.md](CONSTITUTION-DELTA.md) — which v1 rules and ADRs v2
+   amends or retires
+
+**Writing a plugin** — these are the contracts, and what a plugin may rely on:
+
+1. [FEATURES-Plugin-API.md](FEATURES-Plugin-API.md) — manifest, lifecycle,
+   capabilities, host API
+2. [FEATURES-View-Tree.md](FEATURES-View-Tree.md) — the view half: node
+   catalog, styling, input
+3. [FEATURES-Layout.md](FEATURES-Layout.md) — the workspace tree, anchored
+   overlays, measurement
+4. [FEATURES-Animation.md](FEATURES-Animation.md) — motion: timing, identity,
+   leases, accessibility
+5. [FEATURES-Keybindings.md](FEATURES-Keybindings.md) — contexts, conflicts,
+   terminal passthrough, F1, and pane show/hide
+6. [FEATURES-Backend-API.md](FEATURES-Backend-API.md) — the service half: CLI
+   verbs, services, schedules, storage, bus
+7. [FEATURES-Agent-API.md](FEATURES-Agent-API.md) — how agents discover and
+   drive plugin commands
+
+## How v2 reaches users
+
+Not as a big bang. Everything lands on `main` behind a Cargo feature that is
+absent from stable builds, and the gate moves in three steps
+([ADR-V20](ARCHITECTURE.md#adr-v20)):
+
+| Stage | What a user sees | Version |
+|---|---|---|
+| **A** | Nothing. Stable does not contain the plugin host; nightly does | v1.x, unchanged |
+| **B** | Plugins work, opt-in, alongside every native pane | an ordinary v1 **minor** |
+| **C** | Plugins *are* the panes; `extensions/` gone | **2.0.0** |
+
+There is no long-lived `v2` branch. v1 keeps releasing on its existing cadence
+throughout, from the same trigger, with the same process.
+
+## Status
+
+| Area | State |
+|---|---|
+| Design | In review — this directory |
+| Phase 0 — foundations | Not started |
+| Phase 1 — plugin host | Not started |
+| Phases 2–3 — service half, motion | Not started |
+| Phase 4 — bundled plugins | Not started |
+| Phase 5 — command registry | Not started |
+| Phase 6 — teardown, 2.0.0 | Not started |
+
+Two questions can still change the architecture, and each has a deadline
+earlier than the work that depends on it:
+
+| Question | Due | If the answer is no |
+|---|---|---|
+| Does Luau hold up for a real pane? ([DECISION-plugin-runtime.md](DECISION-plugin-runtime.md)) | End of Phase 1 | Reversal to an out-of-process runtime, at the cost of the enforced capability model and a bundled runtime returning |
+| Does the session list meet its frame budget as a plugin? ([MIGRATION §3](MIGRATION.md#3-the-session-list-decision-gate)) | End of Phase 1 | A kernel `sessionList` surface — a recorded retreat from [ADR-V1](ARCHITECTURE.md#adr-v1), taken before six panes assume otherwise |
+
+Both are settled by building, not by arguing: Phase 1's validation gate writes
+one hard pane — the code review or the session list — in Luau, and has an agent
+write it too. A language that makes those awkward makes every third-party pane
+awkward.
+
+## Conventions
+
+Same rule as `docs/`: if an implementation change invalidates or extends a
+decision here, update the document in the same PR. v2 ADRs are numbered
+`ADR-V*` so they never collide with v1's `ADR-*` / `ADR-P*` series.
+Cross-references between these documents are checked by
+`scripts/dev/check-doc-links.sh`, wired into `just lint` and the pre-commit
+hooks — markdown links are invisible to rumdl and to the compiler, so without it
+they rot silently.

--- a/docs/v2/RELEASE-STRATEGY.md
+++ b/docs/v2/RELEASE-STRATEGY.md
@@ -1,0 +1,512 @@
+# Thurbox v2 — Delivery Model, Release Channels, and the Website
+
+v2 is a long refactor that will be unstable for months while v1 keeps shipping.
+This document defines how the two coexist: what carries the in-flight work, how
+nightly builds reach people who want them, and how the website serves both
+versions without confusing anyone on stable.
+
+Two constraints govern everything below, and they pull in opposite directions:
+
+> **C1 — A v1 user must not be able to end up on v2 by accident.** Not through
+> `install.sh`, not through Homebrew, Chocolatey, winget or the AUR, and not by
+> reading the docs site.
+
+> **C2 — v1 must stay exactly as maintainable during the refactor as it is
+> today.** No v1 fix may become slower or riskier to ship because v2 is in
+> flight.
+
+The obvious answer — a long-lived `v2` branch — satisfies C1 and violates C2.
+§1 shows the cost; §2 buys C1 a cheaper way.
+
+---
+
+## 1. Why not a long-lived `v2` branch
+
+An earlier draft of this document specified a `v2` branch merged back at 2.0.0,
+with `main` merged in at every v1 release. It is the instinctive answer and it
+is the expensive one.
+
+| Cost | Magnitude |
+|---|---|
+| **Divergence** | `main` runs ~3.5 commits/day (50 in the 14 days to 2026-08-08). A 4–6 month refactor is 400–700 commits to reconcile |
+| **Collision** | v2's work *is* the restructuring of `src/app/mod.rs` (14,605 lines) and `src/ui/` (36 modules) — precisely the files v1 fixes touch. Every merge conflicts inside the file being rewritten |
+| **Plumbing** | `ci.yml` must be widened to the branch; a second release workflow must live on it and drift from `cd.yml`; `pages.yml` must do a cross-branch checkout, a mechanism the earlier draft itself flagged as possibly fragile and gave a fallback for |
+| **The cut** | One merge commit is the single riskiest moment in the project, and it lands with no incremental user exposure behind it |
+| **Abandonment** | If v2 stalls at Phase 2, the work is orphaned on a branch nobody wants to merge |
+
+The branch buys exactly one property: `main` cannot accidentally ship v2. That
+property is worth having, and §2 buys it for a Cargo feature flag.
+
+The branch model is not deleted from the record — it is the documented fallback,
+with its adoption trigger in [§10](#10-fallback-the-branch-model).
+
+---
+
+## 2. The delivery model
+
+**Every phase of v2 lands on `main`, continuously, behind a Cargo feature.**
+
+```toml
+# Cargo.toml
+[features]
+default = []
+plugins = ["dep:…"]   # the v2 plugin host, runtime supervisor, and view-tree renderer
+```
+
+Every v2 module is `#[cfg(feature = "plugins")]` at its root. `cd.yml` builds
+stable **without** the feature, so the released v1 binary does not contain the
+plugin host in a disabled state — it does not contain it at all. The nightly
+workflow builds **with** it.
+
+| Property | How it is obtained |
+|---|---|
+| Stable can never ship v2 (C1) | The stable build does not compile the v2 modules |
+| v1 velocity is untouched (C2) | There is no second branch, so there is nothing to merge |
+| No CI widening | Every PR targets `main` and runs the existing required suite |
+| Both configurations stay green | CI adds one matrix leg building and testing `--features plugins` |
+| Abandonment is cheap | Deleting a Cargo feature is an ordinary PR |
+| Exposure is incremental | The gate's default can move at a stage boundary (§3) without a version cut |
+| No artifact-size regression at all | The Luau VM is kilobytes of linked code, not a vendored runtime ([ADR-V3](ARCHITECTURE.md#adr-v3)) |
+
+### Costs, accepted explicitly
+
+- **Two configurations.** `cargo clippy` and `cargo nextest` run twice in CI.
+  This is the direct price of C2 and it is paid in machine time, not in
+  contributor attention.
+- **Coexisting implementations.** A migrated pane exists twice — the native
+  Rust pane and its plugin — from the moment the plugin lands until Stage C.
+  §5 covers why that is cheaper than it sounds, and how it ends.
+- **`cfg` branching at dispatch sites.** Each migrated pane adds one branch in
+  `App::view`, removed with the native pane.
+
+### What this does *not* change
+
+The v1 release process is byte-identical to today: `cd.yml`'s push trigger names
+`main` and nothing else, `cog bump --auto` reads the same history, and the four
+platform artifacts are built from a feature set that has not moved. A v1 fix in
+the middle of Phase 2 is the same PR it would have been before v2 started.
+
+---
+
+## 3. Three stages, three gate positions
+
+This is the part that most reduces risk, and it follows from one observation:
+
+> **Almost all of v2 is additive.** The plugin host, the VM, the
+> view-tree renderer, the `@thurbox` modules, the command registry, the CLI
+> verbs — none of it removes v1 behavior. Only the final pane swaps and the
+> extension teardown do.
+
+So the **value** of v2 (anyone can write a pane) does not have to wait for the
+**breakage** of v2 (native panes deleted, `[features]` flags replaced,
+`extensions/` removed). Splitting them is free, and it moves the interesting
+half months earlier onto the stable channel.
+
+| Stage | Cargo `plugins` | Runtime `[features] plugins` | Ships as |
+|---|---|---|---|---|
+| **A — Development** | off by default | — | nightly only |
+| **B — Experimental** | **on** by default | off by default | an ordinary v1 **minor** release |
+| **C — Default** | on | **on** by default | **2.0.0** |
+
+### Stage A — development
+
+The gate is off in stable builds; only nightly compiles the feature. Phases 0
+through 5 of [MIGRATION.md](MIGRATION.md) run here — the whole plugin host, the
+service half, motion, the bundled plugins, and the command registry. Nothing
+about v2 is reachable by a stable user, and nothing about v1 is harder to ship.
+
+Phase 0 is the exception that proves the model: it is ungated, because it is
+behavior-preserving and snapshot-identical, so it ships to v1 users immediately
+and gets exercised by them before anything depends on it.
+
+### Stage B — experimental, on the stable channel
+
+Once the plugin host is stable enough to write against, the Cargo feature flips
+to **default on** and thurbox ships it in a normal v1 minor release. The runtime
+setting `[features] plugins` still defaults to `false`, so:
+
+- A user who does nothing gets v1, unchanged, with every native pane intact.
+- A user who sets `plugins = true` and points `THURBOX_PLUGIN_RUNTIME` at their
+  gets the plugin host, additively, alongside the native panes.
+
+Three things fall out, and each is worth more than it costs:
+
+1. **The API gets real users before it is frozen.**
+   [N4](CONSTITUTION-DELTA.md#n4--the-plugin-api-is-additive-within-a-major-version)
+   makes the protocol additive-only within a major version. Freezing it at 2.0.0
+   having only ever been used by its authors is how plugin APIs acquire
+   permanent mistakes. Stage B is the period in which those mistakes are still
+   free to fix.
+2. **Artifact size is a non-issue.** [ADR-V3](ARCHITECTURE.md#adr-v3) links the
+   Luau VM into the binary, which costs a few hundred kilobytes — not the
+   40–90 MB per archive a bundled JavaScript runtime would have. There is no
+   staged rollout to design around it and no packaging channel (`packaging/`:
+   brew, AUR, Chocolatey, winget) that needs changing. The single-binary install
+   survives Stage C untouched.
+3. **The remaining runtime question is a build question, and CI answers it.**
+   "Does `mlua`'s vendored Luau cross-build for Windows ARM64, musl, and the
+   macOS universal build?" is settled by a green matrix in Phase 0, not by
+   months of user reports — because nothing has to be *found* on the user's
+   machine at runtime ([MIGRATION §open questions](MIGRATION.md#9-open-questions)).
+
+**Exit criterion for Stage B**: the protocol has gone one full minor release
+without a non-additive change, and at least one plugin exists that thurbox did
+not write.
+
+### Stage C — default, and 2.0.0
+
+The runtime setting defaults to `true`, the runtime is bundled, the native panes
+are deleted, `[features]` flags are replaced by `thurbox plugin enable|disable`,
+and the v1 extension system is removed. This is the breaking release, and by the
+time it happens every part of it except the deletions has been running on the
+stable channel for months.
+
+### Cutting the stage transitions by hand
+
+Each stage transition is a flag flip, and a flag flip is not something the
+release train can be trusted to price correctly. The train reads commit *types*:
+flipping `plugins` from off to on by default is one line of `Cargo.toml`, which
+`cog bump --auto` will read as whatever the commit was labelled — and which the
+artifact-relevance gate will happily wave through, because `Cargo.toml` is on
+its path list. The version that ships a stage transition should be chosen, not
+computed.
+
+`cd.yml` already has the mechanism: a `workflow_dispatch` with a `version`
+input, which runs `cog bump --version <v>` instead of `--auto` and **skips the
+artifact-relevance gate** — an explicit human cut is always honoured. It is how
+v1 crossed 0.x → 1.0.0, and it carries over unchanged.
+
+| Transition | How it is cut | Why |
+|---|---|---|
+| Any ordinary v1 release, during any stage | The train — push to `main` | Unchanged from today. This is the common case and stays automatic |
+| **A → B** (`plugins` on by default in Cargo) | Dispatch with an explicit minor, e.g. `1.9.0` | The train would compute *a* version from the flip commit's type; which minor carries the plugin host to stable users is a decision, and it is announced |
+| **B → C** (2.0.0) | Dispatch with `2.0.0` | The breaking release. `cog bump --auto` reaches a major from 1.x only via a `BREAKING CHANGE` footer, which makes the biggest release in the project's history contingent on a commit-message convention. Dispatch it |
+| A hotfix on a stage-transition release | The train | Ordinary `fix`, ordinary patch |
+
+Two properties of the dispatch path matter here and are easy to lose:
+
+1. **A forced cut skips the relevance gate, not the invariants.** §9's rules
+   still bind — in particular, a dispatched release before Stage C must not
+   build `--features plugins`. The gate lives in `cd.yml`'s build matrix, not
+   in the trigger, so this holds by construction; the workflow-lint script that
+   checks invariants 1–4 should assert it against the dispatch path too, since
+   a hand-typed version is exactly the moment someone is also hand-editing the
+   workflow.
+2. **A dispatch cannot rescue a bad trunk.** It tags whatever `main` is at, and
+   the same CI must be green. Manual means *choosing the version*, not
+   *bypassing the checks* — if that distinction ever blurs, the manual path has
+   become the thing the train exists to prevent.
+
+---
+
+## 4. The nightly channel
+
+People who want to try v2 before Stage B need builds, and those builds must be
+unmistakably not stable.
+
+### 4.1 The workflow
+
+A `nightly.yml` on `main`, triggered by `schedule` (daily) and
+`workflow_dispatch` (§4.3), which:
+
+- runs only if the day's `main` is CI-green — a red trunk produces no nightly
+  rather than a broken artifact;
+- builds the same four platform artifacts `cd.yml` builds, **with
+  `--features plugins`**;
+- publishes a GitHub release with **`prerelease: true`**;
+- **runs none of** `publish-homebrew`, `publish-aur`, `publish-chocolatey`,
+  `publish-winget`;
+- prunes to the most recent 14 nightlies, so the release list stays finite.
+
+The package channels are the sharpest edge. Homebrew and the AUR update
+automatically, and Chocolatey and winget go through moderation queues a
+prerelease would pollute — the same queues the throttles in `cd.yml` already
+exist to protect. None of them should see a v2 artifact before 2.0.0.
+
+Building nightly from `main` rather than from a branch has a property the branch
+model could not offer: **a nightly is a stable build plus one Cargo feature.**
+Any difference in behavior is attributable to the feature, because nothing else
+differs.
+
+### 4.2 Tag naming, and why it is not semver
+
+Nightly tags are **non-semver**: `nightly-2026-08-08`, not
+`v2.0.0-nightly.20260808`.
+
+Cocogitto computes the next version from the latest tag reachable from the
+branch, and under this model nightly tags are reachable from `main`
+immediately — there is no branch separating them. A semver-shaped prerelease tag
+is exactly what a version calculator will try to interpret; a tag that does not
+parse as semver is skipped instead.
+
+**This must be verified against cocogitto's actual tag filter before the first
+nightly ships**, not assumed. It is now a release-blocking check rather than a
+background question, because trunk-based delivery makes the tags reachable on
+day one instead of at the merge. If `cog` rejects unparseable tags rather than
+ignoring them, the fallback is to publish nightlies as releases pointing at a
+SHA with no tag at all.
+
+### 4.3 Triggering a nightly by hand
+
+The daily schedule is the floor, not the only path. `workflow_dispatch` on
+`nightly.yml` covers the cases the schedule cannot:
+
+- **A plugin author needs today's host**, and the API changed this morning.
+  Waiting until tomorrow's build to hand them an artifact is the kind of
+  friction that loses the third-party plugin Stage B's exit criterion depends
+  on.
+- **The scheduled build was skipped** because `main` was red at the time, and
+  the fix has since landed.
+- **Verifying the nightly pipeline itself** without waiting a day per attempt —
+  which matters most at Phase 0, when nothing has run yet.
+
+Two inputs, both optional:
+
+| Input | Default | Effect |
+|---|---|---|
+| `ref` | `main` | Build a specific branch or SHA |
+| `tag_suffix` | none | Disambiguates a second nightly on one day (`nightly-2026-08-08.2`), so a re-run does not collide with the scheduled tag |
+
+**A dispatched nightly obeys every rule the scheduled one does** — `prerelease:
+true`, no package-channel job, the 14-build prune, the CI-green guard. The
+trigger changes when a build happens, never what it is.
+
+The `ref` input carries one caveat worth stating, because it quietly costs the
+property §4.1 is built on: a nightly built from a branch is **no longer "stable
+plus one Cargo feature"**, so a behavior difference is no longer attributable to
+the feature alone. That is an acceptable trade for handing someone a build of an
+unmerged change, and a bad one for anything a bug report will be filed against.
+Branch-built nightlies should carry `tag_suffix` naming the branch, so the tag
+says what it is.
+
+### 4.4 Installing a nightly
+
+Both installers already accept an explicit version, so no installer feature is
+needed:
+
+```bash
+VERSION=nightly-2026-08-08 curl -fsSL .../install.sh | sh
+THURBOX_VERSION=nightly-2026-08-08 irm .../install.ps1 | iex
+```
+
+---
+
+## 5. Why coexistence beats divergence
+
+The one real cost of the trunk model is that a migrated pane exists twice
+between the day its plugin lands and Stage C. This is the objection to answer,
+because [MIGRATION.md](MIGRATION.md)'s earlier principle was "delete on
+completion — no dual implementations".
+
+That principle is **amended**: deletion is gated on the plugin becoming the
+*default* for that pane, not on the plugin merely existing.
+
+Four things make the interim cheap:
+
+1. **A frozen implementation costs almost nothing.** The Rust tasks pane is
+   finished. It is not being edited during the migration; it is being kept
+   compiling. The maintenance burden of code nobody touches is close to zero,
+   and it is bounded — it ends at Stage C.
+2. **The pair is self-checking.** Constitution rule 10, as amended in
+   [CONSTITUTION-DELTA.md](CONSTITUTION-DELTA.md#rule-10--test-driven-development),
+   requires a migrated pane to pass the tests its predecessor passed. With both
+   present, the same insta snapshot is asserted against both implementations in
+   the same run. Under the branch model the native pane's snapshot would be a
+   memory of another branch; here it is a live assertion.
+3. **Deletion is still per-pane and still one PR.** At Stage C each pane is
+   deleted in the PR that flips it to plugin-default, along with its
+   `InputFocus`, `Action`, `PanelAreas`, `ClickAction`, and `FeatureFlags`
+   entries — the same bisectable, per-pane teardown the branch model wanted, on
+   the trunk.
+4. **It is an insurance policy the branch model cannot offer.** If one pane's
+   migration stalls, 2.0.0 can ship with that pane still native. The failure
+   mode degrades to "the code review isn't a plugin yet" instead of blocking the
+   release or forcing a bad merge.
+
+---
+
+## 6. CI
+
+Three changes, all on `main`, all small:
+
+| Change | Why |
+|---|---|
+| A `--features plugins` matrix leg (build, clippy, nextest) | Otherwise the gated code rots and Stage B is a surprise |
+| Luau toolchain — `luau-analyze` strict, plugin test runner | Constitution rule 3 as extended in [CONSTITUTION-DELTA.md](CONSTITUTION-DELTA.md). Lands in Phase 0 so the first Luau PR does not also carry the toolchain |
+| A workflow-invariant lint (§9) | Invariants 1–3 are one script and are expensive to discover broken |
+
+Notably absent: widening `ci.yml`'s `pull_request` trigger. Under the branch
+model that was a prerequisite hazard — a PR into `v2` would have run no checks
+at all. With one trunk, the existing `branches: [main]` trigger already covers
+every v2 PR. **The trunk model deletes that hazard rather than mitigating it.**
+
+The `check-release` gate in `cd.yml` needs no change: its `shipped` step already
+keys on `src/`, `Cargo.toml`, and friends, so v2 work on `main` participates in
+v1 releases exactly as any other source change does — which is correct, because
+it *is* in the source tree even when it is not in the binary.
+
+---
+
+## 7. The installer hazard
+
+Publishing nightlies as prereleases is safe on the **primary** version-resolution
+path and unsafe on **both fallback** paths. Both installers resolve a version in
+two steps:
+
+```sh
+# Primary — safe. GitHub's releases/latest excludes prereleases and drafts.
+fetch_url "https://api.github.com/repos/${REPO}/releases/latest"
+
+# Fallback — scrapes the releases page, which DOES list prereleases.
+grep -o 'releases/tag/v[0-9.]*' | head -1
+```
+
+`install.sh`'s character class is `[0-9.]`, so a nightly tagged
+`v2.0.0-nightly.20260808` would match as `v2.0.0` — a version that does not exist
+as a release, failing later at asset download with a confusing 404.
+`install.ps1`'s pattern is worse, because it accepts the whole tag:
+
+```powershell
+[regex]::Match($page.Content, 'releases/tag/(v[0-9][0-9A-Za-z.\-+]*)')
+```
+
+A Windows user whose API call failed would install a v2 nightly believing it to
+be stable.
+
+**§4.2 already defuses this.** Both patterns anchor on a literal `v`, and
+`nightly-2026-08-08` has no `v`, so neither fallback can match a nightly under
+the chosen tag format — the scrape skips it and finds the newest `v1.x.y` on the
+page, which is the correct answer. The two sections were written independently
+and the interaction went unnoticed; it is stated here so nobody "fixes" the tag
+format back to something semver-shaped without realizing it re-arms the bug.
+
+**The fix is still required**, as defense in depth and as the thing that *keeps*
+the property true: both fallbacks should accept only `v<major>.<minor>.<patch>`
+with no suffix, with a regression test using a prerelease fixture in the existing
+`scripts/install.bats` and `scripts/install.Tests.ps1` suites. It is a small,
+testable change with CI jobs already gating both files. It is no longer a release
+blocker for the first nightly — it is a Phase 0 hardening item.
+
+---
+
+## 8. The website
+
+### 8.1 Shape
+
+| Path | Serves |
+|---|---|
+| `/` and `/docs/*` | v1 stable — unchanged, and the default for every visitor |
+| `/v2/*` | v2 documentation |
+
+Stable stays at the root deliberately. Most visitors want the thing they can
+install today, and moving v1 to `/v1/` would break every existing inbound link
+and search result for the sake of symmetry.
+
+### 8.2 Build mechanics
+
+The existing `website.11tydata.js` computes permalinks from `filePathStem`, so
+`website/v2/installation.html` already emits `/v2/installation.html` with **no
+config change**.
+
+Because there is no branch, that is the entire mechanism. The v2 pages live at
+`website/v2/` on `main`, next to the code they describe, and `pages.yml` builds
+them in the same pass as everything else. The cross-branch checkout the earlier
+draft needed — and the fallback it needed for that — are both gone.
+
+`pages.yml` already has `workflow_dispatch` and triggers on `website/**`, so no
+trigger change is required either.
+
+### 8.3 Required affordances
+
+Serving two versions is mostly a question of never letting someone read the
+wrong one by accident:
+
+| Affordance | Why |
+|---|---|
+| **Version switcher** in the docs chrome (`base.njk` / `sidebar.njk`) | The only way to move deliberately between trees |
+| **Persistent banner** on every `/v2/` page — naming the current stage, and stating that it is not installable via Homebrew/winget/Chocolatey/AUR | A visitor arriving from search has no other signal |
+| **`noindex`** on `/v2/*` until 2.0.0 | Otherwise v2 pages compete with v1 in search results, which is precisely the accident C1 forbids |
+| **Exclude `/v2/` from `sitemap.njk`** | The sitemap is generated; without this it advertises the v2 tree |
+| **No install commands on `/v2/`** that do not carry an explicit `VERSION=` | A copy-pasteable stable-looking command on a v2 page is the easiest way to get this wrong |
+
+The banner's text is stage-dependent, which is the one place the website has to
+track §3: at Stage A it reads "unreleased", at Stage B "experimental, opt-in in
+v1.x", at Stage C it is removed.
+
+At 2.0.0 the switch is: drop `noindex`, add v2 to the sitemap, move `/v2/` to
+`/`, and archive the v1 tree at `/v1/` with canonical tags pointing forward.
+
+### 8.4 Sidebar
+
+`sidebar.njk` hardcodes its section tree in a `{%- set sections = [...] %}`
+block. Two trees means either duplicating that block or lifting it into
+`website/_data/nav.js` keyed by version. The data-file route is the better one —
+it is the same amount of work either way, and it stops the two sidebars
+drifting.
+
+---
+
+## 9. Invariants
+
+Things that must remain true for the whole refactor. Each is cheap to check and
+expensive to discover broken:
+
+1. `cd.yml`'s push trigger names `main` and nothing else.
+2. `cd.yml` never builds with `--features plugins` before Stage C.
+3. No package-channel publish job ever runs from `nightly.yml`.
+4. Every nightly GitHub release has `prerelease: true`.
+5. `install.sh` and `install.ps1`, with no version pinned, resolve to the latest
+   **stable** tag — including when the API path fails and the scrape fallback
+   runs (§7).
+6. `/v2/` is `noindex` and absent from the sitemap until 2.0.0.
+7. The `--features plugins` CI leg is required, not advisory. A gated feature
+   that is allowed to fail is a gated feature that is broken.
+8. A dispatched release is subject to invariants 1–7 exactly as a pushed one
+   is. The `version` input chooses a number; it never relaxes a gate.
+
+Invariants 1–4 are enforceable by a small workflow-lint script, in the spirit of
+Constitution rule 11. Invariant 5 belongs in `install.bats` and
+`install.Tests.ps1` as a regression test with a prerelease fixture. Invariant 7
+is a branch-protection setting.
+
+---
+
+## 10. Fallback: the branch model
+
+Trunk-based delivery is the plan. The branch model is the documented retreat, so
+that adopting it later is a decision rather than a capitulation.
+
+**Adopt a `v2` branch if any of these fire:**
+
+1. **A v2 PR breaks the stable build twice in one month.** That would mean the
+   `cfg` boundary is not holding and the compile-time gate is not buying C1.
+2. **The `cfg` surface in `app/mod.rs` exceeds roughly 20 branch sites.** Past
+   that, the dispatch layer is being maintained in two shapes at once and the
+   coexistence argument in §5 stops holding.
+3. **Stage B slips past the point where the trunk carries more v2 than v1.** If
+   most of `main` is gated code, the gate has become a branch with worse
+   ergonomics.
+
+If adopted, the earlier plan applies in full: widen `ci.yml` to
+`pull_request: branches: [main, v2]` **first**, merge `main` → `v2` at every v1
+release, never reverse the direction, and cut 2.0.0 with a merge commit rather
+than a squash so the per-pane deletions stay bisectable.
+
+---
+
+## 11. Open questions
+
+1. **Does cocogitto ignore or reject non-semver tags?** §4.2 depends on it, and
+   under trunk-based delivery nightly tags are reachable from `main`
+   immediately. Verify before the first nightly.
+2. **Where exactly does the Cargo feature boundary fall?** Some Phase 0 work
+   (the view-tree types in `session::view`, the native renderer in `ui/`) is
+   behavior-preserving and belongs in stable ungated; the host and runtime are
+   clearly gated. The renderer is the ambiguous one, and the answer should be
+   "ungated" if its snapshots are byte-identical.
+3. **Does the demo recording pipeline need a v2 variant?**
+   `scripts/demo/record.sh` drives the real TUI, and v2's panes will diverge
+   visually before 2.0.0. The website's hero media is currently shared between
+   both trees.
+4. **Docs-site search**, if added later, must be scoped per version — one index
+   across both trees reintroduces exactly the confusion §8.3 prevents.

--- a/docs/v2/SECURITY.md
+++ b/docs/v2/SECURITY.md
@@ -1,0 +1,316 @@
+# Thurbox v2 — Security Model
+
+v2 introduces something v1 does not have: **third-party code running
+continuously inside a tool that holds credentials, drives shells on remote
+hosts, and is operated by LLM agents**. This document states the threat model,
+what the capability system does and does not buy, and the changes required
+before third-party plugins are installable.
+
+It is written to be uncomfortable where the design is weak. Two of the findings
+it once recorded have since been closed by
+[ADR-V2](ARCHITECTURE.md#adr-v2) — §3 and §4 keep the history, because a
+capability model that was once decorative is worth remembering as one.
+
+---
+
+## 1. What capabilities are
+
+Capabilities are an **informed-consent and least-privilege** mechanism. They
+are not a sandbox, and the docs say so — but the phrasing has been doing more
+work than the mechanism can support, which §3 corrects.
+
+| They do | They do not |
+|---|---|
+| Make a plugin declare its reach before it runs | Confine a plugin that lies or is compromised |
+| Let the installer show that reach to a human | Prevent a granted capability being abused |
+| Bind only the host functions a plugin declared | Make a granted capability safe to hand out |
+| Keep an unprivileged pane genuinely unprivileged | Make `shell`, `pty`, or broad `fs` anything less than full trust |
+
+The honest summary: **all sixteen capabilities are enforced** — §3. What they
+do not do is make a *granted* capability safe.
+
+---
+
+## 2. Trust boundaries and assets
+
+```text
+┌─ user's account ───────────────────────────────────────────────┐
+│                                                                │
+│  thurbox kernel ──calls──▶ plugin VM + thread (per plugin)     │
+│      │                        ▲                                │
+│      │                        └── same UID and process; reaches │
+│      │                            env/fs/net only via bindings  │
+│      │                                                         │
+│      ├──▶ tmux ──▶ agent CLIs (hold provider credentials)      │
+│      ├──▶ ssh ──▶ remote hosts (worktrees, shells)             │
+│      ├──▶ SQLite (sessions, tasks, messages, plugin data)      │
+│      └──▶ control socket ◀── thurbox-cli, agents, any local    │
+│                              process that can open it          │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Assets worth protecting**, in rough order of severity:
+
+1. **Provider credentials** — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+   `GITHUB_TOKEN`, `~/.claude`, `~/.codex`, ssh keys. thurbox's whole purpose
+   is running CLIs that authenticate.
+2. **Source code** across every repo the user has a session in.
+3. **Remote hosts** — a `sessions = control` plugin can spawn shells on any
+   host in `hosts.toml`.
+4. **The user's git history** — a plugin with `shell` can force-push.
+5. Session/task/message state in SQLite.
+
+**Adversaries**, in rough order of likelihood:
+
+| Adversary | Vector |
+|---|---|
+| A careless plugin | Overbroad capabilities, leaked secrets in logs |
+| A compromised vendored module | A plugin vendors a Luau module it does not audit |
+| A malicious plugin | Published to look useful |
+| **Prompt injection via an agent** | Untrusted text (PR comment, issue body, CI log) instructing an agent to invoke a destructive command |
+| A hostile local process | Connecting to the control socket |
+
+The fourth is not hypothetical for this project: thurbox's own PR-watching
+workflows feed GitHub comment bodies to agents, and `docs/v2` makes every
+plugin command agent-callable.
+
+---
+
+## 3. Resolved — `fs`, `net` and `shell` are now enforced
+
+**This section previously recorded a defect.** An earlier draft of
+[FEATURES-Plugin-API.md §7](FEATURES-Plugin-API.md#7-host-api) claimed `fs`
+was "enforced on the runtime process itself", which was not implementable on
+Bun — no shipping JavaScript runtime except Deno has a permission model, so
+`fs`, `net` and `shell` were declared but unenforceable, and three of sixteen
+capabilities were theatre.
+
+[ADR-V2](ARCHITECTURE.md#adr-v2) closes it. Under Luau the enforcement is not
+a check the kernel performs — it is an **absence**:
+
+| Capability | How it is enforced |
+|---|---|
+| `fs` | There is no `io` table in the plugin's environment unless the kernel binds one, scoped to the granted paths |
+| `net` | No socket or HTTP library exists unless `ctx.fetch` is bound, and it is bound with the host allowlist baked in |
+| `shell` | No `os.execute`, no `io.popen`. `ctx.exec` exists only when granted |
+| `require` | Not bound. Module resolution is the kernel's, so a plugin cannot reach outside its own directory |
+
+All sixteen capabilities are now enforced, and
+[N3](CONSTITUTION-DELTA.md#n3--capabilities-are-declared-gated-and-shown) is
+restored to its full form rather than narrowed to "gated where gateable".
+
+### What this does *not* make it
+
+A sandbox is not a proof. Two honest caveats:
+
+- **Lua sandbox escapes are a real class**, historically via metatables, the
+  string metatable, `debug`, and coroutine tricks. Luau is hardened against
+  these — read-only tables, `safeenv`, no `debug` by default, no
+  `setfenv`/`getfenv` — and Roblox's business depends on the hardening holding
+  against a far more adversarial population than thurbox will ever have. But
+  "hardened by a company with strong incentives" is a different claim from
+  "proven", and the design should not pretend otherwise.
+- **A granted capability is still full trust in its domain.** `shell = true`
+  is arbitrary code execution; `fs` over `{repo}` can read every secret in the
+  repo. Capabilities constrain reach, not intent.
+
+### What replaces the old open decision
+
+The Bun-versus-Deno choice this section used to leave open is moot — there is
+no JavaScript runtime. The remaining runtime risk is different in kind: a
+memory-safety bug in the Luau VM itself would be in-process, and
+[C2](ARCHITECTURE.md#adr-v2) (no native code in plugins) is what keeps that
+surface to the VM rather than to every plugin's dependency tree.
+
+---
+
+## 4. Plugin environment
+
+Out of process, the danger was inheritance: a child process gets the parent's
+environment by default, and thurbox's holds `ANTHROPIC_API_KEY`,
+`GITHUB_TOKEN` and similar. A plugin with no capabilities at all could have
+read them from `process.env`.
+
+In-process there is **no ambient environment to inherit**. A Luau VM has no
+`os.getenv` unless the kernel binds one, so the exposure is opt-in rather than
+opt-out — the inverse of the process model's default, and strictly safer.
+
+**Required, and now trivial**:
+
+- Do not bind `os.getenv` at all. A plugin needing configuration reads a
+  declared setting or a path granted under `fs`.
+- The `THURBOX_*` identity vars a plugin legitimately needs (`THURBOX_SESSION`,
+  `THURBOX_TASK`) are exposed as typed fields on `ctx`, not as environment
+  lookups.
+- `ctx.exec`, when granted, spawns children with a **scrubbed environment** —
+  an explicit allowlist plus `THURBOX_*`. The inheritance hazard moves from
+  the plugin to the processes a plugin spawns, and that is where it must be
+  handled.
+
+An earlier draft of this document claimed in-process would make environment
+scrubbing *harder*. That was true of an embedded JavaScript engine with Node
+compatibility, and false of Luau, where the binding simply does not exist.
+
+---
+
+## 5. The control socket
+
+[FEATURES-Agent-API.md §6](FEATURES-Agent-API.md#6-control-socket) places a control socket at
+`$XDG_RUNTIME_DIR/thurbox/control.sock` exposing `command/run`,
+`event/subscribe`, and `state/query` — enough to create sessions, drive panes,
+and run every plugin command. Its permissions are unspecified.
+
+**Required**:
+
+- Socket mode `0600`, in a directory the kernel creates `0700`, with an
+  ownership check on connect. `$XDG_RUNTIME_DIR` is usually already
+  user-private; when it is unset the fallback path must not be world-writable
+  `/tmp`.
+- On Windows, a named pipe with an explicit DACL granting the current user
+  only — the default is more permissive than people expect.
+- Reject connections whose peer UID differs from the kernel's (`SO_PEERCRED` /
+  `LOCAL_PEERCRED`).
+- The socket exists only while the TUI runs, and is unlinked on shutdown and on
+  the panic path.
+
+Without this, any local process — including a compromised dependency in an
+unrelated project — can drive the user's thurbox.
+
+---
+
+## 6. Supply chain
+
+v1 pinned official extensions to the binary's release tag, which was a real
+integrity property. v2's `plugin install <name|url|path>` has no stated
+equivalent.
+
+**Required before third-party plugins are installable**:
+
+| Control | Why |
+|---|---|
+| A lockfile recording resolved version **and content hash** per plugin and per dependency | `plugin update` must be able to detect substitution, not just a version change |
+| Official plugins pinned to the binary's release tag, as v1 did | Keeps the fetched plugin matched to the binary |
+| `plugin install` prints the capability set and prompts on anything beyond `db` | Already specified; it is the consent moment |
+| Deterministic re-resolution — no floating ranges at install time | A reinstall must produce the same bytes |
+| License allowlist for bundled plugins in CI | Already specified in the Rule 4/5 amendment. There is no package manager to audit ([ADR-V2](ARCHITECTURE.md#adr-v2)), so the whole supply chain is the plugin's own source |
+
+Signature verification is **not** proposed for 2.0.0: it needs a key
+distribution story thurbox does not have, and a lockfile with content hashes
+gets most of the benefit.
+
+---
+
+## 7. Agent-driven execution and prompt injection
+
+[ADR-V10](ARCHITECTURE.md#adr-v10) makes every plugin command agent-callable,
+and thurbox agents routinely read untrusted text. The existing controls are
+sound as far as they go: per-command `agent_policy` (`allow`/`confirm`/`deny`)
+and a depth-3 loop guard.
+
+What is missing is the **threat being named** and the **defaults being derived
+from it**:
+
+- A command that deletes, force-pushes, installs, or spawns a process defaults
+  to `confirm` or `deny`. A plugin opts *down* explicitly, and `plugin doctor`
+  reports every command that did.
+- `plugin.install`, `plugin enable`, and anything mutating capabilities are
+  `deny` — permanently. An agent must never be able to widen its own reach.
+- `thurbox-cli command list` already reports policy, so an agent can tell in
+  advance which calls block on a human. That is the property to preserve.
+
+The realistic attack is not an agent turning malicious; it is an agent
+faithfully following instructions embedded in a PR comment it was asked to
+summarize. Confirmation prompts are the control, and they only work if the
+dangerous defaults are conservative from the start.
+
+---
+
+## 8. Spawn contributions
+
+[FEATURES-Backend-API.md §11](FEATURES-Backend-API.md#11-spawn-contributions) lets a plugin append
+env vars and args to spawned agent sessions. Append-only and veto-free bounds
+*who wins*, not *what can be injected*.
+
+Appending `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `GIT_SSH_COMMAND`,
+`GIT_EXTERNAL_DIFF`, `BASH_ENV`, `NODE_OPTIONS`, or `PATH` turns a spawn
+contribution into arbitrary code execution inside every agent session.
+
+**Required**: a denylist of env keys a contribution may not set, plus a rule
+that `PATH` may only be prepended with paths under `{plugin_data}`. Rejections
+are logged and surfaced in `plugin doctor` rather than silently dropped.
+
+---
+
+## 9. Remote blast radius
+
+A plugin with `sessions = "control"` can spawn on any host in `hosts.toml`.
+The reach is therefore not bounded by the local machine, and neither the
+install prompt nor the capability table says so.
+
+**Required**: `sessions = "control"` is described at install as granting
+*local and remote* session creation, and `plugin doctor` lists which hosts are
+reachable. A finer `sessions = "control-local"` is worth considering but is
+not proposed for 2.0.0 — one more axis for a distinction most plugins will not
+use.
+
+---
+
+## 10. What is already sound
+
+Worth stating, so the findings above are read in proportion:
+
+- **VM isolation** ([ADR-V4](ARCHITECTURE.md#adr-v4)) genuinely contains
+  errors, hangs and runaway memory: an uncaught error unwinds one VM, the
+  interrupt handler stops a spinning one, and `set_memory_limit` caps its
+  allocation. What it does *not* contain is memory corruption, which is why
+  [C2](ARCHITECTURE.md#adr-v2) forbids native code in a plugin.
+- **The kernel renders**
+  ([N1](CONSTITUTION-DELTA.md#n1--the-kernel-renders-plugins-describe)) —
+  view-tree text is escape-stripped when the tree is converted at push time, so
+  a plugin cannot emit OSC 52 to steal the clipboard or rewrite the user's
+  terminal title. The `surface` carve-out
+  terminates escapes in the kernel's own parser.
+- **No raw SQL handle** ([ADR-V17](ARCHITECTURE.md#adr-v17)) — namespace
+  rewriting means a plugin cannot read the sessions table or another plugin's
+  data.
+- **Default-deny capabilities** — a plugin that declares nothing can draw and
+  nothing else.
+- **`pty` is correctly classified** as arbitrary code execution rather than a
+  weaker `shell`.
+- **Stdout is the protocol**, so a plugin cannot smuggle escape sequences to
+  the terminal through logging.
+
+---
+
+## 11. Required before third-party plugins are installable
+
+Ordered by severity. The first two are gating.
+
+| # | Change | Phase |
+|---|---|---|
+| 1 | No `os.getenv` binding; `ctx.exec` children get a scrubbed environment (§4) | 1 |
+| 2 | ~~Resolve the enforcement gap~~ — closed by [ADR-V2](ARCHITECTURE.md#adr-v2) (§3) | done |
+| 3 | Control-socket permissions, peer-UID check, Windows DACL (§5) | 5 |
+| 4 | Spawn-contribution env denylist (§8) | 2 |
+| 5 | Conservative `agent_policy` defaults for destructive verbs (§7) | 5 |
+| 6 | Lockfile with content hashes; official plugins tag-pinned (§6) | before a public registry |
+| 7 | Install prompt names remote reach for `sessions = control` (§9) | 1 |
+
+Items 1, 3, 4, and 7 are each small and testable. Item 2 is a decision, not an
+implementation, and item 6 is a prerequisite for a surface (a public registry)
+that 2.0.0 does not ship.
+
+---
+
+## 12. Non-goals
+
+- **A real sandbox for plugins on Bun.** Rejected as out of scope for 2.0.0
+  (§3 option C).
+- **Signature verification.** No key distribution story yet (§6).
+- **Defending against a malicious *kernel* build.** If thurbox itself is
+  compromised, nothing here helps.
+- **Multi-user isolation.** thurbox is single-user; the control socket is
+  local and owner-only by §5, and that is the whole model.
+- **Protecting the user from their own agents.** An agent with a shell in a
+  worktree can do what the user can. Confirmation prompts reduce accidents,
+  not authority.

--- a/docs/v2/VISION.md
+++ b/docs/v2/VISION.md
@@ -1,0 +1,208 @@
+# Thurbox v2 — Vision
+
+## The problem v1 has
+
+Thurbox v1 works, and its architecture is coherent: one `App` model, one
+`view()`, strict module isolation, deterministic tests. But every user-visible
+surface is compiled in, and the cost of that shows up as a **cross-cutting tax
+on every new pane**.
+
+Adding one pane to v1 means touching, at minimum:
+
+| Site | v1 size today |
+|---|---|
+| `App` struct fields | 80 fields |
+| `InputFocus` | 11 variants |
+| `Action` | 61 variants |
+| `KeyContext` | 6 variants |
+| `FeatureFlags` | 13 flags |
+| `PanelAreas` + `compute_layout` | 10 fixed rects, 9-argument signature |
+| `ClickAction` | 17 variants |
+| `App::view` + a `ui/` module | 36 modules, 2,273 lines of view dispatch |
+| `SettingsField`, `focus_ring`, `enforce_feature_visibility` | 3 more parallel tables |
+| Acceptance snapshots | 7 pinned screens |
+
+`src/app/mod.rs` is 14,605 lines. The tasks pane, the file viewer, the code
+review, and the automations pane are all *features of the binary* rather than
+things that plug into it. Three consequences follow:
+
+1. **Nobody but us can add a pane.** A user who wants a Jira column, a CI
+   dashboard, or a log tailer must fork a 95k-line Rust codebase, learn the
+   TEA conventions, and ship a build.
+2. **Every experiment is permanent.** A pane cannot be tried out, iterated on
+   in an afternoon, and thrown away — it must survive review, clippy, the
+   architecture rules test, and a release.
+3. **The extension system solved the wrong half.** v1's `extensions/` reach
+   agents (sessions, automations, prompts, shell scripts) but never the UI.
+   Roughly 5,000 lines of manifest/install/self-heal machinery buy zero ability
+   to draw a pane.
+
+Meanwhile the parts of thurbox that are genuinely hard — persistent tmux
+sessions across local/SSH/WSL transports, worktree orchestration, the
+demand-driven render loop, multi-instance SQLite sync — are the parts almost
+nobody needs to modify.
+
+## The v2 thesis
+
+**Split the hard kernel from the soft surface.**
+
+The Rust kernel keeps what is genuinely hard and genuinely shared: session
+lifecycle, backends, git, storage, the event loop, the layout solver, the
+theme, the keymap, and the frame. Everything a user *sees and argues about* —
+which panes exist, what they show, how they behave — moves into Luau
+plugins that load at runtime, reload without recompiling, and can be written
+by anyone in an afternoon.
+
+Prior art: neovim, wezterm and yazi all embed Lua for exactly this — a small
+sandboxed VM, discovered from a directory, reloadable without rebuilding the
+host. [pi](https://github.com/earendil-works/pi) does the same shape with
+TypeScript around an agent loop. Thurbox v2 takes the same shape and
+points it at the thing thurbox is actually good at: **many agent sessions
+across many repos and hosts**.
+
+## What changes for users
+
+**Nothing, on first launch.** The bundled plugin set ships inside the binary
+and is enabled by default, so a fresh `thurbox` looks and behaves like v1:
+session list, terminal, info panel, files, tasks, automations, review.
+
+What becomes possible:
+
+```bash
+thurbox plugin list                  # what's loaded, and what each provides
+thurbox plugin install <name|url>    # from the registry, a git URL, or a path
+thurbox plugin disable tasks         # replaces [features] tasks = false
+thurbox plugin dev ./my-plugin       # load from disk, reload on save
+```
+
+A plugin is a directory with a manifest and a Luau entry point. The
+manifest is what the pane, the command, and the keybinding *are* — the kernel
+reads it without starting anything, so the UI is complete before a line of
+plugin code runs ([ADR-V15](ARCHITECTURE.md#adr-v15)):
+
+```toml
+# plugin.toml
+name = "ci-status"
+
+[[panes]]
+id = "ci"
+slot = "right"
+title = "CI"
+
+[[commands]]
+id = "ci.refresh"
+title = "Refresh CI status"
+```
+
+```lua
+-- src/view.luau — behavior only
+local thurbox = require("@thurbox")
+local ui = thurbox.ui
+
+return thurbox.definePlugin({
+    init = function(ctx) return { runs = fetchRuns(ctx) } end,
+    render = function(ctx, s)
+        return ui.list(s.runs, function(r)
+            return ui.row(ui.text(r.name), ui.statusDot(r.state))
+        end)
+    end,
+    commands = {
+        ["ci.refresh"] = function(ctx) ctx.setState({ runs = fetchRuns(ctx) }) end,
+    },
+})
+```
+
+Because plugins declare **commands with typed schemas**, and because thurbox
+already puts an agent inside every session, those commands are callable by the
+agents themselves — a session's agent can create tasks, open a review, or
+drive a pane through the same surface a keybinding uses. Thurbox stops being a
+TUI that agents happen to run inside and becomes an orchestrator agents can
+operate. See [FEATURES-Agent-API.md](FEATURES-Agent-API.md).
+
+## What v2 is not
+
+- **Not a rewrite of the session layer.** tmux backends, the control-mode
+  protocol, SSH/WSL transports, worktrees, and the SQLite schema carry over
+  largely intact. They are the kernel.
+- **Not a plugin marketplace.** v2 ships a plugin *format*, a local install
+  path, and a small curated registry. Discovery, ratings, and sandboxed
+  third-party hosting are later problems.
+- **Not a general TUI framework.** The view tree is scoped to what thurbox
+  panes need. Plugins that want arbitrary pixels are out of scope by design —
+  see [FEATURES-View-Tree.md](FEATURES-View-Tree.md).
+- **Not a config-file replacement.** `settings.toml`, `agents.toml`,
+  `hosts.toml`, `themes.toml`, and `keybindings.json` survive. Plugins add
+  their own namespaced config; they do not restructure the existing files.
+- **Not multi-language.** The plugin runtime is Luau only. WASM guests and
+  native modules are explicitly rejected in
+  [ADR-V2](ARCHITECTURE.md#adr-v2).
+
+## How it arrives
+
+Not as a big bang. v2 lands on `main` behind a compile-time gate and the gate
+moves in three steps, so the capability reaches users well before the breakage
+does ([ADR-V20](ARCHITECTURE.md#adr-v20)):
+
+| Stage | What a user sees | Version |
+|---|---|---|
+| A | Nothing. Stable builds do not contain the plugin host | v1.x, unchanged |
+| B | Plugins work, opt-in, alongside every native pane | an ordinary v1 **minor** |
+| C | Plugins are the panes; `extensions/` gone | **2.0.0** |
+
+Stage B is the point of the exercise arriving early: a plugin author gets a
+stable binary to build against, and the protocol gets real third-party use while
+its mistakes are still free to fix. Nothing breaks until 2.0.0.
+
+## What v2 costs
+
+Stated plainly, because these are real and permanent:
+
+- **Two languages, two toolchains.** Rust *and* Luau in CI, in the pre-commit
+  hooks, and in every contributor's head.
+- **No package ecosystem.** Luau has no npm. Every capability a plugin needs
+  comes from the host or gets written by hand
+  ([ADR-V2](ARCHITECTURE.md#adr-v2)).
+- **A public API you cannot casually break.** Once third-party plugins exist,
+  the view tree, the host bindings, and the command schemas are versioned
+  surfaces.
+- **A plugin fault is closer than it was.** Plugins run in the thurbox process
+  ([ADR-V2](ARCHITECTURE.md#adr-v2)). Errors, hangs and memory are contained
+  per VM; a segfault in native code would not be, which is why plugins may not
+  carry any.
+- **A larger trust surface.** v1 extensions already run arbitrary shell, but
+  they run it *on demand*. Plugins run continuously, which is why capabilities
+  are declared and enforced ([ADR-V4](ARCHITECTURE.md#adr-v4)).
+
+The trade is deliberate: thurbox gives up a package ecosystem and absolute
+fault isolation in exchange for being extensible by its users, at no cost to
+the single-binary install.
+
+## Success criteria
+
+Each is written to be falsifiable, and the measurable ones carry their bar.
+
+**Stage B is done when:**
+
+1. A new pane can be written, loaded, and iterated on without recompiling the
+   Rust binary or restarting the TUI.
+2. [FEATURES-Plugin-API.md](FEATURES-Plugin-API.md) is sufficient to build a
+   working plugin without reading kernel source — tested by someone outside the
+   project doing it.
+3. At least one plugin exists that thurbox did not write, and one full minor
+   release has passed with no non-additive protocol change.
+
+**2.0.0 is done when, additionally:**
+
+1. The session list, terminal, info panel, files, tasks, automations, and code
+   review are plugins, and disabling any one of them leaves a working thurbox.
+2. With the default bundled set active, `first_frame_ms`
+   (`THURBOX_PERF_LOG=1`) is within **115%** of v1's, and the idle paint rate is
+   unchanged at v1's ~4 fps floor — plugins must not defeat the demand-driven
+   loop. Measured with plugins *active*, since lazy activation makes the
+   no-plugins number meaningless
+   ([MIGRATION §3](MIGRATION.md#3-the-session-list-decision-gate)).
+3. An agent inside a session can list and invoke every bundled plugin command
+   through `thurbox-cli`.
+4. The v1 `extensions/` tree is gone and its ~5,000 lines of Rust are deleted
+   rather than deprecated, with the 554 lines of hooks behavior absorbed into
+   the kernel ([MIGRATION §4](MIGRATION.md#4-teardown-inventory--the-v1-extension-system)).

--- a/justfile
+++ b/justfile
@@ -36,6 +36,7 @@ lint:
     cargo deny check advisories
     cargo deny check bans licenses sources
     rumdl check .
+    scripts/dev/check-doc-links.sh
     git ls-files -z '*.sh' | xargs -0 shellcheck
 
 # Architecture-rule + doc checks.

--- a/scripts/dev/check-doc-links.sh
+++ b/scripts/dev/check-doc-links.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Verify every relative Markdown link in the docs resolves: the target file
+# exists, and any #anchor matches a heading (or an explicit <a id="…">) in it.
+#
+# Broken cross-references are invisible to rumdl (which lints style, not links)
+# and to the compiler, so they rot silently as headings get renamed. This is the
+# deterministic check for them — Constitution rule 11.
+#
+# Usage: scripts/dev/check-doc-links.sh [path ...]     (default: docs README.md)
+set -euo pipefail
+
+targets=("$@")
+if [ "${#targets[@]}" -eq 0 ]; then
+    targets=(docs README.md)
+fi
+
+# GitHub's heading-slug rule, near enough: lowercase, drop everything that is
+# not alphanumeric/space/hyphen/underscore, then spaces to hyphens. Explicit
+# <a id="…"> anchors are emitted as-is.
+slugs_of() {
+    awk '
+        function slug(s,   out, i, c) {
+            s = tolower(s)
+            out = ""
+            for (i = 1; i <= length(s); i++) {
+                c = substr(s, i, 1)
+                if (c ~ /[a-z0-9_-]/) out = out c
+                else if (c == " ") out = out "-"
+            }
+            return out
+        }
+        /^```/ { inblock = !inblock; next }
+        inblock { next }
+        /^#+ / { line = $0; sub(/^#+ /, "", line); print slug(line) }
+        match($0, /<a id="[^"]+"/) { print substr($0, RSTART + 7, RLENGTH - 8) }
+    ' "$1"
+}
+
+broken=0
+
+while IFS= read -r -d '' file; do
+    dir=$(dirname "$file")
+    links=$({ grep -o '](<\?[^)>]*>\?)' "$file" || true; } | sed 's/^](<\?//; s/>\?)$//')
+
+    while IFS= read -r link; do
+        case "$link" in
+            '' | http://* | https://* | mailto:* | '#') continue ;;
+        esac
+
+        path=${link%%#*}
+        anchor=""
+        case "$link" in *#*) anchor=${link#*#} ;; esac
+
+        if [ -n "$path" ]; then
+            resolved="$dir/$path"
+        else
+            resolved="$file"
+        fi
+
+        if [ ! -e "$resolved" ]; then
+            echo "$file: missing target -> $link"
+            broken=$((broken + 1))
+            continue
+        fi
+
+        [ -n "$anchor" ] || continue
+        case "$resolved" in *.md) ;; *) continue ;; esac
+
+        if ! slugs_of "$resolved" | grep -qxF "$anchor"; then
+            echo "$file: bad anchor -> $link"
+            broken=$((broken + 1))
+        fi
+    done <<<"$links"
+done < <(find "${targets[@]}" -name '*.md' -not -path '*/node_modules/*' -print0)
+
+if [ "$broken" -gt 0 ]; then
+    echo >&2
+    echo "doc links: $broken broken reference(s)" >&2
+    exit 1
+fi
+
+echo "doc links: all references resolve"


### PR DESCRIPTION
Adds `docs/v2/`, the design set for **Thurbox v2**: a minimal Rust kernel hosting reloadable **Luau** plugins, where every user-visible surface — including the session list — is a plugin rather than a compiled-in pane.

**Nothing here is implemented.** `docs/` remains authoritative for the shipping product until v2 lands.

## Why

Every v1 surface is compiled in, and adding one pane means touching, at minimum: 80 `App` fields, 61 `Action` variants, 11 `InputFocus` variants, 13 feature flags, 10 fixed rects in `PanelAreas`, 15 `ClickAction` variants, a `ui/` module, three parallel lookup tables, and the pinned snapshots. `src/app/mod.rs` is 14,605 lines. Three consequences: nobody outside the project can add a pane, every experiment is permanent, and v1's `extensions/` reach agents but never the UI — 4,786 lines of manifest machinery that cannot draw a row.

## What's in it

| Document | Covers |
|---|---|
| `VISION.md` | Why v2 exists, what changes for users, the costs it accepts |
| `ARCHITECTURE.md` | Twenty-three `ADR-V*` decisions in the repo's Choice/Why/Rejected format |
| `FEATURES-Plugin-API.md` | Manifest, contribution points, lifecycle, the host boundary, capabilities |
| `FEATURES-View-Tree.md` | The view half — node catalog, layout, styling, input |
| `FEATURES-Layout.md` | The workspace tree, anchored overlays, measurement |
| `FEATURES-Animation.md` | Motion — timing, identity, leases, accessibility, determinism |
| `FEATURES-Keybindings.md` | Contexts, conflicts, terminal passthrough, F1, pane show/hide |
| `FEATURES-Backend-API.md` | The service half — CLI verbs, services, schedules, storage, bus |
| `FEATURES-Agent-API.md` | How agents discover and drive plugin commands |
| `DECISION-plugin-runtime.md` | The runtime comparison across seven candidates, and why Luau won |
| `SECURITY.md` | Threat model, what capabilities do and do not buy |
| `LIMITATIONS.md` | What the design cannot do, and the tripwires for reconsidering it |
| `MIGRATION.md` | Phased plan, the v1 teardown inventory, user-facing breakage |
| `RELEASE-STRATEGY.md` | Trunk delivery behind a Cargo gate, nightlies, the website |
| `CONSTITUTION-DELTA.md` | Which v1 principles and ADRs v2 amends or retires |

## The runtime decision, and why it moved

The set was first drafted around **TypeScript in a sidecar process over JSON-RPC**, and it now specifies **Luau in-process via `mlua`**, one VM and one thread per plugin. `DECISION-plugin-runtime.md` carries the full comparison (Luau, plain Lua 5.4, LuaJIT, QuickJS, Rhai, Starlark, V8/`deno_core`) and `ADR-V2` records the reversal rather than hiding it.

What the sidecar was buying was crash isolation. What it was costing was everything else:

| | Sidecar (TS) | In-process (Luau) |
|---|---|---|
| Memory per plugin | 15–30 MB RSS × 2 halves × ~7 bundled | kilobytes per VM, capped by `set_memory_limit` |
| Cold start | 20–50 ms — lazy activation was load-bearing | microseconds — lazy activation is now just an optimization |
| `fs` / `net` / `shell` enforcement | **impossible** — no shipping JS runtime but Deno has a permission model | enforced, because Luau has no ambient I/O to reach around a binding |
| Artifact size | +40–90 MB per archive for a bundled runtime | a few hundred KB, linked in |
| Ecosystem | npm | none — every capability is host-provided or hand-written |

Three conditions keep the isolation the process boundary was there for, and they are stated as **C1/C2/C3** in `ADR-V2`: a thread per plugin, **no native code in a plugin** (the one thing a process gave that a thread cannot), and the VM as the unit of reload — unloading is a `Drop`, so there is no teardown protocol to get wrong. Hot reload is unaffected: it comes from choosing a scripting language, not from the boundary.

The honest costs are recorded, not buried: losing npm pulls widget versioning back toward the kernel (`ADR-V14`), agents write TypeScript better than Luau, and a memory-safety bug in the VM itself is now in-process. `DECISION-plugin-runtime.md` lists the conditions that would reverse this again.

## Other decisions worth reviewing

- **Keep ratatui** (ADR-V13). v1 uses it as a substrate, not a widget toolkit — 5 widget types but 395 `Span::styled` call sites and 19 pure view-model structs handed to pure renderers. The view-tree architecture already exists statically; v2 collapses 19 typed view models into one node set.
- **Widgets are a Luau library** (ADR-V14). The kernel catalog is two tiers split on one test — does the kernel own the data or the clock? Everything else is userland Luau.
- **A plugin has a headless service half** (ADR-V16). v1 guarantees automations fire with the TUI closed; a backend living only inside the TUI would silently revoke that.
- **Motion is declared, not pushed** (ADR-V18). The plugin owns the data, the kernel owns the clock, so animation costs a repaint rather than a plugin call and a tree conversion per frame.
- **Pane geometry is a workspace tree; slots are a preset** (ADR-V23). The layout solver stays in the kernel — a plugin-owned solver was considered and rejected for four reasons recorded in the ADR.
- **Pane visibility is kernel state** (ADR-V21). `[features]` and the F2/F3/F5/F9 toggles are two axes; collapsing them into `plugin enable|disable` would have silently dropped the second.
- **Delivery is on the trunk behind a Cargo gate** (ADR-V20), not a long-lived branch. `main` runs ~3.5 commits/day and v2's work *is* the restructuring of the files v1 fixes touch, so a branch would conflict inside the file being rewritten for months.

## Defects found by auditing the design against its own claims

1. **`fs`/`net`/`shell` were not enforceable** under the sidecar design, because no shipping JS runtime except Deno has a permission model ([oven-sh/bun#26637](https://github.com/oven-sh/bun/issues/26637)) — three of sixteen capabilities were documented as enforced and were not. **Closed by the runtime change**: under Luau enforcement is an *absence* (there is no `io` table, no `os.execute`, no socket library unless the kernel binds one), so all sixteen are real and `N3` is restored to its full form.
2. **Plugin processes would inherit thurbox's environment**, so a plugin declaring *no* capabilities could read `ANTHROPIC_API_KEY` / `GITHUB_TOKEN`. **Also closed**: in-process there is no ambient environment to inherit — `os.getenv` simply is not bound. The hazard moves to children a plugin spawns via `ctx.exec`, where it is handled with a scrubbed environment.
3. **The control socket** exposes `command/run` with no stated permissions — any local process could drive thurbox. Still open; peer-UID check and Windows DACL scheduled at Phase 5. This is now the only place v2 has a wire protocol at all.
4. **Spawn contributions** are append-only but unbounded in what they inject; `LD_PRELOAD` and friends are now refused.

Checking the release automation surfaced two more, scheduled ahead of any v2 code: `ci.yml` triggers on `pull_request: branches: [main]` only, so PRs into a v2 branch would run no checks; and both installers' version fallbacks accept prereleases — `install.ps1` would install a nightly believing it stable.

## Also

`scripts/dev/check-doc-links.sh`, wired into `just lint` and the pre-commit hooks. Markdown cross-references are invisible to rumdl and to the compiler, so they rot silently as headings get renamed. The checker found 64 broken anchors in this set, all now fixed.

## Review notes

Docs-only plus one lint script — no `src/` changes, so no release is cut. The most useful things to push back on are `DECISION-plugin-runtime.md` (the runtime choice and the conditions that would reverse it), `LIMITATIONS.md` (whether the named costs are acceptable), and `CONSTITUTION-DELTA.md` (which principles v2 amends).
