### PR TITLE
fix(core): keep the caret where the frame put it, and follow a new session

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -236,6 +236,15 @@ not applicable.
    session. Skipped when only one agent is defined in
    `agents.toml`.
 
+**The new session is the one you end up looking at.** Creation is a command, so
+its id does not exist when the flow closes — the spawn pipeline mints it. It
+travels back with the completion (`CommandBus::take_created`), and the loop then
+selects that session and puts the input focus on the pane showing it, through the
+same `focus_session` path a clicked notification and `thurbox-cli session focus`
+use. The session list *follows the id* rather than a row number, so the selection
+lands correctly across the frames between "created" and "in the snapshot".
+`Ctrl+F` fork reports its new session the same way.
+
 A session is fully described by its repos and agent. There is no
 per-session model selection, permissions, prompt, tool, or skill
 configuration — those concerns belong to the agent CLI itself,
@@ -2329,8 +2338,16 @@ visually and only the terminal's hyperlink state is added. Windows
 Terminal, kitty, WezTerm and iTerm2 then underline the label on hover and
 open the user's own browser on Ctrl/Cmd+Click.
 
-Two properties keep this safe and cheap:
+Three properties keep this safe and cheap:
 
+- **Bracketed in DECSC/DECRC**: the draw places the caret last and leaves it
+  *shown*, so re-printing walks it away — a focused text field's caret was left
+  wherever the final run ended, and the forced-redraw floor put it back and took
+  it away again several times a second. That reads as a cursor blinking in the
+  wrong place, which is why it looked like a rendering fault rather than a moved
+  cursor. The pass saves and restores the position itself instead of leaving it
+  to the next `draw`: any number of frames may pass before that one, and every
+  one of them is a frame with a stray caret.
 - **Validated against what was drawn** (`helpers::drawn_label_cells`): a
   candidate is emitted only if the frame's cells still print that label
   there, so a covering overlay, a scrolled pane, or a repainted row

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -78,7 +78,8 @@ rewrites the cells, so the escapes must follow each draw — and is gated on
 rows, so a session whose agent never printed a link pays a single emptiness
 check per frame. When links are present the scan is bounded (the newest 128
 runs × the visible rows) and the writes are a handful of short `queue!`s per
