### PR TITLE
fix(ui): keep a throwing pane from taking the pointer with it

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -197,7 +197,7 @@ levers, in the order they pay:
    once so per-row matching does not. Read once per render, pass down.
 5. **Concatenate through a table.** `s = s .. piece` across a wide row is
    O(width²); accumulate and `table.concat`, or emit `string.rep` runs.
-6. **Animate off the shared clock only** — `widgets.spinner(ctx.elapsed)`
+6. **Animate off the shared clock only** — `theme.spinner_frame(ctx.elapsed)`
    follows the kernel's animation tick, which advances only while something is
    animating. A hand-rolled timer re-renders forever and defeats `pure`.
 

--- a/src/coordinator/draw.rs
+++ b/src/coordinator/draw.rs
@@ -458,6 +458,15 @@ impl App {
                 paint::render_error(frame, rect, &e.plugin, &e.message);
                 Counters::bump(&self.perf.failures);
                 self.errors.push(e);
+                // The pane's own rect, though it drew no rows to record. A
+                // press matching no target at all falls through to
+                // `begin_selection`, so without this a throwing plugin costs
+                // not just its pane but the pointer over it — clicks there
+                // silently paint a text selection across the error panel
+                // instead of focusing it. Isolation is the rule everywhere
+                // else here; this is its mouse half.
+                let fallback = self.host.plugins[index].focusable.then_some(rect);
+                self.push_targets(index, fallback, Vec::new());
                 return;
             }
         };

--- a/src/kernel/host/mod.rs
+++ b/src/kernel/host/mod.rs
@@ -421,7 +421,7 @@ type GroupKey = [u64; 4];
 
 /// How often the shared animation clock may advance, in Hz.
 ///
-/// Set to the rate `widgets.status_glyph` advances the working spinner at
+/// Set to the rate `theme.spinner_frame` advances the working spinner at
 /// (`math.floor(elapsed * 8)`), so a cached tree is dropped exactly when the
 /// spinner would move to its next frame and never merely because time passed.
 /// Changing one without the other either freezes the animation or re-renders

--- a/ui/lib/theme.lua
+++ b/ui/lib/theme.lua
@@ -99,6 +99,27 @@ end
 -- The braille spinner the working state animates through.
 theme.spinner = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
 
+--- The spinner glyph for this frame.
+---
+--- Here rather than in `lib/widgets.lua` so that it ships in the same file as
+--- the table it indexes. A pane and a `lib/` module are delivered separately and
+--- an edit to either is preserved, so a directory can carry an updated pane
+--- beside a module predating a helper it calls; the call then throws from
+--- `render`, and a pane that throws records no click targets, so its rows stop
+--- answering the mouse. Nothing makes a pane immune to a stale module — but the
+--- glyphs and the arithmetic over them can at least not skew against each
+--- other.
+---
+--- The 8 is the kernel's `ANIMATION_HZ` (`kernel::host`), and the two must stay
+--- in lockstep: the shared animation clock invalidates `pure` panes at that rate
+--- and only while something is animating, so a spinner advancing faster than the
+--- clock would skip frames and one advancing slower would be re-rendered for no
+--- visible change.
+function theme.spinner_frame(elapsed)
+  local frame = math.floor((elapsed or 0) * 8) % #theme.spinner + 1
+  return theme.spinner[frame]
+end
+
 function theme.dim(text)
   return { text = text, style = { fg = theme.muted } }
 end

--- a/ui/lib/widgets.lua
+++ b/ui/lib/widgets.lua
@@ -330,28 +330,6 @@ function widgets.hints(pairs_list)
   return { type = "text", len = 1, text = { spans } }
 end
 
---- The spinner glyph for this frame.
----
---- The 8 is the kernel's `ANIMATION_HZ` (`kernel::host`), and the two must
---- stay in lockstep: the shared animation clock invalidates `pure` panes at
---- that rate and only while something is animating, so a spinner advancing
---- faster than the clock would skip frames and one advancing slower would be
---- re-rendered for no visible change.
-function widgets.spinner(elapsed)
-  local frame = math.floor((elapsed or 0) * 8) % #theme.spinner + 1
-  return theme.spinner[frame]
-end
-
---- The animated glyph for a session status.
-function widgets.status_glyph(status, elapsed)
-  local spec = theme.status(status)
-  local glyph = spec.glyph
-  if status == "working" then
-    glyph = widgets.spinner(elapsed)
-  end
-  return { text = glyph, style = { fg = spec.color } }
-end
-
 --- Index of the row whose identity is `id`, or nil when no row carries it.
 ---
 --- The find-the-clicked-row loop, shared: a click hands back the id the row

