### PR TITLE
ci: push the release tag, not the branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -212,11 +212,14 @@ jobs:
           git-user: 'github-actions[bot]'
           git-user-email: 'github-actions[bot]@users.noreply.github.com'
 
+      # Push the tag and nothing else. `ad-m/github-push-action` stood here and
+      # defaults its `branch` to the repository's default: from `main` that is
+      # the ref already checked out, so pushing it is a no-op and the tag rides
+      # along — but from `v1.x` it tries to push this branch's tip onto `main`,
+      # is rejected as a non-fast-forward, and the tag it was there to deliver
+      # never leaves the runner. A tag push is what this step means; say so.
       - name: Push tag to repository
-        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tags: true
+        run: git push origin "refs/tags/${{ needs.check-release.outputs.version }}"
 
   # Build binaries for all platforms (only if tag created)
   build:


### PR DESCRIPTION
Second blocker on the v1.8.7 cut. [Run 32306989293](https://github.com/Thurbeen/thurbox/actions/runs/32306989293) got past `cog bump` (thanks to #960) and then lost the tag at the push:

```text
Push to branch main
hint: Updates were rejected because a pushed branch tip is behind its remote counterpart
Error: Invalid exit code: 1
```

`ad-m/github-push-action` defaults its `branch` input to the repository's **default branch**. From `main` that is the ref already checked out, so the push is a no-op fast-forward and `tags: true` delivers the tag — which is why this has always worked. Dispatched from `v1.x` it tries to push this branch's tip onto `main`, is rejected as a non-fast-forward, and the tag `cog bump` had just created never leaves the runner. Everything downstream (`build`, `publish`, the channel jobs) is gated on this job, so the cut is lost with nothing published.

Nothing was left behind: no `v1.8.7` tag exists on the remote, and `main` was not touched.

Pushing the tag by refspec says what the step means, needs no third-party action, and cannot touch a branch on any ref. `cog bump` runs with `--disable-bump-commit`, so the tag is the only thing there is to push — the branch push was never doing anything on `main` either.

Same fix goes to `main` so the copies stay identical.