### PR TITLE
fix(core): type hyphens on Windows through psmux's send-keys parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -712,6 +712,15 @@ control-mode protocol is byte-identical over either transport/binary, with
   `'` typed arrived in the pane as `\` (`it's` → `it\s`) — the `-N` flag makes
   psmux's coalescing decoder bail, and its direct handler reads the
   double-quote framing correctly (`flush_psmux_literal` / `psmux_quote`).
+  Quoting alone can't carry every run, because psmux classifies arguments
+  *after* tokenizing (the quotes are gone by then): it drops each one starting
+  with `-` as an unknown flag, so a typed hyphen never reached the pane (issue
+  #920), and it rewrites a `0xNN`-shaped argument into the character it names,
+  so a run spelling `0x41` would arrive as `A`. `psmux_literal_args` escapes
+  both by re-emitting the offending leading character *as* a `0xNN` argument —
+  psmux decodes it back and, in literal mode, joins the arguments with no
+  separator, so the run is reassembled exactly. Delivery is probed by
+  `scripts/dev/e2e/windows-vm.sh test` (probe D).
 - **`new-window` trailing tokens are not joined** — tmux joins them into one
   shell command; psmux keeps only the *first* token and silently drops the
   rest, so the agent launched with **no args**. And **`new-window -e` is

--- a/scripts/dev/e2e/windows-vm.sh
+++ b/scripts/dev/e2e/windows-vm.sh
@@ -354,6 +354,38 @@ cmd_test() {
   fi
   ssh_vm "psmux -L $SOCKET kill-server" >/dev/null 2>&1 || true
 
+  # --- literal-hyphen probe (evidence, not verdict) -------------------------
+  # psmux classifies a send-keys argument only *after* tokenizing it, dropping
+  # every one that starts with `-` as an unknown flag — so a quoted literal `-`
+  # never reached the pane and hyphens could not be typed on Windows (issue
+  # #920). thurbox escapes such a run into psmux's own `0xNN` codepoint form
+  # (`control_mode::psmux_literal_args`). The psmux CLI forwards both encodings
+  # to the same server-side classifier thurbox's control-mode line hits, so
+  # typing them into one prompt line is evidence about that rule: the old
+  # encoding must lose its hyphen, the new one must keep it.
+  log "probing psmux literal-hyphen delivery (keystroke encoding evidence)"
+  local hpane hcontent
+  ssh_vm "psmux -L $SOCKET new-session -d -s hyphenprobe" >/dev/null 2>&1 || true
+  hpane="$(ssh_vm "psmux -L $SOCKET list-panes -s -t hyphenprobe -F '#{pane_id}'" 2>/dev/null | tr -d '\r' | head -n1)"
+  if [ -n "$hpane" ]; then
+    ssh_vm "psmux -L $SOCKET send-keys -t $hpane -l -N 1 'HYPA' '-'" >/dev/null 2>&1 || true
+    ssh_vm "psmux -L $SOCKET send-keys -t $hpane -l -N 1 'HYPB' '0x2d'" >/dev/null 2>&1 || true
+    sleep 2
+    hcontent="$(ssh_vm "psmux -L $SOCKET capture-pane -p -t $hpane" 2>/dev/null | tr -d '\r')"
+    case "$hcontent" in
+      *HYPA-*) info "probe D: a quoted literal '-' survives — the #920 escape is no longer needed" ;;
+      *HYPA*) ok "probe D: a quoted literal '-' is dropped as a flag (the #920 bug, as encoded for)" ;;
+      *) info "probe D: nothing delivered (got: ${hcontent:-<none>})" ;;
+    esac
+    case "$hcontent" in
+      *HYPB-*) ok "probe D: the 0xNN escape delivers a hyphen into the pane" ;;
+      *) info "probe D: the 0xNN escape delivered no hyphen (got: ${hcontent:-<none>})" ;;
+    esac
+  else
+    info "hyphen probe skipped: could not resolve a probe pane id"
+  fi
+  ssh_vm "psmux -L $SOCKET kill-server" >/dev/null 2>&1 || true
+
   echo
   if printf '%s\n' "$sessions" | grep -qx smoke; then
     pass "psmux is installed and a -L $SOCKET session round-tripped"

