### PR TITLE
fix(core): keep a session working while its agent is still printing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,8 @@ kernel over the real `ui/`** rather than a harness that imitates either:
   `v2_search`, `v2_new_session`, `v2_terminal_pane`, `v2_session_lifetime`,
   `v2_keymap`, `v2_focus`, `v2_modals`, `v2_chrome`, `v2_mouse`, `v2_hover`,
   `v2_decoration`, `v2_plugin_{authoring,commands,lifecycle,settings,switching}`,
-  `v2_repo_memory`, `v2_remote_status`, `v2_core_settings`, `v2_attach_by_name`.
+  `v2_repo_memory`, `v2_remote_status`, `v2_session_status`, `v2_core_settings`,
+  `v2_attach_by_name`.
   Several build an interface in a tempdir from the embedded copy, so delivery and
   loading are exercised together.
 - **`tests/kernel_limits.rs`** — instruction and memory ceilings, in their own file
@@ -1261,14 +1262,16 @@ frame; the static `icon()` is used in non-animated contexts (info panel).
   fresh spawn seeds **nothing** — a never-reported session is `Idle`, and the
   agent's hooks drive it from there (so an idle, just-booted agent doesn't look
   stuck working).
-- **Derivation.** The snapshot carries each session's `hook_state` and
-  `SnapshotStore` folds attach state into the published status
-  (`with_reachability`) — exited → `Idle`; a *remote* session with no live pane →
-  `Unreachable`; else the persisted state (`working`/`blocked`; `idle`/none →
-  `Idle`). A local session is never unreachable: this is its machine, and a missing
-  pane there means the agent was not launched. The rows are read on the snapshot's
-  own schedule rather than per frame, gated on `PRAGMA data_version` moving (see
-  `docs/PERFORMANCE.md` ADR-P6). `done` shows as `Done` (blue)
+- **Derivation.** The snapshot carries each session's `hook_state` and folds
+  attach state into the published status — a *remote* session with no live pane
+  → `Unreachable` (`with_reachability`); a `working` one gone quiet → `Idle`
+  (the fallback below, which subsumes exited → `Idle`); else the persisted state
+  (`working`/`blocked`; `idle`/none → `Idle`). A local session is never
+  unreachable: this is its machine, and a missing pane there means the agent was
+  not launched. The rows are read on the snapshot's own schedule rather than per
+  frame, gated on `PRAGMA data_version` moving (see `docs/PERFORMANCE.md`
+  ADR-P6) — but the quiescence fallback is re-derived every tick, since output
+  moves between reads. `done` shows as `Done` (blue)
   **whether focused or not** — so a turn you're watching visibly completes — and
   becomes `Idle` only when you **move focus off it** (acknowledge it): the focus
   change vs. `last_active_session_id` marks the just-left `done` session `seen`
@@ -1277,12 +1280,20 @@ frame; the static `icon()` is used in non-animated contexts (info panel).
 - **Stuck-`working` fallback.** Hooks can miss the turn-end edge: Claude Code
   fires **no hook on interrupt** (Esc/Ctrl+C) nor when it returns to the idle
   prompt, so an interrupted (or crashed) turn would leave `hook_state = working`
