### PR TITLE
fix(core): paste through psmux's own paste path on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -728,6 +728,27 @@ control-mode protocol is byte-identical over either transport/binary, with
   arg. The local socket honors the `THURBOX_SOCKET` env override
   (`local_socket()`) so test/sandbox tooling can scope an instance on Windows,
   where every `-L <name>` resolves machine-wide (no `TMUX_TMPDIR`).
+- **A paste cannot be key-encoded at all**, so it goes **out of band** through
+  psmux's own paste command (`control_mode::PsmuxPaste`, issue #916). The key
+  encoding above has to emit an ESC byte as its own `Escape` key-name, which
+  reaches the pane as a standalone PTY write: the agent read a bare Escape
+  keypress instead of the `ESC[200~` opening marker and then took every
+  embedded CR as Enter, so a pasted stack trace was submitted one line at a
+  time. psmux's control-mode dispatcher implements **no** paste command
+  (`paste-buffer`/`set-buffer`/`send-paste` are CLI/server-only), so a
+  bracketed-paste payload (`bracketed_paste_text` unwraps one; anything else
+  keeps the key encoding) is handed to the one-shot CLI `psmux send-paste -t
+  <pane> <base64>` — the same command psmux's own client uses for a
+  Ctrl+Shift+V, so psmux normalizes CRLF for ConPTY, writes the markers
+  contiguously, and adds them **only** when the pane's app enabled bracketed
+  paste. A failure falls back to the key encoding (degraded beats dropped).
+  The payload is base64 because a raw newline in a psmux command argument is
+  cut by the server's line-oriented read, which truncates the payload *and*
+  executes its tail as a psmux command (psmux #560) — the same reason the
+  headless one-shot prompt path (`paste_prompt_args`, feeding
+  `send_prompt_now` / `deferred_prompt_script`) sends `send-paste` instead of
+  the `send-keys -l <ESC[200~…>` that tmux still gets. Delivery is probed by
+  `scripts/dev/e2e/windows-vm.sh test` (probe C).
 
 Each host registers a backend named
 `ssh:<name>` / `wsl:<name>` (`TmuxBackend::from_host`, registered lazily in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -374,7 +374,11 @@ by the existing `Session::reader_loop`. This allows multiple instances
 to independently parse and render terminal state in real-time.
 
 **Input**: `send-keys -H <hex>` through the shared control mode
-stdin, wrapped in a `ControlModeWriter` (implements `Write`).
+stdin, wrapped in a `ControlModeWriter` (implements `Write`). On a
+**psmux** backend, which has no `-H`, the same writer encodes the byte
+stream from the primitives psmux does support, and a **paste** leaves
+control mode entirely for psmux's own `send-paste` — see the psmux
+divergences in `CLAUDE.md` and `control_mode::PsmuxPaste`.
 
 **Command synchronization**: All commands that precede a
 `send_command` (waited) call must themselves be waited. A

--- a/scripts/dev/e2e/windows-vm.sh
+++ b/scripts/dev/e2e/windows-vm.sh
@@ -321,6 +321,39 @@ cmd_test() {
   fi
   ssh_vm "psmux -L $SOCKET kill-server" >/dev/null 2>&1 || true
 
+  # --- paste-delivery probe (evidence, not verdict) -------------------------
+  # A paste cannot be key-encoded for psmux (a split ESC arrives as a bare
+  # Escape keypress, losing the ESC[200~ marker, and every embedded CR then
+  # submits — issue #916), so thurbox hands pastes to psmux's own
+  # `send-paste` (see `control_mode::PsmuxPaste`). This probes the two
+  # properties that path relies on: the payload is standard **base64**, and a
+  # multi-line payload keeps its newlines instead of being cut on the wire with
+  # its tail executed as a psmux command (psmux #560). `rename-window` is the
+  # observable, harmless injection canary, exactly as in that report.
+  log "probing psmux send-paste multi-line delivery (paste path evidence)"
+  local ppane pcontent pname
+  # base64 of: PASTE_HEAD_916\nrename-window pastePWNED
+  local payload="UEFTVEVfSEVBRF85MTYKcmVuYW1lLXdpbmRvdyBwYXN0ZVBXTkVE"
+  ssh_vm "psmux -L $SOCKET new-session -d -s pasteprobe" >/dev/null 2>&1 || true
+  ppane="$(ssh_vm "psmux -L $SOCKET list-panes -s -t pasteprobe -F '#{pane_id}'" 2>/dev/null | tr -d '\r' | head -n1)"
+  if [ -n "$ppane" ]; then
+    ssh_vm "psmux -L $SOCKET send-paste -t $ppane $payload" >/dev/null 2>&1 || true
+    sleep 2
+    pcontent="$(ssh_vm "psmux -L $SOCKET capture-pane -p -t $ppane" 2>/dev/null | tr -d '\r')"
+    pname="$(ssh_vm "psmux -L $SOCKET display-message -p -t pasteprobe '#{window_name}'" 2>/dev/null | tr -d '\r')"
+    case "$pcontent" in
+      *PASTE_HEAD_916*) ok "probe C: send-paste delivers a base64 payload into the pane" ;;
+      *) info "probe C: send-paste delivered nothing (got: ${pcontent:-<none>})" ;;
+    esac
+    case "$pname" in
+      *pastePWNED*) info "probe C: the payload tail RAN as a psmux command (psmux #560 reaches send-paste too)" ;;
+      *) ok "probe C: a multi-line payload executes nothing (no wire-cut injection)" ;;
+    esac
+  else
+    info "paste probe skipped: could not resolve a probe pane id"
+  fi
+  ssh_vm "psmux -L $SOCKET kill-server" >/dev/null 2>&1 || true
+
   echo
   if printf '%s\n' "$sessions" | grep -qx smoke; then
     pass "psmux is installed and a -L $SOCKET session round-tripped"

