### PR TITLE
docs: mark winget package as live, recommend the PowerShell installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/Thurbeen
 VERSION=v1.0.0 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
 ```
 
-**Windows (PowerShell):**
+**Windows (PowerShell) — recommended:**
 
 > [!NOTE]
 > Windows support is **experimental** for now. The core works (psmux as the
@@ -66,12 +66,8 @@ winget install Thurbeen.thurbox
 Installs the prebuilt x86_64 Windows binaries (`thurbox.exe` +
 `thurbox-cli.exe`) from the GitHub Release as portable commands on your `PATH`.
 Needs [psmux](https://github.com/psmux/psmux) as the multiplexer (installed
-separately).
-
-> **⚠️ Pending review.** The winget package has been submitted to
-> `microsoft/winget-pkgs` but is **not yet merged/live**, so `winget install
-> Thurbeen.thurbox` won't resolve it until the PR is approved. Use
-> **Chocolatey** or the PowerShell installer (both below) in the meantime.
+separately). Live on
+[`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs).
 
 **Chocolatey (Windows):**
 
@@ -83,6 +79,15 @@ Installs the prebuilt x86_64 Windows binaries (`thurbox.exe` +
 `thurbox-cli.exe`) from the GitHub Release and shims them onto your `PATH`.
 Needs [psmux](https://github.com/psmux/psmux) as the multiplexer (installed
 separately — there is no Chocolatey package for it).
