### PR TITLE
refactor(core): clear the SonarCloud board

### DIFF
--- a/src/agent/extension_config.rs
+++ b/src/agent/extension_config.rs
@@ -10,6 +10,7 @@
 //! extension's installer. Read/parse errors degrade gracefully (a bad manifest
 //! is skipped with a warning, never aborting startup).
 
+use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -267,10 +268,10 @@ pub fn list_manifests_with_warnings() -> (Vec<ExtensionDef>, Vec<String>) {
     };
     // Collect + sort filenames so the scan order is deterministic across runs.
     let mut stems: Vec<String> = entries
-        .filter_map(|e| e.ok())
+        .filter_map(Result::ok)
         .map(|e| e.path())
-        .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("toml"))
-        .filter_map(|p| p.file_stem().and_then(|s| s.to_str()).map(String::from))
+        .filter(|p| p.extension().and_then(OsStr::to_str) == Some("toml"))
+        .filter_map(|p| p.file_stem().and_then(OsStr::to_str).map(String::from))
         .collect();
     stems.sort();
 
@@ -578,7 +579,7 @@ pub fn remove_agent_patches(patches: &[AgentPatch]) -> Result<Vec<String>, Strin
 }
 
 fn edit_agent_patches(patches: &[AgentPatch], add: bool) -> Result<Vec<String>, String> {
-    use toml_edit::{Array, DocumentMut};
+    use toml_edit::DocumentMut;
 
     if patches.is_empty() {
         return Ok(Vec::new());
@@ -601,56 +602,13 @@ fn edit_agent_patches(patches: &[AgentPatch], add: bool) -> Result<Vec<String>, 
     };
 
     let mut changed = Vec::new();
-    for patch in patches {
-        if patch.append_args.is_empty() {
-            continue;
-        }
+    for patch in patches.iter().filter(|p| !p.append_args.is_empty()) {
         // A patch targets its named built-in agent AND every custom agent that
         // declared `hook_schema = "<patch.name>"` — so a rebranded-claude agent
         // gets the same `--settings` wiring. No `break`: fan out to all matches.
         for table in agents.iter_mut() {
-            // Snapshot the identity fields into owned strings first: the args
-            // mutation below reborrows `table` mutably.
-            let agent_name = table
-                .get("name")
-                .and_then(|v| v.as_str())
-                .map(str::to_string);
-            let hook_schema = table
-                .get("hook_schema")
-                .and_then(|v| v.as_str())
-                .map(str::to_string);
-            let matches = agent_name.as_deref() == Some(patch.name.as_str())
-                || hook_schema.as_deref() == Some(patch.name.as_str());
-            if !matches {
-                continue;
-            }
-            // A hook_schema match with no `name` can't be patched — skip it.
-            let Some(agent_name) = agent_name else {
-                continue;
-            };
-            if table.get("args").is_none() {
-                table["args"] = toml_edit::value(Array::new());
-            }
-            let Some(args) = table.get_mut("args").and_then(|i| i.as_array_mut()) else {
-                continue;
-            };
-            let current: Vec<String> = args
-                .iter()
-                .filter_map(|v| v.as_str().map(str::to_string))
-                .collect();
-            let present = contains_subsequence(&current, &patch.append_args);
-            if add && !present {
-                for a in &patch.append_args {
-                    args.push(a.as_str());
-                }
-                changed.push(agent_name);
-            } else if !add && present {
-                let mut arr = Array::new();
-                for a in remove_subsequence(&current, &patch.append_args) {
-                    arr.push(a.as_str());
-                }
-                table["args"] = toml_edit::value(arr);
-                changed.push(agent_name);
+            if let Some(name) = patch_one_agent(table, patch, add) {
+                changed.push(name);
             }
         }
     }
@@ -660,6 +618,54 @@ fn edit_agent_patches(patches: &[AgentPatch], add: bool) -> Result<Vec<String>, 
             .map_err(|e| format!("write {}: {e}", path.display()))?;
     }
     Ok(changed)
+}
+
+/// Add or remove one patch's `append_args` on one `[[agents]]` table.
+///
+/// `Some(name)` when the table was actually changed — a patch already applied (or
+/// already absent) is a no-op, which is what makes install/uninstall idempotent.
+fn patch_one_agent(table: &mut toml_edit::Table, patch: &AgentPatch, add: bool) -> Option<String> {
+    use toml_edit::Array;
+
+    // Snapshot the identity fields into owned strings first: the args mutation
+    // below reborrows `table` mutably.
+    let agent_name = table
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let hook_schema = table
+        .get("hook_schema")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let targeted = agent_name.as_deref() == Some(patch.name.as_str())
+        || hook_schema.as_deref() == Some(patch.name.as_str());
+    // A hook_schema match with no `name` can't be patched — skip it.
+    let agent_name = agent_name.filter(|_| targeted)?;
+
+    if table.get("args").is_none() {
+        table["args"] = toml_edit::value(Array::new());
+    }
+    let args = table.get_mut("args").and_then(|i| i.as_array_mut())?;
+    let current: Vec<String> = args
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_string))
+        .collect();
+    let present = contains_subsequence(&current, &patch.append_args);
+    if add && !present {
+        for a in &patch.append_args {
+            args.push(a.as_str());
+        }
+        return Some(agent_name);
+    }
+    if !add && present {
+        let mut arr = Array::new();
+        for a in remove_subsequence(&current, &patch.append_args) {
+            arr.push(a.as_str());
+        }
+        table["args"] = toml_edit::value(arr);
+        return Some(agent_name);
+    }
+    None
 }
 
 /// Whether `hay` contains `needle` as a contiguous subsequence.

--- a/src/agent/self_update.rs
+++ b/src/agent/self_update.rs
@@ -98,7 +98,7 @@ fn parse_checksum(checksums: &str, artifact: &str) -> Option<String> {
         .lines()
         .find(|line| line.contains(artifact))
         .and_then(|line| line.split_whitespace().next())
-        .map(|s| s.to_string())
+        .map(str::to_string)
 }
 
 /// Verify `file`'s SHA256 against `expected`, shelling out to `sha256sum`
@@ -159,7 +159,7 @@ fn stage_binary(src: &Path, dest: &Path) -> Result<PathBuf, String> {
         .ok_or_else(|| format!("no parent dir for {}", dest.display()))?;
     let name = dest
         .file_name()
-        .and_then(|n| n.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .ok_or_else(|| format!("bad destination name {}", dest.display()))?;
     let staged = dir.join(format!(".{name}.new"));
     std::fs::copy(src, &staged)

--- a/src/agent/themes_config.rs
+++ b/src/agent/themes_config.rs
@@ -111,27 +111,24 @@ pub fn load_or_seed_with_warnings() -> (Vec<ThemeEntry>, Vec<String>) {
         return (Vec::new(), Vec::new());
     }
 
-    let file = match std::fs::read_to_string(&path) {
+    match std::fs::read_to_string(&path) {
         Ok(contents) => {
             match super::agent_config::parse_toml_reporting_unknown::<ThemesFile>(
                 &contents,
                 "themes.toml",
             ) {
                 Ok((file, warnings)) => return_resolved(file, warnings),
-                Err(e) => {
-                    return (
-                        Vec::new(),
-                        vec![format!(
-                            "themes.toml: {}; no custom themes",
-                            super::agent_config::compact_toml_error(&e.to_string())
-                        )],
-                    )
-                }
+                Err(e) => (
+                    Vec::new(),
+                    vec![format!(
+                        "themes.toml: {}; no custom themes",
+                        super::agent_config::compact_toml_error(&e.to_string())
+                    )],
+                ),
             }
         }
-        Err(e) => return (Vec::new(), vec![format!("Failed to read themes.toml: {e}")]),
-    };
-    file
+        Err(e) => (Vec::new(), vec![format!("Failed to read themes.toml: {e}")]),
+    }
 }
 
 fn return_resolved(file: ThemesFile, mut warnings: Vec<String>) -> (Vec<ThemeEntry>, Vec<String>) {

--- a/src/agent/tmux.rs
+++ b/src/agent/tmux.rs
@@ -177,10 +177,7 @@ fn parse_tmux_version(version_str: &str) -> Result<(u32, u32)> {
         "Cannot parse tmux major version from: {version_str}"
     ))?;
     // Minor might have a trailing letter (e.g., "3a"), strip non-digits.
-    let minor_str: String = parts[1]
-        .chars()
-        .take_while(|c| c.is_ascii_digit())
-        .collect();
+    let minor_str: String = parts[1].chars().take_while(char::is_ascii_digit).collect();
     let minor: u32 = minor_str.parse().context(format!(
         "Cannot parse tmux minor version from: {version_str}"
     ))?;
@@ -445,22 +442,59 @@ impl ControlMode {
                         }
                     };
                     let changed = control_mode::diff_polled_hook_states(&mut last, &body);
-                    if changed.is_empty() {
-                        continue;
-                    }
-                    if let Ok(mut events) = events.lock() {
-                        for ev in changed {
-                            if events.len() >= SUB_EVENTS_CAP {
-                                events.pop_front();
-                            }
-                            events.push_back(ev);
-                        }
-                    }
+                    Self::queue_sub_events(&events, changed);
                 }
             });
         if let Err(e) = spawned {
             warn!("failed to spawn the psmux hook poller: {e}");
         }
+    }
+
+    /// Append polled hook changes to the subscription queue, oldest dropped
+    /// first once it is full — the same bound the passive tmux subscription
+    /// honours.
+    fn queue_sub_events(
+        events: &Arc<Mutex<VecDeque<(String, String)>>>,
+        changed: Vec<(String, String)>,
+    ) {
+        if changed.is_empty() {
+            return;
+        }
+        let Ok(mut events) = events.lock() else {
+            return;
+        };
+        for ev in changed {
+            if events.len() >= SUB_EVENTS_CAP {
+                events.pop_front();
+            }
+            events.push_back(ev);
+        }
+    }
+
+    /// One newline-terminated control-mode line, or `None` at EOF / on an I/O
+    /// error (both of which end the reader).
+    ///
+    /// Lossy conversion: tmux control mode is mostly ASCII, but raw bytes can
+    /// appear (e.g. in `%extended-output`). Replacing invalid sequences with
+    /// U+FFFD is safe — the octal-encoded payload in `%output` lines is always
+    /// valid ASCII.
+    fn next_control_line(
+        reader: &mut BufReader<std::process::ChildStdout>,
+        line_buf: &mut Vec<u8>,
+    ) -> Option<String> {
+        line_buf.clear();
+        match reader.read_until(b'\n', line_buf) {
+            Ok(0) => return None,
+            Ok(_) => {}
+            Err(e) => {
+                debug!("Control reader I/O error: {e}");
+                return None;
+            }
+        }
+        if line_buf.last() == Some(&b'\n') {
+            line_buf.pop();
+        }
+        Some(String::from_utf8_lossy(line_buf).into_owned())
     }
 
     /// Background thread that reads and dispatches control mode output.
