### PR TITLE
docs: point at the renamed v1.x branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1365,7 +1365,7 @@ overflow the banner.
 **The view is gone.** v1's native diff reviewer (`ui/code_review.rs` +
 `app/code_review.rs`) went with `src/ui`; there is no replacement yet, and it is the
 largest single thing v2 owes v1 (`openspec/changes/v2-code-review/` has the design,
-`v2-parity-gaps` tracks it). v1 keeps it on the `1.x` branch.
+`v2-parity-gaps` tracks it). v1 keeps it on the `v1.x` branch.
 
 What survived, because it is not view code:
 
@@ -1434,7 +1434,7 @@ and `README.md` embeds the gifs, so regenerating them propagates everywhere.
 The interface is **Lua running on a Rust kernel**. `thurbox` boots the kernel,
 which reads `ui/` and renders whatever plugins it finds; there is no built-in
 pane. v1's `src/app` (TEA model/update/view) and `src/ui` (35 render modules) were
-deleted when the kernel took the binary name — v1 lives on the `1.x` branch.
+deleted when the kernel took the binary name — v1 lives on the `v1.x` branch.
 
 ### The five rules
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ worktrees are first-class citizens.
 >
 > Then set `auto_update = false` under `[features]` in
 > `~/.config/thurbox/settings.toml`, or the next launch pulls v2 back. v1 is
