### PR TITLE
fix(ui): stop a pane toggle blinking the whole screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,12 +130,15 @@ any input, a resize, a reload, a worker result, and **new agent output** —
 `Terminals::output_generation` is summed each iteration, which is what stops a
 printing agent being drawn at 4 fps. A **reflow** — the arrangement placing a
 slot at a new rect, so a column opened or closed — additionally forces one *full*
-repaint (`Terminal::clear` before the paint): the cell diff is only correct while
-ratatui and the terminal agree on a glyph's width, and where they cannot (a flag,
-an emoji presentation sequence) the pane that closed leaves characters behind.
+repaint: the cell diff is only correct while ratatui and the terminal agree on a
+glyph's width, and where they cannot (a flag, an emoji presentation sequence) the
+pane that closed leaves characters behind.
 `kernel::paint::normalize_ambiguous_width` strips the one such disagreement that
 is strippable — `U+FE0F` — from every painted cell, panes and vt100 surfaces
-alike.
+alike, and `kernel::paint::force_full_repaint` covers the rest by marking every
+cell of the reflowed frame as one the diff must print. It is deliberately **not**
+`Terminal::clear`: erasing flushes a blank screen and leaves the repaint to the
+next flush, so every pane toggle blinked the whole interface.
 
 A frame is more expensive than v1's, structurally: every pane is a Lua call
 returning a table that is converted to nodes and painted. So the loop settles

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -716,17 +716,29 @@ marks the screen dirty:
 
 **One frame is deliberately NOT a diff: a reflow.** When the arrangement places a
 slot at a different rect — a side column opening or closing, the search strip, the
-message band taking its row — the next paint is preceded by `Terminal::clear`, so
-every cell is printed rather than only the ones the diff believes moved. The diff is
-correct exactly while ratatui's idea of a cell's width matches the terminal's, and
-grapheme clusters exist where it cannot: a regional-indicator flag is two columns to
-`unicode-width` and a different number to several emulators, so a pane that closes
-leaves glyphs in the column that replaced it, and they survive until something else
-happens to repaint those cells. `kernel::paint::normalize_ambiguous_width` removes
-the one disagreement that can be removed (the emoji-presentation selector, stripped
-from every painted cell); this covers the rest by spending one full repaint on an
-event the user just caused. It is bounded by how often a layout moves, which is a
-keypress — not a frame.
+message band taking its row — every cell of that frame is printed rather than only
+the ones the diff believes moved. The diff is correct exactly while ratatui's idea
+of a cell's width matches the terminal's, and grapheme clusters exist where it
+cannot: a regional-indicator flag is two columns to `unicode-width` and a different
+number to several emulators, so a pane that closes leaves glyphs in the column that
+replaced it, and they survive until something else happens to repaint those cells.
+`kernel::paint::normalize_ambiguous_width` removes the one disagreement that can be
+removed (the emoji-presentation selector, stripped from every painted cell); this
+covers the rest by spending one full repaint on an event the user just caused. It is
+bounded by how often a layout moves, which is a keypress — not a frame.
+
+**How that full repaint is asked for matters as much as that it happens.**
+`kernel::paint::force_full_repaint` marks every cell of the finished frame
+`CellDiffOption::AlwaysUpdate`, so the flush that follows prints all of them. The
+obvious instrument, `Terminal::clear`, is the wrong one on three counts: it flushes
+an erase on its own and the repaint only arrives in the *next* flush, so the whole
+interface visibly blinked on every pane toggle; it queries the terminal for the
+cursor position first, which is a synchronous round trip on the input stream, on a
+keypress; and a reflow never needed an empty terminal in the first place — it needed
+every cell printed, which is what the marks say and nothing more. The cost is that
+the marks land in the buffer the next frame is diffed against, so the frame after a
+reflow prints in full too: one extra full write, invisible, on the same keypress
+bound.
 
 **Why the settling had to get stricter**: two things marked every frame changed
 unconditionally and so pinned the loop at the frame cap — an open float, and a

--- a/src/kernel/paint.rs
+++ b/src/kernel/paint.rs
@@ -7,7 +7,7 @@
 //! walks it with rects rather than computing them: a `box` divides its own
 //! rect among children ([`super::node::divide`]) and recurses.
 
