### PR TITLE
docs: drop the experimental Windows note for a psmux one

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ it are data files you edit too. No fork, no recompile, no restart.
 > v1 — on those channels the shell/PowerShell installers are the way to v1.
 
 > [!NOTE]
-> **Windows support is experimental**, on either line. The core works (psmux as
-> the multiplexer, a native ConPTY backend, WSL distros as remote hosts) but sees
-> less testing than Linux/macOS — expect rough edges and please report issues.
-> Every Windows route needs [psmux](https://github.com/psmux/psmux) as the
-> multiplexer, installed separately.
+> **Windows uses psmux, not tmux.** Every Windows route needs
+> [psmux](https://github.com/psmux/psmux) — a native ConPTY multiplexer speaking
+> tmux's control-mode protocol — installed separately; WSL distros run tmux
+> inside the distro as remote hosts. psmux is newer than tmux and a bit less
+> stable, so please report anything you hit.
 
 ### Recommended: v1, the stable line
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ it are data files you edit too. No fork, no recompile, no restart.
 
 > [!NOTE]
 > **Windows uses psmux, not tmux.** Every Windows route needs
-> [psmux](https://github.com/psmux/psmux) — a native ConPTY multiplexer speaking
-> tmux's control-mode protocol — installed separately; WSL distros run tmux
-> inside the distro as remote hosts. psmux is newer than tmux and a bit less
-> stable, so please report anything you hit.
+> [psmux](https://github.com/psmux/psmux), a drop-in tmux clone on ConPTY that
+> speaks the same control-mode protocol, installed separately. (A WSL distro is
+> a remote host and runs tmux inside the distro.) psmux is the newer of the two
+> and a bit less stable, so please report anything you hit.
 
 ### Recommended: v1, the stable line
 

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -98,10 +98,10 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
             <p>
               <strong>Windows uses psmux, not tmux.</strong>
               Every Windows route needs
-              <a href="https://github.com/psmux/psmux">psmux</a>
-              &mdash; a native ConPTY multiplexer speaking tmux's control-mode
-              protocol &mdash; installed separately; WSL distros run tmux inside
-              the distro as remote hosts. psmux is newer than tmux and a bit less
+              <a href="https://github.com/psmux/psmux">psmux</a>, a drop-in tmux
+              clone on ConPTY that speaks the same control-mode protocol,
+              installed separately. (A WSL distro is a remote host and runs tmux
+              inside the distro.) psmux is the newer of the two and a bit less
               stable, so please report anything you hit.
             </p>
           </div>
@@ -112,9 +112,7 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
             carries the newest release. It installs to
             <code>%LOCALAPPDATA%\Programs\thurbox</code>
             (added to your user
-            <code>PATH</code>) and uses
-            <a href="https://github.com/psmux/psmux">psmux</a>
-            as the multiplexer.
+            <code>PATH</code>).
           </p>
           <pre data-wrap><code class="language-powershell">irm https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/install.ps1 | iex</code></pre>
           <p>

--- a/website/docs/installation.html
+++ b/website/docs/installation.html
@@ -94,13 +94,15 @@ curl -fsSL https://raw.githubusercontent.com/Thurbeen/thurbox/main/scripts/insta
           </p>
 
           <h3>Windows (PowerShell)</h3>
-          <div class="info-box warning">
+          <div class="info-box">
             <p>
-              <strong>Experimental.</strong>
-              Windows support is experimental for now &mdash; the core works
-              (psmux as the multiplexer, a native ConPTY backend, WSL distros as
-              remote hosts), but it sees less testing than Linux/macOS. Expect
-              rough edges and please report issues.
+              <strong>Windows uses psmux, not tmux.</strong>
+              Every Windows route needs
+              <a href="https://github.com/psmux/psmux">psmux</a>
+              &mdash; a native ConPTY multiplexer speaking tmux's control-mode
+              protocol &mdash; installed separately; WSL distros run tmux inside
+              the distro as remote hosts. psmux is newer than tmux and a bit less
+              stable, so please report anything you hit.
             </p>
           </div>
           <p>


### PR DESCRIPTION
## Summary

- Windows support is no longer experimental, so the two notes that said so (the README install section and the website installation page) no longer say it.
- Both now state what actually differs on Windows: the multiplexer is **psmux**, not tmux — a drop-in tmux clone on ConPTY speaking the same control-mode protocol, installed separately — with a WSL distro noted as a remote host that runs tmux inside the distro.
- psmux being the newer of the two is kept as the reason to expect the occasional rough edge, in place of the blanket "experimental" framing.
- The website box drops its `warning` class (it is information now, not a caution), and the paragraph beneath it drops its duplicated psmux link now that the box carries it.

## Test plan

- Docs only — no code, no build or behaviour change.
- `git diff origin/main...HEAD` touches `README.md` and `website/docs/installation.html` only.
- CI covers the rest: `rumdl` for the README, Prettier/HTMLHint/Stylelint for the website page. Neither linter is installed in this container, so CI is the first real run of both.

---
_Generated by [Claude Code](https://claude.ai/code/session_0118j5oB5yCJAkcStTSFzyew)_