### PR TITLE
docs(ui): document restoring a broken plugin from the Interface tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1679,10 +1679,21 @@ thirds of the core rows are restart-only, which made it read as "my settings do
 not survive a restart".
 
 `]` switches to the **Interface tab** (`kernel::modals::interface`): every file, where
-it came from (bundled / edited / yours / removed), whether it is on screen, and
-`r` restore · `d` delete · `space` turn off · `t` trust. It was a pane once — an
-honest test of whether the plugin API could build a pane that lists panes — and is
-chrome now because a recovery tool must not be the thing that is broken.
+it came from (bundled / edited / yours / installed / removed), whether it is on
+screen, and `r` restore · `d` delete · `space` turn off · `t` trust. It was a pane
+once — an honest test of whether the plugin API could build a pane that lists panes
+— and is chrome now because a recovery tool must not be the thing that is broken.
+
+It is therefore **the recovery path for a broken interface**, and the shape of that
+is not symmetric: a `failed` row sorts to the top with its load error in the footer,
+but `r` only writes back a copy thurbox *ships* — it refuses for a file the user
+wrote ("thurbox ships no version of it") and points an installed pane at
+`thurbox-cli plugin sync`. For a pane of the user's own the way back is `space`:
+present on disk, not loaded, so nothing tried to load it and its error is silent
+until it is switched on. Each of the four keys reloads the interface, so the result
+is on the next frame. Documented for users in `docs/PLUGINS.md` → **When something
+goes wrong**; the same three answers with no TTY are `plugin list` / `plugin dir` /
+`plugin check`.
 
 `settings.toml` is **live-reloaded** (mtime poll): an outside edit re-applies the
 live half and toasts, noting a restart when `restart_only_differs` says so.

--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ you can open in an editor.
 | A pane — the session list included | `ui/plugins/*.lua` |
 | Where the panes go, and at what widths | `ui/layout.lua` |
 | Which panes load at all | `Ctrl+,` → Interface tab (`]`) |
+| A pane that broke the interface | the same tab — `r` to restore, `space` to turn off |
 | Panes somebody else wrote | `ui/plugins.toml` → `thurbox-cli plugin sync` |
 | Which agent CLIs you can launch | `agents.toml` |
 | Remote SSH machines and WSL distros | `hosts.toml` |
@@ -691,6 +692,30 @@ to its digest, so a trusted file that changes reads `trusted · modified`. It is
 deliberately not a sandbox; thurbox's position is that it can only refuse to run
 things unasked. See [docs/PLUGINS.md](docs/PLUGINS.md) and
 [docs/V2-KERNEL.md](docs/V2-KERNEL.md).