-use ratatui::buffer::Buffer;
+use ratatui::buffer::{Buffer, CellDiffOption};
 use ratatui::layout::{Position, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
@@ -366,7 +366,7 @@ const VARIATION_SELECTOR_16: char = '\u{FE0F}';
 ///
 /// The clusters it cannot help (a regional-indicator flag is two columns here
 /// and a different number there) are why a reflow repaints in full — see
-/// `App::last_placed`.
+/// [`force_full_repaint`] and `App::last_placed`.
 pub fn normalize_ambiguous_width(buf: &mut Buffer) {
     let area = buf.area;
     for y in area.top()..area.bottom() {
@@ -389,7 +389,37 @@ pub fn normalize_ambiguous_width(buf: &mut Buffer) {
     }
 }
 
-/// Shrink a rect by `padding` on every side, never past zero.
+/// Mark every cell of a painted frame as one the diff must print, so the next
+/// flush repaints the whole screen.
+///
+/// This is what a reflow owes (see `App::last_placed`): the cell diff is only
+/// correct while ratatui's idea of a glyph's width matches the terminal's, and
+/// where they cannot agree the pane that just closed leaves characters behind in
+/// the column that replaced it.
+///
+/// Erasing the screen first would do the same job and is what `Terminal::clear`
+/// is for, but it is the wrong instrument here, for three reasons. It flushes a
+/// blank screen and the repaint arrives in the *next* flush, so every pane
+/// toggle blinks. It asks the terminal where the cursor is first — a synchronous
+/// round trip on the input stream, on a keypress. And it is unnecessary: what a
+/// reflow actually needs is not an empty terminal but a print of every cell, and
+/// [`CellDiffOption::AlwaysUpdate`] says exactly that without emitting anything
+/// of its own. The screen goes straight from the old arrangement to the new one.
+///
+/// The marks travel into the buffer the next frame is diffed against, so the
+/// frame after a reflow prints in full as well. That is one extra full write,
+/// invisible and bounded by how often a layout moves — which is a keypress.
+pub fn force_full_repaint(buf: &mut Buffer) {
+    let area = buf.area;
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            if let Some(cell) = buf.cell_mut(Position::new(x, y)) {
+                cell.set_diff_option(CellDiffOption::AlwaysUpdate);
+            }
+        }
+    }
+}
+
 fn build_block(spec: &NodeFrame) -> Block<'static> {
     let mut block = Block::default().style(spec.style);
     block = match spec.borders {
@@ -424,6 +454,7 @@ fn build_block(spec: &NodeFrame) -> Block<'static> {
     block
 }
 
