### PR TITLE
fix(core): survive a cramped pane, and focus a pane that just opened

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,24 @@ a failed branch fetch stuck for the process lifetime, and a backend surveyed onc
 was treated as surveyed since. Each is now a TTL, an in-flight marker, or a
 generation counter — if you add a cache here, give it one.
 
+`republish` — the one call that rebuilds every `thurbox.*` table — runs once per
+painted frame and **once per input batch**, not once per event: a held-down key
+otherwise paid for it per repeat. The three reads in it that touch a screen or the
+disk carry the age above (ADR-P14): link extraction is keyed on that session's
+`output_stamp`, the search content scan on `output_generation`, and the interface
+inventory's per-file digests on a `trust_stale` flag every path that changes the
+directory or a grant already sets.
+
+**A vt100 grid is never given fewer than two rows or two columns**
+(`agent::backend::vt_floor`). A cramped layout really does compute a one-cell pane,
+and vt100 underflows on the next byte written into one — in `row_inc_scroll` when a
+line wraps, in `col_wrap` (`cols - width`) when a double-width character arrives.
+The panic lands on the session's *reader* thread, so the process lives while that
+session's terminal is blank for the rest of the run: the unwind poisons the parser
+mutex, and every reader of it (paint, links, selection, copy) reads a poisoned lock
+as "no live terminal". A panic is also written to `thurbox.log`, because a worker's
+stderr is scrolled away long before anyone looks.
+
 **Observability**: `F12` toggles the perf HUD (`[features] perf_hud`); launching with
 `THURBOX_PERF_LOG=1` writes `startup`, `perf_window` and `slow op` lines to
 `thurbox.log`; while either is active a JSON snapshot is published for

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -748,6 +748,45 @@ frame either.
 
 ---
 
+## ADR-P14: Publish once per input batch, and gate every screen read on a stamp
+
+**Choice**: `App::republish` — the call that rebuilds every `thurbox.*` table Lua can
+read — runs **once per event batch** rather than once per event, and the three reads
+inside it that touch a screen or the filesystem are gated on something that says
+whether the answer could have changed.
+
+It ran per event because a handler has to read something current. It does; nothing
+between two events of one batch can change what it would say, since the snapshot is
+refreshed at the top of the iteration and a command a handler queues is drained on
+the next one. What that cost, per keystroke — and a held-down key is 30 or more a
+second, each one draining in the same batch:
+
+| Read | What it did per event | What gates it now |
+|---|---|---|
+| `Terminals::links` | walked every cell of **every** live session's grid, building a `String` per row, to find OSC 8 targets and bare URLs | that session's `output_stamp` — the same atomic the redraw signal reads |
+| `Terminals::screens` (search content) | re-read every grid again, capped at `CONTENT_LINE_CAP` | `output_generation`, plus the existing "is anything asking" check |
+| the interface inventory | `read_to_string` + digest of **every file** in the interface directory, and a `plugins.lock` TOML parse, to answer "is this file still the one that was trusted" | a `trust_stale` flag set by `refresh_sources`, which every path that changes the directory or a grant already calls |
+
+The rows of the inventory are still assembled every publish: which pane is *on
+screen* depends on the frame, and that half is a set lookup. Only the file reads
+behind them are cached, which is ADR-P13's rule applied — the cached answer carries
+the thing that makes it current, not merely the fact that it exists.
+
+**Measured by**: the `renders` counter is unchanged (the same trees are built); what
+falls is the work between them. There is no counter for "publishes", which is the
+honest gap here — the change was reasoned from what the reads do, and the reads are
+the same ones ADR-P13 already treats as per-frame costs.
+
+**Rejected**:
+
+- *Publishing lazily, on the first `thurbox.*` read from Lua* — the publish builds one
+  table; making it per-field would put a Rust callback on every field read, which is
+  the cost this avoids, spread thinner.
+- *Not publishing before input at all* — a handler would read the previous frame's
+  world, and a key pressed on what a frame showed has to act on what that frame showed.
+
+---
+
 ## Investigation 2026-07-09: where the time actually goes
 
 A measurement pass over the render loop, the tick, the draw path, startup, the

--- a/scripts/dev/smoke/tui-smoke.sh
+++ b/scripts/dev/smoke/tui-smoke.sh
@@ -137,7 +137,25 @@ send Escape
 wait_gone "filter themes"
 ok "Escape closed it"
 
