### PR TITLE
docs: point the retired panes at the plugins that give them back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1362,10 +1362,18 @@ overflow the banner.
 
 ## Code review
 
-**The view is gone.** v1's native diff reviewer (`ui/code_review.rs` +
-`app/code_review.rs`) went with `src/ui`; there is no replacement yet, and it is the
-largest single thing v2 owes v1 (`openspec/changes/v2-code-review/` has the design,
-`v2-parity-gaps` tracks it). v1 keeps it on the `v1.x` branch.
+**The view is gone from the binary.** v1's native diff reviewer
+(`ui/code_review.rs` + `app/code_review.rs`) went with `src/ui`
+(`openspec/changes/v2-code-review/` has the design that was written for a native
+replacement, `v2-parity-gaps` tracks it); v1 keeps it on the `v1.x` branch. It came
+back **as a pane**, in its own repository:
+[`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) —
+installed by clone (`thurbox-cli plugin install
+git+https://github.com/Thurbeen/thurbox-code-review`), takes the `center` switch
+slot beside the agent, reclaims `Ctrl+X`/`F7`, and is the first consumer of
+`thurbox.diffs` anywhere. It is not vendored here and not bundled: a change to the
+snapshot's diff shape or to `command("focus", { toggle })` breaks it, so treat it as
+a downstream consumer of that contract.
 
 What survived, because it is not view code:
 
@@ -1719,6 +1727,14 @@ thurbox-cli plugin list           # the inventory the Interface tab shows
 thurbox-cli plugin install top    # a distributed pane, recorded in plugins.toml
 thurbox-cli plugin sync           # make the directory match the spec
 ```
+
+Two of v1's surfaces are maintained as **out-of-tree panes**, each its own
+repository, installed by clone:
+[`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) (the diff
+reviewer, asks for `run` only for the targets the kernel does not compute) and
+[`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) (v1's info
+panel, no capabilities — everything from the snapshot). Neither is bundled or
+vendored; both are downstream consumers of the published `thurbox.*` shape.
 
 Two **example** panes live in `ui-plugins/` (`tasks`, `top`) and install by bare
 name; `docs/examples/{plugin,composite,layout}.lua` are copied by hand. They are

--- a/README.md
+++ b/README.md
@@ -20,19 +20,31 @@ worktrees are first-class citizens.
 > **v2 is out, and it is not a drop-in v1.** The interface is now Lua plugins on
 > a Rust kernel, and some v1 surfaces did not come with it:
 >
-> | Gone from the interface | v1 chord | Where it lives now |
+> | Gone from the binary | v1 chord | Where it lives now |
 > |---|---|---|
-> | Code review | `Ctrl+X` / `F7` | nothing yet |
+> | Code review | `Ctrl+X` / `F7` | the [`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) plugin |
 > | File viewer | `Ctrl+E` / `F3` | nothing yet |
-> | Info panel | `Ctrl+B` / `F2` | nothing yet |
+> | Info panel | `Ctrl+B` / `F2` | the [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) plugin |
 > | Tasks panel | `Ctrl+W` / `F5` | `thurbox-cli task` |
 > | Automations pane | `Ctrl+P` | `thurbox-cli automation` |
 > | Restore list | `Ctrl+U` | `thurbox-cli session restore` |
 >
-> Each freed chord is deliberately left **unbound** rather than reused, so no
-> muscle memory quietly does something else. Everything outside the interface —
-> sessions, agents, worktrees, remote hosts, automations, your database — is
-> unchanged.
+> Two of them have been rebuilt as **plugins**, each its own repository, and
+> installing one is a clone:
+>
+> ```bash
+> thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-code-review
+> thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-info-panel
+> ```
+>
+> The review pane takes the centre slot beside the agent and reclaims `Ctrl+X` /
+> `F7` on its own; the info panel wants one line in your `layout.lua` to give the
+> column a place (its README has it).
+>
+> Each freed chord is otherwise deliberately left **unbound** rather than reused,
+> so no muscle memory quietly does something else. Everything outside the
+> interface — sessions, agents, worktrees, remote hosts, automations, your
+> database — is unchanged.
 >
 > **Upgrading** asks once, on the first v2 launch of a profile with v1 history,
 > before anything changes. **To stay on v1**, answer `q` at that prompt: it turns
@@ -198,7 +210,7 @@ several repos. Thurbox optimizes the boring-but-load-bearing end of that list.
 
 | Tool | Interface | Session backend | Agents | Multi-repo session | Code review | Platforms | Remote / SSH | License |
 |------|-----------|-----------------|--------|--------------------|-------------|-----------|--------------|---------|