+/// Shrink a rect by `padding` on every side, never past zero.
 fn pad(area: Rect, padding: u16) -> Rect {
     if padding == 0 {
         return area;
@@ -476,6 +507,26 @@ mod tests {
         normalize_ambiguous_width(&mut buffer);
 
         assert_eq!(buffer[(0, 0)].symbol(), " ");
+    }
+
+    /// A reflow repaints in full by marking the frame, not by erasing the
+    /// screen: every cell of an otherwise-identical frame has to reach the
+    /// terminal, and nothing may be emitted before it — an erase flushed on its
+    /// own is a blank screen the user sees.
+    #[test]
+    fn a_forced_repaint_prints_every_cell_of_an_unchanged_frame() {
+        let area = Rect::new(0, 0, 4, 2);
+        let mut previous = Buffer::empty(area);
+        previous.set_string(0, 0, "abcd", Style::default());
+        let mut next = previous.clone();
+        assert_eq!(previous.diff_iter(&next).count(), 0);
+
+        force_full_repaint(&mut next);
+
+        assert_eq!(
+            previous.diff_iter(&next).count(),
+            usize::from(area.width) * usize::from(area.height)
+        );
     }
 
     /// Render a Lua-authored tree and return the screen as text lines.

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,7 +242,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         drawn_floats: std::collections::HashSet::new(),
         last_paint: Instant::now(),
         last_placed: Vec::new(),
-        pending_clear: false,
         dirty: true,
         changed_this_frame: false,
         last_output_painted: std::collections::HashMap::new(),
@@ -891,8 +890,8 @@ struct App {
     /// reading the cache instead is what reported a closed modal as visible.
     drawn_floats: std::collections::HashSet<usize>,
     last_paint: Instant,
-    /// The slot rects the arrangement placed last frame, and whether the screen
-    /// owes a full repaint because they moved.
+    /// The slot rects the arrangement placed last frame — the signal that the
+    /// screen owes a full repaint, because they moved.
     ///
     /// A pane opening or closing reflows every column beside it, and a cell the
     /// diff believes it already printed is a cell it will not print again. That
@@ -901,11 +900,15 @@ struct App {
     /// two columns to `unicode-width` and a different number to several
     /// emulators, so glyphs from the pane that just closed survive in the column
     /// that replaced it. `normalize_ambiguous_width` removes the one such
-    /// disagreement it can (see `kernel::paint`); this covers the rest by making
-    /// the toggle itself the forced redraw the leftovers otherwise wait for.
+    /// disagreement it can (see `kernel::paint`); this covers the rest by
+    /// marking the reflowed frame `paint::force_full_repaint`, which prints
+    /// every cell of it.
+    ///
+    /// Deliberately NOT `Terminal::clear`: erasing flushes a blank screen and
+    /// leaves the repaint to the next flush, so every toggle blinks the whole
+    /// interface. The frame is the same either way — only the empty one in
+    /// between is avoided.
     last_placed: Vec<thurbox::kernel::layout::SlotRect>,
-    /// Set when `last_placed` moved; consumed by the next paint.
-    pending_clear: bool,
     /// Set by anything that invalidates the screen outside the tree diff:
     /// input, a reload, a resize, a completed command.
     dirty: bool,
@@ -1397,13 +1400,6 @@ impl App {
             // that was 100 rebuilds a second to feed a screen that redraws four
             // times.
             self.republish();
-            // Before the frame, not after: clearing resets the diff's memory of
-            // the screen, so the draw that follows prints every cell rather than
-            // only the ones it thinks moved.
-            if self.pending_clear {
-                self.pending_clear = false;
-                terminal.clear()?;
-            }
             let painted = terminal.draw(|frame| self.draw(frame))?;
             // Cloned so the borrow of `terminal` ends here: the two
             // corrections below both need it back.
@@ -1997,11 +1993,12 @@ impl App {
             }
         };
         let placed = resolve(&region, area);
-        // A reflow owes a full repaint — see `last_placed`. Marked as a change so
-        // the clearing paint follows immediately rather than at the redraw floor.
-        if self.last_placed != placed {
+        // A reflow owes a full repaint — see `last_placed`. Marked as a change
+        // too, so this frame is the one that pays it rather than whichever one
+        // the redraw floor gets to next.
+        let reflowed = self.last_placed != placed;
+        if reflowed {
             self.last_placed = placed.clone();
-            self.pending_clear = true;
             self.changed_this_frame = true;
         }
         self.visible_slots = placed.iter().map(|s| s.slot.clone()).collect();
@@ -2159,11 +2156,16 @@ impl App {
             paint::render_error(frame, error_area(area), "reload failed", &error);
         }
 
-        // Last, so both cover every pane, float and toast painted above. The
-        // width normalisation goes first: it changes symbols, and the repaint
-        // below reads styles, so neither can undo the other.
+        // Last, so all three cover every pane, float and toast painted above,
+        // and in this order: the width normalisation changes symbols and the
+        // background repaint reads styles, so neither can undo the other, and
+        // the reflow's forced print comes after both because it is the finished
+        // cells that have to reach the terminal.
         paint::normalize_ambiguous_width(frame.buffer_mut());
         self.repaint_theme_background(frame);
+        if reflowed {
+            paint::force_full_repaint(frame.buffer_mut());
+        }
     }
 
     /// Repaint cells that fell back to terminal-default colours with the active


### PR DESCRIPTION
## Summary

- The reflow's full repaint asked for itself with `Terminal::clear`. Crossterm's clear is an `execute!` — it flushes the erase on its own and the repaint only arrives in the **next** flush, so the terminal genuinely displays a blank screen in between and every pane toggle blinked the whole interface.
- `Terminal::clear` also calls `backend.get_cursor_position()` first, a synchronous DSR round trip on the input stream, run on a keypress.
- A reflow never needed an *empty* terminal — it needed **every cell printed**. `paint::force_full_repaint` marks the finished frame `CellDiffOption::AlwaysUpdate`, which says exactly that and emits nothing of its own, so the frame's own flush prints all of it. The screen goes straight from the old arrangement to the new one; the leftover glyphs the clear was there to prevent are covered as before.
- Cost, documented: the marks land in the buffer the next frame is diffed against, so the frame after a reflow prints in full too. One extra full write, invisible, on the same keypress bound.
- `pending_clear` and the pre-draw clear are gone; the reflow test is a local in `draw`, applied at the end of the same frame beside `normalize_ambiguous_width` and the theme-background repaint.
- Restores the `pad` doc comment, which the previous commit moved onto `build_block`.

## Test plan

- `cargo nextest run --all` — 1887 passed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- New `kernel::paint::tests::a_forced_repaint_prints_every_cell_of_an_unchanged_frame`: an identical frame diffs to zero cells before the mark and to every cell after it
- Manual: toggling a side column no longer flashes the screen, and leaves no glyphs behind