### PR TITLE
docs: say v2 is out and how to stay on v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,40 @@ worktrees are first-class citizens.
 [![Website](https://img.shields.io/badge/Website-thurbox.thurbeen.eu-blue)](https://thurbox.thurbeen.eu/)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Thurbeen_thurbox&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Thurbeen_thurbox)
 
+> [!IMPORTANT]
+> **v2 is out, and it is not a drop-in v1.** The interface is now Lua plugins on
+> a Rust kernel, and some v1 surfaces did not come with it:
+>
+> | Gone from the interface | v1 chord | Where it lives now |
+> |---|---|---|
+> | Code review | `Ctrl+X` / `F7` | nothing yet |
+> | File viewer | `Ctrl+E` / `F3` | nothing yet |
+> | Info panel | `Ctrl+B` / `F2` | nothing yet |
+> | Tasks panel | `Ctrl+W` / `F5` | `thurbox-cli task` |
+> | Automations pane | `Ctrl+P` | `thurbox-cli automation` |
+> | Restore list | `Ctrl+U` | `thurbox-cli session restore` |
+>
+> Each freed chord is deliberately left **unbound** rather than reused, so no
+> muscle memory quietly does something else. Everything outside the interface —
+> sessions, agents, worktrees, remote hosts, automations, your database — is
+> unchanged.
+>
+> **Upgrading** asks once, on the first v2 launch of a profile with v1 history,
+> before anything changes. **To stay on v1**, answer `q` at that prompt: it turns
+> auto-update off and prints the reinstall command. Or reinstall it yourself:
+>
+> ```bash
+> # export, not a prefix: `VERSION=… curl | sh` binds it to curl, not to the sh
+> export VERSION=v1.8.6
+> curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
+> ```
+>
+> Then set `auto_update = false` under `[features]` in
+> `~/.config/thurbox/settings.toml`, or the next launch pulls v2 back. v1 is
+> maintained on the [`1.x`](https://github.com/Thurbeen/thurbox/tree/1.x) branch;
+> newer 1.x patches are on the
+> [releases page](https://github.com/Thurbeen/thurbox/releases).
+
 ![Thurbox Demo](./docs/media/thurbox-demo.gif)
 
 ## Installation
@@ -956,11 +990,10 @@ capability, granted per plugin and only after you trust it.
 See [docs/PLUGINS.md](docs/PLUGINS.md) and
 [docs/V2-KERNEL.md](docs/V2-KERNEL.md).
 
-**Moving from v1?** Code review, the file viewer and the info panel
-have no equivalent yet; tasks, automations, the restore list and the
-perf HUD moved to `thurbox-cli`. thurbox asks once on the first
-launch after the upgrade before changing anything, and v1 is
-maintained on the `1.x` branch.
+**Moving from v1?** Some panes are owed rather than ported, and some
+moved to `thurbox-cli`. The note at the top of this file has the list,
+what asks you before anything changes, and how to stay on v1 — which
+is maintained on the `1.x` branch.
 
 ## Documentation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1116,7 +1116,7 @@ gate (`kernel::consent`) before anything changes. See `docs/RELEASING.md`.
 table that is converted and painted — so the loop settles aggressively and every
 cached answer carries an age. And v1 surfaces are owed rather than ported: code
 review, the file viewer and the info panel have no equivalent, and tasks,
-automations, the restore list and the perf HUD are `thurbox-cli` only. Tracked in
+automations and the restore list are `thurbox-cli` only. Tracked in
 `openspec/changes/v2-parity-gaps/`.
 
 **Rejected**:

--- a/src/kernel/consent.rs
+++ b/src/kernel/consent.rs
@@ -23,14 +23,16 @@ use crate::storage::Database;
 ///
 /// Stated here rather than in prose so the gate, the release notes and the docs
 /// cannot drift: this is the list, and it is the only list.
-pub const GONE: [(&str, &str, &str); 7] = [
+///
+/// The perf HUD is deliberately *not* here, having been listed once by mistake:
+/// `F12` still opens it, gated on `[features] perf_hud` exactly as in v1.
+pub const GONE: [(&str, &str, &str); 6] = [
     ("code review", "Ctrl+X / F7", ""),
     ("file viewer", "Ctrl+E / F3", ""),
     ("info panel", "Ctrl+B / F2", ""),
-    ("tasks panel", "F5", "thurbox-cli task"),
+    ("tasks panel", "Ctrl+W / F5", "thurbox-cli task"),
     ("automations pane", "Ctrl+P", "thurbox-cli automation"),
     ("restore list", "Ctrl+U", "thurbox-cli session restore"),
-    ("perf HUD", "F12", "thurbox-cli perf"),
 ];
 
 /// thurbox's mark, as `scripts/install.sh` prints it. Shared shape on purpose:


### PR DESCRIPTION
## Summary

- The README advertised the current interface with no word that upgrading removes panes a v1 user may open every day — the first notice they got was the pane not being there. An `[!IMPORTANT]` note above the fold now carries the list, the chord each surface answered to, where it lives now, and the reinstall command for the 1.x line.
- Everything in the note is taken from `kernel::consent`, the gate that already tells the same story on the first v2 launch — including *why* the downgrade uses `export VERSION=…` rather than a prefix (a prefix binds to `curl`, not to the `sh` reading from it) and the `auto_update = false` that stops the next launch pulling v2 back.
- Two inaccuracies that note would have propagated are fixed **at the source**, in `consent::GONE` (whose doc comment claims to be "the only list", so drift there reaches the gate, the release notes and the docs):
  - the **perf HUD** was listed as gone, but `F12` still opens it behind `[features] perf_hud` — dropped from the list, with a comment recording why it must not come back;
  - the **tasks panel** named only its `F5` alternate where every other row leads with the primary chord — now `Ctrl+W / F5`, matching what v1 binds and what `tests/v2_keymap.rs` asserts is unbound.
- `docs/ARCHITECTURE.md` repeated the perf-HUD claim; the pre-existing "Moving from v1?" paragraph near the bottom of the README restated the whole list a second time and is now a pointer to the one at the top.

## Test plan

- `cargo nextest run -E 'test(consent)'` — 3/3 pass, including `the_notice_names_every_dropped_surface` (renders the gate from `GONE` and asserts every name, chord and destination appears) and `the_screen_fits_eighty_columns` (`Ctrl+W / F5` is the same width as the existing `Ctrl+X / F7`, so the column layout is unchanged).
- Full pre-commit suite passed: fmt, clippy, check, nextest (1841 tests), architecture rules, deny, doc, rumdl.
- `rumdl check README.md docs/ARCHITECTURE.md` clean.
- Cross-checked the removed-pane list against `tests/v2_keymap.rs::CHORDS_AWAITING_THEIR_PANE` and the v1 bindings on `1.x`, and the pinned version against `v1.8.6`'s release assets (the current `install.sh` resolves them unchanged).

Docs only, plus one const in `kernel::consent` — no behaviour change.