### PR TITLE
ci: keep a maintenance release off the newest-version channels

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,6 +40,11 @@ jobs:
       # path is deterministic — the ternary form silently fell back to `--auto`
       # when an output briefly evaluated empty, defeating the forced cut.
       bump_args: ${{ steps.parse.outputs.bump_args }}
+      # Whether this cut is the highest version the repository has ever tagged.
+      # A maintenance release off `v1.x` is not: everything downstream of the
+      # tag points at "the current thurbox" rather than at a version, so a 1.8.x
+      # cut would drag all of it backwards past 2.x. See the `newest` step.
+      newest: ${{ steps.newest.outputs.newest }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -155,6 +160,41 @@ jobs:
           else
             echo "shipped=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Skipping release ${{ steps.parse.outputs.version }} — no shipped artifact changed since $LAST_TAG (docs/website/CI only). The commits stay in history and ride along with the next real release."
+          fi
+
+      - name: Is this the highest version ever tagged
+        id: newest
+        run: |
+          # The release line is not a single line any more: 2.x ships from
+          # `main` while 1.8.x is maintained on `v1.x`, and a v1 patch is cut by
+          # dispatching this workflow from that ref. Nothing downstream of the
+          # tag knows that. The GitHub Release would claim "Latest" — which is
+          # what `scripts/install.{sh,ps1}` resolve, so every fresh install would
+          # land on the older line — and the Homebrew formula and the AUR
+          # PKGBUILDs would be rewritten to it, moving 2.x users *backwards* on
+          # their next upgrade. The moderated channels (Chocolatey, winget) would
+          # merely reject a version behind what they already carry.
+          #
+          # So compare the cut against every tag that exists. Behind the highest
+          # one means this is a maintenance release: still tagged, still built,
+          # still published with its binaries, but not marked latest and not
+          # pushed to any channel. The version is the whole test — not the ref —
+          # because that is the property those consumers care about, and a hotfix
+          # cut from some other ref that *is* the newest version should still
+          # ship everywhere.
+          TARGET="${{ steps.parse.outputs.version }}"
+          HIGHEST="$(git tag --list 'v*' | sort -V | tail -1)"
+          echo "cutting ${TARGET:-(nothing)}; highest existing tag ${HIGHEST:-(none)}"
+          if [ -z "$TARGET" ]; then
+            # No release is being cut; the value is unused but must not be empty.
+            echo "newest=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$HIGHEST" ] \
+            || [ "$(printf '%s\n%s\n' "$HIGHEST" "$TARGET" | sort -V | tail -1)" = "$TARGET" ]; then
+            echo "newest=true" >> "$GITHUB_OUTPUT"
+            echo "$TARGET leads the line — release as latest, push to every channel"
+          else
+            echo "newest=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::$TARGET is behind $HIGHEST — cutting it as a maintenance release: tagged and published with binaries, but not marked latest and not pushed to Homebrew/AUR/Chocolatey/winget."
           fi
 
   # Create git tag (only if release needed)
