### PR TITLE
docs: lead the README with v2's customizable interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ you describe — inside persistent tmux panes that survive
 crashes, restarts, and reboots. Sessions, agents, and git
 worktrees are first-class citizens.
 
+**v2's headline feature: the whole interface is yours to shape.** There is no
+built-in UI compiled into the binary any more. thurbox boots a kernel, reads a
+directory of Lua files, and draws whatever it finds — so every pane, including
+the session list, is a file you can move, turn off, delete, rewrite, or install
+from someone else. The agents, hosts, themes, keybindings and settings behind
+it are data files you edit too. No fork, no recompile, no restart.
+
+**[Customization →](#customization)**
+
 [![CI](https://github.com/Thurbeen/thurbox/workflows/CI/badge.svg)](https://github.com/Thurbeen/thurbox/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Website](https://img.shields.io/badge/Website-thurbox.thurbeen.eu-blue)](https://thurbox.thurbeen.eu/)
@@ -18,7 +27,9 @@ worktrees are first-class citizens.
 
 > [!IMPORTANT]
 > **v2 is out, and it is not a drop-in v1.** The interface is now Lua plugins on
-> a Rust kernel, and some v1 surfaces did not come with it:
+> a Rust kernel — which is what makes it fully customizable, and is also why some
+> v1 surfaces did not come with it. They were compiled-in panes; they are panes
+> anyone can write now, and two of them have already been rewritten that way:
 >
 > | Gone from the binary | v1 chord | Where it lives now |
 > |---|---|---|
@@ -29,8 +40,7 @@ worktrees are first-class citizens.
 > | Automations pane | `Ctrl+P` | `thurbox-cli automation` |
 > | Restore list | `Ctrl+U` | `thurbox-cli session restore` |
 >
-> Two of them have been rebuilt as **plugins**, each its own repository, and
-> installing one is a clone:
+> Installing a plugin is a clone:
 >
 > ```bash
 > thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-code-review
@@ -186,6 +196,11 @@ you want to keep sessions alive across crashes, isolate them
 per-branch, or juggle different agents side-by-side. Thurbox
 adds:
 
+- **Full customization** — the interface is a directory of Lua
+  files, not a compiled-in UI: rearrange it, switch panes off,
+  write your own, or install someone else's. Agents, hosts,
+  themes, keybindings and settings are data files beside it.
+  [More →](#customization)
 - **Persistence** — sessions live in tmux and survive Thurbox
   crashes, restarts, and reboots. Reattach from any terminal with
   `tmux -L thurbox attach`.
@@ -210,7 +225,7 @@ several repos. Thurbox optimizes the boring-but-load-bearing end of that list.
 
 | Tool | Interface | Session backend | Agents | Multi-repo session | Code review | Platforms | Remote / SSH | License |
 |------|-----------|-----------------|--------|--------------------|-------------|-----------|--------------|---------|
-| **Thurbox** | TUI | **Real tmux** (+ psmux on Windows) | **Any CLI** — data in `agents.toml` | **✓** (one session, many repos) | **✓** (in-TUI diff, as an installable pane) | Linux · macOS · Windows | **✓** (SSH hosts) | MIT |
+| **Thurbox** | TUI — **editable Lua panes** | **Real tmux** (+ psmux on Windows) | **Any CLI** — data in `agents.toml` | **✓** (one session, many repos) | **✓** (in-TUI diff, as an installable pane) | Linux · macOS · Windows | **✓** (SSH hosts) | MIT |
 | [GitHub Copilot App](https://github.com/github/app) | Desktop GUI | App-managed (worktrees + GitHub cloud envs) | Copilot (GitHub's agent) | ✗ | Agent Merge (PR review) | Linux · macOS · Windows | GitHub-hosted cloud envs | Proprietary (paid Copilot) |
 | [Conductor](https://www.conductor.build/) | Native GUI | App-managed PTY | Claude, Codex, Cursor | ✗ | Visual diff (GUI) | macOS only | Cloud Workspaces | Free (closed source) |
 | [Herdr](https://herdr.dev/) | TUI | **Own** multiplexer (Rust) | Claude, Codex + many (any CLI) | ✗ | ✗ | Linux · macOS | Runs on a remote box | AGPL-3.0 |
@@ -222,6 +237,11 @@ several repos. Thurbox optimizes the boring-but-load-bearing end of that list.
 What makes Thurbox different (some of these are shared — the combination is the
 point):
 
+- **The interface is yours, not ours.** Every other tool here ships a UI you
+  can configure at the edges; thurbox ships a *kernel* and a directory of Lua
+  files. Rearrange the panes, switch one off, delete it, write a replacement, or
+  install one somebody else wrote — while it is running, with no fork and no
+  recompile. This is what v2 is for. [More →](#customization)
 - **Real tmux, not a re-implemented multiplexer.** Sessions live in the same
   battle-tested mux that already survives crashes, restarts, and reboots —
   reattach from any terminal with `tmux -L thurbox attach`. A custom multiplexer
@@ -276,13 +296,32 @@ as of June 2026; check each project for the latest.
 > Thurbox itself evolves quickly to fit how people actually work, and that's the
 > deeper point: AI has lowered the cost of building tooling so far that anyone can
 > rewrite a workflow into their own custom tool rather than wait for a vendor to
-> ship it. Thurbox leans into that — agents, hosts, themes, keybindings, and
-> extensions are all **data you edit**, not code you fork — so the "right" tool is
-> increasingly the one you shape for yourself.
+> ship it. Thurbox leans into that — the panes themselves, plus agents, hosts,
+> themes, keybindings, and extensions, are all **data you edit**, not code you
+> fork — so the "right" tool is increasingly the one you shape for yourself.
 
 ## Features
 
 <table>
+<tr>
+<td width="50%" valign="middle">
+
+### A Customizable Interface
+
+**v2's headline feature.** Every pane is a Lua file under `ui/` — move it,
+turn it off, delete it, rewrite it, or install one someone else wrote, and
+the arrangement closes up around what is left. `F10` reloads from disk; no
+recompile, no restart. A pane is handed a snapshot and returns a tree: no
+filesystem, no network, no process unless you trust it.
+
+[Customization →](#customization)
+
+</td>
+<td width="50%">
+  <img src="./docs/media/thurbox-interface.gif"
+       alt="Turning a pane off from the Interface tab" width="100%" />
+</td>
+</tr>
 <tr>
 <td width="50%" valign="middle">
 
@@ -349,9 +388,9 @@ keeper.
 > the same records.
 
 A built-in todo list whose items can be handed to a coding agent with the
-same Send/Spawn model — or stay plain local todos. Lives in a toggleable
-side column (`Ctrl+W` / `F5`); triggering a task (`r`) runs its action and
-advances it to *in progress*.
+same Send/Spawn model — or stay plain local todos. Running a task
+(`task run`) fires its action and advances it to *in progress*. A pane for
+it is one of the surfaces v2 is waiting on someone to write.
 
 [CLI →](#tasks-alias-todo)
 
@@ -364,10 +403,11 @@ advances it to *in progress*.
 
 ### Global Search
 
-One key (`Ctrl+/`) searches every scope at once — sessions (including live
-terminal-buffer content), tasks, automations, and the file tree —
-highlighting matches live in the panels themselves. `Enter` jumps to a
-result; `Esc` restores exactly what you had.
+One key (`Ctrl+/`) searches sessions by name, agent, branch and repo — **and
+by the text on their screens**, which is the half that finds a session by the
+error in it. Matches highlight *inside* the panes being searched rather than
+being reprinted; `Esc` puts back exactly what you were looking at. Scopes are
+per-pane, so a returning pane is a scope added and nothing else changed.
 
 [Keybindings →](#keybindings)
 
@@ -445,8 +485,10 @@ metrics, right beside the terminal.
 
 ### Themes
 
-Nine palettes (five dark, four light) plus user-defined custom themes,
-switched live with `Ctrl+Y` (or `F4`) and persisted across restarts.
+Thirty-six palettes (twenty-eight dark, eight light) plus your own in
+`themes.toml`, switched live with `Ctrl+Y` (or `F4`) and persisted across
+restarts. Plugins ask for *roles* (`theme.accent`, `theme.muted`) rather than
+colours, so a pane you write looks right under all thirty-six.
 
 [Config →](docs/CONFIG.md)
 
@@ -461,9 +503,9 @@ switched live with `Ctrl+Y` (or `F4`) and persisted across restarts.
 
 - **[Extensions](https://thurbeen.github.io/thurbox/docs/extensions.html)**
   *(experimental)* — opt-in, agent-agnostic add-ons that are **data, not
-  code**: `flow`, `forge`, `ci-shepherd`, `renovate`, and bidirectional
-  task-integration for GitHub Issues / GitLab / Linear / Jira. One command
-  installs, activates, and self-heals each.
+  code**: `flow`, `forge`, `ci-shepherd`, `renovate`. One command installs,
+  activates, and self-heals each; the manifest format is documented, so your
+  own is a TOML file.
 - **[Inter-session messages](#features)** — an agent-neutral mailbox queue
   for structured agent↔agent coordination, with atomic exactly-once
   `--claim` drains and wake nudges. Agents pass no ids — thurbox injects a
@@ -483,14 +525,114 @@ switched live with `Ctrl+Y` (or `F4`) and persisted across restarts.
 - **Mouse navigation** — the whole TUI is clickable: select rows, confirm
   picker entries in one click, wheel-scroll, drag-select text, `Ctrl+Click`
   URLs. Toggle with `mouse` in `settings.toml`.
-- **[Feature flags](docs/CONFIG.md)** — switch whole panels off in
-  `settings.toml`; a disabled feature hides its UI but keeps its data and
-  CLI surface, so flipping it back on is lossless.
-- **Responsive layout** — `< 80` cols: terminal only · `>= 80`: + sidebar ·
-  `>= 120`: + info panel. Vim-inspired keys throughout.
+- **[Settings, live](docs/CONFIG.md)** — `Ctrl+,` edits core settings and every
+  setting the loaded panes declare; `settings.toml` is written back with its
+  comments intact and re-read when you edit it from outside.
+- **Responsive layout** — the arrangement is `layout.lua`, so what appears at
+  which width is yours to decide. Vim-inspired keys throughout, all rebindable.
 
 > **Note:** Some features (tasks, extensions, the session-list display) are
 > new and still evolving — expect their UX to keep improving release to release.
+
+## Customization
+
+**This is what v2 is for.** v1 had a compiled-in interface and feature flags to
+switch parts of it off. v2 has no built-in interface at all: the binary boots a
+kernel, reads a directory, and draws whatever Lua it finds there. Everything the
+tool *is* — its panes, its agents, its hosts, its colours, its chords — is a file
+you can open in an editor.
+
+| What | Where you change it | When it takes effect |
+|---|---|---|
+| The panes themselves | `~/.config/thurbox/ui/plugins/*.lua` | `F10`, or on save |
+| Where each pane goes | `~/.config/thurbox/ui/layout.lua` | `F10`, or on save |
+| Which panes load at all | `Ctrl+,` → Interface tab (`]`) | next frame |
+| Panes other people wrote | `plugins.toml` + `thurbox-cli plugin sync` | on sync |
+| Agents you can launch | `~/.config/thurbox/agents.toml` | next session |
+| Remote SSH / WSL hosts | `~/.config/thurbox/hosts.toml` | next session |
+| Themes | `Ctrl+Y`, or `~/.config/thurbox/themes.toml` | live |
+| Keybindings | the `F1` editor → `~/.config/thurbox/ui.json` | live |
+| Core + plugin settings | `Ctrl+,` → `~/.config/thurbox/settings.toml` | live (`⟳` = restart) |
+| Whole workflows | `thurbox-cli extension install <name>` | on install |
+
+### The interface is a directory you can edit
+
+Every pane — the session list included — is a Lua file under `ui/`.
+Move one, turn it off, delete it, or write your own, and the
+arrangement closes up around what is left. No recompile, no restart.
+
+```bash
+thurbox-cli plugin dir          # which interface directory is live, and why
+thurbox-cli plugin new notes    # a starter that already loads
+thurbox-cli plugin check        # load it the way thurbox does; non-zero on failure
+thurbox-cli plugin list         # the same inventory the Interface tab shows
+```
+
+A plugin is handed a snapshot and returns a tree of four node kinds (`text`,
+`box`, `input`, `surface`); everything else composes from those. Reads come
+from an in-memory snapshot and return instantly, writes are commands the
+kernel picks up — so no pane can stall the render loop on SQLite, git, or an
+unreachable host.
+
+**Capabilities are granted by absence.** `io`, `os`, `debug`, `package` and the
+loaders are simply not in a plugin's environment, and the linter enforces that
+statically. Running a program is two separate capabilities — `run` for a bounded,
+captured command (`git status`, `docker compose ps`) and `program` for a real
+interactive pane (`htop`, `lazygit`) — each declared in the plugin's own header
+and granted only after **you** trust the file: settings → Interface → `t`, keyed
+to its digest, so a trusted file that changes reads `trusted · modified`. It is
+deliberately not a sandbox; thurbox's position is that it can only refuse to run
+things unasked. See [docs/PLUGINS.md](docs/PLUGINS.md) and
+[docs/V2-KERNEL.md](docs/V2-KERNEL.md).
+
+### Panes you did not write
+
+```bash
+thurbox-cli plugin install top                                          # by name
+thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-code-review
+thurbox-cli plugin sync                                                 # converge to the spec
+```
+
+[`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) and
+[`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) give back
+two of v1's surfaces this way. `plugin install` records each in `plugins.toml`
+with the commit it resolved to in `plugins.lock`, so `plugin sync` reproduces
+the same interface on another machine. Your edits to an installed pane are kept,
+and a pane you delete is remembered as deleted rather than reinstalled — the
+same delivery rules the bundled panes follow.
+
+### Three files, three different questions
+
+Customization stays legible because *delivery*, *your decisions*, and
+*composition* are recorded separately:
+
+- `.bundled.json` — what delivery did (bundled · edited · yours · removed ·
+  installed)
+- `ui.json` — what **you** decided (panes turned off, panes trusted, chords
+  rebound)
+- `plugins.toml` / `plugins.lock` — what the interface is composed of, and what
+  each entry resolved to
+
+Deleting a bundled pane is how you remove it: the removal is recorded and never
+written back, which is what makes replacing a shipped pane with your own — under
+a different name — possible on equal terms.
+
+### Everything behind the interface is data too
+
+- **Agents** — `agents.toml` is a list of `command + args`; thurbox knows
+  nothing about any agent's model, prompts, or tools, so a new CLI is a TOML
+  entry rather than a release. [More →](#agents)
+- **Hosts** — `hosts.toml` declares SSH machines and WSL distros; each becomes
+  an `ssh:<name>` / `wsl:<name>` backend a session can spawn on, with the same
+  persistence and restore as a local one.
+- **Themes** — thirty-six presets, plus your own as a `base` and per-colour
+  overrides in `themes.toml`. Panes ask for roles, not colours.
+- **Keybindings** — one registry, so `F1` renders what is actually bound and
+  cannot drift from it. Every chord is rebindable there; a chord freed by a pane
+  you removed stays unbound rather than being quietly reused.
+- **Extensions** — whole workflows (`flow`, `forge`, `ci-shepherd`, `renovate`)
+  shipped as a declarative manifest that the binary knows how to install,
+  activate, and self-heal — without knowing what any of them *are*.
 
 ## Prerequisites
 
@@ -530,7 +672,10 @@ rm -rf ~/.local/share/thurbox ~/.config/thurbox
 ## Getting Started
 
 1. **Launch** — run `thurbox`. You'll see a sidebar on the left
-   listing your sessions and a terminal panel on the right.
+   listing your sessions and a terminal panel on the right — that is
+   the *default* arrangement, materialised into
+   `~/.config/thurbox/ui/` on first run, and every part of it is
+   yours to change.
 2. **Create your first session** — press `Ctrl+N` to open the repo
    picker. Toggle repos with `Space`; press `w` on a repo to mark
    it as worktree mode (you'll be prompted for a base branch and
@@ -545,8 +690,14 @@ rm -rf ~/.local/share/thurbox ~/.config/thurbox
    `Ctrl+O` opens the session's worktree in your editor.
 5. **Quit without killing** — `Ctrl+Q` detaches all sessions.
    Tmux keeps them running; relaunch `thurbox` and they resume.
+6. **Make it yours** — `Ctrl+,` then `]` lists every pane and lets
+   you turn one off; `Ctrl+Y` changes the palette; `F1` rebinds any
+   chord. When you want to go further, the panes are Lua files in
+   the directory `thurbox-cli plugin dir` prints, and `F10` reloads
+   them.
 
-See the full [keybindings](#keybindings) below.
+See the full [keybindings](#keybindings) below, and
+[Customization](#customization) for the rest.
 
 ## Agents
 
@@ -781,8 +932,8 @@ Terminal.app delivers no Cmd chords; everything else works there.
 
 Searching is unified into the global search strip (`Ctrl+/`); there
 is no separate per-list `/` filter. It matches sessions on name,
-agent, branch, and live terminal-buffer content. (The file viewer's
-own in-file `/` text search is unrelated and still there.)
+agent, branch, repo, and live terminal-buffer content. (The theme
+picker keeps its own `/` filter — it is a kernel modal, not a pane.)
 
 ### Terminal Scrollback and Selection
 
@@ -928,6 +1079,27 @@ task, and recipient to the caller's injected identity
 (`THURBOX_SESSION` / `THURBOX_TASK`), so an agent passes no ids. `send`
 and `reply` wake the recipient by default (`--no-wake` to suppress).
 
+### Interface (`plugin`)
+
+Shape the interface with no TTY — which is also how an agent does it:
+edit one file, run one command, read the exit status.
+
+```bash
+thurbox-cli plugin dir                # which directory is live, and which rule chose it
+thurbox-cli plugin new <name>         # write a starter pane that already loads
+thurbox-cli plugin check              # load it the way thurbox does; non-zero on failure
+thurbox-cli plugin list               # the inventory the Interface tab shows
+thurbox-cli plugin install <src>      # a bare name, a URL, a path, or git+<url>
+thurbox-cli plugin sync               # converge the directory to plugins.toml
+thurbox-cli plugin update [<name>]    # re-resolve and re-deliver
+thurbox-cli plugin remove <name>      # withdraw it, remembering the removal
+thurbox-cli plugin available          # the example panes a bare name resolves to
+```
+
+`check` also fails on a pane that **loaded but which no arrangement places** —
+the only failure with no symptom — and prints the `layout.lua` line to add.
+See [Customization](#customization) and [docs/PLUGINS.md](docs/PLUGINS.md).
+
 ### Extensions (alias `ext`)
 
 Manage opt-in add-ons (see [Extensions](#features) for the model).
@@ -974,61 +1146,47 @@ thurbox-cli config show                  # print the effective resolved config
 
 ## Architecture
 
-Thurbox follows **The Elm Architecture** (TEA):
-`Event → Message → update(model, msg) → view(model) → Frame`.
-All state lives in a single `App` model. Sessions run via a
-`SessionBackend` trait backed by local tmux (`tmux -L thurbox`).
-Terminal output is parsed by `vt100::Parser` and rendered by
-`tui_term`. All persistent state (sessions, worktrees, automations)
-is stored in SQLite.
+The interface is **Lua running on a Rust kernel**. `thurbox` boots the kernel,
+which reads `ui/` and renders whatever plugins it finds; there is no built-in
+pane. Sessions run via a `SessionBackend` trait backed by tmux over a transport
+(local, SSH, or WSL); terminal output is parsed by `vt100::Parser` and rendered
+by `tui_term`. All persistent state (sessions, worktrees, automations, tasks,
+messages) is stored in SQLite.
+
+Five rules hold the kernel together:
+
+1. **Four node kinds, forever** — `text`, `box`, `input`, `surface`. Everything
+   else composes in Lua.
+2. **Layout resolves before render** — rects are computed first, then each
+   plugin is called with its own. Panes declare their size statically, which is
+   what breaks the circularity.
+3. **Snapshot-read, command-write** — reads return instantly from an in-memory
+   snapshot; writes are commands accepted now and surfaced later. Lua never
+   blocks.
+4. **Capabilities by absence** — an ungranted capability is not *in* the
+   environment, and the linter enforces that statically.
+5. **Anything touching the world runs on a worker** — terminal attach, commands,
+   diffs, metrics, git stats, repository reads, update checks.
 
 ### Module Dependency Rules
 
 ```text
-session  ← pure data types, no local imports
-agent    ← imports session only (NEVER ui or git)
-ui       ← imports session only (NEVER agent or git)
-app      ← coordinator, imports all modules
+session  ← pure data types, no crate-internal references
+agent    ← session (+ paths/shell utils; NEVER git)
+kernel   ← session + storage + sync + paths + session_ops + git
+main     ← the coordinator: the loop, the workers, the chrome
 ```
 
-These rules are enforced by `tests/architecture_rules.rs`.
-For the full set of architectural decisions with rationale,
-see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
-
-### The interface is a directory you can edit
-
-<div align="center">
-  <img src="./docs/media/thurbox-interface.gif" alt="Turning a pane off from the Interface tab" width="100%" />
-</div>
-
-Every pane — the session list included — is a Lua file under `ui/`.
-Move one, turn it off, delete it, or write your own, and the
-arrangement closes up around what is left. No recompile, no restart.
-
-```bash
-thurbox-cli plugin dir          # which interface directory is live
-thurbox-cli plugin new notes    # a starter that already loads
-thurbox-cli plugin check        # load it the way thurbox does
-```
-
-A plugin is handed a snapshot and returns a tree; it gets no
-filesystem, no network and no process. Running a program is one
-capability, granted per plugin and only after you trust it.
-See [docs/PLUGINS.md](docs/PLUGINS.md) and
+These rules are enforced by `tests/architecture_rules.rs` as an **allowlist**:
+a new module fails the test until its place is declared. For the full set of
+architectural decisions with rationale, see
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md); for the kernel itself, see
 [docs/V2-KERNEL.md](docs/V2-KERNEL.md).
 
-A pane does not have to be one you wrote:
-[`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review)
-and [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel)
-give back two of v1's surfaces (commands in the note at the top).
-`plugin install` records each in `plugins.toml` with the commit it
-resolved to in `plugins.lock`, so `plugin sync` reproduces the same
-interface on another machine.
-
-**Moving from v1?** Some panes are owed rather than ported, and some
-moved to `thurbox-cli`. The note at the top of this file has the list,
-what asks you before anything changes, and how to stay on v1 — which
-is maintained on the `v1.x` branch.
+**Moving from v1?** Some panes are owed rather than ported, and some moved to
+`thurbox-cli`. The note at the top of this file has the list, what asks you
+before anything changes, and how to stay on v1 — which is maintained on the
+`v1.x` branch.
 
 ## Documentation
 
@@ -1043,6 +1201,7 @@ is maintained on the `v1.x` branch.
 - [docs/V2-KERNEL.md](docs/V2-KERNEL.md) — The plugin kernel: its
   shape, its five rules, and the traps in changing it
 - [docs/PLUGINS.md](docs/PLUGINS.md) — Writing an interface plugin
+  (start at [Customization](#customization) for the tour)
 - [docs/RELEASING.md](docs/RELEASING.md) — What a release may and may
   not change about the artifacts (and why removing a binary silently
   breaks auto-update)

--- a/README.md
+++ b/README.md
@@ -308,30 +308,37 @@ as of June 2026; check each project for the latest.
 
 ### What v1 had, and where it is in v2
 
-v1 drew every surface from the binary. v2 draws none of them from the binary —
-which is what makes the interface yours, and also means a surface can be
-*bundled*, *installable*, or *owed*. This is the full map; the note at the top
-of this file is the short, urgent version of the last four rows.
+v1 drew every surface from the binary, so the only question was which chord
+opened it. v2 draws **none** of them from the binary — which is what makes the
+interface yours, and means each surface is now bundled, installable, CLI-only,
+or owed.
 
-| Surface | In v1 | In v2 | How you get it |
+| Surface | In v1 | In v2 | Where it lives |
 |---|---|---|---|
-| Session list | built in | **bundled pane** | `10_sessions.lua` — edit it, move it, turn it off |
-| Agent terminal | built in | **bundled pane** | `20_agent.lua` (the `Ctrl+T` shell too) |
-| Global search | built in | **bundled pane** | `65_search.lua` — sessions and their screens |
-| Session creation | built in | **bundled float** | `70_new_session.lua`, `Ctrl+N` |
-| Themes · settings · help | built in | **kernel chrome** | `Ctrl+Y` · `Ctrl+,` · `F1`; panes contribute rows |
-| Code review | built in, `Ctrl+X` | **a pane you install** | [`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) — reclaims `Ctrl+X`/`F7` itself |
-| Info panel | built in, `Ctrl+B`/`F2` | **a pane you install** | [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) — plus one `layout.lua` line |
-| Tasks | built in, `Ctrl+W`/`F5` | **CLI, no pane yet** | `thurbox-cli task`; `ui-plugins/tasks` is an example pane over the same records |
-| Automations | built in, `Ctrl+P` | **CLI, no pane yet** | `thurbox-cli automation` — they still fire with the TUI closed |
-| Restore list | built in, `Ctrl+U` | **CLI, no pane yet** | `thurbox-cli session restore` |
-| File viewer | built in, `Ctrl+E`/`F3` | **owed** | nothing yet — the one surface with no replacement |
-| The arrangement | compiled-in breakpoints | **a file you edit** | `ui/layout.lua` — new in v2 |
-| CPU / RAM gauges | ✗ | **a pane you install** | `thurbox-cli plugin install top` — new in v2 |
-| Panes anyone else wrote | ✗ | **`plugins.toml`** | `plugin install` / `sync` — new in v2 |
+| Session list | on screen | bundled | `10_sessions.lua` |
+| Agent terminal | on screen | bundled | `20_agent.lua` |
+| Global search | `Ctrl+/` | bundled | `65_search.lua` |
+| Session creation | `Ctrl+N` | bundled | `70_new_session.lua` (a float) |
+| The arrangement | fixed, compiled in | bundled | `ui/layout.lua` |
+| Themes · settings · help | `Ctrl+Y` · `Ctrl+,` · `F1` | kernel chrome | the same chords |
+| Code review | `Ctrl+X` / `F7` | installable | [`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) |
+| Info panel | `Ctrl+B` / `F2` | installable | [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) |
+| CPU / RAM gauges | — | installable | `thurbox-cli plugin install top` |
+| Panes anyone else wrote | — | installable | `ui/plugins.toml` |
+| Tasks | `Ctrl+W` / `F5` | CLI only | `thurbox-cli task` |
+| Automations | `Ctrl+P` | CLI only | `thurbox-cli automation` |
+| Restore list | `Ctrl+U` | CLI only | `thurbox-cli session restore` |
+| File viewer | `Ctrl+E` / `F3` | owed | — |
 
-The chords freed by the four owed surfaces are deliberately left **unbound**
-rather than reused, so no muscle memory quietly does something else.
+**Bundled** means it ships with thurbox and is yours to edit, move or delete —
+including the arrangement, which v1 compiled in. **Installable** ones sit in
+`plugins.toml` on exactly the same terms: the review pane reclaims `Ctrl+X`/`F7`
+by itself, the info panel wants one `layout.lua` line, and the two rows marked
+`—` are things v1 had no answer for at all. **CLI only** means the records and the
+commands are all there and nobody has written the pane yet — `ui-plugins/tasks`
+is an example pane over the same task records. The chords of the four paneless
+surfaces stay **unbound** rather than being reused, so no muscle memory quietly
+does something else.
 
 <table>
 <tr>
@@ -573,18 +580,23 @@ kernel, reads a directory, and draws whatever Lua it finds there. Everything the
 tool *is* — its panes, its agents, its hosts, its colours, its chords — is a file
 you can open in an editor.
 
-| What | Where you change it | When it takes effect |
-|---|---|---|
-| The panes themselves | `~/.config/thurbox/ui/plugins/*.lua` | `F10`, or on save |
-| Where each pane goes | `~/.config/thurbox/ui/layout.lua` | `F10`, or on save |
-| Which panes load at all | `Ctrl+,` → Interface tab (`]`) | next frame |
-| Panes other people wrote | `plugins.toml` + `thurbox-cli plugin sync` | on sync |
-| Agents you can launch | `~/.config/thurbox/agents.toml` | next session |
-| Remote SSH / WSL hosts | `~/.config/thurbox/hosts.toml` | next session |
-| Themes | `Ctrl+Y`, or `~/.config/thurbox/themes.toml` | live |
-| Keybindings | the `F1` editor → `~/.config/thurbox/ui.json` | live |
-| Core + plugin settings | `Ctrl+,` → `~/.config/thurbox/settings.toml` | live (`⟳` = restart) |
-| Whole workflows | `thurbox-cli extension install <name>` | on install |
+| What you change | Where |
+|---|---|
+| A pane — the session list included | `ui/plugins/*.lua` |
+| Where the panes go, and at what widths | `ui/layout.lua` |
+| Which panes load at all | `Ctrl+,` → Interface tab (`]`) |
+| Panes somebody else wrote | `ui/plugins.toml` → `thurbox-cli plugin sync` |
+| Which agent CLIs you can launch | `agents.toml` |
+| Remote SSH machines and WSL distros | `hosts.toml` |
+| Colours | `Ctrl+Y`, or `themes.toml` |
+| Chords | the `F1` editor, or `ui.json` |
+| Core and plugin settings | `Ctrl+,`, or `settings.toml` |
+
+All of it lives under `~/.config/thurbox/`. Panes and the arrangement reload on
+`F10` or when you save; colours, chords and most settings apply live (the
+settings panel marks the restart-only ones `⟳`); a changed agent or host applies
+to the next session you create. Whole workflows are a layer above all of this —
+`thurbox-cli extension install flow` and the like.
 
 ### Ask the agent to do it
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ it are data files you edit too. No fork, no recompile, no restart.
 > interface — sessions, agents, worktrees, remote hosts, automations, your
 > database — is unchanged.
 >
+> The table above lists only what *left*. For the full map — what is bundled,
+> what installs, what is owed, and what v2 gained — see
+> [What v1 had, and where it is in v2](#what-v1-had-and-where-it-is-in-v2).
+>
 > **Upgrading** asks once, on the first v2 launch of a profile with v1 history,
 > before anything changes. **To stay on v1**, answer `q` at that prompt: it turns
 > auto-update off and prints the reinstall command. Or reinstall it yourself:
@@ -301,6 +305,33 @@ as of June 2026; check each project for the latest.
 > fork — so the "right" tool is increasingly the one you shape for yourself.
 
 ## Features
+
+### What v1 had, and where it is in v2
+
+v1 drew every surface from the binary. v2 draws none of them from the binary —
+which is what makes the interface yours, and also means a surface can be
+*bundled*, *installable*, or *owed*. This is the full map; the note at the top
+of this file is the short, urgent version of the last four rows.
+
+| Surface | In v1 | In v2 | How you get it |
+|---|---|---|---|
+| Session list | built in | **bundled pane** | `10_sessions.lua` — edit it, move it, turn it off |
+| Agent terminal | built in | **bundled pane** | `20_agent.lua` (the `Ctrl+T` shell too) |
+| Global search | built in | **bundled pane** | `65_search.lua` — sessions and their screens |
+| Session creation | built in | **bundled float** | `70_new_session.lua`, `Ctrl+N` |
+| Themes · settings · help | built in | **kernel chrome** | `Ctrl+Y` · `Ctrl+,` · `F1`; panes contribute rows |
+| Code review | built in, `Ctrl+X` | **a pane you install** | [`thurbox-code-review`](https://github.com/Thurbeen/thurbox-code-review) — reclaims `Ctrl+X`/`F7` itself |
+| Info panel | built in, `Ctrl+B`/`F2` | **a pane you install** | [`thurbox-info-panel`](https://github.com/Thurbeen/thurbox-info-panel) — plus one `layout.lua` line |
+| Tasks | built in, `Ctrl+W`/`F5` | **CLI, no pane yet** | `thurbox-cli task`; `ui-plugins/tasks` is an example pane over the same records |
+| Automations | built in, `Ctrl+P` | **CLI, no pane yet** | `thurbox-cli automation` — they still fire with the TUI closed |
+| Restore list | built in, `Ctrl+U` | **CLI, no pane yet** | `thurbox-cli session restore` |
+| File viewer | built in, `Ctrl+E`/`F3` | **owed** | nothing yet — the one surface with no replacement |
+| The arrangement | compiled-in breakpoints | **a file you edit** | `ui/layout.lua` — new in v2 |
+| CPU / RAM gauges | ✗ | **a pane you install** | `thurbox-cli plugin install top` — new in v2 |
+| Panes anyone else wrote | ✗ | **`plugins.toml`** | `plugin install` / `sync` — new in v2 |
+
+The chords freed by the four owed surfaces are deliberately left **unbound**
+rather than reused, so no muscle memory quietly does something else.
 
 <table>
 <tr>
@@ -554,6 +585,70 @@ you can open in an editor.
 | Keybindings | the `F1` editor → `~/.config/thurbox/ui.json` | live |
 | Core + plugin settings | `Ctrl+,` → `~/.config/thurbox/settings.toml` | live (`⟳` = restart) |
 | Whole workflows | `thurbox-cli extension install <name>` | on install |
+
+### Ask the agent to do it
+
+You do not have to learn Lua to change the interface. thurbox runs coding
+agents, and the interface is a directory of plain text files those agents can
+read — so the shortest path to a change is usually to point a session at that
+directory and ask in English:
+
+```bash
+thurbox-cli plugin dir          # prints the directory
+thurbox-cli session create --name ui --repo-path ~/.config/thurbox/ui
+```
+
+Then prompts like these do the whole job:
+
+> - *Install the info panel plugin.*
+> - *Add a new pane on the left with CPU and RAM usage. There is a `top` example
+>   plugin — install it and give it a slot in the layout.*
+> - *Move the search strip to the bottom, and make the session column 30% wide.*
+> - *The session list is too noisy — drop the repo group headers and show the
+>   branch instead of the agent name.*
+
+That works because the directory ships an **`AGENTS.md`** that any coding CLI
+loads as context without being asked. It is what stops "install a plugin" being
+read as an npm request, tells the agent that `thurbox-cli plugin check` is how
+it verifies its own work, and warns it off the mistakes that are invisible until
+runtime. Press `F10` and the change is on your screen.
+
+#### What that second prompt actually does
+
+Worth seeing once, because **every** interface change has this shape — a pane,
+and a slot for it:
+
+1. **The pane.** `thurbox-cli plugin install top` delivers `plugins/85_top.lua`
+   and records the entry in `plugins.toml`. It declares `slot = "top"` and the
+   `run` capability.
+2. **The slot.** `ui/layout.lua` decides where a slot goes, so putting it on the
+   left is putting it first in the column list:
+
+   ```lua
+   local columns = {}
+   if filled(ctx, "top") then
+     columns[#columns + 1] = { slot = "top", pct = 20, min = 24 }
+   end
+   if panels.shown("sessions") and filled(ctx, "sessions") then
+     columns[#columns + 1] = { slot = "sessions", pct = 25, min = 20 }
+   end
+   columns[#columns + 1] = { slot = "center" }
+   ```
+
+Then `F10` — and trust it, settings → Interface → `t`, because it shells out to
+`top` and an untrusted plugin does not get `run` **at all**. Until you do, it
+draws the reason rather than a blank pane.
+
+Two things that follow from the split, and are easy to miss: the plugin manager
+never writes `layout.lua` (placement stays yours, which is why step 2 is a
+separate edit), and a pane that loads but which no arrangement places draws
+nothing while looking perfectly healthy — `thurbox-cli plugin check` is what
+fails on that, and prints the line to add.
+
+The `top` pane also reads the machine **the selected session runs on**, because
+`run` executes in that session's directory on that session's host. Select a
+session running over SSH and you are looking at that box's load — without the
+plugin knowing what SSH is.
 
 ### The interface is a directory you can edit
 

--- a/website/css/components.css
+++ b/website/css/components.css
@@ -812,3 +812,40 @@
     display: none;
   }
 }
+
+/* ---- Prompt examples ----
+   Things you SAY to an agent, not commands you run. Deliberately unlike the
+   <pre> blocks around them: dashed, italic, no copy affordance, so nobody
+   pastes one into a shell. */
+.prompts {
+  list-style: none;
+  margin: 0 0 var(--space-lg);
+  padding: 0;
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.prompts li {
+  position: relative;
+  padding: var(--space-sm) var(--space-md);
+  padding-left: var(--space-xl);
+  background: var(--bg-secondary);
+  border: 1px dashed var(--border);
+  border-radius: var(--border-radius-sm);
+  color: var(--text-secondary);
+  font-style: italic;
+  line-height: 1.6;
+}
+
+.prompts li::before {
+  content: '\203A';
+  position: absolute;
+  left: var(--space-md);
+  color: var(--accent);
+  font-style: normal;
+  font-weight: 700;
+}
+
+.prompts li code {
+  font-style: normal;
+}

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -27,11 +27,11 @@ breadcrumb: 'Features'
             <a href="#v1-map" class="heading-anchor">#</a>
           </h3>
           <p>
-            v1 drew every surface from the binary. v2 draws none of them from the binary &mdash;
-            which is what makes the interface yours, and also means a surface can be
-            <em>bundled</em>, <em>installable</em>, or <em>owed</em>.
-            <a href="deprecated.html">Deprecated surfaces</a>
-            covers the last group in detail.
+            v1 drew every surface from the binary, so the only question was which chord opened it.
+            v2 draws
+            <strong>none</strong>
+            of them from the binary &mdash; which is what makes the interface yours, and means each
+            surface is now bundled, installable, CLI-only, or owed.
           </p>
           <table>
             <thead>
@@ -39,116 +39,118 @@ breadcrumb: 'Features'
                 <th>Surface</th>
                 <th>In v1</th>
                 <th>In v2</th>
-                <th>How you get it</th>
+                <th>Where it lives</th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <td>Session list</td>
-                <td>built in</td>
-                <td><strong>Bundled pane</strong></td>
-                <td><code>10_sessions.lua</code> &mdash; edit it, move it, turn it off</td>
+                <td>on screen</td>
+                <td>bundled</td>
+                <td><code>10_sessions.lua</code></td>
               </tr>
               <tr>
                 <td>Agent terminal</td>
-                <td>built in</td>
-                <td><strong>Bundled pane</strong></td>
-                <td><code>20_agent.lua</code>, with the <kbd>Ctrl</kbd>+<kbd>T</kbd> shell</td>
+                <td>on screen</td>
+                <td>bundled</td>
+                <td><code>20_agent.lua</code></td>
               </tr>
               <tr>
                 <td><a href="#global-search">Global search</a></td>
-                <td>built in</td>
-                <td><strong>Bundled pane</strong></td>
-                <td><code>65_search.lua</code> &mdash; sessions and their screens</td>
+                <td><kbd>Ctrl</kbd>+<kbd>/</kbd></td>
+                <td>bundled</td>
+                <td><code>65_search.lua</code></td>
               </tr>
               <tr>
                 <td>Session creation</td>
-                <td>built in</td>
-                <td><strong>Bundled float</strong></td>
-                <td><code>70_new_session.lua</code>, <kbd>Ctrl</kbd>+<kbd>N</kbd></td>
+                <td><kbd>Ctrl</kbd>+<kbd>N</kbd></td>
+                <td>bundled</td>
+                <td><code>70_new_session.lua</code> (a float)</td>
+              </tr>
+              <tr>
+                <td><a href="#responsive-ui">The arrangement</a></td>
+                <td>fixed, compiled in</td>
+                <td>bundled</td>
+                <td><code>ui/layout.lua</code></td>
               </tr>
               <tr>
                 <td><a href="#themes">Themes</a> &middot; settings &middot; help</td>
-                <td>built in</td>
-                <td><strong>Kernel chrome</strong></td>
-                <td>
-                  <kbd>Ctrl</kbd>+<kbd>Y</kbd> &middot; <kbd>Ctrl</kbd>+<kbd>,</kbd> &middot;
-                  <kbd>F1</kbd> &mdash; panes contribute rows to them
-                </td>
+                <td><kbd>Ctrl</kbd>+<kbd>Y</kbd> &middot; <kbd>Ctrl</kbd>+<kbd>,</kbd> &middot; <kbd>F1</kbd></td>
+                <td>kernel chrome</td>
+                <td>the same chords</td>
               </tr>
               <tr>
                 <td>Code review</td>
-                <td>built in, <kbd>Ctrl</kbd>+<kbd>X</kbd></td>
-                <td><strong>A pane you install</strong></td>
-                <td>
-                  <a href="https://github.com/Thurbeen/thurbox-code-review" target="_blank" rel="noopener">thurbox-code-review</a>
-                  &mdash; reclaims the chord itself
-                </td>
+                <td><kbd>Ctrl</kbd>+<kbd>X</kbd> / <kbd>F7</kbd></td>
+                <td>installable</td>
+                <td><a href="https://github.com/Thurbeen/thurbox-code-review" target="_blank" rel="noopener">thurbox-code-review</a></td>
               </tr>
               <tr>
                 <td>Info panel</td>
-                <td>built in, <kbd>Ctrl</kbd>+<kbd>B</kbd> / <kbd>F2</kbd></td>
-                <td><strong>A pane you install</strong></td>
-                <td>
-                  <a href="https://github.com/Thurbeen/thurbox-info-panel" target="_blank" rel="noopener">thurbox-info-panel</a>
-                  &mdash; plus one <code>layout.lua</code> line
-                </td>
+                <td><kbd>Ctrl</kbd>+<kbd>B</kbd> / <kbd>F2</kbd></td>
+                <td>installable</td>
+                <td><a href="https://github.com/Thurbeen/thurbox-info-panel" target="_blank" rel="noopener">thurbox-info-panel</a></td>
+              </tr>
+              <tr>
+                <td>CPU / RAM gauges</td>
+                <td>&mdash;</td>
+                <td>installable</td>
+                <td><code>thurbox-cli plugin install top</code></td>
+              </tr>
+              <tr>
+                <td>Panes anyone else wrote</td>
+                <td>&mdash;</td>
+                <td>installable</td>
+                <td><code>ui/plugins.toml</code></td>
               </tr>
               <tr>
                 <td><a href="#tasks">Tasks</a></td>
-                <td>built in, <kbd>Ctrl</kbd>+<kbd>W</kbd> / <kbd>F5</kbd></td>
-                <td><strong>CLI, no pane yet</strong></td>
-                <td>
-                  <code>thurbox-cli task</code>; <code>ui-plugins/tasks</code> is an example pane
-                  over the same records
-                </td>
+                <td><kbd>Ctrl</kbd>+<kbd>W</kbd> / <kbd>F5</kbd></td>
+                <td>CLI only</td>
+                <td><code>thurbox-cli task</code></td>
               </tr>
               <tr>
                 <td><a href="#automations">Automations</a></td>
-                <td>built in, <kbd>Ctrl</kbd>+<kbd>P</kbd></td>
-                <td><strong>CLI, no pane yet</strong></td>
-                <td>
-                  <code>thurbox-cli automation</code> &mdash; they still fire with the TUI closed
-                </td>
+                <td><kbd>Ctrl</kbd>+<kbd>P</kbd></td>
+                <td>CLI only</td>
+                <td><code>thurbox-cli automation</code></td>
               </tr>
               <tr>
                 <td>Restore list</td>
-                <td>built in, <kbd>Ctrl</kbd>+<kbd>U</kbd></td>
-                <td><strong>CLI, no pane yet</strong></td>
+                <td><kbd>Ctrl</kbd>+<kbd>U</kbd></td>
+                <td>CLI only</td>
                 <td><code>thurbox-cli session restore</code></td>
               </tr>
               <tr>
                 <td>File viewer</td>
-                <td>built in, <kbd>Ctrl</kbd>+<kbd>E</kbd> / <kbd>F3</kbd></td>
-                <td><strong>Owed</strong></td>
-                <td>Nothing yet &mdash; the one surface with no replacement</td>
-              </tr>
-              <tr>
-                <td><a href="#responsive-ui">The arrangement</a></td>
-                <td>compiled-in breakpoints</td>
-                <td><strong>A file you edit</strong></td>
-                <td><code>ui/layout.lua</code> &mdash; new in v2</td>
-              </tr>
-              <tr>
-                <td>CPU / RAM gauges</td>
-                <td>&#10007;</td>
-                <td><strong>A pane you install</strong></td>
-                <td><code>thurbox-cli plugin install top</code> &mdash; new in v2</td>
-              </tr>
-              <tr>
-                <td>Panes anyone else wrote</td>
-                <td>&#10007;</td>
-                <td><strong><code>plugins.toml</code></strong></td>
-                <td>
-                  <code>thurbox-cli plugin install</code> / <code>sync</code> &mdash; new in v2
-                </td>
+                <td><kbd>Ctrl</kbd>+<kbd>E</kbd> / <kbd>F3</kbd></td>
+                <td>owed</td>
+                <td>&mdash;</td>
               </tr>
             </tbody>
           </table>
           <p>
-            The chords freed by the four owed surfaces are deliberately left
+            <strong>Bundled</strong>
+            means it ships with thurbox and is yours to edit, move or delete &mdash; including the
+            arrangement, which v1 compiled in.
+            <strong>Installable</strong>
+            ones sit in
+            <code>plugins.toml</code>
+            on exactly the same terms: the review pane reclaims its chord by itself, the info panel
+            wants one
+            <code>layout.lua</code>
+            line, and the two rows marked
+            &mdash;
+            are things v1 had no answer for at all.
+            <strong>CLI only</strong>
+            means the records and the commands are all there and nobody has written the pane yet;
+            <code>ui-plugins/tasks</code>
+            is an example pane over the same task records. The chords of the four paneless surfaces
+            stay
             <strong>unbound</strong>
-            rather than reused, so no muscle memory quietly does something else.
+            rather than being reused, so no muscle memory quietly does something else.
+            <a href="deprecated.html">Deprecated surfaces</a>
+            covers what is owed in detail.
           </p>
 
           <h2 id="session-orchestration">

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -1,11 +1,155 @@
 ---
 layout: docs.njk
 title: 'Features — Thurbox Docs'
-description: 'Thurbox features: persistent coding-agent sessions, agent definitions, git worktrees, remote SSH sessions, automations, a responsive UI, and a headless CLI.'
+description: 'Thurbox features: a fully customizable Lua-plugin interface (with a v1-to-v2 surface map), persistent coding-agent sessions, agent definitions, git worktrees, remote SSH sessions, automations, and a headless CLI.'
 currentPage: 'features'
 breadcrumb: 'Features'
 ---
 <h1>Features</h1>
+
+          <h2 id="customizable-interface">
+            A customizable interface
+            <a href="#customizable-interface" class="heading-anchor">#</a>
+          </h2>
+          <p>
+            <strong>v2's headline feature.</strong>
+            There is no interface compiled into the binary. thurbox boots a kernel, reads a
+            directory, and draws whatever Lua it finds there &mdash; so every pane, the session list
+            included, is a file you can move, turn off, delete, rewrite, or install from someone
+            else. You do not have to write any of it yourself:
+            <a href="v2-interface.html#ask-the-agent">ask the agent you already have running</a>.
+            The full tour is
+            <a href="v2-interface.html">The Interface</a>.
+          </p>
+
+          <h3 id="v1-map">
+            What v1 had, and where it is in v2
+            <a href="#v1-map" class="heading-anchor">#</a>
+          </h3>
+          <p>
+            v1 drew every surface from the binary. v2 draws none of them from the binary &mdash;
+            which is what makes the interface yours, and also means a surface can be
+            <em>bundled</em>, <em>installable</em>, or <em>owed</em>.
+            <a href="deprecated.html">Deprecated surfaces</a>
+            covers the last group in detail.
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Surface</th>
+                <th>In v1</th>
+                <th>In v2</th>
+                <th>How you get it</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Session list</td>
+                <td>built in</td>
+                <td><strong>Bundled pane</strong></td>
+                <td><code>10_sessions.lua</code> &mdash; edit it, move it, turn it off</td>
+              </tr>
+              <tr>
+                <td>Agent terminal</td>
+                <td>built in</td>
+                <td><strong>Bundled pane</strong></td>
+                <td><code>20_agent.lua</code>, with the <kbd>Ctrl</kbd>+<kbd>T</kbd> shell</td>
+              </tr>
+              <tr>
+                <td><a href="#global-search">Global search</a></td>
+                <td>built in</td>
+                <td><strong>Bundled pane</strong></td>
+                <td><code>65_search.lua</code> &mdash; sessions and their screens</td>
+              </tr>
+              <tr>
+                <td>Session creation</td>
+                <td>built in</td>
+                <td><strong>Bundled float</strong></td>
+                <td><code>70_new_session.lua</code>, <kbd>Ctrl</kbd>+<kbd>N</kbd></td>
+              </tr>
+              <tr>
+                <td><a href="#themes">Themes</a> &middot; settings &middot; help</td>
+                <td>built in</td>
+                <td><strong>Kernel chrome</strong></td>
+                <td>
+                  <kbd>Ctrl</kbd>+<kbd>Y</kbd> &middot; <kbd>Ctrl</kbd>+<kbd>,</kbd> &middot;
+                  <kbd>F1</kbd> &mdash; panes contribute rows to them
+                </td>
+              </tr>
+              <tr>
+                <td>Code review</td>
+                <td>built in, <kbd>Ctrl</kbd>+<kbd>X</kbd></td>
+                <td><strong>A pane you install</strong></td>
+                <td>
+                  <a href="https://github.com/Thurbeen/thurbox-code-review" target="_blank" rel="noopener">thurbox-code-review</a>
+                  &mdash; reclaims the chord itself
+                </td>
+              </tr>
+              <tr>
+                <td>Info panel</td>
+                <td>built in, <kbd>Ctrl</kbd>+<kbd>B</kbd> / <kbd>F2</kbd></td>
+                <td><strong>A pane you install</strong></td>
+                <td>
+                  <a href="https://github.com/Thurbeen/thurbox-info-panel" target="_blank" rel="noopener">thurbox-info-panel</a>
+                  &mdash; plus one <code>layout.lua</code> line
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#tasks">Tasks</a></td>
+                <td>built in, <kbd>Ctrl</kbd>+<kbd>W</kbd> / <kbd>F5</kbd></td>
+                <td><strong>CLI, no pane yet</strong></td>
+                <td>
+                  <code>thurbox-cli task</code>; <code>ui-plugins/tasks</code> is an example pane
+                  over the same records
+                </td>
+              </tr>
+              <tr>
+                <td><a href="#automations">Automations</a></td>
+                <td>built in, <kbd>Ctrl</kbd>+<kbd>P</kbd></td>
+                <td><strong>CLI, no pane yet</strong></td>
+                <td>
+                  <code>thurbox-cli automation</code> &mdash; they still fire with the TUI closed
+                </td>
+              </tr>
+              <tr>
+                <td>Restore list</td>
+                <td>built in, <kbd>Ctrl</kbd>+<kbd>U</kbd></td>
+                <td><strong>CLI, no pane yet</strong></td>
+                <td><code>thurbox-cli session restore</code></td>
+              </tr>
+              <tr>
+                <td>File viewer</td>
+                <td>built in, <kbd>Ctrl</kbd>+<kbd>E</kbd> / <kbd>F3</kbd></td>
+                <td><strong>Owed</strong></td>
+                <td>Nothing yet &mdash; the one surface with no replacement</td>
+              </tr>
+              <tr>
+                <td><a href="#responsive-ui">The arrangement</a></td>
+                <td>compiled-in breakpoints</td>
+                <td><strong>A file you edit</strong></td>
+                <td><code>ui/layout.lua</code> &mdash; new in v2</td>
+              </tr>
+              <tr>
+                <td>CPU / RAM gauges</td>
+                <td>&#10007;</td>
+                <td><strong>A pane you install</strong></td>
+                <td><code>thurbox-cli plugin install top</code> &mdash; new in v2</td>
+              </tr>
+              <tr>
+                <td>Panes anyone else wrote</td>
+                <td>&#10007;</td>
+                <td><strong><code>plugins.toml</code></strong></td>
+                <td>
+                  <code>thurbox-cli plugin install</code> / <code>sync</code> &mdash; new in v2
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            The chords freed by the four owed surfaces are deliberately left
+            <strong>unbound</strong>
+            rather than reused, so no muscle memory quietly does something else.
+          </p>
 
           <h2 id="session-orchestration">
             Sessions

--- a/website/docs/v2-interface.html
+++ b/website/docs/v2-interface.html
@@ -38,6 +38,100 @@ breadcrumb: 'Interface'
   in the database, not the interface.
 </p>
 
+<h2 id="ask-the-agent">
+  You can just ask the agent
+  <a href="#ask-the-agent" class="heading-anchor">#</a>
+</h2>
+<p>
+  You do not have to learn Lua to change the interface. thurbox runs coding agents, and the
+  interface is a directory of plain text files those agents can read &mdash; so the shortest path to
+  a change is usually to point a session at that directory and ask in English.
+</p>
+<pre data-wrap><code class="language-bash">thurbox-cli plugin dir          # prints the directory
+thurbox-cli session create --name ui --repo-path ~/.config/thurbox/ui</code></pre>
+<p>Then prompts like these do the whole job:</p>
+<ul class="prompts">
+  <li>Install the info panel plugin.</li>
+  <li>
+    Add a new pane on the left with CPU and RAM usage. There is a
+    <code>top</code>
+    example plugin &mdash; install it and give it a slot in the layout.
+  </li>
+  <li>Move the search strip to the bottom, and make the session column 30% wide.</li>
+  <li>
+    The session list is too noisy &mdash; drop the repo group headers and show the branch instead of
+    the agent name.
+  </li>
+</ul>
+<p>
+  That works because the directory ships an
+  <code>AGENTS.md</code>
+  that any coding CLI loads as context without being asked. It is what stops &ldquo;install a
+  plugin&rdquo; being read as an npm request, tells the agent that
+  <code>thurbox-cli plugin check</code>
+  is how it verifies its own work, and warns it off the mistakes that are invisible until runtime
+  &mdash; building under a recursively watched directory, or writing inside a cloned plugin's own
+  working copy. Press
+  <kbd>F10</kbd>
+  and the change is on your screen.
+</p>
+
+<h3 id="ask-the-agent-worked">
+  What the second prompt actually does
+  <a href="#ask-the-agent-worked" class="heading-anchor">#</a>
+</h3>
+<p>
+  Worth seeing once, because
+  <strong>every</strong>
+  interface change has this shape &mdash; a pane, and a slot for it.
+</p>
+<p>
+  <strong>1. The pane.</strong>
+  <code>thurbox-cli plugin install top</code>
+  delivers
+  <code>plugins/85_top.lua</code>
+  and records the entry in
+  <code>plugins.toml</code>. It declares
+  <code>slot = "top"</code>
+  and the
+  <code>run</code>
+  capability.
+</p>
+<p>
+  <strong>2. The slot.</strong>
+  <code>ui/layout.lua</code>
+  decides where a slot goes, so putting it on the left is putting it first in the column list:
+</p>
+<pre><code class="language-lua">local columns = {}
+if filled(ctx, "top") then
+  columns[#columns + 1] = { slot = "top", pct = 20, min = 24 }
+end
+if panels.shown("sessions") and filled(ctx, "sessions") then
+  columns[#columns + 1] = { slot = "sessions", pct = 25, min = 20 }
+end
+columns[#columns + 1] = { slot = "center" }</code></pre>
+<p>
+  Then
+  <kbd>F10</kbd>
+  &mdash; and trust it (settings &rarr; Interface &rarr;
+  <kbd>t</kbd>), because it shells out to
+  <code>top</code>
+  and an untrusted plugin does not get
+  <code>run</code>
+  <strong>at all</strong>. Until you do, it draws the reason rather than a blank pane.
+</p>
+<div class="info-box">
+  <p>
+    Two things follow from that split and are easy to miss. The plugin manager
+    <strong>never writes</strong>
+    <code>layout.lua</code>
+    &mdash; placement stays yours, which is why step 2 is a separate edit. And a pane that loads but
+    which no arrangement places draws nothing while looking perfectly healthy:
+    <code>thurbox-cli plugin check</code>
+    is what fails on that, and prints the line to add.
+  </p>
+</div>
+
 <h2 id="every-pane-is-a-plugin">
   Every pane is a plugin
   <a href="#every-pane-is-a-plugin" class="heading-anchor">#</a>

--- a/website/index.html
+++ b/website/index.html
@@ -1,7 +1,7 @@
 ---
 layout: base.njk
 title: 'Thurbox — TUI Agentic IDE'
-description: 'Thurbox runs any coding-agent CLI (Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, pi, Oh My Pi) in persistent tmux panes — sessions, agents, and git worktrees as first-class citizens.'
+description: 'Thurbox runs any coding-agent CLI (Claude Code, Codex, Antigravity, opencode, aider, GitHub Copilot CLI, Vibe, pi, Oh My Pi) in persistent tmux panes — with a fully customizable interface: every pane is a Lua file you can edit, move, turn off or replace.'
 root: '.'
 extraCss: ['landing.css']
 footer: true
@@ -507,6 +507,41 @@ cp docs/examples/layout.lua ~/.config/thurbox/ui/layout.lua</code></pre>
             <em>the selected session runs on</em>
             , which means picking a session over SSH shows you that host's load &mdash; without the
             plugin knowing what SSH is.
+          </p>
+        </div>
+
+        <!-- The on-ramp that needs no Lua at all. The prompts are deliberately
+             styled unlike the <pre> blocks around them, so nobody pastes one
+             into a shell. -->
+        <div class="ui-lab__demo">
+          <p class="ui-lab__demo-lede">
+            <strong>Or just ask the agent.</strong>
+            You do not have to learn Lua to change any of this. thurbox
+            <em>runs coding agents</em>, and the interface is a directory of plain text files those
+            agents can read &mdash; so point a session at it and say what you want:
+          </p>
+          <pre data-wrap><code class="language-bash">thurbox-cli session create --name ui --repo-path ~/.config/thurbox/ui</code></pre>
+          <ul class="prompts">
+            <li>Install the info panel plugin.</li>
+            <li>
+              Add a new pane on the left with CPU and RAM usage. There is a
+              <code>top</code>
+              example plugin &mdash; install it and give it a slot in the layout.
+            </li>
+            <li>Move the search strip to the bottom, and make the session column 30% wide.</li>
+          </ul>
+          <p class="ui-lab__demo-note">
+            It works because the directory ships an
+            <code>AGENTS.md</code>
+            that any coding CLI loads as context without being asked &mdash; so
+            &ldquo;install a plugin&rdquo; is read as
+            <code>thurbox-cli plugin install</code>
+            rather than an npm request, and the agent knows
+            <code>thurbox-cli plugin check</code>
+            is how it verifies its own work. Press
+            <kbd>F10</kbd>
+            and the change is on your screen.
+            <a href="docs/v2-interface.html#ask-the-agent">The worked example &rarr;</a>
           </p>
         </div>
       </div>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -9,20 +9,30 @@
 > open source under the MIT license, and runs on Linux, macOS, and Windows
 > (plus remote hosts over SSH). A headless companion binary, `thurbox-cli`,
 > drives the same sessions for scripting and automation.
+>
+> Since 2.0 its defining feature is that the interface is fully customizable:
+> no UI is compiled into the binary. thurbox boots a Rust kernel that reads a
+> directory of Lua files and draws whatever it finds, so every pane — the
+> session list included — is a file the user can move, turn off, delete,
+> rewrite, or install from someone else, with no recompile and no restart. The
+> arrangement (`ui/layout.lua`), agents (`agents.toml`), hosts (`hosts.toml`),
+> themes, keybindings and settings are all data files. Because the interface is
+> plain text in a directory, the usual way to change it is to point a coding
+> session at that directory and ask for the change in English.
 
 ## Docs
 
 - [Documentation hub](https://thurbox.thurbeen.eu/docs/index.html): entry point to all Thurbox documentation.
 - [FAQ](https://thurbox.thurbeen.eu/docs/faq.html): short answers to the most common questions (what it is, how it differs, install, platforms, license).
-- [Features](https://thurbox.thurbeen.eu/docs/features.html): sessions, agent definitions, git worktrees, remote SSH and WSL hosts, automations, tasks, global search, headless CLI.
+- [Features](https://thurbox.thurbeen.eu/docs/features.html): the customizable interface and a full v1-to-v2 surface map, plus sessions, agent definitions, git worktrees, remote SSH and WSL hosts, automations, tasks, global search, headless CLI.
 - [Built-in agents](https://thurbox.thurbeen.eu/docs/agents.html): every built-in coding agent (claude, codex, antigravity, opencode, aider, copilot, vibe, pi, omp) with its recommended agents.toml config, resume/fork behavior, and status support.
 - [Comparison](https://thurbox.thurbeen.eu/docs/comparison.html): how Thurbox compares to Conductor, Claude Squad, Cursor, and other parallel coding-agent tools.
 - [Installation](https://thurbox.thurbeen.eu/docs/installation.html): install via curl, Homebrew, AUR, winget, Chocolatey, or from source; prerequisites.
 - [Configuration](https://thurbox.thurbeen.eu/docs/configuration.html): every config file and knob — agents.toml, hosts.toml, settings.toml, themes, keybindings.
 - [Deprecated surfaces](https://thurbox.thurbeen.eu/docs/deprecated.html): the six panes 1.x had that the current interface does not — code review and the info panel, now the installable thurbox-code-review and thurbox-info-panel plugins; the file viewer, with no replacement; and the tasks/automations/restore panes that moved to thurbox-cli.
 - [Using v1](https://thurbox.thurbeen.eu/docs/v1.html): thurbox 1.x is still maintained — what it has that the current interface does not, how to stay on it or go back, and what it will receive.
-- [The Interface](https://thurbox.thurbeen.eu/docs/v2-interface.html): every pane is an editable Lua plugin — how to move, disable, replace or write one, what the kernel refuses a plugin, and the two v1 panes (thurbox-code-review, thurbox-info-panel) you install as plugins.
-- [Architecture](https://thurbox.thurbeen.eu/docs/architecture.html): the Elm Architecture, module isolation, the tmux session backend, and design decisions.
+- [The Interface](https://thurbox.thurbeen.eu/docs/v2-interface.html): every pane is an editable Lua plugin — how to move, disable, replace or write one, how to have a coding agent do it for you, what the kernel refuses a plugin, and the two v1 panes (thurbox-code-review, thurbox-info-panel) you install as plugins.
+- [Architecture](https://thurbox.thurbeen.eu/docs/architecture.html): the Lua-on-Rust plugin kernel and its five rules, module isolation, the tmux session backend, and design decisions (including the Elm Architecture the interface used before 2.0).
 
 ## Extensions
 


### PR DESCRIPTION
v2's defining change is that the interface is no longer compiled in — the
binary boots a kernel and draws whatever Lua it finds in a directory. The
README buried that under a migration note that read as pure loss, so:

- state it in the opening paragraph, the Why list, and the comparison
- add a `## Customization` section: what you change and where, the plugin
  directory, installing panes others wrote, and the delivery/decision/
  composition split that keeps it legible
- give it the first row of the feature wall
- document `thurbox-cli plugin` in the CLI reference
- replace the Architecture section, which still described v1's TEA model
  and the deleted `ui`/`app` modules, with the kernel and its five rules

Also corrects claims the interface no longer backs: nine themes (thirty-six),
a search over tasks/automations/the file tree (sessions and their screens), a
tasks side column, the removed task-integration extensions, and a file viewer
that is gone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XAXbK1G9ySuBwvtEyufwPH