### PR TITLE
fix(core): close two capability leaks and enforce the kernel's own boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,11 +88,20 @@ kernel over the real `ui/`** rather than a harness that imitates either:
 - **`tests/v2_*.rs`** — one file per surface or contract: `v2_session_list`,
   `v2_search`, `v2_new_session`, `v2_terminal_pane`, `v2_session_lifetime`,
   `v2_keymap`, `v2_focus`, `v2_modals`, `v2_chrome`, `v2_mouse`, `v2_hover`,
-  `v2_decoration`, `v2_plugin_{authoring,commands,lifecycle,settings,switching}`,
+  `v2_decoration`,
+  `v2_plugin_{authoring,commands,lifecycle,packages,programs,settings,switching}`,
   `v2_repo_memory`, `v2_remote_status`, `v2_session_status`, `v2_core_settings`,
   `v2_attach_by_name`.
   Several build an interface in a tempdir from the embedded copy, so delivery and
   loading are exercised together.
+- **`tests/common/mod.rs`** — the shared fixtures, included per target with `mod
+  common;`: `host()` (a host over the bundled interface, asserting it loaded),
+  `ui_dir()`, `interface()`, `themes()`, `registry()`, `index_of()`, `ctx()`,
+  `press()`, `publish()` / `publish_with()`, `session_row()`, `git()` /
+  `git_command()`. Reach for it before hand-writing a fixture: `SessionRow` was
+  written out in twenty-seven files and `Published` in sixteen, which made adding
+  one readable field a sixteen-file mechanical edit and a fixture row that had
+  drifted invisible. Seven files use it so far.
 - **`tests/kernel_limits.rs`** — instruction and memory ceilings, in their own file
   because they mutate process-wide limits.
 - **Lua statics** — `selene ui` (undefined names + the sandbox, via `thurbox.yml`),
@@ -155,10 +164,13 @@ asked for by leaving a key in `store`), `kernel::runs`, `kernel::updates`.
 
 Cached answers carry an **age**, not just a value. The mistake this repeatedly
 invited was storing "we have an answer" where "the answer is current" was needed:
-git stats froze at their first reading, a `run` refresh started a process per frame,
-a failed branch fetch stuck for the process lifetime, and a backend surveyed once
-was treated as surveyed since. Each is now a TTL, an in-flight marker, or a
-generation counter — if you add a cache here, give it one.
+git stats froze at their first reading, a diff was computed once per session per
+process (so a pane watching an agent still writing code showed what it first saw),
+a `run` refresh started a process per frame, a failed branch fetch stuck for the
+process lifetime, and a backend surveyed once was treated as surveyed since. Each
+is now a TTL, an in-flight marker, or a generation counter, paired with a `retain`
+so the cache tracks what exists rather than everything that ever did — if you add
+a cache here, give it one.
 
 `republish` — the one call that rebuilds every `thurbox.*` table — runs once per
 painted frame and **once per input batch**, not once per event: a held-down key
@@ -707,12 +719,12 @@ not block startup, so `check_available`/`ensure_ready` are deferred to first use
   (`git::host_launcher` → `ssh …` or `wsl.exe …`). Worktrees live under the
   host's `worktrees_dir` (or `$HOME/.local/share/thurbox/worktrees` resolved +
   cached per backend name — a WSL distro has no `destination`).
-- **Persistence/restore**: `backend_type` round-trips in SQLite; restore
+- **Persistence/restore**: `backend_type` round-trips in SQLite; re-adoption
   discovers windows **per backend** so off-local sessions re-adopt against their
-  own host. Remote backends are readied + discovered **in the background** (one
-  thread per host, drained by `App::poll_remote_restore` each tick) so an
-  unreachable or slow host never blocks the first frame — only local sessions
-  restore synchronously at startup (ADR-P7, `docs/PERFORMANCE.md`).
+  own host. Nothing is restored synchronously at startup: `Terminals::sync`
+  attaches on workers, and a remote backend is readied on the attach worker that
+  needs it (`Attached::readied`), so an unreachable or slow host never blocks the
+  first frame (ADR-P7, `docs/PERFORMANCE.md`).
 - **Headless**: `thurbox-cli session create --host <name>` spawns on the host
   (an SSH name or an auto-discovered WSL distro name).
 - **Agent config on the host**: agent args referencing thurbox-managed config
@@ -1217,7 +1229,7 @@ their screens**, which is the half that finds a session by the error in it.
   at.
 - Sessions is the only scope with a pane today. A result carries the pane it
   belongs to, so a returning surface is a scope added and nothing else changed.
-- One deliberate divergence, recorded in `tests/v2_parity.rs`'s successor notes: v1
+- One deliberate divergence, recorded in `openspec/changes/v2-parity-gaps/`: v1
   also took `Ctrl+P`/`Ctrl+N` inside the strip because its search focus captured
   input ahead of the keybinding table. Here every chord goes through one registry
   where a plugin-scoped claim does not outrank a global one, so declaring them
@@ -1236,37 +1248,39 @@ or done. `SessionStatus` (`src/session/mod.rs`) has six states — five driven b
 | `Done` | blue | `●` (filled) | a turn just finished; shown until you switch away |
 | `Idle` | green | `○` (hollow) | acknowledged (you moved off a Done), never active, or at rest |
 | `Error` | red | `✗` | reserved for a crashed agent — **not derived yet** (no exit-code signal; exited → `Idle`) |
-| `Unreachable` | muted grey | `⊘` | remote host down/offline; a **placeholder** row (no live pane) awaiting reconnect |
+| `Unreachable` | muted grey | `⊘` | remote host down/offline: a remote row with no live pane |
 
-**Unreachable / placeholder sessions.** A persisted **remote** session whose host
-is unreachable at restore (SSH down / auth failing / offline) is inserted as a
-`Session::placeholder` (`src/agent/backend.rs`) so it **always appears** in the
-list instead of silently vanishing, tagged `Unreachable`. A placeholder holds no
-live backend pane — its reader/writer loops are never spawned, keystrokes are
-dropped with a hint, and `resize`/`kill`/`detach`/`save_state` skip it (so it
-never issues a blocking ssh call on the UI thread nor clobbers the persisted
-row). The remote-restore loop (`App::poll_remote_restore` /
-`maybe_retry_remote_restore`) readies each remote backend off-thread, retries a
-down host every `REMOTE_RETRY_INTERVAL` (20 s) — or immediately on restart
-(`Ctrl+R`) — and, once the host recovers, replaces the placeholder **in place**
-with the adopted session (same `SessionId`, so the order signature is unchanged).
+**Unreachable sessions.** There is no placeholder `Session` — the row appears
+because the snapshot is built from the **database**, not from the live panes, so a
+persisted remote session whose host is unreachable (SSH down / auth failing /
+offline) is in the list whether or not anything is attached to it, and
+`kernel::snapshot::with_reachability` reports `unreachable` for exactly that
+shape: a remote row with no live pane. Nothing is faked to carry it — no dead
+input channel, no seeded notice buffer — the row simply has no terminal surface
+until `Terminals::sync` adopts one. The retry is the ordinary attach path: the
+failure is recorded in `Terminals::failed` per session, carrying the **pane** it
+tried — so a row whose candidate pane has changed is retried at once, and only an
+unchanged one waits out `ATTACH_RETRY_INTERVAL` (20 s), which is what stops a
+host that was down at startup staying dead for the life of the process.
 
-The same treatment covers **mid-session host loss**:
-`App::detect_lost_remote_sessions` (per tick) spots a *live* remote session whose
-control-mode connection just died, converts it in place to an `Unreachable`
-placeholder and queues a reconnect (`enqueue_remote_reconnect`). The reliable
-signal is `has_exited()`: with `remain-on-exit=on` a clean agent exit keeps its
-pane alive (no reader EOF), so a remote reader hitting EOF means the host/SSH
-connection dropped. This composes with the fail-fast SSH hardening
-(`crate::shell::SSH_HARDENING_OPTS` = `BatchMode=yes` + `ConnectTimeout` +
-`ServerAlive*`), which stops a broken host from prompting for a password on the
-TUI's terminal or hanging the render loop.
+**Mid-session host loss** goes through the same door.
+`Terminals::drop_lost_panes` (per tick) drops the pane of a live session whose
+reader hit EOF and records "host unreachable" — which is what makes the row read
+`unreachable` on the next snapshot, and which also clears that backend's
+readiness so the next attach re-readies the connection every session on that host
+shares. `has_exited()` is the reliable signal: with `remain-on-exit=on` a clean
+agent exit keeps its pane alive (no reader EOF), so a remote reader hitting EOF
+means the host/SSH connection dropped. This composes with the fail-fast SSH
+hardening (`crate::shell::SSH_HARDENING_OPTS` = `BatchMode=yes` +
+`ConnectTimeout` + `ServerAlive*`), which stops a broken host from prompting for a
+password on the TUI's terminal or hanging the render loop.
 
-The live session list **animates** the `Working` spinner (`ui::SPINNER_FRAMES`,
-`App::spinner_frame` advanced from `tick_count`, ~8 fps, repaints forced only
-while something is working). The filled `●` (Done) vs hollow `○` (Idle) pair
-reads done-vs-seen at a glance. `ui::status_glyph(status, spinner)` picks the
-frame; the static `icon()` is used in non-animated contexts (info panel).
+The session list **animates** the `Working` spinner Lua-side:
+`widgets.status_glyph(status, ctx.elapsed)` over `theme.spinner`, eight frames a
+second off `ctx.elapsed` (the only monotonic reading a plugin gets — the plugin
+stdlib ships no `os`). The filled `●` (Done) vs hollow `○` (Idle) pair reads
+done-vs-seen at a glance; `SessionStatus::icon()` is the static frame, for
+non-animated contexts.
 
 - **The callback.** Agents report transitions with
   `thurbox-cli session signal --state <working|blocked|done|idle>`

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -61,7 +61,7 @@ inventory `plugin list` does, and restores a file you broke. Open settings with
 
 ## Traps
 
-Nine mistakes that are invisible until runtime. Each cost real time in the
+Ten mistakes that are invisible until runtime. Each cost real time in the
 changes that built the bundled panes.
 
 **Reading `state` or `store` hands back a copy.** Mutating it changes nothing —
@@ -106,6 +106,13 @@ symptom is never an error: it is a filter that keeps everything, a count that is
 or a row reported missing that the screen plainly shows. This has cost real time twice,
 once in a bundled pane and once in a plugin written against it. If a table can have a
 hole, iterate its indices (`for i = 1, n`) or do not leave one.
+
+**Declaring one of the kernel's five chords is refused.** `ctrl+q`, `ctrl+h`,
+`ctrl+l`, `f10` and `f12` (`kernel::registry::RESERVED`) are dispatched before the
+registry is consulted, so a plugin claiming one used to load, appear in `F1`, and
+never fire — a no-op with no symptom for whoever wrote it. The declaration is now
+rejected where it is read, naming the file and the chord, so the failure is one
+`plugin check` away instead of a key you keep pressing.
 
 **A pane in a `switch` slot needs one key that goes both ways.** `command("focus",
 { text = "<your pane>", toggle = true })` focuses it, and focuses whatever you came
@@ -200,7 +207,7 @@ that throws costs its own pane and nothing else.
 | `command(kind, opts)` | The only way to change anything. Enqueues and returns |
 | `state` | Private to your plugin. Survives a reload; **not** a restart |
 | `store` | Shared by every plugin — the bus between them. Same lifetime as `state` |
-| `files.list/read` | Directory entries and file text, rooted at a session's directory |
+| `files.list/read` | Directory entries and file text, rooted at a **local** session's directory; a remote session has no root and both calls raise `no directory for session <id>` |
 | `thurbox.settings` | The settings in force: every `[features]` switch, plus the panel breakpoints and scrollback. Read your own switch and decline to draw when it is off — the kernel gates only what it owns |
 | `thurbox.bookmarks/browse/branches` | The creation flow's reads: remembered repositories, a directory listing, a base-branch list — each served only while `store.want_bookmarks`/`want_browse`/`want_branches` asks for it |
 | `require` | Loads **any** `.lua` under the interface directory, and nothing outside it |
@@ -546,6 +553,14 @@ You receive another plugin's rendered tree and return a modified one, matching
 on the `id`/`class`/`role` nodes carry. This is how search highlights matches
 inside panes it does not own. A decorator that throws costs its decoration, not
 the pane.
+
+The tree you receive is the node table as the kernel converts it back, and one
+field is not the shape you wrote: a `frame.title` arrives as a **list of
+`{ text = , style = }` runs**, never a plain string, even for a pane that gave it
+a bare one. Flattening it here would hand you one string for a title that is two
+facts with two styles — the agent pane's is a session's name and its status — so
+an identity decorator would repaint the whole title in one colour. Iterate the
+runs; do not index the title as text.
 
 ## Turning a plugin off
 
@@ -923,7 +938,13 @@ reading:
 
 The third missing surface, the file viewer, has no pane — by nobody having written
 one rather than by anything withheld: `files.list/read` is published, rooted at a
-session's directory.
+session's directory. **A remote session has no root at all**, and both calls raise
+`no directory for session <id>` for one. Not an omission: `files` reads the local
+disk, and since every host's default `worktrees_dir` is the same
+`$HOME/.local/share/thurbox/worktrees`, resolving a remote cwd locally did not fail
+— it handed back another machine's file under the right-looking path. A pane that
+wants remote files has to ask for them the way `kernel::diff` does, on that
+session's own host.
 
 ## Managing panes
 

--- a/docs/V2-KERNEL.md
+++ b/docs/V2-KERNEL.md
@@ -340,12 +340,11 @@ thurbox from a checkout and an unoptimised Lua VM is felt in the UI.
 
 ## The gap to v1
 
-Two lists, and they answer different questions. `tests/v2_parity.rs` holds the
-**rendering** divergences — what v2 draws differently — and asserts their exact
-count, so adding one without recording it fails. `openspec/changes/v2-parity-gaps/`
-holds the **behavioural** ones, found by auditing each v1 pane against its
-plugin; it is the longer and more serious list, and Tier 0 of it is what
-`v2-retire-v1` is really waiting on.
+`openspec/changes/v2-parity-gaps/` is the one list, and it is where every gap is
+tracked: the **behavioural** ones, found by auditing each v1 pane against its
+plugin, and the **rendering** divergences beside them. It is tiered by how much
+a v2 without the entry hurts, Tier 0 being the entries `v2-retire-v1` was waiting
+on.
 
 ## Decisions
 

