### PR TITLE
feat(ui): support rich-text (OSC 8) links in agent output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2062,7 +2062,21 @@ backend dependency stays visible at each call site.
   `terminal_view`, `info_panel`,
   `status_bar`, `repo_picker_modal` (repo selection with
   worktree toggle). `selection.rs` handles mouse-drag text
-  selection, `links.rs` detects clickable URLs for Ctrl+Click.
+  selection, `links.rs` detects plain-text URLs in the rendered rows
+  for Ctrl+Click — while a **rich-text link** (OSC 8) prints only its
+  label, so its target is captured from the escape at parse time
+  (`agent::osc8` → `session::hyperlink`) and wins over a plain-text
+  match at the same cell (`App::url_at_click`). Because ratatui knows
+  nothing about hyperlinks, each painted frame is followed by
+  `App::paint_terminal_hyperlinks`, which re-prints the visible runs
+  wrapped in OSC 8 (same glyphs, same styles, read back out of the drawn
+  frame) so the **outer** terminal can open the user's own browser — the
+  only route to one when thurbox runs on a remote host. The click always toasts
+  its outcome, and on a host with no browser (headless / SSH — no
+  `DISPLAY`, no `BROWSER`) it **copies** the URL instead of spawning an
+  opener that goes nowhere, riding the same OSC 52 leg as `Ctrl+C` so
+  the URL reaches the user's own clipboard. See the Clickable URLs
+  section of `docs/FEATURES.md`.
   Mouse clicks are routed through a per-frame registry
   (`App::click_targets`, mirroring `scrollbar_hits`): list/modal
   renderers return `ui::RowHitbox`es, `App::view` records them as

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1995,11 +1995,90 @@ other panel toggles' F-keys.
 
 ## Clickable URLs
 
-URLs (`https://`, `http://`, `file://`) in terminal output are
-detected via regex at click time and opened on `Ctrl+Click`.
-Trailing punctuation (`.`, `,`, `;`, `:`, `)`, `]`) is stripped
-from detected URLs. Character-based column offsets ensure correct
-positioning with multibyte characters.
+`Ctrl+Click` in the terminal pane opens the link under the cursor.
+Two kinds resolve, and an **OSC 8 hyperlink wins** where both cover
+a cell (`App::url_at_click`):
+
+- **OSC 8 hyperlinks** — an agent renders a markdown link as
+  `OSC 8 ; ; <url>` + label + `OSC 8 ; ;`, so the screen holds only
+  the label (`Github`, never `https://github.com`) and the URL exists
+  *solely* in the escape, which `vt100` discards. The parser callbacks
+  capture each run instead (`agent::osc8` → `session::hyperlink`): the
+  label is read off the screen between the cursor position at the open
+  and the one at the close (the closing escape arrives after its label
+  printed), and stored with its **start column**, not its row — the row
+  moves every time the transcript scrolls, the printed glyphs and their
+  column survive it. A click resolves only if that label is still on
+  screen at that column, so a row whose content has moved on resolves
+  to nothing rather than to a stale URL. A run the screen scrolled
+  under mid-print is dropped for the same reason (agents redraw and
+  re-emit the escape); a run long enough to wrap contributes one entry
+  per row. The table is bounded at 512 runs per session.
+- **Plain-text URLs** (`https://`, `http://`, `file://`) are scanned
+  out of the rendered rows at click time (`ui::links`). Trailing
+  punctuation (`.`, `,`, `;`, `:`, `)`, `]`) is stripped.
+  Display-width column offsets keep positioning correct on rows with
+  wide (CJK/emoji) glyphs.
+
+### Handing links back to the outer terminal
+
+thurbox re-renders the agent's screen through ratatui, which has no
+notion of a hyperlink — so the terminal **thurbox itself runs in** only
+ever receives a plain label and can't offer its own open-link gesture.
+That gesture matters: no escape sequence says "open this URL", so a
+terminal-side click is the *only* way a thurbox on a remote host can open
+a browser on the machine the user is sitting at.
+
+So after each frame is flushed, `App::paint_terminal_hyperlinks`
+re-prints the visible runs wrapped in OSC 8 — the same glyphs with the
+same styles, read back out of the drawn frame, so nothing changes
+visually and only the terminal's hyperlink state is added. Windows
+Terminal, kitty, WezTerm and iTerm2 then underline the label on hover and
+open the user's own browser on Ctrl/Cmd+Click.
+
+Two properties keep this safe and cheap:
+
+- **Validated against what was drawn** (`helpers::drawn_label_cells`): a
+  candidate is emitted only if the frame's cells still print that label
+  there, so a covering overlay, a scrolled pane, or a repainted row
+  yields nothing instead of escapes written over current content. A label
+  clipped by the pane's right edge is linked as far as it is visible.
+- **Off the hot path when unused**: the pass bails on
+  `HyperlinkTable::is_empty()` before computing layout or scanning the
+  screen, so a session whose agent never printed a link pays one check
+  per frame. Only the newest `VISIBLE_SCAN_LIMIT` (128) runs are scanned.
+
+The URL is stripped of control characters before it goes out
+(`hyperlink::osc8_open`): it is agent-controlled text being written back
+to the user's terminal, and an embedded `ESC` would end the sequence
+early and let the rest be interpreted as escapes of its own.
+
+**Caveat:** while thurbox has mouse capture on (`[features] mouse`), a
+terminal that forwards Ctrl+Click to the application instead of handling
+its own hyperlink will land on thurbox's own click path (which opens, or
+falls back to copying, per below). Setting `mouse = false` gives all
+clicks back to the terminal.
+
+### Where the URL goes
+
+The click **always toasts its outcome**, so a resolved link that
+couldn't be acted on is never indistinguishable from a click on plain
+text (it used to be: the opener was spawned with its result discarded).
+
+`helpers::open_url` hands the URL to the platform opener — `open` on
+macOS, `cmd /C start` on Windows, `xdg-open` elsewhere. On Linux/BSD it
+first checks there is something to open *into* (`DISPLAY`,
+`WAYLAND_DISPLAY`, or a `BROWSER` the user set): a thurbox running on a
+headless or SSH host has none, where spawning `xdg-open` either fails or
+— worse — succeeds and does nothing.
+
+With no browser reachable the URL goes to the **clipboard** instead
+(`App::write_clipboard`, the same native → OSC 52 path `Ctrl+C` uses).
+That is what makes the feature work over SSH at all: the OSC 52 leg
+travels to the terminal the user is sitting at, so the URL lands in
+*their* clipboard, ready to paste into a real browser. The toast names
+the route (`(OSC 52)`) so a terminal that drops the sequence is
+diagnosable.
 
 ---
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -58,6 +58,17 @@ stays stale longer than a blink. The black-box smoke test
 (`scripts/dev/smoke/tui-smoke.sh`) still asserts the first frame and every
 post-keystroke frame paint.
 
