### PR TITLE
feat(ui): add a Quit button to the action band

### DIFF
--- a/src/kernel/bands.rs
+++ b/src/kernel/bands.rs
@@ -25,7 +25,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
-use super::registry::{Pill, Registry};
+use super::registry::{Pill, Registry, QUIT_CHORD};
 use super::theme::Themes;
 
 /// How severe a message is. v1's `StatusLevel`, and the same three.
@@ -171,7 +171,8 @@ pub struct Hit {
 pub struct Entry {
     pub label: String,
     /// The chord actually bound, which is what the user must press. `None` when
-    /// the action is reachable but unbound.
+    /// the action is reachable but unbound. The Quit entry's is *reserved* rather
+    /// than bound — see [`quit_entry`], the one entry no binding backs.
     pub chord: Option<String>,
     pub action: String,
     pub priority: i64,
@@ -288,6 +289,32 @@ pub fn fit(mut entries: Vec<Entry>, width: usize) -> Vec<Entry> {
         entries.pop();
     }
     entries
+}
+
+/// The action the Quit entry runs.
+///
+/// Quit is **reserved, not declared**: `ctrl+q` is handled before the registry is
+/// consulted (`dispatch_reserved`), so no binding exists for an entry to resolve
+/// against — and none may, because a *rebindable* quit is what the reserved chord
+/// exists to prevent. So the band carries this entry itself and the loop routes a
+/// press on it directly, which is why the action name lives here rather than in a
+/// declaration table.
+pub const QUIT_ACTION: &str = "core.quit";
+
+/// v1's rightmost footer pill, and the only entry with no binding behind it.
+///
+/// The chord is [`QUIT_CHORD`] — the very string the reserved table
+/// refuses to rebind — put through `compact_chord` like every other entry's, so
+/// the one action the registry cannot resolve still reads identically to the ones
+/// it can. Its priority is below any declared entry's so it renders last, which
+/// is v1's `FOOTER_BUTTONS` order.
+pub fn quit_entry() -> Entry {
+    Entry {
+        label: "Quit".to_string(),
+        chord: Some(compact_chord(QUIT_CHORD)),
+        action: QUIT_ACTION.to_string(),
+        priority: i64::MIN,
+    }
 }
 
 /// The action band's left cluster, in v1's four parts
@@ -484,22 +511,27 @@ fn render_message(frame: &mut Frame, area: Rect, state: &BandState<'_>) {
 }
 
 /// v1 `ui::status_bar::render_footer`: the left cluster, then the entries
-/// right-aligned and shed lowest-priority-first when the width runs out.
+/// right-aligned and shed lowest-priority-first when the width runs out — around
+/// a Quit entry that never sheds.
 fn render_action(frame: &mut Frame, area: Rect, state: &BandState<'_>) -> Vec<Hit> {
     let all = entries(state.registry.pills(), state.registry);
     // The left cluster is bounded by what the entries leave, so it can never run
     // underneath them.
-    let fitted = fit(all, usize::from(area.width).saturating_sub(2));
+    let budget = usize::from(area.width).saturating_sub(2);
+    // Quit's cells come off the top rather than being left to `fit`: v1 sheds
+    // Theme → Settings → Help around it and keeps Quit at every width, because
+    // the button that gets you out must not be the one that disappears. The
+    // declared entries then fit into what is left instead of competing with it.
+    let quit = quit_entry();
+    let reserved = entries_width(std::slice::from_ref(&quit)) + ENTRY_GAP;
+    let mut fitted = fit(all, budget.saturating_sub(reserved));
+    fitted.push(quit);
     let block = entries_width(&fitted);
     let left_width = usize::from(area.width).saturating_sub(block);
 
     let left = fit_to_budget(left_spans(state), left_width);
     if !left.is_empty() {
         frame.render_widget(Paragraph::new(Line::from(left)), area);
-    }
-
-    if fitted.is_empty() {
-        return Vec::new();
     }
 
     // Placed left-to-right from where the right-aligned block starts, so the
@@ -696,6 +728,26 @@ mod tests {
 
         // Nothing fits: an empty run rather than a truncated label.
         assert!(fit(resolved, 3).is_empty());
+    }
+
+    #[test]
+    fn quit_is_advertised_with_the_reserved_chord_and_renders_last() {
+        // The one entry not resolved from the registry, because quit has no
+        // binding to resolve — but it must read like every other entry, and sort
+        // behind them the way v1's footer puts `Quit` last.
+        let quit = quit_entry();
+        assert_eq!(quit.display(), "Quit · ^Q");
+        assert_eq!(quit.action, QUIT_ACTION);
+
+        let registry = registry_with(
+            vec![binding("help.open", "f1")],
+            vec![pill("help.open", "Help", 0)],
+        );
+        let declared = entries(registry.pills(), &registry);
+        assert!(
+            quit.priority < declared[0].priority,
+            "quit must sort behind a declared entry, even an unprioritised one"
+        );
     }
 
     #[test]

--- a/src/kernel/modals/help.rs
+++ b/src/kernel/modals/help.rs
@@ -23,7 +23,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
 use super::chrome::{self, Chrome, Hits, Pill, Replay};
-use crate::kernel::registry::{Binding, Registry, HELP_SECTIONS};
+use crate::kernel::registry::{Binding, Registry, HELP_SECTIONS, QUIT_CHORD};
 
 /// Narrowest the chord column gets, from v1's `help_line` (`{key:<16}`).
 ///
@@ -50,7 +50,7 @@ const KEY_WIDTH: usize = 16;
 /// the settings tabs because they belong to a modal rather than to the registry
 /// — a key nobody can discover is a key nobody uses.
 const RESERVED_ROWS: [(&str, &str); 7] = [
-    ("ctrl+q", "Quit"),
+    (QUIT_CHORD, "Quit"),
     ("f10", "Reload plugins"),
     ("ctrl+h / ctrl+l", "Focus previous / next pane"),
     ("f12", "Perf counters"),

--- a/src/kernel/modals/mod.rs
+++ b/src/kernel/modals/mod.rs
@@ -114,12 +114,11 @@ pub fn bindings() -> Vec<Binding> {
 /// resolves the chord from the registry, so an entry cannot advertise a chord
 /// the keyboard does not honour, and rebinding one moves its entry with it.
 ///
-/// v1's footer also carries `Quit`. It is absent because quit is not a declared
-/// action — `ctrl+q` is handled before the registry is consulted, so it has no
-/// binding for an entry to resolve against, and an entry naming an unknown
-/// action is dropped by design. Giving quit a declaration is a change of its
-/// own, since a *rebindable* quit is exactly what the reserved chord exists to
-/// prevent.
+/// v1's footer also carries `Quit`, and this list deliberately does not: quit is
+/// not a declared action — `ctrl+q` is handled before the registry is consulted,
+/// so it has no binding for an entry to resolve against, and giving it one would
+/// make it rebindable, which is exactly what the reserved chord exists to
+/// prevent. The band carries that entry itself instead (`bands::quit_entry`).
 pub fn pills() -> Vec<Pill> {
     [
         (ModalKind::Help, "Help", 90),

--- a/src/kernel/registry.rs
+++ b/src/kernel/registry.rs
@@ -134,6 +134,14 @@ pub struct Conflict {
     pub shadowed: String,
 }
 
+/// The chord that quits, spelled once.
+///
+/// It is reserved (below), listed in help, and carried by the action band's Quit
+/// entry — three places that must agree about a chord *no binding backs*, since
+/// quit is handled before the registry is consulted. The other four reserved
+/// chords need no such constant: nothing outside this table spells them out.
+pub const QUIT_CHORD: &str = "ctrl+q";
+
 /// Chords the kernel keeps for itself.
 ///
 /// The escape route: a plugin that consumes every key it is offered must not be
@@ -150,7 +158,7 @@ pub struct Conflict {
 // every coding agent uses Tab for completion — taking it for focus movement
 // makes the pane unusable for the thing the pane exists to run. Focus moves on
 // Ctrl+H/Ctrl+L, which v1 reserves for exactly this reason.
-pub const RESERVED: [&str; 5] = ["ctrl+q", "f10", "ctrl+h", "ctrl+l", "f12"];
+pub const RESERVED: [&str; 5] = [QUIT_CHORD, "f10", "ctrl+h", "ctrl+l", "f12"];
 
 /// Everything declared, plus what the user changed.
 #[derive(Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3524,6 +3524,13 @@ impl App {
     /// footer does. Falling back to the clicked plugin covers an action a
     /// plugin handles without declaring a key for it.
     fn run_clicked_action(&mut self, action: &str, clicked: usize) {
+        // Quit is reserved rather than declared, so it has no binding for the
+        // registry lookup below to resolve: the band carries the entry itself
+        // and the press lands here. The mouse half of `dispatch_reserved`.
+        if action == bands::QUIT_ACTION {
+            self.quit = true;
+            return;
+        }
         // The footer names these by action, as it names a pane's — so a pill
         // reaches a modal the same way its chord does.
         if let Some(kind) = ModalKind::from_action(action) {

--- a/tests/v2_chrome.rs
+++ b/tests/v2_chrome.rs
@@ -342,6 +342,9 @@ fn the_action_band_carries_the_focus_the_counts_and_the_entries() {
     assert!(row.contains("Help · F1"), "{row}");
     assert!(row.contains("Theme · F4"), "{row}");
     assert!(row.contains("Settings · F6"), "{row}");
+    // v1's rightmost pill, and the only entry the registry does not resolve:
+    // quit is reserved rather than declared, so the band carries it itself.
+    assert!(row.contains("Quit · ^Q"), "{row}");
     assert!(
         !row.contains("Shell"),
         "the shell is offered by the tab strip, not twice: {row}"
@@ -397,8 +400,11 @@ fn every_entry_is_a_button_with_a_hitbox_over_its_own_label() {
             ClickVerb::Action(action) => action,
             other => panic!("an entry must be an action, got {other:?}"),
         };
+        // Quit is the one exception, and by design: it is reserved rather than
+        // declared, so there is no binding for it to be found under.
         assert!(
-            registry.bindings().iter().any(|b| b.action == action),
+            action == thurbox::kernel::bands::QUIT_ACTION
+                || registry.bindings().iter().any(|b| b.action == action),
             "{action} is not declared anywhere"
         );
         // The hitbox covers the label the user is aiming at.
@@ -456,6 +462,27 @@ fn the_left_cluster_gives_up_its_parts_tail_first() {
     busy.automation_count = 2;
     let with_autos = band_row(thurbox::kernel::bands::Band::Action, &busy, 160);
     assert!(with_autos.contains("2 automation(s)"), "{with_autos}");
+}
+
+#[test]
+fn quit_outlives_every_other_entry_when_the_band_narrows() {
+    // v1 sheds Theme → Settings → Help and keeps `Quit` at any width: the button
+    // that gets you out must not be the one that disappears.
+    let themes = Themes::load(None);
+    let host = host();
+    let registry = action_registry(&host);
+    let state = band_state(&registry, &themes, None);
+
+    let wide = band_row(thurbox::kernel::bands::Band::Action, &state, 160);
+    assert!(wide.contains("Help · F1"), "{wide}");
+    assert!(wide.contains("Quit · ^Q"), "{wide}");
+
+    let narrow = band_row(thurbox::kernel::bands::Band::Action, &state, 20);
+    assert!(narrow.contains("Quit · ^Q"), "quit survives: {narrow}");
+    assert!(
+        !narrow.contains("Help"),
+        "the declared entries shed around it: {narrow}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- v1's footer carried a `Quit · ^Q` pill; v2's action band dropped it, because quit is **reserved rather than declared** — `ctrl+q` is handled before the registry is consulted, so there is no binding for an entry to resolve against and an entry naming an unknown action is dropped by design.
- The band now carries that entry itself (`bands::quit_entry`) rather than giving quit a declaration: a *rebindable* quit is exactly what the reserved chord exists to prevent.
- Its cells come off the top of the width budget instead of being left to `fit`, so the declared entries (Help / Theme / Settings) shed around it and Quit survives at every width — v1's rule that the button which gets you out must not be the one that disappears.
- A press is routed in `run_clicked_action` ahead of the registry lookup: the mouse half of `dispatch_reserved`. Hover comes for free, since the chip carries the same `action:` role every entry does.
- The reserved chord now has one spelling, `registry::QUIT_CHORD`, shared by the reserved table, help's row for it, and the new entry.
- Refreshed the doc comment in `kernel::modals` that explained why Quit was *absent* from the pill list.

## Test plan

- `cargo nextest run --all` — 1872 passed.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc` — clean (full pre-commit gate ran on the commit).
- New coverage: `bands::tests::quit_is_advertised_with_the_reserved_chord_and_renders_last` (spelling + sort position), `v2_chrome::quit_outlives_every_other_entry_when_the_band_narrows` (survives at 20 columns while `Help` sheds), the action-band row assertion extended with `Quit · ^Q`, and `every_entry_is_a_button_with_a_hitbox_over_its_own_label` taught that Quit is the one entry with no binding behind it.