--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -9,6 +9,12 @@ use std::io::{Read, Write};
 use std::sync::mpsc::SyncSender;
 use std::sync::{Arc, Mutex};
 
+use anyhow::{bail, Context, Result};
+use base64::Engine as _;
+use tracing::warn;
+
+use super::transport::TmuxTransport;
+
 /// Per-pane output channel capacity. Sized large enough to buffer heavy output
 /// bursts; chunks are dropped (not blocked) when full to keep the reader thread alive.
 pub const PANE_CHANNEL_CAPACITY: usize = 4096;
@@ -220,19 +226,164 @@ pub(crate) fn psmux_quote(s: &str) -> String {
     )
 }
 
+/// The bracketed-paste markers a paste payload is wrapped in.
+const PASTE_START: &[u8] = b"\x1b[200~";
+const PASTE_END: &[u8] = b"\x1b[201~";
+
+/// The pasted text inside a bracketed-paste payload (`ESC[200~ … ESC[201~`), or
+/// `None` when `buf` is not exactly one such payload — ordinary keystrokes, a
+/// payload split across writes, a marker in the middle (two pastes, or pasted
+/// marker text), or non-UTF-8 bytes. Those keep the key encoding.
+///
+/// The markers are stripped: [`PsmuxPaste`] hands psmux the bare text and psmux
+/// re-adds them itself, only when the receiving app has bracketed paste on.
+fn bracketed_paste_text(buf: &[u8]) -> Option<&str> {
+    let inner = buf.strip_prefix(PASTE_START)?.strip_suffix(PASTE_END)?;
+    let has_marker = |m: &[u8]| inner.windows(m.len()).any(|w| w == m);
+    if has_marker(PASTE_START) || has_marker(PASTE_END) {
+        return None;
+    }
+    std::str::from_utf8(inner).ok()
+}
+
+/// Max text bytes per `send-paste` command. The base64 payload travels as a
+/// process argument, and Windows caps a whole command line at ~32,767 chars —
+/// which base64 reaches at ~24 KB of text. 8 KB leaves generous headroom for
+/// the rest of the argv while keeping an ordinary paste a single command.
+const PASTE_CHUNK_BYTES: usize = 8 * 1024;
+
+/// Split `text` into `send-paste`-sized pieces on **char** boundaries: psmux
+/// decodes the payload as UTF-8 and drops it whole if that fails, so a
+/// multi-byte character must never straddle two chunks.
+fn paste_chunks(text: &str) -> Vec<&str> {
+    if text.len() <= PASTE_CHUNK_BYTES {
+        return vec![text];
+    }
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        let mut end = (start + PASTE_CHUNK_BYTES).min(text.len());
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        chunks.push(&text[start..end]);
+        start = end;
+    }
+    chunks
+}
+
+/// The `send-paste` argv delivering `text` into `pane_id`.
+///
+/// The payload is standard base64 — psmux's own client encodes a paste the same
+/// way, and it is what the server decodes. It also keeps CR/LF off the wire: a
+/// raw newline inside a psmux command argument is cut by the server's
+/// line-oriented read, which delivers a truncated payload and then executes the
+/// tail as a psmux command (psmux #560).
+fn psmux_send_paste_args(pane_id: &str, text: &str) -> Vec<String> {
+    vec![
+        "send-paste".to_string(),
+        "-t".to_string(),
+        pane_id.to_string(),
+        base64::engine::general_purpose::STANDARD.encode(text.as_bytes()),
+    ]
+}
+
+/// Out-of-band paste channel for a psmux backend.
+///
+/// psmux's control-mode dispatcher implements no paste command at all
+/// (`paste-buffer`, `set-buffer` and psmux's own `send-paste` are CLI/server
+/// only), and its `send-keys` encoding cannot carry a paste: an ESC byte has to
+/// go out as its own `Escape` key-name, which reaches the pane as a standalone
+/// PTY write, so the agent sees a bare Escape keypress instead of the
+/// `ESC[200~` opening marker and then reads every embedded CR that follows as
+/// Enter — a pasted stack trace was submitted one line at a time (issue #916).
+///
+/// So a paste is handed to psmux's *own* paste path with a one-shot
+/// `psmux send-paste` (the same command psmux's client uses for a Ctrl+Shift+V):
+/// it normalizes CRLF for ConPTY, writes the markers contiguously with the text,
+/// and adds them only when the pane's app actually enabled bracketed paste.
+/// Verified present since psmux 3.3.6.
+#[derive(Debug, Clone)]
+pub struct PsmuxPaste {
+    transport: TmuxTransport,
+    socket: String,
+}
+
+impl PsmuxPaste {
+    pub fn new(transport: TmuxTransport, socket: String) -> Self {
+        Self { transport, socket }
+    }
+
+    /// Deliver `text` to `pane_id` as a paste. Blocks until psmux has applied it
+    /// (the psmux CLI round-trips a barrier before exiting), so a keystroke
+    /// written to control mode afterwards cannot overtake it. Callers reach this
+    /// through the session's writer task, never the UI thread, so the wait only
+    /// holds back that session's own later input — the ordering we want.
+    ///
+    /// A paste past [`PASTE_CHUNK_BYTES`] goes out as several commands, each its
+    /// own paste — the text still arrives whole and no CR submits. An error on a
+    /// *later* chunk is reported but not returned: the caller's fallback would
+    /// re-send text the pane already has.
+    fn send(&self, pane_id: &str, text: &str) -> Result<()> {
+        for (i, chunk) in paste_chunks(text).into_iter().enumerate() {
+            if let Err(e) = self.send_one(pane_id, chunk) {
+                if i == 0 {
+                    return Err(e);
+                }
+                warn!("psmux send-paste truncated after {i} chunk(s): {e:#}");
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+
+    fn send_one(&self, pane_id: &str, text: &str) -> Result<()> {
+        let args = psmux_send_paste_args(pane_id, text);
+        let argv: Vec<&str> = args.iter().map(String::as_str).collect();
+        let out = self
+            .transport
+            .tmux_command(&self.socket, &argv)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+            .context("failed to run psmux send-paste")?;
+        if !out.status.success() {
+            bail!(
+                "psmux send-paste exited with {}: {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Ok(())
+    }
+}
+
 /// Per-pane writer that sends input via control-mode `send-keys` through the
 /// shared control stdin. `psmux` selects the key-name/literal encoding when the
-/// backend is psmux instead of tmux's `-H` hex (see [`send_keys_commands`]).
+/// backend is psmux instead of tmux's `-H` hex (see [`send_keys_commands`]), and
+/// `paste` carries that backend's out-of-band paste channel ([`PsmuxPaste`]).
 pub struct ControlModeWriter {
     pub stdin: Arc<Mutex<std::process::ChildStdin>>,
     pub pane_id: String,
     pub psmux: bool,
+    pub paste: Option<PsmuxPaste>,
 }
 
 impl Write for ControlModeWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
+        }
+        // A paste cannot be encoded as psmux key-names (see `PsmuxPaste`), so it
+        // goes out of band. A failure falls through to the key encoding: a
+        // degraded paste beats a dropped one.
+        if let Some(paste) = self.paste.as_ref() {
+            if let Some(text) = bracketed_paste_text(buf) {
+                match paste.send(&self.pane_id, text) {
+                    Ok(()) => return Ok(buf.len()),
+                    Err(e) => warn!("psmux send-paste failed, falling back to send-keys: {e:#}"),
+                }
+            }
         }
         let mut stdin = self
             .stdin
@@ -1043,6 +1194,9 @@ mod tests {
     fn psmux_bracketed_paste_splits_markers_from_text() {
         // A paste arrives wrapped in `\x1b[200~ … \x1b[201~`; the ESC bytes
         // become `Escape`, the rest stays literal — reconstructing the wrapper.
+        // This encoding is only the *fallback* for a psmux pane (the split ESC
+        // reaches the pane as a bare Escape keypress, so the marker is lost);
+        // the live path is `PsmuxPaste`.
         assert_eq!(
             send_keys_commands("%1", b"\x1b[200~hi\x1b[201~", true),
             vec![
@@ -1051,6 +1205,91 @@ mod tests {
                 "send-keys -t %1 Escape\n".to_string(),
                 "send-keys -t %1 -l -N 1 \"[201~\"\n".to_string(),
             ]
+        );
+    }
+
+    // --- psmux out-of-band paste (`PsmuxPaste`) ---
+
+    #[test]
+    fn bracketed_paste_text_unwraps_a_whole_payload() {
+        assert_eq!(
+            bracketed_paste_text(b"\x1b[200~line one\nline two\r\x1b[201~"),
+            Some("line one\nline two\r")
+        );
+        // Empty paste is still a paste.
+        assert_eq!(bracketed_paste_text(b"\x1b[200~\x1b[201~"), Some(""));
+    }
+
+    #[test]
+    fn bracketed_paste_text_rejects_non_paste_input() {
+        // Ordinary keystrokes, and each half of a payload on its own.
+        assert_eq!(bracketed_paste_text(b"ls\r"), None);
+        assert_eq!(bracketed_paste_text(b"\x1b[200~partial"), None);
+        assert_eq!(bracketed_paste_text(b"tail\x1b[201~"), None);
+        // Trailing keystroke past the closing marker: not one clean paste.
+        assert_eq!(bracketed_paste_text(b"\x1b[200~hi\x1b[201~\r"), None);
+    }
+
+    #[test]
+    fn bracketed_paste_text_rejects_nested_markers() {
+        // Two coalesced pastes, or pasted marker text: the key encoding keeps
+        // the bytes verbatim rather than flattening them into one paste.
+        assert_eq!(
+            bracketed_paste_text(b"\x1b[200~a\x1b[201~\x1b[200~b\x1b[201~"),
+            None
+        );
+        assert_eq!(bracketed_paste_text(b"\x1b[200~a\x1b[200~b\x1b[201~"), None);
+    }
+
+    #[test]
+    fn bracketed_paste_text_rejects_invalid_utf8() {
+        // psmux's `send-paste` payload is text; a byte run that is not UTF-8
+        // (e.g. a paste chunked mid-character) falls back to the key encoding.
+        assert_eq!(bracketed_paste_text(b"\x1b[200~\xff\x1b[201~"), None);
+    }
+
+    #[test]
+    fn paste_chunks_keeps_an_ordinary_paste_whole() {
+        assert_eq!(paste_chunks("one\ntwo"), vec!["one\ntwo"]);
+        let exact = "x".repeat(PASTE_CHUNK_BYTES);
+        assert_eq!(paste_chunks(&exact), vec![exact.as_str()]);
+    }
+
+    /// A huge paste is split so no single command line exceeds Windows' ~32 KB
+    /// cap — losslessly, and never mid-character (psmux drops a payload that
+    /// isn't valid UTF-8).
+    #[test]
+    fn paste_chunks_splits_large_input_on_char_boundaries() {
+        // Multi-byte chars straddling the cut: 2 bytes each, odd-sized prefix.
+        let text = format!("{}{}", "a", "é".repeat(PASTE_CHUNK_BYTES));
+        let chunks = paste_chunks(&text);
+        assert!(chunks.len() > 1);
+        assert!(chunks.iter().all(|c| c.len() <= PASTE_CHUNK_BYTES));
+        assert_eq!(chunks.concat(), text);
+    }
+
+    #[test]
+    fn send_paste_args_targets_the_pane_with_a_base64_payload() {
+        assert_eq!(
+            psmux_send_paste_args("%7", "hi\nthere"),
+            vec!["send-paste", "-t", "%7", "aGkKdGhlcmU="]
+        );
+    }
+
+    /// The payload must never put a raw CR/LF (or a quote) on psmux's
+    /// line-oriented command wire — base64 is what keeps it off (psmux #560).
+    #[test]
+    fn send_paste_args_payload_is_wire_safe() {
+        let args = psmux_send_paste_args("%1", "first\r\nsecond \"quoted\" \\ '");
+        let payload = args.last().unwrap();
+        assert!(!payload
+            .bytes()
+            .any(|b| matches!(b, b'\r' | b'\n' | b'"' | b'\\' | b'\'' | b' ')));
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(payload)
+                .unwrap(),
+            b"first\r\nsecond \"quoted\" \\ '"
         );
     }
 

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 use anyhow::{bail, Context, Result};
+use base64::Engine as _;
 use tracing::{debug, warn};
 
 use crate::agent::backend::{AdoptedSession, DiscoveredSession, SessionBackend, SpawnedSession};
@@ -1223,13 +1224,17 @@ impl TmuxBackend {
     /// Create a writer for a specific pane.
     fn pane_writer(&self, pane_id: &str) -> Result<ControlModeWriter> {
         // psmux lacks tmux's `send-keys -H`, so the writer encodes keystrokes
-        // differently for it (see `control_mode::send_keys_commands`).
+        // differently for it (see `control_mode::send_keys_commands`) and routes
+        // a paste out of band (see `control_mode::PsmuxPaste`).
         let psmux = self.transport.uses_psmux();
+        let paste = psmux
+            .then(|| control_mode::PsmuxPaste::new(self.transport.clone(), self.socket.clone()));
         self.with_control(|ctrl| {
             Ok(ControlModeWriter {
                 stdin: Arc::clone(&ctrl.stdin),
                 pane_id: pane_id.to_string(),
                 psmux,
+                paste: paste.clone(),
             })
         })
     }
@@ -1652,6 +1657,32 @@ fn bracketed_paste(text: &str) -> String {
     format!("\x1b[200~{text}\x1b[201~")
 }
 
+/// The one-shot argv that delivers `text` into `target` as one paste.
+///
+/// tmux takes the bracketed-paste-wrapped bytes literally (`send-keys -l`).
+/// psmux instead gets its own `send-paste`, which wraps and writes the payload
+/// itself (see [`control_mode::PsmuxPaste`] for why key-encoded markers do not
+/// survive there): a raw newline inside a psmux command argument is cut by the
+/// server's line-oriented read, so a multi-line prompt arrived truncated *and*
+/// its tail ran as a psmux command (psmux #560).
+fn paste_prompt_args(target: &str, text: &str, psmux: bool) -> Vec<String> {
+    if psmux {
+        return vec![
+            "send-paste".to_string(),
+            "-t".to_string(),
+            target.to_string(),
+            base64::engine::general_purpose::STANDARD.encode(text.as_bytes()),
+        ];
+    }
+    vec![
+        "send-keys".to_string(),
+        "-t".to_string(),
+        target.to_string(),
+        "-l".to_string(),
+        bracketed_paste(text),
+    ]
+}
+
 /// Whether a `#{pane_dead}` format string reports an exited pane.
 ///
 /// Only the literal `1` means dead: `display-message` against a *missing*
@@ -1693,22 +1724,22 @@ pub fn send_prompt_now(session_name: &str, text: &str) -> Result<()> {
     if pane_is_dead(&target) {
         bail!("session '{session_name}' has exited; its pane accepts no input");
     }
-    let payload = bracketed_paste(text);
-
-    let status = local_mux_command(&["send-keys", "-t", &target, "-l", &payload])
+    let paste = paste_prompt_args(&target, text, DEFAULT_MUX == "psmux");
+    let paste_argv: Vec<&str> = paste.iter().map(String::as_str).collect();
+    let status = local_mux_command(&paste_argv)
         .status()
-        .context("Failed to run tmux send-keys for prompt text")?;
+        .context("Failed to paste prompt text into the session pane")?;
     if !status.success() {
-        bail!("tmux send-keys (text) exited with status {status}");
+        bail!("{DEFAULT_MUX} {} exited with status {status}", paste[0]);
     }
 
     std::thread::sleep(SEND_KEYS_ENTER_DELAY);
 
     let status = local_mux_command(&["send-keys", "-t", &target, "Enter"])
         .status()
-        .context("Failed to run tmux send-keys for Enter")?;
+        .context("Failed to send Enter to the session pane")?;
     if !status.success() {
-        bail!("tmux send-keys (Enter) exited with status {status}");
+        bail!("{DEFAULT_MUX} send-keys (Enter) exited with status {status}");
     }
     Ok(())
 }
@@ -1787,13 +1818,17 @@ fn deferred_prompt_script(target: &str, text: &str) -> String {
 /// Windows path (`psmux`): psmux's `run-shell` is not a POSIX shell, so drive the
 /// sequence through PowerShell explicitly (`Start-Sleep` for the sub-second beat).
 /// PowerShell single-quoted literals escape an embedded `'` by doubling it.
+///
+/// The prompt travels as psmux's own base64 `send-paste` payload (see
+/// [`paste_prompt_args`]) — which also keeps the script free of the prompt's
+/// newlines and quotes.
 #[cfg(windows)]
 fn deferred_prompt_script(target: &str, text: &str) -> String {
     let t = ps_single_quote(target);
     let socket = local_socket();
-    let body = ps_single_quote(&bracketed_paste(text));
+    let payload = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
     format!(
-        "powershell -NoProfile -Command \"{DEFAULT_MUX} -L {socket} send-keys -t {t} -l {body}; \
+        "powershell -NoProfile -Command \"{DEFAULT_MUX} -L {socket} send-paste -t {t} {payload}; \
          Start-Sleep -Milliseconds 200; \
          {DEFAULT_MUX} -L {socket} send-keys -t {t} Enter\""
     )
@@ -2354,6 +2389,40 @@ mod tests {
         // Local backends inherit the user's interactive PATH — no wrap needed.
         let backend = TmuxBackend::local();
         assert_eq!(backend.login_wrap_for_remote("claude"), "claude");
+    }
+
+    // --- one-shot prompt delivery ---
+
+    #[test]
+    fn paste_prompt_args_wraps_literally_for_tmux() {
+        assert_eq!(
+            paste_prompt_args("thurbox:tb-demo", "line one\nline two", false),
+            vec![
+                "send-keys",
+                "-t",
+                "thurbox:tb-demo",
+                "-l",
+                "\x1b[200~line one\nline two\x1b[201~",
+            ]
+        );
+    }
+
+    /// psmux gets its own `send-paste`: the bracketed markers are psmux's to add,
+    /// and the base64 payload keeps the prompt's newlines off a command wire that
+    /// would otherwise cut the line and run the tail as a command (psmux #560).
+    #[test]
+    fn paste_prompt_args_uses_send_paste_for_psmux() {
+        let args = paste_prompt_args("thurbox:tb-demo", "line one\nline two", true);
+        assert_eq!(
+            args,
+            vec![
+                "send-paste",
+                "-t",
+                "thurbox:tb-demo",
+                "bGluZSBvbmUKbGluZSB0d28=",
+            ]
+        );
+        assert!(!args.iter().any(|a| a.contains('\n') || a.contains('\x1b')));
     }
 
     // --- psmux_window_command tests ---


### PR DESCRIPTION
Closes #916.

## Summary

- A pasted multi-line payload was **submitted one line at a time** in a Windows session. psmux has no `send-keys -H`, so thurbox re-encodes input from key-names — which forces an ESC out as its own `Escape` command, i.e. a standalone PTY write. The agent read a bare Escape keypress instead of the `ESC[200~` opening marker, then took every embedded CR as Enter (and dropped the leading chars of each line while re-rendering).
- psmux's control-mode dispatcher implements **no** paste command (`paste-buffer`/`set-buffer`/`send-paste` are CLI/server-only; `-H` landed only on psmux `master`, after v3.3.7), so a whole bracketed-paste payload now leaves control mode for the one-shot **`psmux send-paste`** — the same command psmux's own client uses for a Ctrl+Shift+V. psmux then normalizes CRLF for ConPTY, writes the markers contiguously, and adds them *only* when the pane's app actually enabled bracketed paste.
- Ordinary keystrokes keep the existing key encoding (`bracketed_paste_text` rejects keystrokes, partials, nested markers and non-UTF-8), and a failed `send-paste` falls back to it — a degraded paste beats a dropped one. Payloads over 8 KB are split on char boundaries (Windows caps a command line at ~32 KB; psmux drops a payload that isn't valid UTF-8).
- The payload is **base64** because a raw newline in a psmux command argument is cut by the server's line-oriented read, which truncates the payload *and executes its tail as a psmux command* ([psmux #560](https://github.com/psmux/psmux/issues/560)).
- Same defect fixed in the **headless one-shot prompt path** (`paste_prompt_args` → `send_prompt_now`, `deferred_prompt_script`): on Windows a multi-line task/automation/mailbox prompt hit exactly that wire-cut, so a task description's tail could run as a psmux command. tmux keeps its byte-exact `send-keys -l` path unchanged.
- Docs: psmux-divergence entry in `CLAUDE.md` + a pointer in `docs/ARCHITECTURE.md`.

## Test plan

- [x] 10 new unit tests (payload detection, char-boundary chunking, argv shape, wire-safety of the payload, both `paste_prompt_args` branches)
- [x] `cargo nextest run --all` — only the 8 pre-existing `git`/`ctrl_d_*` failures, which fail identically on a clean tree (no commit-signing key in this environment)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --test architecture_rules`, `shellcheck`
- [x] `cargo check --target x86_64-pc-windows-gnu --all-targets` (covers the `#[cfg(windows)]` deferred-prompt script)
- [ ] **Not run here:** real psmux. No podman on this box for `scripts/dev/e2e/windows-vm.sh`, and no lab host configured. psmux behaviour was established from v3.3.6/v3.3.7/master source + its control-mode docs (`send-paste` present since ≤3.3.6, base64 payload, `-t` honoured via the server's validated temp-focus). A **probe C** was added to `windows-vm.sh test` that asserts `send-paste` delivers a base64 payload and that a multi-line payload executes nothing — worth running before relying on this.