+
+> [!TIP]
+> **On Windows, `irm … install.ps1 | iex` is the recommended route.** Both
+> winget-pkgs and the Chocolatey community repo are *manually moderated* and
+> rate-limited, so thurbox publishes to each **at most once every 30 days**
+> (intermediate releases are coalesced into the next submission). Those channels
+> therefore lag the newest build; the PowerShell installer and
+> [GitHub Releases](https://github.com/Thurbeen/thurbox/releases) always have it
+> immediately.
 
 **Homebrew (macOS / Linux):**
 

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -9,14 +9,14 @@ commands on your `PATH`.
 winget install Thurbeen.thurbox
 ```
 
-> **Status: pending review.** The package has been submitted to
-> [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs) but the PR
-> has **not yet merged**, so `winget install Thurbeen.thurbox` will not resolve
-> until it goes live (see [Automated publishing](#automated-publishing-ci)
-> below). Until then,
-> install with the approved [Chocolatey](../chocolatey/README.md) package,
-> [`scripts/install.ps1`](../../scripts/install.ps1), or validate the local
-> manifest (see [Manual publishing](#manual-publishing--initial-import)).
+> **Status: live.** The package is published on
+> [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs), so
+> `winget install Thurbeen.thurbox` resolves. Each *new version* still goes
+> through PR review there, and submissions are throttled to one per 30 days (see
+> [Automated publishing](#automated-publishing-ci) below) — so the winget
+> channel trails the newest release. For the latest build immediately, use
+> [`scripts/install.ps1`](../../scripts/install.ps1)
+> (`irm … | iex`) or the GitHub Release zip.
 
 The canonical manifest set lives here under [`manifests/`](manifests/):
 

--- a/website/docs/faq.html
+++ b/website/docs/faq.html
@@ -50,10 +50,12 @@ breadcrumb: 'FAQ'
   <code>curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code>.
   It is also available via Homebrew
   (<code>brew install thurbeen/thurbox/thurbox</code>), the AUR (<code>thurbox</code>
-  or <code>thurbox-bin</code>), and on Windows via PowerShell or Chocolatey
-  (<code>choco install thurbox</code>). A winget package
-  (<code>winget install Thurbeen.thurbox</code>) is submitted but pending review.
-  You can also build from source with
+  or <code>thurbox-bin</code>), and on Windows via winget
+  (<code>winget install Thurbeen.thurbox</code>) or Chocolatey
+  (<code>choco install thurbox</code>). Both of those channels are moderated and
+  only get a new version every 30 days, so the PowerShell installer
+  (<code>irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code>)
+  is the recommended route on Windows. You can also build from source with
   <code>cargo build --release</code>. See
   <a href="installation.html">installation</a> for details.
 </p>
@@ -120,7 +122,7 @@ breadcrumb: 'FAQ'
         "name": "How do I install Thurbox?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "On Linux or macOS, run: curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh. It is also available via Homebrew (brew install thurbeen/thurbox/thurbox), the AUR (thurbox or thurbox-bin), and on Windows via PowerShell or Chocolatey (choco install thurbox). A winget package (winget install Thurbeen.thurbox) is submitted but pending review. You can also build from source with cargo build --release."
+          "text": "On Linux or macOS, run: curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh. It is also available via Homebrew (brew install thurbeen/thurbox/thurbox), the AUR (thurbox or thurbox-bin), and on Windows via winget (winget install Thurbeen.thurbox) or Chocolatey (choco install thurbox). Both of those channels are moderated and only get a new version every 30 days, so the PowerShell installer (irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex) is the recommended route on Windows. You can also build from source with cargo build --release."
         }
       },
       {

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -53,7 +53,10 @@ breadcrumb: 'Installation'
             </p>
           </div>
           <p>
-            On native Windows the install script is PowerShell. It installs to
+            On native Windows the install script is PowerShell, and it is the
+            <strong>recommended route</strong>
+            &mdash; unlike the winget and Chocolatey packages below, it always
+            carries the newest release. It installs to
             <code>%LOCALAPPDATA%\Programs\thurbox</code>
             (added to your user
             <code>PATH</code>) and uses
@@ -105,19 +108,6 @@ breadcrumb: 'Installation'
             (Microsoft's package manager, bundled with Windows 10/11):
           </p>
           <pre><code class="language-powershell">winget install Thurbeen.thurbox</code></pre>
-          <div class="info-box warning">
-            <p>
-              <strong>Pending review.</strong>
-              The winget package has been submitted to
-              <code>microsoft/winget-pkgs</code>
-              but is
-              <strong>not yet merged</strong>
-              , so
-              <code>winget install Thurbeen.thurbox</code>
-              will not resolve until the PR is approved. Use the PowerShell
-              installer above in the meantime.
-            </p>
-          </div>
           <p>
             Installs
             <code>thurbox.exe</code>
@@ -135,11 +125,15 @@ breadcrumb: 'Installation'
               winget-pkgs is manually reviewed, so thurbox submits a new winget
               version
               <strong>at most once every 30 days</strong>
-              (intermediate releases are coalesced into the next submission). The
-              latest build always ships immediately via the PowerShell installer
-              above and
+              (intermediate releases are coalesced into the next submission), and
+              each submission waits on PR review before it goes live. The latest
+              build always ships immediately via the PowerShell installer above
+              and
               <a href="https://github.com/Thurbeen/thurbox/releases">GitHub Releases</a>
-              ; the winget channel intentionally trails a little.
+              , so
+              <code>irm &hellip; install.ps1 | iex</code>
+              stays the recommended route on Windows; the winget channel
+              intentionally trails a little.
             </p>
           </div>
 
@@ -175,7 +169,10 @@ breadcrumb: 'Installation'
               latest build always ships immediately via the PowerShell installer
               above and
               <a href="https://github.com/Thurbeen/thurbox/releases">GitHub Releases</a>
-              ; the Chocolatey channel intentionally trails a little.
+              , so
+              <code>irm &hellip; install.ps1 | iex</code>
+              stays the recommended route on Windows; the Chocolatey channel
+              intentionally trails a little.
             </p>
           </div>
 

--- a/website/index.html
+++ b/website/index.html
@@ -125,7 +125,10 @@ footer: true
             hidden
           >
             <p>
-              Native Windows (PowerShell 5.1+). Verifies checksums and installs the latest release to
+              Native Windows (PowerShell 5.1+), and the
+              <strong>recommended route</strong>
+              &mdash; unlike winget and Chocolatey it always has the newest
+              release. Verifies checksums and installs to
               <code>%LOCALAPPDATA%\Programs\thurbox</code>
               (added to your user
               <code>PATH</code>
@@ -151,14 +154,12 @@ footer: true
               as the multiplexer (installed separately).
             </p>
             <p>
-              <strong>Pending review:</strong>
-              the package is submitted to
-              <code>microsoft/winget-pkgs</code>
-              but not yet merged, so
-              <code>winget install Thurbeen.thurbox</code>
-              won't resolve until the PR is approved &mdash; use
-              <strong>Chocolatey</strong>
-              or the install script meanwhile.
+              <strong>Heads-up:</strong>
+              winget-pkgs is manually moderated, so thurbox submits a new version
+              there at most once every 30 days &mdash; this channel trails the
+              newest build. For the latest release right away, use the
+              <strong>PowerShell</strong>
+              installer.
             </p>
             <pre><code class="language-powershell">winget install Thurbeen.thurbox</code></pre>
           </div>
@@ -178,6 +179,15 @@ footer: true
               . Needs
               <a href="https://github.com/psmux/psmux" target="_blank" rel="noopener">psmux</a>
               as the multiplexer (installed separately).
+            </p>
+            <p>
+              <strong>Heads-up:</strong>
+              the Chocolatey community repo is moderated and rate-limited, so
+              thurbox pushes a new version there at most once every 30 days
+              &mdash; this channel trails the newest build. For the latest
+              release right away, use the
+              <strong>PowerShell</strong>
+              installer.
             </p>
             <pre><code class="language-powershell">choco install thurbox</code></pre>
           </div>


### PR DESCRIPTION
## Summary

- The `Thurbeen.thurbox` manifests are merged into `microsoft/winget-pkgs` (`manifests/t/Thurbeen/thurbox/1.1.1` is published), so the "pending review / not yet merged" warnings are gone from `README.md`, `packaging/winget/README.md`, `website/index.html`, `website/docs/installation.html`, and `website/docs/faq.html`.
- `packaging/winget/README.md` status block now reads **live**, while keeping the caveat that each *new version* still goes through winget-pkgs PR review and the 30-day submission throttle.
- Every Windows install surface now says that winget and Chocolatey are moderated + throttled to one publish per 30 days and therefore trail the newest build, and points at `irm ... install.ps1 | iex` / GitHub Releases as the recommended route.
- FAQ prose and its JSON-LD `acceptedAnswer` updated in sync so the structured data doesn't contradict the page.

## Test plan

- `npm run lint:website` (11ty build + prettier + htmlhint + stylelint + eslint) passes.
- Verified the package is live: `GET /repos/microsoft/winget-pkgs/contents/manifests/t/Thurbeen/thurbox` → 200 with version `1.1.1`.
- New markdown lines stay within the 100-column `MD013` limit.