### PR TITLE
fix(core): stop auto-update carrying a 1.x install into 2.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -838,7 +838,9 @@ deactivate/status — manage opt-in extensions; see below), `version`
 (prints the running version; `--check` queries GitHub's latest release —
 gated on `[features] version_check`, on by default for 1.0), `update`
 (downloads, verifies, and replaces the installed binaries with the latest
-release — `--force` bypasses the up-to-date/dev-build guards; gated on
+release **within the current major** — a new major is reported, never installed,
+because 2.x replaced the whole interface; `--force` bypasses the
+up-to-date/dev-build/major guards; gated on
 `[features] auto_update`, on by default for 1.0; the TUI also runs this silently on
 startup when the flag is on), `notify`
 (diagnose OS desktop notifications: prints the detected delivery backend

--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ it are data files you edit too. No fork, no recompile, no restart.
 > what installs, what is owed, and what v2 gained — see
 > [What v1 had, and where it is in v2](#what-v1-had-and-where-it-is-in-v2).
 >
-> **Upgrading** asks once, on the first v2 launch of a profile with v1 history,
-> before anything changes. **To stay on v1** — the stable line — answer `q` at
-> that prompt: it turns auto-update off and prints the reinstall command. Or
-> install it yourself:
+> **Upgrading to v2 is never automatic.** Auto-update does not cross a major
+> version: a 1.x install is told 2.x exists and keeps updating along 1.x. You
+> cross on purpose, with `thurbox-cli update --force` or a fresh install. And the
+> first v2 launch of a profile with v1 history asks once, before anything changes
+> — answering `q` there prints the reinstall command for 1.x.
+>
+> **To go back to v1** — the stable line:
 >
 > ```bash
 > # export, not a prefix: `VERSION=… curl | sh` binds it to curl, not to the sh
@@ -79,9 +82,12 @@ it are data files you edit too. No fork, no recompile, no restart.
 > curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
 > ```
 >
-> Then set `auto_update = false` under `[features]` in
-> `~/.config/thurbox/settings.toml`, or the next launch pulls the unstable v2
-> back. v1 is maintained on the
+> ```powershell
+> $env:THURBOX_VERSION = 'v1.8.7'
+> irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex
+> ```
+>
+> v1 is maintained on the
 > [`v1.x`](https://github.com/Thurbeen/thurbox/tree/v1.x) branch; 1.x patches are
 > on the [releases page](https://github.com/Thurbeen/thurbox/releases).
 
@@ -89,54 +95,76 @@ it are data files you edit too. No fork, no recompile, no restart.
 
 ## Installation
 
-> [!NOTE]
-> The latest release is **v2, which is unstable**. Every route below takes it by
-> default. The latest **stable** release is **v1.8.7**; to install that instead,
-> pin the version on the shell installer (`VERSION`) or the PowerShell one
-> (`THURBOX_VERSION`), or build from the `v1.x` branch. The package-manager
-> channels (winget, Chocolatey, Homebrew, AUR) always publish the newest
-> release and have no way to pin v1.
+> [!IMPORTANT]
+> **Install v1 unless you specifically want v2's customizable interface.** v1.8.7
+> is the latest stable release; v2 is the newest one, and it is unstable. Every
+> installer takes the *newest* release unless you pin a version, so the
+> recommended commands below pin it. The package-manager channels (winget,
+> Chocolatey, Homebrew, AUR) publish only the newest release and **cannot** pin
+> v1 — on those channels the shell/PowerShell installers are the way to v1.
 
-**One-liner:**
+> [!NOTE]
+> **Windows support is experimental**, on either line. The core works (psmux as
+> the multiplexer, a native ConPTY backend, WSL distros as remote hosts) but sees
+> less testing than Linux/macOS — expect rough edges and please report issues.
+> Every Windows route needs [psmux](https://github.com/psmux/psmux) as the
+> multiplexer, installed separately.
+
+### Recommended: v1, the stable line
+
+**Linux / macOS:**
+
+```bash
+export VERSION=v1.8.7
+curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
+```
+
+**Windows (PowerShell):**
+
+```powershell
+$env:THURBOX_VERSION = 'v1.8.7'
+irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex
+```
+
+> [!WARNING]
+> **`export` / `$env:` on its own line is not a style choice.** In
+> `VERSION=v1.8.7 curl … | sh` the assignment binds to `curl`, and the `sh`
+> reading from the pipe never sees it — you get the newest release, silently.
+> Set the variable first, on its own line.
+
+That install stays on v1: thurbox's auto-update **never crosses a major
+version**, so a 1.x binary will not wake up running 2.x. It still *reports* that
+2.x exists; `thurbox-cli update --force` is the deliberate way across.
+
+### The newest release (v2, unstable)
+
+**Linux / macOS:**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
 ```
 
-Installs the latest release — currently the unstable v2 — to `~/.local/bin`
-with checksum verification and platform auto-detection.
-
-**Options:**
-
-```bash
-# Latest stable (v1)
-VERSION=v1.8.7 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
-
-# Custom directory
-INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
-
-# Pin any version
-VERSION=v1.0.0 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
-```
-
-**Windows (PowerShell) — recommended:**
-
-> [!NOTE]
-> Windows support is **experimental** for now. The core works (psmux as the
-> multiplexer, a native ConPTY backend, WSL distros as remote hosts), but it
-> sees less testing than Linux/macOS — expect rough edges and please report
-> issues.
+**Windows (PowerShell):**
 
 ```powershell
 irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex
 ```
 
-Installs the latest `x86_64-pc-windows-msvc` release to
-`%LOCALAPPDATA%\Programs\thurbox` (added to your user `PATH`) with checksum
-verification. Pin a version or directory with the `THURBOX_VERSION` /
-`THURBOX_INSTALL_DIR` env vars — `$env:THURBOX_VERSION = 'v1.8.7'` before the
-`irm` line installs the latest stable instead. Needs
-[psmux](https://github.com/psmux/psmux) as the multiplexer.
+Installs the latest release — currently the unstable v2 — with checksum
+verification and platform auto-detection, to `~/.local/bin` on Linux/macOS and
+`%LOCALAPPDATA%\Programs\thurbox` (added to your user `PATH`) on Windows.
+
+**Other options:**
+
+```bash
+# Custom directory
+export INSTALL_DIR=/usr/local/bin
+curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
+
+# Pin any version — PowerShell uses $env:THURBOX_VERSION / $env:THURBOX_INSTALL_DIR
+export VERSION=v1.0.0
+curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh
+```
 
 **winget (Windows):**
 
@@ -162,13 +190,14 @@ Needs [psmux](https://github.com/psmux/psmux) as the multiplexer (installed
 separately — there is no Chocolatey package for it).
 
 > [!TIP]
-> **On Windows, `irm … install.ps1 | iex` is the recommended route.** Both
-> winget-pkgs and the Chocolatey community repo are *manually moderated* and
-> rate-limited, so thurbox publishes to each **at most once every 30 days**
-> (intermediate releases are coalesced into the next submission). Those channels
-> therefore lag the newest build; the PowerShell installer and
-> [GitHub Releases](https://github.com/Thurbeen/thurbox/releases) always have it
-> immediately.
+> **On Windows, `irm … install.ps1 | iex` is the recommended route** — and the
+> only Windows route that can install v1. Both winget-pkgs and the Chocolatey
+> community repo are *manually moderated* and rate-limited, so thurbox publishes
+> to each **at most once every 30 days** (intermediate releases are coalesced
+> into the next submission). Those channels carry only the newest release,
+> lagging behind it; the PowerShell installer and
+> [GitHub Releases](https://github.com/Thurbeen/thurbox/releases) have every
+> version immediately.
 
 **Homebrew (macOS / Linux):**
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -299,7 +299,7 @@ effect in either direction. Same for `three_panel_min_cols` above.
 | `notifications` | `true` | OS desktop notifications when a session needs attention |
 | `soft_delete` | `true` | TUI `Ctrl+D` soft-deletes (Ctrl+Z undo); off = hard delete after a confirmation prompt |
 | `version_check` | `true` | GitHub update check: TUI header "update available" badge + `thurbox-cli version --check` |
-| `auto_update` | `true` | Silent self-update: download + verify + replace the binaries on startup + `thurbox-cli update`; also auto-refreshes stale extensions |
+| `auto_update` | `true` | Silent self-update **within the current major**: download + verify + replace the binaries on startup + `thurbox-cli update`; also auto-refreshes stale extensions |
 
 `automations = false` is a full stop on the TUI side: the pane
 disappears (the session list takes the whole left column and `j`/`k`
@@ -356,11 +356,27 @@ terminal and is best-effort (any failure is logged and startup continues on
 the current version). The replaced binary takes effect on the **next launch**
 (the running process keeps its open file), so the TUI shows an "Updated to
 vX.Y.Z — restart to apply" status line. `thurbox-cli update` performs the
-same update on demand (with `--force` to bypass the up-to-date and dev-build
-guards); dev builds (`0.0.0-dev`) never auto-update. The default install
+same update on demand (with `--force` to bypass the up-to-date, dev-build and
+major-version guards); dev builds (`0.0.0-dev`) never auto-update. The default install
 location (`~/.local/bin`) is user-writable; a system-wide install in a
 root-owned directory will fail the replace (logged, non-fatal). `version_check`
 and `auto_update` are independent — enable either or both.
+
+**Auto-update never crosses a major version.** A 1.x install is told that 2.x
+exists (the badge, and `thurbox-cli version --check`, both report it) and is
+never moved onto it; it keeps updating along 1.x. This is not conservatism about
+version numbers — 2.x replaced v1's compiled-in interface with the Lua plugin
+kernel, so a silent crossing would hand someone a different program under the
+same binary name. `thurbox-cli update --force` is the deliberate way across, and
+the first v2 launch of a profile with v1 history still asks before anything
+changes. The guard is `agent::version_check::crosses_major`, and it applies to
+every future major too.
+
+> Only a binary that *carries* the guard is protected by it. Releases up to
+> v1.8.7 predate it, so an existing 1.8.x install with `auto_update = true` will
+> still take 2.x on its next launch until a 1.x maintenance cut ships this
+> commit. Until then, `auto_update = false` in `settings.toml` is the reliable
+> hold — which is exactly what the v1→v2 consent gate writes when you decline.
 
 `auto_update = true` also keeps **installed extensions** in step with the
 binary. Extension versions are pinned to the binary's release tag, so an

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,6 +63,36 @@ once, before the interface takes the terminal, and declining turns `auto_update`
 off and prints how to reinstall 1.x. That gate is the only reason replacing an
 interface under an unchanged binary name is defensible.
 
+### Auto-update does not cross a major, and that has to be shipped to v1
+
+`agent::version_check::crosses_major` stops `perform_update` installing a release
+whose major is higher than the running binary's; it is reported instead
+(`UpdateOutcome::SkippedMajor`, `thurbox-cli update --force` to take it anyway).
+This is what makes "stay on 1.x" a property of the binary rather than a setting
+the user has to remember.
+
+**It only protects a binary that carries it.** Every release up to v1.8.7 predates
+this commit, so those installs still resolve `releases/latest` to a 2.x tag and
+take it. Closing that needs a **1.x maintenance cut carrying this change**,
+released the way this section describes — dispatch `cd.yml` from `v1.x` with an
+explicit `version`, which publishes with `make_latest: false` and skips the
+package channels. Until such a cut exists, the only reliable hold for an existing
+1.x install is `auto_update = false`, which is what the consent gate writes.
+
+Note the ordering trap when you do cut it: the guard reads the running binary's
+own major, so it is the *1.x* build that must contain it. Landing it on `main`
+alone protects 2.x from a future 3.x and nobody else.
+
+The other way to protect those installs was to move GitHub's `releases/latest`
+pointer back to the newest 1.x tag, which every pre-guard binary and every
+installer resolves. **That was considered and rejected: 2.x stays `latest`.** It
+would have frozen auto-update for the whole 2.x population — a 2.x binary
+resolving a 1.x tag sees nothing newer and stops updating — and made the
+unpinned one-liner install 1.x, which is a different claim than "1.x is
+recommended". The cost is that the guard reaches existing 1.x installs only via
+the maintenance cut above, and until then `auto_update = false` is what holds
+them.
+
 Such a cut is a **maintenance release**, and `cd.yml` treats it as one: it
 compares the version being cut against every existing tag and, when it is behind
 the highest, publishes the GitHub Release with `make_latest: false` and skips

--- a/src/agent/self_update.rs
+++ b/src/agent/self_update.rs
@@ -13,16 +13,21 @@
 //!   the up-to-date / dev-build guards).
 //!
 //! It reuses the version-check plumbing ([`fetch_latest_release`],
-//! [`decide_update`], [`current_version`]) so dev builds (`0.0.0-dev`) never
-//! auto-update, and mirrors `scripts/install.sh` exactly: the same release
-//! artifacts, target-triple mapping, and SHA256 verification. Like the rest of
+//! [`decide_update`], [`crosses_major`], [`current_version`]) so dev builds
+//! (`0.0.0-dev`) never auto-update and **a new major is never installed
+//! automatically** — 2.x replaced v1's whole interface, so crossing that line is
+//! the user's decision, not a background download's. It mirrors
+//! `scripts/install.sh` exactly: the same release artifacts, target-triple
+//! mapping, and SHA256 verification. Like the rest of
 //! thurbox it adds no new crate dependency — downloads go through the
 //! `curl`/`wget` helpers and `tar` / `sha256sum`/`shasum` are shelled out to.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::agent::version_check::{current_version, decide_update, fetch_latest_release};
+use crate::agent::version_check::{
+    crosses_major, current_version, decide_update, fetch_latest_release,
+};
 
 /// GitHub release-download base for the thurbox repo (same repo as
 /// `scripts/install.sh`); the per-release directory is `<base>/v{version}/`.
@@ -41,6 +46,9 @@ pub enum UpdateOutcome {
     /// A development build — skipped (its version doesn't order against tags).
     /// Only returned when `force` is false.
     SkippedDevBuild { current: String },
+    /// A newer release exists but it is a new **major**, so it was reported and
+    /// not installed. Only returned when `force` is false.
+    SkippedMajor { current: String, latest: String },
 }
 
 /// Map an OS/arch pair to the release artifact's Rust target triple. Mirrors
@@ -231,9 +239,10 @@ fn install_binaries(extract_dir: &Path, install_dir: &Path) -> Result<Vec<String
 
 /// Download, verify, extract, and install the latest release in place.
 ///
-/// `force` bypasses the up-to-date and dev-build guards (re-downloads + replaces
-/// regardless). Best-effort and side-effect-free until the checksum passes — any
-/// failure before the swap leaves the installed binaries untouched.
+/// `force` bypasses the up-to-date, dev-build and major-version guards
+/// (re-downloads + replaces regardless). Best-effort and side-effect-free until
+/// the checksum passes — any failure before the swap leaves the installed
+/// binaries untouched.
 pub fn perform_update(force: bool) -> Result<UpdateOutcome, String> {
     let current = current_version().to_string();
 
@@ -245,6 +254,14 @@ pub fn perform_update(force: bool) -> Result<UpdateOutcome, String> {
     let latest = fetch_latest_release()?;
     if !force && decide_update(&current, &latest).is_none() {
         return Ok(UpdateOutcome::UpToDate { current, latest });
+    }
+
+    // A new major is a different program under the same binary name — 2.x
+    // replaced v1's compiled-in interface with the plugin kernel — so it is
+    // reported and left for the user to take deliberately. Without this a 1.x
+    // install silently woke up running 2.x.
+    if !force && crosses_major(&current, &latest) {
+        return Ok(UpdateOutcome::SkippedMajor { current, latest });
     }
 
     let target = current_target()?;

--- a/src/agent/settings_config.rs
+++ b/src/agent/settings_config.rs
@@ -61,6 +61,10 @@ config_version = 1
 # also auto-refreshes any installed extension that the upgrade left stale
 # (self-heal, TUI startup + headless tick). `thurbox-cli update` does the same
 # binary update on demand. Set either to `false` to opt out.
+#
+# Neither crosses a MAJOR version. A 1.x install is told 2.x exists and is never
+# moved onto it, because 2.x replaced the whole interface with the Lua plugin
+# kernel. `thurbox-cli update --force` is the deliberate way across.
 # version_check = true    # GitHub update check (TUI badge + `version --check`)
 # auto_update = true      # silently download+verify+replace binaries on startup
 

--- a/src/agent/version_check.rs
+++ b/src/agent/version_check.rs
@@ -20,7 +20,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-use crate::session::extension_def::{compare_versions, is_dev_version};
+use crate::session::extension_def::{compare_versions, is_dev_version, major_version};
 
 /// GitHub "latest release" endpoint for the thurbox repo (same repo + API as
 /// `scripts/install.sh`).
@@ -81,6 +81,29 @@ pub fn decide_update(current: &str, latest: &str) -> Option<UpdateStatus> {
     } else {
         None
     }
+}
+
+/// Whether installing `latest` over `current` would cross a major version.
+///
+/// This is the 1.x → 2.x question, and it is deliberately asked separately from
+/// "is there a newer release". 2.x replaced the whole interface with the plugin
+/// kernel, so an update across that line is not a newer patch of what you are
+/// running — it is a different program wearing the same binary name. Auto-update
+/// therefore reports such a release but does not install it
+/// ([`crate::agent::self_update::perform_update`]); the user crosses on purpose.
+///
+/// `false` whenever the question cannot be answered from the two strings — a dev
+/// build, or a version with no readable major — because the guard exists to stop
+/// a *known* boundary crossing, not to block every update it cannot parse (those
+/// are already refused upstream by [`decide_update`]).
+pub fn crosses_major(current: &str, latest: &str) -> bool {
+    if is_dev_version(current.trim()) {
+        return false;
+    }
+    let (Some(c), Some(l)) = (major_version(current), major_version(latest)) else {
+        return false;
+    };
+    l > c
 }
 
 /// The running binary's version (thin wrapper over the shared
@@ -208,6 +231,31 @@ mod tests {
         assert!(decide_update("", "1.0.0").is_none());
         assert!(decide_update("1.0.0", "").is_none());
         assert!(decide_update("1.0.0", "   ").is_none());
+    }
+
+    #[test]
+    fn crossing_into_a_new_major_is_recognised() {
+        assert!(crosses_major("1.8.7", "2.0.0"));
+        assert!(crosses_major("1.8.7", "v2.2.2"));
+        assert!(crosses_major("2.2.2", "3.0.0"));
+    }
+
+    #[test]
+    fn staying_inside_a_major_is_not_a_crossing() {
+        assert!(!crosses_major("1.8.6", "1.8.7"));
+        assert!(!crosses_major("2.0.0", "2.2.2"));
+        // Same major, and going backwards, are both plainly not crossings.
+        assert!(!crosses_major("2.2.2", "2.2.2"));
+        assert!(!crosses_major("2.0.0", "1.8.7"));
+    }
+
+    #[test]
+    fn unreadable_or_dev_versions_are_not_crossings() {
+        // The guard stops a known boundary crossing; anything it cannot read is
+        // left to `decide_update`, which already refuses these.
+        assert!(!crosses_major("0.0.0-dev", "2.2.2"));
+        assert!(!crosses_major("1.8.7", "main"));
+        assert!(!crosses_major("", "2.0.0"));
     }
 
     #[test]

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -80,6 +80,27 @@ fn run_with(args: UpdateArgs, enabled: bool) -> CommandOutput {
             ),
             )
         }
+        Ok(crate::agent::self_update::UpdateOutcome::SkippedMajor { current, latest }) => {
+            // Reported, not installed: `latest` is a new major line. Name both
+            // ways across, and pin by the running version rather than deriving
+            // its major — the exact tag is what an installer wants anyway.
+            let note = format!(
+                "v{latest} is a new major release. thurbox does not cross a major \
+                 version automatically — run `thurbox-cli update --force` to take \
+                 it, or reinstall pinned to v{current} to stay where you are."
+            );
+            CommandOutput::new(
+                json!({
+                    "version": current,
+                    "latest": latest,
+                    "updated": false,
+                    "update_enabled": true,
+                    "major_upgrade": true,
+                    "summary": note,
+                }),
+                format!("thurbox {current} (latest: {latest})\n{note}"),
+            )
+        }
         Ok(crate::agent::self_update::UpdateOutcome::SkippedDevBuild { current }) => {
             CommandOutput::new(
                 json!({

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -53,23 +53,44 @@ fn run_with(args: VersionArgs, enabled: bool) -> CommandOutput {
 
     match crate::agent::version_check::refresh_cache() {
         Ok((_, Some(status))) => {
+            // A new major is reported but never installed for you, so the two
+            // cases need different advice — pointing a 1.x user at the plain
+            // installer would hand them the 2.x line it is warning them about.
+            let latest = &status.latest;
+            let is_major = crate::agent::version_check::crosses_major(current, latest);
+            let (label, upgrade, summary) = if is_major {
+                (
+                    "available (new major)",
+                    format!(
+                        "thurbox-cli update --force (v{latest} is a NEW MAJOR — \
+                         not installed automatically)"
+                    ),
+                    format!(
+                        "New major available: {current} → {latest}. Not installed \
+                         automatically — `thurbox-cli update --force` takes it."
+                    ),
+                )
+            } else {
+                (
+                    "available",
+                    "thurbox-cli update".to_string(),
+                    format!("Update available: {current} → {latest}"),
+                )
+            };
             let human = kv(&[
                 ("current", current.to_string()),
-                ("latest", status.latest.clone()),
-                ("update", "available".to_string()),
-                (
-                    "upgrade",
-                    "curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh"
-                        .to_string(),
-                ),
+                ("latest", latest.clone()),
+                ("update", label.to_string()),
+                ("upgrade", upgrade),
             ]);
             CommandOutput::new(
                 json!({
                     "version": current,
-                    "latest": status.latest,
+                    "latest": latest,
                     "update_available": true,
+                    "major_upgrade": is_major,
                     "check_enabled": true,
-                    "summary": format!("Update available: {current} → {}", status.latest),
+                    "summary": summary,
                 }),
                 human,
             )

--- a/src/kernel/consent.rs
+++ b/src/kernel/consent.rs
@@ -245,9 +245,18 @@ pub fn notice(version: &str, skin: &Skin) -> String {
 /// On Windows that command is unrunnable, so the PowerShell installer is printed
 /// there instead, with the same pin expressed as `$env:THURBOX_VERSION`.
 pub fn downgrade_instructions(last_v1: &str, skin: &Skin) -> String {
+    downgrade_screen(last_v1, cfg!(windows), skin)
+}
+
+/// [`downgrade_instructions`] with the platform passed in rather than read from
+/// `cfg!`, so the tests can check **both** variants wherever they run.
+///
+/// Without this seam the Windows form is compiled everywhere and exercised only
+/// on the Windows runner, which is exactly how its over-wide line reached CI.
+fn downgrade_screen(last_v1: &str, windows: bool, skin: &Skin) -> String {
     let (a, m, t) = (&skin.accent, &skin.muted, &skin.text);
     let (safe, bold, r) = (&skin.safe, &skin.bold, &skin.reset);
-    let install = if cfg!(windows) {
+    let install = if windows {
         format!(
             "\x20     {a}{bold}$env:THURBOX_VERSION = '{last_v1}'{r}\n\
              \x20     {a}{bold}irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex{r}\n"
@@ -438,34 +447,41 @@ mod tests {
             reset: "\x1b[0m".to_string(),
         };
 
-        let screen = format!(
-            "{}{}",
-            notice("2.0.0", &painted),
-            downgrade_instructions(LAST_V1_RELEASE, &painted)
-        );
-        print!("{screen}");
+        // Both platform variants, on whichever platform is running: the Windows
+        // one is compiled everywhere and would otherwise only ever be measured
+        // by the Windows runner.
+        for windows in [false, true] {
+            let screen = format!(
+                "{}{}",
+                notice("2.0.0", &painted),
+                downgrade_screen(LAST_V1_RELEASE, windows, &painted)
+            );
+            print!("{screen}");
 
-        for line in screen.lines() {
-            let shown = visible(line);
-            // The installer command is one long URL that cannot be broken, and is
-            // meant to be copied rather than read; everything else must fit.
-            if shown.contains("install.sh") {
-                continue;
+            for line in screen.lines() {
+                let shown = visible(line);
+                // The installer command is one long URL that cannot be broken,
+                // and is meant to be copied rather than read; everything else
+                // must fit. Matched on the path both installers share, so
+                // neither is exempt by name.
+                if shown.contains("scripts/install.") {
+                    continue;
+                }
+                assert!(
+                    shown.chars().count() <= 80,
+                    "{} columns (windows={windows}): {shown:?}",
+                    shown.chars().count()
+                );
             }
-            assert!(
-                shown.chars().count() <= 80,
-                "{} columns: {shown:?}",
-                shown.chars().count()
-            );
-        }
 
-        // Painted output must always close its spans, or the colour bleeds into
-        // whatever the shell prints next.
-        for line in screen.lines().filter(|l| l.contains('\x1b')) {
-            assert!(
-                line.ends_with("\x1b[0m") || visible(line).is_empty(),
-                "a painted line has to reset: {line:?}"
-            );
+            // Painted output must always close its spans, or the colour bleeds
+            // into whatever the shell prints next.
+            for line in screen.lines().filter(|l| l.contains('\x1b')) {
+                assert!(
+                    line.ends_with("\x1b[0m") || visible(line).is_empty(),
+                    "a painted line has to reset (windows={windows}): {line:?}"
+                );
+            }
         }
     }
 
@@ -494,22 +510,24 @@ mod tests {
 
     #[test]
     fn the_downgrade_instruction_exports_and_disables_auto_update() {
-        let text = downgrade_instructions("v1.8.6", &Skin::plain());
-        if cfg!(windows) {
+        let posix = downgrade_screen("v1.8.6", false, &Skin::plain());
+        assert!(
+            posix.contains("export VERSION=v1.8.6"),
+            "a bare `VERSION=x curl | sh` sets it for curl, not for sh: {posix}"
+        );
+
+        let windows = downgrade_screen("v1.8.6", true, &Skin::plain());
+        assert!(
+            windows.contains("$env:THURBOX_VERSION = 'v1.8.6'") && windows.contains("install.ps1"),
+            "a Windows reader needs a command Windows can run: {windows}"
+        );
+
+        for text in [&posix, &windows] {
             assert!(
-                text.contains("$env:THURBOX_VERSION = 'v1.8.6'") && text.contains("install.ps1"),
-                "a Windows reader needs a command Windows can run: {text}"
-            );
-        } else {
-            assert!(
-                text.contains("export VERSION=v1.8.6"),
-                "a bare `VERSION=x curl | sh` sets it for curl, not for sh: {text}"
+                text.contains("Auto-update is off"),
+                "reinstalling 1.x is pointless if auto-update will undo it"
             );
         }
-        assert!(
-            text.contains("Auto-update is off"),
-            "reinstalling 1.x is pointless if auto-update will undo it"
-        );
     }
 
     #[test]

--- a/src/kernel/consent.rs
+++ b/src/kernel/consent.rs
@@ -242,14 +242,26 @@ pub fn notice(version: &str, skin: &Skin) -> String {
 /// The command exports `VERSION` rather than prefixing the pipeline because a
 /// prefix binds to `curl`, not to the `sh` reading from it. That is the reason,
 /// not something the prompt explains -- a person at a gate wants the command.
+/// On Windows that command is unrunnable, so the PowerShell installer is printed
+/// there instead, with the same pin expressed as `$env:THURBOX_VERSION`.
 pub fn downgrade_instructions(last_v1: &str, skin: &Skin) -> String {
     let (a, m, t) = (&skin.accent, &skin.muted, &skin.text);
     let (safe, bold, r) = (&skin.safe, &skin.bold, &skin.reset);
+    let install = if cfg!(windows) {
+        format!(
+            "\x20     {a}{bold}$env:THURBOX_VERSION = '{last_v1}'{r}\n\
+             \x20     {a}{bold}irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex{r}\n"
+        )
+    } else {
+        format!(
+            "\x20     {a}{bold}export VERSION={last_v1}{r}\n\
+             \x20     {a}{bold}curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh{r}\n"
+        )
+    };
     format!(
         "\n  {safe}●{r} {t}Staying on v1. Auto-update is off, so nothing moves you again.{r}\n\n\
          \x20   {m}Reinstall it with:{r}\n\n\
-         \x20     {a}{bold}export VERSION={last_v1}{r}\n\
-         \x20     {a}{bold}curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh{r}\n\n\
+         {install}\n\
          \x20   {m}Newer 1.x patches   {r}{t}https://github.com/Thurbeen/thurbox/releases{r}\n\
          \x20   {m}Change your mind    {r}{t}run thurbox again and answer yes{r}\n\n"
     )
@@ -260,7 +272,7 @@ pub fn downgrade_instructions(last_v1: &str, skin: &Skin) -> String {
 /// A concrete version because `install.sh` needs an exact tag; the instructions
 /// point at the releases page for any newer 1.x patch, so this going stale costs
 /// the reader nothing.
-pub const LAST_V1_RELEASE: &str = "v1.8.6";
+pub const LAST_V1_RELEASE: &str = "v1.8.7";
 
 /// Ask if this profile has to be asked, and act on the answer.
 ///
@@ -483,13 +495,28 @@ mod tests {
     #[test]
     fn the_downgrade_instruction_exports_and_disables_auto_update() {
         let text = downgrade_instructions("v1.8.6", &Skin::plain());
-        assert!(
-            text.contains("export VERSION=v1.8.6"),
-            "a bare `VERSION=x curl | sh` sets it for curl, not for sh: {text}"
-        );
+        if cfg!(windows) {
+            assert!(
+                text.contains("$env:THURBOX_VERSION = 'v1.8.6'") && text.contains("install.ps1"),
+                "a Windows reader needs a command Windows can run: {text}"
+            );
+        } else {
+            assert!(
+                text.contains("export VERSION=v1.8.6"),
+                "a bare `VERSION=x curl | sh` sets it for curl, not for sh: {text}"
+            );
+        }
         assert!(
             text.contains("Auto-update is off"),
             "reinstalling 1.x is pointless if auto-update will undo it"
         );
+    }
+
+    #[test]
+    fn the_pinned_v1_release_is_a_1_x_tag() {
+        // The gate hands this straight to an installer, so it has to be an exact
+        // tag on the line it is offering -- a 2.x version here would send a
+        // declining reader back to what they just declined.
+        assert!(LAST_V1_RELEASE.starts_with("v1."), "got: {LAST_V1_RELEASE}");
     }
 }

--- a/src/kernel/updates.rs
+++ b/src/kernel/updates.rs
@@ -3,7 +3,9 @@
 //! Both switches from `[features]` land here, and they are separate on purpose:
 //! `version_check` only *reports*, `auto_update` also *replaces binaries*. One
 //! makes a network call, the other makes a network call and writes to disk, so
-//! neither is inferred from the other.
+//! neither is inferred from the other. Neither crosses a **major** version: the
+//! badge shows a 2.x release to a 1.x install, and the installer half declines
+//! it ([`crate::agent::version_check::crosses_major`]).
 //!
 //! Sixth instance of the worker pattern, and the one with the longest tail: a
 //! release download can take a minute on a slow link. Nothing here is waited on —
@@ -75,6 +77,13 @@ impl Updates {
                         let _ = crate::agent::version_check::refresh_cache();
                         let _ = tx.send(Done::Installed(to));
                     }
+                    Ok(crate::agent::self_update::UpdateOutcome::SkippedMajor {
+                        current,
+                        latest,
+                    }) => tracing::info!(
+                        "auto-update: v{latest} is a new major over v{current} — reported, \
+                         not installed. `thurbox-cli update --force` takes it."
+                    ),
                     // Up to date, or a dev build — `perform_update` skips those
                     // itself, which is why nothing is decided here.
                     Ok(_) => {}

--- a/src/session/extension_def.rs
+++ b/src/session/extension_def.rs
@@ -431,6 +431,23 @@ pub fn is_dev_version(v: &str) -> bool {
     v.contains("-dev") || v.trim_start_matches('v').starts_with("0.0.0")
 }
 
+/// The major component of a dotted version string (optional leading `v`, any
+/// `-suffix` ignored), or `None` when there is no leading number to read.
+///
+/// Split out from [`compare_versions`] because a *major* difference is not just
+/// a bigger ordering: thurbox's 2.x line changed the whole interface, so
+/// crossing that boundary is a decision rather than a newer patch.
+pub fn major_version(v: &str) -> Option<u64> {
+    v.trim()
+        .trim_start_matches('v')
+        .split('-')
+        .next()?
+        .split('.')
+        .next()?
+        .parse::<u64>()
+        .ok()
+}
+
 /// Compare two dotted version strings (`a.b.c`, optional leading `v`, any
 /// `-suffix` ignored) numerically, component by component. Missing trailing
 /// components count as `0` (so `1.2` == `1.2.0`). Non-numeric components sort as
@@ -711,6 +728,20 @@ prompt = "tick"
         assert_eq!(compare_versions("2.0.0", "1.99.99"), Ordering::Greater);
         // Pre-release suffix is ignored for ordering.
         assert_eq!(compare_versions("0.113.0-rc1", "0.113.0"), Ordering::Equal);
+    }
+
+    #[test]
+    fn major_version_reads_the_leading_component() {
+        assert_eq!(major_version("1.8.7"), Some(1));
+        assert_eq!(major_version("v2.2.2"), Some(2));
+        assert_eq!(major_version("2"), Some(2));
+        assert_eq!(major_version("2.0.0-rc1"), Some(2));
+        assert_eq!(major_version("  v10.1.0 "), Some(10));
+        // Nothing numeric to read: report that rather than guessing a `0`,
+        // which `compare_versions` may do because ordering needs a number and a
+        // major-boundary decision needs a fact.
+        assert_eq!(major_version(""), None);
+        assert_eq!(major_version("main"), None);
     }
 
     #[test]

--- a/website/docs/configuration.html
+++ b/website/docs/configuration.html
@@ -605,11 +605,30 @@ min_interval_secs   = 5        # per-session floor between notifications</code><
             best-effort. The replaced binary takes effect on the <strong>next launch</strong>, so the
             TUI shows an &ldquo;Updated to vX.Y.Z &mdash; restart to apply&rdquo; status line.
             <code>thurbox-cli update</code>
-            performs the same update on demand (<code>--force</code> bypasses the up-to-date and
-            dev-build guards); dev builds (<code>0.0.0-dev</code>) never auto-update.
+            performs the same update on demand (<code>--force</code> bypasses the up-to-date,
+            dev-build and major-version guards); dev builds (<code>0.0.0-dev</code>) never
+            auto-update.
             <code>version_check</code> and <code>auto_update</code> are independent &mdash; enable
             either or both.
           </p>
+          <div class="info-box">
+            <p>
+              <strong>Auto-update never crosses a major version.</strong>
+              A 1.x install is told that 2.x exists &mdash; the badge and
+              <code>thurbox-cli version --check</code>
+              both report it &mdash; and is never moved onto it; it keeps updating along 1.x. 2.x
+              replaced v1&rsquo;s compiled-in interface with the Lua plugin kernel, so a silent
+              crossing would hand you a different program under the same binary name.
+              <code>thurbox-cli update --force</code>
+              is the deliberate way across.
+            </p>
+            <p>
+              The guard lives in the binary, so only a build carrying it is protected: releases up
+              to v1.8.7 predate it. On an existing 1.8.x install,
+              <code>auto_update = false</code>
+              is the reliable hold until a 1.x patch carrying the guard ships.
+            </p>
+          </div>
 
           <h3 id="notifications"><code>[notifications]</code> &mdash; OS notification settings</h3>
           <p>

--- a/website/docs/faq.html
+++ b/website/docs/faq.html
@@ -68,7 +68,16 @@ breadcrumb: 'FAQ'
   where the customizable Lua interface lives, but its kernel, the snapshot panes read, and the panes
   it ships can still change between releases &mdash; which can break panes you wrote or installed.
   Every installer takes the newest release unless you pin a version, so 2.x is what you get by
-  default. See
+  default. Pinning v1 is one line before the installer:
+</p>
+<pre data-wrap><code class="language-bash">export VERSION=v1.8.7
+curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
+<pre data-wrap><code class="language-powershell">$env:THURBOX_VERSION = 'v1.8.7'
+irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
+<p>
+  That pin holds: thurbox&rsquo;s auto-update never crosses a major version, so a 1.x install is
+  told 2.x exists and is never moved onto it. The package-manager channels (winget, Chocolatey,
+  Homebrew, AUR) publish only the newest release and cannot pin v1. See
   <a href="installation.html#specific-version">pinning a version</a>
   and
   <a href="v1.html">using v1</a>.
@@ -144,7 +153,7 @@ breadcrumb: 'FAQ'
         "name": "Which version should I install?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "1.x is the latest stable line (newest release v1.8.7), and the one to run if you want a version that does not change under you. 2.x is unstable: it is where the customizable Lua interface lives, but its kernel, the snapshot panes read, and the panes it ships can still change between releases — which can break panes you wrote or installed. Every installer takes the newest release unless you pin a version (export VERSION=v1.8.7 for the shell script, $env:THURBOX_VERSION = 'v1.8.7' for PowerShell), so 2.x is what you get by default."
+          "text": "1.x is the latest stable line (newest release v1.8.7), and the recommended one to install if you want a version that does not change under you. 2.x is unstable: it is where the customizable Lua interface lives, but its kernel, the snapshot panes read, and the panes it ships can still change between releases — which can break panes you wrote or installed. Every installer takes the newest release unless you pin a version, so 2.x is what you get by default. To install v1, set the version on its own line first and then run the installer: export VERSION=v1.8.7 followed by curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh on Linux or macOS, or $env:THURBOX_VERSION = 'v1.8.7' followed by irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex on Windows. That pin holds, because thurbox auto-update never crosses a major version: a 1.x install is told 2.x exists and is never moved onto it. The package-manager channels (winget, Chocolatey, Homebrew, AUR) publish only the newest release and cannot pin v1."
         }
       },
       {

--- a/website/docs/features.html
+++ b/website/docs/features.html
@@ -928,7 +928,7 @@ mouse = true          # mouse capture: clicks, wheel, drag-select, hover
 notifications = true  # OS desktop alerts when a session needs attention
 perf_hud = true       # F12 live counters
 version_check = true  # GitHub update check (makes a network call)
-auto_update = true    # download+verify+replace the binaries on startup</code></pre>
+auto_update = true    # download+verify+replace the binaries on startup (never across a major)</code></pre>
           <p>
             <code>automations = false</code>
             is the flag with teeth beyond the interface: it also stops due schedules from firing and

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -17,14 +17,34 @@ breadcrumb: 'Installation'
               <strong>The newest release is 2.x, and 2.x is unstable.</strong>
               Every route on this page installs it by default. The latest stable release is
               <a href="https://github.com/Thurbeen/thurbox/releases/tag/v1.8.7">v1.8.7</a>
-              on the 1.x line &mdash;
-              <a href="#specific-version">pin a version</a>
-              to install that instead. The package-manager channels below always carry the newest
-              release and cannot pin 1.x. See
+              on the 1.x line, and it is the
+              <strong>recommended</strong>
+              one unless you specifically want 2.x&rsquo;s customizable Lua interface. Only the
+              shell and PowerShell installers can pin it; the package-manager channels below
+              always carry the newest release. See
               <a href="v1.html">using v1</a>.
             </p>
           </div>
 
+          <h3 id="recommended-v1">Recommended: install v1, the stable line</h3>
+          <p>Linux and macOS:</p>
+          <pre data-wrap><code class="language-bash">export VERSION=v1.8.7
+curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
+          <p>Windows (PowerShell 5.1+):</p>
+          <pre data-wrap><code class="language-powershell">$env:THURBOX_VERSION = 'v1.8.7'
+irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
+          <p>
+            The pin holds after install: thurbox&rsquo;s auto-update
+            <strong>never crosses a major version</strong>, so a 1.x install is told that 2.x
+            exists and is never moved onto it.
+            <code>thurbox-cli update --force</code>
+            is the deliberate way across. (That guard is in the binary, and releases up to v1.8.7
+            predate it &mdash; if you are already running 1.8.x, set
+            <code>auto_update = false</code>
+            until a 1.x patch carrying it ships.)
+          </p>
+
+          <h3 id="newest-release">The newest release (2.x, unstable)</h3>
           <p>
             The install script downloads the latest release, detects your platform, and verifies
             checksums automatically.

--- a/website/docs/v1.html
+++ b/website/docs/v1.html
@@ -99,22 +99,40 @@ breadcrumb: 'Using v1'
   Staying on v1, or going back
   <a href="#staying" class="heading-anchor">#</a>
 </h2>
-<p>
-  Pin a 1.x version and turn auto-update off, or the next launch will bring you forward again:
-</p>
+<p>Pin a 1.x version. On Linux and macOS:</p>
 <pre data-wrap><code class="language-bash">export VERSION=v1.8.7
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
+<p>On Windows:</p>
+<pre data-wrap><code class="language-powershell">$env:THURBOX_VERSION = 'v1.8.7'
+irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
 <p>
-  Then set <code>auto_update = false</code> under <code>[features]</code> in
-  <code>~/.config/thurbox/settings.toml</code>. Declining the first-launch prompt does both of these
-  for you and says so.
-</p>
-<p>
-  <code>export</code> matters: in <code>VERSION=x curl … | sh</code> the assignment binds to
-  <code>curl</code>, and the <code>sh</code> reading from the pipe never sees it. The newest 1.x patch
-  is on the
+  <code>export</code> / <code>$env:</code> on its own line matters: in
+  <code>VERSION=x curl … | sh</code> the assignment binds to <code>curl</code>, and the
+  <code>sh</code> reading from the pipe never sees it &mdash; you would get the newest release,
+  silently. The newest 1.x patch is on the
   <a href="https://github.com/Thurbeen/thurbox/releases">releases page</a>.
 </p>
+<div class="info-box">
+  <p>
+    <strong>Auto-update will not carry you into 2.x.</strong>
+    thurbox never crosses a major version on its own: a 1.x install is told that 2.x exists and
+    keeps updating along 1.x.
+    <code>thurbox-cli update --force</code>
+    is the deliberate way across, and the first 2.x launch of a profile with v1 history asks before
+    anything changes.
+  </p>
+  <p>
+    One caveat, because it decides what you should do today: that guard lives in the binary, and
+    releases up to v1.8.7 predate it. If you are already on 1.8.x, set
+    <code>auto_update = false</code>
+    under
+    <code>[features]</code>
+    in
+    <code>~/.config/thurbox/settings.toml</code>
+    until a 1.x patch carrying the guard ships. Declining the first-launch prompt writes that for
+    you and says so.
+  </p>
+</div>
 
 <h2 id="data">
   Your sessions are safe either way

--- a/website/docs/v2-interface.html
+++ b/website/docs/v2-interface.html
@@ -428,10 +428,15 @@ thurbox-cli plugin install git+https://github.com/Thurbeen/thurbox-info-panel</c
 <p>
   It is the stable line, maintained on the <code>v1.x</code> branch and still getting patch
   releases. The first-launch prompt prints the exact command; the short version is to pin a 1.x
-  version and turn auto-update off so nothing moves you again:
+  version:
 </p>
 <pre><code class="language-bash">export VERSION=v1.8.7
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
+<pre><code class="language-powershell">$env:THURBOX_VERSION = 'v1.8.7'
+irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
 <p>
-  Declining the prompt does both of those for you and tells you what it did.
+  Auto-update will not undo that &mdash; it never crosses a major version. Declining the prompt
+  also turns auto-update off outright and tells you what it did, which is the belt-and-braces
+  answer while releases up to v1.8.7, which predate the guard, are still what you would land on.
+  See <a href="v1.html">using v1</a>.
 </p>

--- a/website/index.html
+++ b/website/index.html
@@ -122,23 +122,24 @@ footer: true
 
           <div class="install-panel" role="tabpanel" id="panel-script" aria-labelledby="tab-script">
             <p>
-              Linux &amp; macOS. Auto-detects your platform, verifies checksums, and installs the
-              latest release &mdash; currently the unstable v2 &mdash; to
+              Linux &amp; macOS. Auto-detects your platform, verifies checksums, and installs to
               <code>~/.local/bin</code>
-              .
-            </p>
-            <pre data-wrap><code class="language-bash">curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
-            <p>
-              For the latest
-              <strong>stable</strong>
-              release instead, pin v1 &mdash;
+              . This is the
+              <strong>recommended</strong>
+              command: it pins v1, the latest stable release.
               <code>export</code>
-              on its own line, or the
+              goes on its own line, or the
               <code>sh</code>
-              reading from the pipe never sees it:
+              reading from the pipe never sees it.
             </p>
             <pre data-wrap><code class="language-bash">export VERSION=v1.8.7
 curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
+            <p>
+              Drop the pin to take the newest release instead &mdash; currently
+              <a href="docs/v1.html">v2, which is unstable</a>
+              :
+            </p>
+            <pre data-wrap><code class="language-bash">curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh</code></pre>
           </div>
 
           <div
@@ -151,21 +152,21 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
             <p>
               Native Windows (PowerShell 5.1+), and the
               <strong>recommended route</strong>
-              &mdash; unlike winget and Chocolatey it always has the newest
-              release. Verifies checksums and installs to
+              on Windows &mdash; unlike winget and Chocolatey it can pin a
+              version. Verifies checksums and installs to
               <code>%LOCALAPPDATA%\Programs\thurbox</code>
               (added to your user
               <code>PATH</code>
-              ).
+              ). The pin below takes v1, the latest stable release.
+            </p>
+            <pre data-wrap><code class="language-powershell">$env:THURBOX_VERSION = 'v1.8.7'
+irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
+            <p>
+              Drop the pin to take the newest release instead &mdash; currently
+              <a href="docs/v1.html">v2, which is unstable</a>
+              :
             </p>
             <pre data-wrap><code class="language-powershell">irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
-            <p>
-              For the latest
-              <strong>stable</strong>
-              release, set
-              <code>$env:THURBOX_VERSION = 'v1.8.7'</code>
-              first.
-            </p>
           </div>
 
           <div class="install-panel" role="tabpanel" id="panel-winget" aria-labelledby="tab-winget" hidden>
@@ -1150,8 +1151,9 @@ Ctrl+,  Settings, incl. the Interface tab</pre>
               <p><code>export INSTALL_DIR=/usr/local/bin</code></p>
             </div>
             <div class="install-alt-item">
-              <h4>Latest stable (v1)</h4>
+              <h4>Latest stable (v1) &mdash; recommended</h4>
               <p><code>export VERSION=v1.8.7</code></p>
+              <p><code>$env:THURBOX_VERSION = 'v1.8.7'</code></p>
             </div>
             <div class="install-alt-item">
               <h4>Full Guide</h4>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -13,7 +13,17 @@
 > Release lines: 1.x is the latest stable line (newest release v1.8.7) and gets
 > bug and security fixes; 2.x is published but unstable — its plugin kernel, the
 > snapshot panes read, and the panes it ships can change between releases. Every
-> installer takes the newest release (2.x) unless a version is pinned.
+> installer takes the newest release (2.x) unless a version is pinned, so 1.x is
+> the recommended install: run `export VERSION=v1.8.7` and then
+> `curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.sh | sh`
+> on Linux/macOS, or `$env:THURBOX_VERSION = 'v1.8.7'` and then
+> `irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex`
+> on Windows. The version assignment must be its own line; as a pipeline prefix
+> it binds to curl, not to the sh reading from the pipe. Auto-update never
+> crosses a major version, so a 1.x install is told 2.x exists and is never moved
+> onto it; `thurbox-cli update --force` is the deliberate way across. The
+> package-manager channels (winget, Chocolatey, Homebrew, AUR) publish only the
+> newest release and cannot pin 1.x.
 >
 > Since 2.0 its defining feature is that the interface is fully customizable:
 > no UI is compiled into the binary. thurbox boots a Rust kernel that reads a


### PR DESCRIPTION
## Summary

- **Auto-update no longer crosses a major version.** Every binary polls GitHub's `releases/latest`, so a 1.8.x install with `auto_update = true` resolved 2.x, decided it was newer, and installed it. v2 replaced v1's compiled-in interface with the plugin kernel — that is a different program under the same binary name, arriving unasked. `version_check::crosses_major` makes the boundary a property of the binary rather than a setting to remember: `perform_update` reports such a release and declines it (`UpdateOutcome::SkippedMajor`), `update --force` is the deliberate way across, and the badge still reports that 2.x exists.
- **`version --check` distinguishes a major upgrade** and stops printing the plain `install.sh` one-liner, which would have handed a 1.x user the line it was warning them about. Both commands emit the same `major_upgrade` JSON field.
- **The README's install options were the broken form it warned about eleven lines above.** In `VERSION=v1.8.7 curl … | sh` the assignment binds to `curl`, and the `sh` reading the pipe never sees it — you silently got v2. Both installers are env-only, so the fix is `export` / `$env:` on its own line. Same bug affected `INSTALL_DIR`.
- **The README, landing hero and installation page now lead with the pinned v1 commands** (shell and PowerShell) as the recommended route, with the unpinned newest-release form second. FAQ (and its JSON-LD twin), `v1.html`, `v2-interface.html`, `configuration.html`, `features.html`, `llms.txt`, `docs/CONFIG.md`, the `settings.toml` seed comment and CLAUDE.md follow.
- **Consent gate**: printed a `curl … | sh` command a Windows reader cannot run (now the PowerShell installer there), and its pinned tag was still `v1.8.6` after the earlier docs pass moved four other places to `v1.8.7`.

## Known limitation, recorded in `docs/RELEASING.md`

The guard only protects a binary that carries it, and **no released v1 does** — every release up to v1.8.7 predates it, so those installs still take 2.x on their next launch. Closing that needs a **1.x maintenance cut carrying this change**; landing it on `main` alone protects 2.x from a future 3.x and nobody else. Until then `auto_update = false` is the reliable hold, which is what the consent gate writes.

`RELEASING.md` also records that **2.x stays GitHub's `latest`** as a deliberate choice: moving the pointer back to a 1.x tag would have protected existing v1 installs immediately, but frozen auto-update for the whole 2.x population and made the unpinned one-liner install 1.x.

## Test plan

- `cargo nextest run --all` — 1892 passed, 0 failed (7 new tests: `crosses_major` × 3, `major_version`, the pinned-tag and platform-aware consent assertions).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean.
- `cargo test --test architecture_rules` — 11 passed.
- `npm run lint:website` — prettier, htmlhint (23 files), stylelint, eslint all clean.

https://claude.ai/code/session_01UFNzXQSZiMgPsjse7R7C3g