### PR TITLE
perf(ui): give agent output its own frame floor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,13 @@ sharing `e2e/lib/e2e-common.sh` — colour logging, the PASS/FAIL contract
 
 The loop is **demand-driven**: it paints when something changed or when the 250 ms
 forced-redraw floor (`FORCE_REDRAW_INTERVAL`) elapses, never on every iteration.
-`MIN_FRAME_INTERVAL` is the floor between two paints. What marks the screen dirty:
+There are **two floors between paints**, because typing has to feel instant and
+watching a log scroll does not: `MIN_FRAME_INTERVAL` (16 ms) when a person did
+something — a key, a resize, a worker result they asked for, tracked by
+`input_dirty` — and `OUTPUT_FRAME_INTERVAL` (33 ms) when the only thing owing a
+frame is agent output. Applying the tight floor to both made a chatty agent drive
+60 paints a second to show 30 lines; the split is worth 30% of the loaded cost
+(ADR-P17). What marks the screen dirty:
 any input, a resize, a reload, a worker result, and **new agent output** —
 `Terminals::output_generation` is summed each iteration, which is what stops a
 printing agent being drawn at 4 fps. A **reflow** — the arrangement placing a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,8 @@ forced-redraw floor (`FORCE_REDRAW_INTERVAL`) elapses, never on every iteration.
 There are **two floors between paints**, because typing has to feel instant and
 watching a log scroll does not: `MIN_FRAME_INTERVAL` (16 ms) when a person did
 something — a key, a resize, a worker result they asked for, tracked by
-`input_dirty` — and `OUTPUT_FRAME_INTERVAL` (33 ms) when the only thing owing a
+`input_dirty`, which is set with `dirty` through the one `App::note_input` and
+never alone — and `OUTPUT_FRAME_INTERVAL` (33 ms) when the only thing owing a
 frame is agent output. Applying the tight floor to both made a chatty agent drive
 60 paints a second to show 30 lines; the split is worth 30% of the loaded cost
 (ADR-P17). What marks the screen dirty:

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -988,7 +988,15 @@ a second. Typing has to feel instant. Watching a log scroll does not.
 **Choice**: a second floor, `OUTPUT_FRAME_INTERVAL` (33ms), used when the only
 thing owing a frame is new agent output. `App::input_dirty` marks the other
 kind — a keypress, a resize, a worker result someone asked for — and those keep
-the 16ms floor. Swept across the interval, one agent at 30 lines/s, 200x50:
+the 16ms floor. It is raised only through `App::note_input`, which sets it with
+`dirty`: a site that set just `dirty` would pace a keystroke at 33ms and look
+like nothing more than a slow terminal. The three intervals also only mean
+anything in relation to each other — output slower than input, both under the
+forced-redraw floor — and getting that wrong is silent in either direction (the
+split becomes a no-op, or the 250ms floor quietly becomes the real cadence), so
+the ordering is asserted rather than left to the definitions.
+
+Swept across the interval, one agent at 30 lines/s, 200x50:
 
 | floor | fps | interface | terminal | total |
 |---|---|---|---|---|
@@ -1005,9 +1013,12 @@ thurbox hands it fewer updates.
 resets the frame buffer before every draw, so there is nothing stale to erase
 across frames, and a live terminal covers its own rect — the `Clear` was a second
 full-grid write of ~9,000 cells for a frame about to overwrite them. It is kept
-for the branches that do *not* cover their rect (a smaller grid mid-resize, the
-detached notice, a cell surface). `normalize_ambiguous_width` also rejects a cell
-on a length compare before any substring search, since U+FE0F is three bytes and
+for the branches that do *not* cover their rect, each owning its own clear rather
+than being cleared by the caller: `kernel::terminal::clear_uncovered` for a grid
+still smaller than its rect a frame after a resize, and the detached and notice
+widgets for themselves. `normalize_ambiguous_width` also rejects a cell on a
+length compare (`VARIATION_SELECTOR_16_LEN`, derived from the selector rather
+than written out) before any substring search, since U+FE0F is three bytes and
 almost every cell is one.
 
 **Measured, paired, 3 runs each:**

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -970,6 +970,79 @@ frame partly becomes *more* frames rather than less CPU.
 
 ---
 