-visible run.
+visible run, bracketed in DECSC/DECRC so the caret the frame just placed is put
+back rather than left wherever the last run ended.
 
 ---
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -248,6 +248,16 @@ widgets.panel("title", ctx.focused)
 widgets.gauge(0.7, { width = 20 })
 ```
 
+`input` carries one thing the other three do not: a claim on the **caret**. A
+screen can hold several fields and the terminal has one cursor, so the field
+being typed into says so with `focused = true` and the others say nothing — and
+a field that claims it keeps the caret whether or not it holds text, because a
+field showing its placeholder is still the field you are typing into.
+`lib/textinput.lua` passes its own `focused` option through, so a pane built on
+it already does the right thing; a raw `input` node that never sets the flag
+draws no caret at all, which is visible at once. A caret guessed from the value
+being non-empty is not: it wanders to whichever field happens to hold text.
+
 `surface` is the exception that proves the rule: it carries **cells**, for
 content positioned by character measurement rather than by structure — a live
 terminal, or a diff body. You place and frame it; the kernel fills it.

--- a/src/kernel/command.rs
+++ b/src/kernel/command.rs
@@ -741,6 +741,10 @@ struct Progress {
 struct Done {
     id: u64,
     error: Option<String>,
+    /// The session the command brought into existence, if it did — a creation
+    /// or a fork. Carried on the completion because that is the first moment
+    /// the id exists.
+    created: Option<String>,
 }
 
 /// How long a failed command stays readable before being swept.
@@ -756,6 +760,8 @@ pub struct CommandBus {
     next_id: AtomicU64,
     /// When each failure was recorded, so it can be swept after lingering.
     failed_at: Vec<(u64, std::time::Instant)>,
+    /// Sessions created since the loop last drained this, oldest first.
+    created: Vec<String>,
 }
 
 impl CommandBus {
@@ -770,6 +776,7 @@ impl CommandBus {
             progress_rx,
             next_id: AtomicU64::new(1),
             failed_at: Vec::new(),
+            created: Vec::new(),
         }
     }
 
@@ -799,17 +806,15 @@ impl CommandBus {
                     entry.started();
                 }
             }
-            let error = execute(&command, id, &progress).err();
-            let _ = finished.send(Done { id, error });
+            let (created, error) = match execute(&command, id, &progress) {
+                Ok(created) => (created, None),
+                Err(error) => (None, Some(error)),
+            };
+            let _ = finished.send(Done { id, error, created });
         });
         id
     }
 
-    /// Fold finished commands into the in-flight list.
-    ///
-    /// Returns true when anything completed, so the caller can refresh the
-    /// snapshot immediately rather than waiting out the refresh interval —
-    /// which is what makes a delete feel instant.
     /// Report a command finished, as a worker would.
     ///
     /// The worker path is a thread and a channel; a test that wants to observe
@@ -817,9 +822,20 @@ impl CommandBus {
     /// thread.
     #[doc(hidden)]
     pub fn finish_for_test(&self, id: u64, error: Option<String>) {
-        let _ = self.finished_tx.send(Done { id, error });
+        self.finish_outcome(id, error, None);
     }
 
+    /// As [`Self::finish_for_test`], but also naming a session the command
+    /// created — the other half of a completion the worker supplies.
+    fn finish_outcome(&self, id: u64, error: Option<String>, created: Option<String>) {
+        let _ = self.finished_tx.send(Done { id, error, created });
+    }
+
+    /// Fold finished commands into the in-flight list.
+    ///
+    /// Returns true when anything completed, so the caller can refresh the
+    /// snapshot immediately rather than waiting out the refresh interval —
+    /// which is what makes a delete feel instant.
     pub fn poll(&mut self) -> bool {
         let mut changed = false;
 
@@ -836,6 +852,9 @@ impl CommandBus {
 
         while let Ok(done) = self.finished_rx.try_recv() {
             changed = true;
+            if let Some(session) = done.created {
+                self.created.push(session);
+            }
             if let Ok(mut list) = self.inflight.lock() {
                 match done.error {
                     // Success: the effect is in the database now, so the row
@@ -867,6 +886,15 @@ impl CommandBus {
             changed = true;
         }
         changed
+    }
+
+    /// The sessions completed commands brought into existence, oldest first.
+    ///
+    /// Drained rather than read: the loop acts on each exactly once, and a
+    /// creation nobody consumed must not steer the selection again on the next
+    /// tick.
+    pub fn take_created(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.created)
     }
 
     /// Everything accepted but not yet done, for publishing to plugins.
@@ -912,7 +940,15 @@ impl Default for CommandBus {
 }
 
 /// Run one command. Called on the command's own thread, never the UI thread.
-fn execute(command: &Command, id: u64, progress: &Sender<Progress>) -> Result<(), String> {
+///
+/// `Ok(Some(id))` when the command brought a session into existence: the id is
+/// not knowable when the command is issued — the spawn pipeline mints it — so it
+/// travels back with the completion instead.
+fn execute(
+    command: &Command,
+    id: u64,
+    progress: &Sender<Progress>,
+) -> Result<Option<String>, String> {
     // Handled by the loop before dispatch, because they mutate in-process state
     // the worker cannot reach. Reaching here means a caller bypassed that.
     if command.applied_on_ui_thread() {
@@ -931,26 +967,28 @@ fn execute(command: &Command, id: u64, progress: &Sender<Progress>) -> Result<()
         extras,
     } = command
     {
-        return create(name, repo, branch, base, agent, host, extras, id, progress);
+        return create(name, repo, branch, base, agent, host, extras, id, progress)
+            .map(|session| Some(session.to_string()));
     }
 
     // Repository memory names a path, not a session, so it too runs before the
     // id parse.
     if let Command::Bookmark { host, path, edit } = command {
-        return bookmark(host, path, *edit);
+        return bookmark(host, path, *edit).map(|()| None);
     }
 
     // The settings file names nothing at all.
     if let Command::Configure { settings } = command {
         return crate::agent::settings_config::save_settings(settings)
-            .map_err(|e| format!("write settings.toml: {e}"));
+            .map_err(|e| format!("write settings.toml: {e}"))
+            .map(|()| None);
     }
 
     // Keyed by nothing at all: an explicit order names every session at once.
     if let Command::Order { list } = command {
         let path = crate::paths::database_file().ok_or("could not resolve the database path")?;
         let db = Database::open(&path).map_err(|e| format!("open database: {e}"))?;
-        return order(&db, list);
+        return order(&db, list).map(|()| None);
     }
 
     // Tasks and automations are keyed by number, not by session id.
@@ -977,7 +1015,8 @@ fn execute(command: &Command, id: u64, progress: &Sender<Progress>) -> Result<()
                 delete,
             } => automation(&db, *id, *enabled, *run_now, *delete),
             _ => unreachable!(),
-        };
+        }
+        .map(|()| None);
     }
 
     let id: SessionId = command
@@ -989,6 +1028,12 @@ fn execute(command: &Command, id: u64, progress: &Sender<Progress>) -> Result<()
     // the very reads this is supposed to keep instant.
     let path = crate::paths::database_file().ok_or("could not resolve the database path")?;
     let db = Database::open(&path).map_err(|e| format!("open database: {e}"))?;
+
+    // A fork mints a session too, so it reports its id the way creation does;
+    // every other command leaves the set of sessions as it found it.
+    if let Command::Fork { name, .. } = command {
+        return fork(&db, id, name).map(|session| Some(session.to_string()));
+    }
 
     match command {
         Command::Delete { force, .. } => {
@@ -1018,7 +1063,7 @@ fn execute(command: &Command, id: u64, progress: &Sender<Progress>) -> Result<()
         Command::Reorder { delta, .. } => reorder(&db, id, *delta),
         // Handled above, before the session id is parsed.
         Command::Order { .. } => Ok(()),
-        Command::Fork { name, .. } => fork(&db, id, name),
+        Command::Fork { .. } => unreachable!("handled above, to report its new session"),
 
         Command::Sync { .. } => sync(&db, id),
         // Unreachable: guarded above, and kept exhaustive so adding a command
@@ -1041,6 +1086,7 @@ fn execute(command: &Command, id: u64, progress: &Sender<Progress>) -> Result<()
         | Command::Focus { .. }
         | Command::Plugin { .. } => unreachable!("applied on the UI thread"),
     }
+    .map(|()| None)
 }
 
 /// Create a session.
@@ -1061,7 +1107,7 @@ fn create(
     extras: &[ExtraMember],
     id: u64,
     progress: &Sender<Progress>,
-) -> Result<(), String> {
+) -> Result<SessionId, String> {
     let path = crate::paths::database_file().ok_or("could not resolve the database path")?;
     let db = Database::open(&path).map_err(|e| format!("open database: {e}"))?;
 
@@ -1125,7 +1171,7 @@ fn create(
         });
     };
     crate::session_ops::spawn::spawn_session_headless_with_progress(&db, request, Some(&report))
-        .map(|_| ())
+        .map(|spawned| spawned.session_id)
 }
 
 /// Remember, forget or import a repository path.
@@ -1238,7 +1284,7 @@ fn bookmark(host: &str, path: &str, edit: BookmarkEdit) -> Result<(), String> {
 }
 
 /// Fork a session: a new one on the same repository, recording its parent.
-fn fork(db: &Database, id: SessionId, name: &str) -> Result<(), String> {
+fn fork(db: &Database, id: SessionId, name: &str) -> Result<SessionId, String> {
     let source = db
         .get_session_by_id(id)
         .map_err(|e| format!("get session: {e}"))?
@@ -1285,7 +1331,7 @@ fn fork(db: &Database, id: SessionId, name: &str) -> Result<(), String> {
         // Shared, not created — so the fork shows its branch and can be synced.
         inherit_worktrees: source.worktrees.clone(),
     };
-    crate::session_ops::spawn::spawn_session_headless(db, request).map(|_| ())
+    crate::session_ops::spawn::spawn_session_headless(db, request).map(|spawned| spawned.session_id)
 }
 
 /// Bring a session's worktree up to date with the branch it came from.
@@ -1844,6 +1890,41 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(20));
         }
         panic!("the failure never surfaced");
+    }
+
+    #[test]
+    fn a_created_session_is_reported_once_and_then_drained() {
+        // What the loop needs to steer the selection onto a session the user
+        // just asked for. Drained rather than read, because a creation acted on
+        // twice would keep dragging the cursor back after the user moved it.
+        let mut bus = CommandBus::new();
+        let id = bus.dispatch(Command::Delete {
+            session: "not-a-uuid".into(),
+            force: false,
+        });
+        bus.finish_outcome(id, None, Some("the-new-session".into()));
+        bus.poll();
+
+        assert_eq!(bus.take_created(), vec!["the-new-session".to_string()]);
+        assert!(
+            bus.take_created().is_empty(),
+            "a creation must steer the selection once, not every tick"
+        );
+    }
+
+    #[test]
+    fn a_failed_creation_reports_no_session_to_focus() {
+        // The id would be a lie: nothing was spawned, so following it would
+        // leave the list chasing a session that never appears.
+        let mut bus = CommandBus::new();
+        let id = bus.dispatch(Command::Delete {
+            session: "not-a-uuid".into(),
+            force: false,
+        });
+        bus.finish_for_test(id, Some("worktree add failed".into()));
+        bus.poll();
+
+        assert!(bus.take_created().is_empty());
     }
 
     #[test]

--- a/src/kernel/convert.rs
+++ b/src/kernel/convert.rs
@@ -115,6 +115,11 @@ fn convert_table(table: &Table, path: &str, depth: usize, owner: &str) -> Result
             value: opt_string(table, "value", path)?.unwrap_or_default(),
             cursor: opt_u16(table, "cursor", path)?.unwrap_or(0) as usize,
             placeholder: opt_string(table, "placeholder", path)?.unwrap_or_default(),
+            // Absent means "not the one being typed into". A pane that draws one
+            // field and never says so gets no caret, which is visible at once —
+            // the alternative default hands the caret to every field on screen
+            // and the last one painted wins, which is not.
+            focused: opt_bool(table, "focused", path)?.unwrap_or(false),
             style: read_style_field(table, "style", path)?,
             frame,
             size,
@@ -719,6 +724,7 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
             value,
             cursor,
             placeholder,
+            focused,
             style,
             ..
         } => {
@@ -729,6 +735,7 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
             table
                 .set("placeholder", placeholder.clone())
                 .map_err(|e| e.to_string())?;
+            table.set("focused", *focused).map_err(|e| e.to_string())?;
             if let Some(style) = style_to_lua(lua, style)? {
                 table.set("style", style).map_err(|e| e.to_string())?;
             }

--- a/src/kernel/node.rs
+++ b/src/kernel/node.rs
@@ -221,6 +221,16 @@ pub enum Node {
         value: String,
         cursor: usize,
         placeholder: String,
+        /// Whether this field owns the terminal caret.
+        ///
+        /// A screen can hold several inputs — the creation flow's repo step
+        /// holds two — and there is exactly one caret, so ownership has to be
+        /// declared rather than guessed. It was guessed once, from the value
+        /// being non-empty, which put the caret in whichever field happened to
+        /// have text in it and took it away from an empty field you were
+        /// typing into: the cursor appeared on the first keystroke and vanished
+        /// on the last backspace.
+        focused: bool,
         style: Style,
         frame: Option<Frame>,
         size: Size,

--- a/src/kernel/paint.rs
+++ b/src/kernel/paint.rs
@@ -246,6 +246,7 @@ pub fn render_recording(
             value,
             cursor,
             placeholder,
+            focused,
             style,
             ..
         } => {
@@ -263,9 +264,16 @@ pub fn render_recording(
                 Paragraph::new(Line::from(text.clone()).style(line_style)),
                 inner,
             );
-            // A real caret, so a focused field reads as focused. Clamped into
-            // the rect so a cursor past the end cannot paint outside it.
-            if !showing_placeholder {
+            // A real caret, in the one field that claims it — empty or not. A
+            // field showing its placeholder is still the field being typed
+            // into: keying the caret on the value being non-empty instead, as
+            // this did, made the cursor blink into existence on the first
+            // keystroke and out of it on the last backspace, and handed it to
+            // whichever *other* field on screen happened to hold text. The
+            // placeholder is dim, so a caret at its start cannot be mistaken
+            // for one. Clamped into the rect so a cursor past the end cannot
+            // paint outside it.
+            if *focused {
                 let offset = (*cursor).min(value.chars().count());
                 let column = inner
                     .x

--- a/src/kernel/terminal.rs
+++ b/src/kernel/terminal.rs
@@ -1574,16 +1574,26 @@ fn drawn_label_cells(
 /// can open it.
 ///
 /// Written straight to stdout *after* the backend has flushed the frame, so it
-/// cannot interleave with ratatui's own output. The cursor is left wherever the
-/// last run ended; the next `draw` repositions it.
+/// cannot interleave with ratatui's own output.
+///
+/// Bracketed in DECSC/DECRC, because the frame has already placed the caret and
+/// this walks it away. `draw` positions the caret last and it stays *shown*, so
+/// a focused text field's caret was left sitting wherever the final link run
+/// ended — and, since the loop repaints on the forced-redraw floor, it jumped
+/// back to the field and away again several times a second. That reads as a
+/// cursor blinking in the wrong place rather than as one that moved, which is
+/// why it looked like a rendering fault. Restoring here rather than leaving it
+/// to the next `draw` keeps the two independent: any number of frames may pass
+/// before the next one, and every one of them is a frame with a stray caret.
 pub fn paint_hyperlinks(paints: &[HyperlinkPaint]) -> std::io::Result<()> {
-    use crossterm::cursor::MoveTo;
+    use crossterm::cursor::{MoveTo, RestorePosition, SavePosition};
     use crossterm::queue;
     use crossterm::style::{Print, PrintStyledContent, ResetColor};
     use ratatui::backend::IntoCrossterm;
     use std::io::Write;
 
     let mut out = std::io::stdout();
+    queue!(out, SavePosition)?;
     for paint in paints {
         queue!(
             out,
@@ -1600,6 +1610,7 @@ pub fn paint_hyperlinks(paints: &[HyperlinkPaint]) -> std::io::Result<()> {
             ResetColor
         )?;
     }
+    queue!(out, RestorePosition)?;
     out.flush()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1164,6 +1164,16 @@ impl App {
             // delete feel immediate instead of arriving up to 400ms later.
             if self.commands.poll() {
                 self.report_finished_commands();
+                // A session you just asked for is the one you want to be
+                // looking at. The id is knowable only once the spawn finished,
+                // so it arrives with the completion rather than with the
+                // command — and the list follows an id until it appears, which
+                // is what carries this across the frames between "created" and
+                // "in the snapshot". Of several finishing at once the last to
+                // finish wins; there is one caret and one selection either way.
+                if let Some(created) = self.commands.take_created().pop() {
+                    self.focus_on_session(&created);
+                }
                 // Wait for the last one: two adds in quick succession would
                 // otherwise re-read between them and publish a list missing the
                 // second.
@@ -1294,13 +1304,7 @@ impl App {
             // leave a row in the database for whoever is running the interface.
             // Taken atomically, so two instances cannot both claim it.
             if let Some(id) = self.snapshots.take_focus_request() {
-                self.host.set_shared_string("focus_session", &id);
-                if let Some(index) = self.host.index_of("agent") {
-                    if let Some(position) = self.host.focusable().iter().position(|i| *i == index) {
-                        self.focus = position;
-                    }
-                }
-                self.dirty = true;
+                self.focus_on_session(&id);
             }
 
             // Acknowledge a finished turn on the way out of it: moving the
@@ -3501,6 +3505,23 @@ impl App {
             .iter()
             .filter_map(|row| Some((row.id.clone(), self.terminals.last_rect(&row.id)?)))
             .find(|(_, rect)| rect.contains(position))
+    }
+
+    /// Select a session and put the input focus on the pane that shows it.
+    ///
+    /// Shared by the two things that mean "look at this one": an outside focus
+    /// request (a clicked notification, `thurbox-cli session focus`) and a
+    /// session this instance just created. The selection travels through the
+    /// store rather than being set here, because the list is a plugin and it is
+    /// the only thing that knows the rendered order.
+    fn focus_on_session(&mut self, id: &str) {
+        self.host.set_shared_string("focus_session", id);
+        if let Some(index) = self.host.index_of("agent") {
+            if let Some(position) = self.host.focusable().iter().position(|i| *i == index) {
+                self.focus = position;
+            }
+        }
+        self.dirty = true;
     }
 
     /// Hand every visible OSC 8 run back to the terminal thurbox runs in.

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -1796,6 +1796,73 @@ fn the_review_body_is_a_surface_not_a_tree() {
     assert!(screen.contains("+added"), "{screen}");
 }
 
+// --- text fields -----------------------------------------------------------
+
+/// Paint a tree and report where the caret ended up, if anywhere.
+fn painted_caret(node: &Node, width: u16, height: u16) -> Option<(u16, u16)> {
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+    terminal
+        .draw(|frame| render(frame, frame.area(), node, &PlaceholderSurfaces))
+        .expect("draw");
+    let backend = terminal.backend();
+    let position = backend.cursor_position();
+    backend.cursor_visible().then_some((position.x, position.y))
+}
+
+fn field(value: &str, cursor: usize, focused: bool) -> Node {
+    Node::Input {
+        identity: Default::default(),
+        size: Default::default(),
+        frame: None,
+        value: value.into(),
+        cursor,
+        placeholder: "name".into(),
+        focused,
+        style: Default::default(),
+    }
+}
+
+#[test]
+fn an_empty_focused_field_still_owns_the_caret() {
+    // The caret used to be keyed on the value being non-empty, so the field you
+    // had just opened showed none until the first keystroke and lost it again on
+    // the last backspace. A field showing its placeholder is still the field
+    // being typed into.
+    assert_eq!(painted_caret(&field("", 0, true), 20, 1), Some((0, 0)));
+    assert_eq!(painted_caret(&field("ab", 2, true), 20, 1), Some((2, 0)));
+}
+
+#[test]
+fn only_the_focused_field_owns_the_caret() {
+    // Two fields on one screen and one caret: the creation flow's repo step
+    // draws a search box and a path box together. Ownership is declared, not
+    // inferred from which one holds text — inferring it put the caret in the
+    // other box, and painting order decided the winner.
+    let two = Node::Box {
+        identity: Default::default(),
+        size: Default::default(),
+        frame: None,
+        axis: thurbox::kernel::node::Axis::Vertical,
+        gap: 0,
+        children: vec![field("typed here", 4, true), field("stale", 5, false)],
+    };
+    assert_eq!(painted_caret(&two, 20, 2), Some((4, 0)));
+
+    let none = Node::Box {
+        identity: Default::default(),
+        size: Default::default(),
+        frame: None,
+        axis: thurbox::kernel::node::Axis::Vertical,
+        gap: 0,
+        children: vec![field("typed", 3, false)],
+    };
+    assert_eq!(
+        painted_caret(&none, 20, 2),
+        None,
+        "a field nobody is typing into must not take the caret"
+    );
+}
+
 // --- terminal affordances --------------------------------------------------
 
 #[test]

--- a/tests/v2_decoration.rs
+++ b/tests/v2_decoration.rs
@@ -157,6 +157,7 @@ fn every_field_survives_the_trip_out_and_back() {
                 value: "typed".into(),
                 cursor: 3,
                 placeholder: "hint".into(),
+                focused: true,
                 style: Style::default().fg(Color::Yellow),
             },
             Node::Surface {

--- a/ui/lib/textinput.lua
+++ b/ui/lib/textinput.lua
@@ -183,8 +183,9 @@ end
 
 --- The field as a node: a framed one-line input, its label the frame's title.
 ---
---- `focused` drives the border, as it does for every other surface; the caret is
---- the kernel's, painted only where the value is non-empty.
+--- `focused` drives the border AND the caret: the kernel paints the caret in the
+--- one input that claims it, so a screen holding two fields puts it in the one
+--- being typed into rather than in whichever holds text.
 function textinput.node(field, opts)
   opts = opts or {}
   return {
@@ -193,6 +194,7 @@ function textinput.node(field, opts)
     value = field.value or "",
     cursor = field.cursor or 0,
     placeholder = opts.placeholder or "",
+    focused = opts.focused == true,
     style = { fg = theme.text },
     frame = {
       title = " " .. (opts.label or "") .. " ",

--- a/ui/plugins/65_search.lua
+++ b/ui/plugins/65_search.lua
@@ -286,6 +286,9 @@ local function query_row(search, rows)
         value = search.field.value or "",
         cursor = search.field.cursor or 0,
         placeholder = "type to search sessions",
+        -- The strip is only drawn while searching, and while it is the query is
+        -- what the keyboard is aimed at.
+        focused = true,
         style = { fg = theme.text },
       },
       {

--- a/ui/plugins/70_new_session.lua
+++ b/ui/plugins/70_new_session.lua
@@ -620,6 +620,7 @@ local function render_repo(flow)
         value = flow.input.value or "",
         cursor = flow.input.cursor or 0,
         placeholder = "",
+        focused = flow.focus == "input",
         style = { fg = theme.text },
       },
       {


### PR DESCRIPTION
## Summary

Two things the creation flow got wrong, both about where your attention lands after `Ctrl+N`.

- **The caret wandered.** `paint_hyperlinks` re-prints OSC 8 runs straight to stdout after the frame flushes, and left the cursor wherever the last run ended — on the reasoning that the next `draw` repositions it. But `draw` leaves the caret *shown*, and the loop repaints on the 250 ms forced-redraw floor, so a focused text field's caret jumped into the agent pane and back several times a second. That reads as a cursor blinking in the wrong place rather than as one that moved, which is why it looked like a rendering fault. The pass is bracketed in DECSC/DECRC now and restores the position itself: any number of frames may pass before the next `draw`, and every one of them was a frame with a stray caret.
- **The caret was guessed.** An `input` painted one only where the value was non-empty, so the name field showed none until the first keystroke and lost it again on the last backspace — and the repo step, which draws two fields, gave it to whichever held text rather than to the one being typed into. Ownership is declared now: `Node::Input` carries `focused`, `textinput.node` passes its existing option through, and the two raw input nodes state theirs. A field nobody is typing into draws no caret, which is visible at once; a guess is not.
- **Creation steers the selection.** The id is knowable only once the spawn finished, so it travels back with the completion (`CommandBus::take_created`) rather than with the command, and the loop selects that session through the same `focus_session` path a clicked notification and `thurbox-cli session focus` already use — shared rather than duplicated. The list follows an id until it appears, which carries this across the frames between "created" and "in the snapshot". `Ctrl+F` fork reports its new session the same way.

Docs updated in the same change: the DECSC bracketing in `FEATURES.md` + `PERFORMANCE.md`, the `input` caret claim in `PLUGINS.md`, and the creation-focus behaviour in `FEATURES.md`.

## Test plan

- `cargo nextest run --all` — 1858 pass, including four new ones:
  - `an_empty_focused_field_still_owns_the_caret`, `only_the_focused_field_owns_the_caret` (paint the tree to a `TestBackend`, assert where the caret landed and that an unfocused field does not take it)
  - `a_created_session_is_reported_once_and_then_drained`, `a_failed_creation_reports_no_session_to_focus`
- Full pre-commit gate green: fmt, clippy `-D warnings`, check, nextest, architecture rules, cargo-deny, rustdoc, rumdl, selene, stylua.
- `scripts/dev/smoke/tui-smoke.sh` — all assertions pass (boots, F1, Ctrl+Y, Ctrl+/, Ctrl+Q).
- `lua-language-server` is not installed on this machine, so that one gate did not run locally; only table literals changed in Lua and selene covers those. CI runs it.