### PR TITLE
fix(ui): stop a pane toggle leaving characters behind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,14 @@ forced-redraw floor (`FORCE_REDRAW_INTERVAL`) elapses, never on every iteration.
 `MIN_FRAME_INTERVAL` is the floor between two paints. What marks the screen dirty:
 any input, a resize, a reload, a worker result, and **new agent output** —
 `Terminals::output_generation` is summed each iteration, which is what stops a
-printing agent being drawn at 4 fps.
+printing agent being drawn at 4 fps. A **reflow** — the arrangement placing a
+slot at a new rect, so a column opened or closed — additionally forces one *full*
+repaint (`Terminal::clear` before the paint): the cell diff is only correct while
+ratatui and the terminal agree on a glyph's width, and where they cannot (a flag,
+an emoji presentation sequence) the pane that closed leaves characters behind.
+`kernel::paint::normalize_ambiguous_width` strips the one such disagreement that
+is strippable — `U+FE0F` — from every painted cell, panes and vt100 surfaces
+alike.
 
 A frame is more expensive than v1's, structurally: every pane is a Lua call
 returning a table that is converted to nodes and painted. So the loop settles

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -714,6 +714,20 @@ marks the screen dirty:
   API: a spinner's tree differs each frame, so it keeps the loop awake by itself,
   and a static pane costs one comparison
 
+**One frame is deliberately NOT a diff: a reflow.** When the arrangement places a
+slot at a different rect — a side column opening or closing, the search strip, the
+message band taking its row — the next paint is preceded by `Terminal::clear`, so
+every cell is printed rather than only the ones the diff believes moved. The diff is
+correct exactly while ratatui's idea of a cell's width matches the terminal's, and
+grapheme clusters exist where it cannot: a regional-indicator flag is two columns to
+`unicode-width` and a different number to several emulators, so a pane that closes
+leaves glyphs in the column that replaced it, and they survive until something else
+happens to repaint those cells. `kernel::paint::normalize_ambiguous_width` removes
+the one disagreement that can be removed (the emoji-presentation selector, stripped
+from every painted cell); this covers the rest by spending one full repaint on an
+event the user just caused. It is bounded by how often a layout moves, which is a
+keypress — not a frame.
+
 **Why the settling had to get stricter**: two things marked every frame changed
 unconditionally and so pinned the loop at the frame cap — an open float, and a
 non-empty text selection. With the creation wizard up, that meant rebuilding every

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -431,7 +431,7 @@ leg with a browser to reach. The chord is resolved against `url:` nodes directly
 as well, so it still works in an emulator with no OSC 8 support, or on a bare
 tty.
 
-Three consequences worth knowing:
+Four consequences worth knowing:
 
 - The cells are read back out of the **frame just drawn**, not out of your tree,
   so a node clipped by its pane, covered by a modal or under a float contributes
@@ -441,6 +441,12 @@ Three consequences worth knowing:
   row. Interior blanks stay, so ` Open MR !123 ` links as `Open MR !123`.
 - A node spanning several rows emits one link per row, all naming the same url —
   which is how a wrapped link is spelled in OSC 8 anyway.
+- The re-print is written **outside the frame diff**, so it has to spend exactly
+  as many columns as the cells it came from. A wide glyph is one cell and two
+  columns, and re-printing it moves the cursor over both — so the blank ratatui
+  leaves beside it is skipped rather than printed. Getting that wrong is
+  permanent, not transient: the next frame repaints only the cells it believes
+  moved, so a row shifted by one column stays shifted.
 
 `command("open", { text = url })` is the imperative half, for a link you open
 from a keypress rather than a click. The field is `text`, not `url`.

--- a/src/kernel/paint.rs
+++ b/src/kernel/paint.rs
@@ -7,7 +7,8 @@
 //! walks it with rects rather than computing them: a `box` divides its own
 //! rect among children ([`super::node::divide`]) and recurses.
 
-use ratatui::layout::Rect;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Position, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{Block, BorderType, Borders as RatBorders, Clear, Paragraph, Wrap};
@@ -338,6 +339,57 @@ pub fn render_error(frame: &mut Frame, area: Rect, title: &str, message: &str) {
     );
 }
 
