### PR TITLE
feat(ui): let a pane offer a link the outer terminal can open

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2349,12 +2349,20 @@ That gesture matters: no escape sequence says "open this URL", so a
 terminal-side click is the *only* way a thurbox on a remote host can open
 a browser on the machine the user is sitting at.
 
-So after each frame is flushed, `App::paint_terminal_hyperlinks`
+So after each frame is flushed, `App::paint_outer_hyperlinks`
 re-prints the visible runs wrapped in OSC 8 — the same glyphs with the
 same styles, read back out of the drawn frame, so nothing changes
 visually and only the terminal's hyperlink state is added. Windows
 Terminal, kitty, WezTerm and iTerm2 then underline the label on hover and
 open the user's own browser on Ctrl/Cmd+Click.
+
+**An interface pane rides the same pass**, via the `url:<link>` click verb
+(`ClickVerb::Url`). It has to: a plugin returns cells and the kernel paints
+them, so nothing in that path can put an escape on the wire — the identical
+text in a pane was not Ctrl+Click-able while an agent's transcript was, and
+on a remote host the outer terminal is the only leg with a browser to reach.
+The verb's nodes are read out of the drawn frame like a session's runs, and
+`docs/PLUGINS.md` has the authoring side.
 
 Three properties keep this safe and cheap:
 
@@ -2371,6 +2379,13 @@ Three properties keep this safe and cheap:
   there, so a covering overlay, a scrolled pane, or a repainted row
   yields nothing instead of escapes written over current content. A label
   clipped by the pane's right edge is linked as far as it is visible.
+  A `url:` node has no label to match — its text lives in the plugin's
+  tree, already through wrapping, alignment and scroll — so the covering
+  surfaces are checked directly instead (`App::link_paint_obscured`: a
+  modal owns the screen, a float owns its rect). Without it a modal over
+  such a node would link the modal's own glyphs. Blank cells either side
+  of the node's glyphs are trimmed, since the rect a node is given is
+  wider than the text in it.
 - **Off the hot path when unused**: the pass bails on
   `HyperlinkTable::is_empty()` before computing layout or scanning the
   screen, so a session whose agent never printed a link pays one check

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -70,13 +70,16 @@ stays stale longer than a blink. The black-box smoke test
 post-keystroke frame paint.
 
 **One pass rides along after each paint**:
-`App::paint_terminal_hyperlinks` re-emits the frame's OSC 8 hyperlinks so the
+`App::paint_outer_hyperlinks` re-emits the frame's OSC 8 hyperlinks so the
 outer terminal can offer its own open-link gesture (see the Clickable URLs
 section of `docs/FEATURES.md`). It is bound to the *painted* frames — ratatui
 rewrites the cells, so the escapes must follow each draw — and is gated on
 `HyperlinkTable::is_empty()` **before** it computes layout or extracts screen
 rows, so a session whose agent never printed a link pays a single emptiness