@@ -483,25 +517,7 @@ impl ControlMode {
         let mut collecting: Option<Vec<String>> = None;
         let mut line_buf = Vec::new();
 
-        loop {
-            line_buf.clear();
-            match reader.read_until(b'\n', &mut line_buf) {
-                Ok(0) => break,
-                Ok(_) => {}
-                Err(e) => {
-                    debug!("Control reader I/O error: {e}");
-                    break;
-                }
-            }
-            if line_buf.last() == Some(&b'\n') {
-                line_buf.pop();
-            }
-            // Lossy conversion: tmux control mode is mostly ASCII, but raw
-            // bytes can appear (e.g., in %extended-output). Replacing
-            // invalid sequences with U+FFFD is safe — the octal-encoded
-            // payload in %output lines is always valid ASCII.
-            let line = String::from_utf8_lossy(&line_buf);
-
+        while let Some(line) = Self::next_control_line(&mut reader, &mut line_buf) {
             match control_mode::parse_notification(&line) {
                 Notification::Output { pane_id, data } => {
                     Self::dispatch_output(&pane_senders, &pane_id, data);
@@ -526,12 +542,7 @@ impl ControlMode {
                     value,
                 } => {
                     if name == crate::session::REMOTE_HOOK_SUBSCRIPTION && !value.is_empty() {
-                        if let Ok(mut events) = sub_events.lock() {
-                            if events.len() >= SUB_EVENTS_CAP {
-                                events.pop_front();
-                            }
-                            events.push_back((pane_id, value));
-                        }
+                        Self::queue_sub_events(&sub_events, vec![(pane_id, value)]);
                     }
                 }
                 Notification::Other(text) => {
@@ -1814,7 +1825,7 @@ fn list_window_names() -> Vec<String> {
     }
     String::from_utf8_lossy(&out.stdout)
         .lines()
-        .map(|s| s.to_string())
+        .map(str::to_string)
         .collect()
 }
 
@@ -1956,7 +1967,7 @@ fn heartbeat_loop_command(cli_path: &Path) -> String {
 pub fn resolve_cli_binary() -> std::path::PathBuf {
     let cli_name = format!("thurbox-cli{}", std::env::consts::EXE_SUFFIX);
     if let Ok(exe) = std::env::current_exe() {
-        if exe.file_name().and_then(|n| n.to_str()) == Some(cli_name.as_str()) {
+        if exe.file_name().and_then(std::ffi::OsStr::to_str) == Some(cli_name.as_str()) {
             return exe;
         }
         if let Some(dir) = exe.parent() {

--- a/src/cli/sessions.rs
+++ b/src/cli/sessions.rs
@@ -208,86 +208,8 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
                 human,
             ))
         }
-        Action::Delete { uuid, force } => {
-            let session = resolve(db, &uuid)?;
-            let report = crate::session_ops::delete_session_headless(db, session.id, force)?;
-            let mut human = format!("Deleted session '{}' ({})", session.name, session.id);
-            if force {
-                let mut detail: Vec<(&str, String)> = vec![
-                    ("killed window", report.killed_window.to_string()),
-                    (
-                        "removed worktrees",
-                        report.removed_worktrees.len().to_string(),
-                    ),
-                    (
-                        "disabled automations",
-                        report.disabled_automations.to_string(),
-                    ),
-                ];
-                if !report.worktree_errors.is_empty() {
-                    detail.push(("worktree errors", report.worktree_errors.join("; ")));
-                }
-                if let Some(err) = &report.remote_teardown_error {
-                    detail.push(("remote teardown error", err.clone()));
-                }
-                for line in output::kv(&detail).lines() {
-                    human.push_str(&format!("\n  {line}"));
-                }
-            }
-            Ok(CommandOutput::new(
-                json!({
-                    "deleted": true,
-                    "id": session.id.to_string(),
-                    "name": session.name,
-                    "forced": force,
-                    "killed_window": report.killed_window,
-                    "removed_worktrees": report.removed_worktrees,
-                    "worktree_errors": report.worktree_errors,
-                    "disabled_automations": report.disabled_automations,
-                    "remote_teardown_error": report.remote_teardown_error,
-                }),
-                human,
-            ))
-        }
-        Action::Restore { uuid, best_effort } => {
-            let id: SessionId = uuid
-                .parse()
-                .map_err(|_| format!("Invalid session UUID: {uuid}"))?;
-            let deleted = db
-                .get_deleted_session_by_id(id)
-                .map_err(|e| format!("get_deleted_session_by_id: {e}"))?
-                .ok_or_else(|| format!("Deleted session not found: {uuid}"))?;
-            // A force-deleted session lost its uncommitted work; restoring it only
-            // recovers committed branch state, so require an explicit opt-in.
-            if deleted.force_deleted && !best_effort {
-                return Err(format!(
-                    "Session '{}' was force-deleted; pass --best-effort to recover committed work (uncommitted/untracked changes are gone)",
-                    deleted.name
-                ));
-            }
-            // `restore_session` clears `deleted_at` and `force_deleted`; a running
-            // TUI re-creates worktrees + the tmux window on its next sync.
-            db.restore_session(deleted.id)
-                .map_err(|e| format!("restore_session: {e}"))?;
-            let best_effort_recovery = deleted.force_deleted;
-            let human = if best_effort_recovery {
-                format!(
-                    "Restored session '{}' ({}) — best-effort: uncommitted work was not recovered",
-                    deleted.name, deleted.id
-                )
-            } else {
-                format!("Restored session '{}' ({})", deleted.name, deleted.id)
-            };
-            Ok(CommandOutput::new(
-                json!({
-                    "restored": true,
-                    "id": deleted.id.to_string(),
-                    "name": deleted.name,
-                    "best_effort": best_effort_recovery,
-                }),
-                human,
-            ))
-        }
+        Action::Delete { uuid, force } => delete_session(db, &uuid, force),
+        Action::Restore { uuid, best_effort } => restore_deleted(db, &uuid, best_effort),
         Action::Restart { uuid } => {
             let session = resolve(db, &uuid)?;
             crate::session_ops::restart_session_headless(db, session.id)?;
@@ -359,6 +281,96 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             ))
         }
     }
+}
+
+/// Delete a session, reporting what `--force` teardown actually managed.
+fn delete_session(db: &Database, uuid: &str, force: bool) -> Result<CommandOutput, String> {
+    let session = resolve(db, uuid)?;
+    let report = crate::session_ops::delete_session_headless(db, session.id, force)?;
+    let mut human = format!("Deleted session '{}' ({})", session.name, session.id);
+    if force {
+        for line in output::kv(&force_delete_detail(&report)).lines() {
+            human.push_str(&format!("\n  {line}"));
+        }
+    }
+    Ok(CommandOutput::new(
+        json!({
+            "deleted": true,
+            "id": session.id.to_string(),
+            "name": session.name,
+            "forced": force,
+            "killed_window": report.killed_window,
+            "removed_worktrees": report.removed_worktrees,
+            "worktree_errors": report.worktree_errors,
+            "disabled_automations": report.disabled_automations,
+            "remote_teardown_error": report.remote_teardown_error,
+        }),
+        human,
+    ))
+}
+
+/// The human half of a `--force` delete: teardown counts, plus whichever of the
+/// two best-effort failures happened.
+fn force_delete_detail(
+    report: &crate::session_ops::ForceDeleteReport,
+) -> Vec<(&'static str, String)> {
+    let mut detail = vec![
+        ("killed window", report.killed_window.to_string()),
+        (
+            "removed worktrees",
+            report.removed_worktrees.len().to_string(),
+        ),
+        (
+            "disabled automations",
+            report.disabled_automations.to_string(),
+        ),
+    ];
+    if !report.worktree_errors.is_empty() {
+        detail.push(("worktree errors", report.worktree_errors.join("; ")));
+    }
+    if let Some(err) = &report.remote_teardown_error {
+        detail.push(("remote teardown error", err.clone()));
+    }
+    detail
+}
+
+/// Revive a soft-deleted session. A running TUI re-creates its worktrees and
+/// tmux window on the next sync.
+fn restore_deleted(db: &Database, uuid: &str, best_effort: bool) -> Result<CommandOutput, String> {
+    let id: SessionId = uuid
+        .parse()
+        .map_err(|_| format!("Invalid session UUID: {uuid}"))?;
+    let deleted = db
+        .get_deleted_session_by_id(id)
+        .map_err(|e| format!("get_deleted_session_by_id: {e}"))?
+        .ok_or_else(|| format!("Deleted session not found: {uuid}"))?;
+    // A force-deleted session lost its uncommitted work; restoring it only
+    // recovers committed branch state, so require an explicit opt-in.
+    if deleted.force_deleted && !best_effort {
+        return Err(format!(
+            "Session '{}' was force-deleted; pass --best-effort to recover committed work (uncommitted/untracked changes are gone)",
+            deleted.name
+        ));
+    }
+    // `Database::restore_session` clears `deleted_at` and `force_deleted`.
+    db.restore_session(deleted.id)
+        .map_err(|e| format!("restore_session: {e}"))?;
+    let human = match deleted.force_deleted {
+        true => format!(
+            "Restored session '{}' ({}) — best-effort: uncommitted work was not recovered",
+            deleted.name, deleted.id
+        ),
+        false => format!("Restored session '{}' ({})", deleted.name, deleted.id),
+    };
+    Ok(CommandOutput::new(
+        json!({
+            "restored": true,
+            "id": deleted.id.to_string(),
+            "name": deleted.name,
+            "best_effort": deleted.force_deleted,
+        }),
+        human,
+    ))
 }
 
 /// Resolve the session a `signal` targets: an explicit `--session` UUID, else

--- a/src/cli/tasks.rs
+++ b/src/cli/tasks.rs
@@ -123,14 +123,12 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             if title.trim().is_empty() {
                 return Err("title must not be empty".into());
             }
-            let status = parse_status(status.as_deref())?;
             let extra_repos = super::parse_extra_repos(&add_repo, &add_dir);
-            let action = resolve_action(session, repo, worktree, base, agent, extra_repos, db)?;
             let new = NewTask {
                 title,
                 description: blank_to_none(description),
-                status,
-                action,
+                status: parse_status(status.as_deref())?,
+                action: resolve_action(session, repo, worktree, base, agent, extra_repos, db)?,
                 source: source
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
@@ -169,34 +167,15 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             external_url,
         } => {
             let mut task = load(db, id)?;
-            if let Some(t) = title {
-                if t.trim().is_empty() {
-                    return Err("title must not be empty".into());
-                }
-                task.title = t;
-            }
-            // Passing --description always sets it (trimmed-empty → cleared).
-            if let Some(d) = description {
-                task.description = blank_to_none(Some(d));
-            }
-            if let Some(s) = status {
-                task.status = parse_status(Some(&s))?;
-            }
-            // External-sync fields: passing the flag sets it; an empty string
-            // clears the two external_* to NULL. A blank --source is ignored
-            // (source is NOT NULL).
-            if let Some(s) = source {
-                let s = s.trim();
-                if !s.is_empty() {
-                    task.source = s.to_string();
-                }
-            }
-            if let Some(e) = external_id {
-                task.external_id = blank_to_none(Some(e));
-            }
-            if let Some(u) = external_url {
-                task.external_url = blank_to_none(Some(u));
-            }
+            apply_edits(
+                &mut task,
+                title,
+                description,
+                status,
+                source,
+                external_id,
+                external_url,
+            )?;
             db.update_task(&task)
                 .map_err(|e| format!("update_task: {e}"))?;
             let task = load(db, id)?;
@@ -220,6 +199,48 @@ pub fn run(action: Action, db: &Database) -> Result<CommandOutput, String> {
             Ok(CommandOutput::new(json, human))
         }
     }
+}
+
+/// Fold the `edit` flags that were passed into `task`.
+///
+/// Every field follows the same rule: passing the flag sets it. `--description`
+/// and the two `external_*` clear to NULL when passed empty; a blank `--source`
+/// is ignored, since the column is NOT NULL.
+#[allow(clippy::too_many_arguments)]
+fn apply_edits(
+    task: &mut Task,
+    title: Option<String>,
+    description: Option<String>,
+    status: Option<String>,
+    source: Option<String>,
+    external_id: Option<String>,
+    external_url: Option<String>,
+) -> Result<(), String> {
+    if let Some(t) = title {
+        if t.trim().is_empty() {
+            return Err("title must not be empty".into());
+        }
+        task.title = t;
+    }
+    if let Some(d) = description {
+        task.description = blank_to_none(Some(d));
+    }
+    if let Some(s) = status {
+        task.status = parse_status(Some(&s))?;
+    }
+    if let Some(s) = source
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    {
+        task.source = s;
+    }
+    if let Some(e) = external_id {
+        task.external_id = blank_to_none(Some(e));
+    }
+    if let Some(u) = external_url {
+        task.external_url = blank_to_none(Some(u));
+    }
+    Ok(())
 }
 
 /// Render the task list as an aligned table (or a friendly empty line).

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -671,10 +671,7 @@ pub(crate) fn host_shell_c(host: &HostDef, script: &str) -> Command {
 pub(crate) fn host_powershell_c(host: &HostDef, script: &str) -> Command {
     use base64::Engine as _;
 
-    let utf16: Vec<u8> = script
-        .encode_utf16()
-        .flat_map(|unit| unit.to_le_bytes())
-        .collect();
+    let utf16: Vec<u8> = script.encode_utf16().flat_map(u16::to_le_bytes).collect();
     let encoded = base64::engine::general_purpose::STANDARD.encode(&utf16);
     let mut cmd = host_launcher(host);
     cmd.args(["powershell", "-NoProfile", "-EncodedCommand"])
@@ -930,8 +927,8 @@ pub fn repo_display_name(path: &Path) -> Option<String> {
     }
     let name = repo_name_from_remote(path).or_else(|| {
         path.file_name()
-            .and_then(|f| f.to_str())
-            .map(|s| s.to_string())
+            .and_then(std::ffi::OsStr::to_str)
+            .map(str::to_string)
     })?;
     if let Ok(mut guard) = cache.lock() {
         guard.insert(path.to_path_buf(), name.clone());
@@ -954,7 +951,7 @@ pub fn scan_child_repos(parent: &Path) -> Vec<PathBuf> {
         return Vec::new();
     };
     let mut repos: Vec<PathBuf> = entries
-        .filter_map(|e| e.ok())
+        .filter_map(Result::ok)
         .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
         .filter(|e| {
             !e.file_name()
@@ -1065,7 +1062,7 @@ fn list_dir_entries_local(dir: &Path) -> DirListing {
         return DirListing::Entries(Vec::new());
     };
     let mut names: Vec<(String, bool)> = entries
-        .filter_map(|e| e.ok())
+        .filter_map(Result::ok)
         // `path().is_dir()` follows symlinks, matching the remote `test -d`.
         .filter(|e| e.path().is_dir())
         .filter_map(|e| {
@@ -1677,7 +1674,7 @@ pub fn default_branch_from_remote_on(host: Option<&HostDef>, repo_path: &Path) -
     }
 
     let full_ref = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    full_ref.strip_prefix("origin/").map(|s| s.to_string())
+    full_ref.strip_prefix("origin/").map(str::to_string)
 }
 
 /// Add an existing branch as a worktree (no `-b` flag — branch must already exist).

--- a/src/kernel/command.rs
+++ b/src/kernel/command.rs
@@ -19,7 +19,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, PoisonError};
 
 use super::registry::Value as SettingValue;
 use crate::session::SessionId;
@@ -837,55 +837,75 @@ impl CommandBus {
     /// snapshot immediately rather than waiting out the refresh interval —
     /// which is what makes a delete feel instant.
     pub fn poll(&mut self) -> bool {
-        let mut changed = false;
-
         // Phase changes first, so a command that reports and then finishes in
         // the same window does not show a stale stage.
+        let mut changed = self.drain_progress();
+        changed |= self.drain_finished();
+        changed |= self.sweep_expired_failures();
+        changed
+    }
+
+    /// Apply the stage each running command last reported.
+    fn drain_progress(&mut self) -> bool {
+        let mut changed = false;
         while let Ok(update) = self.progress_rx.try_recv() {
-            if let Ok(mut list) = self.inflight.lock() {
-                if let Some(entry) = list.iter_mut().find(|entry| entry.id == update.id) {
-                    entry.phase = Phase::Stage(update.phase);
-                    changed = true;
-                }
+            let Ok(mut list) = self.inflight.lock() else {
+                continue;
+            };
+            if let Some(entry) = list.iter_mut().find(|entry| entry.id == update.id) {
+                entry.phase = Phase::Stage(update.phase);
+                changed = true;
             }
         }
+        changed
+    }
 
+    /// Retire completed commands: a success leaves the list, a failure lingers
+    /// long enough to be read.
+    fn drain_finished(&mut self) -> bool {
+        let mut changed = false;
         while let Ok(done) = self.finished_rx.try_recv() {
             changed = true;
+            // Recorded before the lock: a poisoned mutex must not lose the
+            // session a command just created.
             if let Some(session) = done.created {
                 self.created.push(session);
             }
-            if let Ok(mut list) = self.inflight.lock() {
-                match done.error {
-                    // Success: the effect is in the database now, so the row
-                    // has nothing left to say.
-                    None => list.retain(|entry| entry.id != done.id),
-                    Some(error) => {
-                        if let Some(entry) = list.iter_mut().find(|entry| entry.id == done.id) {
-                            entry.phase = Phase::Failed;
-                            entry.error = Some(error);
-                        }
-                        self.failed_at.push((done.id, std::time::Instant::now()));
+            let Ok(mut list) = self.inflight.lock() else {
+                continue;
+            };
+            match done.error {
+                // Success: the effect is in the database now, so the row has
+                // nothing left to say.
+                None => list.retain(|entry| entry.id != done.id),
+                Some(error) => {
+                    if let Some(entry) = list.iter_mut().find(|entry| entry.id == done.id) {
+                        entry.phase = Phase::Failed;
+                        entry.error = Some(error);
                     }
+                    self.failed_at.push((done.id, std::time::Instant::now()));
                 }
             }
         }
+        changed
+    }
 
-        // Sweep failures that have been readable long enough.
+    /// Sweep failures that have been readable long enough.
+    fn sweep_expired_failures(&mut self) -> bool {
         let expired: Vec<u64> = self
             .failed_at
             .iter()
             .filter(|(_, at)| at.elapsed().as_millis() as u64 >= FAILURE_LINGER_MS)
             .map(|(id, _)| *id)
             .collect();
-        if !expired.is_empty() {
-            if let Ok(mut list) = self.inflight.lock() {
-                list.retain(|entry| !expired.contains(&entry.id));
-            }
-            self.failed_at.retain(|(id, _)| !expired.contains(id));
-            changed = true;
+        if expired.is_empty() {
+            return false;
         }
-        changed
+        if let Ok(mut list) = self.inflight.lock() {
+            list.retain(|entry| !expired.contains(&entry.id));
+        }
+        self.failed_at.retain(|(id, _)| !expired.contains(id));
+        true
     }
 
     /// The sessions completed commands brought into existence, oldest first.
@@ -1191,28 +1211,22 @@ fn bookmark(host: &str, path: &str, edit: BookmarkEdit) -> Result<(), String> {
     // lets a bookmark be forgotten after its host has been taken out of
     // `hosts.toml`.
     if edit == BookmarkEdit::Remove {
-        let removed = db
-            .delete_repo_bookmark(host, &crate::paths::expand_tilde(path))
-            .map_err(|e| format!("forget repo: {e}"))?;
-        return if removed {
-            Ok(())
-        } else {
-            Err(format!("not a remembered repository: {path}"))
-        };
+        return bookmark_remove(&db, host, path);
     }
 
     // `""` is local; the flow's key is the same string `repo_bookmarks.host`
     // stores, so nothing is translated here.
-    let remote = if host.is_empty() {
-        None
-    } else {
-        let (registry, _warnings) = crate::agent::host_config::load_all_with_warnings();
-        Some(
-            registry
-                .resolve(host)
-                .cloned()
-                .ok_or_else(|| format!("no such host: {host}"))?,
-        )
+    let remote = match host.is_empty() {
+        true => None,
+        false => {
+            let (registry, _warnings) = crate::agent::host_config::load_all_with_warnings();
+            Some(
+                registry
+                    .resolve(host)
+                    .cloned()
+                    .ok_or_else(|| format!("no such host: {host}"))?,
+            )
+        }
     };
 
     let expanded = match remote.as_ref() {
@@ -1222,39 +1236,72 @@ fn bookmark(host: &str, path: &str, edit: BookmarkEdit) -> Result<(), String> {
         None => crate::paths::expand_tilde(path),
     };
 
-    if edit == BookmarkEdit::Parent {
-        let children = match remote.as_ref() {
-            Some(host) => crate::git::scan_child_repos_on(host, &expanded.to_string_lossy())
-                .map_err(|e| format!("{e:#}"))?,
-            None => {
-                if !expanded.is_dir() {
-                    return Err(format!("Path not found: {}", expanded.display()));
-                }
-                crate::git::scan_child_repos(&expanded)
-            }
-        };
-        db.upsert_repo_bookmark_kind(host, &expanded, true)
-            .map_err(|e| format!("remember folder: {e}"))?;
-        // Replace rather than merge: re-importing is how a folder is refreshed,
-        // so a repository that has since been deleted must stop being offered.
-        db.replace_parent_children(host, &expanded, &children)
-            .map_err(|e| format!("remember folder contents: {e}"))?;
-        return if children.is_empty() {
-            // Not a failure — the folder is remembered — but the user asked a
-            // question and "none" is the answer, so it is reported rather than
-            // looking like an import that silently did nothing.
-            Err(format!(
-                "No repositories found under {}",
-                expanded.display()
-            ))
-        } else {
-            Ok(())
-        };
+    match edit {
+        BookmarkEdit::Parent => bookmark_parent(&db, host, remote.as_ref(), &expanded),
+        _ => bookmark_add(&db, host, remote.as_ref(), &expanded),
     }
+}
 
-    // Add: establish what it is, refuse what is not there, and record the
-    // git-ness so the flow knows whether worktree mode is even possible.
-    let is_git = match remote.as_ref() {
+/// Forget a remembered path.
+///
+/// Removal names a path that is already remembered — an absolute one, since the
+/// rows the flow offers come from the database — so it needs neither the
+/// filesystem nor the host. Done BEFORE the host is resolved, which is what lets
+/// a bookmark be forgotten after its host has been taken out of `hosts.toml`.
+fn bookmark_remove(db: &Database, host: &str, path: &str) -> Result<(), String> {
+    let removed = db
+        .delete_repo_bookmark(host, &crate::paths::expand_tilde(path))
+        .map_err(|e| format!("forget repo: {e}"))?;
+    match removed {
+        true => Ok(()),
+        false => Err(format!("not a remembered repository: {path}")),
+    }
+}
+
+/// Import a folder of repositories: remember the folder, then its members.
+fn bookmark_parent(
+    db: &Database,
+    host: &str,
+    remote: Option<&crate::session::HostDef>,
+    expanded: &std::path::Path,
+) -> Result<(), String> {
+    let children = match remote {
+        Some(host) => crate::git::scan_child_repos_on(host, &expanded.to_string_lossy())
+            .map_err(|e| format!("{e:#}"))?,
+        None => {
+            if !expanded.is_dir() {
+                return Err(format!("Path not found: {}", expanded.display()));
+            }
+            crate::git::scan_child_repos(expanded)
+        }
+    };
+    db.upsert_repo_bookmark_kind(host, expanded, true)
+        .map_err(|e| format!("remember folder: {e}"))?;
+    // Replace rather than merge: re-importing is how a folder is refreshed, so a
+    // repository that has since been deleted must stop being offered.
+    db.replace_parent_children(host, expanded, &children)
+        .map_err(|e| format!("remember folder contents: {e}"))?;
+    if children.is_empty() {
+        // Not a failure — the folder is remembered — but the user asked a
+        // question and "none" is the answer, so it is reported rather than
+        // looking like an import that silently did nothing.
+        return Err(format!(
+            "No repositories found under {}",
+            expanded.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Remember one path: establish what it is, refuse what is not there, and record
+/// the git-ness so the flow knows whether worktree mode is even possible.
+fn bookmark_add(
+    db: &Database,
+    host: &str,
+    remote: Option<&crate::session::HostDef>,
+    expanded: &std::path::Path,
+) -> Result<(), String> {
+    let is_git = match remote {
         Some(host) => match crate::git::classify_path_on(host, &expanded.to_string_lossy())
             .map_err(|e| format!("{e:#}"))?
         {
@@ -1272,14 +1319,14 @@ fn bookmark(host: &str, path: &str, edit: BookmarkEdit) -> Result<(), String> {
             if !expanded.is_dir() {
                 return Err(format!("Path not found: {}", expanded.display()));
             }
-            Some(crate::git::is_git_repo(&expanded))
+            Some(crate::git::is_git_repo(expanded))
         }
     };
 
-    // Touches recency as well as adding, which is what lets the flow re-select
-    // a path that was already remembered: the row it asked for is the newest
-    // one (design.md D2).
-    db.upsert_repo_bookmark_checked(host, &expanded, is_git)
+    // Touches recency as well as adding, which is what lets the flow re-select a
+    // path that was already remembered: the row it asked for is the newest one
+    // (design.md D2).
+    db.upsert_repo_bookmark_checked(host, expanded, is_git)
         .map_err(|e| format!("remember repo: {e}"))
 }
 
@@ -1588,7 +1635,7 @@ fn reorder(db: &Database, id: SessionId, delta: i64) -> Result<(), String> {
     // Poisoning only means an earlier reorder panicked; the order is still
     // consistent on disk, so recovering is better than refusing every future
     // move.
-    let _guard = ORDER_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = ORDER_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
 
     let mut sessions = db
         .list_active_sessions()
@@ -1647,7 +1694,7 @@ fn reorder(db: &Database, id: SessionId, delta: i64) -> Result<(), String> {
 /// never showed.
 fn order(db: &Database, list: &[String]) -> Result<(), String> {
     // Same lock as `reorder`: two concurrent renumberings must not interleave.
-    let _guard = ORDER_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = ORDER_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
 
     let mut sessions = db
         .list_active_sessions()

--- a/src/kernel/inventory.rs
+++ b/src/kernel/inventory.rs
@@ -275,7 +275,7 @@ pub fn rows(
 
         let error = error
             .filter(|error| blames(error, path))
-            .map(|error| error.to_string());
+            .map(ToString::to_string);
 
         out.push(Row {
             name: loaded

--- a/src/kernel/modals/theme.rs
+++ b/src/kernel/modals/theme.rs
@@ -53,9 +53,7 @@ fn row_height(row: &Row) -> u16 {
 }
 
 fn total_height(rows: &[Row]) -> u16 {
-    rows.iter()
-        .map(row_height)
-        .fold(0u16, |total, height| total.saturating_add(height))
+    rows.iter().map(row_height).fold(0u16, u16::saturating_add)
 }
 
 /// Pair each surviving choice with its header. A header is emitted at the first

--- a/src/kernel/notify.rs
+++ b/src/kernel/notify.rs
@@ -18,7 +18,7 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use super::snapshot::Snapshot;
+use super::snapshot::{SessionRow, Snapshot};
 use crate::session::settings::NotificationSettings;
 
 /// Status that means the agent is waiting on the user.
@@ -85,22 +85,12 @@ impl Notifier {
         let floor = Duration::from_secs(self.settings.min_interval_secs);
 
         for row in &snapshot.sessions {
-            let was = self.previous.get(&row.id).cloned();
-            self.previous.insert(row.id.clone(), row.status.clone());
+            let was = self.previous.insert(row.id.clone(), row.status.clone());
 
             // The *edge*, not the state: a session that is already blocked when
             // the interface starts has not just asked for anything.
             let Some(previous) = was else { continue };
-            if previous == row.status {
-                continue;
-            }
-            // Blocked always notifies; finishing does so only when asked for.
-            let worth_raising = row.status == BLOCKED
-                || (row.status == DONE && self.settings.also_on_waiting && previous != BLOCKED);
-            if !worth_raising {
-                continue;
-            }
-            if self.settings.suppress_for_active && active == Some(row.id.as_str()) {
+            if previous == row.status || !self.worth_raising(&previous, row, active) {
                 continue;
             }
             // The floor is per session: an agent flipping between states must not
@@ -114,28 +104,7 @@ impl Notifier {
             }
             self.last_raised.insert(row.id.clone(), now);
             raised.push(row.id.clone());
-
-            // A row whose id will not parse cannot be focused from the
-            // notification, so there is nothing useful to deliver.
-            if let (Some(sender), Some(id)) =
-                (&self.sender, crate::kernel::snapshot::parse_id(&row.id))
-            {
-                let blocked = row.status == BLOCKED;
-                sender.send(crate::notifications::Notification {
-                    title: if blocked {
-                        format!("{} needs you", row.name)
-                    } else {
-                        format!("{} finished", row.name)
-                    },
-                    body: if blocked {
-                        format!("{} is waiting for input", row.agent)
-                    } else {
-                        format!("{} finished its turn", row.agent)
-                    },
-                    session_id: id,
-                    sound: self.settings.sound,
-                });
-            }
+            self.deliver(row);
         }
 
         // Sessions that went away stop being tracked, or a deleted-and-recreated
@@ -145,6 +114,48 @@ impl Notifier {
         self.last_raised.retain(|id, _| live(id));
 
         raised
+    }
+
+    /// Whether this transition is one the user asked to hear about.
+    ///
+    /// Blocked always notifies; finishing does so only when asked for. A
+    /// notification for the session you are already looking at is noise, so it is
+    /// suppressed when configured.
+    fn worth_raising(&self, previous: &str, row: &SessionRow, active: Option<&str>) -> bool {
+        let wanted = row.status == BLOCKED
+            || (row.status == DONE && self.settings.also_on_waiting && previous != BLOCKED);
+        if !wanted {
+            return false;
+        }
+        !(self.settings.suppress_for_active && active == Some(row.id.as_str()))
+    }
+
+    /// Hand one notification to the delivery layer.
+    ///
+    /// A row whose id will not parse cannot be focused from the notification, so
+    /// there is nothing useful to deliver.
+    fn deliver(&self, row: &SessionRow) {
+        let (Some(sender), Some(id)) = (&self.sender, crate::kernel::snapshot::parse_id(&row.id))
+        else {
+            return;
+        };
+        let blocked = row.status == BLOCKED;
+        let (title, body) = match blocked {
+            true => (
+                format!("{} needs you", row.name),
+                format!("{} is waiting for input", row.agent),
+            ),
+            false => (
+                format!("{} finished", row.name),
+                format!("{} finished its turn", row.agent),
+            ),
+        };
+        sender.send(crate::notifications::Notification {
+            title,
+            body,
+            session_id: id,
+            sound: self.settings.sound,
+        });
     }
 }
 

--- a/src/kernel/packages.rs
+++ b/src/kernel/packages.rs
@@ -183,73 +183,22 @@ pub fn deliver(
     // Reported as the strongest thing that happened: a package whose pane was
     // updated and whose module was already current is an update.
     let mut outcome = Outcome::Current;
-    // Ranked by what most needs the reader's attention, not by how much work was
-    // done. `Kept` and `Deleted` both mean "you will NOT see the new version", and
-    // a package whose module updated while its pane was left alone has to report
-    // the pane — otherwise an edit silently costing you an update reads as a clean
-    // update.
-    let mut escalate = |candidate: Outcome| {
-        let rank = |outcome: Outcome| match outcome {
-            Outcome::Current => 0,
-            Outcome::Updated => 1,
-            Outcome::Installed => 2,
-            Outcome::Deleted => 3,
-            Outcome::Kept => 4,
-            Outcome::Removed => 5,
-        };
-        if rank(candidate) > rank(outcome) {
-            outcome = candidate;
-        }
-    };
 
     for payload in payloads {
-        let path = dir.join(&payload.file);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
-        }
-        let existing = std::fs::read_to_string(&path).ok();
-        let delivered = match recorded.get(&payload.file) {
-            Some(recorded) => Delivered::Digest(recorded.as_str()),
-            None if tombstoned.contains(&payload.file) => Delivered::Tombstoned,
-            None => Delivered::Never,
-        };
-
-        let action = decide(existing.as_deref(), delivered, &payload.contents);
-        match action {
-            Action::Write | Action::Update => {
-                std::fs::write(&path, &payload.contents)
-                    .map_err(|e| format!("{}: {e}", path.display()))?;
-                files.insert(payload.file.clone(), digest(&payload.contents));
-                escalate(if action == Action::Write {
-                    Outcome::Installed
-                } else {
-                    Outcome::Updated
-                });
+        let (effect, candidate) = deliver_payload(dir, payload, &recorded, &tombstoned)?;
+        match effect {
+            Effect::Recorded(digest) => {
+                files.insert(payload.file.clone(), digest);
             }
-            Action::Settle => {
-                files.insert(payload.file.clone(), digest(&payload.contents));
-            }
-            // Theirs. The record is carried through UNCHANGED — recording the
-            // digest now on disk would make the user's edit look like our own
-            // delivery, and the very next run would decide it was safe to
-            // overwrite. `bundled::materialize` leaves the manifest alone on
-            // `Preserve` for exactly this reason; "the last thing we wrote" is
-            // what makes an edit detectable, so it must not be overwritten with
-            // what the user wrote.
-            Action::Preserve => {
+            // The record is carried through UNCHANGED — see `Action::Preserve`.
+            Effect::Unchanged => {
                 if let Some(recorded) = recorded.get(&payload.file) {
                     files.insert(payload.file.clone(), recorded.clone());
                 }
-                escalate(Outcome::Kept);
             }
-            // Deleted, and recorded as such so the next run leaves it alone. Written
-            // out rather than inferred from a missing digest, which is also what a
-            // newly-added file looks like.
-            Action::Tombstone | Action::Leave => {
-                removed.push(payload.file.clone());
-                escalate(Outcome::Deleted);
-            }
+            Effect::Tombstoned => removed.push(payload.file.clone()),
         }
+        escalate(&mut outcome, candidate);
     }
 
     lock.record(LockEntry {
@@ -261,6 +210,84 @@ pub fn deliver(
         removed,
     });
     Ok(outcome)
+}
+
+/// What one payload's delivery does to the lock record.
+enum Effect {
+    /// Written (or already current): record this digest.
+    Recorded(String),
+    /// The user's edit stands: carry the recorded digest through untouched.
+    Unchanged,
+    /// The user deleted it: drop the digest so convergence stops offering it.
+    Tombstoned,
+}
+
+/// Deliver one payload and report both what the lock should say and how strongly
+/// it wants reporting.
+fn deliver_payload(
+    dir: &Path,
+    payload: &Payload,
+    recorded: &BTreeMap<String, String>,
+    tombstoned: &[String],
+) -> Result<(Effect, Outcome), String> {
+    let path = dir.join(&payload.file);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
+    }
+    let existing = std::fs::read_to_string(&path).ok();
+    let delivered = match recorded.get(&payload.file) {
+        Some(recorded) => Delivered::Digest(recorded.as_str()),
+        None if tombstoned.contains(&payload.file) => Delivered::Tombstoned,
+        None => Delivered::Never,
+    };
+
+    match decide(existing.as_deref(), delivered, &payload.contents) {
+        action @ (Action::Write | Action::Update) => {
+            std::fs::write(&path, &payload.contents)
+                .map_err(|e| format!("{}: {e}", path.display()))?;
+            let outcome = match action == Action::Write {
+                true => Outcome::Installed,
+                false => Outcome::Updated,
+            };
+            Ok((Effect::Recorded(digest(&payload.contents)), outcome))
+        }
+        Action::Settle => Ok((
+            Effect::Recorded(digest(&payload.contents)),
+            Outcome::Current,
+        )),
+        // Theirs. The record is carried through UNCHANGED — recording the digest
+        // now on disk would make the user's edit look like our own delivery, and
+        // the very next run would decide it was safe to overwrite.
+        // `bundled::materialize` leaves the manifest alone on `Preserve` for
+        // exactly this reason; "the last thing we wrote" is what makes an edit
+        // detectable, so it must not be overwritten with what the user wrote.
+        Action::Preserve => Ok((Effect::Unchanged, Outcome::Kept)),
+        // Deleted, and recorded as such so the next run leaves it alone. Written
+        // out rather than inferred from a missing digest, which is also what a
+        // newly-added file looks like.
+        Action::Tombstone | Action::Leave => Ok((Effect::Tombstoned, Outcome::Deleted)),
+    }
+}
+
+/// Raise `current` to `candidate` when the candidate more needs the reader's
+/// attention.
+///
+/// Ranked by that, not by how much work was done. `Kept` and `Deleted` both mean
+/// "you will NOT see the new version", and a package whose module updated while
+/// its pane was left alone has to report the pane — otherwise an edit silently
+/// costing you an update reads as a clean update.
+fn escalate(current: &mut Outcome, candidate: Outcome) {
+    let rank = |outcome: Outcome| match outcome {
+        Outcome::Current => 0,
+        Outcome::Updated => 1,
+        Outcome::Installed => 2,
+        Outcome::Deleted => 3,
+        Outcome::Kept => 4,
+        Outcome::Removed => 5,
+    };
+    if rank(candidate) > rank(*current) {
+        *current = candidate;
+    }
 }
 
 /// Take back the files one record delivered, for an entry the spec no longer
@@ -619,7 +646,7 @@ fn pane_in_working_copy(root: &Path, name: &str, as_file: Option<&str>) -> Resul
              --as plugins/NN_name.lua"
                 .to_string()
         })?
-        .filter_map(|entry| entry.ok())
+        .filter_map(Result::ok)
         .map(|entry| entry.file_name().to_string_lossy().into_owned())
         .filter(|name| name.ends_with(".lua"))
         .collect();

--- a/src/kernel/registry.rs
+++ b/src/kernel/registry.rs
@@ -748,76 +748,111 @@ fn path_display(path: &str) -> &str {
 }
 
 fn read_overrides() -> Overrides {
-    let mut bindings = BTreeMap::new();
-    let mut settings = BTreeMap::new();
-    let mut trusted = BTreeMap::new();
-    let mut disabled = BTreeSet::new();
-    let mut warnings = Vec::new();
-
     let Some(path) = overrides_path() else {
-        return (bindings, settings, trusted, disabled, warnings);
+        return Overrides::default();
     };
     let Ok(text) = std::fs::read_to_string(&path) else {
-        return (bindings, settings, trusted, disabled, warnings);
+        return Overrides::default();
     };
     let parsed: serde_json::Value = match serde_json::from_str(&text) {
         Ok(value) => value,
         Err(e) => {
-            warnings.push(format!("{}: {e}", path.display()));
-            return (bindings, settings, trusted, disabled, warnings);
+            let mut unreadable = Overrides::default();
+            unreadable.4.push(format!("{}: {e}", path.display()));
+            return unreadable;
         }
     };
-    if let Some(map) = parsed.get("bindings").and_then(|v| v.as_object()) {
-        for (action, chord) in map {
-            if let Some(chord) = chord.as_str() {
-                bindings.insert(action.clone(), normalise_chord(chord));
-            }
+
+    let mut warnings = Vec::new();
+    (
+        read_bindings(&parsed),
+        read_settings(&parsed),
+        read_trusted(&parsed, &mut warnings),
+        read_disabled(&parsed),
+        warnings,
+    )
+}
+
+/// The `bindings` half of `ui.json`: action id → chord, normalised.
+fn read_bindings(parsed: &serde_json::Value) -> BTreeMap<String, String> {
+    let mut bindings = BTreeMap::new();
+    let Some(map) = parsed.get("bindings").and_then(|v| v.as_object()) else {
+        return bindings;
+    };
+    for (action, chord) in map {
+        if let Some(chord) = chord.as_str() {
+            bindings.insert(action.clone(), normalise_chord(chord));
         }
     }
-    if let Some(map) = parsed.get("settings").and_then(|v| v.as_object()) {
-        for (key, value) in map {
-            if let Some(value) = json_to_value(value) {
-                settings.insert(key.clone(), value);
-            }
+    bindings
+}
+
+/// The `settings` half of `ui.json`: setting id → the value the user chose.
+fn read_settings(parsed: &serde_json::Value) -> BTreeMap<String, Value> {
+    let mut settings = BTreeMap::new();
+    let Some(map) = parsed.get("settings").and_then(|v| v.as_object()) else {
+        return settings;
+    };
+    for (key, value) in map {
+        if let Some(value) = json_to_value(value) {
+            settings.insert(key.clone(), value);
         }
     }
-    if let Some(map) = parsed.get("trusted").and_then(|v| v.as_object()) {
-        for (path, granted) in map {
-            // A bare string is what every release before managed panes wrote, and
-            // is still what an unmanaged file gets. Read first so an upgrade cannot
-            // forget a grant the user already made.
-            if let Some(digest) = granted.as_str() {
-                trusted.insert(path.clone(), Granted::Contents(digest.to_string()));
-            } else if let Some(object) = granted.as_object() {
-                let pin = object.get("pin").and_then(|v| v.as_str());
-                let digest = object.get("digest").and_then(|v| v.as_str());
-                match (pin, digest) {
-                    (Some(pin), Some(digest)) => {
-                        trusted.insert(
-                            path.clone(),
-                            Granted::Managed {
-                                pin: pin.to_string(),
-                                digest: digest.to_string(),
-                            },
-                        );
-                    }
-                    // A half-written grant is not one. Dropped rather than
-                    // guessed at, since guessing here means granting a capability
-                    // on the strength of a malformed file.
-                    _ => warnings.push(format!(
-                        "{}: trusted[{path}] is not a grant; ignoring it",
-                        path_display(path)
-                    )),
-                }
-            }
+    settings
+}
+
+/// The `trusted` half of `ui.json`: path → the grant made to it.
+fn read_trusted(
+    parsed: &serde_json::Value,
+    warnings: &mut Vec<String>,
+) -> BTreeMap<String, Granted> {
+    let mut trusted = BTreeMap::new();
+    let Some(map) = parsed.get("trusted").and_then(|v| v.as_object()) else {
+        return trusted;
+    };
+    for (path, granted) in map {
+        if let Some(grant) = read_grant(granted) {
+            trusted.insert(path.clone(), grant);
+        } else if granted.is_object() {
+            // A half-written grant is not one. Dropped rather than guessed at,
+            // since guessing here means granting a capability on the strength of
+            // a malformed file.
+            warnings.push(format!(
+                "{}: trusted[{path}] is not a grant; ignoring it",
+                path_display(path)
+            ));
         }
     }
-    if let Some(list) = parsed.get("disabled").and_then(|v| v.as_array()) {
-        for path in list.iter().filter_map(|v| v.as_str()) {
-            disabled.insert(path.to_string());
-        }
+    trusted
+}
+
+/// The `disabled` half of `ui.json`: the files present but not loaded.
+fn read_disabled(parsed: &serde_json::Value) -> BTreeSet<String> {
+    let Some(list) = parsed.get("disabled").and_then(|v| v.as_array()) else {
+        return BTreeSet::new();
+    };
+    list.iter()
+        .filter_map(|v| v.as_str())
+        .map(str::to_string)
+        .collect()
+}
+
+/// One `trusted` entry, in either of the two forms `ui.json` carries.
+///
+/// A bare string is what every release before managed panes wrote, and is still
+/// what an unmanaged file gets. Read first so an upgrade cannot forget a grant the
+/// user already made. `None` = malformed, for the caller to report.
+fn read_grant(granted: &serde_json::Value) -> Option<Granted> {
+    if let Some(digest) = granted.as_str() {
+        return Some(Granted::Contents(digest.to_string()));
     }
-    (bindings, settings, trusted, disabled, warnings)
+    let object = granted.as_object()?;
+    let pin = object.get("pin").and_then(|v| v.as_str())?;
+    let digest = object.get("digest").and_then(|v| v.as_str())?;
+    Some(Granted::Managed {
+        pin: pin.to_string(),
+        digest: digest.to_string(),
+    })
 }
 
 /// Bring v1's `keybindings.json` overrides forward.

--- a/src/kernel/repos.rs
+++ b/src/kernel/repos.rs
@@ -561,41 +561,61 @@ fn flatten(bookmarks: &[Bookmark], local: bool) -> Vec<BookmarkRow> {
     // shared by two folders, a folder nested inside another.
     let mut emitted: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
     for bookmark in bookmarks {
-        if !bookmark.is_parent {
-            if !covered.contains(&bookmark.repo_path) && emitted.insert(bookmark.repo_path.clone())
-            {
-                let mut it = row(&bookmark.repo_path, None, false, bookmark.is_git);
-                it.label = bookmark.label.clone();
-                rows.push(it);
-            }
-            continue;
-        }
-        if !emitted.insert(bookmark.repo_path.clone()) {
-            continue;
-        }
-        let mut header = row(&bookmark.repo_path, None, true, None);
-        header.label = bookmark.label.clone();
-        rows.push(header);
-        let parent = display(&bookmark.repo_path);
-        // Live-scanned members are repositories by construction; persisted ones
-        // carry whatever was established when they were imported.
-        let scanned_members = scanned
-            .get(&bookmark.repo_path)
-            .into_iter()
-            .flatten()
-            .map(|path| (path, Some(true)));
-        let persisted_members = persisted
-            .get(&bookmark.repo_path)
-            .into_iter()
-            .flatten()
-            .map(|child| (&child.repo_path, child.is_git));
-        for (path, is_git) in scanned_members.chain(persisted_members) {
-            if emitted.insert(path.clone()) {
-                rows.push(row(path, Some(parent.clone()), false, is_git));
-            }
+        if bookmark.is_parent {
+            push_folder(&mut rows, &mut emitted, bookmark, &scanned, &persisted);
+        } else if !covered.contains(&bookmark.repo_path) {
+            push_standalone(&mut rows, &mut emitted, bookmark);
         }
     }
     rows
+}
+
+/// One repository not covered by any folder above it.
+fn push_standalone(
+    rows: &mut Vec<BookmarkRow>,
+    emitted: &mut std::collections::HashSet<PathBuf>,
+    bookmark: &Bookmark,
+) {
+    if !emitted.insert(bookmark.repo_path.clone()) {
+        return;
+    }
+    let mut it = row(&bookmark.repo_path, None, false, bookmark.is_git);
+    it.label = bookmark.label.clone();
+    rows.push(it);
+}
+
+/// A folder header followed by its members, live-scanned ones first.
+fn push_folder(
+    rows: &mut Vec<BookmarkRow>,
+    emitted: &mut std::collections::HashSet<PathBuf>,
+    bookmark: &Bookmark,
+    scanned: &HashMap<PathBuf, Vec<PathBuf>>,
+    persisted: &HashMap<&PathBuf, Vec<&Bookmark>>,
+) {
+    if !emitted.insert(bookmark.repo_path.clone()) {
+        return;
+    }
+    let mut header = row(&bookmark.repo_path, None, true, None);
+    header.label = bookmark.label.clone();
+    rows.push(header);
+    let parent = display(&bookmark.repo_path);
+    // Live-scanned members are repositories by construction; persisted ones
+    // carry whatever was established when they were imported.
+    let scanned_members = scanned
+        .get(&bookmark.repo_path)
+        .into_iter()
+        .flatten()
+        .map(|path| (path, Some(true)));
+    let persisted_members = persisted
+        .get(&bookmark.repo_path)
+        .into_iter()
+        .flatten()
+        .map(|child| (&child.repo_path, child.is_git));
+    for (path, is_git) in scanned_members.chain(persisted_members) {
+        if emitted.insert(path.clone()) {
+            rows.push(row(path, Some(parent.clone()), false, is_git));
+        }
+    }
 }
 
 /// The git repositories directly under each folder bookmark, scanned now.

--- a/src/kernel/terminal.rs
+++ b/src/kernel/terminal.rs
@@ -717,47 +717,7 @@ impl Terminals {
             let runtime = self.runtime.clone();
             std::thread::spawn(move || {
                 let _guard = runtime.as_ref().map(|handle| handle.enter());
-                let mut readied = already_ready;
-                // Same rule attach uses: ready once per backend, and only for one
-                // a session actually lives on. An offline host fails here and is
-                // simply not discovered this round.
-                if !already_ready {
-                    match backend.ensure_ready() {
-                        Ok(()) => readied = true,
-                        Err(e) => {
-                            tracing::warn!(
-                                "could not ready {backend_name} to list its windows: {e:#}"
-                            );
-                            let _ = tx.send(Discovered {
-                                backend: backend_name,
-                                readied: false,
-                                panes: None,
-                            });
-                            return;
-                        }
-                    }
-                }
-                let panes = match backend.discover() {
-                    Ok(found) => {
-                        let mut by_name: WindowPanes = HashMap::new();
-                        for window in found {
-                            by_name
-                                .entry(window.name)
-                                .or_default()
-                                .push(window.backend_id);
-                        }
-                        Some(by_name)
-                    }
-                    Err(e) => {
-                        tracing::warn!("could not list windows on {backend_name}: {e:#}");
-                        None
-                    }
-                };
-                let _ = tx.send(Discovered {
-                    backend: backend_name,
-                    readied,
-                    panes,
-                });
+                let _ = tx.send(discover_windows(&backend, backend_name, already_ready));
             });
         }
     }
@@ -1550,6 +1510,51 @@ impl Terminals {
         // A session that went away keeps no stale title.
         self.meta.retain(|id, _| self.live.contains_key(id));
         &self.meta
+    }
+}
+
+/// One backend's window inventory, on the discovery worker.
+///
+/// Split out of [`Terminals::refresh_discovery`] so the throttle and the spawn
+/// stay readable beside the two fallible host calls this makes.
+fn discover_windows(
+    backend: &std::sync::Arc<dyn crate::agent::SessionBackend>,
+    name: String,
+    already_ready: bool,
+) -> Discovered {
+    // Same rule attach uses: ready once per backend, and only for one a session
+    // actually lives on. An offline host fails here and is simply not discovered
+    // this round.
+    if !already_ready {
+        if let Err(e) = backend.ensure_ready() {
+            tracing::warn!("could not ready {name} to list its windows: {e:#}");
+            return Discovered {
+                backend: name,
+                readied: false,
+                panes: None,
+            };
+        }
+    }
+    let panes = match backend.discover() {
+        Ok(found) => {
+            let mut by_name: WindowPanes = HashMap::new();
+            for window in found {
+                by_name
+                    .entry(window.name)
+                    .or_default()
+                    .push(window.backend_id);
+            }
+            Some(by_name)
+        }
+        Err(e) => {
+            tracing::warn!("could not list windows on {name}: {e:#}");
+            None
+        }
+    };
+    Discovered {
+        backend: name,
+        readied: true,
+        panes,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -960,490 +960,532 @@ struct App {
 impl App {
     fn run(&mut self, mut terminal: DefaultTerminal) -> Result<(), Box<dyn Error>> {
         // Consecutive input failures, reset by the first event that reads
-        // cleanly. See the poll below for why one is survivable.
+        // cleanly. See `drain_input` for why one is survivable.
         let mut input_failures: u32 = 0;
         while !self.quit {
             Counters::bump(&self.perf.iterations);
-            if self.watcher.changed() {
-                self.reload_at = Some(Instant::now() + DEBOUNCE);
+            self.poll_reload();
+            self.apply_commands(&mut terminal);
+            self.poll_command_bus();
+            self.sync_terminals_and_agents();
+            self.serve_worker_stores();
+            self.apply_external_requests();
+            self.paint_if_due(&mut terminal)?;
+            self.drain_input(&mut input_failures)?;
+        }
+        Ok(())
+    }
+
+    /// The interface directory and `settings.toml`, both edited from outside.
+    fn poll_reload(&mut self) {
+        if self.watcher.changed() {
+            self.reload_at = Some(Instant::now() + DEBOUNCE);
+        }
+        // The settings file, edited from outside. A live change is already in
+        // force by the time this returns; the other two outcomes are the ones
+        // worth saying out loud.
+        match self.config.poll() {
+            Some(thurbox::kernel::config::Reloaded::Live) => {
+                self.toast("settings reloaded".to_string());
+                self.dirty = true;
             }
-            // The settings file, edited from outside. A live change is already in
-            // force by the time this returns; the other two outcomes are the ones
-            // worth saying out loud.
-            match self.config.poll() {
-                Some(thurbox::kernel::config::Reloaded::Live) => {
-                    self.toast("settings reloaded".to_string());
+            Some(thurbox::kernel::config::Reloaded::NeedsRestart) => {
+                self.toast("settings reloaded — some changes apply on restart".to_string());
+                self.dirty = true;
+            }
+            Some(thurbox::kernel::config::Reloaded::Failed(error)) => {
+                self.report(format!("settings: {error}"), Level::Error);
+            }
+            None => {}
+        }
+        if self.reload_at.is_some_and(|at| Instant::now() >= at) {
+            self.reload_at = None;
+            self.reload_interface();
+            self.refresh_sources();
+            self.collect_declarations();
+            self.clamp_focus();
+            self.dirty = true;
+        }
+    }
+
+    /// Commands plugins issued last frame, handed to the bus.
+    ///
+    /// Draining here rather than inside the render call is what keeps `command()`
+    /// a queue push and nothing more.
+    fn apply_commands(&mut self, terminal: &mut DefaultTerminal) {
+        for command in self.host.drain_commands() {
+            if self.apply_local_command(&command, terminal) {
+                continue;
+            }
+            self.dispatch_tracked(command);
+        }
+    }
+
+    /// The commands the loop applies itself, because they touch something no
+    /// worker thread can reach — in-process state, the tty, the interface's own
+    /// files. `true` = handled here; `false` = hand it to a worker.
+    fn apply_local_command(
+        &mut self,
+        command: &thurbox::kernel::command::Command,
+        terminal: &mut DefaultTerminal,
+    ) -> bool {
+        use thurbox::kernel::command::Command;
+        match command {
+            // Theme is applied here rather than dispatched: it mutates in-process
+            // state a worker thread cannot reach, and it is instant, so nothing is
+            // gained by making it asynchronous.
+            Command::Theme { name } => {
+                if let Err(e) = self.themes.select(name, snapshots_db().as_ref()) {
+                    self.report(e, Level::Error);
+                }
+            }
+            // Open a link, or copy it where nothing can open one — a remote
+            // session or a bare tty has no browser, and spawning an opener there
+            // goes nowhere.
+            Command::OpenLink { url } => self.open_or_copy_link(url),
+            // Editing the interface's own files. Applied here because it is two
+            // file operations and the watcher turns the write into a reload — a
+            // worker would only add a race.
+            Command::Plugin { file, edit } => self.apply_plugin_edit(file, *edit),
+            // Focus is the loop's own state, so it is applied here.
+            Command::Focus { plugin, toggle } => self.apply_focus_command(plugin, *toggle),
+            Command::Shell { session } => self.apply_shell_command(session),
+            Command::Program {
+                owner,
+                name,
+                program,
+                argv,
+                close,
+            } => self.apply_program(owner, name, program, argv, *close),
+            // The editor wants a controlling tty, which only this thread can hand
+            // it — see `Command::Editor`.
+            Command::Editor { session } => self.apply_editor_command(session, terminal),
+            Command::Diff { session } => {
+                // Drop the answer; the request at the top of the next iteration
+                // recomputes it on the worker.
+                self.diffs.invalidate(session);
+                self.dirty = true;
+            }
+            // Copy needs the vt100 screen and the tty, neither of which a worker
+            // thread can reach.
+            Command::Copy { session } => self.apply_copy_command(session),
+            // Settings live in the registry, which is in-process too.
+            Command::Setting { key, value } => {
+                let (plugin, id) = key.split_once('.').unwrap_or((key.as_str(), ""));
+                if let Err(e) = self.registry.set_setting(plugin, id, value.clone()) {
+                    self.report(e, Level::Error);
+                }
+            }
+            // Repository memory is a read the flow also writes, so note the write
+            // and drop the cached rows when it lands. Still dispatched.
+            Command::Bookmark { .. } => {
+                self.bookmark_in_flight = true;
+                return false;
+            }
+            _ => return false,
+        }
+        true
+    }
+
+    /// `Command::Focus`: move focus, or return whence it came.
+    fn apply_focus_command(&mut self, plugin: &str, toggle: bool) {
+        let Some(index) = self.host.index_of(plugin) else {
+            return;
+        };
+        let position = self
+            .host
+            .focusable()
+            .iter()
+            .position(|candidate| *candidate == index);
+        // Already here, and asked to toggle: go back where the last focus change
+        // came from. That memory is `focus_return`, which is the same one `Esc`
+        // uses — so a pane reached by its own key leaves by either.
+        if toggle && position == Some(self.focus) {
+            let back = self.focus_return;
+            if self.host.focusable().get(back).is_some() {
+                self.focus_return = self.focus;
+                self.focus = back;
+                self.dirty = true;
+            }
+            return;
+        }
+        // Through `focus_plugin`, not by assigning `focus`: it records where focus
+        // came from, and holds a request for a slot the arrangement has not placed
+        // yet rather than refusing it (`kernel::focus::defer_until_placed`) —
+        // which is what a pane opening itself needs. Assigning directly skipped
+        // both, so a pane reached from a plugin command could not be left with
+        // `Esc`.
+        self.focus_plugin(index);
+        self.dirty = true;
+    }
+
+    /// `Command::Shell`: a companion shell beside a session's agent.
+    fn apply_shell_command(&mut self, session: &str) {
+        let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+        // Resolved from the snapshot rather than the live
+        // `Session`: an adopted one carries no cwd of its own.
+        let cwd = self
+            .snapshots
+            .current()
+            .session(session)
+            .and_then(|row| self.terminals.launch_cwd(row));
+        if let Err(e) = self
+            .terminals
+            .open_shell(session, rows, cols, cwd.as_deref())
+        {
+            self.report(format!("could not open a shell: {e}"), Level::Error);
+        } else {
+            // Its window outlives this process, so the id has to
+            // as well — otherwise the next start forgets the
+            // shell and orphans the window it left running.
+            self.remember_shell(session);
+        }
+    }
+
+    /// `Command::Editor`: hand the configured editor this thread's tty.
+    fn apply_editor_command(&mut self, session: &str, terminal: &mut DefaultTerminal) {
+        let dirs = self
+            .snapshots
+            .current()
+            .session(session)
+            .map(|row| row.member_dirs.clone())
+            .unwrap_or_default();
+        self.toast(match open_editor(terminal, &dirs) {
+            Ok(message) => message,
+            Err(e) => e,
+        });
+    }
+
+    /// `Command::Copy`: the focused session's visible screen to the clipboard.
+    fn apply_copy_command(&mut self, session: &str) {
+        match self.terminals.visible_text(session) {
+            Some(text) => {
+                let outcome = thurbox::clipboard::copy(
+                    &text,
+                    self.clipboard.as_mut(),
+                    thurbox::session::settings::global().clipboard.provider,
+                );
+                self.toast(match outcome {
+                    Ok(route) => {
+                        format!(
+                            "copied {} lines{}",
+                            text.lines().count(),
+                            route.toast_suffix()
+                        )
+                    }
+                    Err(e) => format!("copy failed: {e}"),
+                });
+            }
+            None => self.report(
+                "nothing to copy — this session has no live terminal yet",
+                Level::Error,
+            ),
+        }
+    }
+
+    /// The command bus, and the snapshot a finished command invalidates.
+    fn poll_command_bus(&mut self) {
+        // A completed command changes what the rows say, so refresh at once
+        // rather than waiting out the interval — that is what makes a
+        // delete feel immediate instead of arriving up to 400ms later.
+        if self.commands.poll() {
+            self.report_finished_commands();
+            // A session you just asked for is the one you want to be looking at.
+            // The id is knowable only once the spawn finished, so it arrives with
+            // the completion rather than with the command — and the list follows
+            // an id until it appears, which is what carries this across the
+            // frames between "created" and "in the snapshot". Of several
+            // finishing at once the last to finish wins; there is one caret and
+            // one selection either way.
+            if let Some(created) = self.commands.take_created().pop() {
+                self.focus_on_session(&created);
+            }
+            // Wait for the last one: two adds in quick succession would
+            // otherwise re-read between them and publish a list missing the
+            // second.
+            if self.bookmark_in_flight
+                && !self
+                    .commands
+                    .inflight()
+                    .iter()
+                    .any(|item| item.kind == "bookmark")
+            {
+                self.bookmark_in_flight = false;
+                self.repos.invalidate_bookmarks();
+            }
+            self.snapshots.refresh();
+            self.dirty = true;
+        } else {
+            self.snapshots.refresh_if_due();
+        }
+    }
+
+    /// Terminals and agents, plus the per-tick derivations that read them.
+    fn sync_terminals_and_agents(&mut self) {
+        // Attach to any session that gained a pane, and drop the ones that
+        // went away. Sized to the screen as a starting point; each surface
+        // resizes its own pane to its real rect when it paints.
+        let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+        self.terminals.sync(self.snapshots.current(), rows, cols);
+        // New agent output, noticed the way v1 notices it: one lock-free sum
+        // of atomics per iteration, marking the screen dirty. Without this a
+        // printing agent is drawn only when the 250ms floor comes round.
+        let output_gen = self.terminals.output_generation();
+        if output_gen != self.last_output_gen {
+            self.last_output_gen = output_gen;
+            self.dirty = true;
+        }
+        // The stuck-`working` fallback, run here because it asks the
+        // terminals a question and they have just been synced — and run
+        // every tick rather than at refresh, because output moves between
+        // two reads of the database.
+        let terminals = &self.terminals;
+        if self
+            .snapshots
+            .apply_output_quiescence(|id| terminals.millis_since_output(id))
+            > 0
+        {
+            self.dirty = true;
+        }
+        // A session whose agent is gone gets it back, which is what v1 does
+        // at restore and what makes a session survive a reboot.
+        self.respawn_missing_agents();
+        // And the shell it had open, whose window outlived the interface.
+        self.readopt_shells();
+        // Programs plugins asked for. Served here because resolving a
+        // session to a directory and a machine is the loop's knowledge, not
+        // a store's — the store owns the bounds and the queue.
+        self.serve_runs();
+        // A remote agent's hooks cannot call `thurbox-cli` — they set a tmux pane
+        // option, which arrives here over the control-mode subscription. Draining
+        // it into the same columns a local signal writes is the whole of remote
+        // status: the dot, the acknowledgment and the notification are all
+        // downstream of that one write.
+        let events = self.terminals.drain_hook_events();
+        if !events.is_empty() && self.snapshots.apply_hook_states(events, Instant::now()) > 0 {
+            self.dirty = true;
+        }
+    }
+
+    /// The worker-backed stores: diffs, repository reads, the deletion reaper,
+    /// update checks and metrics.
+    fn serve_worker_stores(&mut self) {
+        // The selected session's diff, computed on a worker. Requesting is
+        // idempotent, so calling it every frame costs nothing after the
+        // first.
+        //
+        // Driven by the *selection*, not by `focused_session`: the latter is
+        // re-derived each frame from the focused plugin's session surface, so
+        // only a pane drawing a terminal ever asked for one. A pane that shows
+        // a diff draws no terminal by definition, and would never be handed the
+        // thing it exists to show. The selection is what "the session the user
+        // is looking at" actually means, and the session list publishes it.
+        let wanted = self
+            .host
+            .shared_string("selected")
+            .or_else(|| self.focused_session.clone());
+        if let Some(id) = wanted {
+            if let Some(row) = self.snapshots.current().session(&id) {
+                if let Some(cwd) = row.cwd.clone() {
+                    // `base_branch`, never `branch`. Against its own branch a
+                    // session diffs to nothing, and publishing that as `ready`
+                    // is a confident wrong answer.
+                    self.diffs
+                        .request(&id, cwd, row.base_branch.clone(), &row.backend);
+                }
+            }
+        }
+        if self.diffs.poll() {
+            self.dirty = true;
+        }
+
+        // The creation flow's reads. It asks by leaving a key in `store`,
+        // which is written the moment its handler runs, so a request made
+        // on a keystroke is served on the very next iteration. Requesting
+        // is idempotent, so asking every iteration costs three lookups.
+        let wants = self.repo_wants();
+        self.repos.serve(&wants);
+        if self.repos.poll() {
+            self.dirty = true;
+        }
+
+        // A session that has stayed deleted past its undo window keeps its
+        // worktrees and loses its agent — the reap v1 does when the undo
+        // expires.
+        for session in self
+            .reaper
+            .observe(self.snapshots.current(), Instant::now())
+        {
+            self.commands
+                .dispatch(thurbox::kernel::command::Command::Reap { session });
+        }
+
+        // An update that replaced binaries is worth saying once; a check that
+        // merely found a release shows up in the header instead.
+        if let Some(message) = self.updates.poll() {
+            self.toast(message);
+        }
+
+        // Machine, statusline and account metrics. Both calls are gated
+        // internally (an interval, and one sample in flight at a time), so
+        // running them every iteration costs a comparison.
+        self.metrics.sample(self.metric_subjects());
+        if self.metrics.poll() {
+            self.dirty = true;
+        }
+    }
+
+    /// State another process left for this one, and the notifications that
+    /// follow from it.
+    fn apply_external_requests(&mut self) {
+        // A focus request from another process: a clicked notification's
+        // action callback, or `thurbox-cli session focus`, both of which
+        // leave a row in the database for whoever is running the interface.
+        // Taken atomically, so two instances cannot both claim it.
+        if let Some(id) = self.snapshots.take_focus_request() {
+            self.focus_on_session(&id);
+        }
+
+        // Acknowledge a finished turn on the way out of it: moving the
+        // selection off a `done` session is what retires its filled dot.
+        // Read from the store because the selection belongs to the session
+        // list, which is a plugin.
+        let selected = self.host.shared_string("selected");
+        if selected != self.last_selected_session {
+            if let Some(left) = self.last_selected_session.take() {
+                self.snapshots.acknowledge(&left);
+            }
+            self.last_selected_session = selected;
+            self.dirty = true;
+        }
+
+        // Notify on the blocked edge, observed where status is read so the
+        // rule cannot drift from what the list shows.
+        self.notifier
+            .observe(self.snapshots.current(), self.focused_session.as_deref());
+    }
+
+    /// Demand-driven paint: when something changed, or when the forced-redraw
+    /// floor elapsed.
+    ///
+    /// `draw` diffs each plugin's tree and clears `dirty` when every one matched,
+    /// so an idle screen settles at the floor.
+    fn paint_if_due(&mut self, terminal: &mut DefaultTerminal) -> Result<(), Box<dyn Error>> {
+        let since_paint = self.last_paint.elapsed();
+        let due = self.dirty && since_paint >= MIN_FRAME_INTERVAL;
+        if due || since_paint >= FORCE_REDRAW_INTERVAL {
+            // Published HERE rather than every iteration: a plugin only reads
+            // `thurbox.*` while it renders, so rebuilding those tables on a tick
+            // that paints nothing is pure waste. At `drain_input`'s 10ms poll
+            // that was 100 rebuilds a second to feed a screen that redraws four
+            // times.
+            self.republish();
+            let painted = terminal.draw(|frame| self.draw(frame))?;
+            // Cloned so the borrow of `terminal` ends here: the two
+            // corrections below both need it back.
+            let buffer = painted.buffer.clone();
+            // A modal captures input, so it owns the caret — or nothing
+            // does. The panes underneath still draw, and one with a text
+            // field claims the cursor as it goes; a frame that ends with a
+            // cursor position SHOWS it, so it would blink behind the modal,
+            // which reads as the screen refreshing wrongly rather than as a
+            // misplaced cursor. Corrected after the frame because a `Frame`'s
+            // cursor can be set but never unset, and the modal draws last.
+            if self.modals.is_open() {
+                match self.modals.caret() {
+                    Some(position) => {
+                        terminal.show_cursor()?;
+                        terminal.set_cursor_position(position)?;
+                    }
+                    None => terminal.hide_cursor()?,
+                }
+            }
+            // After the backend flushed, so the escapes cannot interleave
+            // with ratatui's own output.
+            self.paint_terminal_hyperlinks(&buffer);
+            self.last_paint = Instant::now();
+            self.frames += 1;
+            Counters::bump(&self.perf.frames);
+        } else {
+            Counters::bump(&self.perf.skipped);
+        }
+        Ok(())
+    }
+
+    /// Drain EVERY pending event, not one per iteration, and dispatch each.
+    ///
+    /// Reading one event per 10ms poll cannot keep up with a mouse: a single drag
+    /// emits events far faster than 100/s, so the queue grew without bound. That
+    /// is felt as an unresponsive mouse, and the backlog outlives the process —
+    /// the leftover reports are what printed `\x1b[<35;92;31M` into the terminal
+    /// afterwards.
+    ///
+    /// The batch is also what `thurbox.*` is published for: once, before the first
+    /// event that runs Lua, rather than once per event. A handler has to read
+    /// something current, and nothing between two events of one batch can change
+    /// what it would say — the snapshot is refreshed at the top of the iteration,
+    /// and a command a handler queues is drained on the next one. Per event, a
+    /// held-down key paid for the whole publish (every session's links, the
+    /// interface inventory, the plugin lock) on every repeat.
+    fn drain_input(&mut self, input_failures: &mut u32) -> Result<(), Box<dyn Error>> {
+        let mut published = false;
+        let mut waited = false;
+        loop {
+            // Only the first read waits; the rest take what is already queued.
+            let timeout = if waited { Duration::ZERO } else { TICK };
+            waited = true;
+            let event = match next_event(timeout) {
+                Ok(Some(event)) => {
+                    *input_failures = 0;
+                    event
+                }
+                Ok(None) => break,
+                // Input is not worth the process. A terminal can hand
+                // crossterm a sequence it cannot parse — a burst of keys
+                // interleaving with a mouse report is enough — and
+                // propagating that error exited thurbox with every session
+                // detached. Logged, dropped, and retried next iteration; only
+                // a stream that keeps failing (a closed stdin, say) is fatal,
+                // since polling a dead terminal would otherwise spin.
+                Err(e) => {
+                    *input_failures += 1;
+                    tracing::warn!("reading input failed: {e}");
+                    if *input_failures > INPUT_FAILURE_LIMIT {
+                        return Err(Box::new(e));
+                    }
+                    break;
+                }
+            };
+            match event {
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    self.publish_for_batch(&mut published);
+                    self.on_key(&key);
                     self.dirty = true;
                 }
-                Some(thurbox::kernel::config::Reloaded::NeedsRestart) => {
-                    self.toast("settings reloaded — some changes apply on restart".to_string());
+                // Dropped rather than merely uncaptured when the feature is
+                // off, so the flag stays authoritative even if a terminal
+                // reports mouse events unasked. v1 does the same in
+                // `App::update`.
+                Event::Mouse(mouse) if self.mouse => {
+                    self.publish_for_batch(&mut published);
+                    self.on_mouse(mouse);
                     self.dirty = true;
                 }
-                Some(thurbox::kernel::config::Reloaded::Failed(error)) => {
-                    self.report(format!("settings: {error}"), Level::Error);
+                // A bracketed paste from the terminal itself. Routed to
+                // whatever has focus, exactly as `ctrl+v` is: a modal's
+                // text field if one is open, else the focused terminal.
+                Event::Paste(text) => {
+                    self.publish_for_batch(&mut published);
+                    self.on_paste(text);
+                    self.dirty = true;
                 }
-                None => {}
-            }
-            if self.reload_at.is_some_and(|at| Instant::now() >= at) {
-                self.reload_at = None;
-                self.reload_interface();
-                self.refresh_sources();
-                self.collect_declarations();
-                self.clamp_focus();
-                self.dirty = true;
-            }
-
-            // Refreshed here, on the kernel's schedule — never inside a plugin
-            // call, which is what keeps every plugin read immediate.
-            // Commands plugins issued last frame, handed to the bus. Draining
-            // here rather than inside the render call is what keeps `command()`
-            // a queue push and nothing more.
-            for command in self.host.drain_commands() {
-                // Theme is applied here rather than dispatched: it mutates
-                // in-process state a worker thread cannot reach, and it is
-                // instant, so nothing is gained by making it asynchronous.
-                match &command {
-                    thurbox::kernel::command::Command::Theme { name } => {
-                        if let Err(e) = self.themes.select(name, snapshots_db().as_ref()) {
-                            self.report(e, Level::Error);
-                        }
-                        continue;
-                    }
-                    // Copy needs the vt100 screen and the tty, neither of
-                    // which a worker thread can reach.
-                    // Open a link, or copy it where nothing can open one —
-                    // a remote session or a bare tty has no browser, and
-                    // spawning an opener there goes nowhere.
-                    thurbox::kernel::command::Command::OpenLink { url } => {
-                        let url = url.clone();
-                        self.open_or_copy_link(&url);
-                        continue;
-                    }
-                    // Editing the interface's own files. Applied here because
-                    // it is two file operations and the watcher turns the
-                    // write into a reload — a worker would only add a race.
-                    thurbox::kernel::command::Command::Plugin { file, edit } => {
-                        let (file, edit) = (file.clone(), *edit);
-                        self.apply_plugin_edit(&file, edit);
-                        continue;
-                    }
-                    // Focus is the loop's own state, so it is applied here.
-                    thurbox::kernel::command::Command::Focus { plugin, toggle } => {
-                        if let Some(index) = self.host.index_of(plugin) {
-                            let position = self
-                                .host
-                                .focusable()
-                                .iter()
-                                .position(|candidate| *candidate == index);
-                            // Already here, and asked to toggle: go back where the
-                            // last focus change came from. That memory is
-                            // `focus_return`, which is the same one `Esc` uses — so
-                            // a pane reached by its own key leaves by either.
-                            if *toggle && position == Some(self.focus) {
-                                let back = self.focus_return;
-                                if self.host.focusable().get(back).is_some() {
-                                    self.focus_return = self.focus;
-                                    self.focus = back;
-                                    self.dirty = true;
-                                }
-                            } else {
-                                // Through `focus_plugin`, not by assigning `focus`:
-                                // it records where focus came from, and holds a
-                                // request for a slot the arrangement has not
-                                // placed yet rather than refusing it
-                                // (`kernel::focus::defer_until_placed`) — which is
-                                // what a pane opening itself needs. Assigning
-                                // directly skipped both, so a pane reached from a
-                                // plugin command could not be left with `Esc`.
-                                self.focus_plugin(index);
-                                self.dirty = true;
-                            }
-                        }
-                        continue;
-                    }
-                    thurbox::kernel::command::Command::Shell { session } => {
-                        let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
-                        let session = session.clone();
-                        // Resolved from the snapshot rather than the live
-                        // `Session`: an adopted one carries no cwd of its own.
-                        let cwd = self
-                            .snapshots
-                            .current()
-                            .session(&session)
-                            .and_then(|row| self.terminals.launch_cwd(row));
-                        if let Err(e) =
-                            self.terminals
-                                .open_shell(&session, rows, cols, cwd.as_deref())
-                        {
-                            self.report(format!("could not open a shell: {e}"), Level::Error);
-                        } else {
-                            // Its window outlives this process, so the id has to
-                            // as well — otherwise the next start forgets the
-                            // shell and orphans the window it left running.
-                            self.remember_shell(&session);
-                        }
-                        continue;
-                    }
-                    thurbox::kernel::command::Command::Program {
-                        owner,
-                        name,
-                        program,
-                        argv,
-                        close,
-                    } => {
-                        self.apply_program(owner, name, program, argv, *close);
-                        continue;
-                    }
-                    // The editor wants a controlling tty, which only this
-                    // thread can hand it — see `Command::Editor`.
-                    thurbox::kernel::command::Command::Editor { session } => {
-                        let dirs = self
-                            .snapshots
-                            .current()
-                            .session(session)
-                            .map(|row| row.member_dirs.clone())
-                            .unwrap_or_default();
-                        self.toast(match open_editor(&mut terminal, &dirs) {
-                            Ok(message) => message,
-                            Err(e) => e,
-                        });
-                        continue;
-                    }
-                    thurbox::kernel::command::Command::Diff { session } => {
-                        // Drop the answer; the request at the top of the next
-                        // iteration recomputes it on the worker.
-                        self.diffs.invalidate(session);
-                        self.dirty = true;
-                        continue;
-                    }
-                    thurbox::kernel::command::Command::Copy { session } => {
-                        match self.terminals.visible_text(session) {
-                            Some(text) => {
-                                let outcome = thurbox::clipboard::copy(
-                                    &text,
-                                    self.clipboard.as_mut(),
-                                    thurbox::session::settings::global().clipboard.provider,
-                                );
-                                self.toast(match outcome {
-                                    Ok(route) => {
-                                        format!(
-                                            "copied {} lines{}",
-                                            text.lines().count(),
-                                            route.toast_suffix()
-                                        )
-                                    }
-                                    Err(e) => format!("copy failed: {e}"),
-                                });
-                            }
-                            None => self.report(
-                                "nothing to copy — this session has no live terminal yet",
-                                Level::Error,
-                            ),
-                        }
-                        continue;
-                    }
-                    // Settings live in the registry, which is in-process too.
-                    thurbox::kernel::command::Command::Setting { key, value } => {
-                        let (plugin, id) = key.split_once('.').unwrap_or((key.as_str(), ""));
-                        if let Err(e) = self.registry.set_setting(plugin, id, value.clone()) {
-                            self.report(e, Level::Error);
-                        }
-                        continue;
-                    }
-                    // Repository memory is a read the flow also writes, so
-                    // note the write and drop the cached rows when it lands.
-                    thurbox::kernel::command::Command::Bookmark { .. } => {
-                        self.bookmark_in_flight = true;
-                    }
-                    _ => {}
-                }
-                self.dispatch_tracked(command.clone());
-            }
-            // A completed command changes what the rows say, so refresh at once
-            // rather than waiting out the interval — that is what makes a
-            // delete feel immediate instead of arriving up to 400ms later.
-            if self.commands.poll() {
-                self.report_finished_commands();
-                // A session you just asked for is the one you want to be
-                // looking at. The id is knowable only once the spawn finished,
-                // so it arrives with the completion rather than with the
-                // command — and the list follows an id until it appears, which
-                // is what carries this across the frames between "created" and
-                // "in the snapshot". Of several finishing at once the last to
-                // finish wins; there is one caret and one selection either way.
-                if let Some(created) = self.commands.take_created().pop() {
-                    self.focus_on_session(&created);
-                }
-                // Wait for the last one: two adds in quick succession would
-                // otherwise re-read between them and publish a list missing the
-                // second.
-                if self.bookmark_in_flight
-                    && !self
-                        .commands
-                        .inflight()
-                        .iter()
-                        .any(|item| item.kind == "bookmark")
-                {
-                    self.bookmark_in_flight = false;
-                    self.repos.invalidate_bookmarks();
-                }
-                self.snapshots.refresh();
-                self.dirty = true;
-            } else {
-                self.snapshots.refresh_if_due();
-            }
-            // Attach to any session that gained a pane, and drop the ones that
-            // went away. Sized to the screen as a starting point; each surface
-            // resizes its own pane to its real rect when it paints.
-            let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
-            self.terminals.sync(self.snapshots.current(), rows, cols);
-            // A remote agent's hooks cannot call `thurbox-cli` — they set a tmux
-            // pane option, which arrives here over the control-mode
-            // subscription. Draining it into the same columns a local signal
-            // writes is the whole of remote status: the dot, the acknowledgment
-            // and the notification are all downstream of that one write.
-            // New agent output, noticed the way v1 notices it: one lock-free sum
-            // of atomics per iteration, marking the screen dirty. Without this a
-            // printing agent is drawn only when the 250ms floor comes round.
-            let output_gen = self.terminals.output_generation();
-            if output_gen != self.last_output_gen {
-                self.last_output_gen = output_gen;
-                self.dirty = true;
-            }
-            // The stuck-`working` fallback, run here because it asks the
-            // terminals a question and they have just been synced — and run
-            // every tick rather than at refresh, because output moves between
-            // two reads of the database.
-            let terminals = &self.terminals;
-            if self
-                .snapshots
-                .apply_output_quiescence(|id| terminals.millis_since_output(id))
-                > 0
-            {
-                self.dirty = true;
-            }
-            // A session whose agent is gone gets it back, which is what v1 does
-            // at restore and what makes a session survive a reboot.
-            self.respawn_missing_agents();
-            // And the shell it had open, whose window outlived the interface.
-            self.readopt_shells();
-            // Programs plugins asked for. Served here because resolving a
-            // session to a directory and a machine is the loop's knowledge, not
-            // a store's — the store owns the bounds and the queue.
-            self.serve_runs();
-            let events = self.terminals.drain_hook_events();
-            if !events.is_empty() && self.snapshots.apply_hook_states(events, Instant::now()) > 0 {
-                self.dirty = true;
-            }
-            // The selected session's diff, computed on a worker. Requesting is
-            // idempotent, so calling it every frame costs nothing after the
-            // first.
-            //
-            // Driven by the *selection*, not by `focused_session`: the latter is
-            // re-derived each frame from the focused plugin's session surface, so
-            // only a pane drawing a terminal ever asked for one. A pane that shows
-            // a diff draws no terminal by definition, and would never be handed the
-            // thing it exists to show. The selection is what "the session the user
-            // is looking at" actually means, and the session list publishes it.
-            let wanted = self
-                .host
-                .shared_string("selected")
-                .or_else(|| self.focused_session.clone());
-            if let Some(id) = wanted {
-                if let Some(row) = self.snapshots.current().session(&id) {
-                    if let Some(cwd) = row.cwd.clone() {
-                        // `base_branch`, never `branch`. Against its own branch a
-                        // session diffs to nothing, and publishing that as `ready`
-                        // is a confident wrong answer.
-                        self.diffs
-                            .request(&id, cwd, row.base_branch.clone(), &row.backend);
-                    }
-                }
-            }
-            if self.diffs.poll() {
-                self.dirty = true;
-            }
-
-            // The creation flow's reads. It asks by leaving a key in `store`,
-            // which is written the moment its handler runs, so a request made
-            // on a keystroke is served on the very next iteration. Requesting
-            // is idempotent, so asking every iteration costs three lookups.
-            let wants = self.repo_wants();
-            self.repos.serve(&wants);
-            if self.repos.poll() {
-                self.dirty = true;
-            }
-
-            // A session that has stayed deleted past its undo window keeps its
-            // worktrees and loses its agent — the reap v1 does when the undo
-            // expires.
-            for session in self
-                .reaper
-                .observe(self.snapshots.current(), Instant::now())
-            {
-                self.commands
-                    .dispatch(thurbox::kernel::command::Command::Reap { session });
-            }
-
-            // An update that replaced binaries is worth saying once; a check that
-            // merely found a release shows up in the header instead.
-            if let Some(message) = self.updates.poll() {
-                self.toast(message);
-            }
-
-            // Machine, statusline and account metrics. Both calls are gated
-            // internally (an interval, and one sample in flight at a time), so
-            // running them every iteration costs a comparison.
-            self.metrics.sample(self.metric_subjects());
-            if self.metrics.poll() {
-                self.dirty = true;
-            }
-
-            // A focus request from another process: a clicked notification's
-            // action callback, or `thurbox-cli session focus`, both of which
-            // leave a row in the database for whoever is running the interface.
-            // Taken atomically, so two instances cannot both claim it.
-            if let Some(id) = self.snapshots.take_focus_request() {
-                self.focus_on_session(&id);
-            }
-
-            // Acknowledge a finished turn on the way out of it: moving the
-            // selection off a `done` session is what retires its filled dot.
-            // Read from the store because the selection belongs to the session
-            // list, which is a plugin.
-            let selected = self.host.shared_string("selected");
-            if selected != self.last_selected_session {
-                if let Some(left) = self.last_selected_session.take() {
-                    self.snapshots.acknowledge(&left);
-                }
-                self.last_selected_session = selected;
-                self.dirty = true;
-            }
-
-            // Notify on the blocked edge, observed where status is read so the
-            // rule cannot drift from what the list shows.
-            self.notifier
-                .observe(self.snapshots.current(), self.focused_session.as_deref());
-
-            // Demand-driven: paint when something changed, or when the floor
-            // elapsed. `draw` diffs each plugin's tree and clears `dirty` when
-            // every one matched, so an idle screen settles at the floor.
-            let since_paint = self.last_paint.elapsed();
-            let due = self.dirty && since_paint >= MIN_FRAME_INTERVAL;
-            if due || since_paint >= FORCE_REDRAW_INTERVAL {
-                // Published HERE rather than every iteration: a plugin only
-                // reads `thurbox.*` while it renders, so rebuilding those
-                // tables on a tick that paints nothing is pure waste. At the
-                // 10ms poll above that was 100 rebuilds a second to feed a
-                // screen that redraws four times.
-                self.republish();
-                let painted = terminal.draw(|frame| self.draw(frame))?;
-                // Cloned so the borrow of `terminal` ends here: the two
-                // corrections below both need it back.
-                let buffer = painted.buffer.clone();
-                // A modal captures input, so it owns the caret — or nothing
-                // does. The panes underneath still draw, and one with a text
-                // field claims the cursor as it goes; a frame that ends with a
-                // cursor position SHOWS it, so it would blink behind the modal,
-                // which reads as the screen refreshing wrongly rather than as a
-                // misplaced cursor. Corrected after the frame because a `Frame`'s
-                // cursor can be set but never unset, and the modal draws last.
-                if self.modals.is_open() {
-                    match self.modals.caret() {
-                        Some(position) => {
-                            terminal.show_cursor()?;
-                            terminal.set_cursor_position(position)?;
-                        }
-                        None => terminal.hide_cursor()?,
-                    }
-                }
-                // After the backend flushed, so the escapes cannot interleave
-                // with ratatui's own output.
-                self.paint_terminal_hyperlinks(&buffer);
-                self.last_paint = Instant::now();
-                self.frames += 1;
-                Counters::bump(&self.perf.frames);
-            } else {
-                Counters::bump(&self.perf.skipped);
-            }
-
-            // Drain EVERY pending event, not one per iteration.
-            //
-            // Reading one event per 10ms poll cannot keep up with a mouse: a
-            // single drag emits events far faster than 100/s, so the queue grew
-            // without bound. That is felt as an unresponsive mouse, and the
-            // backlog outlives the process — the leftover reports are what
-            // printed `\x1b[<35;92;31M` into the terminal afterwards.
-            //
-            // The batch is also what `thurbox.*` is published for: once, before
-            // the first event that runs Lua, rather than once per event. A
-            // handler has to read something current, and nothing between two
-            // events of one batch can change what it would say — the snapshot is
-            // refreshed at the top of the iteration, and a command a handler
-            // queues is drained on the next one. Per event, a held-down key paid
-            // for the whole publish (every session's links, the interface
-            // inventory, the plugin lock) on every repeat.
-            let mut published = false;
-            let mut waited = false;
-            loop {
-                // Only the first read waits; the rest take what is already queued.
-                let timeout = if waited { Duration::ZERO } else { TICK };
-                waited = true;
-                let event = match next_event(timeout) {
-                    Ok(Some(event)) => {
-                        input_failures = 0;
-                        event
-                    }
-                    Ok(None) => break,
-                    // Input is not worth the process. A terminal can hand
-                    // crossterm a sequence it cannot parse — a burst of keys
-                    // interleaving with a mouse report is enough — and
-                    // propagating that error exited thurbox with every session
-                    // detached. Logged, dropped, and retried next iteration; only
-                    // a stream that keeps failing (a closed stdin, say) is fatal,
-                    // since polling a dead terminal would otherwise spin.
-                    Err(e) => {
-                        input_failures += 1;
-                        tracing::warn!("reading input failed: {e}");
-                        if input_failures > INPUT_FAILURE_LIMIT {
-                            return Err(Box::new(e));
-                        }
-                        break;
-                    }
-                };
-                match event {
-                    Event::Key(key) if key.kind == KeyEventKind::Press => {
-                        self.publish_for_batch(&mut published);
-                        self.on_key(&key);
-                        self.dirty = true;
-                    }
-                    // Dropped rather than merely uncaptured when the feature is
-                    // off, so the flag stays authoritative even if a terminal
-                    // reports mouse events unasked. v1 does the same in
-                    // `App::update`.
-                    Event::Mouse(mouse) if self.mouse => {
-                        self.publish_for_batch(&mut published);
-                        self.on_mouse(mouse);
-                        self.dirty = true;
-                    }
-                    // A bracketed paste from the terminal itself. Routed to
-                    // whatever has focus, exactly as `ctrl+v` is: a modal's
-                    // text field if one is open, else the focused terminal.
-                    Event::Paste(text) => {
-                        self.publish_for_batch(&mut published);
-                        self.on_paste(text);
-                        self.dirty = true;
-                    }
-                    Event::Resize(..) => self.dirty = true,
-                    _ => {}
-                }
+                Event::Resize(..) => self.dirty = true,
+                _ => {}
             }
         }
         Ok(())
     }
 
-    /// What the metrics sampler should measure this round: every session in the
-    /// snapshot, with the handle needed to resolve its pane's root process.
     fn metric_subjects(&self) -> Vec<Subject> {
         self.snapshots
             .current()
@@ -1771,6 +1813,136 @@ impl App {
         u16::from(live_message || !self.commands.inflight().is_empty())
     }
 
+    /// Step 2: each placed slot divides its rect among its plugins, by their
+    /// DECLARED sizes — which is why this can happen before rendering.
+    fn draw_slots(
+        &mut self,
+        frame: &mut Frame,
+        placed: &[thurbox::kernel::layout::SlotRect],
+        focused_plugin: Option<usize>,
+    ) {
+        for slot in placed {
+            // A band is a slot the KERNEL occupies: the arrangement names and
+            // places it exactly as it does a pane's region, and the contents come
+            // from here rather than from any plugin. Drawing one runs no Lua, so
+            // no plugin can break it.
+            if let Some(band) = Band::from_slot(&slot.slot) {
+                self.render_band(frame, slot.rect, band);
+                continue;
+            }
+            let members = self.host.in_slot(&slot.slot);
+            if members.is_empty() {
+                continue;
+            }
+            match self.host.slot_mode(&slot.slot) {
+                SlotMode::Switch => self.draw_switch_slot(frame, slot, &members, focused_plugin),
+                SlotMode::Stack => self.draw_stack_slot(frame, slot, &members, focused_plugin),
+            }
+        }
+    }
+
+    /// One visible occupant; the rest are alternatives waiting to be selected.
+    ///
+    /// The focused plugin wins, so tabbing into a pane brings it forward.
+    fn draw_switch_slot(
+        &mut self,
+        frame: &mut Frame,
+        slot: &thurbox::kernel::layout::SlotRect,
+        members: &[usize],
+        focused_plugin: Option<usize>,
+    ) {
+        let visible = members
+            .iter()
+            .position(|index| focused_plugin == Some(*index))
+            .unwrap_or_else(|| {
+                self.slot_selection
+                    .get(&slot.slot)
+                    .copied()
+                    .unwrap_or(0)
+                    .min(members.len().saturating_sub(1))
+            });
+        self.slot_selection.insert(slot.slot.clone(), visible);
+        if let Some(&index) = members.get(visible) {
+            self.draw_plugin(frame, index, slot.rect, focused_plugin == Some(index));
+        }
+    }
+
+    /// Every occupant, stacked vertically by declared size.
+    fn draw_stack_slot(
+        &mut self,
+        frame: &mut Frame,
+        slot: &thurbox::kernel::layout::SlotRect,
+        members: &[usize],
+        focused_plugin: Option<usize>,
+    ) {
+        let sizes: Vec<_> = members.iter().map(|i| self.host.plugins[*i].size).collect();
+        let rects = thurbox::kernel::layout::divide_slot(slot.rect, Axis::Vertical, &sizes, 0);
+        for (nth, &index) in members.iter().enumerate() {
+            let Some(&rect) = rects.get(nth) else {
+                continue;
+            };
+            if rect.width == 0 || rect.height == 0 {
+                continue;
+            }
+            self.draw_plugin(frame, index, rect, focused_plugin == Some(index));
+        }
+    }
+
+    /// Step 2b: floats, above the arrangement.
+    ///
+    /// A plugin only floats on the frames it returns a float node, so a modal
+    /// opens and closes with no separate channel for the kernel to keep in sync.
+    fn draw_floats(&mut self, frame: &mut Frame, area: Rect) {
+        self.grabbed = None;
+        self.drawn_floats.clear();
+        for index in self.host.floating() {
+            let probe = RenderContext {
+                width: area.width,
+                height: area.height,
+                focused: true,
+                elapsed: self.started.elapsed().as_secs_f64(),
+                frame: self.frames,
+            };
+            let Ok(rendered) = self.host.render(index, probe) else {
+                continue;
+            };
+            let Some(float) = rendered.float else {
+                // Not floating this frame: a closed modal draws nothing at all.
+                continue;
+            };
+            let rect = Self::float_rect(area, float);
+            // Dim what is beneath, so the float reads as above rather than
+            // merely drawn later.
+            frame.render_widget(ratatui::widgets::Clear, rect);
+            let mut hits = Vec::new();
+            paint::render_recording(frame, rect, &rendered.node, &self.terminals, &mut hits);
+            // Recorded after every pane, so a float's targets win the overlap for
+            // the same reason its cells do. Its whole rect goes in first — a
+            // click that misses every button still lands on the modal rather than
+            // on the pane it covers.
+            self.push_targets(index, Some(rect), hits);
+            // The topmost float takes input; later plugins win, matching the
+            // order they are painted in.
+            self.grabbed = Some(index);
+            // Settled like a pane, by comparing what it drew — not marked changed
+            // for simply being open. Unconditional, an open float held `dirty` set
+            // forever, so the whole interface rebuilt every Lua tree at the frame
+            // cap for as long as the creation wizard was up. A float that really
+            // does animate still repaints: the 250 ms floor paints it, its tree
+            // differs, and that marks the change.
+            let unchanged = self
+                .last_floats
+                .get(&index)
+                .is_some_and(|(last, node)| *last == rect && node == &rendered.node);
+            if !unchanged {
+                self.changed_this_frame = true;
+            }
+            self.last_floats
+                .insert(index, (rect, rendered.node.clone()));
+            self.drawn_floats.insert(index);
+        }
+    }
+
     fn draw(&mut self, frame: &mut Frame) {
         self.errors.clear();
         self.focused_session = None;
@@ -1830,108 +2002,12 @@ impl App {
         let focusable = self.host.focusable();
         let focused_plugin = focusable.get(self.focus).copied();
 
-        for slot in &placed {
-            // A band is a slot the KERNEL occupies: the arrangement names and
-            // places it exactly as it does a pane's region, and the contents come
-            // from here rather than from any plugin. Drawing one runs no Lua, so
-            // no plugin can break it.
-            if let Some(band) = Band::from_slot(&slot.slot) {
-                self.render_band(frame, slot.rect, band);
-                continue;
-            }
-            let members = self.host.in_slot(&slot.slot);
-            if members.is_empty() {
-                continue;
-            }
-            match self.host.slot_mode(&slot.slot) {
-                // One visible occupant; the rest are alternatives waiting to be
-                // selected. The focused plugin wins, so tabbing into a pane
-                // brings it forward.
-                SlotMode::Switch => {
-                    let visible = members
-                        .iter()
-                        .position(|index| focused_plugin == Some(*index))
-                        .unwrap_or_else(|| {
-                            self.slot_selection
-                                .get(&slot.slot)
-                                .copied()
-                                .unwrap_or(0)
-                                .min(members.len().saturating_sub(1))
-                        });
-                    self.slot_selection.insert(slot.slot.clone(), visible);
-                    if let Some(&index) = members.get(visible) {
-                        self.draw_plugin(frame, index, slot.rect, focused_plugin == Some(index));
-                    }
-                }
-                SlotMode::Stack => {
-                    let sizes: Vec<_> =
-                        members.iter().map(|i| self.host.plugins[*i].size).collect();
-                    let rects =
-                        thurbox::kernel::layout::divide_slot(slot.rect, Axis::Vertical, &sizes, 0);
-                    for (nth, &index) in members.iter().enumerate() {
-                        let Some(&rect) = rects.get(nth) else {
-                            continue;
-                        };
-                        if rect.width == 0 || rect.height == 0 {
-                            continue;
-                        }
-                        self.draw_plugin(frame, index, rect, focused_plugin == Some(index));
-                    }
-                }
-            }
-        }
+        self.draw_slots(frame, &placed, focused_plugin);
 
         // 2b. Floats, above the arrangement. A plugin only floats on the
         //     frames it returns a float node, so a modal opens and closes with
         //     no separate channel for the kernel to keep in sync.
-        self.grabbed = None;
-        self.drawn_floats.clear();
-        for index in self.host.floating() {
-            let probe = RenderContext {
-                width: area.width,
-                height: area.height,
-                focused: true,
-                elapsed: self.started.elapsed().as_secs_f64(),
-                frame: self.frames,
-            };
-            let Ok(rendered) = self.host.render(index, probe) else {
-                continue;
-            };
-            let Some(float) = rendered.float else {
-                // Not floating this frame: a closed modal draws nothing at all.
-                continue;
-            };
-            let rect = Self::float_rect(area, float);
-            // Dim what is beneath, so the float reads as above rather than
-            // merely drawn later.
-            frame.render_widget(ratatui::widgets::Clear, rect);
-            let mut hits = Vec::new();
-            paint::render_recording(frame, rect, &rendered.node, &self.terminals, &mut hits);
-            // Recorded after every pane, so a float's targets win the overlap
-            // for the same reason its cells do. Its whole rect goes in first —
-            // a click that misses every button still lands on the modal rather
-            // than on the pane it covers.
-            self.push_targets(index, Some(rect), hits);
-            // The topmost float takes input; later plugins win, matching the
-            // order they are painted in.
-            self.grabbed = Some(index);
-            // Settled like a pane, by comparing what it drew — not marked changed
-            // for simply being open. Unconditional, an open float held `dirty` set
-            // forever, so the whole interface rebuilt every Lua tree at the frame
-            // cap for as long as the creation wizard was up. A float that really
-            // does animate still repaints: the 250 ms floor paints it, its tree
-            // differs, and that marks the change.
-            let unchanged = self
-                .last_floats
-                .get(&index)
-                .is_some_and(|(last, node)| *last == rect && node == &rendered.node);
-            if !unchanged {
-                self.changed_this_frame = true;
-            }
-            self.last_floats
-                .insert(index, (rect, rendered.node.clone()));
-            self.drawn_floats.insert(index);
-        }
+        self.draw_floats(frame, area);
 
         // System modals, above the arrangement and above every plugin float —
         // they are not in the layout, so nothing below could shrink them and
@@ -2128,293 +2204,116 @@ impl App {
             frame: self.frames,
         };
         Counters::bump(&self.perf.renders);
-        match self.host.render(index, ctx) {
-            Ok(rendered) => {
-                let node = rendered.node;
-                // A plugin that floats is drawn above the arrangement instead,
-                // so it takes no room in its slot.
-                if rendered.float.is_some() {
-                    return;
-                }
-                if focused {
-                    // The session, for everything that is about sessions — the
-                    // focus label, the info the bands show, `Ctrl+O`.
-                    self.focused_session = node.first_session_surface().map(str::to_string);
-                    // And whatever this pane is actually showing, which is where
-                    // raw input goes. `input = "session"` never meant "the
-                    // selected session"; it meant "what this pane is showing", and
-                    // a plugin's own program is now one of the things that can be.
-                    self.focused_surface = node.first_live_surface().map(str::to_string);
-                }
-
-                // Decoration: another plugin may restyle this tree. A decorator
-                // that fails costs its decoration, not the pane — so the
-                // original is what gets drawn.
-                let slot = self.host.plugins[index].slot.clone();
-                let mut node = node;
-                for decorator in self.host.decorators_of(&slot) {
-                    match self.host.decorate(decorator, &node, ctx) {
-                        Ok(decorated) => node = decorated,
-                        Err(e) => self.errors.push(e),
-                    }
-                }
-                // A surface's cells live OUTSIDE the tree, so tree equality
-                // cannot tell whether it changed. Its own output stamp can: a
-                // pane whose agent has said nothing since the last paint is as
-                // settled as a pane of text, which is what lets a screen with a
-                // live terminal on it idle at the redraw floor instead of
-                // repainting at the frame cap forever. v1 gates the same way,
-                // off the same atomic (`detect_output_redraw`).
-                if self.last_trees.len() <= index {
-                    self.last_trees.resize(index + 1, None);
-                }
-                let surface_moved = match node.first_session_surface() {
-                    Some(surface) => {
-                        let stamp = self.terminals.output_stamp(surface);
-                        let previous = self.last_output_painted.get(surface).copied();
-                        if let Some(stamp) = stamp {
-                            self.last_output_painted.insert(surface.to_string(), stamp);
-                        }
-                        // An unattached surface has no stamp and nothing to
-                        // show, so it is settled rather than perpetually new.
-                        stamp.is_some() && previous != stamp
-                    }
-                    None => false,
-                };
-                let unchanged = self.last_trees[index].as_ref() == Some(&node) && !surface_moved;
-                if !unchanged {
-                    self.changed_this_frame = true;
-                }
-                self.last_trees[index] = Some(node.clone());
-                let mut hits = Vec::new();
-                paint::render_recording(frame, rect, &node, &self.terminals, &mut hits);
-                // The pane's own rect is only a target when focus can rest on
-                // it. A footer click must reach the pill it landed on and
-                // nothing else — v1 likewise records no `FocusPane` for panes
-                // that cannot hold focus.
-                let fallback = self.host.plugins[index].focusable.then_some(rect);
-                self.push_targets(index, fallback, hits);
-            }
+        let rendered = match self.host.render(index, ctx) {
+            Ok(rendered) => rendered,
             Err(e) => {
                 paint::render_error(frame, rect, &e.plugin, &e.message);
                 Counters::bump(&self.perf.failures);
                 self.errors.push(e);
+                return;
+            }
+        };
+        // A plugin that floats is drawn above the arrangement instead, so it
+        // takes no room in its slot.
+        if rendered.float.is_some() {
+            return;
+        }
+        if focused {
+            // The session, for everything that is about sessions — the focus
+            // label, the info the bands show, `Ctrl+O`.
+            self.focused_session = rendered.node.first_session_surface().map(str::to_string);
+            // And whatever this pane is actually showing, which is where raw
+            // input goes. `input = "session"` never meant "the selected
+            // session"; it meant "what this pane is showing", and a plugin's own
+            // program is now one of the things that can be.
+            self.focused_surface = rendered.node.first_live_surface().map(str::to_string);
+        }
+
+        let node = self.decorate_tree(index, rendered.node, ctx);
+        if self.last_trees.len() <= index {
+            self.last_trees.resize(index + 1, None);
+        }
+        // Stamped unconditionally, before the tree comparison can short-circuit
+        // it: skipping the stamp on a frame whose tree changed would make the
+        // *next* frame see output that had already been painted.
+        let surface_moved = self.surface_moved(&node);
+        let unchanged = self.last_trees[index].as_ref() == Some(&node) && !surface_moved;
+        if !unchanged {
+            self.changed_this_frame = true;
+        }
+        self.last_trees[index] = Some(node.clone());
+        let mut hits = Vec::new();
+        paint::render_recording(frame, rect, &node, &self.terminals, &mut hits);
+        // The pane's own rect is only a target when focus can rest on it. A
+        // footer click must reach the pill it landed on and nothing else — v1
+        // likewise records no `FocusPane` for panes that cannot hold focus.
+        let fallback = self.host.plugins[index].focusable.then_some(rect);
+        self.push_targets(index, fallback, hits);
+    }
+
+    /// Let every decorator of this plugin's slot restyle its tree.
+    ///
+    /// A decorator that fails costs its decoration, not the pane — so the
+    /// original is what gets drawn.
+    fn decorate_tree(
+        &mut self,
+        index: usize,
+        node: thurbox::kernel::node::Node,
+        ctx: RenderContext,
+    ) -> thurbox::kernel::node::Node {
+        let slot = self.host.plugins[index].slot.clone();
+        let mut node = node;
+        for decorator in self.host.decorators_of(&slot) {
+            match self.host.decorate(decorator, &node, ctx) {
+                Ok(decorated) => node = decorated,
+                Err(e) => self.errors.push(e),
             }
         }
+        node
+    }
+
+    /// Whether this tree's session surface has printed since it was last
+    /// painted.
+    ///
+    /// A surface's cells live OUTSIDE the tree, so tree equality cannot tell
+    /// whether it changed. Its own output stamp can: a pane whose agent has said
+    /// nothing since the last paint is as settled as a pane of text, which is
+    /// what lets a screen with a live terminal on it idle at the redraw floor
+    /// instead of repainting at the frame cap forever. v1 gates the same way, off
+    /// the same atomic (`detect_output_redraw`).
+    fn surface_moved(&mut self, node: &thurbox::kernel::node::Node) -> bool {
+        let Some(surface) = node.first_session_surface() else {
+            return false;
+        };
+        let stamp = self.terminals.output_stamp(surface);
+        let previous = self.last_output_painted.get(surface).copied();
+        if let Some(stamp) = stamp {
+            self.last_output_painted.insert(surface.to_string(), stamp);
+        }
+        // An unattached surface has no stamp and nothing to show, so it is
+        // settled rather than perpetually new.
+        stamp.is_some() && previous != stamp
     }
 
     fn on_key(&mut self, key: &KeyEvent) {
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-
-        // A system modal takes input before anything else — that is what makes
-        // it modal rather than a pane drawn on top. Two things still get
-        // through: the escape route (quit, reload, the perf HUD), and another
-        // modal's own opening chord, since opening one closes another. While
-        // help is capturing, neither does — binding `ctrl+q` has to be
-        // possible, and the kernel can allow it because it knows the capture
-        // lasts exactly one keystroke.
-        if self.modals.is_open() {
-            if self.modals.captures_everything() {
-                self.dispatch_modal_key(key);
-                return;
-            }
-            if let Some(kind) = self.modal_chord(key) {
-                self.toggle_modal(kind);
-                return;
-            }
-            if !thurbox::kernel::modals::escapes(key) {
-                self.dispatch_modal_key(key);
-                return;
-            }
-        }
-
-        // The reserved minimum: focus, reload and quit always work, even if a
-        // plugin consumes every key it is offered.
-        //
-        // Quit is Ctrl+Q, not Ctrl+C: with a live terminal attached, Ctrl+C has
-        // to reach the agent so a turn can be interrupted. v1 reserves the same
-        // chord for the same reason.
-        match key.code {
-            KeyCode::Char('q') if ctrl => {
-                self.quit = true;
-                return;
-            }
-            // F10, not F5: v1 spends F1-F9 and F12 on real UI (F5 is the tasks
-            // panel), so the dev reload takes one of the two keys v1 leaves
-            // free rather than shadowing a pane the user expects.
-            KeyCode::F(10) => {
-                self.reload_interface();
-                self.collect_declarations();
-                self.clamp_focus();
-                return;
-            }
-            // Tab is NOT a focus key: it belongs to the agent. See RESERVED.
-            // v1 binds focus movement to Ctrl+H/Ctrl+L as well, and refuses to
-            // let a focused terminal keep either: they are how you get *out* of
-            // one, so they cannot be among the chords handed to the agent.
-            KeyCode::Char('h') if ctrl => return self.cycle_focus(-1),
-            KeyCode::Char('l') if ctrl => return self.cycle_focus(1),
-            // The HUD reports on this loop, so it is the kernel's own key
-            // rather than a plugin's — nothing a plugin does can hide it. v1
-            // spends F12 on the same thing for the same reason.
-            // The one reserved key that is a *feature*: v1 gates the HUD behind
-            // `[features] perf_hud` because opening it also turns on wall-clock
-            // timing collection, which is not free.
-            KeyCode::F(12) if self.config.features().perf_hud => {
-                self.hud = !self.hud;
-                self.dirty = true;
-                return;
-            }
-
-            // Copy and paste are reserved, like v1's: they must work from any
-            // pane, and `Ctrl+C` must not reach the agent when there is a
-            // selection to copy — that is the one case where thurbox wins the
-            // chord back from the terminal.
-            KeyCode::Char('c') if ctrl && self.selection.is_some() => {
-                // No focused session required: a selection over the session
-                // list, a modal or the footer is still a selection, and v1
-                // copies it. Only the fall-back-to-whole-screen path needs a
-                // terminal, because only a terminal HAS a screen.
-                let session = self.focused_session.clone();
-                self.copy_selection_or_screen(session.as_deref());
-                return;
-            }
-            KeyCode::Char('v') if ctrl => {
-                self.paste_into_focused();
-                return;
-            }
-            _ => {}
-        }
-
-        let press = to_press(key);
-
-        // A float takes every key while it is up — that is what makes it a
-        // modal rather than merely a pane drawn on top. The reserved chords
-        // above still work, so a modal can never trap you.
-        if let Some(plugin) = self
-            .grabbed
-            .and_then(|index| self.host.plugins.get(index))
-            .map(|plugin| plugin.name.clone())
-        {
-            let index = self.grabbed.expect("just resolved through it");
-            if let Some(action) = self
-                .registry
-                .resolve(&press, Some(&plugin))
-                .map(|b| b.action.clone())
-            {
-                match self.host.on_action(index, &action) {
-                    Ok(true) => return,
-                    Ok(false) => {}
-                    Err(e) => self.errors.push(e),
-                }
-            }
-            match self.host.on_key(index, &press) {
-                Ok(_) => {}
-                Err(e) => self.errors.push(e),
-            }
+        if self.dispatch_to_modal(key) {
             return;
         }
-
-        // A declared key first: the registry resolves the chord to an action
-        // and the plugin that owns it. This is the path that can be rebound,
-        // conflict-checked and listed in help.
-        let focused_name = self
-            .host
-            .focusable()
-            .get(self.focus)
-            .and_then(|index| self.host.plugins.get(*index))
-            .map(|plugin| plugin.name.clone());
-        if let Some((plugin, action, passthrough)) = self
-            .registry
-            .resolve(&press, focused_name.as_deref())
-            .map(|binding| {
-                (
-                    binding.plugin.clone(),
-                    binding.action.clone(),
-                    binding.passthrough,
-                )
-            })
-        {
-            // v1's terminal passthrough: a chord the agent's own line editing
-            // needs is left to the pty while a terminal has focus, and the
-            // command stays reachable from every other pane (and its F-key
-            // alternate). Gated on the bound chord, so rebinding a passthrough
-            // action onto a free key makes it work in the terminal again.
-            let defer_to_agent = passthrough
-                && self.focused_wants_session_input()
-                && is_ctrl_letter_chord(&canonical_chord(&press));
-            // A chord the kernel declared for itself opens a system modal;
-            // there is no plugin to hand it to.
-            if !defer_to_agent && plugin == thurbox::kernel::modals::OWNER {
-                if let Some(kind) = ModalKind::from_action(&action) {
-                    self.toggle_modal(kind);
-                    return;
-                }
-            }
-            if !defer_to_agent {
-                if let Some(index) = self.host.index_of(&plugin) {
-                    match self.host.on_action(index, &action) {
-                        Ok(true) => return,
-                        Ok(false) => {}
-                        Err(e) => self.errors.push(e),
-                    }
-                }
-            }
+        if self.dispatch_reserved(key) {
+            return;
         }
-
-        // Then raw keys: the focused plugin, then the non-focusable listeners.
-        let focusable = self.host.focusable();
-        let mut order: Vec<usize> = focusable.get(self.focus).copied().into_iter().collect();
-        order.extend(
-            (0..self.host.plugins.len()).filter(|index| !self.host.plugins[*index].focusable),
-        );
-
-        for index in order {
-            match self.host.on_key(index, &press) {
-                Ok(true) => return,
-                Ok(false) => {}
-                Err(e) => {
-                    // A throwing handler must not swallow the key or the app.
-                    self.errors.push(e);
-                }
-            }
+        let press = to_press(key);
+        if self.dispatch_grabbed(&press) {
+            return;
         }
-
-        // Nothing claimed it. If the focused plugin asked for raw session input
-        // and its surface names a live session, the key belongs to the agent.
-        //
-        // The kernel does not know which plugin is "the terminal": it knows one
-        // declared `input = "session"` and which session the tree it returned
-        // pointed at. Replace that plugin and this still works.
-        if self.focused_wants_session_input() {
-            if let Some(surface) = self.focused_surface.clone() {
-                if let Some(bytes) = key_to_bytes(key.code, key.modifiers) {
-                    // Whether it lands is the terminal's business; either way
-                    // the key belongs to the pane that asked for raw input and
-                    // is not offered to anything else.
-                    //
-                    // Routed by what the pane is SHOWING. A program pane's keys go
-                    // to that program and to nothing else — and a pane with nothing
-                    // behind it swallows nothing, since neither send finds a
-                    // target.
-                    let delivered = match self.terminals.program_key(&surface).cloned() {
-                        Some(program) => self.terminals.send_to_program(&program, bytes),
-                        None => self.terminals.send(&surface, bytes),
-                    };
-                    // Delivered means consumed, which is what the rule above says
-                    // and what this now enforces. Falling through sent `Esc` to a
-                    // program AND dismissed the pane under it in one keypress — a
-                    // game opening its menu on a pane nobody is looking at.
-                    //
-                    // Gated on delivery rather than on having tried, because both
-                    // sends already report it: a surface naming a session that is
-                    // no longer live must not swallow the key, or `Esc` traps the
-                    // user in a pane showing a dead terminal.
-                    if delivered {
-                        return;
-                    }
-                }
-            }
+        if self.dispatch_declared(&press) {
+            return;
+        }
+        if self.dispatch_raw(&press) {
+            return;
+        }
+        if self.dispatch_session_input(key) {
+            return;
         }
 
         // An `Esc` no pane claimed means "leave this one" — the v2 spelling of
@@ -2434,6 +2333,230 @@ impl App {
         // the theme picker -- or any pane that does not claim Esc -- killed the
         // application. Quit is Ctrl+Q, reserved at the top of this function;
         // v1 has no bare-key quit either.
+    }
+
+    /// A system modal takes input before anything else — that is what makes it
+    /// modal rather than a pane drawn on top.
+    ///
+    /// Two things still get through: the escape route (quit, reload, the perf
+    /// HUD), and another modal's own opening chord, since opening one closes
+    /// another. While help is capturing, neither does — binding `ctrl+q` has to
+    /// be possible, and the kernel can allow it because it knows the capture
+    /// lasts exactly one keystroke.
+    fn dispatch_to_modal(&mut self, key: &KeyEvent) -> bool {
+        if !self.modals.is_open() {
+            return false;
+        }
+        if self.modals.captures_everything() {
+            self.dispatch_modal_key(key);
+            return true;
+        }
+        if let Some(kind) = self.modal_chord(key) {
+            self.toggle_modal(kind);
+            return true;
+        }
+        if !thurbox::kernel::modals::escapes(key) {
+            self.dispatch_modal_key(key);
+            return true;
+        }
+        false
+    }
+
+    /// The reserved minimum: focus, reload and quit always work, even if a
+    /// plugin consumes every key it is offered.
+    ///
+    /// Quit is Ctrl+Q, not Ctrl+C: with a live terminal attached, Ctrl+C has to
+    /// reach the agent so a turn can be interrupted. v1 reserves the same chord
+    /// for the same reason.
+    fn dispatch_reserved(&mut self, key: &KeyEvent) -> bool {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        match key.code {
+            KeyCode::Char('q') if ctrl => self.quit = true,
+            // F10, not F5: v1 spends F1-F9 and F12 on real UI (F5 is the tasks
+            // panel), so the dev reload takes one of the two keys v1 leaves
+            // free rather than shadowing a pane the user expects.
+            KeyCode::F(10) => {
+                self.reload_interface();
+                self.collect_declarations();
+                self.clamp_focus();
+            }
+            // Tab is NOT a focus key: it belongs to the agent. See RESERVED.
+            // v1 binds focus movement to Ctrl+H/Ctrl+L as well, and refuses to
+            // let a focused terminal keep either: they are how you get *out* of
+            // one, so they cannot be among the chords handed to the agent.
+            KeyCode::Char('h') if ctrl => self.cycle_focus(-1),
+            KeyCode::Char('l') if ctrl => self.cycle_focus(1),
+            // The HUD reports on this loop, so it is the kernel's own key rather
+            // than a plugin's — nothing a plugin does can hide it. v1 spends F12
+            // on the same thing for the same reason.
+            // The one reserved key that is a *feature*: v1 gates the HUD behind
+            // `[features] perf_hud` because opening it also turns on wall-clock
+            // timing collection, which is not free.
+            KeyCode::F(12) if self.config.features().perf_hud => {
+                self.hud = !self.hud;
+                self.dirty = true;
+            }
+            // Copy and paste are reserved, like v1's: they must work from any
+            // pane, and `Ctrl+C` must not reach the agent when there is a
+            // selection to copy — that is the one case where thurbox wins the
+            // chord back from the terminal.
+            KeyCode::Char('c') if ctrl && self.selection.is_some() => {
+                // No focused session required: a selection over the session
+                // list, a modal or the footer is still a selection, and v1
+                // copies it. Only the fall-back-to-whole-screen path needs a
+                // terminal, because only a terminal HAS a screen.
+                let session = self.focused_session.clone();
+                self.copy_selection_or_screen(session.as_deref());
+            }
+            KeyCode::Char('v') if ctrl => self.paste_into_focused(),
+            _ => return false,
+        }
+        true
+    }
+
+    /// A float takes every key while it is up — that is what makes it a modal
+    /// rather than merely a pane drawn on top.
+    ///
+    /// The reserved chords still work, so a modal can never trap you.
+    fn dispatch_grabbed(&mut self, press: &KeyPress) -> bool {
+        let Some(plugin) = self
+            .grabbed
+            .and_then(|index| self.host.plugins.get(index))
+            .map(|plugin| plugin.name.clone())
+        else {
+            return false;
+        };
+        let index = self.grabbed.expect("just resolved through it");
+        if let Some(action) = self
+            .registry
+            .resolve(press, Some(&plugin))
+            .map(|b| b.action.clone())
+        {
+            match self.host.on_action(index, &action) {
+                Ok(true) => return true,
+                Ok(false) => {}
+                Err(e) => self.errors.push(e),
+            }
+        }
+        if let Err(e) = self.host.on_key(index, press) {
+            self.errors.push(e);
+        }
+        true
+    }
+
+    /// A declared key: the registry resolves the chord to an action and the
+    /// plugin that owns it.
+    ///
+    /// This is the path that can be rebound, conflict-checked and listed in
+    /// help. Falls through (`false`) when nothing claimed the chord — including
+    /// when it was deferred to the agent.
+    fn dispatch_declared(&mut self, press: &KeyPress) -> bool {
+        let focused_name = self
+            .host
+            .focusable()
+            .get(self.focus)
+            .and_then(|index| self.host.plugins.get(*index))
+            .map(|plugin| plugin.name.clone());
+        let Some((plugin, action, passthrough)) = self
+            .registry
+            .resolve(press, focused_name.as_deref())
+            .map(|binding| {
+                (
+                    binding.plugin.clone(),
+                    binding.action.clone(),
+                    binding.passthrough,
+                )
+            })
+        else {
+            return false;
+        };
+        // v1's terminal passthrough: a chord the agent's own line editing needs
+        // is left to the pty while a terminal has focus, and the command stays
+        // reachable from every other pane (and its F-key alternate). Gated on
+        // the bound chord, so rebinding a passthrough action onto a free key
+        // makes it work in the terminal again.
+        let defer_to_agent = passthrough
+            && self.focused_wants_session_input()
+            && is_ctrl_letter_chord(&canonical_chord(press));
+        if defer_to_agent {
+            return false;
+        }
+        // A chord the kernel declared for itself opens a system modal; there is
+        // no plugin to hand it to.
+        if plugin == thurbox::kernel::modals::OWNER {
+            if let Some(kind) = ModalKind::from_action(&action) {
+                self.toggle_modal(kind);
+                return true;
+            }
+        }
+        let Some(index) = self.host.index_of(&plugin) else {
+            return false;
+        };
+        match self.host.on_action(index, &action) {
+            Ok(true) => true,
+            Ok(false) => false,
+            Err(e) => {
+                self.errors.push(e);
+                false
+            }
+        }
+    }
+
+    /// Raw keys: the focused plugin, then the non-focusable listeners.
+    fn dispatch_raw(&mut self, press: &KeyPress) -> bool {
+        let focusable = self.host.focusable();
+        let mut order: Vec<usize> = focusable.get(self.focus).copied().into_iter().collect();
+        order.extend(
+            (0..self.host.plugins.len()).filter(|index| !self.host.plugins[*index].focusable),
+        );
+        for index in order {
+            match self.host.on_key(index, press) {
+                Ok(true) => return true,
+                Ok(false) => {}
+                // A throwing handler must not swallow the key or the app.
+                Err(e) => self.errors.push(e),
+            }
+        }
+        false
+    }
+
+    /// Nothing claimed it. If the focused plugin asked for raw session input and
+    /// its surface names a live session, the key belongs to the agent.
+    ///
+    /// The kernel does not know which plugin is "the terminal": it knows one
+    /// declared `input = "session"` and which session the tree it returned
+    /// pointed at. Replace that plugin and this still works.
+    fn dispatch_session_input(&mut self, key: &KeyEvent) -> bool {
+        if !self.focused_wants_session_input() {
+            return false;
+        }
+        let Some(surface) = self.focused_surface.clone() else {
+            return false;
+        };
+        let Some(bytes) = key_to_bytes(key.code, key.modifiers) else {
+            return false;
+        };
+        // Whether it lands is the terminal's business; either way the key belongs
+        // to the pane that asked for raw input and is not offered to anything
+        // else.
+        //
+        // Routed by what the pane is SHOWING. A program pane's keys go to that
+        // program and to nothing else — and a pane with nothing behind it
+        // swallows nothing, since neither send finds a target.
+        let delivered = match self.terminals.program_key(&surface).cloned() {
+            Some(program) => self.terminals.send_to_program(&program, bytes),
+            None => self.terminals.send(&surface, bytes),
+        };
+        // Delivered means consumed, which is what the rule above says and what
+        // this now enforces. Falling through sent `Esc` to a program AND
+        // dismissed the pane under it in one keypress — a game opening its menu
+        // on a pane nobody is looking at.
+        //
+        // Gated on delivery rather than on having tried, because both sends
+        // already report it: a surface naming a session that is no longer live
+        // must not swallow the key, or `Esc` traps the user in a pane showing a
+        // dead terminal.
+        delivered
     }
 
     /// The modal this keystroke opens, if it is one of the kernel's own chords.

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -520,36 +520,36 @@ pub fn resolve_backend(configured: NotificationBackend, probe: HostProbe) -> Del
                 DeliveryBackend::None
             }
         }
-        NotificationBackend::Auto => {
-            if probe.is_macos {
-                DeliveryBackend::Macos
-            } else if probe.is_windows {
-                // Native Windows: `powershell.exe` ships with the OS, so the
-                // WinRT toast path is always available. (Click-to-focus is not
-                // wired on Windows — the banner shows but is non-interactive.)
-                if probe.has_powershell {
-                    DeliveryBackend::WindowsToast
-                } else {
-                    DeliveryBackend::None
-                }
-            } else if probe.is_linux {
-                // Prefer dbus when a real notification daemon answers. The
-                // common WSL case has no daemon, so fall back to a Windows
-                // toast whenever interop (`powershell.exe`) is available —
-                // this also covers the unusual non-WSL Linux host with
-                // powershell on PATH, still better than dropping silently.
-                // Without either we have nothing (reported via `last_error`).
-                if probe.has_dbus_service {
-                    DeliveryBackend::Dbus
-                } else if probe.has_powershell {
-                    DeliveryBackend::WindowsToast
-                } else {
-                    DeliveryBackend::None
-                }
-            } else {
-                DeliveryBackend::None
-            }
-        }
+        NotificationBackend::Auto => resolve_auto(probe),
+    }
+}
+
+/// The `auto` half of [`resolve_backend`]: pick from what the host offers.
+fn resolve_auto(probe: HostProbe) -> DeliveryBackend {
+    let toast_or_none = |available: bool| match available {
+        true => DeliveryBackend::WindowsToast,
+        false => DeliveryBackend::None,
+    };
+    if probe.is_macos {
+        return DeliveryBackend::Macos;
+    }
+    if probe.is_windows {
+        // Native Windows: `powershell.exe` ships with the OS, so the WinRT
+        // toast path is always available. (Click-to-focus is not wired on
+        // Windows — the banner shows but is non-interactive.)
+        return toast_or_none(probe.has_powershell);
+    }
+    if !probe.is_linux {
+        return DeliveryBackend::None;
+    }
+    // Prefer dbus when a real notification daemon answers. The common WSL case
+    // has no daemon, so fall back to a Windows toast whenever interop
+    // (`powershell.exe`) is available — this also covers the unusual non-WSL
+    // Linux host with powershell on PATH, still better than dropping silently.
+    // Without either we have nothing (reported via `last_error`).
+    match probe.has_dbus_service {
+        true => DeliveryBackend::Dbus,
+        false => toast_or_none(probe.has_powershell),
     }
 }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -503,7 +503,7 @@ fn matching_dir_names(parent: &Path, prefix: &str) -> Vec<String> {
         return Vec::new();
     };
     entries
-        .filter_map(|e| e.ok())
+        .filter_map(Result::ok)
         .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
         .filter_map(|e| {
             let name = e.file_name().to_str()?.to_string();

--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -91,7 +91,7 @@ fn source_or_dest_filename<'a>(source: &'a Option<String>, dest: &'a str) -> &'a
     source.as_deref().unwrap_or_else(|| {
         std::path::Path::new(dest)
             .file_name()
-            .and_then(|s| s.to_str())
+            .and_then(std::ffi::OsStr::to_str)
             .unwrap_or(dest)
     })
 }

--- a/src/session/plugin_spec.rs
+++ b/src/session/plugin_spec.rs
@@ -289,7 +289,7 @@ pub struct PackageFile {
 
 impl PackageManifest {
     /// The file name a package manifest goes by.
-    pub const FILE: &'static str = "plugin.toml";
+    pub const FILE: &str = "plugin.toml";
 
     pub fn parse(text: &str) -> Result<Self, String> {
         let manifest: Self = toml::from_str(text).map_err(|e| e.to_string())?;

--- a/src/session/review.rs
+++ b/src/session/review.rs
@@ -332,53 +332,15 @@ pub struct ChangedFile {
 /// A binary file's counts arrive as `-`, which is not zero and not a number; such a
 /// file is reported with zero counts rather than dropped, since it did change.
 pub fn parse_changed_files(numstat_z: &str, name_status_z: &str) -> Vec<ChangedFile> {
-    let mut statuses: std::collections::BTreeMap<String, (FileStatus, Option<String>)> =
-        std::collections::BTreeMap::new();
-    let mut fields = name_status_z.split('\0').filter(|f| !f.is_empty());
-    while let Some(token) = fields.next() {
-        let status = match token.as_bytes().first() {
-            Some(b'A') => FileStatus::Added,
-            Some(b'D') => FileStatus::Deleted,
-            Some(b'R') | Some(b'C') => FileStatus::Renamed,
-            _ => FileStatus::Modified,
-        };
-        // A rename or copy names both sides; everything else names one.
-        let renamed = matches!(status, FileStatus::Renamed);
-        let first = match fields.next() {
-            Some(path) => path,
-            None => break,
-        };
-        match renamed {
-            true => match fields.next() {
-                Some(new_path) => {
-                    statuses.insert(new_path.to_string(), (status, Some(first.to_string())));
-                }
-                None => break,
-            },
-            false => {
-                statuses.insert(first.to_string(), (status, None));
-            }
-        }
-    }
-
+    let statuses = parse_name_status(name_status_z);
     let mut out = Vec::new();
     let mut fields = numstat_z.split('\0').filter(|f| !f.is_empty());
     while let Some(record) = fields.next() {
         let mut parts = record.split('\t');
         let added = parts.next().unwrap_or_default();
         let removed = parts.next().unwrap_or_default();
-        let path = parts.next().unwrap_or_default();
-        // An empty path field means the two following records are the old and new
-        // names; `-z` is what makes that unambiguous.
-        let path = match path.is_empty() {
-            true => {
-                let _old = fields.next();
-                match fields.next() {
-                    Some(new_path) => new_path.to_string(),
-                    None => break,
-                }
-            }
-            false => path.to_string(),
+        let Some(path) = numstat_path(parts.next().unwrap_or_default(), &mut fields) else {
+            break;
         };
         // `-` for a binary file: it changed, and it has no line counts.
         let count = |field: &str| field.parse::<usize>().unwrap_or(0);
@@ -395,6 +357,43 @@ pub fn parse_changed_files(numstat_z: &str, name_status_z: &str) -> Vec<ChangedF
         });
     }
     out
+}
+
+/// The status half of [`parse_changed_files`]: `--name-status -z` into
+/// `new path -> (status, old path)`.
+fn parse_name_status(
+    name_status_z: &str,
+) -> std::collections::BTreeMap<String, (FileStatus, Option<String>)> {
+    let mut statuses = std::collections::BTreeMap::new();
+    let mut fields = name_status_z.split('\0').filter(|f| !f.is_empty());
+    while let Some(token) = fields.next() {
+        let status = match token.as_bytes().first() {
+            Some(b'A') => FileStatus::Added,
+            Some(b'D') => FileStatus::Deleted,
+            Some(b'R') | Some(b'C') => FileStatus::Renamed,
+            _ => FileStatus::Modified,
+        };
+        let Some(first) = fields.next() else { break };
+        // A rename or copy names both sides; everything else names one.
+        if matches!(status, FileStatus::Renamed) {
+            let Some(new_path) = fields.next() else { break };
+            statuses.insert(new_path.to_string(), (status, Some(first.to_string())));
+        } else {
+            statuses.insert(first.to_string(), (status, None));
+        }
+    }
+    statuses
+}
+
+/// The path a `--numstat -z` record names. An empty path field means the two
+/// following records are the old and new names; `-z` is what makes that
+/// unambiguous. `None` = the record was truncated mid-rename.
+fn numstat_path<'a>(field: &str, fields: &mut impl Iterator<Item = &'a str>) -> Option<String> {
+    if !field.is_empty() {
+        return Some(field.to_string());
+    }
+    let _old = fields.next();
+    fields.next().map(str::to_string)
 }
 
 /// Apply a file-header metadata line (mode / rename / `---` / `+++`) to `f`,

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -46,25 +46,8 @@ pub fn run_exec_command(command: &str) -> (AutomationRunStatus, String) {
         Ok(out) => out,
         Err(e) => return (AutomationRunStatus::Error, format!("spawn failed: {e}")),
     };
-    // Keep the last 500 chars of each stream. Single pass via a capped ring so a
-    // huge stream isn't walked twice (count + skip) or materialized in full.
-    const TAIL_CHARS: usize = 500;
-    let tail = |s: &[u8]| -> String {
-        let t = String::from_utf8_lossy(s);
-        let t = t.trim();
-        let mut ring: std::collections::VecDeque<char> =
-            std::collections::VecDeque::with_capacity(TAIL_CHARS + 1);
-        for c in t.chars() {
-            if ring.len() == TAIL_CHARS {
-                ring.pop_front();
-            }
-            ring.push_back(c);
-        }
-        ring.into_iter().collect()
-    };
-    let stdout = tail(&out.stdout);
-    let stderr = tail(&out.stderr);
-    let mut detail = stdout;
+    let mut detail = exec_tail(&out.stdout);
+    let stderr = exec_tail(&out.stderr);
     if !stderr.is_empty() {
         if !detail.is_empty() {
             detail.push('\n');
@@ -72,21 +55,35 @@ pub fn run_exec_command(command: &str) -> (AutomationRunStatus, String) {
         detail.push_str(&stderr);
     }
     if out.status.success() {
-        let msg = if detail.is_empty() {
-            "ok".into()
-        } else {
-            detail
+        let msg = match detail.is_empty() {
+            true => "ok".to_string(),
+            false => detail,
         };
-        (AutomationRunStatus::Success, msg)
-    } else {
-        let code = out.status.code().map_or("signal".into(), |c| c.to_string());
-        let msg = if detail.is_empty() {
-            format!("exit {code}")
-        } else {
-            format!("exit {code}: {detail}")
-        };
-        (AutomationRunStatus::Error, msg)
+        return (AutomationRunStatus::Success, msg);
     }
+    let code = out.status.code().map_or("signal".into(), |c| c.to_string());
+    let msg = match detail.is_empty() {
+        true => format!("exit {code}"),
+        false => format!("exit {code}: {detail}"),
+    };
+    (AutomationRunStatus::Error, msg)
+}
+
+/// The trailing 500 chars of one captured stream, trimmed. Single pass via a
+/// capped ring so a huge stream isn't walked twice (count + skip) or
+/// materialized in full.
+fn exec_tail(stream: &[u8]) -> String {
+    const TAIL_CHARS: usize = 500;
+    let text = String::from_utf8_lossy(stream);
+    let mut ring: std::collections::VecDeque<char> =
+        std::collections::VecDeque::with_capacity(TAIL_CHARS + 1);
+    for c in text.trim().chars() {
+        if ring.len() == TAIL_CHARS {
+            ring.pop_front();
+        }
+        ring.push_back(c);
+    }
+    ring.into_iter().collect()
 }
 
 /// Decide whether to pass the agent's resume group vs starting fresh when

--- a/src/session_ops/spawn.rs
+++ b/src/session_ops/spawn.rs
@@ -802,42 +802,74 @@ fn rewrite_config_path_args(
         if path_under_root(&arg, config_root) {
             match map(&arg) {
                 Some(new) => out.push(new),
-                None => {
-                    tracing::warn!("dropping agent arg for remote spawn: {arg}");
-                    // A `--flag=value` token is self-contained — never a
-                    // dangling flag for the dropped path — so popping it would
-                    // eat an unrelated (possibly already-rewritten) arg.
-                    if out
-                        .last()
-                        .is_some_and(|prev| prev.starts_with('-') && !prev.contains('='))
-                    {
-                        out.pop();
-                    }
-                }
+                None => drop_path_arg(&mut out, &arg),
             }
             continue;
         }
-        // `--flag=<path>` form: rewrite the value in place, or drop the whole
-        // token (it is self-contained — nothing precedes it to pop).
-        if let Some((flag, value)) = arg.split_once('=') {
-            if flag.starts_with('-') && path_under_root(value, config_root) {
-                match map(value) {
-                    Some(new) => out.push(format!("{flag}={new}")),
-                    None => tracing::warn!("dropping agent arg for remote spawn: {arg}"),
-                }
-                continue;
-            }
+        match rewrite_flag_value(&arg, config_root, &mut map) {
+            Rewritten::Replaced(new) => out.push(new),
+            Rewritten::Unchanged => out.push(arg),
+            Rewritten::Dropped => {}
         }
-        out.push(arg);
     }
     out
+}
+
+/// Drop a bare path arg, plus the flag in front of it when the two belong
+/// together.
+///
+/// A `--flag=value` token is self-contained — never a dangling flag for the
+/// dropped path — so popping it would eat an unrelated (possibly
+/// already-rewritten) arg.
+fn drop_path_arg(out: &mut Vec<String>, arg: &str) {
+    tracing::warn!("dropping agent arg for remote spawn: {arg}");
+    if out
+        .last()
+        .is_some_and(|prev| prev.starts_with('-') && !prev.contains('='))
+    {
+        out.pop();
+    }
+}
+
+/// What [`rewrite_flag_value`] decided about one `--flag=value` token.
+enum Rewritten {
+    /// Not a config path in `--flag=value` form; keep the arg as it is.
+    Unchanged,
+    Replaced(String),
+    Dropped,
+}
+
+/// The `--flag=<path>` form: rewrite the value in place, or drop the whole token
+/// (it is self-contained — nothing precedes it to pop).
+fn rewrite_flag_value(
+    arg: &str,
+    config_root: &str,
+    map: &mut impl FnMut(&str) -> Option<String>,
+) -> Rewritten {
+    let Some((flag, value)) = arg.split_once('=') else {
+        return Rewritten::Unchanged;
+    };
+    if !flag.starts_with('-') || !path_under_root(value, config_root) {
+        return Rewritten::Unchanged;
+    }
+    match map(value) {
+        Some(new) => Rewritten::Replaced(format!("{flag}={new}")),
+        None => {
+            tracing::warn!("dropping agent arg for remote spawn: {arg}");
+            Rewritten::Dropped
+        }
+    }
 }
 
 /// A human-friendly label for a member directory in the symlink workspace:
 /// the git repo display name, falling back to the final path component.
 fn dir_label(path: &std::path::Path) -> String {
     crate::git::repo_display_name(path)
-        .or_else(|| path.file_name().and_then(|s| s.to_str()).map(String::from))
+        .or_else(|| {
+            path.file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .map(String::from)
+        })
         .unwrap_or_else(|| "repo".to_string())
 }
 

--- a/src/storage/messages.rs
+++ b/src/storage/messages.rs
@@ -408,6 +408,36 @@ mod tests {
         );
     }
 
+    /// One claimer in [`concurrent_claims_deliver_each_message_exactly_once`]:
+    /// claim until the inbox is drained, recording every id and counting any
+    /// claimed twice.
+    fn drain_inbox(
+        path: &std::path::Path,
+        to: SessionId,
+        seen: &std::sync::Mutex<std::collections::HashSet<i64>>,
+        dupes: &std::sync::Mutex<usize>,
+    ) {
+        let db = Database::open(path).unwrap();
+        loop {
+            let batch = db.claim_messages(to, Some(3)).unwrap();
+            if batch.is_empty() {
+                // Could be a transient empty between other threads' batches;
+                // confirm the inbox is actually drained before giving up.
+                if db.count_unread_messages(to).unwrap() == 0 {
+                    return;
+                }
+                continue;
+            }
+            let mut seen = seen.lock().unwrap();
+            let mut dupes = dupes.lock().unwrap();
+            for m in batch {
+                if !seen.insert(m.id) {
+                    *dupes += 1;
+                }
+            }
+        }
+    }
+
     #[test]
     fn concurrent_claims_deliver_each_message_exactly_once() {
         // A file-based DB so several Database connections share one store, then
@@ -436,25 +466,7 @@ mod tests {
             let seen = Arc::clone(&seen);
             let dupes = Arc::clone(&dupes);
             handles.push(std::thread::spawn(move || {
-                let db = Database::open(&path).unwrap();
-                loop {
-                    let batch = db.claim_messages(to, Some(3)).unwrap();
-                    if batch.is_empty() {
-                        // Could be a transient empty between other threads' batches;
-                        // confirm the inbox is actually drained before giving up.
-                        if db.count_unread_messages(to).unwrap() == 0 {
-                            break;
-                        }
-                        continue;
-                    }
-                    let mut seen = seen.lock().unwrap();
-                    let mut dupes = dupes.lock().unwrap();
-                    for m in batch {
-                        if !seen.insert(m.id) {
-                            *dupes += 1;
-                        }
-                    }
-                }
+                drain_inbox(&path, to, &seen, &dupes);
             }));
         }
         for h in handles {

--- a/tests/architecture_rules.rs
+++ b/tests/architecture_rules.rs
@@ -223,103 +223,123 @@ fn is_ident_char(b: u8) -> bool {
 
 /// Strip comments and string/char-literal contents from Rust source,
 /// preserving newlines so byte offsets still map to line numbers.
+///
+/// One `skip_*` helper per lexical form, each returning the index just past what
+/// it consumed and pushing only the newlines it swallowed.
 fn strip_comments_and_strings(src: &str) -> String {
     let bytes = src.as_bytes();
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        let b = bytes[i];
-        match b {
-            b'/' if bytes.get(i + 1) == Some(&b'/') => {
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    i += 1;
-                }
-            }
-            b'/' if bytes.get(i + 1) == Some(&b'*') => {
-                let mut depth = 1usize;
-                i += 2;
-                while i < bytes.len() && depth > 0 {
-                    if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
-                        depth += 1;
-                        i += 2;
-                    } else if bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/') {
-                        depth -= 1;
-                        i += 2;
-                    } else {
-                        if bytes[i] == b'\n' {
-                            out.push(b'\n');
-                        }
-                        i += 1;
-                    }
-                }
-            }
-            b'"' => {
-                i += 1;
-                while i < bytes.len() {
-                    match bytes[i] {
-                        b'\\' => i += 2,
-                        b'"' => {
-                            i += 1;
-                            break;
-                        }
-                        b'\n' => {
-                            out.push(b'\n');
-                            i += 1;
-                        }
-                        _ => i += 1,
-                    }
-                }
-            }
+        i = match bytes[i] {
+            b'/' if bytes.get(i + 1) == Some(&b'/') => skip_line_comment(bytes, i),
+            b'/' if bytes.get(i + 1) == Some(&b'*') => skip_block_comment(bytes, i, &mut out),
+            b'"' => skip_string(bytes, i, &mut out),
             // Raw strings: r"…", r#"…"#, br#"…"# (the `b` is consumed as a
             // normal byte before we land on the `r`).
             b'r' if !(i > 0 && is_ident_char(bytes[i - 1]) && bytes[i - 1] != b'b') => {
-                let mut j = i + 1;
-                while bytes.get(j) == Some(&b'#') {
-                    j += 1;
-                }
-                if bytes.get(j) == Some(&b'"') {
-                    let hashes = j - (i + 1);
-                    let mut close = vec![b'"'];
-                    close.extend(std::iter::repeat(b'#').take(hashes));
-                    i = j + 1;
-                    while i < bytes.len() && bytes[i..].len() >= close.len() {
-                        if bytes[i..i + close.len()] == close[..] {
-                            i += close.len();
-                            break;
-                        }
-                        if bytes[i] == b'\n' {
-                            out.push(b'\n');
-                        }
-                        i += 1;
-                    }
-                } else {
-                    out.push(b'r');
-                    i += 1;
-                }
+                skip_raw_string(bytes, i, &mut out)
             }
             // Char literal vs lifetime: 'x' / '\n' are literals; 'a is a
             // lifetime (kept — it contains no `crate::`).
-            b'\'' => {
-                if bytes.get(i + 1) == Some(&b'\\') {
-                    i += 3;
-                    while i < bytes.len() && bytes[i] != b'\'' {
-                        i += 1;
-                    }
-                    i += 1;
-                } else if bytes.get(i + 2) == Some(&b'\'') && bytes.get(i + 1) != Some(&b'\'') {
-                    i += 3;
-                } else {
-                    out.push(b'\'');
-                    i += 1;
-                }
-            }
-            _ => {
+            b'\'' => skip_char_literal(bytes, i, &mut out),
+            b => {
                 out.push(b);
-                i += 1;
+                i + 1
             }
-        }
+        };
     }
     String::from_utf8(out).expect("stripped source remains valid UTF-8")
+}
+
+/// `// …` to the end of the line. The newline itself is left for the caller.
+fn skip_line_comment(bytes: &[u8], mut i: usize) -> usize {
+    while i < bytes.len() && bytes[i] != b'\n' {
+        i += 1;
+    }
+    i
+}
+
+/// `/* … */`, nested.
+fn skip_block_comment(bytes: &[u8], mut i: usize, out: &mut Vec<u8>) -> usize {
+    let mut depth = 1usize;
+    i += 2;
+    while i < bytes.len() && depth > 0 {
+        if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
+            depth += 1;
+            i += 2;
+        } else if bytes[i] == b'*' && bytes.get(i + 1) == Some(&b'/') {
+            depth -= 1;
+            i += 2;
+        } else {
+            if bytes[i] == b'\n' {
+                out.push(b'\n');
+            }
+            i += 1;
+        }
+    }
+    i
+}
+
+/// `"…"`, honouring backslash escapes.
+fn skip_string(bytes: &[u8], mut i: usize, out: &mut Vec<u8>) -> usize {
+    i += 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2,
+            b'"' => return i + 1,
+            b'\n' => {
+                out.push(b'\n');
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    i
+}
+
+/// `r"…"` / `r#"…"#`. Not a raw string after all (a bare `r` identifier) → emit
+/// the `r` and move on.
+fn skip_raw_string(bytes: &[u8], i: usize, out: &mut Vec<u8>) -> usize {
+    let mut j = i + 1;
+    while bytes.get(j) == Some(&b'#') {
+        j += 1;
+    }
+    if bytes.get(j) != Some(&b'"') {
+        out.push(b'r');
+        return i + 1;
+    }
+    let hashes = j - (i + 1);
+    let mut close = vec![b'"'];
+    close.extend(std::iter::repeat(b'#').take(hashes));
+    let mut at = j + 1;
+    while at < bytes.len() && bytes[at..].len() >= close.len() {
+        if bytes[at..at + close.len()] == close[..] {
+            return at + close.len();
+        }
+        if bytes[at] == b'\n' {
+            out.push(b'\n');
+        }
+        at += 1;
+    }
+    at
+}
+
+/// `'x'` / `'\n'` are literals and are consumed; `'a` is a lifetime and the
+/// quote is kept, since a lifetime contains no `crate::`.
+fn skip_char_literal(bytes: &[u8], mut i: usize, out: &mut Vec<u8>) -> usize {
+    if bytes.get(i + 1) == Some(&b'\\') {
+        i += 3;
+        while i < bytes.len() && bytes[i] != b'\'' {
+            i += 1;
+        }
+        return i + 1;
+    }
+    if bytes.get(i + 2) == Some(&b'\'') && bytes.get(i + 1) != Some(&b'\'') {
+        return i + 3;
+    }
+    out.push(b'\'');
+    i + 1
 }
 
 /// Byte spans of `use …;` statements in stripped source.
@@ -331,9 +351,7 @@ fn use_spans(stripped: &str) -> Vec<(usize, usize)> {
         let start = search + found;
         search = start + 3;
         let before_ok = start == 0 || !is_ident_char(bytes[start - 1]);
-        let after_ok = bytes
-            .get(start + 3)
-            .is_some_and(|b| b.is_ascii_whitespace());
+        let after_ok = bytes.get(start + 3).is_some_and(u8::is_ascii_whitespace);
         if before_ok && after_ok {
             let end = stripped[start..]
                 .find(';')
@@ -361,33 +379,32 @@ fn brace_group_segments(bytes: &[u8], open: usize) -> Vec<String> {
     let mut expect_segment = false;
     let mut i = open;
     while i < bytes.len() {
-        let b = bytes[i];
-        if b == b'{' {
-            depth += 1;
-            expect_segment = depth == 1;
-            i += 1;
-        } else if b == b'}' {
-            depth -= 1;
-            if depth == 0 {
-                break;
-            }
-            i += 1;
-        } else if b == b',' {
-            if depth == 1 {
-                expect_segment = true;
-            }
-            i += 1;
-        } else if b.is_ascii_whitespace() {
-            i += 1;
-        } else if depth == 1 && expect_segment {
-            if is_ident_char(b) {
-                segments.push(read_ident(bytes, &mut i));
-            } else {
+        match bytes[i] {
+            b'{' => {
+                depth += 1;
+                expect_segment = depth == 1;
                 i += 1;
             }
-            expect_segment = false;
-        } else {
-            i += 1;
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+                i += 1;
+            }
+            b',' => {
+                expect_segment |= depth == 1;
+                i += 1;
+            }
+            b if depth == 1 && expect_segment && !b.is_ascii_whitespace() => {
+                if is_ident_char(b) {
+                    segments.push(read_ident(bytes, &mut i));
+                } else {
+                    i += 1;
+                }
+                expect_segment = false;
+            }
+            _ => i += 1,
         }
     }
     segments
@@ -403,26 +420,11 @@ fn crate_refs(stripped: &str) -> Vec<RefSite> {
     while let Some(found) = stripped[search..].find(TOKEN) {
         let pos = search + found;
         search = pos + TOKEN.len();
-        if pos > 0 {
-            let prev = bytes[pos - 1];
-            // Skip `$crate::` (macros) and path tails like `my_crate::`.
-            if is_ident_char(prev) || prev == b':' || prev == b'$' {
-                continue;
-            }
+        if is_crate_tail(bytes, pos) {
+            continue;
         }
-        let mut i = pos + TOKEN.len();
-        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-            i += 1;
-        }
-        let segments = if bytes.get(i) == Some(&b'{') {
-            brace_group_segments(bytes, i)
-        } else if i < bytes.len() && is_ident_char(bytes[i]) {
-            vec![read_ident(bytes, &mut i)]
-        } else {
-            Vec::new()
-        };
         let in_use = spans.iter().any(|&(s, e)| pos >= s && pos < e);
-        for segment in segments {
+        for segment in refs_after(bytes, pos + TOKEN.len()) {
             refs.push(RefSite {
                 offset: pos,
                 segment,
@@ -431,6 +433,31 @@ fn crate_refs(stripped: &str) -> Vec<RefSite> {
         }
     }
     refs
+}
+
+/// Whether the `crate::` at `pos` is really the tail of something else —
+/// `$crate::` (macros) or a path like `my_crate::`.
+fn is_crate_tail(bytes: &[u8], pos: usize) -> bool {
+    if pos == 0 {
+        return false;
+    }
+    let prev = bytes[pos - 1];
+    is_ident_char(prev) || prev == b':' || prev == b'$'
+}
+
+/// The segment(s) a `crate::` names: a brace group's members, or one identifier.
+fn refs_after(bytes: &[u8], from: usize) -> Vec<String> {
+    let mut i = from;
+    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if bytes.get(i) == Some(&b'{') {
+        return brace_group_segments(bytes, i);
+    }
+    match bytes.get(i).is_some_and(|&b| is_ident_char(b)) {
+        true => vec![read_ident(bytes, &mut i)],
+        false => Vec::new(),
+    }
 }
 
 /// Check one module against its allowlist.

--- a/tests/v2_plugin_switching.rs
+++ b/tests/v2_plugin_switching.rs
@@ -43,7 +43,7 @@ fn interface(files: &[(&str, String)]) -> (tempfile::TempDir, std::path::PathBuf
 
 fn loaded(ui: &std::path::Path, disabled: &[&str]) -> LuaHost {
     let host = LuaHost::new(ui);
-    host.set_disabled(disabled.iter().map(|s| s.to_string()).collect());
+    host.set_disabled(disabled.iter().copied().map(str::to_string).collect());
     let mut host = host;
     host.reload();
     host


### PR DESCRIPTION
## Summary

Fixes all **50** open issues on [SonarCloud `Thurbeen_thurbox`](https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=Thurbeen_thurbox). No behaviour changes.

- **25 × `rust:S1612`** (redundant closure) — replaced with method references: `Result::ok`, `str::to_string`, `OsStr::to_str`, `u16::to_le_bytes`, `PoisonError::into_inner`, `char::is_ascii_digit`, `u8::is_ascii_whitespace`.
  Worth knowing: Sonar's Rust analyzer runs clippy's **pedantic** `redundant_closure_for_method_calls`, which `cargo clippy -D warnings` does *not* enable — so a green `just lint` says nothing about this rule.
- **24 × `rust:S3776`** (cognitive complexity > 15) — brought under the threshold by extracting named helpers, never by changing what the code does:
  - `main.rs::run` (130) → eight named loop stages (`poll_reload`, `apply_commands`, `poll_command_bus`, `sync_terminals_and_agents`, `serve_worker_stores`, `apply_external_requests`, `paint_if_due`, `drain_input`)
  - `main.rs::on_key` (55) → the six dispatch stages it already was in comments
  - `main.rs::draw` (30) → `draw_slots` / `draw_switch_slot` / `draw_stack_slot` / `draw_floats`
  - `main.rs::draw_plugin` (21) → `decorate_tree` / `surface_moved`
  - `architecture_rules::strip_comments_and_strings` (65) → one `skip_*` helper per lexical form
  - plus `extension_config`, `registry::read_overrides`, `tmux::{reader_thread, spawn_psmux_hook_poller}`, `cli::{sessions, tasks}::run`, `notify::observe_at`, `spawn::rewrite_config_path_args`, `notifications::resolve_backend`, `command::{poll, bookmark}`, `packages::deliver`, `session_ops::run_exec_command`, `terminal::refresh_discovery`, `review::parse_changed_files`, `repos::flatten`, `storage::messages` test
- **1 × `rust:S1488`** (needless `let` before return) and **1 × `rust:S8863`** (redundant `'static` on an associated const).

Two ordering details were preserved deliberately rather than found the hard way later:

- `draw_plugin` stamps the output generation **before** the tree comparison can short-circuit it — skipping the stamp on a frame whose tree changed would make the *next* frame see output already painted.
- `read_overrides` still warns only for an **object-shaped** malformed `trusted` entry, matching the old silence for other shapes.

Comments moved with the code they explain: the remote-hook note now sits on `drain_hook_events` instead of orphaned above the output-generation check.

## Test plan

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all` — **1854 passed, 0 failed**
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- `cargo test --test architecture_rules` — passed (the comment-stripper rewrite is what the module allowlist is parsed with, so its own tests are the check)
- All 19 pre-commit hooks passed, including `cargo deny`