--- a/ui/plugins/10_sessions.lua
+++ b/ui/plugins/10_sessions.lua
@@ -96,7 +96,7 @@ end
 local function status_glyph(status, elapsed)
   local spec = theme.status(status)
   if status == "working" then
-    return widgets.spinner(elapsed), spec.color
+    return theme.spinner_frame(elapsed), spec.color
   end
   return spec.glyph, spec.color
 end
@@ -313,7 +313,7 @@ local function pending_line(command, inner_width, elapsed)
     glyph, glyph_style = "✗", { fg = theme.role("status_error") }
   else
     -- A spinner only while something is actually running.
-    glyph, glyph_style = widgets.spinner(elapsed), { fg = theme.warn }
+    glyph, glyph_style = theme.spinner_frame(elapsed), { fg = theme.warn }
   end
 
   local label = command.subject or "new session"
@@ -479,8 +479,8 @@ return {
   -- may reuse the tree it returned while neither has changed. The working
   -- spinner still animates: the kernel drops the cached tree when the shared
   -- animation clock moves, and that clock ticks at the same rate
-  -- `widgets.status_glyph` advances the spinner at — but only while something
-  -- is actually animating, so an idle list settles instead of re-rendering.
+  -- `theme.spinner_frame` advances the spinner at — but only while something is
+  -- actually animating, so an idle list settles instead of re-rendering.
   pure = true,
 
   -- Declared as DATA, not just handled. That is what lets the kernel list these

--- a/ui/plugins/70_new_session.lua
+++ b/ui/plugins/70_new_session.lua
@@ -57,16 +57,15 @@ local function agents()
   return (thurbox and thurbox.agents) or {}
 end
 
+--- The spinner frame for this paint, from the flow's own clock.
+local function spinner(flow)
+  return theme.spinner_frame(flow.elapsed)
+end
+
 --- Is a repository-memory write still running?
 ---
 --- v1 renders `Add Repo Path ⠋ checking…` while it validates a typed path on a
 --- host. The same state is readable here: the command is in flight.
---- The spinner frame for this paint. One definition, so three waits cannot
---- animate at different rates.
-local function spinner(flow)
-  return widgets.spinner(flow.elapsed)
-end
-
 local function bookmark_pending()
   for _, item in ipairs((thurbox and thurbox.commands) or {}) do
     if item.kind == "bookmark" and item.phase ~= "failed" then


### PR DESCRIPTION
## Summary

- A pane whose `render` threw painted its error panel and returned **before** `push_targets`, recording no click targets — not even its own rect. A press landing in it matched nothing and fell through to `begin_selection`, so the session list stopped answering the mouse and clicks painted an invisible text selection across the error panel. The pane's rect is now recorded whether or not its tree survived: a plugin that throws costs its own pane and nothing else, the mouse included.
- The throw that surfaced this was `widgets.spinner` being nil in `10_sessions.lua`. It is reached only once a session goes to `working`, which is why the pane loads clean (`plugin check` passes) and dies later.
- A pane and a `lib/` module are delivered as separate files and an edit to either is preserved, so a directory can carry an updated pane beside a module predating a helper it calls. Nothing makes a pane immune to a stale module, but the frame arithmetic can ship beside the glyphs it indexes: `widgets.spinner` → `theme.spinner_frame`, next to `theme.spinner`.
- `widgets.status_glyph` had no caller left and is removed. `ANIMATION_HZ`'s doc and `docs/PLUGINS.md` are updated to name the function that exists.

## Test plan

- `cargo nextest run --all` — 1938 passed
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- `thurbox-cli plugin check` against this `ui/` — loads

Note: the coordinator change has no automated coverage — `App` is not reachable from the test harness, which is why this class of regression went unnoticed.

https://claude.ai/code/session_018PvWmYp5fQ4wfUoYZzFieB