-check per frame. When links are present the scan is bounded (the newest 128
+check per frame. The pane half (a `url:` node, `ClickVerb::Url`) walks the
+hitboxes the paint just recorded, which costs one `split_once` per target — no
+allocation unless a role actually is a verb — and reads cells only for the
+targets that are one. When links are present the scan is bounded (the newest 128
 runs × the visible rows) and the writes are a handful of short `queue!`s per
 visible run, bracketed in DECSC/DECRC so the caret the frame just placed is put
 back rather than left wherever the last run ended.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -402,6 +402,7 @@ verb and the kernel answers it without calling you at all:
 { type = "text", len = 8, role = "action:themes.open", text = " Theme " }
 { type = "text", len = 5, role = "key:ctrl+q",         text = " Quit " }
 { type = "text", len = 7, role = "focus:notes",        text = " Notes " }
+{ type = "text", len = 1, role = "url:" .. mr.url,     text = { … } }
 ```
 
 - `action:<id>` runs a declared action, on whichever plugin declared it — so one
@@ -410,6 +411,38 @@ verb and the kernel answers it without calling you at all:
   a button and its letter cannot come to mean different things.
 - `focus:<plugin>` focuses that plugin, which in a `switch` slot is also how its
   view is brought forward.
+- `url:<link>` opens the link, and is the one verb that also changes how the
+  node is *painted* — see below.
+
+### `url:` is a link, not just a click
+
+The value is the whole rest of the role, so a url keeps its own `:` and `//`
+(`url:https://example.test/a`, `url:mailto:me@example.test`). A plain click hands
+it to the same opener a `Ctrl+Click` on a link in an agent's transcript rides —
+including the copy-to-clipboard fallback that carries the url back over ssh — so
+a pane's link and a transcript's link cannot open in two different places.
+
+What the other verbs do not do: the node's **drawn cells are re-printed wrapped
+in OSC 8**, so `Ctrl+Click` over them is answered by the terminal thurbox itself
+runs in. That matters because a pane hands the kernel cells and can emit no
+escape of its own, and because on a remote host the outer terminal is the only
+leg with a browser to reach. The chord is resolved against `url:` nodes directly
+as well, so it still works in an emulator with no OSC 8 support, or on a bare
+tty.
+
+Three consequences worth knowing:
+
+- The cells are read back out of the **frame just drawn**, not out of your tree,
+  so a node clipped by its pane, covered by a modal or under a float contributes
+  no link — the same rule an agent's own runs follow.
+- Blank cells are trimmed from either end, because the rect a node was given is
+  wider than the glyphs in it and linking the padding would underline the whole
+  row. Interior blanks stay, so ` Open MR !123 ` links as `Open MR !123`.
+- A node spanning several rows emits one link per row, all naming the same url —
+  which is how a wrapped link is spelled in OSC 8 anyway.
+
+`command("open", { text = url })` is the imperative half, for a link you open
+from a keypress rather than a click. The field is `text`, not `url`.
 
 Everything else — a list row, most often — is offered to the plugin that painted
 it:

--- a/docs/V2-KERNEL.md
+++ b/docs/V2-KERNEL.md
@@ -227,6 +227,20 @@ Change the recording order and the collapse chevron on a pane's border silently
 starts focusing the pane instead. v1 spells the same rule the other way round
 (specific targets recorded first, first match wins).
 
+**A pane cannot emit an escape, so a link has to be re-printed for it.** A
+plugin returns cells; the kernel paints them. Nothing in that path can put an
+OSC 8 sequence on the wire, which is why a url a pane draws was not
+`Ctrl+Click`-able even though the identical text in an agent's transcript was —
+the transcript's runs are re-printed wrapped in the escape after the frame
+flushes (`paint_outer_hyperlinks`), and only sessions were offered to that
+leg. The `url:<link>` click verb is that asymmetry closed: the verb's nodes ride
+the same re-print, so the outer terminal owns the chord over them, and the
+kernel resolves the chord against them too for an emulator that does not
+understand OSC 8. The cells are read back out of the frame just drawn rather
+than off the tree, so wrapping, alignment and scroll need not be re-derived —
+and the covering surfaces are checked explicitly, because a pane's node has no
+label to match against the buffer the way a vt100 run does.
+
 **Terminal encodings differ, and folding them belongs in the kernel.** A legacy
 terminal sends a bare `J` with no SHIFT; a kitty-protocol one sends `j` plus
 SHIFT. `ctrl+/` arrives as one of three things. `registry::canonical_chord`

--- a/src/kernel/command.rs
+++ b/src/kernel/command.rs
@@ -558,7 +558,10 @@ impl Command {
         if kind == "open" {
             return match text.filter(|t| !t.is_empty()) {
                 Some(url) => Ok(Command::OpenLink { url }),
-                None => Err("command \"open\" needs a url".to_string()),
+                // Names the field, because the field is what goes wrong:
+                // `{ url = ... }` is what "needs a url" invites, and it parses
+                // to no text and so to no visible effect at all.
+                None => Err("command \"open\" needs a url in text".to_string()),
             };
         }
         // Theme is global; every other command acts on one session.

--- a/src/kernel/node.rs
+++ b/src/kernel/node.rs
@@ -108,6 +108,19 @@ pub enum ClickVerb {
     /// `ClickAction::FocusPane` and `CentralTab`, which in v2 are the same act:
     /// a `switch` slot shows whichever occupant holds focus.
     Focus(String),
+    /// `url:<link>` — open the link, through the very opener (and the same
+    /// copy-to-clipboard fallback) a `Ctrl+Click` on an agent's own OSC 8 run
+    /// rides, so a pane's link and a transcript's link cannot open in two
+    /// different places.
+    ///
+    /// The one verb whose value is not a name the kernel resolves, and the
+    /// reason it is a verb at all: the node's drawn cells are also re-printed
+    /// wrapped in OSC 8, which is what hands `Ctrl+Click` over them to the
+    /// terminal thurbox itself runs in — the only leg with a browser to reach
+    /// when the interface is on the far end of an ssh connection. A pane emits
+    /// no escapes of its own, so without this there is no route from painted
+    /// pane content to a link the outer terminal knows about.
+    Url(String),
 }
 
 impl ClickVerb {
@@ -123,6 +136,9 @@ impl ClickVerb {
             "action" => Some(ClickVerb::Action(rest.to_string())),
             "key" => Some(ClickVerb::Key(rest.to_string())),
             "focus" => Some(ClickVerb::Focus(rest.to_string())),
+            // `split_once` stopped at the FIRST colon, which is what leaves a
+            // url's own scheme separator and its `//` intact.
+            "url" => Some(ClickVerb::Url(rest.to_string())),
             _ => None,
         }
     }
@@ -689,6 +705,23 @@ mod tests {
             ClickVerb::parse(Some("focus:review")),
             Some(ClickVerb::Focus("review".to_string()))
         );
+    }
+
+    /// A url is the one verb value with structure of its own, and both halves
+    /// of that structure are colons the parse must not eat: the scheme's
+    /// separator and the `//` after it.
+    #[test]
+    fn a_url_verb_keeps_the_links_own_colons() {
+        assert_eq!(
+            ClickVerb::parse(Some("url:https://example.test/a:b?q=1#f")),
+            Some(ClickVerb::Url("https://example.test/a:b?q=1#f".to_string()))
+        );
+        assert_eq!(
+            ClickVerb::parse(Some("url:mailto:someone@example.test")),
+            Some(ClickVerb::Url("mailto:someone@example.test".to_string()))
+        );
+        assert_eq!(ClickVerb::parse(Some("url:")), None);
+        assert_eq!(ClickVerb::parse(Some("url:   ")), None);
     }
 
     #[test]

--- a/src/kernel/terminal.rs
+++ b/src/kernel/terminal.rs
@@ -1673,16 +1673,81 @@ fn drawn_label_cells(
         if !cell.symbol().starts_with(ch) {
             return None;
         }
-        cells.push((
-            cell.symbol().to_string(),
-            Style::new()
-                .fg(cell.fg)
-                .bg(cell.bg)
-                .add_modifier(cell.modifier),
-        ));
+        cells.push((cell.symbol().to_string(), cell_style(cell)));
         cx = cx.saturating_add(width);
     }
     (!cells.is_empty()).then_some(cells)
+}
+
+/// The style a drawn cell carries, as re-printing it needs it back.
+fn cell_style(cell: &ratatui::buffer::Cell) -> Style {
+    Style::new()
+        .fg(cell.fg)
+        .bg(cell.bg)
+        .add_modifier(cell.modifier)
+}
+
+/// One paint per drawn row of `rect`, so a node a plugin painted can be a link
+/// the outer terminal opens. Every row names the same url, which is how a
+/// wrapped link is spelled in OSC 8 anyway.
+///
+/// The pane counterpart of `drawn_label_cells`, and it differs in the one way
+/// a pane differs from a vt100 grid: there is no label to match the glyphs
+/// against, because the text lives in the plugin's tree and has already been
+/// through wrapping, alignment and scroll by the time it reaches the frame. So
+/// the frame is the source of truth outright — whatever the node's rect
+/// actually shows is what gets linked, which keeps the property that a node
+/// clipped by its pane or drawn nowhere contributes nothing.
+///
+/// Blank cells are trimmed from either end because a pane indents its text: the
+/// rect a node was given is wider than the glyphs in it, and linking the
+/// padding would put the underline (and the click target the emulator draws)
+/// across the whole row. Interior blanks stay — they are inside the label.
+/// Ratatui's filler cell after a wide glyph is skipped for the reason
+/// `drawn_label_cells` advances by display width: re-printing the wide glyph
+/// moves the cursor over both cells itself.
+pub fn drawn_link_paints(buf: &Buffer, rect: Rect, url: &str) -> Vec<HyperlinkPaint> {
+    let mut paints = Vec::new();
+    for y in rect.top()..rect.bottom() {
+        // The first glyph's column, and `None` while the row has shown none:
+        // only a non-blank cell sets it, so a row the plugin left blank yields
+        // no link at all rather than a link with no text in it.
+        let mut start = None;
+        let mut cells: Vec<(String, Style)> = Vec::new();
+        for x in rect.left()..rect.right() {
+            // Outside the frame entirely: nothing further along this row is
+            // drawn either.
+            let Some(cell) = buf.cell(Position::new(x, y)) else {
+                break;
+            };
+            let symbol = cell.symbol();
+            if symbol.is_empty() {
+                continue;
+            }
+            if start.is_none() && symbol.trim().is_empty() {
+                continue;
+            }
+            start.get_or_insert(x);
+            cells.push((symbol.to_string(), cell_style(cell)));
+        }
+        // Trailing padding, trimmed the way the leading padding was skipped.
+        // It cannot empty `cells`: the cell that set `start` is not blank.
+        while cells
+            .last()
+            .is_some_and(|(symbol, _)| symbol.trim().is_empty())
+        {
+            cells.pop();
+        }
+        if let Some(x) = start {
+            paints.push(HyperlinkPaint {
+                x,
+                y,
+                url: url.to_string(),
+                cells,
+            });
+        }
+    }
+    paints
 }
 
 /// Re-print each run wrapped in OSC 8, so the terminal thurbox itself runs in