+/// The emoji-presentation selector, the one codepoint that makes a cell's width
+/// a matter of opinion.
+const VARIATION_SELECTOR_16: char = '\u{FE0F}';
+
+/// Strip the emoji-presentation selector (`U+FE0F`) from every cell of a
+/// painted frame.
+///
+/// A cell is one column or two, `unicode-width` calls an emoji-presentation
+/// sequence two, and a terminal is free to disagree — Windows Terminal and
+/// Ghostty draw many of them in one. Both answers damage the screen, in opposite
+/// directions. Drawn two columns wide, the row receives the emoji *and* the
+/// blank ratatui pairs with it, so it emits three columns for two cells and
+/// wraps into the next row. Drawn one column wide, the trailing column is left
+/// holding whatever was there before, because the diff only prints a cell whose
+/// contents changed — which is the leftover glyphs a pane opening or closing
+/// exposes, since the diff believes those columns already say what the frame
+/// says.
+///
+/// Guessing which kind of terminal this is would settle neither, so the
+/// ambiguity is removed instead: without the selector the base glyph is one
+/// column everywhere, and the blank ratatui already reserved beside it keeps the
+/// row the width it was measured at. Applied to the finished frame, so it covers
+/// panes, bands, modals and the vt100 surfaces alike — an agent printing `✔️`
+/// corrupts a row exactly as a plugin does.
+///
+/// The clusters it cannot help (a regional-indicator flag is two columns here
+/// and a different number there) are why a reflow repaints in full — see
+/// `App::last_placed`.
+pub fn normalize_ambiguous_width(buf: &mut Buffer) {
+    let area = buf.area;
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            let Some(cell) = buf.cell_mut(Position::new(x, y)) else {
+                continue;
+            };
+            if !cell.symbol().contains(VARIATION_SELECTOR_16) {
+                continue;
+            }
+            let stripped: String = cell
+                .symbol()
+                .chars()
+                .filter(|c| *c != VARIATION_SELECTOR_16)
+                .collect();
+            // A cell holding nothing but the selector would print nothing at
+            // all, which is the leftover this exists to prevent.
+            cell.set_symbol(if stripped.is_empty() { " " } else { &stripped });
+        }
+    }
+}
+
+/// Shrink a rect by `padding` on every side, never past zero.
 fn build_block(spec: &NodeFrame) -> Block<'static> {
     let mut block = Block::default().style(spec.style);
     block = match spec.borders {
@@ -372,7 +424,6 @@ fn build_block(spec: &NodeFrame) -> Block<'static> {
     block
 }
 
-/// Shrink a rect by `padding` on every side, never past zero.
 fn pad(area: Rect, padding: u16) -> Rect {
     if padding == 0 {
         return area;
@@ -389,11 +440,43 @@ fn pad(area: Rect, padding: u16) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 
     use crate::kernel::convert::to_node;
     use mlua::{Lua, Value};
+
+    /// The emoji-presentation selector is what makes a cell's width a matter of
+    /// opinion between ratatui and the terminal, and the leftover glyphs a pane
+    /// toggle used to expose are that disagreement showing. Stripped, the glyph
+    /// is one column everywhere.
+    #[test]
+    fn variation_selector_is_stripped_from_painted_cells() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 6, 1));
+        buffer.set_string(0, 0, "⚠️a", ratatui::style::Style::default());
+        assert!(buffer[(0, 0)].symbol().contains('\u{FE0F}'));
+
+        normalize_ambiguous_width(&mut buffer);
+
+        assert_eq!(buffer[(0, 0)].symbol(), "⚠");
+        // The blank ratatui reserved beside it stays, so nothing after the glyph
+        // moves: the row is the width it was measured at.
+        assert_eq!(buffer[(1, 0)].symbol(), " ");
+        assert_eq!(buffer[(2, 0)].symbol(), "a");
+    }
+
+    /// A cell holding nothing but the selector would print nothing at all, which
+    /// is the leftover the pass exists to prevent.
+    #[test]
+    fn lone_variation_selector_becomes_a_blank() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 2, 1));
+        buffer[(0, 0)].set_symbol("\u{FE0F}");
+
+        normalize_ambiguous_width(&mut buffer);
+
+        assert_eq!(buffer[(0, 0)].symbol(), " ");
+    }
 
     /// Render a Lua-authored tree and return the screen as text lines.
     fn screen(source: &str, width: u16, height: u16) -> Vec<String> {

--- a/src/kernel/terminal.rs
+++ b/src/kernel/terminal.rs
@@ -25,7 +25,7 @@ use ratatui::layout::{Position, Rect};
 use ratatui::style::Style;
 use ratatui::Frame;
 use tui_term::widget::PseudoTerminal;
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::paint::SurfaceProvider;
 use super::snapshot::Snapshot;
@@ -1703,9 +1703,16 @@ fn cell_style(cell: &ratatui::buffer::Cell) -> Style {
 /// rect a node was given is wider than the glyphs in it, and linking the
 /// padding would put the underline (and the click target the emulator draws)
 /// across the whole row. Interior blanks stay — they are inside the label.
-/// Ratatui's filler cell after a wide glyph is skipped for the reason
-/// `drawn_label_cells` advances by display width: re-printing the wide glyph
-/// moves the cursor over both cells itself.
+///
+/// The walk advances by each cell's DISPLAY WIDTH, for the reason
+/// `drawn_label_cells` does: re-printing a wide glyph moves the cursor over both
+/// its columns itself, so the filler ratatui leaves beside it must not be
+/// printed as well. Reading that filler as "the cell is empty" is not enough —
+/// ratatui writes a BLANK there, which is indistinguishable from a space inside
+/// the label — and a printed row one column longer than the cells it came from
+/// shifts every glyph after the first wide one. Out here that damage is
+/// permanent: this print is outside the frame diff, so the next frame repaints
+/// only the cells it thinks moved and the shifted glyphs stay.
 pub fn drawn_link_paints(buf: &Buffer, rect: Rect, url: &str) -> Vec<HyperlinkPaint> {
     let mut paints = Vec::new();
     for y in rect.top()..rect.bottom() {
@@ -1714,20 +1721,25 @@ pub fn drawn_link_paints(buf: &Buffer, rect: Rect, url: &str) -> Vec<HyperlinkPa
         // no link at all rather than a link with no text in it.
         let mut start = None;
         let mut cells: Vec<(String, Style)> = Vec::new();
-        for x in rect.left()..rect.right() {
+        let mut x = rect.left();
+        while x < rect.right() {
             // Outside the frame entirely: nothing further along this row is
             // drawn either.
             let Some(cell) = buf.cell(Position::new(x, y)) else {
                 break;
             };
             let symbol = cell.symbol();
+            // A width of zero is a cell a wide glyph already covered, so it
+            // cannot advance the walk on its own.
+            let width = UnicodeWidthStr::width(symbol).max(1) as u16;
+            x = x.saturating_add(width);
             if symbol.is_empty() {
                 continue;
             }
             if start.is_none() && symbol.trim().is_empty() {
                 continue;
             }
-            start.get_or_insert(x);
+            start.get_or_insert(x.saturating_sub(width));
             cells.push((symbol.to_string(), cell_style(cell)));
         }
         // Trailing padding, trimmed the way the leading padding was skipped.
@@ -2281,6 +2293,29 @@ mod tests {
 
         assert!(drawn_link_paints(&buf, Rect::new(0, 0, 20, 0), "u").is_empty());
         assert!(drawn_link_paints(&buf, Rect::new(0, 5, 20, 1), "u").is_empty());
+    }
+
+    /// A wide glyph is one cell and two columns, and ratatui leaves a BLANK in
+    /// the second. Re-printing that blank puts a space inside the label and
+    /// shifts every glyph after it one column right — the row this print lands
+    /// on is then permanently out of step with the frame the diff believes it
+    /// painted.
+    #[test]
+    fn a_wide_glyph_does_not_re_print_the_filler_beside_it() {
+        let buf = buffer_with(20, 1, &["docs 漢字 x"]);
+        let paints = drawn_link_paints(&buf, Rect::new(0, 0, 20, 1), "https://example.test/w");
+
+        assert_eq!(paints.len(), 1);
+        assert_eq!(paints[0].x, 0);
+        let printed: String = paints[0]
+            .cells
+            .iter()
+            .map(|(symbol, _)| symbol.as_str())
+            .collect();
+        assert_eq!(printed, "docs 漢字 x");
+        // The genuine space between the glyphs and `x` survives: only the cells
+        // a wide glyph already covers are skipped.
+        assert_eq!(paints[0].cells.len(), "docs 漢字 x".chars().count());
     }
 
     /// One paint per row, all naming the same url: that is how a wrapped link is

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,6 +241,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         last_floats: std::collections::HashMap::new(),
         drawn_floats: std::collections::HashSet::new(),
         last_paint: Instant::now(),
+        last_placed: Vec::new(),
+        pending_clear: false,
         dirty: true,
         changed_this_frame: false,
         last_output_painted: std::collections::HashMap::new(),
@@ -889,6 +891,21 @@ struct App {
     /// reading the cache instead is what reported a closed modal as visible.
     drawn_floats: std::collections::HashSet<usize>,
     last_paint: Instant,
+    /// The slot rects the arrangement placed last frame, and whether the screen
+    /// owes a full repaint because they moved.
+    ///
+    /// A pane opening or closing reflows every column beside it, and a cell the
+    /// diff believes it already printed is a cell it will not print again. That
+    /// is fine while ratatui's model of a cell's width matches the terminal's,
+    /// and grapheme clusters exist where it cannot: a regional-indicator flag is
+    /// two columns to `unicode-width` and a different number to several
+    /// emulators, so glyphs from the pane that just closed survive in the column
+    /// that replaced it. `normalize_ambiguous_width` removes the one such
+    /// disagreement it can (see `kernel::paint`); this covers the rest by making
+    /// the toggle itself the forced redraw the leftovers otherwise wait for.
+    last_placed: Vec<thurbox::kernel::layout::SlotRect>,
+    /// Set when `last_placed` moved; consumed by the next paint.
+    pending_clear: bool,
     /// Set by anything that invalidates the screen outside the tree diff:
     /// input, a reload, a resize, a completed command.
     dirty: bool,
@@ -1380,6 +1397,13 @@ impl App {
             // that was 100 rebuilds a second to feed a screen that redraws four
             // times.
             self.republish();
+            // Before the frame, not after: clearing resets the diff's memory of
+            // the screen, so the draw that follows prints every cell rather than
+            // only the ones it thinks moved.
+            if self.pending_clear {
+                self.pending_clear = false;
+                terminal.clear()?;
+            }
             let painted = terminal.draw(|frame| self.draw(frame))?;
             // Cloned so the borrow of `terminal` ends here: the two
             // corrections below both need it back.
@@ -1973,6 +1997,13 @@ impl App {
             }
         };
         let placed = resolve(&region, area);
+        // A reflow owes a full repaint — see `last_placed`. Marked as a change so
+        // the clearing paint follows immediately rather than at the redraw floor.
+        if self.last_placed != placed {
+            self.last_placed = placed.clone();
+            self.pending_clear = true;
+            self.changed_this_frame = true;
+        }
         self.visible_slots = placed.iter().map(|s| s.slot.clone()).collect();
         // A focus request that named a slot this layout has only just placed —
         // the search strip's, which shows itself and asks for focus in one
@@ -2128,7 +2159,10 @@ impl App {
             paint::render_error(frame, error_area(area), "reload failed", &error);
         }
 
-        // Last, so it covers every pane, float and toast painted above.
+        // Last, so both cover every pane, float and toast painted above. The
+        // width normalisation goes first: it changes symbols, and the repaint
+        // below reads styles, so neither can undo the other.
+        paint::normalize_ambiguous_width(frame.buffer_mut());
         self.repaint_theme_background(frame);
     }
 


### PR DESCRIPTION
## Summary

- Opening or closing a custom side pane left glyphs from the pane that moved in the columns that replaced it, and they stayed until something else repainted those cells. Reported on Windows Terminal and Ghostty; reproduced in a tmux pane with a custom `side` column toggled four times — every ghost was on a row carrying an emoji-presentation sequence.
- **Strip the emoji-presentation selector** (`kernel::paint::normalize_ambiguous_width`). `unicode-width` calls `U+FE0F` sequences two columns and terminals disagree. Drawn two wide, a row emits three columns for two cells and wraps into the next row; drawn one wide, the trailing column keeps whatever was there, since the diff prints only cells whose contents changed. Guessing the terminal settles neither, so the ambiguity is removed — on the finished frame, so panes, bands, modals and the vt100 surfaces are covered alike (an agent printing `✔️` corrupted a row exactly as a plugin did).
- **A reflow repaints in full.** For the clusters that cannot be normalised (a regional-indicator flag is two columns to `unicode-width` and a different number to several emulators), the arrangement placing a slot at a new rect now clears before the next paint. Bounded by how often a layout moves, which is a keypress — not a frame.
- **Fix the OSC 8 re-print's advance** (`drawn_link_paints`). It skipped ratatui's filler beside a wide glyph by testing for an *empty* symbol; ratatui writes a *blank* there, indistinguishable from a space inside the label. So every wide glyph in a `url:` node re-printed a stray space and shifted the rest of the row. It now advances by display width, as `drawn_label_cells` already did. This is the one whose damage was permanent: the re-print is outside the frame diff, so the next frame repaints only what it believes moved.
- Docs updated where the decisions live: ADR-P13 in `docs/PERFORMANCE.md` (the one frame that is deliberately not a diff), the render-loop section of `CLAUDE.md`, and the `url:` consequences list in `docs/PLUGINS.md`.

## Test plan

- `cargo nextest run --all` — 1886 pass, including three new tests: the selector stripped from a painted cell (with the reserved blank left in place, so nothing after it moves), a lone selector becoming a blank, and a wide glyph not re-printing the filler beside it.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc` — clean.
- `scripts/dev/smoke/tui-smoke.sh` — all assertions pass.
- Manual, in an isolated sandbox (own `THURBOX_CONFIG_DIR`/`THURBOX_DATA_DIR`/`TMUX_TMPDIR`, a live session and a custom `side` column toggled repeatedly): rows of ASCII, CJK, emoji-presentation sequences, ZWJ, skin-tone and flag clusters, plus `url:` nodes mixing wide glyphs and links. Before: ghosts on the emoji rows survived three further toggles and a `#` survived on the flag row. After: no residue in any state, and `docs 漢字 https://…` re-prints without the inserted space.