### PR TITLE
fix(ui): ask before a force-delete only when work is at risk

### DIFF
--- a/tests/v2_session_list.rs
+++ b/tests/v2_session_list.rs
@@ -9,7 +9,7 @@
 use thurbox::kernel::command::Command;
 use thurbox::kernel::host::{KeyPress, LuaHost, Published, RenderContext};
 use thurbox::kernel::registry::Registry;
-use thurbox::kernel::snapshot::{SessionRow, Snapshot};
+use thurbox::kernel::snapshot::{GitState, SessionRow, Snapshot};
 use thurbox::kernel::theme::Themes;
 
 const PLUGIN: &str = "sessions";
@@ -53,7 +53,7 @@ fn snapshot() -> Snapshot {
     }
 }
 
-fn publish(host: &LuaHost) {
+fn publish_in(host: &LuaHost, snapshot: &Snapshot) {
     let themes = Themes::load(None);
     let mut registry = Registry::default();
     let (bindings, settings) = host.declarations();
@@ -61,7 +61,7 @@ fn publish(host: &LuaHost) {
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
-        snapshot: &snapshot(),
+        snapshot,
         attach_errors: &Default::default(),
         inflight: &[],
         themes: &themes,
@@ -86,7 +86,11 @@ fn publish(host: &LuaHost) {
 
 /// Render the list, which is also what publishes the selection.
 fn render(host: &LuaHost) {
-    publish(host);
+    render_in(host, &snapshot());
+}
+
+fn render_in(host: &LuaHost, snapshot: &Snapshot) {
+    publish_in(host, snapshot);
     let index = host.index_of(PLUGIN).expect("no sessions plugin");
     host.render(
         index,
@@ -102,7 +106,11 @@ fn render(host: &LuaHost) {
 }
 
 fn press(host: &LuaHost, chord: &str) {
-    publish(host);
+    press_in(host, &snapshot(), chord);
+}
+
+fn press_in(host: &LuaHost, snapshot: &Snapshot, chord: &str) {
+    publish_in(host, snapshot);
     let index = host.index_of(PLUGIN).expect("no sessions plugin");
     let mut key = KeyPress {
         name: chord.to_string(),
@@ -198,5 +206,144 @@ fn a_session_that_went_away_does_not_freeze_the_selection() {
         host.shared_string("selected").as_deref(),
         Some("aaa"),
         "the cursor stayed on a row that exists"
+    );
+}
+
+/// A worktree with nothing in it that a delete could not put back.
+fn clean() -> GitState {
+    GitState {
+        files_changed: 0,
+        insertions: 0,
+        deletions: 0,
+        untracked: 0,
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+    }
+}
+
+/// Render the confirmation float and return what it drew, so a test can ask
+/// whether a question was put at all — and what it itemised.
+fn confirm_tree(host: &LuaHost, snapshot: &Snapshot) -> String {
+    publish_in(host, snapshot);
+    let index = host.index_of("confirm").expect("no confirm plugin");
+    let rendered = host
+        .render(
+            index,
+            RenderContext {
+                width: 60,
+                height: 12,
+                focused: false,
+                elapsed: 0.0,
+                frame: 0,
+            },
+        )
+        .expect("render the confirmation");
+    format!("{:?}", rendered.node)
+}
+
+#[test]
+fn force_deleting_a_clean_session_does_not_ask() {
+    // v1's rule, in `App::delete_active_session`: `assess_delete_risk` returning
+    // `Some(risk)` opened `ConfirmDelete`, `None` deleted on the keystroke. v2
+    // asked every time, which is how the answer to a question stops being a
+    // decision.
+    let host = host();
+    let mut snapshot = snapshot();
+    snapshot.sessions[0].git = Some(clean());
+    render_in(&host, &snapshot);
+    press_in(&host, &snapshot, "D");
+
+    assert_eq!(
+        host.drain_commands(),
+        vec![Command::Delete {
+            session: "aaa".into(),
+            force: true,
+        }],
+        "a known-clean session is torn down on the keystroke"
+    );
+    assert!(
+        !confirm_tree(&host, &snapshot).contains("Confirm"),
+        "and no question was put: a worktree directory alone is not work at risk"
+    );
+}
+
+#[test]
+fn force_deleting_a_session_with_work_asks_first_and_says_what_is_lost() {
+    let host = host();
+    let mut snapshot = snapshot();
+    snapshot.sessions[0].git = Some(GitState {
+        files_changed: 2,
+        untracked: 1,
+        dirty: true,
+        ahead: 3,
+        ..clean()
+    });
+    snapshot.sessions[0].worktree_count = 1;
+    render_in(&host, &snapshot);
+    press_in(&host, &snapshot, "D");
+
+    assert!(
+        host.drain_commands().is_empty(),
+        "nothing is torn down until the question is answered"
+    );
+    let tree = confirm_tree(&host, &snapshot);
+    assert!(tree.contains("and its worktree?"), "the question: {tree}");
+    assert!(
+        tree.contains("3 uncommitted or untracked file(s)"),
+        "{tree}"
+    );
+    assert!(
+        tree.contains("3 commit(s) not pushed anywhere else"),
+        "{tree}"
+    );
+    assert!(
+        tree.contains("its worktree directory"),
+        "listed as what else goes, once a question is owed: {tree}"
+    );
+}
+
+#[test]
+fn a_clean_primary_does_not_speak_for_the_other_worktrees() {
+    // The snapshot stats one directory per session, so on a multi-worktree
+    // session a clean answer covers the primary and nothing else. v1 assessed
+    // every worktree it was about to remove; not being able to is unknown.
+    let host = host();
+    let mut snapshot = snapshot();
+    snapshot.sessions[0].git = Some(clean());
+    snapshot.sessions[0].worktree_count = 2;
+    render_in(&host, &snapshot);
+    press_in(&host, &snapshot, "D");
+
+    assert!(
+        host.drain_commands().is_empty(),
+        "a checkout nobody read must not be torn down unasked"
+    );
+    let tree = confirm_tree(&host, &snapshot);
+    assert!(
+        tree.contains("its other worktrees could not be read"),
+        "{tree}"
+    );
+    assert!(
+        tree.contains("its 2 worktree directories"),
+        "and what goes is counted, not assumed singular: {tree}"
+    );
+}
+
+#[test]
+fn a_state_that_could_not_be_read_asks_rather_than_assume_clean() {
+    // `git` is nil for a stat that has not run, a directory that is not a
+    // worktree, and a host that could not be reached. v1 folded all three into
+    // `DeleteRisk::unknown()` and confirmed.
+    let host = host();
+    let snapshot = snapshot();
+    assert!(snapshot.sessions[0].git.is_none());
+    render_in(&host, &snapshot);
+    press_in(&host, &snapshot, "D");
+
+    assert!(host.drain_commands().is_empty(), "it must not delete blind");
+    assert!(
+        confirm_tree(&host, &snapshot).contains("its state could not be read"),
+        "and it says why it is asking"
     );
 }

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -759,32 +759,82 @@ local function soft_delete()
   return settings.features.soft_delete ~= false
 end
 
---- What deleting this session would destroy, itemised.
+--- What deleting this session would destroy, itemised — or nil when it would
+--- destroy nothing.
 ---
---- v1's `DeleteRisk::from_stats`: uncommitted files, commits that exist nowhere
---- else, and — the case that matters most — a worktree whose state could not be
---- read at all, which is reported rather than assumed clean.
+--- v1's `DeleteRisk::from_stats`, its decision included: work is at risk when
+--- there are uncommitted or untracked files, commits that exist nowhere else,
+--- or — the case that matters most — a state that could not be read at all,
+--- which is reported rather than assumed clean. Everything else is a
+--- known-clean session, and nil says so.
+---
+--- The worktree *directory* is deliberately not a reason to ask: force-delete
+--- removes the checkout and leaves the branch, so a clean one comes back from
+--- it. It is listed as context for a question already owed, never as the cause.
 local function at_risk(session)
-  local lines = {}
   local git = session.git
-  if (session.worktrees or 0) > 0 and not git then
-    lines[#lines + 1] = "its worktree state could not be read"
-    return lines
-  end
   if not git then
-    return lines
+    -- Not computed yet, not a git worktree, or a host that could not be
+    -- reached. v1 confirms rather than assume clean.
+    return { "its state could not be read" }
   end
-  local dirty = (git.files or 0) + (git.untracked or 0)
-  if dirty > 0 then
-    lines[#lines + 1] = dirty .. " uncommitted or untracked file(s)"
+
+  local lines = {}
+  local uncommitted = (git.files or 0) + (git.untracked or 0)
+  if uncommitted > 0 then
+    lines[#lines + 1] = uncommitted .. " uncommitted or untracked file(s)"
+  elseif git.dirty then
+    -- `dirty` is any `status --porcelain` output, so it outlives a count of
+    -- zero (a mode change, a submodule). Still work, still unrecoverable.
+    lines[#lines + 1] = "uncommitted changes"
   end
   if (git.ahead or 0) > 0 then
     lines[#lines + 1] = git.ahead .. " commit(s) not pushed anywhere else"
   end
-  if (session.worktrees or 0) > 0 then
+
+  -- Everything above speaks for the session's *primary* directory, which is the
+  -- only one the snapshot stats. v1 inspected every worktree it was about to
+  -- remove, so on a session that owns several the rest are unknown rather than
+  -- clean — a reason to ask in its own right.
+  local worktrees = session.worktrees or 0
+  if worktrees > 1 then
+    lines[#lines + 1] = "its other worktrees could not be read"
+  end
+
+  if #lines == 0 then
+    return nil
+  end
+
+  -- What else goes, once a question is owed. Never the reason for one.
+  if worktrees == 1 then
     lines[#lines + 1] = "its worktree directory"
+  elseif worktrees > 1 then
+    lines[#lines + 1] = "its " .. worktrees .. " worktree directories"
   end
   return lines
+end
+
+--- Delete for good, asking first only when there is something to lose.
+---
+--- v1's `App::delete_active_session`: it assessed the risk and opened
+--- `ConfirmDelete` only for `Some(risk)`, deleting a known-clean session on the
+--- keystroke. Asking about nothing trains the answer, which is the opposite of
+--- what a confirmation is for.
+---
+--- The question travels through `store`, so the confirm plugin needs to know
+--- nothing about sessions.
+local function delete_for_good(session, question)
+  local lines = at_risk(session)
+  if not lines then
+    command("delete", { session = session.id, force = true })
+    return
+  end
+  store.confirm = {
+    question = question,
+    lines = lines,
+    command = "delete",
+    options = { session = session.id, force = true },
+  }
 end
 
 --- The chord bound to opening the creation flow, if anything is.
@@ -1397,26 +1447,19 @@ return {
         state.deleted = id
         command("delete", { session = id })
       else
-        -- The switch is off, so this key deletes for real. v1 asks first and
-        -- itemises what would be lost, because there is no undo to fall back on.
+        -- The switch is off, so this key deletes for real. v1 asks first when
+        -- there is work to lose, because there is no undo to fall back on.
         local session = items[at].session
-        store.confirm = {
-          question = "Delete " .. (session.name or "this session") .. " for good?",
-          lines = at_risk(session),
-          command = "delete",
-          options = { session = id, force = true },
-        }
+        delete_for_good(session, "Delete " .. (session.name or "this session") .. " for good?")
       end
     elseif action == "sessions.force_delete" and id then
-      -- Destructive: ask first. The question travels through `store`, so the
-      -- confirm plugin needs to know nothing about sessions.
+      -- Destructive, and undone by nothing — but only worth a question when it
+      -- would take work with it.
       local session = items[at].session
-      store.confirm = {
-        question = "Delete " .. (session.name or "this session") .. " and its worktree?",
-        lines = at_risk(session),
-        command = "delete",
-        options = { session = id, force = true },
-      }
+      delete_for_good(
+        session,
+        "Delete " .. (session.name or "this session") .. " and its worktree?"
+      )
     elseif action == "sessions.restart" and id then
       command("restart", { session = id })
     elseif action == "sessions.fork" and id then


### PR DESCRIPTION
## Summary

- A force-delete (`D`, and `Ctrl+D` with `[features] soft_delete = false`) now confirms **only when the session has work at risk** — v1's rule, in `App::delete_active_session`: `assess_delete_risk` returning `Some(risk)` opened `ConfirmDelete`, `None` deleted on the keystroke. v2 asked every time, which is how the answer to a question stops being a decision.
- `at_risk` returns nil for a known-clean session, and `delete_for_good` issues the delete straight through. Risk is v1's `DeleteRisk::from_stats` set: uncommitted or untracked files, `dirty` surviving a zero count (a mode change, a submodule), and commits that exist nowhere else.
- The worktree **directory** is no longer a reason to ask: force-delete removes the checkout and leaves the branch, so a clean one comes back from it. It is still listed as context once a question is owed, counted rather than assumed singular.
- Two cases still ask, because neither is known-clean: an unread state (`session.git` nil — the stat has not run, the path is not a git worktree, or the host could not be reached), and a session owning **more than one worktree**, since the snapshot stats the primary directory and no other while v1 inspected every worktree it was about to remove. Silently deleting a dirty secondary checkout is the loss this guards.

## Test plan

- `tests/v2_session_list.rs`, through the real plugins: a clean session is torn down on the keystroke with no question put; a session with work asks and itemises the files, the commits and the worktree directory; an unread state asks and says why; a clean primary on a two-worktree session asks and counts what goes.
- `cargo nextest run --all` — 1870 passed.
- `stylua --check ui`, `selene ui`, `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean.