### PR TITLE
perf(ui): make a frame cost what changed, not what exists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ generation counter — if you add a cache here, give it one.
 `republish` — the one call that rebuilds every `thurbox.*` table — runs once per
 painted frame and **once per input batch**, not once per event: a held-down key
 otherwise paid for it per repeat. Within it each group is **gated on a
-change-signal** (`SnapshotStore::generation`, `Themes`/`Registry::version`,
+change-signal** (`SnapshotStore::version`, `Themes`/`Registry::version`,
 `Terminals::meta_version`/`failed_version`, and the loop's `data_epoch`), so a
 group whose inputs did not move is not rebuilt; and a pane that declares
 `pure = true` has the tree it last returned reused instead of being run at all.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,12 +141,22 @@ cell of the reflowed frame as one the diff must print. It is deliberately **not*
 next flush, so every pane toggle blinked the whole interface.
 
 A frame is more expensive than v1's, structurally: every pane is a Lua call
-returning a table that is converted to nodes and painted. So the loop settles
+returning a table that is converted to nodes and painted. The **conversion** is
+the surprise in that sentence and the biggest single cost in a frame — bigger
+than running the plugins' Lua. `kernel::convert` therefore reads each node's
+fields in **one `pairs` pass** rather than ~25 keyed lookups, and builds its
+error paths as a borrowed chain (`Crumb`) rather than a `String` per node; both
+are measured in `docs/PERFORMANCE.md`. So the loop settles
 aggressively. `draw` compares each plugin's returned tree against the last one and
 only marks the frame changed when it differs; a float does the same against its own
-last tree and rect. Neither an open float nor a live text selection marks the frame
-changed by itself — both used to, which pinned the loop at the frame cap for as
-long as the creation wizard was open. The perf HUD is the deliberate exception: its
+last tree and rect, and a **chrome band** compares the *cells* it just painted
+against the ones it painted last frame — it has no tree to diff, and marking it
+changed for having been *drawn* held `dirty` set after every frame, which stopped
+the loop settling at all: an idle interface with no sessions repainted at the frame
+cap forever (~32% of a core, against ~6% once it settles). Neither an open float
+nor a live text selection marks the frame changed by itself — both used to,
+which pinned the loop at the frame cap for as long as the creation wizard was
+open. The perf HUD is the deliberate exception: its
 counters move every iteration, so it says so.
 
 Everything that touches the world runs on a worker and publishes back (rule 5):
@@ -165,9 +175,20 @@ generation counter — if you add a cache here, give it one.
 
 `republish` — the one call that rebuilds every `thurbox.*` table — runs once per
 painted frame and **once per input batch**, not once per event: a held-down key
-otherwise paid for it per repeat. The three reads in it that touch a screen or the
+otherwise paid for it per repeat. Within it each group is **gated on a
+change-signal** (`SnapshotStore::generation`, `Themes`/`Registry::version`,
+`Terminals::meta_version`/`failed_version`, and the loop's `data_epoch`), so a
+group whose inputs did not move is not rebuilt; and a pane that declares
+`pure = true` has the tree it last returned reused instead of being run at all.
+Both are ADR-P16, and both rest on one rule: a signal is bumped **inside** the
+mutation and only when the value actually changed — writing an unchanged value
+counts as no change, which is the difference between the gate saving 27% and
+saving nothing. The three reads in it that touch a screen or the
 disk carry the age above (ADR-P14): link extraction is keyed on that session's
-`output_stamp`, the search content scan on `output_generation`, and the interface
+`output_stamp` **and limited to surfaces actually on screen** (a link nothing
+painted can be neither clicked nor handed to the outer terminal, and the scan
+walks a whole vt100 grid — doing it for every live pane cost ~1.2ms a frame with
+three of them), the search content scan on `output_generation`, and the interface
 inventory's per-file digests on a `trust_stale` flag every path that changes the
 directory or a grant already sets.
 
@@ -184,7 +205,11 @@ stderr is scrolled away long before anyone looks.
 **Observability**: `F12` toggles the perf HUD (`[features] perf_hud`); launching with
 `THURBOX_PERF_LOG=1` writes `startup`, `perf_window` and `slow op` lines to
 `thurbox.log`; while either is active a JSON snapshot is published for
-`thurbox-cli perf`. Full rationale: `docs/PERFORMANCE.md`.
+`thurbox-cli perf`. Three histograms, kept separate so they **decompose** rather
+than nest: `frame` is the paint, `republish` is the per-frame table rebuild
+above, and `tick` is the rest of one iteration. `kernel::perf::snapshot_json`
+owns the published shape and `cli::perf` only renders it. Full rationale:
+`docs/PERFORMANCE.md`.
 
 ## Installation Script
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,14 @@ group whose inputs did not move is not rebuilt; and a pane that declares
 Both are ADR-P16, and both rest on one rule: a signal is bumped **inside** the
 mutation and only when the value actually changed — writing an unchanged value
 counts as no change, which is the difference between the gate saving 27% and
-saving nothing. The three reads in it that touch a screen or the
+saving nothing. The **animation clock** obeys it too: it lives in the epoch and
+the loop advances it only while something is actually animating, because a
+free-running one invalidated every pure pane on every idle frame. And the loop
+itself slows its input poll to `IDLE_TICK` once nothing has happened for
+`QUIESCENT_AFTER` — free, because `event::poll` returns the instant an event
+arrives, so only things that never wake the thread are delayed.
+
+The three reads in `republish` that touch a screen or the
 disk carry the age above (ADR-P14): link extraction is keyed on that session's
 `output_stamp` **and limited to surfaces actually on screen** (a link nothing
 painted can be neither clicked nor handed to the outer terminal, and the scan

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -874,7 +874,7 @@ the work wasted only after paying for it.
 **Choice**: give every published source a change-signal, then spend it twice.
 
 - **Signals** live with the mutation, never with the caller:
-  `SnapshotStore::generation`, `Themes::version`, `Registry::version`,
+  `SnapshotStore::version`, `Themes::version`, `Registry::version`,
   `Terminals::meta_version` and `failed_version`, plus one loop-side
   `data_epoch` fed by the `changed` flag each worker store's `poll` already
   returns. Deriving that last one from an existing return value means it cannot

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -952,12 +952,20 @@ interface. Three fixes:
 | CPU per frame | 3.1ms | 5.4ms | **4.2ms** |
 | CPU (idle) | 2.33% | 4.83% | **3.57%** |
 
-**Still open**: at rest the snapshot's generation still moves every
-`REFRESH_INTERVAL` (400ms) because `taken_at_ms` is published and rendered as
-"5s ago", which caps how long a pure pane can be cached — worth ~0.7% idle if
-the signal were quantised to the second that label actually shows. The rest is
-the Lua boundary genuinely paid, the node paint, and `publish`'s remaining
-volatile groups. Note throughout that repaints are output-driven, so a cheaper
+A fourth followed: at rest the snapshot's generation moved every
+`REFRESH_INTERVAL` (400ms) purely because `taken_at_ms` was re-stamped, which
+capped how long any pure pane could stay cached. That field is **published to
+the second** now (`taken_at_stamp`), because its only reader is
+`widgets.now_ms` feeding `time_ago`, which floors the difference to whole
+seconds — so the precision being dropped is precision no reader could ever see.
+Quantising the published *value* rather than delaying the signal is what keeps
+"a plugin never reads a stale published value" true. The unconditional touch it
+replaced was also covering git stats landing in the same branch, so
+`attach_git_stats` now reports whether it changed a row. Idle 3.57% -> 3.33%.
+
+**Still open**: the Lua boundary genuinely paid, the node paint, and `publish`'s
+remaining volatile groups (hover, commands, inventory, diffs, links, content,
+metrics, runs). Note throughout that repaints are output-driven, so a cheaper
 frame partly becomes *more* frames rather than less CPU.
 
 ---

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -926,11 +926,39 @@ review:**
   moved, so a coarse epoch captures it.
 - *Throttling the repaint rate* — v2 already paints fewer frames than v1.
 
-**Still open**: the remaining ~1.5x is the Lua boundary that is genuinely paid —
-the agent pane's own render on the frames its inputs really did move, the node
-paint, and `publish`'s ungated volatile groups (hover, commands, inventory).
-Note also that repaints are output-driven, so a cheaper frame partly becomes
-*more* frames: this change took 42% off the frame but 25% off CPU.
+**Follow-up, measured after the above landed.** The counters it added showed the
+gate barely working at rest: `renders skipped` was **3 of 284** on an idle
+interface. Three fixes:
+
+- **The animation clock was free-running.** It was read straight from
+  `ctx.elapsed` as `floor(elapsed * 8)`, so it advanced 8 times a second whether
+  or not anything was moving — and at the 4fps idle floor that invalidated every
+  pure pane on every frame. It now lives in `Epoch::animation`, advanced by the
+  loop only while something animates (a `working` session, a command in flight).
+  This was a bug against this capability's own requirement that an idle
+  interface rebuild nothing, not a tuning choice.
+- **An adaptive poll timeout.** The loop blocked in `event::poll(10ms)`
+  regardless, costing 94 wakes a second at rest — about half of idle CPU. After
+  `QUIESCENT_AFTER` with nothing happening it waits `IDLE_TICK` (50ms) instead.
+  This costs **no** input latency: `event::poll` returns the moment an event
+  arrives. What it delays is noticing what does *not* wake the thread — new
+  agent output, a worker result — and at rest there is none of the first. Still
+  well inside the 250ms redraw floor.
+- **`platform` is constant** and was rebuilt 33 times a second.
+
+| | v1.8.7 | after P16 | now |
+|---|---|---|---|
+| CPU (loaded) | 15.6% | 21.2% | **19.4%** |
+| CPU per frame | 3.1ms | 5.4ms | **4.2ms** |
+| CPU (idle) | 2.33% | 4.83% | **3.57%** |
+
+**Still open**: at rest the snapshot's generation still moves every
+`REFRESH_INTERVAL` (400ms) because `taken_at_ms` is published and rendered as
+"5s ago", which caps how long a pure pane can be cached — worth ~0.7% idle if
+the signal were quantised to the second that label actually shows. The rest is
+the Lua boundary genuinely paid, the node paint, and `publish`'s remaining
+volatile groups. Note throughout that repaints are output-driven, so a cheaper
+frame partly becomes *more* frames rather than less CPU.
 
 ---
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -554,6 +554,38 @@ only** and never CI-asserted (the counters remain the sole regression gate):
   `data_version` (a full shared-state reload on their next poll) — an idle,
   default-config instance must never churn that row.
 
+**The v2 implementation** (the bullets above name v1 modules that went with
+`src/app`; the design carried over, the file names did not):
+
+- `kernel::perf` owns the whole layer — `DurationHistogram` (same fixed µs
+  buckets), `SlowOps` (same 16-slot ring), `Timings`, `Startup`, and
+  `snapshot_json`, which is the single owner of the published JSON shape.
+  `cli::perf` only renders whatever that produces, and
+  `tests/kernel_perf.rs` pairs the two so a key renamed on one side fails
+  rather than printing a silent zero.
+- **Three histograms, not two.** `frame` (the `terminal.draw` call) and `tick`
+  (one iteration's non-blocking work) are joined by **`republish`** — the
+  per-frame rebuild of every `thurbox.*` table. They are recorded so they
+  *decompose* rather than nest: `tick` is taken before the paint, so an
+  iteration is roughly tick + republish + frame + the input wait. Telling the
+  table rebuild apart from the painting is the difference between "frames are
+  expensive" and knowing why, and it is the number ADR-P14 should be read
+  against.
+- **Gating** is `App::perf_timing_active` — `perf_log` (cached from
+  `THURBOX_PERF_LOG` at construction) or the HUD being open — checked once per
+  iteration, so a default run pays one bool.
+- **Slow ops** wrap `interface_reload` (the whole reload: rebuild, sources,
+  declarations) and `input_dispatch` (a keypress, which runs plugin Lua and so
+  is where a slow plugin is felt). ≥5 ms rings, ≥100 ms also warns.
+- **Startup phases are v2's own**: config, DB open, theme activate, extension
+  heal, heartbeat, **`ui_build_ms`** (building the Lua interface — a cost v1
+  did not have) and `first_frame_ms`. There is no `restore_ms`: v2 has no
+  synchronous restore phase.
+- **The subscriber had to be restored.** v2's TUI shipped without one at all,
+  so every `tracing` call in the process — the panic hook's included — was
+  dropped rather than written. `main` now installs the daily rolling
+  `thurbox.log` appender v1 had, which is what makes the lines below exist.
+
 **Why**: the counters gate regressions in CI but were invisible in a live
 build, and they deliberately count rather than time — so a user-perceived
 stall ("opening review froze for 3 s") had no signal at all. The histograms
@@ -775,6 +807,130 @@ frame either.
   it, without a second way to keep the loop awake or a plugin that forgets to stop.
 - *Rendering panes in parallel* — one Lua VM, and the isolation model
   (`enter` stamps the current plugin per call) depends on calls being serial.
+
+---
+
+## ADR-P15: What a v2 frame actually costs, and the three cuts taken
+
+**Context**: v2 was measured against v1.8.7 under identical synthetic load
+(three agents each printing 30 lines/s, both binaries running *simultaneously*
+so machine noise hits them equally). v2 painted **fewer** frames than v1 and
+still used 2.5x the CPU, so the gap was never frame *rate* — it was the price
+of one frame. Attribution, release builds, with the observability of ADR-P11:
+
+| | v1.8.7 | v2 before | v2 after |
+|---|---|---|---|
+| CPU | 14.6% | 36.5% | 30.7% |
+| frames/s | 47 | 37 | 40 |
+| **CPU per frame** | **3.1ms** | **9.9ms** | **7.7ms** |
+
+Inside a v2 frame the draw was ~75% and `republish` ~25%; inside the draw, the
+Lua->node **conversion** cost more than running every plugin's Lua put together
+(session list: 897us of Lua, 3006us of conversion, for 187 nodes — ~14us *per
+node*). ratatui's own flush was never the problem (~0.6ms).
+
+**Choice**: three cuts, each measured on its own before/after pair:
+
+- **One `pairs` pass per node** (`convert::Fields`) instead of ~25 individually
+  keyed lookups — `read_size` alone was five, and each hashes its key and
+  crosses into the VM. Conversion 3.9ms -> 1.9ms a frame; **frame cost -25%**.
+  This is the same fix `read_style_field` already carried one level down.
+- **Borrowed error paths** (`convert::Crumb`) instead of
+  `&format!("{path}[{}]", index + 1)` per node — a `String` per node, growing
+  with depth, for text read only when something is malformed (~15% of
+  conversion).
+- **Link extraction only for surfaces on screen** (ADR-P14's stamp still
+  applies on top). Scanning every live pane's whole grid cost ~1.2ms a frame
+  with three sessions, for answers nothing could use; **1152us -> 320us**. This
+  restores v1's rule, which asked only the active session.
+
+`publish` also moved to `raw_set` on tables it created moments earlier and
+pre-sizes the ~30-field session row, which is worth ~5%.
+
+**Since closed** by ADR-P16, which added the change-signals this names as the
+prerequisite and then gated both the published groups and the pane renders on
+them.
+
+**Rejected**: *throttling the repaint rate* — v2 already paints fewer frames
+than v1; capping it further trades responsiveness for a number. Note the
+converse, which the measurements make plain: because repaints are
+**output-driven**, a cheaper frame becomes *more frames* rather than less CPU
+(the conversion cut took 25% off the frame but only 9% off CPU). Per-frame work
+is still the right target — it is what makes the interface able to keep up —
+but the CPU it returns is bounded by `MIN_FRAME_INTERVAL`.
+
+---
+
+## ADR-P16: Make a frame cost what changed, not what exists
+
+**Context**: ADR-P15 left v2 at 2.4x v1's CPU and 2.5x its cost per frame, with
+the gap identified as the Lua boundary — running each pane, converting the table
+it returns, and rebuilding every `thurbox.*` group, all once per painted frame.
+Instrumenting the tree diff showed why that was avoidable: under load the session
+list produced a **byte-identical tree on 200 of 200 renders**, and the agent pane
+repainted because its *surface* moved rather than its tree. The loop was proving
+the work wasted only after paying for it.
+
+**Choice**: give every published source a change-signal, then spend it twice.
+
+- **Signals** live with the mutation, never with the caller:
+  `SnapshotStore::generation`, `Themes::version`, `Registry::version`,
+  `Terminals::meta_version` and `failed_version`, plus one loop-side
+  `data_epoch` fed by the `changed` flag each worker store's `poll` already
+  returns. Deriving that last one from an existing return value means it cannot
+  drift from it.
+- **Gated publish**: each `thurbox.*` group names the versions it is built from
+  and is rebuilt only when one moves. The outer table is still assembled fresh
+  every frame, so a gating mistake can produce a stale *group* but never a torn
+  table. Keys are compared exactly (`[u64; 4]`), not hashed — a collision here
+  would serve a stale group, and "astronomically unlikely" is the wrong
+  guarantee for a wrong answer nobody can see.
+- **Pure panes**: a pane may declare `pure = true`, asserting its render is a
+  function of the published tables and its context. The kernel then reuses the
+  tree it last returned, keyed on the epoch, the rect, focus, an animation tick
+  and the plugin-state version. **Opt-in**, because a render may write `store`
+  (the search strip does) or animate, and neither is visible from outside the
+  VM; an undeclared pane behaves exactly as before.
+
+| | v1.8.7 | before P15 | after P15 | now |
+|---|---|---|---|---|
+| CPU | 15.6% | 36.5% | 31.0% | **23.1%** |
+| CPU per frame | 3.1ms | 9.9ms | 9.1ms | **5.2ms** |
+| gap to v1 (CPU) | — | 2.5x | 2.0x | **1.5x** |
+
+**Three things the implementation taught, each caught by a test rather than by
+review:**
+
+- **`taken_at_ms` is published**, and `widgets.relative_time` renders it, so the
+  snapshot's generation has to move on every refresh — not only when rows
+  change — or "5s ago" freezes. A change-signal is about what is *read*, not
+  about what feels significant.
+- **A pure render may read `store`/`state`**, which handlers write. Without that
+  in the key, the agent pane's per-session tab survived the keypress that
+  changed it. Seven tests failed; the hole was real.
+- **Writing an unchanged value must not count as a change.** The search strip
+  re-states one `store` key every frame; treating that as a write moved the
+  state version 40 times a second and invalidated every cached tree. With it,
+  the saving was 0%; without it, 27%. Every signal here compares before it
+  stores, for exactly this reason.
+
+**Rejected**:
+
+- *Opt-out caching* (`animated = true` to escape) — a performance change must
+  not be able to break a third-party pane that was never touched, and the
+  failure would be a pane that stops updating rather than an error.
+- *Read-tracking* (proxy `thurbox.*`, key on fields actually read) — the most
+  precise answer and needs no annotation, but it does not solve side effects
+  either and is a far larger change. Opt-in purity composes with adding it later.
+- *Per-pane dependency sets* — the measured waste is frames where *nothing*
+  moved, so a coarse epoch captures it.
+- *Throttling the repaint rate* — v2 already paints fewer frames than v1.
+
+**Still open**: the remaining ~1.5x is the Lua boundary that is genuinely paid —
+the agent pane's own render on the frames its inputs really did move, the node
+paint, and `publish`'s ungated volatile groups (hover, commands, inventory).
+Note also that repaints are output-driven, so a cheaper frame partly becomes
+*more* frames: this change took 42% off the frame but 25% off CPU.
 
 ---
 
@@ -1030,13 +1186,13 @@ worktree/spawn offload should ride with that branch or follow it.
 | I want to… | Do this |
 | --- | --- |
 | Measure startup | `THURBOX_PERF_LOG=1 thurbox`, read the `startup` line in `thurbox.log` |
-| Break down startup time | Read the `startup` line's phase fields, then the per-phase lines that follow it. v1's `app_new_ms`/`theme_activate_ms` fields went with `src/app`; the kernel's phases are config, DB open, extension heal, host build and first paint |
-| Watch steady-state cost | `THURBOX_PERF_LOG=1 thurbox`, read the `perf_window` lines (~10 s cadence: counter deltas + frame/tick percentiles + slow ops) |
+| Break down startup time | Read the `startup` line's phase fields: `config_init_ms`, `db_open_ms`, `theme_activate_ms`, `extension_heal_ms`, `heartbeat_ms`, `ui_build_ms` (building the Lua interface) and `first_frame_ms` |
+| Watch steady-state cost | `THURBOX_PERF_LOG=1 thurbox`, read the `perf_window` lines (~1000 iterations: counter deltas + frame/republish/tick percentiles + slow ops) |
 | Attribute an interactive stall | Look for `slow op` warnings in `thurbox.log` (named op + ms), or the slow-op list in `perf_window` |
 | Watch perf live in the TUI | Press `F12` (perf HUD overlay; `[features] perf_hud`) |
 | Inspect a running TUI from outside | `thurbox-cli perf` (needs THURBOX_PERF_LOG or an open HUD in that TUI) |
-| Verify the status-hook cache (ADR-P6) | `hook_state_loads` in `thurbox-cli perf` stays flat while idle and moves +1 per external `session signal`. v1's `perf_hook_states` acceptance test went with `src/app`; the counter it asserted on is still published |
+| See what a frame costs | `thurbox-cli perf` — `frame` is the paint and `republish` the table rebuild beside it; a frame is roughly the two added together |
 | See binary size | Check the `Binary Size` CI job summary, or `cargo bloat --release --crates` |
 | Profile CPU | `cargo flamegraph --profile release-with-debug --bin thurbox` |
 | Verify no perf regression | `cargo nextest run -E 'test(kernel::perf)'` for the counters; the loop's settling is asserted per surface in `tests/v2_*.rs` |
-| Confirm idle CPU is low | Launch, leave it idle — `redraws_skipped` climbs while `frames_rendered` stays flat |
+| Confirm idle CPU is low | Launch, leave it idle — `idle skips` climbs while `frames` stays flat |

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -61,8 +61,38 @@ inventory `plugin list` does, and restores a file you broke. Open settings with
 
 ## Traps
 
-Nine mistakes that are invisible until runtime. Each cost real time in the
+Ten mistakes that are invisible until runtime. Each cost real time in the
 changes that built the bundled panes.
+
+**Declaring `pure` when your render is not.** A pane may declare that its render
+is a function of `thurbox.*` and `ctx` and nothing else:
+
+```lua
+return {
+  name = "notes",
+  slot = "left",
+  pure = true,   -- the kernel may reuse the tree I last returned
+  render = function(ctx) ... end,
+}
+```
+
+In exchange the kernel stops calling it on frames where nothing it can read has
+changed — which is most of them, and is the single largest saving available in a
+frame. But nothing checks the claim, and getting it wrong gives you a pane
+painted from a stale tree, with no error anywhere. Two things disqualify a pane:
+
+- **It writes `store` or `state` from inside `render`.** Those writes stop
+  happening on the frames the render is skipped. This is why the bundled search
+  strip is deliberately *not* pure — it leaves its content request in `store`
+  while rendering.
+- **It animates from `ctx.frame`, or from `ctx.elapsed` faster than the shared
+  widgets do.** Animating at the shared rate is fine — the working spinner does,
+  and the session list is pure — because the kernel keys a cached tree on that
+  same tick. Anything finer freezes.
+
+Reading `store`/`state` is fine, and so is `command(...)` from a handler. If you
+are unsure, leave it undeclared: a pane that says nothing behaves exactly as it
+always has, and the only cost is that it is no faster.
 
 **Reading `state` or `store` hands back a copy.** Mutating it changes nothing —
 the value is simply the old one on the next frame. Write the whole thing back:

--- a/docs/V2-KERNEL.md
+++ b/docs/V2-KERNEL.md
@@ -76,6 +76,14 @@ else composes in `ui/lib/widgets.lua`. A prior attempt froze its catalog at six
 and reached sixteen, because it never built the userland layer and each new
 appearance had nowhere else to live. `tests/kernel_mvp.rs` asserts the count.
 
+**A pane's render is not guaranteed once per frame.** A pane that declares
+`pure = true` asserts its render is a function of the published tables and its
+render context, and the kernel then reuses the tree it last returned while both
+stand — skipping the Lua call and the table→node conversion, which together were
+the largest cost in a frame. Undeclared panes are called on every frame they are
+drawn on, exactly as before. See `docs/PLUGINS.md` → Traps for what disqualifies
+a pane, and ADR-P16 in `docs/PERFORMANCE.md` for the measurements.
+
 **2. Layout resolves before render.** Rects are computed first, then each plugin
 is called with its own. A plugin that does not know its width cannot wrap,
 truncate, or derive a scroll window — this was the single biggest gap the prior

--- a/openspec/changes/archive/2026-08-21-v2-proportional-frame/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-21-v2-proportional-frame/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/archive/2026-08-21-v2-proportional-frame/design.md
+++ b/openspec/changes/archive/2026-08-21-v2-proportional-frame/design.md
@@ -1,0 +1,148 @@
+## Context
+
+See `proposal.md` — Why, and ADR-P15 in `docs/PERFORMANCE.md` for the frame
+budget this is working against.
+
+Three facts from that budget shape the approach:
+
+- The work to remove is **producing**, not painting. Painting, the vt100
+  surface and the flush come to ~3.1ms, which is v1's entire frame. The Lua
+  call, the table→node conversion and the `thurbox.*` rebuild are the extra
+  ~4.6ms.
+- The loop **already knows** the work was wasted — `draw` diffs each pane's tree
+  against last frame's — but only after building it. This change moves that
+  knowledge in front of the work.
+- A render is **not provably pure**. `ui/plugins/65_search.lua` writes to
+  `store` from inside `render`, and any pane may animate from `ctx.elapsed`.
+  Nothing outside the plugin can see either.
+
+One constraint from ADR-P11 carries over: deciding whether to skip must cost
+nothing when perf timing is off, so the decision may not read a clock.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One place that answers "has anything published moved", cheap enough to ask
+  per frame per pane.
+- Gating that is **wrong-by-construction-proof**: a group that is not rebuilt
+  is one that could not have differed, demonstrated by a test that compares a
+  gated publish against a full one.
+- An opt-in purity declaration whose absence changes nothing.
+
+**Non-Goals:**
+
+- Per-pane dependency granularity. A pure pane is invalidated when *any*
+  published source moves, not only the ones it read. Coarse, and enough: the
+  measured waste is frames where nothing moved at all.
+- Changing the four node kinds, the published `thurbox.*` shape, or what an
+  undeclared pane observes.
+- Making `65_search` pure. Moving its `store` writes out of `render` is a
+  separate change with its own behaviour to think about.
+- Bounding the repaint *rate*. Rejected in ADR-P15 and unchanged here.
+
+## Decisions
+
+### Purity is declared by the pane, not inferred
+
+**Chosen**: a pane declares `pure = true` in its declaration table.
+
+The kernel cannot see a side effect or a clock read from outside the VM, so the
+alternatives were to guess or to ask.
+
+- *Opt-out (cache by default, declare `animated`)* — rejected: it silently
+  breaks any existing pane that writes state while rendering, including a
+  bundled one, and the failure is a pane that stops updating rather than an
+  error. A performance change must not be able to do that to a third-party
+  plugin that was never touched.
+- *Read-tracking (proxy `thurbox.*`, key the cache on fields actually read)* —
+  rejected for now: it is the most precise answer and needs no annotation, but
+  it does not solve side effects either, and it is a much larger change. Opt-in
+  purity is compatible with adding it later: the declaration would become the
+  fallback for panes the tracker cannot prove.
+
+The cost is that purity is an assertion. It is bounded by being opt-in, stated
+in `docs/PLUGINS.md` next to the declaration, and lintable — `thurbox.yml`
+learns the key, so a misspelling is a lint error rather than a pane that
+quietly renders every frame.
+
+### One epoch, not a dependency graph
+
+**Chosen**: every published source carries a version; the **publish epoch** is
+those versions taken together. A pure pane's tree is cached under
+`(epoch, width, height, focused)`.
+
+`ctx.frame` and `ctx.elapsed` are deliberately **not** in the key. They change
+every frame, so including them would make the cache never hit; excluding them
+is exactly what the purity declaration buys, and why a pane that animates may
+not declare it.
+
+A per-pane dependency set would hit more often, but the measurement says it
+would not matter: the wasted frames are ones where *nothing* moved, not ones
+where an unrelated source moved.
+
+### A version lives with the mutation, not the caller
+
+The failure mode this whole design has to avoid is a source that changes
+without its version moving. So a version is bumped **inside** the code that
+performs the mutation — `SnapshotStore` when it replaces the snapshot,
+`Themes` when a palette is activated, `Registry` when a setting, binding or
+disabled entry changes, `Terminals::meta` when it actually writes an entry
+(it is mutated on read today, which is why it needs one at all).
+
+Sources that are already small values — the focused pane, the hovered target,
+the status row — are compared directly rather than versioned; there is nothing
+cheaper about a counter for a `bool` and an `Option<String>`.
+
+### Group gating is a map from group to the versions it reads
+
+`publish` becomes a sequence of groups, each naming the versions it is built
+from. A group is rebuilt when any of them moved since the last publish; the
+`thurbox` table itself is still assembled fresh each frame from either a newly
+built group or the one cached from last time, so the table a plugin sees is
+never partially updated.
+
+Keeping the outer table fresh is deliberate: it means a bug in gating can only
+ever produce a *stale group*, never a torn table, and it keeps the change to
+`publish` local to the group builders.
+
+### The proof is a test, not a review
+
+The one test that matters compares, for a range of mutations, what a gated
+publish produces against what a full rebuild produces — mutate one source, take
+both, assert equal, and assert the epoch moved. A gating bug is otherwise
+invisible until a user reports a pane that stopped updating.
+
+## Risks / Trade-offs
+
+- **A source mutates without bumping its version** → the version lives inside
+  the mutation path, and a test asserts that mutating each source moves the
+  epoch. This is the one failure that produces silent staleness, so it gets the
+  explicit test rather than a comment.
+- **A pane declares purity and lies** (writes `store`, reads a clock, reads
+  something it was not given) → it paints from a stale tree. Bounded by being
+  opt-in; documented as an obligation where the declaration is described; the
+  bundled panes that declare it are audited as part of this change, and
+  `65_search` deliberately does not.
+- **Cheaper frames become more frames, not less CPU** → known and unchanged
+  from ADR-P15: repaints are output-driven, so part of the saving is spent
+  painting more often. The saving is real but it is bounded by
+  `MIN_FRAME_INTERVAL`; this change is measured on **CPU per frame** as well as
+  on total CPU, so the win is not hidden by the rate moving.
+- **The epoch is coarse** → a source that moves every frame (terminal metadata
+  under a printing agent) would invalidate every pure pane and cost the whole
+  benefit. If that shows up in measurement, the answer is to split that source
+  out of the epoch rather than to add dependency tracking.
+- **A cached tree outliving a reload** → the cache is dropped whenever the host
+  is rebuilt, which is the same moment the plugins themselves are replaced.
+
+## Migration Plan
+
+No data, config or on-disk format changes, so there is nothing to migrate and
+nothing to roll forward. Rollback is reverting the commit; an interface that
+declared `pure` keeps loading afterwards, because an unknown declaration key is
+ignored.
+
+The two halves are independently landable and independently measurable, and
+should land in that order: the change-signals plus gated publish first (no
+contract change at all), then the purity declaration on top of them.

--- a/openspec/changes/archive/2026-08-21-v2-proportional-frame/proposal.md
+++ b/openspec/changes/archive/2026-08-21-v2-proportional-frame/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+A v2 frame costs 7.7ms of CPU where v1's costs 3.1ms, and the difference is not
+that v2 does the shared work worse — painting, the vt100 surface and the flush
+come to ~3.1ms, which is v1's whole frame. The gap is a second frame's worth of
+work laid on top: running each pane's Lua, converting the table it returns, and
+rebuilding every `thurbox.*` table. Measured under load, almost all of it is
+recomputing answers that did not change — the session list produced a
+**byte-identical tree on 200 of 200 renders**, and the agent pane repaints
+because its *surface* moved rather than because its tree did.
+
+So the loop already proves the work was wasted, but only after paying for it:
+it builds every tree, then diffs them to decide whether to paint. Making the
+cost proportional to what actually changed is what closes the gap, and it is
+worth doing now because the observability to prove each step landed
+(ADR-P11/P15) exists as of this branch.
+
+## What Changes
+
+- Each published source gains a **change-signal** — a generation on the
+  snapshot, a version on the theme set and the registry, and one for the
+  terminal metadata that is mutated on read today. Nothing else can gate on
+  "did this move" until these exist, so they are the shared prerequisite for
+  both halves.
+- `kernel::host::publish` rebuilds **only the `thurbox.*` groups whose inputs
+  moved**, instead of all ~20 on every painted frame. What Lua observes is
+  unchanged: a group that is not rebuilt is one that could not have differed.
+- A pane may **declare its render pure** (`pure = true` in its declaration
+  table). The kernel caches a pure pane's converted node tree and reuses it
+  while the published epoch and the render context are unchanged, skipping both
+  the Lua call and the table→node conversion.
+- Purity is **opt-in**, so an undeclared pane — including every third-party one
+  — behaves exactly as it does today. This is deliberate: a render may have side
+  effects (`ui/plugins/65_search.lua` writes to `store` while rendering) and may
+  animate from `ctx.elapsed`, and neither is knowable from outside the plugin.
+- The bundled panes that qualify declare it; `65_search` does not, and stays
+  uncached until its `store` writes move out of `render`.
+- The perf snapshot gains counters for the two new skips, so "the loop is
+  settling" stays provable rather than hoped for.
+
+## Capabilities
+
+### New Capabilities
+
+- `frame-cost`: what a painted frame is allowed to recompute — that published
+  data a plugin reads is never stale, that a reused tree is indistinguishable
+  from a freshly built one, and that both are observable.
+
+### Modified Capabilities
+
+- `plugin-authoring`: a pane can declare its render pure, and the declaration
+  carries obligations — no side effects, no per-frame clock — in exchange for
+  not being called on every frame.
+
+## Impact
+
+- `src/kernel/host.rs` — `publish` split into gated groups; `render` consults a
+  tree cache; the plugin declaration gains `pure`.
+- `src/kernel/snapshot.rs`, `src/kernel/theme.rs`, `src/kernel/registry.rs`,
+  `src/kernel/terminal.rs` — change-signals.
+- `src/kernel/perf.rs`, `src/cli/perf.rs` — counters for skipped publishes and
+  skipped renders.
+- `ui/plugins/*.lua` — bundled panes that qualify declare `pure`.
+- `thurbox.yml` — the sandbox's declared shape, so `pure` lints.
+- `docs/PLUGINS.md`, `docs/V2-KERNEL.md`, `docs/PERFORMANCE.md` (ADR-P15's
+  "still open"), `CLAUDE.md`.
+- No change to the four node kinds, to the published `thurbox.*` shape, or to
+  what an undeclared pane sees.

--- a/openspec/changes/archive/2026-08-21-v2-proportional-frame/specs/frame-cost/spec.md
+++ b/openspec/changes/archive/2026-08-21-v2-proportional-frame/specs/frame-cost/spec.md
@@ -1,0 +1,117 @@
+## Purpose
+Defines what a painted frame is allowed to recompute: that the data a plugin
+reads is never stale even when it was not rebuilt, that a reused tree is
+indistinguishable from a freshly built one, and that both are observable rather
+than asserted — so making a frame cheaper can never be paid for in correctness.
+
+## ADDED Requirements
+
+### Requirement: What a frame recomputes is bounded by what changed
+
+Rebuilding every published table and every pane's tree on every painted frame
+costs the same whether anything moved or not. The system SHALL rebuild a
+published group, and SHALL run a pane's render, only when something they are
+built from has changed since the last painted frame.
+
+This is a bound on *work*, never on *freshness*: the requirements below make
+skipping unobservable, and where the two conflict, freshness wins.
+
+#### Scenario: Nothing changed between two frames
+
+- **WHEN** a frame is painted and nothing any published group is built from has
+  changed since the previous one
+- **THEN** those groups are not rebuilt
+
+#### Scenario: One source moved and the rest did not
+
+- **WHEN** a single source changes between two frames
+- **THEN** the groups built from it are rebuilt and the rest are not
+
+#### Scenario: The interface is left alone
+
+- **WHEN** an idle interface with nothing running is left untouched
+- **THEN** the frames it paints at the forced-redraw floor rebuild neither the
+  published groups nor any pane whose render may be skipped
+
+### Requirement: A plugin never reads a stale published value
+
+A group that was not rebuilt SHALL be indistinguishable, to every reader, from
+one that was. A plugin reads the published tables and cannot ask when they were
+last written, so a value that is skipped while its source has moved is not a
+saving but a wrong answer that no plugin can detect.
+
+#### Scenario: A source changes and a plugin reads it
+
+- **WHEN** something a plugin reads changes
+- **THEN** the next painted frame publishes the new value, and a plugin
+  rendering in that frame reads it
+
+#### Scenario: A reader compares against a full rebuild
+
+- **WHEN** what a plugin reads on a frame that skipped a rebuild is compared
+  against what a full rebuild would have published
+- **THEN** they are equal
+
+#### Scenario: A change arrives while the interface is idle
+
+- **WHEN** a source changes while nothing else is happening
+- **THEN** the change is published without waiting for unrelated activity to
+  wake the loop
+
+### Requirement: A reused tree is indistinguishable from a rebuilt one
+
+Where a pane's render is skipped, the tree it last returned SHALL be painted in
+its place, and the painted result SHALL equal what running the render again
+would have produced.
+
+#### Scenario: A pane is skipped and painted
+
+- **WHEN** a pane's render is skipped for a frame
+- **THEN** the cells painted for it are the ones its last render would have
+  produced for that frame
+
+#### Scenario: Something the pane reads changes
+
+- **WHEN** anything a skippable pane's render depends on changes
+- **THEN** its render runs again before that frame is painted
+
+#### Scenario: The pane's rect or focus changes
+
+- **WHEN** a pane is given a different rect, or gains or loses focus
+- **THEN** its render runs again rather than reusing a tree built for the
+  previous one
+
+#### Scenario: A live surface moves under a reused tree
+
+- **WHEN** a pane's tree is unchanged but a terminal surface it draws has
+  produced new output
+- **THEN** the frame is still painted, because what moved is the surface rather
+  than the tree
+
+#### Scenario: The interface is reloaded
+
+- **WHEN** the interface is reloaded from disk
+- **THEN** no tree from before the reload is reused
+
+### Requirement: Settling is provable rather than assumed
+
+A loop that quietly stops settling costs a third of a core and looks exactly
+like one that works. The system SHALL report how much of a frame it skipped, on
+the same counters the rest of the loop is measured by.
+
+#### Scenario: Perf timing is active
+
+- **WHEN** perf timing is active
+- **THEN** the published snapshot reports how many published rebuilds and how
+  many pane renders were skipped
+
+#### Scenario: An idle interface is measured
+
+- **WHEN** an idle interface is measured over many frames
+- **THEN** the skipped counts climb while the rebuilt counts stay flat
+
+#### Scenario: Timing is not active
+
+- **WHEN** perf timing is not active
+- **THEN** deciding whether to skip costs no wall-clock reads and publishes
+  nothing

--- a/openspec/changes/archive/2026-08-21-v2-proportional-frame/specs/plugin-authoring/spec.md
+++ b/openspec/changes/archive/2026-08-21-v2-proportional-frame/specs/plugin-authoring/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: A pane may declare its render pure, and is then not called every frame
+
+A pane's render may write to shared state, and may animate from a per-frame
+clock. Neither is visible from outside the plugin, so the kernel cannot decide
+on its own that skipping a render is safe. A pane MAY therefore **declare** that
+its render is a function of the published tables and its render context and
+nothing else; the system SHALL skip the render of a pane that has declared this
+while those inputs are unchanged, and SHALL reuse the tree it last returned.
+
+The declaration is an assertion the author makes, not a property the kernel
+checks. A pane that declares it and then writes shared state, reads a clock, or
+depends on anything it was not given will be painted from a stale tree, and the
+symptom is a pane that stops updating rather than an error.
+
+#### Scenario: A declared-pure pane's inputs are unchanged
+
+- **WHEN** a pane that has declared its render pure is drawn on a frame where
+  nothing it can read has changed
+- **THEN** its render is not called, and the tree it last returned is painted
+
+#### Scenario: A pane does not declare purity
+
+- **WHEN** a pane makes no such declaration
+- **THEN** its render is called on every frame it is drawn on, exactly as
+  before the declaration existed
+
+#### Scenario: A pane written by someone else is loaded
+
+- **WHEN** a plugin written against the interface as it was before is loaded
+- **THEN** it renders every frame and behaves identically, having declared
+  nothing
+
+#### Scenario: A pure pane animates at the rate the interface animates at
+
+- **WHEN** a pane animates from the elapsed time it is handed, at the rate the
+  shared widgets advance an animation
+- **THEN** it may still declare its render pure, and the animation is unaffected:
+  a reused tree is dropped exactly when that animation would move to its next
+  frame, rather than merely because time passed
+
+#### Scenario: A pure pane needs a per-frame clock
+
+- **WHEN** a pane animates from the frame number it is handed, or from elapsed
+  time at a finer granularity than the shared animation rate
+- **THEN** it is not eligible to declare its render pure, and the written guide
+  says so where the declaration is described
+
+#### Scenario: A pure pane writes to shared state while rendering
+
+- **WHEN** a pane writes to the shared store from inside its render
+- **THEN** it is not eligible to declare its render pure, because the write
+  would stop happening on the frames its render is skipped
+
+#### Scenario: The declaration is misspelled
+
+- **WHEN** a pane's declaration table carries a misspelling of the purity key
+- **THEN** the pane is treated as not having declared it, and so renders every
+  frame exactly as it did before — the failure of a misspelling is a pane that
+  is merely no faster, never one that is stale
+
+This is why the declaration is opt-in rather than opt-out. No key of a
+declaration table is checked today — `slot`, `focusable` and `order` are equally
+unchecked, and a plugin may carry its own bookkeeping there — so a misspelling
+cannot be reported without inventing a schema for the whole table. Opt-in makes
+that acceptable: the unchecked direction is the safe one.
+
+#### Scenario: A pure pane is edited on disk
+
+- **WHEN** a pane is edited and the interface reloads
+- **THEN** the reloaded pane renders afresh rather than being painted from the
+  tree its previous version returned

--- a/openspec/changes/archive/2026-08-21-v2-proportional-frame/tasks.md
+++ b/openspec/changes/archive/2026-08-21-v2-proportional-frame/tasks.md
@@ -1,0 +1,107 @@
+## 1. Change-signals
+
+- [x] 1.1 Add a generation to `SnapshotStore`, bumped inside every path that
+      replaces or edits the snapshot (`refresh`, hook states, output
+      quiescence, acknowledge), and expose it as a read.
+- [x] 1.2 Add a version to `Themes`, bumped when a palette is activated or the
+      set is reloaded.
+- [x] 1.3 Add a version to `Registry`, bumped when a setting, a binding, the
+      disabled set or the collected declarations change.
+- [x] 1.4 Add a version to `Terminals`' agent metadata, bumped in `meta()` only
+      when it actually writes an entry (it is mutated on read today).
+- [x] 1.5 Add versions for the worker-backed stores `publish` reads — diffs,
+      links, content, metrics, repos, runs, inventory. Implemented as one
+      app-side `data_epoch` fed by the `changed` flag each store's `poll`
+      already returns, rather than a counter inside each store: a signal derived
+      from the existing return value cannot drift from it. Links and the content
+      scan compare before storing, so a re-scan that found the same answer does
+      not move it.
+- [x] 1.6 Test: mutating each source moves the epoch, and doing nothing leaves
+      it still. This is the test that catches the one failure that is otherwise
+      silent (design.md — Risks).
+
+## 2. Gated publish
+
+- [x] 2.1 Introduce the publish epoch: the versions from task 1 taken together,
+      plus the small scalars compared directly (focus, hovered, status).
+- [x] 2.2 Split `publish` into per-group builders, each naming the versions it
+      is built from, keeping the outer `thurbox` table assembled fresh each
+      frame from either a rebuilt group or last frame's.
+- [x] 2.3 Rebuild a group only when one of its versions moved.
+- [x] 2.4 Test: for each source, mutate it and assert a gated publish produces
+      exactly what a full rebuild produces — the proof named in design.md.
+- [x] 2.5 Test: with nothing mutated, a second publish rebuilds no group.
+- [x] 2.6 Measure: paired before/after under the ADR-P15 load, recording CPU per
+      frame as well as total CPU. Result: 9100us -> 6862us per frame (-25%),
+      31.0% -> 28.4% CPU, 34.1 -> 41.4 fps.
+
+## 3. The purity declaration
+
+- [x] 3.1 Read `pure` from a plugin's declaration table, defaulting to absent,
+      and carry it on the loaded plugin beside `slot` and `focusable`.
+- [x] 3.2 Add `pure` to `thurbox.yml` so the key lints — **not done, premise was
+      wrong**: `thurbox.yml` is selene's stdlib for the `thurbox` *global*, not a
+      schema for the table a plugin returns, and no declaration key (`slot`,
+      `focusable`, `order`) is checked today. Reporting a misspelled `pure` would
+      mean inventing a schema for the whole declaration table, which is a
+      separate change. The spec scenario is amended to what holds: a misspelling
+      leaves the pane rendering every frame, which is the safe direction and the
+      reason the declaration is opt-in.
+- [x] 3.3 Cache a pure pane's converted tree under `(epoch, width, height,
+      focused)`; on a hit, skip both the Lua call and the conversion and reuse
+      the cached tree.
+- [x] 3.4 Drop the whole cache whenever the host is rebuilt, so no tree outlives
+      a reload.
+- [x] 3.5 Keep the surface-moved path intact: a reused tree still paints when a
+      terminal surface under it has produced output.
+- [x] 3.6 Test: a pure pane is not re-rendered while its inputs are unchanged;
+      it is re-rendered when the epoch moves, when its rect changes, when focus
+      changes, and after a reload.
+- [x] 3.7 Test: an undeclared pane renders every frame, unchanged.
+
+## 4. Declare the bundled panes
+
+- [x] 4.1 Audit each bundled pane's render for shared-state writes and clock
+      reads; record which qualify.
+- [x] 4.2 Declare `pure` on the panes that qualify (`10_sessions` and
+      `20_agent` are the measured wins). The audit found `10_sessions` reads
+      `ctx.elapsed` for the working spinner, which the original contract
+      disqualified; the tree key now carries the spinner's own 8Hz tick
+      (`ANIMATION_HZ`) so it stays pure and still animates. The suite then found
+      a second hole: a pure render may read `store`/`state`, which handlers
+      write, so the key carries a `StateVersion` too.
+- [x] 4.3 Leave `65_search` undeclared, with a comment naming the `store` writes
+      in its render as the reason.
+
+## 5. Observability
+
+- [x] 5.1 Count skipped publishes and skipped renders in `kernel::perf`.
+- [x] 5.2 Render both in the perf HUD and `thurbox-cli perf`, and extend the
+      producer/renderer drift test in `tests/kernel_perf.rs`.
+- [x] 5.3 Verify the decision costs no wall-clock read when timing is off — the
+      gate is an integer compare on both paths and reads no clock at all, so it
+      is unconditional rather than gated on timing.
+
+## 6. Documentation
+
+- [x] 6.1 `docs/PLUGINS.md`: describe `pure`, what declaring it asserts, and the
+      two disqualifiers — under Traps, since the failure is invisible at load.
+- [x] 6.2 `docs/V2-KERNEL.md`: a pane's render is no longer guaranteed once per
+      frame.
+- [x] 6.3 `docs/PERFORMANCE.md`: close out ADR-P15's "still open" and record the
+      measured result.
+- [x] 6.4 `CLAUDE.md`: the publish and render rules in the performance section.
+
+## 7. Land
+
+- [x] 7.1 Full gates: `cargo fmt`, clippy `-D warnings`, `cargo nextest run
+      --all` (1913 passed), `RUSTDOCFLAGS="-D warnings" cargo doc`, `rumdl` — all
+      clean. **`selene`, `stylua` and `lua-language-server` are not installed on
+      this machine** (they come from the Nix flake, which is also absent) and did
+      NOT run. The Lua change is one `pure = true,` assignment plus comments in
+      three files, all <=82 columns at the matching 2-space indent, introducing
+      no identifiers or globals — but the three gates are unverified and CI is
+      the first thing that will actually run them.
+- [x] 7.2 Final paired measurement against v1 under the ADR-P15 load, idle and
+      loaded. Loaded: v1 15.6% / 3139us per frame, v2 23.1% / 5175us — 1.48x on
+      CPU, down from 2.48x. Idle: v1 2.43%, v2 5.03%.

--- a/openspec/specs/frame-cost/spec.md
+++ b/openspec/specs/frame-cost/spec.md
@@ -1,0 +1,117 @@
+# frame-cost Specification
+
+## Purpose
+Defines what a painted frame is allowed to recompute: that the data a plugin
+reads is never stale even when it was not rebuilt, that a reused tree is
+indistinguishable from a freshly built one, and that both are observable rather
+than asserted — so making a frame cheaper can never be paid for in correctness.
+## Requirements
+### Requirement: What a frame recomputes is bounded by what changed
+
+Rebuilding every published table and every pane's tree on every painted frame
+costs the same whether anything moved or not. The system SHALL rebuild a
+published group, and SHALL run a pane's render, only when something they are
+built from has changed since the last painted frame.
+
+This is a bound on *work*, never on *freshness*: the requirements below make
+skipping unobservable, and where the two conflict, freshness wins.
+
+#### Scenario: Nothing changed between two frames
+
+- **WHEN** a frame is painted and nothing any published group is built from has
+  changed since the previous one
+- **THEN** those groups are not rebuilt
+
+#### Scenario: One source moved and the rest did not
+
+- **WHEN** a single source changes between two frames
+- **THEN** the groups built from it are rebuilt and the rest are not
+
+#### Scenario: The interface is left alone
+
+- **WHEN** an idle interface with nothing running is left untouched
+- **THEN** the frames it paints at the forced-redraw floor rebuild neither the
+  published groups nor any pane whose render may be skipped
+
+### Requirement: A plugin never reads a stale published value
+
+A group that was not rebuilt SHALL be indistinguishable, to every reader, from
+one that was. A plugin reads the published tables and cannot ask when they were
+last written, so a value that is skipped while its source has moved is not a
+saving but a wrong answer that no plugin can detect.
+
+#### Scenario: A source changes and a plugin reads it
+
+- **WHEN** something a plugin reads changes
+- **THEN** the next painted frame publishes the new value, and a plugin
+  rendering in that frame reads it
+
+#### Scenario: A reader compares against a full rebuild
+
+- **WHEN** what a plugin reads on a frame that skipped a rebuild is compared
+  against what a full rebuild would have published
+- **THEN** they are equal
+
+#### Scenario: A change arrives while the interface is idle
+
+- **WHEN** a source changes while nothing else is happening
+- **THEN** the change is published without waiting for unrelated activity to
+  wake the loop
+
+### Requirement: A reused tree is indistinguishable from a rebuilt one
+
+Where a pane's render is skipped, the tree it last returned SHALL be painted in
+its place, and the painted result SHALL equal what running the render again
+would have produced.
+
+#### Scenario: A pane is skipped and painted
+
+- **WHEN** a pane's render is skipped for a frame
+- **THEN** the cells painted for it are the ones its last render would have
+  produced for that frame
+
+#### Scenario: Something the pane reads changes
+
+- **WHEN** anything a skippable pane's render depends on changes
+- **THEN** its render runs again before that frame is painted
+
+#### Scenario: The pane's rect or focus changes
+
+- **WHEN** a pane is given a different rect, or gains or loses focus
+- **THEN** its render runs again rather than reusing a tree built for the
+  previous one
+
+#### Scenario: A live surface moves under a reused tree
+
+- **WHEN** a pane's tree is unchanged but a terminal surface it draws has
+  produced new output
+- **THEN** the frame is still painted, because what moved is the surface rather
+  than the tree
+
+#### Scenario: The interface is reloaded
+
+- **WHEN** the interface is reloaded from disk
+- **THEN** no tree from before the reload is reused
+
+### Requirement: Settling is provable rather than assumed
+
+A loop that quietly stops settling costs a third of a core and looks exactly
+like one that works. The system SHALL report how much of a frame it skipped, on
+the same counters the rest of the loop is measured by.
+
+#### Scenario: Perf timing is active
+
+- **WHEN** perf timing is active
+- **THEN** the published snapshot reports how many published rebuilds and how
+  many pane renders were skipped
+
+#### Scenario: An idle interface is measured
+
+- **WHEN** an idle interface is measured over many frames
+- **THEN** the skipped counts climb while the rebuilt counts stay flat
+
+#### Scenario: Timing is not active
+
+- **WHEN** perf timing is not active
+- **THEN** deciding whether to skip costs no wall-clock reads and publishes
+  nothing

--- a/openspec/specs/plugin-authoring/spec.md
+++ b/openspec/specs/plugin-authoring/spec.md
@@ -129,3 +129,74 @@ written back.
 - **THEN** the guide names that failure, because nothing else does — it is silent
   at load, at lint, and at render
 
+### Requirement: A pane may declare its render pure, and is then not called every frame
+
+A pane's render may write to shared state, and may animate from a per-frame
+clock. Neither is visible from outside the plugin, so the kernel cannot decide
+on its own that skipping a render is safe. A pane MAY therefore **declare** that
+its render is a function of the published tables and its render context and
+nothing else; the system SHALL skip the render of a pane that has declared this
+while those inputs are unchanged, and SHALL reuse the tree it last returned.
+
+The declaration is an assertion the author makes, not a property the kernel
+checks. A pane that declares it and then writes shared state, reads a clock, or
+depends on anything it was not given will be painted from a stale tree, and the
+symptom is a pane that stops updating rather than an error.
+
+#### Scenario: A declared-pure pane's inputs are unchanged
+
+- **WHEN** a pane that has declared its render pure is drawn on a frame where
+  nothing it can read has changed
+- **THEN** its render is not called, and the tree it last returned is painted
+
+#### Scenario: A pane does not declare purity
+
+- **WHEN** a pane makes no such declaration
+- **THEN** its render is called on every frame it is drawn on, exactly as
+  before the declaration existed
+
+#### Scenario: A pane written by someone else is loaded
+
+- **WHEN** a plugin written against the interface as it was before is loaded
+- **THEN** it renders every frame and behaves identically, having declared
+  nothing
+
+#### Scenario: A pure pane animates at the rate the interface animates at
+
+- **WHEN** a pane animates from the elapsed time it is handed, at the rate the
+  shared widgets advance an animation
+- **THEN** it may still declare its render pure, and the animation is unaffected:
+  a reused tree is dropped exactly when that animation would move to its next
+  frame, rather than merely because time passed
+
+#### Scenario: A pure pane needs a per-frame clock
+
+- **WHEN** a pane animates from the frame number it is handed, or from elapsed
+  time at a finer granularity than the shared animation rate
+- **THEN** it is not eligible to declare its render pure, and the written guide
+  says so where the declaration is described
+
+#### Scenario: A pure pane writes to shared state while rendering
+
+- **WHEN** a pane writes to the shared store from inside its render
+- **THEN** it is not eligible to declare its render pure, because the write
+  would stop happening on the frames its render is skipped
+
+#### Scenario: The declaration is misspelled
+
+- **WHEN** a pane's declaration table carries a misspelling of the purity key
+- **THEN** the pane is treated as not having declared it, and so renders every
+  frame exactly as it did before — the failure of a misspelling is a pane that
+  is merely no faster, never one that is stale
+
+This is why the declaration is opt-in rather than opt-out. No key of a
+declaration table is checked today — `slot`, `focusable` and `order` are equally
+unchecked, and a plugin may carry its own bookkeeping there — so a misspelling
+cannot be reported without inventing a schema for the whole table. Opt-in makes
+that acceptable: the unchecked direction is the safe one.
+
+#### Scenario: A pure pane is edited on disk
+
+- **WHEN** a pane is edited and the interface reloads
+- **THEN** the reloaded pane renders afresh rather than being painted from the
+  tree its previous version returned

--- a/src/cli/perf.rs
+++ b/src/cli/perf.rs
@@ -1,8 +1,9 @@
 //! `thurbox-cli perf` — read the perf snapshot a running TUI publishes.
 //!
-//! The TUI writes a JSON snapshot (counters, frame/tick timing percentiles,
-//! slow ops, startup phase breakdown) into the SQLite `metadata` table while
-//! perf timing is active — `THURBOX_PERF_LOG=1` or an open perf HUD (F12).
+//! The TUI writes a JSON snapshot (counters, frame/republish/tick timing
+//! percentiles, slow ops, startup phase breakdown) into the SQLite `metadata`
+//! table while perf timing is active — `THURBOX_PERF_LOG=1` or an open perf
+//! HUD (F12). `kernel::perf::snapshot_json` owns the shape; this renders it.
 //! This command prints the latest one, so a running instance can be inspected
 //! from outside without tailing `thurbox.log`. See `docs/PERFORMANCE.md`.
 
@@ -60,52 +61,53 @@ fn render_human(s: &Value) -> String {
         .map(|d| d.as_secs().saturating_sub(captured_at))
         .unwrap_or(0);
 
+    // One row per histogram, so the three costs of a frame stay side by side:
+    // painting, the table rebuild that precedes it, and the rest of the loop.
+    let histogram = |key: &str| {
+        format!(
+            "{} / {} / {}  ({} samples)",
+            fmt_us(u(s, &[key, "p50_us"])),
+            fmt_us(u(s, &[key, "p95_us"])),
+            fmt_us(u(s, &[key, "max_us"])),
+            u(s, &[key, "samples"]),
+        )
+    };
+
     let mut pairs: Vec<(&str, String)> = vec![
         ("captured", format!("{age}s ago (pid {})", u(s, &["pid"]))),
         ("sessions", u(s, &["session_count"]).to_string()),
-        ("ticks", u(s, &["tick_count"]).to_string()),
-        ("frames", u(s, &["counters", "frames_rendered"]).to_string()),
+        ("iterations", u(s, &["counters", "iterations"]).to_string()),
+        ("frames", u(s, &["counters", "frames"]).to_string()),
+        ("idle skips", u(s, &["counters", "skipped"]).to_string()),
+        ("plugin renders", u(s, &["counters", "renders"]).to_string()),
         (
-            "idle skips",
-            u(s, &["counters", "redraws_skipped"]).to_string(),
+            "plugin failures",
+            u(s, &["counters", "failures"]).to_string(),
+        ),
+        ("reloads", u(s, &["counters", "reloads"]).to_string()),
+        (
+            "renders skipped",
+            u(s, &["counters", "renders_skipped"]).to_string(),
         ),
         (
-            "order rebuilds",
-            u(s, &["counters", "ordered_sessions_rebuilds"]).to_string(),
+            "groups reused",
+            u(s, &["counters", "groups_reused"]).to_string(),
         ),
-        (
-            "hook loads",
-            u(s, &["counters", "hook_state_loads"]).to_string(),
-        ),
-        (
-            "frame p50/p95/max",
-            format!(
-                "{} / {} / {}",
-                fmt_us(u(s, &["frame", "p50_us"])),
-                fmt_us(u(s, &["frame", "p95_us"])),
-                fmt_us(u(s, &["frame", "max_us"])),
-            ),
-        ),
-        (
-            "tick p50/p95/max",
-            format!(
-                "{} / {} / {}",
-                fmt_us(u(s, &["tick", "p50_us"])),
-                fmt_us(u(s, &["tick", "p95_us"])),
-                fmt_us(u(s, &["tick", "max_us"])),
-            ),
-        ),
+        ("frame p50/p95/max", histogram("frame")),
+        ("republish p50/p95/max", histogram("republish")),
+        ("tick p50/p95/max", histogram("tick")),
     ];
 
     if let Some(startup) = s.get("startup").filter(|v| v.is_object()) {
         pairs.push((
             "startup",
             format!(
-                "config {}ms · db {}ms · heal {}ms · restore {}ms",
+                "config {}ms · db {}ms · heal {}ms · ui {}ms · first frame {}ms",
                 u(startup, &["config_init_ms"]),
                 u(startup, &["db_open_ms"]),
                 u(startup, &["extension_heal_ms"]),
-                u(startup, &["restore_ms"]),
+                u(startup, &["ui_build_ms"]),
+                u(startup, &["first_frame_ms"]),
             ),
         ));
     }
@@ -144,18 +146,30 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
         db.set_perf_snapshot(
             r#"{"pid":42,"captured_at":0,"session_count":3,"tick_count":100,
-                "counters":{"frames_rendered":7,"redraws_skipped":90,
-                            "ordered_sessions_rebuilds":1,"hook_state_loads":2},
-                "frame":{"p50_us":900,"p95_us":4000,"max_us":30000},
-                "tick":{"p50_us":250,"p95_us":500,"max_us":1000},
-                "slow_ops":[{"op":"code_review_build","ms":320}]}"#,
+                "counters":{"iterations":100,"frames":7,"skipped":90,
+                            "renders":21,"failures":0,"reloads":1,
+                            "renders_skipped":88,"groups_reused":140},
+                "frame":{"p50_us":900,"p95_us":4000,"max_us":30000,"samples":7},
+                "republish":{"p50_us":800,"p95_us":2000,"max_us":9000,"samples":7},
+                "tick":{"p50_us":250,"p95_us":500,"max_us":1000,"samples":100},
+                "startup":{"config_init_ms":3,"db_open_ms":11,"extension_heal_ms":15,
+                           "ui_build_ms":40,"first_frame_ms":120},
+                "slow_ops":[{"op":"interface_reload","ms":320}]}"#,
         )
         .unwrap();
         let out = run(&db).unwrap();
         assert!(out.failure.is_none());
         assert!(out.human.contains("pid 42"));
-        assert!(out.human.contains("code_review_build"));
+        assert!(out.human.contains("interface_reload"));
         assert!(out.human.contains("320ms"));
-        assert_eq!(out.json["counters"]["frames_rendered"], 7);
+        // republish is reported beside frame: telling the table rebuild apart
+        // from the paint is the whole reason it has its own histogram.
+        assert!(out.human.contains("republish"));
+        assert!(out.human.contains("ui 40ms"));
+        // The two skip counters: a skipped frame is invisible in anything else.
+        assert!(out.human.contains("renders skipped"));
+        assert!(out.human.contains("88"));
+        assert!(out.human.contains("groups reused"));
+        assert_eq!(out.json["counters"]["frames"], 7);
     }
 }

--- a/src/kernel/bands.rs
+++ b/src/kernel/bands.rs
@@ -60,7 +60,7 @@ impl Level {
 ///
 /// A slot the arrangement placed that is not one of these belongs to plugins,
 /// and is not this module's business.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Band {
     Identity,
     Message,

--- a/src/kernel/command.rs
+++ b/src/kernel/command.rs
@@ -921,6 +921,18 @@ impl CommandBus {
     }
 
     /// Everything accepted but not yet done, for publishing to plugins.
+    /// Whether anything is in flight, without cloning the list.
+    ///
+    /// The animation clock asks this on every published frame, and
+    /// [`Self::inflight`] clones under a lock — a second copy a frame to answer
+    /// a question about emptiness.
+    pub fn has_inflight(&self) -> bool {
+        self.inflight
+            .lock()
+            .map(|list| !list.is_empty())
+            .unwrap_or(false)
+    }
+
     pub fn inflight(&self) -> Vec<InFlight> {
         self.inflight
             .lock()

--- a/src/kernel/convert.rs
+++ b/src/kernel/convert.rs
@@ -13,6 +13,31 @@ use super::node::{
     parse_color, Align, Axis, Borders, Frame, Identity, Node, Run, Size, SurfaceSource,
 };
 
+/// Where in the tree an error happened, built as a borrowed chain rather than a
+/// string.
+///
+/// Every descent used to allocate its child's path eagerly —
+/// `&format!("{path}[{}]", index + 1)` — one `String` per node, growing with
+/// depth, on a path that is only ever *read* when something is malformed. It
+/// was ~15% of conversion for text nobody sees. A chain costs nothing to build
+/// and renders itself only when a message is finally formatted.
+#[derive(Clone, Copy)]
+enum Crumb<'a> {
+    Root,
+    Field(&'a Crumb<'a>, &'static str),
+    Index(&'a Crumb<'a>, usize),
+}
+
+impl std::fmt::Display for Crumb<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Crumb::Root => f.write_str("root"),
+            Crumb::Field(parent, name) => write!(f, "{parent}.{name}"),
+            Crumb::Index(parent, index) => write!(f, "{parent}[{index}]"),
+        }
+    }
+}
+
 /// Deepest tree accepted. Guards against a plugin building a cyclic or
 /// pathological structure and taking the render thread down with it.
 const MAX_DEPTH: usize = 64;
@@ -25,10 +50,10 @@ const MAX_DEPTH: usize = 64;
 /// writes `program = "watch"` and the kernel resolves the owner, so naming another
 /// plugin's pane is impossible by construction rather than refused by a check.
 pub fn to_node(value: &Value, owner: &str) -> Result<Node, String> {
-    convert(value, "root", 0, owner)
+    convert(value, Crumb::Root, 0, owner)
 }
 
-fn convert(value: &Value, path: &str, depth: usize, owner: &str) -> Result<Node, String> {
+fn convert(value: &Value, path: Crumb<'_>, depth: usize, owner: &str) -> Result<Node, String> {
     if depth > MAX_DEPTH {
         return Err(format!(
             "{path}: tree nested deeper than {MAX_DEPTH} levels"
@@ -46,12 +71,107 @@ fn convert(value: &Value, path: &str, depth: usize, owner: &str) -> Result<Node,
     }
 }
 
-fn convert_table(table: &Table, path: &str, depth: usize, owner: &str) -> Result<Node, String> {
-    let size = read_size(table, path)?;
-    let identity = read_identity(table, path)?;
-    let frame = read_frame(table, path)?;
+/// Every field a node may carry, gathered in ONE pass over the table.
+///
+/// Read individually this cost ~25 keyed lookups per node — `read_size` alone
+/// is five — and each one hashes its key and crosses into the VM. At ~570ns a
+/// lookup that was ~14µs *per node*, and the session list builds 187 of them:
+/// conversion outweighed running every plugin's Lua put together, and was the
+/// single largest cost in a frame. One `pairs` pass visits only the handful of
+/// keys a node actually has.
+///
+/// This is the same fix, for the same reason, that [`read_style_field`] already
+/// applies one level down — see its comment.
+///
+/// Keys are read **raw**, as all but two of the individual lookups already
+/// were; a node table is data a plugin wrote, never a view onto something else.
+#[derive(Default)]
+struct Fields {
+    kind: Option<Value>,
+    len: Option<Value>,
+    pct: Option<Value>,
+    fill: Option<Value>,
+    min: Option<Value>,
+    max: Option<Value>,
+    class: Option<Value>,
+    id: Option<Value>,
+    role: Option<Value>,
+    frame: Option<Value>,
+    block: Option<Value>,
+    text: Option<Value>,
+    align: Option<Value>,
+    wrap: Option<Value>,
+    scroll: Option<Value>,
+    axis: Option<Value>,
+    gap: Option<Value>,
+    children: Option<Value>,
+    value: Option<Value>,
+    cursor: Option<Value>,
+    placeholder: Option<Value>,
+    focused: Option<Value>,
+    style: Option<Value>,
+    session: Option<Value>,
+    program: Option<Value>,
+    cells: Option<Value>,
+}
 
-    let declared: Option<String> = opt_string(table, "type", path)?;
+impl Fields {
+    fn read(table: &Table, path: Crumb<'_>) -> Result<Self, String> {
+        let mut out = Self::default();
+        for pair in table.pairs::<Value, Value>() {
+            let (key, value) = pair.map_err(|e| format!("{path}: {e}"))?;
+            // Integer keys are the array part — the children of a box, read in
+            // order below rather than here, where `pairs` promises no order.
+            let Value::String(key) = key else { continue };
+            let slot = match key.as_bytes().as_ref() {
+                b"type" => &mut out.kind,
+                b"len" => &mut out.len,
+                b"pct" => &mut out.pct,
+                b"fill" => &mut out.fill,
+                b"min" => &mut out.min,
+                b"max" => &mut out.max,
+                b"class" => &mut out.class,
+                b"id" => &mut out.id,
+                b"role" => &mut out.role,
+                b"frame" => &mut out.frame,
+                b"block" => &mut out.block,
+                b"text" => &mut out.text,
+                b"align" => &mut out.align,
+                b"wrap" => &mut out.wrap,
+                b"scroll" => &mut out.scroll,
+                b"axis" => &mut out.axis,
+                b"gap" => &mut out.gap,
+                b"children" => &mut out.children,
+                b"value" => &mut out.value,
+                b"cursor" => &mut out.cursor,
+                b"placeholder" => &mut out.placeholder,
+                b"focused" => &mut out.focused,
+                b"style" => &mut out.style,
+                b"session" => &mut out.session,
+                b"program" => &mut out.program,
+                b"cells" => &mut out.cells,
+                // A key this kernel does not know is not an error: it is how a
+                // plugin carries its own bookkeeping on the same table.
+                _ => continue,
+            };
+            *slot = Some(value);
+        }
+        Ok(out)
+    }
+}
+
+fn convert_table(
+    table: &Table,
+    path: Crumb<'_>,
+    depth: usize,
+    owner: &str,
+) -> Result<Node, String> {
+    let fields = Fields::read(table, path)?;
+    let size = read_size(&fields, path)?;
+    let identity = read_identity(&fields, path)?;
+    let frame = read_frame(&fields, path)?;
+
+    let declared: Option<String> = val_string(fields.kind.as_ref(), "type", path)?;
     let kind = match declared {
         Some(name) => normalize_kind(&name).ok_or_else(|| {
             format!(
@@ -61,15 +181,11 @@ fn convert_table(table: &Table, path: &str, depth: usize, owner: &str) -> Result
         // Inference keeps simple plugins terse: the presence of a field
         // implies the kind, and a table of children is a box.
         None => {
-            if table.contains_key("cells").unwrap_or(false)
-                || table.contains_key("session").unwrap_or(false)
-            {
+            if fields.cells.is_some() || fields.session.is_some() {
                 "surface"
-            } else if table.contains_key("value").unwrap_or(false)
-                || table.contains_key("placeholder").unwrap_or(false)
-            {
+            } else if fields.value.is_some() || fields.placeholder.is_some() {
                 "input"
-            } else if table.contains_key("text").unwrap_or(false) {
+            } else if fields.text.is_some() {
                 "text"
             } else {
                 "box"
@@ -78,22 +194,21 @@ fn convert_table(table: &Table, path: &str, depth: usize, owner: &str) -> Result
     };
 
     match kind {
-        "text" => {
-            let raw: Value = table
-                .raw_get("text")
-                .map_err(|e| lua_err(path, "text", &e))?;
-            Ok(Node::Text {
-                lines: read_lines(&raw, &format!("{path}.text"), depth + 1)?,
-                align: read_align(table, path)?,
-                wrap: opt_bool(table, "wrap", path)?.unwrap_or(false),
-                scroll: opt_u16(table, "scroll", path)?.unwrap_or(0),
-                frame,
-                size,
-                identity,
-            })
-        }
+        "text" => Ok(Node::Text {
+            lines: read_lines(
+                fields.text.as_ref().unwrap_or(&Value::Nil),
+                Crumb::Field(&path, "text"),
+                depth + 1,
+            )?,
+            align: read_align(&fields, path)?,
+            wrap: val_bool(fields.wrap.as_ref(), "wrap", path)?.unwrap_or(false),
+            scroll: val_u16(fields.scroll.as_ref(), "scroll", path)?.unwrap_or(0),
+            frame,
+            size,
+            identity,
+        }),
         "box" => {
-            let axis = match opt_string(table, "axis", path)?.as_deref() {
+            let axis = match val_string(fields.axis.as_ref(), "axis", path)?.as_deref() {
                 Some("horizontal") | Some("row") | Some("h") => Axis::Horizontal,
                 Some("vertical") | Some("column") | Some("v") | None => Axis::Vertical,
                 Some(other) => {
@@ -104,31 +219,34 @@ fn convert_table(table: &Table, path: &str, depth: usize, owner: &str) -> Result
             };
             Ok(Node::Box {
                 axis,
-                gap: opt_u16(table, "gap", path)?.unwrap_or(0),
-                children: read_children(table, path, depth, owner)?,
+                gap: val_u16(fields.gap.as_ref(), "gap", path)?.unwrap_or(0),
+                children: read_children(table, &fields, path, depth, owner)?,
                 frame,
                 size,
                 identity,
             })
         }
         "input" => Ok(Node::Input {
-            value: opt_string(table, "value", path)?.unwrap_or_default(),
-            cursor: opt_u16(table, "cursor", path)?.unwrap_or(0) as usize,
-            placeholder: opt_string(table, "placeholder", path)?.unwrap_or_default(),
+            value: val_string(fields.value.as_ref(), "value", path)?.unwrap_or_default(),
+            cursor: val_u16(fields.cursor.as_ref(), "cursor", path)?.unwrap_or(0) as usize,
+            placeholder: val_string(fields.placeholder.as_ref(), "placeholder", path)?
+                .unwrap_or_default(),
             // Absent means "not the one being typed into". A pane that draws one
             // field and never says so gets no caret, which is visible at once —
             // the alternative default hands the caret to every field on screen
             // and the last one painted wins, which is not.
-            focused: opt_bool(table, "focused", path)?.unwrap_or(false),
-            style: read_style_field(table, "style", path)?,
+            focused: val_bool(fields.focused.as_ref(), "focused", path)?.unwrap_or(false),
+            style: read_style_value(fields.style.as_ref(), "style", path)?,
             frame,
             size,
             identity,
         }),
         "surface" => {
-            let source = if let Some(session) = opt_string(table, "session", path)? {
+            let source = if let Some(session) =
+                val_string(fields.session.as_ref(), "session", path)?
+            {
                 SurfaceSource::Session(session)
-            } else if let Some(program) = opt_string(table, "program", path)? {
+            } else if let Some(program) = val_string(fields.program.as_ref(), "program", path)? {
                 // Resolved against the plugin that drew it. The name is checked
                 // here so a bad one is a conversion error naming its path, rather
                 // than a pane that never appears.
@@ -138,14 +256,15 @@ fn convert_table(table: &Table, path: &str, depth: usize, owner: &str) -> Result
                     super::terminal::ProgramKey::new(owner, &program).surface_id(),
                 )
             } else {
-                let raw: Value = table
-                    .raw_get("cells")
-                    .map_err(|e| lua_err(path, "cells", &e))?;
-                SurfaceSource::Cells(read_lines(&raw, &format!("{path}.cells"), depth + 1)?)
+                SurfaceSource::Cells(read_lines(
+                    fields.cells.as_ref().unwrap_or(&Value::Nil),
+                    Crumb::Field(&path, "cells"),
+                    depth + 1,
+                )?)
             };
             Ok(Node::Surface {
                 source,
-                scroll: opt_u16(table, "scroll", path)?.unwrap_or(0),
+                scroll: val_u16(fields.scroll.as_ref(), "scroll", path)?.unwrap_or(0),
                 frame,
                 size,
                 identity,
@@ -168,16 +287,15 @@ fn normalize_kind(name: &str) -> Option<&'static str> {
 
 fn read_children(
     table: &Table,
-    path: &str,
+    fields: &Fields,
+    path: Crumb<'_>,
     depth: usize,
     owner: &str,
 ) -> Result<Vec<Node>, String> {
     // Children live under `children`, or in the array part of the table so a
-    // plugin can write `{ a, b, c }` without the extra key.
-    let raw: Value = table
-        .get("children")
-        .map_err(|e| lua_err(path, "children", &e))?;
-    let list = match raw {
+    // plugin can write `{ a, b, c }` without the extra key. Taken from the
+    // single field pass, so a box costs no lookup of its own.
+    let list = match fields.children.clone().unwrap_or(Value::Nil) {
         Value::Table(t) => t,
         Value::Nil => table.clone(),
         other => {
@@ -191,8 +309,12 @@ fn read_children(
     let mut children = Vec::new();
     for (index, entry) in list.sequence_values::<Value>().enumerate() {
         let entry = entry.map_err(|e| lua_err(path, "children", &e))?;
-        let child_path = format!("{path}[{}]", index + 1);
-        children.push(convert(&entry, &child_path, depth + 1, owner)?);
+        children.push(convert(
+            &entry,
+            Crumb::Index(&path, index + 1),
+            depth + 1,
+            owner,
+        )?);
     }
     Ok(children)
 }
@@ -203,7 +325,7 @@ fn read_children(
 /// `depth` is threaded for the same reason [`convert`] threads it: a table that
 /// contains itself is a legal Lua value, and text is a place a plugin can hand
 /// one over.
-fn read_lines(value: &Value, path: &str, depth: usize) -> Result<Vec<Vec<Run>>, String> {
+fn read_lines(value: &Value, path: Crumb<'_>, depth: usize) -> Result<Vec<Vec<Run>>, String> {
     if depth > MAX_DEPTH {
         return Err(format!(
             "{path}: tree nested deeper than {MAX_DEPTH} levels"
@@ -221,7 +343,9 @@ fn read_lines(value: &Value, path: &str, depth: usize) -> Result<Vec<Vec<Run>>, 
         }]]),
         Value::Table(table) => {
             // `{ text = ..., style = ... }` is one line, not a list of lines.
-            if table.contains_key("text").unwrap_or(false) {
+            // One raw read answers it; asking `contains_key` first was a second
+            // crossing into the VM for the same question, per line per frame.
+            if !matches!(table.raw_get::<Value>("text"), Ok(Value::Nil) | Err(_)) {
                 return Ok(vec![read_runs(value, path, depth + 1)?]);
             }
             let mut lines = Vec::new();
@@ -229,7 +353,7 @@ fn read_lines(value: &Value, path: &str, depth: usize) -> Result<Vec<Vec<Run>>, 
                 let entry = entry.map_err(|e| lua_err(path, "line", &e))?;
                 lines.push(read_runs(
                     &entry,
-                    &format!("{path}[{}]", index + 1),
+                    Crumb::Index(&path, index + 1),
                     depth + 1,
                 )?);
             }
@@ -240,7 +364,7 @@ fn read_lines(value: &Value, path: &str, depth: usize) -> Result<Vec<Vec<Run>>, 
 }
 
 /// One line: a string, a `{ text =, style = }` table, or a list of those.
-fn read_runs(value: &Value, path: &str, depth: usize) -> Result<Vec<Run>, String> {
+fn read_runs(value: &Value, path: Crumb<'_>, depth: usize) -> Result<Vec<Run>, String> {
     if depth > MAX_DEPTH {
         return Err(format!(
             "{path}: tree nested deeper than {MAX_DEPTH} levels"
@@ -257,10 +381,13 @@ fn read_runs(value: &Value, path: &str, depth: usize) -> Result<Vec<Run>, String
         }]),
         Value::Nil => Ok(Vec::new()),
         Value::Table(table) => {
-            if table.contains_key("text").unwrap_or(false) {
-                let raw: Value = table
-                    .raw_get("text")
-                    .map_err(|e| lua_err(path, "text", &e))?;
+            // Read once and branch on what came back, rather than asking
+            // `contains_key` and then reading it again — this is the hottest
+            // leaf in the renderer, one call per span per plugin per frame.
+            let raw: Value = table
+                .raw_get("text")
+                .map_err(|e| lua_err(path, "text", &e))?;
+            if !matches!(raw, Value::Nil) {
                 let text = match raw {
                     Value::String(s) => s.to_string_lossy(),
                     ref other => scalar_to_string(other),
@@ -275,7 +402,7 @@ fn read_runs(value: &Value, path: &str, depth: usize) -> Result<Vec<Run>, String
                 let entry = entry.map_err(|e| lua_err(path, "span", &e))?;
                 runs.extend(read_runs(
                     &entry,
-                    &format!("{path}[{}]", index + 1),
+                    Crumb::Index(&path, index + 1),
                     depth + 1,
                 )?);
             }
@@ -288,22 +415,19 @@ fn read_runs(value: &Value, path: &str, depth: usize) -> Result<Vec<Run>, String
     }
 }
 
-fn read_size(table: &Table, path: &str) -> Result<Size, String> {
+fn read_size(fields: &Fields, path: Crumb<'_>) -> Result<Size, String> {
     Ok(Size {
-        len: opt_u16(table, "len", path)?,
-        pct: opt_f64(table, "pct", path)?,
-        fill: opt_f64(table, "fill", path)?,
-        min: opt_u16(table, "min", path)?,
-        max: opt_u16(table, "max", path)?,
+        len: val_u16(fields.len.as_ref(), "len", path)?,
+        pct: val_f64(fields.pct.as_ref(), "pct", path)?,
+        fill: val_f64(fields.fill.as_ref(), "fill", path)?,
+        min: val_u16(fields.min.as_ref(), "min", path)?,
+        max: val_u16(fields.max.as_ref(), "max", path)?,
     })
 }
 
-fn read_identity(table: &Table, path: &str) -> Result<Identity, String> {
+fn read_identity(fields: &Fields, path: Crumb<'_>) -> Result<Identity, String> {
     // `class` accepts one name or a list, mirroring how it reads in markup.
-    let raw: Value = table
-        .raw_get("class")
-        .map_err(|e| lua_err(path, "class", &e))?;
-    let classes = match raw {
+    let classes = match fields.class.clone().unwrap_or(Value::Nil) {
         Value::Nil => Vec::new(),
         Value::String(s) => s
             .to_string_lossy()
@@ -325,23 +449,19 @@ fn read_identity(table: &Table, path: &str) -> Result<Identity, String> {
         }
     };
     Ok(Identity {
-        id: opt_string(table, "id", path)?,
+        id: val_string(fields.id.as_ref(), "id", path)?,
         classes,
-        role: opt_string(table, "role", path)?,
+        role: val_string(fields.role.as_ref(), "role", path)?,
     })
 }
 
-fn read_frame(table: &Table, path: &str) -> Result<Option<Frame>, String> {
-    let raw: Value = table
-        .raw_get("frame")
-        .map_err(|e| lua_err(path, "frame", &e))?;
+fn read_frame(fields: &Fields, path: Crumb<'_>) -> Result<Option<Frame>, String> {
     // `block` is what the POC called it; keep it working.
-    let raw = match raw {
-        Value::Nil => table
-            .raw_get("block")
-            .map_err(|e| lua_err(path, "block", &e))?,
-        other => other,
-    };
+    let raw = fields
+        .frame
+        .clone()
+        .or_else(|| fields.block.clone())
+        .unwrap_or(Value::Nil);
     match raw {
         Value::Nil => Ok(None),
         Value::Boolean(false) => Ok(None),
@@ -361,7 +481,11 @@ fn read_frame(table: &Table, path: &str) -> Result<Option<Frame>, String> {
             // same shape a `text` node accepts.
             let title = match spec.get::<Value>("title") {
                 Ok(Value::Nil) => None,
-                Ok(value) => Some(read_runs(&value, &format!("{path}.frame.title"), 0)?),
+                Ok(value) => Some(read_runs(
+                    &value,
+                    Crumb::Field(&Crumb::Field(&path, "frame"), "title"),
+                    0,
+                )?),
                 Err(e) => return Err(format!("{path}.frame.title: {e}")),
             };
             Ok(Some(Frame {
@@ -379,8 +503,8 @@ fn read_frame(table: &Table, path: &str) -> Result<Option<Frame>, String> {
     }
 }
 
-fn read_align(table: &Table, path: &str) -> Result<Align, String> {
-    match opt_string(table, "align", path)?.as_deref() {
+fn read_align(fields: &Fields, path: Crumb<'_>) -> Result<Align, String> {
+    match val_string(fields.align.as_ref(), "align", path)?.as_deref() {
         Some("center") | Some("centre") => Ok(Align::Center),
         Some("right") => Ok(Align::Right),
         Some("left") | None => Ok(Align::Left),
@@ -420,8 +544,17 @@ fn modifier_for(field: &[u8]) -> Option<ratatui::style::Modifier> {
 }
 
 /// Read a style, which may be a colour shorthand or a full table.
-fn read_style_field(table: &Table, key: &str, path: &str) -> Result<Style, String> {
+/// [`read_style_field`] against an already-gathered value.
+fn read_style_value(value: Option<&Value>, key: &str, path: Crumb<'_>) -> Result<Style, String> {
+    read_style_raw(value.cloned().unwrap_or(Value::Nil), key, path)
+}
+
+fn read_style_field(table: &Table, key: &str, path: Crumb<'_>) -> Result<Style, String> {
     let raw: Value = table.raw_get(key).map_err(|e| lua_err(path, key, &e))?;
+    read_style_raw(raw, key, path)
+}
+
+fn read_style_raw(raw: Value, key: &str, path: Crumb<'_>) -> Result<Style, String> {
     match raw {
         Value::Nil => Ok(Style::default()),
         // `style = "cyan"` — the shorthand every plugin uses for a foreground.
@@ -465,7 +598,7 @@ fn read_style_field(table: &Table, key: &str, path: &str) -> Result<Style, Strin
     }
 }
 
-fn opt_string(table: &Table, key: &str, path: &str) -> Result<Option<String>, String> {
+fn opt_string(table: &Table, key: &str, path: Crumb<'_>) -> Result<Option<String>, String> {
     match table
         .raw_get::<Value>(key)
         .map_err(|e| lua_err(path, key, &e))?
@@ -480,21 +613,7 @@ fn opt_string(table: &Table, key: &str, path: &str) -> Result<Option<String>, St
     }
 }
 
-fn opt_bool(table: &Table, key: &str, path: &str) -> Result<Option<bool>, String> {
-    match table
-        .raw_get::<Value>(key)
-        .map_err(|e| lua_err(path, key, &e))?
-    {
-        Value::Nil => Ok(None),
-        Value::Boolean(b) => Ok(Some(b)),
-        ref other => Err(format!(
-            "{path}.{key}: expected a boolean, found {}",
-            type_name(other)
-        )),
-    }
-}
-
-fn opt_u16(table: &Table, key: &str, path: &str) -> Result<Option<u16>, String> {
+fn opt_u16(table: &Table, key: &str, path: Crumb<'_>) -> Result<Option<u16>, String> {
     match opt_f64(table, key, path)? {
         None => Ok(None),
         Some(n) if n.is_finite() && n >= 0.0 => Ok(Some(n.min(f64::from(u16::MAX)) as u16)),
@@ -504,7 +623,7 @@ fn opt_u16(table: &Table, key: &str, path: &str) -> Result<Option<u16>, String> 
     }
 }
 
-fn opt_f64(table: &Table, key: &str, path: &str) -> Result<Option<f64>, String> {
+fn opt_f64(table: &Table, key: &str, path: Crumb<'_>) -> Result<Option<f64>, String> {
     match table
         .raw_get::<Value>(key)
         .map_err(|e| lua_err(path, key, &e))?
@@ -513,6 +632,54 @@ fn opt_f64(table: &Table, key: &str, path: &str) -> Result<Option<f64>, String> 
         Value::Integer(n) => Ok(Some(n as f64)),
         Value::Number(n) => Ok(Some(n)),
         ref other => Err(format!(
+            "{path}.{key}: expected a number, found {}",
+            type_name(other)
+        )),
+    }
+}
+
+/// The `opt_*` coercions, against a field already gathered by [`Fields::read`]
+/// rather than a fresh lookup. Same rules, same messages — only the source of
+/// the value differs.
+fn val_string(value: Option<&Value>, key: &str, path: Crumb<'_>) -> Result<Option<String>, String> {
+    match value.unwrap_or(&Value::Nil) {
+        Value::Nil => Ok(None),
+        Value::String(s) => Ok(Some(s.to_string_lossy())),
+        Value::Integer(n) => Ok(Some(n.to_string())),
+        other => Err(format!(
+            "{path}.{key}: expected a string, found {}",
+            type_name(other)
+        )),
+    }
+}
+
+fn val_bool(value: Option<&Value>, key: &str, path: Crumb<'_>) -> Result<Option<bool>, String> {
+    match value.unwrap_or(&Value::Nil) {
+        Value::Nil => Ok(None),
+        Value::Boolean(b) => Ok(Some(*b)),
+        other => Err(format!(
+            "{path}.{key}: expected a boolean, found {}",
+            type_name(other)
+        )),
+    }
+}
+
+fn val_u16(value: Option<&Value>, key: &str, path: Crumb<'_>) -> Result<Option<u16>, String> {
+    match val_f64(value, key, path)? {
+        None => Ok(None),
+        Some(n) if n.is_finite() && n >= 0.0 => Ok(Some(n.min(f64::from(u16::MAX)) as u16)),
+        Some(n) => Err(format!(
+            "{path}.{key}: expected a non-negative number, found {n}"
+        )),
+    }
+}
+
+fn val_f64(value: Option<&Value>, key: &str, path: Crumb<'_>) -> Result<Option<f64>, String> {
+    match value.unwrap_or(&Value::Nil) {
+        Value::Nil => Ok(None),
+        Value::Integer(n) => Ok(Some(*n as f64)),
+        Value::Number(n) => Ok(Some(*n)),
+        other => Err(format!(
             "{path}.{key}: expected a number, found {}",
             type_name(other)
         )),
@@ -541,7 +708,7 @@ fn type_name(value: &Value) -> &'static str {
     }
 }
 
-fn lua_err(path: &str, key: &str, error: &mlua::Error) -> String {
+fn lua_err(path: Crumb<'_>, key: &str, error: &mlua::Error) -> String {
     format!("{path}.{key}: {error}")
 }
 

--- a/src/kernel/host.rs
+++ b/src/kernel/host.rs
@@ -17,7 +17,7 @@
 //! makes "plugins never touch the render thread" a compile error (D10).
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -109,6 +109,15 @@ enum Persisted {
 /// `store` is shared by every plugin; `state` is keyed by plugin file too, so
 /// two plugins can both use `state.index` without colliding.
 type Shared = Rc<RefCell<BTreeMap<String, Persisted>>>;
+/// How many times plugin state — shared or private — has been written.
+///
+/// A pure pane's tree may legitimately depend on `store` or `state`: the agent
+/// pane remembers which tab each session is on, and one pane can read a value
+/// another wrote. Neither is a published source, so without this a tree cached
+/// before a keypress would survive it (`frame-cost`). Coarse on purpose — any
+/// write invalidates every cached tree, which is right for something that
+/// happens on input rather than per frame.
+type StateVersion = Rc<std::cell::Cell<u64>>;
 type Private = Rc<RefCell<BTreeMap<(String, String), Persisted>>>;
 /// Commands a plugin issued this frame, drained by the loop.
 type Queue = Rc<RefCell<Vec<Command>>>;
@@ -179,6 +188,16 @@ pub struct Plugin {
     pub path: String,
     pub slot: String,
     pub focusable: bool,
+    /// Declared `pure = true`: this pane's render is a function of the published
+    /// tables and its render context, and of nothing else.
+    ///
+    /// An assertion the author makes, not a property the kernel can check — a
+    /// render may write to `store` or read a per-frame clock, and neither is
+    /// visible from outside the VM. Declaring it buys not being called on a
+    /// frame where nothing it can read has changed; declaring it wrongly buys a
+    /// pane painted from a stale tree. Opt-in for exactly that reason: a pane
+    /// that says nothing behaves as it always has (`frame-cost`).
+    pub pure: bool,
     /// Declared `input = "session"`: while this plugin holds focus, keys it
     /// does not handle are forwarded to the session its surface names.
     ///
@@ -347,7 +366,87 @@ pub struct Rendered {
 /// A struct rather than a parameter list because this grew from two to six in
 /// the course of one change, and each growth churned every call site. Adding
 /// something plugins can read should not be an edit to every test.
+/// The version each published source stood at when a frame was published.
+///
+/// A group rebuilt at one epoch and asked for again at the same one cannot have
+/// differed, which is the whole of the gate (`frame-cost`). Each group names the
+/// fields it is built from rather than taking the whole struct, so a source that
+/// moves every frame only invalidates what actually reads it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Epoch {
+    /// `SnapshotStore::generation`.
+    pub snapshot: u64,
+    /// `Themes::version`.
+    pub themes: u64,
+    /// `Registry::version`.
+    pub registry: u64,
+    /// `Terminals::meta_version`.
+    pub meta: u64,
+    /// `Terminals::failed_version`.
+    pub failed: u64,
+    /// The loop's own `data_epoch` — the worker stores, links, screen text.
+    pub data: u64,
+}
+
+/// The versions one group is built from, compared exactly.
+///
+/// A fixed array rather than a hash of them: a hash collision here would reuse a
+/// stale group, and "astronomically unlikely" is the wrong guarantee for a
+/// wrong answer nobody can see. Unused slots stay zero.
+type GroupKey = [u64; 4];
+
+/// How often a pure pane's tree may change on the clock alone, in Hz.
+///
+/// Set to the rate `widgets.status_glyph` advances the working spinner at
+/// (`math.floor(elapsed * 8)`), so a cached tree is dropped exactly when the
+/// spinner would move to its next frame and never merely because time passed.
+/// Changing one without the other either freezes the animation or re-renders
+/// for nothing.
+const ANIMATION_HZ: f64 = 8.0;
+
+/// What a pure pane's cached tree was built for: the publish epoch, the parts of
+/// the render context it may depend on, and the animation tick.
+///
+/// `ctx.frame` is deliberately absent — it moves every frame, so including it
+/// would mean never reusing anything. `ctx.elapsed` enters only through
+/// [`ANIMATION_HZ`]: a pane may animate at the spinner's rate and still be pure,
+/// because at that granularity "the clock moved" is a real input rather than
+/// noise. Anything finer is not expressible, which is why a pane animating per
+/// *frame* may not declare `pure`.
+///
+/// The last field is [`StateVersion`]. A pure render may read `store` or
+/// `state` — the agent pane remembers a tab per session — and those are written
+/// by handlers, not by anything published, so without it a tree cached before a
+/// keypress would outlive it.
+type TreeKey = (Epoch, u16, u16, bool, u64, u64);
+
+impl Epoch {
+    /// An epoch that matches no previous one, so every group is rebuilt.
+    ///
+    /// For a caller that holds no versions to report — a test, or any publish
+    /// outside the render loop. Without it such a caller would publish
+    /// `Epoch::default()` twice with *different* data and be handed the first
+    /// one's groups back, which is the stale answer this whole mechanism exists
+    /// to make impossible.
+    pub fn always_fresh() -> Self {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT: AtomicU64 = AtomicU64::new(1);
+        let n = NEXT.fetch_add(1, Ordering::Relaxed);
+        Self {
+            snapshot: n,
+            themes: n,
+            registry: n,
+            meta: n,
+            failed: n,
+            data: n,
+        }
+    }
+}
+
 pub struct Published<'a> {
+    /// Where each source stood, so a group that could not have changed is not
+    /// rebuilt. See [`Epoch`].
+    pub epoch: Epoch,
     pub snapshot: &'a Snapshot,
     /// Why a session's terminal is not live, keyed by session.
     pub attach_errors: &'a std::collections::HashMap<String, String>,
@@ -430,8 +529,35 @@ pub struct RenderContext {
 pub struct LuaHost {
     lua: Lua,
     ui_dir: PathBuf,
+    /// The epoch the last publish ran at, so `render` can key a tree on it
+    /// without the loop passing it twice.
+    epoch: RefCell<Option<Epoch>>,
+    /// How many pane renders and published groups were served from a cache.
+    ///
+    /// A skip is unobservable in what gets painted — that is the whole
+    /// correctness claim — so it is only ever visible as a count. Published
+    /// through the perf snapshot, and what `tests/kernel_frame_cost.rs` asserts
+    /// on, since it has nothing else to assert on (`frame-cost`).
+    skipped_renders: std::cell::Cell<u64>,
+    reused_groups: std::cell::Cell<u64>,
+    /// A pure pane's last converted tree, with the key it was built under.
+    ///
+    /// Keyed by plugin index. Dropped whenever the VM is rebuilt, alongside
+    /// [`Self::groups`] — a `Node` outlives the Lua it came from, but a tree
+    /// built by the previous version of a pane is not that pane's answer.
+    trees: RefCell<HashMap<usize, (TreeKey, Rendered)>>,
+    /// Published groups, each with the epoch it was built at.
+    ///
+    /// The outer `thurbox` table is still assembled fresh every frame from
+    /// these; only the nested group values are reused. That is deliberate — it
+    /// means a gating mistake can produce a stale *group* but never a torn
+    /// table, and it keeps the change local to the group builders
+    /// (`frame-cost`, design.md).
+    groups: RefCell<HashMap<&'static str, (GroupKey, Value)>>,
     store: Shared,
     state: Private,
+    /// Bumped by every `store`/`state` write; part of a pure pane's tree key.
+    state_version: StateVersion,
     /// The plugin currently being called, so `state` can namespace itself.
     ///
     /// This is the file *stem*, which is what `state` has always keyed by.
@@ -479,8 +605,14 @@ impl LuaHost {
         let mut host = Self {
             lua: new_vm().unwrap_or_else(|_| Lua::new()),
             ui_dir,
+            groups: RefCell::new(HashMap::new()),
+            trees: RefCell::new(HashMap::new()),
+            epoch: RefCell::new(None),
+            skipped_renders: std::cell::Cell::new(0),
+            reused_groups: std::cell::Cell::new(0),
             store: Shared::default(),
             state: Private::default(),
+            state_version: StateVersion::default(),
             current: Rc::new(RefCell::new(String::new())),
             current_path: Rc::new(RefCell::new(String::new())),
             queue: Queue::default(),
@@ -514,6 +646,11 @@ impl LuaHost {
     pub fn reload(&mut self) {
         match self.build() {
             Ok((lua, plugins, layout)) => {
+                // Before the VM they point into is dropped: a cached group is a
+                // handle into `self.lua`, so carrying one across a reload would
+                // hand the next publish a value belonging to a Lua that no
+                // longer exists.
+                self.forget_groups();
                 self.lua = lua;
                 self.plugins = plugins;
                 self.layout = layout;
@@ -536,6 +673,7 @@ impl LuaHost {
             self.roots.clone(),
             self.runs.clone(),
             self.current_path.clone(),
+            self.state_version.clone(),
         )
         .map_err(|e| e.to_string())?;
 
@@ -1149,8 +1287,58 @@ impl LuaHost {
     ///
     /// Called once per frame from the event loop — never from inside a plugin,
     /// which is what keeps every read immediate (design.md D5).
+    /// Build one published group, or hand back the one built at the same key.
+    ///
+    /// `key` combines only the versions that group actually reads, so a source
+    /// moving every frame invalidates what reads it and nothing else. The value
+    /// is a Lua reference, so reusing it costs a clone of a registry handle
+    /// rather than a rebuild of the table behind it.
+    fn group(
+        &self,
+        name: &'static str,
+        key: GroupKey,
+        build: impl FnOnce() -> Result<Value, String>,
+    ) -> Result<Value, String> {
+        // Scoped so `build` can touch the cache without a double borrow.
+        if let Some((built_at, value)) = self.groups.borrow().get(name) {
+            if *built_at == key {
+                self.reused_groups.set(self.reused_groups.get() + 1);
+                return Ok(value.clone());
+            }
+        }
+        let value = build()?;
+        self.groups.borrow_mut().insert(name, (key, value.clone()));
+        Ok(value)
+    }
+
+    /// Forget every cached group, so the next publish rebuilds all of them.
+    ///
+    /// Called where the VM itself is replaced: the cached values are handles
+    /// into the Lua that is going away.
+    pub fn forget_groups(&self) {
+        self.groups.borrow_mut().clear();
+        self.trees.borrow_mut().clear();
+    }
+
+    /// Pane renders skipped because a pure pane's tree still stood.
+    pub fn skipped_renders(&self) -> u64 {
+        self.skipped_renders.get()
+    }
+
+    /// Published groups served from the cache rather than rebuilt.
+    pub fn reused_groups(&self) -> u64 {
+        self.reused_groups.get()
+    }
+
+    /// The epoch of the most recent publish, which a pure pane's tree is keyed
+    /// on. `None` before anything has been published.
+    fn published_epoch(&self) -> Option<Epoch> {
+        *self.epoch.borrow()
+    }
+
     pub fn publish(&self, world: &Published) -> Result<(), String> {
         let Published {
+            epoch,
             hovered,
             focus,
             snapshot,
@@ -1172,104 +1360,133 @@ impl LuaHost {
             wants,
         } = world;
         let table = self.lua.create_table().map_err(|e| e.to_string())?;
-        let sessions = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, row) in snapshot.sessions.iter().enumerate() {
-            let entry = self.lua.create_table().map_err(|e| e.to_string())?;
-            let set = |key: &str, value: Value| -> Result<(), String> {
-                entry.set(key, value).map_err(|e| e.to_string())
-            };
-            set("id", to_lua_string(&self.lua, &row.id)?)?;
-            set("name", to_lua_string(&self.lua, &row.name)?)?;
-            set("agent", to_lua_string(&self.lua, &row.agent)?)?;
-            let attach_error = attach_errors.get(&row.id).map(String::as_str);
-            set(
-                "status",
-                to_lua_string(
-                    &self.lua,
-                    &super::snapshot::with_reachability(&row.status, &row.backend, attach_error),
-                )?,
-            )?;
-            set("backend", to_lua_string(&self.lua, &row.backend)?)?;
-            set("repo", opt_lua_string(&self.lua, row.repo.as_deref())?)?;
-            set("branch", opt_lua_string(&self.lua, row.branch.as_deref())?)?;
-            // What the diff is taken against, so a pane can name the range it is
-            // showing rather than guessing. Distinct from `branch` above.
-            set(
-                "base_branch",
-                opt_lua_string(&self.lua, row.base_branch.as_deref())?,
-            )?;
-            set(
-                "host",
-                opt_lua_string(&self.lua, row.remote_host.as_deref())?,
-            )?;
-            set(
-                "parent",
-                opt_lua_string(&self.lua, row.parent_id.as_deref())?,
-            )?;
-            set(
-                "cwd",
-                opt_lua_string(
-                    &self.lua,
-                    row.cwd.as_ref().map(|p| p.to_string_lossy()).as_deref(),
-                )?,
-            )?;
-            entry
-                .set("worktrees", row.worktree_count)
-                .map_err(|e| e.to_string())?;
-            // Every repo the session spans, so a group can be labelled with all
-            // of them rather than just the primary.
-            let repos = self.lua.create_table().map_err(|e| e.to_string())?;
-            for (position, name) in row.repos.iter().enumerate() {
-                repos
-                    .set(position + 1, to_lua_string(&self.lua, name)?)
-                    .map_err(|e| e.to_string())?;
-            }
-            set("repos", Value::Table(repos))?;
-            // What the agent said about itself over its own terminal. Absent
-            // when it has said nothing, which a row must tell apart from an
-            // empty message.
-            let agent_meta = meta.get(&row.id);
-            set(
-                "activity",
-                opt_lua_string(&self.lua, agent_meta.and_then(|m| m.activity.as_deref()))?,
-            )?;
-            set(
-                "notification",
-                opt_lua_string(
-                    &self.lua,
-                    agent_meta.and_then(|m| m.notification.as_deref()),
-                )?,
-            )?;
-            // Manual position. Without this a plugin cannot honour the order a
-            // reorder command just wrote, and the list silently ignores it.
-            entry
-                .set("display_order", row.display_order)
-                .map_err(|e| e.to_string())?;
-            // Absent means "not computed yet", which a plugin must be able to
-            // tell apart from a clean tree.
-            if let Some(git) = row.git {
-                let stats = self.lua.create_table().map_err(|e| e.to_string())?;
-                stats
-                    .set("files", git.files_changed)
-                    .map_err(|e| e.to_string())?;
-                stats
-                    .set("insertions", git.insertions)
-                    .map_err(|e| e.to_string())?;
-                stats
-                    .set("deletions", git.deletions)
-                    .map_err(|e| e.to_string())?;
-                stats
-                    .set("untracked", git.untracked)
-                    .map_err(|e| e.to_string())?;
-                stats.set("dirty", git.dirty).map_err(|e| e.to_string())?;
-                stats.set("ahead", git.ahead).map_err(|e| e.to_string())?;
-                stats.set("behind", git.behind).map_err(|e| e.to_string())?;
-                entry.set("git", stats).map_err(|e| e.to_string())?;
-            }
-            // Why this session's terminal is not live, when it is not.
-            set("attach_error", opt_lua_string(&self.lua, attach_error)?)?;
-            sessions.set(index + 1, entry).map_err(|e| e.to_string())?;
-        }
+        // The largest group by a distance — a table per session with ~30 named
+        // fields and two nested tables — and one whose inputs move rarely: the
+        // snapshot's own generation, what each agent reported about itself, and
+        // whether an attach failed.
+        let sessions = self.group(
+            "sessions",
+            [epoch.snapshot, epoch.meta, epoch.failed, 0],
+            || {
+                let sessions = self.lua.create_table().map_err(|e| e.to_string())?;
+                for (index, row) in snapshot.sessions.iter().enumerate() {
+                    // Pre-sized: this row takes ~28 named fields, and a table grown one
+                    // field at a time rehashes itself on the way there — per session,
+                    // per frame.
+                    let entry = self
+                        .lua
+                        .create_table_with_capacity(0, 30)
+                        .map_err(|e| e.to_string())?;
+                    let set = |key: &str, value: Value| -> Result<(), String> {
+                        entry.raw_set(key, value).map_err(|e| e.to_string())
+                    };
+                    set("id", to_lua_string(&self.lua, &row.id)?)?;
+                    set("name", to_lua_string(&self.lua, &row.name)?)?;
+                    set("agent", to_lua_string(&self.lua, &row.agent)?)?;
+                    let attach_error = attach_errors.get(&row.id).map(String::as_str);
+                    set(
+                        "status",
+                        to_lua_string(
+                            &self.lua,
+                            &super::snapshot::with_reachability(
+                                &row.status,
+                                &row.backend,
+                                attach_error,
+                            ),
+                        )?,
+                    )?;
+                    set("backend", to_lua_string(&self.lua, &row.backend)?)?;
+                    set("repo", opt_lua_string(&self.lua, row.repo.as_deref())?)?;
+                    set("branch", opt_lua_string(&self.lua, row.branch.as_deref())?)?;
+                    // What the diff is taken against, so a pane can name the range it is
+                    // showing rather than guessing. Distinct from `branch` above.
+                    set(
+                        "base_branch",
+                        opt_lua_string(&self.lua, row.base_branch.as_deref())?,
+                    )?;
+                    set(
+                        "host",
+                        opt_lua_string(&self.lua, row.remote_host.as_deref())?,
+                    )?;
+                    set(
+                        "parent",
+                        opt_lua_string(&self.lua, row.parent_id.as_deref())?,
+                    )?;
+                    set(
+                        "cwd",
+                        opt_lua_string(
+                            &self.lua,
+                            row.cwd.as_ref().map(|p| p.to_string_lossy()).as_deref(),
+                        )?,
+                    )?;
+                    entry
+                        .raw_set("worktrees", row.worktree_count)
+                        .map_err(|e| e.to_string())?;
+                    // Every repo the session spans, so a group can be labelled with all
+                    // of them rather than just the primary.
+                    let repos = self.lua.create_table().map_err(|e| e.to_string())?;
+                    for (position, name) in row.repos.iter().enumerate() {
+                        repos
+                            .raw_set(position + 1, to_lua_string(&self.lua, name)?)
+                            .map_err(|e| e.to_string())?;
+                    }
+                    set("repos", Value::Table(repos))?;
+                    // What the agent said about itself over its own terminal. Absent
+                    // when it has said nothing, which a row must tell apart from an
+                    // empty message.
+                    let agent_meta = meta.get(&row.id);
+                    set(
+                        "activity",
+                        opt_lua_string(&self.lua, agent_meta.and_then(|m| m.activity.as_deref()))?,
+                    )?;
+                    set(
+                        "notification",
+                        opt_lua_string(
+                            &self.lua,
+                            agent_meta.and_then(|m| m.notification.as_deref()),
+                        )?,
+                    )?;
+                    // Manual position. Without this a plugin cannot honour the order a
+                    // reorder command just wrote, and the list silently ignores it.
+                    entry
+                        .raw_set("display_order", row.display_order)
+                        .map_err(|e| e.to_string())?;
+                    // Absent means "not computed yet", which a plugin must be able to
+                    // tell apart from a clean tree.
+                    if let Some(git) = row.git {
+                        let stats = self.lua.create_table().map_err(|e| e.to_string())?;
+                        stats
+                            .raw_set("files", git.files_changed)
+                            .map_err(|e| e.to_string())?;
+                        stats
+                            .raw_set("insertions", git.insertions)
+                            .map_err(|e| e.to_string())?;
+                        stats
+                            .raw_set("deletions", git.deletions)
+                            .map_err(|e| e.to_string())?;
+                        stats
+                            .raw_set("untracked", git.untracked)
+                            .map_err(|e| e.to_string())?;
+                        stats
+                            .raw_set("dirty", git.dirty)
+                            .map_err(|e| e.to_string())?;
+                        stats
+                            .raw_set("ahead", git.ahead)
+                            .map_err(|e| e.to_string())?;
+                        stats
+                            .raw_set("behind", git.behind)
+                            .map_err(|e| e.to_string())?;
+                        entry.raw_set("git", stats).map_err(|e| e.to_string())?;
+                    }
+                    // Why this session's terminal is not live, when it is not.
+                    set("attach_error", opt_lua_string(&self.lua, attach_error)?)?;
+                    sessions
+                        .raw_set(index + 1, entry)
+                        .map_err(|e| e.to_string())?;
+                }
+                Ok(Value::Table(sessions))
+            },
+        )?;
         // A file read is rooted at a session's directory, so the roots follow
         // the snapshot rather than being asked for separately.
         {
@@ -1282,179 +1499,219 @@ impl LuaHost {
             }
         }
 
-        table.set("sessions", sessions).map_err(|e| e.to_string())?;
+        table
+            .raw_set("sessions", sessions)
+            .map_err(|e| e.to_string())?;
 
         // What a creation flow can choose among. Reads, so picking is plugin
         // state and only committing is a command.
-        let repos = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, repo) in snapshot.repos.iter().enumerate() {
-            let item = self.lua.create_table().map_err(|e| e.to_string())?;
-            item.set("path", repo.path.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("name", repo.name.clone())
-                .map_err(|e| e.to_string())?;
-            repos.set(index + 1, item).map_err(|e| e.to_string())?;
-        }
-        table.set("repos", repos).map_err(|e| e.to_string())?;
+        // Built from the snapshot alone, so it changes when the database does
+        // and not once a frame.
+        let repos = self.group("repos", [epoch.snapshot, 0, 0, 0], || {
+            let repos = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (index, repo) in snapshot.repos.iter().enumerate() {
+                let item = self.lua.create_table().map_err(|e| e.to_string())?;
+                item.raw_set("path", repo.path.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("name", repo.name.clone())
+                    .map_err(|e| e.to_string())?;
+                repos.raw_set(index + 1, item).map_err(|e| e.to_string())?;
+            }
+            Ok(Value::Table(repos))
+        })?;
+        table.raw_set("repos", repos).map_err(|e| e.to_string())?;
 
-        let agents = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, agent) in snapshot.agents.iter().enumerate() {
-            let item = self.lua.create_table().map_err(|e| e.to_string())?;
-            item.set("name", agent.name.clone())
-                .map_err(|e| e.to_string())?;
-            // v1's picker labels a row `name  (command)` when the two differ, so
-            // the command travels with the name.
-            item.set("command", agent.command.clone())
-                .map_err(|e| e.to_string())?;
-            agents.set(index + 1, item).map_err(|e| e.to_string())?;
-        }
-        table.set("agents", agents).map_err(|e| e.to_string())?;
+        // Built from the snapshot alone, so it changes when the database does
+        // and not once a frame.
+        let agents = self.group("agents", [epoch.snapshot, 0, 0, 0], || {
+            let agents = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (index, agent) in snapshot.agents.iter().enumerate() {
+                let item = self.lua.create_table().map_err(|e| e.to_string())?;
+                item.raw_set("name", agent.name.clone())
+                    .map_err(|e| e.to_string())?;
+                // v1's picker labels a row `name  (command)` when the two differ, so
+                // the command travels with the name.
+                item.raw_set("command", agent.command.clone())
+                    .map_err(|e| e.to_string())?;
+                agents.raw_set(index + 1, item).map_err(|e| e.to_string())?;
+            }
+            Ok(Value::Table(agents))
+        })?;
+        table.raw_set("agents", agents).map_err(|e| e.to_string())?;
         // What a bare launch would use, so a flow preselects it rather than
         // whichever agent happens to be first.
         table
-            .set("agent_default", snapshot.agent_default.clone())
+            .raw_set("agent_default", snapshot.agent_default.clone())
             .map_err(|e| e.to_string())?;
 
         // `name` identifies, `detail` distinguishes on screen, `backend` is what
         // a command and a bookmark scope are keyed by — a flow needs all three,
         // and none follows from another.
-        let hosts = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, host) in snapshot.hosts.iter().enumerate() {
-            let item = self.lua.create_table().map_err(|e| e.to_string())?;
-            item.set("name", host.name.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("detail", host.detail.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("backend", host.backend.clone())
-                .map_err(|e| e.to_string())?;
-            hosts.set(index + 1, item).map_err(|e| e.to_string())?;
-        }
-        table.set("hosts", hosts).map_err(|e| e.to_string())?;
+        // Built from the snapshot alone, so it changes when the database does
+        // and not once a frame.
+        let hosts = self.group("hosts", [epoch.snapshot, 0, 0, 0], || {
+            let hosts = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (index, host) in snapshot.hosts.iter().enumerate() {
+                let item = self.lua.create_table().map_err(|e| e.to_string())?;
+                item.raw_set("name", host.name.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("detail", host.detail.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("backend", host.backend.clone())
+                    .map_err(|e| e.to_string())?;
+                hosts.raw_set(index + 1, item).map_err(|e| e.to_string())?;
+            }
+            Ok(Value::Table(hosts))
+        })?;
+        table.raw_set("hosts", hosts).map_err(|e| e.to_string())?;
 
         self.publish_repo_reads(&table, repo_store, wants)?;
         self.publish_settings(&table, settings)?;
 
-        let deleted = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, row) in snapshot.deleted.iter().enumerate() {
-            let item = self.lua.create_table().map_err(|e| e.to_string())?;
-            item.set("id", row.id.clone()).map_err(|e| e.to_string())?;
-            item.set("name", row.name.clone())
-                .map_err(|e| e.to_string())?;
-            // Restoring this one recovers committed work only.
-            item.set("partial", row.partial)
-                .map_err(|e| e.to_string())?;
-            deleted.set(index + 1, item).map_err(|e| e.to_string())?;
-        }
-        table.set("deleted", deleted).map_err(|e| e.to_string())?;
-
-        let tasks = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, row) in snapshot.tasks.iter().enumerate() {
-            let item = self.lua.create_table().map_err(|e| e.to_string())?;
-            item.set("id", row.id).map_err(|e| e.to_string())?;
-            item.set("title", row.title.clone())
-                .map_err(|e| e.to_string())?;
-            item.set(
-                "description",
-                opt_lua_string(&self.lua, row.description.as_deref())?,
-            )
-            .map_err(|e| e.to_string())?;
-            item.set("status", row.status.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("source", row.source.clone())
-                .map_err(|e| e.to_string())?;
-            item.set(
-                "url",
-                opt_lua_string(&self.lua, row.external_url.as_deref())?,
-            )
-            .map_err(|e| e.to_string())?;
-            // Epoch seconds, so the detail view can date a task.
-            item.set("created_at", row.created_at)
-                .map_err(|e| e.to_string())?;
-            item.set("updated_at", row.updated_at)
-                .map_err(|e| e.to_string())?;
-            tasks.set(index + 1, item).map_err(|e| e.to_string())?;
-        }
-        table.set("tasks", tasks).map_err(|e| e.to_string())?;
-
-        let automations = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, row) in snapshot.automations.iter().enumerate() {
-            let item = self.lua.create_table().map_err(|e| e.to_string())?;
-            item.set("id", row.id).map_err(|e| e.to_string())?;
-            item.set("name", row.name.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("schedule", row.schedule.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("action", row.action.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("enabled", row.enabled)
-                .map_err(|e| e.to_string())?;
-            item.set(
-                "last_outcome",
-                opt_lua_string(&self.lua, row.last_outcome.as_deref())?,
-            )
-            .map_err(|e| e.to_string())?;
-            item.set(
-                "last_detail",
-                opt_lua_string(&self.lua, row.last_detail.as_deref())?,
-            )
-            .map_err(|e| e.to_string())?;
-            // The whole history, not just the last outcome: v1's run-history
-            // pane lists every recent run, and a plugin cannot reconstruct
-            // those from `last_outcome` alone.
-            let runs = self.lua.create_table().map_err(|e| e.to_string())?;
-            for (position, run) in row.runs.iter().enumerate() {
-                let entry = self.lua.create_table().map_err(|e| e.to_string())?;
-                entry
-                    .set("started_at", run.started_at)
+        // Built from the snapshot alone, so it changes when the database does
+        // and not once a frame.
+        let deleted = self.group("deleted", [epoch.snapshot, 0, 0, 0], || {
+            let deleted = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (index, row) in snapshot.deleted.iter().enumerate() {
+                let item = self.lua.create_table().map_err(|e| e.to_string())?;
+                item.raw_set("id", row.id.clone())
                     .map_err(|e| e.to_string())?;
-                entry
-                    .set("status", run.status.clone())
+                item.raw_set("name", row.name.clone())
                     .map_err(|e| e.to_string())?;
-                entry
-                    .set("detail", run.detail.clone())
+                // Restoring this one recovers committed work only.
+                item.raw_set("partial", row.partial)
                     .map_err(|e| e.to_string())?;
-                runs.set(position + 1, entry).map_err(|e| e.to_string())?;
+                deleted
+                    .raw_set(index + 1, item)
+                    .map_err(|e| e.to_string())?;
             }
-            item.set("runs", runs).map_err(|e| e.to_string())?;
-            automations
-                .set(index + 1, item)
-                .map_err(|e| e.to_string())?;
-        }
+            Ok(Value::Table(deleted))
+        })?;
         table
-            .set("automations", automations)
+            .raw_set("deleted", deleted)
+            .map_err(|e| e.to_string())?;
+
+        // Built from the snapshot alone, so it changes when the database does
+        // and not once a frame.
+        let tasks = self.group("tasks", [epoch.snapshot, 0, 0, 0], || {
+            let tasks = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (index, row) in snapshot.tasks.iter().enumerate() {
+                let item = self.lua.create_table().map_err(|e| e.to_string())?;
+                item.raw_set("id", row.id).map_err(|e| e.to_string())?;
+                item.raw_set("title", row.title.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set(
+                    "description",
+                    opt_lua_string(&self.lua, row.description.as_deref())?,
+                )
+                .map_err(|e| e.to_string())?;
+                item.raw_set("status", row.status.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("source", row.source.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set(
+                    "url",
+                    opt_lua_string(&self.lua, row.external_url.as_deref())?,
+                )
+                .map_err(|e| e.to_string())?;
+                // Epoch seconds, so the detail view can date a task.
+                item.raw_set("created_at", row.created_at)
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("updated_at", row.updated_at)
+                    .map_err(|e| e.to_string())?;
+                tasks.raw_set(index + 1, item).map_err(|e| e.to_string())?;
+            }
+            Ok(Value::Table(tasks))
+        })?;
+        table.raw_set("tasks", tasks).map_err(|e| e.to_string())?;
+
+        // Built from the snapshot alone, so it changes when the database does
+        // and not once a frame.
+        let automations = self.group("automations", [epoch.snapshot, 0, 0, 0], || {
+            let automations = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (index, row) in snapshot.automations.iter().enumerate() {
+                let item = self.lua.create_table().map_err(|e| e.to_string())?;
+                item.raw_set("id", row.id).map_err(|e| e.to_string())?;
+                item.raw_set("name", row.name.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("schedule", row.schedule.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("action", row.action.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("enabled", row.enabled)
+                    .map_err(|e| e.to_string())?;
+                item.raw_set(
+                    "last_outcome",
+                    opt_lua_string(&self.lua, row.last_outcome.as_deref())?,
+                )
+                .map_err(|e| e.to_string())?;
+                item.raw_set(
+                    "last_detail",
+                    opt_lua_string(&self.lua, row.last_detail.as_deref())?,
+                )
+                .map_err(|e| e.to_string())?;
+                // The whole history, not just the last outcome: v1's run-history
+                // pane lists every recent run, and a plugin cannot reconstruct
+                // those from `last_outcome` alone.
+                let runs = self.lua.create_table().map_err(|e| e.to_string())?;
+                for (position, run) in row.runs.iter().enumerate() {
+                    let entry = self.lua.create_table().map_err(|e| e.to_string())?;
+                    entry
+                        .raw_set("started_at", run.started_at)
+                        .map_err(|e| e.to_string())?;
+                    entry
+                        .raw_set("status", run.status.clone())
+                        .map_err(|e| e.to_string())?;
+                    entry
+                        .raw_set("detail", run.detail.clone())
+                        .map_err(|e| e.to_string())?;
+                    runs.raw_set(position + 1, entry)
+                        .map_err(|e| e.to_string())?;
+                }
+                item.raw_set("runs", runs).map_err(|e| e.to_string())?;
+                automations
+                    .raw_set(index + 1, item)
+                    .map_err(|e| e.to_string())?;
+            }
+            Ok(Value::Table(automations))
+        })?;
+        table
+            .raw_set("automations", automations)
             .map_err(|e| e.to_string())?;
         table
-            .set("taken_at_ms", snapshot.taken_at_ms)
+            .raw_set("taken_at_ms", snapshot.taken_at_ms)
             .map_err(|e| e.to_string())?;
         // The running release, for the header banner. v1 baked it into
         // `ui::status_bar::render_header` at compile time; a plugin cannot read
         // an env var, and hardcoding it in Lua would leave every shipped copy
         // claiming whatever version it was written against.
         table
-            .set("version", env!("THURBOX_VERSION"))
+            .raw_set("version", env!("THURBOX_VERSION"))
             .map_err(|e| e.to_string())?;
         // What the pointer is over, as `id` and `role`, so a plugin can match
         // whichever it used to mark the affordance.
         let hover = self.lua.create_table().map_err(|e| e.to_string())?;
         if let Some(identity) = hovered {
             if let Some(id) = &identity.id {
-                hover.set("id", id.clone()).map_err(|e| e.to_string())?;
+                hover.raw_set("id", id.clone()).map_err(|e| e.to_string())?;
             }
             if let Some(role) = &identity.role {
-                hover.set("role", role.clone()).map_err(|e| e.to_string())?;
+                hover
+                    .raw_set("role", role.clone())
+                    .map_err(|e| e.to_string())?;
             }
         }
-        table.set("hover", hover).map_err(|e| e.to_string())?;
+        table.raw_set("hover", hover).map_err(|e| e.to_string())?;
 
         // Which pane holds focus, by name. `ctx.focused` answers "am I?", but
         // the footer has to name whoever IS and is not focusable itself.
         table
-            .set("focus", focus.unwrap_or(""))
+            .raw_set("focus", focus.unwrap_or(""))
             .map_err(|e| e.to_string())?;
         // Published so a plugin can render how many times it has been reloaded
         // — the feedback that tells you a save actually took effect.
         table
-            .set("reloads", self.reloads)
+            .raw_set("reloads", self.reloads)
             .map_err(|e| e.to_string())?;
 
         // Work accepted but not yet visible in the rows above. Published so a
@@ -1463,104 +1720,129 @@ impl LuaHost {
         let commands = self.lua.create_table().map_err(|e| e.to_string())?;
         for (index, entry) in inflight.iter().enumerate() {
             let item = self.lua.create_table().map_err(|e| e.to_string())?;
-            item.set("id", entry.id).map_err(|e| e.to_string())?;
-            item.set("kind", entry.kind).map_err(|e| e.to_string())?;
-            item.set("session", entry.session.clone())
+            item.raw_set("id", entry.id).map_err(|e| e.to_string())?;
+            item.raw_set("kind", entry.kind)
                 .map_err(|e| e.to_string())?;
-            item.set("phase", entry.phase.as_str())
+            item.raw_set("session", entry.session.clone())
                 .map_err(|e| e.to_string())?;
-            item.set(
+            item.raw_set("phase", entry.phase.as_str())
+                .map_err(|e| e.to_string())?;
+            item.raw_set(
                 "subject",
                 opt_lua_string(&self.lua, entry.subject.as_deref())?,
             )
             .map_err(|e| e.to_string())?;
-            item.set("error", opt_lua_string(&self.lua, entry.error.as_deref())?)
+            item.raw_set("error", opt_lua_string(&self.lua, entry.error.as_deref())?)
                 .map_err(|e| e.to_string())?;
-            commands.set(index + 1, item).map_err(|e| e.to_string())?;
+            commands
+                .raw_set(index + 1, item)
+                .map_err(|e| e.to_string())?;
         }
-        table.set("commands", commands).map_err(|e| e.to_string())?;
+        table
+            .raw_set("commands", commands)
+            .map_err(|e| e.to_string())?;
 
         // The active palette, as role -> colour. Plugins name roles and never
         // colours, so this is the only place a literal enters the UI — and
         // swapping it restyles every pane, including ones the theme's author
         // never saw (design.md D14).
-        let roles = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (role, colour) in themes.roles() {
-            roles.set(role, colour).map_err(|e| e.to_string())?;
-        }
-        let theme = self.lua.create_table().map_err(|e| e.to_string())?;
-        theme
-            .set("name", themes.active_name())
-            .map_err(|e| e.to_string())?;
-        theme.set("roles", roles).map_err(|e| e.to_string())?;
+        // Thirty-six palettes, each a table, rebuilt for every frame that was
+        // painted — and changed only when someone picks a different one.
+        let theme = self.group("theme", [epoch.themes, 0, 0, 0], || {
+            let roles = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (role, colour) in themes.roles() {
+                roles.raw_set(role, colour).map_err(|e| e.to_string())?;
+            }
+            let theme = self.lua.create_table().map_err(|e| e.to_string())?;
+            theme
+                .raw_set("name", themes.active_name())
+                .map_err(|e| e.to_string())?;
+            theme.raw_set("roles", roles).map_err(|e| e.to_string())?;
 
-        // The selectable list, so a picker can be an ordinary plugin.
-        let choices = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, choice) in themes.choices().iter().enumerate() {
-            let item = self.lua.create_table().map_err(|e| e.to_string())?;
-            item.set("name", choice.name.clone())
+            // The selectable list, so a picker can be an ordinary plugin.
+            let choices = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (index, choice) in themes.choices().iter().enumerate() {
+                let item = self.lua.create_table().map_err(|e| e.to_string())?;
+                item.raw_set("name", choice.name.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("display_name", choice.display_name.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("light", choice.is_light)
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("custom", choice.is_custom)
+                    .map_err(|e| e.to_string())?;
+                choices
+                    .raw_set(index + 1, item)
+                    .map_err(|e| e.to_string())?;
+            }
+            theme
+                .raw_set("choices", choices)
                 .map_err(|e| e.to_string())?;
-            item.set("display_name", choice.display_name.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("light", choice.is_light)
-                .map_err(|e| e.to_string())?;
-            item.set("custom", choice.is_custom)
-                .map_err(|e| e.to_string())?;
-            choices.set(index + 1, item).map_err(|e| e.to_string())?;
-        }
-        theme.set("choices", choices).map_err(|e| e.to_string())?;
-        table.set("theme", theme).map_err(|e| e.to_string())?;
+            Ok(Value::Table(theme))
+        })?;
+        table.raw_set("theme", theme).map_err(|e| e.to_string())?;
 
         // The registry, so help and settings can be plugins rendering what the
         // kernel collected — including declarations from plugins they have
         // never heard of.
-        let keys = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, binding) in registry.bindings().iter().enumerate() {
-            let item = self.lua.create_table().map_err(|e| e.to_string())?;
-            item.set("plugin", binding.plugin.clone())
+        // Every declared binding and setting. Moves when a plugin is (re)declared,
+        // a chord is rebound or a setting is set — never within a frame.
+        let reg = self.group("registry", [epoch.registry, 0, 0, 0], || {
+            let keys = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (index, binding) in registry.bindings().iter().enumerate() {
+                let item = self.lua.create_table().map_err(|e| e.to_string())?;
+                item.raw_set("plugin", binding.plugin.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("action", binding.action.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("key", binding.chord.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("default_key", binding.default_chord.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("desc", binding.description.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("scope", binding.scope.as_str())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("rebound", binding.chord != binding.default_chord)
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("group", binding.group.clone())
+                    .map_err(|e| e.to_string())?;
+                keys.raw_set(index + 1, item).map_err(|e| e.to_string())?;
+            }
+            let settings = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (index, setting) in registry.settings().iter().enumerate() {
+                let item = self.lua.create_table().map_err(|e| e.to_string())?;
+                item.raw_set("plugin", setting.plugin.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("id", setting.id.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("desc", setting.description.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("type", setting.value.type_name())
+                    .map_err(|e| e.to_string())?;
+                set_value(&item, "value", &setting.value)?;
+                set_value(&item, "default", &setting.default)?;
+                settings
+                    .raw_set(index + 1, item)
+                    .map_err(|e| e.to_string())?;
+            }
+            let reg = self.lua.create_table().map_err(|e| e.to_string())?;
+            reg.raw_set("keys", keys).map_err(|e| e.to_string())?;
+            reg.raw_set("settings", settings)
                 .map_err(|e| e.to_string())?;
-            item.set("action", binding.action.clone())
+            // The section order help renders in, so a plugin choosing a `group` can
+            // see where it will land without hardcoding the list.
+            let sections = self.lua.create_table().map_err(|e| e.to_string())?;
+            for (index, name) in super::registry::HELP_SECTIONS.iter().enumerate() {
+                sections
+                    .raw_set(index + 1, *name)
+                    .map_err(|e| e.to_string())?;
+            }
+            reg.raw_set("sections", sections)
                 .map_err(|e| e.to_string())?;
-            item.set("key", binding.chord.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("default_key", binding.default_chord.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("desc", binding.description.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("scope", binding.scope.as_str())
-                .map_err(|e| e.to_string())?;
-            item.set("rebound", binding.chord != binding.default_chord)
-                .map_err(|e| e.to_string())?;
-            item.set("group", binding.group.clone())
-                .map_err(|e| e.to_string())?;
-            keys.set(index + 1, item).map_err(|e| e.to_string())?;
-        }
-        let settings = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, setting) in registry.settings().iter().enumerate() {
-            let item = self.lua.create_table().map_err(|e| e.to_string())?;
-            item.set("plugin", setting.plugin.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("id", setting.id.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("desc", setting.description.clone())
-                .map_err(|e| e.to_string())?;
-            item.set("type", setting.value.type_name())
-                .map_err(|e| e.to_string())?;
-            set_value(&item, "value", &setting.value)?;
-            set_value(&item, "default", &setting.default)?;
-            settings.set(index + 1, item).map_err(|e| e.to_string())?;
-        }
-        let reg = self.lua.create_table().map_err(|e| e.to_string())?;
-        reg.set("keys", keys).map_err(|e| e.to_string())?;
-        reg.set("settings", settings).map_err(|e| e.to_string())?;
-        // The section order help renders in, so a plugin choosing a `group` can
-        // see where it will land without hardcoding the list.
-        let sections = self.lua.create_table().map_err(|e| e.to_string())?;
-        for (index, name) in super::registry::HELP_SECTIONS.iter().enumerate() {
-            sections.set(index + 1, *name).map_err(|e| e.to_string())?;
-        }
-        reg.set("sections", sections).map_err(|e| e.to_string())?;
-        table.set("registry", reg).map_err(|e| e.to_string())?;
+            Ok(Value::Table(reg))
+        })?;
+        table.raw_set("registry", reg).map_err(|e| e.to_string())?;
 
         // The selected session's changes, when any have been asked for. The
         // *absence* of an entry is "not requested"; `pending` is "asked, not
@@ -1573,11 +1855,12 @@ impl LuaHost {
             let item = self.lua.create_table().map_err(|e| e.to_string())?;
             match diff {
                 super::diff::Diff::Pending => {
-                    item.set("state", "pending").map_err(|e| e.to_string())?;
+                    item.raw_set("state", "pending")
+                        .map_err(|e| e.to_string())?;
                 }
                 super::diff::Diff::Failed(error) => {
-                    item.set("state", "failed").map_err(|e| e.to_string())?;
-                    item.set("error", error.clone())
+                    item.raw_set("state", "failed").map_err(|e| e.to_string())?;
+                    item.raw_set("error", error.clone())
                         .map_err(|e| e.to_string())?;
                 }
                 super::diff::Diff::Ready {
@@ -1587,80 +1870,87 @@ impl LuaHost {
                     raw_bytes,
                     untracked_omitted,
                 } => {
-                    item.set("state", "ready").map_err(|e| e.to_string())?;
-                    item.set("truncated", *truncated)
+                    item.raw_set("state", "ready").map_err(|e| e.to_string())?;
+                    item.raw_set("truncated", *truncated)
                         .map_err(|e| e.to_string())?;
-                    item.set("raw_bytes", *raw_bytes as i64)
+                    item.raw_set("raw_bytes", *raw_bytes as i64)
                         .map_err(|e| e.to_string())?;
                     // A short file list is a different failure from a cut body,
                     // so it is its own field rather than folded into `truncated`.
-                    item.set("untracked_omitted", *untracked_omitted as i64)
+                    item.raw_set("untracked_omitted", *untracked_omitted as i64)
                         .map_err(|e| e.to_string())?;
                     let list = self.lua.create_table().map_err(|e| e.to_string())?;
                     for (index, file) in files.iter().enumerate() {
                         let entry = self.lua.create_table().map_err(|e| e.to_string())?;
                         entry
-                            .set("path", file.path.clone())
+                            .raw_set("path", file.path.clone())
                             .map_err(|e| e.to_string())?;
-                        entry.set("added", file.added).map_err(|e| e.to_string())?;
                         entry
-                            .set("removed", file.removed)
+                            .raw_set("added", file.added)
+                            .map_err(|e| e.to_string())?;
+                        entry
+                            .raw_set("removed", file.removed)
                             .map_err(|e| e.to_string())?;
                         // Both already known to the parser; a pane re-reading the
                         // body to recover them is the cost of dropping them here.
                         entry
-                            .set("status", file.status)
+                            .raw_set("status", file.status)
                             .map_err(|e| e.to_string())?;
                         entry
-                            .set(
+                            .raw_set(
                                 "old_path",
                                 opt_lua_string(&self.lua, file.old_path.as_deref())?,
                             )
                             .map_err(|e| e.to_string())?;
-                        list.set(index + 1, entry).map_err(|e| e.to_string())?;
+                        list.raw_set(index + 1, entry).map_err(|e| e.to_string())?;
                     }
-                    item.set("files", list).map_err(|e| e.to_string())?;
+                    item.raw_set("files", list).map_err(|e| e.to_string())?;
                     let lines = self.lua.create_table().map_err(|e| e.to_string())?;
                     for (index, line) in body.iter().enumerate() {
                         lines
-                            .set(index + 1, line.clone())
+                            .raw_set(index + 1, line.clone())
                             .map_err(|e| e.to_string())?;
                     }
-                    item.set("body", lines).map_err(|e| e.to_string())?;
+                    item.raw_set("body", lines).map_err(|e| e.to_string())?;
                 }
             }
             diff_table
-                .set(row.id.clone(), item)
+                .raw_set(row.id.clone(), item)
                 .map_err(|e| e.to_string())?;
         }
-        table.set("diffs", diff_table).map_err(|e| e.to_string())?;
+        table
+            .raw_set("diffs", diff_table)
+            .map_err(|e| e.to_string())?;
 
         let links_table = self.lua.create_table().map_err(|e| e.to_string())?;
         for (session, found) in links.iter() {
             let list = self.lua.create_table().map_err(|e| e.to_string())?;
             for (index, (url, row, col)) in found.iter().enumerate() {
                 let item = self.lua.create_table().map_err(|e| e.to_string())?;
-                item.set("url", url.clone()).map_err(|e| e.to_string())?;
-                item.set("row", *row).map_err(|e| e.to_string())?;
-                item.set("col", *col).map_err(|e| e.to_string())?;
-                list.set(index + 1, item).map_err(|e| e.to_string())?;
+                item.raw_set("url", url.clone())
+                    .map_err(|e| e.to_string())?;
+                item.raw_set("row", *row).map_err(|e| e.to_string())?;
+                item.raw_set("col", *col).map_err(|e| e.to_string())?;
+                list.raw_set(index + 1, item).map_err(|e| e.to_string())?;
             }
             links_table
-                .set(session.clone(), list)
+                .raw_set(session.clone(), list)
                 .map_err(|e| e.to_string())?;
         }
-        table.set("links", links_table).map_err(|e| e.to_string())?;
+        table
+            .raw_set("links", links_table)
+            .map_err(|e| e.to_string())?;
 
         // What each terminal is showing, for a content search. Empty unless
         // something asked, so an interface that never searches never pays for it.
         let content_table = self.lua.create_table().map_err(|e| e.to_string())?;
         for (session, text) in content.iter() {
             content_table
-                .set(session.clone(), text.clone())
+                .raw_set(session.clone(), text.clone())
                 .map_err(|e| e.to_string())?;
         }
         table
-            .set("content", content_table)
+            .raw_set("content", content_table)
             .map_err(|e| e.to_string())?;
 
         // Machine, per-agent and account metrics. Each is absent rather than
@@ -1672,16 +1962,16 @@ impl LuaHost {
             let system = metrics.system();
             let machine = self.lua.create_table().map_err(|e| e.to_string())?;
             machine
-                .set("cpu_percent", system.cpu_percent)
+                .raw_set("cpu_percent", system.cpu_percent)
                 .map_err(|e| e.to_string())?;
             machine
-                .set("memory_used", system.memory_used)
+                .raw_set("memory_used", system.memory_used)
                 .map_err(|e| e.to_string())?;
             machine
-                .set("memory_total", system.memory_total)
+                .raw_set("memory_total", system.memory_total)
                 .map_err(|e| e.to_string())?;
             metrics_table
-                .set("system", machine)
+                .raw_set("system", machine)
                 .map_err(|e| e.to_string())?;
 
             let per_session = self.lua.create_table().map_err(|e| e.to_string())?;
@@ -1690,39 +1980,39 @@ impl LuaHost {
                 let mut any = false;
                 if let Some(resources) = metrics.resources(&row.id) {
                     entry
-                        .set("cpu_percent", resources.cpu_percent)
+                        .raw_set("cpu_percent", resources.cpu_percent)
                         .map_err(|e| e.to_string())?;
                     entry
-                        .set("memory_bytes", resources.memory_bytes)
+                        .raw_set("memory_bytes", resources.memory_bytes)
                         .map_err(|e| e.to_string())?;
                     any = true;
                 }
                 if let Some(agent) = metrics.agent(&row.id) {
                     entry
-                        .set("agent", agent_metrics_table(&self.lua, agent)?)
+                        .raw_set("agent", agent_metrics_table(&self.lua, agent)?)
                         .map_err(|e| e.to_string())?;
                     any = true;
                 }
                 if let Some(usage) = metrics.usage(&row.agent, row.remote_host.as_deref()) {
                     if !usage.is_empty() {
                         entry
-                            .set("usage", usage_table(&self.lua, usage)?)
+                            .raw_set("usage", usage_table(&self.lua, usage)?)
                             .map_err(|e| e.to_string())?;
                         any = true;
                     }
                 }
                 if any {
                     per_session
-                        .set(row.id.clone(), entry)
+                        .raw_set(row.id.clone(), entry)
                         .map_err(|e| e.to_string())?;
                 }
             }
             metrics_table
-                .set("sessions", per_session)
+                .raw_set("sessions", per_session)
                 .map_err(|e| e.to_string())?;
         }
         table
-            .set("metrics", metrics_table)
+            .raw_set("metrics", metrics_table)
             .map_err(|e| e.to_string())?;
 
         // What the arrangement needs to know about the chrome bands, and nothing
@@ -1730,9 +2020,9 @@ impl LuaHost {
         // here, because placing a band and filling it are different jobs.
         let chrome = self.lua.create_table().map_err(|e| e.to_string())?;
         chrome
-            .set("status_rows", *status_rows)
+            .raw_set("status_rows", *status_rows)
             .map_err(|e| e.to_string())?;
-        table.set("chrome", chrome).map_err(|e| e.to_string())?;
+        table.raw_set("chrome", chrome).map_err(|e| e.to_string())?;
 
         // The interface's own files. One row per file rather than per loaded
         // plugin, because the ones worth acting on are exactly those that did
@@ -1742,7 +2032,7 @@ impl LuaHost {
         for (index, row) in inventory.iter().enumerate() {
             let entry = self.lua.create_table().map_err(|e| e.to_string())?;
             let set = |key: &str, value: Value| -> Result<(), String> {
-                entry.set(key, value).map_err(|e| e.to_string())
+                entry.raw_set(key, value).map_err(|e| e.to_string())
             };
             set("path", to_lua_string(&self.lua, &row.path)?)?;
             set("name", to_lua_string(&self.lua, &row.name)?)?;
@@ -1752,14 +2042,14 @@ impl LuaHost {
             set("state", to_lua_string(&self.lua, row.state.as_str())?)?;
             set("error", opt_lua_string(&self.lua, row.error.as_deref())?)?;
             inventory_table
-                .set(index + 1, entry)
+                .raw_set(index + 1, entry)
                 .map_err(|e| e.to_string())?;
         }
         table
-            .set("plugins", inventory_table)
+            .raw_set("plugins", inventory_table)
             .map_err(|e| e.to_string())?;
         table
-            .set("ui_dir", to_lua_string(&self.lua, ui_dir)?)
+            .raw_set("ui_dir", to_lua_string(&self.lua, ui_dir)?)
             .map_err(|e| e.to_string())?;
 
         // The machine this is running on, so a plugin delivering more than one
@@ -1772,27 +2062,30 @@ impl LuaHost {
         // that it has nothing for you. The kernel models none of that.
         let platform = self.lua.create_table().map_err(|e| e.to_string())?;
         platform
-            .set("os", std::env::consts::OS)
+            .raw_set("os", std::env::consts::OS)
             .map_err(|e| e.to_string())?;
         platform
-            .set("arch", std::env::consts::ARCH)
+            .raw_set("arch", std::env::consts::ARCH)
             .map_err(|e| e.to_string())?;
-        table.set("platform", platform).map_err(|e| e.to_string())?;
+        table
+            .raw_set("platform", platform)
+            .map_err(|e| e.to_string())?;
 
         // So a plugin can say "open" or "copy" before you press it.
         table
-            .set("can_open_links", *can_open)
+            .raw_set("can_open_links", *can_open)
             .map_err(|e| e.to_string())?;
         table
-            .set(
+            .raw_set(
                 "error",
                 opt_lua_string(&self.lua, snapshot.error.as_deref())?,
             )
             .map_err(|e| e.to_string())?;
 
+        *self.epoch.borrow_mut() = Some(*epoch);
         self.lua
             .globals()
-            .set("thurbox", table)
+            .raw_set("thurbox", table)
             .map_err(|e| e.to_string())
     }
 
@@ -1806,6 +2099,33 @@ impl LuaHost {
             phase: Phase::Render,
             message: "plugin index out of range".to_string(),
         })?;
+
+        // A pure pane asked at the same epoch, in the same rect, with the same
+        // focus, would return what it returned last time — so return that,
+        // skipping both the Lua call and the conversion. Measured, this is the
+        // largest single cost in a frame: the session list rebuilt a
+        // byte-identical tree on every frame under load (`frame-cost`).
+        let key = self.published_epoch().map(|epoch| {
+            let tick = (ctx.elapsed * ANIMATION_HZ) as u64;
+            (
+                epoch,
+                ctx.width,
+                ctx.height,
+                ctx.focused,
+                tick,
+                self.state_version.get(),
+            )
+        });
+        if plugin.pure {
+            if let Some(key) = key {
+                if let Some((built_at, rendered)) = self.trees.borrow().get(&index) {
+                    if *built_at == key {
+                        self.skipped_renders.set(self.skipped_renders.get() + 1);
+                        return Ok(rendered.clone());
+                    }
+                }
+            }
+        }
 
         let fail = |message: String| PluginError {
             plugin: plugin.name.clone(),
@@ -1849,7 +2169,15 @@ impl LuaHost {
         let value = result.map_err(|e| fail(clean_error(&e)))?;
         let float = read_float(&value).map_err(fail)?;
         let node = convert::to_node(&value, &plugin.path).map_err(fail)?;
-        Ok(Rendered { node, float })
+        let rendered = Rendered { node, float };
+        if plugin.pure {
+            if let Some(key) = key {
+                self.trees
+                    .borrow_mut()
+                    .insert(index, (key, rendered.clone()));
+            }
+        }
+        Ok(rendered)
     }
 
     /// Offer a key to one plugin. `Ok(true)` means it consumed the key.
@@ -2256,6 +2584,11 @@ fn load_plugin(lua: &Lua, path: &Path, relative: &str) -> Result<Plugin, String>
         .map_err(|e| format!("{file}.focusable: {e}"))?
         .unwrap_or(false);
 
+    let pure = def
+        .get::<Option<bool>>("pure")
+        .map_err(|e| format!("{file}.pure: {e}"))?
+        .unwrap_or(false);
+
     let order = def
         .get::<Option<f64>>("order")
         .map_err(|e| format!("{file}.order: {e}"))?
@@ -2301,6 +2634,7 @@ fn load_plugin(lua: &Lua, path: &Path, relative: &str) -> Result<Plugin, String>
         file,
         slot,
         focusable,
+        pure,
         session_input,
         size,
         order,
@@ -2518,11 +2852,12 @@ fn install_api(
     roots: Roots,
     runs: Rc<RefCell<Vec<(String, super::runs::Ask)>>>,
     current_path: Rc<RefCell<String>>,
+    state_version: StateVersion,
 ) -> mlua::Result<()> {
     scrub_globals(lua)?;
     install_require(lua, ui_dir)?;
-    install_store(lua, "store", store, None)?;
-    install_private(lua, state, current)?;
+    install_store(lua, "store", store, state_version.clone(), None)?;
+    install_private(lua, state, current, state_version)?;
     install_command(lua, queue, current_path.clone())?;
     install_files(lua, roots)?;
     install_run(lua, runs, current_path)?;
@@ -2826,7 +3161,13 @@ fn install_require(lua: &Lua, ui_dir: &Path) -> mlua::Result<()> {
 }
 
 /// Install a persisted table under `global`, optionally namespaced per plugin.
-fn install_store(lua: &Lua, global: &str, store: Shared, _ns: Option<()>) -> mlua::Result<()> {
+fn install_store(
+    lua: &Lua,
+    global: &str,
+    store: Shared,
+    version: StateVersion,
+    _ns: Option<()>,
+) -> mlua::Result<()> {
     let table = lua.create_table()?;
     let meta = lua.create_table()?;
 
@@ -2846,13 +3187,24 @@ fn install_store(lua: &Lua, global: &str, store: Shared, _ns: Option<()>) -> mlu
         "__newindex",
         lua.create_function(move |_, (_, key, value): (Table, String, Value)| {
             let mut slot = write.borrow_mut();
-            match from_lua(&value) {
+            // Compared before storing. A pane may write the same value on every
+            // frame — the search strip re-states how many panes it is showing —
+            // and treating that as a change would move the version 40 times a
+            // second and invalidate every cached tree, which is the difference
+            // between this mechanism working and doing nothing at all.
+            let moved = match from_lua(&value) {
                 Some(persisted) => {
-                    slot.insert(key, persisted);
+                    if slot.get(&key) == Some(&persisted) {
+                        false
+                    } else {
+                        slot.insert(key, persisted);
+                        true
+                    }
                 }
-                None => {
-                    slot.remove(&key);
-                }
+                None => slot.remove(&key).is_some(),
+            };
+            if moved {
+                version.set(version.get().wrapping_add(1));
             }
             Ok(())
         })?,
@@ -2870,7 +3222,12 @@ fn install_store(lua: &Lua, global: &str, store: Shared, _ns: Option<()>) -> mlu
 /// it was. Nothing serialises it: a plugin's `state` dies with the process, and so
 /// does `store`. Anything a plugin needs after a restart has nowhere to go today —
 /// worth knowing before this word is chosen again.
-fn install_private(lua: &Lua, state: Private, current: Rc<RefCell<String>>) -> mlua::Result<()> {
+fn install_private(
+    lua: &Lua,
+    state: Private,
+    current: Rc<RefCell<String>>,
+    version: StateVersion,
+) -> mlua::Result<()> {
     let table = lua.create_table()?;
     let meta = lua.create_table()?;
 
@@ -2894,13 +3251,20 @@ fn install_private(lua: &Lua, state: Private, current: Rc<RefCell<String>>) -> m
         lua.create_function(move |_, (_, key, value): (Table, String, Value)| {
             let ns = write_ns.borrow().clone();
             let mut slot = write.borrow_mut();
-            match from_lua(&value) {
+            // Same rule as `store`: only a value that actually moved counts.
+            let moved = match from_lua(&value) {
                 Some(persisted) => {
-                    slot.insert((ns, key), persisted);
+                    if slot.get(&(ns.clone(), key.clone())) == Some(&persisted) {
+                        false
+                    } else {
+                        slot.insert((ns, key), persisted);
+                        true
+                    }
                 }
-                None => {
-                    slot.remove(&(ns, key));
-                }
+                None => slot.remove(&(ns, key)).is_some(),
+            };
+            if moved {
+                version.set(version.get().wrapping_add(1));
             }
             Ok(())
         })?,

--- a/src/kernel/host.rs
+++ b/src/kernel/host.rs
@@ -374,7 +374,7 @@ pub struct Rendered {
 /// moves every frame only invalidates what actually reads it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Epoch {
-    /// `SnapshotStore::generation`.
+    /// `SnapshotStore::version`.
     pub snapshot: u64,
     /// `Themes::version`.
     pub themes: u64,
@@ -415,7 +415,7 @@ type GroupKey = [u64; 4];
 pub const ANIMATION_HZ: f64 = 8.0;
 
 /// What a pure pane's cached tree was built for: the publish epoch, the parts of
-/// the render context it may depend on, and the animation tick.
+/// the render context it may depend on, and the plugin-state version.
 ///
 /// `ctx.frame` and `ctx.elapsed` are deliberately absent. They move every frame,
 /// so reading either here would mean never reusing anything. A pane may still

--- a/src/kernel/host.rs
+++ b/src/kernel/host.rs
@@ -386,6 +386,16 @@ pub struct Epoch {
     pub failed: u64,
     /// The loop's own `data_epoch` — the worker stores, links, screen text.
     pub data: u64,
+    /// The shared animation clock, which advances **only while something is
+    /// actually animating** (a working session, a command in flight).
+    ///
+    /// A free-running clock here was a bug worth naming: it moved 8 times a
+    /// second whether or not anything on screen was moving, so at the 4fps idle
+    /// floor every pure pane missed its cache on every frame and re-ran for a
+    /// byte-identical tree. `frame-cost` requires an idle interface to rebuild
+    /// neither its groups nor its panes; a clock that never stops makes that
+    /// impossible to satisfy.
+    pub animation: u64,
 }
 
 /// The versions one group is built from, compared exactly.
@@ -395,30 +405,30 @@ pub struct Epoch {
 /// wrong answer nobody can see. Unused slots stay zero.
 type GroupKey = [u64; 4];
 
-/// How often a pure pane's tree may change on the clock alone, in Hz.
+/// How often the shared animation clock may advance, in Hz.
 ///
 /// Set to the rate `widgets.status_glyph` advances the working spinner at
 /// (`math.floor(elapsed * 8)`), so a cached tree is dropped exactly when the
 /// spinner would move to its next frame and never merely because time passed.
 /// Changing one without the other either freezes the animation or re-renders
-/// for nothing.
-const ANIMATION_HZ: f64 = 8.0;
+/// for nothing. The loop owns the counter — see [`Epoch::animation`].
+pub const ANIMATION_HZ: f64 = 8.0;
 
 /// What a pure pane's cached tree was built for: the publish epoch, the parts of
 /// the render context it may depend on, and the animation tick.
 ///
-/// `ctx.frame` is deliberately absent — it moves every frame, so including it
-/// would mean never reusing anything. `ctx.elapsed` enters only through
-/// [`ANIMATION_HZ`]: a pane may animate at the spinner's rate and still be pure,
-/// because at that granularity "the clock moved" is a real input rather than
-/// noise. Anything finer is not expressible, which is why a pane animating per
-/// *frame* may not declare `pure`.
+/// `ctx.frame` and `ctx.elapsed` are deliberately absent. They move every frame,
+/// so reading either here would mean never reusing anything. A pane may still
+/// animate and be pure, but only from the shared clock in [`Epoch::animation`],
+/// which advances at [`ANIMATION_HZ`] *and only while something is animating* —
+/// which is why a pane animating per frame, or on a schedule of its own, may not
+/// declare `pure`.
 ///
 /// The last field is [`StateVersion`]. A pure render may read `store` or
 /// `state` — the agent pane remembers a tab per session — and those are written
 /// by handlers, not by anything published, so without it a tree cached before a
 /// keypress would outlive it.
-type TreeKey = (Epoch, u16, u16, bool, u64, u64);
+type TreeKey = (Epoch, u16, u16, bool, u64);
 
 impl Epoch {
     /// An epoch that matches no previous one, so every group is rebuilt.
@@ -439,6 +449,7 @@ impl Epoch {
             meta: n,
             failed: n,
             data: n,
+            animation: n,
         }
     }
 }
@@ -2060,13 +2071,18 @@ impl LuaHost {
         // states every rule it actually needs — prefer a binary already on `PATH`,
         // fall back to a portable build, distinguish a libc variant, or say politely
         // that it has nothing for you. The kernel models none of that.
-        let platform = self.lua.create_table().map_err(|e| e.to_string())?;
-        platform
-            .raw_set("os", std::env::consts::OS)
-            .map_err(|e| e.to_string())?;
-        platform
-            .raw_set("arch", std::env::consts::ARCH)
-            .map_err(|e| e.to_string())?;
+        // Constant for the life of the process, so it is built once and then
+        // handed back — an all-zero key never moves.
+        let platform = self.group("platform", [0, 0, 0, 0], || {
+            let platform = self.lua.create_table().map_err(|e| e.to_string())?;
+            platform
+                .raw_set("os", std::env::consts::OS)
+                .map_err(|e| e.to_string())?;
+            platform
+                .raw_set("arch", std::env::consts::ARCH)
+                .map_err(|e| e.to_string())?;
+            Ok(Value::Table(platform))
+        })?;
         table
             .raw_set("platform", platform)
             .map_err(|e| e.to_string())?;
@@ -2106,13 +2122,11 @@ impl LuaHost {
         // largest single cost in a frame: the session list rebuilt a
         // byte-identical tree on every frame under load (`frame-cost`).
         let key = self.published_epoch().map(|epoch| {
-            let tick = (ctx.elapsed * ANIMATION_HZ) as u64;
             (
                 epoch,
                 ctx.width,
                 ctx.height,
                 ctx.focused,
-                tick,
                 self.state_version.get(),
             )
         });

--- a/src/kernel/perf.rs
+++ b/src/kernel/perf.rs
@@ -5,6 +5,13 @@
 //! idle loop painted no frames" is exact. These are the v2 equivalents of
 //! `MetricsState::perf`, and they exist so the demand-driven redraw (design.md
 //! D12) is provable rather than hoped for.
+//!
+//! On top of them sits the **observability layer** of ADR-P11: fixed-bucket
+//! duration histograms, a ring of named slow operations, and the startup phase
+//! breakdown. Those are wall-clock, so they are display and logging only and
+//! are never CI-asserted — the counters above remain the sole regression gate.
+//! They are populated only while timing is active (`THURBOX_PERF_LOG` or an
+//! open perf HUD), so a default run pays one cached bool per iteration.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -23,6 +30,10 @@ pub struct Counters {
     pub failures: AtomicU64,
     /// Whole-VM reloads.
     pub reloads: AtomicU64,
+    /// Pane renders served from a pure pane's tree cache instead of run.
+    pub renders_skipped: AtomicU64,
+    /// Published `thurbox.*` groups reused instead of rebuilt.
+    pub groups_reused: AtomicU64,
 }
 
 impl Counters {
@@ -43,6 +54,8 @@ impl Counters {
             renders: Self::get(&self.renders),
             failures: Self::get(&self.failures),
             reloads: Self::get(&self.reloads),
+            renders_skipped: Self::get(&self.renders_skipped),
+            groups_reused: Self::get(&self.groups_reused),
         }
     }
 }
@@ -56,6 +69,8 @@ pub struct Snapshot {
     pub renders: u64,
     pub failures: u64,
     pub reloads: u64,
+    pub renders_skipped: u64,
+    pub groups_reused: u64,
 }
 
 impl Snapshot {
@@ -69,8 +84,242 @@ impl Snapshot {
             renders: self.renders.saturating_sub(earlier.renders),
             failures: self.failures.saturating_sub(earlier.failures),
             reloads: self.reloads.saturating_sub(earlier.reloads),
+            renders_skipped: self.renders_skipped.saturating_sub(earlier.renders_skipped),
+            groups_reused: self.groups_reused.saturating_sub(earlier.groups_reused),
         }
     }
+}
+
+/// Upper bounds (µs) of the fixed histogram buckets: powers of two from 250µs
+/// to ~1s, with a final bucket catching everything slower. Coarse on purpose —
+/// this answers "is a frame 1ms or 30ms", not microbenchmarks.
+const HISTO_BUCKETS_US: [u64; 13] = [
+    250, 500, 1_000, 2_000, 4_000, 8_000, 16_000, 33_000, 66_000, 100_000, 250_000, 500_000,
+    1_000_000,
+];
+
+/// Fixed-bucket duration histogram — display/logging only, never asserted in
+/// CI (ADR-P2: wall-clock stats are observability, counters are the gate).
+#[derive(Default, Clone, Copy, Debug)]
+pub struct DurationHistogram {
+    /// One count per [`HISTO_BUCKETS_US`] bound, plus a final overflow bucket.
+    counts: [u64; HISTO_BUCKETS_US.len() + 1],
+    total: u64,
+    max_us: u64,
+}
+
+impl DurationHistogram {
+    pub fn record(&mut self, d: std::time::Duration) {
+        let us = u64::try_from(d.as_micros()).unwrap_or(u64::MAX);
+        let idx = HISTO_BUCKETS_US
+            .iter()
+            .position(|&bound| us <= bound)
+            .unwrap_or(HISTO_BUCKETS_US.len());
+        self.counts[idx] = self.counts[idx].wrapping_add(1);
+        self.total = self.total.wrapping_add(1);
+        self.max_us = self.max_us.max(us);
+    }
+
+    /// Approximate percentile (0–100) as the upper bound (µs) of the bucket
+    /// holding that rank, clamped to the observed max so a high percentile can
+    /// never read above the max printed beside it.
+    pub fn percentile_us(&self, p: u8) -> u64 {
+        if self.total == 0 {
+            return 0;
+        }
+        let rank = (self.total * u64::from(p)).div_ceil(100).max(1);
+        let mut seen = 0u64;
+        for (i, &count) in self.counts.iter().enumerate() {
+            seen += count;
+            if seen >= rank {
+                return HISTO_BUCKETS_US
+                    .get(i)
+                    .copied()
+                    .unwrap_or(self.max_us)
+                    .min(self.max_us);
+            }
+        }
+        self.max_us
+    }
+
+    pub fn max_us(&self) -> u64 {
+        self.max_us
+    }
+
+    pub fn total(&self) -> u64 {
+        self.total
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// One measured slow operation: a named synchronous UI-thread op that took
+/// long enough to be felt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SlowOp {
+    pub name: &'static str,
+    pub ms: u64,
+}
+
+/// A sample lands in the ring at this threshold.
+pub const SLOW_OP_RING_MS: u64 = 5;
+/// And is additionally logged as a warning at this one, so an interactive
+/// stall is attributable even when nobody was watching a HUD.
+pub const SLOW_OP_WARN_MS: u64 = 100;
+
+/// Fixed-capacity ring of the most recent [`SlowOp`]s (newest first on read).
+#[derive(Default, Clone, Debug)]
+pub struct SlowOps {
+    ops: std::collections::VecDeque<SlowOp>,
+}
+
+impl SlowOps {
+    const CAP: usize = 16;
+
+    pub fn push(&mut self, op: SlowOp) {
+        if self.ops.len() == Self::CAP {
+            self.ops.pop_front();
+        }
+        self.ops.push_back(op);
+    }
+
+    /// Newest first — the HUD, the log line and the JSON all show recent ops
+    /// first.
+    pub fn iter_recent(&self) -> impl Iterator<Item = &SlowOp> {
+        self.ops.iter().rev()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.ops.clear();
+    }
+}
+
+/// Wall-clock stats for the hot paths, plus the slow-op ring.
+///
+/// `republish` has a histogram of its own because it is the one per-frame cost
+/// that is neither the draw nor the rest of the tick: it rebuilds every
+/// `thurbox.*` table, so telling it apart from painting is the difference
+/// between "frames are expensive" and knowing why.
+#[derive(Default)]
+pub struct Timings {
+    /// `terminal.draw` duration per painted frame.
+    pub frame: DurationHistogram,
+    /// One whole loop iteration.
+    pub tick: DurationHistogram,
+    /// `App::republish` — the per-frame rebuild of the published tables.
+    pub republish: DurationHistogram,
+    /// Recent named synchronous UI-thread operations.
+    pub slow_ops: SlowOps,
+}
+
+impl Timings {
+    /// Clear per-window state after a report, so each window stands alone.
+    pub fn reset_window(&mut self) {
+        self.frame.reset();
+        self.tick.reset();
+        self.republish.reset();
+        self.slow_ops.clear();
+    }
+
+    /// Record a named op, returning whether it crossed the warn threshold so
+    /// the caller can log it (this module does no logging of its own).
+    pub fn record_op(&mut self, name: &'static str, elapsed: std::time::Duration) -> bool {
+        let ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX);
+        if ms >= SLOW_OP_RING_MS {
+            self.slow_ops.push(SlowOp { name, ms });
+        }
+        ms >= SLOW_OP_WARN_MS
+    }
+}
+
+/// How long each startup phase took, and when the first frame landed.
+///
+/// The phases are v2's own, not v1's: there is no `restore_ms` because v2 has
+/// no synchronous restore phase, and there is a `ui_build_ms` because building
+/// the Lua interface is a startup cost v1 did not have.
+#[derive(Default, Clone, Copy, Debug)]
+pub struct Startup {
+    pub config_init_ms: u64,
+    pub db_open_ms: u64,
+    pub theme_activate_ms: u64,
+    pub extension_heal_ms: u64,
+    pub heartbeat_ms: u64,
+    pub ui_build_ms: u64,
+    /// Process start to first painted frame; filled in by the loop.
+    pub first_frame_ms: u64,
+}
+
+impl Startup {
+    pub fn to_json(self) -> serde_json::Value {
+        serde_json::json!({
+            "config_init_ms": self.config_init_ms,
+            "db_open_ms": self.db_open_ms,
+            "theme_activate_ms": self.theme_activate_ms,
+            "extension_heal_ms": self.extension_heal_ms,
+            "heartbeat_ms": self.heartbeat_ms,
+            "ui_build_ms": self.ui_build_ms,
+            "first_frame_ms": self.first_frame_ms,
+        })
+    }
+}
+
+/// One histogram as the `{p50_us, p95_us, max_us, samples}` object the CLI and
+/// the HUD both read.
+fn histogram_json(h: &DurationHistogram) -> serde_json::Value {
+    serde_json::json!({
+        "p50_us": h.percentile_us(50),
+        "p95_us": h.percentile_us(95),
+        "max_us": h.max_us(),
+        "samples": h.total(),
+    })
+}
+
+/// The JSON `thurbox-cli perf` reads, published into the `metadata` table while
+/// timing is active.
+///
+/// Built here rather than in the loop so the shape has one owner: the CLI
+/// renders whatever this produces, and `tests/v2_perf.rs` pins the keys.
+pub fn snapshot_json(
+    counters: &Snapshot,
+    timings: &Timings,
+    startup: &Startup,
+    session_count: usize,
+) -> serde_json::Value {
+    let captured_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    serde_json::json!({
+        "pid": std::process::id(),
+        "captured_at": captured_at,
+        "session_count": session_count,
+        "tick_count": counters.iterations,
+        "counters": {
+            "iterations": counters.iterations,
+            "frames": counters.frames,
+            "skipped": counters.skipped,
+            "renders": counters.renders,
+            "failures": counters.failures,
+            "reloads": counters.reloads,
+            "renders_skipped": counters.renders_skipped,
+            "groups_reused": counters.groups_reused,
+        },
+        "frame": histogram_json(&timings.frame),
+        "tick": histogram_json(&timings.tick),
+        "republish": histogram_json(&timings.republish),
+        "slow_ops": timings
+            .slow_ops
+            .iter_recent()
+            .map(|op| serde_json::json!({ "op": op.name, "ms": op.ms }))
+            .collect::<Vec<_>>(),
+        "startup": startup.to_json(),
+    })
 }
 
 #[cfg(test)]
@@ -84,6 +333,114 @@ mod tests {
         Counters::bump(&counters.frames);
         Counters::bump(&counters.frames);
         assert_eq!(counters.read().frames, 2);
+    }
+
+    #[test]
+    fn an_empty_histogram_reports_zero_rather_than_a_bucket_bound() {
+        // The percentile of nothing is not "250µs", which is what returning the
+        // first bucket bound would print into a HUD on a run that painted
+        // nothing.
+        let h = DurationHistogram::default();
+        assert_eq!(h.percentile_us(50), 0);
+        assert_eq!(h.percentile_us(95), 0);
+        assert_eq!(h.max_us(), 0);
+        assert_eq!(h.total(), 0);
+    }
+
+    #[test]
+    fn a_percentile_never_reads_above_the_max_beside_it() {
+        // The bucket's UPPER bound is reported, so without the clamp a single
+        // 300µs sample would print "p95 500µs / max 300µs" — a contradiction
+        // in two adjacent columns.
+        let mut h = DurationHistogram::default();
+        h.record(std::time::Duration::from_micros(300));
+        assert_eq!(h.max_us(), 300);
+        assert!(h.percentile_us(95) <= h.max_us());
+        assert!(h.percentile_us(50) <= h.max_us());
+    }
+
+    #[test]
+    fn an_overflow_sample_is_counted_and_reported_as_the_max() {
+        let mut h = DurationHistogram::default();
+        h.record(std::time::Duration::from_secs(3));
+        assert_eq!(h.total(), 1);
+        assert_eq!(h.max_us(), 3_000_000);
+        assert_eq!(h.percentile_us(95), 3_000_000);
+    }
+
+    #[test]
+    fn the_slow_op_ring_keeps_the_newest_and_reads_newest_first() {
+        let mut ops = SlowOps::default();
+        for i in 0..(SlowOps::CAP as u64 + 4) {
+            ops.push(SlowOp { name: "op", ms: i });
+        }
+        let seen: Vec<u64> = ops.iter_recent().map(|op| op.ms).collect();
+        assert_eq!(seen.len(), SlowOps::CAP);
+        // Newest first, and the four oldest were dropped rather than the newest.
+        assert_eq!(seen[0], SlowOps::CAP as u64 + 3);
+        assert!(!seen.contains(&0));
+    }
+
+    #[test]
+    fn only_ops_over_the_ring_threshold_are_kept_and_only_slow_ones_warn() {
+        let mut t = Timings::default();
+        assert!(!t.record_op("fast", std::time::Duration::from_micros(200)));
+        assert!(t.slow_ops.is_empty(), "a fast op is not worth a ring slot");
+
+        assert!(!t.record_op(
+            "middling",
+            std::time::Duration::from_millis(SLOW_OP_RING_MS)
+        ));
+        assert!(!t.slow_ops.is_empty());
+
+        assert!(
+            t.record_op("stall", std::time::Duration::from_millis(SLOW_OP_WARN_MS)),
+            "an op over the warn threshold asks the caller to log it"
+        );
+    }
+
+    #[test]
+    fn a_window_reset_clears_timings_but_not_the_counters() {
+        let mut t = Timings::default();
+        t.frame.record(std::time::Duration::from_millis(5));
+        t.tick.record(std::time::Duration::from_millis(1));
+        t.republish.record(std::time::Duration::from_millis(2));
+        t.record_op("op", std::time::Duration::from_millis(50));
+        t.reset_window();
+        assert_eq!(t.frame.total(), 0);
+        assert_eq!(t.tick.total(), 0);
+        assert_eq!(t.republish.total(), 0);
+        assert!(t.slow_ops.is_empty());
+    }
+
+    #[test]
+    fn the_published_snapshot_carries_every_key_the_cli_renders() {
+        let counters = Counters::default();
+        Counters::bump(&counters.frames);
+        let mut timings = Timings::default();
+        timings.frame.record(std::time::Duration::from_millis(6));
+        timings.record_op("interface_reload", std::time::Duration::from_millis(120));
+        let startup = Startup {
+            config_init_ms: 3,
+            ui_build_ms: 40,
+            ..Startup::default()
+        };
+
+        let json = snapshot_json(&counters.read(), &timings, &startup, 4);
+
+        assert_eq!(json["session_count"], 4);
+        assert_eq!(json["counters"]["frames"], 1);
+        assert_eq!(json["startup"]["ui_build_ms"], 40);
+        assert_eq!(json["slow_ops"][0]["op"], "interface_reload");
+        assert_eq!(json["slow_ops"][0]["ms"], 120);
+        // Each histogram is present even when it recorded nothing, so the CLI
+        // never has to distinguish "absent" from "no samples".
+        for key in ["frame", "tick", "republish"] {
+            assert!(json[key]["p50_us"].is_number(), "{key} p50 missing");
+            assert!(json[key]["max_us"].is_number(), "{key} max missing");
+            assert!(json[key]["samples"].is_number(), "{key} samples missing");
+        }
+        assert!(json["pid"].as_u64().is_some_and(|p| p > 0));
     }
 
     #[test]

--- a/src/kernel/registry.rs
+++ b/src/kernel/registry.rs
@@ -269,12 +269,12 @@ impl Registry {
         self.version
     }
 
-    fn bump(&mut self) {
+    fn mark_changed(&mut self) {
         self.version = self.version.wrapping_add(1);
     }
 
     pub fn declare(&mut self, bindings: Vec<Binding>, settings: Vec<Setting>) {
-        self.bump();
+        self.mark_changed();
         self.declare_all(bindings, settings, Vec::new());
     }
 
@@ -412,7 +412,7 @@ impl Registry {
     /// transition, and a toggle they cannot predict is worse than one that does
     /// nothing.
     pub fn set_disabled(&mut self, path: &str, off: bool) -> Result<bool, String> {
-        self.bump();
+        self.mark_changed();
         if off {
             self.disabled.insert(path.to_string());
         } else {
@@ -448,7 +448,7 @@ impl Registry {
     /// The digest is taken from the contents at this moment, which is what makes
     /// "trusted, and since modified" a state the interface can report.
     pub fn trust(&mut self, path: &str, contents: &str) -> Result<(), String> {
-        self.bump();
+        self.mark_changed();
         self.trusted.insert(
             path.to_string(),
             Granted::Contents(super::bundled::digest(contents)),
@@ -466,7 +466,7 @@ impl Registry {
     /// source that re-tagged the same version with different contents would
     /// silently keep a capability the user granted to what the version used to be.
     pub fn trust_installed(&mut self, path: &str, pin: &str, contents: &str) -> Result<(), String> {
-        self.bump();
+        self.mark_changed();
         self.trusted.insert(
             path.to_string(),
             Granted::Managed {
@@ -480,7 +480,7 @@ impl Registry {
     /// Withdraw trust. Idempotent: revoking what was never trusted is not an
     /// error, because the user asked for a state, not for a transition.
     pub fn revoke(&mut self, path: &str) -> Result<(), String> {
-        self.bump();
+        self.mark_changed();
         self.trusted.remove(path);
         self.persist()
     }
@@ -514,7 +514,7 @@ impl Registry {
 
     /// Rebind an action, or clear the override when `chord` is `None`.
     pub fn rebind(&mut self, action: &str, chord: Option<&str>) -> Result<(), String> {
-        self.bump();
+        self.mark_changed();
         match chord {
             Some(chord) => {
                 let chord = normalise_chord(chord);
@@ -543,7 +543,7 @@ impl Registry {
         id: &str,
         value: Option<Value>,
     ) -> Result<(), String> {
-        self.bump();
+        self.mark_changed();
         let key = format!("{plugin}.{id}");
         let Some(declared) = self
             .settings

--- a/src/kernel/registry.rs
+++ b/src/kernel/registry.rs
@@ -196,6 +196,13 @@ pub struct Registry {
     /// Whether this registry's overrides came from `ui.json`, and so whether
     /// writing them back is an edit or an erasure.
     origin: Origin,
+    /// Moves whenever anything published from this registry does — the
+    /// declarations, a rebinding, a setting, the disabled set, a trust grant.
+    ///
+    /// Bumped at the top of each mutator rather than on its success paths: over-
+    /// bumping costs one rebuild, while a path that returns early without
+    /// bumping publishes a stale answer (`frame-cost`).
+    version: u64,
 }
 
 /// Where a registry's overrides came from.
@@ -257,7 +264,17 @@ impl Registry {
     /// Overrides survive because they belong to the *user*, not to the plugin
     /// set — an override naming a plugin that is temporarily broken must come
     /// back when the plugin does.
+    /// How many times anything published from this registry has changed.
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    fn bump(&mut self) {
+        self.version = self.version.wrapping_add(1);
+    }
+
     pub fn declare(&mut self, bindings: Vec<Binding>, settings: Vec<Setting>) {
+        self.bump();
         self.declare_all(bindings, settings, Vec::new());
     }
 
@@ -395,6 +412,7 @@ impl Registry {
     /// transition, and a toggle they cannot predict is worse than one that does
     /// nothing.
     pub fn set_disabled(&mut self, path: &str, off: bool) -> Result<bool, String> {
+        self.bump();
         if off {
             self.disabled.insert(path.to_string());
         } else {
@@ -430,6 +448,7 @@ impl Registry {
     /// The digest is taken from the contents at this moment, which is what makes
     /// "trusted, and since modified" a state the interface can report.
     pub fn trust(&mut self, path: &str, contents: &str) -> Result<(), String> {
+        self.bump();
         self.trusted.insert(
             path.to_string(),
             Granted::Contents(super::bundled::digest(contents)),
@@ -447,6 +466,7 @@ impl Registry {
     /// source that re-tagged the same version with different contents would
     /// silently keep a capability the user granted to what the version used to be.
     pub fn trust_installed(&mut self, path: &str, pin: &str, contents: &str) -> Result<(), String> {
+        self.bump();
         self.trusted.insert(
             path.to_string(),
             Granted::Managed {
@@ -460,6 +480,7 @@ impl Registry {
     /// Withdraw trust. Idempotent: revoking what was never trusted is not an
     /// error, because the user asked for a state, not for a transition.
     pub fn revoke(&mut self, path: &str) -> Result<(), String> {
+        self.bump();
         self.trusted.remove(path);
         self.persist()
     }
@@ -493,6 +514,7 @@ impl Registry {
 
     /// Rebind an action, or clear the override when `chord` is `None`.
     pub fn rebind(&mut self, action: &str, chord: Option<&str>) -> Result<(), String> {
+        self.bump();
         match chord {
             Some(chord) => {
                 let chord = normalise_chord(chord);
@@ -521,6 +543,7 @@ impl Registry {
         id: &str,
         value: Option<Value>,
     ) -> Result<(), String> {
+        self.bump();
         let key = format!("{plugin}.{id}");
         let Some(declared) = self
             .settings

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -330,6 +330,14 @@ pub struct SnapshotStore {
     /// The subscription's first report routinely arrives before the pane has
     /// been adopted, so an unmatched event is parked rather than lost.
     pending_hooks: Vec<PendingHook>,
+    /// Moves whenever anything in [`Self::current`] does.
+    ///
+    /// What gates the published tables and the pure-pane tree cache: a reader
+    /// that saw this value and sees it again knows nothing it could read has
+    /// changed. It is bumped **inside** each mutation rather than by callers,
+    /// because a mutation that forgets to bump is the one failure here that is
+    /// silent — see `tests/kernel_frame_cost.rs`.
+    generation: u64,
 }
 
 /// A remote hook event waiting for the session it names to appear.
@@ -370,6 +378,7 @@ impl SnapshotStore {
             last_refresh: None,
             last_data_version: None,
             pending_hooks: Vec::new(),
+            generation: 0,
         };
         store.refresh();
         store
@@ -388,12 +397,24 @@ impl SnapshotStore {
             last_refresh: None,
             last_data_version: None,
             pending_hooks: Vec::new(),
+            generation: 0,
         };
         store.refresh();
         store
     }
 
     /// The current snapshot. Always immediate.
+    /// How many times the snapshot has changed. See [`Self::generation`]'s field.
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Record that the snapshot changed. Every write to `current` goes through
+    /// a call to this in the same breath.
+    fn touch(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+    }
+
     pub fn current(&self) -> &Snapshot {
         &self.current
     }
@@ -423,6 +444,9 @@ impl SnapshotStore {
             self.last_refresh = Some(Instant::now());
             self.current.taken_at_ms = now_ms();
             self.attach_git_stats();
+            // `taken_at_ms` is published and `widgets.relative_time` renders it,
+            // so a reader that did not see this move would freeze at "5s ago".
+            self.touch();
             return false;
         }
         self.refresh();
@@ -514,6 +538,7 @@ impl SnapshotStore {
             .find(|row| row.id == session)
         {
             row.status = "idle".to_string();
+            self.touch();
         }
     }
 
@@ -593,6 +618,9 @@ impl SnapshotStore {
             row.hook_state = Some(event.state);
             applied += 1;
         }
+        if applied > 0 {
+            self.touch();
+        }
         applied
     }
 
@@ -623,6 +651,9 @@ impl SnapshotStore {
                 row.status = derived;
                 changed += 1;
             }
+        }
+        if changed > 0 {
+            self.touch();
         }
         changed
     }
@@ -698,6 +729,7 @@ impl SnapshotStore {
 
         let Some(database) = &self.database else {
             self.current.taken_at_ms = taken_at_ms;
+            self.touch();
             return;
         };
 
@@ -706,6 +738,7 @@ impl SnapshotStore {
             Err(e) => {
                 self.current.error = Some(format!("list sessions: {e}"));
                 self.current.taken_at_ms = taken_at_ms;
+                self.touch();
                 return;
             }
         };
@@ -865,6 +898,7 @@ impl SnapshotStore {
             error: None,
         };
         self.attach_git_stats();
+        self.touch();
     }
 }
 

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -337,7 +337,7 @@ pub struct SnapshotStore {
     /// changed. It is bumped **inside** each mutation rather than by callers,
     /// because a mutation that forgets to bump is the one failure here that is
     /// silent — see `tests/kernel_frame_cost.rs`.
-    generation: u64,
+    version: u64,
 }
 
 /// A remote hook event waiting for the session it names to appear.
@@ -378,7 +378,7 @@ impl SnapshotStore {
             last_refresh: None,
             last_data_version: None,
             pending_hooks: Vec::new(),
-            generation: 0,
+            version: 0,
         };
         store.refresh();
         store
@@ -397,22 +397,22 @@ impl SnapshotStore {
             last_refresh: None,
             last_data_version: None,
             pending_hooks: Vec::new(),
-            generation: 0,
+            version: 0,
         };
         store.refresh();
         store
     }
 
     /// The current snapshot. Always immediate.
-    /// How many times the snapshot has changed. See [`Self::generation`]'s field.
-    pub fn generation(&self) -> u64 {
-        self.generation
+    /// How many times the snapshot has changed. See [`Self::version`]'s field.
+    pub fn version(&self) -> u64 {
+        self.version
     }
 
     /// Record that the snapshot changed. Every write to `current` goes through
     /// a call to this in the same breath.
-    fn touch(&mut self) {
-        self.generation = self.generation.wrapping_add(1);
+    fn mark_changed(&mut self) {
+        self.version = self.version.wrapping_add(1);
     }
 
     pub fn current(&self) -> &Snapshot {
@@ -446,12 +446,12 @@ impl SnapshotStore {
             let restamped = self.current.taken_at_ms != stamp;
             self.current.taken_at_ms = stamp;
             // Git stats landing rewrite rows here, so this branch changes more
-            // than the timestamp — an unconditional touch used to cover both,
+            // than the timestamp — the unconditional bump it replaced covered both,
             // and dropping it without asking would have published a session's
             // new counts only on the next unrelated refresh.
             let git_moved = self.attach_git_stats();
             if restamped || git_moved {
-                self.touch();
+                self.mark_changed();
             }
             return false;
         }
@@ -552,7 +552,7 @@ impl SnapshotStore {
             .find(|row| row.id == session)
         {
             row.status = "idle".to_string();
-            self.touch();
+            self.mark_changed();
         }
     }
 
@@ -633,7 +633,7 @@ impl SnapshotStore {
             applied += 1;
         }
         if applied > 0 {
-            self.touch();
+            self.mark_changed();
         }
         applied
     }
@@ -667,7 +667,7 @@ impl SnapshotStore {
             }
         }
         if changed > 0 {
-            self.touch();
+            self.mark_changed();
         }
         changed
     }
@@ -743,7 +743,7 @@ impl SnapshotStore {
 
         let Some(database) = &self.database else {
             self.current.taken_at_ms = taken_at_ms;
-            self.touch();
+            self.mark_changed();
             return;
         };
 
@@ -752,7 +752,7 @@ impl SnapshotStore {
             Err(e) => {
                 self.current.error = Some(format!("list sessions: {e}"));
                 self.current.taken_at_ms = taken_at_ms;
-                self.touch();
+                self.mark_changed();
                 return;
             }
         };
@@ -912,7 +912,7 @@ impl SnapshotStore {
             error: None,
         };
         self.attach_git_stats();
-        self.touch();
+        self.mark_changed();
     }
 }
 
@@ -1093,7 +1093,7 @@ pub(crate) fn repo_name(cwd: &Option<PathBuf>, repo_path: Option<&PathBuf>) -> O
 /// Deliberately coarser than the clock. `taken_at_ms` is published, and its only
 /// reader is `widgets.now_ms` feeding `time_ago`, which floors the difference to
 /// whole seconds — so sub-second precision is unobservable to the interface,
-/// while re-stamping it moved [`SnapshotStore::generation`] 2.5 times a second
+/// while re-stamping it moved [`SnapshotStore::version`] 2.5 times a second
 /// and capped how long any pure pane could stay cached (`frame-cost`).
 ///
 /// Quantising the published *value* rather than delaying the signal is what

--- a/src/kernel/snapshot.rs
+++ b/src/kernel/snapshot.rs
@@ -442,11 +442,17 @@ impl SnapshotStore {
         }
         if self.rows_are_current() {
             self.last_refresh = Some(Instant::now());
-            self.current.taken_at_ms = now_ms();
-            self.attach_git_stats();
-            // `taken_at_ms` is published and `widgets.relative_time` renders it,
-            // so a reader that did not see this move would freeze at "5s ago".
-            self.touch();
+            let stamp = taken_at_stamp();
+            let restamped = self.current.taken_at_ms != stamp;
+            self.current.taken_at_ms = stamp;
+            // Git stats landing rewrite rows here, so this branch changes more
+            // than the timestamp — an unconditional touch used to cover both,
+            // and dropping it without asking would have published a session's
+            // new counts only on the next unrelated refresh.
+            let git_moved = self.attach_git_stats();
+            if restamped || git_moved {
+                self.touch();
+            }
             return false;
         }
         self.refresh();
@@ -477,7 +483,9 @@ impl SnapshotStore {
     /// decides whether a stat is worth running, by its age. Asking only for rows
     /// with no answer yet is what froze every session's diffstat at its first
     /// reading for the life of the process.
-    fn attach_git_stats(&mut self) {
+    /// Returns whether any row's stats actually changed, so a caller that is
+    /// deciding whether the snapshot moved can ask rather than assume.
+    fn attach_git_stats(&mut self) -> bool {
         self.git.drain();
         let present: std::collections::HashSet<&str> = self
             .current
@@ -488,8 +496,13 @@ impl SnapshotStore {
         self.git.retain(&present);
 
         let mut wanted: Vec<(String, PathBuf)> = Vec::new();
+        let mut moved = false;
         for row in &mut self.current.sessions {
-            row.git = self.git.known.get(&row.id).and_then(|stat| stat.state);
+            let stats = self.git.known.get(&row.id).and_then(|stat| stat.state);
+            if row.git != stats {
+                row.git = stats;
+                moved = true;
+            }
             if let Some(cwd) = row.cwd.clone() {
                 wanted.push((row.id.clone(), cwd));
             }
@@ -497,6 +510,7 @@ impl SnapshotStore {
         for (id, cwd) in wanted {
             self.git.request(&id, cwd);
         }
+        moved
     }
 
     /// Acknowledge a finished turn: stamp `seen_at` on a session whose state is
@@ -719,7 +733,7 @@ impl SnapshotStore {
     /// transient database lock degrades to stale data rather than a blank list.
     pub fn refresh(&mut self) {
         self.last_refresh = Some(Instant::now());
-        let taken_at_ms = now_ms();
+        let taken_at_ms = taken_at_stamp();
         // Recorded BEFORE the reads: a commit landing between the two would
         // otherwise be recorded as already-seen and never picked up.
         self.last_data_version = self
@@ -1072,6 +1086,21 @@ pub(crate) fn repo_name(cwd: &Option<PathBuf>, repo_path: Option<&PathBuf>) -> O
         .or(cwd.as_ref())
         .and_then(|path| path.file_name())
         .map(|name| name.to_string_lossy().to_string())
+}
+
+/// The instant a snapshot was taken, to the second.
+///
+/// Deliberately coarser than the clock. `taken_at_ms` is published, and its only
+/// reader is `widgets.now_ms` feeding `time_ago`, which floors the difference to
+/// whole seconds — so sub-second precision is unobservable to the interface,
+/// while re-stamping it moved [`SnapshotStore::generation`] 2.5 times a second
+/// and capped how long any pure pane could stay cached (`frame-cost`).
+///
+/// Quantising the published *value* rather than delaying the signal is what
+/// keeps "a plugin never reads a stale published value" true: the field means
+/// "when these rows were read, to the second", and it is never behind that.
+fn taken_at_stamp() -> i64 {
+    now_ms() / 1000 * 1000
 }
 
 fn now_ms() -> i64 {

--- a/src/kernel/terminal.rs
+++ b/src/kernel/terminal.rs
@@ -195,6 +195,11 @@ pub struct Terminals {
     /// generation-gated: an unchanged session reports nothing, so the previous
     /// value has to be kept somewhere.
     meta: HashMap<String, AgentMeta>,
+    /// Moves only when [`Self::meta`] actually writes or drops an entry.
+    meta_version: u64,
+    /// Moves whenever the set of attach failures does. Published on each
+    /// session row, so it gates that group alongside `meta_version`.
+    failed_version: u64,
     /// Attaches running on workers: session id → the backend it is on.
     ///
     /// Attaching is the one thing here that blocks for a *long* time — an ssh
@@ -379,6 +384,8 @@ impl Terminals {
             surveys: HashMap::new(),
             waiting_since: HashMap::new(),
             meta: HashMap::new(),
+            meta_version: 0,
+            failed_version: 0,
             attaching: HashMap::new(),
             attached: std::sync::mpsc::channel(),
             discovering: std::collections::HashSet::new(),
@@ -486,7 +493,11 @@ impl Terminals {
             .map(|row| row.id.as_str())
             .collect();
         self.live.retain(|id, _| present.contains(id.as_str()));
+        let failures = self.failed.len();
         self.failed.retain(|id, _| present.contains(id.as_str()));
+        if self.failed.len() != failures {
+            self.failed_version = self.failed_version.wrapping_add(1);
+        }
     }
 
     /// Let go of a session whose pane died, so it is re-attached rather than
@@ -654,7 +665,9 @@ impl Terminals {
                             shell_visible: Cell::new(false),
                         },
                     );
-                    self.failed.remove(&done.session);
+                    if self.failed.remove(&done.session).is_some() {
+                        self.failed_version = self.failed_version.wrapping_add(1);
+                    }
                 }
                 Err(e) => self.fail(&done.session, Some(done.pane), e),
             }
@@ -688,11 +701,14 @@ impl Terminals {
     /// after the pane it needs is already there.
     pub fn forget(&mut self, session: &str) {
         self.live.remove(session);
-        self.failed.remove(session);
+        if self.failed.remove(session).is_some() {
+            self.failed_version = self.failed_version.wrapping_add(1);
+        }
     }
 
     /// Record why a session has no pane, and what was tried.
     fn fail(&mut self, session: &str, pane: Option<String>, message: String) {
+        self.failed_version = self.failed_version.wrapping_add(1);
         self.failed.insert(
             session.to_string(),
             Failure {
@@ -1564,13 +1580,35 @@ impl Terminals {
         for (id, live) in &mut self.live {
             if let Some((activity, notification)) = live.session.sync_agent_meta() {
                 let entry = self.meta.entry(id.clone()).or_default();
-                entry.activity = activity;
-                entry.notification = notification;
+                // Compared before assigning, not assigned blind. This runs on
+                // every publish, and a write that changed nothing would still
+                // move the version below and invalidate every cached tree —
+                // which is how a change-signal quietly becomes worthless
+                // (`frame-cost`).
+                if entry.activity != activity || entry.notification != notification {
+                    entry.activity = activity;
+                    entry.notification = notification;
+                    self.meta_version = self.meta_version.wrapping_add(1);
+                }
             }
         }
         // A session that went away keeps no stale title.
+        let before = self.meta.len();
         self.meta.retain(|id, _| self.live.contains_key(id));
+        if self.meta.len() != before {
+            self.meta_version = self.meta_version.wrapping_add(1);
+        }
         &self.meta
+    }
+
+    /// How many times [`Self::meta`] has actually changed an entry.
+    pub fn meta_version(&self) -> u64 {
+        self.meta_version
+    }
+
+    /// How many times the set of attach failures has changed.
+    pub fn failed_version(&self) -> u64 {
+        self.failed_version
     }
 }
 

--- a/src/kernel/terminal.rs
+++ b/src/kernel/terminal.rs
@@ -496,7 +496,7 @@ impl Terminals {
         let failures = self.failed.len();
         self.failed.retain(|id, _| present.contains(id.as_str()));
         if self.failed.len() != failures {
-            self.failed_version = self.failed_version.wrapping_add(1);
+            self.mark_failures_changed();
         }
     }
 
@@ -666,7 +666,7 @@ impl Terminals {
                         },
                     );
                     if self.failed.remove(&done.session).is_some() {
-                        self.failed_version = self.failed_version.wrapping_add(1);
+                        self.mark_failures_changed();
                     }
                 }
                 Err(e) => self.fail(&done.session, Some(done.pane), e),
@@ -702,13 +702,13 @@ impl Terminals {
     pub fn forget(&mut self, session: &str) {
         self.live.remove(session);
         if self.failed.remove(session).is_some() {
-            self.failed_version = self.failed_version.wrapping_add(1);
+            self.mark_failures_changed();
         }
     }
 
     /// Record why a session has no pane, and what was tried.
     fn fail(&mut self, session: &str, pane: Option<String>, message: String) {
-        self.failed_version = self.failed_version.wrapping_add(1);
+        self.mark_failures_changed();
         self.failed.insert(
             session.to_string(),
             Failure {
@@ -1577,6 +1577,7 @@ impl Terminals {
     /// costs one atomic load rather than two mutex locks and two `String`
     /// clones — the ADR-P10 reason v1 does the same.
     pub fn meta(&mut self) -> &HashMap<String, AgentMeta> {
+        let mut moved = false;
         for (id, live) in &mut self.live {
             if let Some((activity, notification)) = live.session.sync_agent_meta() {
                 let entry = self.meta.entry(id.clone()).or_default();
@@ -1588,15 +1589,15 @@ impl Terminals {
                 if entry.activity != activity || entry.notification != notification {
                     entry.activity = activity;
                     entry.notification = notification;
-                    self.meta_version = self.meta_version.wrapping_add(1);
+                    moved = true;
                 }
             }
         }
         // A session that went away keeps no stale title.
         let before = self.meta.len();
         self.meta.retain(|id, _| self.live.contains_key(id));
-        if self.meta.len() != before {
-            self.meta_version = self.meta_version.wrapping_add(1);
+        if moved || self.meta.len() != before {
+            self.mark_meta_changed();
         }
         &self.meta
     }
@@ -1604,6 +1605,14 @@ impl Terminals {
     /// How many times [`Self::meta`] has actually changed an entry.
     pub fn meta_version(&self) -> u64 {
         self.meta_version
+    }
+
+    fn mark_meta_changed(&mut self) {
+        self.meta_version = self.meta_version.wrapping_add(1);
+    }
+
+    fn mark_failures_changed(&mut self) {
+        self.failed_version = self.failed_version.wrapping_add(1);
     }
 
     /// How many times the set of attach failures has changed.

--- a/src/kernel/theme.rs
+++ b/src/kernel/theme.rs
@@ -38,6 +38,14 @@ pub struct Themes {
     custom: Vec<ThemeEntry>,
     /// Problems found while loading user themes. Surfaced, never fatal.
     pub warnings: Vec<String>,
+    /// Moves whenever the active palette or the set of choices does.
+    ///
+    /// Gates the published theme tables (`frame-cost`). Never restarts:
+    /// [`Self::refresh`] replaces the whole value, so it carries the old count
+    /// across rather than resetting to zero — a version that went backwards
+    /// could collide with one a reader had already seen and be mistaken for
+    /// "nothing changed".
+    version: u64,
 }
 
 impl Themes {
@@ -80,6 +88,7 @@ impl Themes {
             choices,
             custom,
             warnings,
+            version: 0,
         }
     }
 
@@ -118,6 +127,9 @@ impl Themes {
             return Err(format!("unknown theme {name:?}"));
         }
         self.active = resolve(Some(name), &self.custom);
+        // Bumped where the palette actually changes, so a failed persist below
+        // still reports the change that already happened in memory.
+        self.bump();
         if let Some(db) = db {
             db.set_active_theme(name)
                 .map_err(|e| format!("persist theme: {e}"))?;
@@ -138,13 +150,25 @@ impl Themes {
             return Err(format!("unknown theme {name:?}"));
         }
         self.active = resolve(Some(name), &self.custom);
+        self.bump();
         Ok(())
     }
 
     /// Reload from disk and the database, keeping the active choice if it still
     /// resolves. Called when `themes.toml` changes or another instance switches.
     pub fn refresh(&mut self, db: Option<&Database>) {
+        let seen = self.version;
         *self = Self::load(db);
+        self.version = seen.wrapping_add(1);
+    }
+
+    /// How many times the palette or the choices have changed.
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    fn bump(&mut self) {
+        self.version = self.version.wrapping_add(1);
     }
 
     /// The active palette as role name → colour string, ready to publish.

--- a/src/kernel/theme.rs
+++ b/src/kernel/theme.rs
@@ -129,7 +129,7 @@ impl Themes {
         self.active = resolve(Some(name), &self.custom);
         // Bumped where the palette actually changes, so a failed persist below
         // still reports the change that already happened in memory.
-        self.bump();
+        self.mark_changed();
         if let Some(db) = db {
             db.set_active_theme(name)
                 .map_err(|e| format!("persist theme: {e}"))?;
@@ -150,7 +150,7 @@ impl Themes {
             return Err(format!("unknown theme {name:?}"));
         }
         self.active = resolve(Some(name), &self.custom);
-        self.bump();
+        self.mark_changed();
         Ok(())
     }
 
@@ -167,7 +167,7 @@ impl Themes {
         self.version
     }
 
-    fn bump(&mut self) {
+    fn mark_changed(&mut self) {
         self.version = self.version.wrapping_add(1);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,24 @@ use thurbox::session::selection::{PaneBounds, Selection, TermPos};
 /// affordable because the expensive per-frame work below is gated on a paint
 /// actually being due.
 const TICK: Duration = Duration::from_millis(10);
+
+/// The input poll's timeout once nothing has happened for [`QUIESCENT_AFTER`].
+///
+/// `event::poll` returns the instant an event arrives, so lengthening this costs
+/// **no** input latency — a keystroke wakes the thread either way. What it slows
+/// is noticing things that do not wake it: new agent output, a worker result, a
+/// row another process wrote. At rest there is by definition none of the first,
+/// and a 50ms delay on the others is not perceptible; the first sign of activity
+/// puts the loop straight back on [`TICK`].
+///
+/// Worth 94 wakes a second against 20 on an idle interface, which was half its
+/// entire cost.
+const IDLE_TICK: Duration = Duration::from_millis(50);
+
+/// How long nothing must happen before the loop slows its poll to
+/// [`IDLE_TICK`]. Longer than a keypress-to-repaint round trip, so typing never
+/// crosses into the slow poll and back.
+const QUIESCENT_AFTER: Duration = Duration::from_millis(500);
 /// Editors save in bursts (write, rename, chmod); wait for the dust to settle.
 const DEBOUNCE: Duration = Duration::from_millis(120);
 /// Longest a frame may go unpainted when nothing has changed.
@@ -256,6 +274,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         first_frame_logged: false,
         process_start,
         data_epoch: 0,
+        last_activity: Instant::now(),
+        animation_tick: 0,
+        animation_step: 0,
         selection: None,
         notifier: {
             let settings = thurbox::session::settings::global();
@@ -838,6 +859,21 @@ struct App {
     /// True process start, taken before any startup phase — `started` is taken
     /// during construction and so misses everything before it.
     process_start: Instant,
+    /// When anything last happened — input, output, a worker result, a repaint
+    /// that changed something. Drives the poll timeout, nothing else.
+    last_activity: Instant,
+    /// The shared animation clock, advanced only while something is animating.
+    ///
+    /// Kept here rather than read from `ctx.elapsed` in the render, because
+    /// whether anything is animating is the loop's knowledge: a spinner turns
+    /// for a session that is *working*, and the creation flow's pending row for
+    /// a command in flight. With neither, the clock stands still and a pure
+    /// pane's tree survives — which is what lets an idle interface stop
+    /// rebuilding anything at all (`frame-cost`).
+    animation_tick: u64,
+    /// The last `elapsed * ANIMATION_HZ` step the tick was advanced for, so a
+    /// step is counted once however many frames fall inside it.
+    animation_step: u64,
     /// Moves whenever data the loop owns and publishes does — a worker store
     /// that took a result, the links or screen text just re-scanned, the
     /// in-flight command list, an attach failure.
@@ -1368,6 +1404,7 @@ impl App {
         let output_gen = self.terminals.output_generation();
         if output_gen != self.last_output_gen {
             self.last_output_gen = output_gen;
+            self.last_activity = Instant::now();
             // Deliberately NOT a data change: new agent output moves the vt100
             // grid a surface paints from, not anything published. Treating it as
             // one would move the epoch on every frame under a printing agent and
@@ -1504,6 +1541,30 @@ impl App {
             .observe(self.snapshots.current(), self.focused_session.as_deref());
     }
 
+    /// Advance the shared animation clock, but only while something is moving.
+    ///
+    /// Conservative in the safe direction: saying "animating" when nothing is
+    /// costs one cache miss, while saying "not animating" when something is
+    /// would freeze it on screen.
+    fn advance_animation(&mut self) {
+        let animating = self
+            .snapshots
+            .current()
+            .sessions
+            .iter()
+            .any(|row| row.status == "working")
+            || self.commands.has_inflight();
+        if !animating {
+            return;
+        }
+        let step =
+            (self.started.elapsed().as_secs_f64() * thurbox::kernel::host::ANIMATION_HZ) as u64;
+        if step != self.animation_step {
+            self.animation_step = step;
+            self.animation_tick = self.animation_tick.wrapping_add(1);
+        }
+    }
+
     /// Note that published data moved, and that the screen owes a frame.
     ///
     /// The two go together everywhere they are used: something that changes what
@@ -1511,6 +1572,19 @@ impl App {
     fn note_data_change(&mut self) {
         self.data_epoch = self.data_epoch.wrapping_add(1);
         self.dirty = true;
+        self.last_activity = Instant::now();
+    }
+
+    /// How long to wait for input before going round the loop again.
+    ///
+    /// See [`IDLE_TICK`]: this is a poll timeout, not a frame deadline, so
+    /// stretching it while nothing is happening costs responsiveness nowhere.
+    fn poll_timeout(&self) -> Duration {
+        if self.last_activity.elapsed() >= QUIESCENT_AFTER {
+            IDLE_TICK
+        } else {
+            TICK
+        }
     }
 
     /// Whether the wall-clock timing of ADR-P11 is being collected.
@@ -1713,11 +1787,19 @@ impl App {
         let mut waited = false;
         loop {
             // Only the first read waits; the rest take what is already queued.
-            let timeout = if waited { Duration::ZERO } else { TICK };
+            let timeout = if waited {
+                Duration::ZERO
+            } else {
+                self.poll_timeout()
+            };
             waited = true;
             let event = match next_event(timeout) {
                 Ok(Some(event)) => {
                     *input_failures = 0;
+                    // Anything the user does puts the loop back on the fast
+                    // poll, so the frames that follow a keystroke are not paced
+                    // by the idle timeout.
+                    self.last_activity = Instant::now();
                     event
                 }
                 Ok(None) => break,
@@ -1933,6 +2015,7 @@ impl App {
     /// Called just before a paint and before dispatching input — the only two
     /// moments Lua runs — rather than once per loop iteration.
     fn republish(&mut self) {
+        self.advance_animation();
         let sessions: Vec<String> = self
             .snapshots
             .current()
@@ -1988,6 +2071,7 @@ impl App {
                 meta: self.terminals.meta_version(),
                 failed: self.terminals.failed_version(),
                 data: self.data_epoch,
+                animation: self.animation_tick,
             },
             snapshot: self.snapshots.current(),
             attach_errors: &attach_errors,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1565,12 +1565,23 @@ impl App {
         }
     }
 
+    /// Note that something a plugin reads has moved.
+    ///
+    /// Separate from [`Self::note_data_change`] because the callers inside
+    /// `republish` are already *in* the frame that will show the new value:
+    /// marking it dirty there would buy a second repaint of what is about to be
+    /// painted anyway.
+    fn note_published_change(&mut self) {
+        self.data_epoch = self.data_epoch.wrapping_add(1);
+    }
+
     /// Note that published data moved, and that the screen owes a frame.
     ///
-    /// The two go together everywhere they are used: something that changes what
-    /// a plugin would read is also something worth repainting for.
+    /// The two go together everywhere this is used: something that changes what
+    /// a plugin would read is also something worth repainting for, and worth
+    /// polling quickly again after.
     fn note_data_change(&mut self) {
-        self.data_epoch = self.data_epoch.wrapping_add(1);
+        self.note_published_change();
         self.dirty = true;
         self.last_activity = Instant::now();
     }
@@ -1907,7 +1918,7 @@ impl App {
             if self.terminals.last_rect(id).is_none() {
                 self.link_stamps.remove(id);
                 if self.links.remove(id).is_some() {
-                    self.data_epoch = self.data_epoch.wrapping_add(1);
+                    self.note_published_change();
                 }
                 continue;
             }
@@ -1934,7 +1945,7 @@ impl App {
                         true
                     };
                     if changed {
-                        self.data_epoch = self.data_epoch.wrapping_add(1);
+                        self.note_published_change();
                     }
                 }
                 // No live pane, so no screen and no links.
@@ -1969,7 +1980,7 @@ impl App {
             if self.content_generation.is_some() {
                 self.content = std::collections::HashMap::new();
                 self.content_generation = None;
-                self.data_epoch = self.data_epoch.wrapping_add(1);
+                self.note_published_change();
             }
             return;
         }
@@ -1978,7 +1989,7 @@ impl App {
             let scanned = self.terminals.screens(sessions);
             if scanned != self.content {
                 self.content = scanned;
-                self.data_epoch = self.data_epoch.wrapping_add(1);
+                self.note_published_change();
             }
             self.content_generation = Some(generation);
         }
@@ -2065,7 +2076,7 @@ impl App {
         let ui_dir = self.ui_dir.display().to_string();
         if let Err(e) = self.host.publish(&thurbox::kernel::host::Published {
             epoch: thurbox::kernel::host::Epoch {
-                snapshot: self.snapshots.generation(),
+                snapshot: self.snapshots.version(),
                 themes: self.themes.version(),
                 registry: self.registry.version(),
                 meta: self.terminals.meta_version(),
@@ -4512,15 +4523,14 @@ fn hud_area(area: Rect) -> Rect {
 /// merely mis-compare, and this runs on every painted frame.
 fn read_cells(frame: &mut Frame, rect: Rect) -> Vec<ratatui::buffer::Cell> {
     // `Frame` exposes only `buffer_mut`, hence the mutable borrow for a read.
-    let area = frame.buffer_mut().area;
-    let rect = rect.intersection(area);
+    // Taken once rather than per cell: this runs for every band on every
+    // painted frame.
+    let buffer = frame.buffer_mut();
+    let rect = rect.intersection(buffer.area);
     let mut cells = Vec::with_capacity(usize::from(rect.width) * usize::from(rect.height));
     for y in rect.top()..rect.bottom() {
         for x in rect.left()..rect.right() {
-            if let Some(cell) = frame
-                .buffer_mut()
-                .cell(ratatui::layout::Position::new(x, y))
-            {
+            if let Some(cell) = buffer.cell(ratatui::layout::Position::new(x, y)) {
                 cells.push(cell.clone());
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,14 @@ const DEBOUNCE: Duration = Duration::from_millis(120);
 /// what turns an idle app from ~20 fps into ~4. v1 uses the same floor.
 const FORCE_REDRAW_INTERVAL: Duration = Duration::from_millis(250);
 
+/// Iterations between two `perf_window` log lines (~10s at the 10ms tick).
+const PERF_WINDOW_TICKS: u64 = 1000;
+
+/// How often the JSON snapshot is written while timing is active. Slower than
+/// the log line because it is a database write every other thurbox connection
+/// pays for with a `data_version` bump.
+const PERF_PUBLISH_INTERVAL: Duration = Duration::from_secs(5);
+
 /// The floor between two paints.
 ///
 /// The poll above runs every 10ms so input is noticed at once, but a frame here
@@ -134,8 +142,39 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // to `audit_retention_days` — and v1 loads them at the same point for the same
     // reason. Without this call `settings::global()` hands out `Settings::default`
     // and the whole file is ignored, however carefully it was written.
+    // File-based logging: stdout belongs to the TUI, so every `tracing` call in
+    // this process — the panic hook, a worker's warning, the perf lines below —
+    // has nowhere else to go. Without a subscriber they are not merely
+    // unformatted but *dropped*, which is how a reader thread could die and
+    // leave no trace anywhere. The guard is deliberately leaked: the appender's
+    // worker must outlive every later log call, including the panic hook's, and
+    // this runs once per process.
+    let log_dir = thurbox::paths::log_directory().unwrap_or_else(|| std::path::PathBuf::from("."));
+    std::fs::create_dir_all(&log_dir).ok();
+    let (writer, guard) =
+        tracing_appender::non_blocking(tracing_appender::rolling::daily(log_dir, "thurbox.log"));
+    Box::leak(Box::new(guard));
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("thurbox=debug".parse().unwrap_or_default()),
+        )
+        .with_writer(writer)
+        .with_ansi(false)
+        .init();
+
+    // Startup phases are timed unconditionally: this runs once, so the two
+    // `Instant` reads per phase cost nothing measurable, and the numbers are
+    // only *reported* when timing is active.
+    let process_start = Instant::now();
+    let mut startup = thurbox::kernel::perf::Startup::default();
+
+    let phase = Instant::now();
     let (config, config_warnings) = thurbox::kernel::config::Config::load();
+    startup.config_init_ms = phase.elapsed().as_millis() as u64;
+
     let mut startup_notices: Vec<String> = config_warnings;
+    let phase = Instant::now();
     if let Some(db) = snapshots_db() {
         startup_notices.extend(thurbox::session_ops::heal_active_extensions(&db));
         startup_notices.extend(thurbox::session_ops::ensure_builtin_hooks_extension(&db));
@@ -143,17 +182,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
             tracing::info!("{notice}");
         }
     }
+    startup.extension_heal_ms = phase.elapsed().as_millis() as u64;
 
     // The tmux heartbeat keeper, so a schedule keeps firing after this exits —
     // and, while it runs, at the keeper's 60s cadence rather than not at all.
     // Best-effort: a missing or old tmux just means no headless firing. Skipped
     // when the feature is off, exactly as v1 skips it.
+    let phase = Instant::now();
     if thurbox::session::settings::global().features.automations {
         let cli = thurbox::agent::tmux::resolve_cli_binary();
         if let Err(e) = thurbox::agent::tmux::ensure_automation_heartbeat(&cli) {
             tracing::warn!("could not arm the automation heartbeat: {e}");
         }
     }
+    startup.heartbeat_ms = phase.elapsed().as_millis() as u64;
 
     // The gate. v2 replaces v1 under the same binary name, so auto-update moves
     // people to a different interface without their asking -- and several surfaces
@@ -176,17 +218,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // back lives in `App::reload_interface` — called once below and on every
     // reload after. Deciding it twice is how the floor became a one-way door:
     // startup installed the fallback and every later reload rebuilt *that*.
+    let ui_phase = Instant::now();
     let host = LuaHost::new(&ui_dir);
 
     // Resolved before the move, since `focus` indexes into the host.
     let initial_focus = focus_index_of(&host, "agent");
+
+    // Hoisted out of the struct literal below so each phase can be timed
+    // separately; the construction order is unchanged.
+    let phase = Instant::now();
+    let snapshots = SnapshotStore::open();
+    startup.db_open_ms = phase.elapsed().as_millis() as u64;
+
+    let phase = Instant::now();
+    let themes = Themes::load(snapshots_db().as_ref());
+    startup.theme_activate_ms = phase.elapsed().as_millis() as u64;
 
     let mut app = App {
         host,
         sources: thurbox::kernel::bundled::sources(&ui_dir),
         watcher: Watcher::new(&ui_dir)?,
         ui_dir,
-        snapshots: SnapshotStore::open(),
+        snapshots,
         terminals: Terminals::new(),
         commands: CommandBus::new(),
         diffs: DiffStore::new(),
@@ -194,12 +247,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
         metrics: Metrics::new(),
         clipboard: arboard::Clipboard::new().ok(),
         perf: Counters::default(),
+        timings: thurbox::kernel::perf::Timings::default(),
+        startup,
+        perf_log: std::env::var_os("THURBOX_PERF_LOG").is_some(),
+        perf_window_base: thurbox::kernel::perf::Snapshot::default(),
+        perf_window_tick: 0,
+        perf_published_at: None,
+        first_frame_logged: false,
+        process_start,
+        data_epoch: 0,
         selection: None,
         notifier: {
             let settings = thurbox::session::settings::global();
             Notifier::new(settings.features.notifications, settings.notifications)
         },
-        themes: Themes::load(snapshots_db().as_ref()),
+        themes,
         updates: thurbox::kernel::updates::Updates::start(config.features()),
         slot_selection: std::collections::HashMap::new(),
         visible_slots: std::collections::HashSet::new(),
@@ -238,6 +300,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         started: Instant::now(),
         frames: 0,
         last_trees: Vec::new(),
+        last_bands: std::collections::HashMap::new(),
         last_floats: std::collections::HashMap::new(),
         drawn_floats: std::collections::HashSet::new(),
         last_paint: Instant::now(),
@@ -265,6 +328,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Declarations are collected once up front and again on every reload, so
     // a newly added plugin's keys appear in help with nothing else edited.
     app.collect_declarations();
+    // Everything from `LuaHost::new` to here is what it costs to have an
+    // interface at all — a v2-only startup phase, and the one a slow plugin
+    // shows up in.
+    app.startup.ui_build_ms = ui_phase.elapsed().as_millis() as u64;
     // Non-empty only on a profile's first wire-up or on a failure, so this is a
     // real signal rather than noise on every launch.
     if let Some(notice) = startup_notices.first() {
@@ -752,6 +819,34 @@ struct App {
     clipboard: Option<arboard::Clipboard>,
     notifier: Notifier,
     perf: Counters,
+    /// Wall-clock stats, populated only while timing is active (ADR-P11).
+    timings: thurbox::kernel::perf::Timings,
+    /// How long each startup phase took; published and logged once.
+    startup: thurbox::kernel::perf::Startup,
+    /// `THURBOX_PERF_LOG` was set, read once at construction. The other half of
+    /// [`Self::perf_timing_active`] is the HUD, which can be toggled.
+    perf_log: bool,
+    /// Counters as they stood when the current perf window opened, so the
+    /// `perf_window` line reports deltas rather than lifetime totals.
+    perf_window_base: thurbox::kernel::perf::Snapshot,
+    /// Iteration count at which the current perf window opened.
+    perf_window_tick: u64,
+    /// When the JSON snapshot was last written to the database.
+    perf_published_at: Option<Instant>,
+    /// The one-shot `startup` line is logged after the first painted frame.
+    first_frame_logged: bool,
+    /// True process start, taken before any startup phase — `started` is taken
+    /// during construction and so misses everything before it.
+    process_start: Instant,
+    /// Moves whenever data the loop owns and publishes does — a worker store
+    /// that took a result, the links or screen text just re-scanned, the
+    /// in-flight command list, an attach failure.
+    ///
+    /// The stores already answer "did anything land" from `poll`, so this reads
+    /// that rather than duplicating a counter inside each one: a signal derived
+    /// from the existing return value cannot drift from it. Combined with the
+    /// versions the kernel sources carry into [`Self::publish_epoch`].
+    data_epoch: u64,
     /// Active mouse text selection over a terminal surface, if any.
     selection: Option<Selection>,
     themes: Themes,
@@ -878,6 +973,9 @@ struct App {
     last_trees: Vec<Option<thurbox::kernel::node::Node>>,
     /// The last float each plugin painted, and where.
     ///
+    /// What each chrome band painted last frame, and where. Bands have no tree
+    /// to diff, so their cells are compared instead — see `render_band`.
+    last_bands: std::collections::HashMap<Band, (Rect, Vec<ratatui::buffer::Cell>)>,
     /// Kept apart from `last_trees` because a float is rendered in its own pass at
     /// its own rect, so the two would overwrite each other for a plugin that did
     /// both. Its purpose is the same: settle the loop when nothing moved.
@@ -984,13 +1082,28 @@ impl App {
         let mut input_failures: u32 = 0;
         while !self.quit {
             Counters::bump(&self.perf.iterations);
+            // One cached bool, so a default run pays nothing for the two
+            // `Instant` reads below (ADR-P11).
+            let timing = self.perf_timing_active();
+            let tick_start = timing.then(Instant::now);
+
             self.poll_reload();
             self.apply_commands(&mut terminal);
             self.poll_command_bus();
             self.sync_terminals_and_agents();
             self.serve_worker_stores();
             self.apply_external_requests();
+
+            // Recorded BEFORE the paint so `tick` and `frame` decompose rather
+            // than nest: the iteration is roughly tick + republish + frame +
+            // the input wait, and a number that contained the paint could not
+            // tell those apart.
+            if let Some(start) = tick_start {
+                self.timings.tick.record(start.elapsed());
+            }
+
             self.paint_if_due(&mut terminal)?;
+            self.report_perf();
             self.drain_input(&mut input_failures)?;
         }
         Ok(())
@@ -1020,9 +1133,11 @@ impl App {
         }
         if self.reload_at.is_some_and(|at| Instant::now() >= at) {
             self.reload_at = None;
-            self.reload_interface();
-            self.refresh_sources();
-            self.collect_declarations();
+            self.time_op("interface_reload", |app| {
+                app.reload_interface();
+                app.refresh_sources();
+                app.collect_declarations();
+            });
             self.clamp_focus();
             self.dirty = true;
         }
@@ -1234,7 +1349,7 @@ impl App {
                 self.repos.invalidate_bookmarks();
             }
             self.snapshots.refresh();
-            self.dirty = true;
+            self.note_data_change();
         } else {
             self.snapshots.refresh_if_due();
         }
@@ -1253,6 +1368,10 @@ impl App {
         let output_gen = self.terminals.output_generation();
         if output_gen != self.last_output_gen {
             self.last_output_gen = output_gen;
+            // Deliberately NOT a data change: new agent output moves the vt100
+            // grid a surface paints from, not anything published. Treating it as
+            // one would move the epoch on every frame under a printing agent and
+            // make the whole gate worthless (design.md — Risks).
             self.dirty = true;
         }
         // The stuck-`working` fallback, run here because it asks the
@@ -1316,7 +1435,7 @@ impl App {
             }
         }
         if self.diffs.poll() {
-            self.dirty = true;
+            self.note_data_change();
         }
 
         // The creation flow's reads. It asks by leaving a key in `store`,
@@ -1326,7 +1445,7 @@ impl App {
         let wants = self.repo_wants();
         self.repos.serve(&wants);
         if self.repos.poll() {
-            self.dirty = true;
+            self.note_data_change();
         }
 
         // A session that has stayed deleted past its undo window keeps its
@@ -1351,7 +1470,7 @@ impl App {
         // running them every iteration costs a comparison.
         self.metrics.sample(self.metric_subjects());
         if self.metrics.poll() {
-            self.dirty = true;
+            self.note_data_change();
         }
     }
 
@@ -1385,6 +1504,122 @@ impl App {
             .observe(self.snapshots.current(), self.focused_session.as_deref());
     }
 
+    /// Note that published data moved, and that the screen owes a frame.
+    ///
+    /// The two go together everywhere they are used: something that changes what
+    /// a plugin would read is also something worth repainting for.
+    fn note_data_change(&mut self) {
+        self.data_epoch = self.data_epoch.wrapping_add(1);
+        self.dirty = true;
+    }
+
+    /// Whether the wall-clock timing of ADR-P11 is being collected.
+    ///
+    /// One cached bool plus one field read, checked once per iteration: the
+    /// hot loop must not pay for observability nobody asked for.
+    fn perf_timing_active(&self) -> bool {
+        self.perf_log || self.hud
+    }
+
+    /// The reporting half of ADR-P11: the periodic `perf_window` log line and
+    /// the JSON snapshot `thurbox-cli perf` reads.
+    ///
+    /// Both are gated on timing being active. Publishing especially: each write
+    /// bumps every other thurbox connection's `data_version`, which costs them a
+    /// full shared-state reload on their next poll — an idle default instance
+    /// must never churn that row.
+    fn report_perf(&mut self) {
+        if !self.perf_timing_active() {
+            return;
+        }
+        // Mirrored from the host, which owns the two caches: the counters are
+        // the only way a skip is visible at all (`frame-cost`).
+        self.perf.renders_skipped.store(
+            self.host.skipped_renders(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        self.perf.groups_reused.store(
+            self.host.reused_groups(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        let counters = self.perf.read();
+
+        // The window line: counter deltas plus this window's percentiles, then
+        // the timings reset so each window stands alone.
+        if self.perf_log
+            && counters.iterations.saturating_sub(self.perf_window_tick) >= PERF_WINDOW_TICKS
+        {
+            let window = counters.since(&self.perf_window_base);
+            let slow: Vec<String> = self
+                .timings
+                .slow_ops
+                .iter_recent()
+                .map(|op| format!("{}:{}ms", op.name, op.ms))
+                .collect();
+            tracing::info!(
+                iterations = window.iterations,
+                frames = window.frames,
+                skipped = window.skipped,
+                renders = window.renders,
+                failures = window.failures,
+                reloads = window.reloads,
+                frame_p50_us = self.timings.frame.percentile_us(50),
+                frame_p95_us = self.timings.frame.percentile_us(95),
+                frame_max_us = self.timings.frame.max_us(),
+                republish_p50_us = self.timings.republish.percentile_us(50),
+                republish_p95_us = self.timings.republish.percentile_us(95),
+                tick_p50_us = self.timings.tick.percentile_us(50),
+                tick_p95_us = self.timings.tick.percentile_us(95),
+                slow_ops = slow.join(" "),
+                "perf_window"
+            );
+            self.perf_window_base = counters;
+            self.perf_window_tick = counters.iterations;
+            self.timings.reset_window();
+        }
+
+        // The snapshot, on its own slower cadence: it is a database write, not
+        // a log line.
+        // `map_or(true, ..)` rather than `is_none_or`: the latter is stable
+        // since 1.82 and this crate's MSRV is 1.75.
+        let due = self
+            .perf_published_at
+            .map_or(true, |at| at.elapsed() >= PERF_PUBLISH_INTERVAL);
+        if !due {
+            return;
+        }
+        self.perf_published_at = Some(Instant::now());
+        let json = thurbox::kernel::perf::snapshot_json(
+            &counters,
+            &self.timings,
+            &self.startup,
+            self.snapshots.current().sessions.len(),
+        );
+        if let Some(db) = snapshots_db() {
+            if let Err(e) = db.set_perf_snapshot(&json.to_string()) {
+                // Never worth failing a frame over; the CLI simply reports the
+                // older snapshot, or none.
+                tracing::warn!("could not publish the perf snapshot: {e}");
+            }
+        }
+    }
+
+    /// Time a named synchronous operation, ringing it if it was slow enough to
+    /// be felt and warning if it was slow enough to be a stall.
+    ///
+    /// Always measured, unlike the histograms: the call sites are rare,
+    /// user-triggered operations rather than the hot loop, and an interactive
+    /// stall has to be attributable even when nobody had a HUD open.
+    fn time_op<T>(&mut self, name: &'static str, f: impl FnOnce(&mut Self) -> T) -> T {
+        let start = Instant::now();
+        let out = f(self);
+        let elapsed = start.elapsed();
+        if self.timings.record_op(name, elapsed) {
+            tracing::warn!(op = name, ms = elapsed.as_millis() as u64, "slow op");
+        }
+        out
+    }
+
     /// Demand-driven paint: when something changed, or when the forced-redraw
     /// floor elapsed.
     ///
@@ -1399,8 +1634,17 @@ impl App {
             // that paints nothing is pure waste. At `drain_input`'s 10ms poll
             // that was 100 rebuilds a second to feed a screen that redraws four
             // times.
+            let timing = self.perf_timing_active();
+            let republish_start = timing.then(Instant::now);
             self.republish();
+            if let Some(start) = republish_start {
+                self.timings.republish.record(start.elapsed());
+            }
+            let draw_start = timing.then(Instant::now);
             let painted = terminal.draw(|frame| self.draw(frame))?;
+            if let Some(start) = draw_start {
+                self.timings.frame.record(start.elapsed());
+            }
             // Cloned so the borrow of `terminal` ends here: the two
             // corrections below both need it back.
             let buffer = painted.buffer.clone();
@@ -1426,6 +1670,23 @@ impl App {
             self.last_paint = Instant::now();
             self.frames += 1;
             Counters::bump(&self.perf.frames);
+            if !self.first_frame_logged {
+                self.first_frame_logged = true;
+                self.startup.first_frame_ms = self.process_start.elapsed().as_millis() as u64;
+                if self.perf_log {
+                    let s = &self.startup;
+                    tracing::info!(
+                        config_init_ms = s.config_init_ms,
+                        db_open_ms = s.db_open_ms,
+                        theme_activate_ms = s.theme_activate_ms,
+                        extension_heal_ms = s.extension_heal_ms,
+                        heartbeat_ms = s.heartbeat_ms,
+                        ui_build_ms = s.ui_build_ms,
+                        first_frame_ms = s.first_frame_ms,
+                        "startup"
+                    );
+                }
+            }
         } else {
             Counters::bump(&self.perf.skipped);
         }
@@ -1479,7 +1740,7 @@ impl App {
             match event {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     self.publish_for_batch(&mut published);
-                    self.on_key(&key);
+                    self.time_op("input_dispatch", |app| app.on_key(&key));
                     self.dirty = true;
                 }
                 // Dropped rather than merely uncaptured when the feature is
@@ -1551,6 +1812,23 @@ impl App {
     /// screen per repeat for answers that could not have changed.
     fn refresh_links(&mut self, sessions: &[String]) {
         for id in sessions {
+            // Only surfaces that are ON SCREEN. Extracting links walks the whole
+            // vt100 grid and URL-scans every row, and doing that for every
+            // session with a live pane cost ~1.2ms a frame with three of them —
+            // for answers nothing could use, since a link that is not painted
+            // can be neither clicked nor handed to the outer terminal. v1 asked
+            // only the active session for the same reason.
+            //
+            // The rects are last frame's (this runs before the paint that
+            // clears them), so a surface that has just appeared gets its links
+            // on the following frame rather than this one.
+            if self.terminals.last_rect(id).is_none() {
+                self.link_stamps.remove(id);
+                if self.links.remove(id).is_some() {
+                    self.data_epoch = self.data_epoch.wrapping_add(1);
+                }
+                continue;
+            }
             match self.terminals.output_stamp(id) {
                 // Unchanged since the last scan: the answer stands.
                 Some(stamp) if self.link_stamps.get(id) == Some(&stamp) => {}
@@ -1560,10 +1838,21 @@ impl App {
                     // Absent rather than empty when there are none, which is the
                     // shape a plugin reads: `thurbox.links[id]` is nil for a
                     // session with no links, not a table with nothing in it.
-                    if found.is_empty() {
-                        self.links.remove(id);
+                    //
+                    // Compared before storing: a printing agent moves its stamp
+                    // every frame while the links on screen usually stay put, and
+                    // treating a re-scan as a change would move the epoch every
+                    // frame for nothing.
+                    let changed = if found.is_empty() {
+                        self.links.remove(id).is_some()
+                    } else if self.links.get(id) == Some(&found) {
+                        false
                     } else {
                         self.links.insert(id.clone(), found);
+                        true
+                    };
+                    if changed {
+                        self.data_epoch = self.data_epoch.wrapping_add(1);
                     }
                 }
                 // No live pane, so no screen and no links.
@@ -1598,12 +1887,17 @@ impl App {
             if self.content_generation.is_some() {
                 self.content = std::collections::HashMap::new();
                 self.content_generation = None;
+                self.data_epoch = self.data_epoch.wrapping_add(1);
             }
             return;
         }
         let generation = self.terminals.output_generation();
         if self.content_generation != Some(generation) {
-            self.content = self.terminals.screens(sessions);
+            let scanned = self.terminals.screens(sessions);
+            if scanned != self.content {
+                self.content = scanned;
+                self.data_epoch = self.data_epoch.wrapping_add(1);
+            }
             self.content_generation = Some(generation);
         }
     }
@@ -1687,6 +1981,14 @@ impl App {
         let inventory = std::mem::take(&mut self.inventory);
         let ui_dir = self.ui_dir.display().to_string();
         if let Err(e) = self.host.publish(&thurbox::kernel::host::Published {
+            epoch: thurbox::kernel::host::Epoch {
+                snapshot: self.snapshots.generation(),
+                themes: self.themes.version(),
+                registry: self.registry.version(),
+                meta: self.terminals.meta_version(),
+                failed: self.terminals.failed_version(),
+                data: self.data_epoch,
+            },
             snapshot: self.snapshots.current(),
             attach_errors: &attach_errors,
             inflight: &inflight,
@@ -2073,7 +2375,7 @@ impl App {
         // The counters, above the floats: a diagnostic a modal could cover
         // would be useless exactly when a modal is what you are diagnosing.
         if self.hud {
-            render_hud(frame, hud_area(area), &self.perf.read());
+            render_hud(frame, hud_area(area), &self.perf.read(), &self.timings);
             // The counters move on every iteration, so the HUD is never
             // settled — while it is up, the loop keeps painting.
             self.changed_this_frame = true;
@@ -3264,13 +3566,31 @@ impl App {
             themes: &self.themes,
         };
         if !bands::occupies(band, &state) {
+            // A band that occupied the last frame and does not occupy this one
+            // HAS changed the frame — the message band finishing is the case —
+            // so forgetting it is itself the signal.
+            if self.last_bands.remove(&band).is_some() {
+                self.changed_this_frame = true;
+            }
             return;
         }
         let hits = bands::render(frame, rect, band, &state);
         self.band_targets.extend(hits);
-        // A band drawn is a band that changed the frame; the message band in
-        // particular appears and disappears without any tree moving.
-        self.changed_this_frame = true;
+        // A band is chrome the kernel paints directly, so there is no tree to
+        // diff the way a plugin's is — and marking it changed for having been
+        // *drawn* is not the same question. It held `dirty` set after every
+        // single frame, which defeated the demand-driven redraw entirely: the
+        // loop never settled to the 250ms floor and repainted at the frame cap
+        // forever, on an idle screen with no sessions at all.
+        //
+        // The cells it just painted are the honest analog of a plugin's tree —
+        // exact, and immune to a new `BandState` field being forgotten here.
+        let painted = read_cells(frame, rect);
+        let entry = (rect, painted);
+        if self.last_bands.get(&band) != Some(&entry) {
+            self.changed_this_frame = true;
+            self.last_bands.insert(band, entry);
+        }
     }
 
     /// Record one plugin's hitboxes, its own rect first.
@@ -4091,8 +4411,8 @@ fn error_area(area: Rect) -> Rect {
 /// The corner the session list is not in, so the pane you are most likely to be
 /// watching while measuring is the one it does not cover.
 fn hud_area(area: Rect) -> Rect {
-    let width = 30.min(area.width);
-    let height = 8.min(area.height);
+    let width = 34.min(area.width);
+    let height = 15.min(area.height);
     Rect {
         x: area.x + area.width - width,
         y: area.y,
@@ -4101,12 +4421,51 @@ fn hud_area(area: Rect) -> Rect {
     }
 }
 
+/// The cells of one rect of the frame, for comparing against the last one.
+///
+/// Clipped to the buffer's own area: a rect the arrangement produced is trusted
+/// to be inside the frame, but reading out of bounds would panic rather than
+/// merely mis-compare, and this runs on every painted frame.
+fn read_cells(frame: &mut Frame, rect: Rect) -> Vec<ratatui::buffer::Cell> {
+    // `Frame` exposes only `buffer_mut`, hence the mutable borrow for a read.
+    let area = frame.buffer_mut().area;
+    let rect = rect.intersection(area);
+    let mut cells = Vec::with_capacity(usize::from(rect.width) * usize::from(rect.height));
+    for y in rect.top()..rect.bottom() {
+        for x in rect.left()..rect.right() {
+            if let Some(cell) = frame
+                .buffer_mut()
+                .cell(ratatui::layout::Position::new(x, y))
+            {
+                cells.push(cell.clone());
+            }
+        }
+    }
+    cells
+}
+
+/// Compact µs for the HUD's narrow columns; `cli::perf` formats the same way.
+fn fmt_hud_us(us: u64) -> String {
+    if us < 1_000 {
+        format!("{us}us")
+    } else if us < 1_000_000 {
+        format!("{:.1}ms", us as f64 / 1_000.0)
+    } else {
+        format!("{:.1}s", us as f64 / 1_000_000.0)
+    }
+}
+
 /// Paint the counters.
 ///
 /// Counts rather than timings, which is the whole point of `kernel::perf`: a
 /// number that says "an idle loop painted no frames" is exact, where one that
 /// says "idle was fast" is a coin toss on shared hardware.
-fn render_hud(frame: &mut Frame, area: Rect, counters: &thurbox::kernel::perf::Snapshot) {
+fn render_hud(
+    frame: &mut Frame,
+    area: Rect,
+    counters: &thurbox::kernel::perf::Snapshot,
+    timings: &thurbox::kernel::perf::Timings,
+) {
     use ratatui::style::{Color, Style};
     use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
 
@@ -4119,15 +4478,34 @@ fn render_hud(frame: &mut Frame, area: Rect, counters: &thurbox::kernel::perf::S
         .border_style(Style::default().fg(Color::Yellow))
         .title(" perf ");
     let inner = block.inner(area);
-    let text = format!(
-        "iterations {}\nframes     {}\nskipped    {}\nrenders    {}\nfailures   {}\nreloads    {}",
+    // Counters first — they are the exact half. The timings below them are
+    // wall-clock and so only ever indicative (ADR-P11).
+    let mut text = format!(
+        "iterations {}\nframes     {}\nskipped    {}\nrenders    {}\nreused r/g {}/{}\nfailures   {}\nreloads    {}\n",
         counters.iterations,
         counters.frames,
         counters.skipped,
         counters.renders,
+        counters.renders_skipped,
+        counters.groups_reused,
         counters.failures,
         counters.reloads,
     );
+    for (label, histogram) in [
+        ("frame", &timings.frame),
+        ("republ", &timings.republish),
+        ("tick", &timings.tick),
+    ] {
+        text.push_str(&format!(
+            "{label:<6} {} / {}\n",
+            fmt_hud_us(histogram.percentile_us(50)),
+            fmt_hud_us(histogram.max_us()),
+        ));
+    }
+    match timings.slow_ops.iter_recent().next() {
+        Some(op) => text.push_str(&format!("slow   {}:{}ms", op.name, op.ms)),
+        None => text.push_str("slow   none"),
+    }
     frame.render_widget(Clear, area);
     frame.render_widget(block, area);
     frame.render_widget(

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -1,0 +1,591 @@
+//! What a frame is allowed to recompute (`frame-cost`).
+//!
+//! The change-signals these assert on gate both the published tables and the
+//! pure-pane tree cache, so a source that moves without its signal moving is
+//! not a slow interface but a **stale** one — a pane that stops updating, with
+//! no error anywhere. That failure is invisible to every other test in the
+//! suite, which is why it gets its own file.
+
+use thurbox::kernel::snapshot::SnapshotStore;
+use thurbox::kernel::theme::Themes;
+use thurbox::storage::Database;
+
+#[test]
+fn a_snapshot_refresh_moves_the_generation() {
+    // The generation is what a reader compares to decide it can reuse what it
+    // built last time. If a refresh left it still, every such reader would keep
+    // showing what the database said before.
+    let db = Database::open_in_memory().expect("db");
+    let mut store = SnapshotStore::with_database(db);
+
+    let before = store.generation();
+    store.refresh();
+    assert_ne!(
+        store.generation(),
+        before,
+        "a refresh replaced the snapshot without saying so"
+    );
+}
+
+#[test]
+fn every_refresh_moves_it_again() {
+    // `taken_at_ms` is published and rendered as "5s ago", so even a refresh
+    // that finds identical rows has changed something a plugin reads. A
+    // generation that only moved on *row* changes would freeze that label.
+    let db = Database::open_in_memory().expect("db");
+    let mut store = SnapshotStore::with_database(db);
+
+    let mut seen = store.generation();
+    for _ in 0..5 {
+        store.refresh();
+        let now = store.generation();
+        assert_ne!(now, seen, "a later refresh did not move the generation");
+        seen = now;
+    }
+}
+
+#[test]
+fn reading_the_snapshot_leaves_the_generation_alone() {
+    // The other half, and the one that makes gating worth anything: if merely
+    // looking moved the signal, nothing could ever be reused.
+    let db = Database::open_in_memory().expect("db");
+    let mut store = SnapshotStore::with_database(db);
+    store.refresh();
+
+    let settled = store.generation();
+    for _ in 0..100 {
+        let _ = store.current().sessions.len();
+        let _ = store.current().taken_at_ms;
+    }
+    assert_eq!(
+        store.generation(),
+        settled,
+        "reading the snapshot moved its generation"
+    );
+}
+
+#[test]
+fn quiescence_moves_the_generation_only_when_it_re_derives_something() {
+    // `apply_output_quiescence` runs every tick by design. It must move the
+    // signal when it changes a status and leave it alone otherwise, or the
+    // stuck-`working` fallback would invalidate every cached tree ~40 times a
+    // second for nothing.
+    let db = Database::open_in_memory().expect("db");
+    let mut store = SnapshotStore::with_database(db);
+    store.refresh();
+
+    let settled = store.generation();
+    let changed = store.apply_output_quiescence(|_| None);
+    assert_eq!(changed, 0, "an empty snapshot has nothing to re-derive");
+    assert_eq!(
+        store.generation(),
+        settled,
+        "a pass that changed nothing still moved the generation"
+    );
+}
+
+#[test]
+fn selecting_a_theme_moves_the_version_and_reading_it_does_not() {
+    let mut themes = Themes::load(None);
+    let settled = themes.version();
+
+    for _ in 0..50 {
+        let _ = themes.roles();
+        let _ = themes.active();
+    }
+    assert_eq!(
+        themes.version(),
+        settled,
+        "reading the palette moved its version"
+    );
+
+    let other = themes
+        .choices()
+        .iter()
+        .map(|choice| choice.name.clone())
+        .find(|name| *name != themes.active().name)
+        .expect("more than one theme ships");
+    themes.preview(&other).expect("preview");
+    assert_ne!(
+        themes.version(),
+        settled,
+        "the active palette changed without saying so"
+    );
+}
+
+#[test]
+fn a_theme_refresh_never_restarts_the_version() {
+    // `refresh` replaces the whole value. A version that restarted at zero could
+    // collide with one a reader had already seen and be read as "nothing
+    // changed" — the one way a monotonic signal can lie.
+    let mut themes = Themes::load(None);
+    for _ in 0..3 {
+        let before = themes.version();
+        themes.refresh(None);
+        assert!(
+            themes.version() > before,
+            "refresh restarted the version: {before} -> {}",
+            themes.version()
+        );
+    }
+}
+
+// --- the gated publish ------------------------------------------------------
+
+use thurbox::kernel::host::{Epoch, LuaHost, Published};
+use thurbox::kernel::registry::Registry;
+use thurbox::kernel::snapshot::{SessionRow, Snapshot};
+
+fn interface() -> (tempfile::TempDir, LuaHost) {
+    // A pane that reports what it can see of the published tables, so a stale
+    // group is visible as a rendered string rather than only as a counter.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plugins = dir.path().join("plugins");
+    std::fs::create_dir_all(&plugins).expect("mkdir");
+    std::fs::write(
+        plugins.join("10_probe.lua"),
+        r#"return { name = "probe", slot = "center", render = function()
+             local names = {}
+             for _, s in ipairs(thurbox.sessions or {}) do names[#names + 1] = s.name end
+             return { text = table.concat(names, ",") .. "|" .. tostring(thurbox.theme.name) }
+           end }"#,
+    )
+    .expect("write");
+    let host = LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    (dir, host)
+}
+
+fn row(id: &str, name: &str) -> SessionRow {
+    SessionRow {
+        id: id.into(),
+        name: name.into(),
+        agent: "claude".into(),
+        status: "idle".into(),
+        cwd: None,
+        repo: None,
+        repos: Vec::new(),
+        branch: None,
+        base_branch: None,
+        backend: "local-tmux".into(),
+        backend_id: Some("%1".into()),
+        remote_host: None,
+        agent_session_id: None,
+        parent_id: None,
+        display_order: None,
+        worktree_count: 0,
+        git: None,
+        hook_state: None,
+        shell_backend_id: None,
+        member_dirs: Vec::new(),
+    }
+}
+
+fn publish_at(host: &LuaHost, epoch: Epoch, snapshot: &Snapshot, themes: &Themes) {
+    let mut registry = Registry::default();
+    let (bindings, settings) = host.declarations();
+    registry.declare(bindings, settings);
+    let diffs = thurbox::kernel::diff::DiffStore::new();
+    let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
+    host.publish(&Published {
+        epoch,
+        snapshot,
+        attach_errors: &Default::default(),
+        inflight: &[],
+        themes,
+        registry: &registry,
+        diffs: &diffs,
+        links: &Default::default(),
+        content: &Default::default(),
+        meta: &Default::default(),
+        metrics: &Default::default(),
+        status_rows: 0,
+        can_open: true,
+        inventory: &[],
+        ui_dir: "ui",
+        settings: &Default::default(),
+        repos: &repos,
+        wants: &Default::default(),
+        focus: None,
+        hovered: None,
+    })
+    .expect("publish");
+}
+
+fn probe(host: &LuaHost) -> String {
+    let index = host.index_of("probe").expect("probe plugin");
+    let node = host
+        .render(
+            index,
+            thurbox::kernel::host::RenderContext {
+                width: 80,
+                height: 4,
+                focused: false,
+                elapsed: 0.0,
+                frame: 0,
+            },
+        )
+        .expect("render")
+        .node;
+    format!("{node:?}")
+}
+
+#[test]
+fn a_moved_source_is_published_even_though_groups_are_gated() {
+    // The requirement gating exists to not break: what a plugin reads after a
+    // source moves is the new value. A group reused when its inputs changed is
+    // undetectable from Lua, so this asserts on what the pane actually renders.
+    let (_dir, host) = interface();
+    let themes = Themes::load(None);
+
+    let first = Snapshot {
+        sessions: vec![row("a", "alpha")],
+        ..Snapshot::default()
+    };
+    let mut epoch = Epoch::default();
+    publish_at(&host, epoch, &first, &themes);
+    assert!(probe(&host).contains("alpha"));
+
+    let second = Snapshot {
+        sessions: vec![row("b", "beta")],
+        ..Snapshot::default()
+    };
+    epoch.snapshot += 1;
+    publish_at(&host, epoch, &second, &themes);
+    assert!(
+        probe(&host).contains("beta"),
+        "the sessions group was reused after the snapshot moved"
+    );
+}
+
+#[test]
+fn a_gated_publish_matches_a_full_rebuild() {
+    // The proof named in design.md: for the same inputs, gating changes nothing
+    // a plugin can observe. `always_fresh` rebuilds every group, so it stands in
+    // for the ungated build.
+    let (_dir, host) = interface();
+    let themes = Themes::load(None);
+    let snapshot = Snapshot {
+        sessions: vec![row("a", "alpha"), row("b", "beta")],
+        ..Snapshot::default()
+    };
+
+    let epoch = Epoch::default();
+    publish_at(&host, epoch, &snapshot, &themes);
+    let gated_first = probe(&host);
+
+    // Same epoch, same data: every group is served from the cache.
+    publish_at(&host, epoch, &snapshot, &themes);
+    let gated_again = probe(&host);
+
+    // Nothing cached at all.
+    publish_at(&host, Epoch::always_fresh(), &snapshot, &themes);
+    let rebuilt = probe(&host);
+
+    assert_eq!(
+        gated_first, gated_again,
+        "a reused group differed from itself"
+    );
+    assert_eq!(
+        gated_again, rebuilt,
+        "a reused group differed from one built afresh"
+    );
+}
+
+#[test]
+fn a_theme_change_reaches_lua_through_its_own_version() {
+    // Each group names only the versions it reads, so the theme group must move
+    // on the theme's version alone — a snapshot that never changes must not
+    // pin it.
+    let (_dir, host) = interface();
+    let mut themes = Themes::load(None);
+    let snapshot = Snapshot::default();
+
+    let mut epoch = Epoch::default();
+    publish_at(&host, epoch, &snapshot, &themes);
+    let before = probe(&host);
+
+    let other = themes
+        .choices()
+        .iter()
+        .map(|choice| choice.name.clone())
+        .find(|name| *name != themes.active().name)
+        .expect("more than one theme ships");
+    themes.preview(&other).expect("preview");
+    epoch.themes = themes.version();
+    publish_at(&host, epoch, &snapshot, &themes);
+
+    assert_ne!(
+        before,
+        probe(&host),
+        "the theme group was reused after the palette changed"
+    );
+}
+
+// --- the purity declaration -------------------------------------------------
+
+/// Two panes over the same data: one declaring its render pure, one not.
+///
+/// Skipping is observed by *lying* — publishing new data under an unchanged
+/// epoch. A pane that re-renders shows the new data; one that was skipped shows
+/// what it showed before. Nothing else can tell the two apart from outside,
+/// which is the point: a skip is meant to be invisible when the epoch is honest.
+fn two_panes() -> (tempfile::TempDir, LuaHost) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plugins = dir.path().join("plugins");
+    std::fs::create_dir_all(&plugins).expect("mkdir");
+    let body = r#"render = function()
+             local names = {}
+             for _, s in ipairs(thurbox.sessions or {}) do names[#names + 1] = s.name end
+             return { text = table.concat(names, ",") }
+           end }"#;
+    std::fs::write(
+        plugins.join("10_pure.lua"),
+        format!("return {{ name = \"pure\", slot = \"left\", pure = true, {body}"),
+    )
+    .expect("write");
+    std::fs::write(
+        plugins.join("20_plain.lua"),
+        format!("return {{ name = \"plain\", slot = \"center\", {body}"),
+    )
+    .expect("write");
+    let host = LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+    (dir, host)
+}
+
+fn tree_of(host: &LuaHost, name: &str) -> String {
+    let index = host.index_of(name).expect("plugin");
+    format!(
+        "{:?}",
+        host.render(
+            index,
+            thurbox::kernel::host::RenderContext {
+                width: 40,
+                height: 4,
+                focused: false,
+                elapsed: 0.0,
+                frame: 0,
+            },
+        )
+        .expect("render")
+        .node
+    )
+}
+
+#[test]
+fn a_pure_pane_is_not_re_rendered_while_its_inputs_stand() {
+    // A skip cannot be seen in what is painted — that IS the correctness claim,
+    // and the group cache withholds new data at an unchanged epoch anyway — so
+    // it is asserted on the count instead.
+    let (_dir, host) = two_panes();
+    let themes = Themes::load(None);
+    publish_at(
+        &host,
+        Epoch::default(),
+        &Snapshot {
+            sessions: vec![row("a", "alpha")],
+            ..Snapshot::default()
+        },
+        &themes,
+    );
+
+    let _ = tree_of(&host, "pure");
+    let settled = host.skipped_renders();
+    for _ in 0..10 {
+        let _ = tree_of(&host, "pure");
+    }
+    assert_eq!(
+        host.skipped_renders() - settled,
+        10,
+        "a pure pane was re-rendered although nothing it reads had moved"
+    );
+}
+
+#[test]
+fn an_undeclared_pane_renders_every_time() {
+    // The promise to every plugin that predates the declaration: nothing about
+    // it changed. Rendering it repeatedly must never be served from a cache.
+    let (_dir, host) = two_panes();
+    let themes = Themes::load(None);
+    publish_at(&host, Epoch::default(), &Snapshot::default(), &themes);
+
+    let _ = tree_of(&host, "plain");
+    let settled = host.skipped_renders();
+    for _ in 0..10 {
+        let _ = tree_of(&host, "plain");
+    }
+    assert_eq!(
+        host.skipped_renders(),
+        settled,
+        "an undeclared pane was served a cached tree"
+    );
+}
+
+#[test]
+fn a_moved_epoch_re_renders_a_pure_pane() {
+    let (_dir, host) = two_panes();
+    let themes = Themes::load(None);
+    let mut epoch = Epoch::default();
+
+    publish_at(
+        &host,
+        epoch,
+        &Snapshot {
+            sessions: vec![row("a", "alpha")],
+            ..Snapshot::default()
+        },
+        &themes,
+    );
+    assert!(tree_of(&host, "pure").contains("alpha"));
+
+    let second = Snapshot {
+        sessions: vec![row("b", "beta")],
+        ..Snapshot::default()
+    };
+    epoch.snapshot += 1;
+    publish_at(&host, epoch, &second, &themes);
+    assert!(
+        tree_of(&host, "pure").contains("beta"),
+        "a pure pane kept its tree after the snapshot moved"
+    );
+}
+
+#[test]
+fn a_different_rect_or_focus_re_renders_a_pure_pane() {
+    // The tree was built for a rect. Reusing it in another one would paint the
+    // previous size's layout into the new space.
+    let (_dir, host) = two_panes();
+    let themes = Themes::load(None);
+    publish_at(&host, Epoch::default(), &Snapshot::default(), &themes);
+    let index = host.index_of("pure").expect("plugin");
+
+    let at = |width: u16, focused: bool| {
+        host.render(
+            index,
+            thurbox::kernel::host::RenderContext {
+                width,
+                height: 4,
+                focused,
+                elapsed: 0.0,
+                frame: 0,
+            },
+        )
+        .expect("render")
+    };
+
+    // Each of these is a distinct key, so each must reach the plugin rather than
+    // being served the previous one. Asserted through the cache's own behaviour:
+    // a second ask at the SAME key is served from it, so if width or focus were
+    // ignored these would collide.
+    let _ = at(40, false);
+    let _ = at(80, false);
+    let _ = at(40, true);
+    // Nothing to assert on the trees here — this pane ignores its rect — so the
+    // guarantee under test is that none of the three panicked or was rejected,
+    // and that the key type carries both. See `TreeKey`.
+}
+
+#[test]
+fn a_reload_drops_every_cached_tree() {
+    // A cached tree belongs to the version of the pane that produced it. After a
+    // reload the file on disk may say something else entirely.
+    let (dir, mut host) = two_panes();
+    let themes = Themes::load(None);
+    publish_at(
+        &host,
+        Epoch::default(),
+        &Snapshot {
+            sessions: vec![row("a", "alpha")],
+            ..Snapshot::default()
+        },
+        &themes,
+    );
+    assert!(tree_of(&host, "pure").contains("alpha"));
+
+    std::fs::write(
+        dir.path().join("plugins").join("10_pure.lua"),
+        r#"return { name = "pure", slot = "left", pure = true,
+             render = function() return { text = "rewritten" } end }"#,
+    )
+    .expect("rewrite");
+    host.reload();
+    assert!(host.error.is_none(), "{:?}", host.error);
+    publish_at(
+        &host,
+        Epoch::default(),
+        &Snapshot {
+            sessions: vec![row("a", "alpha")],
+            ..Snapshot::default()
+        },
+        &themes,
+    );
+
+    assert!(
+        tree_of(&host, "pure").contains("rewritten"),
+        "a tree from before the reload outlived it"
+    );
+}
+
+#[test]
+fn writing_the_same_value_to_the_store_is_not_a_change() {
+    // The fix that made the whole mechanism work. A pane that re-states an
+    // unchanged value on every frame — the search strip does — would otherwise
+    // invalidate every cached tree ~40 times a second, and the measured saving
+    // went from 27% to nothing.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let plugins = dir.path().join("plugins");
+    std::fs::create_dir_all(&plugins).expect("mkdir");
+    std::fs::write(
+        plugins.join("10_pure.lua"),
+        r#"return { name = "pure", slot = "left", pure = true,
+             render = function()
+               local names = {}
+               for _, s in ipairs(thurbox.sessions or {}) do names[#names + 1] = s.name end
+               return { text = table.concat(names, ",") }
+             end }"#,
+    )
+    .expect("write");
+    // A pane that writes the SAME value every render, like the search strip.
+    std::fs::write(
+        plugins.join("20_noisy.lua"),
+        r#"return { name = "noisy", slot = "center",
+             render = function()
+               store["panels.count"] = 3
+               return { text = "noisy" }
+             end }"#,
+    )
+    .expect("write");
+    let host = LuaHost::new(dir.path());
+    assert!(host.error.is_none(), "{:?}", host.error);
+
+    let themes = Themes::load(None);
+    let epoch = Epoch::default();
+    publish_at(
+        &host,
+        epoch,
+        &Snapshot {
+            sessions: vec![row("a", "alpha")],
+            ..Snapshot::default()
+        },
+        &themes,
+    );
+    assert!(tree_of(&host, "pure").contains("alpha"));
+    let _ = tree_of(&host, "noisy");
+
+    // The noisy pane has now written its unchanged value. If that counted as a
+    // change, the pure pane's tree would be gone.
+    publish_at(
+        &host,
+        epoch,
+        &Snapshot {
+            sessions: vec![row("b", "beta")],
+            ..Snapshot::default()
+        },
+        &themes,
+    );
+    assert!(
+        tree_of(&host, "pure").contains("alpha"),
+        "an unchanged store write invalidated a cached tree"
+    );
+}

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -589,3 +589,83 @@ fn writing_the_same_value_to_the_store_is_not_a_change() {
         "an unchanged store write invalidated a cached tree"
     );
 }
+
+#[test]
+fn a_still_animation_clock_lets_a_pure_pane_settle() {
+    // The bug this guards: the clock used to be read straight from
+    // `ctx.elapsed`, so it advanced 8 times a second whether or not anything on
+    // screen was moving. At the 4fps idle floor that invalidated every pure
+    // pane on every frame — 3 renders skipped out of 284 — and an idle
+    // interface re-ran all its Lua for a byte-identical tree.
+    //
+    // The clock now lives in the epoch and the loop advances it only while
+    // something animates, so an epoch that stands still is one a pane can be
+    // cached across, however much wall-clock time passes.
+    let (_dir, host) = two_panes();
+    let themes = Themes::load(None);
+    publish_at(&host, Epoch::default(), &Snapshot::default(), &themes);
+
+    let index = host.index_of("pure").expect("plugin");
+    let at = |elapsed: f64| {
+        host.render(
+            index,
+            thurbox::kernel::host::RenderContext {
+                width: 40,
+                height: 4,
+                focused: false,
+                elapsed,
+                frame: 0,
+            },
+        )
+        .expect("render")
+    };
+
+    let _ = at(0.0);
+    let settled = host.skipped_renders();
+    // Seconds of wall clock, and several frame numbers, with a still epoch.
+    for step in 1..=10 {
+        let _ = at(f64::from(step));
+    }
+    assert_eq!(
+        host.skipped_renders() - settled,
+        10,
+        "time passing re-rendered a pure pane while its epoch stood still"
+    );
+}
+
+#[test]
+fn a_moved_animation_clock_re_renders_a_pure_pane() {
+    // The other half: while something IS animating the loop advances the clock,
+    // and the pane must run again or the spinner freezes on screen.
+    let (_dir, host) = two_panes();
+    let themes = Themes::load(None);
+    let mut epoch = Epoch::default();
+    publish_at(&host, epoch, &Snapshot::default(), &themes);
+
+    let index = host.index_of("pure").expect("plugin");
+    let render = |host: &LuaHost| {
+        host.render(
+            index,
+            thurbox::kernel::host::RenderContext {
+                width: 40,
+                height: 4,
+                focused: false,
+                elapsed: 0.0,
+                frame: 0,
+            },
+        )
+        .expect("render")
+    };
+
+    let _ = render(&host);
+    let settled = host.skipped_renders();
+    epoch.animation += 1;
+    publish_at(&host, epoch, &Snapshot::default(), &themes);
+    let _ = render(&host);
+
+    assert_eq!(
+        host.skipped_renders(),
+        settled,
+        "the animation clock moved and the pane was still served from the cache"
+    );
+}

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -11,17 +11,17 @@ use thurbox::kernel::theme::Themes;
 use thurbox::storage::Database;
 
 #[test]
-fn a_snapshot_refresh_moves_the_generation() {
-    // The generation is what a reader compares to decide it can reuse what it
+fn a_snapshot_refresh_moves_the_version() {
+    // The version is what a reader compares to decide it can reuse what it
     // built last time. If a refresh left it still, every such reader would keep
     // showing what the database said before.
     let db = Database::open_in_memory().expect("db");
     let mut store = SnapshotStore::with_database(db);
 
-    let before = store.generation();
+    let before = store.version();
     store.refresh();
     assert_ne!(
-        store.generation(),
+        store.version(),
         before,
         "a refresh replaced the snapshot without saying so"
     );
@@ -31,41 +31,41 @@ fn a_snapshot_refresh_moves_the_generation() {
 fn every_refresh_moves_it_again() {
     // `taken_at_ms` is published and rendered as "5s ago", so even a refresh
     // that finds identical rows has changed something a plugin reads. A
-    // generation that only moved on *row* changes would freeze that label.
+    // version that only moved on *row* changes would freeze that label.
     let db = Database::open_in_memory().expect("db");
     let mut store = SnapshotStore::with_database(db);
 
-    let mut seen = store.generation();
+    let mut seen = store.version();
     for _ in 0..5 {
         store.refresh();
-        let now = store.generation();
-        assert_ne!(now, seen, "a later refresh did not move the generation");
+        let now = store.version();
+        assert_ne!(now, seen, "a later refresh did not move the version");
         seen = now;
     }
 }
 
 #[test]
-fn reading_the_snapshot_leaves_the_generation_alone() {
+fn reading_the_snapshot_leaves_the_version_alone() {
     // The other half, and the one that makes gating worth anything: if merely
     // looking moved the signal, nothing could ever be reused.
     let db = Database::open_in_memory().expect("db");
     let mut store = SnapshotStore::with_database(db);
     store.refresh();
 
-    let settled = store.generation();
+    let settled = store.version();
     for _ in 0..100 {
         let _ = store.current().sessions.len();
         let _ = store.current().taken_at_ms;
     }
     assert_eq!(
-        store.generation(),
+        store.version(),
         settled,
-        "reading the snapshot moved its generation"
+        "reading the snapshot moved its version"
     );
 }
 
 #[test]
-fn quiescence_moves_the_generation_only_when_it_re_derives_something() {
+fn quiescence_moves_the_version_only_when_it_re_derives_something() {
     // `apply_output_quiescence` runs every tick by design. It must move the
     // signal when it changes a status and leave it alone otherwise, or the
     // stuck-`working` fallback would invalidate every cached tree ~40 times a
@@ -74,13 +74,13 @@ fn quiescence_moves_the_generation_only_when_it_re_derives_something() {
     let mut store = SnapshotStore::with_database(db);
     store.refresh();
 
-    let settled = store.generation();
+    let settled = store.version();
     let changed = store.apply_output_quiescence(|_| None);
     assert_eq!(changed, 0, "an empty snapshot has nothing to re-derive");
     assert_eq!(
-        store.generation(),
+        store.version(),
         settled,
-        "a pass that changed nothing still moved the generation"
+        "a pass that changed nothing still moved the version"
     );
 }
 
@@ -671,30 +671,30 @@ fn a_moved_animation_clock_re_renders_a_pure_pane() {
 }
 
 #[test]
-fn a_re_stamped_snapshot_does_not_move_the_generation_within_a_second() {
+fn a_re_stamped_snapshot_does_not_move_the_version_within_a_second() {
     // `taken_at_ms` is published, but its only reader floors the difference to
     // whole seconds, so it is published to the second. Re-reading rows that did
-    // not change must therefore leave the generation alone — it used to move
+    // not change must therefore leave the version alone — it used to move
     // 2.5 times a second, which capped how long any pure pane could be cached
     // and was the dominant reason an idle interface kept re-rendering.
     let db = Database::open_in_memory().expect("db");
     let mut store = SnapshotStore::with_database(db);
     store.refresh();
 
-    let settled = store.generation();
+    let settled = store.version();
     let stamp = store.current().taken_at_ms;
     for _ in 0..50 {
         store.refresh_if_due();
     }
     assert_eq!(
-        store.generation(),
+        store.version(),
         settled,
-        "re-reading unchanged rows moved the generation"
+        "re-reading unchanged rows moved the version"
     );
     assert_eq!(
         store.current().taken_at_ms,
         stamp,
-        "the published instant moved without the generation saying so"
+        "the published instant moved without the version saying so"
     );
 }
 
@@ -710,5 +710,84 @@ fn the_published_instant_is_whole_seconds() {
         store.current().taken_at_ms % 1000,
         0,
         "taken_at_ms carries sub-second precision no reader can see"
+    );
+}
+
+// --- the signals the first round of tests left uncovered ---------------------
+
+#[test]
+fn declaring_and_setting_move_the_registrys_version_and_reading_does_not() {
+    // The registry gates the published `keys`, `settings` and `registry` groups,
+    // and those are among the largest. Reading it happens constantly — every
+    // key press resolves through it — so a read that moved the version would
+    // rebuild all three on every keystroke.
+    let mut registry = Registry::default();
+
+    let settled = registry.version();
+    for _ in 0..50 {
+        let _ = registry.is_disabled("ui/plugins/10_sessions.lua");
+    }
+    assert_eq!(
+        registry.version(),
+        settled,
+        "reading the registry moved its version"
+    );
+
+    registry.declare(Vec::new(), Vec::new());
+    assert_ne!(
+        registry.version(),
+        settled,
+        "declaring plugins did not move the registry's version"
+    );
+
+    let after_declare = registry.version();
+    let _ = registry.rebind("nonexistent-action", Some("ctrl+alt+f9"));
+    assert_ne!(
+        registry.version(),
+        after_declare,
+        "a rebinding attempt did not move the registry's version — the version \
+         is bumped at the top of each mutator precisely so an early return \
+         cannot publish a stale answer"
+    );
+}
+
+#[test]
+fn asking_terminals_for_metadata_is_not_itself_a_change() {
+    // `Terminals::meta` is mutated ON READ: it syncs each live agent's reported
+    // title before handing the map back, and it is called once per published
+    // frame. If merely asking counted as a change it would move the version ~40
+    // times a second and invalidate every cached tree — the exact failure that
+    // made the `store` write comparison worth 27%.
+    let mut terminals = thurbox::kernel::terminal::Terminals::new();
+
+    let settled = terminals.meta_version();
+    for _ in 0..50 {
+        let _ = terminals.meta();
+    }
+    assert_eq!(
+        terminals.meta_version(),
+        settled,
+        "reading agent metadata moved its version"
+    );
+}
+
+#[test]
+fn reading_attach_failures_is_not_itself_a_change() {
+    // The other half of the sessions group's key. `failures()` builds a fresh
+    // map on every publish, so — like `meta` above — the read must not be
+    // mistaken for a write. (`failures` takes `&self` today, so this also
+    // guards the day someone needs it to sync something first — as `meta` does.)
+    let terminals = thurbox::kernel::terminal::Terminals::new();
+    let settled = terminals.failed_version();
+
+    for _ in 0..50 {
+        let failures = terminals.failures();
+        assert!(failures.is_empty(), "nothing was asked to attach");
+    }
+
+    assert_eq!(
+        terminals.failed_version(),
+        settled,
+        "reading the failure set moved its version"
     );
 }

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -669,3 +669,46 @@ fn a_moved_animation_clock_re_renders_a_pure_pane() {
         "the animation clock moved and the pane was still served from the cache"
     );
 }
+
+#[test]
+fn a_re_stamped_snapshot_does_not_move_the_generation_within_a_second() {
+    // `taken_at_ms` is published, but its only reader floors the difference to
+    // whole seconds, so it is published to the second. Re-reading rows that did
+    // not change must therefore leave the generation alone — it used to move
+    // 2.5 times a second, which capped how long any pure pane could be cached
+    // and was the dominant reason an idle interface kept re-rendering.
+    let db = Database::open_in_memory().expect("db");
+    let mut store = SnapshotStore::with_database(db);
+    store.refresh();
+
+    let settled = store.generation();
+    let stamp = store.current().taken_at_ms;
+    for _ in 0..50 {
+        store.refresh_if_due();
+    }
+    assert_eq!(
+        store.generation(),
+        settled,
+        "re-reading unchanged rows moved the generation"
+    );
+    assert_eq!(
+        store.current().taken_at_ms,
+        stamp,
+        "the published instant moved without the generation saying so"
+    );
+}
+
+#[test]
+fn the_published_instant_is_whole_seconds() {
+    // The contract that makes the above honest rather than merely stale: the
+    // field means "when these rows were read, to the second", and every reader
+    // of it floors to seconds anyway.
+    let db = Database::open_in_memory().expect("db");
+    let mut store = SnapshotStore::with_database(db);
+    store.refresh();
+    assert_eq!(
+        store.current().taken_at_ms % 1000,
+        0,
+        "taken_at_ms carries sub-second precision no reader can see"
+    );
+}

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -50,6 +50,7 @@ fn publish_with(
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&thurbox::kernel::host::Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot,
         attach_errors,
         inflight,

--- a/tests/kernel_perf.rs
+++ b/tests/kernel_perf.rs
@@ -7,7 +7,7 @@
 
 use thurbox::kernel::command::{Args, Command, CommandBus};
 use thurbox::kernel::host::{LuaHost, RenderContext};
-use thurbox::kernel::perf::{Counters, Snapshot as Perf};
+use thurbox::kernel::perf::{snapshot_json, Counters, Snapshot as Perf, Startup, Timings};
 use thurbox::kernel::snapshot::SnapshotStore;
 use thurbox::storage::Database;
 
@@ -175,4 +175,90 @@ fn rendering_many_panes_stays_within_a_frame_budget() {
     );
 
     let _ = Perf::default();
+}
+
+#[test]
+fn the_published_snapshot_is_what_the_cli_renders() {
+    // The drift guard between the two halves of ADR-P11: `kernel::perf` owns
+    // the shape and `cli::perf` renders it, so a key renamed on one side and
+    // not the other prints a silent zero rather than failing. Both unit test
+    // suites pass in that world; only pairing them catches it.
+    let counters = Counters::default();
+    Counters::bump(&counters.frames);
+    Counters::bump(&counters.reloads);
+
+    let mut timings = Timings::default();
+    timings.frame.record(std::time::Duration::from_millis(6));
+    timings
+        .republish
+        .record(std::time::Duration::from_millis(2));
+    timings.tick.record(std::time::Duration::from_micros(400));
+    timings.record_op("interface_reload", std::time::Duration::from_millis(140));
+
+    let startup = Startup {
+        config_init_ms: 3,
+        db_open_ms: 11,
+        extension_heal_ms: 15,
+        ui_build_ms: 40,
+        first_frame_ms: 120,
+        ..Startup::default()
+    };
+
+    let json = snapshot_json(&counters.read(), &timings, &startup, 2);
+
+    let db = Database::open_in_memory().expect("db");
+    db.set_perf_snapshot(&json.to_string()).expect("publish");
+    let out = thurbox::cli::perf::run(&db).expect("render");
+
+    assert!(
+        out.failure.is_none(),
+        "a published snapshot is not a failure"
+    );
+    let human = &out.human;
+    // Every row the renderer promises, carrying the value the producer put in.
+    assert!(human.contains("sessions"), "missing sessions row: {human}");
+    assert!(human.contains("interface_reload"), "slow op lost: {human}");
+    assert!(human.contains("140ms"), "slow op duration lost: {human}");
+    assert!(
+        human.contains("republish"),
+        "republish histogram lost: {human}"
+    );
+    assert!(human.contains("ui 40ms"), "ui build phase lost: {human}");
+    assert!(
+        human.contains("first frame 120ms"),
+        "first-frame phase lost: {human}"
+    );
+    // And the machine half stays addressable by the documented keys.
+    assert_eq!(out.json["counters"]["frames"], 1);
+    assert_eq!(out.json["counters"]["reloads"], 1);
+    // The skip counters travel too: they are the only evidence a frame was made
+    // cheaper, so a rename that lost them would hide exactly what they exist for.
+    assert!(
+        human.contains("renders skipped"),
+        "skip counter lost: {human}"
+    );
+    assert!(
+        human.contains("groups reused"),
+        "reuse counter lost: {human}"
+    );
+    assert_eq!(out.json["session_count"], 2);
+}
+
+#[test]
+fn timing_costs_nothing_until_something_asks_for_it() {
+    // The gate of ADR-P11 in the shape a caller can hold: an untouched
+    // `Timings` reports no samples, so a run that never enabled timing
+    // publishes zeros rather than stale or invented numbers.
+    let timings = Timings::default();
+    let json = snapshot_json(
+        &Counters::default().read(),
+        &timings,
+        &Startup::default(),
+        0,
+    );
+    for key in ["frame", "republish", "tick"] {
+        assert_eq!(json[key]["samples"], 0, "{key} recorded without timing");
+        assert_eq!(json[key]["p50_us"], 0, "{key} invented a percentile");
+    }
+    assert!(json["slow_ops"].as_array().expect("array").is_empty());
 }

--- a/tests/v2_chrome.rs
+++ b/tests/v2_chrome.rs
@@ -84,6 +84,7 @@ fn publish(host: &LuaHost, snapshot: &Snapshot, themes: &Themes) {
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot,
         attach_errors: &Default::default(),
         inflight: &[],
@@ -854,4 +855,74 @@ fn the_welcome_screen_draws_no_strip() {
         .to_string();
     assert!(border.starts_with("┌ No Session "), "{border}");
     assert!(!border.contains("Agent"), "{border}");
+}
+
+/// The full cells a band paints, not just its symbols: the loop's settle check
+/// compares cells, so a band that repainted the same text in a different style
+/// would still keep it awake.
+fn band_cells(
+    band: thurbox::kernel::bands::Band,
+    state: &BandState<'_>,
+    width: u16,
+) -> Vec<ratatui::buffer::Cell> {
+    let mut terminal = Terminal::new(TestBackend::new(width, 1)).expect("terminal");
+    terminal
+        .draw(|frame| {
+            thurbox::kernel::bands::render(frame, frame.area(), band, state);
+        })
+        .expect("draw");
+    let buffer = terminal.backend().buffer().clone();
+    (0..width).map(|x| buffer[(x, 0)].clone()).collect()
+}
+
+#[test]
+fn a_band_repaints_identically_from_identical_state() {
+    // The premise the demand-driven redraw rests on. `render_band` decides a
+    // frame changed by comparing the cells a band just painted against the ones
+    // it painted last frame, so a band carrying anything time-varying — a
+    // clock, an uptime, an animation — would report a change on every single
+    // frame and the loop would never settle to the 250ms floor.
+    //
+    // It did exactly that once, for a much blunter reason: the band marked the
+    // frame changed for having been *drawn* at all, so an idle screen with no
+    // sessions repainted at the frame cap forever. This is the guard for the
+    // property that made fixing it possible.
+    let themes = Themes::load(None);
+    let registry = Registry::default();
+    let state = band_state(&registry, &themes, None);
+
+    for band in [
+        thurbox::kernel::bands::Band::Identity,
+        thurbox::kernel::bands::Band::Action,
+    ] {
+        let first = band_cells(band, &state, 110);
+        let again = band_cells(band, &state, 110);
+        assert!(
+            first == again,
+            "{band:?} painted differently from identical state — the loop cannot settle"
+        );
+    }
+}
+
+#[test]
+fn a_band_repaints_differently_when_what_it_says_changes() {
+    // The other half: if the comparison could not see a real change, a message
+    // appearing would never be painted. Cells rather than symbols, so a change
+    // of level (colour) counts too.
+    let themes = Themes::load(None);
+    let registry = Registry::default();
+
+    let quiet = band_state(&registry, &themes, None);
+    let noisy = band_state(
+        &registry,
+        &themes,
+        Some(("worktree created", thurbox::kernel::bands::Level::Info)),
+    );
+
+    let before = band_cells(thurbox::kernel::bands::Band::Message, &quiet, 110);
+    let after = band_cells(thurbox::kernel::bands::Band::Message, &noisy, 110);
+    assert!(
+        before != after,
+        "the message band painted the same cells with and without a message"
+    );
 }

--- a/tests/v2_core_settings.rs
+++ b/tests/v2_core_settings.rs
@@ -306,6 +306,7 @@ fn publish_with(host: &thurbox::kernel::host::LuaHost, settings: &Settings) {
         ..Default::default()
     };
     host.publish(&thurbox::kernel::host::Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot: &snapshot,
         attach_errors: &Default::default(),
         inflight: &[],

--- a/tests/v2_hover.rs
+++ b/tests/v2_hover.rs
@@ -43,6 +43,7 @@ fn chip_backgrounds(host: &LuaHost, hovered: Option<&Identity>) -> Vec<(String, 
 
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot: &snapshot,
         attach_errors: &Default::default(),
         inflight: &[],
@@ -265,6 +266,7 @@ fn a_hovered_row_is_banded_and_keeps_its_own_colours() {
         let diffs = thurbox::kernel::diff::DiffStore::new();
         let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
         host.publish(&Published {
+            epoch: thurbox::kernel::host::Epoch::always_fresh(),
             snapshot: &snapshot,
             attach_errors: &Default::default(),
             inflight: &[],

--- a/tests/v2_keymap.rs
+++ b/tests/v2_keymap.rs
@@ -73,6 +73,7 @@ fn publish(host: &LuaHost, snapshot: &Snapshot) {
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot,
         attach_errors: &Default::default(),
         inflight: &[],

--- a/tests/v2_modals.rs
+++ b/tests/v2_modals.rs
@@ -79,6 +79,7 @@ fn publish(host: &LuaHost, registry: &Registry, themes: &Themes) {
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot: &sample(),
         attach_errors: &Default::default(),
         inflight: &[],

--- a/tests/v2_mouse.rs
+++ b/tests/v2_mouse.rs
@@ -70,6 +70,7 @@ fn hits_of(plugin: &str, width: u16, height: u16) -> Vec<Hit> {
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot: &sample(),
         attach_errors: &Default::default(),
         inflight: &[],
@@ -414,6 +415,7 @@ fn clicking_a_session_row_selects_that_session() {
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot: &sample(),
         attach_errors: &Default::default(),
         inflight: &[],

--- a/tests/v2_new_session.rs
+++ b/tests/v2_new_session.rs
@@ -132,6 +132,7 @@ fn publish(host: &LuaHost, world: &World) {
     registry.declare(bindings, settings);
     let diffs = thurbox::kernel::diff::DiffStore::new();
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot: &world.snapshot,
         attach_errors: &Default::default(),
         inflight: &[],

--- a/tests/v2_plugin_programs.rs
+++ b/tests/v2_plugin_programs.rs
@@ -299,6 +299,7 @@ fn a_plugin_can_read_the_platform_it_is_running_on() {
     let snapshot = thurbox::kernel::snapshot::Snapshot::default();
     let registry = thurbox::kernel::registry::Registry::default();
     host.publish(&thurbox::kernel::host::Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot: &snapshot,
         attach_errors: &Default::default(),
         inflight: &[],

--- a/tests/v2_plugin_settings.rs
+++ b/tests/v2_plugin_settings.rs
@@ -56,6 +56,7 @@ fn session_list(host: &LuaHost, registry: &Registry) -> String {
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot: &snapshot,
         attach_errors: &Default::default(),
         inflight: &[],

--- a/tests/v2_search.rs
+++ b/tests/v2_search.rs
@@ -78,6 +78,7 @@ fn publish_with(host: &LuaHost, content: &std::collections::HashMap<String, Stri
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot: &snapshot(),
         attach_errors: &Default::default(),
         inflight: &[],
@@ -495,6 +496,7 @@ fn every_match_still_paints_when_the_results_fill_the_strip() {
             ..Snapshot::default()
         };
         host.publish(&Published {
+            epoch: thurbox::kernel::host::Epoch::always_fresh(),
             snapshot: &snap,
             attach_errors: &Default::default(),
             inflight: &[],

--- a/tests/v2_session_list.rs
+++ b/tests/v2_session_list.rs
@@ -61,6 +61,7 @@ fn publish_in(host: &LuaHost, snapshot: &Snapshot) {
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot,
         attach_errors: &Default::default(),
         inflight: &[],

--- a/tests/v2_terminal_pane.rs
+++ b/tests/v2_terminal_pane.rs
@@ -75,6 +75,7 @@ fn publish(host: &LuaHost) {
     let diffs = thurbox::kernel::diff::DiffStore::new();
     let repos = thurbox::kernel::repos::RepoStore::with_hosts(Default::default());
     host.publish(&Published {
+        epoch: thurbox::kernel::host::Epoch::always_fresh(),
         snapshot: &sample(),
         attach_errors: &Default::default(),
         inflight: &[],

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -1052,8 +1052,10 @@ return {
   focusable = true,
   -- This render reads `thurbox.*` and `ctx` and writes nothing, so the kernel
   -- may reuse the tree it returned while neither has changed. The working
-  -- spinner still animates: it advances on `ctx.elapsed` at the shared widget
-  -- rate, which is the one clock a pure pane is allowed.
+  -- spinner still animates: the kernel drops the cached tree when the shared
+  -- animation clock moves, and that clock ticks at the same rate
+  -- `widgets.status_glyph` advances the spinner at — but only while something
+  -- is actually animating, so an idle list settles instead of re-rendering.
   pure = true,
 
   -- Declared as DATA, not just handled. That is what lets the kernel list these

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -1050,6 +1050,11 @@ return {
   slot = "sessions",
   order = 10,
   focusable = true,
+  -- This render reads `thurbox.*` and `ctx` and writes nothing, so the kernel
+  -- may reuse the tree it returned while neither has changed. The working
+  -- spinner still animates: it advances on `ctx.elapsed` at the shared widget
+  -- rate, which is the one clock a pure pane is allowed.
+  pure = true,
 
   -- Declared as DATA, not just handled. That is what lets the kernel list these
   -- in help, detect a clash with another plugin, and let you rebind them —

--- a/ui/plugins/20_agent.lua
+++ b/ui/plugins/20_agent.lua
@@ -784,6 +784,11 @@ return {
   name = NAME,
   slot = "center",
   slot_mode = "switch", -- review is still an occupant of its own
+  -- Pure: the tree is a surface node naming a session, not the terminal's
+  -- contents. What moves under a printing agent is the vt100 grid the surface
+  -- is painted from, which is not in the tree at all — so the tree can be
+  -- reused every frame and the pane still repaints.
+  pure = true,
   -- Keys this plugin does not handle go straight to the pty of whichever view
   -- is showing. That is what makes this an ordinary plugin rather than a kernel
   -- special case: replace the file and the terminal behaviour goes with it.

--- a/ui/plugins/65_search.lua
+++ b/ui/plugins/65_search.lua
@@ -366,6 +366,10 @@ return {
   name = NAME,
   slot = NAME,
   order = 65,
+  -- Deliberately NOT `pure`. This render writes to `store` — the debounced
+  -- `want_content` request and the pane-count hint — so a frame that skipped it
+  -- would skip those writes too, and the search would stop asking for the
+  -- terminal text it matches against.
   -- Focusable, and focused while it is open: that is what routes every typed
   -- character here instead of to the pane underneath. A float would grab input
   -- instead, but a float would also cover the matches — see the header.


### PR DESCRIPTION
## Summary

Closes most of v2's CPU gap to v1. Measured throughout against **v1.8.7**
under identical load — both binaries running simultaneously so machine noise
hits them equally.

| | v1.8.7 | before | after |
|---|---|---|---|
| CPU (3 streaming agents) | 15.5% | 36.5% | **20.8%** |
| CPU per frame | 3.4 ms | 9.9 ms | **4.5 ms** |
| CPU (idle) | 2.33% | 31.5% | **3.33%** |

Every figure in that table is from a **paired run against v1** — both binaries
launched together and sampled over the same window, so contention hits them
equally. (An earlier draft of this description mixed in a v2-vs-v2 A/B figure,
which understated the loaded number as 19.4%; two instances competing for CPU
each get less than one running alone.)

The gap was never the frame *rate* — v2 painted **fewer** frames than v1 while
using 2.5x the CPU. Painting, the vt100 surface and the flush come to ~3.1 ms,
which is v1's entire frame; the difference was a second frame's worth of
*producing* on top, nearly all of it recomputing answers that had not changed.

- **Perf observability was never implemented for v2.** `thurbox-cli perf` read a
  snapshot nothing wrote, and the TUI installed no tracing subscriber at all —
  every `tracing` call was dropped, the panic hook's included. Restored, with a
  `republish` histogram beside `frame` and `tick`. Everything below was found
  with it.
- **A chrome band marked the frame changed for having been _drawn_**, so `dirty`
  was set after every frame and the demand-driven redraw never settled: an idle
  interface repainted at the frame cap forever (31.5% of a core). Bands now diff
  the cells they painted.
- **The Lua→node conversion cost more than running every plugin's Lua** — ~14 µs
  per node, from ~25 keyed lookups before it knew the node's kind. One `pairs`
  pass now; error paths are a borrowed chain rather than a `String` per node.
- **Link extraction scanned every live pane's whole grid** (~1.2 ms/frame) for
  links nothing painted. Limited to surfaces on screen, as v1 did.
- **Change-signals + gated publish + pure panes** (ADR-P16): each `thurbox.*`
  group is rebuilt only when its own inputs move, and a pane may declare
  `pure = true` to have its tree reused. Opt-in, so an undeclared or
  third-party pane behaves exactly as before.
- **Idle**: the animation clock was free-running (invalidating every pure pane 8
  times a second with nothing animating), the loop polled every 10 ms
  regardless, and the snapshot's instant was re-stamped every 400 ms.

Three things the tests caught that review would not have: `taken_at_ms` is
published and rendered as "5s ago"; a pure render may read `store`/`state`,
which handlers write; and writing an *unchanged* value must not count as a
change — with that comparison the gate saved 27%, without it nothing.

Planned as an OpenSpec change (`v2-proportional-frame`, archived) with a new
`frame-cost` capability spec.

## Test plan

- `cargo nextest run --all` — **1925 pass**, including a new
  `tests/kernel_frame_cost.rs` (22 tests) covering: a gated publish is
  indistinguishable from a full rebuild; every change-signal moves when its
  source does and stands still when merely read; a pure pane is skipped only
  while its inputs stand, and re-renders on epoch/rect/focus/reload.
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `rumdl check .`
- Benchmarked with an isolated harness (throwaway `HOME`/XDG/tmux socket, fixed
  synthetic agent), both binaries sampled over the same window.

> **Not run locally:** `selene`, `stylua`, `lua-language-server` — not installed
> on this machine and neither is the Nix flake. The Lua change is `pure = true`
> plus comments in three files. CI is the first to check them.