@@ -359,6 +399,10 @@ jobs:
           files: release-assets/*
           draft: false
           prerelease: false
+          # A maintenance cut off an older line must not claim the pointer the
+          # installers resolve. Not `prerelease`: 1.8.7 is a real release, it is
+          # simply not the newest one.
+          make_latest: ${{ needs.check-release.outputs.newest }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -370,6 +414,7 @@ jobs:
     name: Publish AUR (${{ matrix.pkgname }})
     needs: [check-release, create-tag, publish]
     if: needs.check-release.outputs.should_release == 'true'
+      && needs.check-release.outputs.newest == 'true'
     runs-on: ubuntu-latest
     # Hoisted so the publish step can be skipped when the secret is unset
     # (the `secrets` context cannot be used directly in an `if` condition).
@@ -416,6 +461,7 @@ jobs:
     name: Publish Homebrew formula
     needs: [check-release, create-tag, publish]
     if: needs.check-release.outputs.should_release == 'true'
+      && needs.check-release.outputs.newest == 'true'
     runs-on: ubuntu-latest
     # Hoisted so the push step can be skipped when the secret is unset
     # (the `secrets` context cannot be used directly in an `if` condition).
@@ -487,6 +533,7 @@ jobs:
     name: Publish Chocolatey package
     needs: [check-release, create-tag, publish]
     if: needs.check-release.outputs.should_release == 'true'
+      && needs.check-release.outputs.newest == 'true'
     runs-on: windows-latest
     # Hoisted so the steps can be skipped when the secret is unset
     # (the `secrets` context cannot be used directly in an `if` condition).
@@ -629,6 +676,7 @@ jobs:
     name: Publish winget manifest
     needs: [check-release, create-tag, publish]
     if: needs.check-release.outputs.should_release == 'true'
+      && needs.check-release.outputs.newest == 'true'
     runs-on: windows-latest
     # Hoisted so the steps can be skipped when the secret is unset
     # (the `secrets` context cannot be used directly in an `if` condition).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,6 +63,17 @@ once, before the interface takes the terminal, and declining turns `auto_update`
 off and prints how to reinstall 1.x. That gate is the only reason replacing an
 interface under an unchanged binary name is defensible.
 
+Such a cut is a **maintenance release**, and `cd.yml` treats it as one: it
+compares the version being cut against every existing tag and, when it is behind
+the highest, publishes the GitHub Release with `make_latest: false` and skips
+Homebrew, AUR, Chocolatey and winget. The tag, the four-platform build and the
+release assets are unchanged — what is withheld is every pointer that means "the
+current thurbox" rather than a version. Without it a 1.8.x cut would take the
+`releases/latest` pointer the installers resolve and rewrite the tap and the
+PKGBUILDs to it, walking 2.x users backwards. The test is the version, not the
+ref, so a hotfix from any branch that really is the newest still ships
+everywhere.
+
 ## Checklist for a release that changes artifacts
 
 - [ ] `thurbox` and `thurbox-cli` are still in **both** archive steps of `cd.yml`


### PR DESCRIPTION
The `v1.x` copy is #956; this is the same guard on `main`, so the two cannot drift. Cutting **v1.8.7** off `v1.x` needs it in place first.

## What goes wrong without it

`cd.yml` was written when there was one release line. There are two now — 2.x from `main`, 1.8.x from `v1.x` — and nothing downstream of the tag knows it. Dispatching the workflow from `v1.x` with `version: 1.8.7` would:

- publish the GitHub Release as **Latest** (`draft: false, prerelease: false`, no `make_latest`), the pointer `scripts/install.sh` and `install.ps1` resolve — so every fresh `curl | sh` would install 1.8.7 instead of 2.0.4;
- rewrite `Formula/thurbox.rb` in the tap to 1.8.7 and push it, walking 2.x users backwards on `brew upgrade`;
- do the same to both AUR PKGBUILDs;
- and offer Chocolatey/winget a version behind what they carry (throttled and moderated, so most likely rejected).

The four channel jobs are gated on `should_release` alone — nothing about which line the cut belongs to.

## The guard

`check-release` gains a `newest` output: the target version compared, with `sort -V`, against every tag that exists. `publish` then passes `make_latest: ${{ needs.check-release.outputs.newest }}`, and the four channel jobs each also require `newest == 'true'`.

A maintenance cut stays a real release — tagged, built for all four platforms, published with its binaries and changelog. What is withheld is only the pointers that mean "the current thurbox" rather than a version. `create-tag` is deliberately **not** gated, and `prerelease` stays false.

The test is the **version, not the ref**: a hotfix cut from some other branch that genuinely is the newest should still ship everywhere. Verified against `1.8.7` vs `2.0.4` → false, and `2.0.5` / `2.1.0` / a re-cut of `2.0.4` / `1.8.10` vs `1.8.9` / a first-ever release with no tags → true.

`docs/RELEASING.md`'s "v1 is a branch, not a binary" section records the behaviour (appended at the end of that section, so it does not collide with #954's rename edit near the top of it).