+## ADR-P17: Separate the frame floor for output from the one for input
+
+**Context**: with ADR-P16 landed, a frame costs ~2.6ms and the interface still
+took ~19% of a core to show one agent printing 30 lines a second. Measuring the
+whole process tree against the same workload run bare (agent in a tmux pane, no
+thurbox) put bare at **1.20%** — agent 0.56, tmux 0.64. Two of those components
+are unavoidable for thurbox: the same agent, plus its own inner tmux (~0.9%),
+which is what makes a session survive a restart. So thurbox starts at roughly
+bare's *entire* cost before it paints anything, and parity is not a reachable
+target; the question is only how much of the rest is waste.
+
+The waste was the frame rate. `MIN_FRAME_INTERVAL` (16ms) was applied to every
+reason a frame was owed, so an agent printing 30 lines a second drove ~60 paints
+a second. Typing has to feel instant. Watching a log scroll does not.
+
+**Choice**: a second floor, `OUTPUT_FRAME_INTERVAL` (33ms), used when the only
+thing owing a frame is new agent output. `App::input_dirty` marks the other
+kind — a keypress, a resize, a worker result someone asked for — and those keep
+the 16ms floor. Swept across the interval, one agent at 30 lines/s, 200x50:
+
+| floor | fps | interface | terminal | total |
+|---|---|---|---|---|
+| 16ms | 62 | 19.08 | 0.84 | 21.24 |
+| **33ms** | **30** | **12.40** | **0.62** | **14.40** |
+| 50ms | 20 | 11.12 | 0.52 | 13.08 |
+| 100ms | 10 | 8.30 | 0.34 | 10.18 |
+
+Most of the saving arrives by 30fps and the curve flattens after; below it the
+scroll begins to look stepped. The terminal's own cost falls with it, because
+thurbox hands it fewer updates.
+
+**Also**: the surface paint stopped clearing its whole rect first. `swap_buffers`
+resets the frame buffer before every draw, so there is nothing stale to erase
+across frames, and a live terminal covers its own rect — the `Clear` was a second
+full-grid write of ~9,000 cells for a frame about to overwrite them. It is kept
+for the branches that do *not* cover their rect (a smaller grid mid-resize, the
+detached notice, a cell surface). `normalize_ambiguous_width` also rejects a cell
+on a length compare before any substring search, since U+FE0F is three bytes and
+almost every cell is one.
+
+**Measured, paired, 3 runs each:**
+
+| | interface | total |
+|---|---|---|
+| before | 16.80 | 18.72 |
+| the paint changes alone | — | ~18.4 |
+| the output floor alone | 11.36 | 13.20 |
+| both | 11.12 | **12.92** |
+
+**-31% overall.** Worth recording honestly: the paint changes were predicted at
+~13% and delivered **~2%**. `Clear` writes blank cells, which is cheap beside the
+terminal widget's per-cell read-convert-style work that still happens; and any
+per-frame saving is halved once the frame rate is. The frame *rate* was the
+money, not the frame *cost*.
+
+**Rejected**:
+
+- *Chasing bare* — arithmetically impossible while sessions live in tmux, since
+  the agent plus that tmux already exceed bare's total.
+- *Row-level surface diffing* — vt100 exposes `rows_diff`, but it emits terminal
+  byte streams for a multiplexer forwarding to a real terminal, not row indices a
+  ratatui cell buffer could use. It needs a per-row change signal that does not
+  exist yet.
+- *A lower floor than 30fps* — 20fps buys 1.3 more points and 10fps another 2.9,
+  against a visibly stepped scroll. Not worth it as a default.
+
+**Still open**: `publish` rebuilds 15 of its 25 groups every frame; painting is
+still whole-frame even for panes whose tree the cache knows is unchanged; and
+the vt100 surface repaint (~800us) is now the largest single line item in a
+frame.
+
+---
+
 ## ADR-P14: Publish once per input batch, and gate every screen read on a stamp
 
 **Choice**: `App::republish` — the call that rebuilds every `thurbox.*` table Lua can

