### PR TITLE
fix: report the real version from --version, and let accepting v2 restore auto-update

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,6 +63,15 @@ once, before the interface takes the terminal, and declining turns `auto_update`
 off and prints how to reinstall 1.x. That gate is the only reason replacing an
 interface under an unchanged binary name is defensible.
 
+That off-switch is reversible, and only by the gate that threw it. Declining
+records a marker in `metadata` alongside the `settings.toml` write, and a later
+**accept** puts `auto_update` back only when that marker is present — so someone
+who declined once and returned to v2 is not left pinned forever, while an
+`auto_update = false` the *user* set is never overridden. The marker is the whole
+mechanism: without it the two cases are indistinguishable on disk, and the accept
+branch has to choose between overturning a preference and stranding a profile.
+It is taken in one `DELETE … RETURNING`, so it acts once.
+
 ### Auto-update does not cross a major, and that has to be shipped to v1
 
 `agent::version_check::crosses_major` stops `perform_update` installing a release

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -35,8 +35,18 @@ pub mod version;
 use output::{CommandOutput, Format};
 
 /// Thurbox CLI — manage sessions, scheduled commands, and more.
+///
+/// `version` is spelled out rather than left bare: clap's implicit form reads
+/// `CARGO_PKG_VERSION`, which is the static `0.0.0-dev` marker this project
+/// never bumps, so `--version` reported a dev build on every release while the
+/// `version` subcommand was right. Both now call the one
+/// `version_check::current_version`.
 #[derive(Parser, Debug)]
-#[command(name = "thurbox-cli", version, about)]
+#[command(
+    name = "thurbox-cli",
+    version = crate::agent::version_check::current_version(),
+    about
+)]
 pub struct Cli {
     /// Output JSON instead of the human-readable default.
     #[arg(long, global = true)]

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -688,3 +688,41 @@ fn task_run_parses() {
         }
     ));
 }
+
+/// `--version` must report the build-time-injected version, not clap's default.
+///
+/// Two assertions because neither alone bites everywhere. The behavioural one
+/// is the contract but is **vacuous in a dev build**: clap's implicit `version`
+/// reads `CARGO_PKG_VERSION`, which equals `THURBOX_VERSION` exactly when no
+/// release version was injected — which is every local and CI test run. So the
+/// source check is the one that actually catches a regression here, in the
+/// style of `kernel::updates`' single-installer guard.
+#[test]
+fn version_flag_reports_the_injected_version_not_the_dev_marker() {
+    let rendered = Cli::try_parse_from(["thurbox-cli", "--version"])
+        .unwrap_err()
+        .to_string();
+    let expected = crate::agent::version_check::current_version();
+    assert_eq!(
+        rendered.trim(),
+        format!("thurbox-cli {expected}"),
+        "--version must print the version the `version` subcommand reports"
+    );
+
+    // The bare `version,` attribute is the bug: it silently reads
+    // CARGO_PKG_VERSION, which this project pins to the `0.0.0-dev` marker and
+    // never bumps, so every release shipped a `--version` claiming a dev build.
+    let src = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/cli/mod.rs"),
+    )
+    .expect("read src/cli/mod.rs");
+    let command_attr = {
+        let start = src.find("#[command(").expect("the Cli command attribute");
+        &src[start..src[start..].find(")]").expect("attribute end") + start]
+    };
+    assert!(
+        command_attr.contains("version = crate::agent::version_check::current_version()"),
+        "the Cli #[command(..)] must name the injected version explicitly; \
+         a bare `version` falls back to CARGO_PKG_VERSION. Got: {command_attr:?}"
+    );
+}

--- a/src/kernel/consent.rs
+++ b/src/kernel/consent.rs
@@ -13,6 +13,17 @@
 //! Declining cannot load v1 — it is not in this binary any more. What it does is
 //! turn `auto_update` **off** and print how to reinstall the 1.x line, because a
 //! downgrade that leaves auto-update on would be undone on the next launch.
+//!
+//! That off-switch is the gate's to undo, and only its own: accepting v2 puts
+//! `auto_update` back if — and only if — declining is what took it, which a
+//! marker in `metadata` records. Without the marker the accept branch cannot
+//! act at all, since a `false` in `settings.toml` reads the same whether the
+//! gate wrote it or the user did.
+//!
+//! Which makes this forward-looking only, and deliberately so: a profile that
+//! declined and then accepted *before* the marker existed carries an
+//! indistinguishable `false`, and is left alone rather than guessed at. Turning
+//! it back on there is a one-line edit the user makes.
 
 use std::io::Write;
 