-# 4. Ctrl+Q exits cleanly (the tmux session ends when thurbox returns).
+# 4. Ctrl+/ opens the global search strip *and* focuses it.
+#
+# The typed text is the assertion, not the strip appearing: focus may only rest on
+# a slot the last painted frame placed, and a pane that opens itself is not in that
+# set until the next paint — so the focus request that came with the chord was
+# refused and dropped, and every letter of the query went to the agent's terminal
+# instead. Anything that reintroduces that shows up here as a strip with an empty
+# field. `C-_` is what a terminal sends for ctrl+/.
+send C-_
+wait_for "Search"
+ok "Ctrl+/ opened the search strip"
+send "zq"
+wait_for "Search zq"
+ok "the strip has focus, so the query is typed into it"
+send Escape
+wait_gone "Search zq"
+ok "Escape closed it"
+
+# 5. Ctrl+Q exits cleanly (the tmux session ends when thurbox returns).
 send C-q
 for _ in $(seq 1 50); do
   if ! tmux -L "$SOCKET" has-session -t "$SESSION" 2>/dev/null; then

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -22,6 +22,26 @@ pub(crate) fn now_millis() -> u64 {
         .as_millis() as u64
 }
 
+/// The smallest grid a `vt100` parser may be given, as `(rows, cols)`.
+///
+/// Two, not one, and the difference is a crash. `set_size(0, _)` underflows
+/// outright, which is why every size here used to be clamped at 1 — but a
+/// **one-row** grid underflows in `row_inc_scroll` the moment output wraps, and a
+/// **one-column** grid underflows in `col_wrap` (`cols - width`) the moment a
+/// double-width character arrives, which for an agent that prints emoji is the
+/// first line it writes. A cramped layout really does compute those rects — a
+/// pane one column wide is what a 20-column terminal with the session list open
+/// leaves for the terminal — and the panic lands on the *reader* thread, so the
+/// process survives while that session's pane is blank for the rest of the run:
+/// the unwind poisons the parser mutex, and every reader of it (paint, links,
+/// selection, copy) treats a poisoned lock as "no live terminal".
+///
+/// Nothing is readable at two columns either, so clamping loses nothing a
+/// smaller grid would have shown.
+fn vt_floor(rows: u16, cols: u16) -> (u16, u16) {
+    (rows.max(2), cols.max(2))
+}
+
 /// Length of the prefix of `buf` that is safe to feed to the vt100 parser
 /// without splitting a UTF-8 character. Returns `buf.len()` unless `buf` ends
 /// with the start of a multi-byte character whose continuation bytes have not