-  forever. `derive_session_status` guards with an **output-quiescence fallback**
-  (`WORKING_OUTPUT_STALE_MS`, 10 s): a `working` session with no terminal output
-  for that long is treated as `Idle`. TUI agents animate their progress line
-  (Claude's `(Xs · esc to interrupt)` ticks every second) so a genuinely-live turn
-  never trips it; only `working` is time-gated. The DB row is left untouched — the
-  override is purely per-tick derivation, like exited → `Idle`.
+  forever. `snapshot::with_output_quiescence` guards with an **output-quiescence
+  fallback** (`WORKING_QUIET_MS`, 10 s): a `working` session with no terminal
+  output for that long is treated as `Idle`, and so is one with no live pane —
+  which is where v1's exited → `Idle` branch lands, since a pane whose stream
+  ended leaves the live set. TUI agents animate their progress line (Claude's
+  `(Xs · esc to interrupt)` ticks every second) so a genuinely-live turn never
+  trips it; only `working` is time-gated. The signal is **terminal output, never
+  the age of the hook state**: keyed on `hook_state_at` instead, every turn
+  reports itself finished ten seconds in and starts again at the next hook — a
+  spinner that stops early and restarts. Applied by `SnapshotStore::
+  apply_output_quiescence` on the loop's own tick rather than in `refresh`
+  (whose cadence is the database's) and re-derived from `hook_state` each pass,
+  so it reverses itself when output resumes. The DB row is left untouched — the
+  override is purely per-tick derivation.
 - **Per-session only.** Status renders on the session's own row (and in the
   ` Sessions ` panel border title, one dot per session). Repo-group headers
   (`ui::project_list::group_header_line`) carry **no** status — a rolled-up group

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -596,6 +596,37 @@ impl SnapshotStore {
         applied
     }
 
+    /// Re-derive every `working` row against terminal quiescence, returning how
+    /// many rows changed.
+    ///
+    /// Called each tick rather than folded into `refresh`, because the answer
+    /// moves with the agent's output and `refresh` runs on the database's
+    /// cadence — a row read once and left alone would report a turn as finished
+    /// for as long as the snapshot stood.
+    ///
+    /// Re-derived from `hook_state` rather than adjusted from `status`, so the
+    /// pass is idempotent and reverses itself: a session that goes quiet and
+    /// then prints again is `working` once more without a database read.
+    ///
+    /// `quiet_for` is asked only about the rows that are actually `working`, and
+    /// answers `None` for a session with no live pane. A closure rather than a
+    /// map because the answer is one atomic load and a map would allocate every
+    /// tick to carry the sessions nobody asked about (ADR-P10).
+    pub fn apply_output_quiescence(&mut self, quiet_for: impl Fn(&str) -> Option<u64>) -> usize {
+        let mut changed = 0;
+        for row in &mut self.current.sessions {
+            if row.hook_state.as_deref() != Some("working") {
+                continue;
+            }
+            let derived = with_output_quiescence("working", quiet_for(&row.id));
+            if row.status != derived {
+                row.status = derived;
+                changed += 1;
+            }
+        }
+        changed
+    }
+
     /// Record — or forget — the pane id of a session's companion shell.
     ///
     /// Written straight through and corrected in place, like `acknowledge`: this
@@ -874,24 +905,13 @@ fn read_hosts() -> Vec<HostRow> {
 
 /// Map the persisted hook state onto a status name.
 ///
-/// Mirrors v1's derivation, including the stuck-`working` fallback: agents fire
-/// no hook when a turn is interrupted, so a `working` state that has not moved
-/// for a while is reported as idle rather than spinning forever. The stored row
-/// is not touched — this is a read-time decision, exactly as v1 does it.
+/// The stuck-`working` fallback is deliberately **not** here: it is a question
+/// about the terminal, not the row, so it belongs to the per-frame fold in
+/// [`with_output_quiescence`]. The stored row is never touched — every rule in
+/// this file is a read-time decision, exactly as v1 does it.
 pub fn derive_status(state: Option<&str>, state_at: Option<i64>, seen_at: Option<i64>) -> String {
-    /// How long a `working` state may stand without an update before it is
-    /// treated as finished. v1 uses the same 10s bound.
-    const WORKING_STALE_MS: i64 = 10_000;
-
     match state {
-        Some("working") => {
-            let stale = state_at.is_some_and(|at| now_ms().saturating_sub(at) > WORKING_STALE_MS);
-            if stale {
-                "idle".to_string()
-            } else {
-                "working".to_string()
-            }
-        }
+        Some("working") => "working".to_string(),
         Some("blocked") => "blocked".to_string(),
         Some("done") => {
             // Acknowledged once the user moved off it, which v1 records by
@@ -908,6 +928,38 @@ pub fn derive_status(state: Option<&str>, state_at: Option<i64>, seen_at: Option
         }
         _ => "idle".to_string(),
     }
+}
+
+/// How long a `working` session may produce **no terminal output** before it is
+/// reported as idle. v1 uses the same 10s bound.
+///
+/// The signal is output, not the age of the hook state, and the difference is
+/// the whole point: a turn that runs for a minute is still `working` the whole
+/// minute, because the agent is printing throughout. Keying on the hook's
+/// timestamp instead ends every turn after ten seconds and starts it again at
+/// the next hook — a spinner that stops early and restarts, which is precisely
+/// what the fallback exists to avoid.
+const WORKING_QUIET_MS: u64 = 10_000;
+
+/// Fold terminal quiescence into a `working` session's status.
+///
+/// Agents fire no hook when a turn is **interrupted** (Esc / Ctrl+C) and none
+/// when they return to the idle prompt, so a `working` state can stand forever
+/// with nothing running behind it. TUI agents animate their in-progress line
+/// while a turn runs (Claude's `(Xs · esc to interrupt)` ticks every second), so
+/// a genuinely live turn is never quiet for `WORKING_QUIET_MS` and only the
+/// stuck state falls through.
+///
+/// `quiet_for_ms` is `None` when the session has no live pane — nothing can be
+/// producing output, so that reads as quiet too. This is where v1's `exited →
+/// Idle` branch lands: a pane whose stream ended is dropped from the live set.
+/// Only `working` is time-gated; `blocked` is a standing request for input and
+/// says nothing about output.
+pub fn with_output_quiescence(status: &str, quiet_for_ms: Option<u64>) -> String {
+    if status == "working" && quiet_for_ms.unwrap_or(u64::MAX) > WORKING_QUIET_MS {
+        return "idle".to_string();
+    }
+    status.to_string()
 }
 
 /// Fold what the terminal store knows into a session's status.
@@ -1017,11 +1069,42 @@ mod tests {
     }
 
     #[test]
-    fn a_stale_working_state_falls_back_to_idle() {
+    fn a_long_turn_stays_working_however_old_its_hook_is() {
+        // The regression this guards: keyed on the hook's own timestamp, every
+        // turn reported itself finished ten seconds in and started again at the
+        // next hook — a spinner that stopped early and restarted. How long ago
+        // the agent said "working" says nothing about whether it still is.
+        let long_ago = now_ms() - 600_000;
+        assert_eq!(
+            derive_status(Some("working"), Some(long_ago), None),
+            "working"
+        );
+    }
+
+    #[test]
+    fn a_quiet_working_session_falls_back_to_idle() {
         // Agents fire no hook on interrupt, so without this a cancelled turn
-        // would spin forever. v1 guards the same way.
-        let long_ago = now_ms() - 60_000;
-        assert_eq!(derive_status(Some("working"), Some(long_ago), None), "idle");
+        // would spin forever. v1 guards the same way, on the same signal.
+        assert_eq!(
+            with_output_quiescence("working", Some(WORKING_QUIET_MS + 1)),
+            "idle"
+        );
+    }
+
+    #[test]
+    fn a_printing_working_session_stays_working() {
+        assert_eq!(with_output_quiescence("working", Some(0)), "working");
+        assert_eq!(
+            with_output_quiescence("working", Some(WORKING_QUIET_MS)),
+            "working"
+        );
+    }
+
+    #[test]
+    fn a_working_session_with_no_live_pane_is_idle() {
+        // Nothing can be producing output, which is where v1's exited → Idle
+        // branch lands: a pane whose stream ended leaves the live set.
+        assert_eq!(with_output_quiescence("working", None), "idle");
     }
 
     #[test]
@@ -1030,6 +1113,12 @@ mod tests {
         assert_eq!(
             derive_status(Some("blocked"), Some(long_ago), None),
             "blocked"
+        );
+        // A session waiting on you produces no output while it waits.
+        assert_eq!(with_output_quiescence("blocked", None), "blocked");
+        assert_eq!(
+            with_output_quiescence("done", Some(WORKING_QUIET_MS * 10)),
+            "done"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1132,6 +1132,18 @@ impl App {
                 self.last_output_gen = output_gen;
                 self.dirty = true;
             }
+            // The stuck-`working` fallback, run here because it asks the
+            // terminals a question and they have just been synced — and run
+            // every tick rather than at refresh, because output moves between
+            // two reads of the database.
+            let terminals = &self.terminals;
+            if self
+                .snapshots
+                .apply_output_quiescence(|id| terminals.millis_since_output(id))
+                > 0
+            {
+                self.dirty = true;
+            }
             // A session whose agent is gone gets it back, which is what v1 does
             // at restore and what makes a session survive a reboot.
             self.respawn_missing_agents();

--- a/tests/v2_session_status.rs
+++ b/tests/v2_session_status.rs
@@ -1,0 +1,136 @@
+//! What makes a session's dot say `working`, and what makes it stop.
+//!
+//! The regression these guard: the fallback that rescues a stuck `working`
+//! state was keyed on the age of the hook row rather than on terminal output,
+//! so every turn reported itself finished ten seconds in and started again at
+//! the agent's next hook — a spinner that stopped early and restarted while the
+//! agent was still visibly printing. Hooks only mark the edges of a turn; only
+//! the terminal says whether one is still running.
+//!
+//! Driven through `SnapshotStore` rather than the pure fold, because the part
+//! that can be wrong is that the pass runs every tick and reverses itself: a
+//! session that goes quiet and then prints again has to be `working` once more
+//! without waiting for a hook that is never coming.
+
+use thurbox::kernel::snapshot::SnapshotStore;
+use thurbox::session::SessionId;
+use thurbox::storage::Database;
+use thurbox::sync::SharedSession;
+
+/// Longer than the fallback's bound, whatever it is set to.
+const QUIET: u64 = 60_000;
+
+/// Every session is printing right now.
+fn printing(_id: &str) -> Option<u64> {
+    Some(0)
+}
+
+/// Every session has a live pane that has said nothing for a long time.
+fn silent(_id: &str) -> Option<u64> {
+    Some(QUIET)
+}
+
+/// No session has a live pane at all.
+fn detached(_id: &str) -> Option<u64> {
+    None
+}
+
+fn store_with_working_session() -> (tempfile::TempDir, SnapshotStore, String) {
+    let home = tempfile::tempdir().expect("tempdir");
+    let path = home.path().join("thurbox.db");
+    let row = SharedSession {
+        id: SessionId::default(),
+        name: "long-turn".into(),
+        agent: "claude".into(),
+        backend_id: "%3".into(),
+        backend_type: "local-tmux".into(),
+        agent_session_id: Some("sid".into()),
+        cwd: Some(std::path::PathBuf::from("/srv/repo")),
+        additional_dirs: Vec::new(),
+        worktrees: Vec::new(),
+        shell_backend_id: None,
+        parent_session_id: None,
+        display_order: None,
+        tombstone: false,
+        tombstone_at: None,
+    };
+    let database = Database::open(&path).expect("db");
+    database.upsert_session(&row).expect("upsert");
+    database.set_hook_state(row.id, "working").expect("signal");
+    let mut store = SnapshotStore::with_database(Database::open(&path).expect("db"));
+    store.refresh();
+    (home, store, row.id.to_string())
+}
+
+fn status_of(store: &SnapshotStore, id: &str) -> String {
+    store
+        .current()
+        .sessions
+        .iter()
+        .find(|row| row.id == id)
+        .map(|row| row.status.clone())
+        .unwrap_or_else(|| "<missing>".to_string())
+}
+
+/// A hook fired long ago and never followed up, with the agent printing the
+/// whole time. This is an ordinary turn that outlasts the fallback's bound.
+#[test]
+fn a_long_turn_keeps_working_while_its_agent_prints() {
+    let (_home, mut store, id) = store_with_working_session();
+    assert_eq!(status_of(&store, &id), "working");
+
+    for _ in 0..3 {
+        assert_eq!(store.apply_output_quiescence(printing), 0);
+        assert_eq!(status_of(&store, &id), "working");
+    }
+}
+
+/// The turn was interrupted, which fires no hook at all: the row still says
+/// `working` and nothing is left to print.
+#[test]
+fn a_turn_that_went_quiet_is_reported_idle() {
+    let (_home, mut store, id) = store_with_working_session();
+
+    assert_eq!(store.apply_output_quiescence(silent), 1);
+    assert_eq!(status_of(&store, &id), "idle");
+    // Idempotent: the second pass has nothing left to change.
+    assert_eq!(store.apply_output_quiescence(silent), 0);
+}
+
+/// A session absent from the map has no live pane, so nothing can be producing
+/// output — where the old exited → `Idle` branch lands.
+#[test]
+fn a_working_session_with_no_live_pane_is_reported_idle() {
+    let (_home, mut store, id) = store_with_working_session();
+    assert_eq!(store.apply_output_quiescence(detached), 1);
+    assert_eq!(status_of(&store, &id), "idle");
+}
+
+/// The half a one-way fallback gets wrong. An agent that goes quiet mid-turn
+/// and then resumes fires no hook to say so, so the pass has to re-derive from
+/// `hook_state` rather than adjust the status it wrote last time.
+#[test]
+fn a_session_that_prints_again_goes_back_to_working() {
+    let (_home, mut store, id) = store_with_working_session();
+
+    assert_eq!(store.apply_output_quiescence(silent), 1);
+    assert_eq!(status_of(&store, &id), "idle");
+
+    assert_eq!(store.apply_output_quiescence(printing), 1);
+    assert_eq!(status_of(&store, &id), "working");
+}
+
+/// A session waiting on you produces no output while it waits, and saying so is
+/// the whole point of the dot. Only `working` is time-gated.
+#[test]
+fn a_blocked_session_is_never_time_gated() {
+    let (home, mut store, id) = store_with_working_session();
+    let database = Database::open(&home.path().join("thurbox.db")).expect("db");
+    let parsed: SessionId = id.parse().expect("id");
+    database.set_hook_state(parsed, "blocked").expect("signal");
+    store.refresh();
+    assert_eq!(status_of(&store, &id), "blocked");
+
+    assert_eq!(store.apply_output_quiescence(silent), 0);
+    assert_eq!(status_of(&store, &id), "blocked");
+}


### PR DESCRIPTION
## Summary

- The stuck-`working` fallback was keyed on the **age of the hook row**
  (`hook_state_at`) rather than on terminal output, so any turn longer than
  10s reported itself finished — and started again at the agent's next hook.
  The visible symptom is a spinner that stops early and restarts while the
  agent is still printing.
- Hooks only mark the *edges* of a turn; only the terminal says whether one
  is still running. That is the signal v1 used, and the reason a 10s bound is
  safe: a TUI agent animates its in-progress line every second
  (Claude's `(Xs · esc to interrupt)`), so a live turn is never quiet that long.
- `derive_status` stops time-gating `working`. The fallback moves to
  `snapshot::with_output_quiescence`, applied by
  `SnapshotStore::apply_output_quiescence` on the loop's own tick — output
  moves between two reads of the database, so it cannot ride the snapshot's
  refresh cadence.
- Each pass **re-derives from `hook_state`**, so it reverses itself when an
  agent prints again (no hook is coming to say so), and a session with **no
  live pane** reads as quiet — which is where v1's exited → `Idle` branch lands.
- Docs: the Session-status section of `CLAUDE.md` described v1's symbols and
  is updated to the v2 ones, naming output-not-hook-age as the rule.

## Test plan

- `cargo nextest run --all` — 1849 passed.
- New `tests/v2_session_status.rs` drives `SnapshotStore` directly and covers
  what the pure fold cannot: a long turn stays `working` across repeated
  passes while its agent prints; an interrupted turn goes `idle` and the pass
  is idempotent; a session with no live pane is `idle`; a session that prints
  again **goes back to `working`**; `blocked` is never time-gated.
- Unit tests in `kernel::snapshot` pin the regression itself — a `working`
  hook 10 minutes old still derives `working`.
- `cargo clippy --all-targets --all-features -- -D warnings`,
  `RUSTDOCFLAGS="-D warnings" cargo doc`, `rumdl check .`, and the full
  19-hook pre-commit suite all pass.