+**One pass rides along after each paint**:
+`App::paint_terminal_hyperlinks` re-emits the frame's OSC 8 hyperlinks so the
+outer terminal can offer its own open-link gesture (see the Clickable URLs
+section of `docs/FEATURES.md`). It is bound to the *painted* frames — ratatui
+rewrites the cells, so the escapes must follow each draw — and is gated on
+`HyperlinkTable::is_empty()` **before** it computes layout or extracts screen
+rows, so a session whose agent never printed a link pays a single emptiness
+check per frame. When links are present the scan is bounded (the newest 128
+runs × the visible rows) and the writes are a handful of short `queue!`s per
+visible run.
+
 ---
 
 ## ADR-P2: Deterministic perf counters as the regression gate

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -11,8 +11,9 @@ use anyhow::Result;
 use tokio::sync::mpsc;
 use tracing::{debug, error};
 
+use crate::agent::osc8;
 use crate::agent::provider::AgentProvider;
-use crate::session::{SessionConfig, SessionInfo};
+use crate::session::{HyperlinkTable, SessionConfig, SessionInfo};
 
 pub(crate) fn now_millis() -> u64 {
     SystemTime::now()
@@ -69,6 +70,8 @@ fn utf8_ready_prefix_len(buf: &[u8]) -> usize {
 ///   the time of the latest such signal, plus its message text when the OSC
 ///   carries one. This is how we surface a real "needs attention" state instead
 ///   of timing-only Busy/Waiting.
+/// - **Hyperlinks** (OSC `8`) → the target of each rich-text link the agent
+///   printed, which `vt100` itself discards (see the `osc8` module).
 #[derive(Clone, Default)]
 pub struct TermSignals {
     title: Arc<Mutex<Option<String>>>,
@@ -80,6 +83,12 @@ pub struct TermSignals {
     /// per-tick status refresh can skip the mutex locks + String clones while
     /// nothing changed (ADR-P10; see [`Session::sync_agent_meta`]).
     meta_gen: Arc<AtomicU64>,
+    /// OSC 8 hyperlink runs the agent printed. Unlike the cells above this is
+    /// not shared state: readers reach it through the parser lock they already
+    /// take to read the screen ([`Self::hyperlink_at`]).
+    hyperlinks: HyperlinkTable,
+    /// The OSC 8 run whose closing sequence has not arrived yet.
+    pending_link: Option<osc8::PendingHyperlink>,
 }
 
 impl TermSignals {
@@ -91,6 +100,14 @@ impl TermSignals {
         // After the write, so a reader that observes the new generation also
         // observes the new value.
         self.meta_gen.fetch_add(1, Ordering::Release);
+    }
+
+    /// The OSC 8 runs captured from the agent's output — the targets of its
+    /// rich-text links, of which the screen holds only the labels. Resolve a
+    /// clicked cell against it with [`HyperlinkTable::resolve`], or list what is
+    /// on screen with [`HyperlinkTable::visible_runs`].
+    pub fn hyperlinks(&self) -> &HyperlinkTable {
+        &self.hyperlinks
     }
 
     /// Mark an attention signal, optionally with notification message text.
@@ -122,10 +139,12 @@ impl vt100::Callbacks for TermSignals {
         self.signal_attention(None);
     }
 
-    fn unhandled_osc(&mut self, _: &mut vt100::Screen, params: &[&[u8]]) {
+    fn unhandled_osc(&mut self, screen: &mut vt100::Screen, params: &[&[u8]]) {
         // Desktop-notification escapes carry the agent's status message.
         //   OSC 9 ; <message>
         //   OSC 777 ; notify ; <title> ; <body>
+        // A hyperlink pair brackets its label's glyphs.
+        //   OSC 8 ; <params> ; <uri>   …label…   OSC 8 ; ;
         match params {
             [b"9", msg] => self.signal_attention(Some(String::from_utf8_lossy(msg).into_owned())),
             [b"777", kind, rest @ ..] if kind.eq_ignore_ascii_case(b"notify") => {
@@ -135,6 +154,10 @@ impl vt100::Callbacks for TermSignals {
                     .collect::<Vec<_>>()
                     .join(": ");
                 self.signal_attention(Some(msg));
+            }
+            [b"8", fields @ ..] => {
+                let uri = osc8::uri_from_fields(fields);
+                osc8::handle(screen, &mut self.pending_link, &mut self.hyperlinks, &uri);
             }
             _ => {}
         }
@@ -539,6 +562,7 @@ impl Session {
                 attention_at: Arc::clone(&attention_at),
                 notification: Arc::clone(&notification),
                 meta_gen: Arc::clone(&meta_gen),
+                ..Default::default()
             },
         )));
 
@@ -632,6 +656,7 @@ impl Session {
                 attention_at: Arc::clone(&attention_at),
                 notification: Arc::clone(&notification),
                 meta_gen: Arc::clone(&meta_gen),
+                ..Default::default()
             },
         )));
         let host = info.remote_host.clone().unwrap_or_else(|| "?".into());
@@ -1097,6 +1122,7 @@ impl Session {
                     attention_at: Arc::clone(&attention_at),
                     notification: Arc::clone(&notification),
                     meta_gen: Arc::clone(&meta_gen),
+                    ..Default::default()
                 },
             ))),
             input_tx,

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,6 +6,7 @@ pub mod generic;
 pub mod host_config;
 pub mod input;
 pub mod json_merge;
+mod osc8;
 pub mod provider;
 pub mod registry;
 pub mod self_update;

