### PR TITLE
fix(ui): don't pull the view onto a session that just finished spawning

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -236,14 +236,15 @@ not applicable.
    session. Skipped when only one agent is defined in
    `agents.toml`.
 
-**The new session is the one you end up looking at.** Creation is a command, so
-its id does not exist when the flow closes — the spawn pipeline mints it. It
-travels back with the completion (`CommandBus::take_created`), and the loop then
-selects that session and puts the input focus on the pane showing it, through the
-same `focus_session` path a clicked notification and `thurbox-cli session focus`
-use. The session list *follows the id* rather than a row number, so the selection
-lands correctly across the frames between "created" and "in the snapshot".
-`Ctrl+F` fork reports its new session the same way.
+**Creating a session moves nothing.** The new row appears in the list and waits
+to be picked; the selection, the pane showing it and the keyboard all stay where
+they were. Creation is a command that finishes on a worker seconds after the flow
+closed, so the moment it lands is not a moment the user chose — steering the view
+then interrupted whatever they had gone back to reading, and made creating three
+sessions in a row a fight with the cursor. `Ctrl+F` fork behaves the same way.
+Selection is still *steerable*, by the two requests that are deliberate: a
+clicked notification and `thurbox-cli session focus`, both through
+`focus_session`, which the list follows by id rather than by row number.
 
 A session is fully described by its repos and agent. There is no
 per-session model selection, permissions, prompt, tool, or skill

--- a/src/kernel/command.rs
+++ b/src/kernel/command.rs
@@ -744,10 +744,6 @@ struct Progress {
 struct Done {
     id: u64,
     error: Option<String>,
-    /// The session the command brought into existence, if it did — a creation
-    /// or a fork. Carried on the completion because that is the first moment
-    /// the id exists.
-    created: Option<String>,
 }
 
 /// How long a failed command stays readable before being swept.
@@ -763,8 +759,6 @@ pub struct CommandBus {
     next_id: AtomicU64,
     /// When each failure was recorded, so it can be swept after lingering.
     failed_at: Vec<(u64, std::time::Instant)>,
-    /// Sessions created since the loop last drained this, oldest first.
-    created: Vec<String>,
 }
 
 impl CommandBus {
@@ -779,7 +773,6 @@ impl CommandBus {
             progress_rx,
             next_id: AtomicU64::new(1),
             failed_at: Vec::new(),
-            created: Vec::new(),
         }
     }
 
@@ -809,11 +802,8 @@ impl CommandBus {
                     entry.started();
                 }
             }
-            let (created, error) = match execute(&command, id, &progress) {
-                Ok(created) => (created, None),
-                Err(error) => (None, Some(error)),
-            };
-            let _ = finished.send(Done { id, error, created });
+            let error = execute(&command, id, &progress).err();
+            let _ = finished.send(Done { id, error });
         });
         id
     }