--- a/src/kernel/paint.rs
+++ b/src/kernel/paint.rs
@@ -286,27 +286,34 @@ pub fn render_recording(
         }
 
         Node::Surface { source, scroll, .. } => {
-            // A surface is opaque: clear first, so whatever it paints is not
-            // composited over a sibling's leftovers.
-            frame.render_widget(Clear, inner);
+            // Cleared per branch rather than up front. `swap_buffers` resets the
+            // frame buffer before every draw, so there are no leftovers to
+            // erase across frames — and a live terminal covers its rect itself,
+            // so a blanket `Clear` was a second full-grid write of ~9,000 cells
+            // for a frame that was about to overwrite them all. The branches
+            // that do NOT cover their rect still clear.
             match source {
                 SurfaceSource::Cells(cells) => {
+                    frame.render_widget(Clear, inner);
                     let lines: Vec<Line> = cells.iter().map(|runs| to_line(runs)).collect();
                     frame.render_widget(Paragraph::new(lines).scroll((*scroll, 0)), inner);
                 }
                 SurfaceSource::Session(id) => {
                     if !surfaces.render_session(frame, inner, id, *scroll) {
+                        frame.render_widget(Clear, inner);
                         render_detached(frame, inner, id);
                     }
                 }
                 SurfaceSource::Program(id) => match surfaces.render_program(frame, inner, id) {
                     ProgramPaint::Painted => {}
                     ProgramPaint::NotStarted => {
+                        frame.render_widget(Clear, inner);
                         render_notice(frame, inner, "program surface", "nothing started here yet")
                     }
                     // Said rather than shown: the grid a finished program left
                     // behind looks exactly like one that is still running.
                     ProgramPaint::Exited(program) => {
+                        frame.render_widget(Clear, inner);
                         render_notice(frame, inner, &program, "exited")
                     }
                 },
@@ -374,7 +381,12 @@ pub fn normalize_ambiguous_width(buf: &mut Buffer) {
             let Some(cell) = buf.cell_mut(Position::new(x, y)) else {
                 continue;
             };
-            if !cell.symbol().contains(VARIATION_SELECTOR_16) {
+            // `len() < 3` rejects every ASCII cell — nearly all of them — with
+            // an integer compare, before the substring search. This walks the
+            // whole buffer on every painted frame, so the common case has to be
+            // as close to free as possible.
+            let symbol = cell.symbol();
+            if symbol.len() < 3 || !symbol.contains(VARIATION_SELECTOR_16) {
                 continue;
             }
             let stripped: String = cell

--- a/src/kernel/paint.rs
+++ b/src/kernel/paint.rs
@@ -92,6 +92,9 @@ impl SurfaceProvider for PlaceholderSurfaces {
 /// What a session-backed surface shows when nothing live is behind it.
 /// A centred two-line notice, for a surface with nothing to paint.
 fn render_notice(frame: &mut Frame, area: Rect, title: &str, detail: &str) {
+    // Clears its own rect: it stands in for a surface and paints only the few
+    // centred rows, so whatever the layout left underneath would show through.
+    frame.render_widget(Clear, area);
     let mut lines = Vec::new();
     let blank = usize::from(area.height).saturating_sub(2) / 2;
     for _ in 0..blank {
@@ -111,6 +114,8 @@ fn render_notice(frame: &mut Frame, area: Rect, title: &str, detail: &str) {
 }
 
 fn render_detached(frame: &mut Frame, area: Rect, session: &str) {
+    // Clears its own rect, for the reason `render_notice` does.
+    frame.render_widget(Clear, area);
     let mut lines = Vec::new();
     let blank = usize::from(area.height).saturating_sub(3) / 2;
     for _ in 0..blank {
@@ -286,12 +291,13 @@ pub fn render_recording(
         }
 
         Node::Surface { source, scroll, .. } => {
-            // Cleared per branch rather than up front. `swap_buffers` resets the
-            // frame buffer before every draw, so there are no leftovers to
-            // erase across frames — and a live terminal covers its rect itself,
-            // so a blanket `Clear` was a second full-grid write of ~9,000 cells
-            // for a frame that was about to overwrite them all. The branches
-            // that do NOT cover their rect still clear.
+            // No blanket `Clear` here. `swap_buffers` resets the frame buffer
+            // before every draw, so nothing stale survives to be erased, and a
+            // live terminal covers its rect itself — clearing first was a second
+            // full-grid write of ~9,000 cells for a frame about to overwrite
+            // them (ADR-P17). Whatever does *not* cover its rect clears itself
+            // instead: the paragraph below, `render_notice`/`render_detached`,
+            // and `clear_uncovered` for a grid still catching up to a resize.
             match source {
                 SurfaceSource::Cells(cells) => {
                     frame.render_widget(Clear, inner);
@@ -300,20 +306,17 @@ pub fn render_recording(
                 }
                 SurfaceSource::Session(id) => {
                     if !surfaces.render_session(frame, inner, id, *scroll) {
-                        frame.render_widget(Clear, inner);
                         render_detached(frame, inner, id);
                     }
                 }
                 SurfaceSource::Program(id) => match surfaces.render_program(frame, inner, id) {
                     ProgramPaint::Painted => {}
                     ProgramPaint::NotStarted => {
-                        frame.render_widget(Clear, inner);
                         render_notice(frame, inner, "program surface", "nothing started here yet")
                     }
                     // Said rather than shown: the grid a finished program left
                     // behind looks exactly like one that is still running.
                     ProgramPaint::Exited(program) => {
-                        frame.render_widget(Clear, inner);
                         render_notice(frame, inner, &program, "exited")
                     }
                 },
@@ -350,6 +353,13 @@ pub fn render_error(frame: &mut Frame, area: Rect, title: &str, message: &str) {
 /// a matter of opinion.
 const VARIATION_SELECTOR_16: char = '\u{FE0F}';
 
+/// How many bytes [`VARIATION_SELECTOR_16`] occupies in UTF-8.
+///
+/// A symbol shorter than this cannot contain it, which rejects every ASCII cell
+/// on an integer compare — and this walks the whole buffer on every painted
+/// frame. Derived rather than written as `3` so the two cannot drift apart.
+const VARIATION_SELECTOR_16_LEN: usize = VARIATION_SELECTOR_16.len_utf8();
+
 /// Strip the emoji-presentation selector (`U+FE0F`) from every cell of a
 /// painted frame.
 ///
@@ -381,12 +391,8 @@ pub fn normalize_ambiguous_width(buf: &mut Buffer) {
             let Some(cell) = buf.cell_mut(Position::new(x, y)) else {
                 continue;
             };
-            // `len() < 3` rejects every ASCII cell — nearly all of them — with
-            // an integer compare, before the substring search. This walks the
-            // whole buffer on every painted frame, so the common case has to be
-            // as close to free as possible.
             let symbol = cell.symbol();
-            if symbol.len() < 3 || !symbol.contains(VARIATION_SELECTOR_16) {
+            if symbol.len() < VARIATION_SELECTOR_16_LEN || !symbol.contains(VARIATION_SELECTOR_16) {
                 continue;
             }
             let stripped: String = cell
@@ -507,6 +513,36 @@ mod tests {
         // moves: the row is the width it was measured at.
         assert_eq!(buffer[(1, 0)].symbol(), " ");
         assert_eq!(buffer[(2, 0)].symbol(), "a");
+    }
+
+    /// The fast path must not eat multi-byte glyphs that merely *look* like
+    /// candidates. `len < VARIATION_SELECTOR_16_LEN` rejects a cell before the
+    /// substring search, so the boundary — a symbol as long as the selector, or
+    /// longer, carrying no selector — is where a wrong comparison would corrupt
+    /// the screen rather than merely slow it down.
+    #[test]
+    fn multi_byte_glyphs_without_the_selector_are_left_alone() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 1));
+        // 2 bytes (below the threshold), 3 bytes (exactly at it), 4 bytes (above).
+        buffer[(0, 0)].set_symbol("é");
+        buffer[(1, 0)].set_symbol("中");
+        buffer[(2, 0)].set_symbol("𝄞");
+
+        normalize_ambiguous_width(&mut buffer);
+
+        assert_eq!(buffer[(0, 0)].symbol(), "é");
+        assert_eq!(buffer[(1, 0)].symbol(), "中");
+        assert_eq!(buffer[(2, 0)].symbol(), "𝄞");
+    }
+
+    /// The threshold is derived from the selector rather than written as `3`,
+    /// so this pins the two together: a symbol shorter than the selector cannot
+    /// contain it, and skipping it is what makes the common cell free.
+    #[test]
+    fn the_length_threshold_is_the_selectors_own_width() {
+        assert_eq!(VARIATION_SELECTOR_16_LEN, VARIATION_SELECTOR_16.len_utf8());
+        assert_eq!(VARIATION_SELECTOR_16_LEN, 3);
+        assert!("a".len() < VARIATION_SELECTOR_16_LEN);
     }
 
     /// A cell holding nothing but the selector would print nothing at all, which

--- a/src/kernel/terminal.rs
+++ b/src/kernel/terminal.rs
@@ -1972,6 +1972,54 @@ impl SurfaceProvider for Terminals {
 mod tests {
     use super::*;
     use crate::kernel::snapshot::SessionRow;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    /// Paint `x` into the top-left cell, run `clear_uncovered` over the whole
+    /// rect for a grid of `grid`, and report whether the cell survived.
+    fn survives_clear(rect: (u16, u16), grid: (u16, u16)) -> bool {
+        let (cols, rows) = rect;
+        let mut terminal = Terminal::new(TestBackend::new(cols, rows)).expect("terminal");
+        let parser = vt100::Parser::new(grid.1, grid.0, 0);
+        terminal
+            .draw(|frame| {
+                frame.buffer_mut()[(0, 0)].set_symbol("x");
+                clear_uncovered(frame, Rect::new(0, 0, cols, rows), parser.screen());
+            })
+            .expect("draw");
+        terminal.backend().buffer()[(0, 0)].symbol() == "x"
+    }
+
+    /// The optimisation itself: a grid that covers its rect is about to
+    /// overwrite every cell, so clearing first was a second full-grid write for
+    /// nothing (ADR-P17). Asserted by leaving a mark the clear would erase.
+    #[test]
+    fn a_grid_that_covers_its_rect_is_not_cleared() {
+        assert!(
+            survives_clear((10, 4), (10, 4)),
+            "a covering grid still triggered a clear"
+        );
+    }
+
+    /// And the case that keeps it correct. A pane lags a resize by a frame, so
+    /// the grid can be smaller than the rect it is painted into; without the
+    /// clear the rows it never reaches would show whatever the layout left
+    /// underneath.
+    #[test]
+    fn a_grid_shorter_than_its_rect_still_clears() {
+        assert!(
+            !survives_clear((10, 4), (10, 2)),
+            "a grid with fewer rows than its rect left the uncovered part unclear"
+        );
+    }
+
+    #[test]
+    fn a_grid_narrower_than_its_rect_still_clears() {
+        assert!(
+            !survives_clear((10, 4), (6, 4)),
+            "a grid with fewer columns than its rect left the uncovered part unclear"
+        );
+    }
 
     fn row(id: &str, backend: &str, backend_id: Option<&str>) -> SessionRow {
         SessionRow {

--- a/src/kernel/terminal.rs
+++ b/src/kernel/terminal.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Position, Rect};
 use ratatui::style::Style;
+use ratatui::widgets::Clear;
 use ratatui::Frame;
 use tui_term::widget::PseudoTerminal;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -1853,6 +1854,20 @@ pub fn paint_hyperlinks(paints: &[HyperlinkPaint]) -> std::io::Result<()> {
     out.flush()
 }
 
+/// Blank the rect only where the grid will not reach it.
+///
+/// The frame buffer is reset by `swap_buffers` before every draw, so there
+/// is nothing stale to erase across frames — a `Clear` over the whole rect
+/// was a second full-grid write for cells the terminal widget is about to
+/// overwrite anyway. It is still owed when the grid is *smaller* than its
+/// rect, which happens for a frame after a resize while the pane catches up.
+fn clear_uncovered(frame: &mut Frame, area: Rect, screen: &vt100::Screen) {
+    let (rows, cols) = screen.size();
+    if rows < area.height || cols < area.width {
+        frame.render_widget(Clear, area);
+    }
+}
+
 impl SurfaceProvider for Terminals {
     fn render_program(
         &self,
@@ -1915,6 +1930,7 @@ impl SurfaceProvider for Terminals {
             let Ok(parser) = shell.parser.lock() else {
                 return false;
             };
+            clear_uncovered(frame, area, parser.screen());
             frame.render_widget(
                 PseudoTerminal::new(parser.screen()).style(Style::default()),
                 area,
@@ -1943,6 +1959,7 @@ impl SurfaceProvider for Terminals {
         // Scrollback is a property of the screen, not of the widget, so it is
         // set before reading and left where the plugin asked for it.
         parser.screen_mut().set_scrollback(usize::from(scroll));
+        clear_uncovered(frame, area, parser.screen());
         frame.render_widget(
             PseudoTerminal::new(parser.screen()).style(Style::default()),
             area,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1591,6 +1591,17 @@ impl App {
         self.data_epoch = self.data_epoch.wrapping_add(1);
     }
 
+    /// Note that a person did something — a key, a click, a paste, a resize.
+    ///
+    /// Distinct from [`Self::note_data_change`] only in what it does *not* do:
+    /// no published value moved, so nothing needs re-publishing. Both mark the
+    /// frame as owed to a person, which is what buys it [`MIN_FRAME_INTERVAL`]
+    /// rather than the slower floor agent output gets.
+    fn note_input(&mut self) {
+        self.dirty = true;
+        self.input_dirty = true;
+    }
+
     /// Note that published data moved, and that the screen owes a frame.
     ///
     /// The two go together everywhere this is used: something that changes what
@@ -1598,11 +1609,10 @@ impl App {
     /// polling quickly again after.
     fn note_data_change(&mut self) {
         self.note_published_change();
-        self.dirty = true;
         // A worker result or a row another process wrote is the answer to
         // something someone asked for, so it earns the tight floor. Only agent
         // output — which arrives whether or not anyone is looking — does not.
-        self.input_dirty = true;
+        self.note_input();
         self.last_activity = Instant::now();
     }
 
@@ -1860,8 +1870,7 @@ impl App {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     self.publish_for_batch(&mut published);
                     self.time_op("input_dispatch", |app| app.on_key(&key));
-                    self.dirty = true;
-                    self.input_dirty = true;
+                    self.note_input();
                 }
                 // Dropped rather than merely uncaptured when the feature is
                 // off, so the flag stays authoritative even if a terminal
@@ -1870,8 +1879,7 @@ impl App {
                 Event::Mouse(mouse) if self.mouse => {
                     self.publish_for_batch(&mut published);
                     self.on_mouse(mouse);
-                    self.dirty = true;
-                    self.input_dirty = true;
+                    self.note_input();
                 }
                 // A bracketed paste from the terminal itself. Routed to
                 // whatever has focus, exactly as `ctrl+v` is: a modal's
@@ -1879,13 +1887,9 @@ impl App {
                 Event::Paste(text) => {
                     self.publish_for_batch(&mut published);
                     self.on_paste(text);
-                    self.dirty = true;
-                    self.input_dirty = true;
+                    self.note_input();
                 }
-                Event::Resize(..) => {
-                    self.dirty = true;
-                    self.input_dirty = true;
-                }
+                Event::Resize(..) => self.note_input(),
                 _ => {}
             }
         }
@@ -4664,6 +4668,30 @@ fn to_press(key: &KeyEvent) -> KeyPress {
 mod tests {
     use super::*;
     use thurbox::kernel::host::Float;
+
+    /// The three intervals only mean anything in relation to each other, and
+    /// nothing enforces that at the definitions.
+    ///
+    /// Output must wait longer than input, or the split buys nothing; and both
+    /// must stay under the forced-redraw floor, or the floor becomes the real
+    /// cadence and the constant above it is silently dead — a setting that
+    /// looks tuned while doing nothing (ADR-P17).
+    #[test]
+    fn the_frame_floors_stand_in_the_right_order() {
+        assert!(
+            OUTPUT_FRAME_INTERVAL > MIN_FRAME_INTERVAL,
+            "output is paced no slower than input, so the split is a no-op"
+        );
+        assert!(
+            OUTPUT_FRAME_INTERVAL < FORCE_REDRAW_INTERVAL,
+            "output waits past the forced-redraw floor, which then sets the \
+             cadence instead — the constant would be dead"
+        );
+        assert!(
+            MIN_FRAME_INTERVAL < FORCE_REDRAW_INTERVAL,
+            "input waits past the forced-redraw floor"
+        );
+    }
 
     /// Startup says which interface loaded, but only when there is a question.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,17 @@ const PERF_PUBLISH_INTERVAL: Duration = Duration::from_secs(5);
 /// what made v2 feel less responsive than v1.
 const MIN_FRAME_INTERVAL: Duration = Duration::from_millis(16);
 
+/// The floor when the only thing owed a frame is new agent output.
+///
+/// Typing has to feel instant; watching a log scroll does not, and applying the
+/// 16ms floor to both meant a chatty agent drove ~60 paints a second to show 30
+/// lines. Measured across the interval (`docs/PERFORMANCE.md`, ADR-P17): 62fps
+/// costs 21.2% of a core, 30fps costs 14.4% and 20fps 13.1% — most of the saving
+/// arrives by 30, and below it the scroll starts to look stepped rather than
+/// smooth. So: 30fps for output, and a keystroke still repaints on the next
+/// frame.
+const OUTPUT_FRAME_INTERVAL: Duration = Duration::from_millis(33);
+
 /// Consecutive input-read failures tolerated before the loop gives up.
 ///
 /// One is a terminal handing crossterm bytes it cannot parse, which is a
@@ -275,6 +286,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         process_start,
         data_epoch: 0,
         last_activity: Instant::now(),
+        input_dirty: true,
         animation_tick: 0,
         animation_step: 0,
         selection: None,
@@ -859,6 +871,10 @@ struct App {
     /// True process start, taken before any startup phase — `started` is taken
     /// during construction and so misses everything before it.
     process_start: Instant,
+    /// Whether this frame is owed to something a person did — a keypress, a
+    /// resize, a worker result they asked for — rather than to an agent
+    /// printing. Only the first kind gets [`MIN_FRAME_INTERVAL`].
+    input_dirty: bool,
     /// When anything last happened — input, output, a worker result, a repaint
     /// that changed something. Drives the poll timeout, nothing else.
     last_activity: Instant,
@@ -1583,6 +1599,10 @@ impl App {
     fn note_data_change(&mut self) {
         self.note_published_change();
         self.dirty = true;
+        // A worker result or a row another process wrote is the answer to
+        // something someone asked for, so it earns the tight floor. Only agent
+        // output — which arrives whether or not anyone is looking — does not.
+        self.input_dirty = true;
         self.last_activity = Instant::now();
     }
 
@@ -1712,7 +1732,12 @@ impl App {
     /// so an idle screen settles at the floor.
     fn paint_if_due(&mut self, terminal: &mut DefaultTerminal) -> Result<(), Box<dyn Error>> {
         let since_paint = self.last_paint.elapsed();
-        let due = self.dirty && since_paint >= MIN_FRAME_INTERVAL;
+        let floor = if self.input_dirty {
+            MIN_FRAME_INTERVAL
+        } else {
+            OUTPUT_FRAME_INTERVAL
+        };
+        let due = self.dirty && since_paint >= floor;
         if due || since_paint >= FORCE_REDRAW_INTERVAL {
             // Published HERE rather than every iteration: a plugin only reads
             // `thurbox.*` while it renders, so rebuilding those tables on a tick
@@ -1753,6 +1778,7 @@ impl App {
             // with ratatui's own output.
             self.paint_outer_hyperlinks(&buffer);
             self.last_paint = Instant::now();
+            self.input_dirty = false;
             self.frames += 1;
             Counters::bump(&self.perf.frames);
             if !self.first_frame_logged {
@@ -1835,6 +1861,7 @@ impl App {
                     self.publish_for_batch(&mut published);
                     self.time_op("input_dispatch", |app| app.on_key(&key));
                     self.dirty = true;
+                    self.input_dirty = true;
                 }
                 // Dropped rather than merely uncaptured when the feature is
                 // off, so the flag stays authoritative even if a terminal
@@ -1844,6 +1871,7 @@ impl App {
                     self.publish_for_batch(&mut published);
                     self.on_mouse(mouse);
                     self.dirty = true;
+                    self.input_dirty = true;
                 }
                 // A bracketed paste from the terminal itself. Routed to
                 // whatever has focus, exactly as `ctrl+v` is: a modal's
@@ -1852,8 +1880,12 @@ impl App {
                     self.publish_for_batch(&mut published);
                     self.on_paste(text);
                     self.dirty = true;
+                    self.input_dirty = true;
                 }
-                Event::Resize(..) => self.dirty = true,
+                Event::Resize(..) => {
+                    self.dirty = true;
+                    self.input_dirty = true;
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
One agent printing 30 lines a second cost **18.72%** of a core. It now costs
**12.92%** — **-31%**, paired, three runs each.

## What was wrong

`MIN_FRAME_INTERVAL` (16ms) was applied to every reason a frame was owed, so an
agent printing 30 lines a second drove about **60 paints a second**. Typing has
to feel instant. Watching a log scroll does not.

Output-only frames now wait `OUTPUT_FRAME_INTERVAL` (33ms). Anything a person
did — a key, a resize, a worker result they asked for — still takes the 16ms
floor, tracked by `input_dirty` and raised through the one `App::note_input`.

Swept before choosing the number, one agent at 30 lines/s, 200x50:

| floor | fps | interface | terminal | total |
|---|---|---|---|---|
| 16ms | 62 | 19.08 | 0.84 | 21.24 |
| **33ms** | **30** | **12.40** | **0.62** | **14.40** |
| 50ms | 20 | 11.12 | 0.52 | 13.08 |
| 100ms | 10 | 8.30 | 0.34 | 10.18 |

Most of the saving arrives by 30fps and the curve flattens after; below it the
scroll begins to look stepped. The terminal's own cost falls alongside, because
it is handed fewer updates.

## The paint half, and what it actually delivered

The surface paint stopped clearing its whole rect first — `swap_buffers` resets
the frame buffer before every draw, so nothing stale survives to be erased, and
a live terminal covers its own rect. The clear is kept for the branches that do
*not* cover theirs, each now owning it: `clear_uncovered` for a grid still
catching up to a resize, and the detached and notice widgets for themselves.

**Predicted at ~13%, measured at ~2%.** `Clear` writes blank cells, which is
cheap beside the terminal widget's per-cell read-convert-style work that still
happens — and any per-frame saving is halved once the frame rate is. The frame
*rate* was the money, not the frame *cost*. Recorded that way in ADR-P17 rather
than quietly dropped.

## Why parity with a bare agent is not the target

Measured against the same workload run bare — the agent in a tmux pane, no
thurbox — bare costs **1.20%** (agent 0.56, tmux 0.64). thurbox pays the same
agent plus its own inner tmux (~0.9%), which is what makes a session survive a
restart. Those two already exceed bare's entire cost. The frame rate was the
reachable part.

## Second commit: refactor and the coverage this went in without

`clear_uncovered` decides whether a surface clears at all and had no test; it is
now pinned from both sides. The length fast path is pinned at its boundary,
where a wrong compare corrupts the screen rather than merely slowing it. And the
three intervals are asserted **in order** — output no slower than input makes
the split a no-op, output past the forced-redraw floor makes that floor the real
cadence, and both failures are silent.

No behaviour change in that commit. **1939 tests pass.**

Docs: ADR-P17 in `docs/PERFORMANCE.md`, plus the render-loop section of
`CLAUDE.md`.

https://claude.ai/code/session_01Cu2wDmYFQ9KetJqUESKhZW