--- a/src/agent/control_mode.rs
+++ b/src/agent/control_mode.rs
@@ -179,8 +179,8 @@ fn psmux_key_name(b: u8) -> Option<String> {
 /// tokenizer cannot read back, so any `'` in the text arrived in the pane as
 /// `\` (`it's` was typed as `it\s`), regardless of how the client framed it.
 /// The decoder bails on a `-N` flag, letting the original line reach the
-/// direct send-keys handler, whose single parse handles the double-quote
-/// framing of [`psmux_quote`] correctly. Verified against psmux 3.3.6.
+/// direct send-keys handler, whose single parse handles the argument encoding
+/// of [`psmux_literal_args`] correctly. Verified against psmux 3.3.6.
 fn flush_psmux_literal(pane_id: &str, literal: &mut Vec<u8>, cmds: &mut Vec<String>) {
     if literal.is_empty() {
         return;
@@ -189,7 +189,7 @@ fn flush_psmux_literal(pane_id: &str, literal: &mut Vec<u8>, cmds: &mut Vec<Stri
     let emit = |chunk: &str, cmds: &mut Vec<String>| {
         cmds.push(format!(
             "send-keys -t {pane_id} -l -N 1 {}\n",
-            psmux_quote(chunk)
+            psmux_literal_args(chunk)
         ));
     };
     let mut chunk = String::new();
@@ -206,10 +206,53 @@ fn flush_psmux_literal(pane_id: &str, literal: &mut Vec<u8>, cmds: &mut Vec<Stri
     literal.clear();
 }
 
-/// Double-quote `s` for a psmux `send-keys -l` argument. Always quotes (even a
-/// bare word) so a leading `-` is never read as a flag. Double quotes — not
-/// POSIX single quotes — because psmux's tokenizer has no working escape for a
-/// `'` inside `'…'`, but inside `"…"` it passes `'` through untouched and
+/// Encode one printable run as the argument list of a psmux `send-keys -l`
+/// command.
+///
+/// Quoting alone is not enough, because psmux classifies arguments *after*
+/// tokenizing (which strips the quotes) and drops every one that
+/// `starts_with('-')` as an unknown flag — so a typed `-` never reached the
+/// pane (issue #920). It also rewrites any argument shaped like tmux's `0xNN`
+/// hex codepoint (the encoding iTerm2's gateway sends) into the character it
+/// names, so a run literally spelling `0x41` would arrive as `A`.
+///
+/// Both are escaped by emitting the offending *leading* character as its own
+/// `0xNN` argument: psmux converts that back to the same character and, in
+/// literal mode, joins the arguments with no separator, so the run is
+/// reassembled exactly. Escaping repeats until the remainder is safe — `--x`
+/// needs both hyphens escaped, and `-0x41` needs the hyphen and then the `0`.
+fn psmux_literal_args(run: &str) -> String {
+    let mut args: Vec<String> = Vec::new();
+    let mut rest = run;
+    while let Some(ch) = rest.chars().next() {
+        if !psmux_arg_is_reinterpreted(rest) {
+            break;
+        }
+        args.push(format!("0x{:x}", ch as u32));
+        rest = &rest[ch.len_utf8()..];
+    }
+    if !rest.is_empty() {
+        args.push(psmux_quote(rest));
+    }
+    args.join(" ")
+}
+
+/// Whether psmux would read `arg` as anything other than the literal text it
+/// spells: a flag (any leading `-`, quoted or not) or a `0xNN` hex codepoint.
+fn psmux_arg_is_reinterpreted(arg: &str) -> bool {
+    if arg.starts_with('-') {
+        return true;
+    }
+    arg.strip_prefix("0x")
+        .or_else(|| arg.strip_prefix("0X"))
+        .is_some_and(|hex| !hex.is_empty() && hex.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
+/// Double-quote `s` for a psmux `send-keys -l` argument. Always quotes, even a
+/// bare word, so whitespace never splits the run into several arguments (a
+/// leading `-` needs more than quoting — see [`psmux_literal_args`]). Double
+/// quotes — not POSIX single quotes — because psmux's tokenizer has no working
+/// escape for a `'` inside `'…'`, but inside `"…"` it passes `'` through and
 /// reads exactly two escapes: `\"` (literal quote) and `\\` (literal
 /// backslash); any other backslash stays literal, so both are escaped here. A
 /// literal run never contains a newline (LF and CR map to key-names), but the
@@ -1176,6 +1219,49 @@ mod tests {
             send_keys_commands("%1", br#"say "hi" C:\p"#, true),
             vec!["send-keys -t %1 -l -N 1 \"say \\\"hi\\\" C:\\\\p\"\n".to_string()]
         );
+    }
+
+    #[test]
+    fn psmux_literal_escapes_a_leading_hyphen() {
+        // Regression (#920): psmux classifies arguments after tokenizing, so
+        // the quotes are gone by the time it drops everything starting with
+        // `-` as a flag — a typed `-` was silently swallowed. It comes back as
+        // psmux's own `0xNN` codepoint form, which decodes to the same char.
+        assert_eq!(
+            send_keys_commands("%1", b"-", true),
+            vec!["send-keys -t %1 -l -N 1 0x2d\n".to_string()]
+        );
+        // Only the leading hyphens need escaping; the rest stays one literal.
+        assert_eq!(
+            send_keys_commands("%1", b"--flag=a-b", true),
+            vec!["send-keys -t %1 -l -N 1 0x2d 0x2d \"flag=a-b\"\n".to_string()]
+        );
+    }
+
+    #[test]
+    fn psmux_literal_escapes_a_hex_codepoint_lookalike() {
+        // psmux rewrites a `0xNN` argument into the character it names, so a
+        // run literally spelling `0x41` would have arrived as `A`.
+        assert_eq!(
+            send_keys_commands("%1", b"0x41", true),
+            vec!["send-keys -t %1 -l -N 1 0x30 \"x41\"\n".to_string()]
+        );
+        // A hyphen ahead of one still leaves a lookalike behind it.
+        assert_eq!(
+            send_keys_commands("%1", b"-0x41", true),
+            vec!["send-keys -t %1 -l -N 1 0x2d 0x30 \"x41\"\n".to_string()]
+        );
+        // Not a lookalike: text past the hex digits is ordinary literal text.
+        assert_eq!(
+            send_keys_commands("%1", b"0x41z", true),
+            vec!["send-keys -t %1 -l -N 1 \"0x41z\"\n".to_string()]
+        );
+    }
+
+    #[test]
+    fn psmux_literal_args_escapes_an_all_hyphen_run() {
+        assert_eq!(psmux_literal_args("---"), "0x2d 0x2d 0x2d");
+        assert_eq!(psmux_literal_args(""), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes #920 — a `-` typed into a session on Windows never reached the pane, while `_` and every other character did.
- Root cause, from psmux 3.3.6's own source (`src/server/connection.rs`): the control-mode `send-keys` handler classifies arguments **after** tokenizing, and `parse_command_line` strips the quotes first. So `send-keys -t %1 -l -N 1 "-"` arrived as the bare argument `-` and its `!a.starts_with('-')` filter dropped it as an unknown flag. Quoting could never have protected against this, so the claim that it did is gone from `psmux_quote`'s doc.
- `psmux_literal_args` re-emits the offending leading character as psmux's own `0xNN` codepoint argument, which psmux decodes back to the same character and — in literal mode — joins with no separator, so the run is reassembled exactly. Escaping repeats until the remainder is safe (`--x` needs both hyphens; `-0x41` the hyphen and then the `0`). Interior hyphens are untouched.
- Closes a sibling bug of the same class found while in that handler: psmux rewrites **any** `0xNN`-shaped argument into the character it names, so a literal run spelling `0x41` would have been typed as `A`. The same escape covers it.
- Docs: updated the psmux-divergences bullet in `CLAUDE.md` per the repo's same-PR doc rule.

## Test plan

- `cargo nextest run -E 'test(psmux)'` — 23/23 pass, including 3 new tests: leading-hyphen escaping (`-`, `--flag=a-b`), the `0xNN` lookalike (`0x41`, `-0x41`, and the non-lookalike `0x41z`), and the all-hyphen/empty run.
- `cargo clippy --all-targets --all-features -- -D warnings` and `shellcheck` clean.
- Probe D added to `scripts/dev/e2e/windows-vm.sh test`: types both encodings into one prompt line on a real psmux and asserts the old form loses its hyphen while the `0xNN` form keeps it. Evidence-level like probes A–C, so a future psmux fix surfaces as a reported observation rather than silence.
- Not run: the Windows VM suite (needs `/dev/kvm`); CI's native `windows` job covers it.