### PR TITLE
fix(ui): open the search strip focused, and keep its matches lit

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -305,6 +305,12 @@ separate answers in `kernel::focus`. Conflating them cost the old plugins pane e
 way in it had — the ring skipped it, and its own opening chord was undone a frame
 later by the guard that keeps focus off closed columns.
 
+A pane may open **its own** column and ask for focus in the same action — show the
+panel, then `command("focus", { text = name })`, the way `65_search.lua` does. The
+slot does not exist until the arrangement runs again, so the kernel holds that
+request for one layout and takes it there; you do not have to wait a frame or press
+the chord twice.
+
 Because layout resolves *before* render, anything the arrangement needs to know
 cannot live inside a render function. Panel visibility therefore lives in
 `lib/panels.lua`, which keeps it in `store` so it survives a reload:

--- a/docs/V2-KERNEL.md
+++ b/docs/V2-KERNEL.md
@@ -146,6 +146,15 @@ still a switch slot, so the next pane to share it inherits the fix.)
 reports about itself, `can_focus` for where focus may go. A pane that brings
 itself forward by being focused needs the second one.
 
+There is a third fact underneath both, and it is a matter of *timing*: a pane can
+open its own slot. The search strip shows itself and asks for focus in one action,
+and `panels.show` is only read by the arrangement — so at the moment the request
+is judged, the slot it named does not exist yet and focus is refused for a rect
+that is one frame away. `defer_until_placed` is the answer: a request focus cannot
+take is held for exactly one layout and re-asked there, which is why `ctrl+/`
+leaves you typing in the strip rather than in the pane underneath it. Exactly one
+layout, because a slot still unplaced then is one nothing brings forward.
+
 ## Settings are two halves of one screen
 
 `settings.toml` and a plugin's declared settings are edited from the same

--- a/src/kernel/focus.rs
+++ b/src/kernel/focus.rs
@@ -73,6 +73,25 @@ pub fn can_focus(placement: Placement) -> bool {
     placement.floats || placement.slot_placed
 }
 