@@ -2156,5 +2221,78 @@ mod tests {
         let all: Vec<ProgramKey> = stale_program_keys(keys.iter(), &[]);
         assert_eq!(all.len(), 2);
         let _ = watch;
+    }
+
+    /// A buffer with `text` written into row `y` starting at column 0, the rest
+    /// left as the blanks a pane's padding is.
+    fn buffer_with(width: u16, height: u16, rows: &[&str]) -> Buffer {
+        let mut buf = Buffer::empty(Rect::new(0, 0, width, height));
+        for (y, text) in rows.iter().enumerate() {
+            buf.set_string(0, y as u16, text, Style::default());
+        }
+        buf
+    }
+
+    /// The glyphs, and only the glyphs: a pane indents its text, and linking a
+    /// node's whole rect would underline the padding either side of it.
+    #[test]
+    fn a_nodes_drawn_cells_are_the_link_and_its_padding_is_not() {
+        let buf = buffer_with(30, 1, &["  https://example.test/a   "]);
+        let paints = drawn_link_paints(&buf, Rect::new(0, 0, 30, 1), "https://example.test/a");
+
+        assert_eq!(paints.len(), 1);
+        let paint = &paints[0];
+        assert_eq!((paint.x, paint.y), (2, 0));
+        assert_eq!(paint.url, "https://example.test/a");
+        let printed: String = paint
+            .cells
+            .iter()
+            .map(|(symbol, _)| symbol.as_str())
+            .collect();
+        assert_eq!(printed, "https://example.test/a");
+    }
+
+    /// Interior blanks are inside the label, so a linked button keeps its own
+    /// spacing — only the ends are trimmed.
+    #[test]
+    fn interior_blanks_stay_inside_the_label() {
+        let buf = buffer_with(20, 1, &[" Open MR !123 "]);
+        let paints = drawn_link_paints(&buf, Rect::new(0, 0, 20, 1), "https://example.test/1");
+
+        assert_eq!(paints.len(), 1);
+        assert_eq!(paints[0].x, 1);
+        let printed: String = paints[0]
+            .cells
+            .iter()
+            .map(|(symbol, _)| symbol.as_str())
+            .collect();
+        assert_eq!(printed, "Open MR !123");
+    }
+
+    /// A row the plugin left blank is not a link with no text in it — it is not
+    /// a link. Same for a rect the frame is too small to hold.
+    #[test]
+    fn a_blank_row_yields_no_link() {
+        let buf = buffer_with(20, 2, &["   ", "  x"]);
+        // Row 0 is blank: only row 1 contributes.
+        let paints = drawn_link_paints(&buf, Rect::new(0, 0, 20, 2), "https://example.test");
+        assert_eq!(paints.len(), 1);
+        assert_eq!((paints[0].x, paints[0].y), (2, 1));
+
+        assert!(drawn_link_paints(&buf, Rect::new(0, 0, 20, 0), "u").is_empty());
+        assert!(drawn_link_paints(&buf, Rect::new(0, 5, 20, 1), "u").is_empty());
+    }
+
+    /// One paint per row, all naming the same url: that is how a wrapped link is
+    /// spelled in OSC 8, and a multi-row node is the same shape.
+    #[test]
+    fn every_drawn_row_of_a_node_carries_the_same_url() {
+        let buf = buffer_with(20, 2, &["  first", "  second"]);
+        let paints = drawn_link_paints(&buf, Rect::new(0, 0, 20, 2), "https://example.test");
+
+        assert_eq!(paints.len(), 2);
+        assert!(paints.iter().all(|p| p.url == "https://example.test"));
+        assert_eq!(paints[0].y, 0);
+        assert_eq!(paints[1].y, 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1402,7 +1402,7 @@ impl App {
             }
             // After the backend flushed, so the escapes cannot interleave
             // with ratatui's own output.
-            self.paint_terminal_hyperlinks(&buffer);
+            self.paint_outer_hyperlinks(&buffer);
             self.last_paint = Instant::now();
             self.frames += 1;
             Counters::bump(&self.perf.frames);
@@ -3423,13 +3423,21 @@ impl App {
         // action and leaves focus where it was. v1's footer pills behave the same
         // — you press Help without leaving the terminal you were in.
         if let Some(hit) = self.band_target_at(x, y) {
-            if let Some(ClickVerb::Action(action)) = hit.identity.click_verb() {
+            match hit.identity.click_verb() {
                 // `clicked` is only the fallback owner, and a band has no plugin
                 // to fall back to; the action's own declaration is what resolves
                 // it, exactly as for a pill drawn by a pane.
-                self.run_clicked_action(&action, self.focus);
-                self.dirty = true;
-                return;
+                Some(ClickVerb::Action(action)) => {
+                    self.run_clicked_action(&action, self.focus);
+                    self.dirty = true;
+                    return;
+                }
+                Some(ClickVerb::Url(url)) => {
+                    self.open_or_copy_link(&url);
+                    self.dirty = true;
+                    return;
+                }
+                _ => {}
             }
         }
 
@@ -3490,6 +3498,12 @@ impl App {
                 if let Some(index) = self.host.index_of(&plugin) {
                     self.focus_plugin(index);
                 }
+                true
+            }
+            // The same opener a `Ctrl+Click` on an agent's link rides, so the
+            // two cannot open the same URL in two different places.
+            Some(ClickVerb::Url(url)) => {
+                self.open_or_copy_link(&url);
                 true
             }
             // A pane that paints itself cell by cell (the theme picker, the
@@ -3588,7 +3602,16 @@ impl App {
     ///
     /// Silent when there is not: v1 emits no toast for a control-click on plain
     /// text, because the chord is also how you click *through* the terminal.
+    ///
+    /// A pane's `url:` node is resolved as well as a session's OSC 8 run. The
+    /// re-printed escapes already hand the chord to the outer terminal wherever
+    /// it understands them, so this leg is what makes the same press work in an
+    /// emulator that does not — or on a bare tty.
     fn open_clicked_link(&mut self, x: u16, y: u16) {
+        if let Some(url) = self.clicked_node_url(x, y) {
+            self.open_or_copy_link(&url);
+            return;
+        }
         let Some((session, rect)) = self.surface_at(x, y) else {
             return;
         };
@@ -3597,6 +3620,37 @@ impl App {
         if let Some(url) = self.terminals.url_at(&session, row, col) {
             self.open_or_copy_link(&url);
         }
+    }
+
+    /// The link a painted node declares under a point.
+    ///
+    /// Bands before panes, the order `on_click` resolves a plain press in. But
+    /// **every** target under the point is considered, innermost first, rather
+    /// than only the topmost one: a `url:` box with a styled child inside it
+    /// records the child last, so the topmost-only rule the other verbs follow
+    /// would leave the chord finding nothing over cells the paint pass had
+    /// already wrapped in OSC 8 — the two legs of one verb disagreeing, with
+    /// nothing to see. `Ctrl+Click` is a link gesture and nothing else, so
+    /// looking past a node that declares no link costs no other behaviour.
+    fn clicked_node_url(&self, x: u16, y: u16) -> Option<String> {
+        let position = ratatui::layout::Position::new(x, y);
+        let bands = self
+            .band_targets
+            .iter()
+            .rev()
+            .map(|hit| (hit.rect, &hit.identity));
+        let panes = self
+            .click_targets
+            .iter()
+            .rev()
+            .map(|target| (target.rect, &target.identity));
+        bands
+            .chain(panes)
+            .filter(|(rect, _)| rect.contains(position))
+            .find_map(|(_, identity)| match identity.click_verb() {
+                Some(ClickVerb::Url(url)) => Some(url),
+                _ => None,
+            })
     }
 
     /// Open a link, or copy it where nothing can open one.
@@ -3656,21 +3710,70 @@ impl App {
         self.dirty = true;
     }
 
-    /// Hand every visible OSC 8 run back to the terminal thurbox runs in.
+    /// Hand every visible link back to the terminal thurbox runs in.
     ///
     /// The only route to a browser when the agent is on a remote host: the
     /// outer terminal opens the link, so it has to be told the runs are links.
     /// Every attached session is offered rather than only the focused one,
     /// because the paints are validated against the drawn buffer — a session
     /// not painted this frame contributes nothing on its own.
-    fn paint_terminal_hyperlinks(&self, buf: &ratatui::buffer::Buffer) {
+    ///
+    /// A pane's [`ClickVerb::Url`] nodes ride the same leg, which is the whole
+    /// point of the verb: a plugin hands the kernel cells and can emit no
+    /// escape of its own, so this is the only place its content can become a
+    /// link the outer terminal knows about.
+    fn paint_outer_hyperlinks(&self, buf: &ratatui::buffer::Buffer) {
         let mut paints = Vec::new();
         for row in &self.snapshots.current().sessions {
             paints.extend(self.terminals.hyperlink_paints(&row.id, buf));
         }
+        // A band's hit carries no plugin, which is also what makes it unable to
+        // be its own float — hence the `Option`.
+        let panes = self
+            .click_targets
+            .iter()
+            .map(|target| (Some(target.plugin), target.rect, &target.identity));
+        let bands = self
+            .band_targets
+            .iter()
+            .map(|hit| (None, hit.rect, &hit.identity));
+        for (plugin, rect, identity) in panes.chain(bands) {
+            let Some(ClickVerb::Url(url)) = identity.click_verb() else {
+                continue;
+            };
+            if self.link_paint_obscured(plugin, rect) {
+                continue;
+            }
+            paints.extend(thurbox::kernel::terminal::drawn_link_paints(
+                buf, rect, &url,
+            ));
+        }
         if !paints.is_empty() {
             let _ = thurbox::kernel::terminal::paint_hyperlinks(&paints);
         }
+    }
+
+    /// Is something drawn over these cells, so that linking them would link
+    /// somebody else's glyphs?
+    ///
+    /// `hyperlink_paints` gets this for free by matching the glyphs it expects
+    /// against the frame — a run the frame no longer prints there drops out. A
+    /// pane's node has no label to match (the text is in the plugin's tree, and
+    /// wrapping and scroll have moved it since), so what covers it is checked
+    /// directly instead: a modal owns the whole screen while it is up, and a
+    /// float owns its rect. Without this a modal over a `url:` node would make
+    /// the modal's own text `Ctrl+Click` to that url.
+    fn link_paint_obscured(&self, plugin: Option<usize>, rect: Rect) -> bool {
+        if self.modals.is_open() {
+            return true;
+        }
+        self.drawn_floats.iter().any(|index| {
+            Some(*index) != plugin
+                && self
+                    .last_floats
+                    .get(index)
+                    .is_some_and(|(float, _)| float.intersects(rect))
+        })
     }
 
     /// Arm a drag-to-select over the terminal surface under the point.

--- a/tests/v2_mouse.rs
+++ b/tests/v2_mouse.rs
@@ -164,9 +164,71 @@ fn a_verb_is_read_off_the_role_and_nothing_else_is() {
         ClickVerb::parse(Some("focus:shell")),
         Some(ClickVerb::Focus("shell".into()))
     );
+    // A url's own colons belong to the url: the verb is read off the FIRST one
+    // and everything after it is the link.
+    assert_eq!(
+        ClickVerb::parse(Some("url:https://example.test/a?q=1")),
+        Some(ClickVerb::Url("https://example.test/a?q=1".into()))
+    );
     // `row` is what widgets.lua writes for an ordinary list row, and it must
     // keep meaning "ask the plugin" rather than becoming a kernel verb.
     assert!(ClickVerb::parse(Some("row")).is_none());
+}
+
+/// The seam the loop uses to turn a pane's `url:` node into a link the outer
+/// terminal can open: the recorded hit's rect, read back out of the frame that
+/// was just painted.
+///
+/// Asserted here rather than in the kernel's own tests because it is the
+/// *combination* that has to hold — a hitbox is recorded for the node, and the
+/// cells at that rect are the ones the plugin drew. A node whose rect drifted
+/// from its glyphs would link the wrong text without either half looking wrong.
+#[test]
+fn a_pane_url_node_becomes_a_link_over_the_cells_it_drew() {
+    use thurbox::kernel::node::{Node, Run, Size};
+    use thurbox::kernel::terminal::drawn_link_paints;
+
+    let url = "https://example.test/some/page";
+    let node = Node::Text {
+        // Indented, as a pane indents its text: the padding must not be linked.
+        lines: vec![vec![Run::plain(format!("  {url}"))]],
+        align: Default::default(),
+        wrap: false,
+        scroll: 0,
+        frame: None,
+        size: Size::default(),
+        identity: Identity {
+            role: Some(format!("url:{url}")),
+            ..Identity::default()
+        },
+    };
+
+    let mut hits = Vec::new();
+    let mut terminal = Terminal::new(TestBackend::new(40, 1)).expect("terminal");
+    let painted = terminal
+        .draw(|frame| render_recording(frame, frame.area(), &node, &PlaceholderSurfaces, &mut hits))
+        .expect("draw");
+
+    assert_eq!(hits.len(), 1, "the node carries a role, so it is a target");
+    assert_eq!(
+        hits[0].identity.click_verb(),
+        Some(ClickVerb::Url(url.into())),
+        "and the loop reads a url verb off it"
+    );
+
+    let paints = drawn_link_paints(painted.buffer, hits[0].rect, url);
+    assert_eq!(paints.len(), 1);
+    assert_eq!(paints[0].url, url);
+    assert_eq!(
+        paints[0].x, 2,
+        "the two-space indent is not part of the link"
+    );
+    let printed: String = paints[0]
+        .cells
+        .iter()
+        .map(|(symbol, _)| symbol.as_str())
+        .collect();
+    assert_eq!(printed, url);
 }
 
 // ── recording ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #972.

## Summary

- A plugin returns cells and the kernel paints them, so nothing in that path can put an escape on the wire. The OSC 8 re-print that hands `Ctrl+Click` to the terminal thurbox runs in only walked sessions — so the identical URL was clickable in an agent's transcript and inert in a pane, and on a remote host that re-print is the only leg with a browser to reach.
- Adds a fourth `ClickVerb`, **`url:<link>`**, exactly as proposed in the issue, with three halves: a plain click goes through the same opener (and clipboard fallback) a transcript's link rides, so one URL cannot open in two different places; the node's drawn cells join the re-print pass; and the chord is resolved against `url:` nodes directly, so it still works in an emulator with no OSC 8 support or on a bare tty. Parsed off the first colon, so a link keeps its own `:` and `//`.
- `kernel::terminal::drawn_link_paints` is the pane counterpart of `drawn_label_cells`: reads glyphs back out of the frame just drawn, one paint per row, trimming the blank cells either side of a node's text (a pane indents) and skipping ratatui's wide-glyph filler.
- **Not in the issue's sketch:** a vt100 run validates itself by matching the label it expects, so a covered run drops out for free. A pane's node has no label to match, so the covering surfaces are checked directly (`App::link_paint_obscured`) — without it a modal over a `url:` node would make the *modal's* own text `Ctrl+Click` to that URL.
- The chord resolves against **every** target under the point, innermost first, not just the topmost: a `url:` box with a styled child records the child last, and the topmost-only rule would leave the two legs of one verb disagreeing with nothing to see.
- `paint_terminal_hyperlinks` → `paint_outer_hyperlinks`, since it no longer covers only session terminals.
- Also the issue's smaller nit: `command "open" needs a url` now names the field (`… needs a url in text`). The parser reads `text`, and `{ url = ... }` — which the old message invites — parsed to nothing and did nothing visible.

Deliberately out of scope, both raised in the issue as context: no modifiers added to the `hit` table (the verb makes the chord unnecessary; two spellings for one thing is worse), and `open_url` still has no WSL branch, so a plain click inside WSL opens the Linux browser while the OSC 8 leg opens the Windows default. That asymmetry is pre-existing for agent transcripts and changing it alters every existing link open — worth its own issue.

Docs: `PLUGINS.md` (authoring, with the three consequences), `V2-KERNEL.md` (the trap: a pane cannot emit an escape), `FEATURES.md` and `PERFORMANCE.md` (both were independently stale about the session-only behaviour).

## Test plan

- `cargo nextest run --all` — 1883 pass (+7 new): the verb parse keeping a url's own colons and rejecting an empty one; the cell reader over padding, interior blanks, a blank row, a zero-height rect and multi-row; and, in `v2_mouse`, the hit-rect → drawn-cells seam end-to-end against the real paint walk, since a rect that drifted from its glyphs would link the wrong text with neither half looking wrong.
- `cargo clippy --all-targets --all-features`, `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `rumdl check .` — clean. All 19 pre-commit hooks pass.
- **Ran the real binary** with a `url:` pane under a pty and decoded the output stream: the emitted run is `ESC]8;;https://example.test/some/page BEL` with linked cells exactly `https://example.test/some/page` — the two-space indent trimmed, cursor moved to pane x+2, bracketed in DECSC. Then pressed `F1`: zero further link paints once the modal is up, confirming the obscured guard.