### PR TITLE
fix(ui): drop a deleted session from the list on the keystroke

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1674,7 +1674,7 @@ branch name) is saved in the database and reconstructed on restore.
   unless `--force`. Either way the row **leaves the list on the
   keystroke** rather than sitting there tagged while the teardown runs:
   the session list drops any session whose `delete` is in flight
-  (`deleting()` in `ui/plugins/10_sessions.lua`), so the cursor lands on
+  (`live_sessions()` in `ui/plugins/10_sessions.lua`), so the cursor lands on
   the next session and a repo group whose last session went takes its
   header with it. A delete that *failed* keeps its row — the failure is
   the only thing that says the session is still there.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1671,7 +1671,13 @@ branch name) is saved in the database and reconstructed on restore.
   delete** — the full teardown with no `Ctrl+Z` undo, so it is gated
   behind a confirmation modal (`Modal::ConfirmDeleteSession`) instead.
   The flag never affects `thurbox-cli session delete`, which stays soft
-  unless `--force`.
+  unless `--force`. Either way the row **leaves the list on the
+  keystroke** rather than sitting there tagged while the teardown runs:
+  the session list drops any session whose `delete` is in flight
+  (`deleting()` in `ui/plugins/10_sessions.lua`), so the cursor lands on
+  the next session and a repo group whose last session went takes its
+  header with it. A delete that *failed* keeps its row — the failure is
+  the only thing that says the session is still there.
 
 ### Multi-instance support
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -898,7 +898,7 @@ the work wasted only after paying for it.
 | CPU per frame | 3.1ms | 9.9ms | 9.1ms | **5.2ms** |
 | gap to v1 (CPU) | — | 2.5x | 2.0x | **1.5x** |
 
-**Three things the implementation taught, each caught by a test rather than by
+**Four things the implementation taught, each caught by a test rather than by
 review:**
 
 - **`taken_at_ms` is published**, and `widgets.relative_time` renders it, so the
@@ -913,6 +913,17 @@ review:**
   state version 40 times a second and invalidated every cached tree. With it,
   the saving was 0%; without it, 27%. Every signal here compares before it
   stores, for exactly this reason.
+- **`thurbox.commands` is read too, and accepting one had no signal.** The
+  in-flight list is published every frame, but only its *completion* side moved
+  the data epoch (`poll_command_bus`); submitting a command moved nothing. The
+  session list drops the row a `delete` names as soon as it is accepted, and
+  being pure it was handed the tree built before the command existed — so the
+  deleted row survived until the animation clock ticked 125ms later, or until
+  the delete finished, which is the wait the feature exists to avoid.
+  `dispatch_tracked` now moves the epoch as the command is accepted. Asserted by
+  `accepting_a_command_must_move_the_epoch_to_reach_a_pure_pane`, which settles
+  the pane first — a pane that is never cached cannot go stale, so a test that
+  skips the settle proves nothing.
 
 **Rejected**:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3201,15 +3201,13 @@ impl App {
                 failed: false,
             },
         );
-        // Accepting a command changes `thurbox.commands`, which panes draw from
-        // — the session list drops the row a `delete` names the moment one is
-        // accepted. Every such pane is `pure`, so without moving the published
-        // epoch here it is handed the tree it built *before* the command
-        // existed, and the change waits for whatever moves a signal next: the
-        // animation clock 125ms later, or the completion itself. The completion
-        // side already does this (see `poll_command_bus`); this is the other
-        // half, and it is what makes the acceptance visible on the next frame
-        // rather than eventually.
+        // Accepting a command changes `thurbox.commands`, which panes draw from:
+        // the session list drops the row a `delete` names as soon as one is
+        // accepted. Such a pane is `pure`, so without moving the epoch here it
+        // is handed the tree built *before* the command existed, and the change
+        // waits for whatever moves a signal next — the animation clock 125ms
+        // later, or the completion. `poll_command_bus` already does this for the
+        // completion; this is the submission half.
         self.note_data_change();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3201,6 +3201,16 @@ impl App {
                 failed: false,
             },
         );