-> maintained on the [`1.x`](https://github.com/Thurbeen/thurbox/tree/1.x) branch;
+> maintained on the [`v1.x`](https://github.com/Thurbeen/thurbox/tree/v1.x) branch;
 > newer 1.x patches are on the
 > [releases page](https://github.com/Thurbeen/thurbox/releases).
 
@@ -368,7 +368,7 @@ result; `Esc` restores exactly what you had.
 ### Code Review
 
 > **Not in the current interface**, and no replacement yet. `1.x` keeps it;
-> see [docs/v1](https://github.com/Thurbeen/thurbox/tree/1.x/docs).
+> see [docs/v1](https://github.com/Thurbeen/thurbox/tree/v1.x/docs).
 
 A native, GitHub-style diff reviewer (`Ctrl+X`, `F7` alternate) — no external tool. Browse the
 branch (`<base>..HEAD`), a single commit, or the uncommitted changes; the
@@ -729,7 +729,7 @@ cannot drift from what is running.
 Gone with the panes they opened: `Ctrl+X`/`F7` (code review), `Ctrl+E`/`F3`
 (file viewer), `Ctrl+B`/`F2` (info panel), `F5` (tasks), `Ctrl+P`
 (automations — now the creation flow's folder import) and `Ctrl+U` (restore
-list). See [docs/V2-KERNEL.md](docs/V2-KERNEL.md), or the `1.x` branch if you
+list). See [docs/V2-KERNEL.md](docs/V2-KERNEL.md), or the `v1.x` branch if you
 need them.
 
 Every chord is rebindable from the `F1` editor; rebindings persist to
@@ -993,7 +993,7 @@ See [docs/PLUGINS.md](docs/PLUGINS.md) and
 **Moving from v1?** Some panes are owed rather than ported, and some
 moved to `thurbox-cli`. The note at the top of this file has the list,
 what asks you before anything changes, and how to stay on v1 — which
-is maintained on the `1.x` branch.
+is maintained on the `v1.x` branch.
 
 ## Documentation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@ Each decision follows a mini-ADR format:
 > the plugin kernel took the `thurbox` binary name. The reasoning below is why the
 > kernel keeps a single source of truth and one direction of data flow — reads are
 > snapshots, writes are commands — rather than letting each pane own state. v1 is
-> maintained on the `1.x` branch.
+> maintained on the `v1.x` branch.
 
 **Choice**: All state lives in a single `App` model.
 Events become messages, `update()` applies them,

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -652,7 +652,7 @@ editor of choice can open them as a workspace.
 > survived and is waiting for a plugin: `session::review` (pure diff types +
 > `parse_unified_diff`), `storage::review` (`review_comments` + `review_marks`,
 > schema v38), and `kernel::diff` (diffs on a worker, published into the snapshot).
-> `openspec/changes/v2-code-review/` has the design. v1 keeps the view on `1.x`.
+> `openspec/changes/v2-code-review/` has the design. v1 keeps the view on `v1.x`.
 
 Thurbox ships a **native, built-in** tuicr-like review view (`Ctrl+X`, `F7` alternate): a
 GitHub-style continuous diff of the active session's worktree

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -50,7 +50,7 @@ expect a new tool to reach the existing population.
 ## v1 is a branch, not a binary
 
 `thurbox` runs the plugin kernel; `src/app` and `src/ui` are gone. v1 is
-maintained on the **`1.x`** branch, and a patch is released by dispatching
+maintained on the **`v1.x`** branch, and a patch is released by dispatching
 `cd.yml` from that ref with an explicit `version` (e.g. `1.8.7`) — `cog bump
 --auto` computes from tags and would try to move the 2.x line instead.
 

--- a/docs/V2-KERNEL.md
+++ b/docs/V2-KERNEL.md
@@ -16,7 +16,7 @@ Writing a plugin starts at `docs/PLUGINS.md` — **Start here**, which is four
 
 Runs as `thurbox`. It **is** the interface now: `src/app/` and `src/ui/` were
 deleted when the kernel took the binary name, so there is no second interface to
-fall back to inside the process. v1 is maintained on the `1.x` branch and still
+fall back to inside the process. v1 is maintained on the `v1.x` branch and still
 takes patch releases.
 
 The name matters more than it looks. The updater in an already-installed binary

--- a/website/docs/v1.html
+++ b/website/docs/v1.html
@@ -113,14 +113,14 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
 </h2>
 <ul>
   <li><strong>Will</strong>: bug fixes, security fixes, and fixes to the session engine, backends and
-    CLI, released as 1.x patch versions from the <code>1.x</code> branch.</li>
+    CLI, released as 1.x patch versions from the <code>v1.x</code> branch.</li>
   <li><strong>Will not</strong>: new features. Those land on the current line, where the interface is
     a plugin set rather than a fixed set of panes.</li>
 </ul>
 <p>
   The reference documentation on this site describes the current interface. For v1's own docs, read
   them at the tag you are running &mdash;
-  <a href="https://github.com/Thurbeen/thurbox/tree/1.x/docs">the <code>1.x</code> branch</a> carries
+  <a href="https://github.com/Thurbeen/thurbox/tree/v1.x/docs">the <code>v1.x</code> branch</a> carries
   the versions that match it, including its keybindings, its feature notes and its architecture
   decisions.
 </p>

--- a/website/docs/v2-interface.html
+++ b/website/docs/v2-interface.html
@@ -22,7 +22,7 @@ breadcrumb: 'Interface'
     Several panes have no equivalent here yet &mdash; code review, the file viewer and the info
     panel are gone, and tasks, automations, the restore list and the perf HUD moved to
     <code>thurbox-cli</code>. thurbox asks once, on the first launch after the upgrade, before
-    changing anything. v1 stays maintained on the <code>1.x</code> branch.
+    changing anything. v1 stays maintained on the <code>v1.x</code> branch.
   </p>
 </div>
 
@@ -257,7 +257,7 @@ breadcrumb: 'Interface'
   <a href="#v1" class="heading-anchor">#</a>
 </h2>
 <p>
-  It is maintained on the <code>1.x</code> branch and still gets patch releases. The first-launch
+  It is maintained on the <code>v1.x</code> branch and still gets patch releases. The first-launch
   prompt prints the exact command; the short version is to pin a 1.x version and turn auto-update
   off so nothing moves you again:
 </p>


### PR DESCRIPTION
The v1 maintenance branch is now **`v1.x`**, matching the `v1.8.6` tag spelling. GitHub retargeted the open PR against it (#952) and redirects the old URLs, but the prose still said `1.x`.

Moved: the eight places that name the **branch** — `README.md` (including the two `tree/1.x` links), `CLAUDE.md`, `docs/{ARCHITECTURE,FEATURES,RELEASING,V2-KERNEL}.md`, and `website/docs/{v1,v2-interface}.html`.

Left alone: every `1.x` that means the **version line** — "reinstall 1.x", "released as 1.x patch versions", "1.x had a native in-TUI diff", "at 1.x+ a breaking change bumps the major". Those sentences are about versions, not a ref, and rewriting them would make them wrong.

The `v1.x` branch itself carries no reference to its own name, so nothing is owed on that side.