### PR TITLE
refactor(core): one focus-deferral mechanism, and fix a flaky command phase

### DIFF
--- a/src/kernel/command.rs
+++ b/src/kernel/command.rs
@@ -716,6 +716,21 @@ pub struct InFlight {
     pub error: Option<String>,
 }
 
+impl InFlight {
+    /// Note that the worker has started, unless this row is already finished.
+    ///
+    /// A phase only ever moves forward. The worker announces itself from its own
+    /// thread, so the announcement can be scheduled *after* something has already
+    /// resolved the row — and an unguarded write then puts a failed command back
+    /// on the progress line, where it hides the error that explains it. Only a
+    /// row still reading `Queued` has anything to learn from "it started".
+    fn started(&mut self) {
+        if self.phase == Phase::Queued {
+            self.phase = Phase::Running;
+        }
+    }
+}
+
 /// A phase change reported from a running command.
 struct Progress {
     id: u64,
@@ -781,7 +796,7 @@ impl CommandBus {
         std::thread::spawn(move || {
             if let Ok(mut list) = inflight.lock() {
                 if let Some(entry) = list.iter_mut().find(|entry| entry.id == id) {
-                    entry.phase = Phase::Running;
+                    entry.started();
                 }
             }
             let error = execute(&command, id, &progress).err();
@@ -1871,6 +1886,34 @@ mod tests {
         let found = bus.first_running().expect("the running command");
         assert_eq!(found.id, running);
         assert_ne!(found.phase, Phase::Failed);
+    }
+
+    #[test]
+    fn a_worker_announcing_itself_cannot_revive_a_finished_row() {
+        // The worker sets `Running` from its own thread, so that write races
+        // whatever resolved the row first. Losing the race used to overwrite
+        // `Failed` — which put the failure back on the progress line, hiding the
+        // error that explains it, and made
+        // `a_failure_is_skipped_to_find_the_work_still_running_behind_it` fail
+        // about one run in twenty.
+        let mut entry = InFlight {
+            id: 1,
+            kind: "delete",
+            session: "s1".into(),
+            subject: None,
+            phase: Phase::Failed,
+            error: Some("bad session id".into()),
+        };
+        entry.started();
+        assert_eq!(entry.phase, Phase::Failed, "a phase only moves forward");
+
+        // A queued row is exactly what the announcement is for.
+        let mut queued = InFlight {
+            phase: Phase::Queued,
+            ..entry
+        };
+        queued.started();
+        assert_eq!(queued.phase, Phase::Running);
     }
 
     #[test]

--- a/src/kernel/focus.rs
+++ b/src/kernel/focus.rs
@@ -13,14 +13,6 @@
 //! lands the pane is not yet the chosen one — judging it by the previous frame's
 //! selection is judging it by the state it is about to change.
 //!
-//! There is a third case, and it belongs to the loop rather than to these two
-//! predicates: a pane that opens *itself* writes its visibility to `store`, so the
-//! arrangement only places its slot on the next paint, and [`can_focus`] answers no
-//! until then. A focus request refused there must be **held over that paint**, not
-//! dropped — `App::deferred_focus` is where. Dropping it is how `ctrl+/` opened the
-//! search strip and left focus on the agent, so the query was typed into the agent's
-//! terminal.
-//!
 //! Kept here rather than in the binary because it is the rule that was wrong,
 //! and a rule worth a test is worth a home.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         focus_return: initial_focus,
         reload_at: None,
         errors: Vec::new(),
-        deferred_focus: None,
         links: std::collections::HashMap::new(),
         link_stamps: std::collections::HashMap::new(),
         content: std::collections::HashMap::new(),
@@ -907,17 +906,6 @@ struct App {
     last_output_gen: u64,
     /// Plugin holding an exclusive key grab this frame, if any.
     grabbed: Option<usize>,
-    /// A pane that asked for focus before it was on screen.
-    ///
-    /// Focus may only rest on a slot the *last painted frame* placed
-    /// (`kernel::focus::can_focus`), and a pane opening itself writes its
-    /// visibility to `store` — so the arrangement only learns about it on the
-    /// next paint. A `focus` command drained in between was therefore refused
-    /// and dropped: `ctrl+/` opened the search strip and left focus on the
-    /// agent, which is not a cosmetic difference — every letter of the query
-    /// went to the agent's terminal instead. Held over the paint that places the
-    /// slot and applied there, so the strip is focused on the frame it appears.
-    deferred_focus: Option<usize>,
     /// Programs plugins asked to be run, and what they printed.
     runs: thurbox::kernel::runs::RunStore,
     /// Every file of the interface, as of the last painted frame.
@@ -1058,19 +1046,16 @@ impl App {
                                     self.focus = back;
                                     self.dirty = true;
                                 }
-                            } else if self.can_focus_plugin(index) {
-                                // Through `focus_plugin`, not by assigning `focus`:
-                                // it records where focus came from and refuses a
-                                // pane focus cannot rest on. Assigning directly
-                                // skipped both, so a pane reached from a plugin
-                                // command could not be left with `Esc` — the user
-                                // had to walk out with the focus cycle.
-                                self.focus_plugin(index);
-                                self.dirty = true;
                             } else {
-                                // Not on screen yet — it is opening itself this
-                                // very frame. See `deferred_focus`.
-                                self.deferred_focus = Some(index);
+                                // Through `focus_plugin`, not by assigning `focus`:
+                                // it records where focus came from, and holds a
+                                // request for a slot the arrangement has not
+                                // placed yet rather than refusing it
+                                // (`kernel::focus::defer_until_placed`) — which is
+                                // what a pane opening itself needs. Assigning
+                                // directly skipped both, so a pane reached from a
+                                // plugin command could not be left with `Esc`.
+                                self.focus_plugin(index);
                                 self.dirty = true;
                             }
                         }
@@ -1371,19 +1356,6 @@ impl App {
                 // After the backend flushed, so the escapes cannot interleave
                 // with ratatui's own output.
                 self.paint_terminal_hyperlinks(&buffer);
-                // The frame that just painted is what placed the slots, so a
-                // pane that asked for focus while it was still invisible can be
-                // answered now — before this iteration reads any input, so the
-                // first key after the one that opened it lands in the right pane.
-                // Dropped rather than retried if the paint did not place it: the
-                // pane declined to draw, and a request that outlives that would
-                // steal focus later for no visible reason.
-                if let Some(index) = self.deferred_focus.take() {
-                    if self.can_focus_plugin(index) {
-                        self.focus_plugin(index);
-                        self.dirty = true;
-                    }
-                }
                 self.last_paint = Instant::now();
                 self.frames += 1;
                 Counters::bump(&self.perf.frames);


### PR DESCRIPTION
## Summary

Follow-up to #950, which merged an hour after #948 fixed the same
search-strip focus bug from the other side. Both landed cleanly, so nothing
misbehaves — but `main` carried two mechanisms for one rule, and a flaky test
turned up while verifying that.

- **One way to hold a focus request over a layout.** `pending_focus` (#948,
  inside `focus_plugin`, re-asked where the arrangement resolves) and
  `deferred_focus` (#950, in the `Focus` command arm, applied after the paint)
  both existed; the command arm reached its own branch first, so the other never
  fired for that path. `kernel::focus::defer_until_placed` is kept: every caller
  of `focus_plugin` gets it including a click, it is re-asked one paint earlier,
  and the rule has a name and a test in the kernel. The module-doc paragraph
  #950 added goes with it — `defer_until_placed`'s own doc says the same thing
  where a reader is already standing.
- **A command's phase only ever moves forward.**
  `a_failure_is_skipped_to_find_the_work_still_running_behind_it` fails about
  one run in twenty (reproduced 2/40 on an unloaded machine; it is what turned a
  pre-commit run red for a change touching neither the bus nor a test). The race
  is real: `dispatch` registers the row `Queued` and spawns the worker, whose
  first act is to write `Running` from its own thread — so anything that
  resolves the row in between is overwritten. In the test that is a `Done`
  marking it `Failed`, after which `first_running` hands back the failed
  command; in the interface it would put a failure back on the progress line,
  where it hides the error explaining it. The announcement is now
  `InFlight::started`, which only a row still reading `Queued` accepts.

## Test plan

- `cargo nextest run --all` plus all 19 pre-commit hooks on each commit.
- The flake, before and after: 2 failures in 40 runs on `main`, 0 in 60 with the
  guard. New unit test asserts a `Failed` row is not revived by a late `started()`
  and that a `Queued` one still advances.
- `scripts/dev/smoke/tui-smoke.sh` — the search-focus assertion #950 added still
  passes against the surviving mechanism, which is the point of asserting on
  behaviour rather than on which field holds the request.