@@ -825,13 +815,7 @@ impl CommandBus {
     /// thread.
     #[doc(hidden)]
     pub fn finish_for_test(&self, id: u64, error: Option<String>) {
-        self.finish_outcome(id, error, None);
-    }
-
-    /// As [`Self::finish_for_test`], but also naming a session the command
-    /// created — the other half of a completion the worker supplies.
-    fn finish_outcome(&self, id: u64, error: Option<String>, created: Option<String>) {
-        let _ = self.finished_tx.send(Done { id, error, created });
+        let _ = self.finished_tx.send(Done { id, error });
     }
 
     /// Fold finished commands into the in-flight list.
@@ -869,11 +853,6 @@ impl CommandBus {
         let mut changed = false;
         while let Ok(done) = self.finished_rx.try_recv() {
             changed = true;
-            // Recorded before the lock: a poisoned mutex must not lose the
-            // session a command just created.
-            if let Some(session) = done.created {
-                self.created.push(session);
-            }
             let Ok(mut list) = self.inflight.lock() else {
                 continue;
             };
@@ -909,15 +888,6 @@ impl CommandBus {
         }
         self.failed_at.retain(|(id, _)| !expired.contains(id));
         true
-    }
-
-    /// The sessions completed commands brought into existence, oldest first.
-    ///
-    /// Drained rather than read: the loop acts on each exactly once, and a
-    /// creation nobody consumed must not steer the selection again on the next
-    /// tick.
-    pub fn take_created(&mut self) -> Vec<String> {
-        std::mem::take(&mut self.created)
     }
 
     /// Everything accepted but not yet done, for publishing to plugins.
@@ -976,14 +946,10 @@ impl Default for CommandBus {
 
 /// Run one command. Called on the command's own thread, never the UI thread.
 ///
-/// `Ok(Some(id))` when the command brought a session into existence: the id is
-/// not knowable when the command is issued — the spawn pipeline mints it — so it
-/// travels back with the completion instead.
-fn execute(
-    command: &Command,
-    id: u64,
-    progress: &Sender<Progress>,
-) -> Result<Option<String>, String> {
+/// Only the outcome travels back. A creation mints an id the caller could not
+/// know, but nothing in the loop consumes it: a session that finished spawning
+/// is a row in the list, not a reason to move the user's selection there.
+fn execute(command: &Command, id: u64, progress: &Sender<Progress>) -> Result<(), String> {
     // Handled by the loop before dispatch, because they mutate in-process state
     // the worker cannot reach. Reaching here means a caller bypassed that.
     if command.applied_on_ui_thread() {
@@ -1002,28 +968,26 @@ fn execute(
         extras,
     } = command
     {
-        return create(name, repo, branch, base, agent, host, extras, id, progress)
-            .map(|session| Some(session.to_string()));
+        return create(name, repo, branch, base, agent, host, extras, id, progress).map(|_| ());
     }
 
     // Repository memory names a path, not a session, so it too runs before the
     // id parse.
     if let Command::Bookmark { host, path, edit } = command {
-        return bookmark(host, path, *edit).map(|()| None);
+        return bookmark(host, path, *edit);
     }
 
     // The settings file names nothing at all.
     if let Command::Configure { settings } = command {
         return crate::agent::settings_config::save_settings(settings)
-            .map_err(|e| format!("write settings.toml: {e}"))
-            .map(|()| None);
+            .map_err(|e| format!("write settings.toml: {e}"));
     }
 
     // Keyed by nothing at all: an explicit order names every session at once.
     if let Command::Order { list } = command {
         let path = crate::paths::database_file().ok_or("could not resolve the database path")?;
         let db = Database::open(&path).map_err(|e| format!("open database: {e}"))?;
-        return order(&db, list).map(|()| None);
+        return order(&db, list);
     }
 
     // Tasks and automations are keyed by number, not by session id.
@@ -1050,8 +1014,7 @@ fn execute(
                 delete,
             } => automation(&db, *id, *enabled, *run_now, *delete),
             _ => unreachable!(),
-        }
-        .map(|()| None);
+        };
     }
 
     let id: SessionId = command
@@ -1064,10 +1027,10 @@ fn execute(
     let path = crate::paths::database_file().ok_or("could not resolve the database path")?;
     let db = Database::open(&path).map_err(|e| format!("open database: {e}"))?;
 
-    // A fork mints a session too, so it reports its id the way creation does;
-    // every other command leaves the set of sessions as it found it.
+    // A fork mints a session too; like a creation, the new row simply appears
+    // in the list rather than pulling the selection onto itself.
     if let Command::Fork { name, .. } = command {
-        return fork(&db, id, name).map(|session| Some(session.to_string()));
+        return fork(&db, id, name).map(|_| ());
     }
 
     match command {
@@ -1098,7 +1061,7 @@ fn execute(
         Command::Reorder { delta, .. } => reorder(&db, id, *delta),
         // Handled above, before the session id is parsed.
         Command::Order { .. } => Ok(()),
-        Command::Fork { .. } => unreachable!("handled above, to report its new session"),
+        Command::Fork { .. } => unreachable!("handled above, where it mints its session"),
 
         Command::Sync { .. } => sync(&db, id),
         // Unreachable: guarded above, and kept exhaustive so adding a command
@@ -1121,7 +1084,6 @@ fn execute(
         | Command::Focus { .. }
         | Command::Plugin { .. } => unreachable!("applied on the UI thread"),
     }
-    .map(|()| None)
 }
 
 /// Create a session.
@@ -1952,41 +1914,6 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(20));
         }
         panic!("the failure never surfaced");
-    }
-
-    #[test]
-    fn a_created_session_is_reported_once_and_then_drained() {
-        // What the loop needs to steer the selection onto a session the user
-        // just asked for. Drained rather than read, because a creation acted on
-        // twice would keep dragging the cursor back after the user moved it.
-        let mut bus = CommandBus::new();
-        let id = bus.dispatch(Command::Delete {
-            session: "not-a-uuid".into(),
-            force: false,
-        });
-        bus.finish_outcome(id, None, Some("the-new-session".into()));
-        bus.poll();
-
-        assert_eq!(bus.take_created(), vec!["the-new-session".to_string()]);
-        assert!(
-            bus.take_created().is_empty(),
-            "a creation must steer the selection once, not every tick"
-        );
-    }
-
-    #[test]
-    fn a_failed_creation_reports_no_session_to_focus() {
-        // The id would be a lie: nothing was spawned, so following it would
-        // leave the list chasing a session that never appears.
-        let mut bus = CommandBus::new();
-        let id = bus.dispatch(Command::Delete {
-            session: "not-a-uuid".into(),
-            force: false,
-        });
-        bus.finish_for_test(id, Some("worktree add failed".into()));
-        bus.poll();
-
-        assert!(bus.take_created().is_empty());
     }
 
     #[test]

--- a/src/kernel/command.rs
+++ b/src/kernel/command.rs
@@ -946,9 +946,9 @@ impl Default for CommandBus {
 
 /// Run one command. Called on the command's own thread, never the UI thread.
 ///
-/// Only the outcome travels back. A creation mints an id the caller could not
-/// know, but nothing in the loop consumes it: a session that finished spawning
-/// is a row in the list, not a reason to move the user's selection there.
+/// Only the outcome travels back. A creation and a fork each mint a session id,
+/// and neither reports it: a session that finished spawning is a row in the
+/// list, not a reason to move the user's selection onto it.
 fn execute(command: &Command, id: u64, progress: &Sender<Progress>) -> Result<(), String> {
     // Handled by the loop before dispatch, because they mutate in-process state
     // the worker cannot reach. Reaching here means a caller bypassed that.
@@ -968,7 +968,7 @@ fn execute(command: &Command, id: u64, progress: &Sender<Progress>) -> Result<()
         extras,
     } = command
     {
-        return create(name, repo, branch, base, agent, host, extras, id, progress).map(|_| ());
+        return create(name, repo, branch, base, agent, host, extras, id, progress);
     }
 
     // Repository memory names a path, not a session, so it too runs before the
@@ -1030,7 +1030,7 @@ fn execute(command: &Command, id: u64, progress: &Sender<Progress>) -> Result<()
     // A fork mints a session too; like a creation, the new row simply appears
     // in the list rather than pulling the selection onto itself.
     if let Command::Fork { name, .. } = command {
-        return fork(&db, id, name).map(|_| ());
+        return fork(&db, id, name);
     }
 
     match command {
@@ -1104,7 +1104,7 @@ fn create(
     extras: &[ExtraMember],
     id: u64,
     progress: &Sender<Progress>,
-) -> Result<SessionId, String> {
+) -> Result<(), String> {
     let path = crate::paths::database_file().ok_or("could not resolve the database path")?;
     let db = Database::open(&path).map_err(|e| format!("open database: {e}"))?;
 
@@ -1168,7 +1168,7 @@ fn create(
         });
     };
     crate::session_ops::spawn::spawn_session_headless_with_progress(&db, request, Some(&report))
-        .map(|spawned| spawned.session_id)
+        .map(|_| ())
 }
 
 /// Remember, forget or import a repository path.
@@ -1308,7 +1308,7 @@ fn bookmark_add(
 }
 
 /// Fork a session: a new one on the same repository, recording its parent.
-fn fork(db: &Database, id: SessionId, name: &str) -> Result<SessionId, String> {
+fn fork(db: &Database, id: SessionId, name: &str) -> Result<(), String> {
     let source = db
         .get_session_by_id(id)
         .map_err(|e| format!("get session: {e}"))?
@@ -1355,7 +1355,7 @@ fn fork(db: &Database, id: SessionId, name: &str) -> Result<SessionId, String> {
         // Shared, not created — so the fork shows its branch and can be synced.
         inherit_worktrees: source.worktrees.clone(),
     };
-    crate::session_ops::spawn::spawn_session_headless(db, request).map(|spawned| spawned.session_id)
+    crate::session_ops::spawn::spawn_session_headless(db, request).map(|_| ())
 }
 
 /// Bring a session's worktree up to date with the branch it came from.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1377,16 +1377,14 @@ impl App {
         // delete feel immediate instead of arriving up to 400ms later.
         if self.commands.poll() {
             self.report_finished_commands();
-            // A session you just asked for is the one you want to be looking at.
-            // The id is knowable only once the spawn finished, so it arrives with
-            // the completion rather than with the command — and the list follows
-            // an id until it appears, which is what carries this across the
-            // frames between "created" and "in the snapshot". Of several
-            // finishing at once the last to finish wins; there is one caret and
-            // one selection either way.
-            if let Some(created) = self.commands.take_created().pop() {
-                self.focus_on_session(&created);
-            }
+            // A creation deliberately steers nothing. It finishes on a worker,
+            // so the moment it lands is not a moment the user chose: moving the
+            // selection — and with it what the agent pane shows and where the
+            // keyboard goes — pulled them out of whatever they were reading,
+            // several seconds after they asked. The new session appears in the
+            // list and waits to be picked. `focus_session` still exists for the
+            // two requests that ARE deliberate: a clicked notification and
+            // `thurbox-cli session focus`.
             // Wait for the last one: two adds in quick succession would
             // otherwise re-read between them and publish a list missing the
             // second.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1377,14 +1377,10 @@ impl App {
         // delete feel immediate instead of arriving up to 400ms later.
         if self.commands.poll() {
             self.report_finished_commands();
-            // A creation deliberately steers nothing. It finishes on a worker,
-            // so the moment it lands is not a moment the user chose: moving the
-            // selection — and with it what the agent pane shows and where the
-            // keyboard goes — pulled them out of whatever they were reading,
-            // several seconds after they asked. The new session appears in the
-            // list and waits to be picked. `focus_session` still exists for the
-            // two requests that ARE deliberate: a clicked notification and
-            // `thurbox-cli session focus`.
+            // A finished creation is deliberately not acted on here: see
+            // `focus_on_session` for why a session that just spawned does not
+            // pull the view onto itself.
+
             // Wait for the last one: two adds in quick succession would
             // otherwise re-read between them and publish a list missing the
             // second.
@@ -4180,11 +4176,16 @@ impl App {
 
     /// Select a session and put the input focus on the pane that shows it.
     ///
-    /// Shared by the two things that mean "look at this one": an outside focus
-    /// request (a clicked notification, `thurbox-cli session focus`) and a
-    /// session this instance just created. The selection travels through the
-    /// store rather than being set here, because the list is a plugin and it is
-    /// the only thing that knows the rendered order.
+    /// Only for a request made *now*: a clicked notification, or
+    /// `thurbox-cli session focus`. A session this instance just created is
+    /// deliberately not one — creation finishes on a worker seconds after the
+    /// wizard closed, so steering the view then lands at a moment the user did
+    /// not choose, and taking the selection back after every one of them made
+    /// creating several sessions in a row a fight with the cursor.
+    ///
+    /// The selection travels through the store rather than being set here,
+    /// because the list is a plugin and it is the only thing that knows the
+    /// rendered order.
     fn focus_on_session(&mut self, id: &str) {
         self.host.set_shared_string("focus_session", id);
         if let Some(index) = self.host.index_of("agent") {


### PR DESCRIPTION
## Summary

- Creating a session no longer steers the interface. `App::poll_command_bus` drained `CommandBus::take_created()` and called `focus_on_session`, which moved the session-list selection *and* put the input focus on the agent pane. The new row now just appears in the list and waits to be picked.
- The two steers that are deliberate are untouched: a clicked OS notification and `thurbox-cli session focus` still go through `focus_session`, and the list still follows an id rather than a row number. `Ctrl+F` fork behaves like creation.
- Why: a creation finishes on a worker seconds after the wizard closed, so the jump arrived at a moment nobody chose — and creating several sessions in a row was a fight with the cursor, each completion dragging it away again.
- With nothing consuming it, the created id no longer travels back on the completion: `execute` returns `Result<(), String>`, and `Done.created`, `CommandBus::created` / `take_created` and the two tests that pinned the drain are gone. Second commit is the tidy-up: `create` and `fork` return `()` like every other command helper instead of a `SessionId` both call sites discarded.
- `docs/FEATURES.md` promised the opposite ("The new session is the one you end up looking at") and now documents the rule and its rationale, as does `focus_on_session`'s doc comment.

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all` — applied.
- `cargo test --lib` — 1466 passed. (`kernel::bundled::the_fallback_directory_holds_a_loadable_interface` fails intermittently under `cargo test`'s thread-per-test model — it deletes a process-shared fallback directory — and passes under the repo's `cargo nextest`; unrelated to this diff.)
- Integration targets (`v2_repo_memory`, `v2_plugin_packages`, `v2_attach_by_name`, …) fail in my container for want of tmux and git-identity isolation; verified they fail identically on a stashed tree, so CI is the real check for those.
- Behaviour: create a session while reading another one — the selection, the centre pane and the keyboard stay put; `thurbox-cli session focus <id>` still moves them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMZ3g47DnkDZxwDfRxtDhw)_