@@ -319,9 +330,18 @@ pub fn consent_gate(db: &Database) -> std::io::Result<Decision> {
             if let Err(e) = db.acknowledge_v2() {
                 tracing::warn!("could not record the v2 acknowledgement: {e}");
             }
+            restore_auto_update_if_gate_disabled(db);
         }
         Decision::Declined => {
-            let disabled = disable_auto_update();
+            let disabled = set_auto_update(false);
+            // Only a change *this* branch made is the gate's to undo later. An
+            // `Ok(false)` means auto-update was already off -- somebody else's
+            // decision, which an accept must leave exactly where it found it.
+            if let Ok(true) = &disabled {
+                if let Err(e) = db.note_auto_update_disabled_by_gate() {
+                    tracing::warn!("could not record that the gate disabled auto-update: {e}");
+                }
+            }
             let mut out = std::io::stdout();
             if let Err(e) = &disabled {
                 // Say so rather than claim it: an instruction to downgrade is
@@ -340,17 +360,68 @@ pub fn consent_gate(db: &Database) -> std::io::Result<Decision> {
     Ok(decision)
 }
 
-/// Turn `auto_update` off, so a downgrade is not undone on the next launch.
+/// Write `auto_update = on`, reporting whether the file actually changed.
+///
+/// `Ok(false)` means it already held that value and nothing was written. Both
+/// callers depend on that distinction — only a change the gate *made* may the
+/// gate later undo, and only a change it *needs* is worth logging.
 ///
 /// Written through `settings_config::save_settings`, which edits the file with
 /// `toml_edit` and therefore keeps the seed's documentation comments.
-fn disable_auto_update() -> Result<(), String> {
+fn set_auto_update(on: bool) -> Result<bool, String> {
     let (mut settings, _) = crate::agent::settings_config::load_or_seed_with_warnings();
-    if !settings.features.auto_update {
-        return Ok(());
+    if settings.features.auto_update == on {
+        return Ok(false);
     }
-    settings.features.auto_update = false;
-    crate::agent::settings_config::save_settings(&settings).map_err(|e| e.to_string())
+    settings.features.auto_update = on;
+    crate::agent::settings_config::save_settings(&settings).map_err(|e| e.to_string())?;
+    Ok(true)
+}
+
+/// Put `auto_update` back, but only if declining is what took it.
+///
+/// The gate's two branches were asymmetric: declining turned auto-update off to
+/// protect a downgrade, and accepting never turned it back on. Someone who
+/// declined once and later accepted stayed pinned to whatever version they had,
+/// with no sign of why — `thurbox-cli update` just reported itself disabled.
+///
+/// The marker is what makes this safe to do silently. Re-enabling on every
+/// accept would overturn an `auto_update = false` the user set themselves,
+/// which is a setting thurbox has no business overriding; re-enabling only when
+/// the gate wrote that `false` restores the state the user actually left.
+///
+/// Best-effort and quiet: this runs a breath before the interface takes the
+/// terminal, so there is nowhere to print. A failure leaves auto-update off —
+/// recoverable by hand, and the marker is put back so the next launch retries.
+fn restore_auto_update_if_gate_disabled(db: &Database) {
+    let ours = match db.take_auto_update_disabled_by_gate() {
+        Ok(ours) => ours,
+        Err(e) => {
+            tracing::warn!("could not read the gate's auto-update marker: {e}");
+            return;
+        }
+    };
+    if !ours {
+        return;
+    }
+
+    match set_auto_update(true) {
+        Ok(true) => tracing::info!(
+            "auto_update turned back on: the consent gate is what disabled it, \
+             and this profile has now accepted v2"
+        ),
+        // Already on -- put back by hand, or by an earlier run of this. Either
+        // way the marker is spent, which is the point of taking it.
+        Ok(false) => {}
+        Err(e) => {
+            tracing::warn!("could not turn auto_update back on: {e}");
+            // Hand the marker back rather than swallow it: the reason to
+            // re-enable has not gone away just because this write failed.
+            if let Err(e) = db.note_auto_update_disabled_by_gate() {
+                tracing::warn!("could not restore the gate's auto-update marker: {e}");
+            }
+        }
+    }
 }
 
 /// Show the notice and read one key.

--- a/src/storage/settings.rs
+++ b/src/storage/settings.rs
@@ -13,6 +13,10 @@ const THEME_KEY: &str = "active_theme";
 /// `storage` owns the `metadata` table; the kernel reads it through the
 /// accessors below rather than the other way round.
 const V2_ACK_KEY: &str = "v2_interface_acknowledged";
+/// Set when the gate's decline branch is what turned `auto_update` off, so a
+/// later accept can tell its own doing from a preference the user set. Owned
+/// here for the same reason as [`V2_ACK_KEY`]: `storage` owns `metadata`.
+const AUTO_UPDATE_OFF_BY_GATE_KEY: &str = "auto_update_disabled_by_consent_gate";
 const ACTIVE_EXTENSIONS_KEY: &str = "active_extensions";
 const PERF_SNAPSHOT_KEY: &str = "perf_snapshot";
 
@@ -126,6 +130,40 @@ impl Database {
             params![V2_ACK_KEY, "1"],
         )?;
         Ok(())
+    }
+
+    /// Record that the consent gate is what turned `auto_update` off.
+    ///
+    /// The gate disables auto-update when someone declines v2, so a downgrade to
+    /// the 1.x line is not undone on the next launch. Without this marker the
+    /// accept branch cannot undo that: a `false` in `settings.toml` looks the
+    /// same whether the gate wrote it or the user did, and re-enabling
+    /// unconditionally would silently overturn a deliberate preference.
+    pub fn note_auto_update_disabled_by_gate(&self) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "INSERT INTO metadata (key, value) VALUES (?1, ?2) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![AUTO_UPDATE_OFF_BY_GATE_KEY, "1"],
+        )?;
+        Ok(())
+    }
+
+    /// Read **and clear** that marker: did the gate turn `auto_update` off?
+    ///
+    /// One shot, in one statement, mirroring
+    /// [`Self::take_pending_focus_session_id`] — the flag exists only to be
+    /// acted on once, and leaving it behind would re-enable auto-update again
+    /// on some later launch the user had since opted out of.
+    pub fn take_auto_update_disabled_by_gate(&self) -> rusqlite::Result<bool> {
+        Ok(self
+            .conn
+            .query_row(
+                "DELETE FROM metadata WHERE key = ?1 RETURNING value",
+                params![AUTO_UPDATE_OFF_BY_GATE_KEY],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .is_some())
     }
 
     /// Whether this profile has ever had a session.
@@ -343,6 +381,27 @@ mod tests {
         assert!(
             db.v2_acknowledged().expect("read"),
             "the answer has to persist, or the gate asks on every launch"
+        );
+    }
+
+    #[test]
+    fn the_gates_auto_update_marker_is_one_shot() {
+        let db = Database::open_in_memory().expect("in-memory");
+        assert!(
+            !db.take_auto_update_disabled_by_gate().expect("read"),
+            "a profile the gate never touched must not have its auto_update \
+             re-enabled: that `false` would be the user's own setting"
+        );
+
+        db.note_auto_update_disabled_by_gate().expect("write");
+        assert!(
+            db.take_auto_update_disabled_by_gate().expect("read"),
+            "the decline branch's doing has to be readable by a later accept"
+        );
+        assert!(
+            !db.take_auto_update_disabled_by_gate().expect("read"),
+            "taking it clears it -- left behind, it would re-enable auto-update \
+             on some later launch the user had since opted out of"
         );
     }
 


### PR DESCRIPTION
## Summary

Two version/update bugs found while investigating `thurbox-cli` reporting `0.0.0-dev`.

**`--version` printed the dev marker on every release.** The `version` subcommand was always right; the `--version`/`-V` flag was not:

```
thurbox-cli version      → thurbox 2.5.3        ✅
thurbox-cli --version    → thurbox-cli 0.0.0-dev ❌
```

`src/cli/mod.rs` used clap's bare `version` attribute, which reads `CARGO_PKG_VERSION` — the static marker this project pins and deliberately never bumps. The real version is injected by `build.rs` into `THURBOX_VERSION`, which only the subcommand read. Both now call `version_check::current_version`.

The regression test carries a source guard alongside the behavioural assertion, because the behavioural one is **vacuous in a dev build**: `CARGO_PKG_VERSION` and `THURBOX_VERSION` are both `0.0.0-dev` when nothing is injected, which is every local and CI test run. The guard is verified to fail against the old attribute.

**The consent gate never undid its own auto-update off-switch.** Declining v2 turns `auto_update` off so a downgrade to 1.x is not undone on the next launch; accepting never turned it back on. Someone who declined once and later accepted stayed pinned, with no sign of why — `thurbox-cli update` just reported itself disabled.

Accepting now restores it, but *only when declining is what took it*. A marker in `metadata` records that, because a `false` in `settings.toml` reads the same whether the gate wrote it or the user did — re-enabling unconditionally would overturn a deliberate preference. Taken in one `DELETE … RETURNING`, so it acts once.

Forward-looking only, and deliberately so: a profile that declined and then accepted before the marker existed carries an indistinguishable `false` and is left alone rather than guessed at.

## Test plan

- [x] `cargo nextest run --all` — 1940 passed, 0 failed
- [x] New `version_flag_reports_the_injected_version_not_the_dev_marker`; its source guard confirmed to **fail** when the attribute is reverted to bare `version`
- [x] New `the_gates_auto_update_marker_is_one_shot` — absent / set / taken-once, on an in-memory DB (no global state)
- [x] End-to-end: `THURBOX_RELEASE_VERSION=v2.5.3 cargo build` → `--version` prints `2.5.3`, matching the subcommand
- [x] `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all`, `cargo test --test architecture_rules` (11 passed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `docs/RELEASING.md` updated per the repo's doc rule — it documented the gate's off-switch as one-way

https://claude.ai/code/session_01JBpHpGDPrDpT69G9ETqNg8