### PR TITLE
fix(ui): select the repo just added, not the row offered above it

### DIFF
--- a/src/kernel/host/publish.rs
+++ b/src/kernel/host/publish.rs
@@ -455,6 +455,11 @@ impl LuaHost {
                     .map_err(|e| e.to_string())?;
                 item.set("is_parent", row.is_parent)
                     .map_err(|e| e.to_string())?;
+                // True only for a row the flow offers on its own account. It
+                // leads the list by construction, so a plugin reading the list
+                // as most-recent-first has to be able to step over it.
+                item.set("offered", row.offered)
+                    .map_err(|e| e.to_string())?;
                 // `nil` means never established, which is a third state beside
                 // true and false: it stays worktree-capable.
                 item.set(

--- a/src/kernel/repos.rs
+++ b/src/kernel/repos.rs
@@ -58,6 +58,15 @@ pub struct BookmarkRow {
     /// the interface directory is a long, install-specific path whose leaf
     /// (`ui`) says nothing about what picking it would do.
     pub label: Option<String>,
+    /// Whether the flow offered this row itself rather than reading it from
+    /// memory.
+    ///
+    /// An offered row is not a bookmark: it leads the list by construction, so
+    /// its position says nothing about when it was last used. The flow needs
+    /// the distinction because it finds a *just-added* path by recency — the
+    /// first row of memory — and an offered row ahead of memory is picked up as
+    /// that path instead.
+    pub offered: bool,
 }
 
 /// One entry of the browse dropdown.
@@ -558,6 +567,9 @@ fn offer_interface_dir(rows: &mut Vec<BookmarkRow>) {
     // is usually `ui`, which tells a reader nothing, and the rest of the path is
     // install-specific boilerplate that the row was truncating anyway.
     offered.label = Some("Thurbox interface — edit your panes".to_string());
+    // Flagged so a reader of the list can tell placement from recency: this row
+    // is first because this function puts it here, not because it was just used.
+    offered.offered = true;
     rows.insert(0, offered);
 }
 
@@ -692,6 +704,7 @@ fn row(path: &Path, parent: Option<String>, is_parent: bool, is_git: Option<bool
         is_parent,
         is_git,
         label: None,
+        offered: false,
     }
 }
 
@@ -1107,6 +1120,9 @@ mod tests {
             label.contains("interface"),
             "the name says what it is: {label}"
         );
+        // The flag is what keeps it out of the flow's recency lookup: being
+        // first here is placement, not a bookmark that was just used.
+        assert!(rows[0].offered, "an offered row says so");
         std::env::remove_var("THURBOX_UI_DIR");
     }
 

--- a/tests/v2_new_session.rs
+++ b/tests/v2_new_session.rs
@@ -53,6 +53,9 @@ fn snapshot() -> Snapshot {
     }
 }
 
+/// Where an installed interface lives, as `offered` reports it.
+const INTERFACE_DIR: &str = "/home/me/.config/thurbox/ui";
+
 fn bookmark(path: &str, is_git: Option<bool>) -> BookmarkRow {
     BookmarkRow {
         name: path.rsplit('/').next().unwrap_or(path).to_string(),
@@ -61,6 +64,17 @@ fn bookmark(path: &str, is_git: Option<bool>) -> BookmarkRow {
         is_parent: false,
         is_git,
         label: None,
+        offered: false,
+    }
+}
+
+/// The interface directory, which the kernel offers at the top of the local list
+/// under a name of its own rather than reading it from memory.
+fn offered() -> BookmarkRow {
+    BookmarkRow {
+        label: Some("Thurbox interface — edit your panes".into()),
+        offered: true,
+        ..bookmark(INTERFACE_DIR, Some(false))
     }
 }
 
@@ -89,6 +103,7 @@ fn folder_rows() -> Vec<BookmarkRow> {
             is_parent: true,
             is_git: None,
             label: None,
+            offered: false,
         },
         BookmarkRow {
             path: "/src/thurbox".into(),
@@ -97,6 +112,7 @@ fn folder_rows() -> Vec<BookmarkRow> {
             is_parent: false,
             is_git: Some(true),
             label: None,
+            offered: false,
         },
     ]
 }
@@ -717,6 +733,31 @@ fn a_typed_path_is_committed_as_a_bookmark_rather_than_trusted() {
             edit: BookmarkEdit::Add,
         }],
         "the tilde is left for the target machine to expand"