--- a/src/agent/backend.rs
+++ b/src/agent/backend.rs
@@ -38,7 +38,7 @@ pub(crate) fn now_millis() -> u64 {
 ///
 /// Nothing is readable at two columns either, so clamping loses nothing a
 /// smaller grid would have shown.
-fn vt_floor(rows: u16, cols: u16) -> (u16, u16) {
+pub(crate) fn vt_floor(rows: u16, cols: u16) -> (u16, u16) {
     (rows.max(2), cols.max(2))
 }
 
@@ -621,13 +621,38 @@ pub struct Session {
     pub shell_pane: Option<ShellPane>,
     /// Session environment variables, passed to shell pane spawns.
     env: HashMap<String, String>,
-    /// True for a **placeholder** session: a persisted remote session whose host
-    /// is currently unreachable, so it has no live backend pane / reader / writer
-    /// (its `input_tx` is a dead channel and its `parser` holds a static "host
-    /// unreachable" notice). Rendered with `SessionStatus::Unreachable` and
-    /// replaced in place by the real adopted session once the host recovers. See
-    /// `App::start_remote_restore` / the remote retry loop.
-    placeholder: bool,
+}
+
+/// One session's panes, ready to be resized from another thread.
+///
+/// A remote session's resize is two control-mode round trips, each blocking on
+/// `COMMAND_TIMEOUT` (10 s). Issued where the size change is *noticed* — inside
+/// the paint — a connection that had gone away without the socket noticing froze
+/// the whole render loop until both timeouts ran out. Rule 5: anything that
+/// touches the world runs on a worker, so the render thread resizes the grids
+/// ([`Session::resize_grids`]) and hands this to one.
+pub struct PaneResize {
+    backend: Arc<dyn SessionBackend>,
+    /// The agent pane, then its companion shell when there is one. Both are told
+    /// the same size because they take turns in the same rect.
+    panes: Vec<String>,
+}
+
+impl PaneResize {
+    /// Push the size to every pane. **Blocking** — call it on a worker.
+    ///
+    /// Each pane is attempted even if an earlier one failed: they are separate
+    /// panes, and skipping the shell because the agent's round trip timed out
+    /// leaves it wrapping at a width nothing will correct until the next rect
+    /// change.
+    pub fn apply(&self, rows: u16, cols: u16) {
+        let (rows, cols) = vt_floor(rows, cols);
+        for pane in &self.panes {
+            if let Err(e) = self.backend.resize(pane, rows, cols) {
+                tracing::warn!("Failed to resize pane {pane}: {e}");
+            }
+        }
+    }
 }
 
 impl Session {
@@ -807,85 +832,7 @@ impl Session {
             attention_ack_at: 0,
             shell_pane: None,
             env,
-            placeholder: false,
         }
-    }
-
-    /// Build a **placeholder** session for a persisted remote session whose host
-    /// is currently unreachable. It carries no live backend pane: the reader /
-    /// writer loops are never spawned, `input_tx` is a dead channel (keystrokes
-    /// are silently dropped), and the `parser` is seeded with a static notice.
-    /// The row renders like any other (grouping/ordering/nesting all key off
-    /// `info`) but shows `SessionStatus::Unreachable` until the host recovers and
-    /// [`Self::adopt`] replaces it in place. `info.status` is forced to
-    /// `Unreachable` here regardless of the caller's value.
-    pub fn placeholder(
-        mut info: SessionInfo,
-        rows: u16,
-        cols: u16,
-        backend: &Arc<dyn SessionBackend>,
-        provider: &Arc<dyn AgentProvider>,
-        env: HashMap<String, String>,
-    ) -> Self {
-        info.status = crate::session::SessionStatus::Unreachable;
-        info.backend_id = None;
-
-        let last_title = Arc::new(Mutex::new(None));
-        let attention_at = Arc::new(AtomicU64::new(0));
-        let notification = Arc::new(Mutex::new(None));
-        let meta_gen = Arc::new(AtomicU64::new(0));
-        let (rows, cols) = vt_floor(rows, cols);
-        let parser = Arc::new(Mutex::new(vt100::Parser::new_with_callbacks(
-            rows,
-            cols,
-            crate::session::settings::global().scrollback_lines,
-            TermSignals {
-                title: Arc::clone(&last_title),
-                attention_at: Arc::clone(&attention_at),
-                notification: Arc::clone(&notification),
-                meta_gen: Arc::clone(&meta_gen),
-                ..Default::default()
-            },
-        )));
-        let host = info.remote_host.clone().unwrap_or_else(|| "?".into());
-        let notice = format!(
-            "\r\n  \u{2298} Remote host '{host}' unreachable \u{2014} retrying\u{2026}\r\n\r\n  \
-             This session will reconnect automatically when the host comes back.\r\n  \
-             Press restart to retry now, or delete to remove it.\r\n"
-        );
-        if let Ok(mut p) = parser.lock() {
-            p.process(notice.as_bytes());
-        }
-
-        // A dead input channel: the receiver is dropped immediately, so any
-        // keystroke `try_send` fails fast and the byte is discarded.
-        let (input_tx, _dead_rx) = mpsc::channel(INPUT_CHANNEL_CAPACITY);
-
-        Self {
-            info,
-            parser,
-            input_tx,
-            backend_id: String::new(),
-            backend: Arc::clone(backend),
-            provider: Arc::clone(provider),
-            exited: Arc::new(AtomicBool::new(false)),
-            last_output_at: Arc::new(AtomicU64::new(0)),
-            last_title,
-            attention_at,
-            notification,
-            meta_gen,
-            last_synced_meta_gen: u64::MAX,
-            attention_ack_at: 0,
-            shell_pane: None,
-            env,
-            placeholder: true,
-        }
-    }
-
-    /// Whether this is a placeholder for an unreachable remote session (no live
-    /// backend pane). See [`Self::placeholder`].
-    pub fn is_placeholder(&self) -> bool {
-        self.placeholder
     }
 
     /// Blocking read loop feeding the vt100 parser. Runs on a
@@ -961,37 +908,39 @@ impl Session {
         send_to_input_channel(&self.input_tx, data, "Session")
     }
 
-    pub fn resize(&self, rows: u16, cols: u16) {
+    /// Match this session's vt100 grids to a new size.
+    ///
+    /// The half of a resize that touches nothing but this process's memory, and
+    /// so is safe where a rect change is noticed — inside the paint. The panes
+    /// the multiplexer owns are told separately, on a worker: see
+    /// [`Self::pane_resize`].
+    ///
+    /// The shell pane's grid moves with the agent's because the two take turns
+    /// in the same rect.
+    pub fn resize_grids(&self, rows: u16, cols: u16) {
         // A cramped layout (tiny terminal + open panels/strips) can compute a
         // one-cell content area, which vt100 cannot be fed without underflowing
-        // — see [`vt_floor`]. Floored at this boundary for every path below,
-        // including the pane the backend is told about, so the grid and the pane
-        // agree on a size they can both hold.
+        // — see [`vt_floor`]. Floored here and in [`PaneResize::apply`], so the
+        // grid and the pane agree on a size they can both hold.
         let (rows, cols) = vt_floor(rows, cols);
-        // A placeholder has no live pane; only resize its local notice buffer.
-        // Talking to the (possibly-down) backend here would issue a blocking
-        // ssh resize on the UI thread — the freeze we're avoiding.
-        if self.placeholder {
-            if let Ok(mut parser) = self.parser.lock() {
-                parser.screen_mut().set_size(rows, cols);
-            }
-            return;
-        }
-        if let Err(e) = self.backend.resize(&self.backend_id, rows, cols) {
-            tracing::warn!("Failed to resize session: {e}");
-            return;
-        }
         if let Ok(mut parser) = self.parser.lock() {
             parser.screen_mut().set_size(rows, cols);
         }
         if let Some(shell) = &self.shell_pane {
-            if let Err(e) = self.backend.resize(&shell.backend_id, rows, cols) {
-                tracing::warn!("Failed to resize shell pane: {e}");
-                return;
-            }
             if let Ok(mut parser) = shell.parser.lock() {
                 parser.screen_mut().set_size(rows, cols);
             }
+        }
+    }
+
+    /// The multiplexer half of a resize, detached from the session so it can be
+    /// applied somewhere it is allowed to block.
+    pub fn pane_resize(&self) -> PaneResize {
+        let mut panes = vec![self.backend_id.clone()];
+        panes.extend(self.shell_pane.iter().map(|s| s.backend_id.clone()));
+        PaneResize {
+            backend: Arc::clone(&self.backend),
+            panes,
         }
     }
 
@@ -1150,10 +1099,6 @@ impl Session {
 
     /// Kill/destroy the backend session (for Ctrl+X close).
     pub fn kill(&self) {
-        // A placeholder owns no live backend pane (see `placeholder`).
-        if self.placeholder {
-            return;
-        }
         self.kill_shell_pane();
         if let Err(e) = self.backend.kill(&self.backend_id) {
             tracing::warn!("Failed to kill session: {e}");
@@ -1162,11 +1107,6 @@ impl Session {
 
     /// Detach from the backend session without killing it (for Ctrl+Q quit).
     pub fn detach(self) {
-        // A placeholder owns no live backend pane — detaching would issue a
-        // blocking ssh call (possibly to a down host) for nothing.
-        if self.placeholder {
-            return;
-        }
         if let Some(shell) = &self.shell_pane {
             if let Err(e) = self.backend.detach(&shell.backend_id) {
                 tracing::warn!("Failed to detach shell pane: {e}");
@@ -1311,7 +1251,6 @@ impl Session {
             attention_ack_at: 0,
             shell_pane: None,
             env: HashMap::new(),
-            placeholder: false,
         };
         (session, input_rx)
     }

--- a/src/cli/plugins.rs
+++ b/src/cli/plugins.rs
@@ -341,7 +341,13 @@ fn check() -> Result<CommandOutput, String> {
 
 fn list() -> Result<CommandOutput, String> {
     let (dir, _chosen) = resolve()?;
-    let host = crate::kernel::host::LuaHost::new(&dir);
+    // `host_at`, not a bare host: `build` aborts the whole load on the first
+    // plugin that fails, so loading a pane the user turned off *because* it was
+    // broken left `plugins` empty and reported every other pane as `failed` with
+    // no slot and no capabilities — defeating the listing in exactly the
+    // recovery the switch exists for. The `disabled` closure below then agrees
+    // with the host it is describing, as it does in `check`.
+    let host = host_at(&dir);
     let sources = crate::kernel::bundled::sources(&dir);
     let registry = crate::kernel::registry::Registry::load();
     // The name each managed file answers to. `name` below is what the pane calls
@@ -377,14 +383,11 @@ fn list() -> Result<CommandOutput, String> {
         // Trust is a decision the user made in a running interface; from here it
         // is read, not judged — so this reports what was recorded and nothing
         // about whether the file has changed since.
-        &|path| {
-            let absolute = dir.join(path);
-            match registry.is_trusted(&absolute.to_string_lossy()) {
-                true => crate::kernel::inventory::Trust::Trusted,
-                false => crate::kernel::inventory::Trust::Untrusted,
-            }
+        &|path| match registry.is_trusted(&crate::kernel::bundled::absolute_key(&dir, path)) {
+            true => crate::kernel::inventory::Trust::Trusted,
+            false => crate::kernel::inventory::Trust::Untrusted,
         },
-        &|path| registry.is_disabled(&dir.join(path).to_string_lossy()),
+        &|path| registry.is_disabled(&crate::kernel::bundled::absolute_key(&dir, path)),
     );
 
     let table = super::output::table(
@@ -547,6 +550,11 @@ fn entry_rows(reports: &[crate::kernel::packages::EntryReport]) -> (Vec<String>,
             report.outcome.as_str(),
             report.file
         ));
+        // Named, because a kept file is one the entry no longer accounts for: it
+        // is still on disk and still loaded, and its spec entry has just gone.
+        if !report.kept.is_empty() {
+            lines.push(format!("      kept {}", report.kept.join(", ")));
+        }
         rows.push(json!({
             "file": report.file,
             "name": report.name,
@@ -554,6 +562,7 @@ fn entry_rows(reports: &[crate::kernel::packages::EntryReport]) -> (Vec<String>,
             "version": report.version,
             "from": report.from,
             "outcome": report.outcome.as_str(),
+            "kept": report.kept,
         }));
     }
     (lines, rows)
@@ -563,7 +572,13 @@ fn sync() -> Result<CommandOutput, String> {
     let dir = install_dir()?;
     let reports = crate::kernel::packages::sync(&dir)?;
     let (lines, rows) = entry_rows(&reports);
-    let changed = reports.iter().any(|report| report.outcome.changed());
+    // A withdrawal that kept a file reports `kept` rather than `withdrawn`, and
+    // `Kept` on its own means "nothing moved" — but the entry it belonged to is
+    // gone from the spec and the lock, and a pane beside it may well have been
+    // taken back. So a non-empty `kept` counts as a change too.
+    let changed = reports
+        .iter()
+        .any(|report| report.outcome.changed() || !report.kept.is_empty());
 
     let human = if reports.is_empty() {
         format!("{}\n  nothing installed", dir.display())
@@ -607,6 +622,19 @@ fn update(name: Option<&str>) -> Result<CommandOutput, String> {
 fn remove(name: &str) -> Result<CommandOutput, String> {
     let (dir, _chosen) = resolve()?;
     let report = crate::kernel::packages::remove(&dir, name)?;
+    // The outcome, not the verb: `withdraw` leaves a file the user changed where
+    // it is, so saying "removed" would claim a pane is gone while it is still on
+    // disk, still loaded and still claiming its keys — with its spec entry now
+    // removed, so nothing later would ever mention it again.
+    let mut human = format!(
+        "{} {} ({})",
+        report.outcome.as_str(),
+        report.file,
+        report.src
+    );
+    if !report.kept.is_empty() {
+        human.push_str(&format!("\n  kept {}", report.kept.join(", ")));
+    }
     Ok(CommandOutput::new(
         json!({
             "dir": dir.display().to_string(),
@@ -614,9 +642,10 @@ fn remove(name: &str) -> Result<CommandOutput, String> {
             "name": report.name,
             "src": report.src,
             "outcome": report.outcome.as_str(),
-            "summary": format!("removed {}", report.file),
+            "kept": report.kept,
+            "summary": format!("{} {}", report.outcome.as_str(), report.file),
         }),
-        format!("removed {} ({})", report.file, report.src),
+        human,
     ))
 }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -652,6 +652,21 @@ pub(crate) fn host_shell_c(host: &HostDef, script: &str) -> Command {
     cmd
 }
 
+/// [`host_shell_c`], run in a directory **on the host**.
+///
+/// The `cd` is part of the script rather than a `Command::current_dir`, which
+/// would name a path on this machine — the directory is on the other one. The
+/// quoting is done here rather than at the call site so a caller outside this
+/// module does not have to reach for `shell::posix_quote` itself: a worktree
+/// path can contain anything a filesystem allows, and `kernel::runs` is the
+/// caller, which may not touch `shell` at all (see `MODULE_RULES`).
+pub(crate) fn host_shell_c_in(host: &HostDef, cwd: &Path, script: &str) -> Command {
+    host_shell_c(
+        host,
+        &format!("cd {} && {script}", posix_quote(&cwd.to_string_lossy())),
+    )
+}
+
 /// Build a `<launcher> powershell -NoProfile -EncodedCommand <base64>`
 /// [`Command`] — [`host_shell_c`] for a **native-Windows** host, which has no
 /// `sh` at all (`sh -c …` there fails with PowerShell's

--- a/src/kernel/bands.rs
+++ b/src/kernel/bands.rs
@@ -128,10 +128,9 @@ pub struct BandState<'a> {
 
 impl BandState<'_> {
     fn colour(&self, role: &str) -> Option<ratatui::style::Color> {
-        self.themes
-            .roles()
-            .get(role)
-            .and_then(|raw| super::node::parse_color(raw))
+        // `Themes::role`, not `roles()`: this is asked once per span, and the
+        // whole-palette accessor builds 31 `String`s each time it is called.
+        self.themes.role(role)
     }
 
     fn style(&self, role: &str) -> Style {

--- a/src/kernel/bundled.rs
+++ b/src/kernel/bundled.rs
@@ -348,6 +348,21 @@ const LIB_DEPTH: usize = 3;
 /// a no-op on Windows.
 ///
 /// `None` when `absolute` is not inside `dir`, or is `dir` itself.
+/// The inverse of [`relative_to`]: the storage key for one file of `dir`.
+///
+/// Trust, the disabled set and the rebindings are keyed by the **absolute** path
+/// as `Path::join` writes it, so every reader and every writer has to build that
+/// string the same way — and the way that breaks is invisible on Linux. `dir` is
+/// a `Path` while the relative half carries `/` separators, so on Windows
+/// `dir.join("plugins/90_notes.lua")` yields `C:\ui\plugins/90_notes.lua`: a key
+/// that is *stable* (writer and reader agree, which is why turning a plugin off
+/// works) but that nothing constructed any other way will ever match. Anything
+/// that reaches for a stored decision goes through here rather than joining for
+/// itself, so a second construction cannot drift from the first.
+pub fn absolute_key(dir: &Path, relative: &str) -> String {
+    dir.join(relative).to_string_lossy().into_owned()
+}
+
 pub fn relative_to(dir: &Path, absolute: &str) -> Option<String> {
     let root = dir.to_string_lossy();
     let rest = absolute.strip_prefix(root.as_ref())?;
@@ -538,12 +553,29 @@ pub fn remove(dir: &Path, relative: &str) -> Result<(), String> {
     write_manifest(dir, &manifest)
 }
 
+/// The extensions delivery ships, and so the only ones [`checked`] opens onto.
+///
+/// Every entry in [`BUNDLED`] has one of these, which
+/// `the_bundle_covers_the_whole_interface` pins — the door has to widen with the
+/// bundle, or a newly shipped kind of file would be listed by [`sources`] and
+/// refused by the command that restores it.
+const SHIPPED_EXTENSIONS: [&str; 2] = ["lua", "md"];
+
 /// Resolve a path that came from a plugin, or refuse it.
 ///
 /// Lua has no filesystem and this command is the one door into one, so the door
-/// opens only onto Lua files inside the interface directory: no absolute paths,
-/// no `..`, and nothing that is not a `.lua` file — which also keeps the
-/// manifest itself out of reach.
+/// opens only onto what delivery itself ships, inside the interface directory:
+/// no absolute paths, no `..`, and no extension outside
+/// [`SHIPPED_EXTENSIONS`].
+///
+/// `.md` is there because the guidance files are shipped, listed by [`sources`]
+/// and tombstoned like any other bundled file — refusing them here meant the
+/// Interface tab armed `r` and `d` on rows whose action could never complete, so
+/// a `README.md` deleted outside thurbox could not be restored from the one view
+/// that lists it. Everything else stays shut by the same rule: the bookkeeping
+/// files nobody edits (`.bundled.json`, `plugins.lock`, `ui.json`) are `.json`
+/// and `.lock`, so they remain out of reach without a second list to keep in
+/// step.
 fn checked(dir: &Path, relative: &str) -> Result<PathBuf, String> {
     let candidate = Path::new(relative);
     if !candidate
@@ -552,8 +584,12 @@ fn checked(dir: &Path, relative: &str) -> Result<PathBuf, String> {
     {
         return Err(format!("{relative} is not inside the interface directory"));
     }
-    if candidate.extension() != Some("lua".as_ref()) {
-        return Err(format!("{relative} is not a Lua file"));
+    let shipped = candidate
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| SHIPPED_EXTENSIONS.contains(&ext));
+    if !shipped {
+        return Err(format!("{relative} is not a file the interface ships"));
     }
     Ok(dir.join(candidate))
 }
@@ -685,13 +721,14 @@ impl Chosen {
 
 /// The interface directory, and which rule chose it.
 ///
-/// Two rules, in order: `THURBOX_UI_DIR`, then the user's own copy —
+/// Two rules, in order: `THURBOX_UI_DIR`, else the user's own copy —
 /// materialized from the embedded interface on first run, preserving anything
 /// they edited. There is deliberately no automatic `./ui` rule; the comment on
-/// the branch below says why. A missing or unwritable config directory is not
-/// fatal: the embedded copies are written somewhere throwaway and used from
-/// there, because no interface at all is the one outcome worth avoiding
-/// (`v2-plugin-kernel` design.md D11).
+/// the branch below says why, and [`Chosen::Checkout`] is a *label* for an
+/// override that happens to point at a checkout's `ui/`, not a third rule. A
+/// missing or unwritable config directory is not fatal: the embedded copies are
+/// written somewhere throwaway and used from there, because no interface at all
+/// is the one outcome worth avoiding (`v2-plugin-kernel` design.md D11).
 ///
 /// Lives here rather than in the interface binary so that anything asking "which
 /// directory is live" gets the same answer the interface will use — two
@@ -945,6 +982,29 @@ mod tests {
         assert_eq!(relative_to(dir, "/home/me/.config/thurbox/ui/"), None);
     }
 
+    /// [`absolute_key`] and [`relative_to`] are inverses, on every platform.
+    ///
+    /// This is the property every stored decision depends on: the writer keys by
+    /// `absolute_key`, the readers look one up by the same, and `host_at` /
+    /// `publish_disabled` convert back with `relative_to` to tell `build` which
+    /// files to skip. Written as a round trip because the failure is invisible on
+    /// Linux — on Windows the key carries a `/` inside a `\`-separated path, which
+    /// is fine as long as nothing constructs it a second way, and this is what
+    /// says so. A test that hand-joined the components instead reported a
+    /// disabled pane as `failed` on Windows only.
+    #[test]
+    fn a_storage_key_converts_back_to_the_file_it_names() {
+        let dir = Path::new("/home/me/.config/thurbox/ui");
+        for relative in ["plugins/90_notes.lua", "lib/atlas/util.lua", "layout.lua"] {
+            let key = absolute_key(dir, relative);
+            assert_eq!(
+                relative_to(dir, &key).as_deref(),
+                Some(relative),
+                "{relative} did not survive the round trip through {key}"
+            );
+        }
+    }
+
     /// The directory tells whoever edits it how to, under the name their tool reads.
     ///
     /// `README.md` is what a person opens; `AGENTS.md` is what a coding CLI loads as
@@ -1003,6 +1063,16 @@ mod tests {
         }
         for (name, contents) in BUNDLED {
             assert!(!contents.is_empty(), "{name} is empty");
+            // And every shipped kind of file is one `checked` will open, so a
+            // new one cannot be delivered and then be unrestorable.
+            let extension = Path::new(name)
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .unwrap_or_default();
+            assert!(
+                SHIPPED_EXTENSIONS.contains(&extension),
+                "{name} ships but `checked` refuses its extension"
+            );
         }
     }
 

--- a/src/kernel/command.rs
+++ b/src/kernel/command.rs
@@ -703,6 +703,16 @@ impl Phase {
     }
 }
 
+/// Commands running at once before the bus starts refusing.
+///
+/// The Lua-side queue is unbounded and every non-local command becomes its own
+/// OS thread, so a pane looping on `command` could spawn without limit — while
+/// `RunStore` next door states the opposite as a bound ("twenty asks are slow,
+/// not a fork bomb"). High enough that no honest interaction reaches it: the
+/// commands that take real time are one per session, and the rest are applied
+/// on the loop without ever reaching the bus.
+const MAX_IN_FLIGHT: usize = 32;
+
 /// A command that has been accepted but whose effect is not yet visible.
 #[derive(Debug, Clone)]
 pub struct InFlight {
@@ -794,8 +804,30 @@ impl CommandBus {
             phase: Phase::Queued,
             error: None,
         };
+        let mut refused = false;
         if let Ok(mut inflight) = self.inflight.lock() {
+            refused = inflight
+                .iter()
+                .filter(|entry| entry.phase != Phase::Failed)
+                .count()
+                >= MAX_IN_FLIGHT;
             inflight.push(entry);
+        }
+        // Admission, not queuing: holding one back until another finishes would
+        // reintroduce exactly the head-of-line blocking on a down host that the
+        // thread-per-command shape below exists to prevent. Refused through the
+        // ordinary completion channel, so the message band reports it and the
+        // entry expires like any other failure — a silently dropped command is
+        // indistinguishable from a slow one.
+        if refused {
+            self.finish_outcome(
+                id,
+                Some(format!(
+                    "too many commands in flight ({MAX_IN_FLIGHT}); this one was not started"
+                )),
+                None,
+            );
+            return id;
         }
 
         let inflight = self.inflight.clone();
@@ -1959,6 +1991,44 @@ mod tests {
         assert!(
             bus.take_created().is_empty(),
             "a creation must steer the selection once, not every tick"
+        );
+    }
+
+    #[test]
+    fn the_bus_refuses_past_its_in_flight_ceiling_instead_of_spawning() {
+        // Every non-local command becomes its own OS thread and the Lua-side
+        // queue that feeds them is unbounded, so a pane looping on `command`
+        // had no ceiling at all. The refusal travels the ordinary completion
+        // path: the entry is drawable, then reported, then expires — which is
+        // what stops it looking like a command that is merely slow.
+        let mut bus = CommandBus::new();
+        let mut ids = Vec::new();
+        for _ in 0..MAX_IN_FLIGHT {
+            ids.push(bus.dispatch(Command::Restore {
+                session: "s1".into(),
+                best_effort: false,
+            }));
+        }
+        let refused = bus.dispatch(Command::Restore {
+            session: "s1".into(),
+            best_effort: false,
+        });
+        bus.poll();
+
+        let entry = bus
+            .inflight()
+            .iter()
+            .find(|entry| entry.id == refused)
+            .expect("the refused row is still drawable")
+            .clone();
+        assert_eq!(entry.phase, Phase::Failed);
+        assert!(
+            entry
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("too many commands in flight")),
+            "the refusal must say why: {:?}",
+            entry.error
         );
     }
 

--- a/src/kernel/convert.rs
+++ b/src/kernel/convert.rs
@@ -15,9 +15,12 @@ use super::node::{
 
 /// Deepest tree accepted. Guards against a plugin building a cyclic or
 /// pathological structure and taking the render thread down with it.
-const MAX_DEPTH: usize = 64;
+///
+/// Reachable from the rest of the kernel because the persistence path bounds
+/// itself by the same ceiling (`host::MAX_PERSISTED_DEPTH`): two spellings of
+/// one number are two numbers as soon as either moves.
+pub(crate) const MAX_DEPTH: usize = 64;
 
-/// Convert a plugin's returned value into a node tree.
 /// Read a plugin's returned tree.
 ///
 /// `owner` is the path of the plugin that produced it, needed because a
@@ -25,10 +28,53 @@ const MAX_DEPTH: usize = 64;
 /// writes `program = "watch"` and the kernel resolves the owner, so naming another
 /// plugin's pane is impossible by construction rather than refused by a check.
 pub fn to_node(value: &Value, owner: &str) -> Result<Node, String> {
+    to_node_with(
+        value,
+        &Owner {
+            path: owner,
+            resolved_program_ok: false,
+        },
+    )
+}
+
+/// Read a tree on its way *back* from a decorator.
+///
+/// The same conversion, except a `program` surface may already carry the
+/// resolved id [`to_lua`] emitted (`program:<plugin>#<name>`) instead of the
+/// bare name a plugin authors. Without that an identity decorator over a pane
+/// holding a program surface fails conversion — [`validate_program_name`] allows
+/// no `:`, `/` or `#` — and the pane it wrapped becomes an error panel.
+///
+/// A separate entry point rather than a relaxation of [`to_node`], because the
+/// resolved form names an owner: accepting one from every plugin would let any
+/// pane paint a surface belonging to another, which stamping the owner exists to
+/// prevent.
+///
+/// [`validate_program_name`]: super::terminal::validate_program_name
+pub fn to_node_decorated(value: &Value, owner: &str) -> Result<Node, String> {
+    to_node_with(
+        value,
+        &Owner {
+            path: owner,
+            resolved_program_ok: true,
+        },
+    )
+}
+
+/// Whose tree this is, and how far its `program` surfaces are trusted.
+struct Owner<'a> {
+    /// Path of the plugin a bare program name resolves against.
+    path: &'a str,
+    /// Whether an already-resolved program id is accepted verbatim. True only
+    /// on the decoration path, where the id was minted by the kernel itself.
+    resolved_program_ok: bool,
+}
+
+fn to_node_with(value: &Value, owner: &Owner) -> Result<Node, String> {
     convert(value, "root", 0, owner)
 }
 
-fn convert(value: &Value, path: &str, depth: usize, owner: &str) -> Result<Node, String> {
+fn convert(value: &Value, path: &str, depth: usize, owner: &Owner) -> Result<Node, String> {
     if depth > MAX_DEPTH {
         return Err(format!(
             "{path}: tree nested deeper than {MAX_DEPTH} levels"
@@ -46,7 +92,7 @@ fn convert(value: &Value, path: &str, depth: usize, owner: &str) -> Result<Node,
     }
 }
 
-fn convert_table(table: &Table, path: &str, depth: usize, owner: &str) -> Result<Node, String> {
+fn convert_table(table: &Table, path: &str, depth: usize, owner: &Owner) -> Result<Node, String> {
     let size = read_size(table, path)?;
     let identity = read_identity(table, path)?;
     let frame = read_frame(table, path)?;
@@ -63,6 +109,7 @@ fn convert_table(table: &Table, path: &str, depth: usize, owner: &str) -> Result
         None => {
             if table.contains_key("cells").unwrap_or(false)
                 || table.contains_key("session").unwrap_or(false)
+                || table.contains_key("program").unwrap_or(false)
             {
                 "surface"
             } else if table.contains_key("value").unwrap_or(false)
@@ -129,14 +176,22 @@ fn convert_table(table: &Table, path: &str, depth: usize, owner: &str) -> Result
             let source = if let Some(session) = opt_string(table, "session", path)? {
                 SurfaceSource::Session(session)
             } else if let Some(program) = opt_string(table, "program", path)? {
-                // Resolved against the plugin that drew it. The name is checked
-                // here so a bad one is a conversion error naming its path, rather
-                // than a pane that never appears.
-                super::terminal::validate_program_name(&program)
-                    .map_err(|e| format!("{path}.program: {e}"))?;
-                SurfaceSource::Program(
-                    super::terminal::ProgramKey::new(owner, &program).surface_id(),
-                )
+                let id =
+                    if owner.resolved_program_ok && super::terminal::is_program_surface(&program) {
+                        // Already resolved — this came back from a decorator, which
+                        // was handed the id `to_lua` wrote. Re-resolving it would
+                        // make the decorator the owner of a pane the plugin it
+                        // decorated started, and validating it would reject it.
+                        program
+                    } else {
+                        // Resolved against the plugin that drew it. The name is
+                        // checked here so a bad one is a conversion error naming its
+                        // path, rather than a pane that never appears.
+                        super::terminal::validate_program_name(&program)
+                            .map_err(|e| format!("{path}.program: {e}"))?;
+                        super::terminal::ProgramKey::new(owner.path, &program).surface_id()
+                    };
+                SurfaceSource::Program(id)
             } else {
                 let raw: Value = table
                     .raw_get("cells")
@@ -170,7 +225,7 @@ fn read_children(
     table: &Table,
     path: &str,
     depth: usize,
-    owner: &str,
+    owner: &Owner,
 ) -> Result<Vec<Node>, String> {
     // Children live under `children`, or in the array part of the table so a
     // plugin can write `{ a, b, c }` without the extra key.
@@ -545,12 +600,6 @@ fn lua_err(path: &str, key: &str, error: &mlua::Error) -> String {
     format!("{path}.{key}: {error}")
 }
 
-/// Convert a [`Node`] back into the Lua table a plugin would have written.
-///
-/// Needed only by decoration: a decorator receives another plugin's rendered
-/// tree, so the tree has to cross back into Lua. Round-tripping through the
-/// same shape `to_node` accepts means a decorator can return the table it was
-/// given, modified or not, and it converts back cleanly.
 /// A `Style` as the same table shape a plugin would have written, so the value
 /// a decorator receives is indistinguishable from one it could author.
 ///
@@ -589,6 +638,44 @@ fn style_to_lua(lua: &mlua::Lua, style: &Style) -> Result<Option<Table>, String>
     Ok(any.then_some(table))
 }
 
+/// One line as the `{ { text =, style = }, … }` table [`read_runs`] accepts.
+///
+/// The style MUST round-trip. A decorator is handed the tree and returns one,
+/// so anything dropped here is dropped from the pane -- and a decorator that
+/// returns its input untouched (the common case, when its query is empty) would
+/// silently strip every colour the pane drew. That is exactly what happened:
+/// the session list rendered colourless because search decorates its slot.
+fn runs_to_lua(lua: &mlua::Lua, runs: &[Run]) -> Result<Table, String> {
+    let line = lua.create_table().map_err(|e| e.to_string())?;
+    for (span, run) in runs.iter().enumerate() {
+        let entry = lua.create_table().map_err(|e| e.to_string())?;
+        entry
+            .set("text", run.text.clone())
+            .map_err(|e| e.to_string())?;
+        if let Some(style) = style_to_lua(lua, &run.style)? {
+            entry.set("style", style).map_err(|e| e.to_string())?;
+        }
+        line.set(span + 1, entry).map_err(|e| e.to_string())?;
+    }
+    Ok(line)
+}
+
+/// A block of lines, each one a list of runs.
+fn lines_to_lua(lua: &mlua::Lua, lines: &[Vec<Run>]) -> Result<Table, String> {
+    let out = lua.create_table().map_err(|e| e.to_string())?;
+    for (index, runs) in lines.iter().enumerate() {
+        out.set(index + 1, runs_to_lua(lua, runs)?)
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(out)
+}
+
+/// Convert a [`Node`] back into the Lua table a plugin would have written.
+///
+/// Needed only by decoration: a decorator receives another plugin's rendered
+/// tree, so the tree has to cross back into Lua. Round-tripping through the
+/// same shape `to_node` accepts means a decorator can return the table it was
+/// given, modified or not, and it converts back cleanly.
 pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
     let table = lua.create_table().map_err(|e| e.to_string())?;
     let set = |key: &str, value: Value| -> Result<(), String> {
@@ -629,8 +716,13 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
     }
     if let Some(frame) = node.frame() {
         let spec = lua.create_table().map_err(|e| e.to_string())?;
-        if let Some(text) = frame.title_text() {
-            spec.set("title", text).map_err(|e| e.to_string())?;
+        // Runs, not `title_text()`: a title is often two facts with two styles
+        // — the agent pane's is a session's name and its status — and flattening
+        // it here hands a decorator one string, so an identity decorator repaints
+        // the whole title in one colour. `read_frame` reads runs back.
+        if let Some(runs) = &frame.title {
+            spec.set("title", runs_to_lua(lua, runs)?)
+                .map_err(|e| e.to_string())?;
         }
         spec.set(
             "borders",
@@ -659,29 +751,9 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
             scroll,
             ..
         } => {
-            let out = lua.create_table().map_err(|e| e.to_string())?;
-            for (index, runs) in lines.iter().enumerate() {
-                let line = lua.create_table().map_err(|e| e.to_string())?;
-                for (span, run) in runs.iter().enumerate() {
-                    let entry = lua.create_table().map_err(|e| e.to_string())?;
-                    entry
-                        .set("text", run.text.clone())
-                        .map_err(|e| e.to_string())?;
-                    // The style MUST round-trip. A decorator is handed the
-                    // tree and returns one, so anything dropped here is
-                    // dropped from the pane -- and a decorator that returns
-                    // its input untouched (the common case, when its query is
-                    // empty) would silently strip every colour the pane drew.
-                    // That is exactly what happened: the session list rendered
-                    // colourless because search decorates its slot.
-                    if let Some(style) = style_to_lua(lua, &run.style)? {
-                        entry.set("style", style).map_err(|e| e.to_string())?;
-                    }
-                    line.set(span + 1, entry).map_err(|e| e.to_string())?;
-                }
-                out.set(index + 1, line).map_err(|e| e.to_string())?;
-            }
-            table.set("text", out).map_err(|e| e.to_string())?;
+            table
+                .set("text", lines_to_lua(lua, lines)?)
+                .map_err(|e| e.to_string())?;
             set(
                 "align",
                 string_value(
@@ -756,22 +828,9 @@ pub fn to_lua(lua: &mlua::Lua, node: &Node) -> Result<Value, String> {
                     // line: a plugin-fed surface is where a review diff's syntax
                     // colouring lives, and joining the text throws all of it away
                     // the moment any decorator touches the pane.
-                    let out = lua.create_table().map_err(|e| e.to_string())?;
-                    for (index, runs) in lines.iter().enumerate() {
-                        let line = lua.create_table().map_err(|e| e.to_string())?;
-                        for (span, run) in runs.iter().enumerate() {
-                            let entry = lua.create_table().map_err(|e| e.to_string())?;
-                            entry
-                                .set("text", run.text.clone())
-                                .map_err(|e| e.to_string())?;
-                            if let Some(style) = style_to_lua(lua, &run.style)? {
-                                entry.set("style", style).map_err(|e| e.to_string())?;
-                            }
-                            line.set(span + 1, entry).map_err(|e| e.to_string())?;
-                        }
-                        out.set(index + 1, line).map_err(|e| e.to_string())?;
-                    }
-                    table.set("cells", out).map_err(|e| e.to_string())?;
+                    table
+                        .set("cells", lines_to_lua(lua, lines)?)
+                        .map_err(|e| e.to_string())?;
                 }
             }
         }
@@ -813,6 +872,10 @@ mod tests {
         assert_eq!(node_of("{ children = {} }").unwrap().kind(), "box");
         assert_eq!(node_of("{ value = \"x\" }").unwrap().kind(), "input");
         assert_eq!(node_of("{ session = \"abc\" }").unwrap().kind(), "surface");
+        assert_eq!(
+            node_of("{ program = \"watch\" }").unwrap().kind(),
+            "surface"
+        );
     }
 
     #[test]
@@ -957,6 +1020,49 @@ mod tests {
         assert_eq!(size.len, Some(3));
         assert_eq!(size.min, Some(1));
         assert_eq!(size.max, Some(9));
+    }
+
+    /// The decoration path is the only one that may name a program by its
+    /// resolved id, because that id names an owner: a plugin handed one has been
+    /// handed a pane belonging to somebody else, and the ordinary path resolves
+    /// against the plugin doing the drawing instead.
+    #[test]
+    fn a_resolved_program_id_is_accepted_only_from_a_decorator() {
+        let lua = Lua::new();
+        let value: Value = lua
+            .load("return { program = \"program:plugins/90_watch.lua#watch\" }")
+            .eval()
+            .expect("test source should evaluate");
+
+        let error = to_node(&value, "plugins/91_other.lua").unwrap_err();
+        assert!(error.contains("must be letters"), "{error}");
+
+        match to_node_decorated(&value, "plugins/91_other.lua").expect("decorated converts") {
+            Node::Surface {
+                source: SurfaceSource::Program(id),
+                ..
+            } => assert_eq!(id, "program:plugins/90_watch.lua#watch"),
+            other => panic!("expected a program surface, got {}", other.kind()),
+        }
+    }
+
+    /// A decorator's own bare name still resolves against the decorator, so
+    /// letting the resolved form through does not cost it the ability to draw a
+    /// pane of its own.
+    #[test]
+    fn a_decorator_still_owns_the_program_names_it_writes() {
+        let lua = Lua::new();
+        let value: Value = lua
+            .load("return { program = \"watch\" }")
+            .eval()
+            .expect("test source should evaluate");
+        match to_node_decorated(&value, "plugins/91_other.lua").expect("decorated converts") {
+            Node::Surface {
+                source: SurfaceSource::Program(id),
+                ..
+            } => assert_eq!(id, "program:plugins/91_other.lua#watch"),
+            other => panic!("expected a program surface, got {}", other.kind()),
+        }
     }
 
     #[test]

--- a/src/kernel/diff.rs
+++ b/src/kernel/diff.rs
@@ -10,9 +10,21 @@
 //! state, distinct from "no changes" — a diff that is merely slow must not look
 //! like a clean worktree.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, Sender};
+use std::time::{Duration, Instant};
+
+/// How long a computed diff is trusted before it is computed again.
+///
+/// Every other worker store here caches an *age*, not a value, and this one
+/// cached a value: computed once per session per process, so a pane watching an
+/// agent that is still writing code showed the diff it first saw. `Command::Diff`
+/// was the only way back, and nothing else ever evicted — so a selection the loop
+/// asks for every frame pinned up to [`MAX_DIFF_BYTES`] for the life of the
+/// process. Matches `snapshot::GIT_STAT_TTL`, which shells out to git on the same
+/// cadence for the same rows.
+pub const DIFF_TTL: Duration = Duration::from_secs(5);
 
 /// Largest diff read, in bytes. Beyond this the cap is *reported*, because a
 /// silently truncated diff is a review that quietly omits things.
@@ -65,9 +77,33 @@ struct Computed {
     diff: Diff,
 }
 
+/// One session's last diff, when it landed, and whether a run is under way.
+struct Held {
+    diff: Diff,
+    /// `None` while nothing has landed yet — freshness is a property of an
+    /// answer, and a computation still running has not produced one.
+    at: Option<Instant>,
+    /// A computation for this session is on a thread.
+    ///
+    /// Tracked separately because `Diff::Pending` cannot answer it: a refresh
+    /// deliberately leaves the previous diff readable, so the entry still reads
+    /// `Ready` while the next run is in flight. Without the marker every frame's
+    /// ask would start another `git` — and the loop asks every frame.
+    inflight: bool,
+}
+
+impl Held {
+    /// Whether a fresh computation should start for this entry.
+    ///
+    /// `map_or(true, …)` rather than `is_none_or`, which is above the 1.75 MSRV.
+    fn due(&self) -> bool {
+        !self.inflight && self.at.map_or(true, |at| at.elapsed() >= DIFF_TTL)
+    }
+}
+
 /// Computes and caches diffs, one per session.
 pub struct DiffStore {
-    diffs: HashMap<String, Diff>,
+    diffs: HashMap<String, Held>,
     tx: Sender<Computed>,
     rx: Receiver<Computed>,
 }
@@ -84,14 +120,14 @@ impl DiffStore {
 
     /// What is known about `session`, if anything has been asked for.
     pub fn get(&self, session: &str) -> Option<&Diff> {
-        self.diffs.get(session)
+        self.diffs.get(session).map(|held| &held.diff)
     }
 
-    /// Ask for a session's diff, unless it is already known or in flight.
+    /// Ask for a session's diff, unless one is in flight or the last is fresh.
     ///
     /// Idempotent by design: this is called from the loop with whatever session
-    /// is selected, so it happens every frame and must cost nothing after the
-    /// first.
+    /// is selected, so it happens every frame and must cost nothing until the
+    /// answer it holds is [`DIFF_TTL`] old.
     pub fn request(
         &mut self,
         session: &str,
@@ -99,10 +135,19 @@ impl DiffStore {
         base: Option<String>,
         backend: &str,
     ) {
-        if self.diffs.contains_key(session) {
+        if self.diffs.get(session).is_some_and(|held| !held.due()) {
             return;
         }
-        self.diffs.insert(session.to_string(), Diff::Pending);
+
+        // The previous diff stays readable until the new one lands, so a pane does
+        // not blink back to `Pending` every time it renews — only a session nobody
+        // has asked about before starts out pending.
+        let entry = self.diffs.entry(session.to_string()).or_insert(Held {
+            diff: Diff::Pending,
+            at: None,
+            inflight: false,
+        });
+        entry.inflight = true;
 
         // The worktree is a path on the session's OWN machine. Running the local
         // `git` against a remote path either fails or, on an unlucky collision,
@@ -129,7 +174,14 @@ impl DiffStore {
     pub fn poll(&mut self) -> bool {
         let mut changed = false;
         while let Ok(done) = self.rx.try_recv() {
-            self.diffs.insert(done.session, done.diff);
+            self.diffs.insert(
+                done.session,
+                Held {
+                    diff: done.diff,
+                    at: Some(Instant::now()),
+                    inflight: false,
+                },
+            );
             changed = true;
         }
         changed
@@ -138,12 +190,33 @@ impl DiffStore {
     /// Seed a diff directly, so a test can render a known one without git.
     #[doc(hidden)]
     pub fn set_for_test(&mut self, session: &str, diff: Diff) {
-        self.diffs.insert(session.to_string(), diff);
+        self.diffs.insert(
+            session.to_string(),
+            Held {
+                diff,
+                at: Some(Instant::now()),
+                inflight: false,
+            },
+        );
     }
 
-    /// Forget a session's diff, so the next request recomputes it.
+    /// Forget a session's diff, so the next request recomputes it now rather
+    /// than when its age runs out.
     pub fn invalidate(&mut self, session: &str) {
         self.diffs.remove(session);
+    }
+
+    /// Forget sessions that are no longer in the snapshot, so the cache tracks
+    /// what exists rather than everything that ever did.
+    ///
+    /// A diff is by far the largest thing any worker store holds — up to
+    /// [`MAX_DIFF_BYTES`] of `Vec<String>` per session — and the default
+    /// interface has no pane that reads one, so without this every session ever
+    /// selected kept its body until the process ended. Mirrors
+    /// `snapshot::GitStats::retain`; an answer that lands for a session pruned
+    /// here is pruned again on the next call.
+    pub fn retain(&mut self, present: &HashSet<&str>) {
+        self.diffs.retain(|id, _| present.contains(id.as_str()));
     }
 }
 
@@ -317,6 +390,77 @@ mod tests {
         );
         ask(&mut store);
         assert_eq!(store.get("s1"), Some(&Diff::Pending), "and recomputes");
+    }
+
+    /// An entry as it would be after `age` with a run either out or finished,
+    /// mirroring `repos::tests::held`.
+    fn held(age: Option<Duration>, inflight: bool) -> Held {
+        Held {
+            diff: Diff::Pending,
+            at: age.map(|age| Instant::now() - age),
+            inflight,
+        }
+    }
+
+    #[test]
+    fn a_settled_diff_is_computed_again_once_it_is_old() {
+        // Without an age a diff is computed once per session per process, so a
+        // pane watching an agent still writing code shows what it first saw.
+        assert!(!held(Some(Duration::ZERO), false).due());
+        assert!(held(Some(DIFF_TTL), false).due());
+    }
+
+    #[test]
+    fn a_diff_in_flight_is_never_asked_for_twice() {
+        // However long it takes: the loop asks every frame, so without the marker
+        // a slow diff starts a fresh `git` per frame for as long as it runs.
+        assert!(!held(None, true).due());
+        assert!(!held(Some(DIFF_TTL * 10), true).due());
+        assert!(held(None, false).due(), "and nothing running is due");
+    }
+
+    #[test]
+    fn a_stale_diff_stays_readable_while_the_next_one_runs() {
+        // A pane must not blink back to `Pending` every five seconds.
+        let mut store = DiffStore::new();
+        let ready = Diff::Ready {
+            files: Vec::new(),
+            body: vec!["+one".to_string()],
+            truncated: false,
+            raw_bytes: 4,
+            untracked_omitted: 0,
+        };
+        store.set_for_test("s1", ready.clone());
+        store.diffs.get_mut("s1").expect("seeded").at = Some(Instant::now() - DIFF_TTL);
+
+        store.request(
+            "s1",
+            PathBuf::from("/definitely/not/a/repo"),
+            None,
+            "local-tmux",
+        );
+
+        assert!(
+            store.diffs["s1"].inflight,
+            "the stale answer was recomputed"
+        );
+        assert_eq!(store.get("s1"), Some(&ready), "and the old one still reads");
+    }
+
+    #[test]
+    fn a_session_that_is_gone_loses_its_diff() {
+        // A diff is the largest thing any worker store holds, and the loop asks
+        // for one per selection — so without eviction every session ever selected
+        // kept up to MAX_DIFF_BYTES until the process ended.
+        let mut store = DiffStore::new();
+        store.set_for_test("s1", Diff::Pending);
+        store.set_for_test("s2", Diff::Pending);
+
+        let present: HashSet<&str> = ["s2"].into_iter().collect();
+        store.retain(&present);
+
+        assert!(store.get("s1").is_none(), "the gone session was dropped");
+        assert!(store.get("s2").is_some(), "the live one was kept");
     }
 
     #[test]

--- a/src/kernel/host.rs
+++ b/src/kernel/host.rs
@@ -21,7 +21,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
-use std::time::Instant;
 
 use mlua::{Function, Lua, StdLib, Table, Value, VmState};
 use ratatui::layout::Rect;
@@ -30,7 +29,10 @@ use super::command::{Args, Command, ExtraMember, InFlight};
 use super::convert;
 use super::layout::{Region, SlotMode};
 use super::node::{Node, Size};
-use super::registry::{binding_from, Binding, Pill, Registry, Setting, Value as SettingValue};
+use super::registry::{
+    binding_from, normalise_chord, Binding, Pill, Registry, Setting, Value as SettingValue,
+    RESERVED,
+};
 use super::snapshot::Snapshot;
 use super::theme::Themes;
 
@@ -283,6 +285,16 @@ pub struct KeyPress {
     pub ctrl: bool,
     pub alt: bool,
     pub shift: bool,
+    /// The Command / Super / Windows key.
+    ///
+    /// Carried although only macOS terminals reliably deliver it, because
+    /// `registry::normalise_chord` accepts `cmd`/`command`/`super`/`win` and
+    /// `canonical_chord` has to be able to answer with the same spelling. While
+    /// this field did not exist, a declared `cmd+j` matched nothing *and* a real
+    /// Cmd+J canonicalised to plain `"j"` — firing whatever `j` was bound to,
+    /// which is worse than not binding it. The kitty flags pushed at startup are
+    /// what make it arrive at all.
+    pub cmd: bool,
 }
 
 /// A click resolved onto a node one plugin painted.
@@ -396,9 +408,10 @@ pub struct Published<'a> {
     pub inventory: &'a [super::inventory::Row],
     /// The directory the interface was loaded from.
     ///
-    /// A `./ui` beside the working directory wins over the user's own copy, so
-    /// edits that "did nothing" are usually edits to a file that is not the one
-    /// running. Reporting it is the whole fix (design D7).
+    /// Two rules pick it ([`super::bundled::resolve`]): `THURBOX_UI_DIR` when
+    /// set, otherwise the user's own copy — and a dev build's copy lives under
+    /// `thurbox-dev`, so edits that "did nothing" are usually edits to a file
+    /// that is not the one running. Reporting it is the whole fix (design D7).
     pub ui_dir: &'a str,
     /// The settings in force — the live half as last read, the restart-only half
     /// as published at startup (`kernel::config`).
@@ -732,9 +745,12 @@ impl LuaHost {
         drop(guard);
 
         let value = result.map_err(|e| fail(clean_error(&e)))?;
-        // The DECORATOR owns what it returns: a program surface it names is one of
-        // its own panes, not one belonging to the plugin whose tree it decorated.
-        convert::to_node(&value, &plugin.path).map_err(fail)
+        // A program surface the decorator NAMES is one of its own panes; one it
+        // hands back by the resolved id `to_lua` wrote still belongs to the plugin
+        // whose tree it decorated, which is the only reason an identity decorator
+        // over a program pane is not an error panel. The render path below keeps
+        // plain `to_node`: a rendering plugin may only name its own programs.
+        convert::to_node_decorated(&value, &plugin.path).map_err(fail)
     }
 
     /// Publish the settings in force.
@@ -986,16 +1002,6 @@ impl LuaHost {
             .collect()
     }
 
-    /// Take the commands plugins issued since the last drain.
-    /// Make `plugin` the current one, and give it exactly the capabilities it
-    /// has been granted.
-    ///
-    /// Capabilities are **installed and removed per call** rather than once at
-    /// load, because every plugin shares one Lua state: a global installed for
-    /// one would be reachable by all. Setting it to nil for a plugin that was
-    /// not granted it is what makes "capabilities are absent rather than
-    /// blocked" true here — `run` is not a function that refuses, it is not a
-    /// function (design D7).
     /// The other half of [`Self::enter`]: withdraw every per-plugin capability.
     ///
     /// For Lua that runs outside any plugin. `enter` installs `run` for the plugin
@@ -1005,7 +1011,75 @@ impl LuaHost {
     fn enter_nothing(&self) {
         self.current.borrow_mut().clear();
         self.current_path.borrow_mut().clear();
+        self.publish_grants(None);
         let _ = self.lua.globals().set("run", Value::Nil);
+    }
+
+    /// The `thurbox` table plugins read from, created if a publish has not built
+    /// one yet — so an answer is readable without depending on the order those
+    /// two happened in.
+    fn read_surface(&self) -> Option<Table> {
+        let globals = self.lua.globals();
+        if let Ok(table) = globals.get::<Table>("thurbox") {
+            return Some(table);
+        }
+        let fresh = self.lua.create_table().ok()?;
+        let _ = globals.set("thurbox", fresh.clone());
+        Some(fresh)
+    }
+
+    /// `thurbox.runs` for one plugin: its own answers, and nothing else's.
+    ///
+    /// Built per call rather than at publish because `thurbox` is one shared
+    /// table — publishing every plugin's runs into it would let any pane read
+    /// another's output. A plugin with no answers, and the no-plugin case, get an
+    /// empty table rather than no table; see [`Self::publish_grants`].
+    fn runs_table(&self, plugin: Option<&Plugin>) -> Option<Table> {
+        let table = self.lua.create_table().ok()?;
+        let held = self.run_answers.borrow();
+        let answers = plugin.and_then(|plugin| held.get(&plugin.path));
+        for (key, run) in answers.into_iter().flatten() {
+            if let Ok(entry) = run_to_lua(&self.lua, run) {
+                let _ = table.set(key.clone(), entry);
+            }
+        }
+        Some(table)
+    }
+
+    /// Write `thurbox.runs` and `thurbox.granted` for the plugin about to be
+    /// called — or empty tables when no plugin is (`enter_nothing`).
+    ///
+    /// **Unconditional**, including for a plugin that declared no capabilities.
+    /// These two keys are written nowhere else and `publish` rebuilds the
+    /// `thurbox` table only once per frame, so skipping the write leaves
+    /// whatever the *previous* plugin in the frame put there — which handed an
+    /// untrusted pane a trusted one's captured output, under the same names it
+    /// would read its own by. Absence is the grant model (design D7); a stale
+    /// value is not absence.
+    fn publish_grants(&self, plugin: Option<&Plugin>) {
+        let Some(surface) = self.read_surface() else {
+            return;
+        };
+        if let Some(runs) = self.runs_table(plugin) {
+            let _ = surface.set("runs", runs);
+        }
+
+        // What this plugin has actually been granted, as `thurbox.granted.<name>`.
+        //
+        // Needed because not every capability can be withheld by absence. `run` is
+        // a global, so a plugin checks `if not run then` and draws an honest hint —
+        // that IS the absence. `program` is asked for through `command`, which
+        // every plugin has, so absence cannot express it and a pane would have no
+        // way to tell "not trusted" from "still starting". This is that answer, and
+        // it grants nothing: it is a boolean about a decision the user already made.
+        if let Ok(table) = self.lua.create_table() {
+            for capability in Capability::ALL {
+                if plugin.is_some_and(|plugin| self.may(plugin, capability)) {
+                    let _ = table.set(capability.as_str(), true);
+                }
+            }
+            let _ = surface.set("granted", table);
+        }
     }
 
     /// May this plugin use `capability`?
@@ -1029,68 +1103,20 @@ impl LuaHost {
             .is_some_and(|plugin| self.may(plugin, capability))
     }
 
+    /// Make `plugin` the current one, and give it exactly the capabilities it
+    /// has been granted.
+    ///
+    /// Capabilities are **installed and removed per call** rather than once at
+    /// load, because every plugin shares one Lua state: a global installed for
+    /// one would be reachable by all. Setting it to nil for a plugin that was
+    /// not granted it is what makes "capabilities are absent rather than
+    /// blocked" true here — `run` is not a function that refuses, it is not a
+    /// function (design D7).
     fn enter(&self, plugin: &Plugin) {
         *self.current.borrow_mut() = plugin.file.clone();
         *self.current_path.borrow_mut() = plugin.path.clone();
         let granted = self.may(plugin, Capability::Run);
-        // Only a plugin that asked for a capability can have answers, so every
-        // other one skips the rest. Worth the check: `enter` runs on every call
-        // to every plugin, and building a table per call for the panes that can
-        // never have runs would be a per-frame allocation for nothing.
-        if plugin.capabilities.is_empty() {
-            let _ = self.lua.globals().set("run", Value::Nil);
-            return;
-        }
-
-        // This plugin's own answers, and nothing else's. Set per call rather
-        // than at publish because `thurbox` is one shared table: publishing
-        // every plugin's runs into it would let any pane read another's output.
-        //
-        // The read surface is created if it does not exist yet, so an answer is
-        // readable without depending on a publish having happened first.
-        let globals = self.lua.globals();
-        let surface = match globals.get::<Table>("thurbox") {
-            Ok(table) => Some(table),
-            // Not `Option::inspect`: that is stable since 1.76 and the MSRV is
-            // 1.75.
-            Err(_) => match self.lua.create_table() {
-                Ok(fresh) => {
-                    let _ = globals.set("thurbox", fresh.clone());
-                    Some(fresh)
-                }
-                Err(_) => None,
-            },
-        };
-        if let (Some(surface), Ok(table)) = (surface, self.lua.create_table()) {
-            if let Some(answers) = self.run_answers.borrow().get(&plugin.path) {
-                for (key, run) in answers {
-                    if let Ok(entry) = run_to_lua(&self.lua, run) {
-                        let _ = table.set(key.clone(), entry);
-                    }
-                }
-            }
-            let _ = surface.set("runs", table);
-        }
-
-        // What this plugin has actually been granted, as `thurbox.granted.<name>`.
-        //
-        // Needed because not every capability can be withheld by absence. `run` is
-        // a global, so a plugin checks `if not run then` and draws an honest hint —
-        // that IS the absence. `program` is asked for through `command`, which
-        // every plugin has, so absence cannot express it and a pane would have no
-        // way to tell "not trusted" from "still starting". This is that answer, and
-        // it grants nothing: it is a boolean about a decision the user already made.
-        if let (Ok(surface), Ok(table)) = (
-            self.lua.globals().get::<Table>("thurbox"),
-            self.lua.create_table(),
-        ) {
-            for capability in Capability::ALL {
-                if self.may(plugin, capability) {
-                    let _ = table.set(capability.as_str(), true);
-                }
-            }
-            let _ = surface.set("granted", table);
-        }
+        self.publish_grants(Some(plugin));
 
         // Resolved out of the VM rather than held in Rust, because a reload
         // replaces the VM and a cached handle would outlive the state it came
@@ -1272,10 +1298,21 @@ impl LuaHost {
         }
         // A file read is rooted at a session's directory, so the roots follow
         // the snapshot rather than being asked for separately.
+        //
+        // A remote session gets none: its cwd is a path on ITS machine, and
+        // `files` reads the local filesystem. Since every host's default
+        // `worktrees_dir` is the same `$HOME/.local/share/thurbox/worktrees`,
+        // reading one locally does not fail cleanly — it hands back another
+        // machine's file under the right-looking path. Left out, both bindings
+        // raise `no directory for session <id>`, which is the honest answer.
+        // Same reasoning as `kernel::diff`, which resolves the host first.
         {
             let mut roots = self.roots.borrow_mut();
             roots.clear();
             for row in &snapshot.sessions {
+                if crate::session::is_remote_backend(&row.backend) {
+                    continue;
+                }
                 if let Some(cwd) = &row.cwd {
                     roots.insert(row.id.clone(), cwd.clone());
                 }
@@ -2281,7 +2318,7 @@ fn load_plugin(lua: &Lua, path: &Path, relative: &str) -> Result<Plugin, String>
         .map_err(|e| format!("{file}.floats: {e}"))?
         .unwrap_or(false);
 
-    let bindings = read_bindings(&def, &name)?;
+    let bindings = read_bindings(&def, &name, &file)?;
     let settings = read_settings(&def, &name)?;
     let pills = read_pills(&def, &name)?;
     let capabilities = read_capabilities(&def, &file)?;
@@ -2377,15 +2414,19 @@ fn read_float(value: &Value) -> Result<Option<Float>, String> {
 ///
 /// Declared as data rather than handled imperatively so the registry can
 /// enumerate, conflict-check and rebind them without ever calling the plugin.
-fn read_bindings(def: &Table, plugin: &str) -> Result<Vec<Binding>, String> {
-    let raw: Value = def.get("keys").map_err(|e| format!("{plugin}.keys: {e}"))?;
+///
+/// `plugin` is the declared name, which the bindings carry; `file` is the file
+/// stem the rest of [`load_plugin`]'s errors name, because the reader of one
+/// has a file to open and a plugin may call itself anything.
+fn read_bindings(def: &Table, plugin: &str, file: &str) -> Result<Vec<Binding>, String> {
+    let raw: Value = def.get("keys").map_err(|e| format!("{file}.keys: {e}"))?;
     let Value::Table(list) = raw else {
         return Ok(Vec::new());
     };
     let mut bindings = Vec::new();
     for (index, entry) in list.sequence_values::<Table>().enumerate() {
-        let entry = entry.map_err(|e| format!("{plugin}.keys[{}]: {e}", index + 1))?;
-        let where_ = format!("{plugin}.keys[{}]", index + 1);
+        let entry = entry.map_err(|e| format!("{file}.keys[{}]: {e}", index + 1))?;
+        let where_ = format!("{file}.keys[{}]", index + 1);
         let chord: String = entry
             .get::<Option<String>>("key")
             .map_err(|e| format!("{where_}.key: {e}"))?
@@ -2411,6 +2452,20 @@ fn read_bindings(def: &Table, plugin: &str) -> Result<Vec<Binding>, String> {
         let group: Option<String> = entry
             .get::<Option<String>>("group")
             .map_err(|e| format!("{where_}.group: {e}"))?;
+        // The kernel's chords are dispatched before the registry is consulted,
+        // so a plugin claiming one used to load, appear in F1, and never fire —
+        // a no-op with no symptom for whoever wrote it. Refused here, where the
+        // declaration is read, for the reason `read_capabilities` refuses an
+        // unknown name: a declaration the kernel cannot honour is a mistake to
+        // report. `Registry::rebind` already refuses the same chords.
+        let normalised = normalise_chord(&chord);
+        if RESERVED.contains(&normalised.as_str()) {
+            return Err(format!(
+                "{where_}: {normalised} is reserved by the kernel and cannot be declared \
+                 (reserved: {})",
+                RESERVED.join(", ")
+            ));
+        }
         bindings.push(binding_from(
             plugin,
             &chord,
@@ -2626,6 +2681,10 @@ fn install_run(
 /// directory listing and a file's text, both rooted at that session's working
 /// directory and refusing anything outside it. It never gets a filesystem.
 /// design.md D2 of v2-navigation-panes.
+///
+/// The roots come from [`LuaHost::publish`], which holds back every remote
+/// session — these read the *local* disk — so both calls raise `no directory
+/// for session` for one.
 fn install_files(lua: &Lua, roots: Roots) -> mlua::Result<()> {
     let files = lua.create_table()?;
 
@@ -2846,7 +2905,7 @@ fn install_store(lua: &Lua, global: &str, store: Shared, _ns: Option<()>) -> mlu
         "__newindex",
         lua.create_function(move |_, (_, key, value): (Table, String, Value)| {
             let mut slot = write.borrow_mut();
-            match from_lua(&value) {
+            match persisted_write(&value) {
                 Some(persisted) => {
                     slot.insert(key, persisted);
                 }
@@ -2894,7 +2953,7 @@ fn install_private(lua: &Lua, state: Private, current: Rc<RefCell<String>>) -> m
         lua.create_function(move |_, (_, key, value): (Table, String, Value)| {
             let ns = write_ns.borrow().clone();
             let mut slot = write.borrow_mut();
-            match from_lua(&value) {
+            match persisted_write(&value) {
                 Some(persisted) => {
                     slot.insert((ns, key), persisted);
                 }
@@ -2927,7 +2986,69 @@ fn to_lua(lua: &Lua, value: &Persisted) -> mlua::Result<Value> {
     })
 }
 
-fn from_lua(value: &Value) -> Option<Persisted> {
+/// Deepest table accepted into `store`/`state`: the render path's ceiling, not a
+/// second number that happens to agree with it.
+///
+/// Without it `store.x = t` where `t[1] = t` recurses until the stack is gone,
+/// and stack exhaustion is an **abort**, not a panic: the terminal-restoring
+/// hook never runs and the shell inherits raw mode from a process that is
+/// already dead. [`convert`] refuses a cyclic tree for the same reason, which is
+/// why the bound is shared rather than restated.
+const MAX_PERSISTED_DEPTH: usize = convert::MAX_DEPTH;
+
+/// How many values one write may convert.
+///
+/// Depth alone does not bound the work: a table holding *two* references to
+/// itself is only one level deeper per step, so the walk fans out 2^64 ways
+/// before any branch reaches the depth ceiling — a frozen render loop rather
+/// than a crash. The count is what makes the walk finite for a cycle of any
+/// shape, and is far above what a plugin's own state reaches.
+const MAX_PERSISTED_VALUES: usize = 100_000;
+
+/// How much of one write's conversion is left, and whether it ran out.
+///
+/// `exceeded` is separate from `remaining` because the two answers differ: a
+/// value can be skipped for being a function, which is not a bound at all. Only
+/// a bound refuses the *whole* write, so an unconvertible field still costs
+/// just that field.
+struct Bounds {
+    remaining: usize,
+    exceeded: bool,
+}
+
+impl Bounds {
+    fn new() -> Self {
+        Self {
+            remaining: MAX_PERSISTED_VALUES,
+            exceeded: false,
+        }
+    }
+}
+
+/// One `store`/`state` write, converted and bounded.
+///
+/// The walk *records* a bound it hit; this is where hitting one refuses the whole
+/// write. [`from_lua`] answers `None` both for a value that cannot be persisted
+/// at all (a function) and for one that ran into a bound, and only the second may
+/// cost more than its own field — a table refused for its depth or its size must
+/// not land as a truncated husk under the key the plugin believes it just set.
+/// Both `__newindex` handlers go through here, and both read `None` as "delete
+/// this key".
+fn persisted_write(value: &Value) -> Option<Persisted> {
+    let mut bounds = Bounds::new();
+    from_lua(value, 0, &mut bounds).filter(|_| !bounds.exceeded)
+}
+
+/// Convert a Lua value into the persisted form, or `None` if it cannot be one.
+///
+/// Called through [`persisted_write`], which owns the bound check the recursion
+/// only records.
+fn from_lua(value: &Value, depth: usize, bounds: &mut Bounds) -> Option<Persisted> {
+    if depth > MAX_PERSISTED_DEPTH || bounds.remaining == 0 {
+        bounds.exceeded = true;
+        return None;
+    }
+    bounds.remaining -= 1;
     match value {
         Value::Nil => None,
         Value::Boolean(b) => Some(Persisted::Bool(*b)),
@@ -2938,7 +3059,12 @@ fn from_lua(value: &Value) -> Option<Persisted> {
             let mut entries = Vec::new();
             for pair in table.pairs::<Value, Value>() {
                 let (key, entry) = pair.ok()?;
-                if let (Some(key), Some(entry)) = (from_lua(&key), from_lua(&entry)) {
+                let key = from_lua(&key, depth + 1, bounds);
+                let entry = from_lua(&entry, depth + 1, bounds);
+                if bounds.exceeded {
+                    return None;
+                }
+                if let (Some(key), Some(entry)) = (key, entry) {
                     entries.push((key, entry));
                 }
             }
@@ -3075,9 +3201,4 @@ fn clean_error(error: &mlua::Error) -> String {
         .unwrap_or(&text)
         .trim()
         .to_string()
-}
-
-/// Wall-clock start, shared by the loop and any plugin animating off `elapsed`.
-pub fn started() -> Instant {
-    Instant::now()
 }

--- a/src/kernel/inventory.rs
+++ b/src/kernel/inventory.rs
@@ -27,7 +27,12 @@ pub enum Kind {
     /// Prose, not code: shipped guidance for whoever edits this directory.
     Doc,
     /// `plugins.toml`: what the interface is composed of.
-    Manifest,
+    ///
+    /// Named for the file — `plugin_spec::SPEC_FILE` — rather than "manifest",
+    /// which in this codebase already names two other files: a package's own
+    /// `plugin.toml` (`PackageManifest::FILE`) and delivery's `.bundled.json`
+    /// record (`bundled::MANIFEST`).
+    Spec,
 }
 
 impl Kind {
@@ -37,7 +42,7 @@ impl Kind {
             Kind::Module => "module",
             Kind::Arrangement => "arrangement",
             Kind::Doc => "doc",
-            Kind::Manifest => "manifest",
+            Kind::Spec => "spec",
         }
     }
 
@@ -45,10 +50,10 @@ impl Kind {
         if relative == "layout.lua" {
             Kind::Arrangement
         } else if relative == crate::session::plugin_spec::SPEC_FILE {
-            // Before the `plugins/` fallthrough, for the same reason `Doc` is: a
-            // manifest reported as a pane that failed to load is a false alarm,
-            // and the loader never offers it one (it reads `plugins/*.lua`).
-            Kind::Manifest
+            // Before the `plugins/` fallthrough, for the same reason `Doc` is: the
+            // spec reported as a pane that failed to load is a false alarm, and
+            // the loader never offers it one (it reads `plugins/*.lua`).
+            Kind::Spec
         } else if relative.ends_with(".md") {
             Kind::Doc
         } else if relative.starts_with("lib/") {

--- a/src/kernel/metrics.rs
+++ b/src/kernel/metrics.rs
@@ -338,3 +338,75 @@ fn collect(mut collector: Box<sysinfo::System>, subjects: Vec<SampleInput>) -> S
         collector,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn subject(session: &str) -> Subject {
+        Subject {
+            session: session.to_string(),
+            agent_session_id: None,
+            pane: None,
+            agent: "claude".to_string(),
+            host: None,
+        }
+    }
+
+    /// The unbounded-growth guard: [`Metrics::poll`] *merges* each sample, so
+    /// without this a deleted session's numbers are held for the life of the
+    /// process — and rendered on whatever row later reuses the id.
+    #[test]
+    fn a_session_that_is_gone_loses_its_numbers() {
+        let mut metrics = Metrics::new();
+        for id in ["s1", "s2"] {
+            metrics
+                .agents
+                .insert(id.to_string(), AgentMetrics::default());
+            metrics
+                .resources
+                .insert(id.to_string(), SessionResources::default());
+        }
+
+        metrics.forget_gone(&[subject("s2")]);
+
+        assert!(
+            metrics.agent("s1").is_none(),
+            "the gone session was dropped"
+        );
+        assert!(metrics.resources("s1").is_none());
+        assert!(metrics.agent("s2").is_some(), "the live one was kept");
+        assert!(metrics.resources("s2").is_some());
+    }
+
+    /// Account usage is keyed by (agent, host), not by session, so pruning the
+    /// per-session maps must not take it with them.
+    #[test]
+    fn forgetting_sessions_leaves_account_usage_alone() {
+        let mut metrics = Metrics::new();
+        metrics.usage.insert(
+            ("claude".to_string(), None),
+            AgentUsage {
+                note: Some("kept".to_string()),
+                ..Default::default()
+            },
+        );
+
+        metrics.forget_gone(&[]);
+
+        assert!(metrics.usage("claude", None).is_some());
+    }
+
+    /// Absence is a real state: a session whose agent writes no statusline file
+    /// contributes no entry at all, because a defaulted `AgentMetrics` would
+    /// render as an agent that has spent nothing.
+    #[test]
+    fn a_subject_with_no_statusline_file_reports_nothing() {
+        let sample = collect(
+            Box::new(sysinfo::System::new()),
+            vec![("s1".to_string(), None, None)],
+        );
+        assert!(!sample.agents.contains_key("s1"));
+        assert!(!sample.resources.contains_key("s1"));
+    }
+}

--- a/src/kernel/modals/interface.rs
+++ b/src/kernel/modals/interface.rs
@@ -31,7 +31,7 @@ use ratatui::Frame;
 
 use super::chrome::{self, Chrome, Hits};
 use crate::kernel::bundled::Source;
-use crate::kernel::inventory::{Row, State as FileState, Trust as FileTrust};
+use crate::kernel::inventory::{Kind, Row, State as FileState, Trust as FileTrust};
 
 /// The interface's files and where they live, as one argument.
 ///
@@ -284,6 +284,19 @@ impl InterfaceTab {
         let Some(row) = self.current(inventory) else {
             return (None, None);
         };
+        if row.kind == Kind::Spec {
+            // Deleting the spec would orphan every pane it installed, and the
+            // command that takes one back already exists. Said instead of armed,
+            // because a confirmation the delivery gate then refuses is worse than
+            // no offer at all.
+            return (
+                Some(format!(
+                    "{} composes the interface; `thurbox-cli plugin remove` takes a pane back",
+                    row.path
+                )),
+                None,
+            );
+        }
         let path = row.path.clone();
         if self.armed.as_deref() != Some(path.as_str()) {
             self.armed = Some(path);
@@ -478,7 +491,6 @@ impl InterfaceTab {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kernel::inventory::Kind;
 
     fn row(path: &str, source: Source, state: FileState) -> Row {
         Row {
@@ -700,6 +712,60 @@ mod tests {
             .collect();
         assert!(theirs.contains("restorable"), "{theirs}");
         assert_ne!(mine, theirs, "the two must not be worded alike");
+    }
+
+    /// `d` on the spec says why not, rather than arming a removal that the
+    /// delivery gate then refuses — the state this tab exists to end is a view
+    /// that offers an action it cannot perform.
+    #[test]
+    fn deleting_the_spec_is_refused_with_the_command_that_does_it() {
+        let mut spec = row(
+            crate::session::plugin_spec::SPEC_FILE,
+            Source::User,
+            FileState::Present,
+        );
+        spec.kind = Kind::Spec;
+        let mut tab = InterfaceTab::default();
+        let (message, edit) = tab.on_key(&press(KeyCode::Char('d')), &[spec], &Hits::default());
+        assert!(edit.is_none(), "nothing is asked of the loop");
+        assert!(tab.armed().is_none(), "and nothing is armed");
+        let message = message.unwrap_or_default();
+        assert!(message.contains("plugin remove"), "{message}");
+    }
+
+    /// A shipped doc is a file delivery wrote, tombstones and can put back, so
+    /// the tab's `d`/`r` have to reach it: refusing every non-`.lua` path left a
+    /// `README.md` deleted outside thurbox listed as `removed` and unrestorable
+    /// from the one view that lists it.
+    #[test]
+    fn a_shipped_doc_can_be_removed_and_restored_from_the_tab() {
+        let mut doc = row("AGENTS.md", Source::Bundled, FileState::Present);
+        doc.kind = Kind::Doc;
+        let mut tab = InterfaceTab::default();
+        let rows = [doc.clone()];
+        tab.on_key(&press(KeyCode::Char('d')), &rows, &Hits::default());
+        assert_eq!(tab.armed(), Some("AGENTS.md"), "the first `d` arms it");
+        let (_, edit) = tab.on_key(&press(KeyCode::Char('d')), &rows, &Hits::default());
+        assert_eq!(
+            edit,
+            Some(Edit::File {
+                file: "AGENTS.md".into(),
+                kind: crate::kernel::command::PluginEdit::Remove,
+            })
+        );
+
+        let mut gone = doc;
+        gone.source = Source::Removed;
+        gone.state = FileState::Removed;
+        let (message, edit) = tab.on_key(&press(KeyCode::Char('r')), &[gone], &Hits::default());
+        assert_eq!(
+            edit,
+            Some(Edit::File {
+                file: "AGENTS.md".into(),
+                kind: crate::kernel::command::PluginEdit::Restore,
+            }),
+            "{message:?}"
+        );
     }
 
     #[test]

--- a/src/kernel/node.rs
+++ b/src/kernel/node.rs
@@ -8,7 +8,8 @@
 //! nowhere to live but a kernel enum variant. Adding a variant here costs a
 //! release; adding a widget in Lua costs a file save.
 //!
-//! `kinds()` is the tripwire — `tests/kernel_node_catalog.rs` pins it at four.
+//! [`KINDS`] is the tripwire — `kernel_mvp`'s
+//! `the_kernel_still_exposes_exactly_four_node_kinds` pins it at four.
 //!
 //! Lua never holds a ratatui object. A plugin returns a plain table, this
 //! module translates it, and that indirection is exactly why throwing the VM

--- a/src/kernel/packages.rs
+++ b/src/kernel/packages.rs
@@ -119,12 +119,18 @@ pub enum Outcome {
     Updated,
     /// Present and already what the source carries.
     Current,
-    /// Changed by the user, and therefore theirs. Not overwritten.
+    /// Changed by the user, and therefore theirs. Not overwritten — and, when the
+    /// spec stopped listing it, not taken back either ([`withdraw`]), which is the
+    /// case [`EntryReport::kept`] names the files for.
     Kept,
     /// Deleted by the user, and remembered as such. Not reinstalled.
     Deleted,
     /// Taken back, because the spec no longer lists it.
-    Removed,
+    ///
+    /// Named for the [`withdraw`] that produces it rather than "removed", which
+    /// is the word `bundled::Report.removed` already uses for the opposite half
+    /// of the same delivery path — there it means the *user* deleted the file.
+    Withdrawn,
 }
 
 impl Outcome {
@@ -135,7 +141,7 @@ impl Outcome {
             Outcome::Current => "current",
             Outcome::Kept => "kept",
             Outcome::Deleted => "deleted",
-            Outcome::Removed => "removed",
+            Outcome::Withdrawn => "withdrawn",
         }
     }
 
@@ -143,7 +149,7 @@ impl Outcome {
     pub fn changed(self) -> bool {
         matches!(
             self,
-            Outcome::Installed | Outcome::Updated | Outcome::Removed
+            Outcome::Installed | Outcome::Updated | Outcome::Withdrawn
         )
     }
 }
@@ -283,7 +289,7 @@ fn escalate(current: &mut Outcome, candidate: Outcome) {
         Outcome::Installed => 2,
         Outcome::Deleted => 3,
         Outcome::Kept => 4,
-        Outcome::Removed => 5,
+        Outcome::Withdrawn => 5,
     };
     if rank(candidate) > rank(*current) {
         *current = candidate;
@@ -305,7 +311,7 @@ pub fn withdraw(dir: &Path, entry: &LockEntry) -> Result<Vec<(String, Outcome)>,
             Ok(current) if digest(&current) == *recorded => {
                 std::fs::remove_file(&path).map_err(|e| format!("{}: {e}", path.display()))?;
                 prune_empty(dir, &path);
-                report.push((file.clone(), Outcome::Removed));
+                report.push((file.clone(), Outcome::Withdrawn));
             }
             // Theirs now — it outlived the entry that delivered it.
             Ok(_) => report.push((file.clone(), Outcome::Kept)),
@@ -313,6 +319,28 @@ pub fn withdraw(dir: &Path, entry: &LockEntry) -> Result<Vec<(String, Outcome)>,
         }
     }
     Ok(report)
+}
+
+/// [`withdraw`] an entry, and say what it came to: the files left on disk because
+/// the user had changed them, and the outcome to report for the entry as a whole.
+///
+/// One answer for both callers — `sync` for an entry the spec dropped, `remove`
+/// for one the user dropped — because they must not diverge. `Kept` wins over
+/// `Withdrawn` here, the opposite of [`escalate`]'s ranking for a convergence:
+/// reporting `withdrawn` for an entry whose pane is still on disk — still loaded,
+/// still claiming its keys — leaves it with no spec entry, so no later `sync`
+/// could ever explain it.
+fn take_back(dir: &Path, record: &LockEntry) -> Result<(Vec<String>, Outcome), String> {
+    let kept: Vec<String> = withdraw(dir, record)?
+        .into_iter()
+        .filter(|(_, outcome)| *outcome == Outcome::Kept)
+        .map(|(file, _)| file)
+        .collect();
+    let outcome = match kept.is_empty() {
+        true => Outcome::Withdrawn,
+        false => Outcome::Kept,
+    };
+    Ok((kept, outcome))
 }
 
 /// Remove the directories a withdrawn file leaves empty, up to (never including)
@@ -384,27 +412,26 @@ pub struct Resolved {
 /// otherwise ignored. For a bare name it selects the git ref, which is what makes
 /// a lock reproducible after the binary moves on.
 pub fn resolve_source(src: &str, pin: Option<&str>) -> Resolved {
-    use crate::agent::extension_config as ext;
     let bare = plugin_spec::is_bare_name(src);
     let version = match (pin, bare) {
         (Some(pin), _) => pin.to_string(),
         // A bare name is fetched at the binary's release tag, so that IS the
         // version of a freshly-installed one.
-        (None, true) => ext::official_ref(),
+        (None, true) => crate::agent::extension_config::official_ref(),
         (None, false) => String::new(),
     };
     let source = if bare {
-        ext::ExtensionSource::Remote(format!(
+        crate::agent::extension_config::ExtensionSource::Remote(format!(
             "{}/{src}",
-            ext::official_set_base_at(EXAMPLE_SET, &version)
+            crate::agent::extension_config::official_set_base_at(EXAMPLE_SET, &version)
         ))
     } else {
-        ext::resolve_source_in(src, EXAMPLE_SET)
+        crate::agent::extension_config::resolve_source_in(src, EXAMPLE_SET)
     };
     let at = match &source {
-        ext::ExtensionSource::Remote(base) => base.clone(),
-        ext::ExtensionSource::Local(dir) => dir.display().to_string(),
-        ext::ExtensionSource::Git(url) => url.clone(),
+        crate::agent::extension_config::ExtensionSource::Remote(base) => base.clone(),
+        crate::agent::extension_config::ExtensionSource::Local(dir) => dir.display().to_string(),
+        crate::agent::extension_config::ExtensionSource::Git(url) => url.clone(),
     };
     Resolved {
         source,
@@ -430,55 +457,74 @@ pub struct Fetched {
 /// `as_file` overrides the destination the manifest proposes. It is required for
 /// the degenerate shape, which proposes none.
 pub fn fetch(src: &str, resolved: &Resolved, as_file: Option<&str>) -> Result<Fetched, String> {
-    use crate::agent::extension_config as ext;
-
     if src.trim().ends_with(".lua") {
         let file = as_file
             .ok_or_else(|| {
                 format!("{src} is a single file, so it needs a destination: --as plugins/90_x.lua")
             })?
             .to_string();
-        plugin_spec::validate_destination(&file)?;
+        plugin_spec::validate_pane_destination(&file)?;
         // Fetched relative to the *parent*, since the source names the file itself.
         let (base, name) = split_last(src);
         let source = match &resolved.source {
-            ext::ExtensionSource::Remote(_) => ext::ExtensionSource::Remote(base),
-            ext::ExtensionSource::Local(_) => ext::ExtensionSource::Local(ext::expand_tilde(&base)),
+            crate::agent::extension_config::ExtensionSource::Remote(_) => {
+                crate::agent::extension_config::ExtensionSource::Remote(base)
+            }
+            crate::agent::extension_config::ExtensionSource::Local(_) => {
+                crate::agent::extension_config::ExtensionSource::Local(
+                    crate::agent::extension_config::expand_tilde(&base),
+                )
+            }
             // A `.lua` source cannot also be a repository: `git_url` matched first,
             // so a `git+…/x.lua` never reaches here.
-            ext::ExtensionSource::Git(url) => ext::ExtensionSource::Git(url.clone()),
+            crate::agent::extension_config::ExtensionSource::Git(url) => {
+                crate::agent::extension_config::ExtensionSource::Git(url.clone())
+            }
         };
-        let contents = ext::fetch_file(&source, &name)?;
+        let contents = crate::agent::extension_config::fetch_file(&source, &name)?;
         return Ok(Fetched {
             manifest: None,
             payloads: vec![Payload { file, contents }],
         });
     }
 
-    let manifest_text = ext::fetch_file(&resolved.source, crate::session::PackageManifest::FILE)
-        .map_err(|e| {
-            format!(
-                "{src}: no {} at {} ({e})",
-                crate::session::PackageManifest::FILE,
-                resolved.at
-            )
-        })?;
+    let manifest_text = crate::agent::extension_config::fetch_file(
+        &resolved.source,
+        crate::session::PackageManifest::FILE,
+    )
+    .map_err(|e| {
+        format!(
+            "{src}: no {} at {} ({e})",
+            crate::session::PackageManifest::FILE,
+            resolved.at
+        )
+    })?;
     let manifest = crate::session::PackageManifest::parse(&manifest_text)
         .map_err(|e| format!("{src}: {e}"))?;
 
     let mut payloads = Vec::new();
     for (index, file) in manifest.files().enumerate() {
+        // `files()` yields the pane first, then the modules.
+        let is_pane = index == 0;
         // Only the PANE may be redirected. A module's path is the namespace rule
         // the manifest was validated against, and letting `--as` move it would
         // hand back the collision that rule exists to prevent.
-        let destination = match (index, as_file) {
-            (0, Some(file)) => file.to_string(),
+        let destination = match (is_pane, as_file) {
+            (true, Some(file)) => file.to_string(),
             _ => file.path.clone(),
         };
-        plugin_spec::validate_destination(&destination)?;
+        // The pane is held to the pane rule even when `--as` named the
+        // destination: the manifest's own is checked by `validate`, and a
+        // redirection that skipped it would deliver a pane into `lib/`, where
+        // nothing loads it and nothing reports it missing.
+        if is_pane {
+            plugin_spec::validate_pane_destination(&destination)?;
+        } else {
+            plugin_spec::validate_destination(&destination)?;
+        }
         payloads.push(Payload {
             file: destination,
-            contents: ext::fetch_file(&resolved.source, &file.source)?,
+            contents: crate::agent::extension_config::fetch_file(&resolved.source, &file.source)?,
         });
     }
     Ok(Fetched {
@@ -496,6 +542,23 @@ fn split_last(src: &str) -> (String, String) {
     }
 }
 
+/// Does this standing grant the capabilities the file declared?
+///
+/// The other half of [`trust_of`], named rather than written out at the call
+/// site, because the two must agree: the Interface tab *labels* a row from
+/// `trust_of` and the kernel *grants* from this, and a second, weaker predicate
+/// beside it is exactly how they drifted — bare key presence granted an
+/// installed pane whose pin had moved, while the tab already said `untrusted`.
+///
+/// [`Drifted`](super::inventory::Trust::Drifted) grants: a trusted file the user
+/// then edited is the documented trusted-and-changed case, not a revocation.
+pub fn grants_capabilities(trust: super::inventory::Trust) -> bool {
+    matches!(
+        trust,
+        super::inventory::Trust::Trusted | super::inventory::Trust::Drifted
+    )
+}
+
 /// Where one file of the interface stands with the user, for what it declares.
 ///
 /// One implementation because the question splits two ways and the split is easy
@@ -509,7 +572,7 @@ pub fn trust_of(
     registry: &super::registry::Registry,
 ) -> super::inventory::Trust {
     let absolute = dir.join(relative);
-    let key = absolute.to_string_lossy();
+    let key = super::bundled::absolute_key(dir, relative);
     let current = std::fs::read_to_string(&absolute)
         .ok()
         .map(|text| digest(&text));
@@ -537,6 +600,12 @@ pub struct EntryReport {
     /// The version this moved from, when it moved.
     pub from: Option<String>,
     pub outcome: Outcome,
+    /// Files [`withdraw`] left on disk because the user had changed them.
+    ///
+    /// Carried rather than inferred from `outcome`: a caller reporting `kept` has
+    /// to be able to name what is still there, and the entry it belonged to is
+    /// gone from the spec by then — so nothing else could ever explain the file.
+    pub kept: Vec<String>,
 }
 
 /// Is this entry's source a repository, and therefore a working copy on disk?
@@ -735,6 +804,7 @@ fn install_repository(
         version: commit,
         from: None,
         outcome: Outcome::Installed,
+        kept: Vec::new(),
     })
 }
 
@@ -801,6 +871,7 @@ pub fn install(
         version,
         from: None,
         outcome,
+        kept: Vec::new(),
     })
 }
 
@@ -924,7 +995,7 @@ pub fn sync(dir: &Path) -> Result<Vec<EntryReport>, String> {
         .cloned()
         .collect::<Vec<LockEntry>>()
     {
-        withdraw(dir, &stale)?;
+        let (kept, outcome) = take_back(dir, &stale)?;
         lock.forget(&stale.file);
         reports.push(EntryReport {
             name: stale.file.clone(),
@@ -932,7 +1003,8 @@ pub fn sync(dir: &Path) -> Result<Vec<EntryReport>, String> {
             src: stale.src.clone(),
             version: stale.version.clone(),
             from: None,
-            outcome: Outcome::Removed,
+            outcome,
+            kept,
         });
     }
 
@@ -947,6 +1019,7 @@ pub fn sync(dir: &Path) -> Result<Vec<EntryReport>, String> {
                 version: commit,
                 from,
                 outcome,
+                kept: Vec::new(),
             });
             continue;
         }
@@ -971,6 +1044,7 @@ pub fn sync(dir: &Path) -> Result<Vec<EntryReport>, String> {
             version,
             from: None,
             outcome,
+            kept: Vec::new(),
         });
     }
 
@@ -1010,6 +1084,7 @@ pub fn update(dir: &Path, key: Option<&str>) -> Result<Vec<EntryReport>, String>
                 version: commit,
                 from,
                 outcome,
+                kept: Vec::new(),
             });
             continue;
         }
@@ -1035,6 +1110,7 @@ pub fn update(dir: &Path, key: Option<&str>) -> Result<Vec<EntryReport>, String>
             from: was.filter(|was| *was != version),
             version,
             outcome,
+            kept: Vec::new(),
         });
     }
 
@@ -1067,20 +1143,23 @@ pub fn remove(dir: &Path, key: &str) -> Result<EntryReport, String> {
             src: removed.src.clone(),
             version: record.map(|record| record.version).unwrap_or_default(),
             from: None,
-            outcome: Outcome::Removed,
+            outcome: Outcome::Withdrawn,
+            kept: Vec::new(),
         });
     }
 
-    if let Some(record) = &record {
-        withdraw(dir, record)?;
-    } else {
-        // Listed in the spec but never delivered — nothing on disk to take back,
-        // and the entry is gone either way.
-        let path = dir.join(&removed.file);
-        if path.is_file() {
-            std::fs::remove_file(&path).map_err(|e| format!("{}: {e}", path.display()))?;
+    let (kept, outcome) = match &record {
+        Some(record) => take_back(dir, record)?,
+        None => {
+            // Listed in the spec but never delivered — nothing on disk to take
+            // back, and the entry is gone either way.
+            let path = dir.join(&removed.file);
+            if path.is_file() {
+                std::fs::remove_file(&path).map_err(|e| format!("{}: {e}", path.display()))?;
+            }
+            (Vec::new(), Outcome::Withdrawn)
         }
-    }
+    };
     write_lock(dir, &lock)?;
 
     Ok(EntryReport {
@@ -1089,7 +1168,8 @@ pub fn remove(dir: &Path, key: &str) -> Result<EntryReport, String> {
         src: removed.src.clone(),
         version: record.map(|record| record.version).unwrap_or_default(),
         from: None,
-        outcome: Outcome::Removed,
+        outcome,
+        kept,
     })
 }
 
@@ -1592,5 +1672,29 @@ mod tests {
             .expect("parent")
             .join("escape.lua")
             .exists());
+    }
+
+    /// The grant predicate answers for all four standings, and in particular
+    /// refuses the one that used to slip through: an installed pane whose pin
+    /// has moved. `plugin update` advancing a version must not let new upstream
+    /// code inherit the grant made to the old one.
+    #[test]
+    fn only_trusted_and_drifted_grant_capabilities() {
+        use super::super::inventory::Trust;
+        assert!(grants_capabilities(Trust::Trusted));
+        assert!(
+            grants_capabilities(Trust::Drifted),
+            "an edited own file is trusted-and-changed, not revoked"
+        );
+        assert!(!grants_capabilities(Trust::Untrusted));
+        assert!(!grants_capabilities(Trust::NotAsked));
+        assert!(
+            !grants_capabilities(Trust::resolve_installed(
+                Some(("atlas@v1", "a")),
+                "atlas@v2",
+                Some("b")
+            )),
+            "a moved pin must not carry the old grant"
+        );
     }
 }

--- a/src/kernel/paint.rs
+++ b/src/kernel/paint.rs
@@ -89,7 +89,6 @@ impl SurfaceProvider for PlaceholderSurfaces {
     }
 }
 
-/// What a session-backed surface shows when nothing live is behind it.
 /// A centred two-line notice, for a surface with nothing to paint.
 fn render_notice(frame: &mut Frame, area: Rect, title: &str, detail: &str) {
     let mut lines = Vec::new();
@@ -110,6 +109,7 @@ fn render_notice(frame: &mut Frame, area: Rect, title: &str, detail: &str) {
     frame.render_widget(Paragraph::new(lines), area);
 }
 
+/// What a session-backed surface shows when nothing live is behind it.
 fn render_detached(frame: &mut Frame, area: Rect, session: &str) {
     let mut lines = Vec::new();
     let blank = usize::from(area.height).saturating_sub(3) / 2;

--- a/src/kernel/registry.rs
+++ b/src/kernel/registry.rs
@@ -643,7 +643,16 @@ pub fn canonical_chord(press: &KeyPress) -> String {
         }
     }
     if key == "backtab" {
+        // Last, and not folded into the loop above: crossterm reports shift+Tab
+        // as its own code, so the shift is in the KEY rather than the modifiers,
+        // and `normalise_chord` spells the result "shift+tab". A cmd+shift+Tab
+        // would be unspellable either way — no terminal delivers it.
         return "shift+tab".to_string();
+    }
+    // Last in the fixed order `normalise_chord` uses, so a chord canonicalises
+    // to one string whichever end it came from.
+    if press.cmd {
+        parts.push("cmd".to_string());
     }
     parts.push(key);
     parts.join("+")
@@ -1003,6 +1012,7 @@ mod tests {
             ctrl,
             alt: false,
             shift,
+            cmd: false,
         }
     }
 

--- a/src/kernel/runs.rs
+++ b/src/kernel/runs.rs
@@ -174,6 +174,11 @@ pub struct RunStore {
     queued: VecDeque<(String, Ask)>,
     running: usize,
     channel: Option<(Sender<Finished>, Receiver<Finished>)>,
+    /// The plugins the interface has, as of the last [`Self::retain_plugins`].
+    ///
+    /// `None` before the first reload, which means "everything is live" — the
+    /// bundled interface asks for runs before anything has ever been pruned.
+    live: Option<std::collections::HashSet<String>>,
 }
 
 impl RunStore {
@@ -255,13 +260,26 @@ impl RunStore {
     /// anything arrived, so the caller can repaint.
     pub fn poll(&mut self, runner: &std::sync::Arc<Runner>) -> bool {
         let mut changed = false;
+        // A finished run always frees its slot, even when its answer is dropped
+        // below — so the queue is drained on that, not on whether anything was
+        // stored.
+        let mut freed = false;
         let finished: Vec<Finished> = match &self.channel {
             Some((_, rx)) => rx.try_iter().collect(),
             None => Vec::new(),
         };
         for done in finished {
             self.running = self.running.saturating_sub(1);
+            freed = true;
             let id = (done.plugin, done.key);
+            // An ask that outlived the reload it was made during belongs to a
+            // plugin that is gone. Inserting its answer puts back the key
+            // `retain_plugins` just dropped, which nothing reads and nothing
+            // evicts — and `is_empty` then keeps the whole `serve_runs` path warm
+            // until the next reload.
+            if self.live.as_ref().is_some_and(|live| !live.contains(&id.0)) {
+                continue;
+            }
             let ttl = self.answers.get(&id).map(|a| a.ttl).unwrap_or(DEFAULT_TTL);
             self.answers.insert(
                 id,
@@ -274,7 +292,7 @@ impl RunStore {
             );
             changed = true;
         }
-        if changed {
+        if freed {
             self.drain_queue(runner);
         }
         changed
@@ -311,6 +329,9 @@ impl RunStore {
     pub fn retain_plugins(&mut self, live: &[String]) {
         self.answers.retain(|(plugin, _), _| live.contains(plugin));
         self.queued.retain(|(plugin, _)| live.contains(plugin));
+        // Kept so `poll` can drop an answer that is still on its way — a run
+        // started before the reload finishes after it.
+        self.live = Some(live.iter().cloned().collect());
     }
 }
 
@@ -465,16 +486,11 @@ pub fn command_for(
             command.arg(program).current_dir(cwd);
             command
         }
-        Some(host) => {
-            // The directory is on the host, so `cd` is part of the script rather
-            // than a `current_dir` on this machine. Quoted, because a worktree
-            // path can contain anything a filesystem allows.
-            let script = format!(
-                "cd {} && {program}",
-                crate::shell::posix_quote(&cwd.to_string_lossy())
-            );
-            crate::git::host_shell_c(host, &script)
-        }
+        // The directory is on the host, so the `cd` belongs in the script rather
+        // than in a `current_dir` on this machine — `host_shell_c_in` owns that,
+        // and the quoting a worktree path needs, so this module does not reach
+        // into `shell` for it.
+        Some(host) => crate::git::host_shell_c_in(host, cwd, program),
     }
 }
 
@@ -526,6 +542,45 @@ mod tests {
             std::thread::sleep(Duration::from_millis(5));
         }
         panic!("runs never settled");
+    }
+
+    /// The in-flight ask that crosses an `F10` reload.
+    ///
+    /// Its answer arrives after `retain_plugins` has dropped the plugin, and
+    /// writing it back resurrects a key nothing reads and nothing evicts —
+    /// leaving `is_empty` false, which keeps the loop serving runs for an
+    /// interface that asks for none.
+    #[test]
+    fn an_answer_for_a_plugin_that_is_gone_is_dropped() {
+        let (release, held) = std::sync::mpsc::channel::<()>();
+        let held = std::sync::Mutex::new(held);
+        let runner: Arc<Runner> = Arc::new(move |_ask: &Ask| {
+            let _ = held.lock().expect("gate").recv();
+            Run::Done(Output {
+                stdout: "ok\n".into(),
+                stderr: String::new(),
+                status: Some(0),
+                truncated: false,
+                timed_out: false,
+            })
+        });
+
+        let mut store = RunStore::new();
+        store.request("gone", ask("k"), &runner);
+        store.retain_plugins(&["kept".to_string()]);
+        assert!(store.is_empty(), "the reload dropped the pending entry");
+
+        // Only now does the run it started finish.
+        release.send(()).expect("release the run");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline && store.running > 0 {
+            store.poll(&runner);
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        assert_eq!(store.running, 0, "the slot was freed anyway");
+        assert!(store.is_empty(), "and the answer was not written back");
+        assert!(store.get("gone", "k").is_none());
     }
 
     #[test]

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -227,8 +227,8 @@ struct Stat {
     ///
     /// Recorded rather than dropped: a miss nobody remembers is asked again on
     /// every single refresh, which is a thread and a `git` process per
-    /// non-repository session forever — and *every remote session* is a miss, its
-    /// worktree being on another machine entirely.
+    /// non-repository session forever. (A remote session is never asked at all —
+    /// see `attach_git_stats`.)
     state: Option<GitState>,
     at: Instant,
 }
@@ -466,6 +466,16 @@ impl SnapshotStore {
         let mut wanted: Vec<(String, PathBuf)> = Vec::new();
         for row in &mut self.current.sessions {
             row.git = self.git.known.get(&row.id).and_then(|stat| stat.state);
+            // A remote session's worktree is a path on its OWN machine, and
+            // `git::worktree_stats` runs the LOCAL git: it either fails or — since
+            // every host defaults to the same `worktrees_dir` — reports another
+            // machine's checkout on this row. `DiffStore::request` resolves the
+            // host for the same reason; there is no host-aware `worktree_stats`
+            // to resolve one for, so the row stays `None`, which already reads as
+            // "not computed" rather than "clean".
+            if crate::session::is_remote_backend(&row.backend) {
+                continue;
+            }
             if let Some(cwd) = row.cwd.clone() {
                 wanted.push((row.id.clone(), cwd));
             }
@@ -988,13 +998,9 @@ fn remote_host_of(backend: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Best-effort repo label: the worktree's repo directory name, else the cwd's.
-///
-/// Shared with the reorder command so a move stays inside the group the list
-/// actually draws.
-/// Every repository a session spans, in member order — mirroring v1's
-/// `session_member_dirs`: one entry per worktree (or the cwd when there are
-/// none), then each attached directory that is not already a worktree.
+/// Every repository a session spans, in member order: one entry per worktree (or
+/// the cwd when there are none), then each attached directory that is not already
+/// a worktree.
 ///
 /// Names come from the path's last component rather than `git::repo_display_name`
 /// deliberately: that helper resolves the name from the git *remote*, which
@@ -1033,6 +1039,10 @@ fn session_members(
     members
 }
 
+/// Best-effort repo label: the worktree's repo directory name, else the cwd's.
+///
+/// Shared with the reorder command so a move stays inside the group the list
+/// actually draws.
 pub(crate) fn repo_name(cwd: &Option<PathBuf>, repo_path: Option<&PathBuf>) -> Option<String> {
     repo_path
         .or(cwd.as_ref())
@@ -1055,6 +1065,126 @@ pub fn parse_id(raw: &str) -> Option<SessionId> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// One session's cached answer, aged by `age`, mirroring `repos::tests::held`.
+    fn stat_at(age: Duration) -> Stat {
+        Stat {
+            state: None,
+            at: Instant::now() - age,
+        }
+    }
+
+    /// A row with only the fields the git-stat path reads.
+    fn row(id: &str, backend: &str, cwd: Option<&str>) -> SessionRow {
+        SessionRow {
+            id: id.to_string(),
+            name: id.to_string(),
+            agent: "claude".to_string(),
+            status: "idle".to_string(),
+            cwd: cwd.map(PathBuf::from),
+            repo: None,
+            repos: Vec::new(),
+            member_dirs: Vec::new(),
+            branch: None,
+            base_branch: None,
+            backend: backend.to_string(),
+            backend_id: None,
+            remote_host: None,
+            agent_session_id: None,
+            parent_id: None,
+            display_order: None,
+            worktree_count: 0,
+            git: None,
+            shell_backend_id: None,
+            hook_state: None,
+        }
+    }
+
+    /// A `GitStats` that has never touched the world: its channel is `None`
+    /// until `request` actually starts a worker, which is how these tests see
+    /// whether one did.
+    fn asked(stats: &GitStats) -> bool {
+        stats.channel.is_some()
+    }
+
+    #[test]
+    fn a_fresh_stat_is_not_computed_again() {
+        // Shelling out to `git` per refresh, per session, is what the age is for.
+        let mut stats = GitStats::default();
+        stats
+            .known
+            .insert("s1".to_string(), stat_at(Duration::ZERO));
+        stats.request("s1", PathBuf::from("/definitely/not/a/repo"));
+        assert!(stats.inflight.is_empty());
+        assert!(!asked(&stats), "no worker was started");
+    }
+
+    #[test]
+    fn a_stat_older_than_the_ttl_is_computed_again() {
+        // Answered once, a session's diffstat froze at whatever it was the first
+        // time it was looked at and never moved again.
+        let mut stats = GitStats::default();
+        stats.known.insert("s1".to_string(), stat_at(GIT_STAT_TTL));
+        stats.request("s1", PathBuf::from("/definitely/not/a/repo"));
+        assert!(stats.inflight.contains("s1"));
+        assert!(asked(&stats));
+    }
+
+    #[test]
+    fn a_stat_in_flight_is_never_asked_for_twice() {
+        // The refresh runs every 400ms and `git` does not; without the marker a
+        // slow repository accumulates a thread per refresh.
+        let mut stats = GitStats::default();
+        stats.inflight.insert("s1".to_string());
+        stats
+            .known
+            .insert("s1".to_string(), stat_at(GIT_STAT_TTL * 10));
+        stats.request("s1", PathBuf::from("/definitely/not/a/repo"));
+        assert_eq!(stats.inflight.len(), 1);
+        assert!(!asked(&stats), "the run already out is the only one");
+    }
+
+    #[test]
+    fn a_session_that_is_gone_loses_its_stat() {
+        let mut stats = GitStats::default();
+        stats
+            .known
+            .insert("s1".to_string(), stat_at(Duration::ZERO));
+        stats
+            .known
+            .insert("s2".to_string(), stat_at(Duration::ZERO));
+        let present: std::collections::HashSet<&str> = ["s2"].into_iter().collect();
+        stats.retain(&present);
+        assert!(!stats.known.contains_key("s1"));
+        assert!(stats.known.contains_key("s2"));
+    }
+
+    #[test]
+    fn a_remote_session_is_never_stat_ed_with_the_local_git() {
+        // Its worktree is a path on another machine, and every host's default
+        // `worktrees_dir` is the same path — so the local `git` either fails or
+        // reports somebody else's checkout on this row. `None` already reads as
+        // "not computed", which is the honest answer here.
+        let database = Database::open_in_memory().expect("in-memory database opens");
+        let mut store = SnapshotStore::with_database(database);
+        store.current.sessions = vec![
+            row("local", "local-tmux", Some("/definitely/not/a/repo")),
+            row("remote", "ssh:devbox", Some("/definitely/not/a/repo")),
+            row("wsl", "wsl:ubuntu", Some("/definitely/not/a/repo")),
+        ];
+
+        store.attach_git_stats();
+
+        assert!(store.git.inflight.contains("local"));
+        assert!(!store.git.inflight.contains("remote"));
+        assert!(!store.git.inflight.contains("wsl"));
+        assert!(store
+            .current
+            .sessions
+            .iter()
+            .filter(|row| row.id != "local")
+            .all(|row| row.git.is_none()));
+    }
 
     #[test]
     fn an_unreported_session_is_idle() {

--- a/src/kernel/terminal.rs
+++ b/src/kernel/terminal.rs
@@ -214,6 +214,22 @@ pub struct Terminals {
     /// Captured once rather than looked up per attach so the failure mode is
     /// "no runtime at construction", not a surprise mid-session.
     runtime: Option<tokio::runtime::Handle>,
+    /// Sizes the multiplexer has yet to be told about, last-write-wins per
+    /// session.
+    ///
+    /// A rect change is noticed inside the paint, and pushing it is a blocking
+    /// round trip per pane (see [`crate::agent::backend::PaneResize`]) — so the
+    /// paint records the size it wants and [`Self::serve_resizes`] hands it to a
+    /// worker. A `RefCell` because `SurfaceProvider::render_session` takes
+    /// `&self`, like the rect and size memos beside it.
+    resizes: RefCell<HashMap<String, (u16, u16)>>,
+    /// Sessions whose resize worker has not reported back.
+    ///
+    /// Without it a drag across a slow host stacks a thread per frame, each
+    /// waiting out the same timeout. The pending size is *kept* while one is out,
+    /// so the last size asked for is still pushed once the worker lands.
+    resizing: std::collections::HashSet<String>,
+    resized: (Sender<String>, Receiver<String>),
     /// Programs plugins asked for, keyed by [`ProgramKey`].
     ///
     /// Here beside `live` rather than in a module of their own, because a pane
@@ -384,6 +400,9 @@ impl Terminals {
             discovering: std::collections::HashSet::new(),
             discovered_rx: std::sync::mpsc::channel(),
             runtime: tokio::runtime::Handle::try_current().ok(),
+            resizes: RefCell::new(HashMap::new()),
+            resizing: std::collections::HashSet::new(),
+            resized: std::sync::mpsc::channel(),
             programs: HashMap::new(),
         }
     }
@@ -402,6 +421,7 @@ impl Terminals {
         self.collect_discovered();
         self.collect_attached(rows, cols);
         self.drop_lost_panes(snapshot);
+        self.serve_resizes();
 
         // Only pay for discovery while something needs it, and never for a remote
         // row: a remote spawn drives control mode and records the real pane id, so
@@ -504,7 +524,7 @@ impl Terminals {
     /// records the new pane id; a local one has none to record and forgets
     /// instead.
     fn drop_lost_panes(&mut self, snapshot: &Snapshot) {
-        let lost: Vec<(String, Option<String>, bool)> = snapshot
+        let lost: Vec<(String, Option<String>, String, bool)> = snapshot
             .sessions
             .iter()
             .filter_map(|row| {
@@ -522,17 +542,26 @@ impl Terminals {
                         // by name, on every frame, forever.
                         && (remote || self.pane_placed(row, id))
                 });
-                (live.session.has_exited() || moved)
-                    .then(|| (row.id.clone(), row.backend_id.clone(), remote))
+                (live.session.has_exited() || moved).then(|| {
+                    (
+                        row.id.clone(),
+                        row.backend_id.clone(),
+                        row.backend.clone(),
+                        remote,
+                    )
+                })
             })
             .collect();
-        for (id, pane, remote) in lost {
+        for (id, pane, backend, remote) in lost {
             self.live.remove(&id);
             if remote {
                 // The backend has to be readied again before the next attach can
                 // adopt anything: the connection this session died with is the
-                // one every other session on that host shares.
-                self.ready.borrow_mut().clear();
+                // one every other session on THAT host shares. Only that one —
+                // clearing the whole set made one host going down re-ready every
+                // other backend, the local one included, and each re-ready is a
+                // blocking round trip on a connection that never broke.
+                self.ready.borrow_mut().remove(&backend);
                 self.fail(&id, pane, "host unreachable".to_string());
             } else {
                 // Locally the pane is simply gone. Recorded against the pane that
@@ -540,6 +569,55 @@ impl Terminals {
                 // one a restart just created — as worth trying at once.
                 self.fail(&id, pane, "session has no pane yet".to_string());
             }
+        }
+    }
+
+    /// Record the size a surface was painted at, for the multiplexer to be told
+    /// on the next tick.
+    ///
+    /// The grids move **now**, because they are this process's own memory and a
+    /// pane painted at a size its parser disagrees with wraps wrongly for the
+    /// whole frame. The panes themselves are queued: telling them is a blocking
+    /// round trip, and this runs inside the paint.
+    fn want_resize(&self, session: &str, live: &crate::agent::backend::Session, size: (u16, u16)) {
+        live.resize_grids(size.0, size.1);
+        self.resizes.borrow_mut().insert(session.to_string(), size);
+    }
+
+    /// Hand each queued size to a worker, one at a time per session.
+    ///
+    /// Last-write-wins: a drag through fifty widths is fifty entries overwriting
+    /// each other and one round trip per tick, rather than fifty round trips the
+    /// render loop waits on.
+    fn serve_resizes(&mut self) {
+        while let Ok(done) = self.resized.1.try_recv() {
+            self.resizing.remove(&done);
+        }
+        let wanted: Vec<(String, (u16, u16))> = {
+            let mut queue = self.resizes.borrow_mut();
+            let ready: Vec<String> = queue
+                .keys()
+                .filter(|id| !self.resizing.contains(*id))
+                .cloned()
+                .collect();
+            ready
+                .into_iter()
+                .filter_map(|id| queue.remove(&id).map(|size| (id, size)))
+                .collect()
+        };
+        for (id, (rows, cols)) in wanted {
+            // A session that went away between the paint and now: its panes are
+            // not ours to resize any more.
+            let Some(live) = self.live.get(&id) else {
+                continue;
+            };
+            let resize = live.session.pane_resize();
+            let tx = self.resized.0.clone();
+            self.resizing.insert(id.clone());
+            std::thread::spawn(move || {
+                resize.apply(rows, cols);
+                let _ = tx.send(id);
+            });
         }
     }
 
@@ -689,6 +767,8 @@ impl Terminals {
     pub fn forget(&mut self, session: &str) {
         self.live.remove(session);
         self.failed.remove(session);
+        // A size wanted for a pane we no longer hold is nobody's to push.
+        self.resizes.borrow_mut().remove(session);
     }
 
     /// Record why a session has no pane, and what was tried.
@@ -999,7 +1079,10 @@ impl Terminals {
             &key.name,
         );
         let env: HashMap<String, String> = HashMap::new();
-        let (rows, cols) = (rows.max(1), cols.max(1));
+        // The same floor the parser gets: clamped at 1 the multiplexer pane was
+        // born one cell smaller than the `vt100` grid `wire_up` floors to 2, so
+        // the two disagreed from the first byte.
+        let (rows, cols) = crate::agent::backend::vt_floor(rows, cols);
 
         // An existing window of that name is this same pane from a previous run of
         // the interface: the name is deterministic, so finding it IS the
@@ -1856,14 +1939,14 @@ impl SurfaceProvider for Terminals {
             // The shell is opened at the terminal's size, not the pane's, and
             // while it is the visible view nothing else drives a resize — so it
             // is matched to its rect here, exactly as the agent surface below
-            // is. `Session::resize` sizes both panes, which is right: they take
+            // is. One queued resize covers both panes, which is right: they take
             // turns in the same rect.
             live.rect.set(area);
             live.shell_visible.set(true);
             let wanted = (area.height, area.width);
             if live.size.get() != wanted {
                 live.size.set(wanted);
-                live.session.resize(area.height, area.width);
+                self.want_resize(id, &live.session, wanted);
             }
             let Ok(parser) = shell.parser.lock() else {
                 return false;
@@ -1880,14 +1963,14 @@ impl SurfaceProvider for Terminals {
         };
 
         // The pane must match the rect it is painted into, or the agent wraps
-        // at the wrong width. `resize` is a no-op when nothing changed, but the
-        // comparison keeps a tmux round-trip off every frame.
+        // at the wrong width. Compared against the last size rather than pushed
+        // every frame, so an unchanged rect queues nothing.
         live.rect.set(area);
         live.shell_visible.set(false);
         let wanted = (area.height, area.width);
         if live.size.get() != wanted {
             live.size.set(wanted);
-            live.session.resize(area.height, area.width);
+            self.want_resize(session, &live.session, wanted);
         }
 
         let Ok(mut parser) = live.session.parser.lock() else {
@@ -1951,6 +2034,51 @@ mod tests {
         // And the attempt is recorded as "there was no pane", which is what lets
         // a window appearing later be picked up instead of latched out.
         assert_eq!(terminals.failed["a"].pane, None);
+    }
+
+    /// The paint records the size it wants; the tick pushes it. Two frames of
+    /// dragging must cost one round trip, not two — and a session that went away
+    /// in between costs none.
+    #[test]
+    fn queued_resizes_coalesce_and_die_with_their_session() {
+        let mut terminals = Terminals::new();
+        terminals.resizes.borrow_mut().insert("a".into(), (10, 40));
+        terminals.resizes.borrow_mut().insert("a".into(), (24, 80));
+        assert_eq!(terminals.resizes.borrow().len(), 1, "last write wins");
+
+        terminals.serve_resizes();
+
+        assert!(terminals.resizes.borrow().is_empty());
+        assert!(
+            terminals.resizing.is_empty(),
+            "there is no live session to resize, so no worker was started"
+        );
+    }
+
+    /// The guard that stops a drag across a down host stacking one blocked
+    /// thread per frame — while keeping the size the drag ended on.
+    #[test]
+    fn a_resize_in_flight_holds_the_next_one_rather_than_losing_it() {
+        let mut terminals = Terminals::new();
+        terminals.resizing.insert("a".into());
+        terminals.resizes.borrow_mut().insert("a".into(), (24, 80));
+
+        terminals.serve_resizes();
+
+        assert_eq!(
+            terminals.resizes.borrow().get("a"),
+            Some(&(24, 80)),
+            "the size asked for while a worker was out is still owed"
+        );
+
+        // The worker reports; the queue is free to move again.
+        terminals.resized.0.send("a".into()).expect("report");
+        terminals.serve_resizes();
+        assert!(terminals.resizing.is_empty());
+        assert!(
+            terminals.resizes.borrow().is_empty(),
+            "and the owed size is taken off the queue"
+        );
     }
 
     #[test]

--- a/src/kernel/theme.rs
+++ b/src/kernel/theme.rs
@@ -12,7 +12,7 @@
 
 use std::collections::BTreeMap;
 
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 
 use crate::session::theme_config::{ThemeEntry, ThemePalette, ThemePreset};
 use crate::storage::Database;
@@ -31,6 +31,14 @@ pub struct ThemeChoice {
 /// The resolved theme plus everything a picker needs.
 pub struct Themes {
     active: ThemeEntry,
+    /// The active palette, already flattened to role → colour string.
+    ///
+    /// Cached rather than derived per call: [`Self::roles`] builds a 31-entry
+    /// `BTreeMap` of freshly formatted `String`s, and `BandState::colour` asked
+    /// for one role at a time — roughly thirty full rebuilds per painted frame,
+    /// for three bands of text. Rebuilt wherever [`Self::active`] is assigned,
+    /// which is what `set_active` exists to make impossible to forget.
+    roles: BTreeMap<&'static str, String>,
     choices: Vec<ThemeChoice>,
     /// The user's `themes.toml` entries, kept so a palette other than the
     /// active one can be resolved without re-reading the file — the picker's
@@ -76,11 +84,18 @@ impl Themes {
         let active = resolve(wanted.as_deref(), &custom);
 
         Self {
+            roles: palette_roles(&active.palette),
             active,
             choices,
             custom,
             warnings,
         }
+    }
+
+    /// Adopt a resolved theme, keeping the published roles in step with it.
+    fn set_active(&mut self, entry: ThemeEntry) {
+        self.roles = palette_roles(&entry.palette);
+        self.active = entry;
     }
 
     /// Resolve any offered theme to its full entry, palette included.
@@ -117,7 +132,7 @@ impl Themes {
         if !self.choices.iter().any(|choice| choice.name == name) {
             return Err(format!("unknown theme {name:?}"));
         }
-        self.active = resolve(Some(name), &self.custom);
+        self.set_active(resolve(Some(name), &self.custom));
         if let Some(db) = db {
             db.set_active_theme(name)
                 .map_err(|e| format!("persist theme: {e}"))?;
@@ -137,7 +152,7 @@ impl Themes {
         if !self.choices.iter().any(|choice| choice.name == name) {
             return Err(format!("unknown theme {name:?}"));
         }
-        self.active = resolve(Some(name), &self.custom);
+        self.set_active(resolve(Some(name), &self.custom));
         Ok(())
     }
 
@@ -152,8 +167,21 @@ impl Themes {
     /// Colours are emitted as `#rrggbb` (or a palette index) so Lua can hand
     /// them straight back through the node vocabulary without the kernel
     /// needing a second colour type on the boundary.
+    ///
+    /// Cloned rather than borrowed: its one caller in the loop publishes the
+    /// whole table into Lua once per republish, and handing out a borrow of
+    /// `self` there costs more than the copy does. A single role is
+    /// [`Self::role`], which is the cheap path and the one the bands use.
     pub fn roles(&self) -> BTreeMap<&'static str, String> {
-        palette_roles(&self.active.palette)
+        self.roles.clone()
+    }
+
+    /// One role, parsed. The form every caller inside the kernel wants, and the
+    /// one that must not cost a palette rebuild — the bands ask per span.
+    pub fn role(&self, name: &str) -> Option<Color> {
+        self.roles
+            .get(name)
+            .and_then(|raw| super::node::parse_color(raw))
     }
 
     /// How a text selection is painted: the palette's own selection pair.
@@ -163,17 +191,11 @@ impl Themes {
     /// each cell already had — so a selection over styled text came out a
     /// different colour per span and matched no theme.
     pub fn selection_style(&self) -> Style {
-        let roles = self.roles();
-        let colour = |role: &str| {
-            roles
-                .get(role)
-                .and_then(|raw| super::node::parse_color(raw))
-        };
         let mut style = Style::default();
-        if let Some(bg) = colour("selection_bg") {
+        if let Some(bg) = self.role("selection_bg") {
             style = style.bg(bg);
         }
-        if let Some(fg) = colour("selection_fg") {
+        if let Some(fg) = self.role("selection_fg") {
             style = style.fg(fg);
         }
         // A palette defining neither still has to show a selection.
@@ -439,6 +461,38 @@ mod tests {
         themes.select(&other, None).expect("select");
         assert_eq!(themes.active_name(), other);
         assert_ne!(before, themes.roles(), "the palette should have changed");
+    }
+
+    /// The cache the bands read must never lag the active palette — a stale one
+    /// would paint the chrome in the theme you just left.
+    #[test]
+    fn the_cached_roles_follow_a_preview_as_well_as_a_selection() {
+        let mut themes = Themes::load(None);
+        let agrees = |themes: &Themes| {
+            let published = themes.roles();
+            let expected = palette_roles(&themes.active().palette);
+            assert_eq!(published, expected, "the cache drifted from the palette");
+            assert_eq!(
+                themes.role("accent"),
+                published
+                    .get("accent")
+                    .and_then(|raw| super::super::node::parse_color(raw)),
+                "the single-role accessor reads the same cache"
+            );
+        };
+        agrees(&themes);
+
+        let other = themes
+            .choices()
+            .iter()
+            .find(|c| c.name != themes.active_name())
+            .expect("more than one theme")
+            .name
+            .clone();
+        themes.preview(&other).expect("preview");
+        agrees(&themes);
+        themes.select(&other, None).expect("select");
+        agrees(&themes);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,10 @@
 //! Every surface you see — the session list included — is a file under `ui/`
 //! that you can edit while this is running.
 //!
-//! Runs alongside the v1 binary; nothing in `src/app/` or `src/ui/` is touched.
+//! This IS the `thurbox` binary: `src/app` (v1's TEA model) and `src/ui` (its 35
+//! render modules) were deleted when the kernel took the name, and v1 lives on
+//! the `v1.x` branch. `main` is the coordinator — the loop, the workers and the
+//! chrome — which is why it is the one module the architecture rules exempt.
 //! See `openspec/changes/v2-plugin-kernel/`.
 
 use std::error::Error;
@@ -136,7 +139,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // and the whole file is ignored, however carefully it was written.
     let (config, config_warnings) = thurbox::kernel::config::Config::load();
     let mut startup_notices: Vec<String> = config_warnings;
-    if let Some(db) = snapshots_db() {
+    if let Some(db) = open_db() {
         startup_notices.extend(thurbox::session_ops::heal_active_extensions(&db));
         startup_notices.extend(thurbox::session_ops::ensure_builtin_hooks_extension(&db));
         for notice in &startup_notices {
@@ -161,7 +164,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // the interface takes the terminal so it shows even if the interface would fail
     // to build. Declining cannot load v1 (it is not in this binary), so it turns
     // auto-update off and says how to reinstall the 1.x line.
-    if let Some(db) = snapshots_db() {
+    if let Some(db) = open_db() {
         if thurbox::kernel::consent::consent_gate(&db)?
             == thurbox::kernel::consent::Decision::Declined
         {
@@ -199,7 +202,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let settings = thurbox::session::settings::global();
             Notifier::new(settings.features.notifications, settings.notifications)
         },
-        themes: Themes::load(snapshots_db().as_ref()),
+        themes: Themes::load(open_db().as_ref()),
+        theme_db: None,
         updates: thurbox::kernel::updates::Updates::start(config.features()),
         slot_selection: std::collections::HashMap::new(),
         visible_slots: std::collections::HashSet::new(),
@@ -300,11 +304,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
     result
 }
 
-/// A connection for reading the persisted theme choice at startup.
+/// A short-lived connection for a one-shot read or write outside the snapshot
+/// store, which owns its own.
 ///
-/// Separate from the snapshot store's: this is read once, and opening a second
-/// short-lived connection is cheaper than threading one through construction.
-fn snapshots_db() -> Option<thurbox::storage::Database> {
+/// **Not cheap.** `Database::open` runs `schema::initialize` — the busy timeout,
+/// the WAL pragma, the pragma batch and the whole migration pass — plus
+/// `prune_audit_log` and `prune_old_messages`. Fine at startup, once; per
+/// keystroke it replays all of that and two DELETEs on the render thread, which
+/// is why the theme picker holds its connection instead (see `App::theme_db`).
+///
+/// Named for what it is rather than for the one store that never uses it: it was
+/// `snapshots_db`.
+fn open_db() -> Option<thurbox::storage::Database> {
     thurbox::paths::database_file().and_then(|path| thurbox::storage::Database::open(&path).ok())
 }
 
@@ -384,7 +395,17 @@ fn key_event_from_chord(chord: &str) -> Option<KeyEvent> {
     let code = match name {
         "enter" => KeyCode::Enter,
         "esc" => KeyCode::Esc,
+        // shift+Tab is a KEY, not a modified Tab: that is how crossterm reports
+        // it and how `canonical_chord` spells it back. Emitting Tab+SHIFT did not
+        // round-trip — `canonical_chord` drops the shift for tab, so the chord
+        // came back as plain "tab" and a `key:shift+tab` click verb replayed as
+        // Tab. The SHIFT bit is cleared with it, since the code now carries it.
+        "tab" if modifiers.contains(KeyModifiers::SHIFT) => {
+            modifiers.remove(KeyModifiers::SHIFT);
+            KeyCode::BackTab
+        }
         "tab" => KeyCode::Tab,
+        // Still accepted as a spelling: a plugin may branch on the raw name.
         "backtab" => KeyCode::BackTab,
         "space" => KeyCode::Char(' '),
         "backspace" => KeyCode::Backspace,
@@ -419,7 +440,7 @@ fn key_event_from_chord(chord: &str) -> Option<KeyEvent> {
 /// v1's chain, from `resolve_editor` (`src/cli/config.rs`): the DB setting
 /// `thurbox-cli editor set` writes, then `$VISUAL`, then `$EDITOR`.
 fn editor_command() -> Option<String> {
-    snapshots_db()
+    open_db()
         .and_then(|db| db.get_editor_command().ok().flatten())
         .or_else(|| std::env::var("VISUAL").ok())
         .or_else(|| std::env::var("EDITOR").ok())
@@ -430,7 +451,7 @@ fn editor_command() -> Option<String> {
 ///
 /// `Auto` — the default — leaves the decision to the name-based classification.
 fn editor_mode() -> thurbox::session::settings::EditorMode {
-    snapshots_db()
+    open_db()
         .and_then(|db| db.get_editor_mode().ok())
         .unwrap_or_default()
 }
@@ -756,6 +777,14 @@ struct App {
     /// Active mouse text selection over a terminal surface, if any.
     selection: Option<Selection>,
     themes: Themes,
+    /// The connection the theme picker persists through, opened on first use.
+    ///
+    /// Lazy because most runs never open the picker, and **held** because
+    /// [`open_db`] runs schema init plus two prunes: opening one per call replayed
+    /// all of that on the render thread for every key the picker saw, so holding
+    /// `j` down paid for a migration pass and two DELETEs per key repeat — and
+    /// with a five-second busy timeout a contended write lock could park the loop.
+    theme_db: Option<thurbox::storage::Database>,
     /// Which occupant of each `switch` slot is visible, by slot name.
     ///
     /// Focusing a plugin in a switch slot makes it the visible one, which is
@@ -1052,7 +1081,13 @@ impl App {
             // state a worker thread cannot reach, and it is instant, so nothing is
             // gained by making it asynchronous.
             Command::Theme { name } => {
-                if let Err(e) = self.themes.select(name, snapshots_db().as_ref()) {
+                // Through the same held connection the picker reads (see
+                // `theme_db`) rather than a fresh `open_db`: a pane may send this
+                // as often as it likes, and this is the write half of that read.
+                if self.theme_db.is_none() {
+                    self.theme_db = open_db();
+                }
+                if let Err(e) = self.themes.select(name, self.theme_db.as_ref()) {
                     self.report(e, Level::Error);
                 }
             }
@@ -1315,6 +1350,18 @@ impl App {
         if self.diffs.poll() {
             self.dirty = true;
         }
+        // The cache tracks the sessions that exist, not every one ever selected: a
+        // diff is up to `MAX_DIFF_BYTES` and the default interface draws none of
+        // it, so without this the process holds a 4 MiB answer per session you
+        // ever looked at. Every other worker store has its own retain.
+        let present: std::collections::HashSet<&str> = self
+            .snapshots
+            .current()
+            .sessions
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect();
+        self.diffs.retain(&present);
 
         // The creation flow's reads. It asks by leaving a key in `store`,
         // which is written the moment its handler runs, so a request made
@@ -1686,7 +1733,7 @@ impl App {
                     .copied()
                     .unwrap_or(thurbox::kernel::inventory::Trust::NotAsked)
             },
-            &|path| registry.is_disabled(&ui_dir.join(path).to_string_lossy()),
+            &|path| registry.is_disabled(&thurbox::kernel::bundled::absolute_key(&ui_dir, path)),
         );
         let inventory = std::mem::take(&mut self.inventory);
         let ui_dir = self.ui_dir.display().to_string();
@@ -1954,10 +2001,7 @@ impl App {
             // cap for as long as the creation wizard was up. A float that really
             // does animate still repaints: the 250 ms floor paints it, its tree
             // differs, and that marks the change.
-            let unchanged = self
-                .last_floats
-                .get(&index)
-                .is_some_and(|(last, node)| *last == rect && node == &rendered.node);
+            let unchanged = float_settled(self.last_floats.get(&index), rect, &rendered.node);
             if !unchanged {
                 self.changed_this_frame = true;
             }
@@ -2197,12 +2241,8 @@ impl App {
         }
     }
 
-    /// Render one plugin, painting an error panel in ITS OWN rect on failure.
-    ///
-    /// This is the isolation rule made concrete: a plugin that throws costs its
-    /// own pane and nothing else. Its neighbours keep drawing, and its state
-    /// survives for when the file is fixed.
-    /// Centre a rect taking `width_pct` x `height_pct` of `area`.
+    /// Centre a rect taking `width_pct` x `height_pct` of `area`, or the exact
+    /// `cols`/`rows` a plugin asked for.
     fn float_rect(area: Rect, float: thurbox::kernel::host::Float) -> Rect {
         // Cells when the plugin knows them, else a share of the screen. A modal
         // whose height follows its content — v1's pickers, all of them — can only
@@ -2229,6 +2269,11 @@ impl App {
         }
     }
 
+    /// Render one plugin, painting an error panel in ITS OWN rect on failure.
+    ///
+    /// This is the isolation rule made concrete: a plugin that throws costs its
+    /// own pane and nothing else. Its neighbours keep drawing, and its state
+    /// survives for when the file is fixed.
     fn draw_plugin(&mut self, frame: &mut Frame, index: usize, rect: Rect, focused: bool) {
         let ctx = RenderContext {
             width: rect.width,
@@ -2271,7 +2316,7 @@ impl App {
         // it: skipping the stamp on a frame whose tree changed would make the
         // *next* frame see output that had already been painted.
         let surface_moved = self.surface_moved(&node);
-        let unchanged = self.last_trees[index].as_ref() == Some(&node) && !surface_moved;
+        let unchanged = pane_settled(self.last_trees[index].as_ref(), &node, surface_moved);
         if !unchanged {
             self.changed_this_frame = true;
         }
@@ -2930,8 +2975,7 @@ impl App {
     /// the same key, and confirming a reversible act is what teaches people to
     /// confirm without reading.
     fn apply_switch(&mut self, file: &str, off: bool) {
-        let absolute = self.ui_dir.join(file);
-        let key = absolute.to_string_lossy().into_owned();
+        let key = thurbox::kernel::bundled::absolute_key(&self.ui_dir, file);
         match self.registry.set_disabled(&key, off) {
             Ok(now_off) => {
                 self.publish_disabled();
@@ -2957,7 +3001,7 @@ impl App {
     /// refusing (design D7).
     fn apply_trust(&mut self, file: &str, trusted: bool) {
         let absolute = self.ui_dir.join(file);
-        let key = absolute.to_string_lossy().into_owned();
+        let key = thurbox::kernel::bundled::absolute_key(&self.ui_dir, file);
         let outcome = if trusted {
             match std::fs::read_to_string(&absolute) {
                 // Trusted as it is *now*: the digest recorded here is what makes
@@ -3004,9 +3048,10 @@ impl App {
         &mut self,
         act: impl FnOnce(&mut Modals, &mut thurbox::kernel::modals::World<'_>) -> T,
     ) -> T {
-        let db = matches!(self.modals.kind(), Some(ModalKind::Theme))
-            .then(snapshots_db)
-            .flatten();
+        if matches!(self.modals.kind(), Some(ModalKind::Theme)) && self.theme_db.is_none() {
+            self.theme_db = open_db();
+        }
+        let db = self.theme_db.as_ref();
         // The settings the modal shows, and the slot a save comes back through.
         // What the *file* holds rather than what is in force: the panel edits the
         // file, and a restart-only change lives only there until the next launch
@@ -3026,7 +3071,7 @@ impl App {
                 save_settings: &mut saved,
                 inventory: &inventory,
                 interface_edit: &mut edit,
-                db: db.as_ref(),
+                db,
             };
             act(&mut self.modals, &mut world)
         };
@@ -3088,24 +3133,29 @@ impl App {
     /// Relative, because that is `Plugin::path`; trust is stored absolute so two
     /// interface directories cannot share it, so this is where the two meet.
     fn publish_trust(&self) {
+        // Through `trust_of`, not `Registry::is_trusted`, so the grant is decided
+        // by the same function that labels the row in the Interface tab — bare key
+        // presence reads neither the lock's pin nor the digest, so an installed
+        // pane whose pin had moved kept the grant made to the old one. The rule
+        // itself is `packages::grants_capabilities`.
+        let lock = thurbox::kernel::packages::read_lock(&self.ui_dir).unwrap_or_default();
         let trusted: Vec<String> = self
             .host
             .plugins
             .iter()
             .map(|plugin| plugin.path.clone())
             .filter(|path| {
-                let absolute = self.ui_dir.join(path);
-                self.registry.is_trusted(&absolute.to_string_lossy())
+                thurbox::kernel::packages::grants_capabilities(thurbox::kernel::packages::trust_of(
+                    &self.ui_dir,
+                    path,
+                    &lock,
+                    &self.registry,
+                ))
             })
             .collect();
         self.host.set_trusted(trusted);
     }
 
-    /// Tell the host which plugins the user turned off.
-    ///
-    /// Derived from the *stored* absolute paths rather than from the loaded
-    /// plugins, because a disabled one is not loaded — it would not be in the
-    /// list to filter. Relative, because that is what `build` compares against.
     /// Start or close a plugin's program pane.
     ///
     /// The gate is here rather than in the queue: a command is honoured after the
@@ -3169,6 +3219,11 @@ impl App {
         self.changed_this_frame = true;
     }
 
+    /// Tell the host which plugins the user turned off.
+    ///
+    /// Derived from the *stored* absolute paths rather than from the loaded
+    /// plugins, because a disabled one is not loaded — it would not be in the
+    /// list to filter. Relative, because that is what `build` compares against.
     fn publish_disabled(&self) {
         let disabled: Vec<String> = self
             .registry
@@ -4134,6 +4189,40 @@ fn render_hud(frame: &mut Frame, area: Rect, counters: &thurbox::kernel::perf::S
     );
 }
 
+/// Has this float settled — same tree, same rect — so the frame need not be
+/// marked changed?
+///
+/// Free rather than a method, and named rather than written out at the call site,
+/// because it is one of the two rules that decide whether the loop settles at all
+/// and neither was reachable from `tests/` inside this binary target. Being open
+/// is deliberately NOT a change: while it was, an open float held `dirty` set
+/// forever and the whole interface rebuilt every Lua tree at the frame cap for as
+/// long as the creation wizard was up. The rect is compared as well as the tree —
+/// the same content in a new place is a repaint.
+fn float_settled(
+    last: Option<&(Rect, thurbox::kernel::node::Node)>,
+    rect: Rect,
+    node: &thurbox::kernel::node::Node,
+) -> bool {
+    last.is_some_and(|(seen, tree)| *seen == rect && tree == node)
+}
+
+/// Has this pane settled? [`float_settled`] for a pane, plus the one thing a tree
+/// comparison cannot see.
+///
+/// `surface_moved` is that thing: a live terminal's contents change underneath an
+/// identical tree, so a pane holding one that produced output is not settled even
+/// though it returned the same nodes. A live text selection, by contrast, is not a
+/// change by itself — it used to be, which pinned the loop at the frame cap for as
+/// long as a selection existed.
+fn pane_settled(
+    last: Option<&thurbox::kernel::node::Node>,
+    node: &thurbox::kernel::node::Node,
+    surface_moved: bool,
+) -> bool {
+    last == Some(node) && !surface_moved
+}
+
 /// Flatten a crossterm key into what Lua is told about it.
 fn to_press(key: &KeyEvent) -> KeyPress {
     let name = match key.code {
@@ -4151,6 +4240,7 @@ fn to_press(key: &KeyEvent) -> KeyPress {
         ctrl: key.modifiers.contains(KeyModifiers::CONTROL),
         alt: key.modifiers.contains(KeyModifiers::ALT),
         shift: key.modifiers.contains(KeyModifiers::SHIFT),
+        cmd: key.modifiers.contains(KeyModifiers::SUPER),
     }
 }
 
@@ -4158,6 +4248,108 @@ fn to_press(key: &KeyEvent) -> KeyPress {
 mod tests {
     use super::*;
     use thurbox::kernel::host::Float;
+
+    /// A chord survives the trip out to a key event and back.
+    ///
+    /// The two halves are written in different modules and had drifted:
+    /// `KeyPress` carried no `cmd` and `to_press` never read `SUPER`, so a
+    /// declared `cmd+j` matched nothing *and* a real Cmd+J canonicalised to plain
+    /// `"j"` — firing whatever `j` was bound to, which is worse than not binding
+    /// it. `shift+tab` failed the other way: emitted as Tab+SHIFT, it came back as
+    /// plain `"tab"`. Both are one-line defects that only a round trip finds.
+    #[test]
+    fn every_chord_survives_the_round_trip_through_a_key_event() {
+        for chord in [
+            "j",
+            "ctrl+j",
+            "alt+j",
+            "shift+j",
+            "ctrl+alt+shift+j",
+            "cmd+j",
+            "ctrl+cmd+j",
+            "enter",
+            "esc",
+            "tab",
+            "shift+tab",
+            "backspace",
+            "up",
+            "pagedown",
+            "space",
+            "f1",
+            "f12",
+            "ctrl+/",
+        ] {
+            let wanted = thurbox::kernel::registry::normalise_chord(chord);
+            let event = key_event_from_chord(chord)
+                .unwrap_or_else(|| panic!("{chord} produced no key event"));
+            let got = thurbox::kernel::registry::canonical_chord(&to_press(&event));
+            assert_eq!(got, wanted, "{chord} did not round-trip");
+        }
+    }
+
+    /// `backtab` is still an accepted spelling, and canonicalises to the one name
+    /// the registry uses — a plugin may branch on the raw name, so the alias
+    /// cannot simply be dropped.
+    #[test]
+    fn backtab_is_an_accepted_alias_for_shift_tab() {
+        let event = key_event_from_chord("backtab").expect("backtab");
+        assert_eq!(event.code, KeyCode::BackTab);
+        assert_eq!(
+            thurbox::kernel::registry::canonical_chord(&to_press(&event)),
+            "shift+tab"
+        );
+    }
+
+    /// A different tree from [`Node::empty`], and the smallest one available.
+    fn other_tree() -> thurbox::kernel::node::Node {
+        thurbox::kernel::node::Node::Box {
+            axis: Axis::Vertical,
+            gap: 1,
+            children: Vec::new(),
+            frame: None,
+            size: Default::default(),
+            identity: Identity::default(),
+        }
+    }
+
+    /// The float settle rule: same tree AND same rect, or the frame changed.
+    #[test]
+    fn a_float_settles_only_when_neither_its_tree_nor_its_rect_moved() {
+        let rect = Rect::new(0, 0, 20, 5);
+        let moved = Rect::new(1, 0, 20, 5);
+        let tree = thurbox::kernel::node::Node::empty();
+
+        assert!(
+            float_settled(Some(&(rect, tree.clone())), rect, &tree),
+            "an open float that drew the same thing in the same place is settled"
+        );
+        assert!(
+            !float_settled(Some(&(rect, tree.clone())), moved, &tree),
+            "the same content in a new place is a repaint"
+        );
+        assert!(
+            !float_settled(Some(&(rect, other_tree())), rect, &tree),
+            "a changed tree is a repaint"
+        );
+        assert!(
+            !float_settled(None, rect, &tree),
+            "a float not drawn last frame has nothing to settle against"
+        );
+    }
+
+    /// The pane settle rule, and the one thing a tree comparison cannot see.
+    #[test]
+    fn a_pane_with_a_live_surface_is_not_settled_by_an_identical_tree() {
+        let tree = thurbox::kernel::node::Node::empty();
+
+        assert!(pane_settled(Some(&tree), &tree, false));
+        assert!(
+            !pane_settled(Some(&tree), &tree, true),
+            "a terminal that produced output is not settled by an unchanged tree"
+        );
+        assert!(!pane_settled(Some(&other_tree()), &tree, false));
+        assert!(!pane_settled(None, &tree, false));
+    }
 
     /// Startup says which interface loaded, but only when there is a question.
     ///

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -133,8 +133,9 @@ impl std::str::FromStr for SessionId {
 }
 
 /// A session's lifecycle state, driven by agent hooks (see
-/// `thurbox-cli session signal`). Repo groups in the session list roll up to
-/// their most-urgent member so the whole list scans at a glance.
+/// `thurbox-cli session signal`). Status renders on a session's own row and
+/// nowhere else: a repo-group header carries no rolled-up dot, because it would
+/// only restate what every member row already shows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionStatus {
     /// 🟡 The agent is actively running (reported by a hook).
@@ -147,23 +148,26 @@ pub enum SessionStatus {
     Idle,
     /// Reserved for a crashed agent. **Not currently derived** — process exit has
     /// no failure signal yet (a clean or crashed exit both map to `Idle`), so this
-    /// variant is wired through colour/glyph/rollup but never assigned. Kept for
+    /// variant is wired through colour and glyph but never assigned. Kept for
     /// when exit-code plumbing lands.
     Error,
     /// The session lives on a remote host that is currently unreachable (SSH
-    /// down / auth failing / host offline). Assigned to placeholder rows so a
-    /// remote session never silently vanishes from the list; cleared to the
-    /// real hook-driven status once the host recovers and the session adopts.
+    /// down / auth failing / host offline). Derived rather than stored:
+    /// `kernel::snapshot::with_reachability` reports it for a remote row that has
+    /// no live pane, the attach failure behind it having been recorded in
+    /// `Terminals::failed`. So a remote session never silently vanishes from the
+    /// list, and it reverts to its hook-driven status the moment the host
+    /// recovers and the ordinary attach retry adopts a pane.
     Unreachable,
 }
 
 impl SessionStatus {
     /// A status glyph chosen for **shape** distinctiveness, not just colour, so
     /// the state survives in greyscale / for colour-blind users: a spinner
-    /// (working — the live session list animates it, see `ui::SPINNER_FRAMES`)
-    /// vs. diamond (blocked) vs. filled circle (done, unseen) vs. hollow circle
-    /// (idle, seen) vs. cross (error). The filled/hollow pair makes
-    /// done-vs-idle read at a glance.
+    /// (working — the static frame; the session list animates it Lua-side from
+    /// `theme.spinner`, see `widgets.spinner_frame`) vs. diamond (blocked) vs.
+    /// filled circle (done, unseen) vs. hollow circle (idle, seen) vs. cross
+    /// (error). The filled/hollow pair makes done-vs-idle read at a glance.
     pub fn icon(self) -> &'static str {
         match self {
             Self::Working => "◐",

--- a/src/session/plugin_spec.rs
+++ b/src/session/plugin_spec.rs
@@ -75,7 +75,7 @@ impl PluginEntry {
         if self.src.trim().is_empty() {
             return Err(format!("{}: src is empty", self.file));
         }
-        validate_destination(&self.file)
+        validate_pane_destination(&self.file)
     }
 }
 
@@ -104,6 +104,23 @@ pub fn validate_destination(file: &str) -> Result<(), String> {
     }
     if !file.ends_with(".lua") {
         return Err(format!("{file}: must be a Lua file"));
+    }
+    Ok(())
+}
+
+/// Refuse a *pane* destination, which is [`validate_destination`] plus the one
+/// rule that only applies to a pane: it may not land in `lib/`.
+///
+/// [`PackageManifest::validate`] has always refused a manifest that puts its pane
+/// there, but `--as` reaches the destination without going through a manifest —
+/// so `plugin install <url>/x.lua --as lib/mine.lua` used to record a spec entry
+/// for a file the loader never reads (`is_nested_pane` is false for `lib/…`) and
+/// which the inventory then classifies as a module: an install that succeeds,
+/// draws nothing, and reports no fault anywhere.
+pub fn validate_pane_destination(file: &str) -> Result<(), String> {
+    validate_destination(file)?;
+    if file.starts_with("lib/") {
+        return Err(format!("{file}: the pane belongs in plugins/"));
     }
     Ok(())
 }
@@ -336,13 +353,7 @@ impl PackageManifest {
                 ));
             }
         }
-        if self.pane.path.starts_with("lib/") {
-            return Err(format!(
-                "{}: the pane {} belongs in plugins/",
-                Self::FILE,
-                self.pane.path
-            ));
-        }
+        validate_pane_destination(&self.pane.path).map_err(|e| format!("{}: {e}", Self::FILE))?;
         Ok(())
     }
 }
@@ -650,6 +661,32 @@ file = "plugins/80_notes.lua"
         }
         .validate()
         .is_ok());
+    }
+
+    /// `lib/` is for modules, and `--as` reaches a destination without going
+    /// through a manifest — so without this rule `plugin install <url>/x.lua --as
+    /// lib/mine.lua` records a spec entry for a pane the loader never reads.
+    #[test]
+    fn a_pane_may_not_be_delivered_into_the_module_namespace() {
+        let error = validate_pane_destination("lib/theme.lua").expect_err("should fail");
+        assert!(error.contains("plugins/"), "says where it belongs: {error}");
+        assert!(validate_pane_destination("plugins/75_atlas.lua").is_ok());
+        // A repository keeps its author's layout, so its pane is nested under the
+        // package's own directory rather than in `plugins/`.
+        assert!(validate_pane_destination("thurbox-widget/plugins/40_x.lua").is_ok());
+        // The manifest half enforces the same rule, through the same function.
+        let manifest = PackageManifest {
+            name: "bad".into(),
+            description: None,
+            version: None,
+            requires_thurbox: None,
+            pane: PackageFile {
+                source: "pane.lua".into(),
+                path: "lib/bad.lua".into(),
+            },
+            modules: Vec::new(),
+        };
+        assert!(manifest.validate().is_err());
     }
 
     #[test]

--- a/src/session_ops/mod.rs
+++ b/src/session_ops/mod.rs
@@ -1,9 +1,11 @@
 //! Headless session operations — spawn and restart sessions without the TUI.
 //!
-//! Callers (MCP, CLI) use these helpers to drive the same local-tmux-backed
-//! sessions the TUI manages, without requiring the TUI event loop. All
-//! operations are synchronous against the SQLite database and the `tmux -L
-//! thurbox` server.
+//! The callers are `thurbox-cli` and the kernel's command workers: both drive
+//! the same tmux-backed sessions the interface shows, without needing the render
+//! loop. All operations are synchronous against the SQLite database and the
+//! `tmux -L thurbox` server — local, or that server reached over the session's
+//! own transport for a remote backend — which is why the kernel only ever calls
+//! them from a worker (rule 5).
 
 pub mod builtin_hooks;
 pub mod delete;

--- a/tests/architecture_rules.rs
+++ b/tests/architecture_rules.rs
@@ -38,7 +38,7 @@ const MODULE_RULES: &[ModuleRules] = &[
         allowed: &[],
         allowed_path_only: &[],
     },
-    // Side-effect layer (PTY/tmux). Never ui, git, or app.
+    // Side-effect layer (PTY/tmux). Never `git`.
     ModuleRules {
         name: "agent",
         allowed: &["session", "paths", "shell"],
@@ -97,8 +97,8 @@ const MODULE_RULES: &[ModuleRules] = &[
     // session engine to build the snapshot plugins render from (`storage` +
     // `sync` for the rows, `session` for the types, `paths` for the DB and
     // plugin directories). Never `ui` or `app` — it is their replacement, not
-    // their peer — and never `git`/`agent` directly: side effects reach it as
-    // commands, not as calls from a render path.
+    // their peer — and never `agent` by `use`: side effects reach it as commands
+    // or, where a render path genuinely needs one, as a fully-qualified call.
     ModuleRules {
         name: "kernel",
         allowed: &[
@@ -136,8 +136,8 @@ const MODULE_RULES: &[ModuleRules] = &[
     },
     // Leaf side-effect module: OS desktop notifications. Knows about
     // `session` (for `SessionId`) and `paths` (for the DB path the click
-    // callback writes to); never reaches into agent / ui / app / storage
-    // beyond a single SQL statement on its own short-lived connection.
+    // callback writes to); never reaches into agent or storage beyond a single
+    // SQL statement on its own short-lived connection.
     ModuleRules {
         name: "notifications",
         allowed: &["session", "paths"],
@@ -145,7 +145,7 @@ const MODULE_RULES: &[ModuleRules] = &[
     },
     // Leaf side-effect module: clipboard writes (native + OSC 52). Knows
     // `session` only for the `ClipboardProvider` setting; writes to the tty
-    // and never reaches into agent / ui / app / storage.
+    // and never reaches into agent or storage.
     ModuleRules {
         name: "clipboard",
         allowed: &["session"],
@@ -153,10 +153,10 @@ const MODULE_RULES: &[ModuleRules] = &[
     },
 ];
 
-/// Modules exempt from the allowlist: `app` is the coordinator (imports
-/// everything by design); `bin`, `lib`, and `main` are crate roots, not
-/// architecture modules.
-// `main` is the coordinator, as `app` was before v1 was retired.
+/// Modules exempt from the allowlist, all three of them crate roots rather than
+/// architecture modules: `main` is the coordinator and imports everything by
+/// design (the role `app` held before v1 was retired), and `bin` / `lib` are the
+/// other two entry points.
 const EXEMPT: &[&str] = &["bin", "lib", "main"];
 
 /// A single architecture violation: a forbidden crate-module reference.
@@ -542,56 +542,18 @@ fn assert_module_clean(name: &str) {
     );
 }
 
+/// Every rule in [`MODULE_RULES`] is enforced, by construction.
+///
+/// One loop rather than a test per module: the hand-written list stopped at
+/// `notifications` while entries for `kernel` and `clipboard` sat in
+/// [`MODULE_RULES`] with nothing asserting them — a declared boundary that no
+/// test checked, which is how three violations of the kernel's own rule
+/// accumulated. A new entry cannot go unenforced now.
 #[test]
-fn session_module_purity() {
-    assert_module_clean("session");
-}
-
-#[test]
-fn agent_module_isolation() {
-    assert_module_clean("agent");
-}
-
-#[test]
-fn git_module_independence() {
-    assert_module_clean("git");
-}
-
-#[test]
-fn storage_module_isolation() {
-    assert_module_clean("storage");
-}
-
-#[test]
-fn sync_module_isolation() {
-    assert_module_clean("sync");
-}
-
-#[test]
-fn usage_module_isolation() {
-    assert_module_clean("usage");
-}
-
-#[test]
-fn session_ops_module_isolation() {
-    assert_module_clean("session_ops");
-}
-
-#[test]
-fn cli_module_isolation() {
-    assert_module_clean("cli");
-}
-
-#[test]
-fn util_modules_are_leaves() {
-    for name in ["paths", "shell", "workspace"] {
-        assert_module_clean(name);
+fn every_rule_is_enforced() {
+    for rules in MODULE_RULES {
+        assert_module_clean(rules.name);
     }
-}
-
-#[test]
-fn notifications_module_isolation() {
-    assert_module_clean("notifications");
 }
 
 /// Every module under `src/` must be governed: either a MODULE_RULES entry

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,233 @@
+//! What every integration test needs, in one place.
+//!
+//! `Published` names the whole read side of the kernel, and its own doc says
+//! adding something plugins can read should not be an edit to every test. It
+//! was: the struct literal was hand-written in sixteen files, `SessionRow` in
+//! twenty-seven, and `fn host()` in thirteen — so a new field was a
+//! sixteen-file mechanical edit and a diverging fixture row was invisible.
+//! Everything here is the *shared* half; a test that needs a different fixture
+//! still writes its own, usually as `..session_row(..)`.
+//!
+//! Rust 2021 includes this per test target via `mod common;`, so an item no
+//! single target uses warns there. Hence the blanket allow — the alternative is
+//! a `cfg` per helper.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+use thurbox::kernel::command::InFlight;
+use thurbox::kernel::host::{KeyPress, LuaHost, Published, RenderContext};
+use thurbox::kernel::registry::Registry;
+use thurbox::kernel::snapshot::{SessionRow, Snapshot};
+use thurbox::kernel::theme::Themes;
+
+/// The interface the binary ships, as the repository holds it.
+pub fn ui_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui")
+}
+
+/// A host over the bundled interface, asserting it loaded.
+///
+/// The assert is the point: a plugin that failed to load renders as an absent
+/// pane, so without it a test reads as "the feature is gone" rather than "the
+/// file has a syntax error".
+pub fn host() -> LuaHost {
+    let host = LuaHost::new(ui_dir());
+    assert!(
+        host.error.is_none(),
+        "the bundled plugins must load: {:?}",
+        host.error
+    );
+    host
+}
+
+/// An interface built from the bundled set with `plugins` written over it, each
+/// `(file name, source)`.
+///
+/// Returns the tempdir as well as the path: dropping it deletes the directory,
+/// so a caller that lets it go loads from nothing.
+pub fn interface(plugins: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf) {
+    let home = tempfile::tempdir().expect("tempdir");
+    let ui = home.path().join("ui");
+    thurbox::kernel::bundled::materialize(&ui);
+    for (name, source) in plugins {
+        std::fs::write(ui.join("plugins").join(name), source).expect("write");
+    }
+    (home, ui)
+}
+
+/// Whatever palette the environment resolves, which keeps tests independent of
+/// the user's active choice.
+pub fn themes() -> Themes {
+    Themes::load(None)
+}
+
+/// A registry holding whatever the given host's plugins declared.
+pub fn registry(host: &LuaHost) -> Registry {
+    let mut registry = Registry::default();
+    let (bindings, settings) = host.declarations();
+    registry.declare(bindings, settings);
+    registry
+}
+
+/// Publish a snapshot with the defaults every test wants.
+pub fn publish(host: &LuaHost, snapshot: &Snapshot) {
+    publish_with(host, snapshot, &Default::default(), &[]);
+}
+
+/// Publish with attach errors and in-flight commands spelled out.
+pub fn publish_with(
+    host: &LuaHost,
+    snapshot: &Snapshot,
+    attach_errors: &std::collections::HashMap<String, String>,
+    inflight: &[InFlight],
+) {
+    let themes = themes();
+    let registry = registry(host);
+    let diffs = thurbox::kernel::diff::DiffStore::new();
+    let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
+    host.publish(&Published {
+        snapshot,
+        attach_errors,
+        inflight,
+        themes: &themes,
+        registry: &registry,
+        diffs: &diffs,
+        links: &Default::default(),
+        content: &Default::default(),
+        meta: &Default::default(),
+        metrics: &Default::default(),
+        status_rows: 0,
+        can_open: true,
+        inventory: &[],
+        ui_dir: "ui",
+        settings: &Default::default(),
+        repos: &repos,
+        wants: &Default::default(),
+        focus: None,
+        hovered: None,
+    })
+    .expect("publish");
+}
+
+/// Index of a plugin by name, naming it when it is not there.
+pub fn index_of(host: &LuaHost, name: &str) -> usize {
+    host.index_of(name)
+        .unwrap_or_else(|| panic!("no plugin named {name}"))
+}
+
+/// A render context, the one thing a plugin is handed that it did not declare.
+pub fn ctx(width: u16, height: u16, focused: bool) -> RenderContext {
+    RenderContext {
+        width,
+        height,
+        focused,
+        elapsed: 1.0,
+        frame: 1,
+    }
+}
+
+/// The keypress a terminal would deliver for a canonical chord.
+pub fn press(chord: &str) -> KeyPress {
+    let mut key = KeyPress::default();
+    for part in chord.split('+') {
+        match part {
+            "ctrl" => key.ctrl = true,
+            "alt" => key.alt = true,
+            "shift" => key.shift = true,
+            "cmd" => key.cmd = true,
+            name => {
+                key.name = name.to_string();
+                let mut chars = name.chars();
+                key.ch = match (chars.next(), chars.next()) {
+                    (Some(c), None) => Some(c),
+                    _ => None,
+                };
+            }
+        }
+    }
+    key
+}
+
+/// A session row with the fields nobody varies already filled in.
+///
+/// `SessionRow` derives no `Default` — it is in `src/`, and every field there is
+/// load-bearing enough that a blanket default would be a lie — so this is the
+/// fixture base. Override what the test is about:
+/// `SessionRow { status: "working".into(), ..session_row("a", "one") }`.
+pub fn session_row(id: &str, name: &str) -> SessionRow {
+    SessionRow {
+        id: id.to_string(),
+        name: name.to_string(),
+        agent: "claude".to_string(),
+        status: "idle".to_string(),
+        cwd: None,
+        repo: Some("thurbox".to_string()),
+        repos: vec!["thurbox".to_string()],
+        member_dirs: Vec::new(),
+        branch: Some("main".to_string()),
+        base_branch: None,
+        backend: "local-tmux".to_string(),
+        backend_id: Some("%1".to_string()),
+        remote_host: None,
+        agent_session_id: None,
+        parent_id: None,
+        display_order: None,
+        worktree_count: 0,
+        git: None,
+        shell_backend_id: None,
+        hook_state: None,
+    }
+}
+
+/// A `git` invocation in `dir` with the whole of `git::GIT_LOCATION_ENV`
+/// scrubbed.
+///
+/// The same scrub `git::scrub_git_location_env` makes for thurbox's own calls,
+/// and for the reason named there: git exports these to hook processes, so the
+/// suite running under this project's pre-commit `cargo nextest` inherits a
+/// `GIT_DIR` pointing at the real repository. `git init` then fails — and had it
+/// succeeded, a fixture `commit` would have landed in *that* repository rather
+/// than the tempdir.
+///
+/// Returned rather than run, because a caller that wants the output configures
+/// its own stdio; [`git`] is the common case.
+pub fn git_command(dir: &Path, args: &[&str]) -> std::process::Command {
+    let mut command = std::process::Command::new("git");
+    command
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null");
+    for name in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_COMMON_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_PREFIX",
+        "GIT_NAMESPACE",
+        // Config given on the *command line* — `git -c commit.gpgsign=true
+        // commit` — travels to every child through these, hooks included, and
+        // outranks the repo config a test could set. `GIT_CONFIG_GLOBAL` above
+        // does not cover it. Left in place, a contributor signing this
+        // project's own commits fails these tests and nothing else: there is no
+        // key here to sign a fixture commit with.
+        "GIT_CONFIG_PARAMETERS",
+        "GIT_CONFIG_COUNT",
+    ] {
+        command.env_remove(name);
+    }
+    command
+}
+
+/// Run `git` in `dir`, asserting it succeeded and saying nothing.
+pub fn git(dir: &Path, args: &[&str]) {
+    let status = git_command(dir, args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {args:?}");
+}

--- a/tests/create_e2e.rs
+++ b/tests/create_e2e.rs
@@ -8,8 +8,11 @@
 //! Everything it touches is scoped to a throwaway socket and a temporary
 //! directory, so it can never disturb a real session.
 
-use std::path::Path;
 use std::process::Command;
+
+mod common;
+
+use common::git;
 
 /// A throwaway tmux socket, so this never touches the real one.
 const SOCKET: &str = "thurbox-create-e2e";
@@ -22,35 +25,17 @@ fn have_tmux() -> bool {
         .unwrap_or(false)
 }
 
-fn git(dir: &Path, args: &[&str]) {
-    let ok = Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        // Scrubbed so an inherited GIT_* var cannot reach into this repo.
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .output()
-        .expect("run git")
-        .status
-        .success();
-    assert!(ok, "git {args:?} failed");
-}
-
 /// A repository with one commit, which is the minimum a worktree needs.
 fn repo() -> tempfile::TempDir {
     let dir = tempfile::tempdir().expect("tempdir");
     git(dir.path(), &["init", "-q", "-b", "main"]);
     git(dir.path(), &["config", "user.email", "t@example.com"]);
     git(dir.path(), &["config", "user.name", "thurbox-test"]);
-    // Commit signing is a user setting that fails in a bare environment, and
-    // this repo is not the place to be signing anything.
+    // Signing would make this depend on a key in the user's agent, and the repo
+    // is throwaway.
     git(dir.path(), &["config", "commit.gpgsign", "false"]);
     std::fs::write(dir.path().join("README.md"), "# probe\n").expect("write");
     git(dir.path(), &["add", "."]);
-    // Signing would make this depend on a key in the user's agent; the repo is
-    // throwaway, so it is disabled here rather than required of the machine.
-    git(dir.path(), &["config", "commit.gpgsign", "false"]);
     git(dir.path(), &["commit", "-qm", "init"]);
     dir
 }
@@ -113,9 +98,21 @@ fn creating_a_session_produces_a_worktree_a_row_and_a_window() {
         Ok(spawned) => spawned,
         Err(e) => {
             cleanup();
-            // A tmux server that will not start is an environment problem.
-            if e.contains("tmux") {
-                eprintln!("skipping: tmux would not spawn a window: {e}");
+            // A server that will not start is an environment fact, like a
+            // missing binary. Anything else is this pipeline breaking, and this
+            // is the only test that runs the whole of it — so the skip has to
+            // name the condition rather than the tool. Matching the substring
+            // "tmux" over the whole error exited GREEN on every backend failure
+            // that merely mentions it ("can't find pane", "failed to create
+            // window", any `reportable_stderr` line), which is the one outcome
+            // an end-to-end test must never have.
+            const NO_SERVER: [&str; 3] = [
+                "no server running",
+                "failed to connect to server",
+                "error connecting to",
+            ];
+            if NO_SERVER.iter().any(|marker| e.contains(marker)) {
+                eprintln!("skipping: no multiplexer server to spawn into: {e}");
                 return;
             }
             panic!("creation failed: {e}");

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -24,99 +24,21 @@ use thurbox::kernel::layout::{divide_slot, resolve, SlotMode};
 use thurbox::kernel::node::{Axis, Node, KINDS};
 use thurbox::kernel::paint::{render, PlaceholderSurfaces};
 use thurbox::kernel::registry::Registry;
-use thurbox::kernel::snapshot::{SessionRow, Snapshot};
-use thurbox::kernel::theme::Themes;
+use thurbox::kernel::snapshot::{SessionRow, Snapshot, SnapshotStore};
+use thurbox::storage::Database;
 
-/// The theme every test publishes with: whatever the environment resolves,
-/// which keeps these tests independent of the user's active choice.
-fn themes() -> Themes {
-    Themes::load(None)
-}
+mod common;
 
-/// Publish a snapshot with the defaults every test wants.
-fn publish(host: &LuaHost, snapshot: &Snapshot) {
-    publish_with(host, snapshot, &Default::default(), &[]);
-}
-
-/// Publish with attach errors and in-flight commands spelled out.
-fn publish_with(
-    host: &LuaHost,
-    snapshot: &Snapshot,
-    attach_errors: &std::collections::HashMap<String, String>,
-    inflight: &[thurbox::kernel::command::InFlight],
-) {
-    let themes = themes();
-    let registry = registry(host);
-    let diffs = thurbox::kernel::diff::DiffStore::new();
-    let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
-    host.publish(&thurbox::kernel::host::Published {
-        snapshot,
-        attach_errors,
-        inflight,
-        themes: &themes,
-        registry: &registry,
-        diffs: &diffs,
-        links: &Default::default(),
-        content: &Default::default(),
-        meta: &Default::default(),
-        metrics: &Default::default(),
-        status_rows: 0,
-        can_open: true,
-        inventory: &[],
-        ui_dir: "ui",
-        settings: &Default::default(),
-        repos: &repos,
-        wants: &Default::default(),
-        focus: None,
-        hovered: None,
-    })
-    .expect("publish");
-}
-
-/// A registry holding whatever the given host's plugins declared.
-fn registry(host: &LuaHost) -> Registry {
-    let mut registry = Registry::default();
-    let (bindings, settings) = host.declarations();
-    registry.declare(bindings, settings);
-    registry
-}
-
-fn ui_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui")
-}
-
-fn host() -> LuaHost {
-    let host = LuaHost::new(ui_dir());
-    assert!(
-        host.error.is_none(),
-        "the bundled plugins must load: {:?}",
-        host.error
-    );
-    host
-}
+use common::{ctx, host, index_of, publish, publish_with, registry, themes, ui_dir};
 
 fn row(name: &str, repo: &str, status: &str) -> SessionRow {
     SessionRow {
-        id: format!("{name}-0000-0000-0000-000000000000"),
-        name: name.to_string(),
-        agent: "claude".to_string(),
         status: status.to_string(),
-        cwd: None,
         repo: Some(repo.to_string()),
         repos: vec![repo.to_string()],
         branch: Some(format!("feat/{name}")),
-        base_branch: None,
-        backend: "local-tmux".to_string(),
-        backend_id: Some("%1".to_string()),
-        agent_session_id: None,
-        remote_host: None,
-        parent_id: None,
-        display_order: None,
         worktree_count: 1,
-        git: None,
-        hook_state: None,
-        shell_backend_id: None,
-        member_dirs: Vec::new(),
+        ..common::session_row(&format!("{name}-0000-0000-0000-000000000000"), name)
     }
 }
 
@@ -135,16 +57,6 @@ fn sample() -> Snapshot {
         row("perf-cache", "thurbox", "done"),
         row("update-deps", "website", "idle"),
     ])
-}
-
-fn ctx(width: u16, height: u16, focused: bool) -> RenderContext {
-    RenderContext {
-        width,
-        height,
-        focused,
-        elapsed: 1.0,
-        frame: 1,
-    }
 }
 
 /// Render one plugin into a rect and return the painted screen as text.
@@ -205,13 +117,6 @@ fn paint_node(node: &Node, width: u16, height: u16) -> Vec<String> {
                 .to_string()
         })
         .collect()
-}
-
-fn index_of(host: &LuaHost, name: &str) -> usize {
-    host.plugins
-        .iter()
-        .position(|plugin| plugin.name == name)
-        .unwrap_or_else(|| panic!("no plugin named {name}"))
 }
 
 #[test]
@@ -507,14 +412,41 @@ fn an_unclaimed_key_is_left_for_the_kernel() {
 
 #[test]
 fn plugin_reads_are_served_from_the_snapshot() {
-    // design.md D5: reads never consult the database, so they cannot block.
-    // Rendering a thousand times touches nothing but the published table.
+    // design.md D5: reads come from the published snapshot, so a plugin cannot
+    // block on SQLite. Asserted by publishing a session that exists in NO
+    // database and watching the pane draw it, then again with the rows an
+    // actual store read — which is empty.
+    //
+    // The previous form rendered a thousand times against a host that owned no
+    // database at all, and asserted nothing: it held whatever the kernel did.
+    let db = Database::open_in_memory().expect("db");
+    let mut store = SnapshotStore::with_database(db);
+    store.refresh();
+    assert!(
+        store.current().sessions.is_empty(),
+        "the fixture database must hold no sessions for this to prove anything"
+    );
+
     let host = host();
-    publish(&host, &sample());
     let index = index_of(&host, "sessions");
-    for _ in 0..1000 {
-        host.render(index, ctx(40, 12, false)).expect("render");
-    }
+
+    publish(&host, store.current());
+    let empty = paint(&host, index, 46, 12).join("\n");
+    assert!(!empty.contains("snap-only"), "{empty}");
+
+    publish(
+        &host,
+        &snapshot(vec![row("snap-only", "thurbox", "working")]),
+    );
+    let drawn = paint(&host, index, 46, 12).join("\n");
+    assert!(
+        drawn.contains("snap-only"),
+        "the pane drew rows the database has never held: {drawn}"
+    );
+
+    // And rendering was not a path back to the database: the store still reads
+    // empty, so nothing the pane did issued a query.
+    assert!(store.current().sessions.is_empty());
 }
 
 #[test]

--- a/tests/kernel_perf.rs
+++ b/tests/kernel_perf.rs
@@ -7,18 +7,15 @@
 
 use thurbox::kernel::command::{Args, Command, CommandBus};
 use thurbox::kernel::host::{LuaHost, RenderContext};
-use thurbox::kernel::perf::{Counters, Snapshot as Perf};
-use thurbox::kernel::snapshot::SnapshotStore;
+use thurbox::kernel::perf::Counters;
+use thurbox::kernel::snapshot::{SnapshotStore, REFRESH_INTERVAL};
 use thurbox::storage::Database;
 
+mod common;
+
+/// This file renders nothing focused; the width and height are what vary.
 fn ctx(width: u16, height: u16) -> RenderContext {
-    RenderContext {
-        width,
-        height,
-        focused: false,
-        elapsed: 0.0,
-        frame: 0,
-    }
+    common::ctx(width, height, false)
 }
 
 fn plugin_dir(source: &str) -> tempfile::TempDir {
@@ -103,22 +100,30 @@ fn counters_distinguish_painted_frames_from_skipped_ones() {
 }
 
 #[test]
-fn a_snapshot_read_never_touches_the_database() {
+fn an_idle_store_stops_querying_the_database() {
     // ADR-P6 re-derived: v1 cached hook state behind a `data_version` check to
-    // keep an idle tick off the sessions table. Here the shape makes it
-    // structural — reads come from the snapshot, and refresh is the only thing
-    // that queries.
+    // keep an idle tick off the sessions table. The interval alone would re-read
+    // five tables every 400 ms forever on a database nobody wrote to, so the
+    // property is that a due refresh with no commit behind it does not rebuild.
+    //
+    // This used to time ten thousand `current()` calls against a store that owned
+    // no database at all, and assert only that the clock had not moved much: it
+    // measured a field read, and would have passed with the gate deleted.
     let db = Database::open_in_memory().expect("db");
-    let store = SnapshotStore::with_database(db);
+    let mut store = SnapshotStore::with_database(db);
+    let rows = store.current().sessions.clone();
 
-    let started = std::time::Instant::now();
-    for _ in 0..10_000 {
-        let _ = store.current().sessions.len();
-    }
+    // Past the interval, so `data_version` is the only thing left to stop a
+    // rebuild — and nothing committed.
+    std::thread::sleep(REFRESH_INTERVAL + std::time::Duration::from_millis(50));
     assert!(
-        started.elapsed() < std::time::Duration::from_millis(500),
-        "10k reads took {:?} — they are not coming from memory",
-        started.elapsed()
+        !store.refresh_if_due(),
+        "an idle store rebuilt anyway — the data_version gate is gone"
+    );
+    assert_eq!(
+        store.current().sessions,
+        rows,
+        "and the rows a plugin reads are the ones already in memory"
     );
 }
 
@@ -173,6 +178,4 @@ fn rendering_many_panes_stays_within_a_frame_budget() {
         each < std::time::Duration::from_millis(20),
         "a 200-row pane took {each:?} per render"
     );
-
-    let _ = Perf::default();
 }

--- a/tests/v2_decoration.rs
+++ b/tests/v2_decoration.rs
@@ -14,7 +14,7 @@
 
 use ratatui::style::{Color, Modifier, Style};
 
-use thurbox::kernel::convert::{to_lua, to_node};
+use thurbox::kernel::convert::{to_lua, to_node_decorated};
 use thurbox::kernel::node::{Identity, Node, Run};
 
 fn styled_tree() -> Node {
@@ -46,10 +46,15 @@ fn styled_tree() -> Node {
 }
 
 /// The round trip a decorator sits inside: Node → Lua → Node.
+///
+/// `to_node_decorated` rather than `to_node` because that is the entry point
+/// `LuaHost::decorate` uses, and it is the one that accepts back the resolved
+/// program id `to_lua` emits — the plain path resolves a program name against
+/// the plugin that wrote it, so it rejects an id it did not mint.
 fn round_trip(node: &Node) -> Node {
     let lua = mlua::Lua::new();
     let value = to_lua(&lua, node).expect("to_lua");
-    to_node(&value, "plugins/90_test.lua").expect("to_node")
+    to_node_decorated(&value, "plugins/90_test.lua").expect("to_node_decorated")
 }
 
 #[test]
@@ -115,6 +120,13 @@ fn an_unstyled_run_stays_unstyled() {
 /// scrolled paragraph jumped back to the top, an input lost its colour, and a
 /// plugin-fed surface — where a review diff's syntax colouring lives — was
 /// flattened to plain text.
+///
+/// Two of them only show up on shapes this test deliberately uses rather than
+/// the simplest one that renders: the frame title is **two differently-styled
+/// runs** (the creation wizard writes one, and a title flattened to a string
+/// comes back in a single colour), and one child is a **program** surface (whose
+/// resolved id the plain read path refuses, so the pane a decorator wrapped
+/// became an error panel).
 #[test]
 fn every_field_survives_the_trip_out_and_back() {
     use thurbox::kernel::node::{Align, Axis, Borders, Frame, Size, SurfaceSource};
@@ -131,7 +143,18 @@ fn every_field_survives_the_trip_out_and_back() {
             max: Some(9),
         },
         frame: Some(Frame {
-            title: Some(vec![thurbox::kernel::node::Run::plain("Panel")]),
+            title: Some(vec![
+                Run {
+                    text: "Panel".into(),
+                    style: Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                },
+                Run {
+                    text: " idle".into(),
+                    style: Style::default().fg(Color::DarkGray),
+                },
+            ]),
             borders: Borders::All,
             border_style: Style::default().fg(Color::Magenta),
             style: Style::default().bg(Color::Indexed(17)),
@@ -175,6 +198,16 @@ fn every_field_survives_the_trip_out_and_back() {
                         style: Style::default().fg(Color::Red),
                     },
                 ]]),
+            },
+            Node::Surface {
+                identity: Identity::default(),
+                size: Default::default(),
+                frame: None,
+                scroll: 0,
+                // The id as the kernel resolved it, which is what a decorator is
+                // handed: it names the plugin that started the program, so it
+                // must survive the trip rather than be re-stamped or refused.
+                source: SurfaceSource::Program("program:plugins/91_watch.lua#watch".into()),
             },
         ],
     };

--- a/tests/v2_keymap.rs
+++ b/tests/v2_keymap.rs
@@ -109,6 +109,7 @@ fn press(chord: &str) -> KeyPress {
             "ctrl" => key.ctrl = true,
             "alt" => key.alt = true,
             "shift" => key.shift = true,
+            "cmd" => key.cmd = true,
             name => {
                 key.name = name.to_string();
                 let mut chars = name.chars();
@@ -430,6 +431,67 @@ fn no_plugin_claims_a_chord_the_kernel_reserves() {
             binding.chord
         );
     }
+}
+
+#[test]
+fn declaring_a_reserved_chord_fails_the_load_instead_of_never_firing() {
+    // The escape route is dispatched before the registry is consulted, so a
+    // pane claiming one of its chords used to load, appear in F1 and in
+    // `bindings()`, and simply never fire — a no-op with no symptom for
+    // whoever wrote it. Refused where the declaration is read, which is what
+    // `plugin check` turns into a non-zero exit.
+    for reserved in RESERVED {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let plugins = dir.path().join("plugins");
+        std::fs::create_dir_all(&plugins).expect("mkdir");
+        std::fs::write(
+            plugins.join("50_greedy.lua"),
+            format!(
+                "return {{\n\
+                   name = \"greedy\", slot = \"center\",\n\
+                   keys = {{ {{ key = \"{reserved}\", action = \"greedy.take\", desc = \"take\" }} }},\n\
+                   render = function() return {{ type = \"text\", text = \"mine\" }} end,\n\
+                 }}\n"
+            ),
+        )
+        .expect("write");
+
+        let host = LuaHost::new(dir.path());
+        let error = host
+            .error
+            .as_deref()
+            .unwrap_or_else(|| panic!("declaring {reserved} must be refused"));
+        assert!(
+            error.contains("50_greedy") && error.contains(reserved),
+            "the error names the file and the chord: {error}"
+        );
+        assert!(
+            host.declarations().0.is_empty(),
+            "and nothing of the refused declaration is registered"
+        );
+    }
+}
+
+#[test]
+fn a_chord_the_kernel_does_not_reserve_still_declares() {
+    // The other half: the check is on the reserved list, not on chords that
+    // merely look kernel-ish, so an ordinary F-key pane still loads.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plugins = dir.path().join("plugins");
+    std::fs::create_dir_all(&plugins).expect("mkdir");
+    std::fs::write(
+        plugins.join("50_polite.lua"),
+        "return {\n\
+           name = \"polite\", slot = \"center\",\n\
+           keys = { { key = \"f9\", action = \"polite.take\", desc = \"take\" } },\n\
+           render = function() return { type = \"text\", text = \"mine\" } end,\n\
+         }\n",
+    )
+    .expect("write");
+
+    let host = LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    assert_eq!(host.declarations().0.len(), 1);
 }
 
 #[test]

--- a/tests/v2_new_session.rs
+++ b/tests/v2_new_session.rs
@@ -1,7 +1,8 @@
 //! The new-session flow, against the real bundled plugin.
 //!
-//! What is worth testing here is not the pixels — `tests/v2_parity.rs` owns that
-//! — but the two things v1 got wrong often enough to have grown machinery for:
+//! What is worth testing here is not the pixels — the gap to v1 is tracked in
+//! `openspec/changes/v2-parity-gaps/` — but the two things v1 got wrong often
+//! enough to have grown machinery for:
 //! **which step the flow is on** after each keystroke, and **what the create
 //! command it finally issues actually carries**. Both are observable from
 //! outside: the step from what is drawn, the command from the queue it is pushed
@@ -175,10 +176,17 @@ fn drawn(host: &LuaHost, world: &World) -> String {
     let Some(float) = rendered.float else {
         return String::new();
     };
-    // The flow asks in cells for its height and a share of the screen for its
-    // width, exactly as v1's modals are sized.
+    // Sized the way `App::float_rect` sizes it: cells when the plugin gives them,
+    // else a share of the screen. The flow gives both — `cols`, because the row
+    // budget it middle-truncates against (`ROW_COLS`) is in columns, so asking as
+    // a percentage meant the two agreed only at an 80-column terminal. Reading
+    // `width_pct` here painted a 72-column float the binary never draws, and
+    // every truncation assertion below was made against 16 columns of slack that
+    // do not exist.
     let rows = float.rows.expect("the flow sizes its own height");
-    let width = (120.0 * float.width_pct / 100.0) as u16;
+    let width = float
+        .cols
+        .unwrap_or_else(|| (120.0 * float.width_pct / 100.0) as u16);
     let mut terminal = Terminal::new(TestBackend::new(width, rows)).expect("terminal");
     terminal
         .draw(|frame| {
@@ -764,7 +772,7 @@ fn a_member_of_a_folder_cannot_be_forgotten_on_its_own() {
         host.drain_commands().is_empty(),
         "a child has no memory of its own to forget"
     );
-    assert!(drawn(&host, &world).contains("delete the parent header instead"));
+    assert!(drawn(&host, &world).contains("delete the header instead"));
 }
 
 // ── Through to creation ────────────────────────────────────────────────────

--- a/tests/v2_plugin_authoring.rs
+++ b/tests/v2_plugin_authoring.rs
@@ -543,7 +543,7 @@ fn the_listing_tells_a_file_you_installed_from_one_you_wrote() {
     // The spec is part of what the interface is made of, and it is not a pane that
     // failed to load — which is what it would read as without its own kind.
     let spec = row("plugins.toml");
-    assert_eq!(spec["kind"], "manifest", "{spec}");
+    assert_eq!(spec["kind"], "spec", "{spec}");
     assert_ne!(spec["state"], "failed", "{spec}");
 
     // Edited locally, or re-tagged upstream under the same pin. Either way the
@@ -772,4 +772,108 @@ fn the_pane_that_draws_by_default_is_not_warned_about() {
         "the shipped interface must be quiet: {:?}",
         output.json
     );
+}
+
+// ── what a plugin may put in `store` ───────────────────────────────────────
+
+/// Render one plugin from `source` and return the text it drew.
+fn drew(source: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plugins = dir.path().join("plugins");
+    std::fs::create_dir_all(&plugins).expect("mkdir");
+    std::fs::write(plugins.join("10_probe.lua"), source).expect("write");
+
+    let host = thurbox::kernel::host::LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    let node = host
+        .render(
+            0,
+            thurbox::kernel::host::RenderContext {
+                width: 40,
+                height: 1,
+                focused: false,
+                elapsed: 0.0,
+                frame: 0,
+            },
+        )
+        .unwrap_or_else(|e| panic!("the plugin should render: {e}"))
+        .node;
+    let mut terminal =
+        ratatui::Terminal::new(ratatui::backend::TestBackend::new(40, 1)).expect("terminal");
+    terminal
+        .draw(|frame| {
+            thurbox::kernel::paint::render(
+                frame,
+                frame.area(),
+                &node,
+                &thurbox::kernel::paint::PlaceholderSurfaces,
+            )
+        })
+        .expect("draw");
+    let buffer = terminal.backend().buffer().clone();
+    (0..40)
+        .map(|x| buffer[(x, 0)].symbol().to_string())
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+#[test]
+fn a_cyclic_table_written_to_store_is_refused_rather_than_overflowing() {
+    // `store.x = t` where `t[1] = t` used to recurse until the stack was gone,
+    // and stack exhaustion is an ABORT: the terminal-restoring hook never runs
+    // and the shell inherits raw mode from a process that is already dead. The
+    // render path refuses a cyclic tree for the same reason
+    // (`convert::MAX_DEPTH`); this is the persistence path's half of it.
+    let drawn = drew(
+        r#"return {
+             name = "probe", slot = "a",
+             render = function()
+               local t = {}
+               t[1] = t
+               t[2] = t
+               store.cycle = t
+               return { type = "text", text = "survived " .. type(store.cycle) }
+             end,
+           }"#,
+    );
+    assert_eq!(
+        drawn, "survived nil",
+        "the write must not land, and the process must still be here"
+    );
+}
+
+#[test]
+fn a_cyclic_table_written_to_state_is_refused_too() {
+    // `state` goes through the same converter as `store`, so it inherits the
+    // same bounds — worth asserting, since only one of the two was ever the
+    // reported crash.
+    let drawn = drew(
+        r#"return {
+             name = "probe", slot = "a",
+             render = function()
+               local t = {}
+               t.self = t
+               state.cycle = t
+               return { type = "text", text = "survived " .. type(state.cycle) }
+             end,
+           }"#,
+    );
+    assert_eq!(drawn, "survived nil");
+}
+
+#[test]
+fn an_ordinary_nested_table_still_round_trips() {
+    // The bound must not cost a plugin the shallow tables it actually keeps —
+    // a guard that refuses real state is a regression wearing a fix's clothes.
+    let drawn = drew(
+        r#"return {
+             name = "probe", slot = "a",
+             render = function()
+               store.prefs = { filter = { query = "err", case = false } }
+               return { type = "text", text = "kept " .. store.prefs.filter.query }
+             end,
+           }"#,
+    );
+    assert_eq!(drawn, "kept err");
 }

--- a/tests/v2_plugin_commands.rs
+++ b/tests/v2_plugin_commands.rs
@@ -244,11 +244,98 @@ fn a_plugin_reads_its_own_answers_and_no_one_elses() {
     );
 }
 
+/// A pane declaring **no** capabilities reads empty tables, not whatever the
+/// plugin rendered before it in the same frame.
+///
+/// `thurbox.runs` and `thurbox.granted` are written only by `enter`, and
+/// `publish` rebuilds the `thurbox` table once per frame — so an `enter` that
+/// skipped those two writes for a capability-less pane left the *previous*
+/// plugin's values in place under the names a pane reads its own by. Absence is
+/// the grant model; a stale value is not absence, so the skip handed an
+/// untrusted third-party pane a trusted one's captured stdout.
+///
+/// Renders `a` first on purpose: that is the order in which the leak existed.
+#[test]
+fn a_pane_that_declares_nothing_inherits_no_one_elses_answers() {
+    let bare = r#"return {
+  name = "bare",
+  slot = "sessions",
+  render = function()
+    local runs = (thurbox and thurbox.runs) or {}
+    local got = runs["mine"]
+    local granted = (thurbox and thurbox.granted) or {}
+    local seen = 0
+    for _ in pairs(runs) do
+      seen = seen + 1
+    end
+    return {
+      type = "text",
+      text = (got and got.stdout or "nothing")
+        .. " runs=" .. seen
+        .. " run=" .. tostring(granted.run)
+        .. " program=" .. tostring(granted.program),
+    }
+  end,
+}"#;
+    let (_home, ui) = interface(&[("91_a.lua", &reader("a")), ("92_bare.lua", bare)]);
+    let host = LuaHost::new(&ui);
+    host.set_trusted(vec!["plugins/91_a.lua".to_string()]);
+    let mut answers = std::collections::HashMap::new();
+    answers.insert(
+        "plugins/91_a.lua".to_string(),
+        vec![(
+            "mine".to_string(),
+            Run::Done(thurbox::kernel::runs::Output {
+                stdout: "secret".into(),
+                stderr: String::new(),
+                status: Some(0),
+                truncated: false,
+                timed_out: false,
+            }),
+        )],
+    );
+    host.set_runs(answers);
+
+    let context = RenderContext {
+        width: 60,
+        height: 4,
+        focused: true,
+        elapsed: 0.0,
+        frame: 0,
+    };
+    let a = host
+        .render(host.index_of("a").expect("a"), context)
+        .expect("render a");
+    assert!(
+        format!("{:?}", a.node).contains("secret"),
+        "a reads its own"
+    );
+
+    let bare = format!(
+        "{:?}",
+        host.render(host.index_of("bare").expect("bare"), context)
+            .expect("render bare")
+            .node
+    );
+    assert!(
+        !bare.contains("secret"),
+        "a capability-less pane read a's output: {bare}"
+    );
+    assert!(
+        bare.contains("runs=0"),
+        "runs must be empty, not inherited: {bare}"
+    );
+    assert!(
+        bare.contains("run=nil") && bare.contains("program=nil"),
+        "granted must be empty, not inherited: {bare}"
+    );
+}
+
 /// A pane that prints whatever its `mine` run returned.
 ///
-/// Declares the capability because only a plugin that can ASK can have answers —
-/// the kernel skips the whole per-call publish for one that declared nothing,
-/// since it could never have any.
+/// Declares the capability because only a plugin that can ASK can have answers.
+/// A pane that declares nothing still gets the publish — with empty tables; see
+/// `a_pane_that_declares_nothing_inherits_no_one_elses_answers`.
 fn reader(name: &str) -> String {
     format!(
         r#"return {{

--- a/tests/v2_plugin_lifecycle.rs
+++ b/tests/v2_plugin_lifecycle.rs
@@ -334,6 +334,46 @@ fn restoring_brings_a_removed_pane_back() {
     );
 }
 
+/// A shipped doc is delivered, tombstoned and restorable like any other file.
+///
+/// `ui/` ships four `.md` files an agent reads before it edits a pane, and
+/// delivery treats them exactly as it treats the Lua: `sources` lists them and
+/// `remove` writes a tombstone. Restoring one was refused anyway — the door into
+/// the filesystem opened onto `.lua` only — so a doc deleted outside thurbox was
+/// listed as `removed` by the one view that could have put it back.
+#[test]
+fn restoring_brings_a_removed_doc_back() {
+    let dir = interface();
+    bundled::remove(dir.path(), "AGENTS.md").expect("remove");
+    bundled::materialize(dir.path());
+    assert!(
+        !dir.path().join("AGENTS.md").exists(),
+        "a deleted file stays deleted"
+    );
+    assert_eq!(sources(dir.path())["AGENTS.md"], Source::Removed);
+
+    bundled::restore(dir.path(), "AGENTS.md").expect("restore");
+    assert_eq!(
+        sources(dir.path())["AGENTS.md"],
+        Source::Bundled,
+        "restored means shipped, not edited"
+    );
+}
+
+/// Bookkeeping nobody edits stays out of reach of the one door into the
+/// filesystem, which a plugin can ask through (`command("plugin", …)`).
+#[test]
+fn the_records_delivery_keeps_are_not_removable() {
+    let dir = interface();
+    for file in [".bundled.json", "plugins.lock", "ui.json"] {
+        assert!(
+            bundled::remove(dir.path(), file).is_err(),
+            "{file} is not the interface's to delete"
+        );
+        assert!(bundled::restore(dir.path(), file).is_err(), "{file}");
+    }
+}
+
 /// The recovery floor is a state, not a one-way door.
 ///
 /// A user copy that will not load is swapped for the bundled interface so thurbox
@@ -381,6 +421,60 @@ fn a_broken_interface_loads_again_once_it_is_fixed() {
     assert!(host.error.is_none(), "{:?}", host.error);
 
     let _ = fs::remove_dir_all(&floor);
+}
+
+/// `plugin list` reads the interface the way the interface does — including the
+/// set the user turned off.
+///
+/// It built a bare host instead, and `build` aborts the whole load on the first
+/// plugin that will not compile: a pane turned off *because* it was broken was
+/// still compiled, so `plugins` came back empty and every other pane in the
+/// listing read `failed`, with no slot and no capabilities. The listing is the
+/// tool for exactly that recovery, so it broke where it was needed.
+#[test]
+fn the_headless_listing_honours_the_panes_the_user_turned_off() {
+    let home = tempfile::tempdir().expect("tempdir");
+    std::env::set_var("THURBOX_CONFIG_DIR", home.path());
+    let ui = home.path().join("ui");
+    fs::create_dir_all(ui.join("plugins")).expect("mkdir");
+    std::env::set_var("THURBOX_UI_DIR", &ui);
+    assert!(bundled::materialize(&ui).errors.is_empty());
+
+    let broken = ui.join("plugins").join("95_broken.lua");
+    fs::write(
+        &broken,
+        "return {
+",
+    )
+    .expect("write");
+    // Keyed the way the interface keys it — `bundled::absolute_key`, which is
+    // what `App::apply_switch` writes and both readers look up. Joining the
+    // components instead produced an all-backslash key on Windows that matched
+    // nothing, so the pane came back `failed` (it does not compile) rather than
+    // `disabled`, and the test passed on Linux only.
+    Registry::load()
+        .set_disabled(&bundled::absolute_key(&ui, "plugins/95_broken.lua"), true)
+        .expect("turn it off");
+
+    let listing = thurbox::cli::plugins::run(thurbox::cli::plugins::Action::List).expect("list");
+    let state = |file: &str| -> String {
+        listing.json["files"]
+            .as_array()
+            .expect("files")
+            .iter()
+            .find(|row| row["file"] == file)
+            .map(|row| row["state"].as_str().unwrap_or_default().to_string())
+            .unwrap_or_else(|| panic!("{file} missing from {}", listing.json))
+    };
+    assert_eq!(state("plugins/95_broken.lua"), "disabled");
+    assert_ne!(
+        state("plugins/10_sessions.lua"),
+        "failed",
+        "the pane that loads is not blamed for the one nobody loads: {}",
+        listing.json
+    );
+    std::env::remove_var("THURBOX_CONFIG_DIR");
+    std::env::remove_var("THURBOX_UI_DIR");
 }
 
 /// Turning a pane off must not leave its column reserved and empty.

--- a/tests/v2_plugin_packages.rs
+++ b/tests/v2_plugin_packages.rs
@@ -13,6 +13,10 @@ use std::path::{Path, PathBuf};
 
 use thurbox::cli::plugins::{run, Action};
 
+mod common;
+
+use common::git_command;
+
 /// Point the interface directory at a fresh tempdir, with the bundled interface
 /// delivered — a plugin `require`s `lib/`, so a bare directory is not one yet.
 fn interface(dir: &Path) -> PathBuf {
@@ -299,6 +303,50 @@ fn a_module_may_not_be_delivered_outside_its_own_namespace() {
     );
 }
 
+#[test]
+fn a_pane_may_not_be_redirected_into_the_module_namespace() {
+    // The manifest half of this rule was always enforced; `--as` reached the
+    // destination without going through a manifest, so a pane could be delivered
+    // into `lib/` — where the loader never reads it (`is_nested_pane` is false for
+    // `lib/…`), the inventory classifies it as a module, and nothing reports a
+    // fault. An install that succeeds and draws nothing, with no symptom anywhere.
+    let home = tempfile::tempdir().expect("tempdir");
+    let ui = interface(home.path());
+    let theme = ui.join("lib/theme.lua");
+    let before = std::fs::read_to_string(&theme).expect("read");
+
+    // The degenerate shape: one `.lua` file, whose destination is `--as` alone.
+    let single = home.path().join("solo.lua");
+    std::fs::write(&single, "return {}\n").expect("write");
+    let error = run(Action::Install {
+        src: single.display().to_string(),
+        as_file: Some("lib/theme.lua".into()),
+        pin: None,
+    })
+    .expect_err("should refuse");
+    assert!(error.contains("plugins/"), "says where it belongs: {error}");
+
+    // And a package's pane, whose manifest proposed a legitimate destination.
+    let src = package(home.path(), "atlas", "v1", "atlas");
+    let error = run(Action::Install {
+        src: src.display().to_string(),
+        as_file: Some("lib/atlas/pane.lua".into()),
+        pin: None,
+    })
+    .expect_err("should refuse");
+    assert!(error.contains("plugins/"), "{error}");
+
+    assert_eq!(
+        std::fs::read_to_string(&theme).expect("read"),
+        before,
+        "the shipped module is untouched"
+    );
+    assert!(
+        !ui.join("plugins.toml").exists(),
+        "and nothing is recorded either"
+    );
+}
+
 // ── converging ─────────────────────────────────────────────────────────────
 
 #[test]
@@ -362,7 +410,7 @@ fn syncing_takes_back_what_the_spec_no_longer_lists() {
 
     let report = run(Action::Sync).expect("sync");
     assert_eq!(
-        report.json["entries"][0]["outcome"], "removed",
+        report.json["entries"][0]["outcome"], "withdrawn",
         "{:?}",
         report.json
     );
@@ -512,6 +560,72 @@ fn removing_works_without_the_source_and_refuses_an_unknown_name() {
     assert!(checked.failure.is_none(), "{:?}", checked.json);
 }
 
+/// What `withdraw` KEPT must be what the command reports.
+///
+/// Both callers used to discard the report and say `removed` unconditionally, so
+/// `plugin remove atlas` claimed a pane was gone while the edited file was still
+/// on disk, still loaded and still claiming its keys — with its spec entry now
+/// removed, so no later `sync` could ever explain it.
+#[test]
+fn a_file_the_user_changed_is_reported_as_kept_rather_than_removed() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let ui = interface(home.path());
+    let src = package(home.path(), "atlas", "v1", "atlas");
+    install(&src);
+
+    let pane = ui.join("plugins/75_atlas.lua");
+    std::fs::write(&pane, "return { name = \"mine\" }\n").expect("edit");
+
+    let removed = run(Action::Remove {
+        name: "atlas".into(),
+    })
+    .expect("remove");
+    assert_eq!(removed.json["outcome"], "kept", "{:?}", removed.json);
+    assert!(
+        pane.is_file(),
+        "the edit outlives the entry that delivered it"
+    );
+    assert!(
+        removed.json["kept"]
+            .to_string()
+            .contains("plugins/75_atlas.lua"),
+        "and the file that is still there is named: {:?}",
+        removed.json
+    );
+    assert!(
+        removed.human.contains("kept"),
+        "including for a reader: {}",
+        removed.human
+    );
+}
+
+#[test]
+fn syncing_reports_what_it_could_not_take_back() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let ui = interface(home.path());
+    let src = package(home.path(), "atlas", "v1", "atlas");
+    install(&src);
+    std::fs::write(ui.join("lib/atlas/util.lua"), "return {}\n").expect("edit the module");
+    std::fs::write(ui.join("plugins.toml"), "").expect("empty the spec");
+
+    let report = run(Action::Sync).expect("sync");
+    let entry = &report.json["entries"][0];
+    assert_eq!(entry["outcome"], "kept", "{:?}", report.json);
+    assert!(
+        entry["kept"].to_string().contains("lib/atlas/util.lua"),
+        "{:?}",
+        report.json
+    );
+    assert!(
+        ui.join("lib/atlas/util.lua").is_file(),
+        "a changed module is the user's, entry or no entry"
+    );
+    assert!(
+        !ui.join("plugins/75_atlas.lua").exists(),
+        "what was untouched is still taken back"
+    );
+}
+
 // ── a plugin that carries more than Lua ────────────────────────────────────
 
 /// Build a throwaway plugin **repository**: a pane in a nested directory, a module
@@ -546,16 +660,7 @@ fn plugin_repo(root: &Path, marker: &str) -> PathBuf {
     std::fs::write(repo.join("bin/payload.bin"), [0x00u8, 0xff, 0xfe, 0x01]).expect("payload");
 
     let git = |args: &[&str]| {
-        let status = std::process::Command::new("git")
-            .args(args)
-            .current_dir(&repo)
-            // The pre-commit hook exports these; without scrubbing them a test's git
-            // call lands in the real repository.
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
-            .status()
-            .expect("git");
+        let status = git_command(&repo, args).status().expect("git");
         assert!(status.success(), "git {args:?}");
     };
     git(&["init", "--initial-branch=main"]);
@@ -567,17 +672,9 @@ fn plugin_repo(root: &Path, marker: &str) -> PathBuf {
     repo
 }
 
-/// Run git in `repo`, scrubbing the location variables the pre-commit hook exports
-/// — without which a test's git call lands in the real repository.
+/// Run git in `repo`, returning its stdout.
 fn git_in(repo: &Path, args: &[&str]) -> String {
-    let out = std::process::Command::new("git")
-        .args(args)
-        .current_dir(repo)
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .output()
-        .expect("git");
+    let out = git_command(repo, args).output().expect("git");
     assert!(
         out.status.success(),
         "git {args:?}: {}",
@@ -995,14 +1092,8 @@ fn a_cloned_repository_takes_its_pane_from_its_own_manifest() {
     )
     .expect("manifest");
     let git = |args: &[&str]| {
-        std::process::Command::new("git")
-            .args(args)
-            .current_dir(&repo)
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
-            .status()
-            .expect("git");
+        let status = git_command(&repo, args).status().expect("git");
+        assert!(status.success(), "git {args:?}");
     };
     git(&["add", "-A"]);
     git(&["commit", "-m", "manifest"]);
@@ -1041,14 +1132,8 @@ fn a_repository_with_several_panes_and_no_manifest_says_so() {
     )
     .expect("second pane");
     for args in [vec!["add", "-A"], vec!["commit", "-m", "two"]] {
-        std::process::Command::new("git")
-            .args(&args)
-            .current_dir(&repo)
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
-            .status()
-            .expect("git");
+        let status = git_command(&repo, &args).status().expect("git");
+        assert!(status.success(), "git {args:?}");
     }
 
     // Guessing which is the entry point would be a silent wrong answer.

--- a/tests/v2_plugin_programs.rs
+++ b/tests/v2_plugin_programs.rs
@@ -12,33 +12,16 @@
 //! that is absent until you read the error, and a pane resolved to the wrong owner
 //! looks like nothing at all until two plugins both want `watch`.
 
-use thurbox::kernel::host::{Capability, LuaHost, RenderContext};
+use thurbox::kernel::host::{Capability, LuaHost};
 use thurbox::kernel::terminal::{ProgramKey, Terminals};
 
-/// Build an interface out of `plugins`, each `(file name, source)`.
-fn interface(plugins: &[(&str, &str)]) -> (tempfile::TempDir, std::path::PathBuf) {
-    let home = tempfile::tempdir().expect("tempdir");
-    let ui = home.path().join("ui");
-    thurbox::kernel::bundled::materialize(&ui);
-    for (name, source) in plugins {
-        std::fs::write(ui.join("plugins").join(name), source).expect("write");
-    }
-    (home, ui)
-}
+mod common;
+
+use common::{ctx, index_of, interface, publish};
 
 fn render(host: &LuaHost, name: &str) -> thurbox::kernel::host::Rendered {
-    let index = host.index_of(name).unwrap_or_else(|| panic!("no {name}"));
-    host.render(
-        index,
-        RenderContext {
-            width: 40,
-            height: 10,
-            focused: true,
-            elapsed: 0.0,
-            frame: 0,
-        },
-    )
-    .expect("render")
+    host.render(index_of(host, name), ctx(40, 10, true))
+        .expect("render")
 }
 
 /// A pane that asks for a program and draws its surface.
@@ -144,16 +127,7 @@ fn a_pane_name_that_could_not_be_a_window_is_a_load_error_not_a_missing_pane() {
     let host = LuaHost::new(&ui);
     let index = host.index_of("bad").expect("the plugin itself loads");
     let error = host
-        .render(
-            index,
-            RenderContext {
-                width: 40,
-                height: 10,
-                focused: true,
-                elapsed: 0.0,
-                frame: 0,
-            },
-        )
+        .render(index, ctx(40, 10, true))
         .expect_err("the tree must not convert");
     let text = format!("{error:?}");
     assert!(text.contains("program"), "{text}");
@@ -252,17 +226,19 @@ fn a_program_surface_is_never_resolved_to_a_session() {
 
 // ── not a session ──────────────────────────────────────────────────────────
 
-/// Nothing that enumerates sessions can see a plugin's pane.
+/// No session-facing read claims a program id as one of its own.
 ///
-/// It holds because a pane is never a database row — but it is asserted, because
-/// the machinery underneath is shared with sessions and a leak would be a session
-/// the user cannot delete, restart or explain.
+/// Every answer here is negative with nothing running, which is exactly what is
+/// being pinned: program panes and sessions share one id space and one
+/// `Terminals`, so what must hold is that a program surface id is never
+/// *mistaken* for a session id by any of these reads. Whether a live pane leaks
+/// into the session set needs a real process and is checked by hand — see the
+/// module doc — so this is the half that is checkable without a multiplexer.
 #[test]
-fn a_program_pane_is_absent_from_every_session_enumeration() {
+fn no_session_facing_read_claims_a_program_id() {
     let terminals = Terminals::new();
     let key = ProgramKey::new("plugins/91_watch.lua", "watch");
 
-    // Not attached, not failed, has no shell, and contributes no output generation.
     assert!(!terminals.is_attached(&key.surface_id()));
     assert!(terminals.failure(&key.surface_id()).is_none());
     assert!(!terminals.has_shell(&key.surface_id()));
@@ -293,33 +269,7 @@ fn a_plugin_can_read_the_platform_it_is_running_on() {
     let host = LuaHost::new(&ui);
     assert!(host.error.is_none(), "{:?}", host.error);
 
-    let themes = thurbox::kernel::theme::Themes::load(None);
-    let diffs = thurbox::kernel::diff::DiffStore::new();
-    let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
-    let snapshot = thurbox::kernel::snapshot::Snapshot::default();
-    let registry = thurbox::kernel::registry::Registry::default();
-    host.publish(&thurbox::kernel::host::Published {
-        snapshot: &snapshot,
-        attach_errors: &Default::default(),
-        inflight: &[],
-        themes: &themes,
-        registry: &registry,
-        diffs: &diffs,
-        links: &Default::default(),
-        content: &Default::default(),
-        meta: &Default::default(),
-        metrics: &Default::default(),
-        status_rows: 0,
-        can_open: true,
-        inventory: &[],
-        ui_dir: &ui.display().to_string(),
-        settings: &Default::default(),
-        repos: &repos,
-        wants: &Default::default(),
-        focus: Some("probe"),
-        hovered: None,
-    })
-    .expect("publish");
+    publish(&host, &thurbox::kernel::snapshot::Snapshot::default());
 
     let drawn = format!("{:?}", render(&host, "probe").node);
     // The values the binary was built for — asserted against the same constants, so

--- a/tests/v2_session_list.rs
+++ b/tests/v2_session_list.rs
@@ -6,43 +6,24 @@
 //! than being overwritten on the next frame. v1 has one `App::select_session` for
 //! that; here it is a value two plugins share, so the rule has to be asserted.
 
-use thurbox::kernel::command::Command;
-use thurbox::kernel::host::{KeyPress, LuaHost, Published, RenderContext};
-use thurbox::kernel::registry::Registry;
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+
+use thurbox::kernel::command::{Command, InFlight, Phase};
+use thurbox::kernel::host::{LuaHost, PluginError};
+use thurbox::kernel::paint::{self, PlaceholderSurfaces};
 use thurbox::kernel::snapshot::{GitState, SessionRow, Snapshot};
-use thurbox::kernel::theme::Themes;
+
+mod common;
+
+use common::{ctx, host, index_of, press, publish, publish_with, registry};
 
 const PLUGIN: &str = "sessions";
 
-fn host() -> LuaHost {
-    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
-    let host = LuaHost::new(dir);
-    assert!(host.error.is_none(), "{:?}", host.error);
-    host
-}
-
 fn row(id: &str, name: &str) -> SessionRow {
     SessionRow {
-        id: id.into(),
-        name: name.into(),
-        agent: "claude".into(),
-        status: "idle".into(),
         cwd: Some(std::path::PathBuf::from("/src/thurbox")),
-        repo: Some("thurbox".into()),
-        repos: vec!["thurbox".into()],
-        branch: Some("main".into()),
-        base_branch: None,
-        backend: "local-tmux".into(),
-        backend_id: Some("%1".into()),
-        remote_host: None,
-        agent_session_id: None,
-        parent_id: None,
-        display_order: None,
-        worktree_count: 0,
-        git: None,
-        hook_state: None,
-        shell_backend_id: None,
-        member_dirs: Vec::new(),
+        ..common::session_row(id, name)
     }
 }
 
@@ -53,82 +34,35 @@ fn snapshot() -> Snapshot {
     }
 }
 
-fn publish_in(host: &LuaHost, snapshot: &Snapshot) {
-    let themes = Themes::load(None);
-    let mut registry = Registry::default();
-    let (bindings, settings) = host.declarations();
-    registry.declare(bindings, settings);
-    let diffs = thurbox::kernel::diff::DiffStore::new();
-    let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
-    host.publish(&Published {
-        snapshot,
-        attach_errors: &Default::default(),
-        inflight: &[],
-        themes: &themes,
-        registry: &registry,
-        diffs: &diffs,
-        links: &Default::default(),
-        content: &Default::default(),
-        meta: &Default::default(),
-        metrics: &Default::default(),
-        status_rows: 0,
-        can_open: true,
-        inventory: &[],
-        ui_dir: "ui",
-        settings: &Default::default(),
-        repos: &repos,
-        wants: &Default::default(),
-        focus: None,
-        hovered: None,
-    })
-    .expect("publish");
-}
-
 /// Render the list, which is also what publishes the selection.
 fn render(host: &LuaHost) {
     render_in(host, &snapshot());
 }
 
 fn render_in(host: &LuaHost, snapshot: &Snapshot) {
-    publish_in(host, snapshot);
-    let index = host.index_of(PLUGIN).expect("no sessions plugin");
-    host.render(
-        index,
-        RenderContext {
-            width: 30,
-            height: 12,
-            focused: true,
-            elapsed: 0.0,
-            frame: 0,
-        },
-    )
-    .expect("render");
-}
-
-fn press(host: &LuaHost, chord: &str) {
-    press_in(host, &snapshot(), chord);
+    publish(host, snapshot);
+    host.render(index_of(host, PLUGIN), ctx(30, 12, true))
+        .expect("render");
 }
 
 fn press_in(host: &LuaHost, snapshot: &Snapshot, chord: &str) {
-    publish_in(host, snapshot);
-    let index = host.index_of(PLUGIN).expect("no sessions plugin");
-    let mut key = KeyPress {
-        name: chord.to_string(),
-        ..KeyPress::default()
-    };
-    if chord.chars().count() == 1 {
-        key.ch = chord.chars().next();
-    }
-    let mut registry = Registry::default();
-    let (bindings, settings) = host.declarations();
-    registry.declare(bindings, settings);
-    if let Some(binding) = registry.resolve(&key, Some(PLUGIN)) {
+    publish(host, snapshot);
+    dispatch(host, chord).expect("the pane must survive its own keys");
+}
+
+/// Route a chord the way the binary does — registry first, then raw `on_key` —
+/// and hand back the failure instead of unwrapping it, so a test can assert
+/// that a key does not take the pane down.
+fn dispatch(host: &LuaHost, chord: &str) -> Result<(), PluginError> {
+    let index = index_of(host, PLUGIN);
+    let key = press(chord);
+    if let Some(binding) = registry(host).resolve(&key, Some(PLUGIN)) {
         let action = binding.action.clone();
-        if host.on_action(index, &action).expect("on_action") {
-            return;
+        if host.on_action(index, &action)? {
+            return Ok(());
         }
     }
-    host.on_key(index, &key).expect("on_key");
+    host.on_key(index, &key).map(|_| ())
 }
 
 #[test]
@@ -137,7 +71,7 @@ fn enter_opens_the_selected_session() {
     // shows a session here, so opening is a focus change.
     let host = host();
     render(&host);
-    press(&host, "enter");
+    press_in(&host, &snapshot(), "enter");
     assert_eq!(
         host.drain_commands(),
         vec![Command::Focus {
@@ -165,7 +99,7 @@ fn the_list_publishes_the_session_under_its_cursor() {
     let host = host();
     render(&host);
     assert_eq!(host.shared_string("selected").as_deref(), Some("aaa"));
-    press(&host, "j");
+    press_in(&host, &snapshot(), "j");
     render(&host);
     assert_eq!(host.shared_string("selected").as_deref(), Some("bbb"));
 }
@@ -189,7 +123,7 @@ fn another_pane_can_steer_the_selection() {
 
     // And the cursor really moved with it, rather than the value merely sticking:
     // stepping on lands past the steered row, not past the old one.
-    press(&host, "k");
+    press_in(&host, &snapshot(), "k");
     render(&host);
     assert_eq!(host.shared_string("selected").as_deref(), Some("aaa"));
 }
@@ -225,19 +159,9 @@ fn clean() -> GitState {
 /// Render the confirmation float and return what it drew, so a test can ask
 /// whether a question was put at all — and what it itemised.
 fn confirm_tree(host: &LuaHost, snapshot: &Snapshot) -> String {
-    publish_in(host, snapshot);
-    let index = host.index_of("confirm").expect("no confirm plugin");
+    publish(host, snapshot);
     let rendered = host
-        .render(
-            index,
-            RenderContext {
-                width: 60,
-                height: 12,
-                focused: false,
-                elapsed: 0.0,
-                frame: 0,
-            },
-        )
+        .render(index_of(host, "confirm"), ctx(60, 12, false))
         .expect("render the confirmation");
     format!("{:?}", rendered.node)
 }
@@ -345,5 +269,130 @@ fn a_state_that_could_not_be_read_asks_rather_than_assume_clean() {
     assert!(
         confirm_tree(&host, &snapshot).contains("its state could not be read"),
         "and it says why it is asking"
+    );
+}
+
+/// A creation in flight for the repo the sessions are already in.
+///
+/// The pane learns about one from `thurbox.commands`: a `create` names no
+/// session yet, so it carries the repository as its `subject` and the list
+/// draws a placeholder at the end of that group. Matching the group label is
+/// the whole point — a `subject` nothing groups under produces no placeholder,
+/// and a test with no placeholder pins nothing.
+fn creating(repo: &str) -> Vec<InFlight> {
+    vec![InFlight {
+        id: 1,
+        kind: "create",
+        session: String::new(),
+        subject: Some(repo.to_string()),
+        phase: Phase::Running,
+        error: None,
+    }]
+}
+
+#[test]
+fn sorting_a_group_that_holds_a_creation_in_flight_does_not_take_the_pane_down() {
+    // The placeholder carries no `session`, and the comparator read
+    // `a[1].session.name` unconditionally. With two blocks in the group — the
+    // common case, since creating into a repo that already holds a session
+    // reuses that group — `table.sort` raised, `draw` cleared the PluginError on
+    // the next frame, and the observable behaviour was Shift+S doing nothing at
+    // all with no message.
+    let host = host();
+    let snapshot = Snapshot {
+        // Reverse alphabetical, so a sort that runs is a sort that is visible.
+        sessions: vec![row("bbb", "second"), row("aaa", "first")],
+        ..Snapshot::default()
+    };
+    publish_with(&host, &snapshot, &Default::default(), &creating("thurbox"));
+    host.render(index_of(&host, PLUGIN), ctx(46, 14, true))
+        .expect("render");
+
+    dispatch(&host, "S").expect("Shift+S must not error the pane");
+
+    // And it really sorted: the placeholder keeps the end of the group, where
+    // the row it will become is already drawn, and carries no id of its own.
+    assert_eq!(
+        host.drain_commands(),
+        vec![Command::Order {
+            list: vec!["aaa".into(), "bbb".into()],
+        }],
+        "the sorted order is persisted, without the placeholder in it"
+    );
+}
+
+/// The confirmation as it is PAINTED, one string per row.
+///
+/// Mirrors `draw_floats`: the plugin is probed with the whole screen and its
+/// tree painted into the float rect the kernel sizes for it. `confirm_tree`
+/// above cannot stand in for this — a text node carries its whole string
+/// whatever width it was given, so a slot narrower than its own label reads
+/// correct in the tree and clipped on the screen.
+fn confirm_paint(host: &LuaHost, snapshot: &Snapshot, screen: (u16, u16)) -> Vec<String> {
+    publish(host, snapshot);
+    let (screen_w, screen_h) = screen;
+    let rendered = host
+        .render(index_of(host, "confirm"), ctx(screen_w, screen_h, false))
+        .expect("render the confirmation");
+    let float = rendered
+        .float
+        .expect("a question that is up floats: the kernel has no other way to place it");
+    // `App::float_rect`'s own sizing — cells when the plugin knows them, else a
+    // share of the screen, clamped to what there is. Only the size is needed:
+    // the tree is painted at the origin here, and centring moves no cell within
+    // it.
+    let width = float
+        .cols
+        .unwrap_or((f64::from(screen_w) * float.width_pct / 100.0) as u16)
+        .min(screen_w);
+    let height = float
+        .rows
+        .unwrap_or((f64::from(screen_h) * float.height_pct / 100.0) as u16)
+        .min(screen_h);
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+    terminal
+        .draw(|frame| paint::render(frame, frame.area(), &rendered.node, &PlaceholderSurfaces))
+        .expect("draw");
+    let buffer = terminal.backend().buffer().clone();
+    (0..height)
+        .map(|y| {
+            (0..width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect()
+}
+
+#[test]
+fn both_pills_are_painted_whole() {
+    // The pill's slot is a fixed `len`, so a label longer than the number beside
+    // it is clipped on the right: `" [ Cancel ]"` is eleven columns and the slot
+    // said ten, which cost every confirmation its closing bracket. Invisible in
+    // the tree, hence the paint — and worth pinning because `70_new_session`'s
+    // footer records having made the identical mistake.
+    let host = host();
+    let mut snapshot = snapshot();
+    snapshot.sessions[0].git = Some(GitState {
+        files_changed: 1,
+        dirty: true,
+        ..clean()
+    });
+    render_in(&host, &snapshot);
+    press_in(&host, &snapshot, "D");
+
+    let painted = confirm_paint(&host, &snapshot, (100, 20));
+    // Anchored on the key hints, which share the row with the pills: anchoring
+    // on a pill's own label would make a clipped pill look like a missing row.
+    let pills = painted
+        .iter()
+        .find(|row| row.contains("esc cancel"))
+        .unwrap_or_else(|| panic!("no pill row was painted: {painted:?}"));
+    assert!(
+        pills.contains("[ Confirm ]"),
+        "the confirm pill lost a bracket: {pills:?}"
+    );
+    assert!(
+        pills.contains("[ Cancel ]"),
+        "the cancel pill lost a bracket: {pills:?}"
     );
 }

--- a/tests/v2_terminal_pane.rs
+++ b/tests/v2_terminal_pane.rs
@@ -11,47 +11,27 @@ use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 use ratatui::Terminal;
 
-use thurbox::kernel::host::{KeyPress, LuaHost, Published, RenderContext};
+use thurbox::kernel::host::{KeyPress, LuaHost};
 use thurbox::kernel::node::{ClickVerb, Node};
 use thurbox::kernel::paint::{render, render_recording, Hit, PlaceholderSurfaces};
-use thurbox::kernel::registry::Registry;
 use thurbox::kernel::snapshot::{SessionRow, Snapshot};
-use thurbox::kernel::theme::Themes;
+
+mod common;
+
+use common::{host, index_of, publish, registry};
 
 /// The plugin under test. It keeps its `agent` name: the name is what
 /// `command("focus", …)`, the footer's focus label and the tests below spell,
 /// and renaming it is a separate edit from merging the views.
 const TERMINAL: &str = "agent";
 
-fn host() -> LuaHost {
-    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
-    let host = LuaHost::new(dir);
-    assert!(host.error.is_none(), "{:?}", host.error);
-    host
-}
-
+/// A session with a worktree, so its title carries the branch bracket v1 draws
+/// there — the rest is the shared fixture.
 fn row(name: &str) -> SessionRow {
     SessionRow {
-        id: format!("{name}-0000-0000-0000-000000000000"),
-        name: name.into(),
-        agent: "claude".into(),
-        status: "idle".into(),
-        cwd: None,
-        repo: Some("thurbox".into()),
-        repos: vec!["thurbox".into()],
         branch: Some(format!("feat/{name}")),
-        base_branch: None,
-        backend: "local-tmux".into(),
-        backend_id: Some("%1".into()),
-        remote_host: None,
-        agent_session_id: None,
-        parent_id: None,
-        display_order: None,
         worktree_count: 1,
-        git: None,
-        hook_state: None,
-        shell_backend_id: None,
-        member_dirs: Vec::new(),
+        ..common::session_row(&format!("{name}-0000-0000-0000-000000000000"), name)
     }
 }
 
@@ -62,64 +42,18 @@ fn sample() -> Snapshot {
     }
 }
 
-fn registry(host: &LuaHost) -> Registry {
-    let mut registry = Registry::default();
-    let (bindings, settings) = host.declarations();
-    registry.declare(bindings, settings);
-    registry
-}
-
-fn publish(host: &LuaHost) {
-    let themes = Themes::load(None);
-    let registry = registry(host);
-    let diffs = thurbox::kernel::diff::DiffStore::new();
-    let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
-    host.publish(&Published {
-        snapshot: &sample(),
-        attach_errors: &Default::default(),
-        inflight: &[],
-        themes: &themes,
-        registry: &registry,
-        diffs: &diffs,
-        links: &Default::default(),
-        content: &Default::default(),
-        meta: &Default::default(),
-        metrics: &Default::default(),
-        status_rows: 0,
-        can_open: true,
-        inventory: &[],
-        ui_dir: "ui",
-        settings: &Default::default(),
-        repos: &repos,
-        wants: &Default::default(),
-        focus: None,
-        hovered: None,
-    })
-    .expect("publish");
-}
-
-fn ctx(width: u16, height: u16) -> RenderContext {
-    RenderContext {
-        width,
-        height,
-        focused: true,
-        elapsed: 0.0,
-        frame: 0,
-    }
-}
-
-fn index_of(host: &LuaHost, name: &str) -> usize {
-    host.plugins
-        .iter()
-        .position(|plugin| plugin.name == name)
-        .unwrap_or_else(|| panic!("no plugin named {name}"))
+/// This pane is only ever rendered focused here: the border style, the title
+/// badge and the tab chips all differ unfocused, and every assertion below is
+/// about the focused frame.
+fn ctx(width: u16, height: u16) -> thurbox::kernel::host::RenderContext {
+    common::ctx(width, height, true)
 }
 
 /// Publish, then let the session list choose a session — the terminal reads its
 /// choice out of `store`, exactly as it does in the binary.
 fn with_a_selection() -> LuaHost {
     let host = host();
-    publish(&host);
+    publish(&host, &sample());
     host.render(index_of(&host, "sessions"), ctx(40, 12))
         .expect("render the list");
     host
@@ -165,6 +99,25 @@ fn column_of(line: &str, needle: &str) -> u16 {
         .find(needle)
         .unwrap_or_else(|| panic!("{needle} is not on the border: {line}"));
     u16::try_from(line[..at].chars().count()).expect("a column")
+}
+
+/// A page key, which the pane answers rather than the registry: paging is this
+/// pane's own policy, so it is declared nowhere and reaches `on_key` raw.
+fn page(name: &str) -> KeyPress {
+    KeyPress {
+        name: name.into(),
+        ..KeyPress::default()
+    }
+}
+
+/// The right border column between the corners. The scrollbar is overlaid there
+/// rather than inset, so it costs the terminal grid no columns — and so a bar
+/// that should not be drawn shows up as a border cell that is not a border.
+fn right_border(painted: &[String]) -> String {
+    painted[1..painted.len() - 1]
+        .iter()
+        .map(|row| row.chars().last().expect("a row reaches its own border"))
+        .collect()
 }
 
 fn session_surface(node: &Node) -> String {
@@ -407,20 +360,59 @@ fn paging_is_the_agent_views_and_the_ptys_everywhere_else() {
     // page key is declined and reaches whatever is running in it instead.
     let host = with_a_selection();
     let index = index_of(&host, TERMINAL);
-    let page = KeyPress {
-        name: "pageup".into(),
-        ..KeyPress::default()
-    };
-    assert!(host.on_key(index, &page).expect("key"), "the agent scrolls");
+    assert!(
+        host.on_key(index, &page("pageup")).expect("key"),
+        "the agent scrolls"
+    );
 
     host.on_action(index, "terminal.shell").expect("select");
     assert!(
-        !host.on_key(index, &page).expect("key"),
+        !host.on_key(index, &page("pageup")).expect("key"),
         "the shell leaves it to the pty"
     );
     // And the title says nothing about a scroll the shell surface cannot honour.
     let line = painted(&tree(&host, 100, 10), 100, 10)[0].clone();
     assert!(!line.contains('↑'), "{line}");
+}
+
+#[test]
+fn paging_back_down_retires_the_scrollbar() {
+    // `pageup` counts past the real scrollback — there is no total to clamp an
+    // offset against — so the depth the bar is scaled against is a high-water
+    // mark. Kept once set, it outlived the scroll it measured: back at the live
+    // screen the bar was still drawn over a screen with nothing above it, thumb
+    // parked at the end of the track. Nothing in the tree says so — the body is
+    // the same `surface` node either way, and the bar is a border column — so
+    // this is asserted in the paint.
+    const W: u16 = 100;
+    const H: u16 = 12;
+    let host = with_a_selection();
+    let index = index_of(&host, TERMINAL);
+
+    assert!(host.on_key(index, &page("pageup")).expect("key"));
+    let scrolled = painted(&tree(&host, W, H), W, H);
+    assert!(
+        scrolled[0].contains("[10↑]"),
+        "the title counts the offset: {}",
+        scrolled[0]
+    );
+    assert!(
+        right_border(&scrolled).contains('█'),
+        "there has to be a bar for retiring it to mean anything: {:?}",
+        right_border(&scrolled)
+    );
+
+    assert!(host.on_key(index, &page("pagedown")).expect("key"));
+    let live = painted(&tree(&host, W, H), W, H);
+    // The `↑` marker is keyed on the offset, not on the mark, so it clears
+    // either way; it is asserted as the companion fact — with the offset back at
+    // zero, nothing on the frame claims a scroll.
+    assert!(!live[0].contains('↑'), "{}", live[0]);
+    let column = right_border(&live);
+    assert!(
+        column.chars().all(|cell| cell == '│'),
+        "at the live screen the border is a border again: {column:?}"
+    );
 }
 
 // ── the chips are click targets ───────────────────────────────────────────

--- a/ui/lib/widgets.lua
+++ b/ui/lib/widgets.lua
@@ -120,6 +120,54 @@ function widgets.middle_truncate(text, width)
     .. string.sub(text, offset(text, len - tail) + 1)
 end
 
+--- The FIRST `count` characters, clipped with no marker.
+---
+--- What a left-aligned border title does when it overruns its area: ratatui
+--- truncates the far side and adds nothing. Lives here rather than in the pane
+--- that needed it first, because two panes had a copy each under two names.
+function widgets.keep_left(text, count)
+  if count <= 0 then
+    return ""
+  end
+  if widgets.len(text) <= count then
+    return text
+  end
+  return string.sub(text, 1, offset(text, count))
+end
+
+--- The LAST `count` characters.
+---
+--- What a right-aligned border title does when it overruns: ratatui's
+--- `Line::render_with_alignment` skips from the left, so the title shrinks
+--- toward the right edge. v1's recorded frame shows exactly this — a 42-char
+--- title in a 40-wide pane renders as `╭-osc52 (claude) …`.
+function widgets.keep_right(text, count)
+  if count <= 0 then
+    return ""
+  end
+  local len = widgets.len(text)
+  if len <= count then
+    return text
+  end
+  return string.sub(text, offset(text, len - count) + 1)
+end
+
+--- v1's `ui::truncate_ellipsis`: `width - 1` characters plus `…`, and NOTHING at
+--- `width <= 1` because a lone ellipsis carries no information.
+---
+--- Deliberately not `widgets.truncate`, which returns `"…"` at width 1 — right
+--- for a name that must still show it was cut, wrong for a column that would
+--- rather spend the cell on the next field.
+function widgets.truncate_hard(text, width)
+  if widgets.len(text) <= width then
+    return text
+  end
+  if width <= 1 then
+    return ""
+  end
+  return widgets.keep_left(text, width - 1) .. "…"
+end
+
 --- Pad `text` out to `width` characters.
 function widgets.pad(text, width)
   local short = width - widgets.len(text)
@@ -214,8 +262,13 @@ function widgets.list(opts)
     }
   end
 
-  -- Overflow markers, so a windowed list never silently hides rows.
-  if more_above then
+  -- Overflow markers, so a windowed list never silently hides rows — but never
+  -- over the selection. `window` centres, so a one- or two-row window around a
+  -- middle selection has both flags set and no spare row: replacing the ends
+  -- then hid the very row the user is on (at height 1, twice). Reachable in the
+  -- shipped interface — an 11-row terminal leaves the search strip's list two
+  -- rows. A marker still appears wherever there is a row to spare.
+  if more_above and first ~= selected then
     children[1] = {
       type = "text",
       len = 1,
@@ -223,7 +276,7 @@ function widgets.list(opts)
       role = "overflow",
     }
   end
-  if more_below then
+  if more_below and last ~= selected then
     children[#children] = {
       type = "text",
       len = 1,
@@ -273,15 +326,29 @@ function widgets.hints(pairs_list)
   return { type = "text", len = 1, text = { spans } }
 end
 
---- The animated glyph for a session status.
+--- Which frame of the braille spinner this paint shows.
+---
+--- Eight frames a second off `elapsed`, which is the only monotonic reading a
+--- plugin gets (`ctx.elapsed`; the stdlib ships no `os`). One definition,
+--- because the expression was written out four times across three panes and two
+--- waits animating at different rates read as two different kinds of wait.
+function widgets.spinner_frame(elapsed)
+  local frame = math.floor((elapsed or 0) * 8) % #theme.spinner + 1
+  return theme.spinner[frame]
+end
+
+--- The animated glyph for a session status, and the colour to draw it in.
+---
+--- Returns the two values rather than a span: both call sites wrap the glyph
+--- themselves — one into a padded cell of a row, one into a panel-border dot —
+--- and a ready-made span was the reason this had no callers while every pane
+--- kept its own copy.
 function widgets.status_glyph(status, elapsed)
   local spec = theme.status(status)
-  local glyph = spec.glyph
   if status == "working" then
-    local frame = math.floor((elapsed or 0) * 8) % #theme.spinner + 1
-    glyph = theme.spinner[frame]
+    return widgets.spinner_frame(elapsed), spec.color
   end
-  return { text = glyph, style = { fg = spec.color } }
+  return spec.glyph, spec.color
 end
 
 --- Epoch milliseconds the frame is being drawn for.

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -76,32 +76,6 @@ local function patch_spans(spans, style, keep_fg)
   return spans
 end
 
---- First `count` characters, cut on a character boundary.
-local function utf8_sub(text, count)
-  if count <= 0 then
-    return ""
-  end
-  local last = utf8.offset(text, count + 1)
-  if not last then
-    return text
-  end
-  return string.sub(text, 1, last - 1)
-end
-
---- v1's `truncate_ellipsis`: a lone `…` carries nothing, so a budget of 1 or
---- less yields the empty string rather than an ellipsis (widgets.truncate keeps
---- the `…`, which is right for a name and wrong here).
-local function truncate_ellipsis(text, max)
-  local count = widgets.len(text)
-  if count <= max then
-    return text
-  end
-  if max <= 1 then
-    return ""
-  end
-  return utf8_sub(text, max - 1) .. "…"
-end
-
 -- ── Border composition ─────────────────────────────────────────────────────
 --
 -- A border row is built as a cell buffer so segments can be *layered* the way
@@ -430,15 +404,6 @@ local function header_line(label, inner_width)
   return { { text = text, style = { fg = theme.muted } } }
 end
 
-local function status_glyph(status, elapsed)
-  local spec = theme.status(status)
-  if status == "working" then
-    local frame = math.floor((elapsed or 0) * 8) % #theme.spinner + 1
-    return theme.spinner[frame], spec.color
-  end
-  return spec.glyph, spec.color
-end
-
 --- The status text that follows the name. v1 shows the agent's notification (or
 --- the word "Blocked") for a blocked row, and the OSC activity title otherwise;
 --- a row with neither carries no text, because the coloured dot already says
@@ -482,7 +447,7 @@ local function push_status(spans, text, style, inner_width)
   local avail = math.max(0, inner_width - used)
   if avail >= MIN_WIDTH then
     spans[#spans + 1] = { text = SEPARATOR }
-    spans[#spans + 1] = { text = truncate_ellipsis(text, avail), style = style }
+    spans[#spans + 1] = { text = widgets.truncate_hard(text, avail), style = style }
   end
 end
 
@@ -529,7 +494,7 @@ end
 
 local function session_line(item, inner_width, elapsed, is_selected, work)
   local session = item.session
-  local glyph, glyph_color = status_glyph(session.status, elapsed)
+  local glyph, glyph_color = widgets.status_glyph(session.status, elapsed)
   local status_style = { fg = glyph_color }
   -- A blocked row's text is an attention message, so it keeps the dot's colour;
   -- plain activity is muted, leaving the name the row's visual anchor. v1 draws
@@ -649,8 +614,7 @@ local function pending_line(command, inner_width, elapsed)
     glyph, glyph_style = "✗", { fg = theme.role("status_error") }
   else
     -- A spinner only while something is actually running.
-    local frame = math.floor((elapsed or 0) * 8) % #theme.spinner + 1
-    glyph, glyph_style = theme.spinner[frame], { fg = theme.warn }
+    glyph, glyph_style = widgets.spinner_frame(elapsed), { fg = theme.warn }
   end
 
   local label = command.subject or "new session"
@@ -988,6 +952,18 @@ local function move_block(items, at, down)
   return moved
 end
 
+--- The name a block sorts under, or nil for a block that has no session yet.
+---
+--- A placeholder carries `kind = "pending"` and no `session` (see `build_model`),
+--- so reading `.name` through it errored — `table.sort` raised, `draw` cleared
+--- the PluginError next frame, and the observable behaviour was Shift+S doing
+--- nothing at all with no message. The same class of bug is recorded against
+--- `depth` in `build_model`.
+local function sort_key(block)
+  local session = block[1].session
+  return session and (session.name or ""):lower() or nil
+end
+
 --- Sort by name **within each repo group**, preserving group order and the
 --- parent/child nesting: roots sort among themselves, each parent's children
 --- among theirs. v1's `sort_alphabetically_within_groups`.
@@ -1014,8 +990,18 @@ local function sorted_within_groups(items)
       block.position = position
     end
     table.sort(blocks, function(a, b)
-      local left = (a[1].session.name or ""):lower()
-      local right = (b[1].session.name or ""):lower()
+      local left, right = sort_key(a), sort_key(b)
+      -- Placeholders keep the end of the group, where the row they will become
+      -- is already drawn, and stay in their own order among themselves.
+      if not (left and right) then
+        if left then
+          return true
+        end
+        if right then
+          return false
+        end
+        return a.position < b.position
+      end
       if left == right then
         return a.position < b.position
       end
@@ -1231,7 +1217,7 @@ return {
     local dots = {}
     for _, item in ipairs(items) do
       if item.kind == "session" then
-        local glyph, color = status_glyph(item.session.status, ctx.elapsed)
+        local glyph, color = widgets.status_glyph(item.session.status, ctx.elapsed)
         dots[#dots + 1] = { text = glyph, style = { fg = color } }
       end
     end

--- a/ui/plugins/20_agent.lua
+++ b/ui/plugins/20_agent.lua
@@ -113,57 +113,10 @@ end
 
 -- --- text measurement ------------------------------------------------------
 --
--- `widgets.len`/`pad` are utf8-aware; `#` is not, and every glyph below is
--- multi-byte.
-
---- Keep the FIRST `max` characters, clipping the rest with no marker.
----
---- What a left-aligned border title does when it overruns its area: ratatui
---- truncates the far side and adds nothing.
-local function keep_left(text, max)
-  if max <= 0 then
-    return ""
-  end
-  if widgets.len(text) <= max then
-    return text
-  end
-  local cut = utf8 and utf8.offset(text, max + 1) or (max + 1)
-  return string.sub(text, 1, (cut or (#text + 1)) - 1)
-end
-
---- Keep the LAST `max` characters.
----
---- What a right-aligned border title does when it overruns: ratatui's
---- `Line::render_with_alignment` skips from the left, so the title shrinks
---- toward the right edge. v1's recorded frame shows exactly this — a 42-char
---- title in a 40-wide pane renders as `╭-osc52 (claude) …`.
-local function keep_right(text, max)
-  if max <= 0 then
-    return ""
-  end
-  local count = widgets.len(text)
-  if count <= max then
-    return text
-  end
-  local skip = count - max
-  local at = utf8 and utf8.offset(text, skip + 1) or (skip + 1)
-  return string.sub(text, at or (#text + 1))
-end
-
---- v1's `ui::truncate_ellipsis`: keep `max - 1` characters plus `…`, and return
---- NOTHING at `max <= 1` because a lone ellipsis carries no information.
----
---- Deliberately not `widgets.truncate`, which returns `"…"` at width 1.
-local function truncate_hard(text, max)
-  if widgets.len(text) <= max then
-    return text
-  end
-  if max <= 1 then
-    return ""
-  end
-  local cut = utf8 and utf8.offset(text, max) or max
-  return string.sub(text, 1, (cut or (#text + 1)) - 1) .. "…"
-end
+-- The cuts are `widgets.keep_left`/`keep_right`/`truncate_hard`: utf8-aware,
+-- where `#` is not, and a border title is full of multi-byte glyphs. They were
+-- local to this pane until the session list turned out to carry two of them
+-- under other names.
 
 --- v1's `ui::fit_right_title`: clamp a right-aligned title to what the tab strip
 --- on the left of the same border leaves it — the border minus its two corners,
@@ -174,7 +127,7 @@ local function fit_right_title(title, border_width, reserved_left)
     return title
   end
   local available = math.max(0, (border_width or 0) - 2 - reserved_left - 1)
-  return truncate_hard(title, available)
+  return widgets.truncate_hard(title, available)
 end
 
 -- --- the title -------------------------------------------------------------
@@ -333,11 +286,13 @@ local COLLAPSE_TOGGLE_MIN_WIDTH = 5
 --- border space for the tabs.
 local COLLAPSE_HINT_MIN_WIDTH = 40
 
---- v1 renders a chord compactly: `^Q`, `⇧J`, `F7`. Mirrors `KeyChord::compact`.
+--- Renders a chord compactly: `^Q`, `⇧J`, `F7`.
 ---
---- Duplicated from `90_footer` rather than shared: a plugin is meant to be
---- replaceable on its own, and a `lib` entry read by two panes would make
---- swapping either one a two-file edit.
+--- The twin is `kernel::bands::compact_chord`, which spells the chord bands the
+--- same way — and being Rust the kernel owns, it is not something a plugin can
+--- call. So this is a deliberate re-implementation, and the spelling must be kept
+--- in step: one action reading `^X` on the border and `Ctrl+X` in the band is the
+--- failure to avoid.
 local function compact_chord(chord)
   local modifiers, key = "", chord
   while true do
@@ -527,8 +482,13 @@ local function border_strip(width, border_style, active)
     -- would light.
     local lit = hover.role(toggle)
     local band = lit and theme.role("selection_bg") or nil
-    put(1, keep_left(label, COLLAPSE_CHEVRON_CELLS), { fg = theme.accent, bg = band }, toggle)
-    local hint = keep_right(label, widgets.len(label) - COLLAPSE_CHEVRON_CELLS)
+    put(
+      1,
+      widgets.keep_left(label, COLLAPSE_CHEVRON_CELLS),
+      { fg = theme.accent, bg = band },
+      toggle
+    )
+    local hint = widgets.keep_right(label, widgets.len(label) - COLLAPSE_CHEVRON_CELLS)
     if hint ~= "" then
       put(cursor, hint, { fg = theme.muted, bg = band }, toggle)
     end
@@ -624,7 +584,7 @@ local function chrome(opts)
     for _, run in ipairs(left) do
       left_w = left_w + widgets.len(run.text)
     end
-    title = keep_right(title, math.max(0, inner_w - left_w))
+    title = widgets.keep_right(title, math.max(0, inner_w - left_w))
     top = { { text = set.tl, style = border } }
     for _, run in ipairs(left) do
       top[#top + 1] = run
@@ -636,7 +596,7 @@ local function chrome(opts)
     top[#top + 1] = { text = title, style = opts.title_style }
     top[#top + 1] = { text = set.tr, style = border }
   else
-    title = keep_left(title, inner_w)
+    title = widgets.keep_left(title, inner_w)
     top = {
       { text = set.tl, style = border },
       { text = title, style = opts.title_style },
@@ -926,7 +886,13 @@ return {
       set_scroll(id, scroll, math.max(scroll_max, scroll))
       return true
     elseif key.key == "pagedown" then
-      set_scroll(id, math.max(0, scroll - 10), scroll_max)
+      -- Back at the live screen the mark is retired, not kept: `pageup` counts
+      -- past the real scrollback (there is no total to clamp against), so an
+      -- inflated depth that outlived the scroll left a scrollbar drawn over a
+      -- screen with nothing above it, thumb parked at the end. Zero here means
+      -- the next `pageup` measures again from scratch.
+      local back = math.max(0, scroll - 10)
+      set_scroll(id, back, back > 0 and scroll_max or 0)
       return true
     end
     return false

--- a/ui/plugins/60_confirm.lua
+++ b/ui/plugins/60_confirm.lua
@@ -73,6 +73,8 @@ return {
     end
 
     children[#children + 1] = { type = "text", len = 1, text = "" }
+    local confirm = "[ Confirm ]"
+    local cancel = " [ Cancel ]"
     children[#children + 1] = {
       type = "box",
       axis = "horizontal",
@@ -92,16 +94,21 @@ return {
         },
         -- The pills replay the keys they name, so a click and a keystroke cannot
         -- come to mean different things.
+        --
+        -- Measured from the string, never hard-coded: `" [ Cancel ]"` is eleven
+        -- columns and the slot said ten, so the closing bracket was clipped off
+        -- every confirmation — the same mistake `70_new_session`'s footer
+        -- records having made.
         {
           type = "text",
-          len = 11,
-          text = { { { text = "[ Confirm ]", style = { fg = theme.bad, bold = true } } } },
+          len = widgets.len(confirm),
+          text = { { { text = confirm, style = { fg = theme.bad, bold = true } } } },
           role = "key:y",
         },
         {
           type = "text",
-          len = 10,
-          text = { { { text = " [ Cancel ]", style = { fg = theme.muted } } } },
+          len = widgets.len(cancel),
+          text = { { { text = cancel, style = { fg = theme.muted } } } },
           role = "key:esc",
         },
       },
@@ -113,6 +120,13 @@ return {
     end
     return {
       -- Danger-bordered, as v1 frames a destructive confirmation.
+      --
+      -- `width` is a PERCENT of the screen (`Float::width_pct`), and 60 is the
+      -- default it restates. Right here, unlike in the creation flow: this float
+      -- spends no fixed column budget, so it can scale with the terminal. Say
+      -- `cols` instead the moment anything inside it is measured in columns —
+      -- reading one as the other is what made the wizard lay out for 56 columns
+      -- inside a 48-cell float at 80 columns wide.
       float = { width = 60, rows = rows },
       type = "box",
       frame = {

--- a/ui/plugins/65_search.lua
+++ b/ui/plugins/65_search.lua
@@ -221,7 +221,13 @@ local function restore(snapshot)
     store.selected = snapshot.selected
   end
   if snapshot.sessions_shown ~= nil then
-    store["panels.sessions"] = snapshot.sessions_shown
+    -- Through `panels`, never `store` by hand: the key layout is that module's
+    -- to own, and `preview` above already opened the column through it.
+    if snapshot.sessions_shown then
+      panels.show("sessions")
+    else
+      panels.hide("sessions")
+    end
   end
 end
 

--- a/ui/plugins/70_new_session.lua
+++ b/ui/plugins/70_new_session.lua
@@ -27,6 +27,7 @@
 -- *kernel* — a path that does not exist, a folder with no repositories — comes
 -- back as a failed command and the band reports it, as it does for every command.
 
+local fuzzy = require("lib.fuzzy")
 local textinput = require("lib.textinput")
 local theme = require("lib.theme")
 local widgets = require("lib.widgets")
@@ -53,17 +54,18 @@ local function agents()
   return (thurbox and thurbox.agents) or {}
 end
 
+--- The spinner frame for this paint, off the flow's own clock. Named here
+--- because three waits use it and none of them should own the arithmetic —
+--- `widgets.spinner_frame` does, so every animation in the interface steps
+--- together.
+local function spinner(flow)
+  return widgets.spinner_frame(flow.elapsed)
+end
+
 --- Is a repository-memory write still running?
 ---
 --- v1 renders `Add Repo Path ⠋ checking…` while it validates a typed path on a
 --- host. The same state is readable here: the command is in flight.
---- The spinner frame for this paint. One definition, so three waits cannot
---- animate at different rates.
-local function spinner(flow)
-  local frame = math.floor((flow.elapsed or 0) * 8) % #theme.spinner + 1
-  return theme.spinner[frame]
-end
-
 local function bookmark_pending()
   for _, item in ipairs((thurbox and thurbox.commands) or {}) do
     if item.kind == "bookmark" and item.phase ~= "failed" then
@@ -164,28 +166,6 @@ end
 
 -- ── The repo step's row model ──────────────────────────────────────────────
 
---- v1's fuzzy match, reduced to what the picker uses: a subsequence match,
---- case-insensitive, returning the matched character positions so they can be
---- accented the way v1 accents them.
-local function fuzzy(query, text)
-  if query == "" then
-    return {}
-  end
-  local positions = {}
-  local at = 1
-  local lower = text:lower()
-  for _, code in utf8.codes(query:lower()) do
-    local char = utf8.char(code)
-    local found = string.find(lower, char, at, true)
-    if not found then
-      return nil
-    end
-    positions[#positions + 1] = found
-    at = found + #char
-  end
-  return positions
-end
-
 --- The rows to draw, in order: every published row, minus the children of a
 --- collapsed parent, minus anything the search excludes.
 ---
@@ -202,13 +182,13 @@ local function rows_for(flow)
     -- and would include every row the search excludes.
     local matched
     if searching then
-      matched = fuzzy(query, row.path)
+      matched = fuzzy.match(query, row.path)
       -- A labelled row is findable by its label too, and the label is what the
       -- reader sees: typing `interface` must reach the interface directory even
       -- though that word appears nowhere in its path. Highlighting stays over the
       -- path, so a label-only hit shows as an unhighlighted match rather than
       -- accenting characters at positions that mean nothing there.
-      if not matched and row.label and fuzzy(query, row.label) then
+      if not matched and row.label and fuzzy.match(query, row.label) then
         matched = {}
       end
     else
@@ -295,8 +275,15 @@ end
 
 -- ── Rendering: the pieces every step shares ────────────────────────────────
 
---- The float's width, and the columns a list row inside it actually gets: the
---- modal's own border, then the border of the panel the list sits in.
+--- The float's width in **columns**, and the columns a list row inside it
+--- actually gets: the modal's own border, then the border of the panel the list
+--- sits in.
+---
+--- Declared as `float.cols`, not `float.width` — `width` is a *percentage*
+--- (`Float::width_pct`), so the two readings coincided only at an 80-column
+--- terminal: narrower gave a float smaller than the row budget spent below,
+--- wider gave a roomy float with its content still truncated to 56. `float_rect`
+--- clamps `cols` to the screen, so a narrow terminal still fits.
 local MODAL_COLS = 60
 local ROW_COLS = MODAL_COLS - 4
 
@@ -341,7 +328,7 @@ local function modal(title, rows_height, children, flow)
     title_runs[#title_runs + 1] = { text = crumbs .. " ", style = { fg = theme.muted } }
   end
   return {
-    float = { width = MODAL_COLS, rows = rows_height },
+    float = { cols = MODAL_COLS, rows = rows_height },
     type = "box",
     frame = {
       title = title_runs,
@@ -399,7 +386,12 @@ end
 --- the row is spent either way and the modal does not change height as messages
 --- come and go.
 local function message_row(flow)
-  local text = flow.message
+  -- Truncated to the same budget every other row in this float spends. The row
+  -- is one line and the float is a fixed width, so a longer message was clipped
+  -- mid-word by the painter with nothing to mark it — and two of the messages
+  -- below were long enough to hit it. Marked, so the next one that overruns is
+  -- visible rather than silently short.
+  local text = flow.message and widgets.truncate(flow.message, ROW_COLS - 1)
   return {
     type = "text",
     len = 1,
@@ -481,25 +473,14 @@ local function repo_row(entry, selected, flow, is_cursor)
     spans[#spans + 1] = { text = row.label .. "  ", style = style }
   end
   -- Matched characters accented, as v1 accents them; the rest keeps the row's
-  -- own style so the cursor row still reads as the cursor row.
+  -- own style so the cursor row still reads as the cursor row. `fuzzy.spans`
+  -- does the cutting, which is also what keeps the accents on the characters the
+  -- search pane says matched — a second highlighter here answered in byte
+  -- offsets and could disagree with the positions it was drawing.
   if #entry.matched > 0 then
-    local last = 0
-    for _, at in ipairs(entry.matched) do
-      if at > last + 1 then
-        spans[#spans + 1] = { text = string.sub(row.path, last + 1, at - 1), style = style }
-      end
-      -- To the next character boundary, not the next byte: slicing a
-      -- multi-byte character in half would render as rubbish (v1 fixed the
-      -- same bug in its own highlighter).
-      local finish = (utf8.offset(row.path, 2, at) or (#row.path + 1)) - 1
-      spans[#spans + 1] = {
-        text = string.sub(row.path, at, finish),
-        style = { fg = theme.accent_bright, bold = true },
-      }
-      last = finish
-    end
-    if last < #row.path then
-      spans[#spans + 1] = { text = string.sub(row.path, last + 1), style = style }
+    local hit = { fg = theme.accent_bright, bold = true }
+    for _, span in ipairs(fuzzy.spans(row.path, entry.matched, style, hit)) do
+      spans[#spans + 1] = span
     end
   else
     -- Middle-truncated: the leaf is what identifies a repository, and it is the
@@ -1180,7 +1161,7 @@ return {
       local entry = current_row(flow)
       if entry then
         if entry.row.parent then
-          flow.message = "Child of a parent bookmark — delete the parent header instead"
+          flow.message = "Child of a parent bookmark — delete the header instead"
         else
           command("bookmark", { host = flow.host, repo = entry.row.path, action = "remove" })
           flow.selected[entry.row.path] = nil
@@ -1202,7 +1183,7 @@ return {
       -- Works from any focus, as v1's does, because it acts on the typed path.
       local path = (flow.input.value or ""):match("^%s*(.-)%s*$")
       if path == "" then
-        flow.message = "Type a folder path, then ctrl+p to import its repos as a parent"
+        flow.message = "Type a folder path, then ctrl+p to import its repos"
       else
         command("bookmark", { host = flow.host, repo = path, action = "parent" })
         textinput.clear(flow.input)
@@ -1295,8 +1276,7 @@ return {
         -- there is no obvious name for a branch that does not exist yet.
         if value == "" and flow.step == "name" then
           value = suggested_name(flow)
-          field.value = value
-          field.cursor = #value
+          textinput.set(field, value)
         end
         if value == "" then
           flow.message = flow.step == "name" and "Session name cannot be empty"
@@ -1442,12 +1422,11 @@ return {
       save(after_repos(flow))
       ask(load())
       return true
-    elseif name == "up" or name == "down" then
-      local count = math.max(1, #rows_for(flow))
-      flow.cursor = math.max(1, math.min((flow.cursor or 1) + (name == "down" and 1 or -1), count))
-      save(flow)
-      return true
     end
+    -- No arrow arm here: the arrows are claimed at the top of `on_key` for every
+    -- step, and the only escape from that claim is the browse dropdown — which
+    -- has `focus == "input"` and so never reaches this far. A second arm clamped
+    -- its own way and could not be exercised.
     return false
   end,
 


### PR DESCRIPTION
## Summary

A review pass over the v2 kernel, its Lua interface and its tests. The five
rules held end to end — the defects clustered at the edges of the primitives
rather than in their cores.

**Two capability leaks.**

- `LuaHost::enter` returned early for a pane that declared no capabilities,
  skipping the only writes of `thurbox.runs` and `thurbox.granted`. `publish`
  rebuilds that table once per *frame*, so an untrusted pane read whatever the
  previous plugin left there — captured stdout and the grant flag both, under
  the names it reads its own by. Absence is the grant model (design D7); a stale
  value is not absence. Both keys are now written from the entered plugin
  unconditionally, empty tables included.
- The trust *gate* was `trusted.contains_key(path)` while the trust *label* was
  `Trust::resolve_installed`, which reads the lock's pin. So after `plugin
  update` advanced a version, new upstream code ran under the grant made to the
  old one while the Interface tab already said `untrusted`. One named predicate,
  `packages::grants_capabilities`, now decides both.

**A declared boundary nothing enforced.** `MODULE_RULES` carried entries for
`kernel` and `clipboard` that no test asserted — the hand-written per-module
tests stopped at `notifications`. One loop over the rules replaces eleven of
them and immediately failed on three real violations of the kernel's own rule
(two `use crate::agent::…` where only fully-qualified paths are allowed, one
`crate::shell` reference that is on neither list). A new entry cannot go
unenforced now.

**Caches, workers and bounds.**

- `DiffStore` was the one worker store with a value, no age and no eviction,
  retaining up to `MAX_DIFF_BYTES` per session ever selected — for content no
  bundled pane draws. It now has a TTL and a `retain`, like every sibling.
- A remote session's resize was two blocking control-mode round trips issued
  *inside the paint*, each on a 10 s timeout. Grids now move on the render
  thread; the panes are coalesced last-write-wins onto a worker (rule 5).
- `from_lua` recursed with no depth guard, so a cyclic table written to `store`
  exhausted the stack — an **abort**, so the terminal-restoring hook never ran.
  Bounded by the same ceiling `convert` already used, plus a value budget,
  because depth alone does not bound a table that references itself twice.
- `attach_git_stats` and the `files` roots map ran *local* reads against remote
  sessions. Because every host's default `worktrees_dir` is the same path, that
  returned another machine's answer rather than failing.
- ~75 lines of dead placeholder-session code, unreachable since `src/app` was
  deleted, removed along with the docs describing it.

**Interface.** Shift+S raised on a pending-create placeholder and read as doing
nothing at all. `widgets.list` overwrote the selected row with an overflow
marker at one- and two-row heights, which an 11-row terminal reaches. The
creation wizard declared `float.width` — a *percentage* — where its own row
budget meant columns, so the two agreed only at 80 columns; at its real width
two of its own refusal messages overflowed and were clipped mid-word.

**Round trips.** `KeyPress` carried no `cmd`, so a declared `cmd+j` matched
nothing *and* a real Cmd+J canonicalised to plain `j`, firing whatever `j` was
bound to. `shift+tab` came back as `tab`. Both pinned by a round-trip test over
the chord vocabulary.

## Observable changes

None breaks a documented contract — no `BREAKING CHANGE` footer. The lib target
is unpublished (`0.0.0-dev`), and neither renamed label appears in `docs/`,
`CLAUDE.md` or `README.md`. Worth knowing all the same:

1. `thurbox-cli plugin sync|remove` reports `withdrawn` where it said `removed`
   — and now correctly reports `kept` for a file you edited, which it used to
   call `removed` while leaving it on disk, loaded, with no spec entry to
   explain it.
2. `thurbox-cli plugin list` reports `kind: "spec"` for `plugins.toml`, not
   `"manifest"` — one word had been naming three different files.
3. Declaring a reserved chord (`ctrl+q`, `ctrl+h`, `ctrl+l`, `f10`, `f12`) now
   fails the interface load, naming the file, instead of loading a binding that
   silently never fires. Loud rather than dead — but it is the one change that
   can turn a working-looking setup into the bundled fallback.

## Test plan

- `cargo nextest run --all` — **1919 pass**, 0 skipped (1883 before).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D
  warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`,
  `rumdl check .` — all clean.
- `cargo nextest run --test architecture_rules` — the allowlist is now enforced
  for every entry, including `kernel`.
- `THURBOX_UI_DIR=$PWD/ui thurbox-cli plugin check` — all five panes load.
- Each fix carries a test, and the behavioural ones were confirmed to **fail
  against the old code** before landing: the capability leak (the pane read
  `secret runs=1 run=true`), the Shift+S crash (`attempt to index a nil value
  (field 'session')`), `cmd+j` and `shift+tab` round-tripping, and the Cancel
  pill clipped in paint.
- No Lua toolchain in the authoring environment, so `selene`/`stylua` did not
  run locally; `ui/` is exercised through the real kernel by the Rust suite and
  by `plugin check`. Worth a `just lint` on a machine that has them.