+        // Accepting a command changes `thurbox.commands`, which panes draw from
+        // — the session list drops the row a `delete` names the moment one is
+        // accepted. Every such pane is `pure`, so without moving the published
+        // epoch here it is handed the tree it built *before* the command
+        // existed, and the change waits for whatever moves a signal next: the
+        // animation clock 125ms later, or the completion itself. The completion
+        // side already does this (see `poll_command_bus`); this is the other
+        // half, and it is what makes the acceptance visible on the next frame
+        // rather than eventually.
+        self.note_data_change();
     }
 
     /// Persist the pane id of a session's companion shell.

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -482,7 +482,7 @@ fn accepting_a_command_must_move_the_epoch_to_reach_a_pure_pane() {
         sessions: vec![row("aaa", "doomed"), row("bbb", "bystander")],
         ..Snapshot::default()
     };
-    let paint = |host: &LuaHost| {
+    let paint = || {
         format!(
             "{:?}",
             host.render(
@@ -502,19 +502,16 @@ fn accepting_a_command_must_move_the_epoch_to_reach_a_pure_pane() {
 
     let mut epoch = Epoch::default();
     publish_at(&host, epoch, &snapshot, &themes);
-    assert!(
-        paint(&host).contains("doomed"),
-        "the row should start present"
-    );
+    assert!(paint().contains("doomed"), "the row should start present");
 
     // Let it settle first. The list publishes the selection as it renders, so
     // its first pass moves the state version — which is part of the cache key —
     // and the second pass is the one whose tree can be reused. A pane that never
     // settled could not go stale either, which would make the rest of this test
     // prove nothing.
-    let _ = paint(&host);
+    let _ = paint();
     let settled = host.skipped_renders();
-    let _ = paint(&host);
+    let _ = paint();
     assert_eq!(
         host.skipped_renders() - settled,
         1,
@@ -534,7 +531,7 @@ fn accepting_a_command_must_move_the_epoch_to_reach_a_pure_pane() {
     // the row it drew before the delete existed is what stays on screen.
     publish_at_with(&host, epoch, &snapshot, &themes, &inflight);
     assert!(
-        paint(&host).contains("doomed"),
+        paint().contains("doomed"),
         "the in-flight list reached a pure pane on its own — this test is \
          asserting the caching that makes the epoch bump necessary, so if it \
          fails the bump may no longer be needed"
@@ -543,7 +540,7 @@ fn accepting_a_command_must_move_the_epoch_to_reach_a_pure_pane() {
     // Moved, as the loop moves it the moment the command is accepted.
     epoch.data += 1;
     publish_at_with(&host, epoch, &snapshot, &themes, &inflight);
-    let screen = paint(&host);
+    let screen = paint();
     assert!(
         !screen.contains("doomed"),
         "the deleted row outlived the epoch that carried its delete:\n{screen}"

--- a/tests/kernel_frame_cost.rs
+++ b/tests/kernel_frame_cost.rs
@@ -182,6 +182,16 @@ fn row(id: &str, name: &str) -> SessionRow {
 }
 
 fn publish_at(host: &LuaHost, epoch: Epoch, snapshot: &Snapshot, themes: &Themes) {
+    publish_at_with(host, epoch, snapshot, themes, &[]);
+}
+
+fn publish_at_with(
+    host: &LuaHost,
+    epoch: Epoch,
+    snapshot: &Snapshot,
+    themes: &Themes,
+    inflight: &[thurbox::kernel::command::InFlight],
+) {
     let mut registry = Registry::default();
     let (bindings, settings) = host.declarations();
     registry.declare(bindings, settings);
@@ -191,7 +201,7 @@ fn publish_at(host: &LuaHost, epoch: Epoch, snapshot: &Snapshot, themes: &Themes
         epoch,
         snapshot,
         attach_errors: &Default::default(),
-        inflight: &[],
+        inflight,
         themes,
         registry: &registry,
         diffs: &diffs,
@@ -449,6 +459,96 @@ fn a_moved_epoch_re_renders_a_pure_pane() {
         tree_of(&host, "pure").contains("beta"),
         "a pure pane kept its tree after the snapshot moved"
     );
+}
+
+#[test]
+fn accepting_a_command_must_move_the_epoch_to_reach_a_pure_pane() {
+    // The session list drops a row the moment its `delete` is accepted, so that
+    // a delete does not sit there wearing a tag until the worker is done. It
+    // reads that from `thurbox.commands` — and it is a PURE pane, so an accepted
+    // command that leaves every published signal standing is served the tree
+    // built before the command existed. The row then survives until whatever
+    // moves a signal next: the animation clock 125ms later, or the completion.
+    //
+    // Hence `dispatch_tracked` moves the data epoch as the command is accepted.
+    // This is that requirement, asserted where the caching lives: the in-flight
+    // list alone must not be expected to reach a pure pane.
+    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
+    let host = LuaHost::new(dir);
+    assert!(host.error.is_none(), "{:?}", host.error);
+    let themes = Themes::load(None);
+    let sessions = host.index_of("sessions").expect("sessions pane");
+    let snapshot = Snapshot {
+        sessions: vec![row("aaa", "doomed"), row("bbb", "bystander")],
+        ..Snapshot::default()
+    };
+    let paint = |host: &LuaHost| {
+        format!(
+            "{:?}",
+            host.render(
+                sessions,
+                thurbox::kernel::host::RenderContext {
+                    width: 40,
+                    height: 10,
+                    focused: true,
+                    elapsed: 0.0,
+                    frame: 0,
+                },
+            )
+            .expect("render")
+            .node
+        )
+    };
+
+    let mut epoch = Epoch::default();
+    publish_at(&host, epoch, &snapshot, &themes);
+    assert!(
+        paint(&host).contains("doomed"),
+        "the row should start present"
+    );
+
+    // Let it settle first. The list publishes the selection as it renders, so
+    // its first pass moves the state version — which is part of the cache key —
+    // and the second pass is the one whose tree can be reused. A pane that never
+    // settled could not go stale either, which would make the rest of this test
+    // prove nothing.
+    let _ = paint(&host);
+    let settled = host.skipped_renders();
+    let _ = paint(&host);
+    assert_eq!(
+        host.skipped_renders() - settled,
+        1,
+        "the session list never settled, so this test cannot observe the cache"
+    );
+
+    let inflight = vec![thurbox::kernel::command::InFlight {
+        id: 1,
+        kind: "delete",
+        session: "aaa".to_string(),
+        subject: None,
+        phase: thurbox::kernel::command::Phase::Running,
+        error: None,
+    }];
+
+    // Accepted, but with every signal left standing: the pane never runs, so
+    // the row it drew before the delete existed is what stays on screen.
+    publish_at_with(&host, epoch, &snapshot, &themes, &inflight);
+    assert!(
+        paint(&host).contains("doomed"),
+        "the in-flight list reached a pure pane on its own — this test is \
+         asserting the caching that makes the epoch bump necessary, so if it \
+         fails the bump may no longer be needed"
+    );
+
+    // Moved, as the loop moves it the moment the command is accepted.
+    epoch.data += 1;
+    publish_at_with(&host, epoch, &snapshot, &themes, &inflight);
+    let screen = paint(&host);
+    assert!(
+        !screen.contains("doomed"),
+        "the deleted row outlived the epoch that carried its delete:\n{screen}"
+    );
+    assert!(screen.contains("bystander"), "{screen}");
 }
 
 #[test]

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -1639,9 +1639,10 @@ fn a_session_being_deleted_leaves_the_list_at_once() {
     // the session back rather than the row.
     let host = host();
     let sessions = index_of(&host, "sessions");
-    let doomed = sample().sessions[0].id.clone();
+    let snapshot = sample();
+    let doomed = snapshot.sessions[0].id.clone();
 
-    publish(&host, &sample());
+    publish(&host, &snapshot);
     let before = paint(&host, sessions, 46, 14).join("\n");
     assert!(before.contains("fix-osc52"), "{before}");
 
@@ -1653,7 +1654,7 @@ fn a_session_being_deleted_leaves_the_list_at_once() {
         phase: Phase::Running,
         error: None,
     }];
-    publish_with(&host, &sample(), &Default::default(), &inflight);
+    publish_with(&host, &snapshot, &Default::default(), &inflight);
 
     let screen = paint(&host, sessions, 46, 14).join("\n");
     assert!(

--- a/tests/kernel_mvp.rs
+++ b/tests/kernel_mvp.rs
@@ -1017,13 +1017,15 @@ fn a_malformed_command_is_reported_against_the_plugin() {
 
 #[test]
 fn work_in_flight_is_drawn_instead_of_the_status() {
-    // Without this a delete looks like nothing happened until the next
-    // snapshot. v1 needed a whole PendingSpawn type for the same reason.
+    // Without this a restart looks like nothing happened until the next
+    // snapshot. v1 needed a whole PendingSpawn type for the same reason. A
+    // delete is the one command with no row left to annotate — see
+    // `a_session_being_deleted_leaves_the_list_at_once`.
     let host = host();
     let target = sample().sessions[0].id.clone();
     let inflight = vec![InFlight {
         id: 1,
-        kind: "delete",
+        kind: "restart",
         session: target,
         subject: None,
         phase: Phase::Running,
@@ -1033,7 +1035,7 @@ fn work_in_flight_is_drawn_instead_of_the_status() {
     publish_with(&host, &sample(), &Default::default(), &inflight);
     let screen = paint(&host, index_of(&host, "sessions"), 46, 12).join("\n");
     assert!(screen.contains('◌'), "pending marker missing:\n{screen}");
-    assert!(screen.contains("delete"), "{screen}");
+    assert!(screen.contains("restart"), "{screen}");
 }
 
 #[test]
@@ -1053,6 +1055,10 @@ fn a_failed_command_is_drawn_as_failed() {
     let screen = paint(&host, index_of(&host, "sessions"), 46, 12).join("\n");
     assert!(screen.contains('✗'), "{screen}");
     assert!(screen.contains("failed"), "{screen}");
+    // And the row is still there to carry it. A delete that has been accepted
+    // takes its session out of the list at once; one that FAILED did not, and
+    // the row is the only thing that says so.
+    assert!(screen.contains("fix-osc52"), "{screen}");
 }
 
 #[test]
@@ -1623,6 +1629,43 @@ fn a_pending_creation_draws_in_the_repo_it_will_land_in() {
         pending > header,
         "placeholder should follow its repo header:\n{screen}"
     );
+}
+
+#[test]
+fn a_session_being_deleted_leaves_the_list_at_once() {
+    // The row is the delete's subject, so annotating it kept showing the very
+    // session you had just removed for as long as the worker took. It goes on
+    // the keystroke instead: the command is already accepted, and Ctrl+Z brings
+    // the session back rather than the row.
+    let host = host();
+    let sessions = index_of(&host, "sessions");
+    let doomed = sample().sessions[0].id.clone();
+
+    publish(&host, &sample());
+    let before = paint(&host, sessions, 46, 14).join("\n");
+    assert!(before.contains("fix-osc52"), "{before}");
+
+    let inflight = vec![InFlight {
+        id: 1,
+        kind: "delete",
+        session: doomed,
+        subject: None,
+        phase: Phase::Running,
+        error: None,
+    }];
+    publish_with(&host, &sample(), &Default::default(), &inflight);
+
+    let screen = paint(&host, sessions, 46, 14).join("\n");
+    assert!(
+        !screen.contains("fix-osc52"),
+        "the deleted row should be gone, not tagged:\n{screen}"
+    );
+    assert!(
+        !screen.contains("delete"),
+        "and nothing should be left saying so:\n{screen}"
+    );
+    // The sessions it did not touch are untouched.
+    assert!(screen.contains("add-wsl-tests"), "{screen}");
 }
 
 #[test]

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -196,7 +196,7 @@ local NO_REPO = "(no repo)"
 --- A command is accepted instantly and lands in a later snapshot, so without
 --- this a restart would look like nothing happened for a moment. v1 needed a
 --- whole `PendingSpawn` type for the same reason. A delete is the exception:
---- see `deleting()`, which removes the row instead of annotating it.
+--- see `live_sessions()`, which drops the row instead of annotating it.
 local function pending()
   local by_session = {}
   for _, item in ipairs(thurbox and thurbox.commands or {}) do
@@ -207,7 +207,7 @@ local function pending()
   return by_session
 end
 
---- Sessions whose delete has been accepted, as a set of ids.
+--- The sessions the list draws: every published row but the ones being deleted.
 ---
 --- Every other in-flight command leaves a row to annotate; a delete is the one
 --- whose subject is the row itself. Waiting for it to land left the session
@@ -219,15 +219,22 @@ end
 ---
 --- A FAILED delete is deliberately kept. The session is still there, and the
 --- failed row is the only thing that says the deletion did not happen.
-local function deleting()
+local function live_sessions(rows)
   local gone = {}
   for _, item in ipairs(thurbox and thurbox.commands or {}) do
-    local id = item.session
-    if item.kind == "delete" and item.phase ~= "failed" and id and id ~= "" then
-      gone[id] = true
+    -- Guarded like `pending()`: a nil key is a runtime error in Lua.
+    if item.kind == "delete" and item.phase ~= "failed" and item.session then
+      gone[item.session] = true
     end
   end
-  return gone
+
+  local live = {}
+  for _, session in ipairs(rows) do
+    if not gone[session.id] then
+      live[#live + 1] = session
+    end
+  end
+  return live
 end
 
 --- Creations in flight, keyed by the repo they will land in.
@@ -354,19 +361,10 @@ end
 
 local function build_model(rows)
   local items = {}
-  -- Before anything is grouped or ordered: a session being deleted is gone from
-  -- the list, not annotated in it. Filtering here rather than at the drawing end
-  -- keeps every consumer of the model agreeing — the cursor lands on the next
-  -- row, the border dots lose one, and a group whose last session went takes its
-  -- header with it.
-  local gone = deleting()
-  local live = {}
-  for _, session in ipairs(rows) do
-    if not gone[session.id] then
-      live[#live + 1] = session
-    end
-  end
-  rows = live
+  -- Dropped before anything is grouped or ordered, so every consumer of the
+  -- model agrees: the cursor lands on the next row, the border dots lose one,
+  -- and a group whose last session went takes its header with it.
+  rows = live_sessions(rows)
 
   local groups, by_key = ordered_groups(rows)
   local creating = pending_creations()

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -194,8 +194,9 @@ local NO_REPO = "(no repo)"
 --- In-flight commands, keyed by the session they concern.
 ---
 --- A command is accepted instantly and lands in a later snapshot, so without
---- this a delete would look like nothing happened for a moment. v1 needed a
---- whole `PendingSpawn` type for the same reason.
+--- this a restart would look like nothing happened for a moment. v1 needed a
+--- whole `PendingSpawn` type for the same reason. A delete is the exception:
+--- see `deleting()`, which removes the row instead of annotating it.
 local function pending()
   local by_session = {}
   for _, item in ipairs(thurbox and thurbox.commands or {}) do
@@ -204,6 +205,29 @@ local function pending()
     end
   end
   return by_session
+end
+
+--- Sessions whose delete has been accepted, as a set of ids.
+---
+--- Every other in-flight command leaves a row to annotate; a delete is the one
+--- whose subject is the row itself. Waiting for it to land left the session
+--- sitting there tagged `delete` for as long as the worker took — so the list
+--- kept showing what you had just removed. Dropping it on the keystroke is what
+--- makes the delete read as done, and there is nothing to be lost by it: the
+--- effect is already accepted, and Ctrl+Z restores the session rather than the
+--- row.
+---
+--- A FAILED delete is deliberately kept. The session is still there, and the
+--- failed row is the only thing that says the deletion did not happen.
+local function deleting()
+  local gone = {}
+  for _, item in ipairs(thurbox and thurbox.commands or {}) do
+    local id = item.session
+    if item.kind == "delete" and item.phase ~= "failed" and id and id ~= "" then
+      gone[id] = true
+    end
+  end
+  return gone
 end
 
 --- Creations in flight, keyed by the repo they will land in.
@@ -330,6 +354,20 @@ end
 
 local function build_model(rows)
   local items = {}
+  -- Before anything is grouped or ordered: a session being deleted is gone from
+  -- the list, not annotated in it. Filtering here rather than at the drawing end
+  -- keeps every consumer of the model agreeing — the cursor lands on the next
+  -- row, the border dots lose one, and a group whose last session went takes its
+  -- header with it.
+  local gone = deleting()
+  local live = {}
+  for _, session in ipairs(rows) do
+    if not gone[session.id] then
+      live[#live + 1] = session
+    end
+  end
+  rows = live
+
   local groups, by_key = ordered_groups(rows)
   local creating = pending_creations()
 


### PR DESCRIPTION
## Summary

Deleting a session left its row in the list, wearing a `◌ … delete` tag, until the worker had killed the tmux pane and removed the worktree. The row is the delete's subject, so annotating it just kept showing what you had removed.

- **The list drops it.** `live_sessions()` in `ui/plugins/10_sessions.lua` filters out any session whose `delete` is in flight, before anything is grouped or ordered — so the cursor lands on the next session, the border dot strip loses one, and a repo group whose last session went takes its header with it. `Ctrl+Z` restores the session, not the row.
- **A failed delete keeps its row**, coming back as `✗ … failed: the error`. The session really is still there, and the failed row is the only thing that says the deletion did not happen.
- **The pane is actually asked to redraw.** The session list is `pure`, so the kernel reuses the tree it last returned, keyed on the published epoch. `poll_command_bus` moves that epoch when a command *finishes*, but nothing moved it when one was *accepted* — so the pane was handed the tree built before the delete existed and the row survived until the animation clock ticked 125 ms later, or until the delete completed. `dispatch_tracked` now moves the epoch as the command enters the bus.

The soft-delete path happened to mask that second half: its handler writes `state.deleted` for `Ctrl+Z`, and any state write invalidates every cached tree. The force-delete path on a clean session issues the command with no state write at all, and really did sit there.

Net effect: key → the next iteration submits the command and moves the epoch → that frame's paint omits the row. One frame, independent of how long teardown takes.

Docs updated in the same change: the `Ctrl+D` section of `docs/FEATURES.md`, and ADR-P16's lesson list in `docs/PERFORMANCE.md` (now four — a published source that is read but has no change-signal is the same class of bug as the three already listed there).

## Test plan

- `kernel_mvp::a_session_being_deleted_leaves_the_list_at_once` — the pane omits the row while the delete is in flight, leaves nothing saying "delete", and does not disturb the other sessions.
- `kernel_mvp::a_failed_command_is_drawn_as_failed` — extended to assert the row survives to carry the failure.
- `kernel_mvp::work_in_flight_is_drawn_instead_of_the_status` — retargeted to a `restart`; it was using a `delete` as its example of annotatable work, which is precisely the case that no longer annotates.
- `kernel_frame_cost::accepting_a_command_must_move_the_epoch_to_reach_a_pure_pane` — the epoch contract, asserted where the caching lives. It settles the pane first: the list publishes its selection as it renders, so its first pass moves the state version and only the pass after that is reusable. A draft that skipped the settle passed against the unfixed loop.
- `cargo test`, `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean locally. Pre-existing sandbox failures unrelated to this change: `v2_attach_by_name`, `v2_plugin_authoring`, `v2_plugin_packages`, `v2_repo_memory`, `v2_session_lifetime`, `v2_core_settings` (tmux/git/network), and `kernel::bundled`'s two tests, which race on a pid-named temp dir. Each verified failing identically on a stashed baseline.
- `selene`/`stylua` were not available in the sandbox, so the Lua was unlinted locally — CI's Lua Lint job covers it and is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182gLEiBqcBfPNaBuLi7pWQ