+/// Must a focus request wait for the arrangement to run again?
+///
+/// [`can_focus`] is asked against the placement of the frame that already
+/// painted, and a pane that opens *its own slot* has not been placed in one yet:
+/// the search strip asks the arrangement for a row and asks for focus in the same
+/// action, and the arrangement only runs again on the next frame. Judged there,
+/// the request is refused for a slot that is about to exist — so the chord opened
+/// the strip and left focus behind it, and every character typed went to the pane
+/// underneath.
+///
+/// So a request focus cannot take now is *held for one layout* and re-asked once
+/// the arrangement has run. Exactly one, deliberately: a slot still not placed
+/// then is one nothing brings forward (a closed column, a pane turned off in the
+/// Interface tab), so the request expires rather than following focus around —
+/// which is [`can_focus`]'s own guarantee, one frame later.
+pub fn defer_until_placed(placement: Placement) -> bool {
+    !can_focus(placement)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -149,6 +168,18 @@ mod tests {
         // Unchanged, and for the same reason a switch alternate keeps it:
         // focusing a float is part of what opens it.
         assert!(can_focus(it));
+    }
+
+    #[test]
+    fn a_pane_that_opens_its_own_slot_holds_its_focus_request() {
+        // The search strip: the chord that shows it also asks for focus, and the
+        // slot it asked for is not placed until the arrangement runs again. The
+        // request has to survive that frame or the strip opens unfocused.
+        assert!(defer_until_placed(placement(false, None)));
+        // Once the slot is there, nothing is deferred — it is taken.
+        assert!(!defer_until_placed(placement(true, None)));
+        // A float needs no slot, so its request is honoured at once.
+        assert!(!defer_until_placed(float(false)));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         updates: thurbox::kernel::updates::Updates::start(config.features()),
         slot_selection: std::collections::HashMap::new(),
         visible_slots: std::collections::HashSet::new(),
+        pending_focus: None,
         click_targets: Vec::new(),
         last_area: Rect::new(0, 0, 0, 0),
         selected_text: None,
@@ -744,6 +745,13 @@ struct App {
     /// keeps Tab from parking focus on a pane nobody can see — v1's rule that a
     /// panel is "a cycle stop only while visible".
     visible_slots: std::collections::HashSet<String>,
+    /// A focus request whose slot the arrangement had not placed yet.
+    ///
+    /// Held for exactly one layout and re-asked there. See
+    /// `kernel::focus::defer_until_placed`: a pane that opens its own slot asks
+    /// for focus a frame before the slot exists, and judging that request against
+    /// the frame that already painted refuses the focus its chord existed to give.
+    pending_focus: Option<usize>,
     /// Every identified node of the frame just painted, in paint order.
     ///
     /// Rebuilt each frame and scanned in reverse, so the innermost node under a
@@ -1605,6 +1613,12 @@ impl App {
         };
         let placed = resolve(&region, area);
         self.visible_slots = placed.iter().map(|s| s.slot.clone()).collect();
+        // A focus request that named a slot this layout has only just placed —
+        // the search strip's, which shows itself and asks for focus in one
+        // action. Taken here because this is the first moment the slot exists,
+        // and before the guard below, which would otherwise read the pane as one
+        // focus cannot rest on and walk straight off it.
+        self.apply_pending_focus();
         // Closing the column you were standing in must not strand focus on it.
         // Corrected here rather than at key time because the toggle only shows
         // up in the arrangement on the frame AFTER it is flipped.
@@ -3215,8 +3229,13 @@ impl App {
     }
 
     /// Move focus onto a plugin, if focus can rest there at all.
+    ///
+    /// A request focus cannot take is *held for one layout* rather than dropped —
+    /// see `kernel::focus::defer_until_placed` for why, and `apply_pending_focus`,
+    /// which re-asks it once the arrangement has run.
     fn focus_plugin(&mut self, index: usize) {
-        if !self.can_focus_plugin(index) {
+        if thurbox::kernel::focus::defer_until_placed(self.placement(index)) {
+            self.pending_focus = Some(index);
             return;
         }
         if let Some(position) = self.host.focusable().iter().position(|i| *i == index) {
@@ -3224,6 +3243,23 @@ impl App {
                 self.focus_return = self.focus;
             }
             self.focus = position;
+        }
+    }
+
+    /// Take a focus request that was waiting for its slot to be placed.
+    ///
+    /// Attempted once and then forgotten, whether or not it landed: a slot still
+    /// not placed is one the arrangement declines to give (a column closed, a pane
+    /// turned off), and a request that outlived its layout would chase focus
+    /// across frames the user has since moved on from. Which is also why the check
+    /// is here rather than left to `focus_plugin`: that one re-arms the request it
+    /// cannot honour, so calling it blind would make the wait permanent.
+    fn apply_pending_focus(&mut self) {
+        let Some(index) = self.pending_focus.take() else {
+            return;
+        };
+        if self.can_focus_plugin(index) {
+            self.focus_plugin(index);
         }
     }
 

--- a/tests/v2_search.rs
+++ b/tests/v2_search.rs
@@ -552,3 +552,104 @@ fn every_match_still_paints_when_the_results_fill_the_strip() {
         );
     }
 }
+
+/// The pane draws the match, and the selection bar must not paint over it.
+///
+/// Previewing moves this list's cursor ONTO the result, so the row carrying the
+/// highlight is always the selected one — which made this the one row where the
+/// match was invisible: the bar patched `fg` over every span, leaving the matched
+/// characters in the selection's own colour with only their underline to show
+/// for it. v1 layered the two the other way round (`highlight_style` is built on
+/// top of the row's base style), and this pins that order.
+#[test]
+fn a_match_keeps_its_colour_under_the_selection_bar() {
+    use ratatui::backend::TestBackend;
+    use ratatui::style::Color;
+    use ratatui::Terminal;
+    use thurbox::kernel::node::parse_color;
+    use thurbox::kernel::paint::{render as paint_render, PlaceholderSurfaces};
+
+    const WIDTH: u16 = 40;
+    const HEIGHT: u16 = 10;
+
+    let themes = Themes::load(None);
+    let roles = themes.roles();
+    let colour =
+        |role: &str| -> Color { parse_color(roles.get(role).expect("role")).expect("colour") };
+    let accent = colour("accent");
+    let selection_bg = colour("selection_bg");
+
+    // Paint the session list, optionally with a query in force.
+    let cells = |query: Option<&str>| -> Vec<(String, Color, Color)> {
+        let host = host();
+        if let Some(text) = query {
+            open(&host);
+            type_query(&host, text);
+            // The strip previews as it renders, which is what selects the row.
+            render(&host, PLUGIN);
+            assert_eq!(selected(&host).as_deref(), Some("bbb"));
+        } else {
+            render(&host, SESSIONS);
+        }
+        publish(&host);
+        let index = host.index_of(SESSIONS).expect("no sessions plugin");
+        let node = host
+            .render(
+                index,
+                RenderContext {
+                    width: WIDTH,
+                    height: HEIGHT,
+                    focused: true,
+                    elapsed: 0.0,
+                    frame: 0,
+                },
+            )
+            .expect("render")
+            .node;
+        let mut terminal = Terminal::new(TestBackend::new(WIDTH, HEIGHT)).expect("terminal");
+        terminal
+            .draw(|frame| paint_render(frame, frame.area(), &node, &PlaceholderSurfaces))
+            .expect("draw");
+        let buffer = terminal.backend().buffer().clone();
+        (0..HEIGHT)
+            .flat_map(|y| (0..WIDTH).map(move |x| (x, y)))
+            .map(|(x, y)| {
+                let cell = &buffer[(x, y)];
+                (cell.symbol().to_string(), cell.fg, cell.bg)
+            })
+            .collect()
+    };
+
+    // `fb` matches `fix-branch` and nothing else, so the two lit characters are
+    // its `f` and its `b`.
+    let searched = cells(Some("fb"));
+    let bar: Vec<&(String, Color, Color)> = searched
+        .iter()
+        .filter(|(_, _, bg)| *bg == selection_bg)
+        .collect();
+    assert!(
+        !bar.is_empty(),
+        "the previewed row should carry the selection bar"
+    );
+    let lit: Vec<&str> = bar
+        .iter()
+        .filter(|(_, fg, _)| *fg == accent)
+        .map(|(symbol, _, _)| symbol.as_str())
+        .collect();
+    assert_eq!(
+        lit,
+        vec!["f", "b"],
+        "the matched characters must keep the accent through the selection bar"
+    );
+
+    // The control: with nothing searched, nothing in the bar is accent — so the
+    // assertion above is reading the highlight and not some other affordance
+    // that happens to be lit.
+    let resting = cells(None);
+    assert!(
+        !resting
+            .iter()
+            .any(|(_, fg, bg)| *bg == selection_bg && *fg == accent),
+        "an unsearched row has no matched characters to light"
+    );
+}

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -50,14 +50,26 @@ end
 
 --- ratatui's `Style::patch` over every span: the overlay wins for the fields it
 --- sets, the span keeps the rest.
-local function patch_spans(spans, style)
-  for _, span in ipairs(spans) do
+---
+--- `keep_fg` names spans whose COLOUR is a signal of its own — the characters a
+--- search query matched. They still take everything else the overlay sets, so the
+--- selection bar paints through them (a bar with a gap in it is not a bar), but
+--- their foreground survives it. v1 layered the same two the same way round:
+--- `highlight_style` was built ON TOP of the row's base style
+--- (`src/ui/highlight.rs`), so an accent match stayed accent on the selected row.
+--- Patching over it left the match wearing the selection's own colour with only
+--- its underline showing — on the one row the strip was pointing at, since
+--- previewing a result moves this list's cursor onto it.
+local function patch_spans(spans, style, keep_fg)
+  for index, span in ipairs(spans) do
     local merged = {}
     for key, value in pairs(span.style or {}) do
       merged[key] = value
     end
     for key, value in pairs(style) do
-      merged[key] = value
+      if not (keep_fg and keep_fg[index] and key == "fg") then
+        merged[key] = value
+      end
     end
     span.style = merged
   end
@@ -568,15 +580,19 @@ local function session_line(item, inner_width, elapsed, is_selected, work)
   local hits = name_hits(session, query)
   local name_style = is_selected and { fg = theme.role("selection_fg"), bold = true }
     or { fg = theme.text }
+  -- Which spans the search highlight owns, by position in `spans`. The overlays
+  -- below are told, so the selection bar cannot repaint a match — see
+  -- `patch_spans`. Identity on the style table is what marks one: `fuzzy.spans`
+  -- hands back the very table it was given for a matched run.
+  local matched_spans = nil
   if hits then
-    for _, span in
-      ipairs(fuzzy.spans(session.name or "?", hits, name_style, {
-        fg = theme.accent,
-        bold = true,
-        underline = true,
-      }))
-    do
+    local hit_style = { fg = theme.accent, bold = true, underline = true }
+    matched_spans = {}
+    for _, span in ipairs(fuzzy.spans(session.name or "?", hits, name_style, hit_style)) do
       spans[#spans + 1] = span
+      if span.style == hit_style then
+        matched_spans[#spans] = true
+      end
     end
   else
     spans[#spans + 1] = { text = session.name or "?", style = name_style }
@@ -599,7 +615,7 @@ local function session_line(item, inner_width, elapsed, is_selected, work)
       bg = theme.role("selection_bg"),
       fg = theme.role("selection_fg"),
       bold = true,
-    })
+    }, matched_spans)
   elseif hover.id(session.id) then
     -- v1's row hover: a subtle band marking what a click would hit. Only the
     -- BACKGROUND is tinted — each cell keeps its own fg, so the status dot and


### PR DESCRIPTION
## Summary

- `ctrl+/` showed the search strip but left focus on the pane underneath, so every character typed went there instead of into the query. The strip opens its **own slot** (`panels.show` is read by the arrangement, which does not run again until the next frame), so the focus request it issues in the same action was judged against a layout where that slot did not exist yet — refused, and dropped.
- `kernel::focus::defer_until_placed` names the rule: a request focus cannot take *now* is held for exactly **one** layout and re-asked once the arrangement has run. Exactly one, because a slot still unplaced then is one nothing brings forward (a closed column, a pane turned off in the Interface tab), so the request expires rather than following focus around.
- The match highlight was lost on the one row that matters. Previewing a result moves the session list's cursor **onto** it, so the matched row is always the selected one — and the selection bar patched `fg` over every span, leaving the match in the selection's own colour with only its underline to show for it. v1 layered the two the other way round (`highlight_style` built on top of the row's base style); the bar now paints *through* a matched span without repainting it, so the accent survives under it.
- Docs updated in the same PR (`docs/V2-KERNEL.md`, `docs/PLUGINS.md`): the timing fact under `is_drawn`/`can_focus`, and the author-facing consequence — a pane may open its own column and ask for focus in one action.

## Test plan

- `tests/v2_search.rs::a_match_keeps_its_colour_under_the_selection_bar` — paints the session list through the real kernel with a query in force and asserts the matched characters keep the accent **inside** the selection bar, with an unsearched control. Verified it fails without the Lua fix (`left: []`, `right: ["f", "b"]`).
- `kernel::focus::tests::a_pane_that_opens_its_own_slot_holds_its_focus_request` — the deferral rule: an unplaced slot defers, a placed one does not, a float never does.
- Black-box: real binary in a throwaway tmux pane with isolated `HOME`/XDG (the `tui-smoke` pattern), `ctrl+/` then two characters. Before: `Search  type to search sessions` (placeholder intact, footer focus on the agent pane). After: `▸ Search` and `Search  zq`.
- `cargo nextest run --all` — 1843 passed. Full pre-commit gate (19 hooks) passed, including clippy, selene, stylua and rumdl.