+
+### When a pane breaks the interface
+
+Editing the thing you are looking at means the thing you are looking at can
+break, so the way back is chrome rather than a pane: `Ctrl+,` → `]` cannot be
+edited away by anything in the directory. A file that failed to load sorts to the
+top of that list with its error underneath, and what undoes it depends on where
+that file came from.
+
+| The file | The way back |
+|---|---|
+| a pane thurbox ships, edited or deleted | `r` — the shipped copy comes out of the binary |
+| a pane **you** wrote | `space` — off, untouched on disk, and the interface loads without it |
+| an installed pane (`from <src>`) | `thurbox-cli plugin sync` |
+| the whole directory | it never loaded, so the embedded copies are running — fix the file from inside them |
+
+`r` restores; it cannot restore a file thurbox never shipped, and says so instead
+of guessing. That is why the second row is `space`, which is also the key for
+bisecting *which* of several files is at fault. Both reload immediately.
+
+With no terminal to trust, `thurbox-cli plugin check` reports the same failure and
+exits non-zero, and `plugin list` / `plugin dir` print the same inventory and
+directory. Full detail:
+[docs/PLUGINS.md → When something goes wrong](docs/PLUGINS.md#when-something-goes-wrong).
 
 ### Panes you did not write
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -154,6 +154,7 @@ interface you edit — there is no second, privileged copy running underneath.
 | remove one | delete the file |
 | undo either | settings → Interface, select it, `r` |
 | turn one off | settings → Interface, select it, `space` |
+| get back a working interface after a bad edit | [When something goes wrong](#when-something-goes-wrong) |
 
 **Deleting is how you remove.** A file thurbox wrote and can no longer find is
 recorded as removed and is not written again — not on the next start, and not by
@@ -546,7 +547,9 @@ the pane.
 file is not touched: it stays exactly where it is and is simply not loaded. That
 is the thing to reach for when you want a pane gone for an afternoon, when you
 are bisecting a problem, or when a plugin you are writing has broken the
-interface — turning it off is enough to get a working one back.
+interface — turning it off is enough to get a working one back, and for a pane you
+wrote it is the *only* way back, since `r` has no shipped copy to restore
+([When something goes wrong](#when-something-goes-wrong)).
 
 **`d` is not that.** It deletes. For a file thurbox ships that is recoverable
 (`r` writes the shipped copy back); for **a file you wrote there is no copy**,
@@ -707,18 +710,88 @@ is the first thing every user of your plugin will see.
 - If your whole plugin directory will not load, the **embedded copies** run
   instead, so you can fix the file from inside the thing it broke.
 
-Three escape hatches, in increasing order of how much you give up:
+### Settings → Interface: the way back
 
-- **Settings → Interface** lists every file with its state, and restores one at a time. It also
-  names the directory in use — if your edits appear to do nothing, they are
-  probably to a file that is not the one loaded (a `./ui` beside the working
-  directory is only used when `THURBOX_UI_DIR` names it). Outside the interface,
-  `thurbox-cli plugin list` and `thurbox-cli plugin dir` answer the same two
-  questions, and `thurbox-cli plugin check` reports a load failure without
-  starting anything.
+`Ctrl+,` (or `F6`), then `]`. It is **chrome, not a pane** — a recovery tool that
+was itself a plugin could be the thing that is broken, so nothing you do to the
+directory can take it away. It lists every file the interface is made of, what
+state that file is in and where it came from; the header line is the directory in
+force, which is the answer to "my edits did nothing" — they are usually edits to a
+file that is not the one loaded.
+
+**Trouble sorts to the top**, so a failure never sits below thirty healthy rows:
+
+| | State | Means |
+|---|---|---|
+| `✗` | `failed` | on disk, did not load. Select the row and the **error is in the footer** |
+| `⊘` | `removed` | thurbox ships it, you deleted it, delivery has stopped writing it |
+| `◌` | `no slot` | it loaded, and `layout.lua` places nothing in its slot — so it never draws |
+| `◍` | `off` | present and intact, deliberately not loaded |
+| `●` | `on screen` | drawing now |
+| `◐` | `on demand` | a float or a modal, at rest |
+| `○` | `hidden` | loaded, not currently drawn |
+| `·` | | not a pane — `layout.lua`, a `lib/` module |
+
+Four keys act on the selected row:
+
+| Key | Does |
+|---|---|
+| `r` | **restore** — write the copy thurbox ships back over the file |
+| `space` | **off / on** — the file is untouched, simply not loaded |
+| `d` | **remove** — deletes. Asked twice, and the confirmation says whether it can be undone |
+| `t` | **trust** — grant or withdraw the capabilities the file declares |
+
+Each of the four reloads the interface, so the result is on screen immediately
+rather than at the next start, and each says what it did.
+
+### What `r` can put back, and what it cannot
+
+`r` means "put back what thurbox ships, and forget what happened to this file",
+which is why it covers both undo cases for a shipped pane — an edit and a
+deletion. It has **nothing to put back for a file thurbox never shipped**, and it
+says so rather than doing something. So which recovery you have depends on where
+the file came from, and the row's own tail is what tells you:
+
+| The row shows | The file is | The way back |
+|---|---|---|
+| no tail at all | a bundled pane, as shipped | `r`, though there is nothing to undo |
+| `edited` | a bundled pane you changed | `r` — the shipped copy is in the binary |
+| `removed` | a bundled pane you deleted | `r` |
+| `yours` | one you wrote | **`space`**, then fix the file. `r` reports that thurbox ships no version of it |
+| `from <src>` | an installed pane | `thurbox-cli plugin sync` — the manager that put it there puts it back. `r` says so and refuses |
+
+A pane you wrote yourself is therefore the one case with no restore, and `space`
+is what you reach for: turning it off is enough to get a working interface back
+while you fix it, and it is also how you bisect which of several files is at
+fault. Remember that **a disabled plugin reports nothing** — nothing tried to
+load it, so its error reappears only when you turn it back on.
+
+`layout.lua` and the `lib/` modules are the files whose mistakes cost the whole
+screen rather than one pane; both are ordinary rows here, and both are restorable
+with `r` while they are the ones thurbox shipped. If the *whole* directory will
+not load, the embedded copies are already running — so you are fixing the file
+from inside a working interface, not from a blank one.
+
+### The same answers without a terminal
+
+- `thurbox-cli plugin list` — the inventory above, as text.
+- `thurbox-cli plugin dir` — the directory in force, and which rule chose it.
+- `thurbox-cli plugin check` — loads the interface the way `thurbox` does and
+  exits non-zero on a failure, including on a pane that loaded but which no
+  arrangement places (it prints the `layout.lua` line to add).
+
+None of the three starts a TUI, which is what makes them the tools for a coding
+agent, a CI check, or a terminal you cannot currently trust.
+
+### Two bigger hammers
+
 - **Delete `.bundled.json`** and the next start re-delivers every bundled file,
   forgetting which ones you had removed. Your own files are untouched.
 - **Delete the whole directory** for the shipped interface exactly as it ships.
+
+Neither touches `ui.json`, which lives beside the directory rather than in it: a
+pane you turned off is still off after both, and a trust you granted is still
+recorded. If a decision is what you want to undo, undo it in the Interface tab.
 
 ## Examples you can install
 

--- a/docs/V2-KERNEL.md
+++ b/docs/V2-KERNEL.md
@@ -3,13 +3,15 @@
 thurbox v2 is a session engine with a Lua-driven renderer. The kernel owns no
 pane: the session list, the terminal and every other surface that shows *your
 work* is a plugin under `ui/`. The bundled set is currently **three** — the
-session list, the agent pane, and the pane that lists the interface's own files
-— plus the new-session flow, which floats rather than filling a slot; the
-interface was cut back to its core and v1's other surfaces are listed
-with their gaps in `openspec/changes/v2-parity-gaps/`. It does own the **system modals** — help,
-settings and the theme picker — which are chrome about thurbox itself rather
-than panes (see below). Written for someone about to change the kernel; if you
-want to *write* a plugin, read `docs/PLUGINS.md`.
+session list, the agent pane and the search strip — plus the new-session flow and
+the confirmation, which float rather than filling a slot; the interface was cut
+back to its core and v1's other surfaces are listed with their gaps in
+`openspec/changes/v2-parity-gaps/`. It does own the **system modals** — help,
+settings, the theme picker and the interface's own file list — which are chrome
+about thurbox itself rather than panes (see below). The file list was a pane and
+is deliberately no longer one: it is how a broken interface is recovered, so it
+must not be a file the interface loads. Written for someone about to change the
+kernel; if you want to *write* a plugin, read `docs/PLUGINS.md`.
 
 Writing a plugin starts at `docs/PLUGINS.md` — **Start here**, which is four
 `thurbox-cli plugin` commands and needs no terminal.
@@ -48,9 +50,9 @@ clone — `docs/PLUGINS.md` has the commands and what the two demonstrate.
    layout    rects before render         lib/theme     roles
    convert   table <-> node              lib/widgets   list, gauge, panel…
    paint     node -> ratatui             lib/tree      decoration helper
-   host      VM, reload, isolation       plugins/*     2 panes
+   host      VM, reload, isolation       plugins/*     3 panes + 2 floats
    registry  keys + settings
-   modals    help, settings, theme
+   modals    help, settings, theme, files
    snapshot  the read side
    command   the write side
    config    the user's settings, live and restart-only
@@ -204,6 +206,19 @@ other. Modularity moved one level down — plugins contribute **data**
 renders it, so declaring one table field is enough to appear in either. The
 theme picker takes no contribution at all: there is nothing a plugin could add
 to a list of palettes.
+
+The **file list** — settings' Interface tab (`kernel::modals::interface`) — is here
+for a second reason on top of those three. It is the recovery tool: it is where a
+file that failed to load is reported with its error, where a bundled file is
+restored (`r`) and where a plugin of the user's own is switched off (`space`) to get
+a working interface back. A recovery tool that is itself a plugin can be the thing
+that is broken, so a bad edit would take away the view you would use to undo it.
+Being chrome also fixed its reachability: as a centre-slot pane it needed a chord of
+its own, and that chord was `F11` — the one F-key terminals commonly claim for
+fullscreen. Note the asymmetry the modal has to make legible, since the kernel is
+the only thing that knows it: `r` writes back a copy the *binary* holds, so it has
+no answer for a file the user wrote (`space` is that answer) or one a package
+delivered (`thurbox-cli plugin sync` is).
 
 The one genuinely modal input in the product lives here too: while help is
 capturing a chord, **every** key is data, `ctrl+q` included. A plugin could

--- a/src/kernel/bundled.rs
+++ b/src/kernel/bundled.rs
@@ -685,11 +685,12 @@ impl Chosen {
 
 /// The interface directory, and which rule chose it.
 ///
-/// In order: `THURBOX_UI_DIR`, a `./ui` dev checkout, then the user's own copy —
+/// Two rules, in order: `THURBOX_UI_DIR`, then the user's own copy —
 /// materialized from the embedded interface on first run, preserving anything
-/// they edited. A missing or unwritable config directory is not fatal: the
-/// embedded copies are written somewhere throwaway and used from there, because
-/// no interface at all is the one outcome worth avoiding
+/// they edited. There is deliberately no automatic `./ui` rule; the comment on
+/// the branch below says why. A missing or unwritable config directory is not
+/// fatal: the embedded copies are written somewhere throwaway and used from
+/// there, because no interface at all is the one outcome worth avoiding
 /// (`v2-plugin-kernel` design.md D11).
 ///
 /// Lives here rather than in the interface binary so that anything asking "which

--- a/src/kernel/modals/interface.rs
+++ b/src/kernel/modals/interface.rs
@@ -431,13 +431,9 @@ impl InterfaceTab {
         if area.height == 0 || area.width == 0 {
             return;
         }
-        // The directory the interface was loaded from. Cheap to draw and the
-        // answer to the one confusion nothing else resolves: a `./ui` beside the
-        // working directory wins over your own copy, so edits that "did nothing"
-        // are usually edits to a file that is not the one running.
-        // Where the files are, and — said out loud — that adding one is putting
-        // a file there. Both answer confusions nothing else can: a `./ui` beside
-        // the working directory wins over the user's copy, so edits that "did
+        // Where the files are, and — said out loud — that adding one is putting a
+        // file there. Both answer confusions nothing else can: `THURBOX_UI_DIR`
+        // and a dev build each move the live directory, so edits that "did
         // nothing" are usually edits to a file that is not the one running; and
         // "how do I add a pane" otherwise lives only in the guide.
         frame.render_widget(

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,8 +534,8 @@ fn open_editor(
 
 /// Find the plugin directory.
 ///
-/// In order: `THURBOX_UI_DIR`, a `./ui` dev checkout, then the user's own copy
-/// — materialized from the embedded interface on first run, preserving anything
+/// Two rules, in order: `THURBOX_UI_DIR`, then the user's own copy —
+/// materialized from the embedded interface on first run, preserving anything
 /// they edited. A missing or unwritable config directory is not fatal: the
 /// embedded copies are written somewhere throwaway and used from there, because
 /// no interface at all is the one outcome worth avoiding (design.md D11).

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -104,3 +104,8 @@ install one — neither fails, because you may have meant it.
 screen, not one pane. Prefer adding a file over editing those two. Anything shipped
 with thurbox can be restored (`Ctrl+,` → `]` → `r`), so a bad edit is recoverable —
 but only if you say what you changed.
+
+A file **you** added has no shipped copy to restore, so the way back for it is
+`space` on its row in that same tab: turned off, untouched on disk, and the
+interface loads without it. `thurbox-cli plugin check` reports the failure with no
+TTY, which is the one you can run yourself.

--- a/ui/README.md
+++ b/ui/README.md
@@ -234,8 +234,15 @@ spec; nothing edits the lock. Commit both and this interface reproduces elsewher
 (which files are off, which are trusted, and any rebindings). Editing a shipped
 file is fine — delivery stops overwriting it once you have. Deleting one is how
 you remove it, and the Interface tab (`Ctrl+,` → `]`) will `r` restore it from
-the binary. So there is no way to break this directory that a restore cannot
-undo.
+the binary. So no edit or deletion of a file thurbox ships is unrecoverable.
+
+A file **you** added is the case `r` cannot help with — thurbox ships no version
+of it to put back, and it says so instead. The way back there is `space` on its
+row: the file stays exactly where it is and is simply not loaded, which is enough
+to get a working interface while you fix it. An installed pane
+(the row reads `from <src>`) is put back by the manager that placed it,
+`thurbox-cli plugin sync`. The tab sorts failures to the top and shows the load
+error of the selected row, so the broken file is the first thing on the list.
 
 ## Full documentation
 


### PR DESCRIPTION
## Summary

- The Interface tab (`Ctrl+,` → `]`) has always been the recovery path for a
  plugin that broke the interface, but the docs never said what recovery is
  actually available. `ui/README.md` went further and claimed *"there is no way
  to break this directory that a restore cannot undo"* — which is false for a
  file the user wrote.
- `r` writes back a copy the **binary** holds, so it answers for a bundled pane
  you edited or deleted, and has nothing to put back for a pane of your own
  (`restore` refuses on `Source::User`) or an installed one (it points at
  `plugin sync`). The way back for your own pane is **`space`** — present on
  disk, not loaded. That asymmetry is now documented where each reader looks:
  `docs/PLUGINS.md` (users), `README.md` (newcomers), `ui/README.md` +
  `ui/AGENTS.md` (inside the directory itself), `CLAUDE.md` +
  `docs/V2-KERNEL.md` (whoever changes the kernel).
- `docs/PLUGINS.md` gains the reference detail verified against the code: the
  state glyphs and their sort order (failures first, error in the footer), the
  four keys and that each reloads, the per-origin recovery table, the no-TTY
  equivalents (`plugin list` / `dir` / `check`), and the note that neither
  bigger hammer touches `ui.json`.

Stale text fixed in the same neighbourhood:

- `docs/V2-KERNEL.md` still described the file list as one of three bundled
  *panes*. It is chrome; the bundled panes are sessions/agent/search plus two
  floats. Its rationale (a recovery tool must not be a file the interface loads)
  is now recorded beside the other system modals.
- Three comments still ordered a `./ui` dev-checkout rule that was removed —
  including a duplicated, self-contradicting block in the tab's own render path.

No behaviour change: the Rust diff is comments only.

## Test plan

- [x] Every claim checked against `kernel::modals::interface` (`state_of` ranks
      and glyphs, the `restore`/`trust`/`switch` refusals and their messages),
      `kernel::bundled::restore` (writes the embedded copy, clears the
      tombstone), and `main.rs` (all four edits reload).
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --all` via the pre-commit hooks — all 18 hooks pass,
      including the bundled-guidance and `a_broken_interface_loads_again_once_it_is_fixed`
      tests that cover `ui/README.md` / `ui/AGENTS.md` (both are `include_str!`'d
      into the binary, so editing them changes delivery)
- [x] `rumdl check` clean; `cargo doc` clean