--- a/src/agent/osc8.rs
+++ b/src/agent/osc8.rs
@@ -1,0 +1,274 @@
+//! OSC 8 hyperlink capture from the agent's byte stream.
+//!
+//! `vt100` has no notion of a hyperlink: it drops the escape and keeps only the
+//! printed label, so the URL would be lost. The sequence is a *pair* — an
+//! opening `OSC 8 ; <params> ; <uri>`, the label's glyphs, then a closing
+//! `OSC 8 ; ; ` with no URI — and both halves arrive at
+//! [`vt100::Callbacks::unhandled_osc`] with the live screen. The label is
+//! therefore read straight off the screen between the cursor position at the
+//! open and the one at the close (the escape arrives *after* its label
+//! printed), and stored in the session's [`HyperlinkTable`] for a `Ctrl+Click`
+//! to resolve.
+
+use crate::session::hyperlink::HyperlinkTable;
+
+/// An OSC 8 run whose closing sequence has not arrived yet: its target plus the
+/// cursor position where its label started printing.
+#[derive(Clone, Debug)]
+pub(crate) struct PendingHyperlink {
+    url: String,
+    row: u16,
+    col: u16,
+    /// See [`scroll_witness`].
+    witness: String,
+}
+
+/// The URI an `OSC 8 ; <params> ; <uri>` sequence carries. `fields` are the OSC
+/// fields after the `8`: the first holds the link params (`id=…`) and
+/// everything after it is the URI — rejoined because `vte` splits fields on
+/// `;`, which a URI may legitimately contain. Empty (or absent) means the
+/// sequence closes the open run.
+pub(crate) fn uri_from_fields(fields: &[&[u8]]) -> String {
+    let uri = fields
+        .iter()
+        .skip(1)
+        .map(|field| String::from_utf8_lossy(field))
+        .collect::<Vec<_>>()
+        .join(";");
+    uri.trim().to_string()
+}
+
+/// Handle one OSC 8 sequence. `uri` empty closes the open run; a non-empty one
+/// closes it too (an unterminated run is still worth keeping) and opens the
+/// next.
+pub(crate) fn handle(
+    screen: &vt100::Screen,
+    pending: &mut Option<PendingHyperlink>,
+    table: &mut HyperlinkTable,
+    uri: &str,
+) {
+    if let Some(open) = pending.take() {
+        close_run(screen, table, open);
+    }
+    if !uri.is_empty() {
+        let (row, col) = screen.cursor_position();
+        *pending = Some(PendingHyperlink {
+            url: uri.to_string(),
+            row,
+            col,
+            witness: scroll_witness(screen, row, col),
+        });
+    }
+}
+
+/// Record the label `open` printed, one entry per screen row it covers (a run
+/// long enough to wrap spans several).
+fn close_run(screen: &vt100::Screen, table: &mut HyperlinkTable, open: PendingHyperlink) {
+    let (end_row, end_col) = screen.cursor_position();
+    // The label is no longer where it printed — the screen scrolled under the
+    // run, or was cleared — so there is nothing to anchor to.
+    if end_row < open.row || scroll_witness(screen, open.row, open.col) != open.witness {
+        return;
+    }
+    let (_, cols) = screen.size();
+    for row in open.row..=end_row {
+        let from = if row == open.row { open.col } else { 0 };
+        // The cursor sits on the cell the *next* glyph goes to, so `end_col` is
+        // exclusive. A label that fills the row to its edge leaves the cursor
+        // parked on the last column (pending wrap) and loses that one cell:
+        // the click target ends up a cell short, never pointing at the wrong
+        // run.
+        let to = if row == end_row { end_col } else { cols };
+        let label = row_glyphs(screen, row, from, to);
+        table.record(&open.url, label.trim_end(), from as usize);
+        // A run reaches the next row only by wrapping. Anything else moved the
+        // cursor down on its own (a newline inside the label), which leaves the
+        // rows below holding text this run never printed — so stop rather than
+        // claim them.
+        if row < end_row && !screen.row_wrapped(row) {
+            break;
+        }
+    }
+}
+
+/// The screen text a run's label cannot touch: the glyphs before it on its own
+/// row, plus the whole row above. A label only ever prints forward from its
+/// start, so that region holds still for the run's lifetime — unless the label
+/// wraps past the bottom row (or carries a newline) and scrolls the screen,
+/// which shifts other content into it. Comparing the witness at the close is
+/// how a run learns its recorded start no longer points at its own label; it is
+/// then dropped rather than anchored to whatever text now sits there.
+fn scroll_witness(screen: &vt100::Screen, row: u16, col: u16) -> String {
+    let mut witness = row_glyphs(screen, row, 0, col);
+    if row > 0 {
+        let (_, cols) = screen.size();
+        witness.push('\n');
+        witness.push_str(&row_glyphs(screen, row - 1, 0, cols));
+    }
+    witness
+}
+
+/// Glyphs printed in `row` between cell columns `from`..`to`. Wide-glyph
+/// continuation cells are skipped, so a captured label compares equal to the
+/// row strings `ui::links::extract_screen_rows` builds when a click or a repaint
+/// resolves it.
+///
+/// The two readers are deliberately separate: `agent` may not depend on `ui` nor
+/// `ui` on `agent` (see the module rules in `tests/architecture_rules.rs`), and
+/// the type they share these strings through — `session::hyperlink` — is
+/// vt100-free pure data. Keep them in step rather than merging them.
+fn row_glyphs(screen: &vt100::Screen, row: u16, from: u16, to: u16) -> String {
+    let mut out = String::new();
+    for col in from..to {
+        match screen.cell(row, col) {
+            Some(cell) if cell.is_wide_continuation() => continue,
+            Some(cell) => out.push(cell.contents().chars().next().unwrap_or(' ')),
+            None => break,
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive a parser the way [`crate::agent::TermSignals`] does, so these
+    /// tests exercise the real escape → table path.
+    #[derive(Default)]
+    struct Capture {
+        pending: Option<PendingHyperlink>,
+        table: HyperlinkTable,
+    }
+
+    impl vt100::Callbacks for Capture {
+        fn unhandled_osc(&mut self, screen: &mut vt100::Screen, params: &[&[u8]]) {
+            if let [b"8", fields @ ..] = params {
+                let uri = uri_from_fields(fields);
+                handle(screen, &mut self.pending, &mut self.table, &uri);
+            }
+        }
+    }
+
+    fn feed(rows: u16, cols: u16, bytes: &[u8]) -> vt100::Parser<Capture> {
+        let mut parser = vt100::Parser::new_with_callbacks(rows, cols, 0, Capture::default());
+        parser.process(bytes);
+        parser
+    }
+
+    fn screen_row(parser: &vt100::Parser<Capture>, row: u16) -> String {
+        let (_, cols) = parser.screen().size();
+        row_glyphs(parser.screen(), row, 0, cols)
+    }
+
+    #[test]
+    fn captures_a_bel_terminated_run() {
+        let parser = feed(
+            4,
+            40,
+            b"see \x1b]8;;https://github.com\x07Github\x1b]8;;\x07 done",
+        );
+        let row = screen_row(&parser, 0);
+        assert_eq!(row.trim_end(), "see Github done");
+        let table = &parser.callbacks().table;
+        assert_eq!(table.resolve(&row, 4), Some("https://github.com"));
+        assert_eq!(table.resolve(&row, 9), Some("https://github.com"));
+        // Only the label's own cells are clickable.
+        assert_eq!(table.resolve(&row, 3), None);
+        assert_eq!(table.resolve(&row, 10), None);
+    }
+
+    #[test]
+    fn captures_an_st_terminated_run_with_params_and_a_uri_semicolon() {
+        // `id=…` link params must not be mistaken for the URI, and a URI
+        // carrying its own `;` arrives split across several OSC fields.
+        let parser = feed(
+            4,
+            40,
+            b"\x1b]8;id=1;https://example.com/a;b=c\x1b\\Docs\x1b]8;;\x1b\\",
+        );
+        let row = screen_row(&parser, 0);
+        assert_eq!(
+            parser.callbacks().table.resolve(&row, 0),
+            Some("https://example.com/a;b=c")
+        );
+    }
+
+    #[test]
+    fn captures_each_row_of_a_wrapped_run() {
+        // The label runs past the right edge, so it lands on two rows and each
+        // gets its own entry.
+        let parser = feed(
+            4,
+            10,
+            b"ab\x1b]8;;https://example.com\x07cdefghijkl\x1b]8;;\x07",
+        );
+        let table = &parser.callbacks().table;
+        let first = screen_row(&parser, 0);
+        let second = screen_row(&parser, 1);
+        assert_eq!(table.resolve(&first, 2), Some("https://example.com"));
+        assert_eq!(table.resolve(&first, 9), Some("https://example.com"));
+        assert_eq!(table.resolve(&second, 0), Some("https://example.com"));
+        assert_eq!(table.resolve(&second, 1), Some("https://example.com"));
+    }
+
+    #[test]
+    fn wide_glyphs_before_a_label_shift_its_column() {
+        let parser = feed(
+            2,
+            40,
+            "漢字 \x1b]8;;https://example.com\x07Github\x1b]8;;\x07".as_bytes(),
+        );
+        let row = screen_row(&parser, 0);
+        let table = &parser.callbacks().table;
+        assert_eq!(table.resolve(&row, 5), Some("https://example.com"));
+        assert_eq!(table.resolve(&row, 4), None);
+    }
+
+    #[test]
+    fn an_unclosed_run_is_flushed_by_the_next_one() {
+        let parser = feed(
+            2,
+            40,
+            b"\x1b]8;;https://a.example\x07one \x1b]8;;https://b.example\x07two\x1b]8;;\x07",
+        );
+        let row = screen_row(&parser, 0);
+        let table = &parser.callbacks().table;
+        assert_eq!(table.resolve(&row, 0), Some("https://a.example"));
+        assert_eq!(table.resolve(&row, 4), Some("https://b.example"));
+    }
+
+    #[test]
+    fn a_label_carrying_a_newline_claims_only_the_row_it_printed_on() {
+        let parser = feed(
+            4,
+            10,
+            b"\x1b]8;;https://example.com\x07hi\r\nmore\x1b]8;;\x07",
+        );
+        let table = &parser.callbacks().table;
+        assert_eq!(
+            table.resolve(&screen_row(&parser, 0), 0),
+            Some("https://example.com")
+        );
+        // The cursor moved down on its own, so "more" is not part of the run.
+        assert_eq!(table.resolve(&screen_row(&parser, 1), 0), None);
+    }
+
+    #[test]
+    fn a_run_that_printed_nothing_records_nothing() {
+        let parser = feed(2, 40, b"\x1b]8;;https://example.com\x07\x1b]8;;\x07");
+        assert_eq!(parser.callbacks().table.runs().count(), 0);
+    }
+
+    #[test]
+    fn a_run_the_screen_scrolled_under_is_dropped() {
+        // Opening on the last row and printing past it scrolls the label above
+        // its recorded row, leaving nothing to anchor to.
+        let parser = feed(
+            2,
+            10,
+            b"\r\n\x1b]8;;https://example.com\x07link\r\nmore\x1b]8;;\x07",
+        );
+        assert_eq!(parser.callbacks().table.runs().count(), 0);
+    }
+}

--- a/src/app/acceptance.rs
+++ b/src/app/acceptance.rs
@@ -3052,6 +3052,76 @@ fn osc_title_and_bell_reach_the_session() {
 }
 
 #[test]
+fn ctrl_click_resolves_a_rich_text_link_to_its_real_target() {
+    let mut h = Harness::standard(1);
+    // What an agent emits for `[Github](https://github.com)`: an OSC 8 pair
+    // around a label, so the screen holds "Github" and nothing else.
+    h.feed_output(
+        0,
+        b"see \x1b]8;;https://github.com\x07Github\x1b]8;;\x07 and https://example.com/x\r\n",
+    );
+    let screen = h.render();
+    assert!(
+        screen.contains("see Github and"),
+        "the terminal prints the label, not the URL:\n{screen}"
+    );
+
+    // The pane rect the click maps through; row/col 0 is the first output line.
+    let pane = ratatui::layout::Rect::new(0, 0, STD_COLS, STD_ROWS);
+    let click = |col: u16| h.app.url_at_click(pane, col, 0);
+
+    // Every cell of the label opens the escape's target…
+    assert_eq!(click(4).as_deref(), Some("https://github.com"));
+    assert_eq!(click(9).as_deref(), Some("https://github.com"));
+    // …and only those cells.
+    assert_eq!(click(3), None);
+    assert_eq!(click(10), None);
+    // A plain-text URL on the same row still resolves the old way.
+    assert_eq!(click(19).as_deref(), Some("https://example.com/x"));
+}
+
+#[test]
+fn a_rendered_rich_text_link_is_handed_to_the_outer_terminal() {
+    // The link the terminal thurbox runs in never saw: thurbox re-renders the
+    // agent's screen through ratatui, so the OSC 8 has to be re-emitted around
+    // the cells that were actually drawn.
+    let mut h = Harness::standard(1);
+    h.feed_output(
+        0,
+        b"see \x1b]8;;https://github.com\x07Github\x1b]8;;\x07\r\n",
+    );
+    h.render();
+
+    let paints = h
+        .app
+        .terminal_hyperlink_paints(h.terminal.backend().buffer());
+    assert_eq!(paints.len(), 1, "one link on screen ⇒ one run to re-emit");
+    let paint = &paints[0];
+    assert_eq!(paint.url, "https://github.com");
+    // The label's own glyphs, taken from the drawn frame so the re-print is a
+    // no-op visually.
+    let painted: String = paint.cells.iter().map(|(sym, _)| sym.as_str()).collect();
+    assert_eq!(painted, "Github");
+    // Positioned inside the terminal pane, offset by the label's column.
+    let inner = ratatui::widgets::Block::default()
+        .borders(ratatui::widgets::Borders::ALL)
+        .inner(h.app.screen_layout().terminal);
+    assert_eq!((paint.x, paint.y), (inner.x + 4, inner.y));
+
+    // The candidate is validated against the cells that were drawn, so once the
+    // agent repaints that row over the label there is nothing left to link —
+    // rather than escapes written over whatever text is there now.
+    h.feed_output(0, b"\x1b[H\x1b[2Ka plain line now\r\n");
+    h.render();
+    assert!(
+        h.app
+            .terminal_hyperlink_paints(h.terminal.backend().buffer())
+            .is_empty(),
+        "a repainted row hands over no links"
+    );
+}
+
+#[test]
 fn split_utf8_output_chunks_render_intact() {
     // The reader loop protects vt100 from mid-codepoint chunks with a carry
     // buffer; `feed_output` bypasses the reader, so this documents that a test

--- a/src/app/helpers.rs
+++ b/src/app/helpers.rs
@@ -1,22 +1,153 @@
 //! Miscellaneous helper functions used by the app module.
 
+use std::io::Write;
 use std::path::PathBuf;
 
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Position, Rect};
+use ratatui::prelude::IntoCrossterm;
+use ratatui::style::Style;
+use unicode_width::UnicodeWidthChar;
+
+use crate::session::hyperlink;
 use crate::session::settings::EditorMode;
 
-pub(super) fn open_url(url: &str) {
-    let cmd = if cfg!(target_os = "macos") {
-        "open"
-    } else {
-        "xdg-open"
+/// One drawn hyperlink run to re-emit to the outer terminal: where it sits on
+/// screen, what it points at, and the exact cells the frame painted there (so
+/// re-printing them changes nothing visible).
+pub(super) struct HyperlinkPaint {
+    pub x: u16,
+    pub y: u16,
+    pub url: String,
+    pub cells: Vec<(String, Style)>,
+}
+
+/// The cells `label` occupies in the frame just drawn, or `None` when the pane
+/// no longer prints it there.
+///
+/// The check is what makes the re-paint safe: a modal, the review view, a
+/// scrolled pane or a repainted row all fail it, so nothing is written over
+/// content that has moved on. A label running past the pane's right edge is
+/// linked as far as it is visible.
+pub(super) fn drawn_label_cells(
+    buf: &Buffer,
+    inner: Rect,
+    x: u16,
+    y: u16,
+    label: &str,
+) -> Option<Vec<(String, Style)>> {
+    let mut cells = Vec::new();
+    let mut cx = x;
+    for ch in label.chars() {
+        // A wide glyph owns two cells: advancing by its width skips ratatui's
+        // filler cell, matching what re-printing the glyph does to the cursor.
+        let width = UnicodeWidthChar::width(ch).unwrap_or(1).max(1) as u16;
+        if cx.saturating_add(width) > inner.right() {
+            break;
+        }
+        let cell = buf.cell(Position::new(cx, y))?;
+        if !cell.symbol().starts_with(ch) {
+            return None;
+        }
+        cells.push((
+            cell.symbol().to_string(),
+            Style::new()
+                .fg(cell.fg)
+                .bg(cell.bg)
+                .add_modifier(cell.modifier),
+        ));
+        cx += width;
+    }
+    (!cells.is_empty()).then_some(cells)
+}
+
+/// Re-print each run wrapped in OSC 8, so the terminal thurbox runs in knows
+/// those cells are a link and can offer its own open-link gesture (in Windows
+/// Terminal, kitty, WezTerm, iTerm2 …, a `Ctrl`/`Cmd`+click that opens the
+/// user's own browser — the only route to a browser when thurbox runs on a
+/// remote host).
+///
+/// Called after the frame is flushed and re-prints the *same* glyphs with the
+/// *same* styles, so nothing changes visually; only the terminal's hyperlink
+/// state is added. Writes go to `stdout` after the backend's flush, so they
+/// cannot interleave with the frame.
+pub(super) fn paint_hyperlinks(paints: &[HyperlinkPaint]) -> std::io::Result<()> {
+    use crossterm::cursor::MoveTo;
+    use crossterm::queue;
+    use crossterm::style::{Print, PrintStyledContent, ResetColor};
+
+    let mut out = std::io::stdout();
+    for paint in paints {
+        queue!(
+            out,
+            MoveTo(paint.x, paint.y),
+            Print(hyperlink::osc8_open(&paint.url))
+        )?;
+        for (symbol, style) in &paint.cells {
+            let content = (*style).into_crossterm();
+            queue!(out, PrintStyledContent(content.apply(symbol.as_str())))?;
+        }
+        queue!(out, Print(hyperlink::OSC8_CLOSE), ResetColor)?;
+    }
+    out.flush()
+}
+
+/// Hand `url` to the platform's URL opener.
+///
+/// `Err` carries a short, user-facing reason the machine can't open a browser —
+/// the common case being a thurbox running on a headless or SSH host, where the
+/// caller falls back to putting the URL on the clipboard instead. The child is
+/// **not** waited on (a browser launcher can take seconds, and the render loop
+/// must not park), so a spawn that succeeds is reported as opened.
+pub(super) fn open_url(url: &str) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    let (program, args): (&str, Vec<&str>) = ("open", vec![url]);
+    #[cfg(target_os = "windows")]
+    // `start` is a cmd builtin; its first quoted argument is the window title,
+    // so an empty one keeps the URL from being eaten as one.
+    let (program, args): (&str, Vec<&str>) = ("cmd", vec!["/C", "start", "", url]);
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let (program, args): (&str, Vec<&str>) = {
+        // Spawning `xdg-open` with nothing to open into either fails or, worse,
+        // succeeds and does nothing — so decide up front rather than report a
+        // browser that never appeared.
+        if !has_browser_target(
+            std::env::var("DISPLAY").ok().as_deref(),
+            std::env::var("WAYLAND_DISPLAY").ok().as_deref(),
+            std::env::var("BROWSER").ok().as_deref(),
+        ) {
+            return Err("No display to open a browser on".into());
+        }
+        ("xdg-open", vec![url])
     };
-    std::process::Command::new(cmd)
-        .arg(url)
+
+    std::process::Command::new(program)
+        .args(args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()
-        .ok();
+        .map(|_| ())
+        .map_err(|e| match e.kind() {
+            std::io::ErrorKind::NotFound => format!("No URL opener ({program} not installed)"),
+            _ => format!("Could not run {program}: {e}"),
+        })
+}
+
+/// Whether anything on this machine could show a URL: a display server, or a
+/// `BROWSER` the user set themselves (which overrides the display check — they
+/// have told us how to open a URL, e.g. a terminal browser).
+///
+/// Unused on macOS/Windows, whose openers need no display server.
+#[cfg_attr(any(target_os = "macos", target_os = "windows"), allow(dead_code))]
+fn has_browser_target(
+    display: Option<&str>,
+    wayland_display: Option<&str>,
+    browser: Option<&str>,
+) -> bool {
+    [display, wayland_display, browser]
+        .iter()
+        .any(|value| value.is_some_and(|v| !v.trim().is_empty()))
 }
 
 /// Spawn `editor_cmd` with `worktree` appended as the final argument.
@@ -249,6 +380,20 @@ pub(super) fn resolve_editor_mode(db: &crate::storage::Database) -> EditorMode {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn browser_target_needs_a_display_or_an_explicit_browser() {
+        // The SSH / headless case: nothing to open into, so the caller falls
+        // back to the clipboard instead of spawning an opener that goes nowhere.
+        assert!(!has_browser_target(None, None, None));
+        // An empty var is as good as unset (a stripped SSH environment).
+        assert!(!has_browser_target(Some(""), Some(" "), Some("")));
+
+        assert!(has_browser_target(Some(":0"), None, None));
+        assert!(has_browser_target(None, Some("wayland-0"), None));
+        // `BROWSER` is the user telling us how to open a URL without a display.
+        assert!(has_browser_target(None, None, Some("firefox")));
+    }
 
     #[test]
     fn open_in_editor_rejects_empty_paths() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -24,6 +24,7 @@ use std::sync::{mpsc, Arc};
 
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
+    buffer::Buffer,
     layout::{Position, Rect},
     widgets::{Block, Borders},
 };
@@ -3035,23 +3036,122 @@ impl App {
     }
 
     /// Open the URL under a Ctrl+Click inside the terminal pane, if any.
-    /// `inner` is the terminal's content area (borders excluded); a click
-    /// outside it (or with no URL at that cell) is a no-op.
+    ///
+    /// Always toasts the outcome: a click that resolved a link but couldn't act
+    /// on it used to be indistinguishable from a click that hit plain text.
     fn open_ctrl_clicked_url(&mut self, inner: Rect, x: u16, y: u16) {
+        let Some(url) = self.url_at_click(inner, x, y) else {
+            return;
+        };
+        match helpers::open_url(&url) {
+            Ok(()) => self.set_status(StatusLevel::Info, format!("Opening {url}")),
+            // No browser reachable — the normal state for a thurbox running on a
+            // headless or SSH host. The clipboard still reaches the user: its
+            // OSC 52 leg travels to the terminal they are sitting at, so the URL
+            // lands in *their* clipboard, ready to paste into a real browser.
+            Err(reason) => match self.write_clipboard(&url) {
+                Ok(route) => self.set_status(
+                    StatusLevel::Info,
+                    format!(
+                        "{reason} — copied {url} to clipboard{}",
+                        route.toast_suffix()
+                    ),
+                ),
+                Err(err) => self.set_error(format!("{reason}, and the clipboard failed: {err}")),
+            },
+        }
+    }
+
+    /// The URL under a click inside the terminal pane. `inner` is the pane's
+    /// content area (borders excluded); a click outside it, or on a cell with no
+    /// link, resolves to `None`.
+    ///
+    /// Two kinds of link resolve here, and an **OSC 8 hyperlink wins**: an agent
+    /// rendering a markdown link prints only the label (`Github`), so the escape
+    /// is the sole place its target exists — and where it wraps a bare URL, the
+    /// escape's target is what a terminal honours anyway.
+    fn url_at_click(&self, inner: Rect, x: u16, y: u16) -> Option<String> {
         use crate::ui::links;
 
         if !inner.contains(Position::new(x, y)) {
-            return;
+            return None;
         }
         let screen_col = (x - inner.x) as usize;
         let screen_row = (y - inner.y) as usize;
+        let mut url = None;
         self.with_active_parser(|parser| {
             let rows = links::extract_screen_rows(parser.screen());
-            let detected = links::detect_urls(&rows);
-            if let Some(url) = links::url_at_position(&detected, screen_row, screen_col) {
-                helpers::open_url(url);
+            url = rows
+                .get(screen_row)
+                .and_then(|row| parser.callbacks().hyperlinks().resolve(row, screen_col))
+                .map(str::to_string)
+                .or_else(|| {
+                    let detected = links::detect_urls(&rows);
+                    links::url_at_position(&detected, screen_row, screen_col).map(str::to_string)
+                });
+        });
+        url
+    }
+
+    /// Hand the hyperlinks of the frame just drawn to the terminal thurbox runs
+    /// in, by re-printing their cells wrapped in OSC 8 (see
+    /// `Self::terminal_hyperlink_paints` for why, and
+    /// `helpers::paint_hyperlinks` for how).
+    ///
+    /// Called by the render loop immediately after the frame is flushed. A write
+    /// failure is ignored: a terminal that drops the escape just gets no links.
+    pub fn paint_terminal_hyperlinks(&self, buf: &Buffer) {
+        let paints = self.terminal_hyperlink_paints(buf);
+        if !paints.is_empty() {
+            let _ = helpers::paint_hyperlinks(&paints);
+        }
+    }
+
+    /// Hyperlink runs visible in the terminal pane of the frame just drawn.
+    ///
+    /// thurbox re-renders the agent's screen through ratatui, which has no
+    /// notion of a hyperlink — so the terminal thurbox itself runs in only ever
+    /// receives a plain label and cannot offer its own "open link" gesture. That
+    /// gesture is the *only* way a thurbox on a remote host can open a browser
+    /// on the machine the user is sitting at: no escape sequence says "open this
+    /// URL", so the link has to be handed to the terminal as a link.
+    ///
+    /// Every candidate is validated against `buf` — the cells actually drawn —
+    /// so a covering modal, the review view, a scrolled pane, or a clipped label
+    /// yields nothing instead of painting stale text over whatever is there now.
+    fn terminal_hyperlink_paints(&self, buf: &Buffer) -> Vec<helpers::HyperlinkPaint> {
+        let mut paints = Vec::new();
+        self.with_active_parser(|parser| {
+            // Most sessions never print a link. Bail before the layout and the
+            // screen scan, so a frame of a link-free session pays one emptiness
+            // check for the whole pass.
+            if parser.callbacks().hyperlinks().is_empty() {
+                return;
+            }
+            let inner = Block::default()
+                .borders(Borders::ALL)
+                .inner(self.screen_layout().terminal);
+            if inner.width == 0 || inner.height == 0 {
+                return;
+            }
+            let rows = crate::ui::links::extract_screen_rows(parser.screen());
+            for run in parser.callbacks().hyperlinks().visible_runs(&rows) {
+                if run.row >= inner.height as usize || run.col >= inner.width as usize {
+                    continue;
+                }
+                let y = inner.y + run.row as u16;
+                let x = inner.x + run.col as u16;
+                if let Some(cells) = helpers::drawn_label_cells(buf, inner, x, y, run.label) {
+                    paints.push(helpers::HyperlinkPaint {
+                        x,
+                        y,
+                        url: run.url.to_string(),
+                        cells,
+                    });
+                }
             }
         });
+        paints
     }
 
     /// Route a click while a modal is open: a hit on a recorded row selects

--- a/src/main.rs
+++ b/src/main.rs
@@ -604,7 +604,14 @@ async fn run_loop(
 
         if app.should_redraw() {
             let draw_start = timing.then(std::time::Instant::now);
-            terminal.draw(|f| app.view(f))?;
+            // ratatui knows nothing about hyperlinks, so a rich-text link in an
+            // agent's output reaches the outer terminal as a plain label. Hand
+            // the links back to it once the frame is flushed, by re-printing
+            // exactly the cells it just drew wrapped in OSC 8 — invisible, but
+            // it lets the terminal open the user's own browser (the only route
+            // to one when thurbox runs on a remote host).
+            let frame = terminal.draw(|f| app.view(f))?;
+            app.paint_terminal_hyperlinks(frame.buffer);
             if let Some(start) = draw_start {
                 app.record_frame_time(start.elapsed());
             }

--- a/src/session/hyperlink.rs
+++ b/src/session/hyperlink.rs
@@ -1,0 +1,334 @@
+//! OSC 8 hyperlink runs captured from an agent's output.
+//!
+//! Agent CLIs render a markdown link as an OSC 8 hyperlink: the escape carries
+//! the target and only the *label* is printed (`Github`, never
+//! `https://github.com`). The plain-text scan in [`crate::ui::links`] therefore
+//! finds nothing on such a row and a `Ctrl+Click` has no target at all — the
+//! URL exists only in the escape sequence, which `vt100` discards. The parser
+//! callbacks record each run here instead (see `crate::agent::osc8`), and a
+//! click resolves against this table.
+//!
+//! A run is keyed by its **label text + start column**, not by screen row: the
+//! row a link sits on moves every time the agent's transcript scrolls, while
+//! the printed glyphs and the column they start at survive scrolling and
+//! redraws. Resolution re-checks that the label is still on screen at that
+//! column, so a row whose content has since been overwritten resolves to
+//! nothing rather than to a stale URL.
+
+use std::collections::{HashSet, VecDeque};
+
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+/// Runs kept per session, oldest dropped first. A long transcript prints far
+/// more links than a click will ever target; the cap keeps the table bounded
+/// without needing to know when a run scrolls out of the scrollback.
+const MAX_RUNS: usize = 512;
+
+/// Newest runs scanned by [`HyperlinkTable::visible_runs`]. That runs once per
+/// painted frame, so the scan is bounded; a run older than this is many
+/// screenfuls back and cannot be on screen.
+const VISIBLE_SCAN_LIMIT: usize = 128;
+
+/// One OSC 8 hyperlink run, on one screen row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HyperlinkRun {
+    /// Target URL the escape carried.
+    pub url: String,
+    /// Glyphs printed while the run was open (a run that wrapped contributes
+    /// one entry per row).
+    pub label: String,
+    /// Screen column the label starts at.
+    pub col: usize,
+}
+
+impl HyperlinkRun {
+    /// Cells the label occupies.
+    fn width(&self) -> usize {
+        UnicodeWidthStr::width(self.label.as_str())
+    }
+
+    /// Whether display column `col` falls on the label.
+    fn covers(&self, col: usize) -> bool {
+        col >= self.col && col < self.col + self.width()
+    }
+
+    /// Whether `row_text` still prints this label where it was captured — the
+    /// check that keeps a scrolled-away or repainted row from resolving to a
+    /// stale target.
+    fn is_printed_in(&self, row_text: &str) -> bool {
+        label_at_column(row_text, self.col, &self.label)
+    }
+}
+
+/// Per-session table of captured hyperlink runs.
+#[derive(Clone, Debug, Default)]
+pub struct HyperlinkTable {
+    runs: VecDeque<HyperlinkRun>,
+}
+
+impl HyperlinkTable {
+    /// Record a run's label.
+    ///
+    /// An agent repaints its transcript constantly, re-emitting the same runs:
+    /// a label already captured at that column is refreshed in place (its target
+    /// may have changed) rather than appended, so a redraw neither grows the
+    /// table nor allocates.
+    pub fn record(&mut self, url: &str, label: &str, col: usize) {
+        if url.is_empty() || label.is_empty() {
+            return;
+        }
+        if let Some(run) = self
+            .runs
+            .iter_mut()
+            .find(|run| run.col == col && run.label == label)
+        {
+            if run.url != url {
+                run.url.clear();
+                run.url.push_str(url);
+            }
+            return;
+        }
+        self.runs.push_back(HyperlinkRun {
+            url: url.to_string(),
+            label: label.to_string(),
+            col,
+        });
+        while self.runs.len() > MAX_RUNS {
+            self.runs.pop_front();
+        }
+    }
+
+    /// Target of the hyperlink under display column `col` of `row_text`, if
+    /// any. `row_text` is one screen row as
+    /// [`crate::ui::links::extract_screen_rows`] renders it (one char per
+    /// glyph), so columns compare directly against a click's cell column.
+    ///
+    /// Newest run first, so a redrawn row resolves against what it prints now.
+    /// A label still has to be present at its recorded column for the run to
+    /// match — the guard against a row that has since scrolled other text into
+    /// that spot.
+    pub fn resolve(&self, row_text: &str, col: usize) -> Option<&str> {
+        self.runs
+            .iter()
+            .rev()
+            .find(|run| run.covers(col) && run.is_printed_in(row_text))
+            .map(|run| run.url.as_str())
+    }
+
+    /// Whether nothing has been captured — the state of a session whose agent
+    /// never printed a link, checked to keep the per-frame
+    /// [`Self::visible_runs`] pass off the render path entirely.
+    pub fn is_empty(&self) -> bool {
+        self.runs.is_empty()
+    }
+
+    /// Captured runs, oldest first (tests / diagnostics).
+    pub fn runs(&self) -> impl Iterator<Item = &HyperlinkRun> {
+        self.runs.iter()
+    }
+
+    /// Every run currently on screen, so the renderer can hand them to the
+    /// outer terminal (see [`osc8_open`]). `rows` is one screenful as
+    /// [`crate::ui::links::extract_screen_rows`] renders it.
+    ///
+    /// Newest first, at most one run per starting cell — the same
+    /// "what does this cell print *now*" rule [`Self::resolve`] applies, so a
+    /// repainted row can't show a link that has scrolled away. Only the newest
+    /// `VISIBLE_SCAN_LIMIT` runs are considered: this drives a per-frame pass,
+    /// and anything older is many screenfuls back.
+    pub fn visible_runs<'a>(&'a self, rows: &[String]) -> Vec<VisibleRun<'a>> {
+        let mut claimed: HashSet<(usize, usize)> = HashSet::new();
+        let mut visible = Vec::new();
+        for run in self.runs.iter().rev().take(VISIBLE_SCAN_LIMIT) {
+            for (row, text) in rows.iter().enumerate() {
+                if run.is_printed_in(text) && claimed.insert((row, run.col)) {
+                    visible.push(VisibleRun {
+                        row,
+                        col: run.col,
+                        label: &run.label,
+                        url: &run.url,
+                    });
+                }
+            }
+        }
+        visible
+    }
+}
+
+/// A run found on the screen as currently drawn.
+#[derive(Debug, PartialEq, Eq)]
+pub struct VisibleRun<'a> {
+    pub row: usize,
+    pub col: usize,
+    pub label: &'a str,
+    pub url: &'a str,
+}
+
+/// Opening half of an OSC 8 hyperlink: everything printed until
+/// [`OSC8_CLOSE`] becomes a link to `url` in the terminal thurbox itself runs
+/// in.
+///
+/// Control characters are stripped. The URL is **agent-controlled text being
+/// written back to the user's own terminal**, and an embedded `ESC` would end
+/// the sequence early and let the rest be interpreted as escapes of its own.
+pub fn osc8_open(url: &str) -> String {
+    let safe: String = url.chars().filter(|c| !c.is_control()).collect();
+    format!("\x1b]8;;{safe}\x07")
+}
+
+/// Closing half of an OSC 8 hyperlink (see [`osc8_open`]).
+pub const OSC8_CLOSE: &str = "\x1b]8;;\x07";
+
+/// Whether `row_text` prints `label` starting exactly at display column `col`.
+fn label_at_column(row_text: &str, col: usize, label: &str) -> bool {
+    let mut width = 0;
+    for (offset, ch) in row_text.char_indices() {
+        if width == col {
+            return row_text[offset..].starts_with(label);
+        }
+        if width > col {
+            // `col` lands inside a wide glyph — no label can start there.
+            return false;
+        }
+        width += UnicodeWidthChar::width(ch).unwrap_or(0);
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_label_under_click() {
+        let mut table = HyperlinkTable::default();
+        table.record("https://github.com", "Github", 4);
+        let row = "see Github done";
+        // Every cell of the label resolves; the cells around it do not.
+        assert_eq!(table.resolve(row, 4), Some("https://github.com"));
+        assert_eq!(table.resolve(row, 9), Some("https://github.com"));
+        assert_eq!(table.resolve(row, 3), None);
+        assert_eq!(table.resolve(row, 10), None);
+    }
+
+    #[test]
+    fn ignores_row_whose_content_moved_on() {
+        let mut table = HyperlinkTable::default();
+        table.record("https://github.com", "Github", 4);
+        // Same column, different text now printed there (the row scrolled and
+        // was reused): no link, rather than the stale one.
+        assert_eq!(table.resolve("see Gitlab done", 4), None);
+        // Right label, wrong column.
+        assert_eq!(table.resolve("Github done", 0), None);
+    }
+
+    #[test]
+    fn newest_run_wins_at_a_column() {
+        let mut table = HyperlinkTable::default();
+        table.record("https://a.example", "docs", 0);
+        table.record("https://b.example", "docs", 0);
+        assert_eq!(table.resolve("docs", 0), Some("https://b.example"));
+        // The replaced entry is gone, not shadowed.
+        assert_eq!(table.runs().count(), 1);
+    }
+
+    #[test]
+    fn same_label_at_two_columns_is_kept_twice() {
+        let mut table = HyperlinkTable::default();
+        table.record("https://a.example", "docs", 0);
+        table.record("https://b.example", "docs", 10);
+        let row = "docs      docs";
+        assert_eq!(table.resolve(row, 0), Some("https://a.example"));
+        assert_eq!(table.resolve(row, 10), Some("https://b.example"));
+    }
+
+    #[test]
+    fn wide_glyphs_before_a_label_shift_its_column() {
+        let mut table = HyperlinkTable::default();
+        // 漢字 spans four cells, so the label starts at column 5.
+        table.record("https://example.com", "Github", 5);
+        let row = "漢字 Github";
+        assert_eq!(table.resolve(row, 5), Some("https://example.com"));
+        // The trailing cell of 字 is not part of the label.
+        assert_eq!(table.resolve(row, 4), None);
+        // A column landing inside a wide glyph never starts a label.
+        assert_eq!(table.resolve(row, 1), None);
+    }
+
+    #[test]
+    fn empty_url_or_label_is_not_recorded() {
+        let mut table = HyperlinkTable::default();
+        table.record("", "Github", 0);
+        table.record("https://example.com", "", 0);
+        assert_eq!(table.runs().count(), 0);
+    }
+
+    #[test]
+    fn table_is_bounded() {
+        let mut table = HyperlinkTable::default();
+        for i in 0..MAX_RUNS + 50 {
+            table.record(&format!("https://example.com/{i}"), "link", i);
+        }
+        assert_eq!(table.runs().count(), MAX_RUNS);
+        // The oldest runs were dropped, the newest kept.
+        assert!(table.resolve("link", 0).is_none());
+        let last = MAX_RUNS + 49;
+        let row = " ".repeat(last) + "link";
+        assert_eq!(
+            table.resolve(&row, last),
+            Some(format!("https://example.com/{last}").as_str())
+        );
+    }
+
+    #[test]
+    fn visible_runs_finds_what_the_screen_prints_now() {
+        let mut table = HyperlinkTable::default();
+        table.record("https://github.com", "Github", 4);
+        table.record("https://gone.example", "Vanished", 0);
+        let rows = vec![
+            "nothing here".to_string(),
+            "see Github done".to_string(),
+            String::new(),
+        ];
+        let visible = table.visible_runs(&rows);
+        assert_eq!(
+            visible,
+            vec![VisibleRun {
+                row: 1,
+                col: 4,
+                label: "Github",
+                url: "https://github.com",
+            }],
+            "a run whose label is no longer on screen is not reported"
+        );
+    }
+
+    #[test]
+    fn visible_runs_reports_the_newest_run_per_cell() {
+        let mut table = HyperlinkTable::default();
+        table.record("https://old.example", "docs", 0);
+        table.record("https://new.example", "docs", 0);
+        let visible = table.visible_runs(&["docs".to_string()]);
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].url, "https://new.example");
+    }
+
+    #[test]
+    fn osc8_open_strips_control_characters() {
+        assert_eq!(
+            osc8_open("https://example.com"),
+            "\x1b]8;;https://example.com\x07"
+        );
+        // An agent-supplied URL must not be able to end the sequence early and
+        // inject escapes into the user's terminal.
+        assert_eq!(
+            osc8_open("https://x.example\x1b[31m\x07\n"),
+            "\x1b]8;;https://x.example[31m\x07"
+        );
+    }
+
+    #[test]
+    fn empty_table_resolves_nothing() {
+        assert_eq!(HyperlinkTable::default().resolve("Github", 0), None);
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -2,6 +2,7 @@ pub mod agent_def;
 pub mod automation;
 pub mod extension_def;
 pub mod host_def;
+pub mod hyperlink;
 pub mod keybindings;
 pub mod message;
 pub mod review;
@@ -22,6 +23,7 @@ pub use host_def::{
     is_remote_backend, is_ssh_backend, is_wsl_backend, HostDef, HostKind, HostRegistry,
     SSH_BACKEND_PREFIX, WSL_BACKEND_PREFIX,
 };
+pub use hyperlink::{HyperlinkRun, HyperlinkTable, VisibleRun};
 pub use keybindings::{compact_shortcut, Action, KeyBindings, KeyChord, KeyContext};
 pub use message::SessionMessage;
 pub use review::{


### PR DESCRIPTION
## Summary

- **Rich-text links now resolve.** An agent renders `[Github](https://github.com)` as an OSC 8 hyperlink, so the screen holds only `Github` and the URL lives solely in the escape — which `vt100` drops. `Ctrl+Click` had nothing to resolve. Each run is now captured in the parser callbacks (`agent::osc8` → `session::hyperlink`) and keyed by **label text + start column, not screen row**: the row moves whenever the transcript scrolls, the glyphs and their column survive it. A click resolves only if the label is *still printed at that column*, so a repainted row yields nothing rather than a stale target; a run the screen scrolled under mid-print is dropped for the same reason, and a wrapped run contributes one entry per row. Bounded at 512 runs/session.
- **Links are handed back to the outer terminal.** ratatui has no hyperlink concept, so the terminal thurbox runs in only ever saw a plain label and could not offer its own open-link gesture. After each frame is flushed, `App::paint_terminal_hyperlinks` re-prints the visible runs wrapped in OSC 8 — same glyphs, same styles, read out of the drawn frame and validated against it, so nothing changes visually and a covering overlay / scrolled pane / repainted row emits nothing. This is what makes the feature work over SSH: no escape sequence says "open this URL", so a terminal-side Ctrl+Click is the only route to a browser on the machine the user is sitting at.
- **The click's outcome is now visible.** It used to spawn an opener and discard the result, so on a headless/SSH host (no `DISPLAY`, no `xdg-open` installed) *nothing happened for any link*, rich or plain. `helpers::open_url` now checks for a display first, returns a reason, and gained the missing Windows branch; the click toasts what happened and falls back to copying the URL over the same native → OSC 52 path `Ctrl+C` uses — which reaches the user's *own* clipboard.
- URLs are stripped of control characters before being echoed back (agent-controlled text going to the user's terminal; an embedded `ESC` could break out of the sequence).
- Perf: the per-frame pass bails on `HyperlinkTable::is_empty()` before layout or the screen scan, so a link-free session pays one check per painted frame. Noted under ADR-P1.
- Docs: Clickable URLs section rewritten (`docs/FEATURES.md`), ADR-P1 note (`docs/PERFORMANCE.md`), `CLAUDE.md` module map.

## Test plan

- `cargo nextest run --all` — 1978 pass. 8 failures are pre-existing and environmental on this machine (global `commit.gpgsign=true` with SSH signing and no key in the agent breaks every test that makes a commit); all 8 pass under `GIT_CONFIG_GLOBAL=/dev/null`.
- 27 new tests: OSC 8 capture through a real `vt100` parser (BEL + ST terminators, `id=` params, a URI containing `;`, wrapped runs, embedded newline, scrolled-under, empty run), table resolution (stale row, newest-per-cell, wide glyphs, bounding), `osc8_open` sanitisation, the display/`BROWSER` decision, plus two acceptance tests over the real `App` — a Ctrl+Click resolving the escape's target, and a rendered frame's runs being handed over (and *not* handed over once the row is repainted).
- `cargo clippy --all-targets --all-features -- -D warnings` and `RUSTDOCFLAGS="-D warnings" cargo doc` clean.
- End-to-end against the real binary, driven with a synthetic SGR ctrl-click in a throwaway tmux: the outer terminal receives `ESC]8;;https://github.com ST Github ESC]8;; ST` wrapping exactly the label with rendered text unchanged, and the click toasts `No display to open a browser on — copied https://github.com to clipboard (OSC 52)`.
- Confirmed by hand in Windows Terminal over SSH: hover underlines the label and Ctrl+Click opens the browser.