+    );
+}
+
+#[test]
+fn a_path_just_added_is_the_row_that_gets_selected() {
+    // The flow finds the row it just added by recency — memory is published
+    // most-recent-first — and the kernel offers the interface directory ahead of
+    // memory. Taking row 1 therefore selected the INTERFACE for every repository
+    // added, leaving the typed one unchecked.
+    let host = host();
+    let mut world = world_with(vec![offered()]);
+    open(&host, &world);
+    press(&host, &world, "tab");
+    type_text(&host, &world, "/src/new");
+    press(&host, &world, "enter");
+
+    // The write lands: the added path is now the newest thing in memory, still
+    // behind the offered row.
+    world.repos = store_with(vec![offered(), bookmark("/src/new", Some(true))]);
+    let screen = drawn(&host, &world);
+    let selected: Vec<&str> = screen.lines().filter(|line| line.contains("[x]")).collect();
+    assert_eq!(selected.len(), 1, "one row is chosen:\n{screen}");
+    assert!(
+        selected[0].contains("new"),
+        "the path just typed is the one chosen:\n{screen}"
     );
 }
 

--- a/ui/lib/repo_picker.lua
+++ b/ui/lib/repo_picker.lua
@@ -79,6 +79,40 @@ function repo_picker.rows(published, query, collapsed)
   return out
 end
 
+--- The most recently used remembered repository — where a path just added lands.
+---
+--- Memory is published most-recent-first, so this is "the first row" — but only
+--- among the rows that ARE memory. A row the kernel **offers** on its own
+--- account (the interface directory) leads the list by construction rather than
+--- by recency, so it is stepped over: selecting it is what select-or-add did
+--- before, which checked the interface directory for every repository added
+--- instead of the one just typed.
+function repo_picker.newest(published)
+  for _, row in ipairs(published or {}) do
+    if not row.offered then
+      -- The first row of memory settles it either way. A folder header there
+      -- means the newest memory is a folder rather than a repository, and
+      -- reaching further down the list would claim one nobody asked for.
+      if row.is_parent then
+        return nil
+      end
+      return row
+    end
+  end
+  return nil
+end
+
+--- Where a path sits among the rendered rows, or nil when it is not drawn — a
+--- search excludes it, or it is folded into a collapsed folder.
+function repo_picker.index_of(entries, path)
+  for index, entry in ipairs(entries) do
+    if entry.row.path == path then
+      return index
+    end
+  end
+  return nil
+end
+
 --- The entry the cursor is on, or nil when the list is empty.
 function repo_picker.current(entries, cursor)
   if #entries == 0 then

--- a/ui/plugins/70_new_session.lua
+++ b/ui/plugins/70_new_session.lua
@@ -889,14 +889,18 @@ return {
     -- A path just added is selected, which is v1's select-or-add. The row cannot
     -- be found by name — the expansion of a `~` on a remote host happened on the
     -- worker — so it is found by RECENCY: memory is published most-recent-first
-    -- and an add touches recency, so the row asked for is the first one
-    -- (design.md D2). Consumed only once the write has landed and the list has
-    -- been re-read, or it would select whatever was previously on top.
+    -- and an add touches recency, so the row asked for is the newest one
+    -- (design.md D2). Newest is not the same as first: the kernel offers the
+    -- interface directory ahead of memory, and taking row 1 selected THAT for
+    -- every repository added. Consumed only once the write has landed and the
+    -- list has been re-read, or it would select whatever was previously on top.
     if flow.select_newest and not bookmark_pending() and not bookmarks().loading then
-      local first = (bookmarks().rows or {})[1]
-      if first and not first.is_parent then
-        flow.selected[first.path] = true
-        flow.cursor = 1
+      local newest = repo_picker.newest(bookmarks().rows or {})
+      if newest then
+        flow.selected[newest.path] = true
+        -- The cursor follows the selection rather than resetting to the top, for
+        -- the same reason: the top row is no longer the row just added.
+        flow.cursor = repo_picker.index_of(rows_for(flow), newest.path) or 1
       end
       flow.select_newest = nil
       save(flow)


### PR DESCRIPTION
## Summary

- Adding a repository in the session-creation flow checked the **wrong row**: the flow finds a just-added path by recency (memory is published most-recent-first) and took row 1, but the kernel offers the interface directory *above* memory — so every add selected "Thurbox interface" and left the typed path unselected.
- `BookmarkRow.offered` marks a row the kernel offers on its own account, published to Lua alongside `is_parent`/`is_git`.
- `repo_picker.newest` steps over offered rows to the first row that *is* memory, keeping the previous bail-out when that turns out to be a folder header; `repo_picker.index_of` puts the cursor on the selected row instead of resetting it to the top, which is no longer the row just added.

## Test plan

- `tests/v2_new_session.rs::a_path_just_added_is_the_row_that_gets_selected` drives the real flow with an offered row leading the list and asserts exactly one `[x]`, on the typed path. Verified it fails against the previous code:

  ```
  │[x] Thurbox interface — edit your panes  /home/m…rbox/ui (dir)  │
  │[ ] /src/new                                                    │
  ```

- `repos.rs`'s offered-row test now also asserts the flag.
- `cargo nextest run --all` — 1941 passed; `cargo clippy --all-targets --all-features -- -D warnings` clean.

https://claude.ai/code/session_01XeecbBuDUDgC4qbMxJtzLL