### PR TITLE
docs: mark v2 as unstable and v1 as the latest stable line

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ it are data files you edit too. No fork, no recompile, no restart.
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Thurbeen_thurbox&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Thurbeen_thurbox)
 
 > [!IMPORTANT]
-> **v2 is out, and it is not a drop-in v1.** The interface is now Lua plugins on
+> **v2 is unstable. The latest stable release is v1 —
+> [v1.8.7](https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7).**
+> v2 is published and usable, but it is still moving: the plugin kernel, the
+> `thurbox.*` snapshot shape and the bundled panes are all subject to change
+> between releases, and a change there can break panes you wrote or installed.
+> Use it if you want the customizable interface and can absorb that; stay on v1
+> if you want the version that does not move under you.
+>
+> **v2 is also not a drop-in v1.** The interface is now Lua plugins on
 > a Rust kernel — which is what makes it fully customizable, and is also why some
 > v1 surfaces did not come with it. They were compiled-in panes; they are panes
 > anyone can write now, and two of them have already been rewritten that way:
@@ -61,24 +69,33 @@ it are data files you edit too. No fork, no recompile, no restart.
 > [What v1 had, and where it is in v2](#what-v1-had-and-where-it-is-in-v2).
 >
 > **Upgrading** asks once, on the first v2 launch of a profile with v1 history,
-> before anything changes. **To stay on v1**, answer `q` at that prompt: it turns
-> auto-update off and prints the reinstall command. Or reinstall it yourself:
+> before anything changes. **To stay on v1** — the stable line — answer `q` at
+> that prompt: it turns auto-update off and prints the reinstall command. Or
+> install it yourself:
 >
 > ```bash
 > # export, not a prefix: `VERSION=… curl | sh` binds it to curl, not to the sh
-> export VERSION=v1.8.6
+> export VERSION=v1.8.7
 > curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
 > ```
 >
 > Then set `auto_update = false` under `[features]` in
-> `~/.config/thurbox/settings.toml`, or the next launch pulls v2 back. v1 is
-> maintained on the [`v1.x`](https://github.com/Thurbeen/thurbox/tree/v1.x) branch;
-> newer 1.x patches are on the
-> [releases page](https://github.com/Thurbeen/thurbox/releases).
+> `~/.config/thurbox/settings.toml`, or the next launch pulls the unstable v2
+> back. v1 is maintained on the
+> [`v1.x`](https://github.com/Thurbeen/thurbox/tree/v1.x) branch; 1.x patches are
+> on the [releases page](https://github.com/Thurbeen/thurbox/releases).
 
 ![Thurbox Demo](./docs/media/thurbox-demo.gif)
 
 ## Installation
+
+> [!NOTE]
+> The latest release is **v2, which is unstable**. Every route below takes it by
+> default. The latest **stable** release is **v1.8.7**; to install that instead,
+> pin the version on the shell installer (`VERSION`) or the PowerShell one
+> (`THURBOX_VERSION`), or build from the `v1.x` branch. The package-manager
+> channels (winget, Chocolatey, Homebrew, AUR) always publish the newest
+> release and have no way to pin v1.
 
 **One-liner:**
 
@@ -86,16 +103,19 @@ it are data files you edit too. No fork, no recompile, no restart.
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
 ```
 
-Installs the latest release to `~/.local/bin` with checksum
-verification and platform auto-detection.
+Installs the latest release — currently the unstable v2 — to `~/.local/bin`
+with checksum verification and platform auto-detection.
 
 **Options:**
 
 ```bash
+# Latest stable (v1)
+VERSION=v1.8.7 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
+
 # Custom directory
 INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
 
-# Pin a version
+# Pin any version
 VERSION=v1.0.0 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
 ```
 
@@ -114,8 +134,9 @@ irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 
 Installs the latest `x86_64-pc-windows-msvc` release to
 `%LOCALAPPDATA%\Programs\thurbox` (added to your user `PATH`) with checksum
 verification. Pin a version or directory with the `THURBOX_VERSION` /
-`THURBOX_INSTALL_DIR` env vars. Needs [psmux](https://github.com/psmux/psmux)
-as the multiplexer.
+`THURBOX_INSTALL_DIR` env vars — `$env:THURBOX_VERSION = 'v1.8.7'` before the
+`irm` line installs the latest stable instead. Needs
+[psmux](https://github.com/psmux/psmux) as the multiplexer.
 
 **winget (Windows):**
 
@@ -182,6 +203,7 @@ your preferred helper.)
 sudo pacman -S --needed git tmux rust   # Arch deps; use your distro's equivalent
 git clone https://github.com/Thurbeen/thurbox.git
 cd thurbox
+git checkout v1.x                       # omit for the unstable v2 on main
 cargo build --release
 # binary at target/release/thurbox
 ```
@@ -1315,10 +1337,11 @@ architectural decisions with rationale, see
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md); for the kernel itself, see
 [docs/V2-KERNEL.md](docs/V2-KERNEL.md).
 
-**Moving from v1?** Some panes are owed rather than ported, and some moved to
-`thurbox-cli`. The note at the top of this file has the list, what asks you
-before anything changes, and how to stay on v1 — which is maintained on the
-`v1.x` branch.
+**Moving from v1?** v2 is the unstable line: some panes are owed rather than
+ported, some moved to `thurbox-cli`, and the kernel's plugin contract can still
+change between releases. The note at the top of this file has the list, what
+asks you before anything changes, and how to stay on the stable v1 — which is
+maintained on the `v1.x` branch.
 
 ## Documentation
 

--- a/website/css/landing.css
+++ b/website/css/landing.css
@@ -116,6 +116,24 @@
   color: var(--text-secondary);
 }
 
+/* Stability notice under the hero copy. Sized and centred like .subtitle above
+   it rather than boxed: the hero is centre-aligned, so a rule down one side has
+   nothing to align to. The yellow badge carries the signal. */
+.hero-stability {
+  max-width: 600px;
+  margin: 0 auto var(--space-xl);
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.hero-stability .badge {
+  margin-right: var(--space-sm);
+}
+
+.hero-stability strong {
+  color: var(--text-primary);
+}
+
 .agent-support {
   display: flex;
   flex-wrap: wrap;

--- a/website/docs/faq.html
+++ b/website/docs/faq.html
@@ -60,6 +60,20 @@ breadcrumb: 'FAQ'
   <a href="installation.html">installation</a> for details.
 </p>
 
+<h2 id="which-version">Which version should I install?</h2>
+<p>
+  <strong>1.x is the latest stable line</strong> (newest release
+  <a href="https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7">v1.8.7</a>), and the one to run
+  if you want a version that does not change under you. <strong>2.x is unstable</strong>: it is
+  where the customizable Lua interface lives, but its kernel, the snapshot panes read, and the panes
+  it ships can still change between releases &mdash; which can break panes you wrote or installed.
+  Every installer takes the newest release unless you pin a version, so 2.x is what you get by
+  default. See
+  <a href="installation.html#specific-version">pinning a version</a>
+  and
+  <a href="v1.html">using v1</a>.
+</p>
+
 <h2 id="platforms">
   Which platforms does Thurbox run on? Does it support remote machines?
 </h2>
@@ -123,6 +137,14 @@ breadcrumb: 'FAQ'
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "On Linux or macOS, run: curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh. It is also available via Homebrew (brew install thurbeen/thurbox/thurbox), the AUR (thurbox or thurbox-bin), and on Windows via winget (winget install Thurbeen.thurbox) or Chocolatey (choco install thurbox). Both of those channels are moderated and only get a new version every 30 days, so the PowerShell installer (irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex) is the recommended route on Windows. You can also build from source with cargo build --release."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Which version should I install?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "1.x is the latest stable line (newest release v1.8.7), and the one to run if you want a version that does not change under you. 2.x is unstable: it is where the customizable Lua interface lives, but its kernel, the snapshot panes read, and the panes it ships can still change between releases — which can break panes you wrote or installed. Every installer takes the newest release unless you pin a version (export VERSION=v1.8.7 for the shell script, $env:THURBOX_VERSION = 'v1.8.7' for PowerShell), so 2.x is what you get by default."
         }
       },
       {

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -92,8 +92,8 @@ currentPage: 'index'
                 <div class="card-icon" aria-hidden="true">&#x21BA;</div>
                 <h3>Using v1</h3>
                 <p>
-                  1.x is still maintained. What it has that the current interface does not, and how
-                  to stay on it.
+                  1.x is the latest stable line, and still maintained. What it has that the current
+                  interface does not, and how to stay on it.
                 </p>
               </div>
             </a>

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -12,6 +12,19 @@ breadcrumb: 'Installation'
             <a href="#from-binary" class="heading-anchor">#</a>
           </h2>
 
+          <div class="info-box warning">
+            <p>
+              <strong>The newest release is 2.x, and 2.x is unstable.</strong>
+              Every route on this page installs it by default. The latest stable release is
+              <a href="https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7">v1.8.7</a>
+              on the 1.x line &mdash;
+              <a href="#specific-version">pin a version</a>
+              to install that instead. The package-manager channels below always carry the newest
+              release and cannot pin 1.x. See
+              <a href="v1.html">using v1</a>.
+            </p>
+          </div>
+
           <p>
             The install script downloads the latest release, detects your platform, and verifies
             checksums automatically.
@@ -49,11 +62,12 @@ breadcrumb: 'Installation'
           <pre data-wrap><code class="language-bash">export INSTALL_DIR=/usr/local/bin
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
 
-          <h3>Specific version</h3>
-          <pre data-wrap><code class="language-bash">export VERSION=v1.8.6
+          <h3 id="specific-version">Specific version</h3>
+          <pre data-wrap><code class="language-bash">export VERSION=v1.8.7
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
           <p>
-            Pinning is also how you
+            Pinning is how you take the stable line rather than the unstable newest release, and how
+            you
             <a href="v1.html">stay on 1.x</a>
             &mdash; the newest patch is on the
             <a href="https://github.com/Thurbeen/thurbox/releases">releases page</a>.
@@ -81,6 +95,11 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
             as the multiplexer.
           </p>
           <pre data-wrap><code class="language-powershell">irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
+          <p>
+            Set
+            <code>$env:THURBOX_VERSION = 'v1.8.7'</code>
+            before that line for the latest stable release instead of the newest one.
+          </p>
 
           <h3>Available platforms</h3>
           <table>

--- a/website/docs/v1.html
+++ b/website/docs/v1.html
@@ -7,9 +7,20 @@ breadcrumb: 'Using v1'
 ---
 <h1>Using v1</h1>
 <p>
-  thurbox 2.0 replaced the interface. If you were using a pane it no longer has, you do not have to
-  give it up: <strong>1.x is still maintained</strong> and still gets patch releases.
+  <strong>1.x is the latest stable line</strong>, and the one to run if you want a thurbox that does
+  not move under you. 2.x is published but <strong>unstable</strong>: it replaced the interface with
+  a plugin kernel that is still changing between releases. If you were using a pane 2.x no longer
+  has, you do not have to give it up &mdash; 1.x is still maintained and still gets patch releases.
 </p>
+
+<div class="info-box warning">
+  <p>
+    <strong>The latest stable release is
+    <a href="https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7">v1.8.7</a>.</strong>
+    Every installer takes the newest release &mdash; currently 2.x &mdash; unless you pin a version,
+    so staying here is a deliberate two-step: pin, then turn auto-update off. Both are below.
+  </p>
+</div>
 
 <div class="info-box">
   <p>
@@ -91,7 +102,7 @@ breadcrumb: 'Using v1'
 <p>
   Pin a 1.x version and turn auto-update off, or the next launch will bring you forward again:
 </p>
-<pre data-wrap><code class="language-bash">export VERSION=v1.8.6
+<pre data-wrap><code class="language-bash">export VERSION=v1.8.7
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
 <p>
   Then set <code>auto_update = false</code> under <code>[features]</code> in
@@ -123,8 +134,9 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
 <ul>
   <li><strong>Will</strong>: bug fixes, security fixes, and fixes to the session engine, backends and
     CLI, released as 1.x patch versions from the <code>v1.x</code> branch.</li>
-  <li><strong>Will not</strong>: new features. Those land on the current line, where the interface is
-    a plugin set rather than a fixed set of panes.</li>
+  <li><strong>Will not</strong>: new features. Those land on the 2.x line, where the interface is
+    a plugin set rather than a fixed set of panes &mdash; and where the plugin contract is still
+    settling, which is why 2.x is the unstable one.</li>
 </ul>
 <p>
   The reference documentation on this site describes the current interface. For v1's own docs, read

--- a/website/docs/v2-interface.html
+++ b/website/docs/v2-interface.html
@@ -16,6 +16,20 @@ breadcrumb: 'Interface'
   it.
 </p>
 
+<div class="info-box warning">
+  <p>
+    <strong>2.x is the unstable line.</strong>
+    Everything on this page is published and usable, but it is still settling: the kernel, the
+    <code>thurbox.*</code>
+    snapshot a pane reads, and the panes thurbox ships can all change between releases, and a change
+    there can break panes you wrote or installed. The latest
+    <strong>stable</strong>
+    release is
+    <a href="https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7">v1.8.7</a>, on the
+    <a href="v1.html">1.x line</a>.
+  </p>
+</div>
+
 <div class="info-box">
   <p>
     <strong>Moved from v1?</strong>
@@ -412,11 +426,11 @@ thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-info-panel</c
   <a href="#v1" class="heading-anchor">#</a>
 </h2>
 <p>
-  It is maintained on the <code>v1.x</code> branch and still gets patch releases. The first-launch
-  prompt prints the exact command; the short version is to pin a 1.x version and turn auto-update
-  off so nothing moves you again:
+  It is the stable line, maintained on the <code>v1.x</code> branch and still getting patch
+  releases. The first-launch prompt prints the exact command; the short version is to pin a 1.x
+  version and turn auto-update off so nothing moves you again:
 </p>
-<pre><code class="language-bash">export VERSION=v1.8.6
+<pre><code class="language-bash">export VERSION=v1.8.7
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
 <p>
   Declining the prompt does both of those for you and tells you what it did.

--- a/website/index.html
+++ b/website/index.html
@@ -26,6 +26,14 @@ footer: true
               <strong>Lua file in a directory you own</strong>
               &mdash; the session list included. Turn one off, reorder them, or write your own.
             </p>
+            <p class="hero-stability">
+              <span class="badge badge-yellow">v2 &middot; unstable</span>
+              The latest release is v2, and it is still moving &mdash; the plugin kernel, the
+              snapshot panes read, and the panes it ships can change between releases. The latest
+              <strong>stable</strong>
+              release is v1.8.7 &mdash;
+              <a href="docs/v1.html">how to stay on v1</a>.
+            </p>
             <div class="hero-ctas">
               <a href="#installation" class="btn btn-primary">Get Started</a>
               <a href="#customizable" class="btn btn-secondary">See it move</a>
@@ -115,11 +123,22 @@ footer: true
           <div class="install-panel" role="tabpanel" id="panel-script" aria-labelledby="tab-script">
             <p>
               Linux &amp; macOS. Auto-detects your platform, verifies checksums, and installs the
-              latest release to
+              latest release &mdash; currently the unstable v2 &mdash; to
               <code>~/.local/bin</code>
               .
             </p>
             <pre data-wrap><code class="language-bash">curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
+            <p>
+              For the latest
+              <strong>stable</strong>
+              release instead, pin v1 &mdash;
+              <code>export</code>
+              on its own line, or the
+              <code>sh</code>
+              reading from the pipe never sees it:
+            </p>
+            <pre data-wrap><code class="language-bash">export VERSION=v1.8.7
+curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
           </div>
 
           <div
@@ -140,6 +159,13 @@ footer: true
               ).
             </p>
             <pre data-wrap><code class="language-powershell">irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
+            <p>
+              For the latest
+              <strong>stable</strong>
+              release, set
+              <code>$env:THURBOX_VERSION = 'v1.8.7'</code>
+              first.
+            </p>
           </div>
 
           <div class="install-panel" role="tabpanel" id="panel-winget" aria-labelledby="tab-winget" hidden>
@@ -1124,8 +1150,8 @@ Ctrl+,  Settings, incl. the Interface tab</pre>
               <p><code>export INSTALL_DIR=/usr/local/bin</code></p>
             </div>
             <div class="install-alt-item">
-              <h4>Pin a Version</h4>
-              <p><code>export VERSION=v1.8.6</code></p>
+              <h4>Latest stable (v1)</h4>
+              <p><code>export VERSION=v1.8.7</code></p>
             </div>
             <div class="install-alt-item">
               <h4>Full Guide</h4>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -10,6 +10,11 @@
 > (plus remote hosts over SSH). A headless companion binary, `thurbox-cli`,
 > drives the same sessions for scripting and automation.
 >
+> Release lines: 1.x is the latest stable line (newest release v1.8.7) and gets
+> bug and security fixes; 2.x is published but unstable — its plugin kernel, the
+> snapshot panes read, and the panes it ships can change between releases. Every
+> installer takes the newest release (2.x) unless a version is pinned.
+>
 > Since 2.0 its defining feature is that the interface is fully customizable:
 > no UI is compiled into the binary. thurbox boots a Rust kernel that reads a
 > directory of Lua files and draws whatever it finds, so every pane — the
@@ -27,10 +32,10 @@
 - [Features](https://thurbox.thurbeen.eu/docs/features.html): the customizable interface and a full v1-to-v2 surface map, plus sessions, agent definitions, git worktrees, remote SSH and WSL hosts, automations, tasks, global search, headless CLI.
 - [Built-in agents](https://thurbox.thurbeen.eu/docs/agents.html): every built-in coding agent (claude, codex, antigravity, opencode, aider, copilot, vibe, pi, omp) with its recommended agents.toml config, resume/fork behavior, and status support.
 - [Comparison](https://thurbox.thurbeen.eu/docs/comparison.html): how Thurbox compares to Conductor, Claude Squad, Cursor, and other parallel coding-agent tools.
-- [Installation](https://thurbox.thurbeen.eu/docs/installation.html): install via curl, Homebrew, AUR, winget, Chocolatey, or from source; prerequisites.
+- [Installation](https://thurbox.thurbeen.eu/docs/installation.html): install via curl, Homebrew, AUR, winget, Chocolatey, or from source; prerequisites; how to pin the latest stable 1.x instead of the unstable 2.x default.
 - [Configuration](https://thurbox.thurbeen.eu/docs/configuration.html): every config file and knob — agents.toml, hosts.toml, settings.toml, themes, keybindings.
 - [Deprecated surfaces](https://thurbox.thurbeen.eu/docs/deprecated.html): the six panes 1.x had that the current interface does not — code review and the info panel, now the installable thurbox-code-review and thurbox-info-panel plugins; the file viewer, with no replacement; and the tasks/automations/restore panes that moved to thurbox-cli.
-- [Using v1](https://thurbox.thurbeen.eu/docs/v1.html): thurbox 1.x is still maintained — what it has that the current interface does not, how to stay on it or go back, and what it will receive.
+- [Using v1](https://thurbox.thurbeen.eu/docs/v1.html): thurbox 1.x is the latest stable line and is still maintained — what it has that the unstable 2.x interface does not, how to stay on it or go back, and what it will receive.
 - [The Interface](https://thurbox.thurbeen.eu/docs/v2-interface.html): every pane is an editable Lua plugin — how to move, disable, replace or write one, how to have a coding agent do it for you, what the kernel refuses a plugin, and the two v1 panes (thurbox-code-review, thurbox-info-panel) you install as plugins.
 - [Architecture](https://thurbox.thurbeen.eu/docs/architecture.html): the Lua-on-Rust plugin kernel and its five rules, module isolation, the tmux session backend, and design decisions (including the Elm Architecture the interface used before 2.0).
 


### PR DESCRIPTION
## Summary

- The README and the site presented v2 as simply the current release. Nothing
  said its plugin contract is still moving, and since every installer takes the
  newest release, the default path was the unstable one — discoverable only by
  hitting a broken pane after an upgrade.
- States it where the install decision is made: the README lead callout +
  install options, the landing hero and its shell/PowerShell panels, the
  installation page, the v1 and interface docs, a new FAQ entry (with its
  JSON-LD twin), and `llms.txt`.
- Pinning is the stable route, so each installer that can pin shows the flag
  with a concrete version (`VERSION` / `THURBOX_VERSION`), and the
  package-manager channels say plainly that they cannot pin 1.x.
- Moves the pinned version to **v1.8.7**, the newest 1.x tag — it read v1.8.6 in
  four places.

Docs and website only: no `src/`, no shipped artifact, so the release
relevance gate leaves this out of a cut.

## Test plan

- `npm run lint:website` — 11ty build, prettier, htmlhint (23 files), stylelint,
  eslint all clean.
- FAQ JSON-LD re-parsed after editing (9 questions), and the visible answer kept
  in step with its structured-data twin.
- Cross-page anchors resolve: `faq.html#which-version` is in the generated TOC,
  and both `installation.html#specific-version` links point at a heading that
  now carries that id.
- New `.hero-stability` rule checked against the hero's `text-align: center` —
  it is centred like `.subtitle`, not ruled down one side.
- README prose checked against `.rumdl.toml`'s MD013 (100 cols); no new line
  exceeds it. `rumdl` itself is not on PATH in this environment.

https://claude.ai/code/session_01AqEkYjxjEJNY5qzx8VyviT