-| **Thurbox** | TUI | **Real tmux** (+ psmux on Windows) | **Any CLI** — data in `agents.toml` | **✓** (one session, many repos) | **✓** (native in-TUI diff) | Linux · macOS · Windows | **✓** (SSH hosts) | MIT |
+| **Thurbox** | TUI | **Real tmux** (+ psmux on Windows) | **Any CLI** — data in `agents.toml` | **✓** (one session, many repos) | **✓** (in-TUI diff, as an installable pane) | Linux · macOS · Windows | **✓** (SSH hosts) | MIT |
 | [GitHub Copilot App](https://github.com/github/app) | Desktop GUI | App-managed (worktrees + GitHub cloud envs) | Copilot (GitHub's agent) | ✗ | Agent Merge (PR review) | Linux · macOS · Windows | GitHub-hosted cloud envs | Proprietary (paid Copilot) |
 | [Conductor](https://www.conductor.build/) | Native GUI | App-managed PTY | Claude, Codex, Cursor | ✗ | Visual diff (GUI) | macOS only | Cloud Workspaces | Free (closed source) |
 | [Herdr](https://herdr.dev/) | TUI | **Own** multiplexer (Rust) | Claude, Codex + many (any CLI) | ✗ | ✗ | Linux · macOS | Runs on a remote box | AGPL-3.0 |
@@ -234,17 +246,19 @@ point):
 - **Mouse support in the terminal.** Clickable session rows, buttons, and
   scrollbars, plus drag-to-select — a gentler on-ramp than most TUIs, while
   staying fully keyboard-first (and toggleable via `[features] mouse`).
-- **Native code review, in the terminal.** A built-in, GitHub-style diff
-  reviewer (`Ctrl+X`) — browse the branch, a commit, or working changes in a folder
-  tree, leave classified comments, fold reviewed files, then send the review
-  back to the agent to address. The click-to-review visual diff that used to be
-  a GUI-only perk, without leaving the TUI.
+- **Code review, in the terminal.** A GitHub-style diff reviewer (`Ctrl+X`) —
+  browse the branch, a commit, or working changes in a folder tree, leave
+  classified comments, fold reviewed files, then send the review back to the
+  agent to address. The click-to-review visual diff that used to be a GUI-only
+  perk, without leaving the TUI. It ships as a pane you install
+  ([`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review)),
+  not in the binary — the interface is plugins, review included.
 
 On top of that, Thurbox is the only entry here that is terminal-native **and**
 runs on Windows **and** over SSH, and it ships a full headless CLI
 (`thurbox-cli`) plus cron-like automations to drive and schedule fleets of
-agents with no GUI at all — now with its own native code-review view, so the
-click-to-review visual diff is no longer a GUI-only trade-off. The GUI tools
+agents with no GUI at all — with a code-review pane one `plugin install` away, so
+the click-to-review visual diff is no longer a GUI-only trade-off. The GUI tools
 still trade footprint and that scriptability for a gentler on-ramp — and the
 most polished of them, [GitHub's Copilot App](https://github.com/github/app),
 also ties you to a single vendor's agent and a paid subscription, where Thurbox
@@ -367,10 +381,15 @@ result; `Esc` restores exactly what you had.
 
 ### Code Review
 
-> **Not in the current interface**, and no replacement yet. `1.x` keeps it;
-> see [docs/v1](https://github.com/Thurbeen/thurbox/tree/v1.x/docs).
+> **Not in the binary** — it is a plugin now:
+> [`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review), which
+> rebuilds v1's reviewer on the plugin kernel and reclaims `Ctrl+X` / `F7`.
+> Install it with
+> `thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-code-review`.
+> `1.x` still draws it natively; see
+> [docs/v1](https://github.com/Thurbeen/thurbox/tree/v1.x/docs).
 
-A native, GitHub-style diff reviewer (`Ctrl+X`, `F7` alternate) — no external tool. Browse the
+A GitHub-style diff reviewer (`Ctrl+X`, `F7` alternate) — no external tool. Browse the
 branch (`<base>..HEAD`), a single commit, or the uncommitted changes; the
 changed files show as a **folder tree** with colored statuses, and the diff is
 syntax-highlighted. Leave classified comments (issue / suggestion / note /
@@ -390,8 +409,12 @@ keyboard-driven, with unified or side-by-side layout.
 
 ### Info Panel & Live Metrics
 
-> **Not in the current interface.** Machine and agent metrics are still
-> collected and published to plugins; there is no pane drawing them yet.
+> **Not in the binary** — it is a plugin now:
+> [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel), which
+> draws v1's panel from the snapshot and the metrics the kernel publishes, and
+> asks for no capability at all. Install it with
+> `thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-info-panel`,
+> then give the column a place in your `layout.lua` (its README has the line).
 
 `Ctrl+B` (`F2`) shows per-session details with live CPU/RAM and agent
 metrics, right beside the terminal.
@@ -729,8 +752,12 @@ cannot drift from what is running.
 Gone with the panes they opened: `Ctrl+X`/`F7` (code review), `Ctrl+E`/`F3`
 (file viewer), `Ctrl+B`/`F2` (info panel), `F5` (tasks), `Ctrl+P`
 (automations — now the creation flow's folder import) and `Ctrl+U` (restore
-list). See [docs/V2-KERNEL.md](docs/V2-KERNEL.md), or the `v1.x` branch if you
-need them.
+list). Two of them come back with a pane you install:
+[`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) claims
+`Ctrl+X`/`F7` again, and
+[`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) claims
+`F2`. See [docs/V2-KERNEL.md](docs/V2-KERNEL.md), or the `v1.x` branch if you
+need the rest.
 
 Every chord is rebindable from the `F1` editor; rebindings persist to
 `~/.config/thurbox/ui.json`, beside the plugins you have turned off and the
@@ -989,6 +1016,14 @@ filesystem, no network and no process. Running a program is one
 capability, granted per plugin and only after you trust it.
 See [docs/PLUGINS.md](docs/PLUGINS.md) and
 [docs/V2-KERNEL.md](docs/V2-KERNEL.md).
+
+A pane does not have to be one you wrote:
+[`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review)
+and [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel)
+give back two of v1's surfaces (commands in the note at the top).
+`plugin install` records each in `plugins.toml` with the commit it
+resolved to in `plugins.lock`, so `plugin sync` reproduces the same
+interface on another machine.
 
 **Moving from v1?** Some panes are owed rather than ported, and some
 moved to `thurbox-cli`. The note at the top of this file has the list,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1114,9 +1114,13 @@ gate (`kernel::consent`) before anything changes. See `docs/RELEASING.md`.
 
 **Cost, accepted**: a frame is more expensive — every pane is a Lua call returning a
 table that is converted and painted — so the loop settles aggressively and every
-cached answer carries an age. And v1 surfaces are owed rather than ported: code
-review, the file viewer and the info panel have no equivalent, and tasks,
-automations and the restore list are `thurbox-cli` only. Tracked in
+cached answer carries an age. And v1 surfaces are owed rather than ported: the
+file viewer has no equivalent, and tasks, automations and the restore list are
+`thurbox-cli` only. Code review and the info panel came back the way the design
+intended — as panes, outside the binary:
+[`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) and
+[`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel), each its
+own repository, installed by clone. What is still owed is tracked in
 `openspec/changes/v2-parity-gaps/`.
 
 **Rejected**:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -280,11 +280,15 @@ in `ui.json`. That does strictly more than a flag could: it works for a
 plugin *you* wrote, which no compiled-in flag could know about.
 
 Five keys are **accepted and ignored**: `tasks`, `file_viewer`,
-`info_panel`, `code_review` and `global_search`. They gated v1 panes that
-no longer exist, and nothing reads them now. They are still parsed rather
-than rejected, so an existing `settings.toml` keeps loading instead of
-failing on an unknown key — but setting one has no effect in either
-direction. Same for `three_panel_min_cols` above.
+`info_panel`, `code_review` and `global_search`. They gated v1 panes the
+binary no longer draws, and nothing reads them now — not even the plugins
+that give `code_review` and `info_panel` back
+([`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review),
+[`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel)),
+which are switched on and off from the Interface tab like any other pane.
+They are still parsed rather than rejected, so an existing `settings.toml`
+keeps loading instead of failing on an unknown key — but setting one has no
+effect in either direction. Same for `three_panel_min_cols` above.
 
 | Key | Default | Controls |
 |-----|---------|----------|

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -647,12 +647,17 @@ editor of choice can open them as a workspace.
 
 ## Code Review (native)
 
-> **Not in the interface.** The view was deleted with `src/ui`; there is no
-> replacement yet, and this is the largest thing owed to v1. The data layer
-> survived and is waiting for a plugin: `session::review` (pure diff types +
+> **Not in the binary.** The view was deleted with `src/ui`; the data layer
+> survived and a plugin took it up:
+> [`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review), the
+> first consumer of `thurbox.diffs` anywhere, which reclaims `Ctrl+X` / `F7` and
+> installs with
+> `thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-code-review`.
+> What it builds on is still here: `session::review` (pure diff types +
 > `parse_unified_diff`), `storage::review` (`review_comments` + `review_marks`,
 > schema v38), and `kernel::diff` (diffs on a worker, published into the snapshot).
-> `openspec/changes/v2-code-review/` has the design. v1 keeps the view on `v1.x`.
+> `openspec/changes/v2-code-review/` has the design that was written for a native
+> replacement. v1 keeps the view on `v1.x`.
 
 Thurbox ships a **native, built-in** tuicr-like review view (`Ctrl+X`, `F7` alternate): a
 GitHub-style continuous diff of the active session's worktree
@@ -2026,9 +2031,10 @@ active terminal can also briefly be empty during spawn.
 
 ## Info Panel Separators
 
-> **Not in the interface.** The info panel went with `src/ui` and has no
-> replacement yet. Kept because the grouping it argues for is what a plugin
-> rebuilding it should reproduce.
+> **Not in the binary.** The info panel went with `src/ui` and was rebuilt as
+> [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel), which
+> reproduces the grouping this section argues for. Kept because that is the reason
+> it argues for it.
 
 Section boundaries in the info panel use styled `──────` separator
 lines instead of blank lines, improving visual structure.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -685,7 +685,9 @@ easier to believe from a pane you added yourself than from prose.
 
 **They are examples, not a catalogue.** They are here to be read and copied from,
 not a set thurbox maintains on your behalf — installing one is a convenience over
-`cp`, and it becomes yours the moment you edit it.
+`cp`, and it becomes yours the moment you edit it. For panes meant to be *used*
+rather than read, see [Panes that give a v1 surface back](#panes-that-give-a-v1-surface-back)
+below.
 
 | Example | What it is |
 |---|---|
@@ -760,6 +762,46 @@ A low `priority` is right for anything optional: the band drops the least import
 entries first when it runs out of width. `plugin check` **warns** about a pane in this
 state, and `plugin install` says it at the moment you install one — but it does not fail
 either, because you may have meant it.
+
+## Panes that give a v1 surface back
+
+Two of the surfaces v2 dropped are maintained as panes, each in its own repository
+rather than in the interface directory thurbox ships. They are not examples: they are
+what a plugin looks like when it has to carry v1's behaviour, and they are the answer
+to "code review is gone" and "the info panel is gone".
+
+| Pane | What it gives back |
+|---|---|
+| [`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) | v1's diff reviewer — the branch, a commit or the working changes, a changed-files tree, notes you send back to the agent. Reclaims `Ctrl+X` / `F7` |
+| [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) | v1's info panel — session, git, agent, usage and system readouts in a column beside the terminal. Reclaims `F2` |
+
+Both carry more than one file, so both install by **cloning** the repository
+([A plugin that carries more than Lua](#a-plugin-that-carries-more-than-lua)):
+
+```bash
+thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-code-review
+thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-info-panel
+```
+
+They differ in the two ways that matter here, which is most of why they are worth
+reading:
+
+- **Placement.** The review pane takes the `center` switch slot beside the agent and
+  declares a pill, so it needs no `layout.lua` edit and the action band advertises it
+  the moment it is installed — the switch-slot problem above, solved the way that
+  section says to solve it. The info panel is a column, so it needs its one line in
+  `layout.lua`, and its README carries the `max` that stops a label-and-value panel
+  being handed a third of a wide screen.
+- **Capabilities.** The info panel asks for **nothing**: every readout is in the
+  snapshot, including the metrics the kernel gathers on its own workers. The review
+  pane asks for `run`, and only for the two targets the kernel does not compute (the
+  uncommitted working changes, and a single commit) — untrusted it still draws the
+  kernel's `thurbox.diffs`, and the target picker names the choices it cannot serve
+  rather than hiding them. That is the shape to copy for an optional capability.
+
+The third missing surface, the file viewer, has no pane — by nobody having written
+one rather than by anything withheld: `files.list/read` is published, rooted at a
+session's directory.
 
 ## Managing panes
 

--- a/docs/V2-KERNEL.md
+++ b/docs/V2-KERNEL.md
@@ -31,6 +31,14 @@ shared and unmigrated, and declining turns auto-update off and prints how to
 reinstall 1.x. What is still owed to v1 is listed in
 `openspec/changes/v2-parity-gaps/`.
 
+Two of those surfaces are answered by panes rather than by the kernel, which is
+the mechanism working as designed:
+[`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) (v1's diff
+reviewer, the first consumer of `thurbox.diffs`) and
+[`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) (v1's info
+panel, drawn entirely from the snapshot). Each is its own repository, installed by
+clone — `docs/PLUGINS.md` has the commands and what the two demonstrate.
+
 ## Shape
 
 ```text

--- a/website/docs/comparison.html
+++ b/website/docs/comparison.html
@@ -44,7 +44,7 @@ breadcrumb: 'Comparison'
                   <code>agents.toml</code>
                 </td>
                 <td><strong>&#x2713;</strong> (one session, many repos)</td>
-                <td>&#x2717; (1.x had a native in-TUI diff)</td>
+                <td><strong>&#x2713;</strong> (in-TUI diff, as an installable pane)</td>
                 <td>Linux &middot; macOS &middot; Windows</td>
                 <td><strong>&#x2713;</strong> (SSH hosts)</td>
                 <td>MIT</td>
@@ -213,10 +213,13 @@ breadcrumb: 'Comparison'
             It is also the only one whose
             <strong>interface is data rather than product</strong>
             &mdash; every pane is a Lua file you can move, disable or replace, which is a kind of
-            extensibility a packaged GUI cannot offer at all. What the GUI tools still have is a
-            click-to-review visual diff, which
-            <a href="deprecated.html#code-review">thurbox 1.x had and 2.x has not replaced yet</a>
-            . They also trade footprint and scriptability for a gentler on-ramp &mdash; and the most
+            extensibility a packaged GUI cannot offer at all. The click-to-review visual diff the
+            GUI tools lead with is
+            <a href="deprecated.html#code-review">one <code>plugin install</code> away</a>
+            &mdash; a pane
+            (<a href="https://github.com/Thurbeen/thurbox-code-review" target="_blank" rel="noopener">thurbox-code-review</a>)
+            rather than something baked into the binary. They also trade footprint and
+            scriptability for a gentler on-ramp &mdash; and the most
             polished of them,
             <a href="https://github.com/github/app" target="_blank" rel="noopener">GitHub&rsquo;s Copilot App</a>,
             also ties you to a single vendor&rsquo;s agent and a paid subscription, where Thurbox stays

--- a/website/docs/deprecated.html
+++ b/website/docs/deprecated.html
@@ -1,15 +1,18 @@
 ---
 layout: docs.njk
 title: 'Deprecated surfaces — Thurbox Docs'
-description: 'The six panes thurbox 1.x had that the current interface does not: what each one did, where its data lives now, and what it would take to bring one back.'
+description: 'The six panes thurbox 1.x had that the current interface does not: what each one did, where its data lives now, and which of them a plugin gives back.'
 currentPage: 'deprecated'
 breadcrumb: 'Deprecated'
 ---
 <h1>Deprecated surfaces</h1>
 <p>
   thurbox 2.0 replaced the interface, and six of 1.x's panes did not come with it. This page is
-  where they are documented &mdash; what each did, what its chord was, and where its data lives now
-  &mdash; so nothing you were relying on is simply undocumented.
+  where they are documented &mdash; what each did, what its chord was, and where it lives now
+  &mdash; so nothing you were relying on is simply undocumented. Two of the six have since been
+  rebuilt as
+  <a href="v2-interface.html#v1-panes">panes you install</a>, which is the interface-as-plugins
+  claim being cashed rather than a special case.
 </p>
 
 <div class="info-box">
@@ -17,7 +20,8 @@ breadcrumb: 'Deprecated'
     <strong>No data was dropped.</strong>
     Every record these panes edited is still in the same database at the same schema version. Three
     of the six were only ever views onto records <code>thurbox-cli</code> can already read and write,
-    so those features are intact and merely have no pane. The other three have no replacement yet.
+    so those features are intact and merely have no pane. Of the other three, code review and the
+    info panel are back as installable plugins; only the file viewer has no replacement.
   </p>
 </div>
 
@@ -38,20 +42,26 @@ breadcrumb: 'Deprecated'
     <tr>
       <td><a href="#code-review">Code review</a></td>
       <td><kbd>Ctrl</kbd>+<kbd>X</kbd> / <kbd>F7</kbd></td>
-      <td>No replacement</td>
-      <td>The largest gap. 1.x keeps it.</td>
+      <td>A plugin</td>
+      <td>
+        <a href="https://github.com/Thurbeen/thurbox-code-review" target="_blank" rel="noopener">thurbox-code-review</a>
+        &mdash; and it takes the chord back
+      </td>
     </tr>
     <tr>
       <td><a href="#file-viewer">File viewer</a></td>
       <td><kbd>Ctrl</kbd>+<kbd>E</kbd> / <kbd>F3</kbd></td>
       <td>No replacement</td>
-      <td>1.x keeps it.</td>
+      <td>1.x keeps it. Nothing is withheld &mdash; nobody has written the pane.</td>
     </tr>
     <tr>
       <td><a href="#info-panel">Info panel</a></td>
       <td><kbd>Ctrl</kbd>+<kbd>B</kbd> / <kbd>F2</kbd></td>
-      <td>No replacement</td>
-      <td>1.x keeps it.</td>
+      <td>A plugin</td>
+      <td>
+        <a href="https://github.com/Thurbeen/thurbox-info-panel" target="_blank" rel="noopener">thurbox-info-panel</a>
+        &mdash; one line in your arrangement
+      </td>
     </tr>
     <tr>
       <td><a href="#tasks">Tasks pane</a></td>
@@ -79,14 +89,23 @@ breadcrumb: 'Deprecated'
   mailbox queue, themes, notifications, and the whole of <code>thurbox-cli</code>.
 </p>
 
-<h2 id="no-replacement">
-  Gone, with nothing in their place
-  <a href="#no-replacement" class="heading-anchor">#</a>
+<h2 id="not-in-the-binary">
+  Gone from the binary
+  <a href="#not-in-the-binary" class="heading-anchor">#</a>
 </h2>
 <p>
-  These three drew things the kernel does not yet publish to a plugin. They are tracked in the
-  repository under <code>openspec/changes/v2-parity-gaps/</code>, which is also the honest answer to
-  &ldquo;when&rdquo;: they are written down and prioritised, not scheduled.
+  These three were rendering, not records, so none of them could move to
+  <code>thurbox-cli</code>. Two are back as panes maintained outside thurbox, each its own
+  repository, each installed by cloning it:
+</p>
+<pre data-wrap><code class="language-bash">thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-code-review
+thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-info-panel</code></pre>
+<p>
+  Installing a pane records it in <code>plugins.toml</code> with the commit it resolved to in
+  <code>plugins.lock</code>, so <code>thurbox-cli plugin sync</code> reproduces the same interface
+  on your next machine, and <code>plugin update</code> moves it forward when you ask. What is still
+  owed is tracked in the repository under <code>openspec/changes/v2-parity-gaps/</code>, which is
+  also the honest answer to &ldquo;when&rdquo;: written down and prioritised, not scheduled.
 </p>
 
 <h3 id="code-review">Code review</h3>
@@ -128,6 +147,22 @@ breadcrumb: 'Deprecated'
   Comments and reviewed-marks are still in SQLite, keyed per session against the session's
   write-once base branch &mdash; so a review you left in 1.x is still there if you go back to it.
 </p>
+<div class="info-box">
+  <p>
+    <strong>Back as a pane:</strong>
+    <a href="https://github.com/Thurbeen/thurbox-code-review" target="_blank" rel="noopener">thurbox-code-review</a>
+    rebuilds all of the above on the plugin kernel and is the first consumer of the diffs the
+    kernel computes on its workers. It needs no change to your arrangement &mdash; it takes the
+    centre slot beside the agent and declares itself to the action band, so
+    <kbd>Ctrl</kbd>+<kbd>X</kbd> / <kbd>F7</kbd> work again the moment it is installed. Two
+    keys are spelled differently on purpose: <code>r</code> is refresh, as it is in every other
+    pane, and marking a file seen is <code>m</code>. It asks for one capability
+    (<code>run</code>) and only for the two review targets the kernel does not compute for
+    itself &mdash; the uncommitted working changes and a single commit; untrusted, it still
+    draws the branch diff and the target picker names what it cannot serve rather than hiding
+    it.
+  </p>
+</div>
 
 <h3 id="file-viewer">File viewer</h3>
 <p>
@@ -146,12 +181,18 @@ breadcrumb: 'Deprecated'
   (<code>Sync:</code>), and whether its status hooks were wired or degraded
   (<code>Hooks:</code>) &mdash; alongside host metrics and agent usage.
 </p>
-<p>
-  Of the three, this is the one most nearly buildable today: a plugin can already read the session
-  snapshot, and <a href="v2-interface.html#running-programs">a plugin that runs a program</a> can get
-  <code>git status</code> for itself. What it cannot yet read is the metrics the kernel gathers on
-  its own workers.
-</p>
+<div class="info-box">
+  <p>
+    <strong>Back as a pane:</strong>
+    <a href="https://github.com/Thurbeen/thurbox-info-panel" target="_blank" rel="noopener">thurbox-info-panel</a>
+    draws all of it &mdash; the session readouts, the worktree state, host metrics and agent usage
+    &mdash; and asks for <strong>no capability at all</strong>, because every number is already in
+    the snapshot the kernel publishes. It is a column rather than a centre view, so it wants one
+    line in your <code>layout.lua</code> to say where the column goes; its README carries the line,
+    including the <code>max</code> width that stops a panel of labels and values being handed a
+    third of a wide screen.
+  </p>
+</div>
 
 <h2 id="cli">
   Still here, just without a pane

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -795,7 +795,9 @@ auto_update = true    # download+verify+replace the binaries on startup</code></
               <strong>Five keys are accepted and ignored.</strong>
               <code>tasks</code>, <code>file_viewer</code>, <code>info_panel</code>,
               <code>code_review</code> and <code>global_search</code> gated
-              <a href="deprecated.html">panes that no longer exist</a>, and nothing reads them now.
+              <a href="deprecated.html">panes the binary no longer draws</a>, and nothing reads them
+              now &mdash; including the plugins that give two of those panes back, which are turned
+              on and off from the Interface tab like any other.
               They are still parsed rather than rejected, so an existing
               <code>settings.toml</code> keeps loading instead of failing on an unknown key &mdash;
               but setting one has no effect, in either direction.

--- a/website/docs/keybindings.html
+++ b/website/docs/keybindings.html
@@ -209,5 +209,10 @@ breadcrumb: 'Keybindings'
   review), <kbd>Ctrl</kbd>+<kbd>E</kbd>/<kbd>F3</kbd> (file viewer),
   <kbd>Ctrl</kbd>+<kbd>B</kbd>/<kbd>F2</kbd> (info panel), <kbd>F5</kbd> (tasks),
   <kbd>Ctrl</kbd>+<kbd>P</kbd> (automations, now the folder import) and <kbd>Ctrl</kbd>+<kbd>U</kbd>
-  (restore list). See <a href="v1.html">using v1</a> for what still has them and how to get it.
+  (restore list). Two of them are one install away:
+  <a href="https://github.com/Thurbeen/thurbox-code-review" target="_blank" rel="noopener">thurbox-code-review</a>
+  claims <kbd>Ctrl</kbd>+<kbd>X</kbd>/<kbd>F7</kbd> back and
+  <a href="https://github.com/Thurbeen/thurbox-info-panel" target="_blank" rel="noopener">thurbox-info-panel</a>
+  claims <kbd>F2</kbd> &mdash; see <a href="v2-interface.html#v1-panes">the interface</a>. For the
+  rest, see <a href="v1.html">using v1</a>.
 </p>

--- a/website/docs/v1.html
+++ b/website/docs/v1.html
@@ -25,8 +25,9 @@ breadcrumb: 'Using v1'
   <a href="#what-v1-has" class="heading-anchor">#</a>
 </h2>
 <p>
-  Six surfaces. Three have no replacement yet; three moved to
-  <code>thurbox-cli</code>, where the data and behaviour are the same.
+  Six surfaces. Three moved to
+  <code>thurbox-cli</code>, where the data and behaviour are the same; two came back as
+  <a href="v2-interface.html#v1-panes">panes you install</a>; one has no replacement.
 </p>
 <table>
   <thead>
@@ -40,7 +41,11 @@ breadcrumb: 'Using v1'
     <tr>
       <td>Code review</td>
       <td><kbd>Ctrl</kbd>+<kbd>X</kbd> / <kbd>F7</kbd></td>
-      <td>Nothing yet &mdash; the largest gap</td>
+      <td>
+        The
+        <a href="https://github.com/Thurbeen/thurbox-code-review" target="_blank" rel="noopener">thurbox-code-review</a>
+        plugin &mdash; same chord
+      </td>
     </tr>
     <tr>
       <td>File viewer</td>
@@ -50,7 +55,11 @@ breadcrumb: 'Using v1'
     <tr>
       <td>Info panel</td>
       <td><kbd>Ctrl</kbd>+<kbd>B</kbd> / <kbd>F2</kbd></td>
-      <td>Nothing yet</td>
+      <td>
+        The
+        <a href="https://github.com/Thurbeen/thurbox-info-panel" target="_blank" rel="noopener">thurbox-info-panel</a>
+        plugin
+      </td>
     </tr>
     <tr>
       <td>Tasks</td>

--- a/website/docs/v2-interface.html
+++ b/website/docs/v2-interface.html
@@ -19,8 +19,9 @@ breadcrumb: 'Interface'
 <div class="info-box">
   <p>
     <strong>Moved from v1?</strong>
-    Several panes have no equivalent here yet &mdash; code review, the file viewer and the info
-    panel are gone, and tasks, automations, the restore list and the perf HUD moved to
+    Several panes are not in the binary any more &mdash; code review and the info panel are
+    <a href="#v1-panes">plugins you install</a>, the file viewer has no replacement, and tasks,
+    automations, the restore list and the perf HUD moved to
     <code>thurbox-cli</code>. thurbox asks once, on the first launch after the upgrade, before
     changing anything. v1 stays maintained on the <code>v1.x</code> branch.
   </p>
@@ -250,6 +251,66 @@ breadcrumb: 'Interface'
   <a href="https://github.com/Thurbeen/thurbox/blob/main/docs/PLUGINS.md">docs/PLUGINS.md</a>; the
   kernel's own shape and constraints are in
   <a href="https://github.com/Thurbeen/thurbox/blob/main/docs/V2-KERNEL.md">docs/V2-KERNEL.md</a>.
+</p>
+
+<h2 id="v1-panes">
+  Two of v1's panes, as plugins
+  <a href="#v1-panes" class="heading-anchor">#</a>
+</h2>
+<p>
+  The strongest test of &ldquo;the interface is a directory&rdquo; is whether a surface thurbox
+  itself dropped can be given back without touching the binary. Two of them have been, each
+  maintained as its own repository:
+</p>
+<table>
+  <thead>
+    <tr>
+      <th>Pane</th>
+      <th>What it gives back</th>
+      <th>What it asks for</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="https://github.com/Thurbeen/thurbox-code-review" target="_blank" rel="noopener">thurbox-code-review</a>
+      </td>
+      <td>
+        v1's diff reviewer &mdash; the branch, a single commit or the uncommitted changes, a
+        changed-files tree, notes you send back to the agent. Takes the centre slot beside the
+        agent and reclaims <kbd>Ctrl</kbd>+<kbd>X</kbd> / <kbd>F7</kbd>, with no change to your
+        arrangement
+      </td>
+      <td>
+        <code>run</code>, and only for the two targets the kernel does not compute; untrusted it
+        still draws the branch diff
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/Thurbeen/thurbox-info-panel" target="_blank" rel="noopener">thurbox-info-panel</a>
+      </td>
+      <td>
+        v1's info panel &mdash; session, git, agent, usage and system readouts in a column beside
+        the terminal. Reclaims <kbd>F2</kbd>; being a column, it wants one line in your
+        <code>layout.lua</code>
+      </td>
+      <td>Nothing &mdash; every readout is already in the snapshot</td>
+    </tr>
+  </tbody>
+</table>
+<p>
+  Both carry more than a single Lua file, so both install by cloning:
+</p>
+<pre data-wrap><code class="language-bash">thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-code-review
+thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-info-panel</code></pre>
+<p>
+  Neither is bundled and neither is vendored into thurbox, which is the point: they are ordinary
+  panes on the same terms as one you write, recorded in your
+  <code>plugins.toml</code>
+  and pinned by your
+  <code>plugins.lock</code>. What each still lacks, and what remains owed to v1 altogether, is on
+  <a href="deprecated.html">deprecated surfaces</a>.
 </p>
 
 <h2 id="v1">

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -19,9 +19,9 @@
 - [Comparison](https://thurbox.thurbeen.eu/docs/comparison.html): how Thurbox compares to Conductor, Claude Squad, Cursor, and other parallel coding-agent tools.
 - [Installation](https://thurbox.thurbeen.eu/docs/installation.html): install via curl, Homebrew, AUR, winget, Chocolatey, or from source; prerequisites.
 - [Configuration](https://thurbox.thurbeen.eu/docs/configuration.html): every config file and knob — agents.toml, hosts.toml, settings.toml, themes, keybindings.
-- [Deprecated surfaces](https://thurbox.thurbeen.eu/docs/deprecated.html): the six panes 1.x had that the current interface does not — code review, file viewer, info panel, and the tasks/automations/restore panes that moved to thurbox-cli.
+- [Deprecated surfaces](https://thurbox.thurbeen.eu/docs/deprecated.html): the six panes 1.x had that the current interface does not — code review and the info panel, now the installable thurbox-code-review and thurbox-info-panel plugins; the file viewer, with no replacement; and the tasks/automations/restore panes that moved to thurbox-cli.
 - [Using v1](https://thurbox.thurbeen.eu/docs/v1.html): thurbox 1.x is still maintained — what it has that the current interface does not, how to stay on it or go back, and what it will receive.
-- [The Interface](https://thurbox.thurbeen.eu/docs/v2-interface.html): every pane is an editable Lua plugin — how to move, disable, replace or write one, and what the kernel refuses a plugin.
+- [The Interface](https://thurbox.thurbeen.eu/docs/v2-interface.html): every pane is an editable Lua plugin — how to move, disable, replace or write one, what the kernel refuses a plugin, and the two v1 panes (thurbox-code-review, thurbox-info-panel) you install as plugins.
 - [Architecture](https://thurbox.thurbeen.eu/docs/architecture.html): the Elm Architecture, module isolation, the tmux session backend, and design decisions.
 
 ## Extensions


### PR DESCRIPTION
## Summary

- Code review and the info panel were documented everywhere as gone with nothing in their place. Both exist again as panes maintained outside the binary — [`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) and [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) — so every "nothing yet" now names the repository to install and what it costs.
- The two differences worth carrying, because they are the plugin API's own claims being cashed: the review pane takes the `center` switch slot and reclaims `Ctrl+X`/`F7` with no `layout.lua` edit, asking for `run` only for the two review targets the kernel does not compute (untrusted it still draws `thurbox.diffs`); the info panel is a column wanting one `layout.lua` line and asks for **no** capability, because every readout is already in the snapshot.
- Covered in the docs: `README.md` (the v1 migration banner, the comparison table + its two claims, the Code Review and Info Panel sections, the freed-chord list, the interface section), `docs/PLUGINS.md` (a new **Panes that give a v1 surface back** section), `docs/V2-KERNEL.md`, `docs/ARCHITECTURE.md`, `docs/FEATURES.md`, `docs/CONFIG.md`, `CLAUDE.md`.
- Covered on the website: `deprecated.html` (table + a per-surface box for each), a new `#v1-panes` section on `v2-interface.html`, plus `v1.html`, `keybindings.html`, `comparison.html`, `features.html` and `llms.txt`.
- Two stale claims fell out of writing it. The info panel was said to be unbuildable for want of the kernel's worker-gathered metrics, which are in fact published — the plugin draws them. And the file viewer, the one surface still with no pane, is unwritten rather than blocked: `files.list`/`files.read` are published, rooted at a session's directory.

`CLAUDE.md` also records that neither plugin is bundled or vendored, so both are downstream consumers of the published `thurbox.*` shape — a change to the snapshot's diff shape or to `command("focus", { toggle })` breaks the review pane.

## Test plan

- [x] Both repositories verified to exist; the install commands, capability asks and placement notes are taken from their `plugin.toml` and README rather than inferred.
- [x] `rumdl check .` — clean (38 files).
- [x] `npm run lint:website` — build + prettier + htmlhint + stylelint + eslint clean (23 pages).
- [x] Every anchor added or retargeted resolves in the built site (`#v1-panes`, `#not-in-the-binary`, `#panes-that-give-a-v1-surface-back`); no inbound link pointed at the renamed `#no-replacement`.
- [x] No remaining doc says code review or the info panel has no replacement; "no replacement" now refers only to the file viewer.
- [x] Docs-only change: no Rust, Lua or CSS touched, so the pre-commit Rust and Lua gates report nothing to check.