@@ -541,10 +561,10 @@ impl ProgramPane {
     }
 
     pub fn resize(&self, rows: u16, cols: u16) {
-        // Clamped at 1 for the reason `Session::resize` documents: a cramped
-        // layout can compute a zero-row area, vt100's `set_size` underflows on 0
-        // and tmux rejects it.
-        let (rows, cols) = (rows.max(1), cols.max(1));
+        // Floored for the reason [`vt_floor`] documents: a cramped layout can
+        // compute a one-cell area, and a grid that small is where vt100
+        // underflows on the next byte the program prints.
+        let (rows, cols) = vt_floor(rows, cols);
         if let Err(e) = self.backend.resize(&self.backend_id, rows, cols) {
             tracing::debug!("could not resize program pane {}: {e:#}", self.backend_id);
             return;
@@ -716,6 +736,10 @@ impl Session {
         let attention_at = Arc::new(AtomicU64::new(0));
         let notification = Arc::new(Mutex::new(None));
         let meta_gen = Arc::new(AtomicU64::new(0));
+        // The floor applies at construction too: a session first painted into a
+        // one-column pane would otherwise panic on its first line of output,
+        // before any resize could correct it.
+        let (rows, cols) = vt_floor(rows, cols);
         let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
             rows,
             cols,
@@ -810,9 +834,10 @@ impl Session {
         let attention_at = Arc::new(AtomicU64::new(0));
         let notification = Arc::new(Mutex::new(None));
         let meta_gen = Arc::new(AtomicU64::new(0));
+        let (rows, cols) = vt_floor(rows, cols);
         let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
-            rows.max(1),
-            cols.max(1),
+            rows,
+            cols,
             crate::session::settings::global().scrollback_lines,
             TermSignals {
                 title: Arc::clone(&last_title),
@@ -938,9 +963,11 @@ impl Session {
 
     pub fn resize(&self, rows: u16, cols: u16) {
         // A cramped layout (tiny terminal + open panels/strips) can compute a
-        // zero-row/col content area; vt100's `set_size` underflows on 0 and
-        // tmux rejects it, so clamp at this boundary for every path below.
-        let (rows, cols) = (rows.max(1), cols.max(1));
+        // one-cell content area, which vt100 cannot be fed without underflowing
+        // — see [`vt_floor`]. Floored at this boundary for every path below,
+        // including the pane the backend is told about, so the grid and the pane
+        // agree on a size they can both hold.
+        let (rows, cols) = vt_floor(rows, cols);
         // A placeholder has no live pane; only resize its local notice buffer.
         // Talking to the (possibly-down) backend here would issue a blocking
         // ssh resize on the UI thread — the freeze we're avoiding.
@@ -1327,6 +1354,31 @@ mod tests {
         drop(rx);
         let err = send_to_input_channel(&tx, vec![b'x'], "Session").unwrap_err();
         assert!(err.to_string().contains("closed"), "got: {err}");
+    }
+
+    #[test]
+    fn a_grid_at_the_floor_survives_what_an_agent_prints() {
+        // The floor is not cosmetic: at one row vt100 underflows in
+        // `row_inc_scroll` as soon as output wraps, and at one column it
+        // underflows in `col_wrap` as soon as a double-width character arrives.
+        // Both used to be reachable — a one-cell pane is what a cramped layout
+        // hands a session — and both killed the reader thread, which poisons the
+        // parser mutex and blanks that pane for the rest of the run.
+        for (rows, cols) in [(0, 0), (1, 1), (1, 2), (2, 1), (1, 40), (3, 1)] {
+            let (rows, cols) = vt_floor(rows, cols);
+            let mut parser = vt100::Parser::new(rows, cols, 0);
+            parser.screen_mut().set_size(rows, cols);
+            // A wide character (the `col_wrap` path) and enough plain text to
+            // wrap and scroll (the `row_inc_scroll` path).
+            parser.process("🚀 done\r\n".repeat(4).as_bytes());
+            parser.process("hello world hello world".as_bytes());
+        }
+    }
+
+    #[test]
+    fn the_grid_floor_leaves_a_usable_size_alone() {
+        assert_eq!(vt_floor(24, 80), (24, 80));
+        assert_eq!(vt_floor(2, 2), (2, 2));
     }
 
     #[test]

--- a/src/kernel/focus.rs
+++ b/src/kernel/focus.rs
@@ -13,6 +13,14 @@
 //! lands the pane is not yet the chosen one — judging it by the previous frame's
 //! selection is judging it by the state it is about to change.
 //!
+//! There is a third case, and it belongs to the loop rather than to these two
+//! predicates: a pane that opens *itself* writes its visibility to `store`, so the
+//! arrangement only places its slot on the next paint, and [`can_focus`] answers no
+//! until then. A focus request refused there must be **held over that paint**, not
+//! dropped — `App::deferred_focus` is where. Dropping it is how `ctrl+/` opened the
+//! search strip and left focus on the agent, so the query was typed into the agent's
+//! terminal.
+//!
 //! Kept here rather than in the binary because it is the rule that was wrong,
 //! and a rule worth a test is worth a home.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,13 @@ const FORCE_REDRAW_INTERVAL: Duration = Duration::from_millis(250);
 /// was drawn at the `FORCE_REDRAW_INTERVAL` floor, four times a second, which is
 /// what made v2 feel less responsive than v1.
 const MIN_FRAME_INTERVAL: Duration = Duration::from_millis(16);
+
+/// Consecutive input-read failures tolerated before the loop gives up.
+///
+/// One is a terminal handing crossterm bytes it cannot parse, which is a
+/// keystroke to drop rather than a reason to quit. A run of them is a stream
+/// that has gone away, and polling it forever would spin at full speed.
+const INPUT_FAILURE_LIMIT: u32 = 64;
 /// How long an outcome message stays up. v1's `STATUS_MESSAGE_TTL`.
 const STATUS_TTL: Duration = Duration::from_secs(5);
 
@@ -89,9 +96,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // afterwards printed `\x1b[<35;…M` into the prompt. Restoring here is also
     // why the message is readable at all: on the alternate screen it would be
     // wiped the moment the shell repainted.
+    //
+    // The message is also written to the log, because stderr is where a panic
+    // is *least* likely to be read: a worker thread's panic does not end the
+    // process, so the pane it printed on is scrolled away long before anyone
+    // looks — which is how a reader thread dying, and taking one session's
+    // terminal with it for the rest of the run, left no trace to report.
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         restore_terminal();
+        tracing::error!(
+            "panicked at {}: {}",
+            info.location()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "an unknown location".to_string()),
+            info.payload()
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| info.payload().downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "a payload of an unknown type".to_string()),
+        );
         original_hook(info);
     }));
 
@@ -195,6 +219,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         focus_return: initial_focus,
         reload_at: None,
         errors: Vec::new(),
+        deferred_focus: None,
+        links: std::collections::HashMap::new(),
+        link_stamps: std::collections::HashMap::new(),
+        content: std::collections::HashMap::new(),
+        content_generation: None,
+        trust: std::collections::HashMap::new(),
+        trust_stale: true,
         layout_error: None,
         floor: None,
         status: None,
@@ -868,6 +899,17 @@ struct App {
     last_output_gen: u64,
     /// Plugin holding an exclusive key grab this frame, if any.
     grabbed: Option<usize>,
+    /// A pane that asked for focus before it was on screen.
+    ///
+    /// Focus may only rest on a slot the *last painted frame* placed
+    /// (`kernel::focus::can_focus`), and a pane opening itself writes its
+    /// visibility to `store` — so the arrangement only learns about it on the
+    /// next paint. A `focus` command drained in between was therefore refused
+    /// and dropped: `ctrl+/` opened the search strip and left focus on the
+    /// agent, which is not a cosmetic difference — every letter of the query
+    /// went to the agent's terminal instead. Held over the paint that places the
+    /// slot and applied there, so the strip is focused on the frame it appears.
+    deferred_focus: Option<usize>,
     /// Programs plugins asked to be run, and what they printed.
     runs: thurbox::kernel::runs::RunStore,
     /// Every file of the interface, as of the last painted frame.
@@ -889,6 +931,31 @@ struct App {
     /// re-reading while the worker is mid-write would publish the old list and
     /// look like the add did nothing.
     bookmark_in_flight: bool,
+    /// Links found on each live session's screen, keyed by session, and the
+    /// output stamp each answer was found at.
+    ///
+    /// Rebuilt for a session only when that session printed something. Finding
+    /// them walks the whole grid cell by cell, and this runs on every frame *and*
+    /// every input event — so a held-down key used to rescan every terminal on
+    /// the screen per repeat, for answers that cannot have changed.
+    links: std::collections::HashMap<String, Vec<(String, usize, usize)>>,
+    link_stamps: std::collections::HashMap<String, u64>,
+    /// What each terminal was showing when a search last asked, and the output
+    /// generation it was read at. Empty while nothing is searching.
+    content: std::collections::HashMap<String, String>,
+    content_generation: Option<u64>,
+    /// Where each interface file stands with the user, and the lock the answer
+    /// was resolved against.
+    ///
+    /// Answering it reads and digests every file in the interface directory and
+    /// parses `plugins.lock`, which is the wrong price to pay per keystroke: the
+    /// answer changes only when the directory or a grant does, and both say so.
+    /// The rows themselves are still assembled every publish — those depend on
+    /// what is on screen this frame, which is cheap and does change.
+    trust: std::collections::HashMap<String, thurbox::kernel::inventory::Trust>,
+    /// Set when the directory, a grant or the disabled set moved, so the trust
+    /// answers above are re-read.
+    trust_stale: bool,
     /// Whether the perf counters are painted over the interface (F12).
     hud: bool,
     quit: bool,
@@ -896,6 +963,9 @@ struct App {
 
 impl App {
     fn run(&mut self, mut terminal: DefaultTerminal) -> Result<(), Box<dyn Error>> {
+        // Consecutive input failures, reset by the first event that reads
+        // cleanly. See the poll below for why one is survivable.
+        let mut input_failures: u32 = 0;
         while !self.quit {
             Counters::bump(&self.perf.iterations);
             if self.watcher.changed() {
@@ -980,7 +1050,7 @@ impl App {
                                     self.focus = back;
                                     self.dirty = true;
                                 }
-                            } else {
+                            } else if self.can_focus_plugin(index) {
                                 // Through `focus_plugin`, not by assigning `focus`:
                                 // it records where focus came from and refuses a
                                 // pane focus cannot rest on. Assigning directly
@@ -988,6 +1058,11 @@ impl App {
                                 // command could not be left with `Esc` — the user
                                 // had to walk out with the focus cycle.
                                 self.focus_plugin(index);
+                                self.dirty = true;
+                            } else {
+                                // Not on screen yet — it is opening itself this
+                                // very frame. See `deferred_focus`.
+                                self.deferred_focus = Some(index);
                                 self.dirty = true;
                             }
                         }
@@ -1276,6 +1351,19 @@ impl App {
                 // After the backend flushed, so the escapes cannot interleave
                 // with ratatui's own output.
                 self.paint_terminal_hyperlinks(&buffer);
+                // The frame that just painted is what placed the slots, so a
+                // pane that asked for focus while it was still invisible can be
+                // answered now — before this iteration reads any input, so the
+                // first key after the one that opened it lands in the right pane.
+                // Dropped rather than retried if the paint did not place it: the
+                // pane declined to draw, and a request that outlives that would
+                // steal focus later for no visible reason.
+                if let Some(index) = self.deferred_focus.take() {
+                    if self.can_focus_plugin(index) {
+                        self.focus_plugin(index);
+                        self.dirty = true;
+                    }
+                }
                 self.last_paint = Instant::now();
                 self.frames += 1;
                 Counters::bump(&self.perf.frames);
@@ -1290,18 +1378,46 @@ impl App {
             // without bound. That is felt as an unresponsive mouse, and the
             // backlog outlives the process — the leftover reports are what
             // printed `\x1b[<35;92;31M` into the terminal afterwards.
-            let mut first = true;
-            while if first {
-                first = false;
-                event::poll(TICK)?
-            } else {
-                event::poll(Duration::ZERO)?
-            } {
-                match event::read()? {
+            //
+            // The batch is also what `thurbox.*` is published for: once, before
+            // the first event that runs Lua, rather than once per event. A
+            // handler has to read something current, and nothing between two
+            // events of one batch can change what it would say — the snapshot is
+            // refreshed at the top of the iteration, and a command a handler
+            // queues is drained on the next one. Per event, a held-down key paid
+            // for the whole publish (every session's links, the interface
+            // inventory, the plugin lock) on every repeat.
+            let mut published = false;
+            let mut waited = false;
+            loop {
+                // Only the first read waits; the rest take what is already queued.
+                let timeout = if waited { Duration::ZERO } else { TICK };
+                waited = true;
+                let event = match next_event(timeout) {
+                    Ok(Some(event)) => {
+                        input_failures = 0;
+                        event
+                    }
+                    Ok(None) => break,
+                    // Input is not worth the process. A terminal can hand
+                    // crossterm a sequence it cannot parse — a burst of keys
+                    // interleaving with a mouse report is enough — and
+                    // propagating that error exited thurbox with every session
+                    // detached. Logged, dropped, and retried next iteration; only
+                    // a stream that keeps failing (a closed stdin, say) is fatal,
+                    // since polling a dead terminal would otherwise spin.
+                    Err(e) => {
+                        input_failures += 1;
+                        tracing::warn!("reading input failed: {e}");
+                        if input_failures > INPUT_FAILURE_LIMIT {
+                            return Err(Box::new(e));
+                        }
+                        break;
+                    }
+                };
+                match event {
                     Event::Key(key) if key.kind == KeyEventKind::Press => {
-                        // A handler reads `thurbox.*` too, and input is rare
-                        // enough that keeping it current costs nothing.
-                        self.republish();
+                        self.publish_for_batch(&mut published);
                         self.on_key(&key);
                         self.dirty = true;
                     }
@@ -1310,7 +1426,7 @@ impl App {
                     // reports mouse events unasked. v1 does the same in
                     // `App::update`.
                     Event::Mouse(mouse) if self.mouse => {
-                        self.republish();
+                        self.publish_for_batch(&mut published);
                         self.on_mouse(mouse);
                         self.dirty = true;
                     }
@@ -1318,7 +1434,7 @@ impl App {
                     // whatever has focus, exactly as `ctrl+v` is: a modal's
                     // text field if one is open, else the focused terminal.
                     Event::Paste(text) => {
-                        self.republish();
+                        self.publish_for_batch(&mut published);
                         self.on_paste(text);
                         self.dirty = true;
                     }
@@ -1353,6 +1469,111 @@ impl App {
     /// can have changed. Not per frame: it digests every file.
     fn refresh_sources(&mut self) {
         self.sources = thurbox::kernel::bundled::sources(&self.ui_dir);
+        // Delivery just re-read the directory, so whatever the cached trust
+        // answers were digested from is no longer the file on disk.
+        self.trust_stale = true;
+    }
+
+    /// Publish the world for this batch of input, unless it already was.
+    ///
+    /// See the drain loop for why once per batch is enough.
+    fn publish_for_batch(&mut self, published: &mut bool) {
+        if !*published {
+            self.republish();
+            *published = true;
+        }
+    }
+
+    /// Rescan for the links on each session's screen, where that screen moved.
+    ///
+    /// Part of publishing rather than a standing cost of the loop, because the
+    /// answer is only ever read by a plugin — and gated on the session's
+    /// `output_stamp`, because finding them walks every cell of its grid building
+    /// a `String` per row. Ungated, a held-down key rescanned every terminal on
+    /// screen per repeat for answers that could not have changed.
+    fn refresh_links(&mut self, sessions: &[String]) {
+        for id in sessions {
+            match self.terminals.output_stamp(id) {
+                // Unchanged since the last scan: the answer stands.
+                Some(stamp) if self.link_stamps.get(id) == Some(&stamp) => {}
+                Some(stamp) => {
+                    self.link_stamps.insert(id.clone(), stamp);
+                    let found = self.terminals.links(id);
+                    // Absent rather than empty when there are none, which is the
+                    // shape a plugin reads: `thurbox.links[id]` is nil for a
+                    // session with no links, not a table with nothing in it.
+                    if found.is_empty() {
+                        self.links.remove(id);
+                    } else {
+                        self.links.insert(id.clone(), found);
+                    }
+                }
+                // No live pane, so no screen and no links.
+                None => {
+                    self.link_stamps.remove(id);
+                    self.links.remove(id);
+                }
+            }
+        }
+        // A session that left the snapshot takes its cached answer with it.
+        let known: std::collections::HashSet<&str> = sessions.iter().map(String::as_str).collect();
+        self.links.retain(|id, _| known.contains(id.as_str()));
+        self.link_stamps.retain(|id, _| known.contains(id.as_str()));
+    }
+
+    /// Read what each terminal is showing, while something is searching them.
+    ///
+    /// The scan is the same walk [`Self::refresh_links`] makes, so serving it
+    /// always would not be ruinous — it would simply be paid by every interface
+    /// that never searches, which is the argument for asking. Gated a second time
+    /// on the screens having *moved*: a query is asked for once and then read on
+    /// every frame and every keystroke of it being narrowed, and re-reading every
+    /// grid for each of those is the whole cost of typing in the search strip.
+    fn refresh_search_content(&mut self, sessions: &[String]) {
+        let asked = self
+            .host
+            .shared_string(thurbox::kernel::terminal::WANT_CONTENT)
+            .is_some_and(|query| !query.is_empty());
+        if !asked {
+            // Dropped the moment nothing is searching, so a closed strip is not
+            // still holding every screen it scanned.
+            if self.content_generation.is_some() {
+                self.content = std::collections::HashMap::new();
+                self.content_generation = None;
+            }
+            return;
+        }
+        let generation = self.terminals.output_generation();
+        if self.content_generation != Some(generation) {
+            self.content = self.terminals.screens(sessions);
+            self.content_generation = Some(generation);
+        }
+    }
+
+    /// Re-read where each file of the interface stands with the user.
+    ///
+    /// Answering it reads and digests every file in the directory and parses
+    /// `plugins.lock`, so it is done when something says the answer moved rather
+    /// than per publish. Trust is keyed by absolute path, and drift is answered by
+    /// reading the file; an INSTALLED file is judged differently (its
+    /// `src@version` as well as its contents), and `trust_of` owns that split so
+    /// no caller can check only one half of it.
+    fn refresh_trust(&mut self) {
+        if !self.trust_stale {
+            return;
+        }
+        let lock = thurbox::kernel::packages::read_lock(&self.ui_dir).unwrap_or_default();
+        self.trust = self
+            .sources
+            .keys()
+            .map(|path| {
+                (
+                    path.clone(),
+                    thurbox::kernel::packages::trust_of(&self.ui_dir, path, &lock, &self.registry),
+                )
+            })
+            .collect();
+        self.trust_stale = false;
     }
 
     /// Rebuild everything a plugin can read.
@@ -1360,36 +1581,15 @@ impl App {
     /// Called just before a paint and before dispatching input — the only two
     /// moments Lua runs — rather than once per loop iteration.
     fn republish(&mut self) {
-        // Links are scanned out of each terminal's screen, so this is part of
-        // publishing rather than a standing cost of the loop.
-        let mut links = std::collections::HashMap::new();
-        for row in &self.snapshots.current().sessions {
-            let found = self.terminals.links(&row.id);
-            if !found.is_empty() {
-                links.insert(row.id.clone(), found);
-            }
-        }
-        // Terminal text, but only while something is searching it. The scan is
-        // the same walk `links` just made, so serving it always would not be
-        // ruinous — it would simply be paid by every interface that never
-        // searches, which is the argument for asking.
-        let content = match self
-            .host
-            .shared_string(thurbox::kernel::terminal::WANT_CONTENT)
-            .filter(|query| !query.is_empty())
-        {
-            Some(_) => {
-                let ids: Vec<String> = self
-                    .snapshots
-                    .current()
-                    .sessions
-                    .iter()
-                    .map(|row| row.id.clone())
-                    .collect();
-                self.terminals.screens(&ids)
-            }
-            None => std::collections::HashMap::new(),
-        };
+        let sessions: Vec<String> = self
+            .snapshots
+            .current()
+            .sessions
+            .iter()
+            .map(|row| row.id.clone())
+            .collect();
+        self.refresh_links(&sessions);
+        self.refresh_search_content(&sessions);
         // Generation-gated, so an idle session costs one atomic load.
         let meta = self.terminals.meta().clone();
         let attach_errors = self.terminals.failures();
@@ -1406,23 +1606,24 @@ impl App {
         let visible: std::collections::HashSet<usize> = (0..self.host.plugins.len())
             .filter(|index| self.is_visible_plugin(*index))
             .collect();
+        // Before the borrows below: it re-reads the directory when something says
+        // the answer moved, which needs `self` mutably.
+        self.refresh_trust();
         let ui_dir = self.ui_dir.clone();
         let registry = &self.registry;
-        // Read once per inventory pass rather than per file: it is one small TOML,
-        // and a per-file read would make the cost scale with the directory.
-        let plugin_lock = thurbox::kernel::packages::read_lock(&ui_dir).unwrap_or_default();
+        let trust = &self.trust;
         self.inventory = thurbox::kernel::inventory::rows(
             &self.host.plugins,
             &self.sources,
             &visible,
             &self.visible_slots,
             self.host.error.as_deref(),
-            // Trust is keyed by absolute path, and drift is answered by reading
-            // the file — cheap, and only for the handful that declare anything.
-            // An INSTALLED file is judged differently (its `src@version` as well as
-            // its contents), and `trust_of` owns that split so no caller can check
-            // only one half of it.
-            &|path| thurbox::kernel::packages::trust_of(&ui_dir, path, &plugin_lock, registry),
+            &|path| {
+                trust
+                    .get(path)
+                    .copied()
+                    .unwrap_or(thurbox::kernel::inventory::Trust::NotAsked)
+            },
             &|path| registry.is_disabled(&ui_dir.join(path).to_string_lossy()),
         );
         let inventory = std::mem::take(&mut self.inventory);
@@ -1434,8 +1635,8 @@ impl App {
             themes: &self.themes,
             registry: &self.registry,
             diffs: &self.diffs,
-            links: &links,
-            content: &content,
+            links: &self.links,
+            content: &self.content,
             meta: &meta,
             metrics: &self.metrics,
             status_rows: self.status_rows(),
@@ -3542,6 +3743,17 @@ impl App {
 /// `u16::clamp` asserts `min <= max`, and every rect below takes its cap from the
 /// space available — which on a short terminal is smaller than the floor the
 /// content wants. The cap wins, because a rect must never exceed its parent.
+/// The next terminal event, or `None` if none arrived within `timeout`.
+///
+/// The two crossterm calls belong together: a `poll` that says yes is what makes
+/// the `read` non-blocking, and either can fail the same way.
+fn next_event(timeout: Duration) -> std::io::Result<Option<Event>> {
+    if !event::poll(timeout)? {
+        return Ok(None);
+    }
+    event::read().map(Some)
+}
+
 fn clamp_span(value: u16, floor: u16, cap: u16) -> u16 {
     value.clamp(floor.min(cap), cap)
 }

--- a/tests/v2_search.rs
+++ b/tests/v2_search.rs
@@ -315,6 +315,12 @@ fn backspace_widens_the_search_again() {
     let host = host();
     open(&host);
     type_query(&host, "docs");
+    // Rendered before asserting because rendering is what previews: typing
+    // records the query, and the frame it causes clamps the cursor to the new
+    // results and points the list at whatever that lands on. The strip used to
+    // do both — the scan of every session, and once a query settled every
+    // session's *screen*, ran twice per keystroke for the same answer.
+    render(&host, PLUGIN);
     assert_eq!(selected(&host).as_deref(), Some("ccc"));
 
     for _ in 0..4 {

--- a/ui/plugins/65_search.lua
+++ b/ui/plugins/65_search.lua
@@ -547,13 +547,14 @@ return {
     end
     save(search)
     store[QUERY] = search.field.value or ""
-    -- The result under the cursor changed out from under it, so the preview has
-    -- to follow the query as well as the arrows — otherwise typing narrows the
-    -- list while the list underneath still shows the old row.
-    local rows = results()
-    search.cursor = widgets.clamp(search.cursor, #rows)
-    save(search)
-    preview(rows[search.cursor])
+    -- The preview follows the query as well as the arrows — otherwise typing
+    -- narrows the list while the list underneath still shows the old row. It is
+    -- `render` that does it, on the frame this keystroke causes: it clamps the
+    -- cursor to the new results and previews whatever that lands on, which is
+    -- the same answer this handler used to compute. Computing it here as well
+    -- scanned every session (and, once a query settles, every session's SCREEN)
+    -- a second time per keystroke, for a row that was about to be previewed
+    -- anyway.
     return true
   end,
 }


### PR DESCRIPTION
## Summary

Found by taking the report "spamming keys and global search crashed the TUI"
literally: a stress harness that drives the real binary in a throwaway tmux
pane (key/chord bursts, search open-type-arrow-escape storms, extreme resizes)
against seeded sessions. It reproduced one panic and two faults that read as a
crash, plus the per-keystroke cost that made all three easy to hit.

- **A one-cell pane killed a session's terminal for the rest of the run.** The
  vt100 grid was floored at one row and one column, and `process` underflows on
  both: `row_inc_scroll` when output wraps on one row, `col_wrap`
  (`cols - width`) when a double-width character lands on one column — the first
  line an agent that prints emoji writes. A cramped layout does compute those
  rects. The panic landed on the session's *reader* thread, so the process lived
  on while the unwind poisoned the parser mutex and every reader of it (paint,
  links, selection, copy) reported "no live terminal". Floored at two by two
  (`vt_floor`), a size nothing was readable at anyway.
- **`ctrl+/` opened the search strip and left focus on the agent**, so every
  letter of the query was typed into the agent's terminal. Focus may only rest on
  a slot the last painted frame placed; a pane that opens itself is not in that
  set until the next paint, so the `focus` command arriving with the chord was
  refused and dropped. It is now held over that paint and applied there, before
  the same iteration reads any input.
- **An unparseable input read exited thurbox** with every session detached
  (`event::poll`/`read` errors propagated out of the loop). Logged and dropped
  now; only a stream that keeps failing is fatal.
- **`republish` ran once per event.** A held-down key is 30 of those a second,
  and each one walked every cell of every live session's grid for links, re-read
  every grid again while a search was open, and digested every file of the
  interface plus a `plugins.lock` parse to answer what the user trusts. Once per
  batch now, each of the three gated on something that says whether the answer
  moved: an output stamp, the output generation, and a staleness flag every path
  that changes the directory already sets (ADR-P14). The search strip also
  stopped scanning every session twice per keystroke — rendering is what
  previews, and it was about to.
- A panic is now written to `thurbox.log`: a worker's stderr is scrolled away
  long before anyone looks, which is why the reader thread dying left no trace.

## Test plan

- `cargo nextest run --all` — 1843 pass, including two new tests pinning the
  grid floor against exactly what underflowed (a wide character, and enough text
  to wrap and scroll).
- `scripts/dev/smoke/tui-smoke.sh` — new assertion types into the search strip
  after `ctrl+/` and asserts the characters land in it; the focus bug shows up
  here as an empty field.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt`,
  `rumdl`, `selene ui`, `stylua --check ui`, plus all 19 pre-commit hooks.
- Manual: the resize storm that produced `attempt to subtract with overflow` in
  `vt100/grid.rs:683` on the reader thread now produces no panic, and a seeded
  two-session sandbox searches by name *and* by terminal text with the strip
  focused and `enter` landing in the session.
